### PR TITLE
Waves 3+4: SECURITY advisories + CI stub gate + doc rot + CHANGELOG + CONTRIBUTING (A-093/102/104/105/107)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,20 @@ jobs:
             exit 1
           fi
           echo "✓ License consistent: Apache-2.0"
+      - name: No GAP stubs remaining in code (A-102)
+        # Fails if any `STUB` marker referencing a GAP-NNN identifier
+        # remains in a code file. Prevents a GAP from being marked closed
+        # in GAP-REGISTRY.md while a stub still lives in the tree.
+        run: |
+          MATCHES=$(grep -rEn "STUB[^\n]*GAP-0[0-9][0-9]" \
+            --include='*.rs' --include='*.ts' --include='*.py' \
+            crates/ packages/ web/src/ 2>/dev/null || true)
+          if [ -n "$MATCHES" ]; then
+            echo "::error::GAP stubs remain in code:"
+            echo "$MATCHES"
+            exit 1
+          fi
+          echo "✓ No GAP stubs remaining in code"
 
   # -----------------------------------------------------------------------
   # Gate 10: SBOM (dry-run generation — no upload, validates toolchain)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,78 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security / Correctness
+
+Driven by the 2026-04-19 full-repo review
+([docs/audit/REVIEW-2026-04-19.md](docs/audit/REVIEW-2026-04-19.md));
+follow-up identifiers below are the plan's A-NN items.
+
+- **Node runs non-root in Docker** (A-040): root `Dockerfile` now creates
+  an unprivileged `exochain` user, installs `gosu`, and chowns the data
+  volume on first boot before stepping down. Adds `HEALTHCHECK` probing
+  the effective API port and uses exec-form `ENTRYPOINT`.
+- **Secrets moved behind fail-fast env vars** (A-043): `docker-compose.yml`
+  no longer carries hardcoded `exochain_dev` / `*-dev-secret`; every
+  secret is now `${VAR:?message}`-guarded and a missing `.env` fails
+  with a clear error.
+- **MCP input validation** (A-020): `tools/call` now validates params
+  against each tool's registered JSON Schema before dispatch. Schema
+  violations return JSON-RPC `INVALID_PARAMS (-32602)` rather than
+  silently reaching the tool body with an empty-defaulted field.
+- **Gateway body cap** (A-022): 1 MiB `DefaultBodyLimit` on every route.
+- **Web XSS hardened** (A-030/031/032): Council AI panel HTML-escapes
+  message content before applying markdown regex; dev-bypass is
+  double-guarded behind `VITE_ALLOW_DEV_BYPASS=true` and dropped from
+  production bundles by Vite DCE; CSP meta added.
+- **CSRF double-submit client** (A-082): fetchJson reads the
+  `XSRF-TOKEN` cookie and echoes it as `X-CSRF-Token` on mutating
+  requests. Server-side enforcement is a separate follow-up.
+- **Consensus scoring clamped** (A-010): `calculate_panel_confidence`
+  now clamps `models_agreeing` to `total_models` and caps the speed
+  sub-score numerator so out-of-range inputs cannot produce a score
+  above 10000 bps. Added property tests.
+- **Signature roundtrip returns `Result`** (A-011/012): `exo-dag`
+  Postgres store no longer silently substitutes `Signature::Empty` on
+  decode failure, and all lossy `as` casts for timestamps / heights
+  are replaced with checked `try_into`.
+- **Explicit shutdown phases** (A-070): exo-node logs HTTP-drain →
+  subsystem-stop → shutdown-complete and adds a 500ms task-drain
+  window. Full per-task CancellationToken plumbing is tracked as a
+  follow-up.
+- **Global concurrency ceiling** (A-071): gateway adds
+  `ConcurrencyLimitLayer(1024)` as admission control.
+- **Python `TransportError` carries status + body** (A-061); Python
+  `HttpTransport.timeout` accepts `httpx.Timeout` for per-phase control.
+- **Python SDK ships `py.typed`** (A-063); all three SDKs expose a
+  matching `PROTOCOL_VERSION` constant (A-066).
+
+### CI
+
+- **GAP stub hygiene** (A-102): CI Gate 9 fails on any `STUB.*GAP-0NN`
+  marker in code so a closed GAP can never leave a stub behind.
+
+### Docs
+
+- `SECURITY.md` now points to GitHub Private Security Advisory as the
+  primary disclosure channel (A-093); the `security@exochain.org`
+  fallback remains documented.
+- `CONTRIBUTING.md` cross-links to `docs/guides/DEPLOYMENT.md` for
+  post-merge shipping guidance (A-107).
+- Doc-rot sweep: `spec v2.1` references updated to `v2.2` in
+  `docs/guides/constitutional-model.md` and
+  `docs/guides/architecture-overview.md` (A-104).
+
+### ⚠ BREAKING
+
+- **DID derivation canonicalized to BLAKE3 across all SDKs** (A-050):
+  the TypeScript and Python SDKs previously used SHA-256(pubkey)[:8]
+  while the Rust SDK used BLAKE3(pubkey)[:8]; identical keypairs
+  yielded different DIDs per language. All three now derive via
+  BLAKE3 and share a fixture file at
+  `tests/fixtures/did-derivation.json`. Applications that persisted
+  locally-generated DIDs from the old TS/Python SDKs must migrate.
+  TS SDK adds `@noble/hashes` dep; Python SDK adds `blake3>=0.4.1` dep.
+
 ## [0.1.0-beta] - 2026-04-10
 
 Promotes alpha to beta. The WASM CGR Kernel is now fully operational, all 7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,13 @@ All of the following must pass before a PR can be merged:
 - [ ] `cargo doc --no-deps` succeeds
 - [ ] Coverage >= 90% (verified by CI)
 
+Once your change passes the PR checklist, see
+[docs/guides/DEPLOYMENT.md](./docs/guides/DEPLOYMENT.md) for how the merged
+binary is shipped (Railway Dockerfile, entrypoint env contract, node bootstrap).
+Deployment-relevant PRs (Dockerfile, `deploy/entrypoint.sh`, `railway.json`,
+`docker-compose*.yml`) should include a note linking to the deployment doc
+section they exercise.
+
 ### The PR Description
 
 Use the following template:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,11 +9,26 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in EXOCHAIN, please report it responsibly.
+If you discover a security vulnerability in EXOCHAIN, please report it
+responsibly via **GitHub Private Security Advisory**. This is the
+preferred channel:
 
-**Do not open a public GitHub issue for security vulnerabilities.**
+- Go to https://github.com/exochain/exochain/security/advisories/new
+- Or, from the repository: **Security** tab → **Advisories** → **New draft advisory**
 
-Instead, please email: **security@exochain.org**
+GitHub Security Advisories give you a private workspace that is scoped to
+the repository, let the maintainers comment in-thread, and coordinate a
+release + CVE assignment when the fix ships. They do not require an email
+server on the reporter's end and they are the fastest path to a patched
+release.
+
+If the GitHub UI is not available to you, email `security@exochain.org`
+as a fallback. Email is monitored on a best-effort basis; the Advisory
+channel is the primary mechanism.
+
+**Do not open a public GitHub issue for security vulnerabilities.** A
+public issue starts the clock on disclosure without letting the
+maintainers coordinate a release.
 
 Include:
 - Description of the vulnerability

--- a/docs/guides/architecture-overview.md
+++ b/docs/guides/architecture-overview.md
@@ -377,7 +377,7 @@ rollbacks.
   resolution. Implemented in `exo-identity::pace` with Verifiable
   Secret Sharing (Feldman commitments) and a geographic-distribution
   requirement (no two stewards in the same jurisdiction).
-- **Species Quorum** (CR-001 / spec v2.1 §3A): PACE recovery must
+- **Species Quorum** (CR-001 / spec v2.2 §3A): PACE recovery must
   include ≥3 human stewards and ≥1 Holon steward. Single-species
   control is rejected.
 

--- a/docs/guides/constitutional-model.md
+++ b/docs/guides/constitutional-model.md
@@ -1,7 +1,7 @@
 # The EXOCHAIN Constitutional Model
 
 > **Status:** Developer guide — canonical reference for the constitutional
-> governance model. Reflects spec v2.1 and CR-001 (AEGIS / SYBIL / Authentic
+> governance model. Reflects spec v2.2 and CR-001 (AEGIS / SYBIL / Authentic
 > Plurality).
 > **Audience:** Engineers building on EXOCHAIN, AI agents operating under
 > EXOCHAIN governance, auditors verifying conformance.


### PR DESCRIPTION
## Summary
- **A-093**: \`SECURITY.md\` now names GitHub Private Security Advisory as the primary disclosure channel. \`security@exochain.org\` remains as a documented fallback.
- **A-102**: CI Gate 9 (Repo Hygiene) fails if any \`STUB[^\n]*GAP-0NN\` marker remains in \`crates/\` / \`packages/\` / \`web/src/\`. Prevents closing a GAP in \`GAP-REGISTRY.md\` while a stub still lives in the tree.
- **A-104**: doc-rot sweep — \`spec v2.1\` → \`spec v2.2\` in \`docs/guides/constitutional-model.md\` (intro banner) and \`docs/guides/architecture-overview.md\` (Species Quorum citation).
- **A-105**: \`[Unreleased]\` in \`CHANGELOG.md\` refreshed with the full remediation surface from this epic.
- **A-107**: \`CONTRIBUTING.md\` cross-links to \`docs/guides/DEPLOYMENT.md\` after the PR checklist.

## Deferred to dedicated follow-ups
- **A-090** ring 0.17 migration
- **A-091** async-graphql MSRV bump
- **A-095** gitleaks in CI
- **A-100** TLA+ \`tlc\` gate
- **A-101** \`verify_nist_mapping()\` test
- **A-106** PRD Last-Verified headers on council panels
- **A-108** pg\_store schema version sentinel

## Test plan
- [x] CI yaml is well-formed under the \`hygiene\` job's \`steps:\`
- [ ] CI all-gates green (incl. new GAP stub check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)