### PR TITLE
fix(exo-node): bundle Onyx-4 AMBER hygiene

### DIFF
--- a/crates/exo-node/src/holons.rs
+++ b/crates/exo-node/src/holons.rs
@@ -34,13 +34,7 @@
 //! 3. **Health Monitor** — tracks consensus round times, peer latency,
 //!    DAG growth rate, and alerts on anomalies.
 
-#![allow(
-    clippy::expect_used,
-    clippy::as_conversions,
-    clippy::float_arithmetic,
-    clippy::float_cmp,
-    clippy::single_match
-)]
+#![allow(clippy::expect_used, clippy::as_conversions, clippy::single_match)]
 #![cfg_attr(not(feature = "unaudited-infrastructure-holons"), allow(dead_code))]
 
 use std::time::Duration;
@@ -89,7 +83,7 @@ pub enum HolonEvent {
     /// Topology analysis completed.
     TopologyAnalysis {
         peer_count: usize,
-        diversity_score: f64,
+        diversity_score_bp: u32,
         recommendation: String,
     },
     /// Scaling recommendation produced.
@@ -317,36 +311,36 @@ pub fn build_holon_adjudication_context(
 // ---------------------------------------------------------------------------
 
 /// Analyze peer topology and produce a diversity recommendation.
-fn analyze_topology(peer_count: usize, _net_handle: &NetworkHandle) -> (f64, String) {
+fn analyze_topology(peer_count: usize, _net_handle: &NetworkHandle) -> (u32, String) {
     // Diversity score: simple heuristic based on peer count.
     // In production, this would query ASN distribution from PeerRegistry.
-    let diversity_score = if peer_count == 0 {
-        0.0
+    let diversity_score_bp = if peer_count == 0 {
+        0
     } else if peer_count < 3 {
-        0.3
+        3000
     } else if peer_count < 7 {
-        0.6
+        6000
     } else if peer_count < 15 {
-        0.8
+        8000
     } else {
-        1.0
+        10_000
     };
 
-    let recommendation = if diversity_score < 0.3 {
+    let recommendation = if diversity_score_bp < 3000 {
         "CRITICAL: No peers connected. Node is isolated.".into()
-    } else if diversity_score < 0.5 {
+    } else if diversity_score_bp < 5000 {
         format!("WARNING: Only {peer_count} peers. Recommend connecting to more diverse nodes.")
-    } else if diversity_score < 0.8 {
+    } else if diversity_score_bp < 8000 {
         format!(
-            "FAIR: {peer_count} peers, diversity score {diversity_score:.1}. Consider adding peers from different ASNs."
+            "FAIR: {peer_count} peers, diversity score {diversity_score_bp} bp. Consider adding peers from different ASNs."
         )
     } else {
         format!(
-            "GOOD: {peer_count} peers, diversity score {diversity_score:.1}. Topology is healthy."
+            "GOOD: {peer_count} peers, diversity score {diversity_score_bp} bp. Topology is healthy."
         )
     };
 
-    (diversity_score, recommendation)
+    (diversity_score_bp, recommendation)
 }
 
 // ---------------------------------------------------------------------------
@@ -359,7 +353,8 @@ fn analyze_scaling(validator_count: usize, node_count: usize) -> String {
         return "No nodes in network.".into();
     }
 
-    let ratio = validator_count as f64 / node_count as f64;
+    let ratio_bp = ((validator_count as u128) * 10_000 / (node_count as u128)) as u32;
+    let ratio_percent = ratio_bp / 100;
 
     if validator_count < 3 {
         format!(
@@ -367,23 +362,20 @@ fn analyze_scaling(validator_count: usize, node_count: usize) -> String {
              Recommend promoting {} more nodes.",
             4usize.saturating_sub(validator_count)
         )
-    } else if ratio < 0.2 {
+    } else if ratio_bp < 2000 {
         format!(
-            "LOW: {validator_count}/{node_count} nodes are validators ({:.0}%). \
+            "LOW: {validator_count}/{node_count} nodes are validators ({ratio_percent}%). \
              Consider promoting more nodes for resilience.",
-            ratio * 100.0
         )
-    } else if ratio >= 0.8 {
+    } else if ratio_bp >= 8000 {
         format!(
-            "HIGH: {validator_count}/{node_count} nodes are validators ({:.0}%). \
+            "HIGH: {validator_count}/{node_count} nodes are validators ({ratio_percent}%). \
              Consider whether all need validator status.",
-            ratio * 100.0
         )
     } else {
         format!(
-            "GOOD: {validator_count}/{node_count} nodes are validators ({:.0}%). \
+            "GOOD: {validator_count}/{node_count} nodes are validators ({ratio_percent}%). \
              Ratio is healthy.",
-            ratio * 100.0
         )
     }
 }
@@ -473,18 +465,18 @@ pub async fn run_holon_manager(
                 }
 
                 let peer_count = net_handle.peer_count().await.unwrap_or(0);
-                let (diversity_score, recommendation) = analyze_topology(peer_count, &net_handle);
+                let (diversity_score_bp, recommendation) = analyze_topology(peer_count, &net_handle);
 
                 let input = CombinatorInput::new()
                     .with("peer_count", peer_count.to_string())
-                    .with("diversity_score", format!("{diversity_score:.2}"));
+                    .with("diversity_score_bp", diversity_score_bp.to_string());
 
                 let ctx = build_holon_adjudication_context(&topology_holon, &config);
                 match holon::step(&mut topology_holon, &input, &kernel, &ctx) {
                     Ok(_output) => {
                         if event_tx.send(HolonEvent::TopologyAnalysis {
                             peer_count,
-                            diversity_score,
+                            diversity_score_bp,
                             recommendation,
                         }).await.is_err() {
                             tracing::warn!("Holon event channel closed — TopologyAnalysis dropped");
@@ -492,7 +484,7 @@ pub async fn run_holon_manager(
 
                         tracing::debug!(
                             peer_count,
-                            diversity_score,
+                            diversity_score_bp,
                             "Topology Holon: analysis complete"
                         );
                     }
@@ -843,26 +835,27 @@ mod tests {
 
     #[test]
     fn topology_analysis_scoring() {
-        let (score, rec) = analyze_topology(0, &{
+        let (score_bp, rec) = analyze_topology(0, &{
             let (tx, _rx) = mpsc::channel(1);
             NetworkHandle::new(tx)
         });
-        assert_eq!(score, 0.0);
+        let _: u32 = score_bp;
+        assert_eq!(score_bp, 0);
         assert!(rec.contains("CRITICAL"));
 
         let handle = {
             let (tx, _rx) = mpsc::channel(1);
             NetworkHandle::new(tx)
         };
-        let (score, rec) = analyze_topology(2, &handle);
-        assert_eq!(score, 0.3);
+        let (score_bp, rec) = analyze_topology(2, &handle);
+        assert_eq!(score_bp, 3000);
         assert!(rec.contains("WARNING"));
 
-        let (score, _) = analyze_topology(10, &handle);
-        assert_eq!(score, 0.8);
+        let (score_bp, _) = analyze_topology(10, &handle);
+        assert_eq!(score_bp, 8000);
 
-        let (score, rec) = analyze_topology(20, &handle);
-        assert_eq!(score, 1.0);
+        let (score_bp, rec) = analyze_topology(20, &handle);
+        assert_eq!(score_bp, 10_000);
         assert!(rec.contains("GOOD"));
     }
 

--- a/crates/exo-node/src/identity.rs
+++ b/crates/exo-node/src/identity.rs
@@ -154,3 +154,64 @@ fn write_secret(path: &Path, data: &[u8]) -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_or_create_creates_identity_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let identity = load_or_create(dir.path()).unwrap();
+
+        let key_bytes = std::fs::read(dir.path().join("identity.key")).unwrap();
+        let did_text = std::fs::read_to_string(dir.path().join("identity.did")).unwrap();
+
+        assert_eq!(key_bytes.len(), 32);
+        assert_eq!(did_text.trim(), identity.did.as_str());
+        assert_eq!(identity.public_key_bytes().len(), 32);
+    }
+
+    #[test]
+    fn load_or_create_reloads_existing_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = load_or_create(dir.path()).unwrap();
+        let second = load_or_create(dir.path()).unwrap();
+
+        assert_eq!(first.did, second.did);
+        assert_eq!(first.public_key_bytes(), second.public_key_bytes());
+    }
+
+    #[test]
+    fn load_or_create_rejects_corrupt_secret_key() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("identity.key"), [7u8; 31]).unwrap();
+        std::fs::write(dir.path().join("identity.did"), b"did:exo:corrupt").unwrap();
+
+        let err = match load_or_create(dir.path()) {
+            Ok(_) => panic!("corrupt secret key must not load"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("Corrupt identity key"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_or_create_writes_secret_key_mode_0600() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let _identity = load_or_create(dir.path()).unwrap();
+
+        let mode = std::fs::metadata(dir.path().join("identity.key"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+}

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -172,8 +172,18 @@ async fn start_node(
         Arc::new(move |payload: &[u8]| identity.sign(payload))
     };
     zerodentity_store.set_receipt_signer(node_identity.did.clone(), zd_receipt_signer);
+    if !zerodentity::store::ZerodentityStore::persistence_ready() {
+        tracing::warn!(
+            persistence_ready = zerodentity::store::ZerodentityStore::persistence_ready(),
+            warning = zerodentity::store::ZerodentityStore::persistence_warning(),
+            "0dentity store persistence is not ready"
+        );
+    }
     let zerodentity_store = std::sync::Arc::new(Mutex::new(zerodentity_store));
-    tracing::info!("0dentity store ready");
+    tracing::info!(
+        persistence_ready = zerodentity::store::ZerodentityStore::persistence_ready(),
+        "0dentity store ready"
+    );
 
     tracing::info!(
         api_port,
@@ -418,7 +428,7 @@ async fn start_node(
                 match event {
                     HolonEvent::TopologyAnalysis {
                         peer_count,
-                        diversity_score,
+                        diversity_score_bp,
                         recommendation,
                     } => {
                         holon_metrics
@@ -426,7 +436,7 @@ async fn start_node(
                             .store(peer_count as u64, std::sync::atomic::Ordering::Relaxed);
                         tracing::info!(
                             peer_count,
-                            diversity_score,
+                            diversity_score_bp,
                             %recommendation,
                             "Topology Holon"
                         );

--- a/crates/exo-node/src/passport.rs
+++ b/crates/exo-node/src/passport.rs
@@ -67,6 +67,8 @@ pub struct AgentPassport {
     pub consent: ConsentProfile,
     /// Trust standing (sanctions, revocation, risk).
     pub standing: StandingProfile,
+    /// Whether the backing 0dentity store is durable across node restarts.
+    pub persistence_ready: bool,
     /// 0dentity sovereign identity score, if available for this DID.
     pub zerodentity: Option<ZerodentityProfile>,
 }
@@ -245,6 +247,7 @@ async fn handle_passport(
         delegations: build_delegation_profile(),
         consent: build_consent_profile(),
         standing,
+        persistence_ready: crate::zerodentity::store::ZerodentityStore::persistence_ready(),
         zerodentity,
     };
 
@@ -510,6 +513,7 @@ mod tests {
         assert_eq!(passport["standing"]["status"], "active");
         assert_eq!(passport["standing"]["revoked"], false);
         assert_eq!(passport["consent"]["default_deny_enforced"], true);
+        assert_eq!(passport["persistence_ready"], false);
     }
 
     #[tokio::test]
@@ -660,12 +664,13 @@ mod tests {
         let body = axum::body::to_bytes(resp.into_body(), 8192).await.unwrap();
         let passport: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
-        // Verify all 6 top-level trust dimensions are present.
+        // Verify all top-level trust dimensions are present.
         assert!(passport.get("did").is_some());
         assert!(passport.get("identity").is_some());
         assert!(passport.get("delegations").is_some());
         assert!(passport.get("consent").is_some());
         assert!(passport.get("standing").is_some());
+        assert!(passport.get("persistence_ready").is_some());
         // zerodentity is Optional — present as null when no score exists.
         assert!(passport.get("zerodentity").is_some());
 

--- a/crates/exo-node/src/provenance.rs
+++ b/crates/exo-node/src/provenance.rs
@@ -54,8 +54,8 @@ pub struct ProvenanceResponse {
     pub committed_height: Option<u64>,
     /// Timestamp (physical_ms from HLC).
     pub timestamp_ms: u64,
-    /// Payload size in bytes.
-    pub payload_size: usize,
+    /// Size in bytes of the stored payload hash.
+    pub payload_hash_size: usize,
     /// Depth: number of hops to reach a root (node with no parents).
     pub depth: u32,
 }
@@ -125,7 +125,7 @@ async fn handle_provenance(
         committed: committed_height.is_some(),
         committed_height,
         timestamp_ms: node.timestamp.physical_ms,
-        payload_size: 32, // payload_hash is 32 bytes
+        payload_hash_size: node.payload_hash.as_bytes().len(),
         depth,
     }))
 }
@@ -222,6 +222,8 @@ mod tests {
         let parents = result["parents"].as_array().unwrap();
         assert_eq!(parents.len(), 1);
         assert_eq!(parents[0], hex::encode(genesis_hash.0));
+        assert!(result.get("payload_size").is_none());
+        assert_eq!(result["payload_hash_size"], 32);
     }
 
     #[tokio::test]

--- a/crates/exo-node/src/zerodentity/mod.rs
+++ b/crates/exo-node/src/zerodentity/mod.rs
@@ -63,9 +63,7 @@ mod tests;
 // ---------------------------------------------------------------------------
 
 #[allow(unused_imports)]
-pub use otp::{
-    OTP_LOCKOUT_MS, OTP_MAX_ATTEMPTS, OTP_RESEND_COOLDOWN_MS, OTP_TTL_MS, OtpError, OtpResult,
-};
+pub use otp::{OTP_LOCKOUT_MS, OTP_MAX_ATTEMPTS, OTP_RESEND_COOLDOWN_MS, OtpError, OtpResult};
 #[allow(unused_imports)]
 pub use store::{SharedZerodentityStore, ZerodentityStore};
 #[allow(unused_imports)]

--- a/crates/exo-node/src/zerodentity/otp.rs
+++ b/crates/exo-node/src/zerodentity/otp.rs
@@ -4,7 +4,7 @@
 //! per §4.3–4.6 of the 0dentity spec.
 //!
 //! ## Properties
-//! - TTL: 600_000ms (10 min) per issue spec
+//! - TTL: channel-specific via `OtpChannel::ttl_ms()`
 //! - Lockout: after 5 failed attempts, locked for 3_600_000ms (1 hour)
 //! - Resend cooldown: 60_000ms (1 min)
 //! - Code format: 6-digit decimal string (leading zeros preserved)
@@ -22,9 +22,6 @@ type HmacSha256 = Hmac<Sha256>;
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-
-/// OTP TTL in milliseconds (10 minutes).
-pub const OTP_TTL_MS: u64 = 600_000;
 
 /// Number of failed attempts before lockout.
 pub const OTP_MAX_ATTEMPTS: u32 = 5;
@@ -97,6 +94,7 @@ impl OtpChallenge {
         id_input.extend_from_slice(&secret);
         let id_hash = Hash256::digest(&id_input);
         let challenge_id = hex::encode(id_hash.as_bytes());
+        let ttl_ms = channel.ttl_ms();
 
         let challenge = OtpChallenge {
             challenge_id,
@@ -104,7 +102,7 @@ impl OtpChallenge {
             channel,
             hmac_secret: secret,
             dispatched_ms: now_ms,
-            ttl_ms: OTP_TTL_MS,
+            ttl_ms,
             attempts: 0,
             max_attempts: OTP_MAX_ATTEMPTS,
             state: OtpState::Pending,
@@ -272,13 +270,25 @@ mod tests {
             OtpChallenge::new(&did, OtpChannel::Email, 0, &mut rng).expect("new ok");
         assert_eq!(challenge.state, OtpState::Pending);
         assert_eq!(challenge.attempts, 0);
-        assert_eq!(challenge.ttl_ms, OTP_TTL_MS);
+        assert_eq!(challenge.ttl_ms, OtpChannel::Email.ttl_ms());
         assert_eq!(challenge.max_attempts, OTP_MAX_ATTEMPTS);
         assert_eq!(code.len(), 6, "code must be 6 digits");
         assert!(
             code.chars().all(|c| c.is_ascii_digit()),
             "code must be digits"
         );
+    }
+
+    #[test]
+    fn new_challenge_ttl_matches_delivery_channel() {
+        let did = test_did();
+        let (email, _) =
+            OtpChallenge::new(&did, OtpChannel::Email, 0, &mut test_rng()).expect("email ok");
+        let (sms, _) =
+            OtpChallenge::new(&did, OtpChannel::Sms, 1, &mut test_rng()).expect("sms ok");
+
+        assert_eq!(email.ttl_ms, OtpChannel::Email.ttl_ms());
+        assert_eq!(sms.ttl_ms, OtpChannel::Sms.ttl_ms());
     }
 
     #[test]
@@ -344,7 +354,7 @@ mod tests {
         let (mut challenge, code) =
             OtpChallenge::new(&did, OtpChannel::Email, now, &mut rng).expect("new ok");
         // Advance past TTL
-        let result = challenge.verify(&code, now + OTP_TTL_MS + 1);
+        let result = challenge.verify(&code, now + OtpChannel::Email.ttl_ms() + 1);
         assert_eq!(result, OtpResult::Expired);
         assert_eq!(challenge.state, OtpState::Expired);
     }
@@ -452,11 +462,11 @@ mod tests {
         let (mut ch, _) =
             OtpChallenge::new(&did, OtpChannel::Email, now, &mut rng).expect("new ok");
         // Expire via TTL (transitions state to Expired)
-        let _ = ch.verify("wrong", now + OTP_TTL_MS + 1);
+        let _ = ch.verify("wrong", now + OtpChannel::Email.ttl_ms() + 1);
         assert_eq!(ch.state, OtpState::Expired);
         let attempts_before = ch.attempts;
         // Verify again — hits Expired early-return (line 135)
-        let result = ch.verify("wrong", now + OTP_TTL_MS + 2);
+        let result = ch.verify("wrong", now + OtpChannel::Email.ttl_ms() + 2);
         assert_eq!(result, OtpResult::Expired, "should be Expired early-return");
         assert_eq!(ch.attempts, attempts_before, "attempts must not change");
     }
@@ -475,8 +485,8 @@ mod tests {
             let _ = ch.verify("000000", 1_000);
         }
         assert_eq!(ch.state, OtpState::LockedOut);
-        // locked_until = dispatched + OTP_TTL_MS + OTP_LOCKOUT_MS
-        let locked_until = dispatched + OTP_TTL_MS + OTP_LOCKOUT_MS;
+        // locked_until = dispatched + challenge ttl + OTP_LOCKOUT_MS
+        let locked_until = dispatched + ch.ttl_ms + OTP_LOCKOUT_MS;
         // Inside the lock window → true (hits lines 184-188)
         assert!(
             ch.is_locked(locked_until - 1),

--- a/crates/exo-node/src/zerodentity/store.rs
+++ b/crates/exo-node/src/zerodentity/store.rs
@@ -28,6 +28,12 @@ use super::types::{
 
 pub type ReceiptSigner = Arc<dyn Fn(&[u8]) -> Signature + Send + Sync>;
 
+/// The current 0dentity store is intentionally volatile process memory.
+pub const ZERODENTITY_STORE_PERSISTENCE_READY: bool = false;
+
+/// Startup warning emitted while 0dentity data is not durable.
+pub const ZERODENTITY_STORE_PERSISTENCE_WARNING: &str = "0dentity store is memory only; claims, sessions, OTPs, scores, and receipts are not durable across process restarts";
+
 #[derive(Clone)]
 pub struct ReceiptSigningContext {
     actor_did: Did,
@@ -104,6 +110,18 @@ impl ZerodentityStore {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Whether the current store implementation is durable across restarts.
+    #[must_use]
+    pub const fn persistence_ready() -> bool {
+        ZERODENTITY_STORE_PERSISTENCE_READY
+    }
+
+    /// Operator-facing warning for the current persistence posture.
+    #[must_use]
+    pub const fn persistence_warning() -> &'static str {
+        ZERODENTITY_STORE_PERSISTENCE_WARNING
     }
 
     /// Configure the node identity used to sign store-emitted trust receipts.
@@ -691,6 +709,15 @@ mod tests {
         assert!(store.get_score(&did("did:exo:a")).is_none());
         assert_eq!(store.get_claims(&did("did:exo:a")).unwrap(), vec![]);
         assert_eq!(store.sample_scored_dids(5), vec![]);
+    }
+
+    #[test]
+    fn in_memory_store_declares_persistence_not_ready() {
+        assert!(!ZerodentityStore::persistence_ready());
+        assert!(
+            ZerodentityStore::persistence_warning().contains("memory only"),
+            "startup warning must plainly identify the volatile store"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- expose 0dentity memory-only persistence posture in startup logs and passport responses
- make OTP challenges use channel-specific TTLs
- convert Holon diversity/scaling math to integer basis points and remove float lint allowances
- rename provenance payload size to payload_hash_size and add identity persistence tests

## Verification
- cargo test -p exo-node new_challenge_ttl_matches_delivery_channel
- cargo test -p exo-node passport_returns_profile_for_known_validator
- cargo test -p exo-node provenance_returns_lineage
- cargo test -p exo-node load_or_create
- cargo test -p exo-node topology_analysis_scoring
- cargo test -p exo-node zerodentity
- cargo test -p exo-node holons
- cargo test -p exo-node holons --features unaudited-infrastructure-holons
- cargo test -p exo-node zerodentity --features unaudited-zerodentity-first-touch-onboarding
- cargo test -p exo-node
- cargo build -p exo-node
- cargo clippy -p exo-node --bin exochain -- -D warnings
- cargo clippy -p exo-node --bin exochain --features unaudited-infrastructure-holons -- -D warnings
- cargo clippy -p exo-node --bin exochain --features unaudited-zerodentity-first-touch-onboarding -- -D warnings
- cargo +nightly fmt --all -- --check
- git diff --check