### PR TITLE
fix(exo-gateway): gate unaudited GraphQL API

### DIFF
--- a/crates/exo-gateway/Cargo.toml
+++ b/crates/exo-gateway/Cargo.toml
@@ -47,6 +47,13 @@ async-stream = { workspace = true }
 ## dev/test environments do not need a live database.
 production-db = []
 
+## Enable the unaudited GraphQL API surface.
+##
+## Default OFF. The current GraphQL resolvers include unaudited governance
+## mutations, fabricated consent evaluation, and proof-verification scaffolding.
+## Keep this disabled outside explicitly-audited development compatibility runs.
+unaudited-gateway-graphql-api = []
+
 [dev-dependencies]
 serde_json = { workspace = true }
 tower = { workspace = true }

--- a/crates/exo-gateway/src/graphql.rs
+++ b/crates/exo-gateway/src/graphql.rs
@@ -27,8 +27,11 @@ use async_graphql::{
     Context, ID, InputObject, Object, Result as GqlResult, Schema, SimpleObject, Subscription,
     futures_util::Stream,
 };
+#[cfg(feature = "unaudited-gateway-graphql-api")]
 use async_graphql_axum::{GraphQL, GraphQLSubscription};
 use async_stream::stream;
+#[cfg(not(feature = "unaudited-gateway-graphql-api"))]
+use axum::{Json, http::StatusCode};
 use axum::{Router, routing::get};
 use exo_consent::{
     bailment::{self, BailmentStatus, BailmentType},
@@ -310,6 +313,11 @@ fn now_str() -> String {
 
 /// Fully-built GraphQL schema type with query, mutation, and subscription roots.
 pub type GovSchema = Schema<QueryRoot, MutationRoot, SubscriptionRoot>;
+
+pub const UNAUDITED_GRAPHQL_API_FEATURE: &str = "unaudited-gateway-graphql-api";
+pub const UNAUDITED_GRAPHQL_API_INITIATIVE: &str = "Initiatives/fix-spline-r1-graphql-auth-gate.md";
+pub const UNAUDITED_GRAPHQL_API_MEMO: &str =
+    "exochain/council-intake/exo-spline-gateway-api-messaging.md";
 
 // ---------------------------------------------------------------------------
 // Query resolvers
@@ -980,7 +988,14 @@ pub fn build_schema(state: Arc<Mutex<AppState>>) -> GovSchema {
 /// - `POST /graphql` — query and mutation handler
 /// - `GET  /graphql` — GraphQL Playground (development)
 /// - `GET  /graphql/ws` — WebSocket subscription endpoint
+#[cfg(feature = "unaudited-gateway-graphql-api")]
 pub fn graphql_router(schema: GovSchema) -> Router {
+    tracing::warn!(
+        feature_flag = UNAUDITED_GRAPHQL_API_FEATURE,
+        initiative = UNAUDITED_GRAPHQL_API_INITIATIVE,
+        memo = UNAUDITED_GRAPHQL_API_MEMO,
+        "unaudited gateway GraphQL API enabled"
+    );
     Router::new()
         .route(
             "/graphql",
@@ -989,11 +1004,41 @@ pub fn graphql_router(schema: GovSchema) -> Router {
         .route_service("/graphql/ws", GraphQLSubscription::new(schema))
 }
 
+/// Construct the default-safe GraphQL router.
+///
+/// The playground remains available for local schema inspection, but executable
+/// GraphQL operations are refused unless `unaudited-gateway-graphql-api` is
+/// explicitly enabled. This avoids exposing resolver-local placeholder caller
+/// identity, fabricated consent, and proof-verification scaffolding.
+#[cfg(not(feature = "unaudited-gateway-graphql-api"))]
+pub fn graphql_router(_schema: GovSchema) -> Router {
+    Router::new()
+        .route(
+            "/graphql",
+            get(graphql_playground_handler).post(graphql_refusal_handler),
+        )
+        .route("/graphql/ws", get(graphql_refusal_handler))
+}
+
 async fn graphql_playground_handler() -> impl axum::response::IntoResponse {
     axum::response::Html(async_graphql::http::playground_source(
         async_graphql::http::GraphQLPlaygroundConfig::new("/graphql")
             .subscription_endpoint("/graphql/ws"),
     ))
+}
+
+#[cfg(not(feature = "unaudited-gateway-graphql-api"))]
+async fn graphql_refusal_handler() -> (StatusCode, Json<serde_json::Value>) {
+    (
+        StatusCode::FORBIDDEN,
+        Json(serde_json::json!({
+            "error": "unaudited_graphql_api_disabled",
+            "message": "The gateway GraphQL execution surface is disabled by default pending Spline R1 remediation.",
+            "feature_flag": UNAUDITED_GRAPHQL_API_FEATURE,
+            "initiative": UNAUDITED_GRAPHQL_API_INITIATIVE,
+            "memo": UNAUDITED_GRAPHQL_API_MEMO,
+        })),
+    )
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -1879,6 +1879,90 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
+    #[cfg(not(feature = "unaudited-gateway-graphql-api"))]
+    #[tokio::test]
+    async fn graphql_post_default_off_returns_403_with_initiative() {
+        let app = build_router(state());
+        let body = serde_json::json!({
+            "query": "mutation { createDecision(input: { tenantId: \"t1\", title: \"x\", body: \"y\", decisionClass: \"Routine\" }) { id } }"
+        });
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/graphql")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let val: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(val["error"], "unaudited_graphql_api_disabled");
+        assert_eq!(val["feature_flag"], "unaudited-gateway-graphql-api");
+        assert_eq!(
+            val["initiative"],
+            "Initiatives/fix-spline-r1-graphql-auth-gate.md"
+        );
+    }
+
+    #[cfg(not(feature = "unaudited-gateway-graphql-api"))]
+    #[tokio::test]
+    async fn graphql_ws_default_off_returns_403_with_initiative() {
+        let app = build_router(state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/graphql/ws")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let val: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(val["feature_flag"], "unaudited-gateway-graphql-api");
+        assert_eq!(
+            val["initiative"],
+            "Initiatives/fix-spline-r1-graphql-auth-gate.md"
+        );
+    }
+
+    #[cfg(feature = "unaudited-gateway-graphql-api")]
+    #[tokio::test]
+    async fn graphql_post_feature_on_preserves_existing_mutation_behavior() {
+        let app = build_router(state());
+        let body = serde_json::json!({
+            "query": "mutation { createDecision(input: { tenantId: \"t1\", title: \"x\", body: \"y\", decisionClass: \"Routine\" }) { id status author } }"
+        });
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/graphql")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let val: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(val["errors"].is_null(), "unexpected errors: {val}");
+        assert_eq!(val["data"]["createDecision"]["status"], "CREATED");
+        assert_eq!(val["data"]["createDecision"]["author"], "system");
+    }
+
     #[tokio::test]
     async fn vote_route_without_authority_returns_403() {
         let body = serde_json::to_string(&serde_json::json!({


### PR DESCRIPTION
## Summary
- add default-off feature flag `unaudited-gateway-graphql-api`
- refuse `POST /graphql` and `GET /graphql/ws` by default with initiative/memo metadata
- preserve existing GraphQL behavior only when the unaudited feature is explicitly enabled

## TDD / Verification
- red: `cargo test -p exo-gateway graphql_` initially failed because default `POST /graphql` returned 200 and `/graphql/ws` returned 400 instead of 403
- `cargo test -p exo-gateway graphql_`
- `cargo test -p exo-gateway graphql_ --features unaudited-gateway-graphql-api`
- `cargo test -p exo-gateway`
- `cargo test -p exo-gateway --features unaudited-gateway-graphql-api`
- `cargo build -p exo-gateway`
- `cargo build -p exo-gateway --features unaudited-gateway-graphql-api`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `cargo clippy -p exo-gateway --all-targets --features unaudited-gateway-graphql-api -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`

Council tracking: SPLINE-R1 from `exo-spline-gateway-api-messaging.md`.