### PR TITLE
fix(exo-node): telegram chat_id auth + API bind-host default-loopback

### DIFF
--- a/crates/exo-node/src/cli.rs
+++ b/crates/exo-node/src/cli.rs
@@ -26,6 +26,16 @@ pub enum Command {
         #[arg(long, default_value = None)]
         api_port: Option<u16>,
 
+        /// HTTP API bind host. Default is `127.0.0.1` (loopback only).
+        /// Set to `0.0.0.0` to expose the admin-write API on all
+        /// interfaces — do so ONLY when you have a front-door TLS
+        /// terminator AND your admin bearer token is appropriately
+        /// scoped (see auth.rs). Exposing 0.0.0.0 with the default
+        /// bearer model is equivalent to publishing your node's
+        /// governance-write credential on the open internet.
+        #[arg(long, default_value = "127.0.0.1")]
+        api_host: String,
+
         /// P2P listen port.
         #[arg(long, default_value = None)]
         p2p_port: Option<u16>,
@@ -53,6 +63,11 @@ pub enum Command {
         /// HTTP API port.
         #[arg(long, default_value = None)]
         api_port: Option<u16>,
+
+        /// HTTP API bind host. Default is `127.0.0.1` (loopback only).
+        /// See `Start --api-host` for rationale on 0.0.0.0.
+        #[arg(long, default_value = "127.0.0.1")]
+        api_host: String,
 
         /// P2P listen port.
         #[arg(long, default_value = None)]

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -136,6 +136,7 @@ fn spawn_event_fanout(
 /// Start all subsystems for a running node.
 async fn start_node(
     data_dir: &std::path::Path,
+    api_host: &str,
     api_port: u16,
     p2p_port: u16,
     validator: bool,
@@ -613,7 +614,21 @@ async fn start_node(
         }));
 
     // Start the gateway HTTP server (blocks).
-    let bind_address = format!("0.0.0.0:{api_port}");
+    //
+    // Security note (GAP AMBER — Onyx pass 3): we bind to the caller-
+    // supplied `api_host` which defaults to `127.0.0.1` (loopback only).
+    // Opt-in to broader exposure (e.g. `0.0.0.0`) requires an explicit
+    // `--api-host` flag. This protects the admin-bearer-token write
+    // surface from accidental internet exposure when the operator
+    // forgets to put a reverse proxy in front.
+    let bind_address = format!("{api_host}:{api_port}");
+    if api_host == "0.0.0.0" {
+        tracing::warn!(
+            %bind_address,
+            "API bound to 0.0.0.0 — admin-write endpoints are reachable on all interfaces. \
+             Ensure you have a TLS-terminating front door AND rotate the admin token regularly."
+        );
+    }
     let gateway_config = exo_gateway::server::GatewayConfig {
         bind_address: bind_address.clone(),
         ..exo_gateway::server::GatewayConfig::default()
@@ -639,6 +654,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
     match cli.command {
         Command::Start {
             api_port,
+            api_host,
             p2p_port,
             data_dir,
             validator,
@@ -655,6 +671,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
 
             start_node(
                 &data_dir,
+                &api_host,
                 api_port,
                 p2p_port,
                 validator,
@@ -668,6 +685,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
         Command::Join {
             seed,
             api_port,
+            api_host,
             p2p_port,
             data_dir,
             validator,
@@ -702,6 +720,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
 
             start_node(
                 &data_dir,
+                &api_host,
                 api_port,
                 p2p_port,
                 validator,

--- a/crates/exo-node/src/telegram.rs
+++ b/crates/exo-node/src/telegram.rs
@@ -76,12 +76,44 @@ pub(crate) struct Update {
 #[derive(Debug, Deserialize)]
 struct TgMessage {
     text: Option<String>,
+    chat: TgChat,
+}
+
+#[derive(Debug, Deserialize)]
+struct TgChat {
+    id: i64,
 }
 
 #[derive(Debug, Deserialize)]
 struct CallbackQuery {
     id: String,
     data: Option<String>,
+    /// The message the inline keyboard was attached to — carries the
+    /// originating chat so we can filter out queries from unauthorized
+    /// chats. May be absent for very old keyboards; when absent we
+    /// reject by default (fail-closed).
+    #[serde(default)]
+    message: Option<TgMessage>,
+}
+
+/// Return true iff `msg` came from the single authorized chat.
+///
+/// Fail-closed: if `expected_chat_id` is `None` (misconfigured env),
+/// no message is authorized.
+fn is_message_authorized(expected_chat_id: Option<i64>, msg: &TgMessage) -> bool {
+    expected_chat_id == Some(msg.chat.id)
+}
+
+/// Return true iff a callback query originated in the authorized chat.
+///
+/// Callback queries must carry their originating `message` with a
+/// `chat` field. Fail-closed: missing message OR missing
+/// `expected_chat_id` rejects.
+fn is_callback_authorized(expected_chat_id: Option<i64>, cb: &CallbackQuery) -> bool {
+    match (&cb.message, expected_chat_id) {
+        (Some(m), Some(id)) => id == m.chat.id,
+        _ => false,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -603,10 +635,32 @@ pub async fn run_adjutant(
 
             // Poll for Telegram updates.
             updates = adjutant.poll_updates() => {
+                // Parse the configured authorized chat id once per batch.
+                // If it fails to parse (misconfigured env), we fail-closed:
+                // no commands are dispatched.
+                let expected_chat_id: Option<i64> =
+                    adjutant.config.chat_id.parse::<i64>().ok();
+                if expected_chat_id.is_none() {
+                    tracing::error!(
+                        configured = %adjutant.config.chat_id,
+                        "TELEGRAM_CHAT_ID is not a valid i64 — rejecting ALL inbound updates (fail-closed)"
+                    );
+                }
+
                 for update in updates {
                     // Handle text commands.
                     if let Some(msg) = &update.message {
-                        if let Some(text) = &msg.text {
+                        // GAP-015 defense: reject messages from any chat other
+                        // than the configured authorized chat. Without this,
+                        // any holder of the bot token could DM the bot and
+                        // receive full node internal state.
+                        if !is_message_authorized(expected_chat_id, msg) {
+                            tracing::warn!(
+                                incoming_chat = msg.chat.id,
+                                expected = %adjutant.config.chat_id,
+                                "Rejected Telegram message from unauthorized chat"
+                            );
+                        } else if let Some(text) = &msg.text {
                             handle_command(
                                 &adjutant,
                                 text,
@@ -622,18 +676,32 @@ pub async fn run_adjutant(
 
                     // Handle callback queries (button presses).
                     if let Some(cb) = &update.callback_query {
-                        adjutant.answer_callback(&cb.id).await;
-                        if let Some(data) = &cb.data {
-                            handle_callback(
-                                &adjutant,
-                                data,
-                                &reactor,
-                                &store,
-                                &challenge_store,
-                                &sentinel_state,
-                                &zerodentity,
-                            )
-                            .await;
+                        // Callback queries must carry an originating message
+                        // whose chat matches. Missing chat info = reject
+                        // (fail-closed).
+                        if !is_callback_authorized(expected_chat_id, cb) {
+                            tracing::warn!(
+                                callback_id = %cb.id,
+                                "Rejected Telegram callback from unauthorized or unknown chat"
+                            );
+                            // Still answer the callback so the user's UI
+                            // clears (prevents their Telegram from showing a
+                            // perpetual spinner), but don't dispatch.
+                            adjutant.answer_callback(&cb.id).await;
+                        } else {
+                            adjutant.answer_callback(&cb.id).await;
+                            if let Some(data) = &cb.data {
+                                handle_callback(
+                                    &adjutant,
+                                    data,
+                                    &reactor,
+                                    &store,
+                                    &challenge_store,
+                                    &sentinel_state,
+                                    &zerodentity,
+                                )
+                                .await;
+                            }
                         }
                     }
                 }
@@ -842,5 +910,73 @@ mod tests {
         let (text, _) = build_challenges_message(&store);
         assert!(text.contains("QuorumContamination"));
         assert!(text.contains("PauseEligible"));
+    }
+
+    // ==== GAP-015 chat_id auth tests ==================================
+
+    fn msg_from_chat(id: i64, text: Option<&str>) -> TgMessage {
+        TgMessage {
+            text: text.map(ToOwned::to_owned),
+            chat: TgChat { id },
+        }
+    }
+
+    #[test]
+    fn is_message_authorized_matches_expected_chat() {
+        let msg = msg_from_chat(42, Some("/status"));
+        assert!(is_message_authorized(Some(42), &msg));
+    }
+
+    #[test]
+    fn is_message_authorized_rejects_other_chat() {
+        let msg = msg_from_chat(999, Some("/status"));
+        assert!(!is_message_authorized(Some(42), &msg));
+    }
+
+    #[test]
+    fn is_message_authorized_fails_closed_when_unconfigured() {
+        // TELEGRAM_CHAT_ID misconfigured / unparseable.
+        let msg = msg_from_chat(42, Some("/status"));
+        assert!(!is_message_authorized(None, &msg));
+    }
+
+    #[test]
+    fn is_callback_authorized_matches_expected_chat() {
+        let cb = CallbackQuery {
+            id: "abc".into(),
+            data: Some("cmd:status".into()),
+            message: Some(msg_from_chat(42, None)),
+        };
+        assert!(is_callback_authorized(Some(42), &cb));
+    }
+
+    #[test]
+    fn is_callback_authorized_rejects_other_chat() {
+        let cb = CallbackQuery {
+            id: "abc".into(),
+            data: Some("cmd:status".into()),
+            message: Some(msg_from_chat(999, None)),
+        };
+        assert!(!is_callback_authorized(Some(42), &cb));
+    }
+
+    #[test]
+    fn is_callback_authorized_fails_closed_without_message() {
+        let cb = CallbackQuery {
+            id: "abc".into(),
+            data: Some("cmd:status".into()),
+            message: None,
+        };
+        assert!(!is_callback_authorized(Some(42), &cb));
+    }
+
+    #[test]
+    fn is_callback_authorized_fails_closed_when_unconfigured() {
+        let cb = CallbackQuery {
+            id: "abc".into(),
+            data: Some("cmd:status".into()),
+            message: Some(msg_from_chat(42, None)),
+        };
+        assert!(!is_callback_authorized(None, &cb));
     }
 }


### PR DESCRIPTION
## Summary
Wave C Onyx-2 + Onyx-3 AMBER closures (×2):

1. **Telegram adjutant accepts commands from any chat_id.** Read-only so direct corruption impact is zero, but internal node state was leaked to any holder of the bot token.
2. **HTTP API binds `0.0.0.0` by default.** Admin-bearer-token write surface exposed on all interfaces on startup; operator must know to put reverse-proxy/firewall in front.

## Fix
**(1) Telegram:**
- `is_message_authorized()` + `is_callback_authorized()` both fail closed when `TELEGRAM_CHAT_ID` unparseable OR originating chat mismatches
- `CallbackQuery.message` field added so inline-keyboard callbacks carry originating chat id
- 7 new unit tests: match, reject-other-chat, fail-closed-unset, fail-closed-no-message

**(2) API bind host:**
- New `--api-host` CLI flag on `start` and `join`, default `127.0.0.1`
- `bind_address` uses caller-supplied host
- Binding `0.0.0.0` now emits `tracing::warn!` explaining reverse-proxy + token-rotation prerequisite

## Test Plan
- [x] `cargo test -p exo-node --bin exochain telegram::tests` → 12 pass (7 new)
- [x] `cargo build -p exo-node` clean
- [x] `cargo test -p exo-node --bin exochain` → 559 pass

## Context
These are hygiene AMBERs — RED-tier surface (admin bearer token) tracked separately.

## Source
Council memos:
- `exochain/council-intake/exo-node-onyx-2-networking.md` (AMBER #1)
- `exochain/council-intake/exo-node-onyx-3-api-mcp.md` (AMBER #2)
