### PR TITLE
fix(exo-node): bind 0dentity sessions to public keys

### DIFF
--- a/crates/exo-node/src/zerodentity/api.rs
+++ b/crates/exo-node/src/zerodentity/api.rs
@@ -18,11 +18,15 @@ use std::{
 
 use axum::{
     Json, Router,
-    extract::{Path, Query, State},
+    body::Bytes,
+    extract::{OriginalUri, Path, Query, State},
     http::{HeaderMap, StatusCode},
     routing::{get, post},
 };
-use exo_core::types::{Did, Hash256};
+use exo_core::{
+    crypto,
+    types::{Did, Hash256},
+};
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -30,6 +34,7 @@ use super::{
         attester_score_impact, build_target_claim, create_attestation, target_score_impact,
         validate_attestation,
     },
+    session_auth::{public_key_from_session_bytes, request_signing_payload, signature_from_hex},
     store::ZerodentityStore,
     types::{AttestationType, IdentityClaim, ZerodentityScore},
 };
@@ -183,6 +188,115 @@ fn parse_did(did_str: &str) -> Result<Did, (StatusCode, Json<serde_json::Value>)
             Json(serde_json::json!({"error": "Invalid DID format"})),
         )
     })
+}
+
+fn json_error(
+    status: StatusCode,
+    error: impl Into<String>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    (status, Json(serde_json::json!({ "error": error.into() })))
+}
+
+fn path_and_query(uri: &axum::http::Uri) -> String {
+    uri.path_and_query()
+        .map_or_else(|| uri.path().to_owned(), |value| value.as_str().to_owned())
+}
+
+fn require_header<'a>(
+    headers: &'a HeaderMap,
+    name: &str,
+    missing: &str,
+) -> Result<&'a str, (StatusCode, Json<serde_json::Value>)> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .ok_or_else(|| json_error(StatusCode::UNAUTHORIZED, missing))
+}
+
+fn validate_nonce(nonce: &str) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
+    if nonce.is_empty() {
+        return Err(json_error(
+            StatusCode::BAD_REQUEST,
+            "X-Exo-Nonce is required",
+        ));
+    }
+    if nonce.len() > 128 || !nonce.bytes().all(|byte| byte.is_ascii_graphic()) {
+        return Err(json_error(
+            StatusCode::BAD_REQUEST,
+            "X-Exo-Nonce must be 1-128 visible ASCII bytes",
+        ));
+    }
+    Ok(())
+}
+
+fn verify_signed_write(
+    state: &ApiState,
+    headers: &HeaderMap,
+    expected_did: &Did,
+    method: &str,
+    path_and_query: &str,
+    body: &[u8],
+) -> Result<String, (StatusCode, Json<serde_json::Value>)> {
+    let token = extract_session_token(headers)
+        .ok_or_else(|| json_error(StatusCode::UNAUTHORIZED, "Bearer session token required"))?;
+
+    let mut store = state
+        .store
+        .lock()
+        .map_err(|_| json_error(StatusCode::INTERNAL_SERVER_ERROR, "lock poisoned"))?;
+    let session = store
+        .get_session(&token)
+        .map_err(|e| {
+            json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Store error: {e}"),
+            )
+        })?
+        .ok_or_else(|| json_error(StatusCode::UNAUTHORIZED, "Invalid or expired session"))?;
+
+    if session.subject_did.as_str() != expected_did.as_str() {
+        return Err(json_error(StatusCode::FORBIDDEN, "Access denied"));
+    }
+
+    let nonce = require_header(headers, "x-exo-nonce", "X-Exo-Nonce header required")?;
+    validate_nonce(nonce)?;
+    let signature_hex = require_header(headers, "x-exo-sig", "X-Exo-Sig header required")?;
+    let signature =
+        signature_from_hex(signature_hex).map_err(|e| json_error(StatusCode::BAD_REQUEST, e))?;
+    if signature.is_empty() {
+        return Err(json_error(
+            StatusCode::UNAUTHORIZED,
+            "X-Exo-Sig must not be empty",
+        ));
+    }
+
+    let public_key = public_key_from_session_bytes(&session.public_key)
+        .map_err(|e| json_error(StatusCode::UNAUTHORIZED, e))?;
+    let body_hash = Hash256::digest(body);
+    let payload = request_signing_payload(method, path_and_query, &token, nonce, &body_hash)
+        .map_err(|e| json_error(StatusCode::INTERNAL_SERVER_ERROR, e))?;
+
+    if !crypto::verify(&payload, &signature, &public_key) {
+        return Err(json_error(
+            StatusCode::UNAUTHORIZED,
+            "X-Exo-Sig verification failed",
+        ));
+    }
+
+    let nonce_is_new = store.consume_session_nonce(&token, nonce).map_err(|e| {
+        json_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Store error: {e}"),
+        )
+    })?;
+    if !nonce_is_new {
+        return Err(json_error(
+            StatusCode::CONFLICT,
+            "X-Exo-Nonce has already been used for this session",
+        ));
+    }
+
+    Ok(token)
 }
 
 fn hex_hash(h: &Hash256) -> String {
@@ -462,42 +576,26 @@ pub async fn list_fingerprints(
 /// `POST /api/v1/0dentity/:did/attest` — submit a peer attestation for a subject.
 pub async fn create_peer_attestation(
     State(state): State<ApiState>,
+    OriginalUri(uri): OriginalUri,
     Path(did_str): Path<String>,
     headers: HeaderMap,
-    Json(req): Json<AttestRequest>,
+    body: Bytes,
 ) -> Result<(StatusCode, Json<AttestResponse>), (StatusCode, Json<serde_json::Value>)> {
     let attester_did = parse_did(&did_str)?;
+    let req: AttestRequest = serde_json::from_slice(&body)
+        .map_err(|_| json_error(StatusCode::BAD_REQUEST, "Invalid JSON body"))?;
     let target_did = parse_did(&req.target_did)?;
     let now = now_ms();
 
-    // Auth required
-    let token = extract_session_token(&headers).ok_or_else(|| {
-        (
-            StatusCode::UNAUTHORIZED,
-            Json(serde_json::json!({"error": "Bearer session token required"})),
-        )
-    })?;
-
-    {
-        let store = state.store.lock().map_err(|_| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": "lock poisoned"})),
-            )
-        })?;
-        let session = store.get_session(&token).ok().flatten().ok_or_else(|| {
-            (
-                StatusCode::UNAUTHORIZED,
-                Json(serde_json::json!({"error": "Invalid or expired session"})),
-            )
-        })?;
-        if session.subject_did.as_str() != attester_did.as_str() {
-            return Err((
-                StatusCode::FORBIDDEN,
-                Json(serde_json::json!({"error": "Access denied"})),
-            ));
-        }
-    }
+    let request_path = path_and_query(&uri);
+    let _token = verify_signed_write(
+        &state,
+        &headers,
+        &attester_did,
+        "POST",
+        &request_path,
+        &body,
+    )?;
 
     let attestation_type = AttestationType::from_str(&req.attestation_type).map_err(|_| {
         (
@@ -652,39 +750,15 @@ pub struct ErasureResponse {
 /// - Emits an erasure TrustReceipt
 pub async fn delete_identity(
     State(state): State<ApiState>,
+    OriginalUri(uri): OriginalUri,
     Path(did_str): Path<String>,
     headers: HeaderMap,
+    body: Bytes,
 ) -> Result<Json<ErasureResponse>, (StatusCode, Json<serde_json::Value>)> {
     let did = parse_did(&did_str)?;
 
-    // Auth: session token required — must own the DID
-    let token = extract_session_token(&headers).ok_or_else(|| {
-        (
-            StatusCode::UNAUTHORIZED,
-            Json(serde_json::json!({"error": "Bearer session token required"})),
-        )
-    })?;
-
-    {
-        let store = state.store.lock().map_err(|_| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": "lock poisoned"})),
-            )
-        })?;
-        let session = store.get_session(&token).ok().flatten().ok_or_else(|| {
-            (
-                StatusCode::UNAUTHORIZED,
-                Json(serde_json::json!({"error": "Invalid or expired session"})),
-            )
-        })?;
-        if session.subject_did.as_str() != did.as_str() {
-            return Err((
-                StatusCode::FORBIDDEN,
-                Json(serde_json::json!({"error": "Access denied — can only erase own identity"})),
-            ));
-        }
-    }
+    let request_path = path_and_query(&uri);
+    let _token = verify_signed_write(&state, &headers, &did, "DELETE", &request_path, &body)?;
 
     let claims_revoked = {
         let mut store = state.store.lock().map_err(|_| {
@@ -743,7 +817,10 @@ pub fn zerodentity_api_router(state: ApiState) -> Router {
 #[allow(clippy::unwrap_used, clippy::needless_borrows_for_generic_args)]
 mod tests {
     use axum::{body::Body, http::Request};
-    use exo_core::types::{Did, Hash256, Signature};
+    use exo_core::{
+        crypto::KeyPair,
+        types::{Did, Hash256, Signature},
+    };
     use tower::ServiceExt;
 
     use super::*;
@@ -758,6 +835,10 @@ mod tests {
             node_did: Did::new("did:exo:test-node").unwrap(),
             started_ms: 1_700_000_000_000,
         }
+    }
+
+    fn test_keypair(seed: u8) -> KeyPair {
+        KeyPair::from_secret_bytes([seed; 32]).unwrap()
     }
 
     fn make_state_with_session(token: &str, did_str: &str) -> ApiState {
@@ -808,6 +889,108 @@ mod tests {
             node_did: Did::new("did:exo:test-node").unwrap(),
             started_ms: 1_700_000_000_000,
         }
+    }
+
+    fn make_state_with_signed_session_and_claim(
+        token: &str,
+        did_str: &str,
+        keypair: &KeyPair,
+    ) -> ApiState {
+        let mut store = ZerodentityStore::new();
+        let did = Did::new(did_str).unwrap();
+        let session = IdentitySession {
+            session_token: token.to_owned(),
+            subject_did: did.clone(),
+            public_key: keypair.public_key().as_bytes().to_vec(),
+            created_ms: 0,
+            last_active_ms: 0,
+            revoked: false,
+        };
+        store.insert_session(&session).unwrap();
+        let claim = IdentityClaim {
+            claim_hash: Hash256::digest(b"email-claim"),
+            subject_did: did,
+            claim_type: ClaimType::Email,
+            status: ClaimStatus::Verified,
+            created_ms: 1000,
+            verified_ms: Some(2000),
+            expires_ms: None,
+            signature: Signature::Empty,
+            dag_node_hash: Hash256::digest(b"dag-node"),
+        };
+        store.insert_claim("claim-001", &claim).unwrap();
+        ApiState {
+            store: Arc::new(Mutex::new(store)),
+            node_did: Did::new("did:exo:test-node").unwrap(),
+            started_ms: 1_700_000_000_000,
+        }
+    }
+
+    fn request_signature_headers(
+        method: &str,
+        uri: &str,
+        token: &str,
+        nonce: &str,
+        body: &[u8],
+        keypair: &KeyPair,
+    ) -> (String, String) {
+        let body_hash = Hash256::digest(body);
+        let payload = crate::zerodentity::session_auth::request_signing_payload(
+            method, uri, token, nonce, &body_hash,
+        )
+        .unwrap();
+        let signature = keypair.sign(&payload);
+        (nonce.to_owned(), hex::encode(signature.to_bytes()))
+    }
+
+    async fn signed_post(
+        app: Router,
+        uri: &str,
+        token: &str,
+        nonce: &str,
+        body: serde_json::Value,
+        keypair: &KeyPair,
+    ) -> axum::response::Response {
+        let body_bytes = serde_json::to_vec(&body).unwrap();
+        let (nonce, signature) =
+            request_signature_headers("POST", uri, token, nonce, &body_bytes, keypair);
+        app.oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {token}"))
+                .header("x-exo-nonce", nonce)
+                .header("x-exo-sig", signature)
+                .body(Body::from(body_bytes))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+    }
+
+    async fn signed_delete(
+        app: Router,
+        uri: &str,
+        token: &str,
+        nonce: &str,
+        keypair: &KeyPair,
+    ) -> axum::response::Response {
+        let body = Vec::new();
+        let (nonce, signature) =
+            request_signature_headers("DELETE", uri, token, nonce, &body, keypair);
+        app.oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(uri)
+                .header("authorization", format!("Bearer {token}"))
+                .header("x-exo-nonce", nonce)
+                .header("x-exo-sig", signature)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
     }
 
     // --- list_fingerprints ---
@@ -981,50 +1164,34 @@ mod tests {
 
     #[tokio::test]
     async fn create_peer_attestation_success_with_message_hash() {
-        let state = make_state_with_session_and_claim("tok-alice", "did:exo:alice");
+        let keypair = test_keypair(41);
+        let state =
+            make_state_with_signed_session_and_claim("tok-alice", "did:exo:alice", &keypair);
         let app = zerodentity_api_router(state);
+        let uri = "/api/v1/0dentity/did%3Aexo%3Aalice/attest";
         let body = serde_json::json!({
             "target_did": "did:exo:carol",
             "attestation_type": "Identity",
             "message_hash": hex::encode([0u8; 32])
         });
-        let resp = app
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri("/api/v1/0dentity/did%3Aexo%3Aalice/attest")
-                    .header("content-type", "application/json")
-                    .header("authorization", "Bearer tok-alice")
-                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+        let resp = signed_post(app, uri, "tok-alice", "nonce-api-attest-1", body, &keypair).await;
         assert_eq!(resp.status(), StatusCode::CREATED);
     }
 
     #[tokio::test]
     async fn create_peer_attestation_short_message_hash_succeeds() {
         // message_hash < 32 bytes → parsed as None (covers the else branch)
-        let state = make_state_with_session_and_claim("tok-alice", "did:exo:alice");
+        let keypair = test_keypair(42);
+        let state =
+            make_state_with_signed_session_and_claim("tok-alice", "did:exo:alice", &keypair);
         let app = zerodentity_api_router(state);
+        let uri = "/api/v1/0dentity/did%3Aexo%3Aalice/attest";
         let body = serde_json::json!({
             "target_did": "did:exo:dave",
             "attestation_type": "Trustworthy",
             "message_hash": hex::encode([0u8; 16])
         });
-        let resp = app
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri("/api/v1/0dentity/did%3Aexo%3Aalice/attest")
-                    .header("content-type", "application/json")
-                    .header("authorization", "Bearer tok-alice")
-                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+        let resp = signed_post(app, uri, "tok-alice", "nonce-api-attest-2", body, &keypair).await;
         assert_eq!(resp.status(), StatusCode::CREATED);
     }
 
@@ -1110,19 +1277,18 @@ mod tests {
 
     #[tokio::test]
     async fn delete_identity_success_returns_erasure_receipt() {
-        let state = make_state_with_session_and_claim("tok-alice", "did:exo:alice");
+        let keypair = test_keypair(43);
+        let state =
+            make_state_with_signed_session_and_claim("tok-alice", "did:exo:alice", &keypair);
         let app = zerodentity_api_router(state);
-        let resp = app
-            .oneshot(
-                Request::builder()
-                    .method("DELETE")
-                    .uri("/api/v1/0dentity/did%3Aexo%3Aalice")
-                    .header("authorization", "Bearer tok-alice")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+        let resp = signed_delete(
+            app,
+            "/api/v1/0dentity/did%3Aexo%3Aalice",
+            "tok-alice",
+            "nonce-api-delete-1",
+            &keypair,
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::OK);
         let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
         let result: serde_json::Value = serde_json::from_slice(&body).unwrap();

--- a/crates/exo-node/src/zerodentity/mod.rs
+++ b/crates/exo-node/src/zerodentity/mod.rs
@@ -18,6 +18,7 @@
 // Core modules
 pub mod otp;
 pub mod scoring;
+pub(crate) mod session_auth;
 pub mod store;
 pub mod types;
 

--- a/crates/exo-node/src/zerodentity/onboarding.rs
+++ b/crates/exo-node/src/zerodentity/onboarding.rs
@@ -11,7 +11,10 @@ use std::{
 };
 
 use axum::{Json, Router, extract::State, http::StatusCode, routing::post};
-use exo_core::types::{Did, Hash256, Signature};
+use exo_core::{
+    crypto,
+    types::{Did, Hash256, PublicKey, Signature},
+};
 use getrandom::getrandom;
 use rand::{SeedableRng, rngs::StdRng};
 use serde::{Deserialize, Serialize};
@@ -19,6 +22,7 @@ use uuid::Uuid;
 
 use super::{
     otp::OtpResult,
+    session_auth::{bootstrap_signing_payload, public_key_from_hex, signature_from_hex},
     store::ZerodentityStore,
     types::{
         ClaimStatus, ClaimType, IdentityClaim, IdentitySession, OtpChallenge, OtpChannel,
@@ -85,6 +89,10 @@ pub struct SubmitClaimResponse {
 pub struct VerifyOtpRequest {
     pub challenge_id: String,
     pub code: String,
+    #[serde(default)]
+    pub public_key: Option<String>,
+    #[serde(default)]
+    pub bootstrap_signature: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -127,6 +135,59 @@ fn parse_did(s: &str) -> Result<Did, (StatusCode, Json<serde_json::Value>)> {
             Json(serde_json::json!({"error": "Invalid DID format"})),
         )
     })
+}
+
+fn json_error(
+    status: StatusCode,
+    error: impl Into<String>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    (status, Json(serde_json::json!({ "error": error.into() })))
+}
+
+fn lock_store(
+    state: &OnboardingState,
+) -> Result<std::sync::MutexGuard<'_, ZerodentityStore>, (StatusCode, Json<serde_json::Value>)> {
+    state
+        .store
+        .lock()
+        .map_err(|_| json_error(StatusCode::INTERNAL_SERVER_ERROR, "Store lock error"))
+}
+
+fn verify_bootstrap_signature(
+    req: &VerifyOtpRequest,
+    challenge: &OtpChallenge,
+) -> Result<PublicKey, (StatusCode, Json<serde_json::Value>)> {
+    let public_key_hex = req
+        .public_key
+        .as_deref()
+        .ok_or_else(|| json_error(StatusCode::BAD_REQUEST, "public_key is required"))?;
+    let signature_hex = req
+        .bootstrap_signature
+        .as_deref()
+        .ok_or_else(|| json_error(StatusCode::BAD_REQUEST, "bootstrap_signature is required"))?;
+
+    let public_key =
+        public_key_from_hex(public_key_hex).map_err(|e| json_error(StatusCode::BAD_REQUEST, e))?;
+    let signature =
+        signature_from_hex(signature_hex).map_err(|e| json_error(StatusCode::BAD_REQUEST, e))?;
+    if signature.is_empty() {
+        return Err(json_error(
+            StatusCode::UNAUTHORIZED,
+            "bootstrap_signature must not be empty",
+        ));
+    }
+
+    let payload =
+        bootstrap_signing_payload(&challenge.challenge_id, &challenge.subject_did, &public_key)
+            .map_err(|e| json_error(StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    if !crypto::verify(&payload, &signature, &public_key) {
+        return Err(json_error(
+            StatusCode::UNAUTHORIZED,
+            "bootstrap_signature verification failed",
+        ));
+    }
+
+    Ok(public_key)
 }
 
 fn parse_claim_type(ct: &str, provider: Option<&str>) -> Option<ClaimType> {
@@ -246,12 +307,7 @@ pub async fn verify_otp(
     let now = now_ms();
 
     let mut challenge = {
-        let store = state.store.lock().map_err(|_| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": "Store lock error"})),
-            )
-        })?;
+        let store = lock_store(&state)?;
         store
             .get_otp_challenge(&req.challenge_id)
             .map_err(|e| {
@@ -270,35 +326,32 @@ pub async fn verify_otp(
 
     let result = challenge.verify(&req.code, now);
 
-    {
-        let mut store = state.store.lock().map_err(|_| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": "Store lock error"})),
-            )
-        })?;
-        let _ = store.update_otp_challenge(&challenge);
-    }
-
     match result {
         OtpResult::Success => {
+            let public_key = verify_bootstrap_signature(&req, &challenge)?;
             let session_token = Uuid::new_v4().to_string();
             let session = IdentitySession {
                 session_token: session_token.clone(),
                 subject_did: challenge.subject_did.clone(),
-                public_key: vec![],
+                public_key: public_key.as_bytes().to_vec(),
                 created_ms: now,
                 last_active_ms: now,
                 revoked: false,
             };
             {
-                let mut store = state.store.lock().map_err(|_| {
+                let mut store = lock_store(&state)?;
+                store.update_otp_challenge(&challenge).map_err(|e| {
                     (
                         StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(serde_json::json!({"error": "Store lock error"})),
+                        Json(serde_json::json!({"error": format!("Store error: {e}")})),
                     )
                 })?;
-                let _ = store.insert_session(&session);
+                store.insert_session(&session).map_err(|e| {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(serde_json::json!({"error": format!("Store error: {e}")})),
+                    )
+                })?;
             }
             Ok(Json(VerifyOtpResponse {
                 verified: true,
@@ -307,20 +360,44 @@ pub async fn verify_otp(
                 message: "Verification successful".into(),
             }))
         }
-        OtpResult::WrongCode { attempts_remaining } => Ok(Json(VerifyOtpResponse {
-            verified: false,
-            session_token: None,
-            attempts_remaining: Some(attempts_remaining),
-            message: "Incorrect code".into(),
-        })),
-        OtpResult::Expired => Err((
-            StatusCode::GONE,
-            Json(serde_json::json!({"error": "Challenge has expired"})),
-        )),
-        OtpResult::Locked { .. } => Err((
-            StatusCode::TOO_MANY_REQUESTS,
-            Json(serde_json::json!({"error": "Too many failed attempts — locked"})),
-        )),
+        OtpResult::WrongCode { attempts_remaining } => {
+            let mut store = lock_store(&state)?;
+            store.update_otp_challenge(&challenge).map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": format!("Store error: {e}")})),
+                )
+            })?;
+            Ok(Json(VerifyOtpResponse {
+                verified: false,
+                session_token: None,
+                attempts_remaining: Some(attempts_remaining),
+                message: "Incorrect code".into(),
+            }))
+        }
+        OtpResult::Expired => {
+            let mut store = lock_store(&state)?;
+            store.update_otp_challenge(&challenge).map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": format!("Store error: {e}")})),
+                )
+            })?;
+            Err(json_error(StatusCode::GONE, "Challenge has expired"))
+        }
+        OtpResult::Locked { .. } => {
+            let mut store = lock_store(&state)?;
+            store.update_otp_challenge(&challenge).map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": format!("Store error: {e}")})),
+                )
+            })?;
+            Err(json_error(
+                StatusCode::TOO_MANY_REQUESTS,
+                "Too many failed attempts — locked",
+            ))
+        }
     }
 }
 

--- a/crates/exo-node/src/zerodentity/session_auth.rs
+++ b/crates/exo-node/src/zerodentity/session_auth.rs
@@ -1,0 +1,171 @@
+//! Session proof-of-possession helpers for 0dentity.
+//!
+//! Session bootstrap and mutating authenticated requests are signed over
+//! domain-tagged CBOR payloads so the same logical authorization challenge has
+//! one deterministic byte representation.
+
+use exo_core::types::{Did, Hash256, PublicKey, Signature};
+use serde::Serialize;
+
+pub(crate) const BOOTSTRAP_SIGNING_DOMAIN: &str = "exo.zerodentity.session_bootstrap.v1";
+pub(crate) const REQUEST_SIGNING_DOMAIN: &str = "exo.zerodentity.session_request.v1";
+
+#[derive(Serialize)]
+struct BootstrapSigningPayload<'a> {
+    domain: &'static str,
+    challenge_id: &'a str,
+    subject_did: &'a str,
+    public_key: &'a PublicKey,
+}
+
+#[derive(Serialize)]
+struct RequestSigningPayload<'a> {
+    domain: &'static str,
+    method: &'a str,
+    path_and_query: &'a str,
+    session_token: &'a str,
+    nonce: &'a str,
+    body_hash: &'a Hash256,
+}
+
+fn encode_cbor<T: Serialize>(payload: &T) -> Result<Vec<u8>, String> {
+    let mut encoded = Vec::new();
+    ciborium::into_writer(payload, &mut encoded)
+        .map_err(|e| format!("canonical CBOR encoding failed: {e:?}"))?;
+    Ok(encoded)
+}
+
+pub(crate) fn bootstrap_signing_payload(
+    challenge_id: &str,
+    subject_did: &Did,
+    public_key: &PublicKey,
+) -> Result<Vec<u8>, String> {
+    encode_cbor(&BootstrapSigningPayload {
+        domain: BOOTSTRAP_SIGNING_DOMAIN,
+        challenge_id,
+        subject_did: subject_did.as_str(),
+        public_key,
+    })
+}
+
+pub(crate) fn request_signing_payload(
+    method: &str,
+    path_and_query: &str,
+    session_token: &str,
+    nonce: &str,
+    body_hash: &Hash256,
+) -> Result<Vec<u8>, String> {
+    encode_cbor(&RequestSigningPayload {
+        domain: REQUEST_SIGNING_DOMAIN,
+        method,
+        path_and_query,
+        session_token,
+        nonce,
+        body_hash,
+    })
+}
+
+pub(crate) fn public_key_from_hex(value: &str) -> Result<PublicKey, String> {
+    let bytes = hex::decode(value).map_err(|_| "public_key must be hex".to_owned())?;
+    if bytes.len() != 32 {
+        return Err(format!("public_key must be 32 bytes, got {}", bytes.len()));
+    }
+    if bytes.iter().all(|byte| *byte == 0) {
+        return Err("public_key must not be all zero".to_owned());
+    }
+
+    let mut public_key = [0u8; 32];
+    public_key.copy_from_slice(&bytes);
+    Ok(PublicKey::from_bytes(public_key))
+}
+
+pub(crate) fn signature_from_hex(value: &str) -> Result<Signature, String> {
+    let bytes = hex::decode(value).map_err(|_| "signature must be hex".to_owned())?;
+    if bytes.len() != 64 {
+        return Err(format!("signature must be 64 bytes, got {}", bytes.len()));
+    }
+
+    let mut signature = [0u8; 64];
+    signature.copy_from_slice(&bytes);
+    Ok(Signature::from_bytes(signature))
+}
+
+pub(crate) fn public_key_from_session_bytes(value: &[u8]) -> Result<PublicKey, String> {
+    if value.len() != 32 {
+        return Err(format!(
+            "session public key must be 32 bytes, got {}",
+            value.len()
+        ));
+    }
+    if value.iter().all(|byte| *byte == 0) {
+        return Err("session public key must not be all zero".to_owned());
+    }
+
+    let mut public_key = [0u8; 32];
+    public_key.copy_from_slice(value);
+    Ok(PublicKey::from_bytes(public_key))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Debug;
+
+    use exo_core::types::Hash256;
+
+    use super::*;
+
+    fn must<T, E: Debug>(result: Result<T, E>) -> T {
+        match result {
+            Ok(value) => value,
+            Err(error) => panic!("unexpected error: {error:?}"),
+        }
+    }
+
+    fn did() -> Did {
+        must(Did::new("did:exo:session-auth"))
+    }
+
+    fn public_key() -> PublicKey {
+        PublicKey::from_bytes([7u8; 32])
+    }
+
+    #[test]
+    fn bootstrap_payload_is_deterministic() {
+        let first = must(bootstrap_signing_payload(
+            "challenge-1",
+            &did(),
+            &public_key(),
+        ));
+        let second = must(bootstrap_signing_payload(
+            "challenge-1",
+            &did(),
+            &public_key(),
+        ));
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn request_payload_changes_with_nonce_and_body() {
+        let body_a = Hash256::digest(b"a");
+        let body_b = Hash256::digest(b"b");
+        let first = must(request_signing_payload(
+            "POST", "/path", "token", "nonce-1", &body_a,
+        ));
+        let different_nonce = must(request_signing_payload(
+            "POST", "/path", "token", "nonce-2", &body_a,
+        ));
+        let different_body = must(request_signing_payload(
+            "POST", "/path", "token", "nonce-1", &body_b,
+        ));
+
+        assert_ne!(first, different_nonce);
+        assert_ne!(first, different_body);
+    }
+
+    #[test]
+    fn parsers_reject_wrong_lengths_and_zero_key() {
+        assert!(public_key_from_hex(&hex::encode([0u8; 32])).is_err());
+        assert!(public_key_from_hex(&hex::encode([1u8; 31])).is_err());
+        assert!(signature_from_hex(&hex::encode([1u8; 63])).is_err());
+    }
+}

--- a/crates/exo-node/src/zerodentity/store.rs
+++ b/crates/exo-node/src/zerodentity/store.rs
@@ -12,7 +12,7 @@
 //! Spec reference: §9, §12.1.
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     path::Path,
     sync::{Arc, Mutex},
 };
@@ -64,6 +64,8 @@ pub struct ZerodentityStore {
     attestations: BTreeMap<(String, String), PeerAttestation>,
     /// Identity sessions by session token.
     sessions: BTreeMap<String, IdentitySession>,
+    /// Consumed request nonces keyed by `(session_token, nonce)`.
+    session_request_nonces: BTreeSet<(String, String)>,
     /// DAG nodes recorded for claim operations (APE-72).
     dag_nodes: Vec<DagNode>,
     /// Trust receipts emitted for claim verification events (APE-72).
@@ -199,6 +201,20 @@ impl ZerodentityStore {
         self.sessions
             .insert(session.session_token.clone(), session.clone());
         Ok(())
+    }
+
+    /// Consume a session request nonce.
+    ///
+    /// Returns `true` when the nonce was new and is now consumed. Returns
+    /// `false` when the same session already used the nonce.
+    pub fn consume_session_nonce(
+        &mut self,
+        session_token: &str,
+        nonce: &str,
+    ) -> anyhow::Result<bool> {
+        Ok(self
+            .session_request_nonces
+            .insert((session_token.to_owned(), nonce.to_owned())))
     }
 
     // -----------------------------------------------------------------------

--- a/crates/exo-node/src/zerodentity/tests.rs
+++ b/crates/exo-node/src/zerodentity/tests.rs
@@ -14,7 +14,10 @@ mod tests {
         body::Body,
         http::{Request, StatusCode, header},
     };
-    use exo_core::types::{Did, Hash256, Signature};
+    use exo_core::{
+        crypto::KeyPair,
+        types::{Did, Hash256, Signature},
+    };
     use rand::{SeedableRng, rngs::StdRng};
     use serde_json::Value;
     use tower::ServiceExt;
@@ -65,14 +68,65 @@ mod tests {
     }
 
     fn make_session(did: &Did, token: &str, ms: u64) -> IdentitySession {
+        make_session_with_public_key(did, token, ms, vec![])
+    }
+
+    fn make_session_with_public_key(
+        did: &Did,
+        token: &str,
+        ms: u64,
+        public_key: Vec<u8>,
+    ) -> IdentitySession {
         IdentitySession {
             session_token: token.to_owned(),
             subject_did: did.clone(),
-            public_key: vec![],
+            public_key,
             created_ms: ms,
             last_active_ms: ms,
             revoked: false,
         }
+    }
+
+    fn test_keypair(seed: u8) -> KeyPair {
+        KeyPair::from_secret_bytes([seed; 32]).unwrap()
+    }
+
+    fn bootstrap_verify_body(
+        challenge_id: &str,
+        code: &str,
+        subject_did: &Did,
+        keypair: &KeyPair,
+    ) -> Value {
+        let payload = crate::zerodentity::session_auth::bootstrap_signing_payload(
+            challenge_id,
+            subject_did,
+            keypair.public_key(),
+        )
+        .unwrap();
+        let signature = keypair.sign(&payload);
+        serde_json::json!({
+            "challenge_id": challenge_id,
+            "code": code,
+            "public_key": hex::encode(keypair.public_key().as_bytes()),
+            "bootstrap_signature": hex::encode(signature.to_bytes())
+        })
+    }
+
+    fn request_signature_headers(
+        method: &str,
+        uri: &str,
+        token: &str,
+        nonce: &str,
+        body: &[u8],
+        keypair: &KeyPair,
+    ) -> (String, String) {
+        let body_hash = Hash256::digest(body);
+        let payload = crate::zerodentity::session_auth::request_signing_payload(
+            method, uri, token, nonce, &body_hash,
+        )
+        .unwrap();
+        let signature = keypair.sign(&payload);
+        (nonce.to_owned(), hex::encode(signature.to_bytes()))
     }
 
     fn make_score(did: &Did, bp: u32, ms: u64) -> ZerodentityScore {
@@ -544,10 +598,53 @@ mod tests {
         let store = new_shared_store();
         let app = onboarding_app(store.clone());
         let did = td("otp-ok-01");
+        let keypair = test_keypair(1);
         // Far-future dispatched_ms so TTL check won't trigger on wall clock
         let dispatched_ms = u64::MAX / 2;
 
         let mut rng = seeded_rng(0xCAFE_0001);
+        let (challenge, code) =
+            OtpChallenge::new(&did, OtpChannel::Email, dispatched_ms, &mut rng).unwrap();
+        let cid = challenge.challenge_id.clone();
+        store
+            .lock()
+            .unwrap()
+            .insert_otp_challenge(&challenge)
+            .unwrap();
+
+        let resp = post_json(
+            &app,
+            "/api/v1/0dentity/verify",
+            bootstrap_verify_body(&cid, &code, &did, &keypair),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["verified"], true);
+        assert!(
+            body["session_token"]
+                .as_str()
+                .is_some_and(|s| !s.is_empty())
+        );
+        let session_token = body["session_token"].as_str().unwrap();
+        let session = store
+            .lock()
+            .unwrap()
+            .get_session(session_token)
+            .unwrap()
+            .unwrap();
+        assert_eq!(session.public_key, keypair.public_key().as_bytes().to_vec());
+    }
+
+    #[tokio::test]
+    async fn verify_otp_success_without_bootstrap_signature_returns_400() {
+        let store = new_shared_store();
+        let app = onboarding_app(store.clone());
+        let did = td("otp-bootstrap-missing");
+        let dispatched_ms = u64::MAX / 2;
+
+        let mut rng = seeded_rng(0xCAFE_1010);
         let (challenge, code) =
             OtpChallenge::new(&did, OtpChannel::Email, dispatched_ms, &mut rng).unwrap();
         let cid = challenge.challenge_id.clone();
@@ -567,14 +664,49 @@ mod tests {
         )
         .await;
 
-        assert_eq!(resp.status(), StatusCode::OK);
-        let body = body_json(resp).await;
-        assert_eq!(body["verified"], true);
-        assert!(
-            body["session_token"]
-                .as_str()
-                .is_some_and(|s| !s.is_empty())
-        );
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn verify_otp_success_rejects_wrong_bootstrap_key() {
+        let store = new_shared_store();
+        let app = onboarding_app(store.clone());
+        let did = td("otp-bootstrap-wrong-key");
+        let keypair = test_keypair(2);
+        let wrong_keypair = test_keypair(3);
+        let dispatched_ms = u64::MAX / 2;
+
+        let mut rng = seeded_rng(0xCAFE_1011);
+        let (challenge, code) =
+            OtpChallenge::new(&did, OtpChannel::Email, dispatched_ms, &mut rng).unwrap();
+        let cid = challenge.challenge_id.clone();
+        store
+            .lock()
+            .unwrap()
+            .insert_otp_challenge(&challenge)
+            .unwrap();
+
+        let payload = crate::zerodentity::session_auth::bootstrap_signing_payload(
+            &cid,
+            &did,
+            keypair.public_key(),
+        )
+        .unwrap();
+        let wrong_signature = wrong_keypair.sign(&payload);
+
+        let resp = post_json(
+            &app,
+            "/api/v1/0dentity/verify",
+            serde_json::json!({
+                "challenge_id": cid,
+                "code": code,
+                "public_key": hex::encode(keypair.public_key().as_bytes()),
+                "bootstrap_signature": hex::encode(wrong_signature.to_bytes())
+            }),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]
@@ -1045,6 +1177,29 @@ mod tests {
         app.clone().oneshot(req).await.unwrap()
     }
 
+    async fn post_with_signed_auth(
+        app: &Router,
+        uri: &str,
+        token: &str,
+        nonce: &str,
+        body: serde_json::Value,
+        keypair: &KeyPair,
+    ) -> axum::response::Response {
+        let body_bytes = body.to_string();
+        let (nonce, signature) =
+            request_signature_headers("POST", uri, token, nonce, body_bytes.as_bytes(), keypair);
+        let req = Request::builder()
+            .method("POST")
+            .uri(uri)
+            .header(header::CONTENT_TYPE, "application/json")
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header("x-exo-nonce", nonce)
+            .header("x-exo-sig", signature)
+            .body(Body::from(body_bytes))
+            .unwrap();
+        app.clone().oneshot(req).await.unwrap()
+    }
+
     #[tokio::test]
     async fn attest_without_auth_returns_401() {
         let app = api_app(new_shared_store());
@@ -1066,6 +1221,7 @@ mod tests {
         let app = api_app(store.clone());
         let attester = td("attest-type-err");
         let token = "attest-type-token";
+        let keypair = test_keypair(11);
 
         {
             let mut s = store.lock().unwrap();
@@ -1074,30 +1230,39 @@ mod tests {
                 &make_claim(&attester, ClaimType::Email, ClaimStatus::Verified, 1_000),
             )
             .unwrap();
-            s.insert_session(&make_session(&attester, token, 1_000_000))
-                .unwrap();
+            s.insert_session(&make_session_with_public_key(
+                &attester,
+                token,
+                1_000_000,
+                keypair.public_key().as_bytes().to_vec(),
+            ))
+            .unwrap();
         }
 
-        let resp = post_with_auth(
+        let uri = format!("/api/v1/0dentity/{}/attest", attester.as_str());
+        let resp = post_with_signed_auth(
             &app,
-            &format!("/api/v1/0dentity/{}/attest", attester.as_str()),
+            &uri,
             token,
+            "nonce-invalid-type",
             serde_json::json!({
                 "target_did": "did:exo:target",
                 "attestation_type": "NotAType"
             }),
+            &keypair,
         )
         .await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]
-    async fn attest_valid_creates_attestation_201() {
+    async fn attest_write_without_session_signature_returns_401() {
         let store = new_shared_store();
         let app = api_app(store.clone());
-        let attester = td("attest-ok-a");
-        let target = td("attest-ok-b");
-        let token = "attest-ok-token";
+        let attester = td("attest-nosig");
+        let target = td("attest-nosig-target");
+        let token = "attest-nosig-token";
+        let keypair = test_keypair(12);
 
         {
             let mut s = store.lock().unwrap();
@@ -1106,8 +1271,13 @@ mod tests {
                 &make_claim(&attester, ClaimType::Email, ClaimStatus::Verified, 1_000),
             )
             .unwrap();
-            s.insert_session(&make_session(&attester, token, 1_000_000))
-                .unwrap();
+            s.insert_session(&make_session_with_public_key(
+                &attester,
+                token,
+                1_000_000,
+                keypair.public_key().as_bytes().to_vec(),
+            ))
+            .unwrap();
         }
 
         let resp = post_with_auth(
@@ -1120,6 +1290,85 @@ mod tests {
             }),
         )
         .await;
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn attest_signed_write_rejects_wrong_key() {
+        let store = new_shared_store();
+        let app = api_app(store.clone());
+        let attester = td("attest-wrong-key-a");
+        let target = td("attest-wrong-key-b");
+        let token = "attest-wrong-key-token";
+        let session_keypair = test_keypair(13);
+        let wrong_keypair = test_keypair(14);
+
+        {
+            let mut s = store.lock().unwrap();
+            s.insert_claim(
+                "e1",
+                &make_claim(&attester, ClaimType::Email, ClaimStatus::Verified, 1_000),
+            )
+            .unwrap();
+            s.insert_session(&make_session_with_public_key(
+                &attester,
+                token,
+                1_000_000,
+                session_keypair.public_key().as_bytes().to_vec(),
+            ))
+            .unwrap();
+        }
+
+        let uri = format!("/api/v1/0dentity/{}/attest", attester.as_str());
+        let resp = post_with_signed_auth(
+            &app,
+            &uri,
+            token,
+            "nonce-wrong-key",
+            serde_json::json!({
+                "target_did": target.as_str(),
+                "attestation_type": "Identity"
+            }),
+            &wrong_keypair,
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn attest_valid_creates_attestation_201() {
+        let store = new_shared_store();
+        let app = api_app(store.clone());
+        let attester = td("attest-ok-a");
+        let target = td("attest-ok-b");
+        let token = "attest-ok-token";
+        let keypair = test_keypair(15);
+
+        {
+            let mut s = store.lock().unwrap();
+            s.insert_claim(
+                "e1",
+                &make_claim(&attester, ClaimType::Email, ClaimStatus::Verified, 1_000),
+            )
+            .unwrap();
+            s.insert_session(&make_session_with_public_key(
+                &attester,
+                token,
+                1_000_000,
+                keypair.public_key().as_bytes().to_vec(),
+            ))
+            .unwrap();
+        }
+
+        let uri = format!("/api/v1/0dentity/{}/attest", attester.as_str());
+        let body = serde_json::json!({
+            "target_did": target.as_str(),
+            "attestation_type": "Identity"
+        });
+        let resp =
+            post_with_signed_auth(&app, &uri, token, "nonce-valid-attest", body, &keypair).await;
         assert_eq!(resp.status(), StatusCode::CREATED);
         let body = body_json(resp).await;
         assert!(
@@ -1131,11 +1380,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn attest_signed_write_rejects_nonce_replay() {
+        let store = new_shared_store();
+        let app = api_app(store.clone());
+        let attester = td("attest-replay-a");
+        let target = td("attest-replay-b");
+        let token = "attest-replay-token";
+        let keypair = test_keypair(16);
+        let nonce = "nonce-replay";
+
+        {
+            let mut s = store.lock().unwrap();
+            s.insert_claim(
+                "e1",
+                &make_claim(&attester, ClaimType::Email, ClaimStatus::Verified, 1_000),
+            )
+            .unwrap();
+            s.insert_session(&make_session_with_public_key(
+                &attester,
+                token,
+                1_000_000,
+                keypair.public_key().as_bytes().to_vec(),
+            ))
+            .unwrap();
+        }
+
+        let uri = format!("/api/v1/0dentity/{}/attest", attester.as_str());
+        let body = serde_json::json!({
+            "target_did": target.as_str(),
+            "attestation_type": "Identity"
+        });
+        let first = post_with_signed_auth(&app, &uri, token, nonce, body.clone(), &keypair).await;
+        assert_eq!(first.status(), StatusCode::CREATED);
+
+        let replay = post_with_signed_auth(&app, &uri, token, nonce, body, &keypair).await;
+        assert_eq!(replay.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
     async fn attest_self_returns_400() {
         let store = new_shared_store();
         let app = api_app(store.clone());
         let did = td("attest-self");
         let token = "attest-self-token";
+        let keypair = test_keypair(17);
 
         {
             let mut s = store.lock().unwrap();
@@ -1144,18 +1432,26 @@ mod tests {
                 &make_claim(&did, ClaimType::Email, ClaimStatus::Verified, 1_000),
             )
             .unwrap();
-            s.insert_session(&make_session(&did, token, 1_000_000))
-                .unwrap();
+            s.insert_session(&make_session_with_public_key(
+                &did,
+                token,
+                1_000_000,
+                keypair.public_key().as_bytes().to_vec(),
+            ))
+            .unwrap();
         }
 
-        let resp = post_with_auth(
+        let uri = format!("/api/v1/0dentity/{}/attest", did.as_str());
+        let resp = post_with_signed_auth(
             &app,
-            &format!("/api/v1/0dentity/{}/attest", did.as_str()),
+            &uri,
             token,
+            "nonce-self",
             serde_json::json!({
                 "target_did": did.as_str(),
                 "attestation_type": "Identity"
             }),
+            &keypair,
         )
         .await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
@@ -1250,6 +1546,7 @@ mod tests {
         let api = api_app(store.clone());
         let did = td("arc-e2e-001");
         let did_str = did.as_str();
+        let keypair = test_keypair(21);
 
         // ── 1. DisplayName claim ──────────────────────────────────────────
         let resp = post_json(
@@ -1299,10 +1596,7 @@ mod tests {
         let resp = post_json(
             &onb,
             "/api/v1/0dentity/verify",
-            serde_json::json!({
-                "challenge_id": email_cid,
-                "code": email_code
-            }),
+            bootstrap_verify_body(&email_cid, &email_code, &did, &keypair),
         )
         .await;
         assert_eq!(resp.status(), StatusCode::OK);
@@ -1356,10 +1650,7 @@ mod tests {
         let resp = post_json(
             &onb,
             "/api/v1/0dentity/verify",
-            serde_json::json!({
-                "challenge_id": phone_cid,
-                "code": phone_code
-            }),
+            bootstrap_verify_body(&phone_cid, &phone_code, &did, &keypair),
         )
         .await;
         assert_eq!(resp.status(), StatusCode::OK);


### PR DESCRIPTION
## Summary
- Add domain-tagged CBOR payloads for 0dentity session bootstrap and mutating request signatures.
- Require `public_key` + `bootstrap_signature` on successful OTP verification and persist the verified Ed25519 public key in `IdentitySession.public_key`.
- Require `X-Exo-Nonce` + `X-Exo-Sig` on signed 0dentity attestation and erasure writes, with rejection coverage for missing signatures, wrong keys, and nonce replay.

## Tests
- `cargo test -p exo-node zerodentity` (190 passed)
- `cargo test -p exo-node` (568 passed, 1 ignored)
- `cargo build -p exo-node`
- `cargo clippy -p exo-node --bin exochain -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- Targeted all-target clippy scan for R7-touched files: clean

Note: `cargo clippy -p exo-node --all-targets -- -D warnings` still fails on the existing test-only unwrap/expect backlog outside this branch's touched files.
