### PR TITLE
fix(exo-gateway): align audit entries with schema

### DIFF
--- a/crates/exo-gateway/migrations/20260425000001_add_decision_id_to_audit_entries.sql
+++ b/crates/exo-gateway/migrations/20260425000001_add_decision_id_to_audit_entries.sql
@@ -1,0 +1,6 @@
+-- Link vote audit entries back to their decision for /api/v1/audit/:decision_id.
+ALTER TABLE audit_entries
+    ADD COLUMN IF NOT EXISTS decision_id TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX IF NOT EXISTS idx_audit_entries_decision_id
+    ON audit_entries(decision_id);

--- a/crates/exo-gateway/src/db.rs
+++ b/crates/exo-gateway/src/db.rs
@@ -422,17 +422,18 @@ pub async fn insert_audit_entry(
     event_type: &str,
     actor: &str,
     tenant_id: &str,
+    decision_id: &str,
     timestamp_physical_ms: i64,
     timestamp_logical: i32,
     entry_hash: &str,
 ) -> Result<(), sqlx::Error> {
     sqlx::query(
-        "INSERT INTO audit_entries (sequence, prev_hash, event_hash, event_type, actor, tenant_id, timestamp_physical_ms, timestamp_logical, entry_hash)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) ON CONFLICT (sequence) DO NOTHING"
+        "INSERT INTO audit_entries (sequence, prev_hash, event_hash, event_type, actor, tenant_id, decision_id, timestamp_physical_ms, timestamp_logical, entry_hash)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)"
     )
     .bind(sequence).bind(prev_hash).bind(event_hash).bind(event_type)
-    .bind(actor).bind(tenant_id).bind(timestamp_physical_ms).bind(timestamp_logical)
-    .bind(entry_hash)
+    .bind(actor).bind(tenant_id).bind(decision_id).bind(timestamp_physical_ms)
+    .bind(timestamp_logical).bind(entry_hash)
     .execute(pool).await?;
     Ok(())
 }
@@ -440,14 +441,28 @@ pub async fn insert_audit_entry(
 /// List all audit entries ordered by sequence number.
 pub async fn list_audit_entries(pool: &PgPool) -> Result<Vec<AuditRow>, sqlx::Error> {
     sqlx::query_as::<_, AuditRow>(
-        "SELECT sequence, prev_hash, event_hash, event_type, actor, tenant_id, timestamp_physical_ms, timestamp_logical, entry_hash FROM audit_entries ORDER BY sequence"
+        "SELECT sequence, prev_hash, event_hash, event_type, actor, tenant_id, decision_id, timestamp_physical_ms, timestamp_logical, entry_hash FROM audit_entries ORDER BY sequence"
     ).fetch_all(pool).await
+}
+
+/// List audit entries for one decision ordered by sequence number.
+pub async fn list_audit_entries_for_decision(
+    pool: &PgPool,
+    decision_id: &str,
+) -> Result<Vec<AuditRow>, sqlx::Error> {
+    sqlx::query_as::<_, AuditRow>(
+        "SELECT sequence, prev_hash, event_hash, event_type, actor, tenant_id, decision_id, timestamp_physical_ms, timestamp_logical, entry_hash
+         FROM audit_entries WHERE decision_id = $1 ORDER BY sequence",
+    )
+    .bind(decision_id)
+    .fetch_all(pool)
+    .await
 }
 
 /// Return the most recent audit entry by sequence number, or `None` if empty.
 pub async fn get_last_audit_entry(pool: &PgPool) -> Result<Option<AuditRow>, sqlx::Error> {
     sqlx::query_as::<_, AuditRow>(
-        "SELECT sequence, prev_hash, event_hash, event_type, actor, tenant_id, timestamp_physical_ms, timestamp_logical, entry_hash FROM audit_entries ORDER BY sequence DESC LIMIT 1"
+        "SELECT sequence, prev_hash, event_hash, event_type, actor, tenant_id, decision_id, timestamp_physical_ms, timestamp_logical, entry_hash FROM audit_entries ORDER BY sequence DESC LIMIT 1"
     ).fetch_optional(pool).await
 }
 
@@ -490,6 +505,7 @@ pub struct AuditRow {
     pub event_type: String,
     pub actor: String,
     pub tenant_id: String,
+    pub decision_id: String,
     pub timestamp_physical_ms: i64,
     pub timestamp_logical: i32,
     pub entry_hash: String,

--- a/crates/exo-gateway/src/handlers.rs
+++ b/crates/exo-gateway/src/handlers.rs
@@ -10,7 +10,7 @@ use decision_forum::{
     decision_object::{ActorKind, DecisionObject, Vote, VoteChoice},
     quorum::{QuorumCheckResult, QuorumRegistry, check_quorum, verify_quorum_precondition},
 };
-use exo_core::{hlc::HybridClock, types::Hash256};
+use exo_core::{Timestamp, hlc::HybridClock, types::Hash256};
 use exo_gatekeeper::{
     kernel::{ActionRequest as GatekeeperActionRequest, Verdict},
     types::{Permission, PermissionSet},
@@ -18,7 +18,7 @@ use exo_gatekeeper::{
 use exo_governance::conflict::{
     ActionRequest as ConflictActionRequest, check_conflicts, must_recuse,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sqlx::Row;
 
@@ -29,11 +29,97 @@ use crate::server::AppState;
 /// Serialize `payload` using canonical CBOR then hash with blake3.
 /// This is deterministic across all deployments regardless of field insertion order.
 /// NEVER replace with serde_json::to_vec — JSON key ordering is non-deterministic.
-fn canonical_hash(payload: &Value) -> Result<blake3::Hash, String> {
+fn canonical_cbor_hash(payload: &impl Serialize) -> Result<blake3::Hash, String> {
     let mut buf = Vec::new();
     ciborium::into_writer(payload, &mut buf)
         .map_err(|e| format!("CBOR serialization failed: {e}"))?;
     Ok(blake3::hash(&buf))
+}
+
+fn canonical_hash(payload: &Value) -> Result<blake3::Hash, String> {
+    canonical_cbor_hash(payload)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AuditEntryRecord {
+    sequence: i64,
+    prev_hash: String,
+    event_hash: String,
+    event_type: String,
+    actor: String,
+    tenant_id: String,
+    decision_id: String,
+    timestamp_physical_ms: i64,
+    timestamp_logical: i32,
+    entry_hash: String,
+}
+
+#[derive(Serialize)]
+struct AuditEntryHashInput<'a> {
+    sequence: i64,
+    prev_hash: &'a str,
+    event_hash: &'a str,
+    event_type: &'a str,
+    actor: &'a str,
+    tenant_id: &'a str,
+    decision_id: &'a str,
+    timestamp_physical_ms: i64,
+    timestamp_logical: i32,
+}
+
+fn compute_audit_entry_hash(input: &AuditEntryHashInput<'_>) -> Result<String, String> {
+    Ok(canonical_cbor_hash(input)?.to_hex().to_string())
+}
+
+fn build_audit_entry(
+    last: Option<&crate::db::AuditRow>,
+    event_type: &str,
+    actor: &str,
+    tenant_id: &str,
+    decision_id: &str,
+    timestamp: Timestamp,
+    payload: &Value,
+) -> Result<AuditEntryRecord, String> {
+    let sequence = match last {
+        Some(row) => row
+            .sequence
+            .checked_add(1)
+            .ok_or_else(|| "audit sequence overflow".to_owned())?,
+        None => 1,
+    };
+    let prev_hash = last
+        .map(|row| row.entry_hash.clone())
+        .unwrap_or_else(|| Hash256::ZERO.to_string());
+    let event_hash = canonical_hash(payload)?.to_hex().to_string();
+    let timestamp_physical_ms = i64::try_from(timestamp.physical_ms)
+        .map_err(|_| "HLC physical timestamp exceeds i64".to_owned())?;
+    let timestamp_logical = i32::try_from(timestamp.logical)
+        .map_err(|_| "HLC logical timestamp exceeds i32".to_owned())?;
+    let hash_input = AuditEntryHashInput {
+        sequence,
+        prev_hash: &prev_hash,
+        event_hash: &event_hash,
+        event_type,
+        actor,
+        tenant_id,
+        decision_id,
+        timestamp_physical_ms,
+        timestamp_logical,
+    };
+    let entry_hash = compute_audit_entry_hash(&hash_input)?;
+
+    Ok(AuditEntryRecord {
+        sequence,
+        prev_hash,
+        event_hash,
+        event_type: event_type.to_owned(),
+        actor: actor.to_owned(),
+        tenant_id: tenant_id.to_owned(),
+        decision_id: decision_id.to_owned(),
+        timestamp_physical_ms,
+        timestamp_logical,
+        entry_hash,
+    })
 }
 
 /// Write an audit entry using CBOR-hashed event payload.
@@ -41,23 +127,51 @@ async fn write_audit(
     state: &AppState,
     event_type: &str,
     actor: &str,
+    tenant_id: &str,
+    decision_id: &str,
     payload: &Value,
 ) -> Result<(), String> {
     let db = state.require_db().map_err(|e| e.to_string())?;
-    let event_hash = canonical_hash(payload)?;
-    let now_ms = chrono::Utc::now().timestamp_millis();
-    sqlx::query(
-        "INSERT INTO audit_entries (event_type, actor, event_hash, payload, created_at_ms) \
-         VALUES ($1, $2, $3, $4, $5)",
+    let mut tx = db.begin().await.map_err(|e| e.to_string())?;
+    sqlx::query("LOCK TABLE audit_entries IN EXCLUSIVE MODE")
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| e.to_string())?;
+    let last = sqlx::query_as::<_, crate::db::AuditRow>(
+        "SELECT sequence, prev_hash, event_hash, event_type, actor, tenant_id, decision_id, timestamp_physical_ms, timestamp_logical, entry_hash
+         FROM audit_entries ORDER BY sequence DESC LIMIT 1",
     )
-    .bind(event_type)
-    .bind(actor)
-    .bind(event_hash.to_hex().as_str())
-    .bind(payload)
-    .bind(now_ms)
-    .execute(db)
+    .fetch_optional(&mut *tx)
     .await
     .map_err(|e| e.to_string())?;
+    let mut clock = HybridClock::new();
+    let entry = build_audit_entry(
+        last.as_ref(),
+        event_type,
+        actor,
+        tenant_id,
+        decision_id,
+        clock.now(),
+        payload,
+    )?;
+    sqlx::query(
+        "INSERT INTO audit_entries (sequence, prev_hash, event_hash, event_type, actor, tenant_id, decision_id, timestamp_physical_ms, timestamp_logical, entry_hash)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
+    )
+    .bind(entry.sequence)
+    .bind(&entry.prev_hash)
+    .bind(&entry.event_hash)
+    .bind(&entry.event_type)
+    .bind(&entry.actor)
+    .bind(&entry.tenant_id)
+    .bind(&entry.decision_id)
+    .bind(entry.timestamp_physical_ms)
+    .bind(entry.timestamp_logical)
+    .bind(&entry.entry_hash)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| e.to_string())?;
+    tx.commit().await.map_err(|e| e.to_string())?;
     Ok(())
 }
 
@@ -151,21 +265,34 @@ pub async fn vote_handler(
     };
 
     // Load and deserialize DecisionObject from DB.
-    let row = sqlx::query("SELECT payload FROM decisions WHERE id_hash = $1")
+    let row = sqlx::query("SELECT tenant_id, payload FROM decisions WHERE id_hash = $1")
         .bind(&body.decision_id)
         .fetch_optional(db)
         .await;
-    let payload_val: Value = match row {
-        Ok(Some(r)) => match r.try_get::<Value, _>("payload") {
-            Ok(p) => p,
-            Err(e) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({"error": e.to_string()})),
-                )
-                    .into_response();
-            }
-        },
+    let (tenant_id, payload_val): (String, Value) = match row {
+        Ok(Some(r)) => {
+            let tenant_id = match r.try_get::<String, _>("tenant_id") {
+                Ok(t) => t,
+                Err(e) => {
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(serde_json::json!({"error": e.to_string()})),
+                    )
+                        .into_response();
+                }
+            };
+            let payload = match r.try_get::<Value, _>("payload") {
+                Ok(p) => p,
+                Err(e) => {
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(serde_json::json!({"error": e.to_string()})),
+                    )
+                        .into_response();
+                }
+            };
+            (tenant_id, payload)
+        }
         Ok(None) => {
             return (
                 StatusCode::NOT_FOUND,
@@ -291,12 +418,22 @@ pub async fn vote_handler(
 
     // ── VIOLATION 3 FIX: CBOR canonical audit hash ──────────────────────
     let audit_payload = serde_json::json!({
-        "event": "vote_recorded",
-        "decision_id": body.decision_id,
-        "voter": body.voter_did,
+        "event": "VoteCast",
+        "decision_id": body.decision_id.as_str(),
+        "tenant_id": tenant_id.as_str(),
+        "voter": body.voter_did.as_str(),
         "choice": body.choice,
     });
-    if let Err(e) = write_audit(&state, "vote_recorded", &body.voter_did, &audit_payload).await {
+    if let Err(e) = write_audit(
+        &state,
+        "VoteCast",
+        &body.voter_did,
+        &tenant_id,
+        &body.decision_id,
+        &audit_payload,
+    )
+    .await
+    {
         tracing::error!("audit write failed for voter {}: {e}", body.voter_did);
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -405,6 +542,185 @@ mod tests {
         let json_bytes = serde_json::to_vec(&payload).expect("json ok");
         let json_hash = blake3::hash(&json_bytes);
         assert_ne!(cbor_hash, json_hash, "CBOR and JSON hashes must differ");
+    }
+
+    #[test]
+    fn audit_entry_record_chains_from_previous_entry() {
+        let previous = crate::db::AuditRow {
+            sequence: 41,
+            prev_hash: Hash256::ZERO.to_string(),
+            event_hash: "event-a".into(),
+            event_type: "VoteCast".into(),
+            actor: "did:exo:alice".into(),
+            tenant_id: "tenant-a".into(),
+            decision_id: "decision-a".into(),
+            timestamp_physical_ms: 1000,
+            timestamp_logical: 0,
+            entry_hash: "previous-entry-hash".into(),
+        };
+        let payload = serde_json::json!({
+            "event": "vote_recorded",
+            "decision_id": "decision-b",
+            "voter": "did:exo:bob",
+            "choice": "Approve",
+        });
+        let timestamp = exo_core::Timestamp::new(2000, 7);
+
+        let first = build_audit_entry(
+            Some(&previous),
+            "VoteCast",
+            "did:exo:bob",
+            "tenant-b",
+            "decision-b",
+            timestamp,
+            &payload,
+        )
+        .expect("audit entry");
+        let second = build_audit_entry(
+            Some(&previous),
+            "VoteCast",
+            "did:exo:bob",
+            "tenant-b",
+            "decision-b",
+            timestamp,
+            &payload,
+        )
+        .expect("audit entry");
+
+        assert_eq!(first.sequence, 42);
+        assert_eq!(first.prev_hash, previous.entry_hash);
+        assert_eq!(
+            first.event_hash,
+            canonical_hash(&payload)
+                .expect("canonical payload hash")
+                .to_hex()
+                .as_str()
+        );
+        assert_eq!(first.decision_id, "decision-b");
+        assert_eq!(first.timestamp_physical_ms, 2000);
+        assert_eq!(first.timestamp_logical, 7);
+        assert_eq!(
+            first.entry_hash, second.entry_hash,
+            "same audit input must hash deterministically"
+        );
+    }
+
+    #[test]
+    fn first_audit_entry_uses_zero_previous_hash() {
+        let payload = serde_json::json!({"event": "vote_recorded", "decision_id": "decision-1"});
+        let timestamp = exo_core::Timestamp::new(3000, 0);
+
+        let entry = build_audit_entry(
+            None,
+            "VoteCast",
+            "did:exo:alice",
+            "tenant-a",
+            "decision-1",
+            timestamp,
+            &payload,
+        )
+        .expect("audit entry");
+
+        assert_eq!(entry.sequence, 1);
+        assert_eq!(entry.prev_hash, Hash256::ZERO.to_string());
+    }
+
+    #[test]
+    fn gateway_vote_audit_path_does_not_call_chrono_utc_now() {
+        let source = include_str!("handlers.rs");
+        let forbidden = ["chrono::Utc", "::now"].concat();
+        assert!(
+            !source.contains(&forbidden),
+            "gateway vote audit path must use HLC timestamps, not wall-clock timestamps"
+        );
+    }
+
+    #[cfg(feature = "production-db")]
+    #[tokio::test]
+    async fn vote_audit_write_is_read_by_audit_route_from_migrated_schema() {
+        use std::sync::{Arc, RwLock};
+
+        use axum::{
+            body::{Body, to_bytes},
+            http::{Request, StatusCode},
+        };
+        use exo_identity::registry::LocalDidRegistry;
+        use sqlx::postgres::PgPoolOptions;
+        use tower::ServiceExt;
+
+        let url = match std::env::var("DATABASE_URL") {
+            Ok(url) => url,
+            Err(_) => return,
+        };
+        let pool = match PgPoolOptions::new().max_connections(1).connect(&url).await {
+            Ok(pool) => pool,
+            Err(_) => return,
+        };
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("migrations");
+        sqlx::query("DELETE FROM audit_entries")
+            .execute(&pool)
+            .await
+            .expect("clean audit entries");
+
+        let state = AppState::new(
+            Some(pool.clone()),
+            Arc::new(RwLock::new(LocalDidRegistry::new())),
+        );
+        let decision_id = "decision-r4-audit-route";
+        let voter = "did:exo:r4-voter";
+        let payload = serde_json::json!({
+            "event": "vote_recorded",
+            "decision_id": decision_id,
+            "voter": voter,
+            "choice": "Approve",
+        });
+
+        write_audit(
+            &state,
+            "VoteCast",
+            voter,
+            "tenant-r4",
+            decision_id,
+            &payload,
+        )
+        .await
+        .expect("first audit write");
+        write_audit(
+            &state,
+            "VoteCast",
+            voter,
+            "tenant-r4",
+            decision_id,
+            &payload,
+        )
+        .await
+        .expect("second audit write");
+
+        let app = crate::server::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/v1/audit/{decision_id}"))
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("body bytes");
+        let body: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        let entries = body["audit_entries"].as_array().expect("entries array");
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0]["sequence"], 1);
+        assert_eq!(entries[1]["sequence"], 2);
+        assert_eq!(entries[0]["decision_id"], decision_id);
+        assert_eq!(entries[1]["prev_hash"], entries[0]["entry_hash"]);
     }
 
     // Violation 1: must_recuse returns true for financial conflict

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -25,6 +25,7 @@ use tokio::net::TcpListener;
 use tower_http::trace::TraceLayer;
 
 use crate::{
+    db,
     error::{GatewayError, Result},
     graphql,
     handlers::{health_handler as db_health_handler, vote_handler},
@@ -588,12 +589,12 @@ async fn handle_decision_get(
 
 /// GET /api/v1/audit/:decision_id — retrieve the audit trail for a decision.
 ///
-/// Queries the `audit_log` table populated by the vote handler.  Requires a DB pool.
+/// Queries the `audit_entries` table populated by the vote handler.  Requires a DB pool.
 async fn handle_audit_trail(
     State(state): State<AppState>,
     Path(decision_id): Path<String>,
 ) -> impl IntoResponse {
-    let db = match state.require_db() {
+    let pool = match state.require_db() {
         Ok(pool) => pool,
         Err(_) => {
             return (
@@ -606,25 +607,22 @@ async fn handle_audit_trail(
                 .into_response();
         }
     };
-    match sqlx::query_as::<_, (String, String, String, serde_json::Value, i64)>(
-        "SELECT id, event_type, actor, payload, created_at \
-         FROM audit_log WHERE actor = $1 OR payload->>'decision_id' = $1 \
-         ORDER BY created_at ASC",
-    )
-    .bind(&decision_id)
-    .fetch_all(db)
-    .await
-    {
+    match db::list_audit_entries_for_decision(pool, &decision_id).await {
         Ok(rows) => {
             let entries: Vec<serde_json::Value> = rows
                 .into_iter()
-                .map(|(id, event_type, actor, payload, created_at)| {
+                .map(|entry| {
                     serde_json::json!({
-                        "id": id,
-                        "event_type": event_type,
-                        "actor": actor,
-                        "payload": payload,
-                        "created_at": created_at,
+                        "sequence": entry.sequence,
+                        "prev_hash": entry.prev_hash,
+                        "event_hash": entry.event_hash,
+                        "event_type": entry.event_type,
+                        "actor": entry.actor,
+                        "tenant_id": entry.tenant_id,
+                        "decision_id": entry.decision_id,
+                        "timestamp_physical_ms": entry.timestamp_physical_ms,
+                        "timestamp_logical": entry.timestamp_logical,
+                        "entry_hash": entry.entry_hash,
                     })
                 })
                 .collect();


### PR DESCRIPTION
## Summary
- add decision_id migration for audit_entries readback by decision
- write vote audit entries into the relational hash-chain schema with HLC physical/logical fields
- route /api/v1/audit/:decision_id through audit_entries instead of nonexistent audit_log

## TDD / Verification
- RED: cargo test -p exo-gateway audit_entry_record_chains_from_previous_entry failed before AuditRow.decision_id and build_audit_entry existed
- cargo test -p exo-gateway audit_entry
- DATABASE_URL=postgres://exochain:exochain_dev@localhost:5432/exochain cargo test -p exo-gateway --features production-db vote_audit_write_is_read_by_audit_route_from_migrated_schema
- cargo test -p exo-gateway
- DATABASE_URL=postgres://exochain:exochain_dev@localhost:5432/exochain cargo test -p exo-gateway --features production-db
- cargo test -p exo-gateway --features unaudited-gateway-graphql-api
- cargo build -p exo-gateway
- cargo build -p exo-gateway --features production-db
- cargo build -p exo-gateway --features unaudited-gateway-graphql-api
- cargo clippy -p exo-gateway --all-targets -- -D warnings
- cargo clippy -p exo-gateway --all-targets --features production-db -- -D warnings
- cargo clippy -p exo-gateway --all-targets --features unaudited-gateway-graphql-api -- -D warnings
- cargo +nightly fmt --all -- --check
- git diff --check