### PR TITLE
fix(exo-node): gate infrastructure holons

### DIFF
--- a/crates/exo-node/Cargo.toml
+++ b/crates/exo-node/Cargo.toml
@@ -161,3 +161,14 @@ unaudited-mcp-simulation-tools = []
 # first-touch 0dentity claim creation is running under the legacy,
 # unaudited onboarding contract tracked by Onyx-4 R1."
 unaudited-zerodentity-first-touch-onboarding = []
+
+# ONYX-4 RED R5: infrastructure Holons currently build kernel adjudication
+# contexts with sentinel authority/provenance signatures (`vec![1, 2, 3]`) and
+# no public key. The Holons are recommendation-only today, but the runtime must
+# not start by default until the context carries real signed authority and
+# provenance.
+#
+# Do NOT enable this in production. Enabling it means: "I accept that
+# infrastructure Holons run with the unaudited R5 adjudication context tracked
+# by fix-onyx-4-r5-holons-stub-context.md."
+unaudited-infrastructure-holons = []

--- a/crates/exo-node/src/holons.rs
+++ b/crates/exo-node/src/holons.rs
@@ -10,6 +10,19 @@
 //! - **INV-005 KernelImmutability**: AI cannot modify the governance kernel
 //! - **MCP-001/002**: AI operates within defined scope, cannot self-escalate
 //!
+//! # Audit status — Onyx-4 R5 (default-off runtime)
+//!
+//! The current infrastructure Holon adjudication context still uses sentinel
+//! authority and provenance signatures (`vec![1, 2, 3]`) with no Ed25519 public
+//! key. That means `ProvenanceVerifiable` can only confirm that bytes are
+//! present, not that the action was signed by a real infrastructure authority.
+//!
+//! The runtime background manager is therefore disabled by default behind the
+//! `unaudited-infrastructure-holons` feature flag. Enabling the feature means
+//! the operator accepts the recommendation-only Holon runtime while the real
+//! signed authority/provenance context is tracked in
+//! `Initiatives/fix-onyx-4-r5-holons-stub-context.md`.
+//!
 //! ## Holons
 //!
 //! 1. **Topology Optimizer** — monitors peer diversity (ASN, geography),
@@ -28,6 +41,7 @@
     clippy::float_cmp,
     clippy::single_match
 )]
+#![cfg_attr(not(feature = "unaudited-infrastructure-holons"), allow(dead_code))]
 
 use std::time::Duration;
 
@@ -51,12 +65,26 @@ use crate::{
     wire::{GovernanceEventType, ValidatorChange},
 };
 
+/// Feature flag required to run infrastructure Holons while R5 remains open.
+pub const INFRASTRUCTURE_HOLONS_FEATURE: &str = "unaudited-infrastructure-holons";
+
+/// Initiative documenting the R5 stub adjudication context and real fix scope.
+pub const INFRASTRUCTURE_HOLONS_INITIATIVE: &str =
+    "Initiatives/fix-onyx-4-r5-holons-stub-context.md";
+
+/// Whether the unaudited infrastructure Holon runtime is compiled in.
+#[must_use]
+pub const fn infrastructure_holons_enabled() -> bool {
+    cfg!(feature = "unaudited-infrastructure-holons")
+}
+
 // ---------------------------------------------------------------------------
 // Holon events (sent to application layer)
 // ---------------------------------------------------------------------------
 
 /// Events emitted by infrastructure Holons.
 #[derive(Debug, Clone)]
+#[cfg_attr(not(feature = "unaudited-infrastructure-holons"), allow(dead_code))]
 pub enum HolonEvent {
     /// Topology analysis completed.
     TopologyAnalysis {
@@ -679,6 +707,45 @@ mod tests {
             scaling_interval_secs: 300,
             health_interval_secs: 30,
         }
+    }
+
+    #[test]
+    fn module_doc_retains_infrastructure_holon_audit_status() {
+        let src = include_str!("holons.rs");
+        assert!(
+            src.contains("# Audit status"),
+            "module doc must retain the R5 audit-status section"
+        );
+        assert!(
+            src.contains(INFRASTRUCTURE_HOLONS_FEATURE),
+            "module doc must name the default-off feature flag"
+        );
+        assert!(
+            src.contains(INFRASTRUCTURE_HOLONS_INITIATIVE),
+            "module doc must point at the R5 initiative"
+        );
+        assert!(
+            src.contains("vec![1, 2, 3]"),
+            "module doc must call out the sentinel adjudication signatures"
+        );
+    }
+
+    #[cfg(not(feature = "unaudited-infrastructure-holons"))]
+    #[test]
+    fn infrastructure_holons_disabled_without_feature_flag() {
+        assert!(
+            !infrastructure_holons_enabled(),
+            "infrastructure Holons must be disabled by default while R5 is open"
+        );
+    }
+
+    #[cfg(feature = "unaudited-infrastructure-holons")]
+    #[test]
+    fn infrastructure_holons_feature_enables_runtime() {
+        assert!(
+            infrastructure_holons_enabled(),
+            "feature flag must explicitly opt into the unaudited Holon runtime"
+        );
     }
 
     #[test]

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -47,6 +47,7 @@ use std::{
 use clap::Parser;
 use cli::{Cli, Command};
 use exo_core::types::Did;
+#[cfg(feature = "unaudited-infrastructure-holons")]
 use holons::{HolonEvent, HolonManagerConfig};
 use network::{NetworkConfig, NetworkEvent, NetworkHandle};
 use reactor::{ReactorConfig, ReactorEvent};
@@ -384,95 +385,115 @@ async fn start_node(
     });
 
     // --- Infrastructure Holons ---
-    let holon_config = HolonManagerConfig {
-        node_did: node_identity.did.clone(),
-        root_did: Did::new("did:exo:root").unwrap_or_else(|_| node_identity.did.clone()),
-        topology_interval_secs: 60,
-        scaling_interval_secs: 300,
-        health_interval_secs: 30,
-    };
+    #[cfg(feature = "unaudited-infrastructure-holons")]
+    {
+        let holon_config = HolonManagerConfig {
+            node_did: node_identity.did.clone(),
+            root_did: Did::new("did:exo:root").unwrap_or_else(|_| node_identity.did.clone()),
+            topology_interval_secs: 60,
+            scaling_interval_secs: 300,
+            health_interval_secs: 30,
+        };
 
-    let (holon_event_tx, mut holon_event_rx) = mpsc::channel::<HolonEvent>(256);
+        let (holon_event_tx, mut holon_event_rx) = mpsc::channel::<HolonEvent>(256);
 
-    tokio::spawn(holons::run_holon_manager(
-        holon_config,
-        Arc::clone(&reactor_state),
-        Arc::clone(&shared_store),
-        net_handle.clone(),
-        holon_event_tx,
-    ));
-    tracing::info!("Infrastructure Holons started (topology, scaling, health)");
+        tokio::spawn(holons::run_holon_manager(
+            holon_config,
+            Arc::clone(&reactor_state),
+            Arc::clone(&shared_store),
+            net_handle.clone(),
+            holon_event_tx,
+        ));
+        tracing::warn!(
+            enabled = holons::infrastructure_holons_enabled(),
+            feature_flag = holons::INFRASTRUCTURE_HOLONS_FEATURE,
+            initiative = holons::INFRASTRUCTURE_HOLONS_INITIATIVE,
+            "Infrastructure Holons started under unaudited feature gate"
+        );
 
-    // Holon event logger (with metrics updates).
-    let holon_metrics = Arc::clone(&node_metrics);
-    tokio::spawn(async move {
-        while let Some(event) = holon_event_rx.recv().await {
-            match event {
-                HolonEvent::TopologyAnalysis {
-                    peer_count,
-                    diversity_score,
-                    recommendation,
-                } => {
-                    holon_metrics
-                        .peer_count
-                        .store(peer_count as u64, std::sync::atomic::Ordering::Relaxed);
-                    tracing::info!(
+        // Holon event logger (with metrics updates).
+        let holon_metrics = Arc::clone(&node_metrics);
+        tokio::spawn(async move {
+            while let Some(event) = holon_event_rx.recv().await {
+                match event {
+                    HolonEvent::TopologyAnalysis {
                         peer_count,
                         diversity_score,
-                        %recommendation,
-                        "Topology Holon"
-                    );
-                }
-                HolonEvent::ScalingRecommendation {
-                    validator_count,
-                    node_count,
-                    recommendation,
-                } => {
-                    holon_metrics
-                        .validator_count
-                        .store(validator_count as u64, std::sync::atomic::Ordering::Relaxed);
-                    tracing::info!(
+                        recommendation,
+                    } => {
+                        holon_metrics
+                            .peer_count
+                            .store(peer_count as u64, std::sync::atomic::Ordering::Relaxed);
+                        tracing::info!(
+                            peer_count,
+                            diversity_score,
+                            %recommendation,
+                            "Topology Holon"
+                        );
+                    }
+                    HolonEvent::ScalingRecommendation {
                         validator_count,
                         node_count,
-                        %recommendation,
-                        "Scaling Holon"
-                    );
-                }
-                HolonEvent::HealthCheck {
-                    consensus_round,
-                    committed_height,
-                    status,
-                } => match &status {
-                    holons::HealthStatus::Healthy => {
-                        tracing::debug!(consensus_round, committed_height, "Health Holon: healthy");
-                    }
-                    holons::HealthStatus::Degraded { reason } => {
-                        tracing::warn!(
-                            consensus_round,
-                            committed_height,
-                            %reason,
-                            "Health Holon: degraded"
+                        recommendation,
+                    } => {
+                        holon_metrics
+                            .validator_count
+                            .store(validator_count as u64, std::sync::atomic::Ordering::Relaxed);
+                        tracing::info!(
+                            validator_count,
+                            node_count,
+                            %recommendation,
+                            "Scaling Holon"
                         );
                     }
-                    holons::HealthStatus::Critical { reason } => {
+                    HolonEvent::HealthCheck {
+                        consensus_round,
+                        committed_height,
+                        status,
+                    } => match &status {
+                        holons::HealthStatus::Healthy => {
+                            tracing::debug!(
+                                consensus_round,
+                                committed_height,
+                                "Health Holon: healthy"
+                            );
+                        }
+                        holons::HealthStatus::Degraded { reason } => {
+                            tracing::warn!(
+                                consensus_round,
+                                committed_height,
+                                %reason,
+                                "Health Holon: degraded"
+                            );
+                        }
+                        holons::HealthStatus::Critical { reason } => {
+                            tracing::error!(
+                                consensus_round,
+                                committed_height,
+                                %reason,
+                                "Health Holon: CRITICAL"
+                            );
+                        }
+                    },
+                    HolonEvent::HolonTerminated { holon_id, reason } => {
                         tracing::error!(
-                            consensus_round,
-                            committed_height,
+                            %holon_id,
                             %reason,
-                            "Health Holon: CRITICAL"
+                            "Infrastructure Holon terminated"
                         );
                     }
-                },
-                HolonEvent::HolonTerminated { holon_id, reason } => {
-                    tracing::error!(
-                        %holon_id,
-                        %reason,
-                        "Infrastructure Holon terminated"
-                    );
                 }
             }
-        }
-    });
+        });
+    }
+
+    #[cfg(not(feature = "unaudited-infrastructure-holons"))]
+    tracing::warn!(
+        enabled = holons::infrastructure_holons_enabled(),
+        feature_flag = holons::INFRASTRUCTURE_HOLONS_FEATURE,
+        initiative = holons::INFRASTRUCTURE_HOLONS_INITIATIVE,
+        "Infrastructure Holons disabled: adjudication context still uses sentinel signatures"
+    );
 
     // NOTE: /health and /ready are provided by the gateway (exo-gateway)
     // with uptime tracking and DB readiness checks. Node-specific probes

--- a/crates/exo-node/src/network.rs
+++ b/crates/exo-node/src/network.rs
@@ -59,6 +59,7 @@ pub enum NetworkCommand {
     #[allow(dead_code)] // Used when governance API enables dynamic peer dialing
     Dial { addr: Multiaddr },
     /// Request the current peer count.
+    #[cfg_attr(not(feature = "unaudited-infrastructure-holons"), allow(dead_code))]
     PeerCount {
         reply: tokio::sync::oneshot::Sender<usize>,
     },
@@ -482,6 +483,7 @@ impl NetworkHandle {
     }
 
     /// Get the current connected peer count.
+    #[cfg_attr(not(feature = "unaudited-infrastructure-holons"), allow(dead_code))]
     pub async fn peer_count(&self) -> anyhow::Result<usize> {
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.cmd_tx

--- a/crates/exo-node/src/wire.rs
+++ b/crates/exo-node/src/wire.rs
@@ -160,6 +160,7 @@ pub enum GovernanceEventType {
 
 /// A request to change the validator set.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "unaudited-infrastructure-holons"), allow(dead_code))]
 pub enum ValidatorChange {
     /// Promote a node to validator status.
     AddValidator { did: Did },


### PR DESCRIPTION
## Summary
- gate infrastructure Holon startup behind `unaudited-infrastructure-holons` default OFF
- add R5 audit-status docs, feature metadata, and regression guards
- keep default-off builds warning-clean while the gated Holon peer-count/validator-change plumbing is dormant

## Tests
- `cargo test -p exo-node holons`
- `cargo test -p exo-node holons --features unaudited-infrastructure-holons`
- `cargo test -p exo-node`
- `cargo build -p exo-node`
- `cargo clippy -p exo-node --bin exochain -- -D warnings`
- `cargo clippy -p exo-node --bin exochain --features unaudited-infrastructure-holons -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`