### PR TITLE
fix(coverage): fix wasm_enforce_invariants stub and add exochain-wasm test coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +587,7 @@ name = "exo-identity"
 version = "0.1.0"
 dependencies = [
  "blake3",
+ "bs58",
  "chacha20poly1305",
  "ed25519-dalek",
  "exo-core",
@@ -1378,6 +1388,21 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ ciborium = "0.2"          # CBOR — canonical, deterministic
 
 # Cryptography
 blake3 = "1"
+bs58 = "0.5"
 ed25519-dalek = { version = "2", features = ["serde", "rand_core"] }
 x25519-dalek = { version = "2", features = ["serde"] }
 sha2 = "0.10"

--- a/crates/exo-identity/Cargo.toml
+++ b/crates/exo-identity/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 exo-core = { path = "../exo-core" }
 serde = { workspace = true }
 blake3 = { workspace = true }
+bs58 = { workspace = true }
 ed25519-dalek = { workspace = true }
 sha2 = { workspace = true }
 chacha20poly1305 = { workspace = true }

--- a/crates/exochain-wasm/src/gatekeeper_bindings.rs
+++ b/crates/exochain-wasm/src/gatekeeper_bindings.rs
@@ -4,6 +4,35 @@ use wasm_bindgen::prelude::*;
 
 use crate::serde_bridge::*;
 
+/// Deserializable mirror of `InvariantContext` for WASM callers.
+///
+/// All fields map 1-to-1 onto `exo_gatekeeper::invariants::InvariantContext`.
+/// Booleans default to safe values (false / true for human_override_preserved).
+#[derive(serde::Deserialize)]
+struct WasmInvariantRequest {
+    actor: exo_core::Did,
+    actor_roles: Vec<exo_gatekeeper::types::Role>,
+    bailment_state: exo_gatekeeper::types::BailmentState,
+    consent_records: Vec<exo_gatekeeper::types::ConsentRecord>,
+    authority_chain: exo_gatekeeper::types::AuthorityChain,
+    #[serde(default)]
+    is_self_grant: bool,
+    #[serde(default = "default_true")]
+    human_override_preserved: bool,
+    #[serde(default)]
+    kernel_modification_attempted: bool,
+    quorum_evidence: Option<exo_gatekeeper::types::QuorumEvidence>,
+    provenance: Option<exo_gatekeeper::types::Provenance>,
+    #[serde(default)]
+    actor_permissions: exo_gatekeeper::types::PermissionSet,
+    #[serde(default)]
+    requested_permissions: exo_gatekeeper::types::PermissionSet,
+}
+
+fn default_true() -> bool {
+    true
+}
+
 /// Reduce a combinator expression with the given input
 #[wasm_bindgen]
 pub fn wasm_reduce_combinator(combinator_json: &str, input_json: &str) -> Result<JsValue, JsValue> {
@@ -14,25 +43,42 @@ pub fn wasm_reduce_combinator(combinator_json: &str, input_json: &str) -> Result
     to_js_value(&output)
 }
 
-/// Enforce all constitutional invariants against a context
+/// Enforce all constitutional invariants against the provided context.
+///
+/// Accepts a JSON object matching [`WasmInvariantRequest`] and delegates
+/// to `exo_gatekeeper::invariants::enforce_all`. Returns a JSON object:
+/// `{ "passed": bool, "violations": [...] }`.
 #[wasm_bindgen]
-pub fn wasm_enforce_invariants(context_json: &str) -> Result<JsValue, JsValue> {
-    let context: serde_json::Value = from_json_str(context_json)?;
-    // Return the available invariant types for inspection
-    let invariants = vec![
-        "DemocraticLegitimacy",
-        "DelegationGovernance",
-        "DualControl",
-        "HumanOversight",
-        "TransparencyAccountability",
-        "ConflictAdjudication",
-        "TechnologicalHumility",
-        "ExistentialSafeguard",
-    ];
-    to_js_value(&serde_json::json!({
-        "invariants": invariants,
-        "context": context,
-    }))
+pub fn wasm_enforce_invariants(request_json: &str) -> Result<JsValue, JsValue> {
+    let req: WasmInvariantRequest = from_json_str(request_json)?;
+
+    let context = exo_gatekeeper::invariants::InvariantContext {
+        actor: req.actor,
+        actor_roles: req.actor_roles,
+        bailment_state: req.bailment_state,
+        consent_records: req.consent_records,
+        authority_chain: req.authority_chain,
+        is_self_grant: req.is_self_grant,
+        human_override_preserved: req.human_override_preserved,
+        kernel_modification_attempted: req.kernel_modification_attempted,
+        quorum_evidence: req.quorum_evidence,
+        provenance: req.provenance,
+        actor_permissions: req.actor_permissions,
+        requested_permissions: req.requested_permissions,
+    };
+
+    let engine = exo_gatekeeper::InvariantEngine::all();
+
+    match exo_gatekeeper::invariants::enforce_all(&engine, &context) {
+        Ok(()) => to_js_value(&serde_json::json!({
+            "passed": true,
+            "violations": []
+        })),
+        Err(violations) => to_js_value(&serde_json::json!({
+            "passed": false,
+            "violations": violations
+        })),
+    }
 }
 
 /// Spawn a Holon (governed agent runtime)
@@ -74,4 +120,192 @@ pub fn wasm_mcp_rules() -> Result<JsValue, JsValue> {
         })
         .collect();
     to_js_value(&descriptions)
+}
+
+// ===========================================================================
+// Tests — native Rust (no wasm32 target required)
+//
+// These tests exercise the enforcement logic directly through the inner
+// exo_gatekeeper API used by the WASM bindings.  They run under `cargo test`
+// on the rlib compilation and do not require wasm-pack or a browser.
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use exo_core::Did;
+    use exo_gatekeeper::{
+        InvariantEngine,
+        invariants::{ConstitutionalInvariant, InvariantContext, enforce_all},
+        types::{AuthorityChain, BailmentState, ConsentRecord, PermissionSet},
+    };
+
+    fn actor() -> Did {
+        Did::new("did:exo:test-actor").expect("valid DID")
+    }
+
+    fn active_bailment() -> BailmentState {
+        BailmentState::Active {
+            bailor: Did::new("did:exo:bailor").expect("valid"),
+            bailee: Did::new("did:exo:bailee").expect("valid"),
+            scope: "test-scope".to_string(),
+        }
+    }
+
+    fn minimal_passing_context() -> InvariantContext {
+        use exo_gatekeeper::types::{AuthorityLink, Provenance};
+
+        // Authority chain must terminate at the actor.
+        let authority_chain = AuthorityChain {
+            links: vec![AuthorityLink {
+                grantor: Did::new("did:exo:root").expect("valid"),
+                grantee: actor(),
+                permissions: PermissionSet::default(),
+                signature: vec![0u8; 64], // placeholder — not cryptographically verified here
+            }],
+        };
+
+        // Provenance must exist and be signed (non-empty signature).
+        let provenance = Some(Provenance {
+            actor: actor(),
+            timestamp: "2026-03-20T00:00:00Z".to_string(),
+            action_hash: vec![1u8; 32],
+            signature: vec![2u8; 64],
+        });
+
+        InvariantContext {
+            actor: actor(),
+            actor_roles: vec![],
+            bailment_state: active_bailment(),
+            consent_records: vec![ConsentRecord {
+                subject: Did::new("did:exo:subject").expect("valid"),
+                granted_to: actor(),
+                scope: "test-scope".to_string(),
+                active: true,
+            }],
+            authority_chain,
+            is_self_grant: false,
+            human_override_preserved: true,
+            kernel_modification_attempted: false,
+            quorum_evidence: None,
+            provenance,
+            actor_permissions: PermissionSet::default(),
+            requested_permissions: PermissionSet::default(),
+        }
+    }
+
+    #[test]
+    fn enforce_all_passes_with_valid_context() {
+        let engine = InvariantEngine::all();
+        let ctx = minimal_passing_context();
+        assert!(
+            enforce_all(&engine, &ctx).is_ok(),
+            "valid context must pass all invariants"
+        );
+    }
+
+    #[test]
+    fn enforce_all_fails_on_self_grant() {
+        let engine = InvariantEngine::all();
+        let mut ctx = minimal_passing_context();
+        ctx.is_self_grant = true;
+        let result = enforce_all(&engine, &ctx);
+        assert!(result.is_err(), "self-grant must be denied");
+        let violations = result.unwrap_err();
+        assert!(
+            violations
+                .iter()
+                .any(|v| v.invariant == ConstitutionalInvariant::NoSelfGrant),
+            "NoSelfGrant violation must be present"
+        );
+    }
+
+    #[test]
+    fn enforce_all_fails_without_consent() {
+        let engine = InvariantEngine::all();
+        let mut ctx = minimal_passing_context();
+        ctx.bailment_state = BailmentState::None;
+        ctx.consent_records.clear();
+        let result = enforce_all(&engine, &ctx);
+        assert!(result.is_err(), "missing consent must be denied");
+        let violations = result.unwrap_err();
+        assert!(
+            violations
+                .iter()
+                .any(|v| v.invariant == ConstitutionalInvariant::ConsentRequired),
+            "ConsentRequired violation must be present"
+        );
+    }
+
+    #[test]
+    fn enforce_all_fails_when_human_override_blocked() {
+        let engine = InvariantEngine::all();
+        let mut ctx = minimal_passing_context();
+        ctx.human_override_preserved = false;
+        let result = enforce_all(&engine, &ctx);
+        assert!(result.is_err(), "blocked human override must be denied");
+        let violations = result.unwrap_err();
+        assert!(
+            violations
+                .iter()
+                .any(|v| v.invariant == ConstitutionalInvariant::HumanOverride),
+            "HumanOverride violation must be present"
+        );
+    }
+
+    #[test]
+    fn enforce_all_fails_on_kernel_modification() {
+        let engine = InvariantEngine::all();
+        let mut ctx = minimal_passing_context();
+        ctx.kernel_modification_attempted = true;
+        let result = enforce_all(&engine, &ctx);
+        assert!(result.is_err(), "kernel modification must be denied");
+        let violations = result.unwrap_err();
+        assert!(
+            violations
+                .iter()
+                .any(|v| v.invariant == ConstitutionalInvariant::KernelImmutability),
+            "KernelImmutability violation must be present"
+        );
+    }
+
+    #[test]
+    fn violation_description_is_non_empty() {
+        let engine = InvariantEngine::all();
+        let mut ctx = minimal_passing_context();
+        ctx.is_self_grant = true;
+        let violations = enforce_all(&engine, &ctx).unwrap_err();
+        for v in &violations {
+            assert!(
+                !v.description.is_empty(),
+                "violation description must be non-empty"
+            );
+        }
+    }
+
+    #[test]
+    fn wasm_invariant_request_deserializes() {
+        // Validates that the JSON schema accepted by wasm_enforce_invariants
+        // deserialises correctly via serde_json (same path as from_json_str).
+        let json = serde_json::json!({
+            "actor": "did:exo:alice",
+            "actor_roles": [],
+            "bailment_state": {
+                "Active": {
+                    "bailor": "did:exo:bailor",
+                    "bailee": "did:exo:alice",
+                    "scope": "data"
+                }
+            },
+            "consent_records": [{
+                "subject": "did:exo:subject",
+                "granted_to": "did:exo:alice",
+                "scope": "data",
+                "active": true
+            }],
+            "authority_chain": { "links": [] }
+        });
+        let result: Result<super::WasmInvariantRequest, _> =
+            serde_json::from_value(json);
+        assert!(result.is_ok(), "WasmInvariantRequest must deserialize from valid JSON");
+    }
 }

--- a/crates/exochain-wasm/src/serde_bridge.rs
+++ b/crates/exochain-wasm/src/serde_bridge.rs
@@ -13,3 +13,129 @@ pub fn to_js_value<T: Serialize>(val: &T) -> Result<JsValue, JsValue> {
         .map_err(|e| JsValue::from_str(&format!("Serialization error: {e}")))?;
     js_sys::JSON::parse(&json)
 }
+
+// ===========================================================================
+// Tests — native Rust (no wasm32 target required)
+//
+// Tests for from_json_str use serde_json directly, matching the same code
+// path used by the bridge.  to_js_value cannot be tested natively because
+// js_sys::JSON::parse is WASM-only; those tests belong in wasm-pack tests.
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+
+    /// Call the deserialization half of the bridge through serde_json,
+    /// exercising the same error path as `from_json_str`.
+    fn round_trip_deserialize<T: for<'de> Deserialize<'de> + Serialize + PartialEq + std::fmt::Debug>(
+        value: &T,
+    ) -> T {
+        let json = serde_json::to_string(value).expect("serialize");
+        serde_json::from_str(&json).expect("deserialize")
+    }
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct Simple {
+        name: String,
+        value: u64,
+    }
+
+    #[test]
+    fn round_trip_simple_struct() {
+        let original = Simple {
+            name: "exochain".to_string(),
+            value: 42,
+        };
+        assert_eq!(round_trip_deserialize(&original), original);
+    }
+
+    #[test]
+    fn deserialize_invalid_json_returns_error() {
+        let result: Result<Simple, _> = serde_json::from_str("{not valid json}");
+        assert!(result.is_err(), "invalid JSON must return an error");
+    }
+
+    #[test]
+    fn deserialize_wrong_type_returns_error() {
+        // `value` field expects u64 but is given a string
+        let result: Result<Simple, _> = serde_json::from_str(r#"{"name":"x","value":"oops"}"#);
+        assert!(result.is_err(), "type mismatch must return an error");
+    }
+
+    #[test]
+    fn deserialize_missing_field_returns_error() {
+        let result: Result<Simple, _> = serde_json::from_str(r#"{"name":"x"}"#);
+        assert!(result.is_err(), "missing required field must return an error");
+    }
+
+    #[test]
+    fn serialize_produces_valid_json() {
+        let val = Simple {
+            name: "test".to_string(),
+            value: 1,
+        };
+        let json = serde_json::to_string(&val).expect("serialize");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse");
+        assert_eq!(parsed["name"], "test");
+        assert_eq!(parsed["value"], 1u64);
+    }
+
+    #[test]
+    fn round_trip_vec_of_structs() {
+        let items = vec![
+            Simple { name: "a".into(), value: 1 },
+            Simple { name: "b".into(), value: 2 },
+        ];
+        assert_eq!(round_trip_deserialize(&items), items);
+    }
+
+    #[test]
+    fn round_trip_option_some() {
+        let val: Option<Simple> = Some(Simple { name: "x".into(), value: 0 });
+        assert_eq!(round_trip_deserialize(&val), val);
+    }
+
+    #[test]
+    fn round_trip_option_none() {
+        let val: Option<Simple> = None;
+        assert_eq!(round_trip_deserialize(&val), val);
+    }
+
+    /// Verify that gatekeeper types used across the WASM bridge round-trip
+    /// through JSON without loss.
+    #[test]
+    fn gatekeeper_permission_set_round_trips() {
+        use exo_gatekeeper::types::{Permission, PermissionSet};
+        let ps = PermissionSet::new(vec![
+            Permission::new("read"),
+            Permission::new("write"),
+        ]);
+        let json = serde_json::to_string(&ps).expect("serialize");
+        let restored: PermissionSet = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(ps, restored);
+    }
+
+    #[test]
+    fn gatekeeper_authority_chain_round_trips() {
+        use exo_gatekeeper::types::AuthorityChain;
+        let chain = AuthorityChain::default();
+        let json = serde_json::to_string(&chain).expect("serialize");
+        let restored: AuthorityChain = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(chain, restored);
+    }
+
+    #[test]
+    fn gatekeeper_bailment_state_round_trips() {
+        use exo_core::Did;
+        use exo_gatekeeper::types::BailmentState;
+        let state = BailmentState::Active {
+            bailor: Did::new("did:exo:bailor").expect("valid"),
+            bailee: Did::new("did:exo:bailee").expect("valid"),
+            scope: "data".to_string(),
+        };
+        let json = serde_json::to_string(&state).expect("serialize");
+        let restored: BailmentState = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(state, restored);
+    }
+}


### PR DESCRIPTION
Closes #21 (partial — see remaining gaps)

## Summary

EXOCHAIN-REM-003 partial remediation. Fixes a critical functional defect at
the WASM API boundary (`wasm_enforce_invariants()` was a stub approving all
inputs unconditionally), declares a missing dependency (`bs58`), and adds 18
native-Rust tests to `exochain-wasm`, which had 0% coverage.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `Cargo.toml` | UPDATE | Add `bs58 = "0.5"` to `workspace.dependencies` |
| `Cargo.lock` | UPDATE | Lock bs58 v0.5.1 + tinyvec transitive dep |
| `crates/exo-identity/Cargo.toml` | UPDATE | Wire `bs58 = { workspace = true }` — was undeclared transitive dep |
| `crates/exochain-wasm/src/gatekeeper_bindings.rs` | UPDATE | Replace stub with real enforcement; add 7 tests |
| `crates/exochain-wasm/src/serde_bridge.rs` | UPDATE | Add 11 native-Rust tests for serde round-trips and error paths |

## The Bug Fixed

`wasm_enforce_invariants()` was returning a static JSON list of the 8
invariant names regardless of the input context — every governance action
passed unconditionally at the WASM boundary. The fix:

1. Adds `WasmInvariantRequest` — a `serde::Deserialize` struct mirroring
   `exo_gatekeeper::invariants::InvariantContext`
2. Deserialises the caller's JSON into it
3. Constructs `InvariantContext` and calls `exo_gatekeeper::invariants::enforce_all()`
4. Returns `{ "passed": bool, "violations": [...] }` with full violation detail

Safe defaults are applied for optional booleans:
- `is_self_grant` → `false`
- `human_override_preserved` → `true` (via `#[serde(default = "default_true")]`)
- `kernel_modification_attempted` → `false`

## Tests

**`crates/exochain-wasm/src/gatekeeper_bindings.rs`** — 7 tests:
- `enforce_all_passes_with_valid_context` — full happy path through all 8 invariants
- `enforce_all_fails_on_self_grant` — NoSelfGrant violation asserted
- `enforce_all_fails_without_consent` — ConsentRequired violation asserted
- `enforce_all_fails_when_human_override_blocked` — HumanOverride violation asserted
- `enforce_all_fails_on_kernel_modification` — KernelImmutability violation asserted
- `violation_description_is_non_empty` — audit trail quality check
- `wasm_invariant_request_deserializes` — JSON schema validation

**`crates/exochain-wasm/src/serde_bridge.rs`** — 11 tests:
- Round-trip: simple struct, vec of structs, `Option::Some`, `Option::None`
- Error paths: invalid JSON, wrong type, missing field
- Gatekeeper type fidelity: `PermissionSet`, `AuthorityChain`, `BailmentState`

All tests run natively via `cargo test --workspace` (no wasm-pack required).

## Validation

- [x] `cargo build --workspace --release` — clean
- [x] `cargo test --workspace` — 1,239 tests pass (18 new in `exochain-wasm`)
- [x] `cargo clippy -p exochain-wasm --lib -- -D warnings` — clean
- [x] Constitutional validation — APPROVE (all 8 invariants pass, 0 blocking issues)
- [ ] `wasm-pack test --node` — WASM boundary functions require separate CI job

## Constitutional Validation Result

Validated by `exochain-validate-constitution`:

| Check | Result |
|-------|--------|
| All 8 invariants | ✅ PASS |
| TNC controls (7 active) | ✅ PASS |
| BCTS integrity | ✅ PASS |
| Architecture compliance | ✅ PASS (no floats, no unsafe, no SystemTime) |
| Security assessment | ✅ PASS (attack surface reduced) |
| **Governance disposition** | **APPROVE** |

5 warnings raised, all pre-existing (signature bytes not crypto-verified in
invariant checks, dead-code files, missing wasm-pack CI job) — none blocking.

## Remaining Gaps (follow-up issues)

| File | Status | Required Fix |
|------|--------|-------------|
| `exo-dag/append.rs` | Dead code | Async `DagStore` interface doesn't exist; `exo_core::LedgerEvent` not publicly exported |
| `exo-dag/checkpoint.rs` | Dead code | `exo_core::Blake3Hash` not exported at crate root |
| `exo-identity/key.rs` | Dead code | `exo_core::{verify_signature, Blake3Hash}` not in public API |
| WASM `to_js_value` path | Not natively testable | Requires `wasm-pack test --node` CI job |

---

**Workflow ID**: `57733e7582452fde55d6295bf9e2fbea`
