### PR TITLE
fix(exo-node): require signed 0dentity peer attestations

### DIFF
--- a/crates/exo-node/src/exoforge.rs
+++ b/crates/exo-node/src/exoforge.rs
@@ -525,7 +525,7 @@ fn build_zerodentity_tasks() -> Vec<ForgeTask> {
         6,
         "Identity API",
         "POST /attest — peer attestation",
-        "Create attestation from verified DID to target DID. Reject self-attestation, duplicate. Compute score impact",
+        "Create signed Ed25519 attestation from verified DID to target DID. Reject self-attestation, duplicate, empty signature, zero signature, wrong key, tampered payload, replayed payload. Compute score impact",
         "§7.2",
         Some(5)
     );

--- a/crates/exo-node/src/zerodentity/api.rs
+++ b/crates/exo-node/src/zerodentity/api.rs
@@ -22,13 +22,13 @@ use axum::{
     http::{HeaderMap, StatusCode},
     routing::{get, post},
 };
-use exo_core::types::{Did, Hash256};
+use exo_core::types::{Did, Hash256, PublicKey, Signature};
 use serde::{Deserialize, Serialize};
 
 use super::{
     attestation::{
-        attester_score_impact, build_target_claim, create_attestation, target_score_impact,
-        validate_attestation,
+        CreateAttestationInput, attester_score_impact, build_target_claim, create_attestation,
+        target_score_impact, validate_attestation,
     },
     store::ZerodentityStore,
     types::{AttestationType, IdentityClaim, ZerodentityScore},
@@ -145,6 +145,9 @@ pub struct AttestRequest {
     pub target_did: String,
     pub attestation_type: String,
     pub message_hash: Option<String>,
+    pub created_ms: Option<u64>,
+    pub attester_public_key: Option<String>,
+    pub signature: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -187,6 +190,53 @@ fn parse_did(did_str: &str) -> Result<Did, (StatusCode, Json<serde_json::Value>)
 
 fn hex_hash(h: &Hash256) -> String {
     hex::encode(h.as_bytes())
+}
+
+fn bad_request(message: &str) -> (StatusCode, Json<serde_json::Value>) {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(serde_json::json!({ "error": message })),
+    )
+}
+
+fn parse_hex_exact<const N: usize>(
+    field: &str,
+    value: &str,
+) -> Result<[u8; N], (StatusCode, Json<serde_json::Value>)> {
+    let bytes =
+        hex::decode(value).map_err(|_| bad_request(&format!("{field} must be hex-encoded")))?;
+    if bytes.len() != N {
+        return Err(bad_request(&format!("{field} must be exactly {N} bytes")));
+    }
+    let mut out = [0u8; N];
+    out.copy_from_slice(&bytes);
+    Ok(out)
+}
+
+fn parse_message_hash(
+    value: Option<&str>,
+) -> Result<Option<Hash256>, (StatusCode, Json<serde_json::Value>)> {
+    value
+        .map(|s| parse_hex_exact::<32>("message_hash", s).map(Hash256::from_bytes))
+        .transpose()
+}
+
+fn parse_public_key(
+    value: Option<&str>,
+) -> Result<PublicKey, (StatusCode, Json<serde_json::Value>)> {
+    let Some(value) = value else {
+        return Err(bad_request("attester_public_key is required"));
+    };
+    parse_hex_exact::<32>("attester_public_key", value).map(PublicKey::from_bytes)
+}
+
+fn parse_signature(
+    value: Option<&str>,
+) -> Result<Signature, (StatusCode, Json<serde_json::Value>)> {
+    let Some(value) = value else {
+        return Err(bad_request("signature is required"));
+    };
+    parse_hex_exact::<64>("signature", value).map(Signature::from_bytes)
 }
 
 fn axes_from_score(s: &ZerodentityScore) -> AxesResponse {
@@ -506,17 +556,12 @@ pub async fn create_peer_attestation(
         )
     })?;
 
-    let message_hash = req.message_hash.as_deref().and_then(|s| {
-        hex::decode(s).ok().and_then(|b| {
-            if b.len() >= 32 {
-                let mut arr = [0u8; 32];
-                arr.copy_from_slice(&b[..32]);
-                Some(Hash256::from_bytes(arr))
-            } else {
-                None
-            }
-        })
-    });
+    let message_hash = parse_message_hash(req.message_hash.as_deref())?;
+    let created_ms = req
+        .created_ms
+        .ok_or_else(|| bad_request("created_ms is required"))?;
+    let attester_public_key = parse_public_key(req.attester_public_key.as_deref())?;
+    let signature = parse_signature(req.signature.as_deref())?;
 
     // Validate
     let (attester_claims, already_exists) = {
@@ -552,14 +597,22 @@ pub async fn create_peer_attestation(
         format!("attest:{}:{}", attester_did.as_str(), target_did.as_str()).as_bytes(),
     );
 
-    let attestation = create_attestation(
-        &attester_did,
-        &target_did,
+    let attestation = create_attestation(CreateAttestationInput {
+        attester_did: &attester_did,
+        target_did: &target_did,
         attestation_type,
         message_hash,
         dag_node_hash,
-        now,
-    );
+        created_ms,
+        attester_public_key,
+        signature,
+    })
+    .map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": e.to_string()})),
+        )
+    })?;
 
     // Persist attestation
     {
@@ -743,11 +796,15 @@ pub fn zerodentity_api_router(state: ApiState) -> Router {
 #[allow(clippy::unwrap_used, clippy::needless_borrows_for_generic_args)]
 mod tests {
     use axum::{body::Body, http::Request};
-    use exo_core::types::{Did, Hash256, Signature};
+    use exo_core::{
+        crypto,
+        types::{Did, Hash256, PublicKey, SecretKey, Signature},
+    };
     use tower::ServiceExt;
 
     use super::*;
     use crate::zerodentity::{
+        attestation::attestation_signing_payload,
         store::ZerodentityStore,
         types::{ClaimStatus, ClaimType, IdentityClaim, IdentitySession},
     };
@@ -808,6 +865,39 @@ mod tests {
             node_did: Did::new("did:exo:test-node").unwrap(),
             started_ms: 1_700_000_000_000,
         }
+    }
+
+    fn keypair(seed: u8) -> (PublicKey, SecretKey) {
+        let pair = crypto::KeyPair::from_secret_bytes([seed; 32]).unwrap();
+        (*pair.public_key(), pair.secret_key().clone())
+    }
+
+    fn signed_attest_body(
+        attester: &Did,
+        target: &Did,
+        attestation_type: AttestationType,
+        message_hash: Option<Hash256>,
+        created_ms: u64,
+        public_key: &PublicKey,
+        secret_key: &SecretKey,
+    ) -> serde_json::Value {
+        let payload = attestation_signing_payload(
+            attester,
+            target,
+            &attestation_type,
+            message_hash.as_ref(),
+            created_ms,
+        )
+        .unwrap();
+        let signature = crypto::sign(&payload, secret_key);
+        serde_json::json!({
+            "target_did": target.as_str(),
+            "attestation_type": attestation_type.to_string(),
+            "message_hash": message_hash.map(|h| hex::encode(h.as_bytes())),
+            "created_ms": created_ms,
+            "attester_public_key": hex::encode(public_key.as_bytes()),
+            "signature": hex::encode(signature.as_bytes())
+        })
     }
 
     // --- list_fingerprints ---
@@ -983,11 +1073,19 @@ mod tests {
     async fn create_peer_attestation_success_with_message_hash() {
         let state = make_state_with_session_and_claim("tok-alice", "did:exo:alice");
         let app = zerodentity_api_router(state);
-        let body = serde_json::json!({
-            "target_did": "did:exo:carol",
-            "attestation_type": "Identity",
-            "message_hash": hex::encode([0u8; 32])
-        });
+        let attester = Did::new("did:exo:alice").unwrap();
+        let target = Did::new("did:exo:carol").unwrap();
+        let message_hash = Hash256::from_bytes([0u8; 32]);
+        let (public_key, secret_key) = keypair(51);
+        let body = signed_attest_body(
+            &attester,
+            &target,
+            AttestationType::Identity,
+            Some(message_hash),
+            1_700_000_100_000,
+            &public_key,
+            &secret_key,
+        );
         let resp = app
             .oneshot(
                 Request::builder()
@@ -1004,15 +1102,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_peer_attestation_short_message_hash_succeeds() {
-        // message_hash < 32 bytes → parsed as None (covers the else branch)
+    async fn create_peer_attestation_short_message_hash_returns_400() {
         let state = make_state_with_session_and_claim("tok-alice", "did:exo:alice");
         let app = zerodentity_api_router(state);
-        let body = serde_json::json!({
-            "target_did": "did:exo:dave",
-            "attestation_type": "Trustworthy",
-            "message_hash": hex::encode([0u8; 16])
-        });
+        let attester = Did::new("did:exo:alice").unwrap();
+        let target = Did::new("did:exo:dave").unwrap();
+        let (public_key, secret_key) = keypair(53);
+        let mut body = signed_attest_body(
+            &attester,
+            &target,
+            AttestationType::Trustworthy,
+            None,
+            1_700_000_200_000,
+            &public_key,
+            &secret_key,
+        );
+        body["message_hash"] = serde_json::Value::String(hex::encode([0u8; 16]));
         let resp = app
             .oneshot(
                 Request::builder()
@@ -1025,7 +1130,7 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(resp.status(), StatusCode::CREATED);
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
     // --- list_claims ---

--- a/crates/exo-node/src/zerodentity/attestation.rs
+++ b/crates/exo-node/src/zerodentity/attestation.rs
@@ -7,9 +7,11 @@
 //!
 //! Spec reference: §7.2 (POST /api/v1/0dentity/:did/attest).
 
-use exo_core::types::{Did, Hash256};
+use exo_core::{
+    crypto,
+    types::{Did, Hash256, PublicKey, Signature},
+};
 use thiserror::Error;
-use uuid::Uuid;
 
 use super::types::{AttestationType, ClaimStatus, ClaimType, IdentityClaim, PeerAttestation};
 
@@ -25,6 +27,21 @@ pub enum AttestationError {
     DuplicateAttestation,
     #[error("Attester is not verified — at least one verified claim is required")]
     AttesterUnverified,
+    #[error("Attestation signature verification failed")]
+    InvalidSignature,
+    #[error("Attestation signing payload encoding failed: {reason}")]
+    SigningPayloadEncoding { reason: String },
+}
+
+pub struct CreateAttestationInput<'a> {
+    pub attester_did: &'a Did,
+    pub target_did: &'a Did,
+    pub attestation_type: AttestationType,
+    pub message_hash: Option<Hash256>,
+    pub dag_node_hash: Hash256,
+    pub created_ms: u64,
+    pub attester_public_key: PublicKey,
+    pub signature: Signature,
 }
 
 // ---------------------------------------------------------------------------
@@ -64,26 +81,110 @@ pub fn validate_attestation(
     Ok(())
 }
 
+/// Canonical CBOR payload that an attester signs.
+///
+/// The domain tag prevents cross-protocol reuse. The tuple binds the signature
+/// to one attester DID, target DID, attestation type, optional statement hash,
+/// and signed creation timestamp.
+pub fn attestation_signing_payload(
+    attester_did: &Did,
+    target_did: &Did,
+    attestation_type: &AttestationType,
+    message_hash: Option<&Hash256>,
+    created_ms: u64,
+) -> Result<Vec<u8>, AttestationError> {
+    let tuple = (
+        "exo.zerodentity.attestation.v1",
+        attester_did,
+        target_did,
+        attestation_type,
+        message_hash,
+        created_ms,
+    );
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&tuple, &mut buf).map_err(|e| {
+        AttestationError::SigningPayloadEncoding {
+            reason: e.to_string(),
+        }
+    })?;
+    Ok(buf)
+}
+
+/// Verify the attester's Ed25519 signature over the canonical payload.
+///
+/// Rejects `Signature::Empty`, all-zero Ed25519 sentinels, malformed payloads,
+/// wrong keys, and signatures replayed over a different payload.
+#[must_use]
+pub fn verify_attestation_signature(
+    attester_did: &Did,
+    target_did: &Did,
+    attestation_type: &AttestationType,
+    message_hash: Option<&Hash256>,
+    created_ms: u64,
+    attester_public_key: &PublicKey,
+    signature: &Signature,
+) -> bool {
+    if signature.is_empty() {
+        return false;
+    }
+    let raw = signature.as_bytes();
+    if !raw.is_empty() && raw.iter().all(|b| *b == 0) {
+        return false;
+    }
+    let Ok(payload) = attestation_signing_payload(
+        attester_did,
+        target_did,
+        attestation_type,
+        message_hash,
+        created_ms,
+    ) else {
+        return false;
+    };
+    crypto::verify(&payload, signature, attester_public_key)
+}
+
 /// Create a new peer attestation.
 ///
 /// Callers must call `validate_attestation` first.
 pub fn create_attestation(
-    attester_did: &Did,
-    target_did: &Did,
-    attestation_type: AttestationType,
-    message_hash: Option<Hash256>,
-    dag_node_hash: Hash256,
-    now_ms: u64,
-) -> PeerAttestation {
-    PeerAttestation {
-        attestation_id: Uuid::new_v4().to_string(),
-        attester_did: attester_did.clone(),
-        target_did: target_did.clone(),
-        attestation_type,
-        message_hash,
-        created_ms: now_ms,
-        dag_node_hash,
+    input: CreateAttestationInput<'_>,
+) -> Result<PeerAttestation, AttestationError> {
+    if !verify_attestation_signature(
+        input.attester_did,
+        input.target_did,
+        &input.attestation_type,
+        input.message_hash.as_ref(),
+        input.created_ms,
+        &input.attester_public_key,
+        &input.signature,
+    ) {
+        return Err(AttestationError::InvalidSignature);
     }
+
+    let signing_payload = attestation_signing_payload(
+        input.attester_did,
+        input.target_did,
+        &input.attestation_type,
+        input.message_hash.as_ref(),
+        input.created_ms,
+    )?;
+    let mut id_input = signing_payload;
+    id_input.extend_from_slice(input.attester_public_key.as_bytes());
+    id_input.extend_from_slice(&input.signature.to_bytes());
+    id_input.extend_from_slice(input.dag_node_hash.as_bytes());
+    let attestation_id = hex::encode(Hash256::digest(&id_input).as_bytes());
+
+    Ok(PeerAttestation {
+        attestation_id,
+        attester_did: input.attester_did.clone(),
+        target_did: input.target_did.clone(),
+        attestation_type: input.attestation_type,
+        message_hash: input.message_hash,
+        created_ms: input.created_ms,
+        attester_public_key: input.attester_public_key,
+        signature: input.signature,
+        dag_node_hash: input.dag_node_hash,
+    })
 }
 
 /// Score impact of an attestation on the target's network_reputation axis.
@@ -107,7 +208,6 @@ pub fn build_target_claim(
     dag_node_hash: Hash256,
     now_ms: u64,
 ) -> IdentityClaim {
-    use exo_core::types::Signature;
     let payload = format!(
         "attestation:{}:{}",
         attestation.attester_did.as_str(),
@@ -123,7 +223,7 @@ pub fn build_target_claim(
         created_ms: now_ms,
         verified_ms: Some(now_ms),
         expires_ms: None,
-        signature: Signature::Empty,
+        signature: attestation.signature.clone(),
         dag_node_hash,
     }
 }
@@ -133,8 +233,12 @@ pub fn build_target_claim(
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
-    use exo_core::types::Signature;
+    use exo_core::{
+        crypto,
+        types::{PublicKey, SecretKey, Signature},
+    };
 
     use super::*;
 
@@ -143,6 +247,30 @@ mod tests {
     }
     fn hash(b: &[u8]) -> Hash256 {
         Hash256::digest(b)
+    }
+
+    fn keypair(seed: u8) -> (PublicKey, SecretKey) {
+        let pair = crypto::KeyPair::from_secret_bytes([seed; 32]).expect("keypair");
+        (*pair.public_key(), pair.secret_key().clone())
+    }
+
+    fn signed_attestation_signature(
+        attester: &Did,
+        target: &Did,
+        attestation_type: &AttestationType,
+        message_hash: Option<&Hash256>,
+        created_ms: u64,
+        secret_key: &SecretKey,
+    ) -> Signature {
+        let payload = attestation_signing_payload(
+            attester,
+            target,
+            attestation_type,
+            message_hash,
+            created_ms,
+        )
+        .expect("signing payload");
+        crypto::sign(&payload, secret_key)
     }
 
     fn verified_claim(d: &Did) -> IdentityClaim {
@@ -218,18 +346,34 @@ mod tests {
     fn create_attestation_fields() {
         let attester = did("did:exo:attester");
         let target = did("did:exo:target");
-        let att = create_attestation(
+        let (public_key, secret_key) = keypair(7);
+        let created_ms = 1_000_000;
+        let signature = signed_attestation_signature(
             &attester,
             &target,
-            AttestationType::Identity,
+            &AttestationType::Identity,
             None,
-            hash(b"dag"),
-            1_000_000,
+            created_ms,
+            &secret_key,
         );
+        let att = create_attestation(CreateAttestationInput {
+            attester_did: &attester,
+            target_did: &target,
+            attestation_type: AttestationType::Identity,
+            message_hash: None,
+            dag_node_hash: hash(b"dag"),
+            created_ms,
+            attester_public_key: public_key,
+            signature: signature.clone(),
+        })
+        .expect("attestation");
         assert_eq!(att.attester_did.as_str(), attester.as_str());
         assert_eq!(att.target_did.as_str(), target.as_str());
         assert_eq!(att.attestation_type, AttestationType::Identity);
         assert_eq!(att.created_ms, 1_000_000);
+        assert_eq!(att.attester_public_key, public_key);
+        assert_eq!(att.signature, signature);
+        assert_eq!(att.attestation_id.len(), 64);
     }
 
     // ---- build_target_claim ----
@@ -238,20 +382,190 @@ mod tests {
     fn build_target_claim_is_verified_peer_attestation() {
         let attester = did("did:exo:attester");
         let target = did("did:exo:target");
-        let att = create_attestation(
+        let (public_key, secret_key) = keypair(9);
+        let signature = signed_attestation_signature(
             &attester,
             &target,
-            AttestationType::Trustworthy,
+            &AttestationType::Trustworthy,
             None,
-            hash(b"dag"),
             500,
+            &secret_key,
         );
+        let att = create_attestation(CreateAttestationInput {
+            attester_did: &attester,
+            target_did: &target,
+            attestation_type: AttestationType::Trustworthy,
+            message_hash: None,
+            dag_node_hash: hash(b"dag"),
+            created_ms: 500,
+            attester_public_key: public_key,
+            signature: signature.clone(),
+        })
+        .expect("attestation");
         let claim = build_target_claim(&att, hash(b"dag2"), 600);
         assert_eq!(claim.subject_did.as_str(), target.as_str());
         assert_eq!(claim.status, ClaimStatus::Verified);
+        assert_eq!(claim.signature, signature);
         assert!(matches!(
             claim.claim_type,
             ClaimType::PeerAttestation { .. }
+        ));
+    }
+
+    #[test]
+    fn attestation_signing_payload_is_deterministic_and_domain_separated() {
+        let attester = did("did:exo:attester");
+        let target = did("did:exo:target");
+        let payload_a =
+            attestation_signing_payload(&attester, &target, &AttestationType::Identity, None, 42)
+                .expect("payload");
+        let payload_b =
+            attestation_signing_payload(&attester, &target, &AttestationType::Identity, None, 42)
+                .expect("payload");
+        let replay_payload = attestation_signing_payload(
+            &attester,
+            &did("did:exo:other-target"),
+            &AttestationType::Identity,
+            None,
+            42,
+        )
+        .expect("payload");
+
+        assert_eq!(payload_a, payload_b);
+        assert_ne!(payload_a, replay_payload);
+        assert!(
+            payload_a
+                .windows(b"exo.zerodentity.attestation.v1".len())
+                .any(|w| w == b"exo.zerodentity.attestation.v1")
+        );
+    }
+
+    #[test]
+    fn verify_attestation_signature_accepts_valid_signature() {
+        let attester = did("did:exo:attester");
+        let target = did("did:exo:target");
+        let message_hash = hash(b"statement");
+        let (public_key, secret_key) = keypair(11);
+        let signature = signed_attestation_signature(
+            &attester,
+            &target,
+            &AttestationType::Professional,
+            Some(&message_hash),
+            1234,
+            &secret_key,
+        );
+
+        assert!(verify_attestation_signature(
+            &attester,
+            &target,
+            &AttestationType::Professional,
+            Some(&message_hash),
+            1234,
+            &public_key,
+            &signature
+        ));
+    }
+
+    #[test]
+    fn verify_attestation_signature_rejects_empty_and_zero_signatures() {
+        let attester = did("did:exo:attester");
+        let target = did("did:exo:target");
+        let (public_key, _) = keypair(13);
+
+        assert!(!verify_attestation_signature(
+            &attester,
+            &target,
+            &AttestationType::Identity,
+            None,
+            1234,
+            &public_key,
+            &Signature::Empty
+        ));
+        assert!(!verify_attestation_signature(
+            &attester,
+            &target,
+            &AttestationType::Identity,
+            None,
+            1234,
+            &public_key,
+            &Signature::from_bytes([0u8; 64])
+        ));
+    }
+
+    #[test]
+    fn verify_attestation_signature_rejects_wrong_key() {
+        let attester = did("did:exo:attester");
+        let target = did("did:exo:target");
+        let (_, secret_key) = keypair(15);
+        let (wrong_public_key, _) = keypair(16);
+        let signature = signed_attestation_signature(
+            &attester,
+            &target,
+            &AttestationType::Identity,
+            None,
+            1234,
+            &secret_key,
+        );
+
+        assert!(!verify_attestation_signature(
+            &attester,
+            &target,
+            &AttestationType::Identity,
+            None,
+            1234,
+            &wrong_public_key,
+            &signature
+        ));
+    }
+
+    #[test]
+    fn verify_attestation_signature_rejects_tampered_payload() {
+        let attester = did("did:exo:attester");
+        let target = did("did:exo:target");
+        let (public_key, secret_key) = keypair(17);
+        let signature = signed_attestation_signature(
+            &attester,
+            &target,
+            &AttestationType::Identity,
+            None,
+            1234,
+            &secret_key,
+        );
+
+        assert!(!verify_attestation_signature(
+            &attester,
+            &target,
+            &AttestationType::Trustworthy,
+            None,
+            1234,
+            &public_key,
+            &signature
+        ));
+    }
+
+    #[test]
+    fn verify_attestation_signature_rejects_replay_to_other_target() {
+        let attester = did("did:exo:attester");
+        let target = did("did:exo:target");
+        let replay_target = did("did:exo:replay-target");
+        let (public_key, secret_key) = keypair(19);
+        let signature = signed_attestation_signature(
+            &attester,
+            &target,
+            &AttestationType::Identity,
+            None,
+            1234,
+            &secret_key,
+        );
+
+        assert!(!verify_attestation_signature(
+            &attester,
+            &replay_target,
+            &AttestationType::Identity,
+            None,
+            1234,
+            &public_key,
+            &signature
         ));
     }
 }

--- a/crates/exo-node/src/zerodentity/tests.rs
+++ b/crates/exo-node/src/zerodentity/tests.rs
@@ -14,7 +14,10 @@ mod tests {
         body::Body,
         http::{Request, StatusCode, header},
     };
-    use exo_core::types::{Did, Hash256, Signature};
+    use exo_core::{
+        crypto,
+        types::{Did, Hash256, PublicKey, SecretKey, Signature},
+    };
     use rand::{SeedableRng, rngs::StdRng};
     use serde_json::Value;
     use tower::ServiceExt;
@@ -23,9 +26,11 @@ mod tests {
         ClaimStatus, ClaimType, IdentityClaim, IdentitySession, OTP_MAX_ATTEMPTS, OtpChallenge,
         OtpChannel, OtpState, PolarAxes, ZerodentityScore,
         api::{ApiState, zerodentity_api_router},
+        attestation::attestation_signing_payload,
         onboarding::{OnboardingState, onboarding_router},
         scoring::compute_symmetry,
         store::{SharedZerodentityStore, ZerodentityStore, new_shared_store},
+        types::AttestationType,
     };
 
     // -----------------------------------------------------------------------
@@ -42,6 +47,39 @@ mod tests {
 
     fn seeded_rng(seed: u64) -> StdRng {
         StdRng::seed_from_u64(seed)
+    }
+
+    fn keypair(seed: u8) -> (PublicKey, SecretKey) {
+        let pair = crypto::KeyPair::from_secret_bytes([seed; 32]).unwrap();
+        (*pair.public_key(), pair.secret_key().clone())
+    }
+
+    fn signed_attest_body(
+        attester: &Did,
+        target: &Did,
+        attestation_type: AttestationType,
+        message_hash: Option<Hash256>,
+        created_ms: u64,
+        public_key: &PublicKey,
+        secret_key: &SecretKey,
+    ) -> serde_json::Value {
+        let payload = attestation_signing_payload(
+            attester,
+            target,
+            &attestation_type,
+            message_hash.as_ref(),
+            created_ms,
+        )
+        .unwrap();
+        let signature = crypto::sign(&payload, secret_key);
+        serde_json::json!({
+            "target_did": target.as_str(),
+            "attestation_type": attestation_type.to_string(),
+            "message_hash": message_hash.map(|h| hex::encode(h.as_bytes())),
+            "created_ms": created_ms,
+            "attester_public_key": hex::encode(public_key.as_bytes()),
+            "signature": hex::encode(signature.as_bytes())
+        })
     }
 
     fn make_claim(did: &Did, ct: ClaimType, status: ClaimStatus, ms: u64) -> IdentityClaim {
@@ -1092,12 +1130,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn attest_valid_creates_attestation_201() {
+    async fn attest_unsigned_body_returns_400() {
         let store = new_shared_store();
         let app = api_app(store.clone());
-        let attester = td("attest-ok-a");
-        let target = td("attest-ok-b");
-        let token = "attest-ok-token";
+        let attester = td("attest-unsigned-a");
+        let target = td("attest-unsigned-b");
+        let token = "attest-unsigned-token";
 
         {
             let mut s = store.lock().unwrap();
@@ -1120,6 +1158,83 @@ mod tests {
             }),
         )
         .await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn attest_wrong_public_key_returns_400() {
+        let store = new_shared_store();
+        let app = api_app(store.clone());
+        let attester = td("attest-wrong-key-a");
+        let target = td("attest-wrong-key-b");
+        let token = "attest-wrong-key-token";
+        let (public_key, _) = keypair(45);
+        let (_, signing_key) = keypair(46);
+
+        {
+            let mut s = store.lock().unwrap();
+            s.insert_claim(
+                "e1",
+                &make_claim(&attester, ClaimType::Email, ClaimStatus::Verified, 1_000),
+            )
+            .unwrap();
+            s.insert_session(&make_session(&attester, token, 1_000_000))
+                .unwrap();
+        }
+
+        let resp = post_with_auth(
+            &app,
+            &format!("/api/v1/0dentity/{}/attest", attester.as_str()),
+            token,
+            signed_attest_body(
+                &attester,
+                &target,
+                AttestationType::Identity,
+                None,
+                1_236_000,
+                &public_key,
+                &signing_key,
+            ),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn attest_valid_creates_attestation_201() {
+        let store = new_shared_store();
+        let app = api_app(store.clone());
+        let attester = td("attest-ok-a");
+        let target = td("attest-ok-b");
+        let token = "attest-ok-token";
+        let (public_key, secret_key) = keypair(41);
+
+        {
+            let mut s = store.lock().unwrap();
+            s.insert_claim(
+                "e1",
+                &make_claim(&attester, ClaimType::Email, ClaimStatus::Verified, 1_000),
+            )
+            .unwrap();
+            s.insert_session(&make_session(&attester, token, 1_000_000))
+                .unwrap();
+        }
+
+        let resp = post_with_auth(
+            &app,
+            &format!("/api/v1/0dentity/{}/attest", attester.as_str()),
+            token,
+            signed_attest_body(
+                &attester,
+                &target,
+                AttestationType::Identity,
+                None,
+                1_234_000,
+                &public_key,
+                &secret_key,
+            ),
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::CREATED);
         let body = body_json(resp).await;
         assert!(
@@ -1136,6 +1251,7 @@ mod tests {
         let app = api_app(store.clone());
         let did = td("attest-self");
         let token = "attest-self-token";
+        let (public_key, secret_key) = keypair(43);
 
         {
             let mut s = store.lock().unwrap();
@@ -1152,10 +1268,15 @@ mod tests {
             &app,
             &format!("/api/v1/0dentity/{}/attest", did.as_str()),
             token,
-            serde_json::json!({
-                "target_did": did.as_str(),
-                "attestation_type": "Identity"
-            }),
+            signed_attest_body(
+                &did,
+                &did,
+                AttestationType::Identity,
+                None,
+                1_235_000,
+                &public_key,
+                &secret_key,
+            ),
         )
         .await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);

--- a/crates/exo-node/src/zerodentity/types.rs
+++ b/crates/exo-node/src/zerodentity/types.rs
@@ -9,7 +9,7 @@
 use std::{collections::BTreeMap, fmt};
 
 pub use exo_core::types::Signature;
-use exo_core::types::{Did, Hash256};
+use exo_core::types::{Did, Hash256, PublicKey};
 use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------
@@ -382,7 +382,7 @@ impl std::str::FromStr for AttestationType {
 /// Spec §7.2.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PeerAttestation {
-    /// Unique identifier for this attestation (UUID v4).
+    /// Deterministic BLAKE3 identifier for this signed attestation.
     pub attestation_id: String,
     /// The DID making the attestation.
     pub attester_did: Did,
@@ -394,6 +394,10 @@ pub struct PeerAttestation {
     pub message_hash: Option<Hash256>,
     /// When this attestation was created (epoch ms).
     pub created_ms: u64,
+    /// Ed25519 public key used to verify the attester's signature.
+    pub attester_public_key: PublicKey,
+    /// Attester signature over the canonical attestation payload.
+    pub signature: Signature,
     /// DAG node hash for this attestation.
     pub dag_node_hash: Hash256,
 }

--- a/docs/0DENTITY-APP-SPEC.md
+++ b/docs/0DENTITY-APP-SPEC.md
@@ -1616,16 +1616,22 @@ GET /api/v1/0dentity/:did/fingerprints
 
 POST /api/v1/0dentity/:did/attest
   Description: Attest/vouch for another identity (peer attestation).
-  Auth: Bearer session_token (attester must be verified)
+  Auth: Bearer session_token (attester must be verified).
+  Signature: Ed25519 over canonical CBOR tuple
+    ("exo.zerodentity.attestation.v1", attester_did, target_did,
+     attestation_type, message_hash, created_ms)
   Request body:
     {
       "target_did": "did:exo:...",
-      "attestation_type": "identity" | "competence" | "trustworthy",
-      "message_hash": "hex..."  // optional hash of attestation message
+      "attestation_type": "Identity" | "Professional" | "Trustworthy" | "Character",
+      "message_hash": "32-byte hex...",  // optional hash of attestation message
+      "created_ms": 1743724800000,
+      "attester_public_key": "32-byte Ed25519 public key hex",
+      "signature": "64-byte Ed25519 signature hex"
     }
   Response 201:
     {
-      "attestation_id": "uuid",
+      "attestation_id": "deterministic blake3 hex",
       "receipt_hash": "hex...",
       "attester_score_impact": { "network_reputation": "+3" },
       "target_score_impact": { "network_reputation": "+5" }
@@ -1890,6 +1896,8 @@ CREATE TABLE IF NOT EXISTS peer_attestations (
     attestation_type TEXT NOT NULL,
     message_hash    BLOB,
     created_ms      INTEGER NOT NULL,
+    attester_public_key BLOB NOT NULL,
+    signature       BLOB NOT NULL,
     dag_node_hash   BLOB NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_attest_target ON peer_attestations(target_did);


### PR DESCRIPTION
## Summary
- Adds canonical CBOR Ed25519 signing payloads for 0dentity peer attestations with domain tag `exo.zerodentity.attestation.v1`.
- Requires `created_ms`, `attester_public_key`, and `signature` on `POST /api/v1/0dentity/:did/attest`.
- Stores attester public key and signature on `PeerAttestation`; derived target peer-attestation claims now carry the attester signature instead of `Signature::Empty`.
- Rejects malformed `message_hash` values instead of silently dropping short hashes.
- Updates local 0DENTITY spec and ExoForge registry text for the signed attestation contract.

## Regression coverage
- Empty signature rejected.
- All-zero signature rejected.
- Wrong key rejected.
- Tampered payload rejected.
- Signature replay to another target rejected.
- Unsigned API body rejected.
- API wrong public key rejected.

## Verification
- cargo fmt --all
- cargo test -p exo-node attest
- cargo test -p exo-node zerodentity
- cargo test -p exo-node
- cargo build -p exo-node
- cargo clippy -p exo-node --bin exochain -- -D warnings

## Gate note
`cargo clippy -p exo-node --all-targets -- -D warnings` still fails on the existing test-only unwrap/expect backlog; after this branch's local test-module allowance, a filtered rerun reports 144 errors and no `zerodentity/attestation` entries.