### PR TITLE
fix(exo-gateway): fail closed on GraphQL consent

### DIFF
--- a/crates/exo-gateway/src/graphql.rs
+++ b/crates/exo-gateway/src/graphql.rs
@@ -33,12 +33,9 @@ use async_stream::stream;
 #[cfg(not(feature = "unaudited-gateway-graphql-api"))]
 use axum::{Json, http::StatusCode};
 use axum::{Router, routing::get};
-use exo_consent::{
-    bailment::{self, BailmentStatus, BailmentType},
-    policy::{
-        ActionRequest as ConsentActionRequest, ActiveConsent, ConsentDecision, ConsentPolicy,
-        ConsentRequirement, PolicyEngine,
-    },
+use exo_consent::policy::{
+    ActionRequest as ConsentActionRequest, ConsentDecision, ConsentPolicy, ConsentRequirement,
+    PolicyEngine,
 };
 use exo_core::{Did, Hash256, Timestamp};
 use exo_identity::registry::{DidRegistry, LocalDidRegistry};
@@ -318,6 +315,8 @@ pub const UNAUDITED_GRAPHQL_API_FEATURE: &str = "unaudited-gateway-graphql-api";
 pub const UNAUDITED_GRAPHQL_API_INITIATIVE: &str = "Initiatives/fix-spline-r1-graphql-auth-gate.md";
 pub const UNAUDITED_GRAPHQL_API_MEMO: &str =
     "exochain/council-intake/exo-spline-gateway-api-messaging.md";
+pub const GRAPHQL_CONSENT_FABRICATION_INITIATIVE: &str =
+    "Initiatives/fix-spline-r2-graphql-consent-fabrication.md";
 
 // ---------------------------------------------------------------------------
 // Query resolvers
@@ -513,7 +512,7 @@ impl QueryRoot {
         let guard = state.lock().await;
         let subject_str = subject.to_string();
         let actor_str = actor.to_string();
-        let subject_did = Did::new(&subject_str)
+        Did::new(&subject_str)
             .map_err(|e| async_graphql::Error::new(format!("invalid subject DID: {e}")))?;
         let actor_did = Did::new(&actor_str)
             .map_err(|e| async_graphql::Error::new(format!("invalid actor DID: {e}")))?;
@@ -530,41 +529,32 @@ impl QueryRoot {
             deny_by_default: true,
         };
 
-        // Build an active bailment from subject (bailor) → actor (bailee) covering
-        // the requested scope.  Terms are hashed from the scope string.
-        let mut active_bailment = bailment::propose(
-            &subject_did,
-            &actor_did,
-            scope.as_bytes(),
-            BailmentType::Processing,
-        );
-        active_bailment.status = BailmentStatus::Active; // grant for evaluation
-        let consents = vec![ActiveConsent {
-            grantor: subject_did,
-            action_type: action_type.clone(),
-            role: "any".into(),
-            clearance_level: 0,
-            bailment: active_bailment,
-        }];
         let action = ConsentActionRequest {
             actor: actor_did,
             action_type: action_type.clone(),
         };
-        let now = Timestamp::now_utc();
         let decision = guard
             .consent_engine
-            .evaluate(&policy, &consents, &action, &now);
+            .evaluate(&policy, &[], &action, &Timestamp::ZERO);
         let (granted, message) = match decision {
             ConsentDecision::Granted { .. } => (
-                true,
+                false,
                 format!(
-                    "Consent granted: {actor_str} may perform '{action_type}' on {subject_str} scope '{scope}'"
+                    "Consent denied: gateway GraphQL has no verified consent evidence for {subject_str} -> {actor_str} scope '{scope}' action '{action_type}'; see {GRAPHQL_CONSENT_FABRICATION_INITIATIVE}"
                 ),
             ),
-            ConsentDecision::Denied { reason } => (false, reason),
-            ConsentDecision::Escalated { to } => {
-                (false, format!("Escalated to {to} for manual review"))
-            }
+            ConsentDecision::Denied { reason } => (
+                false,
+                format!(
+                    "Consent denied: gateway GraphQL has no verified consent evidence for {subject_str} -> {actor_str} scope '{scope}' action '{action_type}'; policy reason: {reason}; see {GRAPHQL_CONSENT_FABRICATION_INITIATIVE}"
+                ),
+            ),
+            ConsentDecision::Escalated { to } => (
+                false,
+                format!(
+                    "Consent denied: gateway GraphQL has no verified consent evidence for {subject_str} -> {actor_str} scope '{scope}' action '{action_type}'; policy escalated to {to}; see {GRAPHQL_CONSENT_FABRICATION_INITIATIVE}"
+                ),
+            ),
         };
         Ok(GqlConsentResult {
             subject: subject_str,
@@ -1469,10 +1459,11 @@ mod tests {
         assert_eq!(data["resolveIdentity"]["activeKeyCount"], 1);
     }
 
-    /// APE-35: evaluateConsent returns `granted: true` when bailment conditions
-    /// are met via the PolicyEngine (end-to-end consent check).
+    /// SPLINE-R2: evaluateConsent must fail closed when GraphQL has no verified
+    /// consent evidence source. The resolver must not fabricate an active
+    /// bailment for the requested subject/actor pair.
     #[tokio::test]
-    async fn query_evaluate_consent_granted() {
+    async fn query_evaluate_consent_denies_without_verified_consent_evidence() {
         let schema = build_test_schema();
         let res = schema
             .execute(
@@ -1486,9 +1477,14 @@ mod tests {
             .await;
         assert!(res.errors.is_empty(), "errors: {:?}", res.errors);
         let data = res.data.into_json().expect("data");
-        assert_eq!(data["evaluateConsent"]["granted"], true);
+        assert_eq!(data["evaluateConsent"]["granted"], false);
         assert_eq!(data["evaluateConsent"]["scope"], "data:medical");
         assert_eq!(data["evaluateConsent"]["subject"], "did:exo:alice");
+        let message = data["evaluateConsent"]["message"]
+            .as_str()
+            .expect("message is a string");
+        assert!(message.contains("no verified consent evidence"));
+        assert!(message.contains("fix-spline-r2-graphql-consent-fabrication.md"));
     }
 
     /// APE-35: resolveIdentity rejects malformed DIDs with a GraphQL error.


### PR DESCRIPTION
## Summary
- remove GraphQL resolver-local active bailment fabrication from `evaluateConsent`
- make consent evaluation fail closed when no verified consent evidence is wired
- update regression coverage so fabricated consent success is no longer accepted

## TDD
- Red: `cargo test -p exo-gateway query_evaluate_consent_denies_without_verified_consent_evidence` initially failed because `evaluateConsent` returned `granted: true`.
- Green: the same test now passes with `granted: false` and an initiative-linked denial message.

## Verification
- `cargo test -p exo-gateway query_evaluate_consent`
- `cargo test -p exo-gateway query_evaluate_consent --features unaudited-gateway-graphql-api`
- `cargo test -p exo-gateway graphql_`
- `cargo test -p exo-gateway graphql_ --features unaudited-gateway-graphql-api`
- `cargo test -p exo-gateway`
- `cargo test -p exo-gateway --features unaudited-gateway-graphql-api`
- `cargo build -p exo-gateway`
- `cargo build -p exo-gateway --features unaudited-gateway-graphql-api`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `cargo clippy -p exo-gateway --all-targets --features unaudited-gateway-graphql-api -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo test --workspace`