### PR TITLE
fix(exo-node): sign 0dentity trust receipts

### DIFF
--- a/crates/exo-core/src/types.rs
+++ b/crates/exo-core/src/types.rs
@@ -12,8 +12,10 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use zeroize::Zeroize;
 
-use crate::crypto;
-use crate::error::{ExoError, Result};
+use crate::{
+    crypto,
+    error::{ExoError, Result},
+};
 
 // ---------------------------------------------------------------------------
 // DeterministicMap

--- a/crates/exo-core/src/types.rs
+++ b/crates/exo-core/src/types.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use zeroize::Zeroize;
 
+use crate::crypto;
 use crate::error::{ExoError, Result};
 
 // ---------------------------------------------------------------------------
@@ -883,7 +884,47 @@ pub struct TrustReceipt {
     pub challenge_reference: Option<Hash256>,
 }
 
+const TRUST_RECEIPT_SIGNING_DOMAIN: &str = "exo.trust_receipt.v1";
+
+#[derive(Serialize)]
+struct TrustReceiptSigningPayload<'a> {
+    domain: &'static str,
+    actor_did: &'a str,
+    authority_chain_hash: &'a Hash256,
+    consent_reference: Option<&'a Hash256>,
+    action_type: &'a str,
+    action_hash: &'a Hash256,
+    outcome: &'a ReceiptOutcome,
+    timestamp: &'a Timestamp,
+}
+
 impl TrustReceipt {
+    fn payload_for_signature(
+        actor_did: &Did,
+        authority_chain_hash: &Hash256,
+        consent_reference: Option<&Hash256>,
+        action_type: &str,
+        action_hash: &Hash256,
+        outcome: &ReceiptOutcome,
+        timestamp: &Timestamp,
+    ) -> Vec<u8> {
+        let payload = TrustReceiptSigningPayload {
+            domain: TRUST_RECEIPT_SIGNING_DOMAIN,
+            actor_did: actor_did.as_str(),
+            authority_chain_hash,
+            consent_reference,
+            action_type,
+            action_hash,
+            outcome,
+            timestamp,
+        };
+        let mut encoded = Vec::new();
+        if ciborium::into_writer(&payload, &mut encoded).is_err() {
+            panic!("TrustReceipt signing payload CBOR serialization failed");
+        }
+        encoded
+    }
+
     /// Create a new trust receipt and compute its content-addressed hash.
     ///
     /// The `sign_fn` is called with the canonical signable payload to
@@ -899,18 +940,15 @@ impl TrustReceipt {
         timestamp: Timestamp,
         sign_fn: &dyn Fn(&[u8]) -> Signature,
     ) -> Self {
-        // Build the signable payload: canonical concatenation of all fields.
-        let mut payload = Vec::new();
-        payload.extend_from_slice(actor_did.to_string().as_bytes());
-        payload.extend_from_slice(&authority_chain_hash.0);
-        if let Some(ref cr) = consent_reference {
-            payload.extend_from_slice(&cr.0);
-        }
-        payload.extend_from_slice(action_type.as_bytes());
-        payload.extend_from_slice(&action_hash.0);
-        payload.extend_from_slice(outcome.to_string().as_bytes());
-        payload.extend_from_slice(&timestamp.physical_ms.to_le_bytes());
-        payload.extend_from_slice(&timestamp.logical.to_le_bytes());
+        let payload = Self::payload_for_signature(
+            &actor_did,
+            &authority_chain_hash,
+            consent_reference.as_ref(),
+            &action_type,
+            &action_hash,
+            &outcome,
+            &timestamp,
+        );
 
         let signature = sign_fn(&payload);
         let receipt_hash = Hash256::digest(&payload);
@@ -932,19 +970,31 @@ impl TrustReceipt {
     /// Verify that the receipt hash matches the content.
     #[must_use]
     pub fn verify_hash(&self) -> bool {
-        let mut payload = Vec::new();
-        payload.extend_from_slice(self.actor_did.to_string().as_bytes());
-        payload.extend_from_slice(&self.authority_chain_hash.0);
-        if let Some(ref cr) = self.consent_reference {
-            payload.extend_from_slice(&cr.0);
-        }
-        payload.extend_from_slice(self.action_type.as_bytes());
-        payload.extend_from_slice(&self.action_hash.0);
-        payload.extend_from_slice(self.outcome.to_string().as_bytes());
-        payload.extend_from_slice(&self.timestamp.physical_ms.to_le_bytes());
-        payload.extend_from_slice(&self.timestamp.logical.to_le_bytes());
-
+        let payload = self.signing_payload();
         Hash256::digest(&payload) == self.receipt_hash
+    }
+
+    /// Return the exact payload signed by the actor for this receipt.
+    #[must_use]
+    pub fn signing_payload(&self) -> Vec<u8> {
+        Self::payload_for_signature(
+            &self.actor_did,
+            &self.authority_chain_hash,
+            self.consent_reference.as_ref(),
+            &self.action_type,
+            &self.action_hash,
+            &self.outcome,
+            &self.timestamp,
+        )
+    }
+
+    /// Verify the actor signature over this receipt's signable payload.
+    #[must_use]
+    pub fn verify_signature(&self, public_key: &PublicKey) -> bool {
+        if self.signature.is_empty() {
+            return false;
+        }
+        crypto::verify(&self.signing_payload(), &self.signature, public_key)
     }
 }
 
@@ -1560,6 +1610,93 @@ mod tests {
         assert_eq!(receipt.action_type, "governance.propose");
         assert_eq!(receipt.outcome, ReceiptOutcome::Executed);
         assert!(receipt.challenge_reference.is_none());
+    }
+
+    #[derive(serde::Deserialize)]
+    struct DecodedTrustReceiptSigningPayload {
+        domain: String,
+        actor_did: String,
+        authority_chain_hash: Hash256,
+        consent_reference: Option<Hash256>,
+        action_type: String,
+        action_hash: Hash256,
+        outcome: ReceiptOutcome,
+        timestamp: Timestamp,
+    }
+
+    #[test]
+    fn trust_receipt_signing_payload_is_domain_tagged_cbor() {
+        let authority_chain_hash = Hash256::digest(b"authority-chain");
+        let consent_reference = Hash256::digest(b"consent-ref");
+        let action_hash = Hash256::digest(b"action-payload");
+        let timestamp = Timestamp::new(1_700_000_000_123, 7);
+        let receipt = TrustReceipt::new(
+            Did::new("did:exo:actor-cbor").unwrap(),
+            authority_chain_hash,
+            Some(consent_reference),
+            "governance.propose".into(),
+            action_hash,
+            ReceiptOutcome::Executed,
+            timestamp,
+            &test_sign_fn,
+        );
+
+        let payload: DecodedTrustReceiptSigningPayload =
+            ciborium::from_reader(&receipt.signing_payload()[..]).expect("decode payload");
+        assert_eq!(payload.domain, TRUST_RECEIPT_SIGNING_DOMAIN);
+        assert_eq!(payload.actor_did, "did:exo:actor-cbor");
+        assert_eq!(payload.authority_chain_hash, authority_chain_hash);
+        assert_eq!(payload.consent_reference, Some(consent_reference));
+        assert_eq!(payload.action_type, "governance.propose");
+        assert_eq!(payload.action_hash, action_hash);
+        assert_eq!(payload.outcome, ReceiptOutcome::Executed);
+        assert_eq!(payload.timestamp, timestamp);
+    }
+
+    #[test]
+    fn trust_receipt_signature_verifies_with_actor_key() {
+        let keypair = crate::crypto::KeyPair::from_secret_bytes([42u8; 32]).unwrap();
+        let public_key = *keypair.public_key();
+        let receipt = TrustReceipt::new(
+            Did::new("did:exo:actor-signer").unwrap(),
+            Hash256::digest(b"authority-chain"),
+            None,
+            "governance.vote".into(),
+            Hash256::digest(b"vote-payload"),
+            ReceiptOutcome::Executed,
+            Timestamp::new(1_700_000_003_000, 0),
+            &|payload| keypair.sign(payload),
+        );
+
+        assert!(receipt.verify_signature(&public_key));
+    }
+
+    #[test]
+    fn trust_receipt_signature_rejects_empty_wrong_key_and_tamper() {
+        let keypair = crate::crypto::KeyPair::from_secret_bytes([43u8; 32]).unwrap();
+        let wrong_keypair = crate::crypto::KeyPair::from_secret_bytes([44u8; 32]).unwrap();
+        let public_key = *keypair.public_key();
+        let wrong_public_key = *wrong_keypair.public_key();
+        let mut receipt = TrustReceipt::new(
+            Did::new("did:exo:actor-signer").unwrap(),
+            Hash256::digest(b"authority-chain"),
+            None,
+            "governance.vote".into(),
+            Hash256::digest(b"vote-payload"),
+            ReceiptOutcome::Executed,
+            Timestamp::new(1_700_000_003_000, 0),
+            &|payload| keypair.sign(payload),
+        );
+
+        assert!(!receipt.verify_signature(&wrong_public_key));
+
+        let signature = receipt.signature.clone();
+        receipt.signature = Signature::Empty;
+        assert!(!receipt.verify_signature(&public_key));
+
+        receipt.signature = signature;
+        receipt.action_type = "governance.escalate".into();
+        assert!(!receipt.verify_signature(&public_key));
     }
 
     #[test]

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -165,7 +165,12 @@ async fn start_node(
     tracing::info!(height, "DAG store opened");
 
     // Open 0dentity store (shares the same dag.db, applies zerodentity migration).
-    let zerodentity_store = zerodentity::store::ZerodentityStore::open(data_dir)?;
+    let mut zerodentity_store = zerodentity::store::ZerodentityStore::open(data_dir)?;
+    let zd_receipt_signer: zerodentity::store::ReceiptSigner = {
+        let identity = identity::load_or_create(data_dir)?;
+        Arc::new(move |payload: &[u8]| identity.sign(payload))
+    };
+    zerodentity_store.set_receipt_signer(node_identity.did.clone(), zd_receipt_signer);
     let zerodentity_store = std::sync::Arc::new(Mutex::new(zerodentity_store));
     tracing::info!("0dentity store ready");
 

--- a/crates/exo-node/src/zerodentity/api.rs
+++ b/crates/exo-node/src/zerodentity/api.rs
@@ -743,7 +743,10 @@ pub fn zerodentity_api_router(state: ApiState) -> Router {
 #[allow(clippy::unwrap_used, clippy::needless_borrows_for_generic_args)]
 mod tests {
     use axum::{body::Body, http::Request};
-    use exo_core::types::{Did, Hash256, Signature};
+    use exo_core::{
+        crypto::KeyPair,
+        types::{Did, Hash256, Signature},
+    };
     use tower::ServiceExt;
 
     use super::*;
@@ -752,16 +755,24 @@ mod tests {
         types::{ClaimStatus, ClaimType, IdentityClaim, IdentitySession},
     };
 
+    fn test_store() -> ZerodentityStore {
+        let keypair = KeyPair::from_secret_bytes([31u8; 32]).unwrap();
+        let signer = Arc::new(move |payload: &[u8]| keypair.sign(payload));
+        let mut store = ZerodentityStore::new();
+        store.set_receipt_signer(Did::new("did:exo:test-node").unwrap(), signer);
+        store
+    }
+
     fn make_state() -> ApiState {
         ApiState {
-            store: Arc::new(Mutex::new(ZerodentityStore::new())),
+            store: Arc::new(Mutex::new(test_store())),
             node_did: Did::new("did:exo:test-node").unwrap(),
             started_ms: 1_700_000_000_000,
         }
     }
 
     fn make_state_with_session(token: &str, did_str: &str) -> ApiState {
-        let mut store = ZerodentityStore::new();
+        let mut store = test_store();
         let did = Did::new(did_str).unwrap();
         let session = IdentitySession {
             session_token: token.to_owned(),
@@ -780,7 +791,7 @@ mod tests {
     }
 
     fn make_state_with_session_and_claim(token: &str, did_str: &str) -> ApiState {
-        let mut store = ZerodentityStore::new();
+        let mut store = test_store();
         let did = Did::new(did_str).unwrap();
         let session = IdentitySession {
             session_token: token.to_owned(),

--- a/crates/exo-node/src/zerodentity/store.rs
+++ b/crates/exo-node/src/zerodentity/store.rs
@@ -13,6 +13,7 @@
 
 use std::{
     collections::BTreeMap,
+    fmt,
     path::Path,
     sync::{Arc, Mutex},
 };
@@ -24,6 +25,30 @@ use super::types::{
     BehavioralSample, ClaimStatus, DeviceFingerprint, IdentityClaim, IdentitySession, OtpChallenge,
     PeerAttestation, ZerodentityScore,
 };
+
+pub type ReceiptSigner = Arc<dyn Fn(&[u8]) -> Signature + Send + Sync>;
+
+#[derive(Clone)]
+pub struct ReceiptSigningContext {
+    actor_did: Did,
+    signer: ReceiptSigner,
+}
+
+impl ReceiptSigningContext {
+    #[must_use]
+    pub fn new(actor_did: Did, signer: ReceiptSigner) -> Self {
+        Self { actor_did, signer }
+    }
+}
+
+impl fmt::Debug for ReceiptSigningContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReceiptSigningContext")
+            .field("actor_did", &self.actor_did)
+            .field("signer", &"<receipt signer>")
+            .finish()
+    }
+}
 
 // ---------------------------------------------------------------------------
 // ZerodentityStore
@@ -68,6 +93,8 @@ pub struct ZerodentityStore {
     dag_nodes: Vec<DagNode>,
     /// Trust receipts emitted for claim verification events (APE-72).
     trust_receipts: Vec<TrustReceipt>,
+    /// Node identity signer used to emit verifiable trust receipts.
+    receipt_signing: Option<ReceiptSigningContext>,
 }
 
 impl ZerodentityStore {
@@ -77,6 +104,11 @@ impl ZerodentityStore {
         Self::default()
     }
 
+    /// Configure the node identity used to sign store-emitted trust receipts.
+    pub fn set_receipt_signer(&mut self, actor_did: Did, signer: ReceiptSigner) {
+        self.receipt_signing = Some(ReceiptSigningContext::new(actor_did, signer));
+    }
+
     /// Open the 0dentity store.
     ///
     /// In this in-memory implementation the `data_dir` argument is accepted but
@@ -84,6 +116,28 @@ impl ZerodentityStore {
     /// allows for future persistence scaling.
     pub fn open(_data_dir: &Path) -> anyhow::Result<Self> {
         Ok(Self::new())
+    }
+
+    fn trust_receipt(
+        &self,
+        action_type: &str,
+        action_hash: Hash256,
+        outcome: ReceiptOutcome,
+        timestamp: Timestamp,
+    ) -> anyhow::Result<TrustReceipt> {
+        let Some(context) = &self.receipt_signing else {
+            anyhow::bail!("0dentity trust receipt signer is not configured");
+        };
+        Ok(TrustReceipt::new(
+            context.actor_did.clone(),
+            Hash256::ZERO,
+            None,
+            action_type.to_owned(),
+            action_hash,
+            outcome,
+            timestamp,
+            &*context.signer,
+        ))
     }
 
     // -----------------------------------------------------------------------
@@ -369,6 +423,18 @@ impl ZerodentityStore {
     ///   `self.trust_receipts` when `claim.status == Verified`.
     #[allow(dead_code)]
     pub fn save_claim(&mut self, claim_id: &str, claim: &IdentityClaim) -> anyhow::Result<()> {
+        let receipt = if claim.status == ClaimStatus::Verified {
+            let verified_ms = claim.verified_ms.unwrap_or(claim.created_ms);
+            Some(self.trust_receipt(
+                "zerodentity.claim_verified",
+                claim.claim_hash,
+                ReceiptOutcome::Executed,
+                Timestamp::new(verified_ms, 0),
+            )?)
+        } else {
+            None
+        };
+
         self.insert_claim(claim_id, claim)?;
 
         // Record DAG node for this claim.
@@ -383,18 +449,7 @@ impl ZerodentityStore {
         self.dag_nodes.push(node);
 
         // Emit TrustReceipt for verified claims.
-        if claim.status == ClaimStatus::Verified {
-            let verified_ms = claim.verified_ms.unwrap_or(claim.created_ms);
-            let receipt = TrustReceipt::new(
-                claim.subject_did.clone(),
-                Hash256::ZERO,
-                None,
-                "zerodentity.claim_verified".to_string(),
-                claim.claim_hash,
-                ReceiptOutcome::Executed,
-                Timestamp::new(verified_ms, 0),
-                &|_payload| Signature::Empty,
-            );
+        if let Some(receipt) = receipt {
             self.trust_receipts.push(receipt);
         }
 
@@ -450,6 +505,10 @@ impl ZerodentityStore {
     ///
     /// Returns the number of claims revoked.
     pub fn erase_did(&mut self, did: &Did) -> anyhow::Result<u32> {
+        if self.receipt_signing.is_none() {
+            anyhow::bail!("0dentity trust receipt signer is not configured");
+        }
+
         let key = did.as_str().to_owned();
         let mut revoked_count = 0u32;
 
@@ -492,16 +551,12 @@ impl ZerodentityStore {
 
         // 7. Emit erasure receipt
         let now_ms = crate::sentinels::now_ms();
-        let receipt = TrustReceipt::new(
-            did.clone(),
-            Hash256::ZERO,
-            None,
-            "zerodentity.identity_erased".to_string(),
+        let receipt = self.trust_receipt(
+            "zerodentity.identity_erased",
             Hash256::digest(format!("erase:{}", did.as_str()).as_bytes()),
             ReceiptOutcome::Executed,
             Timestamp::new(now_ms, 0),
-            &|_payload| Signature::Empty,
-        );
+        )?;
         self.trust_receipts.push(receipt);
 
         Ok(revoked_count)
@@ -549,7 +604,12 @@ pub fn new_shared_store() -> SharedZerodentityStore {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use exo_core::types::{Did, Hash256, Signature};
+    use std::sync::Arc;
+
+    use exo_core::{
+        crypto::KeyPair,
+        types::{Did, Hash256, PublicKey, Signature},
+    };
 
     use super::*;
     use crate::zerodentity::types::{
@@ -562,6 +622,16 @@ mod tests {
 
     fn h() -> Hash256 {
         Hash256::digest(b"t")
+    }
+
+    fn signed_store(seed: u8) -> (ZerodentityStore, Did, PublicKey) {
+        let keypair = KeyPair::from_secret_bytes([seed; 32]).unwrap();
+        let public_key = *keypair.public_key();
+        let actor_did = did(&format!("did:exo:receipt-node-{seed}"));
+        let signer = Arc::new(move |payload: &[u8]| keypair.sign(payload));
+        let mut store = ZerodentityStore::new();
+        store.set_receipt_signer(actor_did.clone(), signer);
+        (store, actor_did, public_key)
     }
 
     fn score_for(subject_did: Did, composite: u32) -> ZerodentityScore {
@@ -697,7 +767,7 @@ mod tests {
 
     #[test]
     fn save_claim_stores_claim_and_dag_node() {
-        let mut store = ZerodentityStore::new();
+        let (mut store, _, _) = signed_store(3);
         let d = did("did:exo:grace");
         let c = claim(&d, ClaimType::Email);
         store.save_claim("apg-001", &c).unwrap();
@@ -713,16 +783,33 @@ mod tests {
 
     #[test]
     fn save_verified_claim_emits_trust_receipt() {
-        let mut store = ZerodentityStore::new();
+        let (mut store, node_did, node_public_key) = signed_store(5);
         let d = did("did:exo:heidi");
         let c = claim(&d, ClaimType::Phone); // claim() sets status=Verified
         store.save_claim("apg-002", &c).unwrap();
 
         assert_eq!(store.trust_receipts().len(), 1);
         let r = &store.trust_receipts()[0];
-        assert_eq!(r.actor_did, d);
+        assert_eq!(r.actor_did, node_did);
         assert_eq!(r.action_hash, c.claim_hash);
         assert_eq!(r.action_type, "zerodentity.claim_verified");
+        assert!(r.verify_signature(&node_public_key));
+    }
+
+    #[test]
+    fn save_verified_claim_emits_node_signed_trust_receipt() {
+        let (mut store, node_did, node_public_key) = signed_store(11);
+        let d = did("did:exo:signed-claim");
+        let c = claim(&d, ClaimType::Phone);
+        store.save_claim("apg-signed-001", &c).unwrap();
+
+        let receipt = &store.trust_receipts()[0];
+        assert_eq!(receipt.actor_did, node_did);
+        assert_eq!(receipt.action_hash, c.claim_hash);
+        assert_eq!(receipt.action_type, "zerodentity.claim_verified");
+        assert!(!receipt.signature.is_empty());
+        assert!(receipt.verify_hash());
+        assert!(receipt.verify_signature(&node_public_key));
     }
 
     #[test]
@@ -773,7 +860,7 @@ mod tests {
     fn erase_did_revokes_claims_and_zeroes_scores() {
         use crate::zerodentity::types::IdentitySession;
 
-        let mut store = ZerodentityStore::new();
+        let (mut store, _, _) = signed_store(7);
         let d = did("did:exo:eraseme");
 
         // Set up: claim, score, session
@@ -820,6 +907,26 @@ mod tests {
     }
 
     #[test]
+    fn erase_did_emits_node_signed_erasure_receipt() {
+        let (mut store, node_did, node_public_key) = signed_store(17);
+        let d = did("did:exo:signed-erase");
+        store.put_claim(claim(&d, ClaimType::Email));
+
+        let revoked = store.erase_did(&d).unwrap();
+        assert_eq!(revoked, 1);
+
+        let receipt = store
+            .trust_receipts()
+            .iter()
+            .find(|r| r.action_type == "zerodentity.identity_erased")
+            .unwrap();
+        assert_eq!(receipt.actor_did, node_did);
+        assert!(!receipt.signature.is_empty());
+        assert!(receipt.verify_hash());
+        assert!(receipt.verify_signature(&node_public_key));
+    }
+
+    #[test]
     fn erase_did_removes_fingerprints_and_behavioral() {
         use std::collections::BTreeMap;
 
@@ -827,7 +934,7 @@ mod tests {
             BehavioralSample, BehavioralSignalType, DeviceFingerprint,
         };
 
-        let mut store = ZerodentityStore::new();
+        let (mut store, _, _) = signed_store(19);
         let d = did("did:exo:fptest");
 
         store.put_fingerprint(
@@ -860,7 +967,7 @@ mod tests {
 
     #[test]
     fn erase_did_tombstones_dag_nodes() {
-        let mut store = ZerodentityStore::new();
+        let (mut store, _, _) = signed_store(23);
         let d = did("did:exo:dagtest");
         let c = claim(&d, ClaimType::Email);
         store.save_claim("dag-001", &c).unwrap();

--- a/crates/exo-node/src/zerodentity/tests.rs
+++ b/crates/exo-node/src/zerodentity/tests.rs
@@ -9,12 +9,17 @@
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::module_inception)]
 mod tests {
+    use std::sync::Arc;
+
     use axum::{
         Router,
         body::Body,
         http::{Request, StatusCode, header},
     };
-    use exo_core::types::{Did, Hash256, Signature};
+    use exo_core::{
+        crypto::KeyPair,
+        types::{Did, Hash256, Signature},
+    };
     use rand::{SeedableRng, rngs::StdRng};
     use serde_json::Value;
     use tower::ServiceExt;
@@ -101,11 +106,21 @@ mod tests {
     }
 
     fn api_app(store: SharedZerodentityStore) -> Router {
+        configure_test_receipt_signer(&store);
         zerodentity_api_router(ApiState {
             store,
             node_did: Did::new("did:exo:test-node").unwrap(),
             started_ms: 1_700_000_000_000,
         })
+    }
+
+    fn configure_test_receipt_signer(store: &SharedZerodentityStore) {
+        let keypair = KeyPair::from_secret_bytes([37u8; 32]).unwrap();
+        let signer = Arc::new(move |payload: &[u8]| keypair.sign(payload));
+        store
+            .lock()
+            .unwrap()
+            .set_receipt_signer(td("test-node"), signer);
     }
 
     async fn post_json(app: &Router, uri: &str, body: Value) -> axum::response::Response {


### PR DESCRIPTION
## Summary
- add domain-tagged canonical CBOR signing payloads and signature verification for TrustReceipt
- wire the running node identity into ZerodentityStore as the 0dentity receipt signer
- replace claim_verified and identity_erased Signature::Empty receipt emissions with node-signed receipts
- add regression coverage for node-signed claim verification receipts, erasure receipts, empty signature rejection, wrong-key rejection, tamper rejection, and CBOR payload decoding

## Verification
- cargo fmt --all
- cargo fmt --all -- --check
- git diff --check
- cargo test -p exo-core
- cargo test -p exo-core trust_receipt
- cargo test -p exo-node node_signed
- cargo test -p exo-node zerodentity::store
- cargo test -p exo-node zerodentity
- cargo test -p exo-node
- cargo build -p exo-node
- cargo clippy -p exo-core --lib -- -D warnings
- cargo clippy -p exo-node --bin exochain -- -D warnings
- cargo clippy -p exo-node --all-targets --message-format=short -- -D warnings is still blocked by pre-existing test unwrap/expect lint debt; targeted scan shows no diagnostics in crates/exo-core/src/types.rs or the R4-touched exo-node files
