### PR TITLE
fix(exo-node): remove fabricated 0dentity server-key endpoint

### DIFF
--- a/crates/exo-node/src/exoforge.rs
+++ b/crates/exo-node/src/exoforge.rs
@@ -482,8 +482,8 @@ fn build_zerodentity_tasks() -> Vec<ForgeTask> {
     task!(
         5,
         "Onboarding API",
-        "GET /server-key — Ed25519 DH public key",
-        "Implemented in api.rs get_server_key(). Returns Ed25519 key bytes as hex + key_hash. \n        Test: get_server_key_returns_ed25519_dh() in tests.rs.",
+        "Server key endpoint removed",
+        "ONYX-4 R6 deleted the fabricated /api/v1/0dentity/server-key route. The removed handler wrapped a BLAKE3 digest as a public key; regression coverage asserts the route is absent.",
         "§7.3",
         Some(2)
     );
@@ -559,7 +559,7 @@ fn build_zerodentity_tasks() -> Vec<ForgeTask> {
         7,
         "Onboarding UI",
         "Email input + OTP steps",
-        "Email form → RSA-OAEP encrypt → dispatch OTP. 6-digit auto-advance input, countdown timer, resend cooldown",
+        "Email form submits claim hash with no server-key dependency. 6-digit auto-advance input, countdown timer, resend cooldown",
         "§4.3-§4.4",
         Some(4)
     );

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -611,14 +611,8 @@ async fn start_node(
     let zd_onboarding_state = zerodentity::onboarding::OnboardingState {
         store: std::sync::Arc::clone(&zerodentity_store),
     };
-    let started_ms = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as u64;
     let zd_api_state = zerodentity::api::ApiState {
         store: std::sync::Arc::clone(&zerodentity_store),
-        node_did: node_identity.did.clone(),
-        started_ms,
     };
     let zerodentity_onboarding_router =
         zerodentity::onboarding::onboarding_router(zd_onboarding_state);

--- a/crates/exo-node/src/zerodentity/api.rs
+++ b/crates/exo-node/src/zerodentity/api.rs
@@ -7,7 +7,6 @@
 //! - `GET /api/v1/0dentity/:did/score/history`  — score history (public)
 //! - `GET /api/v1/0dentity/:did/fingerprints`   — fingerprint timeline (owner only)
 //! - `POST /api/v1/0dentity/:did/attest`        — peer attestation
-//! - `GET /api/v1/0dentity/server-key`          — server RSA-OAEP public key
 //!
 //! Spec reference: §7.2, §7.3.
 
@@ -41,10 +40,6 @@ use super::{
 #[derive(Clone)]
 pub struct ApiState {
     pub store: Arc<Mutex<ZerodentityStore>>,
-    /// Node DID used for deterministic server key derivation.
-    pub node_did: exo_core::types::Did,
-    /// Epoch ms when the node started (used as key rotation timestamp).
-    pub started_ms: u64,
 }
 
 // ---------------------------------------------------------------------------
@@ -153,15 +148,6 @@ pub struct AttestResponse {
     pub receipt_hash: String,
     pub attester_score_impact: serde_json::Value,
     pub target_score_impact: serde_json::Value,
-}
-
-#[derive(Debug, Serialize)]
-pub struct ServerKeyResponse {
-    pub algorithm: String,
-    pub key_size: u32,
-    pub public_key_pem: String,
-    pub key_hash: String,
-    pub rotated_ms: u64,
 }
 
 // ---------------------------------------------------------------------------
@@ -605,31 +591,6 @@ pub async fn create_peer_attestation(
 }
 
 // ---------------------------------------------------------------------------
-// GET /api/v1/0dentity/server-key
-// ---------------------------------------------------------------------------
-
-/// `GET /api/v1/0dentity/server-key` — retrieve the server's RSA-OAEP public key.
-pub async fn get_server_key(State(state): State<ApiState>) -> Json<ServerKeyResponse> {
-    // Derive a deterministic key fingerprint from the node's DID.
-    // In production, this will be replaced by a live RSA-OAEP key pair
-    // generated at startup and rotated on a configurable interval.
-    // The key_hash is a BLAKE3 digest of the node DID, providing a
-    // stable per-node identifier that clients can pin.
-    let key_material = format!("exochain-server-key:{}", state.node_did.as_str());
-    let key_hash = Hash256::digest(key_material.as_bytes());
-    Json(ServerKeyResponse {
-        algorithm: "Ed25519-DH".into(),
-        key_size: 256,
-        public_key_pem: format!(
-            "-----BEGIN PUBLIC KEY-----\n{}\n-----END PUBLIC KEY-----",
-            hex::encode(key_hash.as_bytes())
-        ),
-        key_hash: hex::encode(key_hash.as_bytes()),
-        rotated_ms: state.started_ms,
-    })
-}
-
-// ---------------------------------------------------------------------------
 // DELETE /api/v1/0dentity/:did — right to erasure (§11.4)
 // ---------------------------------------------------------------------------
 
@@ -719,7 +680,6 @@ pub async fn delete_identity(
 
 pub fn zerodentity_api_router(state: ApiState) -> Router {
     Router::new()
-        .route("/api/v1/0dentity/server-key", get(get_server_key))
         .route("/api/v1/0dentity/:did/score", get(get_score))
         .route("/api/v1/0dentity/:did/claims", get(list_claims))
         .route("/api/v1/0dentity/:did/score/history", get(score_history))
@@ -755,8 +715,6 @@ mod tests {
     fn make_state() -> ApiState {
         ApiState {
             store: Arc::new(Mutex::new(ZerodentityStore::new())),
-            node_did: Did::new("did:exo:test-node").unwrap(),
-            started_ms: 1_700_000_000_000,
         }
     }
 
@@ -774,8 +732,6 @@ mod tests {
         store.insert_session(&session).unwrap();
         ApiState {
             store: Arc::new(Mutex::new(store)),
-            node_did: Did::new("did:exo:test-node").unwrap(),
-            started_ms: 1_700_000_000_000,
         }
     }
 
@@ -805,8 +761,6 @@ mod tests {
         store.insert_claim("claim-001", &claim).unwrap();
         ApiState {
             store: Arc::new(Mutex::new(store)),
-            node_did: Did::new("did:exo:test-node").unwrap(),
-            started_ms: 1_700_000_000_000,
         }
     }
 
@@ -1026,6 +980,21 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::CREATED);
+    }
+
+    #[tokio::test]
+    async fn server_key_get_does_not_return_key_material() {
+        let app = zerodentity_api_router(make_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/0dentity/server-key")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
     }
 
     // --- list_claims ---

--- a/crates/exo-node/src/zerodentity/tests.rs
+++ b/crates/exo-node/src/zerodentity/tests.rs
@@ -101,11 +101,7 @@ mod tests {
     }
 
     fn api_app(store: SharedZerodentityStore) -> Router {
-        zerodentity_api_router(ApiState {
-            store,
-            node_did: Did::new("did:exo:test-node").unwrap(),
-            started_ms: 1_700_000_000_000,
-        })
+        zerodentity_api_router(ApiState { store })
     }
 
     async fn post_json(app: &Router, uri: &str, body: Value) -> axum::response::Response {
@@ -1006,28 +1002,8 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // §12.2.7 — server-key and peer attestation
+    // §12.2.7 — peer attestation
     // -----------------------------------------------------------------------
-
-    #[tokio::test]
-    async fn get_server_key_returns_ed25519_dh() {
-        let app = api_app(new_shared_store());
-        let resp = get_req(&app, "/api/v1/0dentity/server-key").await;
-        assert_eq!(resp.status(), StatusCode::OK);
-        let body = body_json(resp).await;
-        assert_eq!(body["algorithm"].as_str().unwrap(), "Ed25519-DH");
-        assert_eq!(body["key_size"].as_u64().unwrap(), 256);
-        assert!(
-            body["public_key_pem"]
-                .as_str()
-                .unwrap()
-                .contains("BEGIN PUBLIC KEY"),
-        );
-        let hash_str = body["key_hash"].as_str().unwrap();
-        assert_eq!(hash_str.len(), 64, "key_hash must be 64 hex chars");
-        // Key hash is deterministic for the test node DID.
-        assert_eq!(body["rotated_ms"].as_u64().unwrap(), 1_700_000_000_000,);
-    }
 
     async fn post_with_auth(
         app: &Router,

--- a/docs/0DENTITY-APP-SPEC.md
+++ b/docs/0DENTITY-APP-SPEC.md
@@ -748,16 +748,15 @@ function normalize_name(raw) {
      device_fingerprint: updated_composite_hash.hex(),
      signal_hashes: { ... },
      verification_channel: "email",
-     // Server-side: dispatches OTP to the ACTUAL email address
-     // The raw email must be transmitted THIS ONCE for delivery
-     // Server hashes it, dispatches OTP, then discards the plaintext
-     encrypted_channel_address: RSA_OAEP.encrypt(server_public_key, email_normalized)
+     // Current node build: creates an OTP challenge for the email channel.
+     // The raw email address is not transmitted to this API.
+     encrypted_channel_address: null
    }
 5. Response: { challenge_id: "...", ttl_ms: 300000, channel: "email" }
 6. Advance to Step 3 (Email OTP)
 ```
 
-**Critical security note:** The raw email address must be transmitted to the server exactly once for OTP dispatch. It is encrypted with the server's RSA-OAEP public key (provided at page load), decrypted server-side only within the OTP dispatch function, used to send the email, then immediately zeroed. The server never persists the raw address — only the BLAKE3 hash.
+**Implementation status note:** the current node build does not route a server public-key endpoint for channel-address encryption. Clients must not depend on RSA-OAEP channel encryption in this build; the API stores only claim hashes and OTP challenge metadata.
 
 ### 4.4 Step 3: Email OTP Verification
 
@@ -824,7 +823,9 @@ function normalize_name(raw) {
      device_fingerprint: updated_composite_hash.hex(),
      signal_hashes: { ... },
      verification_channel: "sms",
-     encrypted_channel_address: RSA_OAEP.encrypt(server_public_key, phone_e164)
+     // Current node build: creates an OTP challenge for the SMS channel.
+     // The raw phone number is not transmitted to this API.
+     encrypted_channel_address: null
    }
 4. Response: { challenge_id: "...", ttl_ms: 180000, channel: "sms" }
 5. Advance to Step 5 (Phone OTP)
@@ -1466,7 +1467,7 @@ POST /api/v1/0dentity/claims
         ...
       },
       "verification_channel": "email" | "sms" | null,
-      "encrypted_channel_address": "base64-RSA-OAEP-encrypted address" | null,
+      "encrypted_channel_address": null,
       "signature": "hex-encoded Ed25519 signature",
       "public_key": "hex-encoded Ed25519 public key"
     }
@@ -1634,19 +1635,7 @@ POST /api/v1/0dentity/:did/attest
 
 ### 7.3 Server Public Key Endpoint
 
-```
-GET /api/v1/0dentity/server-key
-  Description: Retrieve server's RSA-OAEP public key for encrypting channel addresses.
-  Auth: None
-  Response 200:
-    {
-      "algorithm": "RSA-OAEP",
-      "key_size": 4096,
-      "public_key_pem": "-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----",
-      "key_hash": "hex...",    // BLAKE3 hash for pinning
-      "rotated_ms": 1743724800000
-    }
-```
+No server public-key endpoint is routed in the current node build. ONYX-4 R6 removed the previous `/api/v1/0dentity/server-key` handler because it advertised key-agreement semantics while returning a BLAKE3 digest wrapped as PEM. Clients must treat this endpoint as absent.
 
 ---
 
@@ -2049,7 +2038,7 @@ let extra_router = Router::new()
 | Content addressing | BLAKE3 | 256-bit output |
 | Claim signing | Ed25519 | 64-byte signatures |
 | OTP HMAC | SHA-256 HMAC | 256-bit key, 6-digit code |
-| Channel encryption | RSA-OAEP | 4096-bit key, SHA-256 |
+| Channel encryption | Not routed in current node build | No server public-key endpoint |
 | Session token | getrandom | 256-bit, hex-encoded |
 | Fingerprint consistency | Jaccard similarity | Over signal hash sets |
 

--- a/gap/ULTRAPLAN-GAP-011-EXOFORGE-SIGNALS.md
+++ b/gap/ULTRAPLAN-GAP-011-EXOFORGE-SIGNALS.md
@@ -17,7 +17,7 @@
 | `store.rs` | 929 | In-memory DID store, score history, fingerprint history, ceremony management |
 | `behavioral.rs` | 282 | `quantize_to_histogram()`, `histogram_similarity()` — histogram-intersection scoring |
 | `fingerprint.rs` | 249 | `compute_composite_hash()`, `compute_consistency()` — BLAKE3, Jaccard overlap |
-| `api.rs` | ~730 | `GET /score`, `GET /claims`, `GET /score/history`, `GET /fingerprints`, `GET /server-key` |
+| `api.rs` | ~730 | `GET /score`, `GET /claims`, `GET /score/history`, `GET /fingerprints`, peer attestations, erasure |
 
 All Rust modules are complete, tested, and passing. The scoring engine, onboarding pipeline, store, behavioral comparison, and fingerprint consistency logic are production-quality Rust.
 
@@ -77,7 +77,7 @@ SHA-256 via `crypto.subtle` is intentional for this deployment:
 
 ### ExoForge Registry
 
-Phase 4 tasks updated to `Some(1)` (complete) with accurate implementation descriptions. Phase 5 `GET /server-key` updated to reflect Ed25519 DH (not RSA-OAEP as the placeholder said) and `Some(2)`. Phase 6 tasks updated with implementation references.
+Phase 4 tasks updated to `Some(1)` (complete) with accurate implementation descriptions. Phase 5 now records ONYX-4 R6 removal of the fabricated `/api/v1/0dentity/server-key` route instead of advertising a digest as a public key. Phase 6 tasks updated with implementation references.
 
 ---
 


### PR DESCRIPTION
## Summary
- Removes the fabricated 0dentity server-key route and response shape.
- Removes boot-time SystemTime usage that only supported that endpoint.
- Updates the 0DENTITY spec, GAP-011 notes, and ExoForge registry text to reflect endpoint absence.
- Adds regression coverage proving GET /api/v1/0dentity/server-key no longer returns key material.

## Verification
- cargo fmt --all
- cargo test -p exo-node zerodentity
- cargo test -p exo-node
- cargo build -p exo-node
- cargo clippy -p exo-node --bin exochain -- -D warnings

## Gate note
`cargo clippy -p exo-node --all-targets -- -D warnings` currently fails on existing test-only unwrap/expect warnings outside this branch's diff; this branch stays scoped to ONYX-4 R6.