### PR TITLE
fix(exo-node): gate MCP simulation tools + document middleware stub context

### DIFF
--- a/crates/exo-node/Cargo.toml
+++ b/crates/exo-node/Cargo.toml
@@ -98,7 +98,7 @@ ignored = ["ed25519-dalek", "exo-consent", "exo-governance", "exo-identity", "ze
 [features]
 default = []
 
-# GAP (Onyx pass 3, RED): the HTTP endpoint
+# GAP (Onyx pass 3, RED #1): the HTTP endpoint
 # `POST /api/v1/governance/validators` currently mutates the validator
 # set unilaterally on presentation of the node's admin bearer token —
 # no BFT proposal, no quorum, no signature chain, no recorded
@@ -116,3 +116,29 @@ default = []
 # single bearer-token holder controls validator set mutation, without
 # quorum or on-chain record."
 unaudited-admin-governance-shortcut = []
+
+# GAP (Onyx pass 3, RED #2): several MCP governance tools
+# (exochain_create_decision, exochain_cast_vote,
+# exochain_propose_amendment) return `{"recorded": true, ...}` /
+# `{"decision_id": <hash>}` responses without persisting to any
+# store, without invoking the reactor, without any network
+# broadcast — pure simulation. Combined with the MCP middleware's
+# hardcoded-true constitutional context, this means AI agents
+# calling these tools get "success" signals for actions that have
+# zero governance-fabric effect.
+#
+# Mitigation: tools don't mutate real state, so blast radius is
+# "AI agents acting on false success signals" — not state
+# corruption. But signalling truth-that-isn't is itself a
+# constitutional violation (HumanOverride, evidentiary integrity).
+#
+# The real fix is to wire handlers to the reactor propose/vote/
+# commit flow via exo-dag, or replace with read-only helpers, or
+# rename + disclaim. Until a direction is picked, we REFUSE by
+# default and gate the simulators behind this explicit flag so
+# no caller accidentally relies on fake-success semantics.
+#
+# Do NOT enable this in production. Enabling it means: "I accept
+# that these MCP tool calls return truthy-shaped JSON while doing
+# nothing on-chain."
+unaudited-mcp-simulation-tools = []

--- a/crates/exo-node/src/mcp/middleware.rs
+++ b/crates/exo-node/src/mcp/middleware.rs
@@ -6,6 +6,48 @@
 //! 3. Builds an `AdjudicationContext` for the CGR Kernel
 //! 4. Adjudicates the action against all 8 constitutional invariants
 //! 5. Returns Permitted/Denied/Escalated verdict
+//!
+//! # Audit status — Onyx pass 3, RED #3 (defense-in-depth notice)
+//!
+//! The `McpContext` and `AdjudicationContext` built below carry
+//! **hardcoded-true** constitutional booleans:
+//!
+//!   - `has_provenance: true`
+//!   - `consent_active: true`
+//!   - `output_marked_ai: true`
+//!   - `human_override_preserved: true`
+//!   - authority chain: synthetic root → actor with `signature: vec![1, 2, 3]`
+//!   - provenance: `action_hash: vec![1, 2, 3]`, `signature: vec![4, 5, 6]`
+//!
+//! These sentinels mean the middleware cannot actually fail on
+//! `ProvenancePresent`, `ConsentRequired`, or `HumanOverride` —
+//! those invariants rubber-stamp every call. The semantic checks
+//! that DO fire are the structural ones (`NoSelfGrant`,
+//! `KernelModification`, `SeparationOfPowers`) because those look
+//! at fields the caller supplies (`is_self_grant`, `modifies_kernel`,
+//! `actor_roles`).
+//!
+//! **Current blast radius: bounded by the gate on RED #2.** The three
+//! mutating MCP tools (`exochain_create_decision`, `exochain_cast_vote`,
+//! `exochain_propose_amendment`) refuse by default behind the
+//! `unaudited-mcp-simulation-tools` feature flag. Read-only tools
+//! (`exochain_check_quorum`, `exochain_get_decision_status`,
+//! `exochain_list_invariants`, etc.) are the only callers the
+//! middleware currently rubber-stamps, and they can't mutate
+//! governance fabric.
+//!
+//! **When RED #2 is resolved (real reactor wiring), this middleware
+//! MUST be rewritten first.** A rewrite must either:
+//!   (a) accept real `McpContext` / `AdjudicationContext` from the
+//!       caller and verify the embedded signatures/provenance, or
+//!   (b) decline to adjudicate (return Err) when it cannot construct
+//!       a real context and refuse the mutating action at the handler
+//!       layer.
+//!
+//! Tracked in `Initiatives/fix-mcp-simulation-tools.md`. This
+//! module-level doc exists so the stub context is visible to anyone
+//! reading the code — DO NOT remove the audit-status section when
+//! adjusting this middleware.
 
 use exo_core::{Did, Hash256, SignerType};
 use exo_gatekeeper::{
@@ -30,8 +72,23 @@ pub struct ConstitutionalMiddleware {
 
 impl ConstitutionalMiddleware {
     /// Create a new middleware instance with the full constitutional kernel.
+    ///
+    /// **Emits a loud warning** about the stub adjudication context.
+    /// See module-level docs under `# Audit status` for why this
+    /// middleware cannot currently detect provenance/consent/authority
+    /// violations — those invariants rubber-stamp every call.
     #[must_use]
     pub fn new() -> Self {
+        tracing::warn!(
+            "mcp::ConstitutionalMiddleware initialized with STUB \
+             adjudication context (has_provenance/consent_active/ \
+             human_override_preserved hardcoded true; signatures are \
+             sentinel vec![1,2,3]/vec![4,5,6]). This middleware only \
+             rubber-stamps read-only MCP tools — mutating tools MUST \
+             be gated separately (see unaudited-mcp-simulation-tools \
+             feature flag). Tracked in \
+             Initiatives/fix-mcp-simulation-tools.md."
+        );
         let kernel = Kernel::new(b"EXOCHAIN Constitutional Trust Fabric", InvariantSet::all());
         Self { kernel }
     }
@@ -230,6 +287,35 @@ mod tests {
         assert_eq!(
             mw1.kernel.constitution_hash(),
             mw2.kernel.constitution_hash()
+        );
+    }
+
+    /// Regression guard: the module-level `# Audit status` doc must
+    /// remain in place. It's the only durable signal to future readers
+    /// that this middleware cannot detect provenance/consent/authority
+    /// violations. If someone "cleans up" the doc they must re-add it.
+    #[test]
+    fn module_doc_retains_audit_status_section() {
+        // Read the source file at test time. Tests run from the crate
+        // root, so this relative path is stable in the repo layout.
+        let src = std::fs::read_to_string("src/mcp/middleware.rs")
+            .expect("middleware.rs readable from crate root");
+        assert!(
+            src.contains("# Audit status"),
+            "module doc must contain '# Audit status' audit notice; \
+             see RED #3 fix commit. Do not remove this section."
+        );
+        assert!(
+            src.contains("hardcoded-true") || src.contains("hardcoded true"),
+            "audit doc must name the stub behavior explicitly"
+        );
+        assert!(
+            src.contains("unaudited-mcp-simulation-tools"),
+            "audit doc must link to the RED #2 feature flag"
+        );
+        assert!(
+            src.contains("fix-mcp-simulation-tools.md"),
+            "audit doc must link to the remediation initiative"
         );
     }
 }

--- a/crates/exo-node/src/mcp/tools/governance.rs
+++ b/crates/exo-node/src/mcp/tools/governance.rs
@@ -1,11 +1,63 @@
 //! Governance MCP tools — decision creation, voting, quorum checking, decision
 //! status, and constitutional amendment proposals.
+//!
+//! # Simulation gate (Onyx pass 3, RED #2)
+//!
+//! The mutating tools (`exochain_create_decision`, `exochain_cast_vote`,
+//! `exochain_propose_amendment`) currently synthesize response JSON
+//! without persisting to any store or touching the reactor. Behind
+//! the scenes, they don't actually create decisions, record votes,
+//! or register amendments on-chain.
+//!
+//! Until these are wired to the real governance flow (see
+//! `Initiatives/fix-mcp-simulation-tools.md`), they are gated behind
+//! the `unaudited-mcp-simulation-tools` feature flag (default OFF).
+//! When OFF, they return a structured refusal directing callers to
+//! use the real REST API (`POST /api/v1/governance/proposals`, etc.)
+//! or to enable the feature explicitly in dev environments.
 
+#[cfg_attr(
+    not(feature = "unaudited-mcp-simulation-tools"),
+    allow(unused_imports)
+)]
 use exo_core::{Did, Hash256, Timestamp};
 use serde_json::{Value, json};
 
 use crate::mcp::context::NodeContext;
 use crate::mcp::protocol::{ToolDefinition, ToolResult};
+
+/// Build the structured refusal body for a gated simulation tool.
+///
+/// Keeps refusal shape consistent across tools and makes the feature-flag
+/// remediation path discoverable to any caller inspecting the response.
+#[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+fn simulation_refused(tool_name: &str) -> ToolResult {
+    tracing::warn!(
+        tool = %tool_name,
+        "refusing MCP simulation tool: handler does not persist to store \
+         or invoke reactor. Build with \
+         --features exo-node/unaudited-mcp-simulation-tools to allow \
+         simulation responses in dev clusters. Real governance calls \
+         belong on the REST API (see Initiatives/fix-mcp-simulation-tools.md)."
+    );
+    ToolResult::error(
+        json!({
+            "error": "mcp_simulation_tool_disabled",
+            "tool": tool_name,
+            "message": "This MCP tool currently returns simulation JSON \
+                        without persisting to the governance store or \
+                        invoking the reactor. It is disabled by default \
+                        to prevent AI agents from acting on false success \
+                        signals. Use the real REST governance API, or \
+                        build with the `unaudited-mcp-simulation-tools` \
+                        feature flag in a dev cluster.",
+            "feature_flag": "unaudited-mcp-simulation-tools",
+            "initiative": "Initiatives/fix-mcp-simulation-tools.md",
+            "refusal_source": format!("exo-node/mcp/tools/governance.rs::{tool_name}"),
+        })
+        .to_string(),
+    )
+}
 
 // ---------------------------------------------------------------------------
 // exochain_create_decision
@@ -46,7 +98,20 @@ pub fn create_decision_definition() -> ToolDefinition {
 /// Execute the `exochain_create_decision` tool.
 #[must_use]
 pub fn execute_create_decision(params: &Value, _context: &NodeContext) -> ToolResult {
-    let title = match params.get("title").and_then(Value::as_str) {
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    {
+        let _ = params; // silence unused warning
+        return simulation_refused("exochain_create_decision");
+    }
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
+    {
+        tracing::warn!(
+            "UNAUDITED MCP simulation tool in use: exochain_create_decision. \
+             Returns synthetic decision_id without persisting to store or \
+             invoking reactor. Gated by `unaudited-mcp-simulation-tools` \
+             feature and MUST NOT be enabled in production."
+        );
+        let title = match params.get("title").and_then(Value::as_str) {
         Some(s) => s,
         None => {
             return ToolResult::error(
@@ -95,6 +160,7 @@ pub fn execute_create_decision(params: &Value, _context: &NodeContext) -> ToolRe
         "created_at": format!("{}:{}", now.physical_ms, now.logical),
     });
     ToolResult::success(response.to_string())
+    } // end cfg(feature = "unaudited-mcp-simulation-tools") block
 }
 
 // ---------------------------------------------------------------------------
@@ -137,7 +203,20 @@ pub fn cast_vote_definition() -> ToolDefinition {
 /// Execute the `exochain_cast_vote` tool.
 #[must_use]
 pub fn execute_cast_vote(params: &Value, _context: &NodeContext) -> ToolResult {
-    let decision_id = match params.get("decision_id").and_then(Value::as_str) {
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    {
+        let _ = params;
+        return simulation_refused("exochain_cast_vote");
+    }
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
+    {
+        tracing::warn!(
+            "UNAUDITED MCP simulation tool in use: exochain_cast_vote. \
+             Returns `recorded:true` without persisting the vote to any \
+             store or broadcasting it. Gated by \
+             `unaudited-mcp-simulation-tools` feature."
+        );
+        let decision_id = match params.get("decision_id").and_then(Value::as_str) {
         Some(s) => s,
         None => {
             return ToolResult::error(
@@ -193,6 +272,7 @@ pub fn execute_cast_vote(params: &Value, _context: &NodeContext) -> ToolResult {
         "rationale": rationale,
     });
     ToolResult::success(response.to_string())
+    } // end cfg(feature = "unaudited-mcp-simulation-tools") block
 }
 
 // ---------------------------------------------------------------------------
@@ -347,7 +427,19 @@ pub fn propose_amendment_definition() -> ToolDefinition {
 /// Execute the `exochain_propose_amendment` tool.
 #[must_use]
 pub fn execute_propose_amendment(params: &Value, _context: &NodeContext) -> ToolResult {
-    let title = match params.get("title").and_then(Value::as_str) {
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    {
+        let _ = params;
+        return simulation_refused("exochain_propose_amendment");
+    }
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
+    {
+        tracing::warn!(
+            "UNAUDITED MCP simulation tool in use: exochain_propose_amendment. \
+             Returns synthetic amendment_id without persisting or invoking \
+             the reactor. Gated by `unaudited-mcp-simulation-tools` feature."
+        );
+        let title = match params.get("title").and_then(Value::as_str) {
         Some(s) => s,
         None => {
             return ToolResult::error(
@@ -414,6 +506,7 @@ pub fn execute_propose_amendment(params: &Value, _context: &NodeContext) -> Tool
         "warning": "Constitutional amendments require the highest governance threshold. See spec \u{00a7}3A.3.2.",
     });
     ToolResult::success(response.to_string())
+    } // end cfg(feature = "unaudited-mcp-simulation-tools") block
 }
 
 // ===========================================================================
@@ -433,6 +526,7 @@ mod tests {
         assert!(!def.description.is_empty());
     }
 
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_create_decision_success() {
         let result = execute_create_decision(
@@ -451,6 +545,7 @@ mod tests {
         assert!(v["decision_id"].as_str().expect("id").len() > 0);
     }
 
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_create_decision_invalid_proposer() {
         let result = execute_create_decision(
@@ -464,6 +559,7 @@ mod tests {
         assert!(result.is_error);
     }
 
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_create_decision_missing_title() {
         let result = execute_create_decision(
@@ -485,6 +581,7 @@ mod tests {
         assert!(!def.description.is_empty());
     }
 
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_cast_vote_success() {
         let result = execute_cast_vote(
@@ -506,6 +603,7 @@ mod tests {
         assert_eq!(v["rationale"], "Looks good to me.");
     }
 
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_cast_vote_invalid_choice() {
         let result = execute_cast_vote(
@@ -519,6 +617,7 @@ mod tests {
         assert!(result.is_error);
     }
 
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_cast_vote_invalid_voter() {
         let result = execute_cast_vote(
@@ -599,6 +698,7 @@ mod tests {
         assert!(!def.description.is_empty());
     }
 
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_propose_amendment_success() {
         let result = execute_propose_amendment(
@@ -625,6 +725,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_propose_amendment_invalid_target() {
         let result = execute_propose_amendment(
@@ -639,6 +740,7 @@ mod tests {
         assert!(result.is_error);
     }
 
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_propose_amendment_invalid_proposer() {
         let result = execute_propose_amendment(
@@ -651,5 +753,79 @@ mod tests {
             &NodeContext::empty(),
         );
         assert!(result.is_error);
+    }
+
+    // ==================================================================
+    // RED #2 refusal tests (default build only)
+    // ==================================================================
+
+    /// When the `unaudited-mcp-simulation-tools` feature is OFF (default),
+    /// `execute_create_decision` must return the structured simulation
+    /// refusal — not a synthesized success response.
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    #[test]
+    fn execute_create_decision_refused_without_feature_flag() {
+        let result = execute_create_decision(
+            &json!({
+                "title": "Test",
+                "description": "Test",
+                "proposer_did": "did:exo:alice",
+            }),
+            &NodeContext::empty(),
+        );
+        assert!(
+            result.is_error,
+            "default build MUST refuse MCP simulation tool"
+        );
+        let text = result.content[0].text();
+        assert!(
+            text.contains("mcp_simulation_tool_disabled"),
+            "refusal body must carry error tag, got: {text}"
+        );
+        assert!(
+            text.contains("unaudited-mcp-simulation-tools"),
+            "refusal body must name the feature flag, got: {text}"
+        );
+        assert!(
+            text.contains("exochain_create_decision"),
+            "refusal body must name the specific tool, got: {text}"
+        );
+    }
+
+    /// Same refusal for cast_vote — no synthesized "recorded:true".
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    #[test]
+    fn execute_cast_vote_refused_without_feature_flag() {
+        let result = execute_cast_vote(
+            &json!({
+                "decision_id": "abc",
+                "voter_did": "did:exo:bob",
+                "choice": "approve",
+            }),
+            &NodeContext::empty(),
+        );
+        assert!(result.is_error);
+        let text = result.content[0].text();
+        assert!(text.contains("mcp_simulation_tool_disabled"));
+        assert!(text.contains("exochain_cast_vote"));
+    }
+
+    /// Same refusal for propose_amendment — no synthesized amendment_id.
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    #[test]
+    fn execute_propose_amendment_refused_without_feature_flag() {
+        let result = execute_propose_amendment(
+            &json!({
+                "title": "Test",
+                "description": "Test",
+                "proposer_did": "did:exo:alice",
+                "target": "constitution",
+            }),
+            &NodeContext::empty(),
+        );
+        assert!(result.is_error);
+        let text = result.content[0].text();
+        assert!(text.contains("mcp_simulation_tool_disabled"));
+        assert!(text.contains("exochain_propose_amendment"));
     }
 }


### PR DESCRIPTION
## Summary
**Wave C Onyx pass 3 RED #2 + #3 closures, bundled.** Two related findings in the MCP surface:

### RED #2: MCP governance tools return truthy JSON without persisting anything
`exochain_create_decision`, `exochain_cast_vote`, `exochain_propose_amendment` synthesized `decision_id` / `amendment_id` / `"recorded": true` responses without any store write, reactor call, or broadcast. AI agents would act on false success signals.

### RED #3: MCP middleware adjudication context hardcoded true
`ConstitutionalMiddleware` built an `AdjudicationContext` with `has_provenance=true`, `consent_active=true`, `human_override_preserved=true`, and sentinel signatures `vec![1,2,3]` / `vec![4,5,6]`. Every invocation rubber-stamps; ProvenancePresent / ConsentRequired / HumanOverride invariants cannot fail.

## Fix

### For RED #2 (commit be4d1d9)
New crate feature `unaudited-mcp-simulation-tools` (default OFF):

- **Default (OFF):** each of the 3 mutating handlers returns structured refusal:
  ```json
  {
    "error": "mcp_simulation_tool_disabled",
    "tool": "exochain_<name>",
    "message": "...disabled by default to prevent AI agents from acting on false success signals...",
    "feature_flag": "unaudited-mcp-simulation-tools",
    "initiative": "Initiatives/fix-mcp-simulation-tools.md",
    "refusal_source": "exo-node/mcp/tools/governance.rs::<name>"
  }
  ```
- **Feature ON:** existing synthesizer behavior + loud `tracing::warn!`
- Read-only MCP tools (`check_quorum`, `get_decision_status`, `list_invariants`) unaffected
- 9 legacy tests gated; 3 new refusal tests for default build

### For RED #3 (commit 54720cd)
Current blast radius is zero (contingent on RED #2 closure — mutators refuse). The appropriate action is annotation + regression guard:

- 42-line `# Audit status — Onyx pass 3, RED #3` section in module doc enumerating every hardcoded field, every sentinel signature, which invariants cannot fail, and the two rewrite options
- `ConstitutionalMiddleware::new()` emits a loud `tracing::warn!` on every construction
- New test `module_doc_retains_audit_status_section` reads `middleware.rs` at test time, asserts audit section + feature-flag name + initiative path persist — fails if a future cleanup removes the annotations

## Test Plan
- [x] `cargo build -p exo-node` clean (default)
- [x] `cargo test -p exo-node --bin exochain` → 547 pass default
- [x] `cargo test -p exo-node --bin exochain --features unaudited-mcp-simulation-tools mcp::tools::governance` → 18 pass
- [x] 12 governance tests pass on default build (3 refusal + 5 definition + 4 validation)
- [x] 8 middleware tests pass including audit-doc regression guard

## Source
Council memo: `exochain/council-intake/exo-node-onyx-3-api-mcp.md` (RED #2 + RED #3).

NEVER STUB: refusal is real — structured error response, feature-flag discoverable via the refusal body itself.
