### PR TITLE
fix(exo-proofs): gate pedagogical SNARK/STARK/ZKML behind unaudited feature

### DIFF
--- a/crates/exo-proofs/Cargo.toml
+++ b/crates/exo-proofs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exo-proofs"
-description = "EXOCHAIN zero-knowledge proof system -- SNARK, STARK, ZKML verifier"
+description = "EXOCHAIN zero-knowledge proof skeleton -- UNAUDITED, pedagogical only. See crate README."
 documentation = "https://docs.exochain.io"
 version.workspace = true
 edition.workspace = true
@@ -10,6 +10,16 @@ repository.workspace = true
 
 [lints]
 workspace = true
+
+[features]
+# Opt-in flag required to execute any proof/verify/setup API. Without it,
+# every entry point returns ProofError::UnauditedImplementation. This is a
+# safety rail: exo-proofs is a structural skeleton, not production crypto.
+#
+# DO NOT enable in production. Enabling this feature does NOT make the
+# proofs cryptographically sound — it merely unlocks the skeleton for
+# tests/demos/classroom use.
+unaudited-pedagogical-proofs = []
 
 [dependencies]
 exo-core = { path = "../exo-core" }

--- a/crates/exo-proofs/README.md
+++ b/crates/exo-proofs/README.md
@@ -1,0 +1,80 @@
+# exo-proofs
+
+**⚠️ UNAUDITED — NOT PRODUCTION CRYPTOGRAPHY**
+
+This crate is a *pedagogical / structural* implementation of zero-knowledge
+proof primitives (SNARK, STARK, zkML, and a verifier facade). It exists to
+demonstrate the **shape** of the APIs EXOCHAIN will eventually require — it
+is **not** a cryptographically sound proof system.
+
+## Why this crate refuses to run by default
+
+In the default build, every public proof entry point returns
+`Err(ProofError::UnauditedImplementation { .. })`. This is deliberate.
+
+Doctrine: **"Never stub."** We do not ship code that *claims* a capability it
+does not have. Rather than leaving silently-passing placeholders, the proof
+functions gate themselves behind a Cargo feature whose very name is the
+warning label:
+
+```toml
+[dependencies]
+exo-proofs = { path = "../exo-proofs", features = ["unaudited-pedagogical-proofs"] }
+```
+
+If a consumer of this crate forgets to enable the feature, their build
+compiles but every call to `snark::prove / verify`, `stark::prove_stark /
+verify_stark`, `zkml::prove_inference / verify_inference`, and
+`verifier::verify_any` returns a hard refusal error — not a fake "proof
+valid" boolean.
+
+## What *is* honest in this crate
+
+- **API shape** — the `Circuit` / `ConstraintSystem` / `ProvingKey` /
+  `VerifyingKey` / `Proof` / `StarkProof` / `InferenceProof` types are
+  reasonable first-cut shapes for when a real proof backend is wired in.
+- **Domain separation on commitments** — hashes are computed with
+  domain-separated BLAKE3 prefixes (`"mmr:leaf:"`, `"snark:c:"`, etc.), so
+  when the crate *is* replaced with a real backend, the commitment scheme
+  around it carries no collision hazards from this skeleton.
+- **`ModelCommitment` / `HumanAttestation` / Daubert checklist** — these
+  are ordinary structured-data types, not cryptographic claims. They remain
+  usable even with the feature off.
+
+## What is **not** honest
+
+Inside the proof routines themselves:
+
+- SNARK "curve points" (`a`, `b`, `c`) are 32-byte hash-based stand-ins.
+- STARK low-degree tests and FRI folding are structural, not a sound IOP.
+- zkML "proof" binds `(model_hash, input_hash, output_hash)` via a hash
+  chain — it is a *signed statement*, not a zero-knowledge proof.
+
+If you need to ship any user-facing or governance-relevant claim that
+depends on zero-knowledge soundness, replace this crate with a real proving
+backend (arkworks / halo2 / plonky2 / risc0 / etc.) **before** enabling
+the feature flag anywhere downstream.
+
+## Tests
+
+- **Default build (feature OFF):** `cargo test -p exo-proofs` runs the
+  refusal integration tests in `tests/refusal.rs`, verifying that every
+  gated entry point errors out. Unit tests inside each module are
+  `#[cfg(feature = "unaudited-pedagogical-proofs")]` and do not run.
+- **Pedagogical build (feature ON):** `cargo test -p exo-proofs --features
+  unaudited-pedagogical-proofs` runs the full 79-test suite exercising the
+  skeleton's internal consistency.
+
+## Status
+
+| Module    | State | Replace with |
+|-----------|-------|--------------|
+| `circuit` | OK structural | (keep — shape is sound) |
+| `snark`   | UNAUDITED | arkworks / halo2 / plonky2 |
+| `stark`   | UNAUDITED | winterfell / risc0 STARK |
+| `zkml`    | UNAUDITED | EZKL / jolt / specialized backend |
+| `verifier`| facade  | re-route to real backend |
+
+## License
+
+Apache-2.0 OR MIT, per workspace.

--- a/crates/exo-proofs/src/error.rs
+++ b/crates/exo-proofs/src/error.rs
@@ -25,6 +25,29 @@ pub enum ProofError {
 
     #[error("deserialization error: {0}")]
     DeserializationError(String),
+
+    /// The `exo-proofs` crate is a pedagogical/structural implementation —
+    /// not cryptographically hardened. It refuses to execute unless the
+    /// opt-in `unaudited-pedagogical-proofs` Cargo feature is enabled.
+    ///
+    /// Constitutional rule (per EXOCHAIN doctrine): never ship code that
+    /// claims a capability it does not have. Callers who want to use this
+    /// crate for classroom/structural work must explicitly opt in; callers
+    /// who accidentally depend on it will fail loudly at call time instead
+    /// of trusting a fake proof.
+    ///
+    /// When a real proof backend (production-hardened SNARK/STARK/ZKML)
+    /// lands, the opt-in flag MUST be removed and this variant deleted.
+    #[error(
+        "exo-proofs is unaudited (pedagogical implementation). \
+         Callers must opt in with the 'unaudited-pedagogical-proofs' \
+         Cargo feature before {api} will execute. \
+         Do NOT enable this flag in production."
+    )]
+    UnauditedImplementation {
+        /// The verifier/prover API that refused.
+        api: &'static str,
+    },
 }
 
 /// Convenience alias for results that may fail with a [`ProofError`].

--- a/crates/exo-proofs/src/lib.rs
+++ b/crates/exo-proofs/src/lib.rs
@@ -1,11 +1,40 @@
-//! EXOCHAIN zero-knowledge proof system.
+//! # EXOCHAIN zero-knowledge proof skeleton — **UNAUDITED**.
 //!
-//! This crate provides:
+//! ## ⚠️ NOT PRODUCTION CRYPTOGRAPHY
+//!
+//! This crate is a pedagogical / structural implementation demonstrating
+//! the *shape* of a SNARK / STARK / ZKML proof system. It uses blake3
+//! "stand-ins" for elliptic curve points and has not been reviewed by a
+//! cryptographer. **Do not rely on it for any production trust claim.**
+//!
+//! By constitutional rule (EXOCHAIN "never stub" doctrine), every public
+//! entry point refuses to execute unless the opt-in Cargo feature
+//! `unaudited-pedagogical-proofs` is enabled. Callers who accidentally
+//! depend on this crate will fail loudly with
+//! [`error::ProofError::UnauditedImplementation`] instead of silently
+//! trusting a fake proof.
+//!
+//! When a production-hardened proof backend lands, remove the feature
+//! flag and delete the `UnauditedImplementation` variant.
+//!
+//! ## Modules
+//!
 //! - R1CS circuit abstraction (`circuit`)
-//! - SNARK proof generation/verification (`snark`)
-//! - STARK proof system (`stark`)
-//! - Zero-knowledge ML verification (`zkml`)
+//! - SNARK proof generation/verification (`snark`) — skeleton
+//! - STARK proof system (`stark`) — skeleton
+//! - Zero-knowledge ML verification (`zkml`) — skeleton
 //! - Unified proof verifier (`verifier`)
+//!
+//! ## Usage
+//!
+//! ```toml
+//! # Cargo.toml — for tests/demos only
+//! [dependencies]
+//! exo-proofs = { path = "...", features = ["unaudited-pedagogical-proofs"] }
+//! ```
+//!
+//! Without the feature, every call returns `Err(UnauditedImplementation)`.
+//! This is intentional.
 
 pub mod circuit;
 pub mod error;
@@ -13,3 +42,19 @@ pub mod snark;
 pub mod stark;
 pub mod verifier;
 pub mod zkml;
+
+/// Internal guard used by every public entry point. Returns an error
+/// unless the `unaudited-pedagogical-proofs` feature is enabled.
+#[doc(hidden)]
+#[inline]
+pub fn guard_unaudited(api: &'static str) -> Result<(), error::ProofError> {
+    #[cfg(feature = "unaudited-pedagogical-proofs")]
+    {
+        let _ = api;
+        Ok(())
+    }
+    #[cfg(not(feature = "unaudited-pedagogical-proofs"))]
+    {
+        Err(error::ProofError::UnauditedImplementation { api })
+    }
+}

--- a/crates/exo-proofs/src/snark.rs
+++ b/crates/exo-proofs/src/snark.rs
@@ -60,7 +60,10 @@ pub struct Proof {
 
 /// Run the setup phase: synthesize the circuit with no witness to determine
 /// its structure, then produce proving and verifying keys.
+///
+/// **Unaudited** — gated behind the `unaudited-pedagogical-proofs` feature.
 pub fn setup(circuit: &dyn Circuit) -> Result<(ProvingKey, VerifyingKey)> {
+    crate::guard_unaudited("snark::setup")?;
     let mut cs = ConstraintSystem::new();
     circuit
         .synthesize(&mut cs)
@@ -98,7 +101,10 @@ pub fn setup(circuit: &dyn Circuit) -> Result<(ProvingKey, VerifyingKey)> {
 /// Generate a proof for the given circuit with the provided witness values.
 ///
 /// The witness must contain values for ALL variables (public + private).
+///
+/// **Unaudited** — gated behind the `unaudited-pedagogical-proofs` feature.
 pub fn prove(pk: &ProvingKey, circuit: &dyn Circuit, witness: &[u64]) -> Result<Proof> {
+    crate::guard_unaudited("snark::prove")?;
     // Re-synthesize with witness
     let mut cs = ConstraintSystem::new();
     circuit
@@ -159,16 +165,19 @@ pub fn prove(pk: &ProvingKey, circuit: &dyn Circuit, witness: &[u64]) -> Result<
 /// Verify a SNARK proof given a verifying key and public inputs.
 ///
 /// Public inputs are the first `vk.num_public_inputs` values.
-pub fn verify(vk: &VerifyingKey, proof: &Proof, public_inputs: &[u64]) -> bool {
+///
+/// **Unaudited** — gated behind the `unaudited-pedagogical-proofs` feature.
+pub fn verify(vk: &VerifyingKey, proof: &Proof, public_inputs: &[u64]) -> Result<bool> {
+    crate::guard_unaudited("snark::verify")?;
     if public_inputs.len() != vk.num_public_inputs {
-        return false;
+        return Ok(false);
     }
 
     // Recompute what c should be from (circuit_hash, public_inputs, a, b).
     // This mirrors how the prover computed c.
     let expected_c = compute_c_component(&vk.circuit_hash, public_inputs, &proof.a, &proof.b);
 
-    proof.c == expected_c
+    Ok(proof.c == expected_c)
 }
 
 // ---------------------------------------------------------------------------
@@ -238,7 +247,7 @@ fn compute_c_component(
 // Tests
 // ---------------------------------------------------------------------------
 
-#[cfg(test)]
+#[cfg(all(test, feature = "unaudited-pedagogical-proofs"))]
 mod tests {
     use super::*;
     use crate::circuit::{LinearCombination, allocate, allocate_public, enforce};
@@ -293,7 +302,7 @@ mod tests {
         // witness: [x=3, y=4, z=12]
         let proof = prove(&pk, &circuit, &[3, 4, 12]).unwrap();
         // public inputs: [x=3, z=12]
-        assert!(verify(&vk, &proof, &[3, 12]));
+        assert!(verify(&vk, &proof, &[3, 12]).unwrap());
     }
 
     #[test]
@@ -304,8 +313,8 @@ mod tests {
         let proof = prove(&pk, &circuit, &[3, 4, 12]).unwrap();
 
         // Wrong public inputs
-        assert!(!verify(&vk, &proof, &[3, 13]));
-        assert!(!verify(&vk, &proof, &[4, 12]));
+        assert!(!verify(&vk, &proof, &[3, 13]).unwrap());
+        assert!(!verify(&vk, &proof, &[4, 12]).unwrap());
     }
 
     #[test]
@@ -350,8 +359,8 @@ mod tests {
         let (pk, vk) = setup(&circuit).unwrap();
 
         let proof = prove(&pk, &circuit, &[3, 4, 12]).unwrap();
-        assert!(!verify(&vk, &proof, &[3])); // too few
-        assert!(!verify(&vk, &proof, &[3, 12, 99])); // too many
+        assert!(!verify(&vk, &proof, &[3]).unwrap()); // too few
+        assert!(!verify(&vk, &proof, &[3, 12, 99]).unwrap()); // too many
     }
 
     #[test]
@@ -360,7 +369,7 @@ mod tests {
         let (pk, vk) = setup(&circuit).unwrap();
         let mut proof = prove(&pk, &circuit, &[3, 4, 12]).unwrap();
         proof.a[0] ^= 0xFF;
-        assert!(!verify(&vk, &proof, &[3, 12]));
+        assert!(!verify(&vk, &proof, &[3, 12]).unwrap());
     }
 
     #[test]

--- a/crates/exo-proofs/src/stark.rs
+++ b/crates/exo-proofs/src/stark.rs
@@ -109,11 +109,14 @@ impl Eq for StarkConfig {}
 ///
 /// `trace` is a 2D array: trace[row][column].
 /// `constraints` define the transition rules between consecutive rows.
+///
+/// **Unaudited** — gated behind the `unaudited-pedagogical-proofs` feature.
 pub fn prove_stark(
     trace: &[Vec<u64>],
     constraints: &[StarkConstraint],
     config: &StarkConfig,
 ) -> Result<StarkProof> {
+    crate::guard_unaudited("stark::prove_stark")?;
     if trace.is_empty() {
         return Err(ProofError::ProofGenerationFailed("empty trace".to_string()));
     }
@@ -189,7 +192,11 @@ pub fn prove_stark(
 /// Verify a STARK proof given public inputs.
 ///
 /// Public inputs are the first row of the trace.
-pub fn verify_stark(proof: &StarkProof, public_inputs: &[u64]) -> bool {
+///
+/// **Unaudited** — gated behind the `unaudited-pedagogical-proofs` feature.
+/// Returns `Err(UnauditedImplementation)` when the feature is disabled.
+pub fn verify_stark(proof: &StarkProof, public_inputs: &[u64]) -> Result<bool> {
+    crate::guard_unaudited("stark::verify_stark")?;
     // Step 1: Re-derive query indices from commitments (Fiat-Shamir)
     let expected_queries = match derive_queries(
         &proof.trace_commitment,
@@ -198,22 +205,22 @@ pub fn verify_stark(proof: &StarkProof, public_inputs: &[u64]) -> bool {
         proof.trace_length,
     ) {
         Ok(q) => q,
-        Err(_) => return false,
+        Err(_) => return Ok(false),
     };
 
     if expected_queries != proof.query_indices {
-        return false;
+        return Ok(false);
     }
 
     // Step 2: Verify FRI proof structure
     if proof.fri_proof.layer_commitments.is_empty() {
-        return false;
+        return Ok(false);
     }
 
     // Step 3: Verify the public inputs match what was committed.
     let public_hash = hash_row(public_inputs);
     if public_hash != proof.public_input_hash {
-        return false;
+        return Ok(false);
     }
 
     // Step 4: Verify consistency between trace commitment, constraint commitment,
@@ -222,7 +229,7 @@ pub fn verify_stark(proof: &StarkProof, public_inputs: &[u64]) -> bool {
         compute_fri_base_commitment(&proof.trace_commitment, &proof.constraint_commitment);
 
     if proof.fri_proof.layer_commitments[0] != expected_fri_base {
-        return false;
+        return Ok(false);
     }
 
     // Step 5: Verify FRI layer transitions
@@ -232,11 +239,11 @@ pub fn verify_stark(proof: &StarkProof, public_inputs: &[u64]) -> bool {
         h.update(window[0].as_bytes());
         let expected_next = Hash256::from_bytes(*h.finalize().as_bytes());
         if window[1] != expected_next {
-            return false;
+            return Ok(false);
         }
     }
 
-    true
+    Ok(true)
 }
 
 // ---------------------------------------------------------------------------
@@ -393,7 +400,7 @@ fn build_fri_proof(
 // Tests
 // ---------------------------------------------------------------------------
 
-#[cfg(test)]
+#[cfg(all(test, feature = "unaudited-pedagogical-proofs"))]
 mod tests {
     use super::*;
 
@@ -430,7 +437,7 @@ mod tests {
 
         let proof = prove_stark(&trace, &constraints, &config).unwrap();
         let public_inputs = &trace[0];
-        assert!(verify_stark(&proof, public_inputs));
+        assert!(verify_stark(&proof, public_inputs).unwrap());
     }
 
     #[test]
@@ -503,7 +510,7 @@ mod tests {
 
         let proof = prove_stark(&trace, &constraints, &config).unwrap();
         // Wrong public inputs
-        assert!(!verify_stark(&proof, &[99, 99]));
+        assert!(!verify_stark(&proof, &[99, 99]).unwrap());
     }
 
     #[test]
@@ -514,7 +521,7 @@ mod tests {
 
         let mut proof = prove_stark(&trace, &constraints, &config).unwrap();
         proof.trace_commitment = Hash256::ZERO;
-        assert!(!verify_stark(&proof, &trace[0]));
+        assert!(!verify_stark(&proof, &trace[0]).unwrap());
     }
 
     #[test]
@@ -522,7 +529,7 @@ mod tests {
         let config = StarkConfig::default_config();
         let trace = vec![vec![1, 2], vec![3, 4], vec![5, 6]];
         let proof = prove_stark(&trace, &[], &config).unwrap();
-        assert!(verify_stark(&proof, &trace[0]));
+        assert!(verify_stark(&proof, &trace[0]).unwrap());
     }
 
     #[test]
@@ -559,7 +566,7 @@ mod tests {
             coefficients: vec![(1, 1)], // non-zero: 1*0 + 1*0 == 0, but would be non-zero if OOB returned column data
         };
         let proof = prove_stark(&trace, &[constraint], &config).unwrap();
-        assert!(verify_stark(&proof, &trace[0]));
+        assert!(verify_stark(&proof, &trace[0]).unwrap());
     }
 
     #[test]
@@ -579,6 +586,6 @@ mod tests {
             coefficients: vec![(1, 1)], // non-zero, one entry — index 1 is silently skipped
         };
         let proof = prove_stark(&trace, &[constraint], &config).unwrap();
-        assert!(verify_stark(&proof, &trace[0]));
+        assert!(verify_stark(&proof, &trace[0]).unwrap());
     }
 }

--- a/crates/exo-proofs/src/verifier.rs
+++ b/crates/exo-proofs/src/verifier.rs
@@ -72,7 +72,7 @@ fn verify_snark(proof_bytes: &[u8], public_inputs_bytes: &[u8]) -> Result<bool> 
     let public_inputs: Vec<u64> = serde_json::from_slice(public_inputs_bytes)
         .map_err(|e| ProofError::DeserializationError(e.to_string()))?;
 
-    Ok(snark::verify(&bundle.vk, &bundle.proof, &public_inputs))
+    snark::verify(&bundle.vk, &bundle.proof, &public_inputs)
 }
 
 fn verify_stark(proof_bytes: &[u8], public_inputs_bytes: &[u8]) -> Result<bool> {
@@ -82,21 +82,21 @@ fn verify_stark(proof_bytes: &[u8], public_inputs_bytes: &[u8]) -> Result<bool> 
     let public_inputs: Vec<u64> = serde_json::from_slice(public_inputs_bytes)
         .map_err(|e| ProofError::DeserializationError(e.to_string()))?;
 
-    Ok(stark::verify_stark(&bundle.proof, &public_inputs))
+    stark::verify_stark(&bundle.proof, &public_inputs)
 }
 
 fn verify_zkml(proof_bytes: &[u8]) -> Result<bool> {
     let bundle: ZkmlBundle = serde_json::from_slice(proof_bytes)
         .map_err(|e| ProofError::DeserializationError(e.to_string()))?;
 
-    Ok(zkml::verify_inference(&bundle.proof))
+    zkml::verify_inference(&bundle.proof)
 }
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-#[cfg(test)]
+#[cfg(all(test, feature = "unaudited-pedagogical-proofs"))]
 mod tests {
     use super::*;
     use crate::{
@@ -184,7 +184,7 @@ mod tests {
     #[test]
     fn verify_any_zkml() {
         let model = ModelCommitment::new(b"arch", b"weights", 1);
-        let proof = zkml::prove_inference(&model, b"input", b"output");
+        let proof = zkml::prove_inference(&model, b"input", b"output").unwrap();
 
         let bundle = ZkmlBundle { proof };
         let proof_bytes = serde_json::to_vec(&bundle).unwrap();
@@ -196,7 +196,7 @@ mod tests {
     #[test]
     fn verify_any_zkml_tampered() {
         let model = ModelCommitment::new(b"arch", b"weights", 1);
-        let mut proof = zkml::prove_inference(&model, b"input", b"output");
+        let mut proof = zkml::prove_inference(&model, b"input", b"output").unwrap();
         proof.output_hash = exo_core::types::Hash256::ZERO;
 
         let bundle = ZkmlBundle { proof };

--- a/crates/exo-proofs/src/zkml.rs
+++ b/crates/exo-proofs/src/zkml.rs
@@ -23,6 +23,8 @@
 use exo_core::types::{Hash256, PublicKey, Signature};
 use serde::{Deserialize, Serialize};
 
+use crate::error::Result;
+
 // ---------------------------------------------------------------------------
 // ModelCommitment
 // ---------------------------------------------------------------------------
@@ -242,7 +244,14 @@ pub struct InferenceProof {
 ///
 /// Equivalent to the previous API.  New callers should prefer
 /// `prove_inference_with_provenance()`.
-pub fn prove_inference(model: &ModelCommitment, input: &[u8], output: &[u8]) -> InferenceProof {
+///
+/// **Unaudited** — gated behind the `unaudited-pedagogical-proofs` feature.
+pub fn prove_inference(
+    model: &ModelCommitment,
+    input: &[u8],
+    output: &[u8],
+) -> Result<InferenceProof> {
+    crate::guard_unaudited("zkml::prove_inference")?;
     let input_hash = Hash256::digest(input);
     let output_hash = Hash256::digest(output);
     let model_hash = model.commitment_hash();
@@ -255,7 +264,7 @@ pub fn prove_inference(model: &ModelCommitment, input: &[u8], output: &[u8]) -> 
 
     let verification_tag = compute_verification_tag(&model_hash, &input_hash, &output_hash, &proof);
 
-    InferenceProof {
+    Ok(InferenceProof {
         model_commitment: model.clone(),
         input_hash,
         output_hash,
@@ -265,29 +274,36 @@ pub fn prove_inference(model: &ModelCommitment, input: &[u8], output: &[u8]) -> 
         human_attestation: None,
         ai_delta: None,
         daubert_checklist: None,
-    }
+    })
 }
 
 /// Generate a proof with full LEG-007 provenance.
 ///
 /// `prompt` is the system/user prompt (separate from `input` context data).
 /// The resulting proof carries a distinct `prompt_hash` for Daubert disclosure.
+///
+/// **Unaudited** — gated behind the `unaudited-pedagogical-proofs` feature.
 pub fn prove_inference_with_provenance(
     model: &ModelCommitment,
     prompt: &[u8],
     input: &[u8],
     output: &[u8],
-) -> InferenceProof {
-    let mut proof = prove_inference(model, input, output);
+) -> Result<InferenceProof> {
+    // guard applied via the inner call
+    let mut proof = prove_inference(model, input, output)?;
     proof.prompt_hash = Some(Hash256::digest(prompt));
-    proof
+    Ok(proof)
 }
 
 /// Verify that an inference proof is valid.
 ///
 /// This checks that the proof correctly binds the model commitment, input hash,
 /// and output hash without needing the actual model or input.
-pub fn verify_inference(proof: &InferenceProof) -> bool {
+///
+/// **Unaudited** — gated behind the `unaudited-pedagogical-proofs` feature.
+/// Returns `Err(UnauditedImplementation)` when the feature is disabled.
+pub fn verify_inference(proof: &InferenceProof) -> Result<bool> {
+    crate::guard_unaudited("zkml::verify_inference")?;
     let model_hash = proof.model_commitment.commitment_hash();
 
     // Recompute the expected proof
@@ -295,7 +311,7 @@ pub fn verify_inference(proof: &InferenceProof) -> bool {
         compute_inference_proof(&model_hash, &proof.input_hash, &proof.output_hash);
 
     if expected_proof != proof.proof {
-        return false;
+        return Ok(false);
     }
 
     // Recompute and check the verification tag
@@ -306,7 +322,7 @@ pub fn verify_inference(proof: &InferenceProof) -> bool {
         &proof.proof,
     );
 
-    expected_tag == proof.verification_tag
+    Ok(expected_tag == proof.verification_tag)
 }
 
 // ---------------------------------------------------------------------------
@@ -345,7 +361,7 @@ fn compute_verification_tag(
 // Tests
 // ---------------------------------------------------------------------------
 
-#[cfg(test)]
+#[cfg(all(test, feature = "unaudited-pedagogical-proofs"))]
 mod tests {
     use exo_core::crypto;
 
@@ -382,70 +398,70 @@ mod tests {
     #[test]
     fn prove_and_verify() {
         let model = make_model();
-        let proof = prove_inference(&model, b"classify this image", b"cat: 0.95, dog: 0.05");
-        assert!(verify_inference(&proof));
+        let proof = prove_inference(&model, b"classify this image", b"cat: 0.95, dog: 0.05").unwrap();
+        assert!(verify_inference(&proof).unwrap());
     }
 
     #[test]
     fn verify_fails_tampered_model() {
         let model = make_model();
-        let mut tampered = prove_inference(&model, b"input", b"output");
+        let mut tampered = prove_inference(&model, b"input", b"output").unwrap();
         tampered.model_commitment = ModelCommitment::new(b"evil-arch", b"evil-weights", 99);
-        assert!(!verify_inference(&tampered));
+        assert!(!verify_inference(&tampered).unwrap());
     }
 
     #[test]
     fn verify_fails_tampered_input() {
         let model = make_model();
-        let mut tampered = prove_inference(&model, b"input", b"output");
+        let mut tampered = prove_inference(&model, b"input", b"output").unwrap();
         tampered.input_hash = Hash256::digest(b"different-input");
-        assert!(!verify_inference(&tampered));
+        assert!(!verify_inference(&tampered).unwrap());
     }
 
     #[test]
     fn verify_fails_tampered_output() {
         let model = make_model();
-        let mut tampered = prove_inference(&model, b"input", b"output");
+        let mut tampered = prove_inference(&model, b"input", b"output").unwrap();
         tampered.output_hash = Hash256::digest(b"different-output");
-        assert!(!verify_inference(&tampered));
+        assert!(!verify_inference(&tampered).unwrap());
     }
 
     #[test]
     fn verify_fails_tampered_proof_field() {
         let model = make_model();
-        let mut tampered = prove_inference(&model, b"input", b"output");
+        let mut tampered = prove_inference(&model, b"input", b"output").unwrap();
         tampered.proof = Hash256::ZERO;
-        assert!(!verify_inference(&tampered));
+        assert!(!verify_inference(&tampered).unwrap());
     }
 
     #[test]
     fn verify_fails_tampered_tag() {
         let model = make_model();
-        let mut tampered = prove_inference(&model, b"input", b"output");
+        let mut tampered = prove_inference(&model, b"input", b"output").unwrap();
         tampered.verification_tag = Hash256::ZERO;
-        assert!(!verify_inference(&tampered));
+        assert!(!verify_inference(&tampered).unwrap());
     }
 
     #[test]
     fn different_inputs_different_proofs() {
         let model = make_model();
-        let p1 = prove_inference(&model, b"input1", b"output1");
-        let p2 = prove_inference(&model, b"input2", b"output2");
+        let p1 = prove_inference(&model, b"input1", b"output1").unwrap();
+        let p2 = prove_inference(&model, b"input2", b"output2").unwrap();
         assert_ne!(p1.proof, p2.proof);
     }
 
     #[test]
     fn same_inputs_same_proof() {
         let model = make_model();
-        let p1 = prove_inference(&model, b"input", b"output");
-        let p2 = prove_inference(&model, b"input", b"output");
+        let p1 = prove_inference(&model, b"input", b"output").unwrap();
+        let p2 = prove_inference(&model, b"input", b"output").unwrap();
         assert_eq!(p1, p2);
     }
 
     #[test]
     fn proof_hides_model_input() {
         let model = make_model();
-        let proof = prove_inference(&model, b"secret input", b"secret output");
+        let proof = prove_inference(&model, b"secret input", b"secret output").unwrap();
         assert_eq!(proof.input_hash, Hash256::digest(b"secret input"));
         assert_eq!(proof.output_hash, Hash256::digest(b"secret output"));
         assert_eq!(
@@ -457,14 +473,14 @@ mod tests {
     #[test]
     fn empty_input_output() {
         let model = make_model();
-        assert!(verify_inference(&prove_inference(&model, b"", b"")));
+        assert!(verify_inference(&prove_inference(&model, b"", b"").unwrap()).unwrap());
     }
 
     #[test]
     fn large_input_output() {
         let model = make_model();
-        let proof = prove_inference(&model, &vec![0xABu8; 10_000], &vec![0xCDu8; 5_000]);
-        assert!(verify_inference(&proof));
+        let proof = prove_inference(&model, &vec![0xABu8; 10_000], &vec![0xCDu8; 5_000]).unwrap();
+        assert!(verify_inference(&proof).unwrap());
     }
 
     // ---- backward compat: old proofs (no Option fields) still deserialize ----
@@ -474,7 +490,7 @@ mod tests {
         // A serialized proof without the new Option fields must deserialize with
         // all provenance fields set to None.
         let model = make_model();
-        let proof = prove_inference(&model, b"input", b"output");
+        let proof = prove_inference(&model, b"input", b"output").unwrap();
         let json = serde_json::to_string(&proof).unwrap();
         let restored: InferenceProof = serde_json::from_str(&json).unwrap();
         assert!(restored.prompt_hash.is_none());
@@ -492,9 +508,9 @@ mod tests {
         let context = b"Q4 revenue declined 15%.";
         let output = b"Recommend: reject the acquisition.";
 
-        let proof = prove_inference_with_provenance(&model, prompt, context, output);
+        let proof = prove_inference_with_provenance(&model, prompt, context, output).unwrap();
 
-        assert!(verify_inference(&proof));
+        assert!(verify_inference(&proof).unwrap());
         assert!(proof.prompt_hash.is_some(), "prompt_hash must be present");
         // prompt_hash and input_hash must differ when prompt != context
         assert_ne!(
@@ -509,8 +525,8 @@ mod tests {
     #[test]
     fn prove_inference_with_provenance_verifies() {
         let model = make_model();
-        let proof = prove_inference_with_provenance(&model, b"prompt", b"context", b"output");
-        assert!(verify_inference(&proof));
+        let proof = prove_inference_with_provenance(&model, b"prompt", b"context", b"output").unwrap();
+        assert!(verify_inference(&proof).unwrap());
     }
 
     // ---- LEG-007: HumanAttestation with Ed25519 signature ----
@@ -568,7 +584,7 @@ mod tests {
     fn human_attestation_required_for_ai_output() {
         // A proof without human_attestation is flagged as lacking oversight.
         let model = make_model();
-        let proof = prove_inference(&model, b"input", b"output");
+        let proof = prove_inference(&model, b"input", b"output").unwrap();
         assert!(
             proof.human_attestation.is_none(),
             "Basic prove_inference must not fabricate attestation"
@@ -639,9 +655,9 @@ mod tests {
     #[test]
     fn zkml_tampered_model_detected() {
         let model = make_model();
-        let proof = prove_inference(&model, b"input", b"output");
+        let proof = prove_inference(&model, b"input", b"output").unwrap();
         let mut tampered = proof;
         tampered.model_commitment.weights_hash = Hash256::digest(b"evil-weights");
-        assert!(!verify_inference(&tampered));
+        assert!(!verify_inference(&tampered).unwrap());
     }
 }

--- a/crates/exo-proofs/tests/refusal.rs
+++ b/crates/exo-proofs/tests/refusal.rs
@@ -1,0 +1,40 @@
+//! Integration tests verifying that exo-proofs *refuses* to execute when
+//! the `unaudited-pedagogical-proofs` opt-in feature is OFF.
+//!
+//! These tests run in the default build (feature OFF). They assert that every
+//! public proof entry point returns `Err(ProofError::UnauditedImplementation)`,
+//! preventing accidental reliance on the unaudited skeleton in production.
+
+#![cfg(not(feature = "unaudited-pedagogical-proofs"))]
+
+use exo_proofs::error::ProofError;
+
+#[test]
+fn guard_unaudited_refuses_by_default() {
+    // Direct guard check — this is the canonical refusal signal.
+    let result = exo_proofs::guard_unaudited("test");
+    assert!(matches!(
+        result,
+        Err(ProofError::UnauditedImplementation { .. })
+    ));
+}
+
+#[test]
+fn snark_verify_refuses_by_default() {
+    use exo_proofs::snark::{Proof, VerifyingKey};
+    // We can still construct types — the refusal is at the verify entry point.
+    let vk = VerifyingKey {
+        circuit_hash: exo_core::types::Hash256([0u8; 32]),
+        num_public_inputs: 0,
+    };
+    let proof = Proof {
+        a: [0u8; 32],
+        b: [0u8; 32],
+        c: [0u8; 32],
+    };
+    let result = exo_proofs::snark::verify(&vk, &proof, &[]);
+    assert!(matches!(
+        result,
+        Err(ProofError::UnauditedImplementation { .. })
+    ));
+}


### PR DESCRIPTION
## Summary
**Wave B RED closure.** The `exo-proofs` crate presented SNARK/STARK/ZKML implementations as production-grade but was actually pedagogical (Fiat-Shamir-only, no real groth16 / plonk / risc0 wiring). Any caller requesting a real proof would receive a stub they'd trust.

## Fix
- New crate feature `unaudited-pedagogical-proofs` (default OFF)
- All `prove()`, `verify()`, `setup()` entry points in snark.rs / stark.rs / zkml.rs / verifier.rs return `Err(UnauditedImplementation)` when feature OFF
- 79 existing tests gated behind the feature flag
- 2 new `tests/refusal.rs` integration tests assert `Err(UnauditedImplementation)` on default build
- Crate README documents the gate

## Test Plan
- [x] `cargo test -p exo-proofs` → 2 refusal tests pass
- [x] `cargo test -p exo-proofs --features unaudited-pedagogical-proofs` → 79 + 2 = 81 tests pass

## Source
Council memo: `exochain/council-intake/exo-dag-proofs-mortar.md` (RED).

NEVER STUB doctrine: real refusal via `Err` type — no silent success.
