### PR TITLE
fix(exo-node): gate 0dentity first-touch onboarding

### DIFF
--- a/crates/exo-node/Cargo.toml
+++ b/crates/exo-node/Cargo.toml
@@ -142,3 +142,22 @@ unaudited-admin-governance-shortcut = []
 # that these MCP tool calls return truthy-shaped JSON while doing
 # nothing on-chain."
 unaudited-mcp-simulation-tools = []
+
+# ONYX-4 RED R1: `POST /api/v1/0dentity/claims` is the first-touch
+# identity-claim bootstrap path. Before R7, this path allowed a caller
+# with only the node write bearer token to create a pending claim for any
+# DID, then later session flows had no cryptographic key binding. R7
+# now binds OTP sessions to a verified Ed25519 bootstrap key, but the
+# first-touch product design still needs an approved proof-of-possession
+# contract (for example did:exo:<bs58(blake3(pubkey))> derivation match
+# plus signed bootstrap payload) before the open claim-creation path is
+# safe to expose.
+#
+# Until that design is accepted and implemented, the endpoint refuses by
+# default. Enable this only for a controlled dev cluster that explicitly
+# accepts the unaudited first-touch onboarding behavior.
+#
+# Do NOT enable this in production. Enabling it means: "I accept that
+# first-touch 0dentity claim creation is running under the legacy,
+# unaudited onboarding contract tracked by Onyx-4 R1."
+unaudited-zerodentity-first-touch-onboarding = []

--- a/crates/exo-node/src/zerodentity/onboarding.rs
+++ b/crates/exo-node/src/zerodentity/onboarding.rs
@@ -118,6 +118,9 @@ pub struct ResendOtpResponse {
 // Helpers
 // ---------------------------------------------------------------------------
 
+const FIRST_TOUCH_ONBOARDING_FEATURE: &str = "unaudited-zerodentity-first-touch-onboarding";
+const FIRST_TOUCH_ONBOARDING_INITIATIVE: &str = "fix-onyx-4-r1-onboarding-auth.md";
+
 fn now_ms() -> u64 {
     exo_core::hlc::HybridClock::new().now().physical_ms
 }
@@ -205,6 +208,28 @@ fn parse_claim_type(ct: &str, provider: Option<&str>) -> Option<ClaimType> {
     }
 }
 
+fn first_touch_onboarding_refusal() -> (StatusCode, Json<serde_json::Value>) {
+    tracing::warn!(
+        "refusing POST /api/v1/0dentity/claims: first-touch onboarding \
+         is gated. See fix-onyx-4-r1-onboarding-auth initiative. To opt \
+         in for a dev cluster, build with \
+         --features exo-node/unaudited-zerodentity-first-touch-onboarding."
+    );
+    (
+        StatusCode::FORBIDDEN,
+        Json(serde_json::json!({
+            "error": "zerodentity_first_touch_onboarding_disabled",
+            "message": "First-touch 0dentity claim creation is disabled by default. \
+                        The approved onboarding proof-of-possession design must land \
+                        before this path is exposed. See \
+                        Initiatives/fix-onyx-4-r1-onboarding-auth.md.",
+            "feature_flag": FIRST_TOUCH_ONBOARDING_FEATURE,
+            "initiative": FIRST_TOUCH_ONBOARDING_INITIATIVE,
+            "refusal_source": "exo-node/zerodentity/onboarding.rs::submit_claim",
+        })),
+    )
+}
+
 // ---------------------------------------------------------------------------
 // POST /api/v1/0dentity/claims
 // ---------------------------------------------------------------------------
@@ -214,6 +239,11 @@ pub async fn submit_claim(
     State(state): State<OnboardingState>,
     Json(req): Json<SubmitClaimRequest>,
 ) -> Result<Json<SubmitClaimResponse>, (StatusCode, Json<serde_json::Value>)> {
+    if !cfg!(feature = "unaudited-zerodentity-first-touch-onboarding") {
+        let _ = (state, req);
+        return Err(first_touch_onboarding_refusal());
+    }
+
     let subject_did = parse_did(&req.subject_did)?;
     let now = now_ms();
 

--- a/crates/exo-node/src/zerodentity/onboarding_ui.rs
+++ b/crates/exo-node/src/zerodentity/onboarding_ui.rs
@@ -1,7 +1,13 @@
 //! 0dentity Onboarding UI — self-contained HTML Gamma Flow.
 //!
-//! Serves `GET /0dentity` as a single HTML document with all CSS and JavaScript
-//! inlined.  Implements the 7-step Gamma Flow onboarding arc from spec §4:
+//! Serves `GET /0dentity`.
+//!
+//! By default this route returns the Onyx-4 R1 refusal page because the
+//! first-touch claim path is gated. When the
+//! `unaudited-zerodentity-first-touch-onboarding` feature is explicitly
+//! enabled, it serves a single HTML document with all CSS and JavaScript
+//! inlined.  The legacy document implements the 7-step Gamma Flow onboarding
+//! arc from spec §4:
 //!
 //! 1. Landing — "Establish your 0dentity"
 //! 2. Name input → POST /api/v1/0dentity/claims (DisplayName)
@@ -18,7 +24,14 @@
 
 use axum::{Router, response::Html, routing::get};
 
-/// Route: `GET /0dentity`
+/// Route: `GET /0dentity`.
+#[cfg(not(feature = "unaudited-zerodentity-first-touch-onboarding"))]
+pub async fn zerodentity_onboarding() -> Html<&'static str> {
+    Html(ONBOARDING_DISABLED_HTML)
+}
+
+/// Route: `GET /0dentity`.
+#[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
 pub async fn zerodentity_onboarding() -> Html<&'static str> {
     Html(ONBOARDING_HTML)
 }
@@ -32,6 +45,35 @@ pub fn zerodentity_onboarding_router() -> Router {
 // Self-contained onboarding HTML (§4 Gamma Flow)
 // ---------------------------------------------------------------------------
 
+#[cfg(not(feature = "unaudited-zerodentity-first-touch-onboarding"))]
+const ONBOARDING_DISABLED_HTML: &str = r##"<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>0dentity onboarding disabled</title>
+<style>
+  :root { --primary: #38bdf8; --bg: #0a0e17; --text: #e2e8f0; --dim: #94a3b8; --border: #1e2940; }
+  * { box-sizing: border-box; }
+  body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: var(--bg); color: var(--text); font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; padding: 1rem; }
+  main { width: min(100%, 44rem); border: 1px solid var(--border); padding: 2rem; }
+  h1 { margin: 0 0 1rem; font-size: 1.25rem; color: var(--primary); }
+  p { color: var(--dim); line-height: 1.6; }
+  code { color: var(--text); overflow-wrap: anywhere; }
+</style>
+</head>
+<body>
+<main>
+  <h1>0dentity first-touch onboarding is disabled</h1>
+  <p>POST /api/v1/0dentity/claims is refused by default while the approved proof-of-possession design is pending.</p>
+  <p>Feature flag: <code>unaudited-zerodentity-first-touch-onboarding</code></p>
+  <p>Initiative: <code>fix-onyx-4-r1-onboarding-auth.md</code></p>
+</main>
+</body>
+</html>
+"##;
+
+#[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
 const ONBOARDING_HTML: &str = r##"<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -1178,6 +1220,26 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    #[cfg(not(feature = "unaudited-zerodentity-first-touch-onboarding"))]
+    async fn test_onboarding_refuses_when_first_touch_disabled() {
+        let response = zerodentity_onboarding().await;
+        let html = response.0;
+        assert!(
+            html.contains("unaudited-zerodentity-first-touch-onboarding"),
+            "refusal page must name the feature flag"
+        );
+        assert!(
+            html.contains("fix-onyx-4-r1-onboarding-auth.md"),
+            "refusal page must name the R1 initiative"
+        );
+        assert!(
+            !html.contains("'00'.repeat"),
+            "default onboarding page must not ship placeholder key material"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
     async fn test_onboarding_contains_all_steps() {
         let response = zerodentity_onboarding().await;
         let html = response.0;
@@ -1187,6 +1249,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
     async fn test_onboarding_contains_polar_graph() {
         let response = zerodentity_onboarding().await;
         let html = response.0;
@@ -1205,6 +1268,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
     async fn test_onboarding_contains_api_endpoints() {
         let response = zerodentity_onboarding().await;
         let html = response.0;

--- a/crates/exo-node/src/zerodentity/tests.rs
+++ b/crates/exo-node/src/zerodentity/tests.rs
@@ -498,6 +498,42 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[tokio::test]
+    #[cfg(not(feature = "unaudited-zerodentity-first-touch-onboarding"))]
+    async fn submit_claim_refused_without_first_touch_feature_flag() {
+        let store = new_shared_store();
+        let app = onboarding_app(store.clone());
+        let did = td("onb-gated-default");
+
+        let resp = post_json(
+            &app,
+            "/api/v1/0dentity/claims",
+            serde_json::json!({
+                "subject_did": did.as_str(),
+                "claim_type": "DisplayName"
+            }),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        let body = body_json(resp).await;
+        assert_eq!(
+            body["feature_flag"],
+            "unaudited-zerodentity-first-touch-onboarding"
+        );
+        assert!(
+            body["message"]
+                .as_str()
+                .is_some_and(|text| text.contains("fix-onyx-4-r1-onboarding-auth.md")),
+            "refusal body must point at the R1 initiative: {body}"
+        );
+        assert!(
+            store.lock().unwrap().get_claims(&did).unwrap().is_empty(),
+            "default-off refusal must not persist a claim"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
     async fn submit_claim_returns_200_and_claim_id() {
         let app = onboarding_app(new_shared_store());
 
@@ -518,6 +554,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
     async fn submit_claim_invalid_did_returns_400() {
         let app = onboarding_app(new_shared_store());
 
@@ -535,6 +572,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
     async fn submit_claim_unknown_type_returns_400() {
         let app = onboarding_app(new_shared_store());
 
@@ -552,6 +590,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
     async fn submit_claim_with_otp_channel_returns_challenge_id_and_ttl() {
         let app = onboarding_app(new_shared_store());
 
@@ -573,6 +612,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
     async fn submit_claim_stores_claim_in_store() {
         let store = new_shared_store();
         let app = onboarding_app(store.clone());
@@ -1540,6 +1580,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[tokio::test]
+    #[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
     async fn test_full_onboarding_arc() {
         let store = new_shared_store();
         let onb = onboarding_app(store.clone());


### PR DESCRIPTION
## Summary
- add `unaudited-zerodentity-first-touch-onboarding` as a default-off feature gate for `POST /api/v1/0dentity/claims`
- return a structured `403` refusal naming the R1 initiative when the feature is off
- gate the `/0dentity` onboarding UI in default builds so it does not ship the stale placeholder-key flow
- keep the legacy claim-creation and onboarding UI tests under the explicit feature-on build

## Stacking
- Stacked on #120 (`fix/onyx-4-r7-session-pubkey`) because #120 is still open.

## Verification
- `cargo test -p exo-node submit_claim_refused_without_first_touch_feature_flag`
- `cargo test -p exo-node zerodentity::onboarding_ui`
- `cargo test -p exo-node zerodentity::onboarding_ui --features unaudited-zerodentity-first-touch-onboarding`
- `cargo test -p exo-node zerodentity`
- `cargo test -p exo-node zerodentity --features unaudited-zerodentity-first-touch-onboarding`
- `cargo test -p exo-node`
- `cargo test -p exo-node --features unaudited-zerodentity-first-touch-onboarding`
- `cargo build -p exo-node`
- `cargo clippy -p exo-node --bin exochain -- -D warnings`
- `cargo clippy -p exo-node --bin exochain --features unaudited-zerodentity-first-touch-onboarding -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
