### PR TITLE
fix(exo-dag,exo-node): GAP-014 — BFT consensus signature verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,6 +1394,7 @@ version = "0.1.0-beta"
 dependencies = [
  "async-trait",
  "blake3",
+ "ciborium",
  "criterion",
  "exo-core",
  "proptest",

--- a/crates/exo-dag/Cargo.toml
+++ b/crates/exo-dag/Cargo.toml
@@ -19,6 +19,7 @@ postgres = ["dep:sqlx", "dep:serde_json"]
 exo-core = { path = "../exo-core" }
 serde = { workspace = true }
 blake3 = { workspace = true }
+ciborium = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/exo-dag/src/append.rs
+++ b/crates/exo-dag/src/append.rs
@@ -171,7 +171,9 @@ mod tests {
         store.put(genesis.clone()).await.expect("put genesis");
 
         let child = make_child_node(&genesis);
-        validated_append(&mut store, child.clone()).await.expect("validated append");
+        validated_append(&mut store, child.clone())
+            .await
+            .expect("validated append");
 
         assert!(store.contains(&child.hash).await.expect("contains"));
     }
@@ -223,7 +225,11 @@ mod tests {
         let node = make_test_node();
         store.put(node.clone()).await.expect("put");
 
-        assert!(verify_stored_integrity(&store, &node.hash).await.expect("verify"));
+        assert!(
+            verify_stored_integrity(&store, &node.hash)
+                .await
+                .expect("verify")
+        );
     }
 
     #[tokio::test]
@@ -238,13 +244,19 @@ mod tests {
         store.put(node).await.expect("put");
 
         // Integrity check should detect the hash mismatch
-        assert!(!verify_stored_integrity(&store, &original_hash).await.expect("verify"));
+        assert!(
+            !verify_stored_integrity(&store, &original_hash)
+                .await
+                .expect("verify")
+        );
     }
 
     #[tokio::test]
     async fn verify_stored_integrity_not_found() {
         let store = MemoryStore::new();
-        let err = verify_stored_integrity(&store, &Hash256::ZERO).await.unwrap_err();
+        let err = verify_stored_integrity(&store, &Hash256::ZERO)
+            .await
+            .unwrap_err();
         assert!(matches!(err, DagError::NodeNotFound(_)));
     }
 
@@ -253,7 +265,9 @@ mod tests {
         let mut store = MemoryStore::new();
         let genesis = make_test_node();
         // Genesis has no parents — should pass validation
-        validated_append(&mut store, genesis.clone()).await.expect("genesis append");
+        validated_append(&mut store, genesis.clone())
+            .await
+            .expect("genesis append");
         assert!(store.contains(&genesis.hash).await.expect("contains"));
     }
 }

--- a/crates/exo-dag/src/consensus.rs
+++ b/crates/exo-dag/src/consensus.rs
@@ -5,7 +5,10 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use exo_core::types::{Did, Hash256, Signature};
+use exo_core::{
+    crypto,
+    types::{Did, Hash256, PublicKey, Signature},
+};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -94,6 +97,108 @@ pub struct CommitCertificate {
 }
 
 // ---------------------------------------------------------------------------
+// Canonical signing payloads + signature verification (GAP-014)
+// ---------------------------------------------------------------------------
+
+impl Vote {
+    /// Canonical CBOR payload that the voter signs.
+    ///
+    /// Domain tag prevents cross-context reuse. The tuple
+    /// `(tag, voter, round, node_hash)` binds the signature to
+    /// exactly one voter, round, and node.
+    ///
+    /// # Errors
+    /// Returns `DagError::StoreError` on CBOR encoding failure.
+    pub fn signing_payload(&self) -> Result<Vec<u8>> {
+        let tuple = (
+            "exo.dag.consensus.vote.v1",
+            &self.voter,
+            self.round,
+            &self.node_hash,
+        );
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&tuple, &mut buf).map_err(|e| {
+            DagError::StoreError(format!("vote signing payload encoding failed: {e}"))
+        })?;
+        Ok(buf)
+    }
+
+    /// Verify the voter's signature over the canonical payload.
+    ///
+    /// Rejects empty signatures AND all-zero sentinels AND signatures
+    /// that do not verify under `voter_public_key`.
+    #[must_use]
+    pub fn verify_signature(&self, voter_public_key: &PublicKey) -> bool {
+        if self.signature.is_empty() {
+            return false;
+        }
+        let raw = self.signature.as_bytes();
+        if !raw.is_empty() && raw.iter().all(|b| *b == 0) {
+            return false;
+        }
+        let Ok(payload) = self.signing_payload() else {
+            return false;
+        };
+        crypto::verify(&payload, &self.signature, voter_public_key)
+    }
+}
+
+impl Proposal {
+    /// Canonical CBOR payload that the proposer signs.
+    ///
+    /// # Errors
+    /// Returns `DagError::StoreError` on CBOR encoding failure.
+    pub fn signing_payload(&self) -> Result<Vec<u8>> {
+        let tuple = (
+            "exo.dag.consensus.proposal.v1",
+            &self.proposer,
+            self.round,
+            &self.node_hash,
+        );
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&tuple, &mut buf).map_err(|e| {
+            DagError::StoreError(format!("proposal signing payload encoding failed: {e}"))
+        })?;
+        Ok(buf)
+    }
+
+    /// Verify the proposer's signature (supplied separately — `Proposal`
+    /// itself has no signature field; the wire envelope carries it).
+    #[must_use]
+    pub fn verify_signature(&self, proposer_public_key: &PublicKey, signature: &Signature) -> bool {
+        if signature.is_empty() {
+            return false;
+        }
+        let raw = signature.as_bytes();
+        if !raw.is_empty() && raw.iter().all(|b| *b == 0) {
+            return false;
+        }
+        let Ok(payload) = self.signing_payload() else {
+            return false;
+        };
+        crypto::verify(&payload, signature, proposer_public_key)
+    }
+}
+
+/// Resolve a validator DID to its current public key.
+///
+/// Production implementations should back this with the identity
+/// registry (`exo-identity`) and must refuse resolution for revoked
+/// or rotated keys.
+pub trait PublicKeyResolver {
+    fn resolve(&self, did: &Did) -> Option<PublicKey>;
+}
+
+impl<F> PublicKeyResolver for F
+where
+    F: Fn(&Did) -> Option<PublicKey>,
+{
+    fn resolve(&self, did: &Did) -> Option<PublicKey> {
+        (self)(did)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Consensus State
 // ---------------------------------------------------------------------------
 
@@ -135,6 +240,16 @@ impl ConsensusState {
 }
 
 /// Propose a node for commitment.
+///
+/// **⚠️ DEPRECATED (GAP-014):** This function does not verify the
+/// proposer's signature. Use [`propose_verified`] instead, which
+/// requires a [`PublicKeyResolver`] and refuses forged signatures.
+///
+/// Retained only to avoid breaking the legacy test suite; production
+/// callers MUST migrate. Will be removed in a future release.
+#[deprecated(
+    note = "GAP-014: use propose_verified; this variant does not verify the proposer signature"
+)]
 pub fn propose(state: &mut ConsensusState, node: &DagNode, proposer: &Did) -> Result<Proposal> {
     if !state.config.validators.contains(proposer) {
         return Err(DagError::NotAValidator(proposer.to_string()));
@@ -157,6 +272,10 @@ pub fn propose(state: &mut ConsensusState, node: &DagNode, proposer: &Did) -> Re
 }
 
 /// Cast a vote for a node in the current round.
+///
+/// **⚠️ DEPRECATED (GAP-014):** This function does not verify the
+/// voter's signature. Use [`vote_verified`] instead.
+#[deprecated(note = "GAP-014: use vote_verified; this variant does not verify the voter signature")]
 pub fn vote(state: &mut ConsensusState, v: Vote) -> Result<()> {
     if !state.config.validators.contains(&v.voter) {
         return Err(DagError::NotAValidator(v.voter.to_string()));
@@ -214,10 +333,161 @@ pub fn check_commit(state: &ConsensusState, node_hash: &Hash256) -> Option<Commi
 }
 
 /// Commit a node with a certificate.
+///
+/// **⚠️ DEPRECATED (GAP-014):** This function does not verify any
+/// vote signatures in the certificate. Use [`commit_verified`] instead.
+#[deprecated(
+    note = "GAP-014: use commit_verified; this variant does not verify certificate signatures"
+)]
 pub fn commit(state: &mut ConsensusState, cert: CommitCertificate) {
     let hash = cert.node_hash;
     state.committed.push(hash);
     state.certificates.insert(hash, cert);
+}
+
+// ---------------------------------------------------------------------------
+// Verified consensus API (GAP-014) — signature-checking variants
+// ---------------------------------------------------------------------------
+
+/// Register a proposal after verifying the proposer's signature.
+///
+/// Closes GAP-014 for the proposal path. In addition to the membership
+/// check `propose` performs, this verifies that `signature` is a valid
+/// signature by `proposer` over `Proposal::signing_payload()`. Rejects
+/// empty, all-zero, or unverifiable signatures.
+///
+/// The caller supplies the proposer's public key via `resolver`. A
+/// resolver returning `None` for the proposer is treated as "unknown
+/// key" and the proposal is rejected.
+///
+/// # Errors
+/// - `NotAValidator` if `proposer` is not in the validator set.
+/// - `InvalidSignature` if the signature is empty / zero / wrong key /
+///   over the wrong payload.
+pub fn propose_verified<R: PublicKeyResolver>(
+    state: &mut ConsensusState,
+    node: &DagNode,
+    proposer: &Did,
+    signature: &Signature,
+    resolver: &R,
+) -> Result<Proposal> {
+    if !state.config.validators.contains(proposer) {
+        return Err(DagError::NotAValidator(proposer.to_string()));
+    }
+
+    let proposal = Proposal {
+        proposer: proposer.clone(),
+        round: state.current_round,
+        node_hash: node.hash,
+    };
+
+    let Some(key) = resolver.resolve(proposer) else {
+        return Err(DagError::InvalidSignature(node.hash));
+    };
+    if !proposal.verify_signature(&key, signature) {
+        return Err(DagError::InvalidSignature(node.hash));
+    }
+
+    state
+        .pending
+        .entry(state.current_round)
+        .or_default()
+        .entry(node.hash)
+        .or_default();
+
+    Ok(proposal)
+}
+
+/// Cast a vote after verifying the voter's signature.
+///
+/// Closes GAP-014 for the vote path.
+///
+/// # Errors
+/// - `NotAValidator` if `v.voter` is not in the validator set.
+/// - `InvalidRound` if `v.round` does not match the current round.
+/// - `DuplicateVote` if this voter has already voted this round.
+/// - `InvalidSignature` if the signature does not verify against
+///   the public key returned by `resolver` for `v.voter`, or the
+///   resolver returns `None`.
+pub fn vote_verified<R: PublicKeyResolver>(
+    state: &mut ConsensusState,
+    v: Vote,
+    resolver: &R,
+) -> Result<()> {
+    if !state.config.validators.contains(&v.voter) {
+        return Err(DagError::NotAValidator(v.voter.to_string()));
+    }
+
+    if v.round != state.current_round {
+        return Err(DagError::InvalidRound {
+            expected: state.current_round,
+            got: v.round,
+        });
+    }
+
+    let Some(key) = resolver.resolve(&v.voter) else {
+        return Err(DagError::InvalidSignature(v.node_hash));
+    };
+    if !v.verify_signature(&key) {
+        return Err(DagError::InvalidSignature(v.node_hash));
+    }
+
+    let round_voters = state.voted_in_round.entry(v.round).or_default();
+    if round_voters.contains(&v.voter) {
+        return Err(DagError::DuplicateVote {
+            voter: v.voter.to_string(),
+            round: v.round,
+        });
+    }
+
+    round_voters.insert(v.voter.clone());
+
+    state
+        .pending
+        .entry(v.round)
+        .or_default()
+        .entry(v.node_hash)
+        .or_default()
+        .push(v);
+
+    Ok(())
+}
+
+/// Commit a node with a certificate after verifying every vote's signature.
+///
+/// Closes GAP-014 for the commit path. Every vote in the certificate
+/// must:
+///   - reference `cert.node_hash`
+///   - come from a validator in the current set
+///   - carry a signature that verifies against the voter's current key
+///
+/// # Errors
+/// - `InvalidSignature(cert.node_hash)` if any vote fails verification
+///   or references a different node.
+/// - `NotAValidator` if any voter is not in the validator set.
+pub fn commit_verified<R: PublicKeyResolver>(
+    state: &mut ConsensusState,
+    cert: CommitCertificate,
+    resolver: &R,
+) -> Result<()> {
+    for v in &cert.votes {
+        if v.node_hash != cert.node_hash {
+            return Err(DagError::InvalidSignature(cert.node_hash));
+        }
+        if !state.config.validators.contains(&v.voter) {
+            return Err(DagError::NotAValidator(v.voter.to_string()));
+        }
+        let Some(key) = resolver.resolve(&v.voter) else {
+            return Err(DagError::InvalidSignature(cert.node_hash));
+        };
+        if !v.verify_signature(&key) {
+            return Err(DagError::InvalidSignature(cert.node_hash));
+        }
+    }
+    let hash = cert.node_hash;
+    state.committed.push(hash);
+    state.certificates.insert(hash, cert);
+    Ok(())
 }
 
 /// Check if a node has been finalized (committed with a certificate).
@@ -660,5 +930,269 @@ mod tests {
 
         assert!(check_commit(&state, &n1.hash).is_some());
         assert!(check_commit(&state, &n2.hash).is_none());
+    }
+
+    // ===================================================================
+    // GAP-014 fix regression tests — verified consensus path
+    // ===================================================================
+
+    use exo_core::crypto;
+
+    /// Build a minimal DagNode for tests. We don't run append() here
+    /// because we want the test to own the node-hash determinism and
+    /// not depend on signing details.
+    fn make_node(seed: &str) -> (DagNode, (), ()) {
+        let mut dag = Dag::new();
+        let mut clock = HybridClock::new();
+        let did = Did::new("did:exo:proposer").unwrap();
+        let sf = make_sign_fn();
+        let node = append(&mut dag, &[], seed.as_bytes(), &did, &*sf, &mut clock)
+            .expect("append test node");
+        (node, (), ())
+    }
+
+    /// Build a signed vote over its canonical payload.
+    fn signed_vote(
+        voter: &Did,
+        round: u64,
+        node_hash: Hash256,
+        sk: &exo_core::types::SecretKey,
+    ) -> Vote {
+        let mut v = Vote {
+            voter: voter.clone(),
+            round,
+            node_hash,
+            signature: Signature::empty(),
+        };
+        let payload = v.signing_payload().expect("payload");
+        v.signature = crypto::sign(&payload, sk);
+        v
+    }
+
+    #[test]
+    fn verified_vote_accepts_properly_signed() {
+        let (pk_a, sk_a) = crypto::generate_keypair();
+        let a = Did::new("did:exo:alice").unwrap();
+        let mut vs = BTreeSet::new();
+        vs.insert(a.clone());
+        let mut state = ConsensusState::new(ConsensusConfig::new(vs, 1000));
+        let (n, _, _) = make_node("x");
+        let vote = signed_vote(&a, 0, n.hash, &sk_a);
+        let resolver = |d: &Did| -> Option<exo_core::types::PublicKey> {
+            if *d == a { Some(pk_a.clone()) } else { None }
+        };
+        assert!(vote_verified(&mut state, vote, &resolver).is_ok());
+    }
+
+    #[test]
+    fn verified_vote_rejects_forged_signature_with_valid_voter() {
+        // The exact GAP-014 attack: voter is in the validator set, but
+        // the signature is junk bytes (the shape the old `vote()` let
+        // through silently).
+        let (pk_a, _sk_a) = crypto::generate_keypair();
+        let a = Did::new("did:exo:alice").unwrap();
+        let mut vs = BTreeSet::new();
+        vs.insert(a.clone());
+        let mut state = ConsensusState::new(ConsensusConfig::new(vs, 1000));
+        let (n, _, _) = make_node("x");
+        let forged = Vote {
+            voter: a.clone(),
+            round: 0,
+            node_hash: n.hash,
+            signature: Signature::from_bytes([1u8; 64]),
+        };
+        let resolver = |_d: &Did| Some(pk_a.clone());
+        let res = vote_verified(&mut state, forged, &resolver);
+        assert!(matches!(res, Err(DagError::InvalidSignature(_))));
+        // Crucially: state must not have accepted the forged vote.
+        assert!(state.pending.get(&0).is_none_or(|m| m.is_empty()));
+        assert!(state.voted_in_round.get(&0).is_none_or(|s| s.is_empty()));
+    }
+
+    #[test]
+    fn verified_vote_rejects_zero_byte_signature() {
+        let (pk_a, _sk_a) = crypto::generate_keypair();
+        let a = Did::new("did:exo:alice").unwrap();
+        let mut vs = BTreeSet::new();
+        vs.insert(a.clone());
+        let mut state = ConsensusState::new(ConsensusConfig::new(vs, 1000));
+        let (n, _, _) = make_node("x");
+        let zeros = Vote {
+            voter: a.clone(),
+            round: 0,
+            node_hash: n.hash,
+            signature: Signature::from_bytes([0u8; 64]),
+        };
+        let resolver = |_d: &Did| Some(pk_a.clone());
+        let res = vote_verified(&mut state, zeros, &resolver);
+        assert!(matches!(res, Err(DagError::InvalidSignature(_))));
+    }
+
+    #[test]
+    fn verified_vote_rejects_signature_by_wrong_validator_key() {
+        // Alice is the voter in the message, but the signature was
+        // actually produced by Mallory's key. Resolver returns Alice's
+        // pubkey. Verification must fail.
+        let (pk_alice, _sk_alice) = crypto::generate_keypair();
+        let (_, sk_mallory) = crypto::generate_keypair();
+        let a = Did::new("did:exo:alice").unwrap();
+        let mut vs = BTreeSet::new();
+        vs.insert(a.clone());
+        let mut state = ConsensusState::new(ConsensusConfig::new(vs, 1000));
+        let (n, _, _) = make_node("x");
+        // Sign with Mallory's key but claim voter = Alice.
+        let mut bad = Vote {
+            voter: a.clone(),
+            round: 0,
+            node_hash: n.hash,
+            signature: Signature::empty(),
+        };
+        let payload = bad.signing_payload().unwrap();
+        bad.signature = crypto::sign(&payload, &sk_mallory);
+        let resolver = |_d: &Did| Some(pk_alice.clone());
+        let res = vote_verified(&mut state, bad, &resolver);
+        assert!(matches!(res, Err(DagError::InvalidSignature(_))));
+    }
+
+    #[test]
+    fn verified_vote_rejects_when_resolver_returns_none() {
+        // Voter is in validator set but no public key is known.
+        let a = Did::new("did:exo:alice").unwrap();
+        let mut vs = BTreeSet::new();
+        vs.insert(a.clone());
+        let mut state = ConsensusState::new(ConsensusConfig::new(vs, 1000));
+        let (n, _, _) = make_node("x");
+        let (_, sk) = crypto::generate_keypair();
+        let v = signed_vote(&a, 0, n.hash, &sk);
+        let null_resolver = |_d: &Did| None;
+        let res = vote_verified(&mut state, v, &null_resolver);
+        assert!(matches!(res, Err(DagError::InvalidSignature(_))));
+    }
+
+    #[test]
+    fn verified_vote_rejects_replay_from_different_round() {
+        let (pk_a, sk_a) = crypto::generate_keypair();
+        let a = Did::new("did:exo:alice").unwrap();
+        let mut vs = BTreeSet::new();
+        vs.insert(a.clone());
+        let mut state = ConsensusState::new(ConsensusConfig::new(vs, 1000));
+        state.advance_round(); // now at round 1
+        let (n, _, _) = make_node("x");
+        // Signed for round 0 but state is at round 1.
+        let v = signed_vote(&a, 0, n.hash, &sk_a);
+        let resolver = |_d: &Did| Some(pk_a.clone());
+        let res = vote_verified(&mut state, v, &resolver);
+        assert!(matches!(res, Err(DagError::InvalidRound { .. })));
+    }
+
+    #[test]
+    fn verified_propose_rejects_forged_signature() {
+        let (pk_a, _sk_a) = crypto::generate_keypair();
+        let a = Did::new("did:exo:alice").unwrap();
+        let mut vs = BTreeSet::new();
+        vs.insert(a.clone());
+        let mut state = ConsensusState::new(ConsensusConfig::new(vs, 1000));
+        let (n, _, _) = make_node("x");
+        let forged_sig = Signature::from_bytes([1u8; 64]);
+        let resolver = |_d: &Did| Some(pk_a.clone());
+        let res = propose_verified(&mut state, &n, &a, &forged_sig, &resolver);
+        assert!(matches!(res, Err(DagError::InvalidSignature(_))));
+    }
+
+    #[test]
+    fn verified_propose_accepts_properly_signed() {
+        let (pk_a, sk_a) = crypto::generate_keypair();
+        let a = Did::new("did:exo:alice").unwrap();
+        let mut vs = BTreeSet::new();
+        vs.insert(a.clone());
+        let mut state = ConsensusState::new(ConsensusConfig::new(vs, 1000));
+        let (n, _, _) = make_node("x");
+        let proposal_shape = Proposal {
+            proposer: a.clone(),
+            round: 0,
+            node_hash: n.hash,
+        };
+        let payload = proposal_shape.signing_payload().unwrap();
+        let sig = crypto::sign(&payload, &sk_a);
+        let resolver = |_d: &Did| Some(pk_a.clone());
+        let res = propose_verified(&mut state, &n, &a, &sig, &resolver);
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn verified_commit_rejects_forged_vote_in_cert() {
+        let (pk_a, _sk_a) = crypto::generate_keypair();
+        let a = Did::new("did:exo:alice").unwrap();
+        let mut vs = BTreeSet::new();
+        vs.insert(a.clone());
+        let mut state = ConsensusState::new(ConsensusConfig::new(vs, 1000));
+        let (n, _, _) = make_node("x");
+        let forged_vote = Vote {
+            voter: a.clone(),
+            round: 0,
+            node_hash: n.hash,
+            signature: Signature::from_bytes([2u8; 64]),
+        };
+        let cert = CommitCertificate {
+            node_hash: n.hash,
+            votes: vec![forged_vote],
+            round: 0,
+        };
+        let resolver = |_d: &Did| Some(pk_a.clone());
+        let res = commit_verified(&mut state, cert, &resolver);
+        assert!(matches!(res, Err(DagError::InvalidSignature(_))));
+        assert!(state.committed.is_empty());
+    }
+
+    #[test]
+    fn verified_commit_accepts_properly_signed_cert() {
+        let (pk_a, sk_a) = crypto::generate_keypair();
+        let (pk_b, sk_b) = crypto::generate_keypair();
+        let a = Did::new("did:exo:alice").unwrap();
+        let b = Did::new("did:exo:bob").unwrap();
+        let mut vs = BTreeSet::new();
+        vs.insert(a.clone());
+        vs.insert(b.clone());
+        let mut state = ConsensusState::new(ConsensusConfig::new(vs, 1000));
+        let (n, _, _) = make_node("x");
+        let va = signed_vote(&a, 0, n.hash, &sk_a);
+        let vb = signed_vote(&b, 0, n.hash, &sk_b);
+        let cert = CommitCertificate {
+            node_hash: n.hash,
+            votes: vec![va, vb],
+            round: 0,
+        };
+        let resolver = move |d: &Did| -> Option<exo_core::types::PublicKey> {
+            if *d == a {
+                Some(pk_a.clone())
+            } else if *d == b {
+                Some(pk_b.clone())
+            } else {
+                None
+            }
+        };
+        assert!(commit_verified(&mut state, cert, &resolver).is_ok());
+        assert_eq!(state.committed.len(), 1);
+    }
+
+    #[test]
+    fn verified_commit_rejects_cert_with_wrong_hash_vote() {
+        let (pk_a, sk_a) = crypto::generate_keypair();
+        let a = Did::new("did:exo:alice").unwrap();
+        let mut vs = BTreeSet::new();
+        vs.insert(a.clone());
+        let mut state = ConsensusState::new(ConsensusConfig::new(vs, 1000));
+        let (n1, _, _) = make_node("x");
+        let (n2, _, _) = make_node("y");
+        // Vote is for n2 but cert claims n1.
+        let v = signed_vote(&a, 0, n2.hash, &sk_a);
+        let cert = CommitCertificate {
+            node_hash: n1.hash,
+            votes: vec![v],
+            round: 0,
+        };
+        let resolver = |_d: &Did| Some(pk_a.clone());
+        let res = commit_verified(&mut state, cert, &resolver);
+        assert!(matches!(res, Err(DagError::InvalidSignature(_))));
     }
 }

--- a/crates/exo-dag/src/pg_store.rs
+++ b/crates/exo-dag/src/pg_store.rs
@@ -93,13 +93,13 @@ impl PostgresStore {
 impl DagStore for PostgresStore {
     async fn get(&self, hash: &Hash256) -> Result<Option<DagNode>> {
         let row: Option<(
-            Vec<u8>,           // hash
-            Vec<Vec<u8>>,      // parents
-            Vec<u8>,           // payload_hash
-            String,            // creator_did
-            i64,               // ts_physical_ms
-            i64,               // ts_logical
-            Vec<u8>,           // signature
+            Vec<u8>,      // hash
+            Vec<Vec<u8>>, // parents
+            Vec<u8>,      // payload_hash
+            String,       // creator_did
+            i64,          // ts_physical_ms
+            i64,          // ts_logical
+            Vec<u8>,      // signature
         )> = sqlx::query_as(
             "SELECT hash, parents, payload_hash, creator_did, ts_physical_ms, ts_logical, signature
              FROM dag_nodes WHERE hash = $1",
@@ -123,7 +123,8 @@ impl DagStore for PostgresStore {
                     hash: Hash256::from_bytes(hash_arr),
                     parents: Self::decode_parents(&parents_raw),
                     payload_hash: Hash256::from_bytes(payload_arr),
-                    creator_did: Did::new(&did_str).map_err(|e| store_err(format!("invalid DID: {e}")))?,
+                    creator_did: Did::new(&did_str)
+                        .map_err(|e| store_err(format!("invalid DID: {e}")))?,
                     timestamp: Timestamp::new(phys as u64, logical as u32),
                     signature: Self::decode_signature(&sig_bytes),
                 };
@@ -157,13 +158,11 @@ impl DagStore for PostgresStore {
     }
 
     async fn contains(&self, hash: &Hash256) -> Result<bool> {
-        let row: (bool,) = sqlx::query_as(
-            "SELECT EXISTS(SELECT 1 FROM dag_nodes WHERE hash = $1)",
-        )
-        .bind(hash.as_bytes().as_slice())
-        .fetch_one(&self.pool)
-        .await
-        .map_err(store_err)?;
+        let row: (bool,) = sqlx::query_as("SELECT EXISTS(SELECT 1 FROM dag_nodes WHERE hash = $1)")
+            .bind(hash.as_bytes().as_slice())
+            .fetch_one(&self.pool)
+            .await
+            .map_err(store_err)?;
 
         Ok(row.0)
     }
@@ -194,12 +193,10 @@ impl DagStore for PostgresStore {
     }
 
     async fn committed_height(&self) -> Result<u64> {
-        let row: (i64,) = sqlx::query_as(
-            "SELECT COALESCE(MAX(height), 0) FROM dag_committed",
-        )
-        .fetch_one(&self.pool)
-        .await
-        .map_err(store_err)?;
+        let row: (i64,) = sqlx::query_as("SELECT COALESCE(MAX(height), 0) FROM dag_committed")
+            .fetch_one(&self.pool)
+            .await
+            .map_err(store_err)?;
 
         #[allow(clippy::as_conversions)]
         Ok(row.0 as u64)
@@ -264,8 +261,14 @@ mod tests {
         // Run migrations
         PostgresStore::migrate(&pool).await.ok()?;
         // Clean tables for test isolation
-        sqlx::query("DELETE FROM dag_committed").execute(&pool).await.ok()?;
-        sqlx::query("DELETE FROM dag_nodes").execute(&pool).await.ok()?;
+        sqlx::query("DELETE FROM dag_committed")
+            .execute(&pool)
+            .await
+            .ok()?;
+        sqlx::query("DELETE FROM dag_nodes")
+            .execute(&pool)
+            .await
+            .ok()?;
         Some(pool)
     }
 

--- a/crates/exo-node/src/mcp/handler.rs
+++ b/crates/exo-node/src/mcp/handler.rs
@@ -15,9 +15,9 @@ use super::error::McpError;
 use super::middleware::ConstitutionalMiddleware;
 use super::prompts::PromptRegistry;
 use super::protocol::{
-    InitializeParams, InitializeResult, JsonRpcRequest, JsonRpcResponse, PromptsCapability,
+    INTERNAL_ERROR, INVALID_PARAMS, INVALID_REQUEST, InitializeParams, InitializeResult,
+    JsonRpcRequest, JsonRpcResponse, METHOD_NOT_FOUND, PARSE_ERROR, PromptsCapability,
     ResourcesCapability, ServerCapabilities, ServerInfo, ToolContent, ToolResult, ToolsCapability,
-    INTERNAL_ERROR, INVALID_PARAMS, INVALID_REQUEST, METHOD_NOT_FOUND, PARSE_ERROR,
 };
 use super::resources::ResourceRegistry;
 use super::tools::ToolRegistry;
@@ -102,11 +102,7 @@ impl McpServer {
         let request: JsonRpcRequest = match serde_json::from_str(message) {
             Ok(req) => req,
             Err(e) => {
-                let resp = JsonRpcResponse::error(
-                    None,
-                    PARSE_ERROR,
-                    format!("parse error: {e}"),
-                );
+                let resp = JsonRpcResponse::error(None, PARSE_ERROR, format!("parse error: {e}"));
                 return Some(serde_json::to_string(&resp).unwrap_or_default());
             }
         };
@@ -158,12 +154,16 @@ impl McpServer {
         let result = InitializeResult {
             protocol_version: "2024-11-05".into(),
             capabilities: ServerCapabilities {
-                tools: Some(ToolsCapability { list_changed: false }),
+                tools: Some(ToolsCapability {
+                    list_changed: false,
+                }),
                 resources: Some(ResourcesCapability {
                     subscribe: false,
                     list_changed: false,
                 }),
-                prompts: Some(PromptsCapability { list_changed: false }),
+                prompts: Some(PromptsCapability {
+                    list_changed: false,
+                }),
             },
             server_info: ServerInfo {
                 name: "exochain-mcp".into(),
@@ -190,10 +190,7 @@ impl McpServer {
             .filter_map(|t| serde_json::to_value(t).ok())
             .collect();
 
-        JsonRpcResponse::success(
-            request.id.clone(),
-            serde_json::json!({ "tools": tools }),
-        )
+        JsonRpcResponse::success(request.id.clone(), serde_json::json!({ "tools": tools }))
     }
 
     /// Handle `tools/call` — dispatch to a specific tool with constitutional enforcement.
@@ -244,7 +241,10 @@ impl McpServer {
         }
 
         // Execute the tool.
-        match self.registry.execute(tool_name, &tool_params, &self.context) {
+        match self
+            .registry
+            .execute(tool_name, &tool_params, &self.context)
+        {
             Ok(result) => match serde_json::to_value(&result) {
                 Ok(value) => JsonRpcResponse::success(request.id.clone(), value),
                 Err(e) => JsonRpcResponse::error(
@@ -606,10 +606,7 @@ mod tests {
         let result = parsed.result.unwrap();
         let resources = result["resources"].as_array().unwrap();
         assert_eq!(resources.len(), 6, "expected 6 registered resources");
-        let uris: Vec<&str> = resources
-            .iter()
-            .filter_map(|r| r["uri"].as_str())
-            .collect();
+        let uris: Vec<&str> = resources.iter().filter_map(|r| r["uri"].as_str()).collect();
         assert!(uris.contains(&"exochain://constitution"));
         assert!(uris.contains(&"exochain://invariants"));
         assert!(uris.contains(&"exochain://mcp-rules"));
@@ -690,10 +687,7 @@ mod tests {
         let result = parsed.result.unwrap();
         let prompts = result["prompts"].as_array().unwrap();
         assert_eq!(prompts.len(), 4, "expected 4 registered prompts");
-        let names: Vec<&str> = prompts
-            .iter()
-            .filter_map(|p| p["name"].as_str())
-            .collect();
+        let names: Vec<&str> = prompts.iter().filter_map(|p| p["name"].as_str()).collect();
         assert!(names.contains(&"governance_review"));
         assert!(names.contains(&"compliance_check"));
         assert!(names.contains(&"evidence_analysis"));

--- a/crates/exo-node/src/mcp/middleware.rs
+++ b/crates/exo-node/src/mcp/middleware.rs
@@ -13,8 +13,8 @@ use exo_gatekeeper::{
     kernel::{ActionRequest, AdjudicationContext, Kernel, Verdict},
     mcp::{self, McpContext, McpRule},
     types::{
-        AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch,
-        Permission, PermissionSet, Provenance, Role,
+        AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch, Permission,
+        PermissionSet, Provenance, Role,
     },
 };
 
@@ -32,10 +32,7 @@ impl ConstitutionalMiddleware {
     /// Create a new middleware instance with the full constitutional kernel.
     #[must_use]
     pub fn new() -> Self {
-        let kernel = Kernel::new(
-            b"EXOCHAIN Constitutional Trust Fabric",
-            InvariantSet::all(),
-        );
+        let kernel = Kernel::new(b"EXOCHAIN Constitutional Trust Fabric", InvariantSet::all());
         Self { kernel }
     }
 
@@ -81,8 +78,7 @@ impl ConstitutionalMiddleware {
         };
 
         #[allow(clippy::expect_used)] // Static string is always a valid DID.
-        let root_did =
-            Did::new("did:exo:root").expect("static DID is valid");
+        let root_did = Did::new("did:exo:root").expect("static DID is valid");
 
         let adj_context = AdjudicationContext {
             actor_roles: vec![Role {

--- a/crates/exo-node/src/mcp/prompts/evidence_analysis.rs
+++ b/crates/exo-node/src/mcp/prompts/evidence_analysis.rs
@@ -118,7 +118,11 @@ mod tests {
     fn definition_requires_bundle_id() {
         let def = definition();
         assert_eq!(def.name, "evidence_analysis");
-        let bundle_arg = def.arguments.iter().find(|a| a.name == "bundle_id").unwrap();
+        let bundle_arg = def
+            .arguments
+            .iter()
+            .find(|a| a.name == "bundle_id")
+            .unwrap();
         assert!(bundle_arg.required);
     }
 

--- a/crates/exo-node/src/mcp/protocol.rs
+++ b/crates/exo-node/src/mcp/protocol.rs
@@ -273,12 +273,7 @@ impl JsonRpcResponse {
 
     #[must_use]
     #[allow(dead_code)]
-    pub fn error_with_data(
-        id: Option<Value>,
-        code: i32,
-        message: String,
-        data: Value,
-    ) -> Self {
+    pub fn error_with_data(id: Option<Value>, code: i32, message: String, data: Value) -> Self {
         Self {
             jsonrpc: "2.0".into(),
             id,
@@ -373,7 +368,9 @@ mod tests {
         let result = InitializeResult {
             protocol_version: "2024-11-05".into(),
             capabilities: ServerCapabilities {
-                tools: Some(ToolsCapability { list_changed: false }),
+                tools: Some(ToolsCapability {
+                    list_changed: false,
+                }),
                 resources: Some(ResourcesCapability {
                     subscribe: false,
                     list_changed: false,

--- a/crates/exo-node/src/mcp/resources/invariants.rs
+++ b/crates/exo-node/src/mcp/resources/invariants.rs
@@ -115,8 +115,7 @@ pub(crate) fn build_payload() -> Value {
 #[must_use]
 pub fn read(_context: &NodeContext) -> ResourceContent {
     let payload = build_payload();
-    let text = serde_json::to_string_pretty(&payload)
-        .unwrap_or_else(|_| "{}".to_string());
+    let text = serde_json::to_string_pretty(&payload).unwrap_or_else(|_| "{}".to_string());
 
     ResourceContent {
         uri: "exochain://invariants".into(),

--- a/crates/exo-node/src/mcp/resources/mcp_rules.rs
+++ b/crates/exo-node/src/mcp/resources/mcp_rules.rs
@@ -96,8 +96,7 @@ pub(crate) fn build_payload() -> Value {
 #[must_use]
 pub fn read(_context: &NodeContext) -> ResourceContent {
     let payload = build_payload();
-    let text = serde_json::to_string_pretty(&payload)
-        .unwrap_or_else(|_| "{}".to_string());
+    let text = serde_json::to_string_pretty(&payload).unwrap_or_else(|_| "{}".to_string());
 
     ResourceContent {
         uri: "exochain://mcp-rules".into(),

--- a/crates/exo-node/src/mcp/resources/mod.rs
+++ b/crates/exo-node/src/mcp/resources/mod.rs
@@ -126,8 +126,7 @@ mod tests {
         assert!(!text.is_empty());
         // Hash must match what the kernel would compute.
         let hash = exo_core::Hash256::digest(text.as_bytes());
-        let kernel_hash =
-            exo_core::Hash256::digest(constitution::CONSTITUTION_TEXT);
+        let kernel_hash = exo_core::Hash256::digest(constitution::CONSTITUTION_TEXT);
         assert_eq!(hash, kernel_hash);
     }
 

--- a/crates/exo-node/src/mcp/resources/node_status.rs
+++ b/crates/exo-node/src/mcp/resources/node_status.rs
@@ -80,8 +80,7 @@ fn build_payload(context: &NodeContext) -> Value {
 #[must_use]
 pub fn read(context: &NodeContext) -> ResourceContent {
     let payload = build_payload(context);
-    let text = serde_json::to_string_pretty(&payload)
-        .unwrap_or_else(|_| "{}".to_string());
+    let text = serde_json::to_string_pretty(&payload).unwrap_or_else(|_| "{}".to_string());
 
     ResourceContent {
         uri: "exochain://node/status".into(),

--- a/crates/exo-node/src/mcp/resources/tools_summary.rs
+++ b/crates/exo-node/src/mcp/resources/tools_summary.rs
@@ -30,9 +30,7 @@ pub fn definition() -> ResourceDefinition {
 /// Classify a tool name into its canonical domain group.
 fn domain_for(name: &str) -> &'static str {
     match name {
-        "exochain_node_status"
-        | "exochain_list_invariants"
-        | "exochain_list_mcp_rules" => "node",
+        "exochain_node_status" | "exochain_list_invariants" | "exochain_list_mcp_rules" => "node",
         "exochain_create_identity"
         | "exochain_resolve_identity"
         | "exochain_assess_risk"
@@ -152,8 +150,7 @@ pub(crate) fn build_payload() -> Value {
 #[must_use]
 pub fn read(_context: &NodeContext) -> ResourceContent {
     let payload = build_payload();
-    let text = serde_json::to_string_pretty(&payload)
-        .unwrap_or_else(|_| "{}".to_string());
+    let text = serde_json::to_string_pretty(&payload).unwrap_or_else(|_| "{}".to_string());
 
     ResourceContent {
         uri: "exochain://tools".into(),
@@ -189,7 +186,11 @@ mod tests {
         let parsed: Value = serde_json::from_str(&text).unwrap();
         for tool in parsed["tools"].as_array().unwrap() {
             let domain = tool["domain"].as_str().unwrap();
-            assert_ne!(domain, "unknown", "tool {:?} has unknown domain", tool["name"]);
+            assert_ne!(
+                domain, "unknown",
+                "tool {:?} has unknown domain",
+                tool["name"]
+            );
         }
     }
 

--- a/crates/exo-node/src/mcp/tools/authority.rs
+++ b/crates/exo-node/src/mcp/tools/authority.rs
@@ -276,7 +276,8 @@ pub fn execute_verify_authority_chain(params: &Value, _context: &NodeContext) ->
 pub fn check_permission_definition() -> ToolDefinition {
     ToolDefinition {
         name: "exochain_check_permission".to_owned(),
-        description: "Check whether a DID has a specific permission through any authority chain.".to_owned(),
+        description: "Check whether a DID has a specific permission through any authority chain."
+            .to_owned(),
         input_schema: json!({
             "type": "object",
             "properties": {
@@ -322,9 +323,7 @@ pub fn execute_check_permission(params: &Value, _context: &NodeContext) -> ToolR
     }
 
     if permission.is_empty() {
-        return ToolResult::error(
-            json!({"error": "permission must not be empty"}).to_string(),
-        );
+        return ToolResult::error(json!({"error": "permission must not be empty"}).to_string());
     }
 
     // No persistent authority registry — report no chain found.
@@ -527,11 +526,14 @@ mod tests {
 
     #[test]
     fn execute_delegate_authority_success() {
-        let result = execute_delegate_authority(&json!({
-            "grantor_did": "did:exo:root",
-            "grantee_did": "did:exo:alice",
-            "permissions": ["read", "write"],
-        }), &NodeContext::empty());
+        let result = execute_delegate_authority(
+            &json!({
+                "grantor_did": "did:exo:root",
+                "grantee_did": "did:exo:alice",
+                "permissions": ["read", "write"],
+            }),
+            &NodeContext::empty(),
+        );
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(&result.content[0].text()).expect("valid JSON");
         assert_eq!(v["grantor"], "did:exo:root");
@@ -542,21 +544,27 @@ mod tests {
 
     #[test]
     fn execute_delegate_authority_invalid_grantor() {
-        let result = execute_delegate_authority(&json!({
-            "grantor_did": "bad",
-            "grantee_did": "did:exo:alice",
-            "permissions": ["read"],
-        }), &NodeContext::empty());
+        let result = execute_delegate_authority(
+            &json!({
+                "grantor_did": "bad",
+                "grantee_did": "did:exo:alice",
+                "permissions": ["read"],
+            }),
+            &NodeContext::empty(),
+        );
         assert!(result.is_error);
     }
 
     #[test]
     fn execute_delegate_authority_empty_permissions() {
-        let result = execute_delegate_authority(&json!({
-            "grantor_did": "did:exo:root",
-            "grantee_did": "did:exo:alice",
-            "permissions": [],
-        }), &NodeContext::empty());
+        let result = execute_delegate_authority(
+            &json!({
+                "grantor_did": "did:exo:root",
+                "grantee_did": "did:exo:alice",
+                "permissions": [],
+            }),
+            &NodeContext::empty(),
+        );
         assert!(result.is_error);
     }
 
@@ -571,13 +579,16 @@ mod tests {
 
     #[test]
     fn execute_verify_authority_chain_valid() {
-        let result = execute_verify_authority_chain(&json!({
-            "chain": [
-                {"grantor": "did:exo:root", "grantee": "did:exo:mid", "permissions": ["read"]},
-                {"grantor": "did:exo:mid", "grantee": "did:exo:leaf", "permissions": ["read"]},
-            ],
-            "terminal_actor": "did:exo:leaf",
-        }), &NodeContext::empty());
+        let result = execute_verify_authority_chain(
+            &json!({
+                "chain": [
+                    {"grantor": "did:exo:root", "grantee": "did:exo:mid", "permissions": ["read"]},
+                    {"grantor": "did:exo:mid", "grantee": "did:exo:leaf", "permissions": ["read"]},
+                ],
+                "terminal_actor": "did:exo:leaf",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(&result.content[0].text()).expect("valid JSON");
         assert_eq!(v["valid"], true);
@@ -587,13 +598,16 @@ mod tests {
 
     #[test]
     fn execute_verify_authority_chain_topology_break() {
-        let result = execute_verify_authority_chain(&json!({
-            "chain": [
-                {"grantor": "did:exo:root", "grantee": "did:exo:mid", "permissions": ["read"]},
-                {"grantor": "did:exo:other", "grantee": "did:exo:leaf", "permissions": ["read"]},
-            ],
-            "terminal_actor": "did:exo:leaf",
-        }), &NodeContext::empty());
+        let result = execute_verify_authority_chain(
+            &json!({
+                "chain": [
+                    {"grantor": "did:exo:root", "grantee": "did:exo:mid", "permissions": ["read"]},
+                    {"grantor": "did:exo:other", "grantee": "did:exo:leaf", "permissions": ["read"]},
+                ],
+                "terminal_actor": "did:exo:leaf",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(&result.content[0].text()).expect("valid JSON");
         assert_eq!(v["valid"], false);
@@ -602,12 +616,15 @@ mod tests {
 
     #[test]
     fn execute_verify_authority_chain_terminal_mismatch() {
-        let result = execute_verify_authority_chain(&json!({
-            "chain": [
-                {"grantor": "did:exo:root", "grantee": "did:exo:alice", "permissions": ["read"]},
-            ],
-            "terminal_actor": "did:exo:bob",
-        }), &NodeContext::empty());
+        let result = execute_verify_authority_chain(
+            &json!({
+                "chain": [
+                    {"grantor": "did:exo:root", "grantee": "did:exo:alice", "permissions": ["read"]},
+                ],
+                "terminal_actor": "did:exo:bob",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(&result.content[0].text()).expect("valid JSON");
         assert_eq!(v["valid"], false);
@@ -615,10 +632,13 @@ mod tests {
 
     #[test]
     fn execute_verify_authority_chain_empty() {
-        let result = execute_verify_authority_chain(&json!({
-            "chain": [],
-            "terminal_actor": "did:exo:alice",
-        }), &NodeContext::empty());
+        let result = execute_verify_authority_chain(
+            &json!({
+                "chain": [],
+                "terminal_actor": "did:exo:alice",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(&result.content[0].text()).expect("valid JSON");
         assert_eq!(v["valid"], false);
@@ -636,10 +656,13 @@ mod tests {
 
     #[test]
     fn execute_check_permission_success() {
-        let result = execute_check_permission(&json!({
-            "actor_did": "did:exo:alice",
-            "permission": "read",
-        }), &NodeContext::empty());
+        let result = execute_check_permission(
+            &json!({
+                "actor_did": "did:exo:alice",
+                "permission": "read",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(&result.content[0].text()).expect("valid JSON");
         assert_eq!(v["actor"], "did:exo:alice");
@@ -650,19 +673,25 @@ mod tests {
 
     #[test]
     fn execute_check_permission_invalid_did() {
-        let result = execute_check_permission(&json!({
-            "actor_did": "bad",
-            "permission": "read",
-        }), &NodeContext::empty());
+        let result = execute_check_permission(
+            &json!({
+                "actor_did": "bad",
+                "permission": "read",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(result.is_error);
     }
 
     #[test]
     fn execute_check_permission_empty_permission() {
-        let result = execute_check_permission(&json!({
-            "actor_did": "did:exo:alice",
-            "permission": "",
-        }), &NodeContext::empty());
+        let result = execute_check_permission(
+            &json!({
+                "actor_did": "did:exo:alice",
+                "permission": "",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(result.is_error);
     }
 
@@ -677,10 +706,13 @@ mod tests {
 
     #[test]
     fn execute_adjudicate_action_permitted() {
-        let result = execute_adjudicate_action(&json!({
-            "actor_did": "did:exo:alice",
-            "action": "read medical record",
-        }), &NodeContext::empty());
+        let result = execute_adjudicate_action(
+            &json!({
+                "actor_did": "did:exo:alice",
+                "action": "read medical record",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(&result.content[0].text()).expect("valid JSON");
         assert_eq!(v["verdict"], "Permitted");
@@ -690,11 +722,14 @@ mod tests {
 
     #[test]
     fn execute_adjudicate_action_denied_self_grant() {
-        let result = execute_adjudicate_action(&json!({
-            "actor_did": "did:exo:alice",
-            "action": "elevate permissions",
-            "is_self_grant": true,
-        }), &NodeContext::empty());
+        let result = execute_adjudicate_action(
+            &json!({
+                "actor_did": "did:exo:alice",
+                "action": "elevate permissions",
+                "is_self_grant": true,
+            }),
+            &NodeContext::empty(),
+        );
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(&result.content[0].text()).expect("valid JSON");
         assert_eq!(v["verdict"], "Denied");
@@ -703,11 +738,14 @@ mod tests {
 
     #[test]
     fn execute_adjudicate_action_denied_kernel_modification() {
-        let result = execute_adjudicate_action(&json!({
-            "actor_did": "did:exo:alice",
-            "action": "patch kernel",
-            "modifies_kernel": true,
-        }), &NodeContext::empty());
+        let result = execute_adjudicate_action(
+            &json!({
+                "actor_did": "did:exo:alice",
+                "action": "patch kernel",
+                "modifies_kernel": true,
+            }),
+            &NodeContext::empty(),
+        );
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(&result.content[0].text()).expect("valid JSON");
         assert_eq!(v["verdict"], "Denied");
@@ -715,10 +753,13 @@ mod tests {
 
     #[test]
     fn execute_adjudicate_action_invalid_did() {
-        let result = execute_adjudicate_action(&json!({
-            "actor_did": "bad",
-            "action": "read",
-        }), &NodeContext::empty());
+        let result = execute_adjudicate_action(
+            &json!({
+                "actor_did": "bad",
+                "action": "read",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(result.is_error);
     }
 }

--- a/crates/exo-node/src/mcp/tools/consent.rs
+++ b/crates/exo-node/src/mcp/tools/consent.rs
@@ -93,7 +93,9 @@ pub fn execute_propose_bailment(params: &Value, _context: &NodeContext) -> ToolR
     let id_input = format!("{bailor_str}:{bailee_str}:{scope}:{}", now.physical_ms);
     let proposal_id = Hash256::digest(id_input.as_bytes()).to_string();
 
-    let expires_ms = now.physical_ms.saturating_add(duration_hours.saturating_mul(3_600_000));
+    let expires_ms = now
+        .physical_ms
+        .saturating_add(duration_hours.saturating_mul(3_600_000));
 
     let response = json!({
         "proposal_id": proposal_id,
@@ -179,7 +181,8 @@ pub fn execute_check_consent(params: &Value, _context: &NodeContext) -> ToolResu
 pub fn list_bailments_definition() -> ToolDefinition {
     ToolDefinition {
         name: "exochain_list_bailments".to_owned(),
-        description: "List all bailments (active, proposed, terminated) for a given DID.".to_owned(),
+        description: "List all bailments (active, proposed, terminated) for a given DID."
+            .to_owned(),
         input_schema: json!({
             "type": "object",
             "properties": {
@@ -247,7 +250,8 @@ pub fn execute_list_bailments(params: &Value, _context: &NodeContext) -> ToolRes
 pub fn terminate_bailment_definition() -> ToolDefinition {
     ToolDefinition {
         name: "exochain_terminate_bailment".to_owned(),
-        description: "Terminate an active bailment, revoking the bailee's data access consent.".to_owned(),
+        description: "Terminate an active bailment, revoking the bailee's data access consent."
+            .to_owned(),
         input_schema: json!({
             "type": "object",
             "properties": {
@@ -287,14 +291,10 @@ pub fn execute_terminate_bailment(params: &Value, _context: &NodeContext) -> Too
     };
 
     if bailment_id.is_empty() {
-        return ToolResult::error(
-            json!({"error": "bailment_id must not be empty"}).to_string(),
-        );
+        return ToolResult::error(json!({"error": "bailment_id must not be empty"}).to_string());
     }
     if reason.is_empty() {
-        return ToolResult::error(
-            json!({"error": "reason must not be empty"}).to_string(),
-        );
+        return ToolResult::error(json!({"error": "reason must not be empty"}).to_string());
     }
 
     let now = Timestamp::now_utc();
@@ -327,11 +327,14 @@ mod tests {
 
     #[test]
     fn execute_propose_bailment_success() {
-        let result = execute_propose_bailment(&json!({
-            "bailor_did": "did:exo:alice",
-            "bailee_did": "did:exo:bob",
-            "scope": "data:medical",
-        }), &NodeContext::empty());
+        let result = execute_propose_bailment(
+            &json!({
+                "bailor_did": "did:exo:alice",
+                "bailee_did": "did:exo:bob",
+                "scope": "data:medical",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(&result.content[0].text()).expect("valid JSON");
         assert_eq!(v["bailor"], "did:exo:alice");
@@ -344,20 +347,26 @@ mod tests {
 
     #[test]
     fn execute_propose_bailment_invalid_bailor() {
-        let result = execute_propose_bailment(&json!({
-            "bailor_did": "bad",
-            "bailee_did": "did:exo:bob",
-            "scope": "data:medical",
-        }), &NodeContext::empty());
+        let result = execute_propose_bailment(
+            &json!({
+                "bailor_did": "bad",
+                "bailee_did": "did:exo:bob",
+                "scope": "data:medical",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(result.is_error);
     }
 
     #[test]
     fn execute_propose_bailment_missing_scope() {
-        let result = execute_propose_bailment(&json!({
-            "bailor_did": "did:exo:alice",
-            "bailee_did": "did:exo:bob",
-        }), &NodeContext::empty());
+        let result = execute_propose_bailment(
+            &json!({
+                "bailor_did": "did:exo:alice",
+                "bailee_did": "did:exo:bob",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(result.is_error);
     }
 
@@ -372,10 +381,13 @@ mod tests {
 
     #[test]
     fn execute_check_consent_success() {
-        let result = execute_check_consent(&json!({
-            "actor_did": "did:exo:alice",
-            "scope": "data:medical",
-        }), &NodeContext::empty());
+        let result = execute_check_consent(
+            &json!({
+                "actor_did": "did:exo:alice",
+                "scope": "data:medical",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(&result.content[0].text()).expect("valid JSON");
         assert_eq!(v["consent_active"], false);
@@ -384,18 +396,24 @@ mod tests {
 
     #[test]
     fn execute_check_consent_invalid_did() {
-        let result = execute_check_consent(&json!({
-            "actor_did": "bad",
-            "scope": "data:medical",
-        }), &NodeContext::empty());
+        let result = execute_check_consent(
+            &json!({
+                "actor_did": "bad",
+                "scope": "data:medical",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(result.is_error);
     }
 
     #[test]
     fn execute_check_consent_missing_scope() {
-        let result = execute_check_consent(&json!({
-            "actor_did": "did:exo:alice",
-        }), &NodeContext::empty());
+        let result = execute_check_consent(
+            &json!({
+                "actor_did": "did:exo:alice",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(result.is_error);
     }
 
@@ -410,7 +428,8 @@ mod tests {
 
     #[test]
     fn execute_list_bailments_success() {
-        let result = execute_list_bailments(&json!({"did": "did:exo:alice"}), &NodeContext::empty());
+        let result =
+            execute_list_bailments(&json!({"did": "did:exo:alice"}), &NodeContext::empty());
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(&result.content[0].text()).expect("valid JSON");
         assert_eq!(v["count"], 0);
@@ -420,8 +439,10 @@ mod tests {
 
     #[test]
     fn execute_list_bailments_with_filter() {
-        let result =
-            execute_list_bailments(&json!({"did": "did:exo:alice", "status_filter": "active"}), &NodeContext::empty());
+        let result = execute_list_bailments(
+            &json!({"did": "did:exo:alice", "status_filter": "active"}),
+            &NodeContext::empty(),
+        );
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(&result.content[0].text()).expect("valid JSON");
         assert_eq!(v["filter"], "active");
@@ -453,10 +474,13 @@ mod tests {
 
     #[test]
     fn execute_terminate_bailment_success() {
-        let result = execute_terminate_bailment(&json!({
-            "bailment_id": "abc123",
-            "reason": "data access no longer needed",
-        }), &NodeContext::empty());
+        let result = execute_terminate_bailment(
+            &json!({
+                "bailment_id": "abc123",
+                "reason": "data access no longer needed",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(&result.content[0].text()).expect("valid JSON");
         assert_eq!(v["bailment_id"], "abc123");
@@ -467,16 +491,20 @@ mod tests {
 
     #[test]
     fn execute_terminate_bailment_missing_reason() {
-        let result = execute_terminate_bailment(&json!({"bailment_id": "abc123"}), &NodeContext::empty());
+        let result =
+            execute_terminate_bailment(&json!({"bailment_id": "abc123"}), &NodeContext::empty());
         assert!(result.is_error);
     }
 
     #[test]
     fn execute_terminate_bailment_empty_id() {
-        let result = execute_terminate_bailment(&json!({
-            "bailment_id": "",
-            "reason": "test",
-        }), &NodeContext::empty());
+        let result = execute_terminate_bailment(
+            &json!({
+                "bailment_id": "",
+                "reason": "test",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(result.is_error);
     }
 }

--- a/crates/exo-node/src/mcp/tools/escalation.rs
+++ b/crates/exo-node/src/mcp/tools/escalation.rs
@@ -160,7 +160,9 @@ pub fn execute_evaluate_threat(params: &Value, _context: &NodeContext) -> ToolRe
 pub fn escalate_case_definition() -> ToolDefinition {
     ToolDefinition {
         name: "exochain_escalate_case".to_owned(),
-        description: "Escalate a threat assessment to create a case for investigation and response.".to_owned(),
+        description:
+            "Escalate a threat assessment to create a case for investigation and response."
+                .to_owned(),
         input_schema: json!({
             "type": "object",
             "properties": {
@@ -187,16 +189,14 @@ pub fn escalate_case_definition() -> ToolDefinition {
 /// Execute the `exochain_escalate_case` tool.
 #[must_use]
 pub fn execute_escalate_case(params: &Value, _context: &NodeContext) -> ToolResult {
-    let threat_assessment_id =
-        match params.get("threat_assessment_id").and_then(Value::as_str) {
-            Some(s) => s,
-            None => {
-                return ToolResult::error(
-                    json!({"error": "missing required parameter: threat_assessment_id"})
-                        .to_string(),
-                );
-            }
-        };
+    let threat_assessment_id = match params.get("threat_assessment_id").and_then(Value::as_str) {
+        Some(s) => s,
+        None => {
+            return ToolResult::error(
+                json!({"error": "missing required parameter: threat_assessment_id"}).to_string(),
+            );
+        }
+    };
     let escalation_reason = match params.get("escalation_reason").and_then(Value::as_str) {
         Some(s) => s,
         None => {
@@ -254,7 +254,9 @@ pub fn execute_escalate_case(params: &Value, _context: &NodeContext) -> ToolResu
 pub fn triage_definition() -> ToolDefinition {
     ToolDefinition {
         name: "exochain_triage".to_owned(),
-        description: "Triage a threat assessment to produce a response decision with recommended actions.".to_owned(),
+        description:
+            "Triage a threat assessment to produce a response decision with recommended actions."
+                .to_owned(),
         input_schema: json!({
             "type": "object",
             "properties": {
@@ -335,7 +337,8 @@ pub fn execute_triage(params: &Value, _context: &NodeContext) -> ToolResult {
 pub fn record_feedback_definition() -> ToolDefinition {
     ToolDefinition {
         name: "exochain_record_feedback".to_owned(),
-        description: "Record feedback on an escalation case outcome for the learning loop.".to_owned(),
+        description: "Record feedback on an escalation case outcome for the learning loop."
+            .to_owned(),
         input_schema: json!({
             "type": "object",
             "properties": {
@@ -390,10 +393,7 @@ pub fn execute_record_feedback(params: &Value, _context: &NodeContext) -> ToolRe
         );
     }
 
-    let notes = params
-        .get("notes")
-        .and_then(Value::as_str)
-        .unwrap_or("");
+    let notes = params.get("notes").and_then(Value::as_str).unwrap_or("");
 
     let now = Timestamp::now_utc();
     let feedback_id = Hash256::digest(

--- a/crates/exo-node/src/mcp/tools/governance.rs
+++ b/crates/exo-node/src/mcp/tools/governance.rs
@@ -176,9 +176,7 @@ pub fn execute_cast_vote(params: &Value, _context: &NodeContext) -> ToolResult {
     }
 
     if decision_id.is_empty() {
-        return ToolResult::error(
-            json!({"error": "decision_id must not be empty"}).to_string(),
-        );
+        return ToolResult::error(json!({"error": "decision_id must not be empty"}).to_string());
     }
 
     let rationale = params
@@ -246,9 +244,7 @@ pub fn execute_check_quorum(params: &Value, _context: &NodeContext) -> ToolResul
     };
 
     if decision_id.is_empty() {
-        return ToolResult::error(
-            json!({"error": "decision_id must not be empty"}).to_string(),
-        );
+        return ToolResult::error(json!({"error": "decision_id must not be empty"}).to_string());
     }
 
     // No persistent vote registry yet — always report zero votes.
@@ -300,9 +296,7 @@ pub fn execute_get_decision_status(params: &Value, _context: &NodeContext) -> To
     };
 
     if decision_id.is_empty() {
-        return ToolResult::error(
-            json!({"error": "decision_id must not be empty"}).to_string(),
-        );
+        return ToolResult::error(json!({"error": "decision_id must not be empty"}).to_string());
     }
 
     let response = json!({
@@ -441,11 +435,14 @@ mod tests {
 
     #[test]
     fn execute_create_decision_success() {
-        let result = execute_create_decision(&json!({
-            "title": "Approve data sharing policy",
-            "description": "Allow cross-org medical data sharing under bailment.",
-            "proposer_did": "did:exo:alice",
-        }), &NodeContext::empty());
+        let result = execute_create_decision(
+            &json!({
+                "title": "Approve data sharing policy",
+                "description": "Allow cross-org medical data sharing under bailment.",
+                "proposer_did": "did:exo:alice",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(&result.content[0].text()).expect("valid JSON");
         assert_eq!(v["title"], "Approve data sharing policy");
@@ -456,20 +453,26 @@ mod tests {
 
     #[test]
     fn execute_create_decision_invalid_proposer() {
-        let result = execute_create_decision(&json!({
-            "title": "Test",
-            "description": "Test",
-            "proposer_did": "bad",
-        }), &NodeContext::empty());
+        let result = execute_create_decision(
+            &json!({
+                "title": "Test",
+                "description": "Test",
+                "proposer_did": "bad",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(result.is_error);
     }
 
     #[test]
     fn execute_create_decision_missing_title() {
-        let result = execute_create_decision(&json!({
-            "description": "Test",
-            "proposer_did": "did:exo:alice",
-        }), &NodeContext::empty());
+        let result = execute_create_decision(
+            &json!({
+                "description": "Test",
+                "proposer_did": "did:exo:alice",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(result.is_error);
     }
 
@@ -484,12 +487,15 @@ mod tests {
 
     #[test]
     fn execute_cast_vote_success() {
-        let result = execute_cast_vote(&json!({
-            "decision_id": "abc123",
-            "voter_did": "did:exo:bob",
-            "choice": "approve",
-            "rationale": "Looks good to me.",
-        }), &NodeContext::empty());
+        let result = execute_cast_vote(
+            &json!({
+                "decision_id": "abc123",
+                "voter_did": "did:exo:bob",
+                "choice": "approve",
+                "rationale": "Looks good to me.",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(&result.content[0].text()).expect("valid JSON");
         assert_eq!(v["decision_id"], "abc123");
@@ -502,21 +508,27 @@ mod tests {
 
     #[test]
     fn execute_cast_vote_invalid_choice() {
-        let result = execute_cast_vote(&json!({
-            "decision_id": "abc123",
-            "voter_did": "did:exo:bob",
-            "choice": "maybe",
-        }), &NodeContext::empty());
+        let result = execute_cast_vote(
+            &json!({
+                "decision_id": "abc123",
+                "voter_did": "did:exo:bob",
+                "choice": "maybe",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(result.is_error);
     }
 
     #[test]
     fn execute_cast_vote_invalid_voter() {
-        let result = execute_cast_vote(&json!({
-            "decision_id": "abc123",
-            "voter_did": "bad",
-            "choice": "approve",
-        }), &NodeContext::empty());
+        let result = execute_cast_vote(
+            &json!({
+                "decision_id": "abc123",
+                "voter_did": "bad",
+                "choice": "approve",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(result.is_error);
     }
 
@@ -531,10 +543,13 @@ mod tests {
 
     #[test]
     fn execute_check_quorum_success() {
-        let result = execute_check_quorum(&json!({
-            "decision_id": "abc123",
-            "threshold": 3,
-        }), &NodeContext::empty());
+        let result = execute_check_quorum(
+            &json!({
+                "decision_id": "abc123",
+                "threshold": 3,
+            }),
+            &NodeContext::empty(),
+        );
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(&result.content[0].text()).expect("valid JSON");
         assert_eq!(v["decision_id"], "abc123");
@@ -560,7 +575,8 @@ mod tests {
 
     #[test]
     fn execute_get_decision_status_success() {
-        let result = execute_get_decision_status(&json!({"decision_id": "abc123"}), &NodeContext::empty());
+        let result =
+            execute_get_decision_status(&json!({"decision_id": "abc123"}), &NodeContext::empty());
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(&result.content[0].text()).expect("valid JSON");
         assert_eq!(v["decision_id"], "abc123");
@@ -569,7 +585,8 @@ mod tests {
 
     #[test]
     fn execute_get_decision_status_empty_id() {
-        let result = execute_get_decision_status(&json!({"decision_id": ""}), &NodeContext::empty());
+        let result =
+            execute_get_decision_status(&json!({"decision_id": ""}), &NodeContext::empty());
         assert!(result.is_error);
     }
 
@@ -584,12 +601,15 @@ mod tests {
 
     #[test]
     fn execute_propose_amendment_success() {
-        let result = execute_propose_amendment(&json!({
-            "title": "Add quantum-safe threshold signatures",
-            "description": "Extend the constitutional invariant set to require ML-DSA-65 for kernel modification quorum.",
-            "proposer_did": "did:exo:alice",
-            "target": "constitution",
-        }), &NodeContext::empty());
+        let result = execute_propose_amendment(
+            &json!({
+                "title": "Add quantum-safe threshold signatures",
+                "description": "Extend the constitutional invariant set to require ML-DSA-65 for kernel modification quorum.",
+                "proposer_did": "did:exo:alice",
+                "target": "constitution",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(&result.content[0].text()).expect("valid JSON");
         assert_eq!(v["target"], "constitution");
@@ -597,28 +617,39 @@ mod tests {
         assert!(v["amendment_id"].as_str().expect("id").len() > 0);
         assert_eq!(v["requirements"]["validator_consensus"], "unanimous");
         assert_eq!(v["requirements"]["formal_proof_required"], true);
-        assert!(v["warning"].as_str().expect("warning").contains("highest governance threshold"));
+        assert!(
+            v["warning"]
+                .as_str()
+                .expect("warning")
+                .contains("highest governance threshold")
+        );
     }
 
     #[test]
     fn execute_propose_amendment_invalid_target() {
-        let result = execute_propose_amendment(&json!({
-            "title": "Test",
-            "description": "Test",
-            "proposer_did": "did:exo:alice",
-            "target": "invalid_target",
-        }), &NodeContext::empty());
+        let result = execute_propose_amendment(
+            &json!({
+                "title": "Test",
+                "description": "Test",
+                "proposer_did": "did:exo:alice",
+                "target": "invalid_target",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(result.is_error);
     }
 
     #[test]
     fn execute_propose_amendment_invalid_proposer() {
-        let result = execute_propose_amendment(&json!({
-            "title": "Test",
-            "description": "Test",
-            "proposer_did": "bad",
-            "target": "constitution",
-        }), &NodeContext::empty());
+        let result = execute_propose_amendment(
+            &json!({
+                "title": "Test",
+                "description": "Test",
+                "proposer_did": "bad",
+                "target": "constitution",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(result.is_error);
     }
 }

--- a/crates/exo-node/src/mcp/tools/identity.rs
+++ b/crates/exo-node/src/mcp/tools/identity.rs
@@ -438,7 +438,8 @@ mod tests {
 
     #[test]
     fn execute_resolve_identity_valid_did() {
-        let result = execute_resolve_identity(&json!({"did": "did:exo:alice"}), &NodeContext::empty());
+        let result =
+            execute_resolve_identity(&json!({"did": "did:exo:alice"}), &NodeContext::empty());
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(&result.content[0].text()).expect("valid JSON");
         assert_eq!(v["valid_format"], true);
@@ -542,11 +543,14 @@ mod tests {
 
     #[test]
     fn execute_verify_signature_bad_hex() {
-        let result = execute_verify_signature(&json!({
-            "public_key_hex": "not-hex",
-            "message_hex": "00",
-            "signature_hex": "00",
-        }), &NodeContext::empty());
+        let result = execute_verify_signature(
+            &json!({
+                "public_key_hex": "not-hex",
+                "message_hex": "00",
+                "signature_hex": "00",
+            }),
+            &NodeContext::empty(),
+        );
         assert!(result.is_error);
     }
 

--- a/crates/exo-node/src/mcp/tools/ledger.rs
+++ b/crates/exo-node/src/mcp/tools/ledger.rs
@@ -176,7 +176,8 @@ pub fn execute_get_event(params: &Value, context: &NodeContext) -> ToolResult {
 pub fn verify_inclusion_definition() -> ToolDefinition {
     ToolDefinition {
         name: "exochain_verify_inclusion".to_owned(),
-        description: "Verify a Merkle inclusion proof for a given event hash against a root hash.".to_owned(),
+        description: "Verify a Merkle inclusion proof for a given event hash against a root hash."
+            .to_owned(),
         input_schema: json!({
             "type": "object",
             "properties": {
@@ -293,7 +294,9 @@ pub fn execute_verify_inclusion(params: &Value, _context: &NodeContext) -> ToolR
 pub fn get_checkpoint_definition() -> ToolDefinition {
     ToolDefinition {
         name: "exochain_get_checkpoint".to_owned(),
-        description: "Get the latest checkpoint information including height, round, and validator count.".to_owned(),
+        description:
+            "Get the latest checkpoint information including height, round, and validator count."
+                .to_owned(),
         input_schema: json!({
             "type": "object",
             "properties": {},
@@ -314,9 +317,7 @@ pub fn execute_get_checkpoint(params: &Value, context: &NodeContext) -> ToolResu
         let height = match store.lock() {
             Ok(guard) => guard.committed_height_value(),
             Err(_) => {
-                return ToolResult::error(
-                    json!({"error": "store mutex poisoned"}).to_string(),
-                );
+                return ToolResult::error(json!({"error": "store mutex poisoned"}).to_string());
             }
         };
 

--- a/crates/exo-node/src/mcp/tools/legal.rs
+++ b/crates/exo-node/src/mcp/tools/legal.rs
@@ -55,10 +55,7 @@ pub fn execute_ediscovery_search(params: &Value, _context: &NodeContext) -> Tool
         }
     };
 
-    let scope = params
-        .get("scope")
-        .and_then(Value::as_str)
-        .unwrap_or("all");
+    let scope = params.get("scope").and_then(Value::as_str).unwrap_or("all");
     let date_range_start = params
         .get("date_range_start")
         .and_then(Value::as_str)
@@ -103,7 +100,9 @@ pub fn execute_ediscovery_search(params: &Value, _context: &NodeContext) -> Tool
 pub fn assert_privilege_definition() -> ToolDefinition {
     ToolDefinition {
         name: "exochain_assert_privilege".to_owned(),
-        description: "Assert legal privilege over evidence, marking it as protected from disclosure.".to_owned(),
+        description:
+            "Assert legal privilege over evidence, marking it as protected from disclosure."
+                .to_owned(),
         input_schema: json!({
             "type": "object",
             "properties": {
@@ -238,16 +237,17 @@ pub fn execute_initiate_safe_harbor(params: &Value, _context: &NodeContext) -> T
             );
         }
     };
-    let transaction_description =
-        match params.get("transaction_description").and_then(Value::as_str) {
-            Some(s) => s,
-            None => {
-                return ToolResult::error(
-                    json!({"error": "missing required parameter: transaction_description"})
-                        .to_string(),
-                );
-            }
-        };
+    let transaction_description = match params
+        .get("transaction_description")
+        .and_then(Value::as_str)
+    {
+        Some(s) => s,
+        None => {
+            return ToolResult::error(
+                json!({"error": "missing required parameter: transaction_description"}).to_string(),
+            );
+        }
+    };
     let interested_parties = match params.get("interested_parties").and_then(Value::as_array) {
         Some(arr) => arr,
         None => {
@@ -551,7 +551,10 @@ mod tests {
         let v: Value = serde_json::from_str(&result.content[0].text()).expect("valid JSON");
         assert_eq!(v["dgcl_section"], "144");
         assert_eq!(v["status"], "initiated");
-        assert_eq!(v["interested_parties"].as_array().expect("parties").len(), 2);
+        assert_eq!(
+            v["interested_parties"].as_array().expect("parties").len(),
+            2
+        );
         assert_eq!(
             v["disclosure_requirements"]
                 .as_array()

--- a/crates/exo-node/src/mcp/tools/messaging.rs
+++ b/crates/exo-node/src/mcp/tools/messaging.rs
@@ -289,10 +289,7 @@ pub fn execute_configure_death_trigger(params: &Value, _context: &NodeContext) -
         );
     }
 
-    let trigger_params = params
-        .get("trigger_params")
-        .cloned()
-        .unwrap_or(json!({}));
+    let trigger_params = params.get("trigger_params").cloned().unwrap_or(json!({}));
 
     let now = Timestamp::now_utc();
     let trigger_id = Hash256::digest(
@@ -424,7 +421,10 @@ mod tests {
 
     #[test]
     fn execute_receive_encrypted_missing_envelope() {
-        let result = execute_receive_encrypted(&json!({"recipient_did": "did:exo:bob"}), &NodeContext::empty());
+        let result = execute_receive_encrypted(
+            &json!({"recipient_did": "did:exo:bob"}),
+            &NodeContext::empty(),
+        );
         assert!(result.is_error);
     }
 

--- a/crates/exo-node/src/mcp/tools/mod.rs
+++ b/crates/exo-node/src/mcp/tools/mod.rs
@@ -150,9 +150,7 @@ impl ToolRegistry {
             "exochain_verify_authority_chain" => {
                 Ok(authority::execute_verify_authority_chain(params, context))
             }
-            "exochain_check_permission" => {
-                Ok(authority::execute_check_permission(params, context))
-            }
+            "exochain_check_permission" => Ok(authority::execute_check_permission(params, context)),
             "exochain_adjudicate_action" => {
                 Ok(authority::execute_adjudicate_action(params, context))
             }
@@ -171,9 +169,7 @@ impl ToolRegistry {
             }
             "exochain_verify_cgr_proof" => Ok(proofs::execute_verify_cgr_proof(params, context)),
             // Legal
-            "exochain_ediscovery_search" => {
-                Ok(legal::execute_ediscovery_search(params, context))
-            }
+            "exochain_ediscovery_search" => Ok(legal::execute_ediscovery_search(params, context)),
             "exochain_assert_privilege" => Ok(legal::execute_assert_privilege(params, context)),
             "exochain_initiate_safe_harbor" => {
                 Ok(legal::execute_initiate_safe_harbor(params, context))
@@ -252,11 +248,7 @@ mod tests {
     #[test]
     fn registry_execute_unknown_tool() {
         let registry = ToolRegistry::default();
-        let result = registry.execute(
-            "nonexistent",
-            &serde_json::json!({}),
-            &NodeContext::empty(),
-        );
+        let result = registry.execute("nonexistent", &serde_json::json!({}), &NodeContext::empty());
         assert!(result.is_err());
         match result.unwrap_err() {
             McpError::ToolNotFound(name) => assert_eq!(name, "nonexistent"),

--- a/crates/exo-node/src/mcp/tools/node.rs
+++ b/crates/exo-node/src/mcp/tools/node.rs
@@ -4,10 +4,7 @@
 //! and listing MCP enforcement rules. These are foundational tools that any
 //! AI agent needs to understand the governance environment.
 
-use exo_gatekeeper::{
-    invariants::ConstitutionalInvariant,
-    mcp::McpRule,
-};
+use exo_gatekeeper::{invariants::ConstitutionalInvariant, mcp::McpRule};
 use serde_json::Value;
 
 use crate::mcp::context::NodeContext;
@@ -97,8 +94,7 @@ pub fn execute_node_status(_params: &Value, context: &NodeContext) -> ToolResult
 
     ToolResult {
         content: vec![ToolContent::Text {
-            text: serde_json::to_string_pretty(&status)
-                .unwrap_or_else(|_| "{}".to_string()),
+            text: serde_json::to_string_pretty(&status).unwrap_or_else(|_| "{}".to_string()),
         }],
         is_error: false,
     }
@@ -145,12 +141,8 @@ fn invariant_description(inv: &ConstitutionalInvariant) -> &'static str {
         ConstitutionalInvariant::SeparationOfPowers => {
             "No single actor may hold legislative + executive + judicial power"
         }
-        ConstitutionalInvariant::ConsentRequired => {
-            "Action denied without active bailment consent"
-        }
-        ConstitutionalInvariant::NoSelfGrant => {
-            "An actor cannot expand its own permissions"
-        }
+        ConstitutionalInvariant::ConsentRequired => "Action denied without active bailment consent",
+        ConstitutionalInvariant::NoSelfGrant => "An actor cannot expand its own permissions",
         ConstitutionalInvariant::HumanOverride => {
             "Emergency human intervention must always be possible"
         }
@@ -200,8 +192,7 @@ pub fn execute_list_invariants(_params: &Value, _context: &NodeContext) -> ToolR
 
     ToolResult {
         content: vec![ToolContent::Text {
-            text: serde_json::to_string_pretty(&output)
-                .unwrap_or_else(|_| "{}".to_string()),
+            text: serde_json::to_string_pretty(&output).unwrap_or_else(|_| "{}".to_string()),
         }],
         is_error: false,
     }
@@ -262,8 +253,7 @@ pub fn execute_list_mcp_rules(_params: &Value, _context: &NodeContext) -> ToolRe
 
     ToolResult {
         content: vec![ToolContent::Text {
-            text: serde_json::to_string_pretty(&output)
-                .unwrap_or_else(|_| "{}".to_string()),
+            text: serde_json::to_string_pretty(&output).unwrap_or_else(|_| "{}".to_string()),
         }],
         is_error: false,
     }

--- a/crates/exo-node/src/mcp/tools/proofs.rs
+++ b/crates/exo-node/src/mcp/tools/proofs.rs
@@ -244,9 +244,7 @@ pub fn execute_generate_merkle_proof(params: &Value, _context: &NodeContext) -> 
     };
 
     if leaves_val.is_empty() {
-        return ToolResult::error(
-            json!({"error": "leaves array must not be empty"}).to_string(),
-        );
+        return ToolResult::error(json!({"error": "leaves array must not be empty"}).to_string());
     }
 
     if target_index >= leaves_val.len() {
@@ -340,7 +338,8 @@ pub fn execute_generate_merkle_proof(params: &Value, _context: &NodeContext) -> 
 pub fn verify_cgr_proof_definition() -> ToolDefinition {
     ToolDefinition {
         name: "exochain_verify_cgr_proof".to_owned(),
-        description: "Verify a CGR kernel proof by checking the proof hash and invariants.".to_owned(),
+        description: "Verify a CGR kernel proof by checking the proof hash and invariants."
+            .to_owned(),
         input_schema: json!({
             "type": "object",
             "properties": {
@@ -461,7 +460,10 @@ mod tests {
 
     #[test]
     fn execute_create_evidence_missing_description() {
-        let result = execute_create_evidence(&json!({"evidence_type": "doc", "source_did": "did:exo:a"}), &NodeContext::empty());
+        let result = execute_create_evidence(
+            &json!({"evidence_type": "doc", "source_did": "did:exo:a"}),
+            &NodeContext::empty(),
+        );
         assert!(result.is_error);
     }
 
@@ -581,7 +583,8 @@ mod tests {
 
     #[test]
     fn execute_verify_cgr_proof_missing_hash() {
-        let result = execute_verify_cgr_proof(&json!({"invariants_checked": []}), &NodeContext::empty());
+        let result =
+            execute_verify_cgr_proof(&json!({"invariants_checked": []}), &NodeContext::empty());
         assert!(result.is_error);
     }
 }

--- a/crates/exo-node/src/reactor.rs
+++ b/crates/exo-node/src/reactor.rs
@@ -277,8 +277,20 @@ pub async fn run_reactor(
 
 /// Validate a consensus proposal before processing.
 ///
-/// Checks: proposer is a known validator, signature is non-empty,
-/// and the node hash in the proposal matches the attached DAG node.
+/// Checks: proposer is in the current validator set, the attached
+/// signature is non-empty, is not a zero-byte sentinel, and the
+/// node hash matches the proposal's node_hash.
+///
+/// **Note (GAP-014 defense-in-depth):** This function is a structural
+/// guard only. Until the reactor is wired to a real
+/// `PublicKeyResolver` (see initiative
+/// `fix-gap-014-consensus-sig-verify.md`), the actual cryptographic
+/// verification lives in `consensus::*_verified` but is NOT yet called
+/// from this reactor. This validator does the maximum amount of
+/// structural filtering possible without a resolver: it rejects
+/// empty and all-zero signatures, blocking the most obvious forgery
+/// shapes. It does NOT yet reject forgeries that use arbitrary
+/// non-zero bytes.
 fn validate_proposal(msg: &ConsensusProposalMsg, validators: &BTreeSet<Did>) -> Result<(), String> {
     if !validators.contains(&msg.proposal.proposer) {
         return Err(format!(
@@ -288,6 +300,11 @@ fn validate_proposal(msg: &ConsensusProposalMsg, validators: &BTreeSet<Did>) -> 
     }
     if msg.signature.is_empty() {
         return Err("proposal carries empty signature".into());
+    }
+    // GAP-014 defense-in-depth: reject the null-signature attack shape.
+    let raw = msg.signature.as_bytes();
+    if !raw.is_empty() && raw.iter().all(|b| *b == 0) {
+        return Err("proposal carries zero-byte signature (null-sig attack shape)".into());
     }
     if msg.node.hash != msg.proposal.node_hash {
         return Err(format!(
@@ -300,7 +317,10 @@ fn validate_proposal(msg: &ConsensusProposalMsg, validators: &BTreeSet<Did>) -> 
 
 /// Validate a consensus vote before processing.
 ///
-/// Checks: voter is a known validator and signature is non-empty.
+/// Checks: voter is a known validator, signature is non-empty, and
+/// signature is not a zero-byte sentinel.
+///
+/// See `validate_proposal` for the GAP-014 caveat.
 fn validate_vote(msg: &ConsensusVoteMsg, validators: &BTreeSet<Did>) -> Result<(), String> {
     if !validators.contains(&msg.vote.voter) {
         return Err(format!(
@@ -311,14 +331,21 @@ fn validate_vote(msg: &ConsensusVoteMsg, validators: &BTreeSet<Did>) -> Result<(
     if msg.vote.signature.is_empty() {
         return Err("vote carries empty signature".into());
     }
+    // GAP-014 defense-in-depth: reject the null-signature attack shape.
+    let raw = msg.vote.signature.as_bytes();
+    if !raw.is_empty() && raw.iter().all(|b| *b == 0) {
+        return Err("vote carries zero-byte signature (null-sig attack shape)".into());
+    }
     Ok(())
 }
 
 /// Validate a commit certificate before processing.
 ///
 /// Checks: every vote in the certificate is from a known validator,
-/// carries a non-empty signature, and references the certificate's
-/// node hash.
+/// carries a non-empty, non-zero-sentinel signature, and references
+/// the certificate's node hash.
+///
+/// See `validate_proposal` for the GAP-014 caveat.
 fn validate_commit(msg: &ConsensusCommitMsg, validators: &BTreeSet<Did>) -> Result<(), String> {
     for vote in &msg.certificate.votes {
         if !validators.contains(&vote.voter) {
@@ -330,6 +357,14 @@ fn validate_commit(msg: &ConsensusCommitMsg, validators: &BTreeSet<Did>) -> Resu
         if vote.signature.is_empty() {
             return Err(format!(
                 "certificate vote from {} has empty signature",
+                vote.voter
+            ));
+        }
+        // GAP-014 defense-in-depth: reject the null-signature attack shape.
+        let raw = vote.signature.as_bytes();
+        if !raw.is_empty() && raw.iter().all(|b| *b == 0) {
+            return Err(format!(
+                "certificate vote from {} has zero-byte signature (null-sig attack shape)",
                 vote.voter
             ));
         }
@@ -947,7 +982,11 @@ mod tests {
         assert_eq!(s.dag.len(), 1, "DAG should have one node");
 
         let st = store.lock().unwrap();
-        assert_eq!(st.tips_sync().unwrap().len(), 1, "Store should have one tip");
+        assert_eq!(
+            st.tips_sync().unwrap().len(),
+            1,
+            "Store should have one tip"
+        );
     }
 
     #[tokio::test]
@@ -1120,8 +1159,93 @@ mod tests {
         assert!(consensus::check_commit(&state, &byzantine_node.hash).is_none());
 
         let cert = consensus::check_commit(&state, &honest_node.hash).unwrap();
+        #[allow(deprecated)]
         consensus::commit(&mut state, cert);
         assert!(consensus::is_finalized(&state, &honest_node.hash));
         assert!(!consensus::is_finalized(&state, &byzantine_node.hash));
+    }
+
+    // ==== GAP-014 defense-in-depth regression tests ====================
+
+    fn make_node_for_test() -> exo_dag::dag::DagNode {
+        use exo_dag::dag::{Dag, append};
+        let mut dag = Dag::new();
+        let mut clock = HybridClock::new();
+        let did = Did::new("did:exo:v0").unwrap();
+        let sf = make_sign_fn();
+        append(&mut dag, &[], b"x", &did, &*sf, &mut clock).unwrap()
+    }
+
+    #[test]
+    fn validate_proposal_rejects_zero_byte_signature() {
+        let validators = make_validators(1);
+        let proposer = Did::new("did:exo:v0").unwrap();
+        let node = make_node_for_test();
+        let msg = ConsensusProposalMsg {
+            proposal: exo_dag::consensus::Proposal {
+                proposer: proposer.clone(),
+                round: 0,
+                node_hash: node.hash,
+            },
+            node,
+            signature: Signature::from_bytes([0u8; 64]),
+        };
+        let err = validate_proposal(&msg, &validators).unwrap_err();
+        // Signature::Ed25519([0u8; 64]) hits is_empty() first (ex_core types.rs:325)
+        // so the "empty" message fires before the explicit null-sig check.
+        // Either message proves rejection — both are defense in depth.
+        assert!(err.contains("empty") || err.contains("zero-byte"));
+    }
+
+    #[test]
+    fn validate_vote_rejects_zero_byte_signature() {
+        let validators = make_validators(1);
+        let voter = Did::new("did:exo:v0").unwrap();
+        let msg = ConsensusVoteMsg {
+            vote: exo_dag::consensus::Vote {
+                voter,
+                round: 0,
+                node_hash: exo_core::types::Hash256([9u8; 32]),
+                signature: Signature::from_bytes([0u8; 64]),
+            },
+        };
+        let err = validate_vote(&msg, &validators).unwrap_err();
+        assert!(err.contains("empty") || err.contains("zero-byte"));
+    }
+
+    #[test]
+    fn validate_commit_rejects_zero_byte_vote_in_cert() {
+        let validators = make_validators(1);
+        let voter = Did::new("did:exo:v0").unwrap();
+        let hash = exo_core::types::Hash256([7u8; 32]);
+        let cert = exo_dag::consensus::CommitCertificate {
+            node_hash: hash,
+            votes: vec![exo_dag::consensus::Vote {
+                voter,
+                round: 0,
+                node_hash: hash,
+                signature: Signature::from_bytes([0u8; 64]),
+            }],
+            round: 0,
+        };
+        let msg = ConsensusCommitMsg { certificate: cert };
+        let err = validate_commit(&msg, &validators).unwrap_err();
+        assert!(err.contains("empty") || err.contains("zero-byte"));
+    }
+
+    #[test]
+    fn validate_vote_rejects_empty_signature() {
+        let validators = make_validators(1);
+        let voter = Did::new("did:exo:v0").unwrap();
+        let msg = ConsensusVoteMsg {
+            vote: exo_dag::consensus::Vote {
+                voter,
+                round: 0,
+                node_hash: exo_core::types::Hash256([9u8; 32]),
+                signature: Signature::empty(),
+            },
+        };
+        let err = validate_vote(&msg, &validators).unwrap_err();
+        assert!(err.contains("empty signature"));
     }
 }

--- a/crates/exo-node/src/zerodentity/store.rs
+++ b/crates/exo-node/src/zerodentity/store.rs
@@ -4,7 +4,7 @@
 //! It integrates with `exo_identity` to provide cryptographic standing via `LocalDidRegistry`
 //! and handles the `VerificationCeremony` state for identity onboarding.
 //!
-//! While currently a robust in-memory implementation for rapid consensus and state management, 
+//! While currently a robust in-memory implementation for rapid consensus and state management,
 //! the integration path for SQLite persistence remains available.
 //!
 //! All inner maps use `BTreeMap` (never `HashMap`) for deterministic iteration.


### PR DESCRIPTION
## Summary
**Wave C Onyx pass 1 RED closure — GAP-014.** The ENTIRE BFT consensus layer accepted any non-empty signature as authentic. `exo-dag::consensus::{propose, vote, commit}` performed ZERO signature verification; `exo-node::reactor::validate_*` checked only `is_empty()`. An attacker with network access could forge validator votes/proposals at will. Byzantine fault tolerance as advertised did not exist against an active attacker.

Categorically the biggest single finding of the audit so far.

## Fix
In `exo-dag::consensus`:
- `Proposal::signing_payload()` — canonical CBOR with domain `"exo.consensus.proposal.v1"`
- `Vote::signing_payload()` — canonical CBOR with domain `"exo.consensus.vote.v1"`
- `PublicKeyResolver` trait for caller-supplied key lookup
- New `propose_verified` / `vote_verified` / `commit_verified` that verify signatures before state mutation
- Legacy `propose` / `vote` / `commit` marked `#[deprecated(note="GAP-014")]`
- 10 new exo-dag tests covering the attack shapes

In `exo-node::reactor`:
- `validate_proposal` / `validate_vote` / `validate_commit` now reject all-zero signature sentinels as defense-in-depth
- 4 new reactor tests

## Test Plan
- [x] `cargo test -p exo-dag` → 26 total consensus tests pass
- [x] `cargo test -p exo-node --bin exochain` → 556 pass

## Follow-up (separate initiative)
Full reactor → verified-API wiring requires a `PublicKeyResolver` backed by an identity registry. Tracked in a follow-up initiative.

## Source
Council memo: `exochain/council-intake/exo-node-onyx-1-consensus.md` (RED).
