### PR TITLE
fix(exo-node): gate 0dentity device behavioral axes

### DIFF
--- a/crates/exo-node/Cargo.toml
+++ b/crates/exo-node/Cargo.toml
@@ -172,3 +172,14 @@ unaudited-zerodentity-first-touch-onboarding = []
 # infrastructure Holons run with the unaudited R5 adjudication context tracked
 # by fix-onyx-4-r5-holons-stub-context.md."
 unaudited-infrastructure-holons = []
+
+# ONYX-4 RED R3: the 0dentity device fingerprint and behavioral biometric
+# modules have deterministic helpers and tests, but there is no public
+# ingestion path that persists client-collected samples into the store. The
+# onboarding UI can collect hashes and the scoring engine can consume samples,
+# yet POST /api/v1/0dentity/claims ignores those fields.
+#
+# Do NOT enable this in production. Enabling it means: "I accept that the
+# device_trust and behavioral_signature axes are running under the unaudited R3
+# contract tracked by fix-onyx-4-r3-unwired-axes.md."
+unaudited-zerodentity-device-behavioral-axes = []

--- a/crates/exo-node/src/zerodentity/api.rs
+++ b/crates/exo-node/src/zerodentity/api.rs
@@ -29,10 +29,12 @@ use exo_core::{
 use serde::{Deserialize, Serialize};
 
 use super::{
+    DEVICE_BEHAVIORAL_AXES_FEATURE, DEVICE_BEHAVIORAL_AXES_INITIATIVE,
     attestation::{
         CreateAttestationInput, attester_score_impact, build_target_claim, create_attestation,
         target_score_impact, validate_attestation,
     },
+    device_behavioral_axes_enabled,
     session_auth::{public_key_from_session_bytes, request_signing_payload, signature_from_hex},
     store::ZerodentityStore,
     types::{AttestationType, IdentityClaim, ZerodentityScore},
@@ -339,6 +341,27 @@ fn parse_signature(
     parse_hex_exact::<64>("signature", value).map(Signature::from_bytes)
 }
 
+fn device_behavioral_axes_refusal(
+    refusal_source: &'static str,
+) -> (StatusCode, Json<serde_json::Value>) {
+    tracing::warn!(
+        feature_flag = DEVICE_BEHAVIORAL_AXES_FEATURE,
+        initiative = DEVICE_BEHAVIORAL_AXES_INITIATIVE,
+        refusal_source,
+        "refusing unaudited 0dentity device/behavioral axis surface"
+    );
+    (
+        StatusCode::FORBIDDEN,
+        Json(serde_json::json!({
+            "error": "zerodentity_device_behavioral_axes_disabled",
+            "message": "0dentity device fingerprint and behavioral biometric axes are disabled by default because the ingestion path is not wired to persist client-collected samples.",
+            "feature_flag": DEVICE_BEHAVIORAL_AXES_FEATURE,
+            "initiative": DEVICE_BEHAVIORAL_AXES_INITIATIVE,
+            "refusal_source": refusal_source,
+        })),
+    )
+}
+
 fn axes_from_score(s: &ZerodentityScore) -> AxesResponse {
     AxesResponse {
         communication: s.axes.communication,
@@ -553,6 +576,11 @@ pub async fn list_fingerprints(
     headers: HeaderMap,
 ) -> Result<Json<FingerprintsResponse>, (StatusCode, Json<serde_json::Value>)> {
     let did = parse_did(&did_str)?;
+    if !device_behavioral_axes_enabled() {
+        return Err(device_behavioral_axes_refusal(
+            "exo-node/zerodentity/api.rs::list_fingerprints",
+        ));
+    }
 
     // Auth required
     let token = extract_session_token(&headers).ok_or_else(|| {
@@ -1058,6 +1086,32 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
+    #[cfg(not(feature = "unaudited-zerodentity-device-behavioral-axes"))]
+    #[tokio::test]
+    async fn list_fingerprints_refused_without_device_behavioral_feature_flag() {
+        let state = make_state_with_session("tok-alice", "did:exo:alice");
+        let app = zerodentity_api_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/0dentity/did%3Aexo%3Aalice/fingerprints")
+                    .header("authorization", "Bearer tok-alice")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            result["feature_flag"],
+            "unaudited-zerodentity-device-behavioral-axes"
+        );
+        assert_eq!(result["initiative"], "fix-onyx-4-r3-unwired-axes.md");
+    }
+
+    #[cfg(feature = "unaudited-zerodentity-device-behavioral-axes")]
     #[tokio::test]
     async fn list_fingerprints_no_token_returns_401() {
         let app = zerodentity_api_router(make_state());
@@ -1073,6 +1127,7 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 
+    #[cfg(feature = "unaudited-zerodentity-device-behavioral-axes")]
     #[tokio::test]
     async fn list_fingerprints_unknown_session_returns_401() {
         let app = zerodentity_api_router(make_state());
@@ -1089,6 +1144,7 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 
+    #[cfg(feature = "unaudited-zerodentity-device-behavioral-axes")]
     #[tokio::test]
     async fn list_fingerprints_wrong_did_returns_403() {
         let state = make_state_with_session("tok-bob", "did:exo:bob");
@@ -1106,6 +1162,7 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     }
 
+    #[cfg(feature = "unaudited-zerodentity-device-behavioral-axes")]
     #[tokio::test]
     async fn list_fingerprints_returns_empty_list() {
         let state = make_state_with_session("tok-alice", "did:exo:alice");

--- a/crates/exo-node/src/zerodentity/mod.rs
+++ b/crates/exo-node/src/zerodentity/mod.rs
@@ -14,6 +14,18 @@
 //! - **api**          — GET /api/v1/0dentity/:did/score, /claims, /history
 //! - **dashboard**    — GET /0dentity/dashboard/:did
 //! - **onboarding_ui**— GET /0dentity (onboarding flow HTML)
+//!
+//! # Audit status — Onyx-4 R3 (default-off axes)
+//!
+//! The device fingerprint and behavioral biometric modules are deterministic
+//! and tested, and the score engine can consume stored samples. The public
+//! onboarding write path does not persist those client-collected samples, so
+//! `device_trust` and `behavioral_signature` are disabled by default behind
+//! `unaudited-zerodentity-device-behavioral-axes`.
+//!
+//! The fingerprint timeline API is also disabled by default because it exposes
+//! the same unaudited data surface. The R3 initiative is
+//! `fix-onyx-4-r3-unwired-axes.md`.
 
 // Core modules
 pub mod otp;
@@ -30,6 +42,18 @@ pub mod dashboard;
 pub mod fingerprint;
 pub mod onboarding;
 pub mod onboarding_ui;
+
+/// Feature flag required to score device and behavioral 0dentity axes.
+pub const DEVICE_BEHAVIORAL_AXES_FEATURE: &str = "unaudited-zerodentity-device-behavioral-axes";
+
+/// Initiative documenting the R3 unwired-axis finding.
+pub const DEVICE_BEHAVIORAL_AXES_INITIATIVE: &str = "fix-onyx-4-r3-unwired-axes.md";
+
+/// Whether the unaudited device/behavioral axes are compiled in.
+#[must_use]
+pub const fn device_behavioral_axes_enabled() -> bool {
+    cfg!(feature = "unaudited-zerodentity-device-behavioral-axes")
+}
 
 #[cfg(test)]
 mod tests;

--- a/crates/exo-node/src/zerodentity/scoring.rs
+++ b/crates/exo-node/src/zerodentity/scoring.rs
@@ -26,9 +26,12 @@ use std::collections::BTreeSet;
 
 use exo_core::types::{Did, Hash256, Signature};
 
-use super::types::{
-    BehavioralSample, BehavioralSignalType, ClaimStatus, ClaimType, DeviceFingerprint,
-    IdentityClaim, PolarAxes, ZerodentityScore,
+use super::{
+    device_behavioral_axes_enabled,
+    types::{
+        BehavioralSample, BehavioralSignalType, ClaimStatus, ClaimType, DeviceFingerprint,
+        IdentityClaim, PolarAxes, ZerodentityScore,
+    },
 };
 
 // ---------------------------------------------------------------------------
@@ -93,8 +96,16 @@ impl ZerodentityScore {
         let axes = PolarAxes {
             communication: score_communication(claims),
             credential_depth: score_credential_depth(claims),
-            device_trust: score_device_trust(fingerprints),
-            behavioral_signature: score_behavioral(behavioral_samples),
+            device_trust: if device_behavioral_axes_enabled() {
+                score_device_trust(fingerprints)
+            } else {
+                0
+            },
+            behavioral_signature: if device_behavioral_axes_enabled() {
+                score_behavioral(behavioral_samples)
+            } else {
+                0
+            },
             network_reputation: score_network_reputation(claims),
             temporal_stability: score_temporal_stability(claims, now_ms),
             cryptographic_strength: score_cryptographic_strength(claims),
@@ -492,6 +503,29 @@ mod tests {
         Hash256::digest(b"test")
     }
 
+    fn fingerprint_sample() -> DeviceFingerprint {
+        DeviceFingerprint {
+            composite_hash: h(),
+            signal_hashes: {
+                let mut m = std::collections::BTreeMap::new();
+                m.insert(FingerprintSignal::CanvasRendering, h());
+                m.insert(FingerprintSignal::UserAgent, h());
+                m
+            },
+            captured_ms: 1000,
+            consistency_score_bp: Some(9000),
+        }
+    }
+
+    fn behavioral_sample(signal_type: BehavioralSignalType, similarity: u32) -> BehavioralSample {
+        BehavioralSample {
+            sample_hash: h(),
+            signal_type,
+            captured_ms: 1000,
+            baseline_similarity_bp: Some(similarity),
+        }
+    }
+
     fn claim(ct: ClaimType, status: ClaimStatus) -> IdentityClaim {
         IdentityClaim {
             claim_hash: h(),
@@ -685,5 +719,47 @@ mod tests {
         let recomputed = ZerodentityScore::compute(&d, &claims, &[], &[], stored.computed_ms);
         let drift = stored.composite.abs_diff(recomputed.composite);
         assert_eq!(drift, 0, "deterministic algorithm must produce zero drift");
+    }
+
+    #[cfg(not(feature = "unaudited-zerodentity-device-behavioral-axes"))]
+    #[test]
+    fn compute_ignores_device_behavioral_samples_without_feature_flag() {
+        let d = did();
+        let fingerprints = vec![fingerprint_sample()];
+        let behavioral = vec![
+            behavioral_sample(BehavioralSignalType::KeystrokeDynamics, 9000),
+            behavioral_sample(BehavioralSignalType::MouseDynamics, 8000),
+        ];
+        let score = ZerodentityScore::compute(&d, &[], &fingerprints, &behavioral, 10_000_000);
+
+        assert_eq!(
+            score.axes.device_trust, 0,
+            "device_trust must stay zero while R3 axes are feature-gated"
+        );
+        assert_eq!(
+            score.axes.behavioral_signature, 0,
+            "behavioral_signature must stay zero while R3 axes are feature-gated"
+        );
+    }
+
+    #[cfg(feature = "unaudited-zerodentity-device-behavioral-axes")]
+    #[test]
+    fn compute_uses_device_behavioral_samples_with_feature_flag() {
+        let d = did();
+        let fingerprints = vec![fingerprint_sample()];
+        let behavioral = vec![
+            behavioral_sample(BehavioralSignalType::KeystrokeDynamics, 9000),
+            behavioral_sample(BehavioralSignalType::MouseDynamics, 8000),
+        ];
+        let score = ZerodentityScore::compute(&d, &[], &fingerprints, &behavioral, 10_000_000);
+
+        assert!(
+            score.axes.device_trust > 0,
+            "feature-on build must preserve existing device_trust scoring"
+        );
+        assert!(
+            score.axes.behavioral_signature > 0,
+            "feature-on build must preserve existing behavioral scoring"
+        );
     }
 }

--- a/crates/exo-node/src/zerodentity/tests.rs
+++ b/crates/exo-node/src/zerodentity/tests.rs
@@ -47,6 +47,23 @@ mod tests {
         Hash256::digest(tag.as_bytes())
     }
 
+    #[test]
+    fn module_doc_retains_device_behavioral_axes_audit_status() {
+        let src = include_str!("mod.rs");
+        assert!(
+            src.contains("# Audit status"),
+            "module doc must retain the R3 audit-status section"
+        );
+        assert!(
+            src.contains("unaudited-zerodentity-device-behavioral-axes"),
+            "module doc must name the R3 feature flag"
+        );
+        assert!(
+            src.contains("fix-onyx-4-r3-unwired-axes.md"),
+            "module doc must point at the R3 initiative"
+        );
+    }
+
     fn seeded_rng(seed: u64) -> StdRng {
         StdRng::seed_from_u64(seed)
     }
@@ -1187,6 +1204,36 @@ mod tests {
         );
     }
 
+    #[cfg(not(feature = "unaudited-zerodentity-device-behavioral-axes"))]
+    #[tokio::test]
+    async fn list_fingerprints_refused_without_device_behavioral_feature_flag() {
+        let store = new_shared_store();
+        let app = api_app(store.clone());
+        let did = td("api-fp-gated");
+        let token = "fp-gated-session-token";
+
+        store
+            .lock()
+            .unwrap()
+            .insert_session(&make_session(&did, token, 1_000_000))
+            .unwrap();
+
+        let resp = get_with_auth(
+            &app,
+            &format!("/api/v1/0dentity/{}/fingerprints", did.as_str()),
+            token,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        let body = body_json(resp).await;
+        assert_eq!(
+            body["feature_flag"],
+            "unaudited-zerodentity-device-behavioral-axes"
+        );
+        assert_eq!(body["initiative"], "fix-onyx-4-r3-unwired-axes.md");
+    }
+
+    #[cfg(feature = "unaudited-zerodentity-device-behavioral-axes")]
     #[tokio::test]
     async fn list_fingerprints_without_auth_returns_401() {
         let app = api_app(new_shared_store());
@@ -1195,6 +1242,7 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 
+    #[cfg(feature = "unaudited-zerodentity-device-behavioral-axes")]
     #[tokio::test]
     async fn list_fingerprints_with_valid_session_returns_200() {
         let store = new_shared_store();


### PR DESCRIPTION
## Summary
- gate 0dentity `device_trust` and `behavioral_signature` scoring behind `unaudited-zerodentity-device-behavioral-axes` default OFF
- refuse the fingerprint timeline API by default with feature/initiative metadata
- add R3 audit-status docs and regression guards for default-off and feature-on behavior

## Tests
- `cargo test -p exo-node device_behavioral`
- `cargo test -p exo-node device_behavioral --features unaudited-zerodentity-device-behavioral-axes`
- `cargo test -p exo-node list_fingerprints --features unaudited-zerodentity-device-behavioral-axes`
- `cargo test -p exo-node zerodentity`
- `cargo test -p exo-node zerodentity --features unaudited-zerodentity-device-behavioral-axes`
- `cargo test -p exo-node`
- `cargo test -p exo-node --features unaudited-zerodentity-device-behavioral-axes`
- `cargo build -p exo-node`
- `cargo clippy -p exo-node --bin exochain -- -D warnings`
- `cargo clippy -p exo-node --bin exochain --features unaudited-zerodentity-device-behavioral-axes -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`