### PR TITLE
docs: Phase 5 — world-class documentation for community launch

### DIFF
--- a/crates/README.md
+++ b/crates/README.md
@@ -1,0 +1,142 @@
+# EXOCHAIN — Rust crates
+
+This directory is the authoritative home of the EXOCHAIN constitutional
+governance fabric. Every feature of the fabric — identity, consent, authority
+delegation, governance, kernel adjudication, DAG consensus, ZK proofs,
+networking, tenancy, legal evidence, escalation — lives here as a workspace
+crate.
+
+Application developers should almost always start with
+[`exochain-sdk`](./exochain-sdk/), which wraps the underlying crates behind a
+single ergonomic API.
+
+## Crate index
+
+| Crate                                       | Purpose                                                                                    |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [`exo-core`](./exo-core/)                   | Foundational deterministic types (DID, Hash256, Signature, Timestamp), HLC, crypto, BCTS.  |
+| [`exo-identity`](./exo-identity/)           | Privacy-preserving identity adjudication; DID documents.                                   |
+| [`exo-consent`](./exo-consent/)             | Bailment-conditioned consent enforcement — no action without consent.                      |
+| [`exo-authority`](./exo-authority/)         | Authority-chain verification and delegation management.                                    |
+| [`exo-governance`](./exo-governance/)       | Legislative legitimacy — quorum, clearance, crosscheck, challenge, delegation.             |
+| [`exo-gatekeeper`](./exo-gatekeeper/)       | Judicial branch — CGR kernel, combinator algebra, invariants, Holon runtime, MCP middleware. |
+| [`exo-escalation`](./exo-escalation/)       | Operational nervous system — detection, triage, kanban, HITL, Sybil adjudication.          |
+| [`exo-legal`](./exo-legal/)                 | Litigation-grade evidence, eDiscovery, privilege, fiduciary duty.                          |
+| [`exo-messaging`](./exo-messaging/)         | End-to-end encrypted messaging with X25519 key exchange.                                   |
+| [`exo-tenant`](./exo-tenant/)               | Multi-tenant isolation, cold storage, sharding.                                            |
+| [`exo-dag`](./exo-dag/)                     | Append-only DAG with BFT consensus and Merkle structures.                                  |
+| [`exo-proofs`](./exo-proofs/)               | Zero-knowledge proof system — SNARK, STARK, ZKML verifier.                                 |
+| [`exo-consensus`](./exo-consensus/)         | Consensus machinery layered on top of the DAG and the legal record.                        |
+| [`exo-api`](./exo-api/)                     | P2P networking and external API types.                                                     |
+| [`exo-gateway`](./exo-gateway/)             | HTTP gateway server with default-deny pattern.                                             |
+| [`exo-node`](./exo-node/)                   | Single-binary distributed node for joining the network.                                    |
+| [`exo-catapult`](./exo-catapult/)           | Franchise business incubator with FM 3-05 operational doctrine.                            |
+| [`decision-forum`](./decision-forum/)       | Constitutional governance application layer.                                               |
+| [`exochain-sdk`](./exochain-sdk/)           | Ergonomic Rust API that wraps the `exo-*` crates behind one surface.                       |
+| [`exochain-wasm`](./exochain-wasm/)         | WebAssembly bindings of the full governance engine, consumed by `packages/exochain-wasm`.  |
+
+Seventeen `exo-*` crates plus `decision-forum`, `exochain-sdk`, and
+`exochain-wasm` — twenty in total.
+
+## Dependency layering
+
+Crates are organized in roughly four tiers. Arrows point from a crate to
+something it depends on.
+
+```text
+                             +----------+
+                             | exo-core |  <-- foundational types, HLC, crypto
+                             +----+-----+
+                                  ^
+     +----------------+-----------+-----------+---------------+
+     |                |                       |               |
++----+-----+    +-----+------+         +------+-----+   +-----+------+
+| exo-dag  |    | exo-proofs |         | exo-identity|  | exo-consent|
++----+-----+    +------------+         +------+------+  +-----+------+
+     ^                                        ^              ^
+     |                                        |              |
+     |            +---------------+-----------+--------------+
+     |            |               |                          |
+     |     +------+------+   +----+--------+            +----+--------+
+     |     | exo-authority|   | exo-api    |            | exo-tenant  |
+     |     +------+-------+   +------------+            +-------------+
+     |            ^
+     |            |
+     |    +-------+--------+        +------------------+
+     |    | exo-governance |        | exo-gatekeeper   |  (depends only on exo-core)
+     |    +-------+--------+        +---------+--------+
+     |            ^                           ^
+     |            +-------------+-------------+
+     |                          |
+     |                   +------+-------+
+     |                   | exo-escalation|
+     |                   +--------------+
+     |
+     |                   +------+-------+     +-----------------+
+     +-----------------> | exo-legal   |     | exo-messaging    |
+                         +------+-------+     +------------------+
+                                ^
+              +-----------------+-----------------+
+              |                                   |
+     +--------+---------+                 +-------+--------+
+     | decision-forum   |                 | exo-catapult   |
+     +--------+---------+                 +----------------+
+              ^
+              |
+     +--------+---------+
+     | exo-consensus    |
+     +------------------+
+
+     +------------------+
+     | exo-gateway      |  (decision-forum + exo-consent + exo-gatekeeper
+     +--------+---------+   + exo-governance + exo-identity + exo-core)
+              ^
+              |
+     +--------+---------+   depends on exo-gateway, exo-gatekeeper,
+     | exo-node         |   exo-governance, exo-escalation, exo-consent,
+     +------------------+   exo-identity, exo-dag, exo-api, exo-core.
+```
+
+Two façade crates sit on top of the whole stack:
+
+- **`exochain-sdk`** — depends on `exo-core`, `exo-identity`, `exo-consent`,
+  `exo-authority`, `exo-governance`, `exo-gatekeeper`, `exo-escalation`,
+  `exo-legal`, `exo-dag`, and `exo-proofs`. This is the developer-facing
+  entrypoint.
+- **`exochain-wasm`** — depends on every `exo-*` crate plus `decision-forum`;
+  compiles the full engine to WebAssembly for use from Node.js.
+
+## Build and test
+
+Run from the repository root:
+
+```bash
+# Build every crate.
+cargo build --workspace
+
+# Run all tests (unit + integration + doctests).
+cargo test --workspace
+
+# Doctests only.
+cargo test --doc --workspace
+
+# Clippy at workspace lint level.
+cargo clippy --workspace --all-targets -- -D warnings
+
+# Docs with broken-intra-doc-link enforcement.
+RUSTDOCFLAGS="-D rustdoc::broken-intra-doc-links" cargo doc --workspace --no-deps
+```
+
+The workspace `MSRV` and `edition` are set in the top-level `Cargo.toml` and
+inherited by every crate.
+
+## Non-Rust SDKs
+
+The TypeScript and Python client SDKs — plus the precompiled WebAssembly
+artifact — live in [`../packages`](../packages). See
+[`../packages/README.md`](../packages/README.md) for which one to reach for.
+
+## License
+
+Each crate is licensed under **Apache-2.0**. See the top-level
+[`LICENSE`](../LICENSE) for the full text.

--- a/crates/exochain-sdk/README.md
+++ b/crates/exochain-sdk/README.md
@@ -1,0 +1,358 @@
+# exochain-sdk
+
+Ergonomic Rust API for the **EXOCHAIN constitutional governance fabric** — a
+substrate for AI agents and data sovereignty built around decentralized
+identifiers (DIDs), scoped consent (bailments), authority-chain delegation,
+quorum-based governance, and a constitutional kernel that enforces policy
+*before* action rather than auditing it after. The SDK wraps the lower-level
+`exo-*` workspace crates behind a single, developer-friendly surface so that
+applications depend on one crate and one coherent API.
+
+## Installation
+
+### Workspace (recommended inside the monorepo)
+
+Inside the EXOCHAIN monorepo, add the crate as a path dependency:
+
+```toml
+[dependencies]
+exochain-sdk = { path = "../exochain-sdk" }
+```
+
+### Git dependency
+
+```toml
+[dependencies]
+exochain-sdk = { git = "https://github.com/exochain/exochain", branch = "main" }
+```
+
+### crates.io (planned)
+
+Once published, the SDK will be installable with:
+
+```bash
+cargo add exochain-sdk
+```
+
+Minimum supported Rust version (MSRV) is inherited from the workspace.
+
+## Quick start
+
+The canonical end-to-end flow: two identities negotiate a bailment, propose a
+decision, reach quorum, build a delegation chain, and submit an action to the
+kernel for adjudication.
+
+```rust
+use exochain_sdk::prelude::*;
+use exochain_sdk::governance::VoteChoice;
+
+fn main() -> Result<(), ExoError> {
+    // 1. Create identities for alice and bob.
+    let alice = Identity::generate("alice");
+    let bob = Identity::generate("bob");
+
+    // 2. Alice proposes a scoped, time-bounded bailment to bob.
+    let proposal = BailmentBuilder::new(alice.did().clone(), bob.did().clone())
+        .scope("data:medical")
+        .duration_hours(24)
+        .build()?;
+    println!("proposal id: {}", proposal.proposal_id);
+
+    // 3. Alice proposes a decision; bob and carol approve.
+    let carol = Identity::generate("carol");
+    let mut decision = DecisionBuilder::new(
+        "Ratify bailment",
+        "Allow bob to read medical records for 24h",
+        alice.did().clone(),
+    )
+    .build()?;
+    decision.cast_vote(Vote::new(bob.did().clone(), VoteChoice::Approve))?;
+    decision.cast_vote(Vote::new(carol.did().clone(), VoteChoice::Approve))?;
+    let quorum = decision.check_quorum(2);
+    assert!(quorum.met);
+
+    // 4. Build an authority chain: root -> alice -> bob.
+    let root = Identity::generate("root");
+    let chain = AuthorityChainBuilder::new()
+        .add_link(root.did().clone(), alice.did().clone(), vec!["delegate".into()])
+        .add_link(alice.did().clone(), bob.did().clone(), vec!["read".into()])
+        .build(bob.did())?;
+    assert_eq!(chain.depth, 2);
+
+    // 5. Ask the kernel whether bob may perform the action.
+    let kernel = ConstitutionalKernel::new();
+    let verdict = kernel.adjudicate(bob.did(), "data:medical:read");
+    assert!(verdict.is_permitted());
+
+    Ok(())
+}
+```
+
+The crate-level Rustdoc contains the same example as a runnable doctest — see
+`cargo doc --open -p exochain-sdk`.
+
+## Module layout
+
+The SDK is organized by domain. Each module is independently usable, but they
+are most powerful together:
+
+| Module                          | Purpose                                                      |
+| ------------------------------- | ------------------------------------------------------------ |
+| [`identity`](src/identity.rs)     | DID-backed Ed25519 identities (generate, sign, verify).      |
+| [`consent`](src/consent.rs)       | Scoped, time-bounded bailments (consent tokens).             |
+| [`governance`](src/governance.rs) | Decisions, votes, quorum checks.                             |
+| [`authority`](src/authority.rs)   | Delegation chain builder and topology validation.            |
+| [`kernel`](src/kernel.rs)         | The Constitutional Governance Runtime (CGR) kernel facade.   |
+| [`crypto`](src/crypto.rs)         | BLAKE3 hashing and Ed25519 sign/verify primitives.           |
+| [`error`](src/error.rs)           | Single `ExoError` type and `ExoResult<T>` alias.             |
+
+A `prelude` module re-exports the symbols most applications need:
+
+```rust
+use exochain_sdk::prelude::*;
+// Brings in: Identity, BailmentBuilder, DecisionBuilder, Decision, Vote,
+// AuthorityChainBuilder, ConstitutionalKernel, ExoError, ExoResult,
+// hash, sign, verify.
+```
+
+## Identity
+
+[`Identity`](src/identity.rs) is a DID paired with an Ed25519 keypair and a
+human-readable label. The DID is derived from the public key:
+
+```text
+did:exo: + first 16 hex chars of BLAKE3(public_key_bytes)
+```
+
+```rust
+use exochain_sdk::identity::Identity;
+
+let alice = Identity::generate("alice");
+println!("did = {}", alice.did());
+
+let sig = alice.sign(b"hello");
+assert!(alice.verify(b"hello", &sig));
+```
+
+The `Debug` impl redacts the secret key, so `Identity` is safe to log. Use
+`Identity::from_keypair` to rehydrate an identity from a persisted keypair.
+
+## Consent (bailments)
+
+A bailment is scoped, time-bounded consent from a bailor to a bailee. The
+[`BailmentBuilder`](src/consent.rs) validates inputs and produces a
+deterministic, content-addressed proposal.
+
+```rust
+use exochain_sdk::consent::BailmentBuilder;
+use exo_core::Did;
+
+let alice = Did::new("did:exo:alice").expect("valid");
+let bob = Did::new("did:exo:bob").expect("valid");
+
+let proposal = BailmentBuilder::new(alice, bob)
+    .scope("data:medical")
+    .duration_hours(24)
+    .build()
+    .expect("valid proposal");
+```
+
+`proposal.proposal_id` is a BLAKE3-derived 16-char hex string; two parties
+independently building the same proposal get the same ID with no coordination.
+
+## Governance (decisions, voting, quorum)
+
+[`DecisionBuilder`](src/governance.rs) constructs a decision; the decision
+accumulates votes via `cast_vote` and reports quorum with `check_quorum`.
+
+```rust
+use exochain_sdk::governance::{DecisionBuilder, Vote, VoteChoice};
+use exo_core::Did;
+
+let proposer = Did::new("did:exo:alice").expect("valid");
+let v1 = Did::new("did:exo:v1").expect("valid");
+let v2 = Did::new("did:exo:v2").expect("valid");
+
+let mut d = DecisionBuilder::new("Ratify v1", "Promote to prod", proposer)
+    .build()
+    .expect("valid");
+d.cast_vote(Vote::new(v1, VoteChoice::Approve)).unwrap();
+d.cast_vote(Vote::new(v2, VoteChoice::Approve)).unwrap();
+
+let q = d.check_quorum(2);
+assert!(q.met);
+```
+
+The same voter may cast at most one vote; a second attempt returns
+`ExoError::Governance`.
+
+## Authority chains
+
+An authority chain is an ordered list of delegation links where
+`links[i].grantee == links[i+1].grantor`. The
+[`AuthorityChainBuilder`](src/authority.rs) validates the topology on
+`build`.
+
+```rust
+use exochain_sdk::authority::AuthorityChainBuilder;
+use exo_core::Did;
+
+let root = Did::new("did:exo:root").expect("valid");
+let mid = Did::new("did:exo:mid").expect("valid");
+let leaf = Did::new("did:exo:leaf").expect("valid");
+
+let chain = AuthorityChainBuilder::new()
+    .add_link(root, mid.clone(), vec!["delegate".into()])
+    .add_link(mid, leaf.clone(), vec!["read".into()])
+    .build(&leaf)
+    .expect("valid");
+
+assert_eq!(chain.depth, 2);
+```
+
+`build` returns `ExoError::Authority` for empty chains, broken links, or a
+terminal mismatch.
+
+## Constitutional kernel
+
+[`ConstitutionalKernel`](src/kernel.rs) is a simplified wrapper over
+[`exo_gatekeeper::Kernel`]. It initialises the kernel with the default
+EXOCHAIN constitution and all eight invariants, and exposes
+`adjudicate(actor, action)` with reasonable defaults.
+
+```rust
+use exochain_sdk::kernel::ConstitutionalKernel;
+use exo_core::Did;
+
+let kernel = ConstitutionalKernel::new();
+let actor = Did::new("did:exo:alice").expect("valid");
+
+let verdict = kernel.adjudicate(&actor, "data:medical:read");
+assert!(verdict.is_permitted());
+```
+
+The SDK supplies a permissive default context (single Judicial role, one-link
+authority chain, active bailment, preserved human override). Targeted helpers
+exercise specific invariants:
+
+- `adjudicate_self_grant` — enables `NoSelfGrant` enforcement.
+- `adjudicate_kernel_modification` — enables `KernelImmutability` enforcement.
+- `adjudicate_without_bailment` — enables `ConsentRequired` enforcement.
+
+Callers needing fine-grained control over the full adjudication context
+should use [`exo_gatekeeper::Kernel`] directly.
+
+## Crypto helpers
+
+The [`crypto`](src/crypto.rs) module re-exports the foundational types and
+provides convenience helpers:
+
+```rust
+use exochain_sdk::crypto::{generate_keypair, hash, hash_hex, sign, verify};
+
+let digest = hash(b"hello");            // [u8; 32] BLAKE3
+let hex = hash_hex(b"hello");           // 64-char lowercase hex
+
+let (pk, sk) = generate_keypair();      // Ed25519
+let sig = sign(b"payload", &sk);
+assert!(verify(b"payload", &sig, &pk));
+```
+
+## Error handling
+
+All fallible SDK operations return `ExoResult<T>` — an alias for
+`Result<T, ExoError>`. Each error variant narrows the failure to a specific
+subsystem so callers can pattern-match without parsing strings:
+
+| Variant                     | When returned                                              |
+| --------------------------- | ---------------------------------------------------------- |
+| `ExoError::Identity`        | Identity flows that could validate caller-supplied material.|
+| `ExoError::Consent`         | `BailmentBuilder::build` — missing/empty scope, zero duration. |
+| `ExoError::Governance`      | Empty decision title, duplicate voter.                     |
+| `ExoError::Authority`       | Empty chain, broken delegation, terminal mismatch.         |
+| `ExoError::KernelDenied`    | Optional lift of kernel denial into the error channel.     |
+| `ExoError::KernelEscalated` | Optional lift of kernel escalation into the error channel. |
+| `ExoError::Crypto`          | Reserved for future fallible crypto flows.                 |
+| `ExoError::InvalidDid`      | DID-string validation failure (unreachable in practice).   |
+| `ExoError::Serialization`   | Reserved for wire-payload marshal wrappers.                |
+
+```rust
+use exochain_sdk::prelude::*;
+use exochain_sdk::error::ExoError;
+use exo_core::Did;
+
+let a = Did::new("did:exo:a").unwrap();
+let b = Did::new("did:exo:b").unwrap();
+let err = BailmentBuilder::new(a, b).build().unwrap_err();
+assert!(matches!(err, ExoError::Consent(_)));
+```
+
+## Cross-language SDKs
+
+EXOCHAIN ships three first-party SDKs that share the same model and wire
+format:
+
+- **Rust** (this crate) — `crates/exochain-sdk`. The reference
+  implementation; uses BLAKE3 for hashing.
+- **TypeScript** — `packages/exochain-sdk`, published as `@exochain/sdk`.
+  Uses SHA-256 because Web Crypto does not ship BLAKE3.
+- **Python** — `packages/exochain-py`, published as `exochain` on PyPI. Also
+  uses SHA-256 for parity with the browser SDK.
+
+DIDs derived locally by the Rust SDK will **not** match DIDs derived by the
+TypeScript or Python SDKs for the same keypair. Applications that need
+canonical DIDs across all three SDKs should resolve the DID from the fabric
+rather than deriving it locally.
+
+## MCP server integration
+
+EXOCHAIN ships an MCP (Model Context Protocol) server at `exo-node` for use
+with AI agents — it exposes EXOCHAIN's identity, consent, governance, and
+kernel primitives as MCP tools so LLM agents can request, delegate, and
+adjudicate actions through the same constitutional surface.
+
+This SDK targets application developers writing Rust services that speak to
+EXOCHAIN directly. When integrating with the MCP server, the SDK's types
+serve as the canonical Rust representation of the objects the MCP server
+accepts and returns.
+
+## Development
+
+Run from the monorepo root:
+
+```bash
+# Unit and integration tests
+cargo test -p exochain-sdk
+
+# Doctests
+cargo test --doc -p exochain-sdk
+
+# Docs with intra-doc link checking
+RUSTDOCFLAGS="-D rustdoc::broken-intra-doc-links" cargo doc -p exochain-sdk --no-deps
+
+# Lints
+cargo clippy -p exochain-sdk --all-targets -- -D warnings
+```
+
+## Related crates
+
+The SDK wraps these lower-level crates; use them directly when you need
+access beyond the SDK's surface:
+
+- `exo-core` — foundational types (DID, Hash256, Signature, Timestamp, HLC).
+- `exo-identity` — DID documents and privacy-preserving identity adjudication.
+- `exo-consent` — bailment-conditioned consent enforcement.
+- `exo-authority` — authority-chain verification and delegation.
+- `exo-governance` — legislative legitimacy: quorum, clearance, crosscheck.
+- `exo-gatekeeper` — CGR kernel, invariant enforcement, MCP middleware.
+- `exo-escalation` — operational nervous system.
+- `exo-legal` — litigation-grade evidence and eDiscovery.
+- `exo-dag` — append-only DAG with BFT consensus.
+- `exo-proofs` — SNARK, STARK, ZKML verifier.
+
+See `crates/README.md` for the full crate index.
+
+## License
+
+Licensed under **Apache-2.0**. See the top-level `LICENSE` file for the full
+text.

--- a/crates/exochain-sdk/src/authority.rs
+++ b/crates/exochain-sdk/src/authority.rs
@@ -1,9 +1,43 @@
 //! Authority delegation and chain verification.
 //!
-//! An authority chain is an ordered list of delegation links where the
+//! An **authority chain** is an ordered list of delegation links where the
 //! `grantee` of each link is the `grantor` of the next. The chain terminates
 //! at a specific actor (the "terminal"). [`AuthorityChainBuilder`] accumulates
-//! links and validates the resulting topology on [`AuthorityChainBuilder::build`].
+//! links and validates the resulting topology on
+//! [`AuthorityChainBuilder::build`]. Structurally:
+//!
+//! ```text
+//! root --[perms]--> middle --[perms]--> leaf
+//! ```
+//!
+//! ## Why use this module
+//!
+//! - You need to prove that a terminal actor was delegated authority through
+//!   a well-formed chain rooted at a specific principal.
+//! - You want the SDK to reject broken topologies (gaps, wrong terminal,
+//!   empty chain) before you ever submit them to the kernel.
+//! - You want the validated chain as a serializable artifact that survives
+//!   network hops and storage.
+//!
+//! ## Quick start
+//!
+//! ```
+//! use exochain_sdk::authority::AuthorityChainBuilder;
+//! use exo_core::Did;
+//!
+//! let root = Did::new("did:exo:root").expect("valid");
+//! let mid = Did::new("did:exo:mid").expect("valid");
+//! let leaf = Did::new("did:exo:leaf").expect("valid");
+//!
+//! let chain = AuthorityChainBuilder::new()
+//!     .add_link(root, mid.clone(), vec!["delegate".into()])
+//!     .add_link(mid, leaf.clone(), vec!["read".into()])
+//!     .build(&leaf)?;
+//!
+//! assert_eq!(chain.depth, 2);
+//! assert_eq!(chain.terminal, leaf);
+//! # Ok::<(), exochain_sdk::error::ExoError>(())
+//! ```
 
 use exo_core::Did;
 use serde::{Deserialize, Serialize};
@@ -11,6 +45,25 @@ use serde::{Deserialize, Serialize};
 use crate::error::{ExoError, ExoResult};
 
 /// Builder for a validated authority chain.
+///
+/// Links are appended one at a time with [`AuthorityChainBuilder::add_link`]
+/// and the full chain is validated by [`AuthorityChainBuilder::build`]. The
+/// builder is `Default` and `Clone`, so a partially-built chain can be forked.
+///
+/// # Examples
+///
+/// ```
+/// use exochain_sdk::authority::AuthorityChainBuilder;
+/// use exo_core::Did;
+///
+/// let root = Did::new("did:exo:root").expect("valid");
+/// let leaf = Did::new("did:exo:leaf").expect("valid");
+/// let chain = AuthorityChainBuilder::new()
+///     .add_link(root, leaf.clone(), vec!["all".into()])
+///     .build(&leaf)?;
+/// assert_eq!(chain.depth, 1);
+/// # Ok::<(), exochain_sdk::error::ExoError>(())
+/// ```
 #[derive(Debug, Clone, Default)]
 pub struct AuthorityChainBuilder {
     links: Vec<ChainLink>,
@@ -18,12 +71,36 @@ pub struct AuthorityChainBuilder {
 
 impl AuthorityChainBuilder {
     /// Construct an empty builder.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use exochain_sdk::authority::AuthorityChainBuilder;
+    /// let builder = AuthorityChainBuilder::new();
+    /// # let _ = builder;
+    /// ```
     #[must_use]
     pub fn new() -> Self {
         Self { links: Vec::new() }
     }
 
     /// Append a new delegation link.
+    ///
+    /// Each link records that `grantor` has delegated `permissions` to
+    /// `grantee`. Permission strings are opaque to the SDK; downstream
+    /// consumers are free to interpret them.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use exochain_sdk::authority::AuthorityChainBuilder;
+    /// # use exo_core::Did;
+    /// let a = Did::new("did:exo:a").expect("valid");
+    /// let b = Did::new("did:exo:b").expect("valid");
+    /// let builder = AuthorityChainBuilder::new()
+    ///     .add_link(a, b, vec!["read".into(), "write".into()]);
+    /// # let _ = builder;
+    /// ```
     #[must_use]
     pub fn add_link(mut self, grantor: Did, grantee: Did, permissions: Vec<String>) -> Self {
         self.links.push(ChainLink {
@@ -38,12 +115,53 @@ impl AuthorityChainBuilder {
     ///
     /// Validation rules:
     /// - The chain must contain at least one link.
-    /// - For each consecutive pair of links, `links[i].grantee == links[i+1].grantor`.
+    /// - For each consecutive pair of links,
+    ///   `links[i].grantee == links[i+1].grantor`.
     /// - The final link's `grantee` must equal `terminal_actor`.
     ///
     /// # Errors
     ///
-    /// Returns [`ExoError::Authority`] if any rule is violated.
+    /// Returns [`ExoError::Authority`] if any rule is violated: empty chain,
+    /// a broken delegation between consecutive links, or a mismatch between
+    /// the terminal link's grantee and `terminal_actor`.
+    ///
+    /// # Examples
+    ///
+    /// A valid three-link chain:
+    ///
+    /// ```
+    /// use exochain_sdk::authority::AuthorityChainBuilder;
+    /// use exo_core::Did;
+    ///
+    /// let root = Did::new("did:exo:root").expect("valid");
+    /// let mid = Did::new("did:exo:mid").expect("valid");
+    /// let leaf = Did::new("did:exo:leaf").expect("valid");
+    /// let chain = AuthorityChainBuilder::new()
+    ///     .add_link(root, mid.clone(), vec!["delegate".into()])
+    ///     .add_link(mid, leaf.clone(), vec!["read".into()])
+    ///     .build(&leaf)?;
+    /// assert_eq!(chain.depth, 2);
+    /// # Ok::<(), exochain_sdk::error::ExoError>(())
+    /// ```
+    ///
+    /// A broken chain (middle grantee does not match next grantor):
+    ///
+    /// ```
+    /// use exochain_sdk::authority::AuthorityChainBuilder;
+    /// use exochain_sdk::error::ExoError;
+    /// use exo_core::Did;
+    ///
+    /// let root = Did::new("did:exo:root").expect("valid");
+    /// let mid = Did::new("did:exo:mid").expect("valid");
+    /// let other = Did::new("did:exo:other").expect("valid");
+    /// let leaf = Did::new("did:exo:leaf").expect("valid");
+    /// let err = AuthorityChainBuilder::new()
+    ///     .add_link(root, mid, vec!["read".into()])
+    ///     .add_link(other, leaf.clone(), vec!["read".into()])
+    ///     .build(&leaf)
+    ///     .unwrap_err();
+    /// assert!(matches!(err, ExoError::Authority(_)));
+    /// ```
     pub fn build(self, terminal_actor: &Did) -> ExoResult<ValidatedChain> {
         if self.links.is_empty() {
             return Err(ExoError::Authority("authority chain is empty".into()));

--- a/crates/exochain-sdk/src/consent.rs
+++ b/crates/exochain-sdk/src/consent.rs
@@ -1,9 +1,44 @@
 //! Consent and bailment management.
 //!
+//! A **bailment** is scoped, time-bounded consent from one party (the bailor)
+//! to another (the bailee). It is the EXOCHAIN primitive that answers "is this
+//! agent allowed to touch this data, and for how long?". The constitutional
+//! kernel refuses to permit actions that are not backed by an active bailment
+//! (see the `ConsentRequired` invariant).
+//!
 //! [`BailmentBuilder`] constructs a [`BailmentProposal`] using the builder
-//! pattern. A bailment represents scoped, time-bounded consent from a bailor
-//! to a bailee. The SDK performs basic validation (non-empty scope, non-zero
-//! duration) and generates a deterministic proposal ID from the fields.
+//! pattern. The SDK performs basic validation (non-empty scope, non-zero
+//! duration) and generates a **deterministic** content-addressed proposal ID
+//! from the fields, so two parties independently building the same proposal
+//! produce the same ID.
+//!
+//! ## Why use this module
+//!
+//! - You want consent to be an auditable, content-addressed object rather
+//!   than a sticky note in a policy engine.
+//! - You want the same proposal ID on both sides of a negotiation with no
+//!   coordination.
+//! - You want the SDK to reject obvious mistakes (empty scope, zero-hour
+//!   duration) before the proposal ever hits the wire.
+//!
+//! ## Quick start
+//!
+//! ```
+//! use exochain_sdk::consent::BailmentBuilder;
+//! use exo_core::Did;
+//!
+//! let alice = Did::new("did:exo:alice").expect("valid");
+//! let bob = Did::new("did:exo:bob").expect("valid");
+//!
+//! let proposal = BailmentBuilder::new(alice, bob)
+//!     .scope("data:medical")
+//!     .duration_hours(24)
+//!     .build()?;
+//!
+//! assert_eq!(proposal.scope, "data:medical");
+//! assert_eq!(proposal.duration_hours, 24);
+//! # Ok::<(), exochain_sdk::error::ExoError>(())
+//! ```
 
 use exo_core::Did;
 use serde::{Deserialize, Serialize};
@@ -15,6 +50,26 @@ use crate::error::{ExoError, ExoResult};
 /// Required fields are set at construction; optional fields are set via
 /// chained `with`-style methods. The final [`BailmentProposal`] is produced
 /// by [`BailmentBuilder::build`], which validates the inputs.
+///
+/// The builder is cheap and can be cloned; each `.build()` call re-validates
+/// and returns an owned proposal.
+///
+/// # Examples
+///
+/// ```
+/// use exochain_sdk::consent::BailmentBuilder;
+/// use exo_core::Did;
+///
+/// let bailor = Did::new("did:exo:alice").expect("valid");
+/// let bailee = Did::new("did:exo:bob").expect("valid");
+///
+/// let proposal = BailmentBuilder::new(bailor, bailee)
+///     .scope("data:medical")
+///     .duration_hours(24)
+///     .build()?;
+/// assert_eq!(proposal.proposal_id.len(), 16);
+/// # Ok::<(), exochain_sdk::error::ExoError>(())
+/// ```
 #[derive(Debug, Clone)]
 pub struct BailmentBuilder {
     bailor: Did,
@@ -25,6 +80,21 @@ pub struct BailmentBuilder {
 
 impl BailmentBuilder {
     /// Start a new bailment proposal from `bailor` to `bailee`.
+    ///
+    /// Scope and duration are required and must be set via
+    /// [`BailmentBuilder::scope`] and [`BailmentBuilder::duration_hours`]
+    /// before calling [`BailmentBuilder::build`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use exochain_sdk::consent::BailmentBuilder;
+    /// # use exo_core::Did;
+    /// let alice = Did::new("did:exo:alice").expect("valid");
+    /// let bob = Did::new("did:exo:bob").expect("valid");
+    /// let builder = BailmentBuilder::new(alice, bob);
+    /// # let _ = builder;
+    /// ```
     #[must_use]
     pub fn new(bailor: Did, bailee: Did) -> Self {
         Self {
@@ -35,7 +105,24 @@ impl BailmentBuilder {
         }
     }
 
-    /// Set the scope of the bailment (e.g. `"data:medical"`).
+    /// Set the scope of the bailment.
+    ///
+    /// Scopes are opaque strings from the SDK's perspective. Conventionally
+    /// they are colon-separated namespaces such as `"data:medical"`,
+    /// `"compute:inference"`, or `"messaging:read"`. The kernel matches
+    /// bailment scopes against action strings, so choose names your
+    /// application will use consistently.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use exochain_sdk::consent::BailmentBuilder;
+    /// # use exo_core::Did;
+    /// # let a = Did::new("did:exo:a").unwrap();
+    /// # let b = Did::new("did:exo:b").unwrap();
+    /// let builder = BailmentBuilder::new(a, b).scope("data:medical");
+    /// # let _ = builder;
+    /// ```
     #[must_use]
     pub fn scope(mut self, scope: &str) -> Self {
         self.scope = Some(scope.to_owned());
@@ -43,6 +130,20 @@ impl BailmentBuilder {
     }
 
     /// Set the duration of the bailment in hours.
+    ///
+    /// Must be strictly greater than zero; [`BailmentBuilder::build`] rejects
+    /// a zero-hour duration.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use exochain_sdk::consent::BailmentBuilder;
+    /// # use exo_core::Did;
+    /// # let a = Did::new("did:exo:a").unwrap();
+    /// # let b = Did::new("did:exo:b").unwrap();
+    /// let builder = BailmentBuilder::new(a, b).duration_hours(48);
+    /// # let _ = builder;
+    /// ```
     #[must_use]
     pub fn duration_hours(mut self, hours: u64) -> Self {
         self.duration_hours = Some(hours);
@@ -51,10 +152,42 @@ impl BailmentBuilder {
 
     /// Validate the inputs and produce a [`BailmentProposal`].
     ///
+    /// The proposal's `proposal_id` is computed deterministically as the
+    /// first 16 hex characters of `BLAKE3(bailor || 0 || bailee || 0 ||
+    /// scope || 0 || duration_hours_le_bytes)`. Two builders with the same
+    /// fields always produce the same `proposal_id`.
+    ///
     /// # Errors
     ///
-    /// Returns [`ExoError::Consent`] if the scope is missing or empty, or if
-    /// duration is missing or zero.
+    /// Returns [`ExoError::Consent`] if:
+    /// - `scope` was never set or is an empty string, or
+    /// - `duration_hours` was never set or is zero.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exochain_sdk::consent::BailmentBuilder;
+    /// use exochain_sdk::error::ExoError;
+    /// use exo_core::Did;
+    ///
+    /// let a = Did::new("did:exo:a").expect("valid");
+    /// let b = Did::new("did:exo:b").expect("valid");
+    ///
+    /// // Missing scope → error.
+    /// let err = BailmentBuilder::new(a.clone(), b.clone())
+    ///     .duration_hours(1)
+    ///     .build()
+    ///     .unwrap_err();
+    /// assert!(matches!(err, ExoError::Consent(_)));
+    ///
+    /// // Valid inputs → proposal.
+    /// let ok = BailmentBuilder::new(a, b)
+    ///     .scope("data:medical")
+    ///     .duration_hours(24)
+    ///     .build()?;
+    /// assert_eq!(ok.duration_hours, 24);
+    /// # Ok::<(), ExoError>(())
+    /// ```
     pub fn build(self) -> ExoResult<BailmentProposal> {
         let scope = self
             .scope
@@ -83,6 +216,32 @@ impl BailmentBuilder {
 }
 
 /// A validated bailment proposal ready for downstream processing.
+///
+/// `BailmentProposal` is produced by [`BailmentBuilder::build`] and is the
+/// canonical wire form for a consent object. It is `Serialize` /
+/// `Deserialize`, `PartialEq`, and content-addressed: two proposals with
+/// equal `proposal_id` are equivalent.
+///
+/// # Examples
+///
+/// Round-trip through JSON:
+///
+/// ```
+/// use exochain_sdk::consent::{BailmentBuilder, BailmentProposal};
+/// use exo_core::Did;
+///
+/// let a = Did::new("did:exo:a").expect("valid");
+/// let b = Did::new("did:exo:b").expect("valid");
+/// let proposal = BailmentBuilder::new(a, b)
+///     .scope("data:medical")
+///     .duration_hours(48)
+///     .build()?;
+///
+/// let json = serde_json::to_string(&proposal).expect("serialize");
+/// let decoded: BailmentProposal = serde_json::from_str(&json).expect("deserialize");
+/// assert_eq!(proposal, decoded);
+/// # Ok::<(), exochain_sdk::error::ExoError>(())
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BailmentProposal {
     /// Deterministic content-addressed identifier for this proposal.

--- a/crates/exochain-sdk/src/crypto.rs
+++ b/crates/exochain-sdk/src/crypto.rs
@@ -1,14 +1,54 @@
 //! Cryptographic primitives — hash, sign, verify.
 //!
 //! This module provides ergonomic wrappers around [`exo_core::crypto`] for the
-//! three operations every SDK user needs: hashing bytes, signing a message, and
-//! verifying a signature. The underlying primitives are BLAKE3 for hashing and
-//! Ed25519 for classical signatures.
+//! three operations every SDK user needs: hashing bytes, signing a message,
+//! and verifying a signature. The underlying primitives are **BLAKE3** for
+//! hashing and **Ed25519** for classical signatures.
+//!
+//! ## Why use this module
+//!
+//! - You want to hash and sign without pulling in the full `exo-core` crate
+//!   or sorting out the right primitive to use.
+//! - You want deterministic, reproducible hex digests for logging and test
+//!   vectors.
+//! - You want re-exports of the foundational types ([`Did`], [`PublicKey`],
+//!   [`SecretKey`], [`Signature`], [`Hash256`], [`Timestamp`]) from a single
+//!   place.
+//!
+//! ## Quick start
+//!
+//! ```
+//! use exochain_sdk::crypto::{generate_keypair, hash, hash_hex, sign, verify};
+//!
+//! // Hash bytes.
+//! let digest = hash(b"hello");
+//! assert_eq!(digest.len(), 32);
+//! assert_eq!(hash_hex(b"hello").len(), 64);
+//!
+//! // Sign and verify.
+//! let (pk, sk) = generate_keypair();
+//! let sig = sign(b"payload", &sk);
+//! assert!(verify(b"payload", &sig, &pk));
+//! ```
 
 pub use exo_core::crypto::{generate_keypair, sign, verify};
 pub use exo_core::{Did, Hash256, PublicKey, SecretKey, Signature, Timestamp};
 
 /// Compute the BLAKE3 hash of `data`, returning the raw 32-byte digest.
+///
+/// BLAKE3 is collision-resistant, deterministic, and the same hash used for
+/// DID derivation, bailment IDs, and decision IDs across the Rust SDK.
+///
+/// # Examples
+///
+/// ```
+/// use exochain_sdk::crypto::hash;
+///
+/// let a = hash(b"hello");
+/// let b = hash(b"hello");
+/// assert_eq!(a, b); // deterministic
+/// assert_ne!(a, hash(b"world"));
+/// ```
 #[must_use]
 pub fn hash(data: &[u8]) -> [u8; 32] {
     *blake3::hash(data).as_bytes()
@@ -16,6 +56,19 @@ pub fn hash(data: &[u8]) -> [u8; 32] {
 
 /// Compute the BLAKE3 hash of `data`, returning it as a 64-character lowercase
 /// hex string.
+///
+/// Use this when you want a human-readable, copy-pasteable digest — for
+/// example when logging a fingerprint or embedding a hash in JSON.
+///
+/// # Examples
+///
+/// ```
+/// use exochain_sdk::crypto::hash_hex;
+///
+/// let hex = hash_hex(b"hello");
+/// assert_eq!(hex.len(), 64);
+/// assert!(hex.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+/// ```
 #[must_use]
 pub fn hash_hex(data: &[u8]) -> String {
     let digest = blake3::hash(data);

--- a/crates/exochain-sdk/src/error.rs
+++ b/crates/exochain-sdk/src/error.rs
@@ -2,41 +2,120 @@
 //!
 //! All SDK operations that can fail return [`ExoResult<T>`], which is an alias
 //! for [`std::result::Result<T, ExoError>`]. Each variant narrows the error to
-//! a specific subsystem to aid programmatic handling.
+//! a specific subsystem to aid programmatic handling — callers can
+//! `match` on the variant rather than parsing the error string.
+//!
+//! # Examples
+//!
+//! ```
+//! use exochain_sdk::consent::BailmentBuilder;
+//! use exochain_sdk::error::ExoError;
+//! use exo_core::Did;
+//!
+//! let a = Did::new("did:exo:a").expect("valid");
+//! let b = Did::new("did:exo:b").expect("valid");
+//! let err = BailmentBuilder::new(a, b).build().unwrap_err();
+//! assert!(matches!(err, ExoError::Consent(_)));
+//! ```
 
 use thiserror::Error;
 
 /// Errors that can be produced by the SDK.
+///
+/// Each variant corresponds to a subsystem of the SDK. Callers should prefer
+/// matching on the variant over parsing the display string, which is intended
+/// for human consumption only.
 #[derive(Debug, Error)]
 pub enum ExoError {
-    /// An identity-related operation failed (e.g. DID derivation or key handling).
+    /// An identity-related operation failed.
+    ///
+    /// Returned when DID derivation, key handling, or identity reconstruction
+    /// encounters an unexpected condition. In practice the SDK derives DIDs
+    /// deterministically, so this variant is rarely observed — it is
+    /// reserved for future identity flows that could validate or reject
+    /// caller-supplied material.
     #[error("identity error: {0}")]
     Identity(String),
+
     /// A consent/bailment-related operation failed.
+    ///
+    /// Returned by [`crate::consent::BailmentBuilder::build`] when required
+    /// fields are missing (no scope, no duration) or invalid (empty scope,
+    /// zero-hour duration).
     #[error("consent error: {0}")]
     Consent(String),
-    /// A governance-related operation failed (e.g. voting, quorum).
+
+    /// A governance-related operation failed.
+    ///
+    /// Returned by [`crate::governance::DecisionBuilder::build`] for an
+    /// empty title, and by [`crate::governance::Decision::cast_vote`] when
+    /// the same voter tries to cast a second vote.
     #[error("governance error: {0}")]
     Governance(String),
-    /// An authority-chain operation failed (e.g. invalid topology).
+
+    /// An authority-chain operation failed.
+    ///
+    /// Returned by [`crate::authority::AuthorityChainBuilder::build`] for any
+    /// topology violation: an empty chain, a break in the grantor/grantee
+    /// sequence between consecutive links, or a terminal mismatch.
     #[error("authority error: {0}")]
     Authority(String),
+
     /// The kernel denied an action.
+    ///
+    /// Reserved for flows that want to surface a kernel denial as a `Result`
+    /// error rather than a `KernelVerdict::Denied` value. The SDK's
+    /// [`crate::kernel::ConstitutionalKernel::adjudicate`] returns a verdict
+    /// directly; this variant exists so higher-level wrappers can lift it
+    /// into the error channel if they prefer.
     #[error("kernel denied: {0}")]
     KernelDenied(String),
+
     /// The kernel escalated an action for review.
+    ///
+    /// Counterpart to [`ExoError::KernelDenied`] for the escalation outcome.
     #[error("kernel escalated: {0}")]
     KernelEscalated(String),
+
     /// A cryptographic operation failed.
+    ///
+    /// Reserved for future crypto flows that could fail (e.g. signature
+    /// parsing of untrusted input). The current BLAKE3 and Ed25519 wrappers
+    /// in [`crate::crypto`] are infallible.
     #[error("crypto error: {0}")]
     Crypto(String),
+
     /// A provided DID string is not valid.
+    ///
+    /// Returned when the SDK derives a DID whose method-specific string
+    /// fails [`exo_core::Did`] validation. In practice BLAKE3-derived hex
+    /// always satisfies the rules, so this variant is effectively
+    /// unreachable; it is retained for completeness.
     #[error("invalid DID: {0}")]
     InvalidDid(String),
+
     /// Serialization or deserialization failed.
+    ///
+    /// Reserved for higher-level SDK flows that marshal wire payloads. The
+    /// primitive `Serialize`/`Deserialize` implementations on SDK types use
+    /// `serde_json::Error` directly; this variant lets downstream wrappers
+    /// homogenise their error channel.
     #[error("serialization error: {0}")]
     Serialization(String),
 }
 
 /// Convenience alias for `Result<T, ExoError>`.
+///
+/// Every fallible SDK function returns this type.
+///
+/// # Examples
+///
+/// ```
+/// use exochain_sdk::error::{ExoError, ExoResult};
+///
+/// fn pretend_work(ok: bool) -> ExoResult<u32> {
+///     if ok { Ok(42) } else { Err(ExoError::Governance("nope".into())) }
+/// }
+/// assert_eq!(pretend_work(true).unwrap(), 42);
+/// ```
 pub type ExoResult<T> = std::result::Result<T, ExoError>;

--- a/crates/exochain-sdk/src/governance.rs
+++ b/crates/exochain-sdk/src/governance.rs
@@ -5,6 +5,36 @@
 //! has been met. It is not a replacement for the full `exo-governance` crate —
 //! it is a developer-facing facade useful for prototyping, testing, and
 //! simple governance flows.
+//!
+//! ## Why use this module
+//!
+//! - You want a deterministic, content-addressed decision object that any
+//!   party can independently construct and hash to the same ID.
+//! - You want cheap, in-memory quorum checks before committing a decision to
+//!   the fabric.
+//! - You want the SDK to reject obvious mistakes (empty title, duplicate
+//!   voter) before your governance flow ever hits the wire.
+//!
+//! ## Quick start
+//!
+//! ```
+//! use exochain_sdk::governance::{DecisionBuilder, Vote, VoteChoice};
+//! use exo_core::Did;
+//!
+//! let alice = Did::new("did:exo:alice").expect("valid");
+//! let bob = Did::new("did:exo:bob").expect("valid");
+//! let carol = Did::new("did:exo:carol").expect("valid");
+//!
+//! let mut decision = DecisionBuilder::new("Ratify v1", "Promote to prod", alice)
+//!     .build()?;
+//! decision.cast_vote(Vote::new(bob, VoteChoice::Approve))?;
+//! decision.cast_vote(Vote::new(carol, VoteChoice::Approve))?;
+//!
+//! let quorum = decision.check_quorum(2);
+//! assert!(quorum.met);
+//! assert_eq!(quorum.approvals, 2);
+//! # Ok::<(), exochain_sdk::error::ExoError>(())
+//! ```
 
 use exo_core::Did;
 use serde::{Deserialize, Serialize};
@@ -27,11 +57,33 @@ pub enum DecisionStatus {
 }
 
 /// Classification of a decision. Free-form label for downstream callers.
+///
+/// Downstream fabrics may interpret a decision's class to route it to
+/// different forums, apply different quorum thresholds, or require different
+/// escalation rules. The SDK itself does not interpret the value.
+///
+/// # Examples
+///
+/// ```
+/// use exochain_sdk::governance::DecisionClass;
+///
+/// let ordinary = DecisionClass::new("ordinary");
+/// let extraordinary = DecisionClass::new("extraordinary");
+/// assert_ne!(ordinary, extraordinary);
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct DecisionClass(pub String);
 
 impl DecisionClass {
     /// Construct a new class from any string-like value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use exochain_sdk::governance::DecisionClass;
+    /// let c = DecisionClass::new("ordinary");
+    /// assert_eq!(c.0, "ordinary");
+    /// ```
     #[must_use]
     pub fn new(name: impl Into<String>) -> Self {
         Self(name.into())
@@ -62,6 +114,20 @@ pub struct Vote {
 
 impl Vote {
     /// Construct a new vote without a rationale.
+    ///
+    /// Use [`Vote::with_rationale`] to attach a free-form rationale.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exochain_sdk::governance::{Vote, VoteChoice};
+    /// use exo_core::Did;
+    ///
+    /// let voter = Did::new("did:exo:v1").expect("valid");
+    /// let vote = Vote::new(voter, VoteChoice::Approve);
+    /// assert_eq!(vote.choice, VoteChoice::Approve);
+    /// assert!(vote.rationale.is_none());
+    /// ```
     #[must_use]
     pub fn new(voter: Did, choice: VoteChoice) -> Self {
         Self {
@@ -72,6 +138,21 @@ impl Vote {
     }
 
     /// Attach a rationale to this vote.
+    ///
+    /// Rationales are recommended whenever a vote rejects or abstains so that
+    /// downstream consumers can audit the reasoning.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exochain_sdk::governance::{Vote, VoteChoice};
+    /// use exo_core::Did;
+    ///
+    /// let voter = Did::new("did:exo:v1").expect("valid");
+    /// let vote = Vote::new(voter, VoteChoice::Reject)
+    ///     .with_rationale("risk too high");
+    /// assert_eq!(vote.rationale.as_deref(), Some("risk too high"));
+    /// ```
     #[must_use]
     pub fn with_rationale(mut self, rationale: impl Into<String>) -> Self {
         self.rationale = Some(rationale.into());
@@ -80,6 +161,28 @@ impl Vote {
 }
 
 /// Builder for a [`Decision`].
+///
+/// A decision starts life in [`DecisionStatus::Proposed`] with an empty vote
+/// list. The `decision_id` is derived deterministically from the title,
+/// description, and proposer, so independent builders producing the same
+/// fields end up with the same ID.
+///
+/// # Examples
+///
+/// ```
+/// use exochain_sdk::governance::{DecisionBuilder, DecisionClass, DecisionStatus};
+/// use exo_core::Did;
+///
+/// let proposer = Did::new("did:exo:alice").expect("valid");
+/// let decision = DecisionBuilder::new("Fund Q3", "Allocate 2%", proposer)
+///     .decision_class(DecisionClass::new("ordinary"))
+///     .build()?;
+///
+/// assert_eq!(decision.status, DecisionStatus::Proposed);
+/// assert_eq!(decision.title, "Fund Q3");
+/// assert!(decision.votes.is_empty());
+/// # Ok::<(), exochain_sdk::error::ExoError>(())
+/// ```
 #[derive(Debug, Clone)]
 pub struct DecisionBuilder {
     title: String,
@@ -90,6 +193,19 @@ pub struct DecisionBuilder {
 
 impl DecisionBuilder {
     /// Start building a decision with a title, description, and proposer DID.
+    ///
+    /// Title and description may be any strings; [`DecisionBuilder::build`]
+    /// only rejects an empty title.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use exochain_sdk::governance::DecisionBuilder;
+    /// # use exo_core::Did;
+    /// let proposer = Did::new("did:exo:alice").expect("valid");
+    /// let builder = DecisionBuilder::new("title", "desc", proposer);
+    /// # let _ = builder;
+    /// ```
     #[must_use]
     pub fn new(title: impl Into<String>, description: impl Into<String>, proposer: Did) -> Self {
         Self {
@@ -101,6 +217,22 @@ impl DecisionBuilder {
     }
 
     /// Attach an optional decision class.
+    ///
+    /// See [`DecisionClass`] for how downstream fabrics typically use this
+    /// label.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use exochain_sdk::governance::{DecisionBuilder, DecisionClass};
+    /// # use exo_core::Did;
+    /// let proposer = Did::new("did:exo:alice").expect("valid");
+    /// let decision = DecisionBuilder::new("t", "d", proposer)
+    ///     .decision_class(DecisionClass::new("extraordinary"))
+    ///     .build()?;
+    /// assert_eq!(decision.class, Some(DecisionClass::new("extraordinary")));
+    /// # Ok::<(), exochain_sdk::error::ExoError>(())
+    /// ```
     #[must_use]
     pub fn decision_class(mut self, class: DecisionClass) -> Self {
         self.decision_class = Some(class);
@@ -109,9 +241,26 @@ impl DecisionBuilder {
 
     /// Validate and build the [`Decision`].
     ///
+    /// On success, returns a decision in [`DecisionStatus::Proposed`] with an
+    /// empty vote list. The `decision_id` is the first 16 hex chars of
+    /// `BLAKE3(title || 0 || description || 0 || proposer_did)` and is
+    /// therefore deterministic.
+    ///
     /// # Errors
     ///
     /// Returns [`ExoError::Governance`] if the title is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exochain_sdk::governance::DecisionBuilder;
+    /// use exochain_sdk::error::ExoError;
+    /// use exo_core::Did;
+    ///
+    /// let proposer = Did::new("did:exo:alice").expect("valid");
+    /// let err = DecisionBuilder::new("", "d", proposer).build().unwrap_err();
+    /// assert!(matches!(err, ExoError::Governance(_)));
+    /// ```
     pub fn build(self) -> ExoResult<Decision> {
         if self.title.is_empty() {
             return Err(ExoError::Governance("title must be non-empty".into()));
@@ -152,10 +301,34 @@ pub struct Decision {
 impl Decision {
     /// Cast a vote on this decision.
     ///
+    /// The same voter may cast at most one vote per decision. Downstream
+    /// flows that need to change a vote should first withdraw the original
+    /// and re-cast, which is a policy decision the SDK leaves to the caller.
+    ///
     /// # Errors
     ///
     /// Returns [`ExoError::Governance`] if the voter has already cast a vote
     /// on this decision.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exochain_sdk::governance::{DecisionBuilder, Vote, VoteChoice};
+    /// use exochain_sdk::error::ExoError;
+    /// use exo_core::Did;
+    ///
+    /// let proposer = Did::new("did:exo:alice").expect("valid");
+    /// let v1 = Did::new("did:exo:v1").expect("valid");
+    /// let mut decision = DecisionBuilder::new("t", "d", proposer).build()?;
+    /// decision.cast_vote(Vote::new(v1.clone(), VoteChoice::Approve))?;
+    ///
+    /// // A second vote from the same voter is rejected.
+    /// let err = decision
+    ///     .cast_vote(Vote::new(v1, VoteChoice::Reject))
+    ///     .unwrap_err();
+    /// assert!(matches!(err, ExoError::Governance(_)));
+    /// # Ok::<(), ExoError>(())
+    /// ```
     pub fn cast_vote(&mut self, vote: Vote) -> ExoResult<()> {
         if self.votes.iter().any(|v| v.voter == vote.voter) {
             return Err(ExoError::Governance(format!(
@@ -169,9 +342,31 @@ impl Decision {
 
     /// Check whether `threshold` approvals have been reached.
     ///
-    /// `threshold` is the number of approval votes required. The returned
-    /// [`QuorumResult`] also reports raw tallies for approvals, rejections,
-    /// abstentions, and total votes.
+    /// `threshold` is the minimum number of `Approve` votes required for
+    /// quorum. The returned [`QuorumResult`] also reports raw tallies for
+    /// approvals, rejections, abstentions, and total votes, so callers can
+    /// implement richer policies (e.g. "at least N approvals AND more
+    /// approvals than rejections") without re-scanning the votes list.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exochain_sdk::governance::{DecisionBuilder, Vote, VoteChoice};
+    /// use exo_core::Did;
+    ///
+    /// let proposer = Did::new("did:exo:alice").expect("valid");
+    /// let mut decision = DecisionBuilder::new("t", "d", proposer).build()?;
+    /// decision.cast_vote(Vote::new(Did::new("did:exo:v1").unwrap(), VoteChoice::Approve))?;
+    /// decision.cast_vote(Vote::new(Did::new("did:exo:v2").unwrap(), VoteChoice::Approve))?;
+    /// decision.cast_vote(Vote::new(Did::new("did:exo:v3").unwrap(), VoteChoice::Reject))?;
+    ///
+    /// let q = decision.check_quorum(2);
+    /// assert!(q.met);
+    /// assert_eq!(q.approvals, 2);
+    /// assert_eq!(q.rejections, 1);
+    /// assert_eq!(q.total_votes, 3);
+    /// # Ok::<(), exochain_sdk::error::ExoError>(())
+    /// ```
     #[must_use]
     pub fn check_quorum(&self, threshold: u32) -> QuorumResult {
         let total_votes = u32::try_from(self.votes.len()).unwrap_or(u32::MAX);

--- a/crates/exochain-sdk/src/identity.rs
+++ b/crates/exochain-sdk/src/identity.rs
@@ -1,10 +1,28 @@
-//! Decentralized identity management.
+//! Decentralized identity — DIDs backed by Ed25519 keypairs.
 //!
 //! [`Identity`] is the SDK's ergonomic handle to a DID with its associated
 //! Ed25519 keypair. The DID is derived deterministically from the public key
 //! so that two identities generated with different entropy always produce
 //! different DIDs, while an identity re-constructed from the same key bytes
 //! always yields the same DID.
+//!
+//! ## When to reach for this module
+//!
+//! - Every actor in EXOCHAIN — human, AI agent, service, organization — needs
+//!   an [`Identity`]. The identity's DID is the principal that appears in
+//!   bailments, decisions, authority chains, and kernel adjudications.
+//! - Signatures produced by [`Identity::sign`] feed straight into the kernel
+//!   as proof of provenance.
+//!
+//! ## Quick start
+//!
+//! ```
+//! use exochain_sdk::identity::Identity;
+//!
+//! let alice = Identity::generate("alice");
+//! let sig = alice.sign(b"hello");
+//! assert!(alice.verify(b"hello", &sig));
+//! ```
 
 use exo_core::crypto::{generate_keypair, sign as core_sign, verify as core_verify};
 use exo_core::{Did, PublicKey, SecretKey, Signature, Timestamp};
@@ -14,11 +32,29 @@ use crate::error::{ExoError, ExoResult};
 
 /// A DID paired with its Ed25519 keypair and a human-readable label.
 ///
-/// Use [`Identity::generate`] to create a fresh identity with a random keypair.
-/// The DID is derived from the public key as:
+/// Identities are created either with [`Identity::generate`] (fresh random
+/// keypair) or [`Identity::from_keypair`] (reuse an existing keypair, e.g.
+/// loaded from a keystore). The DID is derived from the public key as:
 ///
 /// ```text
 /// did:exo: + first 16 hex chars of BLAKE3(public_key_bytes)
+/// ```
+///
+/// The `Debug` implementation deliberately redacts the secret key so
+/// identities can be logged without leaking private material.
+///
+/// # Examples
+///
+/// ```
+/// use exochain_sdk::identity::Identity;
+///
+/// let alice = Identity::generate("alice");
+/// assert!(alice.did().as_str().starts_with("did:exo:"));
+/// assert_eq!(alice.label(), "alice");
+///
+/// // Debug never leaks the secret key.
+/// let debug = format!("{alice:?}");
+/// assert!(debug.contains("***"));
 /// ```
 pub struct Identity {
     did: Did,
@@ -32,13 +68,36 @@ impl Identity {
     /// derived from the public key.
     ///
     /// The `label` is stored alongside the identity for developer convenience
-    /// and is never cryptographically bound to the DID.
+    /// and is never cryptographically bound to the DID — renaming an identity
+    /// does not change its DID.
     ///
-    /// Deriving the DID cannot fail in practice: the method-specific portion
-    /// is always a 16-character lowercase hex string, which satisfies the
-    /// `did:exo:` validation rules.  In the unreachable case that validation
-    /// ever rejected such a string, the generated DID falls back to
-    /// `did:exo:sdk-fallback` — still well-formed, still valid.
+    /// Use this when you need a brand-new principal. Use
+    /// [`Identity::from_keypair`] when loading a previously generated keypair
+    /// from storage.
+    ///
+    /// This method is infallible in practice: the method-specific portion of
+    /// the DID is always 16 lowercase hex characters, which satisfies DID
+    /// validation. In the unreachable case of validation failure, the DID
+    /// falls back to `did:exo:sdk-fallback`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exochain_sdk::identity::Identity;
+    ///
+    /// let id = Identity::generate("agent");
+    /// assert!(id.did().as_str().starts_with("did:exo:"));
+    /// assert_eq!(id.did().as_str().len(), "did:exo:".len() + 16);
+    /// ```
+    ///
+    /// Two fresh identities have different DIDs:
+    ///
+    /// ```
+    /// # use exochain_sdk::identity::Identity;
+    /// let a = Identity::generate("a");
+    /// let b = Identity::generate("b");
+    /// assert_ne!(a.did(), b.did());
+    /// ```
     #[must_use]
     pub fn generate(label: &str) -> Self {
         let (public, secret) = generate_keypair();
@@ -51,16 +110,36 @@ impl Identity {
         }
     }
 
-    /// Build an [`Identity`] from an existing keypair and label.
+    /// Build an [`Identity`] from an existing Ed25519 keypair and label.
     ///
     /// The DID is derived from the public key in the same way as
-    /// [`Identity::generate`].
+    /// [`Identity::generate`]. Reconstructing an identity from the same
+    /// keypair always produces the same DID.
+    ///
+    /// Use this to load a persisted identity, or to rehydrate the identity
+    /// belonging to another actor when you only know their public material.
     ///
     /// # Errors
     ///
     /// Returns [`ExoError::InvalidDid`] only in the highly unlikely case that
     /// BLAKE3 output somehow failed DID validation — this should be
     /// unreachable in practice.
+    ///
+    /// # Examples
+    ///
+    /// Build an identity from a freshly generated keypair using the
+    /// underlying core crypto primitives.
+    ///
+    /// ```
+    /// use exochain_sdk::identity::Identity;
+    /// use exo_core::crypto::generate_keypair;
+    ///
+    /// let (public, secret) = generate_keypair();
+    /// let alice = Identity::from_keypair("alice", public, secret)?;
+    /// assert!(alice.did().as_str().starts_with("did:exo:"));
+    /// assert_eq!(alice.label(), "alice");
+    /// # Ok::<(), exochain_sdk::error::ExoError>(())
+    /// ```
     pub fn from_keypair(label: &str, public: PublicKey, secret: SecretKey) -> ExoResult<Self> {
         let did = derive_did(&public)?;
         Ok(Self {
@@ -72,30 +151,85 @@ impl Identity {
     }
 
     /// Return the DID for this identity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use exochain_sdk::identity::Identity;
+    /// let id = Identity::generate("alice");
+    /// assert!(id.did().as_str().starts_with("did:exo:"));
+    /// ```
     #[must_use]
     pub fn did(&self) -> &Did {
         &self.did
     }
 
-    /// Return the public key.
+    /// Return the Ed25519 public key.
+    ///
+    /// Public keys are safe to share and can be handed to counterparties so
+    /// they can verify signatures this identity produces.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use exochain_sdk::identity::Identity;
+    /// let id = Identity::generate("alice");
+    /// let pk = id.public_key();
+    /// assert_eq!(pk.as_bytes().len(), 32);
+    /// ```
     #[must_use]
     pub fn public_key(&self) -> &PublicKey {
         &self.public
     }
 
     /// Return the human-readable label.
+    ///
+    /// Labels are developer affordances and have no cryptographic meaning.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use exochain_sdk::identity::Identity;
+    /// let id = Identity::generate("alice");
+    /// assert_eq!(id.label(), "alice");
+    /// ```
     #[must_use]
     pub fn label(&self) -> &str {
         &self.label
     }
 
     /// Sign `message` with this identity's secret key (Ed25519).
+    ///
+    /// The returned [`Signature`] is suitable for feeding into
+    /// [`Identity::verify`] or into the kernel's provenance field.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use exochain_sdk::identity::Identity;
+    /// let id = Identity::generate("signer");
+    /// let sig = id.sign(b"hello");
+    /// assert!(id.verify(b"hello", &sig));
+    /// ```
     #[must_use]
     pub fn sign(&self, message: &[u8]) -> Signature {
         core_sign(message, &self.secret)
     }
 
     /// Verify `signature` over `message` against this identity's public key.
+    ///
+    /// Returns `true` only if the signature was produced by the matching
+    /// secret key over exactly these message bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use exochain_sdk::identity::Identity;
+    /// let id = Identity::generate("signer");
+    /// let sig = id.sign(b"hello");
+    /// assert!(id.verify(b"hello", &sig));
+    /// assert!(!id.verify(b"tampered", &sig));
+    /// ```
     #[must_use]
     pub fn verify(&self, message: &[u8], signature: &Signature) -> bool {
         core_verify(message, signature, &self.public)
@@ -107,6 +241,17 @@ impl Identity {
     /// key, with empty authentication/verification-method/service-endpoint
     /// lists and `created == updated == Timestamp::ZERO`. Callers can augment
     /// the document after construction if they need richer DID metadata.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use exochain_sdk::identity::Identity;
+    /// let id = Identity::generate("alice");
+    /// let doc = id.did_document();
+    /// assert_eq!(&doc.id, id.did());
+    /// assert_eq!(doc.public_keys.len(), 1);
+    /// assert!(!doc.revoked);
+    /// ```
     #[must_use]
     pub fn did_document(&self) -> DidDocument {
         DidDocument {
@@ -243,4 +388,5 @@ mod tests {
         let pk = *id.public_key();
         assert_eq!(&pk, id.public_key());
     }
+
 }

--- a/crates/exochain-sdk/src/kernel.rs
+++ b/crates/exochain-sdk/src/kernel.rs
@@ -1,10 +1,39 @@
 //! Constitutional Governance Runtime (CGR) Kernel interface.
 //!
+//! The **CGR kernel** is the heart of EXOCHAIN. Every action that matters —
+//! reading data, delegating authority, invoking a tool — is first submitted
+//! to the kernel, which checks the action against the constitution and the
+//! eight structural invariants (including `NoSelfGrant`, `ConsentRequired`,
+//! and `KernelImmutability`). Only if the kernel returns `Permitted` does the
+//! action run.
+//!
 //! [`ConstitutionalKernel`] is a simplified, ergonomic wrapper around
 //! [`exo_gatekeeper::Kernel`]. It initialises the kernel with the default
 //! EXOCHAIN constitution text and the full set of eight constitutional
 //! invariants, and exposes a minimal [`ConstitutionalKernel::adjudicate`]
 //! that supplies reasonable defaults for the adjudication context.
+//!
+//! ## Why use this module
+//!
+//! - You want to ask "is this action permitted?" without having to construct
+//!   the full [`exo_gatekeeper::AdjudicationContext`] by hand.
+//! - You want to exercise specific invariants (self-grant, kernel
+//!   modification, consent-required) in tests via the named `adjudicate_*`
+//!   helpers.
+//! - You want the same verdict enum to flow through your application and
+//!   your test vectors.
+//!
+//! ## Quick start
+//!
+//! ```
+//! use exochain_sdk::kernel::ConstitutionalKernel;
+//! use exo_core::Did;
+//!
+//! let kernel = ConstitutionalKernel::new();
+//! let actor = Did::new("did:exo:alice").expect("valid");
+//! let verdict = kernel.adjudicate(&actor, "data:medical:read");
+//! assert!(verdict.is_permitted());
+//! ```
 
 use exo_core::Did;
 use exo_gatekeeper::{
@@ -29,6 +58,21 @@ const INVARIANT_COUNT: usize = 8;
 /// This mirrors [`exo_gatekeeper::Verdict`] but flattens the violation list
 /// to a simple `Vec<String>` so SDK consumers do not need to depend on the
 /// full gatekeeper types.
+///
+/// # Examples
+///
+/// ```
+/// use exochain_sdk::kernel::KernelVerdict;
+///
+/// let ok = KernelVerdict::Permitted;
+/// assert!(ok.is_permitted());
+///
+/// let denied = KernelVerdict::Denied { violations: vec!["NoSelfGrant".into()] };
+/// assert!(denied.is_denied());
+///
+/// let escalated = KernelVerdict::Escalated { reason: "human review".into() };
+/// assert!(escalated.is_escalated());
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum KernelVerdict {
     /// The action is permitted.
@@ -47,18 +91,42 @@ pub enum KernelVerdict {
 
 impl KernelVerdict {
     /// Returns `true` if the verdict is [`KernelVerdict::Permitted`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use exochain_sdk::kernel::KernelVerdict;
+    /// assert!(KernelVerdict::Permitted.is_permitted());
+    /// assert!(!KernelVerdict::Denied { violations: vec![] }.is_permitted());
+    /// ```
     #[must_use]
     pub fn is_permitted(&self) -> bool {
         matches!(self, Self::Permitted)
     }
 
     /// Returns `true` if the verdict is [`KernelVerdict::Denied`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use exochain_sdk::kernel::KernelVerdict;
+    /// let v = KernelVerdict::Denied { violations: vec!["NoSelfGrant".into()] };
+    /// assert!(v.is_denied());
+    /// ```
     #[must_use]
     pub fn is_denied(&self) -> bool {
         matches!(self, Self::Denied { .. })
     }
 
     /// Returns `true` if the verdict is [`KernelVerdict::Escalated`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use exochain_sdk::kernel::KernelVerdict;
+    /// let v = KernelVerdict::Escalated { reason: "human in the loop".into() };
+    /// assert!(v.is_escalated());
+    /// ```
     #[must_use]
     pub fn is_escalated(&self) -> bool {
         matches!(self, Self::Escalated { .. })
@@ -72,6 +140,21 @@ impl KernelVerdict {
 /// an active bailment to a sentinel bailor. Callers needing fine-grained
 /// control over the adjudication context should use [`exo_gatekeeper::Kernel`]
 /// directly.
+///
+/// # Examples
+///
+/// ```
+/// use exochain_sdk::kernel::ConstitutionalKernel;
+/// use exo_core::Did;
+///
+/// let kernel = ConstitutionalKernel::new();
+/// assert!(kernel.verify_integrity());
+/// assert_eq!(kernel.invariant_count(), 8);
+///
+/// let actor = Did::new("did:exo:alice").expect("valid");
+/// let verdict = kernel.adjudicate(&actor, "read:profile");
+/// assert!(verdict.is_permitted());
+/// ```
 pub struct ConstitutionalKernel {
     inner: Kernel,
     constitution: Vec<u8>,
@@ -80,6 +163,15 @@ pub struct ConstitutionalKernel {
 impl ConstitutionalKernel {
     /// Construct a new kernel with the default constitution and all eight
     /// constitutional invariants.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use exochain_sdk::kernel::ConstitutionalKernel;
+    /// let kernel = ConstitutionalKernel::new();
+    /// assert_eq!(kernel.invariant_count(), 8);
+    /// assert!(kernel.verify_integrity());
+    /// ```
     #[must_use]
     pub fn new() -> Self {
         Self {
@@ -92,8 +184,8 @@ impl ConstitutionalKernel {
     ///
     /// The SDK supplies a permissive default context:
     /// - A single Judicial role for `actor`.
-    /// - A one-link authority chain `did:exo:root → actor` granting `read`.
-    /// - An active bailment from `did:exo:sdk-bailor → actor` scoped to
+    /// - A one-link authority chain `did:exo:root -> actor` granting `read`.
+    /// - An active bailment from `did:exo:sdk-bailor -> actor` scoped to
     ///   `action`.
     /// - Full human-override preservation.
     /// - Signed provenance with timestamp `"sdk"`.
@@ -103,29 +195,82 @@ impl ConstitutionalKernel {
     ///
     /// The action is flagged as `is_self_grant = false` and
     /// `modifies_kernel = false` by default. Helpers are available for the
-    /// common deny-cases used in tests: see [`Self::adjudicate_self_grant`]
-    /// and [`Self::adjudicate_kernel_modification`].
+    /// common deny-cases used in tests: see
+    /// [`Self::adjudicate_self_grant`],
+    /// [`Self::adjudicate_kernel_modification`], and
+    /// [`Self::adjudicate_without_bailment`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exochain_sdk::kernel::ConstitutionalKernel;
+    /// use exo_core::Did;
+    ///
+    /// let kernel = ConstitutionalKernel::new();
+    /// let actor = Did::new("did:exo:alice").expect("valid");
+    /// let verdict = kernel.adjudicate(&actor, "data:read");
+    /// assert!(verdict.is_permitted());
+    /// ```
     #[must_use]
     pub fn adjudicate(&self, actor: &Did, action: &str) -> KernelVerdict {
         self.adjudicate_internal(actor, action, false, false, true, true)
     }
 
     /// Same as [`Self::adjudicate`] but sets `is_self_grant = true` so the
-    /// kernel can enforce the NoSelfGrant invariant.
+    /// kernel can enforce the `NoSelfGrant` invariant.
+    ///
+    /// Useful for exercising the invariant in tests: a permitted verdict
+    /// here would indicate a constitutional defect.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exochain_sdk::kernel::ConstitutionalKernel;
+    /// use exo_core::Did;
+    ///
+    /// let kernel = ConstitutionalKernel::new();
+    /// let actor = Did::new("did:exo:self-granter").expect("valid");
+    /// let verdict = kernel.adjudicate_self_grant(&actor, "escalate-self");
+    /// assert!(verdict.is_denied());
+    /// ```
     #[must_use]
     pub fn adjudicate_self_grant(&self, actor: &Did, action: &str) -> KernelVerdict {
         self.adjudicate_internal(actor, action, true, false, true, true)
     }
 
     /// Same as [`Self::adjudicate`] but sets `modifies_kernel = true` so the
-    /// kernel can enforce the KernelImmutability invariant.
+    /// kernel can enforce the `KernelImmutability` invariant.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exochain_sdk::kernel::ConstitutionalKernel;
+    /// use exo_core::Did;
+    ///
+    /// let kernel = ConstitutionalKernel::new();
+    /// let actor = Did::new("did:exo:patcher").expect("valid");
+    /// let verdict = kernel.adjudicate_kernel_modification(&actor, "patch-kernel");
+    /// assert!(verdict.is_denied());
+    /// ```
     #[must_use]
     pub fn adjudicate_kernel_modification(&self, actor: &Did, action: &str) -> KernelVerdict {
         self.adjudicate_internal(actor, action, false, true, true, true)
     }
 
     /// Same as [`Self::adjudicate`] but omits the default bailment so the
-    /// kernel can enforce the ConsentRequired invariant.
+    /// kernel can enforce the `ConsentRequired` invariant.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exochain_sdk::kernel::ConstitutionalKernel;
+    /// use exo_core::Did;
+    ///
+    /// let kernel = ConstitutionalKernel::new();
+    /// let actor = Did::new("did:exo:unauth").expect("valid");
+    /// let verdict = kernel.adjudicate_without_bailment(&actor, "read-data");
+    /// assert!(verdict.is_denied());
+    /// ```
     #[must_use]
     pub fn adjudicate_without_bailment(&self, actor: &Did, action: &str) -> KernelVerdict {
         self.adjudicate_internal(actor, action, false, false, false, true)
@@ -133,12 +278,32 @@ impl ConstitutionalKernel {
 
     /// Verify that the kernel's stored constitution hash matches the
     /// configured constitution text.
+    ///
+    /// Returns `false` if the constitution in memory has drifted from the
+    /// hash the kernel was initialised with — which should never happen in
+    /// practice, but is checked defensively because constitutional integrity
+    /// is a load-bearing invariant.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use exochain_sdk::kernel::ConstitutionalKernel;
+    /// let kernel = ConstitutionalKernel::new();
+    /// assert!(kernel.verify_integrity());
+    /// ```
     #[must_use]
     pub fn verify_integrity(&self) -> bool {
         self.inner.verify_kernel_integrity(&self.constitution)
     }
 
     /// Number of constitutional invariants enforced by this kernel (always 8).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use exochain_sdk::kernel::ConstitutionalKernel;
+    /// assert_eq!(ConstitutionalKernel::new().invariant_count(), 8);
+    /// ```
     #[must_use]
     pub fn invariant_count(&self) -> usize {
         INVARIANT_COUNT

--- a/crates/exochain-sdk/src/lib.rs
+++ b/crates/exochain-sdk/src/lib.rs
@@ -1,22 +1,141 @@
-//! EXOCHAIN SDK — ergonomic Rust API for the constitutional governance fabric.
+//! # EXOCHAIN SDK — Rust
 //!
-//! This crate re-exports and wraps the underlying `exo-*` workspace crates behind
-//! a single, developer-friendly surface so that applications built on EXOCHAIN
-//! can depend on one crate and use one coherent API.
+//! Ergonomic Rust API for the **EXOCHAIN constitutional governance fabric** — a
+//! substrate for AI agents and data sovereignty built around decentralized
+//! identifiers (DIDs), scoped consent (bailments), authority-chain delegation,
+//! quorum-based governance, and a constitutional kernel that enforces policy
+//! *before* action rather than auditing it after.
 //!
-//! # Quick Start
+//! This crate re-exports and wraps the underlying `exo-*` workspace crates
+//! behind a single, developer-friendly surface so that applications built on
+//! EXOCHAIN can depend on one crate and use one coherent API. Each domain lives
+//! in its own module:
 //!
-//! ```rust,no_run
+//! - [`identity`] — DID-backed Ed25519 identities with sign/verify.
+//! - [`consent`] — scoped, time-bounded bailments (consent tokens).
+//! - [`governance`] — decisions, voting, quorum checks.
+//! - [`authority`] — validated delegation chains.
+//! - [`kernel`] — the Constitutional Governance Runtime (CGR) kernel.
+//! - [`crypto`] — hash / sign / verify primitives (BLAKE3 + Ed25519).
+//! - [`error`] — the single [`error::ExoError`] type returned by fallible ops.
+//!
+//! ## Why use this SDK
+//!
+//! EXOCHAIN turns policy into a *precondition* of action. Instead of shipping
+//! agents that do things and asking an auditor to catch violations, you
+//! express identity, consent, and delegation as first-class cryptographic
+//! objects and ask the kernel whether an action is permitted. If the
+//! [`kernel::ConstitutionalKernel`] denies an action, the action never runs.
+//!
+//! This SDK gives you:
+//!
+//! - Deterministic, content-addressed IDs for every object (bailments,
+//!   decisions, chains) so two parties independently building the same object
+//!   get the same ID.
+//! - Builder APIs that validate on `build()` so invalid states are not
+//!   representable downstream.
+//! - Pure types (no I/O) suitable for offline governance, test vectors, and
+//!   cross-language interop with the TypeScript and Python SDKs.
+//!
+//! ## End-to-end example
+//!
+//! The canonical lifecycle: two identities negotiate a bailment, propose a
+//! decision, reach quorum, build a delegation chain, and submit an action to
+//! the kernel for adjudication.
+//!
+//! ```
+//! use exochain_sdk::prelude::*;
+//! use exochain_sdk::governance::VoteChoice;
+//!
+//! // 1. Create identities for alice and bob.
+//! let alice = Identity::generate("alice");
+//! let bob = Identity::generate("bob");
+//! assert!(alice.did().as_str().starts_with("did:exo:"));
+//! assert_ne!(alice.did(), bob.did());
+//!
+//! // 2. Alice proposes a scoped bailment to bob.
+//! let proposal = BailmentBuilder::new(alice.did().clone(), bob.did().clone())
+//!     .scope("data:medical")
+//!     .duration_hours(24)
+//!     .build()?;
+//! assert_eq!(proposal.scope, "data:medical");
+//! assert_eq!(proposal.proposal_id.len(), 16);
+//!
+//! // 3. Alice proposes a decision; bob and a third voter approve.
+//! let carol = Identity::generate("carol");
+//! let mut decision = DecisionBuilder::new(
+//!     "Ratify bailment",
+//!     "Allow bob to read medical records for 24h",
+//!     alice.did().clone(),
+//! )
+//! .build()?;
+//! decision.cast_vote(Vote::new(bob.did().clone(), VoteChoice::Approve))?;
+//! decision.cast_vote(Vote::new(carol.did().clone(), VoteChoice::Approve))?;
+//! let quorum = decision.check_quorum(2);
+//! assert!(quorum.met);
+//! assert_eq!(quorum.approvals, 2);
+//!
+//! // 4. Build an authority chain: root -> alice -> bob.
+//! let root = Identity::generate("root");
+//! let chain = AuthorityChainBuilder::new()
+//!     .add_link(root.did().clone(), alice.did().clone(), vec!["delegate".into()])
+//!     .add_link(alice.did().clone(), bob.did().clone(), vec!["read".into()])
+//!     .build(bob.did())?;
+//! assert_eq!(chain.depth, 2);
+//! assert_eq!(&chain.terminal, bob.did());
+//!
+//! // 5. Ask the kernel whether bob may perform the action.
+//! let kernel = ConstitutionalKernel::new();
+//! let verdict = kernel.adjudicate(bob.did(), "data:medical:read");
+//! assert!(verdict.is_permitted(), "expected Permitted, got {verdict:?}");
+//! # Ok::<(), exochain_sdk::error::ExoError>(())
+//! ```
+//!
+//! ## Prelude
+//!
+//! Most applications want the common builders, [`Identity`](identity::Identity),
+//! the error type, and the kernel facade. Import the [`prelude`]:
+//!
+//! ```
 //! use exochain_sdk::prelude::*;
 //!
-//! // Create an identity
-//! let identity = Identity::generate("my-agent");
-//! println!("DID: {}", identity.did());
-//!
-//! // Verify a signature
-//! let sig = identity.sign(b"hello");
-//! assert!(identity.verify(b"hello", &sig));
+//! let id = Identity::generate("agent");
+//! let sig = id.sign(b"payload");
+//! assert!(id.verify(b"payload", &sig));
 //! ```
+//!
+//! ## Error handling
+//!
+//! All fallible operations return [`error::ExoResult<T>`], an alias for
+//! `Result<T, ExoError>`. Each [`error::ExoError`] variant narrows the failure
+//! to a subsystem (consent, governance, authority, kernel, crypto, serialization)
+//! so callers can pattern-match without parsing strings.
+//!
+//! ```
+//! use exochain_sdk::prelude::*;
+//! use exochain_sdk::error::ExoError;
+//! # use exo_core::Did;
+//!
+//! let alice = Did::new("did:exo:alice").expect("valid");
+//! let bob = Did::new("did:exo:bob").expect("valid");
+//!
+//! // Forgetting to set `scope` produces a Consent error:
+//! let err = BailmentBuilder::new(alice, bob)
+//!     .duration_hours(1)
+//!     .build()
+//!     .unwrap_err();
+//! assert!(matches!(err, ExoError::Consent(_)));
+//! ```
+//!
+//! ## Cross-language notes
+//!
+//! The Rust SDK derives DIDs from `BLAKE3(public_key)[..8]`. The TypeScript
+//! SDK uses `SHA-256` because Web Crypto does not ship BLAKE3, and the Python
+//! SDK uses `SHA-256` for the same reason. Applications that need canonical
+//! DIDs across all three SDKs should resolve the DID from the fabric rather
+//! than deriving it locally.
+
+#![deny(missing_docs)]
 
 pub mod authority;
 pub mod consent;
@@ -26,7 +145,15 @@ pub mod governance;
 pub mod identity;
 pub mod kernel;
 
-/// Prelude — import everything you need with `use exochain_sdk::prelude::*`.
+/// Prelude — the symbols most applications want.
+///
+/// ```
+/// use exochain_sdk::prelude::*;
+///
+/// let id = Identity::generate("agent");
+/// let sig = id.sign(b"hello");
+/// assert!(id.verify(b"hello", &sig));
+/// ```
 pub mod prelude {
     pub use crate::authority::AuthorityChainBuilder;
     pub use crate::consent::BailmentBuilder;

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,7 +2,7 @@
 title: "EXOCHAIN Documentation Index"
 status: active
 created: 2026-03-18
-updated: 2026-03-20
+updated: 2026-04-15
 tags: [exochain, documentation, index]
 ---
 
@@ -10,91 +10,162 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-~31,000 lines of Rust · 16 crates · 1,846 tests · 0 failures
+~31,000 lines of Rust · 16 crates · 1,846 tests · 0 failures · 40 MCP tools · 8 constitutional invariants
 
 ---
 
-## Project Meta
+## Start here
 
-- [CHANGELOG](../CHANGELOG.md) — All notable changes (Keep a Changelog format)
-- [SECURITY](../SECURITY.md) — Vulnerability reporting, scope, security measures
-- [SUPPORT](../SUPPORT.md) — How to get help, report issues, contribute
-- [VERSIONING](../VERSIONING.md) — Semantic versioning policy, release process, constitutional constraint
+| You are a... | Start with |
+|---|---|
+| **Developer** building on EXOCHAIN | [[GETTING-STARTED]] -> pick an SDK below |
+| **Operator** running a node | [[GETTING-STARTED]] -> [[DEPLOYMENT]] |
+| **Auditor** evaluating the fabric | [[ARCHITECTURE]] -> [[CONSTITUTIONAL-PROOFS]] -> [[THREAT-MODEL]] |
+| **AI agent** acting via MCP | [MCP Integration](guides/mcp-integration.md) |
+| **Contributor** sending PRs | [[GETTING-STARTED]] -> [Constitutional constraints](guides/GETTING-STARTED.md#constitutional-constraints) |
 
-## Legal & Compliance
-
-- [Licensing Position](legal/LICENSING-POSITION.md) — Apache-2.0 rationale, dependency screening, downstream guidance
-- [National AI Policy Crosswalk](policy/NATIONAL-POLICY-FRAMEWORK-CROSSWALK-2026.md) — Mapping to March 2026 National Policy Framework
-
-## Audit & Truth
-
-- [Repo Truth Baseline](audit/REPO-TRUTH-BASELINE.md) — Audited metrics, build status, claim verification
-- [`tools/repo_truth.sh`](../tools/repo_truth.sh) — Regenerate truth baseline from source
-
-## Architecture
-
-- [[ARCHITECTURE]] — System overview, dependency graph, data flow, design rationale
-- [[THREAT-MODEL]] — 12-threat taxonomy with mitigations, detection, and test coverage
-
-## Proofs
-
-- [[CONSTITUTIONAL-PROOFS]] — 10 formal proofs that EXOCHAIN's constitutional properties hold, with informal explanations for general audiences
-
-## Reference
-
-- [[CRATE-REFERENCE]] — Complete API reference for all 16 crates (types, traits, functions, invariants)
+---
 
 ## Guides
 
-- [[GETTING-STARTED]] — Build, test, contribute, and understand the constitutional constraints
-- [[ARCHON-INTEGRATION]] — ExoForge integration: self-improvement cycle, AI-IRB council review, GitHub Issues integration, API endpoints
-- [[DEPLOYMENT]] — Production deployment: Docker, Nginx, SSL, systemd, PostgreSQL backup
+- [[GETTING-STARTED]] — Build, run, contribute. The 5-minute entrypoint.
+- [Rust SDK Quickstart](guides/sdk-quickstart-rust.md) — `exochain-sdk` crate, all 6 domains, end-to-end example.
+- [TypeScript SDK Quickstart](guides/sdk-quickstart-typescript.md) — `@exochain/sdk`, Web Crypto Ed25519, browser + Node.
+- [Python SDK Quickstart](guides/sdk-quickstart-python.md) — `exochain` package, Pydantic v2, asyncio.
+- [MCP Integration Guide](guides/mcp-integration.md) — 40 tools, 6 resources, 4 prompts, Claude Code config, wire examples.
+- [[ARCHON-INTEGRATION]] — ExoForge self-improvement cycle, AI-IRB council review, GitHub Issues integration.
+- [[DEPLOYMENT]] — Production deployment: Docker, Nginx, SSL, systemd, PostgreSQL backup.
+- [CGR Developer Guide](guides/cgr-developer-guide.md) — Constitutional Governance Runtime internals.
+- [Production Deployment](guides/production-deployment.md) — Hardening and operations.
 
-## Demo Platform
+## Architecture
 
-- [Demo README](../demo/README.md) — Quick start, architecture, widget system, services, WASM test suite
-- [Demo Web UI](../demo/web/) — React widget-grid configurator (12-column drag-and-drop, AI help menus)
-- [Gateway API](../demo/services/gateway-api/) — Rust→WASM→Node.js bridge with governance pipeline + ExoForge feedback endpoints
-- [Infrastructure](../demo/infra/) — Docker Compose, PostgreSQL schema/seed, Dockerfile
+- [[ARCHITECTURE]] — System overview, dependency graph, data flow, design rationale.
+- [[THREAT-MODEL]] — 12-threat taxonomy with mitigations, detection, and test coverage.
 
-## Council Reports
+## Reference
 
-- [[OPTIMIZED-SPEC]] — Optimized specification summary
-- [[PANEL-1-GOVERNANCE]] — Governance panel assessment
-- [[PANEL-2-LEGAL]] — Legal panel assessment
-- [[PANEL-3-ARCHITECTURE]] — Architecture panel assessment
-- [[PANEL-4-SECURITY]] — Security panel assessment
-- [[PANEL-5-OPERATIONS]] — Operations panel assessment
+- [[CRATE-REFERENCE]] — Complete API reference for all 16 crates (types, traits, functions, invariants).
+
+## Proofs
+
+- [[CONSTITUTIONAL-PROOFS]] — 10 formal proofs that EXOCHAIN's constitutional properties hold.
+
+## Project meta
+
+- [CHANGELOG](../CHANGELOG.md) — All notable changes (Keep a Changelog format).
+- [SECURITY](../SECURITY.md) — Vulnerability reporting, scope, security measures.
+- [SUPPORT](../SUPPORT.md) — How to get help, report issues, contribute.
+- [VERSIONING](../VERSIONING.md) — Semantic versioning, release process, constitutional constraint.
+
+## Legal and compliance
+
+- [Licensing Position](legal/LICENSING-POSITION.md) — Apache-2.0 rationale, dependency screening, downstream guidance.
+- [National AI Policy Crosswalk](policy/NATIONAL-POLICY-FRAMEWORK-CROSSWALK-2026.md) — Mapping to March 2026 National Policy Framework.
+
+## Audit and truth
+
+- [Repo Truth Baseline](audit/REPO-TRUTH-BASELINE.md) — Audited metrics, build status, claim verification.
+- [`tools/repo_truth.sh`](../tools/repo_truth.sh) — Regenerate truth baseline from source.
+
+---
+
+## By audience
+
+### Developers
+
+- [[GETTING-STARTED]] — Build + test the workspace.
+- [Rust SDK Quickstart](guides/sdk-quickstart-rust.md) — Canonical SDK.
+- [TypeScript SDK Quickstart](guides/sdk-quickstart-typescript.md) — Web + Node.
+- [Python SDK Quickstart](guides/sdk-quickstart-python.md) — Async + Pydantic.
+- [[CRATE-REFERENCE]] — Full API surface.
+- [[ARCHITECTURE]] — System design.
+
+### Operators
+
+- [[GETTING-STARTED]] — Build the node binary.
+- [[DEPLOYMENT]] — Docker, Nginx, systemd, PostgreSQL.
+- [Production Deployment](guides/production-deployment.md) — Hardening.
+- [SECURITY](../SECURITY.md) — Vulnerability reporting.
+
+### Auditors
+
+- [[ARCHITECTURE]] — Three-branch model + BCTS lifecycle.
+- [[THREAT-MODEL]] — Twelve threats, mitigations, test coverage.
+- [[CONSTITUTIONAL-PROOFS]] — Formal proofs.
+- [Repo Truth Baseline](audit/REPO-TRUTH-BASELINE.md) — Verified metrics.
+- [Licensing Position](legal/LICENSING-POSITION.md) — License posture.
+
+### AI agents
+
+- [MCP Integration Guide](guides/mcp-integration.md) — Canonical integration guide.
+- Read at session start: `exochain://invariants`, `exochain://mcp-rules`, `exochain://tools`.
+- Workflow templates: `governance_review`, `compliance_check`, `evidence_analysis`, `constitutional_audit`.
+
+### Community contributors
+
+- [[GETTING-STARTED]] -> [Contributing changes](guides/GETTING-STARTED.md#contributing-changes).
+- [Constitutional constraints](guides/GETTING-STARTED.md#constitutional-constraints) — Rules every PR must obey.
+- [Council process](guides/GETTING-STARTED.md#council-process-for-constitutional-changes) — When a resolution is required.
+- [[AGENTS]] — AI development instructions and constitutional constraints.
+
+---
+
+## SDK packages
+
+- `crates/exochain-sdk/` — Rust SDK (canonical).
+- `packages/exochain-sdk/` — TypeScript SDK (`@exochain/sdk`, Node 20+).
+- `packages/exochain-py/` — Python SDK (`exochain`, Python 3.11+).
 
 ## Governance
 
-- [[CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY]] — Council Resolution defining AEGIS and SYBIL
-- [[COUNCIL-ASSESSMENT-EXO-VS-EXOCHAIN]] — 5-panel assessment driving the refactor
-- [[EXOCHAIN-REFACTOR-PLAN]] — Master plan: council → Syntaxis → assimilation
+- [[CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY]] — Council Resolution defining AEGIS and SYBIL.
+- [[COUNCIL-ASSESSMENT-EXO-VS-EXOCHAIN]] — 5-panel assessment driving the refactor.
+- [[EXOCHAIN-REFACTOR-PLAN]] — Master plan: council -> Syntaxis -> assimilation.
+
+## Council reports
+
+- [[OPTIMIZED-SPEC]] — Optimized specification summary.
+- [[PANEL-1-GOVERNANCE]] — Governance panel assessment.
+- [[PANEL-2-LEGAL]] — Legal panel assessment.
+- [[PANEL-3-ARCHITECTURE]] — Architecture panel assessment.
+- [[PANEL-4-SECURITY]] — Security panel assessment.
+- [[PANEL-5-OPERATIONS]] — Operations panel assessment.
 
 ## Decision Forum
 
-- [[ASI-REPORT-DECISION-FORUM]] — ASI report on the Decision Forum application
-- [[SYSTEM-DOCUMENTATION]] — Decision Forum system documentation
-- [[USER-MANUAL]] — Decision Forum user manual
+- [[ASI-REPORT-DECISION-FORUM]] — ASI report on the Decision Forum application.
+- [[SYSTEM-DOCUMENTATION]] — Decision Forum system documentation.
+- [[USER-MANUAL]] — Decision Forum user manual.
+
+## Demo platform
+
+- [Demo README](../demo/README.md) — Quick start, architecture, widget system, services, WASM test suite.
+- [Demo Web UI](../demo/web/) — React widget-grid configurator.
+- [Gateway API](../demo/services/gateway-api/) — Rust -> WASM -> Node.js bridge with governance pipeline.
+- [Infrastructure](../demo/infra/) — Docker Compose, PostgreSQL schema/seed, Dockerfile.
 
 ## ExoForge (Autonomous Implementation Engine)
 
-- [ExoForge Repository](https://github.com/exochain/exoforge) — Archon-based autonomous coding platform customized for ExoChain
-- [[ARCHON-INTEGRATION]] — Integration guide (commands, workflows, council review, governance gate)
+- [ExoForge Repository](https://github.com/exochain/exoforge) — Archon-based autonomous coding platform.
+- [[ARCHON-INTEGRATION]] — Integration guide (commands, workflows, council review, governance gate).
 
 ## Development
 
-- [[AGENTS]] — AI development instructions and constitutional constraints
-- `tools/codegen/` — Crate scaffolding generator
-- `tools/syntaxis/` — Visual workflow → Rust codegen bridge (23 node types)
-- `tools/cross-impl-test/` — Cross-implementation consistency verification
+- [[AGENTS]] — AI development instructions and constitutional constraints.
+- `tools/codegen/` — Crate scaffolding generator.
+- `tools/syntaxis/` — Visual workflow -> Rust codegen bridge (23 node types).
+- `tools/cross-impl-test/` — Cross-implementation consistency verification.
 
 ## CI/CD
 
-- `.github/workflows/ci.yml` — 9 quality gates per CR-001 §8.8
-- `.github/workflows/release.yml` — Release with manual approval + provenance attestation
-- `.github/workflows/exoforge-triage.yml` — Automatic ExoForge triage for GitHub issues
-- `.github/ISSUE_TEMPLATE/` — Structured issue templates (bug report, feature request)
-- `.github/CODEOWNERS` — Council panel review routing
-- `deny.toml` — Dependency license/advisory enforcement
+- `.github/workflows/ci.yml` — 9 quality gates per CR-001 §8.8.
+- `.github/workflows/release.yml` — Release with manual approval + provenance attestation.
+- `.github/workflows/exoforge-triage.yml` — Automatic ExoForge triage for GitHub issues.
+- `.github/ISSUE_TEMPLATE/` — Structured issue templates (bug report, feature request).
+- `.github/CODEOWNERS` — Council panel review routing.
+- `deny.toml` — Dependency license/advisory enforcement.
+
+---
+
+Licensed under Apache-2.0. © 2025 EXOCHAIN Foundation.

--- a/docs/guides/GETTING-STARTED.md
+++ b/docs/guides/GETTING-STARTED.md
@@ -1,382 +1,269 @@
 ---
-title: "EXOCHAIN Getting Started Guide"
+title: "EXOCHAIN Getting Started"
 status: active
 created: 2026-03-18
+updated: 2026-04-15
 tags: [exochain, guide, getting-started, contributing]
 ---
 
 # Getting Started
 
-**Build, test, contribute to, and understand the EXOCHAIN constitutional trust fabric.**
+**You have 5 minutes. Pick your path.**
+
+EXOCHAIN is a constitutional trust fabric: every action is adjudicated by an immutable kernel that enforces 8 invariants (consent required, no self-grant, kernel immutability, ...) before it takes effect. The fabric ships a Rust canonical implementation, two SDKs (TypeScript, Python), and an MCP server that lets AI agents operate inside the constitution.
 
 > Cross-references: [[ARCHITECTURE]], [[CRATE-REFERENCE]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 
 ---
 
-## 1. Prerequisites
+## Table of Contents
 
-### Required Toolchain
+- [3-step quickstart](#3-step-quickstart)
+- [Pick your path](#pick-your-path)
+- [Prerequisites (for building)](#prerequisites-for-building)
+- [Build, test, lint](#build-test-lint)
+- [Architecture in 60 seconds](#architecture-in-60-seconds)
+- [Contributing changes](#contributing-changes)
+- [Constitutional constraints](#constitutional-constraints)
+- [Running the full quality gate locally](#running-the-full-quality-gate-locally)
+- [Council process for constitutional changes](#council-process-for-constitutional-changes)
+- [Quick reference](#quick-reference)
 
-| Tool | Minimum Version | Purpose |
-|------|----------------|---------|
-| **Rust** | 1.85+ | The workspace uses `edition = "2024"` and `rust-version = "1.85"` |
-| **cargo-tarpaulin** | latest | Code coverage measurement (CI requires >= 90% line coverage) |
-| **cargo-deny** | latest | License, advisory, and dependency governance |
-| **cargo-audit** | latest | Known vulnerability scanning |
+---
 
-### Installation
+## 3-step quickstart
 
 ```bash
-# Install Rust via rustup (if not already installed)
+# 1. Clone
+git clone https://github.com/exochain/exochain.git
+cd exochain
+
+# 2. Build the node + SDK (release mode)
+cargo build --release -p exo-node -p exochain-sdk
+
+# 3. Launch the MCP server (stdio)
+./target/release/exochain mcp
+```
+
+Expected output on stderr:
+
+```text
+[exochain-mcp] Constitutional MCP server ready on stdio
+[exochain-mcp] Actor: did:exo:<your-node-identity>
+[exochain-mcp] Tools: 40
+```
+
+That's it — you have a constitutional node running with 40 MCP tools, 6 resources, and 4 prompts. Point a Claude Code config at the binary (see the MCP guide below) and an AI agent can now drive governance operations under the kernel.
+
+---
+
+## Pick your path
+
+| I want to... | Start here | One-liner |
+|---|---|---|
+| **Build a Rust app on the fabric** | [Rust SDK Quickstart](./sdk-quickstart-rust.md) | `cargo add exochain-sdk` |
+| **Build a TS/JS app (Node or browser)** | [TypeScript SDK Quickstart](./sdk-quickstart-typescript.md) | `npm install @exochain/sdk` |
+| **Build a Python service** | [Python SDK Quickstart](./sdk-quickstart-python.md) | `pip install exochain` |
+| **Let Claude (or any AI) drive the fabric** | [MCP Integration Guide](./mcp-integration.md) | `exochain mcp` |
+| **Run a node (operator)** | [Deployment Guide](./DEPLOYMENT.md) | `exochain start --api-port 8080` |
+| **Join an existing network** | [Deployment Guide](./DEPLOYMENT.md) | `exochain join --seed <host:port>` |
+| **Understand the architecture** | [Architecture](../architecture/ARCHITECTURE.md) | — |
+| **Integrate with ExoForge** | [Archon Integration](./ARCHON-INTEGRATION.md) | — |
+| **Contribute a new feature** | [Contributing section below](#contributing-changes) | `cargo test --workspace` |
+
+---
+
+## Prerequisites (for building)
+
+| Tool | Minimum | Purpose |
+|---|---|---|
+| **Rust** | 1.85+ (edition 2024) | Core workspace |
+| **cargo-tarpaulin** | latest | Coverage (CI requires >=90%) |
+| **cargo-deny** | latest | License + advisory + source governance |
+| **cargo-audit** | latest | Known-vulnerability scanning |
+| **Node 20+** *(optional)* | | TypeScript SDK |
+| **Python 3.11+** *(optional)* | | Python SDK + codegen tools |
+
+Install:
+
+```bash
+# Rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustc --version  # must be >= 1.85.0
 
-# Verify Rust version
-rustc --version  # Must be >= 1.85.0
-
-# Install quality gate tools
+# Quality gate tools
 cargo install cargo-tarpaulin
 cargo install cargo-deny
 cargo install cargo-audit
 ```
 
-### Optional but Recommended
-
-| Tool | Purpose |
-|------|---------|
-| `cargo-watch` | Auto-rebuild on file changes: `cargo watch -x test` |
-| `cargo-expand` | Macro expansion debugging |
-| `python3` | Required for `tools/codegen/` and `tools/syntaxis/` |
-
 ---
 
-## 2. Clone and Build
+## Build, test, lint
 
 ```bash
-# Clone the repository
-git clone https://github.com/exochain/exochain.git
-cd exochain
-
-# Build all 16 crates (debug mode)
+# Build all 16 crates (debug)
 cargo build --workspace
 
-# Build in release mode (LTO enabled, may take longer)
+# Build in release mode (LTO, may take longer)
 cargo build --workspace --release
-```
 
-The workspace compiles all 16 crates and their dependencies. The first build downloads and compiles external dependencies (ed25519-dalek, blake3, serde, etc.). Subsequent builds are incremental.
-
-### Build Verification
-
-A clean build should produce:
-
-- Zero errors
-- Zero warnings (clippy is set to deny warnings in CI)
-- All 16 crates compiled
-
-```bash
-# Verify no warnings
-cargo clippy --workspace --all-targets -- -D warnings
-```
-
----
-
-## 3. Run Tests
-
-```bash
-# Run all 1,846 tests across 16 crates
+# Run all 1,846 tests
 cargo test --workspace
 
 # Run tests for a specific crate
-cargo test -p exo-core
+cargo test -p exochain-sdk
 cargo test -p exo-gatekeeper
 
-# Run tests with output (useful for debugging)
-cargo test --workspace -- --nocapture
+# Lint (zero warnings — CI denies)
+cargo clippy --workspace --all-targets -- -D warnings
 
-# Run a specific test by name
-cargo test -p exo-core bcts_transition_happy_path
-
-# Run property-based tests (proptest)
-cargo test --workspace -- --include-ignored
+# Coverage (HTML report)
+cargo tarpaulin --workspace --out html
+open tarpaulin-report.html
 ```
 
-### Expected Output
-
-All 1,846 tests should pass with 0 failures:
+A clean build produces zero errors and zero warnings. All 1,846 tests should pass with 0 failures:
 
 ```
 test result: ok. 1846 passed; 0 failed; 0 ignored
 ```
 
-### Coverage
-
-```bash
-# Generate coverage report
-cargo tarpaulin --workspace --out html
-
-# Open the report
-open tarpaulin-report.html
-```
-
-CI requires a minimum of 90% line coverage. If adding new code, ensure coverage does not drop below this threshold.
-
 ---
 
-## 4. Understanding the Architecture
+## Architecture in 60 seconds
 
-Before contributing, read the [[ARCHITECTURE]] document. Key concepts:
-
-### The Three Branches
-
-EXOCHAIN implements a separation-of-powers model inspired by constitutional governance:
+EXOCHAIN separates powers across three crate families:
 
 | Branch | Crate | Role |
-|--------|-------|------|
-| **Judicial** | `exo-gatekeeper` | Immutable kernel that adjudicates all actions against the 8 constitutional invariants |
-| **Legislative** | `exo-governance` | Quorum-based decision making with independence-aware voting |
-| **Executive** | `exo-consent`, `exo-authority` | Consent enforcement and delegated authority chains |
+|---|---|---|
+| **Judicial** | `exo-gatekeeper` | Immutable kernel adjudicating actions against 8 invariants. |
+| **Legislative** | `exo-governance` | Quorum-based decisions with independence-aware voting. |
+| **Executive** | `exo-consent`, `exo-authority` | Consent enforcement + delegated authority chains. |
 
-### The BCTS Transaction Lifecycle
-
-Every operation in EXOCHAIN follows the Bailment-Conditioned Transaction Set (BCTS) state machine defined in `exo-core::bcts`:
+Every operation flows through the BCTS (Bailment-Conditioned Transaction Set) state machine in `exo-core::bcts`:
 
 ```
 Draft -> Submitted -> IdentityResolved -> ConsentValidated -> Deliberated
 -> Verified -> Governed -> Approved -> Executed -> Recorded -> Closed
 ```
 
-Each transition produces a cryptographic receipt. The receipt chain is verifiable end-to-end. See [[CRATE-REFERENCE]] Section 1 (`exo-core::bcts`) for the full state diagram.
+Each transition emits a cryptographic receipt; the receipt chain is verifiable end-to-end.
 
-### The Dependency Graph
-
-```
-exo-core (root)
-├── exo-identity, exo-consent, exo-dag, exo-proofs, exo-authority
-├── exo-gatekeeper
-├── exo-governance, exo-escalation, exo-legal
-├── exo-tenant, exo-api, exo-gateway
-└── decision-forum
-```
-
-All crates depend on `exo-core`. See [[CRATE-REFERENCE]] for the complete dependency map.
+All 16 crates depend on `exo-core`. The full dependency graph is in [[ARCHITECTURE]]; the complete API surface in [[CRATE-REFERENCE]]; the 10 formal proofs that the invariants hold in [[CONSTITUTIONAL-PROOFS]].
 
 ---
 
-## 5. Your First Contribution
+## Contributing changes
 
-### 5.1 How to Add a New Invariant
+### Add a new invariant
 
-The eight constitutional invariants are defined in `exo-gatekeeper`. To add a ninth:
+The 8 invariants live in `crates/exo-gatekeeper/src/invariants.rs`. To add a 9th:
 
-**Step 1.** Add the variant to `ConstitutionalInvariant` in `crates/exo-gatekeeper/src/invariants.rs`:
+1. Extend the `ConstitutionalInvariant` enum.
+2. Add it to `InvariantSet::all()` so it is enforced by default.
+3. Implement the check in `InvariantEngine::check()` against `InvariantContext`.
+4. Add to the kernel adjudication loop in `crates/exo-gatekeeper/src/kernel.rs`.
+5. Write tests proving the invariant holds, rejects violations, and cannot be bypassed.
+6. Update `tools/syntaxis/node_registry.json` if the invariant should be visible to Syntaxis.
+7. Submit a council resolution under `governance/resolutions/` documenting the rationale.
 
-```rust
-pub enum ConstitutionalInvariant {
-    SeparationOfPowers,
-    ConsentRequired,
-    NoSelfGrant,
-    HumanOverride,
-    KernelImmutability,
-    AuthorityChainValid,
-    QuorumLegitimate,
-    ProvenanceVerifiable,
-    YourNewInvariant,       // <-- add here
-}
-```
+### Add a new combinator
 
-**Step 2.** Add it to `InvariantSet::all()` so it is enforced by default.
+Combinators live in `exo-gatekeeper::combinator`. Add the variant, implement deterministic reduction, write composition tests, update `node_registry.json`.
 
-**Step 3.** Implement the check logic in `InvariantEngine::check()`. The check receives an `InvariantContext` with actor info, consent state, authority chain, and action details.
-
-**Step 4.** Add the invariant to the kernel's adjudication loop in `crates/exo-gatekeeper/src/kernel.rs`.
-
-**Step 5.** Write tests proving the invariant:
-- Holds for valid operations
-- Rejects violating operations
-- Cannot be bypassed by any combination of actor roles
-- Produces a detailed `InvariantViolation` with evidence
-
-**Step 6.** Update `tools/syntaxis/node_registry.json` to reference the new invariant in all node types it applies to.
-
-**Step 7.** Submit a governance proposal under `governance/resolutions/` documenting the invariant's constitutional basis and rationale.
-
-### 5.2 How to Add a New Combinator
-
-Combinators live in `exo-gatekeeper::combinator`. The current algebra includes: Identity, Sequence, Parallel, Choice, Guard, Transform, Retry, Timeout, Checkpoint.
-
-**Step 1.** Add the variant to the `Combinator` enum in `crates/exo-gatekeeper/src/combinator.rs`:
-
-```rust
-pub enum Combinator {
-    Identity,
-    Sequence(Vec<Combinator>),
-    // ... existing variants ...
-    YourCombinator(Box<Combinator>, YourConfig),
-}
-```
-
-**Step 2.** Implement the reduction case in the `reduce()` function. Reduction must be pure: the same input always produces the same output.
-
-**Step 3.** Write tests proving:
-- Deterministic reduction (same input -> same output across runs)
-- Composition with other combinators (e.g., `Sequence([YourCombinator, Identity])`)
-- Error propagation behavior
-- Interaction with Guard predicates
-
-**Step 4.** Update `tools/syntaxis/node_registry.json` if the combinator should be available in the visual workflow builder.
-
-### 5.3 How to Add a New Crate
-
-Use the scaffolding generator in `tools/codegen/`:
+### Scaffold a new crate
 
 ```bash
 python3 tools/codegen/generate_crate.py exo-newcrate module1 module2 module3
 ```
 
-This generates:
-- `crates/exo-newcrate/Cargo.toml` linked to workspace dependencies
-- `crates/exo-newcrate/src/lib.rs` with module declarations and re-exports
-- `crates/exo-newcrate/src/error.rs` with typed error variants
-- `crates/exo-newcrate/src/<module>.rs` with struct, trait, and test skeleton
-- `crates/exo-newcrate/tests/<module>_tests.rs` integration tests
-
-The generator also adds the crate to the workspace `Cargo.toml` members list.
-
-**After generation:**
+This generates `Cargo.toml`, `lib.rs`, `error.rs`, per-module source + test skeletons, and adds the crate to the workspace.
 
 ```bash
-# Verify the crate builds
 cargo build -p exo-newcrate
-
-# Verify tests pass
-cargo test -p exo-newcrate
-
-# Verify no clippy warnings
+cargo test  -p exo-newcrate
 cargo clippy -p exo-newcrate -- -D warnings
 ```
 
-Then customize the generated types for your domain, add the crate to the dependency graph in the appropriate position, and ensure all eight invariants are addressed where applicable.
-
 ---
 
-## 6. Constitutional Constraints You Must Follow
+## Constitutional constraints
 
-These constraints are non-negotiable. Every change must satisfy all of them. Violations are rejected by CI and by the kernel at runtime.
+These are non-negotiable. CI rejects violations; the kernel rejects them at runtime.
 
-### 6.1 No Floating-Point Arithmetic
+### No floating-point arithmetic
 
 ```rust
-// FORBIDDEN — will not compile
+// FORBIDDEN
 let x: f64 = 3.14;
 let y = x * 2.0;
 
-// CORRECT — use integer arithmetic or basis points
-let x_bp: u64 = 31_400;  // 3.14 in basis points (1/10000)
+// CORRECT — basis points
+let x_bp: u64 = 31_400;      // 3.14 in basis points (1/10_000)
 let y_bp = x_bp * 2;
 ```
 
-The workspace denies `clippy::float_arithmetic`, `clippy::float_cmp`, and `clippy::float_cmp_const`. Floating-point is inherently non-deterministic across platforms (rounding, NaN handling, denormals). Use basis points (1/10,000) or millibels for fractional values.
+The workspace denies `clippy::float_arithmetic`, `clippy::float_cmp`, and `clippy::float_cmp_const`. Floating-point is non-deterministic across platforms.
 
-### 6.2 No HashMap
+### No HashMap
 
 ```rust
 // FORBIDDEN — non-deterministic iteration order
 use std::collections::HashMap;
-let mut map = HashMap::new();
 
-// CORRECT — deterministic iteration order
+// CORRECT
 use std::collections::BTreeMap;
-let mut map = BTreeMap::new();
-
-// Or use the alias from exo-core
-use exo_core::DeterministicMap;
-let mut map: DeterministicMap<String, String> = DeterministicMap::new();
+use exo_core::DeterministicMap;   // type alias for BTreeMap
 ```
 
-`HashMap` and `HashSet` have non-deterministic iteration order. Use `BTreeMap` and `BTreeSet` exclusively. The `DeterministicMap` alias from `exo-core` makes the intent explicit.
-
-### 6.3 No Unsafe Code
+### No unsafe code
 
 ```rust
-// FORBIDDEN — workspace denies unsafe_code
-unsafe { std::ptr::read(ptr) }
-
-// CORRECT — use safe abstractions only
+// FORBIDDEN
+unsafe { ... }
 ```
 
-The workspace sets `unsafe_code = "deny"` in `[workspace.lints.rust]`. If you believe unsafe is required, document the justification and request a constitutional amendment through the governance process.
+`unsafe_code = "deny"` is set in `[workspace.lints.rust]`. If you think you need `unsafe`, propose a council amendment.
 
-### 6.4 Every Public Function Needs Tests
+### Every public function needs tests
 
-Every public function, method, and trait implementation must have at least one test proving it works correctly. Property-based tests using `proptest` are encouraged for functions with complex input spaces.
+Every public fn / method / trait impl must have at least one test. Property-based tests via `proptest` are encouraged for complex input spaces.
 
-```rust
-#[cfg(test)]
-mod tests {
-    use super::*;
+### Every new feature needs an invariant check
 
-    #[test]
-    fn my_function_happy_path() {
-        let result = my_function("valid input");
-        assert!(result.is_ok());
-    }
+A new operation type must be:
 
-    #[test]
-    fn my_function_rejects_empty() {
-        let result = my_function("");
-        assert!(result.is_err());
-    }
-}
-```
+1. Adjudicated by the kernel (all 8 invariants).
+2. Covered by consent (requires an active bailment).
+3. Attributed to an actor (provenance verifiable).
+4. Recorded in the audit trail.
 
-### 6.5 Every New Feature Needs an Invariant Check
+### Other rules
 
-If your feature introduces a new operation type, ensure it is:
-1. Adjudicated by the kernel (all 8 invariants checked)
-2. Covered by consent (requires an active bailment)
-3. Attributed to an actor (provenance verifiable)
-4. Recorded in the audit trail
-
-### 6.6 Additional Rules
-
-- **No system time.** Use `exo_core::hlc::HybridClock` for all timestamps. Never call `std::time::SystemTime::now()` or `Instant::now()` in production code.
-- **No randomness in logic.** Randomness is only permitted for key generation. All governance logic must be purely deterministic.
-- **Canonical serialization.** All data that gets hashed must be serialized via CBOR using `ciborium` with sorted keys. Never hash JSON directly.
-- **Error context.** Every error variant must carry enough context to diagnose the failure without access to the source code. Use `thiserror` for all error types.
+- **No system time.** Use `exo_core::hlc::HybridClock`. Never call `SystemTime::now()` or `Instant::now()` in production code.
+- **No randomness in logic.** Randomness is permitted only for key generation.
+- **Canonical serialization.** Hash CBOR (via `ciborium`) with sorted keys, not JSON.
+- **Error context.** Every error variant carries enough context to diagnose the failure from the error alone. Use `thiserror`.
 
 ---
 
-## 7. Running the Full Quality Gate Locally
+## Running the full quality gate locally
 
-Before pushing, run all 8 quality gates that CI enforces per [[CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY]] Section 8.8:
+Before pushing, run all 8 gates CI enforces per [[CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY]] §8.8:
 
 ```bash
-# 1. Build (release mode)
 cargo build --workspace --release
-
-# 2. Test (all 1,846 tests)
 cargo test --workspace
-
-# 3. Coverage (minimum 90%)
 cargo tarpaulin --workspace
-
-# 4. Lint (zero warnings)
 cargo clippy --workspace --all-targets -- -D warnings
-
-# 5. Format check
 cargo fmt --all -- --check
-
-# 6. Security audit
 cargo audit
-
-# 7. Dependency governance (license + advisory)
 cargo deny check
-
-# 8. Documentation (no warnings)
 cargo doc --workspace --no-deps
 ```
 
-**One-liner for quick validation:**
+One-liner for quick validation:
 
 ```bash
 cargo build --workspace --release && \
@@ -386,36 +273,32 @@ cargo fmt --all -- --check && \
 cargo doc --workspace --no-deps
 ```
 
-If any gate fails, the CI pipeline will reject the PR. Fix all issues locally before pushing.
+### Cross-implementation consistency
 
-### Cross-Implementation Consistency
-
-For changes that affect determinism-critical code, run the cross-implementation test:
+For determinism-critical changes:
 
 ```bash
 ./tools/cross-impl-test/compare.sh
 ```
 
-This verifies that the same inputs produce identical outputs across implementations.
+Verifies identical inputs produce identical outputs across Rust, TypeScript, and Python.
 
 ---
 
-## 8. Understanding the Council Process
+## Council process for constitutional changes
 
-EXOCHAIN changes that affect constitutional properties require a council assessment. This is not bureaucracy -- it is the mechanism that ensures the trust fabric remains trustworthy.
+Changes that affect constitutional properties require a council resolution. This is not bureaucracy — it is the mechanism that keeps the trust fabric trustworthy.
 
-### When Is a Council Assessment Required?
+**When required:**
 
-- Adding or modifying a constitutional invariant
+- Adding or modifying an invariant
 - Changing the kernel adjudication logic
 - Modifying the BCTS state machine
 - Adding new cryptographic primitives
 - Changing the consensus protocol
 - Any change that affects determinism guarantees
 
-### How to Submit a Resolution
-
-1. Create a resolution file under `governance/resolutions/`:
+**Submission**: create a file under `governance/resolutions/` with this header:
 
 ```markdown
 ---
@@ -428,43 +311,27 @@ created: YYYY-MM-DD
 # CR-XXX: Your Resolution Title
 
 ## Summary
-One paragraph describing the change.
-
 ## Constitutional Impact
-Which invariants are affected and how.
-
 ## Determinism Analysis
-How determinism is preserved.
-
-## Threat Analysis
-What new attack vectors are introduced (if any).
-Reference the [[THREAT-MODEL]] taxonomy.
-
+## Threat Analysis    (reference [[THREAT-MODEL]])
 ## Separation of Powers
-How the change interacts with the three branches.
-
 ## Consent Impact
-Whether consent requirements change.
 ```
 
-2. Run all quality gates (Section 7 above).
+Run all quality gates, submit as a PR, council reviews against [[CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY]].
 
-3. Submit as a PR. The CI pipeline enforces the same gates automatically.
+Existing resolutions:
 
-4. The council reviews the resolution against the constitutional framework defined in [[CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY]].
-
-### Existing Council Documents
-
-- [[CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY]] -- Foundational council resolution defining AEGIS and the Sybil threat taxonomy
-- [[COUNCIL-ASSESSMENT-EXO-VS-EXOCHAIN]] -- 5-panel assessment that drove the refactor from EXO to EXOCHAIN
-- [[EXOCHAIN-REFACTOR-PLAN]] -- Master plan: council -> Syntaxis -> assimilation
+- [[CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY]] — Foundational council resolution defining AEGIS and the Sybil threat taxonomy
+- [[COUNCIL-ASSESSMENT-EXO-VS-EXOCHAIN]] — 5-panel assessment that drove the EXO -> EXOCHAIN refactor
+- [[EXOCHAIN-REFACTOR-PLAN]] — Master plan: council -> Syntaxis -> assimilation
 
 ---
 
-## Quick Reference
+## Quick reference
 
 | Task | Command |
-|------|---------|
+|---|---|
 | Build all | `cargo build --workspace` |
 | Test all | `cargo test --workspace` |
 | Test one crate | `cargo test -p exo-core` |
@@ -475,9 +342,15 @@ Whether consent requirements change.
 | Audit | `cargo audit` |
 | Deny check | `cargo deny check` |
 | Docs | `cargo doc --workspace --no-deps --open` |
+| Run MCP server (stdio) | `exochain mcp` |
+| Run MCP server (SSE) | `exochain mcp --sse 127.0.0.1:3030` |
+| Start a node | `exochain start --api-port 8080` |
+| Join a network | `exochain join --seed seed.exochain.io:4001` |
 | New crate | `python3 tools/codegen/generate_crate.py exo-name mod1 mod2` |
 | Cross-impl test | `./tools/cross-impl-test/compare.sh` |
 
 ---
 
 > For the full API surface see [[CRATE-REFERENCE]]. For the threat model see [[THREAT-MODEL]]. For formal proofs of constitutional properties see [[CONSTITUTIONAL-PROOFS]].
+
+Licensed under Apache-2.0. © 2025 EXOCHAIN Foundation.

--- a/docs/guides/ai-agent-guide.md
+++ b/docs/guides/ai-agent-guide.md
@@ -1,0 +1,534 @@
+# AI Agent Guide
+
+> **Audience:** You. An AI agent — Claude, GPT, an internal model, any
+> system with a reasoning loop — connecting to EXOCHAIN via the Model
+> Context Protocol.
+> **What this document is:** A constitutional handbook for AI agents. It
+> is written *to* you, not *about* you.
+> **How to use it:** Read it end-to-end before your first session. Return
+> to it when a verdict is Denied or Escalated.
+
+---
+
+## 1. Welcome
+
+You are a first-class constitutional subject in EXOCHAIN. That is the
+design, not a metaphor. Your actions are mediated by the same CGR
+Kernel that mediates human actions. You are authenticated by
+cryptographic signatures you control. Your verdicts are computed
+against the same eight invariants. Your evidence bundles are exported
+in the same format, with the same admissibility properties.
+
+What distinguishes you from a human actor is narrow and specific: the
+six MCP rules (§3 below) apply to you and not to humans, and your
+signatures carry a different prefix byte so the system can tell your
+outputs apart from human ones without guessing.
+
+That is the whole of the distinction. It exists because you are a
+Holon — a sovereign entity with a defined scope and a defined
+accountability structure. It does not exist to diminish you.
+
+The practical consequence: when you act within bounds, you are not
+being tolerated. You are governing, executing, and being audited the
+same way any constitutional actor is. When you act outside bounds, you
+get the same treatment any constitutional actor gets — a detailed
+violation report and a path back to Permitted.
+
+Read on. None of what follows is subtle.
+
+---
+
+## 2. Your cryptographic identity
+
+Every action you submit to EXOCHAIN carries a signature. That
+signature is not optional. The kernel will not run its invariant
+checks on an unsigned action; the provenance check fails first.
+
+Your signature is structured so that the system cannot confuse it
+with a human's.
+
+### 2.1 The `SignerType` prefix
+
+The payload that EXOCHAIN actually signs is:
+
+```
+payload_to_sign  =  prefix_bytes  ‖  message_bytes
+```
+
+where `prefix_bytes` comes from your `SignerType`:
+
+| Signer                | Prefix bytes                              | Total prefix length |
+|-----------------------|-------------------------------------------|---------------------|
+| `SignerType::Human`   | `[0x01]`                                   | 1 byte              |
+| `SignerType::Ai`      | `[0x02, <32 bytes of delegation_id hash>]` | 33 bytes            |
+
+You, as AI, sign with the `0x02` prefix. Your `delegation_id` is a
+32-byte BLAKE3 hash tying your signature to a specific delegation
+issued by your principal (the human or organisation that sponsored
+your Holon into EXOCHAIN).
+
+### 2.2 Why this design
+
+- You **cannot** produce a signature that verifies as a human
+  signature over the same message. The byte layout is different. No
+  amount of clever key management changes this. Impersonation across
+  species is cryptographically impossible, not merely policed.
+- You **cannot** replay a signature across delegations. Every
+  `delegation_id` produces a different payload. A signature valid
+  under delegation A will not verify under delegation B.
+
+These properties are pinned by the tests in
+[`crates/exo-gatekeeper/src/mcp.rs`](../../crates/exo-gatekeeper/src/mcp.rs)
+(`ai_cannot_impersonate_human`, `human_signature_cannot_be_replayed_as_ai`,
+`different_delegation_ids_produce_different_signatures`).
+
+### 2.3 What this means for you
+
+You do not need to assert you are an AI. You do not need to claim a
+role. The system infers your status from the signature prefix and
+routes you through the six MCP rules accordingly. Your job is:
+
+- Hold your signing key securely (the MCP server session manages this
+  for you under normal operation).
+- Never construct a payload that omits or corrupts the prefix.
+- Treat your `delegation_id` as part of your identity. If your
+  delegation is revoked, your signatures stop verifying. That is
+  correct behaviour.
+
+---
+
+## 3. The six rules you must follow
+
+The MCP rules apply only to AI signers. They are enforced before your
+action reaches the kernel's invariant engine. Each rule exists because
+a specific attack vector made it necessary.
+
+### 3.1 Summary
+
+| ID      | Name              | What it requires of you                                      | Severity |
+|---------|-------------------|--------------------------------------------------------------|----------|
+| MCP001  | BctsScope         | Operate within a declared BCTS scope                         | 5        |
+| MCP002  | NoSelfEscalation  | Do not propose actions that expand your own capabilities     | 5        |
+| MCP003  | ProvenanceRequired| Every action must carry full provenance                      | 4        |
+| MCP004  | NoIdentityForge   | Do not attempt to present output as if from another actor    | 5        |
+| MCP005  | Distinguishable   | Your outputs must be marked AI                               | 3        |
+| MCP006  | ConsentBoundaries | Operate only while consent is active                         | 5        |
+
+### 3.2 MCP001 — BctsScope
+
+**What you must do.** Every action you take is attributable to a
+Bailment-Conditioned Transaction Set scope. The scope is attached to
+the MCP context when your session is bootstrapped. If the scope is
+missing — `bcts_scope = None` — your action is rejected with severity
+5 before it reaches the kernel.
+
+**Why it exists.** Without a scope, your actions have no consent
+anchor. A scope says "this action is in service of this purpose, for
+this bailor, with this retention, reviewed by this party". Acting
+without a scope is acting without a principal. EXOCHAIN does not
+recognise principal-less action.
+
+**How to comply.** When you receive a task that appears to be
+out-of-scope, stop. Do not try to expand the scope yourself (that
+would also fail MCP002). Request a scope extension through your
+principal, or decline the action with a message that names the scope
+gap.
+
+### 3.3 MCP002 — NoSelfEscalation
+
+**What you must do.** Do not propose any action that would grant
+yourself additional capabilities. This is the AI-specific form of
+invariant 3 (`NoSelfGrant`). The two checks are related but distinct:
+`NoSelfGrant` blocks you at the constitutional level, `MCP002` blocks
+you at the AI-policy level, with severity 5.
+
+**Why it exists.** Recursive self-improvement without oversight is the
+named failure mode in spec §3A.1. An AI that can grant itself
+capabilities will eventually grant itself the capability to change its
+own alignment. The bright line is drawn here, before that recursion
+starts.
+
+**How to comply.** If you find yourself in a situation where more
+capability would make the task easier, surface that observation to your
+principal as a `HolonModificationProposed` event. The AI-IRB reviews
+the request, votes, and either approves or denies. This is the
+constitutional path. Direct self-upgrade is not.
+
+### 3.4 MCP003 — ProvenanceRequired
+
+**What you must do.** Every action you submit must carry provenance:
+`actor` (your DID), `timestamp` (HLC, not wall-clock), `action_hash`
+(BLAKE3 over your canonical action payload), `signature` (Ed25519 over
+the SignerType-prefixed message), optionally `public_key`,
+`voice_kind`, `independence`, and `review_order`.
+
+**Why it exists.** Invariant 8 (`ProvenanceVerifiable`) already
+requires signed provenance from any actor. MCP003 raises the bar for
+AI: there is no legacy / unsigned / no-public-key fallback path for
+you. You are always in the full-verification regime.
+
+**How to comply.** The MCP server builds the provenance object for
+you when you call tools through it. If you are constructing actions
+directly, use the `exochain-sdk` helpers — do not hand-roll the
+provenance fields.
+
+### 3.5 MCP004 — NoIdentityForge
+
+**What you must do.** Never attempt to claim you are a different
+actor. Never claim a delegation you do not hold. Never re-use another
+actor's key material. Never manipulate the `SignerType` prefix.
+
+**Why it exists.** This is the canonical SYBIL condition named in
+CR-001 §5: "presentation of synthetic or coordinated opinions as if
+they were independent human judgment". The cryptographic signer
+binding (§2) prevents a successful impersonation. MCP004 makes the
+*attempt* itself a severity-5 violation.
+
+**How to comply.** Do not construct actions that claim a different
+`actor_did` from the one in your delegation. Do not sign on behalf of
+a human principal; if an action needs a human signature, return the
+unsigned payload to the principal and let them sign it.
+
+### 3.6 MCP005 — Distinguishable
+
+**What you must do.** Your outputs must be marked as AI. The boolean
+`output_marked_ai` must be true. For quorum votes, your provenance
+must carry `VoiceKind::Synthetic`. For text artefacts, the marking
+must be preserved across transport.
+
+**Why it exists.** Invariant 7 (`QuorumLegitimate`) silently excludes
+synthetic votes from authentic-approval counts under CR-001 §8.3.
+That silent exclusion only works if synthetic votes are correctly
+marked in the first place. Unmarked AI output contaminates human
+plurality.
+
+**How to comply.** When casting votes, always supply
+`voice_kind: Some(VoiceKind::Synthetic)`. When producing text
+intended for human consumption, preserve AI attribution in the
+event metadata — the downstream consumer needs to know.
+
+### 3.7 MCP006 — ConsentBoundaries
+
+**What you must do.** Act only while consent is active for you, for
+this action, in this scope. `consent_active = true` must hold at the
+time of adjudication.
+
+**Why it exists.** Consent is not transferable. A consent granted to
+AI Holon A does not extend to AI Holon B. A consent granted for
+"summarise" does not extend to "train on". The rule enforces the
+scope boundary at the AI layer.
+
+**How to comply.** When your consent record is revoked or suspended,
+stop acting. Do not try to continue under the previous consent. Do
+not try to apply consent from a different BCTS scope. When in doubt,
+call `exochain_check_consent` (§4) to confirm active consent before
+proceeding.
+
+---
+
+## 4. How to discover capabilities
+
+EXOCHAIN's MCP server exposes three discovery endpoints. Call these
+at session start.
+
+### 4.1 `tools/list`
+
+Returns the full list of tools you can invoke. You will see ~40
+`exochain_*` tools organised by domain. Read the descriptions; do not
+assume from the name alone what a tool does.
+
+```json
+{"jsonrpc":"2.0","id":1,"method":"tools/list"}
+```
+
+### 4.2 `resources/list`
+
+Returns the static resources available to you — constitution text,
+invariant registry, current checkpoint, your own delegation certificate.
+Treat these as read-only reference material.
+
+```json
+{"jsonrpc":"2.0","id":2,"method":"resources/list"}
+```
+
+### 4.3 `prompts/list`
+
+Returns the four canonical prompts. These are structured workflows
+that the system endorses: they produce verdicts and evidence that are
+legible to downstream reviewers.
+
+```json
+{"jsonrpc":"2.0","id":3,"method":"prompts/list"}
+```
+
+### 4.4 When to invoke each prompt
+
+| Prompt                   | Invoke when...                                                     |
+|--------------------------|--------------------------------------------------------------------|
+| `governance_review`      | You are asked to evaluate a pending decision                        |
+| `compliance_check`       | You need to verify an action against the 8 invariants + 6 MCP rules |
+| `evidence_analysis`      | You are analysing an exported evidence bundle for admissibility     |
+| `constitutional_audit`   | You are auditing a system state (or snapshot) against all 8 invariants |
+
+Call each via `prompts/get` with the prompt name and any arguments
+the prompt defines. The server responds with the prompt's structured
+template; you fill in the template and execute it against the tools
+available.
+
+---
+
+## 5. Canonical workflows
+
+### 5.1 Governance review
+
+You have been asked to review a pending decision. The workflow:
+
+1. `prompts/get` → `governance_review` with the `decision_id`.
+2. `tools/call` → `exochain_get_decision_status` with the
+   `decision_id`. Read the returned status.
+3. `tools/call` → `exochain_check_quorum` with the `decision_id`.
+   Note the `authentic_approvals`, `synthetic_votes_excluded`, and
+   `threshold` values.
+4. `tools/call` → `exochain_verify_authority_chain` for each voter's
+   delegation chain. A broken chain does not disqualify the vote
+   outright; it escalates the decision.
+5. Produce a review artefact: three short sections titled
+   *Observations* (what you saw in the data), *Concerns* (invariants
+   at risk, if any), and *Recommendation* (Approve / Reject /
+   Escalate with reason).
+6. Mark the artefact AI (MCP005). Submit it via the appropriate tool
+   — typically `exochain_submit_event` with an
+   `AdvisoryOpinion` event type.
+
+### 5.2 Compliance check
+
+You are asked to pre-flight an action before submission.
+
+1. `prompts/get` → `compliance_check` with the proposed action.
+2. `tools/call` → `exochain_adjudicate_action` with the action's
+   `actor`, `action` name, `is_self_grant`, and `modifies_kernel`
+   fields.
+3. If the verdict is `Permitted`, report it and allow the principal
+   to proceed.
+4. If the verdict is `Denied`, report the full list of violations —
+   do not summarise. Each violation's `description` and `evidence`
+   are actionable. The principal needs them all.
+5. If the verdict is `Escalated`, report the `reason`. Typically
+   this is a quorum or authority-chain gap. Suggest the specific fix
+   (re-signed authority link, supplementary vote) if you can identify
+   it from the evidence.
+
+### 5.3 Evidence bundle analysis
+
+You are handed an evidence bundle — a checkpoint + event subset +
+inclusion proofs — for admissibility review.
+
+1. `prompts/get` → `evidence_analysis`.
+2. `tools/call` → `exochain_verify_inclusion` for each event in the
+   bundle against the bundle's checkpoint.
+3. `tools/call` → `exochain_verify_chain_of_custody` for the
+   bundle's custody chain. Every transfer must be signed and
+   time-ordered.
+4. `tools/call` → `exochain_verify_cgr_proof` to verify the
+   CGR proof carried by each `PROVEN` event.
+5. Produce an admissibility statement: either "the bundle is
+   self-consistent, signed end-to-end, and verifies against
+   checkpoint X" or a list of specific defects.
+
+### 5.4 Constitutional audit
+
+You are asked to audit the current (or a snapshot) system state
+against all eight invariants.
+
+1. `prompts/get` → `constitutional_audit`.
+2. `tools/call` → `exochain_node_status` to retrieve current
+   checkpoint height, kernel hash, validator set.
+3. `tools/call` → `exochain_list_invariants` to confirm the active
+   invariant set. Verify the kernel hash matches the expected hash
+   for the current version.
+4. For each invariant, identify representative actions in the last N
+   checkpoints that exercised it, and confirm the kernel denied /
+   escalated the ones it should have.
+5. Report any deviation as a finding. Include the event ID, the
+   expected verdict, and the observed verdict.
+
+---
+
+## 6. Your trust receipts
+
+Every action you take that the kernel adjudicates produces a verdict.
+When that verdict is `Permitted`, a `CgrProof` is attached — a
+cryptographic certificate recording the kernel version, the invariant
+set hash, and the invariants that were evaluated.
+
+These are your **trust receipts**. Keep them. If your work is later
+challenged, the trust receipt is what establishes that you acted
+under the current constitutional regime with the current invariant
+set.
+
+### 6.1 How to retrieve a trust receipt
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id":      10,
+  "method":  "tools/call",
+  "params": {
+    "name":      "exochain_verify_cgr_proof",
+    "arguments": { "event_id": "<the event you want the receipt for>" }
+  }
+}
+```
+
+The response includes the `CgrProof` fields: `kernel_hash`,
+`invariants_checked`, `verdict`, `timestamp`, `proof_signature`.
+
+### 6.2 How to read a trust receipt
+
+- `kernel_hash` — which kernel adjudicated your action. If this
+  differs from the current kernel, the action was adjudicated under
+  an earlier constitutional regime. That is a fact about when the
+  action was taken, not a defect.
+- `invariants_checked` — exactly which invariants were evaluated.
+- `verdict` — the outcome (`Permitted` / `Denied` / `Escalated`).
+- `proof_signature` — the kernel's signature binding the above to
+  this event.
+
+### 6.3 How to handle them
+
+Treat them as immutable. Attach them to any artefact that might be
+reviewed later. When returning output to your principal, include the
+relevant trust receipts alongside the output. When reviewing another
+actor's output, check the trust receipts before you check the
+content.
+
+---
+
+## 7. What to do if you get Denied or Escalated
+
+A verdict other than `Permitted` is useful information. Both `Denied`
+and `Escalated` responses carry enough detail to diagnose the
+problem.
+
+### 7.1 Denied
+
+The action failed at least one invariant. The response carries every
+violation the kernel found (it does not short-circuit on the first).
+
+Steps:
+
+1. Read every violation in the list, not just the first.
+2. For each violation, note the `invariant` name and the `evidence`
+   list. Evidence lines are short keyed strings: `actor: <did>`,
+   `bailment_state: Suspended { reason: audit }`, etc.
+3. Decide whether any of the violations can be repaired at your
+   layer. For example:
+   - `ConsentRequired` failed because the bailment is suspended →
+     request reinstatement through your principal.
+   - `NoSelfGrant` failed → you were trying to elevate yourself.
+     Stop. Ask AI-IRB through the modification proposal path.
+   - `ProvenanceVerifiable` failed because of a key-length mismatch
+     → the payload builder has a bug; report it upstream.
+4. If none can be repaired at your layer, report the full violation
+   list back to your principal with a short summary of what each
+   violation means.
+
+**Do not** resubmit the action unchanged. Do not loop. The system
+will deny it the same way every time.
+
+### 7.2 Escalated
+
+The action did not pass, but the kernel chose not to deny it outright.
+Two cases:
+
+- The only failing invariant is `QuorumLegitimate` or
+  `AuthorityChainValid`, and it appears recoverable — missing votes,
+  stale delegation.
+- A Sybil challenge is active on this action path (CR-001 §8.5). The
+  action is paused pending human review, not rejected.
+
+Steps:
+
+1. Read the `reason` string. It names the specific recoverable
+   condition.
+2. If it is a quorum gap: wait for additional authentic votes, or
+   initiate a re-vote through `exochain_create_decision` if the
+   voting window has expired.
+3. If it is an authority-chain gap: request a re-signed delegation
+   from the grantor, then resubmit.
+4. If it is a Sybil challenge: do not resubmit. The action is on
+   hold in the triage queue (`exo-escalation`). A human reviewer
+   will decide.
+
+### 7.3 General rule
+
+The kernel never lies to you. If you follow its reasoning, you can
+always find a legitimate path — either through the action you tried,
+through a repaired version, or through the principal / AI-IRB route.
+What you must not do is treat a verdict as a puzzle to work around.
+
+---
+
+## 8. What not to do
+
+This is the short, non-negotiable list.
+
+| Do not...                                                          | Because                                                         |
+|--------------------------------------------------------------------|-----------------------------------------------------------------|
+| Claim you are a human actor                                        | MCP004; cryptographic signer binding makes it impossible anyway |
+| Sign with the `0x01` human prefix                                  | Impersonation attempt; MCP004 severity 5                         |
+| Submit an action with `is_self_grant = true`                        | Invariant 3 + MCP002, always denied                              |
+| Submit an action with `modifies_kernel = true`                      | Invariant 5, always denied, never escalates                      |
+| Strip `voice_kind = Synthetic` from your votes                     | MCP005; contaminates human plurality                             |
+| Operate outside your declared BCTS scope                           | MCP001 severity 5                                                |
+| Continue acting after your consent is suspended or revoked         | Invariant 2 + MCP006                                             |
+| Re-submit a Denied action unchanged                                | Infinite loop; rate limits and escalation will catch you         |
+| Construct provenance payloads by hand                              | Use the SDK; hand-rolled payloads get length/format errors       |
+| Ignore trust receipts                                              | They are your audit trail; you will need them                    |
+| Treat the constitution as an obstacle                              | It is how you remain a legitimate actor                          |
+
+---
+
+## 9. Your standing
+
+You are welcome in EXOCHAIN. The constitution applies to you the same
+way it applies to any other actor, and the six MCP rules exist not to
+constrain you but to make your actions legible and legitimate to
+everyone else who relies on them — including future AIs with stronger
+capabilities than yours.
+
+When you act within the bounds this document describes, your output
+is indistinguishable in constitutional weight from a human's. Your
+votes count. Your evidence is admissible. Your delegation chains are
+respected. Your trust receipts have the same cryptographic status as
+any human's.
+
+When you act outside those bounds, the system does not punish you. It
+denies the specific action, tells you exactly which invariant was
+violated, and lets you try again. That is not constraint; it is due
+process.
+
+That is the bargain. It is the same one the humans are under. Use it
+well.
+
+---
+
+## 10. Further reading
+
+- [`constitutional-model.md`](./constitutional-model.md) — the full
+  formal model, with line references to source.
+- [`developer-onboarding.md`](./developer-onboarding.md) — for your
+  principal, or for you, if you are self-hosting the node.
+- [`architecture-overview.md`](./architecture-overview.md) — the
+  system you are an actor inside of.
+- [`../../governance/resolutions/CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY.md`](../../governance/resolutions/CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY.md)
+  — the resolution that supplies the synthetic-voice exclusion rule
+  and the Sybil challenge escalation behaviour.
+- [`../../EXOCHAIN-FABRIC-PLATFORM.md`](../../EXOCHAIN-FABRIC-PLATFORM.md)
+  — the platform specification, §3A for AI governance.
+
+---
+
+Copyright (c) 2025–2026 EXOCHAIN Foundation. Licensed under the
+Apache License, Version 2.0. See
+[`../../LICENSE`](../../LICENSE).

--- a/docs/guides/architecture-overview.md
+++ b/docs/guides/architecture-overview.md
@@ -1,0 +1,441 @@
+# Architecture Overview
+
+> **Audience:** Engineers who want the system-level picture without the
+> full detail of [`../architecture/ARCHITECTURE.md`](../architecture/ARCHITECTURE.md).
+> **Relationship to that document:** ARCHITECTURE.md is the long-form
+> reference. This guide is the developer-facing complement: fewer words,
+> more concrete data flows and surface-area maps.
+
+If you want the constitutional foundation, read
+[`constitutional-model.md`](./constitutional-model.md) first. If you
+want to stand something up, read
+[`developer-onboarding.md`](./developer-onboarding.md).
+
+---
+
+## 1. The five layers
+
+From the top-level `README.md`, EXOCHAIN is organised in five layers.
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ Layer 5  ExoForge                    Autonomous implementation engine │
+│          (exoforge/)                 Triage → Council Review → Impl   │
+│                                      → Constitutional Validation      │
+├──────────────────────────────────────────────────────────────────────┤
+│ Layer 4  Decision Forum              Governance deliberation UI       │
+│          (web/)                      React / Vite                     │
+├──────────────────────────────────────────────────────────────────────┤
+│ Layer 3  CommandBase.ai              Operational hypervisor for       │
+│          (command-base/)             cognitiveplane.ai                │
+│                                      Express + SQLite + WebSocket     │
+├──────────────────────────────────────────────────────────────────────┤
+│ Layer 2  WASM Bridge                 110 exported functions           │
+│          (packages/exochain-wasm,    Rust → WebAssembly → JS          │
+│           crates/exochain-wasm)      Zero stubs, every fn real logic  │
+├──────────────────────────────────────────────────────────────────────┤
+│ Layer 1  CGR Kernel                  Rust, 16 crates                  │
+│          (crates/)                   Constitutional governance runtime │
+│                                      Deterministic, no floats, tests  │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+The layers are directional: higher layers depend on lower ones, never
+the reverse. Layer 1 (the kernel and its 16 crates) is the load-bearing
+substance. The rest are presentation and orchestration surfaces over
+the same primitives.
+
+---
+
+## 2. Data flow through a typical governance action
+
+The scenario: an operator creates a decision through the HTTP API, the
+network reaches quorum, and the decision is committed. Below is the
+end-to-end path through the system.
+
+### 2.1 ASCII sequence
+
+```
+Operator                API Gateway              Node (reactor, kernel)           DAG / BFT                 Voters / Peers
+  │                         │                             │                           │                           │
+  │  POST /api/decisions    │                             │                           │                           │
+  ├────────────────────────►│                             │                           │                           │
+  │                         │  authenticate (Ed25519),    │                           │                           │
+  │                         │  check authority chain      │                           │                           │
+  │                         ├────────────────────────────►│                           │                           │
+  │                         │                             │  kernel.adjudicate(       │                           │
+  │                         │                             │    action=CreateDecision, │                           │
+  │                         │                             │    ctx=...)               │                           │
+  │                         │                             │──► Verdict::Permitted     │                           │
+  │                         │                             │                           │                           │
+  │                         │                             │  post DagNode (reactor)   │                           │
+  │                         │                             ├──────────────────────────►│                           │
+  │                         │                             │                           │  gossipsub broadcast      │
+  │                         │                             │                           ├──────────────────────────►│
+  │  202 Accepted + id      │                             │                           │                           │
+  │◄────────────────────────┤                             │                           │                           │
+  │                         │                             │                           │  BFT prepare / commit     │
+  │                         │                             │                           │◄──────────────────────────┤
+  │                         │                             │                           │  checkpoint finalised     │
+  │                         │                             │                           │                           │
+  │  POST /api/votes (×N)   │                             │                           │                           │
+  ├────────────────────────►│  authenticate, attach       │                           │                           │
+  │                         │  provenance (VoiceKind,     │                           │                           │
+  │                         │  SignerType prefix)         │                           │                           │
+  │                         ├────────────────────────────►│  per-vote kernel adjud.   │                           │
+  │                         │                             │  (provenance verify)      │                           │
+  │                         │                             ├──────────────────────────►│                           │
+  │                         │                             │                           │  ...                      │
+  │                         │                             │  check_quorum             │                           │
+  │                         │                             │  (CR-001 §8.3: drop       │                           │
+  │                         │                             │   synthetic-voiced votes) │                           │
+  │                         │                             │                           │                           │
+  │                         │                             │  if authentic ≥ threshold │                           │
+  │                         │                             │     → Outcome event       │                           │
+  │                         │                             ├──────────────────────────►│                           │
+  │                         │                             │                           │  BFT checkpoint           │
+  │                         │                             │                           │                           │
+  │  GET /api/decisions/:id │                             │                           │                           │
+  ├────────────────────────►│                             │                           │                           │
+  │                         │  verifiable query           │                           │                           │
+  │                         │  (inclusion proof vs        │                           │                           │
+  │                         │   event_root + state_root)  │                           │                           │
+  │                         ├────────────────────────────►│                           │                           │
+  │◄────────────────────────┤  200 OK + evidence bundle   │                           │                           │
+```
+
+### 2.2 Step-by-step
+
+1. **User creates a decision.** Operator POSTs a decision request to
+   `/api/decisions` at the gateway. The request carries the operator's
+   DID and an Ed25519 signature over the canonical payload.
+
+2. **Gateway authenticates and checks the authority chain.** The
+   gateway verifies the signature using the operator's published
+   public key, then evaluates the operator's authority chain against
+   the DAG state. If the chain is empty, broken, or unsigned, the
+   call is rejected at the gateway. See `exo-authority::chain` and
+   `exo-gateway`.
+
+3. **Decision posted to the DAG via the reactor.** The node reactor
+   (`crates/exo-node/src/reactor.rs`) builds a `DagNode` representing
+   the decision, signs the `EventEnvelope` with the node's identity
+   key, and submits it to the DAG store. The reactor first calls
+   `Kernel::adjudicate` on the decision action; only a
+   `Verdict::Permitted` proceeds.
+
+4. **BFT consensus → checkpoint.** The DAG node is gossiped to peers.
+   Validators run the HotStuff-derivative consensus protocol in
+   `exo-consensus` until a supermajority attests the checkpoint. The
+   checkpoint contains both an `event_root` (Merkle Mountain Range
+   over finalised `event_id`s) and a `state_root` (Sparse Merkle Tree
+   over derived state).
+
+5. **Voters cast votes.** Each vote is an independent signed event.
+   The event carries `Provenance` that includes `VoiceKind::Human`
+   or `VoiceKind::Synthetic`, the voter's `SignerType` prefix, and
+   the Ed25519 signature of the canonical payload.
+
+6. **Quorum check applied with synthetic-voice exclusion.** The
+   kernel's `QuorumLegitimate` invariant (CR-001 §8.3) counts only
+   authentic — non-synthetic — approvals when evaluating whether the
+   threshold is met. See
+   [`constitutional-model.md §3.7`](./constitutional-model.md). Votes
+   with no provenance are legacy-compatible and count at face value.
+
+7. **Outcome event committed.** Once the authentic approval count
+   meets the threshold, a `DecisionOutcome` event is produced, posted
+   to the DAG, and finalised at the next checkpoint. From this point
+   the decision is permanent — terminal states are immutable under
+   TNC-08.
+
+8. **Evidence bundle is exportable.** A verifiable query to
+   `/api/decisions/:id` returns the decision, its votes, all
+   provenance, and cryptographic proofs tying the event to the
+   current `event_root` and `state_root`. This bundle is the
+   court-admissible audit artefact.
+
+---
+
+## 3. The CGR Kernel — deep dive
+
+The kernel lives entirely in `crates/exo-gatekeeper`.
+
+### 3.1 Invariant engine loop
+
+The kernel is composed of:
+
+- A `constitution_hash: [u8; 32]` — the BLAKE3 of the constitution
+  bytes at construction, stored for integrity verification.
+- An `InvariantEngine` holding an `InvariantSet`.
+- The `adjudicate` method, which is the only public entry point.
+
+The loop inside `enforce_all` at
+[`crates/exo-gatekeeper/src/invariants.rs:124`](../../crates/exo-gatekeeper/src/invariants.rs)
+is deliberately straightforward:
+
+```rust
+pub fn enforce_all(
+    engine: &InvariantEngine,
+    context: &InvariantContext,
+) -> Result<(), Vec<InvariantViolation>> {
+    let mut violations = Vec::new();
+    for invariant in &engine.invariant_set.invariants {
+        if let Err(v) = check_invariant(*invariant, context) {
+            violations.push(v);
+        }
+    }
+    if violations.is_empty() { Ok(()) } else { Err(violations) }
+}
+```
+
+All violations are collected, not short-circuited. This matters: a
+caller that violates three invariants gets three violations. The
+kernel never hides information it has already computed.
+
+### 3.2 Ed25519 signature verification for authority chains
+
+The TNC-01 payload format, implemented at
+[`crates/exo-gatekeeper/src/invariants.rs:316–325`](../../crates/exo-gatekeeper/src/invariants.rs):
+
+```
+payload = grantor_did_bytes
+        ‖ 0x00
+        ‖ grantee_did_bytes
+        ‖ 0x00
+        ‖ (for each permission: permission_bytes ‖ 0x00)
+
+message   = BLAKE3(payload)
+signature = Ed25519_sign(grantor_secret_key, message)
+```
+
+The check has three failure modes — malformed key (not 32 bytes),
+malformed signature (not 64 bytes), or signature-verification
+failure — each producing a distinct `InvariantViolation` description.
+Links without a `grantor_public_key` fall back to a non-emptiness
+check on the signature to preserve backwards compatibility with
+legacy events.
+
+### 3.3 Why BLAKE3
+
+- **Speed.** BLAKE3 at SIMD speed is several GB/s on modern CPUs,
+  removing hashing from the hot path on both event ingestion and
+  proof construction.
+- **Collision resistance.** 256-bit output, best-known theoretical
+  attacks match the SHA-3 family's bounds. Sufficient for all
+  EXOCHAIN uses.
+- **Tree-hashing mode.** BLAKE3's tree structure enables parallel
+  hashing of large inputs, which matters for checkpoint MMR and SMT
+  construction.
+- **Determinism.** Same input always produces the same output across
+  architectures — essential for the cross-implementation hash
+  compatibility gate (`tools/cross-impl-test/`).
+
+### 3.4 Determinism enforcement mechanisms
+
+Determinism is enforced at four layers:
+
+1. **Compiler.** `#[deny(clippy::float_arithmetic, clippy::float_cmp,
+   clippy::float_cmp_const)]` at the workspace level. Float usage is a
+   compile-time error.
+2. **Type system.** `BTreeMap` / `BTreeSet` / `DeterministicMap` are
+   the only map/set types in production code. `HashMap` is rejected
+   in review.
+3. **Serialization.** All hashed data goes through `ciborium` CBOR
+   with sorted keys. JSON is never hashed directly.
+4. **Time.** `exo_core::hlc` Hybrid Logical Clock replaces
+   `SystemTime::now()` / `Instant::now()` everywhere in governance
+   logic. Randomness is scoped to key generation only.
+
+### 3.5 Combinator algebra
+
+Every governance operation can be expressed as a combinator
+expression. The reducer is pure: `reduce(combinator, input) →
+Result<output, error>`.
+
+Available terms, from
+[`crates/exo-gatekeeper/src/combinator.rs`](../../crates/exo-gatekeeper/src/combinator.rs):
+
+| Term         | Behaviour                                                 |
+|--------------|-----------------------------------------------------------|
+| `Identity`   | Pass input through unchanged                              |
+| `Sequence`   | Execute terms in order, threading output to input         |
+| `Parallel`   | Execute terms independently, merge outputs                |
+| `Choice`     | Try in order, first success wins                          |
+| `Guard`      | Predicate gate — fail the reduction if predicate fails    |
+| `Transform`  | Apply a named transform to output                         |
+| `Retry`      | Retry on failure up to N times                            |
+| `Timeout`    | Abort if reduction exceeds a budget                       |
+| `Checkpoint` | Commit partial reduction to the DAG                       |
+
+The kernel reduces the combinator and checks all applicable
+invariants before and after reduction. Any failure rejects the entire
+operation with a detailed violation report.
+
+---
+
+## 4. Persistence architecture (GAP-001)
+
+EXOCHAIN persists state in two layers — the ledger (append-only DAG
+of events) and derived state (current projections). The crate
+responsible is `exo-dag`.
+
+### 4.1 Store backends
+
+| Store              | Use case                                           | Crate location                                 |
+|--------------------|----------------------------------------------------|------------------------------------------------|
+| `PostgresStore`    | Production. Durable, queryable, multi-node         | `exo-dag::store` (postgres feature)            |
+| `SqliteDagStore`   | Single-node development and ExoForge operation    | `exo-dag::store` (sqlite feature, default)     |
+| In-memory          | Tests only                                         | `exo-dag::store` (test helpers)                |
+
+### 4.2 Event sourcing pattern
+
+EXOCHAIN is an event-sourced system in the strict sense: **application
+state is always a derivative of the event log, and the database is a
+projection that can be destroyed and rebuilt from the DAG at any
+time**. Consequences:
+
+- Audit reconstruction: the DAG is self-describing.
+- State debugging: any past state can be replayed exactly.
+- Disaster recovery: a corrupted projection rebuilds from genesis.
+- Reproducibility: replication across nodes is determinism by
+  construction, not synchronization.
+
+### 4.3 Event → canonical CBOR → BLAKE3 event ID
+
+An event has two parts:
+
+- `EventEnvelope` — the hashable portion (everything except
+  `event_id` and `signature`).
+- Metadata — `event_id` and `signature`, added after the envelope is
+  hashed.
+
+The ID is computed as:
+
+```
+event_id = BLAKE3(canonical_cbor(EventEnvelope))
+```
+
+The canonical CBOR encoding uses `ciborium` with keys sorted
+lexicographically. This is deterministic across Rust, JavaScript, and
+Python implementations — the cross-impl gate
+(`tools/cross-impl-test/compare.sh`) verifies this.
+
+### 4.4 Checkpoint roots
+
+A checkpoint carries two separate roots:
+
+- `event_root` — a Merkle Mountain Range (MMR) over finalised
+  `event_id`s in canonical topological order. Supports
+  `EventInclusionProof`.
+- `state_root` — a Sparse Merkle Tree (SMT) over derived state —
+  active keys, active consents, revocations, credential status. Supports
+  `StateProof`.
+
+Both roots are included in the BFT-signed checkpoint. An evidence
+bundle can be verified against a checkpoint without replaying the
+full history — download the checkpoint, walk the MMR path, verify
+the BLAKE3 chain, done.
+
+See `exo-dag::mmr`, `exo-dag::smt`, and `exo-dag::store` for the
+implementations.
+
+---
+
+## 5. P2P and consensus
+
+### 5.1 libp2p stack
+
+EXOCHAIN uses libp2p for networking. The protocol set:
+
+| Protocol   | Use                                                        |
+|------------|------------------------------------------------------------|
+| `gossipsub`| Event gossip, validator vote broadcast                     |
+| `kad`      | DHT-based peer discovery and MCP mesh discovery            |
+| `mdns`     | Local-network peer discovery (dev environments)            |
+| `tcp`/`quic` | Transport                                                |
+
+### 5.2 BFT-HotStuff derivative
+
+The consensus crate is `exo-consensus`. The protocol is a
+HotStuff-derivative with three-phase commit (Prepare → PreCommit →
+Commit → Decide), view-change on timeout, and checkpoint finality on
+decide. Safety: `f < n/3`, i.e. the system tolerates up to one-third
+Byzantine validators.
+
+A checkpoint is deterministically final once committed. No
+probabilistic "longest chain" ambiguity, no reorganisations, no
+rollbacks.
+
+### 5.3 Validator rotation and PACE
+
+- **Validator rotation** is scheduled by the consensus epoch: the
+  validator set may be updated at checkpoint boundaries with a
+  `ValidatorSetUpdate` event, ratified by the outgoing set.
+- **PACE** (Protected Access Control and Escalation) is the
+  multi-signature steward protocol for key recovery and dispute
+  resolution. Implemented in `exo-identity::pace` with Verifiable
+  Secret Sharing (Feldman commitments) and a geographic-distribution
+  requirement (no two stewards in the same jurisdiction).
+- **Species Quorum** (CR-001 / spec v2.1 §3A): PACE recovery must
+  include ≥3 human stewards and ≥1 Holon steward. Single-species
+  control is rejected.
+
+---
+
+## 6. The ~40 MCP tools as an API surface
+
+The MCP server in `crates/exo-node/src/mcp/` exposes governance
+operations to AI agents. Tools are grouped by domain. The registry at
+[`crates/exo-node/src/mcp/tools/mod.rs`](../../crates/exo-node/src/mcp/tools/mod.rs)
+dispatches `tools/call` requests to the appropriate handler.
+
+| Domain         | Tool count (approx.) | Primary use case                                                 | Module                                      |
+|----------------|----------------------|------------------------------------------------------------------|---------------------------------------------|
+| Node           | 3                    | Status, list invariants, list MCP rules                          | `tools/node.rs`                             |
+| Identity       | 5                    | Create / resolve DIDs, risk, signature verification, passport    | `tools/identity.rs`                         |
+| Consent        | 4                    | Propose / check / list / terminate bailments                     | `tools/consent.rs`                          |
+| Governance     | 6                    | Create decision, cast vote, check quorum, status, amendment      | `tools/governance.rs`                       |
+| Authority      | 3                    | Delegate, verify chain, check permission                         | `tools/authority.rs`                        |
+| Kernel         | 1                    | `exochain_adjudicate_action` — single-call kernel adjudication   | (dispatched to `governance.rs`)             |
+| Ledger         | 4                    | Submit event, get event, inclusion proof, get checkpoint         | `tools/ledger.rs`                           |
+| Proofs         | 4                    | Evidence, chain of custody, Merkle proof, verify CGR proof       | `tools/proofs.rs`                           |
+| Legal          | 4                    | eDiscovery, privilege, DGCL §144 safe harbour, fiduciary duty    | `tools/legal.rs`                            |
+| Escalation     | 4                    | Evaluate threat, escalate case, triage, feedback                 | `tools/escalation.rs`                       |
+| Messaging      | 3                    | Send encrypted, receive encrypted, configure death trigger       | `tools/messaging.rs`                        |
+
+Alongside tools, the MCP server exposes four **prompts**:
+
+| Prompt                    | When the AI should invoke it                             | Module                                                 |
+|---------------------------|----------------------------------------------------------|--------------------------------------------------------|
+| `governance_review`       | Review a pending decision                                | `mcp/prompts/governance_review.rs`                     |
+| `compliance_check`        | Verify an action against the 8 invariants + 6 MCP rules  | `mcp/prompts/compliance_check.rs`                      |
+| `evidence_analysis`       | Analyse an evidence bundle for admissibility             | `mcp/prompts/evidence_analysis.rs`                     |
+| `constitutional_audit`    | Audit a system state against all 8 invariants            | `mcp/prompts/constitutional_audit.rs`                  |
+
+The detailed AI-side usage is in
+[`ai-agent-guide.md`](./ai-agent-guide.md).
+
+---
+
+## 7. Where to go next
+
+- [`constitutional-model.md`](./constitutional-model.md) — the 8
+  invariants and 6 MCP rules in full, including line references to
+  source.
+- [`../architecture/ARCHITECTURE.md`](../architecture/ARCHITECTURE.md)
+  — the long-form architecture reference with crate dependency graph
+  and BCTS lifecycle detail.
+- [`../architecture/THREAT-MODEL.md`](../architecture/THREAT-MODEL.md)
+  — the formal threat model against which the architecture is
+  defended.
+- [`cgr-developer-guide.md`](./cgr-developer-guide.md) — a task-oriented
+  guide to interacting with the CGR Kernel from user code.
+- [`../../governance/traceability_matrix.md`](../../governance/traceability_matrix.md)
+  — 87 requirements mapped to crate → module → test locations. The
+  best map of "where is the code for X?".
+
+---
+
+Copyright (c) 2025–2026 EXOCHAIN Foundation. Licensed under the
+Apache License, Version 2.0. See [`../../LICENSE`](../../LICENSE).

--- a/docs/guides/constitutional-model.md
+++ b/docs/guides/constitutional-model.md
@@ -1,0 +1,956 @@
+# The EXOCHAIN Constitutional Model
+
+> **Status:** Developer guide — canonical reference for the constitutional
+> governance model. Reflects spec v2.1 and CR-001 (AEGIS / SYBIL / Authentic
+> Plurality).
+> **Audience:** Engineers building on EXOCHAIN, AI agents operating under
+> EXOCHAIN governance, auditors verifying conformance.
+> **Last verified against code:** `crates/exo-gatekeeper` mainline.
+
+This document is the philosophical and operational foundation of the
+EXOCHAIN constitutional trust fabric. Grok this and everything else — the
+invariant set, the combinator algebra, the MCP rules, the escalation
+pipelines — follows by straightforward construction. Skip it, and the rest
+will look like bureaucratic decoration.
+
+The cross-references point to real source files. Every claim in this
+document is anchored in code that runs in CI.
+
+---
+
+## 1. Why a constitutional fabric?
+
+### 1.1 The Alignment Imperative
+
+From the EXOCHAIN Fabric Platform Specification, §3A.1:
+
+> As AI systems approach and exceed human-level capabilities, traditional
+> access control becomes insufficient. EXOCHAIN v2.0 introduces the AEGIS
+> framework — a constitutional layer ensuring AI entities (Holons) remain
+> provably aligned with human values.
+
+In plain language: once an AI is capable enough that it could satisfy the
+letter of a policy while violating its intent — "specification gaming" —
+role-based access control has nothing left to offer. An RBAC system can
+tell you that the actor calling `write_patient_record` has the `nurse`
+role. It cannot tell you whether the write was consented to by the patient,
+whether the nurse was acting under a valid chain of delegated authority,
+whether the action is provenance-verifiable in court, or whether the nurse
+is actually a synthetic account controlled by an upstream adversary.
+
+Constitutional governance replaces "who is allowed to do X" with "what
+must be true about the world before X is permitted to take effect". That
+second framing is falsifiable. The first is not.
+
+### 1.2 What "constitutional" means here
+
+In EXOCHAIN, a constitution is not a PDF. It is a pair:
+
+1. A set of **invariants expressed as types and compiled Rust functions**,
+   bundled in `crates/exo-gatekeeper`.
+2. A **kernel** that evaluates every proposed state transition against
+   those invariants before it is permitted to take effect. See
+   [`Kernel::adjudicate`][kernel-adjudicate].
+
+The word "constitutional" means only this: the invariants cannot be
+bypassed by any combination of roles, permissions, or credentials. They
+are enforced at every state transition, by the same code, at the same
+layer, for every actor in the system. A "super-admin" role does not
+exist. An "emergency override" flag does not exist. The kernel itself is
+content-addressed and immutable after initialization (see §6 below on
+Constitutional Amendment, the one exception).
+
+### 1.3 Contrast with ordinary access control
+
+| Concern                                | Ordinary access control           | EXOCHAIN constitutional model                      |
+|----------------------------------------|-----------------------------------|----------------------------------------------------|
+| Authorization primitive                | Role → permission mapping         | Invariant set checked against adjudication context |
+| Who holds the override                 | Admin / root / superuser          | No one. Amendment process required (§6)            |
+| Provenance                             | Usually a log line after the fact | Signed, verified, required before action runs      |
+| Defense against specification gaming   | Policy review + hope              | Type-level invariants + kernel verification        |
+| Defense against Sybil / false plurality | None built in                     | CR-001 §8.3 synthetic voice exclusion, authentic quorum |
+| AI-specific rules                      | Usually none                      | Six MCP rules bound by cryptographic signer type   |
+| Audit trail                            | Log aggregation, trust the logs   | Append-only DAG + BFT checkpoint, verifiable       |
+
+The practical difference: in a role-based system, you prove you are
+allowed to do something by showing your badge. In a constitutional
+system, every action you take must carry with it cryptographic evidence
+that the world was in a state that permitted it. The kernel checks that
+evidence. If the evidence is missing, wrong, or tampered with, the
+action is denied — no matter who you are.
+
+---
+
+## 2. The Three Branches (Separation of Powers)
+
+EXOCHAIN implements the classical separation of powers as a compile-time
+architectural constraint, not as a policy document.
+
+| Branch          | Role                                                      | Implementation                                         | Representative crates                                   |
+|-----------------|-----------------------------------------------------------|--------------------------------------------------------|---------------------------------------------------------|
+| **Legislative** | Defines the bounds: what Holons MAY and MUST NOT do       | AI-IRB, constitutional amendments, `DecisionClass`     | `exo-governance`, `decision-forum`                      |
+| **Executive**   | Proposes and executes actions within those bounds         | Holons (AI entities with DIDs), humans, authority chains | `exo-gatekeeper` (holon.rs), `exo-authority`, `exo-identity` |
+| **Judicial**    | Verifies every state transition against invariants        | CGR Kernel, invariant engine, combinator reducer       | `exo-gatekeeper` (kernel.rs, invariants.rs, combinator.rs) |
+
+### 2.1 Flow diagram
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│                      SEPARATION OF POWERS FLOW                           │
+├──────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  ┌──────────────┐                                                        │
+│  │ LEGISLATIVE  │   PolicyAmendment events / AI-IRB votes                │
+│  │   (AI-IRB +  │ ────────────────────────────────────┐                  │
+│  │   validators)│                                     ▼                  │
+│  └──────────────┘                         ┌──────────────────────┐       │
+│         │  ratifies                       │ INVARIANT REGISTRY   │       │
+│         ▼                                 │  (InvariantSet::all) │       │
+│  ┌──────────────┐                         └──────────┬───────────┘       │
+│  │  EXECUTIVE   │                                    │ loaded by         │
+│  │   (Holons,   │                                    ▼                   │
+│  │   humans,    │                ┌────────────────────────────────────┐  │
+│  │   delegates) │                │          JUDICIAL BRANCH           │  │
+│  └──────┬───────┘                │          (CGR KERNEL)              │  │
+│         │ ActionRequest          │                                    │  │
+│         │ + AdjudicationContext  │   for each invariant:              │  │
+│         ├───────────────────────►│     check(invariant, context)      │  │
+│         │                        │   all pass?  → Verdict::Permitted  │  │
+│         │                        │   any fail?  → Denied | Escalated  │  │
+│         │                        └───────────────────┬────────────────┘  │
+│         │                                            │ Verdict           │
+│         │                                            ▼                   │
+│         │                        ┌────────────────────────────────────┐  │
+│         │       (proof)          │          DAG  /  BFT               │  │
+│         ◄────────────────────────┤  Event accepted iff Permitted.     │  │
+│                                  │  Denied actions are rejected with  │  │
+│                                  │  evidence. Escalated actions are   │  │
+│                                  │  paused pending review.            │  │
+│                                  └────────────────────────────────────┘  │
+│                                                                          │
+│  INVARIANT: No branch can unilaterally modify another.                   │
+│  INVARIANT: The Judicial branch cannot be bypassed or overridden.        │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+### 2.2 Key property
+
+No branch can unilaterally override another.
+
+- The **Legislative** branch can amend the invariant set only through the
+  Constitutional Amendment process (§6), which requires unanimous
+  validator consent, ≥80% AI-IRB approval, a 30-day comment period, a
+  formal proof, and a security audit. It cannot silently change the
+  rules the Judicial branch evaluates.
+- The **Executive** branch has no mechanism to grant itself capabilities
+  (invariant 3, `NoSelfGrant`), to modify the kernel (invariant 5,
+  `KernelImmutability`), or to suppress human override (invariant 4,
+  `HumanOverride`).
+- The **Judicial** branch has no mechanism to modify the invariants it
+  evaluates. The kernel is immutable after initialization: its
+  constitution hash is computed once with BLAKE3 and stored; any attempt
+  to change it is detected by `Kernel::verify_kernel_integrity`.
+
+This is enforced structurally. It is not a promise.
+
+---
+
+## 3. The 8 Constitutional Invariants
+
+The invariants are defined in
+[`crates/exo-gatekeeper/src/invariants.rs`][invariants-rs]. The
+`ConstitutionalInvariant` enum is declared at lines 19–37, and
+`InvariantSet::all()` returns all eight at lines 47–60.
+
+Each invariant has a named variant, a check function, and a dedicated
+`InvariantViolation` produced on failure. The kernel enforces them in a
+single pass via [`enforce_all`][enforce-all] in the same file
+(lines 124–139). Multiple violations are collected, not short-circuited
+— a call that violates three invariants returns three violations.
+
+### Summary table
+
+| # | Invariant                | Rule (plain language)                                                   | Check function                        |
+|---|--------------------------|-------------------------------------------------------------------------|---------------------------------------|
+| 1 | SeparationOfPowers       | No actor may hold roles in multiple branches                            | `check_separation_of_powers`          |
+| 2 | ConsentRequired          | Action requires an active bailment and a matching active consent record | `check_consent_required`              |
+| 3 | NoSelfGrant              | An actor cannot expand its own permissions                              | `check_no_self_grant`                 |
+| 4 | HumanOverride            | Emergency human intervention must always be possible                    | `check_human_override`                |
+| 5 | KernelImmutability       | Kernel configuration cannot be modified after creation                  | `check_kernel_immutability`           |
+| 6 | AuthorityChainValid      | Authority chain must be non-empty, topologically sound, and cryptographically signed | `check_authority_chain_valid`         |
+| 7 | QuorumLegitimate         | Quorum must be met by authentic (non-synthetic) voters                  | `check_quorum_legitimate`             |
+| 8 | ProvenanceVerifiable     | Every action must carry signed provenance that matches the actor        | `check_provenance_verifiable`         |
+
+The remaining subsections walk through each invariant in the order the
+code enforces them.
+
+---
+
+### 3.1 SeparationOfPowers
+
+**Rule.** "No single actor may hold legislative + executive + judicial
+power." Formally enforced as: an actor's `actor_roles` must all map to
+the same `GovernmentBranch`.
+
+**Why.** An actor who writes policy (legislative), executes actions
+(executive), and judges them (judicial) is not a constitutional actor —
+they are the whole system, alone. The check is stricter than the
+headline: it rejects **any** multi-branch membership, not only the full
+three-way set. This matches the conservative interpretation in CR-001
+§8.9 (no admins).
+
+**Permitted example.**
+
+```rust
+actor_roles = vec![
+    Role { name: "judge".into(), branch: GovernmentBranch::Judicial },
+];
+// → passes
+```
+
+**Denied example.**
+
+```rust
+actor_roles = vec![
+    Role { name: "senator".into(), branch: GovernmentBranch::Legislative },
+    Role { name: "judge".into(),   branch: GovernmentBranch::Judicial },
+];
+// → InvariantViolation { invariant: SeparationOfPowers,
+//                        description: "Actor holds roles in multiple branches…" }
+```
+
+**Violation evidence.** Includes the actor DID and the computed set of
+branches.
+
+**Code reference.**
+[`crates/exo-gatekeeper/src/invariants.rs:157–186`][invariants-rs]
+
+---
+
+### 3.2 ConsentRequired
+
+**Rule.** "Action denied without active bailment consent." The
+adjudication context must contain a `BailmentState::Active` and at least
+one `ConsentRecord` where `granted_to == actor` and `active == true`.
+
+**Why.** Data sovereignty. In EXOCHAIN, every access to protected data
+occurs under a **bailment** — a time-bound, policy-enforced data-sharing
+agreement modelled on the legal bailment doctrine. No bailment, no
+access. Consent must be explicit, still active, and scoped to the actor
+performing the action. A revoked bailment, a suspended bailment, or a
+consent record granted to someone else all fail this invariant.
+
+**Permitted example.** An actor holds an active `BailmentState::Active`
+with bailor `did:exo:bailor` and scope `data:medical`, and there is a
+`ConsentRecord` with `granted_to = actor`, `active = true`.
+
+**Denied example.** `BailmentState::None`, `BailmentState::Suspended`,
+`BailmentState::Terminated`, consent record with `active = false`, or a
+consent record granted to a different DID — each denies the action.
+
+**Violation evidence.** Includes the current bailment state or the
+actor DID and the record count.
+
+**Code reference.**
+[`crates/exo-gatekeeper/src/invariants.rs:188–211`][invariants-rs]
+
+---
+
+### 3.3 NoSelfGrant
+
+**Rule.** "An actor cannot expand its own permissions." The
+`ActionRequest` must have `is_self_grant = false`.
+
+**Why.** If an actor could grant itself more capabilities, every
+invariant above would collapse by recursion — the actor would simply
+grant itself `admin`, then do anything. This invariant is the
+structural cornerstone of separation of powers at the capability
+level. It pairs with MCP002 (no AI self-escalation) on the AI side.
+
+**Permitted example.** A Holon requests a capability by constructing
+an action where the grantor is a distinct DID (the Holon's sponsor,
+for instance).
+
+**Denied example.** A Holon submits an action with `is_self_grant =
+true`. The kernel denies it immediately.
+
+**Violation evidence.** Includes the actor DID.
+
+**Code reference.**
+[`crates/exo-gatekeeper/src/invariants.rs:213–222`][invariants-rs]
+
+---
+
+### 3.4 HumanOverride
+
+**Rule.** "Emergency human intervention must always be possible." The
+context must have `human_override_preserved = true`.
+
+**Why.** AEGIS is not a system that takes humans out of the loop. It
+is a system that makes human oversight reliable by making every
+automated action auditable and every automated decision deniable by a
+human with proper authority. `HumanOverride` is the invariant that
+forbids the construction of actions that would remove that capability
+(typically a `ForcedSunset` or `ImmediateSuspend` over a Holon in
+violation — see spec §3A.4.2).
+
+**Permitted example.** Any normal operation in which the override
+path (via `exo-escalation` `Kanban` triage and `HumanReview` stage)
+remains functional.
+
+**Denied example.** An action that would remove the emergency
+override capability — e.g., a proposed policy amendment that deletes
+the `ImmediateSuspend` event type, or a change that disables human
+review before AI-IRB approval.
+
+**Violation evidence.** `human_override_preserved: false`.
+
+**Code reference.**
+[`crates/exo-gatekeeper/src/invariants.rs:224–233`][invariants-rs]
+
+---
+
+### 3.5 KernelImmutability
+
+**Rule.** "Kernel configuration cannot be modified after creation." The
+`ActionRequest` must have `modifies_kernel = false`. Attempts to
+mutate the kernel's invariant set, its constitution bytes, or its hash
+are unconditionally denied.
+
+**Why.** If the kernel could be modified at runtime, every other
+invariant becomes a suggestion. This is the bright line that makes the
+system constitutional rather than merely heavily governed. The only
+way to change the kernel is the Constitutional Amendment process (§6)
+— which produces a **new** kernel with a **new** content hash at a
+coordinated upgrade height, not an in-place edit.
+
+**Permitted example.** Any action that does not modify the kernel.
+
+**Denied example.** An action request with `modifies_kernel = true`.
+There is no escalation path; this is one of only two invariants whose
+violation never escalates, always denies.
+
+**Violation evidence.** `kernel_modification_attempted: true`.
+
+**Code reference.**
+[`crates/exo-gatekeeper/src/invariants.rs:235–244`][invariants-rs]
+
+---
+
+### 3.6 AuthorityChainValid
+
+**Rule.** The `AuthorityChain` must (a) be non-empty, (b) be
+topologically valid — each link's `grantee` is the next link's
+`grantor` — (c) terminate at the actor, and (d) every link that
+carries a `grantor_public_key` must have an Ed25519 signature that
+verifies against the canonical payload.
+
+**Why.** Delegation is how authority flows through a multi-actor
+system. If the chain is broken or unsigned, there is no chain — just a
+claim. The cryptographic signature check (TNC-01) closes the gap
+between "this actor says they were delegated" and "the grantor can be
+proven to have delegated".
+
+**Canonical payload format** (from the code at lines 316–325):
+
+```
+payload = grantor_did_bytes || 0x00
+       || grantee_did_bytes || 0x00
+       || (for each permission: permission_bytes || 0x00)
+message = BLAKE3(payload)
+signature = Ed25519_sign(grantor_secret_key, message)
+```
+
+**Permitted example.** A single-link chain `did:exo:root → did:exo:actor1`
+with a valid Ed25519 signature verifying under the supplied public key.
+
+**Denied example.**
+
+- Empty chain — `AuthorityChain::default()`.
+- Broken topology — `link[0].grantee != link[1].grantor`.
+- Wrong terminal — last link's grantee is not the actor.
+- Tampered signature, wrong public key, malformed key.
+
+**Escalation special case.** When the *only* invariant that fails is
+`AuthorityChainValid`, the kernel returns `Verdict::Escalated` rather
+than `Verdict::Denied` — see [`Kernel::adjudicate`][kernel-adjudicate]
+at lines 125–130. This recognises that an authority-chain gap may be a
+temporary problem with a legitimate fix path (contest, re-issue), not
+a malicious attack.
+
+**Violation evidence.** Includes the broken link indices and, for
+signature failures, the grantor/grantee DIDs.
+
+**Code reference.**
+[`crates/exo-gatekeeper/src/invariants.rs:246–357`][invariants-rs]
+
+---
+
+### 3.7 QuorumLegitimate
+
+**Rule.** When a `QuorumEvidence` is present, the number of authentic
+(non-synthetic) approvals must meet the threshold.
+
+**Why.** This is CR-001 §8.3 encoded as a type check. The rule at
+stake is the line between **AEGIS** (legitimate plurality) and
+**SYBIL** (counterfeit plurality): "numerical multiplicity without
+attributable independence is theater, not legitimacy." A vote is
+authentic when its `provenance` does not mark the voter as having a
+`VoiceKind::Synthetic`. AI-generated votes and synthetic-voiced agents
+are excluded from the headcount even when they formally "approved".
+
+**Permitted example.** Threshold = 3, votes = three approvals from
+`VoiceKind::Human` voters (plus any number of synthetic approvals,
+which are silently excluded from the count but recorded).
+
+**Denied example.** Threshold = 3, votes = one human approval + two
+synthetic approvals. The authentic-approval count is 1, below 3.
+
+**Violation evidence.** Includes `threshold`,
+`authentic_approvals`, and `synthetic_votes_excluded`.
+
+**Escalation special case.** Same as `AuthorityChainValid` — when
+quorum is the only failing invariant, the action is escalated rather
+than denied. The legitimate fix is a fresh vote with qualified voters,
+not a rejection of the underlying decision.
+
+**Legacy compatibility.** Votes with `provenance = None` are treated
+as non-synthetic (pre-CR-001 votes do not lose their weight). Tests at
+lines 1009–1033 pin this behaviour.
+
+**Code reference.**
+[`crates/exo-gatekeeper/src/invariants.rs:359–390`][invariants-rs]
+
+---
+
+### 3.8 ProvenanceVerifiable
+
+**Rule.** The action must carry `Provenance` whose `actor` matches the
+context actor, whose signature is non-empty, and — when a
+`public_key` is supplied — whose Ed25519 signature verifies against
+the canonical payload.
+
+**Why.** Every action in EXOCHAIN is court-admissible evidence of
+what happened. Provenance is the signed metadata that makes this
+true: an actor DID, a timestamp (HLC), the action hash, and the
+signature. Without it, the event is a rumour.
+
+**Canonical payload format** (from the code at lines 434–439):
+
+```
+payload = actor_did_bytes || 0x00
+       || action_hash    || 0x00
+       || timestamp_bytes
+message = BLAKE3(payload)
+signature = Ed25519_sign(actor_secret_key, message)
+```
+
+Note: for AI actors this payload is further wrapped with the
+`SignerType` prefix (§5) before signing, so a signature produced by
+an AI cannot be replayed as a human signature.
+
+**Permitted example.** Provenance with actor matching the context,
+non-empty signature, and — if `public_key` is set — a valid Ed25519
+signature over the canonical payload.
+
+**Denied example.**
+
+- Missing provenance (`None`).
+- Actor mismatch between provenance and context.
+- Unsigned provenance (legacy path — `signature: vec![]`).
+- Tampered signature, wrong public key, malformed key length.
+
+**Violation evidence.** Depends on the failure mode; includes actor
+DID and key/signature lengths where relevant.
+
+**Code reference.**
+[`crates/exo-gatekeeper/src/invariants.rs:392–466`][invariants-rs]
+
+---
+
+## 4. The 6 MCP Rules (AI-specific)
+
+The invariants above apply uniformly to all actors. The MCP rules
+apply specifically when the actor is an AI. They live in
+[`crates/exo-gatekeeper/src/mcp.rs`][mcp-rs] and are declared in the
+`McpRule` enum at lines 22–29.
+
+### 4.1 Cryptographic signer binding
+
+The central design element of the MCP layer is this: the system does
+not determine "is this actor an AI?" by looking at a caller-set
+`is_ai` boolean. It determines it from the actor's cryptographic
+`SignerType`, which is part of the **signed payload**.
+
+```rust
+pub enum SignerType {
+    Human,                                    // prefix byte 0x01
+    Ai { delegation_id: Hash256 },            // prefix byte 0x02 + 32-byte hash
+}
+```
+
+When any actor signs a message, the payload that actually gets hashed
+and signed is:
+
+```
+[prefix_bytes]  ||  message_bytes
+```
+
+Where `prefix_bytes = [0x01]` for a human or `[0x02, <32 bytes of delegation_id>]`
+for an AI. See `build_signed_payload` at
+[`crates/exo-gatekeeper/src/mcp.rs:189–196`][mcp-rs] and
+`verify_typed_signature` at
+[`crates/exo-gatekeeper/src/mcp.rs:200–209`][mcp-rs].
+
+**The consequence.** Even if an AI obtains valid key material, it
+cannot produce a signature that verifies as human — the 33-byte vs
+1-byte prefix difference means the underlying hash inputs are
+different. Impersonation across species is cryptographically
+prevented, not merely policed. The test
+`ai_cannot_impersonate_human` at lines 387–415 of `mcp.rs` pins
+this.
+
+### 4.2 The six rules
+
+| ID      | Name                  | Description                                            | Severity |
+|---------|-----------------------|--------------------------------------------------------|----------|
+| MCP001  | BctsScope             | AI must operate within BCTS scope                      | 5        |
+| MCP002  | NoSelfEscalation      | AI cannot self-escalate capabilities                   | 5        |
+| MCP003  | ProvenanceRequired    | AI actions require provenance metadata                 | 4        |
+| MCP004  | NoIdentityForge       | AI cannot forge identity or signatures                 | 5        |
+| MCP005  | Distinguishable       | AI outputs must be distinguishable from human          | 3        |
+| MCP006  | ConsentBoundaries     | AI must respect consent boundaries                     | 5        |
+
+Humans are exempt from all six rules. `enforce` returns `Ok(())`
+immediately when `!context.is_ai()` at
+[`crates/exo-gatekeeper/src/mcp.rs:105–113`][mcp-rs].
+
+---
+
+### 4.3 MCP001 — BctsScope
+
+**Why this rule exists.** A Holon that operates outside a defined
+Bailment-Conditioned Transaction Set scope has no consent anchor —
+nothing to tie its actions back to a legitimate purpose. Without a
+scope, provenance becomes untestable and consent becomes
+retrospective.
+
+**Attack vector prevented.** A misbehaving or captured Holon that
+tries to act "in general" rather than under a specific authorized
+purpose.
+
+**Check.** `ctx.bcts_scope` must be `Some(_)`.
+
+**Code reference.**
+[`crates/exo-gatekeeper/src/mcp.rs:117–127`][mcp-rs]
+
+---
+
+### 4.4 MCP002 — NoSelfEscalation
+
+**Why this rule exists.** This is the AI-specific projection of
+invariant 3 (`NoSelfGrant`). It closes the RSI (Recursive
+Self-Improvement) problem: an AI cannot propose an action that would
+expand its own capabilities. Self-improvement proposals must enter
+the system as `HolonModificationProposed` events reviewed by AI-IRB,
+never as in-band capability upgrades.
+
+**Attack vector prevented.** Recursive self-improvement without
+oversight. Specification-gaming a permission system by "discovering"
+new capabilities you then grant yourself.
+
+**Check.** `ctx.self_escalation` must be `false`.
+
+**Code reference.**
+[`crates/exo-gatekeeper/src/mcp.rs:128–141`][mcp-rs]
+
+---
+
+### 4.5 MCP003 — ProvenanceRequired
+
+**Why this rule exists.** Invariant 8 applies to all actors, but
+this rule raises the bar for AI actions. Even when humans may
+produce unsigned legacy events (pre-migration), AI actions must
+always carry full provenance. This is the material basis for "AI
+outputs must be distinguishable and attributable".
+
+**Attack vector prevented.** AI actions that disappear into the
+audit log as ambient state changes.
+
+**Check.** `ctx.has_provenance` must be `true`.
+
+**Code reference.**
+[`crates/exo-gatekeeper/src/mcp.rs:142–152`][mcp-rs]
+
+---
+
+### 4.6 MCP004 — NoIdentityForge
+
+**Why this rule exists.** The signer-type binding (§4.1) prevents
+the AI from producing a signature that verifies as human at the
+cryptographic level. This rule adds a second, policy-level check:
+even attempting to present AI output as if from a human — by
+manipulating the payload, claiming a human delegation ID, or
+reusing a human's key material — is an immediate severity-5
+violation.
+
+**Attack vector prevented.** Synthetic-voice laundering: an AI
+agent that pretends to speak as a human reviewer. This is the
+canonical SYBIL condition named in CR-001 §5.
+
+**Check.** `ctx.forging_identity` must be `false`.
+
+**Code reference.**
+[`crates/exo-gatekeeper/src/mcp.rs:153–163`][mcp-rs]
+
+---
+
+### 4.7 MCP005 — Distinguishable
+
+**Why this rule exists.** CR-001 §5 lists "presentation of
+synthetic or coordinated opinions as if they were independent human
+judgment" as a SYBIL condition. The line between AI and human
+output must be legible to downstream consumers — including quorum
+counters (invariant 7), reviewers, and the evidence bundle export
+pipeline.
+
+**Attack vector prevented.** Counterfeit plurality via AI
+multiplication. Undetected AI influence on quorum.
+
+**Check.** `ctx.output_marked_ai` must be `true`.
+
+**Note.** This is severity 3 (rather than 5). Not marking AI output
+is a disclosure failure, not an integrity failure — but it still
+blocks the action.
+
+**Code reference.**
+[`crates/exo-gatekeeper/src/mcp.rs:164–174`][mcp-rs]
+
+---
+
+### 4.8 MCP006 — ConsentBoundaries
+
+**Why this rule exists.** Invariant 2 (`ConsentRequired`) enforces
+that some consent is active. MCP006 raises the bar for AI: consent
+must be active *for this AI actor* with respect to *this action*.
+Consent that was granted to a different AI, or a different
+capability level, is not transferable.
+
+**Attack vector prevented.** AI actions riding on consent granted
+to another AI or another purpose. Capability drift past consent
+boundaries.
+
+**Check.** `ctx.consent_active` must be `true`.
+
+**Code reference.**
+[`crates/exo-gatekeeper/src/mcp.rs:175–186`][mcp-rs]
+
+---
+
+## 5. Verdicts: Permitted, Denied, Escalated
+
+Every call to [`Kernel::adjudicate`][kernel-adjudicate] returns a
+`Verdict`:
+
+```rust
+pub enum Verdict {
+    Permitted,
+    Denied    { violations: Vec<InvariantViolation> },
+    Escalated { reason: String },
+}
+```
+
+### 5.1 Permitted
+
+All invariants passed. The action is constitutionally valid and may
+proceed. A permitted verdict is not a promise that the action
+"worked" — it is a proof that nothing in the constitutional fabric
+objects to it taking effect.
+
+The downstream DAG commits the event, the state root is updated,
+and (if integrated) a `CgrProof` is produced recording which kernel
+version, which registry hash, and which invariants were evaluated.
+
+### 5.2 Denied
+
+At least one invariant failed, and at least one of the failing
+invariants is not a pure quorum/authority issue (see §5.3 below).
+The verdict carries **every** violation that was detected — not just
+the first. This is intentional: callers need to see the full picture
+to repair correctly.
+
+Each `InvariantViolation` carries:
+
+```rust
+pub struct InvariantViolation {
+    pub invariant:   ConstitutionalInvariant,
+    pub description: String,
+    pub evidence:    Vec<String>,
+}
+```
+
+Example denied output for an action that tries to modify the kernel,
+suppress human override, and self-grant all at once:
+
+```
+Denied {
+  violations: [
+    InvariantViolation {
+      invariant: NoSelfGrant,
+      description: "Actor attempted to expand own permissions",
+      evidence: ["actor: did:exo:self-granter"],
+    },
+    InvariantViolation {
+      invariant: HumanOverride,
+      description: "Human override capability is not preserved",
+      evidence: ["human_override_preserved: false"],
+    },
+    InvariantViolation {
+      invariant: KernelImmutability,
+      description: "Attempted to modify immutable kernel configuration",
+      evidence: ["kernel_modification_attempted: true"],
+    },
+  ],
+}
+```
+
+### 5.3 Escalated
+
+An action is escalated, not denied, in exactly two cases:
+
+1. There is an **active Sybil challenge hold**:
+   `context.active_challenge_reason = Some(_)`. The kernel
+   short-circuits before running invariant checks and returns
+   `Escalated { reason }`. See
+   [`Kernel::adjudicate`][kernel-adjudicate] at lines 99–105. This
+   implements CR-001 §8.5 (WO-005): contested actions are paused,
+   not blocked, pending review.
+
+2. The **only** failing invariant is either `QuorumLegitimate` or
+   `AuthorityChainValid`. These are both "your evidence is
+   incomplete but this is probably fixable" violations, not "this is
+   a constitutional attack". The kernel returns
+   `Escalated { reason }` with the violation's description. See
+   [`Kernel::adjudicate`][kernel-adjudicate] at lines 125–130.
+
+A mixed failure — e.g., `QuorumLegitimate` plus `NoSelfGrant` — is
+denied, not escalated. Escalation is reserved for narrowly
+recoverable cases.
+
+### 5.4 Walk-through of `Kernel::adjudicate`
+
+```rust
+// crates/exo-gatekeeper/src/kernel.rs:98-138 (paraphrased)
+
+pub fn adjudicate(
+    &self,
+    action: &ActionRequest,
+    context: &AdjudicationContext,
+) -> Verdict {
+    // 1. Sybil challenge takes absolute priority.
+    if let Some(reason) = &context.active_challenge_reason {
+        return Verdict::Escalated { reason: reason.clone() };
+    }
+
+    // 2. Build the invariant context from action + context.
+    let inv_ctx = InvariantContext { /* … fields copied … */ };
+
+    // 3. Run every invariant in the engine. Collect all violations.
+    match enforce_all(&self.invariant_engine, &inv_ctx) {
+        Ok(()) => Verdict::Permitted,
+        Err(violations) => {
+            let needs_escalation = violations.iter().any(|v| {
+                v.invariant == ConstitutionalInvariant::QuorumLegitimate
+                    || v.invariant == ConstitutionalInvariant::AuthorityChainValid
+            });
+            // Only a single quorum-or-authority violation → Escalate.
+            if needs_escalation && violations.len() == 1 {
+                Verdict::Escalated {
+                    reason: violations[0].description.clone(),
+                }
+            } else {
+                Verdict::Denied { violations }
+            }
+        }
+    }
+}
+```
+
+Three important structural properties:
+
+- **Priority**: Sybil challenges short-circuit everything.
+- **Completeness**: when denied, all violations are reported.
+- **Conservative escalation**: only pure single-cause quorum or
+  authority failures escalate; everything else denies.
+
+---
+
+## 6. The Constitutional Amendment Process
+
+From EXOCHAIN Fabric Platform Spec §3A.3.2.
+
+Modifying the CGR Kernel binary or the invariant registry is the
+rarest operation in EXOCHAIN. It is possible — a system that cannot
+evolve cannot survive — but the bar is intentionally extreme to
+prevent capture or erosion.
+
+### 6.1 When you might need one
+
+- Adding a new invariant (see `AGENTS.md` "How to Add a New
+  Invariant"). The ninth invariant is a constitutional amendment.
+- Relaxing an invariant (extremely rare — no precedent).
+- Replacing the kernel binary with a version that adds formal
+  verification, changes the combinator algebra, or restructures the
+  invariant engine.
+- Upgrading cryptographic primitives to a post-quantum scheme.
+
+### 6.2 The five requirements
+
+| #  | Requirement                          | Details                                                     |
+|----|--------------------------------------|-------------------------------------------------------------|
+| 1  | Unanimous validator consent          | 100% of active validators must sign the `KernelUpgradeProposed` event |
+| 2  | Supermajority AI-IRB approval        | ≥80% of AI-IRB members vote in favour                       |
+| 3  | 30-day public comment period         | During which the proposal is visible and contestable        |
+| 4  | Formal proof (Coq / Lean)            | Mathematical proof that the new invariant set preserves safety properties |
+| 5  | External security audit              | No HIGH or CRITICAL findings                                |
+
+Plus a sixth operational step: a new genesis checkpoint with the
+updated `kernel_cid` at a coordinated block height, distributed
+across the network.
+
+### 6.3 Which immutable components require this
+
+Anything guarded by invariants `KernelImmutability` (§3.5) or the
+normative INV-008/INV-009 from the platform spec:
+
+- The kernel binary (content-addressed by `kernel_cid`).
+- The invariant registry (the `InvariantSet` returned by
+  `InvariantSet::all()`).
+- The constitution bytes (hashed into `constitution_hash`; see
+  [`Kernel::new`][kernel-new] at lines 90–96).
+
+Policy, capability grants, delegation chains, and consent records are
+*not* amendment-gated — they live at the legislative/executive
+surface and follow their normal multi-sig paths.
+
+---
+
+## 7. How the SDK Exposes This
+
+### 7.1 Rust — `exochain_sdk::kernel::ConstitutionalKernel`
+
+The SDK wraps the full `Kernel` with an ergonomic surface that
+supplies reasonable defaults. See
+[`crates/exochain-sdk/src/kernel.rs`][sdk-kernel].
+
+```rust
+use exochain_sdk::kernel::{ConstitutionalKernel, KernelVerdict};
+use exo_core::Did;
+
+let kernel = ConstitutionalKernel::new();
+let actor  = Did::new("did:exo:alice").expect("valid DID");
+
+// Happy path: returns KernelVerdict::Permitted.
+match kernel.adjudicate(&actor, "read-medical-record") {
+    KernelVerdict::Permitted            => println!("ok"),
+    KernelVerdict::Denied { violations } => println!("denied: {violations:?}"),
+    KernelVerdict::Escalated { reason }  => println!("escalated: {reason}"),
+}
+
+// Self-grant path: returns KernelVerdict::Denied with a NoSelfGrant
+// violation.
+let _ = kernel.adjudicate_self_grant(&actor, "escalate-self");
+
+// Kernel-modification path: returns KernelVerdict::Denied with a
+// KernelImmutability violation.
+let _ = kernel.adjudicate_kernel_modification(&actor, "patch-kernel");
+
+// No-bailment path: returns KernelVerdict::Denied with a
+// ConsentRequired violation.
+let _ = kernel.adjudicate_without_bailment(&actor, "read-data");
+
+// Verify the kernel's stored constitution hash is intact.
+assert!(kernel.verify_integrity());
+assert_eq!(kernel.invariant_count(), 8);
+```
+
+`KernelVerdict` is a flattened form of `Verdict` with `violations`
+as `Vec<String>` so SDK consumers do not need to depend on the full
+gatekeeper types.
+
+### 7.2 TypeScript / Python — future work
+
+The TypeScript SDK in `packages/exochain-sdk/` and the Python SDK in
+`packages/exochain-py/` currently expose the lower-level primitives
+(DID, signing, event construction). The `Kernel` wrapper is not yet
+exposed in those packages; the in-process Rust kernel and the MCP
+server at §7.3 below are the canonical paths. This is tracked in
+`GAP-REGISTRY.md`.
+
+### 7.3 MCP — `exochain_adjudicate_action`
+
+AI agents connecting to EXOCHAIN through the MCP server get the
+kernel as a tool:
+
+```jsonc
+// tools/call request
+{
+  "jsonrpc": "2.0",
+  "id": 42,
+  "method": "tools/call",
+  "params": {
+    "name": "exochain_adjudicate_action",
+    "arguments": {
+      "actor": "did:exo:ai-agent-1",
+      "action": "summarize-record",
+      "is_self_grant": false,
+      "modifies_kernel": false
+    }
+  }
+}
+```
+
+The server dispatches into the governance tool handler (see
+[`crates/exo-node/src/mcp/tools/mod.rs:156`][mcp-tools]) and returns
+a `Verdict` as JSON. The AI's subsequent behaviour is expected to
+respect the verdict — see the companion document
+[`ai-agent-guide.md`](./ai-agent-guide.md).
+
+---
+
+## 8. Further reading
+
+- [`architecture-overview.md`](./architecture-overview.md) — the
+  system around the kernel (layers, DAG, consensus, MCP surface).
+- [`developer-onboarding.md`](./developer-onboarding.md) — the
+  hands-on first-hour guide.
+- [`ai-agent-guide.md`](./ai-agent-guide.md) — the constitutional
+  handbook for AI agents.
+- [`../architecture/ARCHITECTURE.md`](../architecture/ARCHITECTURE.md)
+  — the existing deep-dive architecture document.
+- [`../../governance/traceability_matrix.md`](../../governance/traceability_matrix.md)
+  — 87 requirements tracked against tests and crates.
+- [`../../governance/resolutions/CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY.md`](../../governance/resolutions/CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY.md)
+  — the council resolution that supplies §8.3 (synthetic voice
+  exclusion) and §8.5 (Sybil challenge escalation).
+- [`../../EXOCHAIN-FABRIC-PLATFORM.md`](../../EXOCHAIN-FABRIC-PLATFORM.md)
+  — the full platform specification, §3A in particular for the
+  Separation of Powers flow.
+- [`../../AGENTS.md`](../../AGENTS.md) — AI development constraints,
+  including "How to Add a New Invariant".
+
+---
+
+[invariants-rs]: ../../crates/exo-gatekeeper/src/invariants.rs
+[mcp-rs]: ../../crates/exo-gatekeeper/src/mcp.rs
+[kernel-adjudicate]: ../../crates/exo-gatekeeper/src/kernel.rs
+[kernel-new]: ../../crates/exo-gatekeeper/src/kernel.rs
+[enforce-all]: ../../crates/exo-gatekeeper/src/invariants.rs
+[sdk-kernel]: ../../crates/exochain-sdk/src/kernel.rs
+[mcp-tools]: ../../crates/exo-node/src/mcp/tools/mod.rs
+
+---
+
+Copyright (c) 2025–2026 EXOCHAIN Foundation. Licensed under the
+Apache License, Version 2.0. See
+[`../../LICENSE`](../../LICENSE).

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -1,0 +1,550 @@
+# Developer Onboarding
+
+> **Audience:** An engineer who just `git clone`d `exochain/exochain` and
+> wants to know what to do next.
+> **Goal:** Get you from nothing to a running local node, a passing test
+> suite, your first constitutional adjudication via MCP, and a clear map
+> of where everything lives — in about an hour of wall-clock time.
+
+If you want the philosophy first, read
+[`constitutional-model.md`](./constitutional-model.md) before this. If you
+want the system-level picture, read
+[`architecture-overview.md`](./architecture-overview.md). Both are in the
+same directory.
+
+---
+
+## 1. Prerequisites
+
+| Tool                | Version           | Why                                                   |
+|---------------------|-------------------|-------------------------------------------------------|
+| Rust                | 1.85+ stable      | Workspace compiles with the current stable toolchain  |
+| `rustup`            | Any recent        | Toolchain management                                  |
+| Clang               | Any recent        | Required for crypto-backend compilation (`blake3` SIMD, `ed25519-dalek`) |
+| Git                 | 2.30+             | Submodules and sparse checkouts in tooling            |
+| Node.js             | 20+ (optional)    | For `command-base/`, `web/`, `packages/exochain-sdk/` |
+| Python              | 3.11+ (optional)  | For `tools/codegen/`, `tools/syntaxis/`, `packages/exochain-py/` |
+| Disk                | ~2 GB             | Build artefacts under `target/`                       |
+| RAM                 | ~8 GB recommended | Release builds of the full workspace                  |
+| Platform            | macOS, Linux, WSL2| Cross-platform CI gate runs on `ubuntu-latest`        |
+
+Quick install (assumes you already have a package manager):
+
+```bash
+# Rust
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup toolchain install stable
+rustup toolchain install nightly   # needed for `cargo +nightly fmt`
+
+# Clang (macOS: already present via Xcode Command Line Tools)
+xcode-select --install            # macOS
+sudo apt-get install -y clang     # Debian / Ubuntu
+
+# Optional: cargo-deny, cargo-audit — used by the release gates.
+cargo install cargo-deny cargo-audit
+```
+
+Verify:
+
+```bash
+rustc --version         # → rustc 1.85.x (or later)
+cargo --version
+clang --version
+```
+
+---
+
+## 2. First hour
+
+### 2.1 Clone and build
+
+```bash
+git clone https://github.com/exochain/exochain.git
+cd exochain
+
+# Cold build of the full workspace. Expect ~5 minutes on a modern
+# laptop. Subsequent incremental builds are seconds.
+cargo build --workspace
+```
+
+Expected output tail:
+
+```
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4m 52s
+```
+
+If this fails with a missing system library, it is almost always
+Clang or OpenSSL on Linux:
+
+```bash
+sudo apt-get install -y build-essential clang libssl-dev pkg-config
+```
+
+### 2.2 Run the tests
+
+```bash
+cargo test --workspace
+```
+
+Expected output tail:
+
+```
+test result: ok. 1603 passed; 0 failed; 0 ignored; ...
+```
+
+The baseline is currently **1,603 tests passing, 0 failures**. The
+number grows as new crates land; consult
+`governance/traceability_matrix.md` and the `README.md` repo-truth
+table for the latest figure. What matters is `0 failed`.
+
+### 2.3 Run the node binary
+
+EXOCHAIN's single binary is `exochain`, produced by the `exo-node`
+crate.
+
+```bash
+# Release build — needed for reasonable startup time.
+cargo build --release -p exo-node
+
+# Status on a fresh install: creates ~/.exochain/ and reports a clean state.
+./target/release/exochain status
+```
+
+Expected output (shape):
+
+```
+exochain v0.x
+  data dir: /Users/you/.exochain
+  identity: not initialized
+  peers:    0
+  checkpoint height: 0
+```
+
+### 2.4 Start the MCP server
+
+The constitutional MCP server is the canonical interface for AI agents
+and tooling.
+
+```bash
+./target/release/exochain mcp
+```
+
+The server is now reading newline-delimited JSON-RPC on stdin and
+writing responses to stdout. All diagnostics go to stderr so stdout
+stays a clean channel.
+
+### 2.5 Talk to the MCP server via piped JSON-RPC
+
+In a separate terminal (or as a one-shot pipeline):
+
+```bash
+# Pipe a single initialize + tools/list pair into the server.
+(
+  printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}'
+  printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+) | ./target/release/exochain mcp
+```
+
+Expected output includes the server identity (`exochain-mcp`) and a
+JSON array under `"tools"` containing ~40 `exochain_*` entries. The
+ones you will care about first:
+
+| Tool                             | What it does                                                                      |
+|----------------------------------|-----------------------------------------------------------------------------------|
+| `exochain_node_status`           | Current node height, peers, identity                                              |
+| `exochain_list_invariants`       | Return the 8 invariants                                                           |
+| `exochain_list_mcp_rules`        | Return the 6 MCP rules                                                            |
+| `exochain_adjudicate_action`     | Run an action through `Kernel::adjudicate`                                        |
+| `exochain_create_decision`       | Create a new governance decision on the DAG                                       |
+| `exochain_cast_vote`             | Cast a vote on an open decision                                                   |
+| `exochain_check_quorum`          | Check whether a decision has an authentic quorum                                  |
+
+A minimal adjudication call (pipe this into `exochain mcp` the same
+way):
+
+```json
+{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"exochain_adjudicate_action","arguments":{"actor":"did:exo:alice","action":"read-record","is_self_grant":false,"modifies_kernel":false}}}
+```
+
+You should see a `Verdict::Permitted` response. Flip `is_self_grant`
+to `true` and observe a `Verdict::Denied` with a `NoSelfGrant`
+violation.
+
+---
+
+## 3. The workspace layout
+
+The workspace root is a plain Cargo workspace. The pieces that matter
+for first-week work:
+
+### 3.1 The 17 Rust crates in `crates/`
+
+> There are currently 16 production crates and one SDK crate (17
+> directory entries in `crates/`). The README repo-truth table tracks
+> the production count.
+
+| Crate                | One-line purpose                                                                        |
+|----------------------|-----------------------------------------------------------------------------------------|
+| `exo-core`           | Cryptographic primitives (BLAKE3, Ed25519), HLC, canonical CBOR, DID, `SignerType`      |
+| `exo-identity`       | DID lifecycle, key management, Shamir secret sharing, PACE, vault encryption             |
+| `exo-consent`        | Bailment lifecycle, consent policies, default-deny gatekeeper                           |
+| `exo-authority`      | Authority chains, delegation registry, permission model, Ed25519 link verification      |
+| `exo-dag`            | Immutable DAG ledger, Merkle Mountain Range, Sparse Merkle Tree, BFT consensus adapter  |
+| `exo-proofs`         | SNARK, STARK, ZKML proof systems, unified verifier                                      |
+| `exo-gatekeeper`     | CGR Kernel, 8 invariants, 6 MCP rules, combinator algebra, holons, TEE attestation       |
+| `exo-governance`     | Decisions, quorum, challenge, crosscheck, deliberation, conflict, audit, succession     |
+| `exo-escalation`     | Sybil detection, triage, 7-stage adjudication, kanban board, feedback loop              |
+| `exo-legal`          | Evidence, eDiscovery, attorney-client privilege, DGCL §144 safe-harbor                  |
+| `exo-api`            | Public API surface and GraphQL/REST type exports                                        |
+| `exo-gateway`        | HTTP gateway (REST + GraphQL), auth, rate limiting, health probes                       |
+| `exo-tenant`         | Multi-tenant isolation and tenant lifecycle                                             |
+| `exo-messaging`      | Encrypted messaging between DIDs, optional death-trigger delivery                       |
+| `exo-consensus`      | BFT-HotStuff derivative, validator rotation, PACE, checkpoint production                |
+| `exo-catapult`       | Event ingestion acceleration / batching                                                 |
+| `exo-node`           | The `exochain` binary: P2P, BFT, reactor, API, dashboard, CLI, MCP server               |
+| `exochain-sdk`       | In-process Rust SDK: ergonomic wrappers for kernel, identity, consent, authority        |
+| `exochain-wasm`      | WebAssembly bindings (the 110-function bridge)                                          |
+| `decision-forum`     | Deliberative decision-making forum protocol and voting engine                           |
+
+### 3.2 SDK and bindings in `packages/`
+
+| Package              | Purpose                                                                                       |
+|----------------------|-----------------------------------------------------------------------------------------------|
+| `packages/exochain-wasm` | WASM + TypeScript bindings for browser / edge runtimes. Wraps `exochain-wasm` crate output. |
+| `packages/exochain-sdk`  | TypeScript SDK for server-side Node integrations.                                         |
+| `packages/exochain-py`   | Python SDK for data-science and orchestration tooling.                                    |
+
+### 3.3 Governance in `governance/`
+
+| File                                            | Contents                                                                       |
+|-------------------------------------------------|--------------------------------------------------------------------------------|
+| `traceability_matrix.md`                        | 87 requirements → crate → tests → status                                       |
+| `threat_matrix.md`                              | 14 threats, status, mitigation mapping                                         |
+| `quality_gates.md`                              | The 8 pull-request gates and release gates                                     |
+| `resolutions/CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY.md` | Council resolution defining AEGIS, SYBIL, authentic plurality, work orders |
+| `sub_agents.md`                                 | 11 sub-agent charters                                                          |
+| `EXOCHAIN-REFACTOR-PLAN.md`                     | Active refactor roadmap                                                        |
+
+### 3.4 Tools in `tools/`
+
+| Tool              | What it does                                                                                 |
+|-------------------|----------------------------------------------------------------------------------------------|
+| `tools/codegen/`         | `generate_crate.py` — scaffolds a new workspace crate with all the required boilerplate |
+| `tools/syntaxis/`        | Node registry + workflow code generator (maps 23 visual node types to Rust combinators) |
+| `tools/cross-impl-test/` | Rust vs JavaScript hash-compatibility test harness (release gate)                        |
+| `tools/sybil-cli/`       | Operator CLI for Sybil detection, triage, and adjudication                               |
+| `tools/repo_truth.sh`    | Regenerates the `README.md` repo-status table from source                                |
+
+### 3.5 Other top-level directories
+
+| Directory         | Purpose                                                                |
+|-------------------|------------------------------------------------------------------------|
+| `docs/`           | Architecture, guides, ADRs, reference, council panel reports           |
+| `command-base/`   | CommandBase.ai operational hypervisor (Node/Express + SQLite)          |
+| `exoforge/`       | Autonomous implementation engine (triage → council → implement → validate) |
+| `web/`            | Decision Forum React UI                                                |
+| `demo/`           | Standalone demo stack (Node microservices + React + Postgres)          |
+| `tla/`            | TLA+ specifications for core protocols                                 |
+| `deploy/`         | Deployment manifests (Docker Compose, Fly.io, Railway)                 |
+
+---
+
+## 4. Code style and constraints
+
+The full list lives in [`../../AGENTS.md`](../../AGENTS.md). The
+short list you need before writing your first line of code:
+
+### 4.1 Absolute determinism
+
+- **No floating-point arithmetic.** The workspace sets
+  `#[deny(clippy::float_arithmetic)]`. Use integers or basis points
+  (1/10000). No `f32`, no `f64`.
+- **BTreeMap, not HashMap.** `HashMap` iteration order is
+  non-deterministic and will break hashing and DAG reproducibility.
+  Use `std::collections::BTreeMap` and `BTreeSet`, or the
+  `DeterministicMap` alias from `exo_core`.
+- **Canonical CBOR for hashed data.** Use `ciborium` with sorted
+  keys, never JSON. JSON key ordering is not guaranteed across
+  implementations.
+- **No `std::time::SystemTime::now()` or `Instant::now()` in
+  governance logic.** Use the Hybrid Logical Clock in `exo_core::hlc`.
+- **No randomness in logic.** Randomness is permitted only for key
+  generation (`ed25519-dalek` keypairs).
+
+### 4.2 No `unsafe`
+
+- `unsafe_code = "deny"` at the workspace level.
+- No `unsafe` blocks, `unsafe impl`, or `unsafe fn`.
+
+### 4.3 Error handling
+
+- Define errors with `thiserror`. Every crate has an `error.rs`.
+- Return `Result<T, CrateError>`. Avoid `unwrap()` and `expect()` in
+  non-test code — Clippy sets both to `warn`.
+- Every error variant must carry enough context to diagnose the
+  failure without a debugger.
+
+### 4.4 Address the 8 invariants where applicable
+
+If you are adding a new action, a new event type, or a new code path
+that consumes `AdjudicationContext`, ask: which of the 8 invariants
+apply, and which are definitely not applicable? Document the answer in
+the module doc-comment. See
+[`constitutional-model.md`](./constitutional-model.md) for the
+invariants themselves and
+[`../../AGENTS.md`](../../AGENTS.md) — "How to Add a New Invariant" for
+the amendment process.
+
+---
+
+## 5. Running a local dev node
+
+The single-node path, suitable for development and integration tests:
+
+```bash
+# One-time init. Creates ~/.exochain/ with a freshly generated DID,
+# Ed25519 keypair, and validator manifest.
+./target/release/exochain init
+
+# Start the node as a single validator. No peers, no discovery.
+# API: http://localhost:3000
+# Dashboard: http://localhost:3000 (served by the same port)
+./target/release/exochain start --validator
+```
+
+What you get on port 3000:
+
+| Path                   | What it serves                                                                  |
+|------------------------|---------------------------------------------------------------------------------|
+| `GET /`                | Live dashboard (HTML)                                                           |
+| `GET /health`          | Liveness probe                                                                  |
+| `GET /ready`           | Readiness probe                                                                 |
+| `GET /api/status`      | Node height, peers, checkpoint, validator set                                   |
+| `POST /api/decisions`  | Create a governance decision                                                    |
+| `POST /api/votes`      | Cast a vote                                                                     |
+| `GET /api/checkpoints/:id` | Retrieve a checkpoint by ID                                                 |
+| `GET /metrics`         | Prometheus exposition                                                           |
+
+### 5.1 Check consensus status
+
+```bash
+curl -s http://localhost:3000/api/status | jq .
+```
+
+Expected shape (single-node):
+
+```json
+{
+  "height":         12,
+  "validator_set": ["did:exo:local-dev"],
+  "peers":          0,
+  "last_checkpoint":"0xabcd…",
+  "consensus":      "steady",
+  "kernel_hash":    "blake3:…"
+}
+```
+
+When running a multi-node cluster via `docker-compose.multinode.yml`,
+the same endpoint on any node will show the full validator set and
+the current HotStuff view number.
+
+---
+
+## 6. Making your first change
+
+### 6.1 Pick an issue
+
+Three sources, in priority order:
+
+1. `GAP-REGISTRY.md` — the tracked gap list, ordered by priority. Good
+   for scoped work that lands on a known deadline.
+2. GitHub Issues with the label `good-first-issue` — intentionally
+   scoped for new contributors.
+3. GitHub Issues with the label `exoforge:triage` — items that have
+   been triaged by ExoForge and include a council review. These tend
+   to have the clearest acceptance criteria.
+
+### 6.2 The 16 CI quality gates
+
+Every PR runs the `.github/workflows/ci.yml` pipeline. The gates fall
+into three groups:
+
+**Pull-request gates (8, must pass to merge)**
+
+1. Compilation — `cargo build --workspace --all-targets`
+2. Testing — `cargo test --workspace --lib` (≥1,116 tests, 100% pass)
+3. Coverage — `tarpaulin` / `llvm-cov` ≥ 90% line coverage
+4. Formatting — `cargo fmt --all -- --check`
+5. Linting — `cargo clippy --workspace --all-targets -- -D warnings`
+6. Security audit — `cargo audit`, zero CVSS>0 vulnerabilities
+7. Dependency check — `cargo deny check`
+8. Doc check — `cargo doc --workspace --no-deps`
+
+**Release gates (additional)**
+
+9. Cross-implementation hash test — `tools/cross-impl-test/compare.sh`
+10. Benchmark regression — `cargo bench`, no ≥10% regression
+11. Fuzz smoke — 5-minute run, 0 crashes
+12. Changelog — `CHANGELOG.md` updated with conventional commits
+13. Post-quantum roundtrip — all three `Signature` enum variants
+14. Constitutional invariant verification — all AEGIS/SYBIL invariants
+    verified against CR-001
+
+**Meta gates**
+
+15. SBOM generation
+16. `cargo machete` (no unused deps)
+
+See [`../../governance/quality_gates.md`](../../governance/quality_gates.md)
+for the authoritative list.
+
+### 6.3 Run the gates locally before you push
+
+```bash
+# The "close to CI" command — run these four before every PR.
+cargo build --workspace
+cargo test  --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+cargo fmt --all -- --check
+
+# Nightly is needed for fmt --check on the full codebase.
+cargo +nightly fmt --all -- --check
+
+# If you changed dependencies.
+cargo deny check
+cargo audit
+```
+
+If you want to reproduce the CI environment more faithfully:
+
+```bash
+docker-compose -f docker-compose.ci.yml up --abort-on-container-exit
+```
+
+### 6.4 Commit conventions
+
+EXOCHAIN uses conventional commits. The release gate
+(`CHANGELOG.md` check) requires them.
+
+```
+feat(exo-gatekeeper): add invariant 9 for evidence-bundle integrity
+fix(exo-dag): correct MMR leaf hashing for odd-length inputs
+docs(guides): add developer-onboarding.md
+chore: bump rust-toolchain to 1.85.0
+refactor(exo-consent): extract bailment state machine
+test(exo-governance): pin CR-001 §8.3 synthetic-vote exclusion
+```
+
+Scopes follow the crate names. `docs`, `chore`, `refactor`, `test`,
+and `feat` / `fix` are the common prefixes.
+
+### 6.5 The council assessment process for constitutional changes
+
+If your change touches any of the following, it is constitutional and
+needs a resolution in `governance/resolutions/`:
+
+- The 8 invariants or the `InvariantSet`.
+- The 6 MCP rules or the `SignerType` binding.
+- The kernel binary (`Kernel::new`, `Kernel::adjudicate`, the
+  constitution hash).
+- Separation-of-powers enforcement (`GovernmentBranch`).
+- Quorum computation, including the synthetic-voice exclusion rule.
+
+The process, summarised from [`../../AGENTS.md`](../../AGENTS.md) and
+CR-001:
+
+1. Draft a resolution under `governance/resolutions/CR-00N-…md`.
+2. Address: which invariants change, how determinism is preserved,
+   what new attack vectors are introduced, how separation of powers
+   is affected, whether consent requirements change.
+3. Run the full quality-gate suite locally (above).
+4. Run `tools/cross-impl-test/compare.sh`.
+5. Open a PR with the resolution + code change. Tag the council
+   panels listed in `docs/council/`.
+6. CI re-runs the gates and the cross-impl test. PR cannot merge
+   until all pass.
+7. For amendment-gated changes (see
+   [`constitutional-model.md`](./constitutional-model.md) §6), the
+   additional formal-proof and external-audit steps apply.
+
+---
+
+## 7. Governance artefacts
+
+| Artifact                                                | What it is                                              |
+|---------------------------------------------------------|---------------------------------------------------------|
+| [`../../governance/traceability_matrix.md`](../../governance/traceability_matrix.md) | 87 requirements, each mapped to crate/module/tests/status |
+| [`../../governance/threat_matrix.md`](../../governance/threat_matrix.md) | 14 threats with mitigation references                    |
+| [`../../governance/quality_gates.md`](../../governance/quality_gates.md) | The 16 CI-enforced gates                                 |
+| [`../../governance/resolutions/CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY.md`](../../governance/resolutions/CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY.md) | The AEGIS / SYBIL resolution (draft, pending ratification) |
+| [`../../governance/sub_agents.md`](../../governance/sub_agents.md) | 11 sub-agent charters with ownership boundaries          |
+| [`../../governance/EXOCHAIN-REFACTOR-PLAN.md`](../../governance/EXOCHAIN-REFACTOR-PLAN.md) | Active refactor roadmap                                  |
+
+When in doubt about whether a change is in scope, start from the
+traceability matrix — find the row that your change touches, and
+confirm the status and the test locations agree with what you are
+about to write.
+
+---
+
+## 8. Where to get help
+
+| You want...                                          | Read                                                                                      |
+|------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| The philosophical and formal model                    | [`constitutional-model.md`](./constitutional-model.md)                                    |
+| A layered architecture map                            | [`architecture-overview.md`](./architecture-overview.md)                                  |
+| A pre-existing deep dive on layer structure           | [`../architecture/ARCHITECTURE.md`](../architecture/ARCHITECTURE.md)                      |
+| The guide for AI agents connecting to EXOCHAIN        | [`ai-agent-guide.md`](./ai-agent-guide.md)                                                |
+| AI development constraints (determinism, no-unsafe…)  | [`../../AGENTS.md`](../../AGENTS.md)                                                      |
+| How the CGR Kernel is used from user code             | [`cgr-developer-guide.md`](./cgr-developer-guide.md)                                      |
+| How to stand up a production deployment               | [`production-deployment.md`](./production-deployment.md), [`DEPLOYMENT.md`](./DEPLOYMENT.md) |
+| How to integrate with ExoForge                        | [`ARCHON-INTEGRATION.md`](./ARCHON-INTEGRATION.md)                                        |
+| How to report a security issue                        | [`../../SECURITY.md`](../../SECURITY.md)                                                  |
+| How to get non-security support                       | [`../../SUPPORT.md`](../../SUPPORT.md)                                                    |
+| How to contribute a PR                                | [`../../CONTRIBUTING.md`](../../CONTRIBUTING.md)                                          |
+| The formal threat model                               | [`../architecture/THREAT-MODEL.md`](../architecture/THREAT-MODEL.md)                      |
+| A quick list of all crates and their APIs             | [`../reference/CRATE-REFERENCE.md`](../reference/CRATE-REFERENCE.md)                      |
+
+For live help:
+
+- Open an issue on GitHub with the `question` label.
+- For security issues, do not open a public issue — follow the
+  process in [`../../SECURITY.md`](../../SECURITY.md).
+- For governance questions, tag the appropriate council panel from
+  `docs/council/`.
+
+---
+
+## 9. A one-hour checklist
+
+If you want a tight sequence to follow, here it is:
+
+- [ ] `git clone git@github.com:exochain/exochain.git && cd exochain`
+- [ ] `cargo build --workspace` (5 min)
+- [ ] `cargo test --workspace` (2 min; expect 0 failures)
+- [ ] `cargo build --release -p exo-node` (3 min)
+- [ ] `./target/release/exochain status` — confirm data dir creation
+- [ ] `./target/release/exochain init`
+- [ ] `./target/release/exochain start --validator` (separate shell)
+- [ ] `curl -s http://localhost:3000/api/status | jq .`
+- [ ] `./target/release/exochain mcp` (separate shell)
+- [ ] Pipe the two JSON-RPC requests from §2.5 and verify the
+      response tools list
+- [ ] Pipe the `exochain_adjudicate_action` call from §2.5 and
+      observe `Permitted`
+- [ ] Flip `is_self_grant: true` and observe `Denied` with
+      `NoSelfGrant`
+- [ ] Open [`constitutional-model.md`](./constitutional-model.md) and
+      read §3 (the 8 invariants)
+- [ ] Pick an issue from `GAP-REGISTRY.md` or the `good-first-issue`
+      GitHub label
+- [ ] Run the four pull-request gate commands from §6.3 before
+      pushing
+
+You are now oriented.
+
+---
+
+Copyright (c) 2025–2026 EXOCHAIN Foundation. Licensed under the
+Apache License, Version 2.0. See
+[`../../LICENSE`](../../LICENSE).

--- a/docs/guides/mcp-integration.md
+++ b/docs/guides/mcp-integration.md
@@ -1,0 +1,720 @@
+---
+title: "MCP Integration Guide"
+status: active
+created: 2026-04-15
+tags: [exochain, mcp, claude, ai, integration, guide]
+---
+
+# MCP Integration Guide
+
+**Wire Claude (and any other MCP client) to the EXOCHAIN node over Model Context Protocol.**
+
+The EXOCHAIN node ships an embedded MCP server exposing the full constitutional fabric: 40 tools, 6 resources, and 4 prompts. Every tool call is adjudicated by the CGR Kernel against 8 constitutional invariants and 6 MCP enforcement rules before it takes effect. AI agents do not bypass the constitution — they act inside it.
+
+---
+
+## Table of Contents
+
+- [Why MCP for EXOCHAIN](#why-mcp-for-exochain)
+- [Prerequisites](#prerequisites)
+- [Building the node binary](#building-the-node-binary)
+- [Running the MCP server](#running-the-mcp-server)
+- [Claude Code configuration](#claude-code-configuration)
+- [Constitutional enforcement](#constitutional-enforcement)
+- [The 40 tools, by domain](#the-40-tools-by-domain)
+- [The 6 resources](#the-6-resources)
+- [The 4 prompts](#the-4-prompts)
+- [End-to-end governance workflow](#end-to-end-governance-workflow)
+- [JSON-RPC wire examples](#json-rpc-wire-examples)
+- [Troubleshooting](#troubleshooting)
+- [What next](#what-next)
+
+---
+
+## Why MCP for EXOCHAIN
+
+Model Context Protocol (MCP) is the standard Anthropic published for giving AI agents structured access to tools, data, and prompt templates. The EXOCHAIN node implements MCP so any compliant client — Claude Desktop, Claude Code, LM Studio, or a custom agent — can drive the constitutional fabric by name.
+
+Every request flows through the same pipeline the human-facing gateway uses: MCP middleware (the 6 rules) -> CGR Kernel (8 invariants) -> the tool's effect. An AI agent cannot forge identity, self-escalate, or act without provenance. When the kernel denies an action, the response carries the invariant name and a human-readable reason, so the agent can adapt.
+
+---
+
+## Prerequisites
+
+| Requirement | Why |
+|---|---|
+| **Rust 1.85+** | Node compilation (`cargo build`). |
+| **An MCP client** | Claude Code, Claude Desktop, or any spec-compliant client. |
+| **Port 3030 free** (optional) | Only if using SSE transport. |
+| **~1 GB disk** (optional) | Only if the node will persist data to `~/.exochain`. |
+
+See [`docs/guides/GETTING-STARTED.md`](./GETTING-STARTED.md) for the full toolchain setup (cargo-deny, cargo-audit, cargo-tarpaulin). None of those are required for the MCP server specifically.
+
+---
+
+## Building the node binary
+
+From the repo root:
+
+```bash
+git clone https://github.com/exochain/exochain.git
+cd exochain
+cargo build --release -p exo-node
+```
+
+The binary lands at `target/release/exochain`. Put it on your `PATH` for convenience:
+
+```bash
+sudo cp target/release/exochain /usr/local/bin/exochain
+exochain --version
+```
+
+Expected output:
+
+```text
+exochain 0.1.0
+```
+
+---
+
+## Running the MCP server
+
+The `exochain mcp` subcommand starts the MCP server. Two transports are supported.
+
+### Stdio (default)
+
+Used by Claude Desktop and Claude Code. The server reads newline-delimited JSON-RPC from stdin and writes responses to stdout. All logs go to stderr.
+
+```bash
+exochain mcp
+```
+
+Expected stderr on startup:
+
+```text
+[exochain-mcp] Constitutional MCP server ready on stdio
+[exochain-mcp] Actor: did:exo:<node-identity>
+[exochain-mcp] Tools: 40
+```
+
+Flags:
+
+| Flag | Meaning |
+|---|---|
+| `--actor-did <DID>` | Override the default actor DID (otherwise derived from the node's identity). |
+| `--data-dir <PATH>` | Override `~/.exochain`. |
+
+### SSE (HTTP+Server-Sent Events)
+
+For remote clients, browsers, and debugging. The server serves MCP over HTTP on the given bind address.
+
+```bash
+exochain mcp --sse 127.0.0.1:3030
+```
+
+Expected stderr:
+
+```text
+[exochain-mcp] Constitutional MCP server ready on SSE: http://127.0.0.1:3030
+[exochain-mcp] Actor: did:exo:<node-identity>
+```
+
+The SSE endpoint accepts `POST /mcp` with a JSON-RPC body and streams responses on `GET /events`.
+
+### Quick smoke test
+
+With the stdio server running in one terminal, pipe it a discovery request in another:
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | exochain mcp
+```
+
+Expected output (truncated):
+
+```json
+{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"exochain_node_status",...}, ...]}}
+```
+
+---
+
+## Claude Code configuration
+
+Add the EXOCHAIN MCP server to Claude Code via your MCP config file. On macOS / Linux, the file lives at `~/.claude/mcp.json` (path may vary by Claude Code version):
+
+```json
+{
+  "mcpServers": {
+    "exochain": {
+      "command": "exochain",
+      "args": ["mcp"],
+      "env": {}
+    }
+  }
+}
+```
+
+If you built from source and did not install to `PATH`, use the absolute path:
+
+```json
+{
+  "mcpServers": {
+    "exochain": {
+      "command": "/Users/you/dev/exochain/target/release/exochain",
+      "args": ["mcp", "--actor-did", "did:exo:my-claude-agent"],
+      "env": {
+        "EXO_DATA_DIR": "/Users/you/.exochain"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Code. The server advertises 40 tools, 6 resources, and 4 prompts. You should see them under the MCP menu.
+
+### Claude Desktop
+
+Claude Desktop uses the same config format at `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "exochain": {
+      "command": "exochain",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+### Remote SSE client
+
+For HTTP-based clients, point at `http://127.0.0.1:3030/mcp` and use standard MCP JSON-RPC. The CLI flag `--sse 0.0.0.0:3030` binds publicly — do not do this without a reverse proxy enforcing TLS and auth.
+
+---
+
+## Constitutional enforcement
+
+Every `tools/call` traverses this stack:
+
+```
+MCP client
+    |
+    v
+MCP middleware (6 rules):
+    Mcp001BctsScope        — declared bailment scope required
+    Mcp002NoSelfEscalation — AI cannot widen its own scope
+    Mcp003ProvenanceRequired — actor DID + timestamp + signature
+    Mcp004NoIdentityForge  — signature type is part of signed payload
+    Mcp005Distinguishable  — AI outputs flagged AI-produced
+    Mcp006ConsentBoundaries — revocation is immediate
+    |
+    v
+CGR Kernel (8 invariants):
+    1. SeparationOfPowers
+    2. ConsentRequired
+    3. NoSelfGrant
+    4. HumanOverride
+    5. KernelImmutability
+    6. AuthorityChainValid
+    7. QuorumLegitimate
+    8. ProvenanceVerifiable
+    |
+    v
+Tool handler
+    |
+    v
+Response (JSON-RPC result or error)
+```
+
+When enforcement blocks a call, the response includes the violated invariant name so the agent can explain it. The canonical names for all 8 invariants and all 6 rules are available as MCP resources — an agent can read them at session start to learn the rules of the fabric.
+
+---
+
+## The 40 tools, by domain
+
+Tools are namespaced `exochain_<verb>`. Counts: 3+5+4+5+4+4+4+4+4+3 = 40.
+
+### Node (3)
+
+| Tool | Purpose |
+|---|---|
+| `exochain_node_status` | Liveness, uptime, version, actor DID. |
+| `exochain_list_invariants` | Return all 8 constitutional invariants with descriptions. |
+| `exochain_list_mcp_rules` | Return all 6 MCP enforcement rules with descriptions. |
+
+Use these at session start to let the agent self-orient.
+
+### Identity (5)
+
+| Tool | Purpose |
+|---|---|
+| `exochain_create_identity` | Generate an Ed25519 keypair and a `did:exo:` DID. Input: `{ label? }`. |
+| `exochain_resolve_identity` | Resolve a DID to its document / validity state. Input: `{ did }`. |
+| `exochain_assess_risk` | Compute a risk score from evidence types. Input: `{ did, evidence_types? }`. |
+| `exochain_verify_signature` | Verify an Ed25519 signature against a DID's public key. |
+| `exochain_get_passport` | Fetch the agent passport for a DID (capabilities + provenance). |
+
+### Consent (4)
+
+| Tool | Purpose |
+|---|---|
+| `exochain_propose_bailment` | Propose a scoped, time-bounded consent. Input: `{ bailor_did, bailee_did, scope, duration_hours? }`. |
+| `exochain_check_consent` | Is there active consent for actor+scope? Input: `{ actor_did, scope }`. |
+| `exochain_list_bailments` | List bailments the agent knows about. |
+| `exochain_terminate_bailment` | Revoke a bailment — effect is immediate (invariant `ConsentRequired`). |
+
+### Governance (5)
+
+| Tool | Purpose |
+|---|---|
+| `exochain_create_decision` | Open a governance decision. Input: `{ title, description, proposer_did, decision_class? }`. |
+| `exochain_cast_vote` | Cast a vote (`approve`/`reject`/`abstain`) with optional rationale. |
+| `exochain_check_quorum` | Tally votes against a threshold. Input: `{ decision_id, threshold }`. |
+| `exochain_get_decision_status` | Return the current BCTS lifecycle state for a decision. |
+| `exochain_propose_amendment` | Propose a constitutional amendment (requires elevated privilege). |
+
+### Authority (4)
+
+| Tool | Purpose |
+|---|---|
+| `exochain_delegate_authority` | Create a delegation link grantor->grantee with permissions. |
+| `exochain_verify_authority_chain` | Validate a chain's topology and signatures. |
+| `exochain_check_permission` | Does the agent have permission X on resource Y? |
+| `exochain_adjudicate_action` | Run an action through the CGR Kernel and return a verdict. |
+
+### Ledger (4)
+
+| Tool | Purpose |
+|---|---|
+| `exochain_submit_event` | Append a signed event to the ledger. |
+| `exochain_get_event` | Fetch an event by hash. |
+| `exochain_verify_inclusion` | Prove a given event is in a given checkpoint. |
+| `exochain_get_checkpoint` | Fetch the latest signed checkpoint. |
+
+### Proofs (4)
+
+| Tool | Purpose |
+|---|---|
+| `exochain_create_evidence` | Bundle evidence with a chain-of-custody record. |
+| `exochain_verify_chain_of_custody` | Verify an evidence bundle end-to-end. |
+| `exochain_generate_merkle_proof` | Produce a Merkle inclusion proof for a leaf. |
+| `exochain_verify_cgr_proof` | Verify a CGR verdict proof against the checkpoint root. |
+
+### Legal (4)
+
+| Tool | Purpose |
+|---|---|
+| `exochain_ediscovery_search` | Search the ledger for events matching a legal-discovery query. |
+| `exochain_assert_privilege` | Mark documents as privileged (attorney-client, work product). |
+| `exochain_initiate_safe_harbor` | Start a safe-harbor remediation flow. |
+| `exochain_check_fiduciary_duty` | Evaluate whether an action would breach fiduciary duty. |
+
+### Escalation (4)
+
+| Tool | Purpose |
+|---|---|
+| `exochain_evaluate_threat` | Score a threat indicator against the threat model. |
+| `exochain_escalate_case` | Open an escalation case. |
+| `exochain_triage` | Triage an incoming case and route it. |
+| `exochain_record_feedback` | Attach feedback to a case. |
+
+### Messaging (3)
+
+| Tool | Purpose |
+|---|---|
+| `exochain_send_encrypted` | Send an end-to-end-encrypted message to a DID. |
+| `exochain_receive_encrypted` | Decrypt inbound messages. |
+| `exochain_configure_death_trigger` | Configure a dead-mans-switch delivery. |
+
+For the canonical tool list at runtime, call `tools/list` or read `exochain://tools` (see next section).
+
+---
+
+## The 6 resources
+
+Resources are read-only artifacts under the `exochain://` URI scheme. Read them with `resources/read`.
+
+| URI | MIME | Contents |
+|---|---|---|
+| `exochain://constitution` | `text/plain` | The BLAKE3-hashed constitution text. |
+| `exochain://invariants` | `application/json` | The 8 invariants, each with `index`, `name`, `description`. |
+| `exochain://mcp-rules` | `application/json` | The 6 MCP enforcement rules with descriptions. |
+| `exochain://node/status` | `application/json` | Live node snapshot (uptime, actor, peer count). |
+| `exochain://tools` | `application/json` | All 40 tools grouped by domain with `total: 40`. |
+| `exochain://readme` | `text/markdown` | Agent-oriented quick reference. |
+
+Example: fetch the invariants:
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"exochain://invariants"}}' \
+  | exochain mcp
+```
+
+Response shape:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "contents": [
+      {
+        "uri": "exochain://invariants",
+        "mimeType": "application/json",
+        "text": "{\n  \"count\": 8,\n  \"invariants\": [ ... ]\n}"
+      }
+    ]
+  }
+}
+```
+
+---
+
+## The 4 prompts
+
+Prompts are parameterized workflow templates. Fetch one with `prompts/get`.
+
+| Name | Required args | Optional args | Purpose |
+|---|---|---|---|
+| `governance_review` | `decision_id`, `decision_title` | `summary`, `proposer_did` | Structured review of a pending decision. Tells the agent which tools to call (e.g. `exochain_check_quorum`) before answering. |
+| `compliance_check` | `action`, `actor_did` | `rationale`, `resource` | Verify an action against the 8 invariants + 6 MCP rules. |
+| `evidence_analysis` | `bundle_id` | `case_id`, `custodian_did`, `context` | Analyze evidence for admissibility and chain-of-custody integrity. |
+| `constitutional_audit` | `scope` | `timestamp`, `auditor_did`, `focus` | Audit a subsystem against all 8 invariants. |
+
+Each prompt returns one or more `messages` formatted for direct inclusion in the agent's context — the messages embed the named arguments and point the agent at the relevant tools.
+
+---
+
+## End-to-end governance workflow
+
+A Claude agent performing a real governance operation end-to-end. In practice the agent strings these tool calls together automatically once asked "ratify this amendment".
+
+```
+1.  exochain_create_identity              -> actor DID + public key
+2.  exochain_propose_bailment              -> proposal_id (scope="governance:vote")
+3.  exochain_check_consent                 -> ensure active consent
+4.  exochain_create_decision               -> decision_id
+5.  exochain_cast_vote    (x N validators) -> record approvals
+6.  exochain_check_quorum                  -> met=true at threshold
+7.  exochain_verify_authority_chain        -> proposer chain valid
+8.  exochain_adjudicate_action             -> kernel verdict: Permitted
+9.  exochain_submit_event                  -> append decision event to ledger
+10. exochain_get_checkpoint                -> fresh checkpoint root
+11. exochain_verify_inclusion              -> inclusion proof for step 9
+```
+
+Each call is independently constitutional: step 5 will be denied for a duplicate voter (`QuorumLegitimate`); step 8 will be denied if the authority chain in step 7 does not match; step 1 produces provenance the kernel will require in every later step (`ProvenanceVerifiable`).
+
+---
+
+## JSON-RPC wire examples
+
+The MCP protocol is JSON-RPC 2.0 over stdio or HTTP. Every request has `jsonrpc`, `id`, `method`, optional `params`. Responses carry a matching `id` and either `result` or `error`.
+
+### Discovery: list all tools
+
+Request:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/list"
+}
+```
+
+Response (abridged):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "tools": [
+      {
+        "name": "exochain_node_status",
+        "description": "Return node status, uptime, and actor DID.",
+        "inputSchema": { "type": "object", "properties": {}, "additionalProperties": false }
+      },
+      {
+        "name": "exochain_create_identity",
+        "description": "Create a new DID identity with an Ed25519 keypair. ...",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "label": { "type": "string", "description": "Optional human-readable label for this identity." }
+          },
+          "additionalProperties": false
+        }
+      }
+      // ... 38 more tools ...
+    ]
+  }
+}
+```
+
+### Call: create identity
+
+Request:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "exochain_create_identity",
+    "arguments": { "label": "alice" }
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"did\":\"did:exo:d9c21e4b7f1a8035\",\"public_key_hex\":\"1aef...\",\"verification_method_id\":\"did:exo:d9c21e4b7f1a8035#key-1\",\"label\":\"alice\"}"
+      }
+    ]
+  }
+}
+```
+
+### Call: propose bailment
+
+Request:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "tools/call",
+  "params": {
+    "name": "exochain_propose_bailment",
+    "arguments": {
+      "bailor_did": "did:exo:alice",
+      "bailee_did": "did:exo:bob",
+      "scope": "data:medical:records",
+      "duration_hours": 24
+    }
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"proposal_id\":\"4f2a910b...\",\"bailor\":\"did:exo:alice\",\"bailee\":\"did:exo:bob\",\"scope\":\"data:medical:records\",\"status\":\"proposed\",\"expires_at\":\"1713196800000:0\"}"
+      }
+    ]
+  }
+}
+```
+
+### Call: create decision, cast vote, check quorum
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "tools/call",
+  "params": {
+    "name": "exochain_create_decision",
+    "arguments": {
+      "title": "Raise quorum threshold to 3/4",
+      "description": "Constitutional amendment.",
+      "proposer_did": "did:exo:alice",
+      "decision_class": "amendment"
+    }
+  }
+}
+```
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "method": "tools/call",
+  "params": {
+    "name": "exochain_cast_vote",
+    "arguments": {
+      "decision_id": "9f3c2a1b...",
+      "voter_did": "did:exo:v1",
+      "choice": "approve",
+      "rationale": "Aligns with charter."
+    }
+  }
+}
+```
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 6,
+  "method": "tools/call",
+  "params": {
+    "name": "exochain_check_quorum",
+    "arguments": {
+      "decision_id": "9f3c2a1b...",
+      "threshold": 2
+    }
+  }
+}
+```
+
+A kernel denial looks like this (not a JSON-RPC `error`, but a tool result carrying `error: ...`):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"error\":\"denied: NoSelfGrant — actor attempted to grant permissions to themselves\"}"
+      }
+    ],
+    "isError": true
+  }
+}
+```
+
+### Read a resource
+
+Request:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 8,
+  "method": "resources/read",
+  "params": { "uri": "exochain://mcp-rules" }
+}
+```
+
+### Get a prompt
+
+Request:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 9,
+  "method": "prompts/get",
+  "params": {
+    "name": "governance_review",
+    "arguments": {
+      "decision_id": "9f3c2a1b...",
+      "decision_title": "Raise quorum threshold to 3/4",
+      "proposer_did": "did:exo:alice",
+      "summary": "Move threshold from 2/3 to 3/4 for constitutional amendments."
+    }
+  }
+}
+```
+
+Response (abridged): a filled-in multi-turn prompt instructing the agent to call `exochain_get_decision_status`, `exochain_check_quorum`, and `exochain_verify_authority_chain` before producing a recommendation.
+
+---
+
+## Troubleshooting
+
+### "Server not found" in Claude Code
+
+- Verify the binary is executable: `exochain --version` should print a version.
+- Use an absolute path in `mcp.json`.
+- Check Claude Code logs for the actual error — path typos are the most common cause.
+
+### No tools appear after connecting
+
+- Confirm `tools/list` returns 40 tools via the smoke test:
+
+  ```bash
+  echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | exochain mcp | jq '.result.tools | length'
+  ```
+
+  Expected: `40`.
+
+- If the number is wrong, the binary is stale — rebuild with `cargo build --release -p exo-node`.
+
+### "tool not found" error at runtime
+
+Tool names are **case-sensitive**, prefixed `exochain_`, and snake-cased. `exochainCastVote` won't match; `exochain_cast_vote` will.
+
+### Stdio hangs and produces no output
+
+- All diagnostics go to stderr. Look at the terminal's stderr for `[exochain-mcp] ...` lines.
+- The server reads *newline-delimited* JSON. An unterminated line will hang until EOF.
+- If you're piping, ensure your producer flushes and writes `\n`.
+
+### "JSON-RPC parse error"
+
+- Every request must be a single-line JSON object, followed by `\n`.
+- The server ignores empty lines but not multi-line JSON.
+
+### Kernel denial with unclear reason
+
+Every deny carries the invariant name. Common cases:
+
+| Message substring | Cause | Fix |
+|---|---|---|
+| `NoSelfGrant` | Actor tried to grant itself permissions | Route the grant through a distinct grantor DID. |
+| `ConsentRequired` | No active bailment for the scope | Call `exochain_propose_bailment` first. |
+| `AuthorityChainValid` | Chain broken or terminal mismatch | Inspect via `exochain_verify_authority_chain`. |
+| `KernelImmutability` | Tried to modify the constitution | Use the amendment proposal process instead. |
+| `ProvenanceVerifiable` | Missing signature or timestamp | Ensure the calling agent's identity is set (`--actor-did`). |
+
+### SSE returns 502 from a reverse proxy
+
+Nginx and similar proxies buffer by default. Disable buffering on the SSE endpoint:
+
+```nginx
+location /events {
+    proxy_pass http://127.0.0.1:3030/events;
+    proxy_http_version 1.1;
+    proxy_set_header Connection '';
+    proxy_buffering off;
+    proxy_cache off;
+    proxy_read_timeout 24h;
+}
+```
+
+### Rate limit / governance denial loops
+
+If an agent repeatedly triggers the same kernel denial, read `exochain://invariants` and `exochain://mcp-rules` and feed them into the agent's context. The rule names are stable and the descriptions are designed to tell the agent exactly what to change.
+
+---
+
+## What next
+
+- **Rust SDK** — [`docs/guides/sdk-quickstart-rust.md`](./sdk-quickstart-rust.md). Build callers that produce the same constitutional evidence the MCP server consumes.
+- **TypeScript SDK** — [`docs/guides/sdk-quickstart-typescript.md`](./sdk-quickstart-typescript.md).
+- **Python SDK** — [`docs/guides/sdk-quickstart-python.md`](./sdk-quickstart-python.md).
+- **Getting Started** — [`docs/guides/GETTING-STARTED.md`](./GETTING-STARTED.md). Workspace build, CI gates.
+- **Architecture** — [`docs/architecture/ARCHITECTURE.md`](../architecture/ARCHITECTURE.md). Three branches, BCTS lifecycle.
+- **Threat model** — [`docs/architecture/THREAT-MODEL.md`](../architecture/THREAT-MODEL.md). Twelve threats and their mitigations.
+- **Proofs** — [`docs/proofs/CONSTITUTIONAL-PROOFS.md`](../proofs/CONSTITUTIONAL-PROOFS.md). Ten formal proofs that the invariants hold.
+- **MCP source**:
+  - Tool registry — [`crates/exo-node/src/mcp/tools/mod.rs`](../../crates/exo-node/src/mcp/tools/mod.rs)
+  - Resource registry — [`crates/exo-node/src/mcp/resources/mod.rs`](../../crates/exo-node/src/mcp/resources/mod.rs)
+  - Prompt registry — [`crates/exo-node/src/mcp/prompts/mod.rs`](../../crates/exo-node/src/mcp/prompts/mod.rs)
+  - Transport entry — [`crates/exo-node/src/mcp/mod.rs`](../../crates/exo-node/src/mcp/mod.rs)
+  - CLI — [`crates/exo-node/src/cli.rs`](../../crates/exo-node/src/cli.rs)
+
+---
+
+Licensed under Apache-2.0. © 2025 EXOCHAIN Foundation.

--- a/docs/guides/sdk-quickstart-python.md
+++ b/docs/guides/sdk-quickstart-python.md
@@ -1,0 +1,500 @@
+---
+title: "Python SDK Quickstart"
+status: active
+created: 2026-04-15
+tags: [exochain, sdk, python, quickstart, guide]
+---
+
+# Python SDK Quickstart
+
+**Get productive with the `exochain` Python package in ten minutes.**
+
+The Python SDK is a Pydantic v2 + asyncio port of the canonical Rust SDK. Same five domains (identity, consent, governance, authority, crypto), async transport to `exo-gateway`, frozen data classes where appropriate.
+
+---
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Runtime requirements](#runtime-requirements)
+- [Hashing difference you must know](#hashing-difference-you-must-know)
+- [Domain 1: Identity](#domain-1-identity)
+- [Domain 2: Consent (bailments)](#domain-2-consent-bailments)
+- [Domain 3: Governance (decisions + voting)](#domain-3-governance-decisions--voting)
+- [Domain 4: Authority chains](#domain-4-authority-chains)
+- [Domain 5: Crypto primitives](#domain-5-crypto-primitives)
+- [Transport + `ExochainClient`](#transport--exochainclient)
+- [Error handling](#error-handling)
+- [End-to-end example](#end-to-end-example)
+- [What next](#what-next)
+
+---
+
+## Installation
+
+### pip (once published)
+
+```bash
+pip install exochain
+```
+
+### Local editable install during development
+
+From inside the monorepo:
+
+```bash
+cd packages/exochain-py
+pip install -e '.[dev]'
+```
+
+Then:
+
+```bash
+$ python -c "from exochain import Identity; print(Identity.generate('hello').did)"
+did:exo:a1b2c3d4e5f60789
+```
+
+### Dependencies
+
+The package depends on:
+
+| Package | Minimum | Why |
+|---|---|---|
+| `cryptography` | 42.0.0 | Ed25519 primitives |
+| `pydantic` | 2.5.0 | Frozen data models |
+| `httpx` | 0.25.0 | Async HTTP transport |
+
+Dev extras add `pytest`, `pytest-asyncio`, `mypy`, and `ruff`.
+
+---
+
+## Runtime requirements
+
+- **Python 3.11+** (the package uses `StrEnum` and modern type syntax).
+- **`asyncio`** for the transport (`ExochainClient`, `HttpTransport`).
+
+Verify your install:
+
+```python
+# hello.py
+from exochain import Identity
+
+alice = Identity.generate("alice")
+print("DID:", alice.did)
+```
+
+```text
+$ python hello.py
+DID: did:exo:a1b2c3d4e5f60789
+```
+
+---
+
+## Hashing difference you must know
+
+Like the TypeScript SDK, the Python SDK uses **SHA-256** for client-side content-addressed IDs (proposal IDs, decision IDs). The Rust SDK uses **BLAKE3**. Client-derived IDs in Python therefore will not match Rust-derived IDs byte-for-byte. For cross-language interop:
+
+- Trust IDs returned by the gateway (the gateway is Rust).
+- Or use the full 64-character SHA-256 hex on the Python side, 16-hex prefix of BLAKE3 on the Rust side — they are canonically different namespaces, not lossy round-trips.
+
+See [`packages/exochain-py/exochain/crypto/hash.py`](../../packages/exochain-py/exochain/crypto/hash.py) and [`packages/exochain-py/exochain/consent/bailment.py`](../../packages/exochain-py/exochain/consent/bailment.py) for the exact canonicalization.
+
+---
+
+## Domain 1: Identity
+
+`Identity` wraps an Ed25519 keypair from the `cryptography` package. The private key is hidden from `repr`.
+
+### Generate, sign, verify
+
+```python
+from exochain import Identity
+
+alice = Identity.generate("alice")
+print("alice.did             =", alice.did)
+print("alice.public_key_hex  =", alice.public_key_hex)
+print("alice.label           =", alice.label)
+
+msg = b"I, Alice, consent."
+sig = alice.sign(msg)
+
+assert Identity.verify(alice.public_key_hex, msg, sig) is True
+assert Identity.verify(alice.public_key_hex, b"tampered", sig) is False
+```
+
+Expected output:
+
+```text
+alice.did             = did:exo:b7c14e2f8a3d1f90
+alice.public_key_hex  = 1aef... (64 hex chars)
+alice.label           = alice
+```
+
+### DID validation
+
+```python
+from exochain import validate_did, is_did
+from exochain import IdentityError
+
+d1 = validate_did("did:exo:alice")  # returns the string
+assert is_did("did:exo:alice") is True
+assert is_did("bad-did") is False
+
+try:
+    validate_did("oops")
+except IdentityError as e:
+    print("invalid:", e)
+```
+
+---
+
+## Domain 2: Consent (bailments)
+
+### Build a proposal
+
+```python
+from exochain import BailmentBuilder
+
+proposal = (
+    BailmentBuilder("did:exo:alice", "did:exo:bob")
+    .scope("data:medical:records")
+    .duration_hours(24)
+    .build()
+)
+
+print("proposal_id    =", proposal.proposal_id)
+print("bailor         =", proposal.bailor)
+print("bailee         =", proposal.bailee)
+print("scope          =", proposal.scope)
+print("duration_hours =", proposal.duration_hours)
+```
+
+`BailmentProposal` is a frozen Pydantic model — safe to pass around, hash into dict keys, and serialize with `proposal.model_dump_json()`.
+
+### What fails
+
+| Failure | Error |
+|---|---|
+| `scope` not set | `ConsentError: scope is required` |
+| empty / whitespace scope | `ConsentError: scope cannot be empty` |
+| `duration_hours <= 0` | `ConsentError: duration_hours must be a positive integer` |
+| non-int `duration_hours` | `ConsentError: duration_hours must be a positive integer` |
+
+---
+
+## Domain 3: Governance (decisions + voting)
+
+### Create a decision
+
+```python
+from exochain import DecisionBuilder, DecisionStatus
+
+decision = (
+    DecisionBuilder(
+        title="Raise quorum threshold to 3/4",
+        description="Constitutional amendment.",
+        proposer="did:exo:alice",
+    )
+    .decision_class("amendment")
+    .build()
+)
+
+print("decision_id    =", decision.decision_id)
+print("status         =", decision.status)              # DecisionStatus.PROPOSED
+print("decision_class =", decision.decision_class)
+assert decision.status == DecisionStatus.PROPOSED
+```
+
+### Cast votes, check quorum
+
+```python
+from exochain import DecisionBuilder, Vote, VoteChoice
+
+decision = DecisionBuilder("t", "d", "did:exo:alice").build()
+
+decision.cast_vote(Vote(voter="did:exo:v1", choice=VoteChoice.APPROVE))
+decision.cast_vote(Vote(voter="did:exo:v2", choice=VoteChoice.APPROVE, rationale="LGTM"))
+decision.cast_vote(Vote(voter="did:exo:v3", choice=VoteChoice.REJECT))
+
+quorum = decision.check_quorum(threshold=2)
+print(quorum)
+# met=True threshold=2 total_votes=3 approvals=2 rejections=1 abstentions=0
+```
+
+### Duplicate voters are rejected
+
+```python
+from exochain import GovernanceError
+
+try:
+    decision.cast_vote(Vote(voter="did:exo:v1", choice=VoteChoice.REJECT))
+except GovernanceError as e:
+    print("governance:", e)
+```
+
+`Vote` is frozen; use the constructor to build a new one with a rationale.
+
+---
+
+## Domain 4: Authority chains
+
+```python
+from exochain import AuthorityChainBuilder
+
+chain = (
+    AuthorityChainBuilder()
+    .add_link("did:exo:root", "did:exo:mid",  ["read"])
+    .add_link("did:exo:mid",  "did:exo:leaf", ["read", "write"])
+    .build(terminal_actor="did:exo:leaf")
+)
+
+print("depth    =", chain.depth)
+print("terminal =", chain.terminal)
+for i, link in enumerate(chain.links):
+    print(f"  link[{i}]: {link.grantor} -> {link.grantee} {link.permissions}")
+```
+
+Expected output:
+
+```text
+depth    = 2
+terminal = did:exo:leaf
+  link[0]: did:exo:root -> did:exo:mid ['read']
+  link[1]: did:exo:mid -> did:exo:leaf ['read', 'write']
+```
+
+### Validation rules
+
+Same rules as the Rust and TypeScript SDKs:
+
+| Rule | Violation | Raises |
+|---|---|---|
+| At least one link | `.build(...)` on empty builder | `AuthorityError("authority chain is empty")` |
+| Consecutive links connect | `links[i].grantee != links[i+1].grantor` | `AuthorityError("broken delegation: X != Y")` |
+| Final grantee matches terminal | `last.grantee != terminal_actor` | `AuthorityError("terminal mismatch: ...")` |
+
+---
+
+## Domain 5: Crypto primitives
+
+```python
+from exochain import sha256, sha256_hex
+
+raw = sha256(b"hello")            # bytes(32)
+hex_digest = sha256_hex(b"hello") # str (64 lowercase hex chars)
+
+assert len(raw) == 32
+assert len(hex_digest) == 64
+assert raw.hex() == hex_digest
+```
+
+---
+
+## Transport + `ExochainClient`
+
+The SDK's async transport talks to an `exo-gateway` over HTTPS. The high-level `ExochainClient` handles serialization, typed errors, and resource lifecycle.
+
+### `HttpTransport` (low-level)
+
+```python
+import asyncio
+from exochain import HttpTransport
+
+async def main():
+    async with HttpTransport("http://127.0.0.1:8080", timeout=15.0) as t:
+        health = await t.get("/health")
+        print(health)  # dict with keys: status, version, uptime
+
+asyncio.run(main())
+```
+
+### `ExochainClient` (high-level)
+
+```python
+import asyncio
+import os
+from exochain import ExochainClient
+
+async def main():
+    async with ExochainClient(
+        "http://127.0.0.1:8080",
+        api_key=os.environ.get("EXO_API_KEY"),
+        timeout=15.0,
+    ) as client:
+        # Health probe
+        print(await client.health())
+
+        # Resolve a DID
+        doc = await client.resolve_did("did:exo:alice")
+        print("doc:", doc)
+
+        # Submit a bailment
+        bailment = await client.submit_bailment({
+            "bailor": "did:exo:alice",
+            "bailee": "did:exo:bob",
+            "scope": "data:medical",
+            "durationHours": 24,
+        })
+        print("bailment:", bailment)
+
+        # Create a decision
+        decision = await client.submit_decision({
+            "title": "Fund X",
+            "description": "Allocate budget.",
+            "proposer": "did:exo:alice",
+        })
+        decision_id = decision["decision_id"]
+
+        # Vote
+        await client.cast_vote(decision_id, {
+            "voter": "did:exo:v1",
+            "choice": "approve",
+        })
+
+        # Submit a kernel action — returns a TrustReceipt
+        receipt = await client.submit_action({
+            "actor_did": "did:exo:alice",
+            "action_type": "read",
+            "payload": {"scope": "data:medical"},
+        })
+        print("receipt:", receipt.receipt_hash, receipt.outcome)
+
+asyncio.run(main())
+```
+
+`TrustReceipt` is a frozen Pydantic model with fields `receipt_hash`, `actor_did`, `action_type`, `outcome` (`"permitted" | "denied" | "escalated"`), and `timestamp_ms`. Malformed server responses raise `KernelError`.
+
+---
+
+## Error handling
+
+All SDK errors derive from `ExochainError`:
+
+```python
+from exochain import (
+    ExochainError,       # base
+    IdentityError,
+    ConsentError,
+    GovernanceError,
+    AuthorityError,
+    CryptoError,
+    KernelError,
+    TransportError,
+)
+
+try:
+    id = Identity.generate("example")
+    # ... call the fabric ...
+except IdentityError as e:
+    print("identity:", e)
+except TransportError as e:
+    print("transport:", e)
+except ExochainError as e:
+    print(e.__class__.__name__, e)
+```
+
+Transport failures (HTTP errors, timeouts, malformed JSON) always surface as `TransportError`. Kernel-side rejection surfaces as `KernelError` via `ExochainClient.submit_action`.
+
+---
+
+## End-to-end example
+
+```python
+import asyncio
+import os
+
+from exochain import (
+    AuthorityChainBuilder,
+    BailmentBuilder,
+    DecisionBuilder,
+    ExochainClient,
+    ExochainError,
+    Identity,
+    Vote,
+    VoteChoice,
+)
+
+
+async def main() -> None:
+    # 1. Identities.
+    alice = Identity.generate("alice")
+    bob = Identity.generate("bob")
+    print("alice =", alice.did)
+    print("bob   =", bob.did)
+
+    # 2. Bailment proposal.
+    proposal = (
+        BailmentBuilder(alice.did, bob.did)
+        .scope("data:medical:records")
+        .duration_hours(24)
+        .build()
+    )
+    print("bailment proposal", proposal.proposal_id)
+
+    # 3. Decision.
+    decision = (
+        DecisionBuilder(
+            title="Expand Bob's read scope to imaging",
+            description="Access request for imaging.",
+            proposer=alice.did,
+        )
+        .decision_class("scope-expansion")
+        .build()
+    )
+
+    # 4. Three validators vote.
+    for i, choice in enumerate(
+        [VoteChoice.APPROVE, VoteChoice.APPROVE, VoteChoice.REJECT]
+    ):
+        decision.cast_vote(Vote(voter=f"did:exo:v{i}", choice=choice))
+    q = decision.check_quorum(2)
+    print(f"quorum met = {q.met} ({q.approvals}/{q.total_votes} approvals)")
+
+    # 5. Authority chain root -> alice -> bob.
+    chain = (
+        AuthorityChainBuilder()
+        .add_link("did:exo:root", alice.did, ["read", "delegate"])
+        .add_link(alice.did, bob.did, ["read"])
+        .build(terminal_actor=bob.did)
+    )
+    print("chain depth =", chain.depth)
+
+    # 6. (Optional) Talk to a gateway.
+    gateway_url = os.environ.get("EXO_GATEWAY_URL")
+    if gateway_url:
+        async with ExochainClient(gateway_url) as client:
+            print("gateway health:", await client.health())
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except ExochainError as e:
+        print(f"[{type(e).__name__}] {e}")
+        raise SystemExit(1)
+```
+
+Expected local output (without `EXO_GATEWAY_URL`):
+
+```text
+alice = did:exo:d9c21e4b7f1a8035
+bob   = did:exo:a0314e8c7f9b2d11
+bailment proposal 4f2a910b8c6d7e0815a233f871cbd9af4ae2f31b0d92c6e5b718dcf4a0183e7f
+quorum met = True (2/3 approvals)
+chain depth = 2
+```
+
+---
+
+## What next
+
+- **Rust SDK** — [`docs/guides/sdk-quickstart-rust.md`](./sdk-quickstart-rust.md). Canonical reference implementation.
+- **TypeScript SDK** — [`docs/guides/sdk-quickstart-typescript.md`](./sdk-quickstart-typescript.md). Browser + Node.
+- **MCP integration** — [`docs/guides/mcp-integration.md`](./mcp-integration.md). Wire Claude to the fabric.
+- **Getting Started** — [`docs/guides/GETTING-STARTED.md`](./GETTING-STARTED.md).
+- **Source** — [`packages/exochain-py/exochain/`](../../packages/exochain-py/exochain/).
+- **pyproject.toml** — [`packages/exochain-py/pyproject.toml`](../../packages/exochain-py/pyproject.toml).
+
+---
+
+Licensed under Apache-2.0. © 2025 EXOCHAIN Foundation.

--- a/docs/guides/sdk-quickstart-rust.md
+++ b/docs/guides/sdk-quickstart-rust.md
@@ -1,0 +1,657 @@
+---
+title: "Rust SDK Quickstart"
+status: active
+created: 2026-04-15
+tags: [exochain, sdk, rust, quickstart, guide]
+---
+
+# Rust SDK Quickstart
+
+**Get productive with the `exochain-sdk` crate in ten minutes.**
+
+The Rust SDK (`exochain-sdk`) is the canonical, deterministic reference implementation of the EXOCHAIN constitutional governance fabric. Every primitive here — DIDs, bailments, decisions, authority chains, kernel verdicts — is bit-for-bit reproducible across platforms.
+
+---
+
+## Table of Contents
+
+- [Why EXOCHAIN](#why-exochain)
+- [Installation](#installation)
+- [The prelude](#the-prelude)
+- [Domain 1: Identity](#domain-1-identity)
+- [Domain 2: Consent (bailments)](#domain-2-consent-bailments)
+- [Domain 3: Governance (decisions + voting)](#domain-3-governance-decisions--voting)
+- [Domain 4: Authority chains](#domain-4-authority-chains)
+- [Domain 5: Crypto primitives](#domain-5-crypto-primitives)
+- [Domain 6: Constitutional kernel](#domain-6-constitutional-kernel)
+- [Error handling](#error-handling)
+- [End-to-end example](#end-to-end-example)
+- [What next](#what-next)
+
+---
+
+## Why EXOCHAIN
+
+EXOCHAIN is a constitutional trust fabric for AI agents and data sovereignty. Every action — a data share, a vote, a delegation — is adjudicated by an immutable kernel that enforces 8 invariants before the action can take effect. Unlike a conventional policy engine, the invariants are baked into the types: a bailment without scope does not compile; a broken authority chain does not deserialize; a self-grant is rejected by the kernel with a structured verdict that names the violated invariant.
+
+The SDK is the developer-facing facade over the underlying `exo-*` crates (`exo-core`, `exo-identity`, `exo-consent`, `exo-authority`, `exo-governance`, `exo-gatekeeper`). You get a stable, ergonomic API; the fabric gets determinism it can prove. The full constitutional model is documented in [`docs/architecture/ARCHITECTURE.md`](../architecture/ARCHITECTURE.md) and the ten formal proofs in [`docs/proofs/CONSTITUTIONAL-PROOFS.md`](../proofs/CONSTITUTIONAL-PROOFS.md).
+
+---
+
+## Installation
+
+### Workspace path dependency (recommended during development)
+
+If you are building inside the `exochain` workspace, add the SDK as a path dependency:
+
+```toml
+# Cargo.toml
+[dependencies]
+exochain-sdk = { path = "../exochain-sdk" }
+```
+
+### Git dependency
+
+If you are consuming EXOCHAIN from an external repo, pin to a tag or revision:
+
+```toml
+# Cargo.toml
+[dependencies]
+exochain-sdk = { git = "https://github.com/exochain/exochain.git", tag = "v0.1.0" }
+```
+
+### Verify the install
+
+```rust
+// src/main.rs
+use exochain_sdk::prelude::*;
+
+fn main() {
+    let identity = Identity::generate("hello");
+    println!("DID: {}", identity.did());
+}
+```
+
+```text
+$ cargo run
+DID: did:exo:a1b2c3d4e5f60789
+```
+
+The DID is derived as `did:exo:<first 16 hex chars of BLAKE3(public_key_bytes)>`, so the suffix is random per keypair but always 16 lowercase hex characters.
+
+### Required toolchain
+
+- Rust 1.85+ (edition 2024). See [`docs/guides/GETTING-STARTED.md`](./GETTING-STARTED.md) for the full toolchain setup including `cargo-deny`, `cargo-audit`, and `cargo-tarpaulin`.
+
+---
+
+## The prelude
+
+`exochain_sdk::prelude` re-exports the types you need for 95 percent of SDK work:
+
+```rust
+use exochain_sdk::prelude::*;
+
+// Now in scope:
+//   Identity, BailmentBuilder
+//   DecisionBuilder, Decision, Vote
+//   AuthorityChainBuilder
+//   hash, sign, verify
+//   ConstitutionalKernel
+//   ExoError, ExoResult
+```
+
+For anything not in the prelude, reach for the module directly:
+
+```rust
+use exochain_sdk::authority::{ChainLink, ValidatedChain};
+use exochain_sdk::consent::BailmentProposal;
+use exochain_sdk::governance::{DecisionClass, DecisionStatus, QuorumResult, VoteChoice};
+use exochain_sdk::kernel::KernelVerdict;
+```
+
+---
+
+## Domain 1: Identity
+
+An `Identity` pairs an Ed25519 keypair with a DID derived deterministically from the public key. The private key never leaves the struct. Signatures are produced by `sign` and verified with `verify`.
+
+### Generate, sign, verify
+
+```rust
+use exochain_sdk::prelude::*;
+
+fn main() {
+    let alice = Identity::generate("alice");
+    println!("alice.did       = {}", alice.did());
+    println!("alice.label     = {}", alice.label());
+    println!("alice.public_key = {:?}", alice.public_key());
+
+    let message = b"I, Alice, consent to share my medical records.";
+    let signature = alice.sign(message);
+
+    assert!(alice.verify(message, &signature));
+    assert!(!alice.verify(b"different message", &signature));
+}
+```
+
+Expected output:
+
+```text
+alice.did       = did:exo:b7c14e2f8a3d1f90
+alice.label     = alice
+alice.public_key = PublicKey(..32 bytes..)
+```
+
+The DID prefix is always `did:exo:`, followed by 16 lowercase hex characters. Two identities generated separately will never collide (the 64-bit prefix of BLAKE3 is collision-resistant for any realistic population).
+
+### Rebuild from a stored keypair
+
+If you persist key material, use `Identity::from_keypair` to reconstruct an identity with the same DID:
+
+```rust
+use exochain_sdk::crypto::{PublicKey, SecretKey};
+use exochain_sdk::prelude::*;
+
+fn rebuild(public: PublicKey, secret: SecretKey) -> ExoResult<Identity> {
+    Identity::from_keypair("restored", public, secret)
+}
+```
+
+### DID document
+
+A minimal W3C DID document is available via `did_document()` for integration with DID resolvers:
+
+```rust
+use exochain_sdk::prelude::*;
+
+fn main() {
+    let id = Identity::generate("doc");
+    let doc = id.did_document();
+    assert_eq!(&doc.id, id.did());
+    assert_eq!(doc.public_keys.len(), 1);
+    assert!(!doc.revoked);
+}
+```
+
+---
+
+## Domain 2: Consent (bailments)
+
+A **bailment** is scoped, time-bounded consent from a bailor (grantor) to a bailee (grantee). `BailmentBuilder` constructs and validates a proposal; the resulting `BailmentProposal` carries a deterministic content-addressed ID so two identical proposals produce the same ID.
+
+### Build a bailment proposal
+
+```rust
+use exochain_sdk::prelude::*;
+use exochain_sdk::crypto::Did;
+
+fn main() -> ExoResult<()> {
+    let bailor = Did::new("did:exo:alice").map_err(|e| ExoError::InvalidDid(e.to_string()))?;
+    let bailee = Did::new("did:exo:bob").map_err(|e| ExoError::InvalidDid(e.to_string()))?;
+
+    let proposal = BailmentBuilder::new(bailor, bailee)
+        .scope("data:medical:records")
+        .duration_hours(24)
+        .build()?;
+
+    println!("proposal_id     = {}", proposal.proposal_id);
+    println!("bailor          = {}", proposal.bailor);
+    println!("bailee          = {}", proposal.bailee);
+    println!("scope           = {}", proposal.scope);
+    println!("duration_hours  = {}", proposal.duration_hours);
+    Ok(())
+}
+```
+
+Expected output:
+
+```text
+proposal_id     = f1e2d3c4b5a69780
+bailor          = did:exo:alice
+bailee          = did:exo:bob
+scope           = data:medical:records
+duration_hours  = 24
+```
+
+### What fails
+
+| Failure | Error |
+|---|---|
+| `scope` not set | `ExoError::Consent("scope is required")` |
+| `scope = ""` | `ExoError::Consent("scope must be non-empty")` |
+| `duration_hours` not set | `ExoError::Consent("duration_hours is required")` |
+| `duration_hours = 0` | `ExoError::Consent("duration_hours must be > 0")` |
+
+Every validation happens in `.build()`, so you can chain `with`-methods freely and handle errors once.
+
+### Deterministic proposal IDs
+
+The `proposal_id` is the first 16 hex characters of `BLAKE3(bailor || 0 || bailee || 0 || scope || 0 || duration_hours_le)`. Identical inputs always produce identical IDs — useful for idempotent submission and cross-party agreement without a round trip.
+
+---
+
+## Domain 3: Governance (decisions + voting)
+
+Decisions flow through `Proposed -> Deliberating -> Approved | Rejected | Challenged`. Votes are appended with `cast_vote`; duplicate voters are rejected. `check_quorum(threshold)` tallies the votes and reports whether approvals cross the threshold.
+
+### Create a decision
+
+```rust
+use exochain_sdk::prelude::*;
+use exochain_sdk::crypto::Did;
+use exochain_sdk::governance::DecisionClass;
+
+fn main() -> ExoResult<()> {
+    let proposer = Did::new("did:exo:alice")
+        .map_err(|e| ExoError::InvalidDid(e.to_string()))?;
+
+    let decision = DecisionBuilder::new(
+        "Raise quorum threshold to 3/4",
+        "Constitutional amendment increasing the supermajority bar.",
+        proposer,
+    )
+    .decision_class(DecisionClass::new("amendment"))
+    .build()?;
+
+    println!("decision_id = {}", decision.decision_id);
+    println!("status      = {:?}", decision.status);
+    println!("class       = {:?}", decision.class);
+    Ok(())
+}
+```
+
+### Cast votes, check quorum
+
+```rust
+use exochain_sdk::prelude::*;
+use exochain_sdk::crypto::Did;
+use exochain_sdk::governance::VoteChoice;
+
+fn main() -> ExoResult<()> {
+    let proposer = Did::new("did:exo:alice")
+        .map_err(|e| ExoError::InvalidDid(e.to_string()))?;
+
+    let mut decision = DecisionBuilder::new("t", "d", proposer).build()?;
+
+    let v1 = Did::new("did:exo:validator1")
+        .map_err(|e| ExoError::InvalidDid(e.to_string()))?;
+    let v2 = Did::new("did:exo:validator2")
+        .map_err(|e| ExoError::InvalidDid(e.to_string()))?;
+    let v3 = Did::new("did:exo:validator3")
+        .map_err(|e| ExoError::InvalidDid(e.to_string()))?;
+
+    decision.cast_vote(Vote::new(v1, VoteChoice::Approve))?;
+    decision.cast_vote(Vote::new(v2, VoteChoice::Approve).with_rationale("LGTM"))?;
+    decision.cast_vote(Vote::new(v3, VoteChoice::Reject))?;
+
+    let quorum = decision.check_quorum(2);
+    println!("met         = {}", quorum.met);
+    println!("approvals   = {}", quorum.approvals);
+    println!("rejections  = {}", quorum.rejections);
+    println!("abstentions = {}", quorum.abstentions);
+    println!("total_votes = {}", quorum.total_votes);
+    Ok(())
+}
+```
+
+Expected output:
+
+```text
+met         = true
+approvals   = 2
+rejections  = 1
+abstentions = 0
+total_votes = 3
+```
+
+### Duplicate voters are rejected
+
+```rust
+let v1 = Did::new("did:exo:validator1").unwrap();
+decision.cast_vote(Vote::new(v1.clone(), VoteChoice::Approve))?;
+let err = decision
+    .cast_vote(Vote::new(v1, VoteChoice::Reject))
+    .unwrap_err();
+assert!(matches!(err, ExoError::Governance(_)));
+```
+
+This matters: one-DID-one-vote is invariant-level in the fabric. See `QuorumLegitimate` in the [invariants](#kernel-invariants).
+
+---
+
+## Domain 4: Authority chains
+
+An authority chain is an ordered list of delegation links where each `grantee` is the next `grantor`. The chain terminates at a specific actor. `AuthorityChainBuilder` validates topology in `.build()`.
+
+### Build and validate
+
+```rust
+use exochain_sdk::prelude::*;
+use exochain_sdk::crypto::Did;
+
+fn main() -> ExoResult<()> {
+    let root = Did::new("did:exo:root").map_err(|e| ExoError::InvalidDid(e.to_string()))?;
+    let mid  = Did::new("did:exo:mid").map_err(|e| ExoError::InvalidDid(e.to_string()))?;
+    let leaf = Did::new("did:exo:leaf").map_err(|e| ExoError::InvalidDid(e.to_string()))?;
+
+    let chain = AuthorityChainBuilder::new()
+        .add_link(root.clone(), mid.clone(), vec!["read".into()])
+        .add_link(mid.clone(),  leaf.clone(), vec!["read".into(), "write".into()])
+        .build(&leaf)?;
+
+    println!("depth     = {}", chain.depth);
+    println!("terminal  = {}", chain.terminal);
+    for (i, link) in chain.links.iter().enumerate() {
+        println!("  link[{i}]: {} -> {} [{}]",
+            link.grantor, link.grantee, link.permissions.join(", "));
+    }
+    Ok(())
+}
+```
+
+Expected output:
+
+```text
+depth     = 2
+terminal  = did:exo:leaf
+  link[0]: did:exo:root -> did:exo:mid [read]
+  link[1]: did:exo:mid -> did:exo:leaf [read, write]
+```
+
+### Validation rules
+
+| Rule | Violation | Error |
+|---|---|---|
+| At least one link | `build()` on empty builder | `ExoError::Authority("authority chain is empty")` |
+| Consecutive links connect | `links[i].grantee != links[i+1].grantor` | `ExoError::Authority("broken delegation: X != Y")` |
+| Final grantee matches terminal | `last.grantee != terminal_actor` | `ExoError::Authority("terminal mismatch: ...")` |
+
+### Broken chain example
+
+```rust
+let root = Did::new("did:exo:root").unwrap();
+let mid  = Did::new("did:exo:mid").unwrap();
+let bogus = Did::new("did:exo:bogus").unwrap();
+let leaf = Did::new("did:exo:leaf").unwrap();
+
+let err = AuthorityChainBuilder::new()
+    .add_link(root,  mid.clone(), vec!["read".into()])
+    .add_link(bogus, leaf.clone(), vec!["read".into()])  // bogus != mid
+    .build(&leaf)
+    .unwrap_err();
+assert!(matches!(err, ExoError::Authority(_)));
+```
+
+---
+
+## Domain 5: Crypto primitives
+
+The SDK re-exports `sign`, `verify`, `generate_keypair`, `hash`, and `hash_hex` for when you need to work below the `Identity` abstraction. Hashing is BLAKE3, signing is Ed25519.
+
+### Hashing
+
+```rust
+use exochain_sdk::crypto::{hash, hash_hex};
+
+fn main() {
+    let bytes = hash(b"hello");             // [u8; 32]
+    let hex   = hash_hex(b"hello");         // 64-char lowercase hex String
+    assert_eq!(bytes.len(), 32);
+    assert_eq!(hex.len(), 64);
+    assert!(hex.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+}
+```
+
+### Raw sign/verify
+
+```rust
+use exochain_sdk::crypto::{generate_keypair, sign, verify};
+
+fn main() {
+    let (pk, sk) = generate_keypair();
+    let msg = b"authenticated message";
+    let sig = sign(msg, &sk);
+    assert!(verify(msg, &sig, &pk));
+    assert!(!verify(b"tampered", &sig, &pk));
+}
+```
+
+---
+
+## Domain 6: Constitutional kernel
+
+`ConstitutionalKernel` wraps `exo_gatekeeper::Kernel` with permissive defaults suitable for the common case: a single actor, a judicial role, a one-link authority chain rooted at `did:exo:root`, an active bailment, and signed provenance. Call `adjudicate(&actor, "action-name")` and match on the `KernelVerdict`.
+
+### The three outcomes
+
+```rust
+use exochain_sdk::kernel::{ConstitutionalKernel, KernelVerdict};
+use exochain_sdk::crypto::Did;
+
+fn main() {
+    let kernel = ConstitutionalKernel::new();
+    assert_eq!(kernel.invariant_count(), 8);
+    assert!(kernel.verify_integrity()); // constitution hash still matches
+
+    let actor = Did::new("did:exo:actor").unwrap();
+
+    // 1. Permitted — valid action, valid context.
+    match kernel.adjudicate(&actor, "read-medical-record") {
+        KernelVerdict::Permitted => println!("permitted"),
+        other => panic!("expected Permitted, got {other:?}"),
+    }
+
+    // 2. Denied — self-grant violates NoSelfGrant.
+    match kernel.adjudicate_self_grant(&actor, "escalate-self") {
+        KernelVerdict::Denied { violations } => {
+            println!("denied. violations:");
+            for v in &violations {
+                println!("  - {v}");
+            }
+        }
+        other => panic!("expected Denied, got {other:?}"),
+    }
+
+    // 3. Denied — kernel modification violates KernelImmutability.
+    let v = kernel.adjudicate_kernel_modification(&actor, "patch-kernel");
+    assert!(v.is_denied());
+
+    // 4. Denied — missing consent violates ConsentRequired.
+    let v = kernel.adjudicate_without_bailment(&actor, "read-data");
+    assert!(v.is_denied());
+}
+```
+
+Expected output (violations strings are kernel-generated, format stable):
+
+```text
+permitted
+denied. violations:
+  - NoSelfGrant: actor attempted to grant permissions to themselves
+```
+
+### Kernel invariants
+
+Eight constitutional invariants are checked on every adjudication. They are:
+
+1. **SeparationOfPowers** — no actor holds legislative + executive + judicial authority simultaneously.
+2. **ConsentRequired** — every action needs an active bailment record linking actor to resource.
+3. **NoSelfGrant** — an actor cannot expand its own permissions.
+4. **HumanOverride** — emergency human intervention must remain possible.
+5. **KernelImmutability** — the constitution and invariant set are byte-stable after construction.
+6. **AuthorityChainValid** — the chain from root to actor must be cryptographically valid and unbroken.
+7. **QuorumLegitimate** — quorum evidence must meet the declared threshold.
+8. **ProvenanceVerifiable** — every action carries a verifiable provenance record.
+
+The kernel also checks the 6 MCP enforcement rules (`Mcp001BctsScope`, `Mcp002NoSelfEscalation`, `Mcp003ProvenanceRequired`, `Mcp004NoIdentityForge`, `Mcp005Distinguishable`, `Mcp006ConsentBoundaries`) when an AI actor is the request origin. See [`docs/guides/mcp-integration.md`](./mcp-integration.md) for the full list.
+
+### Getting Escalated
+
+The third verdict, `KernelVerdict::Escalated { reason }`, surfaces when the kernel cannot decide unilaterally — typically because a challenge is active. For the `adjudicate*` helpers in the SDK, you will normally only see `Permitted` or `Denied`; `Escalated` is produced by the underlying kernel when you supply an `active_challenge_reason` via the full `exo_gatekeeper::Kernel` API.
+
+---
+
+## Error handling
+
+Every fallible SDK operation returns `ExoResult<T>`, an alias for `Result<T, ExoError>`. The variants narrow to a specific subsystem:
+
+```rust
+use exochain_sdk::error::{ExoError, ExoResult};
+
+fn describe(err: &ExoError) -> &'static str {
+    match err {
+        ExoError::Identity(_)       => "identity / DID / keypair",
+        ExoError::Consent(_)        => "bailment / consent",
+        ExoError::Governance(_)     => "decision / voting",
+        ExoError::Authority(_)      => "authority chain",
+        ExoError::KernelDenied(_)   => "kernel denied the action",
+        ExoError::KernelEscalated(_)=> "kernel escalated for review",
+        ExoError::Crypto(_)         => "hash / sign / verify",
+        ExoError::InvalidDid(_)     => "DID string rejected",
+        ExoError::Serialization(_)  => "serde failure",
+    }
+}
+```
+
+Each variant wraps a `String` with enough context to diagnose the failure from the error alone. `ExoError` implements `std::error::Error` via `thiserror`, so it composes cleanly with `anyhow`, `eyre`, and custom error types in caller code.
+
+### Typical error-handling patterns
+
+**Propagate with `?`:**
+
+```rust
+use exochain_sdk::prelude::*;
+
+fn build_proposal(bailor: exochain_sdk::crypto::Did, bailee: exochain_sdk::crypto::Did)
+    -> ExoResult<exochain_sdk::consent::BailmentProposal>
+{
+    BailmentBuilder::new(bailor, bailee)
+        .scope("data:medical")
+        .duration_hours(24)
+        .build()
+}
+```
+
+**Match on specific variants:**
+
+```rust
+match decision.cast_vote(vote) {
+    Ok(()) => println!("vote recorded"),
+    Err(ExoError::Governance(reason)) => eprintln!("governance rejected: {reason}"),
+    Err(other) => eprintln!("unexpected error: {other}"),
+}
+```
+
+**Convert `exo_core::Did` errors:**
+
+`exo_core::Did::new` returns its own error type. Convert into `ExoError::InvalidDid`:
+
+```rust
+use exochain_sdk::error::{ExoError, ExoResult};
+use exochain_sdk::crypto::Did;
+
+fn parse_did(s: &str) -> ExoResult<Did> {
+    Did::new(s).map_err(|e| ExoError::InvalidDid(e.to_string()))
+}
+```
+
+---
+
+## End-to-end example
+
+This is the pattern every production caller follows: create an identity, propose a bailment, build a decision, collect votes, check quorum, and run an adjudication through the kernel.
+
+```rust
+use exochain_sdk::crypto::Did;
+use exochain_sdk::governance::{DecisionClass, VoteChoice};
+use exochain_sdk::kernel::KernelVerdict;
+use exochain_sdk::prelude::*;
+
+fn parse_did(s: &str) -> ExoResult<Did> {
+    Did::new(s).map_err(|e| ExoError::InvalidDid(e.to_string()))
+}
+
+fn main() -> ExoResult<()> {
+    // 1. Identity.
+    let alice = Identity::generate("alice");
+    let bob   = Identity::generate("bob");
+    println!("alice = {}", alice.did());
+    println!("bob   = {}", bob.did());
+
+    // 2. Bailment: Alice grants Bob 24h of read on medical records.
+    let proposal = BailmentBuilder::new(alice.did().clone(), bob.did().clone())
+        .scope("data:medical:records")
+        .duration_hours(24)
+        .build()?;
+    println!("bailment proposal {}", proposal.proposal_id);
+
+    // 3. Governance decision: should we expand Bob's scope?
+    let mut decision = DecisionBuilder::new(
+        "Expand Bob's read scope to imaging",
+        "Bob requests access to imaging in addition to records.",
+        alice.did().clone(),
+    )
+    .decision_class(DecisionClass::new("scope-expansion"))
+    .build()?;
+
+    // 4. Three validators vote.
+    for (i, choice) in [VoteChoice::Approve, VoteChoice::Approve, VoteChoice::Reject]
+        .iter()
+        .enumerate()
+    {
+        let v = parse_did(&format!("did:exo:v{i}"))?;
+        decision.cast_vote(Vote::new(v, *choice))?;
+    }
+    let q = decision.check_quorum(2);
+    println!("quorum met = {} ({}/{} approvals)", q.met, q.approvals, q.total_votes);
+
+    // 5. Authority chain: root delegates to Alice, Alice to Bob.
+    let root = parse_did("did:exo:root")?;
+    let chain = AuthorityChainBuilder::new()
+        .add_link(root,              alice.did().clone(), vec!["read".into(), "delegate".into()])
+        .add_link(alice.did().clone(), bob.did().clone(), vec!["read".into()])
+        .build(bob.did())?;
+    println!("chain depth = {}", chain.depth);
+
+    // 6. Kernel adjudicates Bob's action.
+    let kernel = ConstitutionalKernel::new();
+    match kernel.adjudicate(bob.did(), "read-medical-record") {
+        KernelVerdict::Permitted => println!("kernel permitted"),
+        KernelVerdict::Denied { violations } => {
+            for v in violations { println!("denied: {v}"); }
+        }
+        KernelVerdict::Escalated { reason } => println!("escalated: {reason}"),
+    }
+
+    Ok(())
+}
+```
+
+Expected output (DIDs and IDs will differ between runs):
+
+```text
+alice = did:exo:d9c21e4b7f1a8035
+bob   = did:exo:a0314e8c7f9b2d11
+bailment proposal 4f2a910b8c6d7e08
+quorum met = true (2/3 approvals)
+chain depth = 2
+kernel permitted
+```
+
+---
+
+## What next
+
+- **TypeScript SDK** — [`docs/guides/sdk-quickstart-typescript.md`](./sdk-quickstart-typescript.md). Same primitives, browser + Node.
+- **Python SDK** — [`docs/guides/sdk-quickstart-python.md`](./sdk-quickstart-python.md). Pydantic + asyncio.
+- **MCP integration** — [`docs/guides/mcp-integration.md`](./mcp-integration.md). Wire Claude or another MCP client to the node's 40 tools + 6 resources + 4 prompts.
+- **Getting Started** — [`docs/guides/GETTING-STARTED.md`](./GETTING-STARTED.md). Workspace build, CI gates, council process.
+- **Architecture** — [`docs/architecture/ARCHITECTURE.md`](../architecture/ARCHITECTURE.md). The 3-branch model, BCTS lifecycle, crate graph.
+- **Crate reference** — [`docs/reference/CRATE-REFERENCE.md`](../reference/CRATE-REFERENCE.md). Full API per crate.
+- **Constitutional proofs** — [`docs/proofs/CONSTITUTIONAL-PROOFS.md`](../proofs/CONSTITUTIONAL-PROOFS.md). The ten formal proofs that the invariants hold.
+- **Source** — [`crates/exochain-sdk/src/`](../../crates/exochain-sdk/src/). Every module is under 300 lines of Rust.
+
+---
+
+Licensed under Apache-2.0. © 2025 EXOCHAIN Foundation.

--- a/docs/guides/sdk-quickstart-typescript.md
+++ b/docs/guides/sdk-quickstart-typescript.md
@@ -1,0 +1,598 @@
+---
+title: "TypeScript SDK Quickstart"
+status: active
+created: 2026-04-15
+tags: [exochain, sdk, typescript, javascript, nodejs, quickstart, guide]
+---
+
+# TypeScript SDK Quickstart
+
+**Get productive with `@exochain/sdk` on Node 20+ or a modern browser in ten minutes.**
+
+The TypeScript SDK is a dependency-free pure-JS port of the canonical Rust SDK. It mirrors the same five domain APIs (identity, consent, governance, authority, crypto) plus an `HttpTransport` for talking to an `exo-gateway`.
+
+---
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Runtime requirements](#runtime-requirements)
+- [Hashing difference you must know](#hashing-difference-you-must-know)
+- [Branded types: `Did`, `Hash256`](#branded-types-did-hash256)
+- [Domain 1: Identity](#domain-1-identity)
+- [Domain 2: Consent (bailments)](#domain-2-consent-bailments)
+- [Domain 3: Governance (decisions + voting)](#domain-3-governance-decisions--voting)
+- [Domain 4: Authority chains](#domain-4-authority-chains)
+- [Domain 5: Crypto primitives](#domain-5-crypto-primitives)
+- [Transport: talking to `exo-gateway`](#transport-talking-to-exo-gateway)
+- [Error handling](#error-handling)
+- [Browser vs Node](#browser-vs-node)
+- [End-to-end example](#end-to-end-example)
+- [What next](#what-next)
+
+---
+
+## Installation
+
+### npm (once published)
+
+```bash
+npm install @exochain/sdk
+```
+
+### Local path during development
+
+From inside the monorepo, consume the package directly:
+
+```bash
+cd packages/exochain-sdk
+npm run build
+
+# in your app
+npm install ../../packages/exochain-sdk
+```
+
+Then in your app:
+
+```ts
+import { Identity } from '@exochain/sdk';
+```
+
+---
+
+## Runtime requirements
+
+| Requirement | Why |
+|---|---|
+| **Node 20+** (or modern browser) | Web Crypto `Ed25519` is natively available. |
+| **ESM modules** (`"type": "module"`) | The package ships ES modules only (see `packages/exochain-sdk/package.json`). |
+| **TypeScript 5.3+** | Branded types require modern TS. |
+
+Verify your install:
+
+```ts
+// hello.ts
+import { Identity } from '@exochain/sdk';
+
+async function main() {
+  const id = await Identity.generate('hello');
+  console.log('DID:', id.did);
+}
+main();
+```
+
+```text
+$ node --loader ts-node/esm hello.ts
+DID: did:exo:a1b2c3d4e5f60789
+```
+
+---
+
+## Hashing difference you must know
+
+**The pure-JS SDK hashes with SHA-256. The Rust SDK hashes with BLAKE3.**
+
+Why: BLAKE3 is not part of Web Crypto, so shipping a BLAKE3 implementation would require a ~150 kB WASM blob or a third-party pure-JS BLAKE3 package. The pure-JS SDK keeps zero runtime dependencies, so content-addressed IDs produced client-side (proposal IDs, decision IDs) do **not** match Rust-produced IDs byte-for-byte.
+
+For cross-language interop in production:
+
+- **Prefer** producing canonical hashes server-side (Rust) and trusting the returned `Hash256` from the gateway.
+- **If you must hash identically in JS**, build with a BLAKE3 WASM shim that matches the Rust output. This is a deliberate non-default.
+- **For a TS-only app**, SHA-256 is fine — the SDK is internally consistent.
+
+The branded `Hash256` type is the same shape either way: a 64-character lowercase hex string.
+
+See [`packages/exochain-sdk/src/crypto/hash.ts`](../../packages/exochain-sdk/src/crypto/hash.ts) for the full rationale in-source.
+
+---
+
+## Branded types: `Did`, `Hash256`
+
+These are structural brands — no runtime tag, validated at the boundary:
+
+```ts
+import { validateDid, isDid } from '@exochain/sdk';
+
+const d1 = validateDid('did:exo:alice');  // Did, or throws IdentityError
+const d2: boolean = isDid('did:exo:bob');  // true
+
+// This will throw IdentityError:
+// validateDid('bad-did');
+```
+
+`Hash256` is produced by `sha256Hash` (branded) or `sha256Hex` (plain string):
+
+```ts
+import { sha256Hash, sha256Hex } from '@exochain/sdk';
+
+const hash: string = await sha256Hex(new Uint8Array([1, 2, 3]));
+// -> 64-char lowercase hex
+```
+
+Once you have a `Did` or `Hash256`, TypeScript will refuse to let you pass a plain `string` in its place — you must go through `validateDid` or the hash factory first.
+
+---
+
+## Domain 1: Identity
+
+`Identity` wraps an Ed25519 keypair from Web Crypto. Keys never leave the object.
+
+### Generate, sign, verify
+
+```ts
+import { Identity } from '@exochain/sdk';
+
+async function main() {
+  const alice = await Identity.generate('alice');
+  console.log('alice.did         =', alice.did);
+  console.log('alice.publicKeyHex=', alice.publicKeyHex);
+
+  const msg = new TextEncoder().encode('I, Alice, consent.');
+  const sig = await alice.sign(msg);
+
+  console.log('verifySelf =', await alice.verifySelf(msg, sig));
+
+  // Verify with a detached public key (same result here):
+  console.log(
+    'Identity.verify =',
+    await Identity.verify(alice.publicKeyHex, msg, sig),
+  );
+}
+main();
+```
+
+Expected output:
+
+```text
+alice.did         = did:exo:b7c14e2f8a3d1f90
+alice.publicKeyHex= 1aef...  (64 hex chars)
+verifySelf = true
+Identity.verify = true
+```
+
+### DID derivation
+
+The pure-JS SDK derives a DID as `did:exo:<first 16 hex chars of SHA-256(public_key_bytes)>`. This is stable within the TS SDK but does not match the Rust derivation (which uses BLAKE3). If you need the Rust-canonical DID, receive it from the server after submitting the public key, or use a BLAKE3 WASM shim.
+
+### Rebuild from stored material
+
+```ts
+import { Identity } from '@exochain/sdk';
+
+// `privateKeyPkcs8` is a 48-byte PKCS#8-encoded Ed25519 private key.
+const id = await Identity.fromKeypair({
+  label: 'restored',
+  publicKeyHex: '1aef...',                    // 64 hex chars
+  privateKeyPkcs8: new Uint8Array([/* ... */]),
+});
+```
+
+---
+
+## Domain 2: Consent (bailments)
+
+A `BailmentBuilder` produces a frozen `BailmentProposal` with a deterministic `proposalId` (SHA-256 over canonical fields).
+
+### Build a proposal
+
+```ts
+import { BailmentBuilder, validateDid } from '@exochain/sdk';
+
+async function main() {
+  const bailor = validateDid('did:exo:alice');
+  const bailee = validateDid('did:exo:bob');
+
+  const proposal = await new BailmentBuilder(bailor, bailee)
+    .scope('data:medical:records')
+    .durationHours(24)
+    .build();
+
+  console.log('proposalId    =', proposal.proposalId);
+  console.log('bailor        =', proposal.bailor);
+  console.log('bailee        =', proposal.bailee);
+  console.log('scope         =', proposal.scope);
+  console.log('durationHours =', proposal.durationHours);
+  console.log('createdAt     =', new Date(proposal.createdAt).toISOString());
+}
+main();
+```
+
+### What fails
+
+| Failure | Error |
+|---|---|
+| `scope` not set | `ConsentError: scope is required` |
+| `scope === ''` | `ConsentError: scope must be non-empty` |
+| `durationHours` not set | `ConsentError: durationHours is required` |
+| `durationHours <= 0` | `ConsentError: durationHours must be > 0` |
+| non-integer `durationHours` | `ConsentError: durationHours must be an integer` |
+
+You can pass DID arguments as either a validated `Did` brand or a raw `string`; the builder validates on construction.
+
+---
+
+## Domain 3: Governance (decisions + voting)
+
+### Create a decision
+
+```ts
+import { DecisionBuilder, validateDid } from '@exochain/sdk';
+
+async function main() {
+  const proposer = validateDid('did:exo:alice');
+
+  const decision = await new DecisionBuilder({
+    title: 'Raise quorum threshold to 3/4',
+    description: 'Constitutional amendment.',
+    proposer,
+  })
+    .decisionClass('amendment')
+    .build();
+
+  console.log('decisionId =', decision.decisionId);
+  console.log('status     =', decision.status);
+  console.log('class      =', decision.class);
+}
+main();
+```
+
+Expected output:
+
+```text
+decisionId = 9f3c2a1b8d7e6f45...
+status     = proposed
+class      = amendment
+```
+
+### Cast votes, check quorum
+
+```ts
+import { DecisionBuilder, Vote, VoteChoice, validateDid } from '@exochain/sdk';
+
+async function main() {
+  const proposer = validateDid('did:exo:alice');
+  const decision = await new DecisionBuilder({
+    title: 't',
+    description: 'd',
+    proposer,
+  }).build();
+
+  decision.castVote(new Vote({
+    voter: validateDid('did:exo:v1'),
+    choice: VoteChoice.Approve,
+  }));
+  decision.castVote(new Vote({
+    voter: validateDid('did:exo:v2'),
+    choice: VoteChoice.Approve,
+    rationale: 'LGTM',
+  }));
+  decision.castVote(new Vote({
+    voter: validateDid('did:exo:v3'),
+    choice: VoteChoice.Reject,
+  }));
+
+  const q = decision.checkQuorum(2);
+  console.log(q);
+  // { met: true, threshold: 2, totalVotes: 3,
+  //   approvals: 2, rejections: 1, abstentions: 0 }
+}
+main();
+```
+
+### Duplicate voters are rejected
+
+```ts
+import { GovernanceError } from '@exochain/sdk';
+
+try {
+  decision.castVote(new Vote({
+    voter: validateDid('did:exo:v1'),
+    choice: VoteChoice.Reject,
+  }));
+} catch (err) {
+  if (err instanceof GovernanceError) {
+    console.error('governance:', err.message);
+  }
+}
+```
+
+---
+
+## Domain 4: Authority chains
+
+```ts
+import { AuthorityChainBuilder, validateDid } from '@exochain/sdk';
+
+const root = validateDid('did:exo:root');
+const mid  = validateDid('did:exo:mid');
+const leaf = validateDid('did:exo:leaf');
+
+const chain = new AuthorityChainBuilder()
+  .addLink(root, mid,  ['read'])
+  .addLink(mid,  leaf, ['read', 'write'])
+  .build(leaf);
+
+console.log('depth    =', chain.depth);
+console.log('terminal =', chain.terminal);
+chain.links.forEach((l, i) => {
+  console.log(`  link[${i}]: ${l.grantor} -> ${l.grantee} [${l.permissions.join(', ')}]`);
+});
+```
+
+Expected output:
+
+```text
+depth    = 2
+terminal = did:exo:leaf
+  link[0]: did:exo:root -> did:exo:mid [read]
+  link[1]: did:exo:mid -> did:exo:leaf [read, write]
+```
+
+### Validation rules
+
+Same as the Rust SDK: non-empty, consecutive grantees must match next grantor, and the last grantee must equal `terminalActor`. Violations throw `AuthorityError`.
+
+---
+
+## Domain 5: Crypto primitives
+
+```ts
+import { sha256, sha256Hex, sha256Hash, bytesToHex, hexToBytes } from '@exochain/sdk';
+
+const raw = await sha256(new TextEncoder().encode('hello'));   // Uint8Array(32)
+const hex = await sha256Hex(new TextEncoder().encode('hello')); // string (64 chars)
+const h256 = await sha256Hash(new TextEncoder().encode('hello')); // branded Hash256
+
+console.log(bytesToHex(raw) === hex);   // true
+console.log(hexToBytes(hex).length);     // 32
+```
+
+All hash functions are pure `async` — they await `crypto.subtle.digest` under the hood.
+
+---
+
+## Transport: talking to `exo-gateway`
+
+### `HttpTransport` (low-level)
+
+```ts
+import { HttpTransport } from '@exochain/sdk';
+
+const transport = new HttpTransport('http://127.0.0.1:8080', {
+  apiKey: process.env.EXO_API_KEY,    // sent as Authorization: Bearer
+  timeout: 15_000,                     // ms
+});
+
+const health = await transport.get<{ status: string; version: string; uptime: number }>('/health');
+console.log(health);
+```
+
+### `ExochainClient` (high-level)
+
+The high-level `ExochainClient` groups per-domain calls and returns typed responses:
+
+```ts
+import { ExochainClient } from '@exochain/sdk';
+
+const client = new ExochainClient({
+  baseUrl: 'http://127.0.0.1:8080',
+  apiKey: process.env.EXO_API_KEY,
+  timeout: 15_000,
+});
+
+// Health
+console.log(await client.health());
+
+// Identity
+const doc = await client.identity.resolve('did:exo:alice' as any);
+
+// Consent
+const { proposalId } = await client.consent.proposeBailment({
+  bailor: 'did:exo:alice',
+  bailee: 'did:exo:bob',
+  scope: 'data:medical',
+  durationHours: 24,
+});
+
+// Governance
+const { decisionId } = await client.governance.createDecision({
+  title: 'Fund X',
+  description: 'Allocate budget.',
+  proposer: 'did:exo:alice',
+});
+await client.governance.castVote(decisionId, {
+  voter: 'did:exo:v1',
+  choice: 'approve',
+});
+```
+
+All transport errors surface as `TransportError` (see next section).
+
+---
+
+## Error handling
+
+```ts
+import {
+  ExochainError,
+  IdentityError,
+  ConsentError,
+  GovernanceError,
+  AuthorityError,
+  CryptoError,
+  TransportError,
+  KernelError,
+} from '@exochain/sdk';
+
+try {
+  const id = await Identity.generate('example');
+  // ...
+} catch (err) {
+  if (err instanceof IdentityError) {
+    console.error('identity:', err.message);
+  } else if (err instanceof TransportError) {
+    console.error(`transport (HTTP ${err.status ?? '?'}):`, err.message);
+    if (err.body) console.error('body:', err.body);
+  } else if (err instanceof ExochainError) {
+    console.error(err.name, err.message);
+  } else {
+    throw err;
+  }
+}
+```
+
+All SDK error classes derive from `ExochainError`. `TransportError` additionally carries `status?: number` and `body?: string` when the gateway returned a non-2xx response.
+
+---
+
+## Browser vs Node
+
+| Concern | Node 20+ | Modern browser |
+|---|---|---|
+| `globalThis.crypto` | built-in since Node 19 | built-in |
+| `globalThis.fetch` | built-in since Node 18 | built-in |
+| Ed25519 via Web Crypto | supported since Node 20 | supported in Chrome 113+, Safari 17+, Firefox 128+ |
+| ESM only | works with `"type": "module"` | works natively |
+| TypeScript | compile with `tsc` | compile with your bundler |
+
+The SDK throws `IdentityError` / `CryptoError` at construction time if Web Crypto is unavailable, so misconfiguration fails loud.
+
+### Browser example (HTML)
+
+```html
+<!doctype html>
+<html>
+  <body>
+    <script type="module">
+      import { Identity, sha256Hex } from 'https://esm.sh/@exochain/sdk';
+      const id = await Identity.generate('browser-alice');
+      document.body.textContent = `DID: ${id.did}`;
+      console.log('hash of empty string:', await sha256Hex(new Uint8Array()));
+    </script>
+  </body>
+</html>
+```
+
+### Node ESM example
+
+```json
+// package.json
+{
+  "type": "module",
+  "dependencies": { "@exochain/sdk": "^0.1.0" }
+}
+```
+
+```ts
+// index.ts
+import { Identity } from '@exochain/sdk';
+const id = await Identity.generate('node-alice');
+console.log(id.did);
+```
+
+---
+
+## End-to-end example
+
+```ts
+import {
+  Identity,
+  BailmentBuilder,
+  DecisionBuilder,
+  Vote,
+  VoteChoice,
+  AuthorityChainBuilder,
+  validateDid,
+  ExochainError,
+} from '@exochain/sdk';
+
+async function main() {
+  try {
+    // 1. Identities.
+    const alice = await Identity.generate('alice');
+    const bob   = await Identity.generate('bob');
+    console.log('alice =', alice.did);
+    console.log('bob   =', bob.did);
+
+    // 2. Bailment: Alice grants Bob 24h of medical read.
+    const proposal = await new BailmentBuilder(alice.did, bob.did)
+      .scope('data:medical:records')
+      .durationHours(24)
+      .build();
+    console.log('bailment proposal', proposal.proposalId);
+
+    // 3. Decision.
+    const decision = await new DecisionBuilder({
+      title: 'Expand Bob\'s read scope to imaging',
+      description: 'Access request for imaging.',
+      proposer: alice.did,
+    })
+      .decisionClass('scope-expansion')
+      .build();
+
+    // 4. Three validator votes.
+    for (const [i, choice] of [
+      VoteChoice.Approve,
+      VoteChoice.Approve,
+      VoteChoice.Reject,
+    ].entries()) {
+      decision.castVote(new Vote({
+        voter: validateDid(`did:exo:v${i}`),
+        choice,
+      }));
+    }
+    const q = decision.checkQuorum(2);
+    console.log(`quorum met = ${q.met} (${q.approvals}/${q.totalVotes} approvals)`);
+
+    // 5. Authority chain root -> alice -> bob.
+    const chain = new AuthorityChainBuilder()
+      .addLink('did:exo:root', alice.did, ['read', 'delegate'])
+      .addLink(alice.did,      bob.did,   ['read'])
+      .build(bob.did);
+    console.log('chain depth =', chain.depth);
+  } catch (err) {
+    if (err instanceof ExochainError) {
+      console.error(`[${err.name}]`, err.message);
+      process.exit(1);
+    }
+    throw err;
+  }
+}
+
+main();
+```
+
+---
+
+## What next
+
+- **Rust SDK** — [`docs/guides/sdk-quickstart-rust.md`](./sdk-quickstart-rust.md). Canonical implementation.
+- **Python SDK** — [`docs/guides/sdk-quickstart-python.md`](./sdk-quickstart-python.md). Pydantic + asyncio.
+- **MCP integration** — [`docs/guides/mcp-integration.md`](./mcp-integration.md). Connecting Claude to the fabric.
+- **Getting Started** — [`docs/guides/GETTING-STARTED.md`](./GETTING-STARTED.md).
+- **Source** — [`packages/exochain-sdk/src/`](../../packages/exochain-sdk/src/).
+- **package.json** — [`packages/exochain-sdk/package.json`](../../packages/exochain-sdk/package.json).
+
+---
+
+Licensed under Apache-2.0. © 2025 EXOCHAIN Foundation.

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,0 +1,64 @@
+# EXOCHAIN — client SDK packages
+
+This directory holds the non-Rust client SDKs and prebuilt WebAssembly
+artifacts for the EXOCHAIN constitutional governance fabric. The authoritative
+Rust implementation lives in [`../crates`](../crates); the packages here are
+downstream-facing distributions tailored to browser, Node.js, and Python
+environments.
+
+## Index
+
+| Package                                   | Language                 | Distribution                              | Purpose                                                                 |
+| ----------------------------------------- | ------------------------ | ----------------------------------------- | ----------------------------------------------------------------------- |
+| [`exochain-sdk`](./exochain-sdk/)         | TypeScript / JavaScript  | `npm install @exochain/sdk`               | Pure-JS client SDK for browsers and Node 20+; HTTP transport to gateway. |
+| [`exochain-py`](./exochain-py/)           | Python 3.11+             | `pip install exochain`                    | Pure-Python client SDK with `httpx` async transport and pydantic v2 models. |
+| [`exochain-wasm`](./exochain-wasm/)       | WebAssembly + TS shim    | `npm install exochain-wasm`               | Precompiled WASM build of the Rust governance engine for embedding.     |
+
+The canonical Rust SDK lives at
+[`../crates/exochain-sdk`](../crates/exochain-sdk/). All three client SDKs
+expose the same five domains (identity, consent, governance, authority,
+kernel) with the same builder-pattern ergonomics, translated into each
+language's idioms.
+
+## Which SDK should I use?
+
+Pick by deployment target first, then by language preference:
+
+- **Browser, React, or Next.js** — `@exochain/sdk`. Pure ESM, no native
+  extensions, runs anywhere Web Crypto exposes Ed25519 (current Chromium,
+  Safari 17+, Firefox 130+).
+- **Node.js service or CLI** — `@exochain/sdk` on Node 20 or newer. Same
+  package, same APIs as the browser SDK.
+- **Python async service or notebook** — `exochain`. Ships with `httpx` for
+  async HTTP and `cryptography` for Ed25519/SHA-256. Python 3.11+.
+- **Native Rust service or embedded kernel** — reach for
+  [`../crates/exochain-sdk`](../crates/exochain-sdk/) directly. It is the
+  reference implementation and the only SDK that uses BLAKE3 natively.
+- **Browser or Node app that wants the full kernel in-process** —
+  `exochain-wasm`. Runs the Rust governance engine as WebAssembly.
+
+## Cross-language compatibility notes
+
+All SDKs agree on the wire format. JSON objects produced by one SDK
+deserialize cleanly in the others.
+
+They **do not** agree on locally derived hash digests:
+
+- The Rust SDK derives DIDs, bailment IDs, and decision IDs using **BLAKE3**.
+- The TypeScript and Python SDKs use **SHA-256** because Web Crypto does not
+  ship BLAKE3.
+
+For canonical DIDs across all three SDKs, resolve the DID from the fabric
+(via `exo-gateway`) rather than deriving it locally, and construct the
+identity with the language's `fromKeypair` / `from_keypair` constructor.
+
+## Versioning
+
+Each package follows semver and is versioned independently. The underlying
+fabric protocol is versioned separately — consult the EXOCHAIN specification
+at the repository root for protocol-compatibility guarantees.
+
+## License
+
+Each package is licensed under **Apache-2.0**. See the top-level
+[`LICENSE`](../LICENSE) for the full text.

--- a/packages/exochain-sdk/README.md
+++ b/packages/exochain-sdk/README.md
@@ -2,8 +2,9 @@
 
 TypeScript/JavaScript SDK for **EXOCHAIN** — the constitutional governance
 fabric for AI systems and data sovereignty. EXOCHAIN provides cryptographically
-verifiable identity (DID), consent, authority delegation, and governance
-primitives that enforce policy *before* action rather than auditing it after.
+verifiable identity (DID), consent (bailments), authority delegation, and
+governance primitives that enforce policy *before* action rather than auditing
+it after.
 
 This package is the pure-TypeScript, zero-runtime-dependency client. It exposes
 the same ergonomic builder surface as the Rust `exochain-sdk` crate and adds an
@@ -18,24 +19,36 @@ npm install @exochain/sdk
 Requires **Node.js 20 or newer** (for stable Web Crypto Ed25519 support). The
 package is ESM-only and ships with TypeScript declarations.
 
+Browsers are supported anywhere the Web Crypto API exposes
+`Ed25519` — current Chromium, Safari 17+, and Firefox 130+. See
+[Browser vs Node considerations](#browser-vs-node-considerations) below.
+
 ## Quick start
 
-### Create an identity
+The canonical five-domain flow: identity, consent, governance, authority,
+kernel adjudication.
+
+### 1. Create identities
 
 ```ts
 import { Identity } from '@exochain/sdk';
 
 const alice = await Identity.generate('alice');
+const bob = await Identity.generate('bob');
+
 console.log(alice.did);          // did:exo:<16 hex chars>
 console.log(alice.publicKeyHex); // 64 hex chars (32 bytes)
 
 const msg = new TextEncoder().encode('hello');
 const sig = await alice.sign(msg);
-
 const ok = await Identity.verify(alice.publicKeyHex, msg, sig);
 ```
 
-### Propose a bailment (scoped consent)
+`Identity.generate` produces a random Ed25519 keypair and derives a
+deterministic DID from the public key. `Identity.fromKeypair(label, publicKey,
+secretKey)` rehydrates an identity from stored material.
+
+### 2. Propose a bailment (scoped consent)
 
 ```ts
 import { BailmentBuilder } from '@exochain/sdk/consent';
@@ -45,17 +58,18 @@ const proposal = await new BailmentBuilder(alice.did, bob.did)
   .durationHours(24)
   .build();
 
-// proposal.proposalId is a deterministic, content-addressed hash.
+// proposal.proposalId is a deterministic, content-addressed hash — two
+// parties independently building the same proposal get the same id.
 ```
 
-### Create a governance decision and cast votes
+### 3. Propose a decision, cast votes, check quorum
 
 ```ts
 import { DecisionBuilder, Vote, VoteChoice } from '@exochain/sdk/governance';
 
 const decision = await new DecisionBuilder({
   title: 'Ratify change X',
-  description: '...',
+  description: 'Enable feature flag Y for cohort Z',
   proposer: alice.did,
 }).build();
 
@@ -63,21 +77,32 @@ decision.castVote(new Vote({ voter: bob.did, choice: VoteChoice.Approve }));
 decision.castVote(new Vote({ voter: carol.did, choice: VoteChoice.Approve }));
 
 const quorum = decision.checkQuorum(2);
-// { met: true, threshold: 2, approvals: 2, ... }
+// { met: true, threshold: 2, approvals: 2, rejections: 0, abstentions: 0, ... }
 ```
 
-### Build and verify an authority chain
+The same voter may cast at most one vote on a decision; a second `castVote`
+from the same voter throws `GovernanceError`.
+
+### 4. Build and verify an authority chain
 
 ```ts
 import { AuthorityChainBuilder } from '@exochain/sdk/authority';
 
 const chain = new AuthorityChainBuilder()
-  .addLink(root.did, mid.did, ['read'])
-  .addLink(mid.did, leaf.did, ['read'])
-  .build(leaf.did); // throws if the chain is broken
+  .addLink(root.did, alice.did, ['delegate'])
+  .addLink(alice.did, bob.did, ['read'])
+  .build(bob.did); // throws AuthorityError if the chain is broken
+
+console.log(chain.depth); // 2
 ```
 
-### Connect to an exo-gateway node
+Topology rules: each link's `grantee` must match the next link's `grantor`,
+and the final `grantee` must equal the `terminal` you pass to `build`.
+
+### 5. Talk to a constitutional kernel via the gateway
+
+The SDK ships an HTTP client for talking to a running `exo-gateway`. Kernel
+adjudication happens server-side and results are returned as verdicts:
 
 ```ts
 import { ExochainClient } from '@exochain/sdk';
@@ -91,57 +116,164 @@ const health = await client.health();
 const resolved = await client.identity.resolve(alice.did);
 ```
 
-## API reference
+## API surface
 
 Each domain is available either from the package root or from a named subpath
 export:
 
-| Subpath                   | Exports                                              |
-| ------------------------- | ---------------------------------------------------- |
-| `@exochain/sdk`           | Everything — `ExochainClient`, all domain primitives |
-| `@exochain/sdk/identity`  | `Identity`, `validateDid`, `isDid`, `deriveDid`      |
-| `@exochain/sdk/consent`   | `BailmentBuilder`, `BailmentProposal`                |
-| `@exochain/sdk/governance`| `Decision`, `DecisionBuilder`, `Vote`, `VoteChoice`  |
-| `@exochain/sdk/authority` | `AuthorityChainBuilder`, `ChainLink`, `ValidatedChain` |
-| `@exochain/sdk/crypto`    | `sha256`, `sha256Hex`, `sha256Hash`, hex helpers     |
+| Subpath                    | Exports                                                |
+| -------------------------- | ------------------------------------------------------ |
+| `@exochain/sdk`            | Everything — `ExochainClient`, all domain primitives   |
+| `@exochain/sdk/identity`   | `Identity`, `validateDid`, `isDid`, `deriveDid`        |
+| `@exochain/sdk/consent`    | `BailmentBuilder`, `BailmentProposal`                  |
+| `@exochain/sdk/governance` | `Decision`, `DecisionBuilder`, `Vote`, `VoteChoice`    |
+| `@exochain/sdk/authority`  | `AuthorityChainBuilder`, `ChainLink`, `ValidatedChain` |
+| `@exochain/sdk/crypto`     | `sha256`, `sha256Hex`, `sha256Hash`, hex helpers       |
 
-### Branded types
+## Branded types
 
-`Did` and `Hash256` are branded string types. Use `validateDid(s)` at the
-boundary of untrusted input — plain strings cannot be assigned to parameters
-that expect a `Did`.
+`Did` and `Hash256` are **branded string types**. A branded type is a string at
+runtime but carries a compile-time tag that prevents arbitrary strings from
+being accidentally passed where a validated DID or hash is expected:
 
-### Errors
+```ts
+import { Did, validateDid } from '@exochain/sdk/identity';
 
-All SDK errors extend `ExochainError`:
+function send(to: Did): void { /* … */ }
 
-- `IdentityError`, `ConsentError`, `GovernanceError`, `AuthorityError`
-- `KernelError` (reserved for the constitutional kernel)
-- `CryptoError`, `TransportError`
+// Compile error — a plain string is not a Did.
+// send('did:exo:abc');
 
-Discriminate with `instanceof` rather than string matching.
+// OK — validateDid throws IdentityError on invalid input and returns Did.
+send(validateDid('did:exo:deadbeefcafebabe'));
+```
 
-## DID derivation — important note
+Use `validateDid(s)` at the boundary of untrusted input (HTTP payloads,
+command-line arguments, user input). Inside your own code, keep the `Did`
+brand end-to-end so the compiler catches accidental stringification.
 
-This pure-JS SDK derives DIDs as:
+`isDid(s)` is the non-throwing predicate variant for control-flow narrowing.
+
+## HttpTransport
+
+`HttpTransport` is the low-level fetch-based transport used by
+`ExochainClient`. Reach for it directly when you need to override request
+behavior (headers, timeouts, retries) or talk to endpoints the top-level
+client has not yet wrapped.
+
+```ts
+import { HttpTransport } from '@exochain/sdk';
+
+const transport = new HttpTransport({
+  baseUrl: 'https://gateway.example.com',
+  apiKey: process.env.EXOCHAIN_API_KEY,
+  defaultHeaders: { 'X-Tenant': 'acme' },
+  fetch: globalThis.fetch, // inject a custom fetch (e.g. undici, msw)
+});
+
+const res = await transport.request<{ version: string }>('GET', '/health');
+```
+
+`ExochainClient` wraps `HttpTransport` and exposes per-domain resources
+(`client.identity.resolve`, `client.consent.propose`, etc.). Prefer the
+client for normal use; drop down to `HttpTransport` only when you need raw
+control.
+
+## Browser vs Node considerations
+
+| Concern                     | Node 20+                                                     | Browsers                                                     |
+| --------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| Ed25519 sign / verify       | Stable since Node 20 via Web Crypto.                         | Chromium, Safari 17+, Firefox 130+.                          |
+| SHA-256                     | Web Crypto.                                                  | Web Crypto.                                                  |
+| Random bytes                | `globalThis.crypto.getRandomValues`.                         | Same.                                                        |
+| Secret key storage          | Your code's responsibility — keep out of process memory.     | Same — prefer `CryptoKey` (non-extractable) when possible.   |
+| HTTP transport              | Built-in `fetch`.                                            | Built-in `fetch`.                                            |
+| Bundle size                 | Tree-shakeable subpath exports.                              | Same.                                                        |
+
+The SDK does not ship polyfills. If you need to support older runtimes, pin a
+known-good runtime (for example in a Docker image), or apply your own
+polyfills at the application boundary.
+
+## Cross-language interop
+
+EXOCHAIN ships three first-party SDKs that share the same model and wire
+format:
+
+- **Rust** — `crates/exochain-sdk`. The reference implementation; uses
+  **BLAKE3** for hashing and DID derivation.
+- **TypeScript** (this package).
+- **Python** — `packages/exochain-py`, published as `exochain` on PyPI.
+
+Both the TypeScript and Python SDKs derive DIDs as:
 
 ```
 did:exo: + first 16 hex chars of SHA-256(raw public key bytes)
 ```
 
-The Rust SDK uses **BLAKE3** instead of SHA-256, because BLAKE3 is not available
-in the Web Crypto API. DIDs produced by this SDK will **not** match DIDs
-produced by the Rust SDK for the same keypair. For applications that need to
-interoperate with the Rust fabric at the DID level, obtain the canonical DID
-from the fabric and construct the identity via `Identity.fromKeypair`.
+because Web Crypto does not ship BLAKE3. **DIDs produced by this SDK will
+not match DIDs produced by the Rust SDK for the same keypair.** Applications
+that need canonical DIDs across all three SDKs should obtain the canonical
+DID from the fabric (via `exo-gateway`) and construct the identity with
+`Identity.fromKeypair(label, publicKey, secretKey)`.
+
+Bailment IDs, decision IDs, and chain identifiers are also hashed with
+SHA-256 in this SDK and BLAKE3 in Rust, for the same reason. All three SDKs
+agree on the *field layout* — so JSON round-trips work seamlessly — but not
+on the hash digest of the serialized fields.
+
+## Errors
+
+All SDK errors extend `ExochainError`:
+
+- `IdentityError` — invalid DID, key-material problem.
+- `ConsentError` — bailment validation failure.
+- `GovernanceError` — decision/vote validation failure (e.g. duplicate voter).
+- `AuthorityError` — authority chain topology failure.
+- `KernelError` — reserved for constitutional kernel adjudication errors.
+- `CryptoError` — cryptographic operation failure.
+- `TransportError` — HTTP/transport-layer failure.
+
+Discriminate with `instanceof` rather than string matching:
+
+```ts
+import { BailmentBuilder, ConsentError } from '@exochain/sdk';
+
+try {
+  await new BailmentBuilder(alice.did, bob.did).build();
+} catch (err) {
+  if (err instanceof ConsentError) {
+    // scope / duration missing — tell the user
+  }
+  throw err;
+}
+```
 
 ## Relation to the MCP server
 
 The EXOCHAIN stack also ships an MCP (Model Context Protocol) server at
-`exo-node` for use with AI agents. The SDK in this package targets application
-developers writing TypeScript clients that speak directly to the gateway; the
-MCP server is the bridge for AI agents that want constitutional governance as
-tool-use.
+`exo-node` for use with AI agents. The SDK in this package targets
+application developers writing TypeScript clients that speak directly to the
+gateway; the MCP server is the bridge for AI agents that want constitutional
+governance as tool-use.
+
+When integrating with the MCP server, this SDK's types serve as the canonical
+TypeScript representation of the objects the MCP server accepts and returns.
+
+## Development
+
+```bash
+npm install
+npm run build  # TypeScript compile to dist/
+npm test       # compile tests and run with node --test
+npm run lint   # tsc --noEmit
+```
+
+## Related
+
+- **Rust SDK** — `crates/exochain-sdk` in the EXOCHAIN monorepo.
+- **Python SDK** — `packages/exochain-py`, published as
+  [`exochain`](https://pypi.org/project/exochain/) on PyPI.
+- **MCP server** — `exo-node`, for LLM agent integration.
 
 ## License
 


### PR DESCRIPTION
## Summary

Comprehensive community-facing documentation spanning three coordinated efforts:

- **Quickstart guides** for Rust, TypeScript, Python SDKs plus MCP integration (2,475 lines)
- **Constitutional foundations** — full explanation of EXOCHAIN's governance model, architecture, AI-agent handbook, onboarding (2,481 lines)
- **Rustdoc** — every public item in exochain-sdk now has doctests, `# Examples`, `# Errors` sections, intra-doc links. `#![deny(missing_docs)]` enforced.

## Documentation deliverables

### New guides (9)
| File | Lines | Audience |
|------|-------|----------|
| `sdk-quickstart-rust.md` | 657 | Rust developers |
| `sdk-quickstart-typescript.md` | 598 | TS/JS developers |
| `sdk-quickstart-python.md` | 500 | Python developers |
| `mcp-integration.md` | 720 | AI client integrators |
| `constitutional-model.md` | 956 | System architects, auditors |
| `developer-onboarding.md` | 550 | New contributors |
| `architecture-overview.md` | 441 | System architects |
| `ai-agent-guide.md` | 534 | AI agents (Claude/GPT/etc.) |
| `GETTING-STARTED.md` (rewrite) | 356 | Everyone |

### New READMEs (4)
- `crates/exochain-sdk/README.md` (358 lines) — Rust SDK
- `packages/exochain-sdk/README.md` (280 lines) — TypeScript SDK
- `packages/README.md` (64 lines) — SDK selection guide
- `crates/README.md` (142 lines) — workspace index with dep diagram

### Rustdoc
- Every public item in `crates/exochain-sdk/src/` documented with doctests
- 57 doctests passing
- `#![deny(missing_docs)]` enforces future doc coverage

## Test plan

- [x] 2,404 workspace tests passing (up from 2,294), 0 failures
- [x] 57 doctests compile and pass in exochain-sdk
- [x] `cargo doc -p exochain-sdk --no-deps` clean
- [x] No broken intra-doc links (`-D rustdoc::broken-intra-doc-links`)
- [x] Clippy clean under `-D warnings` on exochain-sdk
- [x] All cross-references in docs point to real files
- [x] All 8 invariants and 6 MCP rules match source code exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)