### PR TITLE
fix(exo-messaging): verify death trigger confirmations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,15 +497,14 @@ jobs:
       - name: Build WASM
         run: wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm
       - name: Verify WASM exports
-        # Expected export count = 136. Baseline was 110 before
+        # Expected export count = 140. Baseline was 110 before
         # decision-forum, messaging, death-trigger, and franchise/NewCo
-        # scaffold were added. See Initiative `wasm-bridge-test-coverage`
-        # — 26 new exports still need JS-side bridge_verification.mjs
-        # coverage; they are built and exported, but not round-tripped.
+        # scaffold were added. Remaining bridge coverage debt is tracked in
+        # Initiative `wasm-bridge-test-coverage`.
         run: |
           COUNT=$(grep -c "module.exports.wasm_" packages/exochain-wasm/wasm/exochain_wasm.js)
           echo "Found $COUNT WASM exports"
-          [ "$COUNT" -eq 137 ] || (echo "Expected 137 exports, got $COUNT" && exit 1)
+          [ "$COUNT" -eq 140 ] || (echo "Expected 140 exports, got $COUNT" && exit 1)
       - name: Upload WASM artifact
         uses: actions/upload-artifact@v4
         with:
@@ -540,14 +539,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Verify Rust exports match JS expectations
-        # Expected #[wasm_bindgen] count = 136. Baseline was 110 before the
+        # Expected #[wasm_bindgen] count = 140. Baseline was 110 before the
         # Sprint-4 additions (decision-forum, messaging, death-trigger,
-        # franchise/NewCo scaffold). See initiative `wasm-bridge-test-coverage`
-        # — 26 new functions still need bridge_verification.mjs coverage.
+        # franchise/NewCo scaffold). Remaining bridge coverage debt is tracked
+        # in initiative `wasm-bridge-test-coverage`.
         run: |
           RUST_COUNT=$(grep -r '#\[wasm_bindgen\]' crates/exochain-wasm/src/ | wc -l | tr -d ' ')
           echo "Rust #[wasm_bindgen] exports: $RUST_COUNT"
-          [ "$RUST_COUNT" -eq 137 ] || (echo "WASM export count changed from 137 to $RUST_COUNT — update bridge tests" && exit 1)
+          [ "$RUST_COUNT" -eq 140 ] || (echo "WASM export count changed from 140 to $RUST_COUNT — update bridge tests" && exit 1)
 
   # -----------------------------------------------------------------------
   # Constitutional gate: all must pass

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,6 +1522,7 @@ dependencies = [
 name = "exo-messaging"
 version = "0.1.0-beta"
 dependencies = [
+ "ciborium",
  "exo-core",
  "exo-identity",
  "hex",

--- a/crates/exo-messaging/Cargo.toml
+++ b/crates/exo-messaging/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 exo-core = { path = "../exo-core" }
 exo-identity = { path = "../exo-identity" }
+ciborium = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 x25519-dalek = { workspace = true }

--- a/crates/exo-messaging/src/death_trigger.rs
+++ b/crates/exo-messaging/src/death_trigger.rs
@@ -3,12 +3,14 @@
 //! Manages the lifecycle of death verification claims and the
 //! conditional release of afterlife messages.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
-use exo_core::{Did, Timestamp, hlc::HybridClock};
+use exo_core::{Did, PublicKey, Signature, Timestamp, hlc::HybridClock};
 use serde::{Deserialize, Serialize};
 
 use crate::error::MessagingError;
+
+const DEATH_CONFIRMATION_SIGNING_DOMAIN: &str = "exo.messaging.death-trigger.confirmation.v1";
 
 /// Status of a death verification request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -25,6 +27,8 @@ pub enum DeathVerificationStatus {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TrusteeConfirmation {
     pub trustee_did: Did,
+    pub public_key: PublicKey,
+    pub signature: Signature,
     pub confirmed_at: Timestamp,
 }
 
@@ -37,6 +41,10 @@ pub struct DeathVerification {
     pub initiated_by: Did,
     /// Number of trustee confirmations required (default: 3 for 3-of-4 PACE).
     pub required_confirmations: u8,
+    /// Authorized trustee public keys, sorted by DID for deterministic signing payloads.
+    pub authorized_trustees: BTreeMap<Did, PublicKey>,
+    /// Caller-supplied claim nonce binding signatures to this verification instance.
+    pub claim_nonce: Vec<u8>,
     /// Collected trustee confirmations.
     pub confirmations: Vec<TrusteeConfirmation>,
     /// Current verification status.
@@ -47,31 +55,169 @@ pub struct DeathVerification {
     pub resolved_at: Option<Timestamp>,
 }
 
+#[derive(Serialize)]
+struct AuthorizedTrusteeSigningEntry<'a> {
+    did: &'a str,
+    public_key: &'a [u8; 32],
+}
+
+#[derive(Serialize)]
+struct ConfirmationSigningPayload<'a> {
+    domain: &'static str,
+    subject_did: &'a str,
+    initiated_by: &'a str,
+    required_confirmations: u8,
+    claim_nonce: &'a [u8],
+    trustee_did: &'a str,
+    authorized_trustees: Vec<AuthorizedTrusteeSigningEntry<'a>>,
+}
+
+/// Canonical CBOR payload signed for the initiator's first confirmation.
+///
+/// The payload binds the subject, initiator, threshold, authorized trustee set,
+/// caller-supplied claim nonce, and confirming trustee DID. The signature itself
+/// and HLC timestamps are excluded so callers can sign before the state exists.
+pub fn initial_confirmation_signing_payload(
+    subject_did: &Did,
+    initiated_by: &Did,
+    required_confirmations: u8,
+    authorized_trustees: &BTreeMap<Did, PublicKey>,
+    claim_nonce: &[u8],
+) -> Result<Vec<u8>, MessagingError> {
+    confirmation_signing_payload_for(
+        subject_did,
+        initiated_by,
+        required_confirmations,
+        authorized_trustees,
+        claim_nonce,
+        initiated_by,
+    )
+}
+
+fn confirmation_signing_payload_for(
+    subject_did: &Did,
+    initiated_by: &Did,
+    required_confirmations: u8,
+    authorized_trustees: &BTreeMap<Did, PublicKey>,
+    claim_nonce: &[u8],
+    trustee_did: &Did,
+) -> Result<Vec<u8>, MessagingError> {
+    let trustee_entries = authorized_trustees
+        .iter()
+        .map(|(did, public_key)| AuthorizedTrusteeSigningEntry {
+            did: did.as_str(),
+            public_key: public_key.as_bytes(),
+        })
+        .collect();
+    let payload = ConfirmationSigningPayload {
+        domain: DEATH_CONFIRMATION_SIGNING_DOMAIN,
+        subject_did: subject_did.as_str(),
+        initiated_by: initiated_by.as_str(),
+        required_confirmations,
+        claim_nonce,
+        trustee_did: trustee_did.as_str(),
+        authorized_trustees: trustee_entries,
+    };
+    let mut encoded = Vec::new();
+    ciborium::into_writer(&payload, &mut encoded)
+        .map_err(|e| MessagingError::DeathConfirmationPayloadEncoding(e.to_string()))?;
+    Ok(encoded)
+}
+
 impl DeathVerification {
     /// Create a new death verification request.
-    pub fn new(subject_did: Did, initiated_by: Did, required_confirmations: u8) -> Self {
+    pub fn new(
+        subject_did: Did,
+        initiated_by: Did,
+        required_confirmations: u8,
+        authorized_trustees: BTreeMap<Did, PublicKey>,
+        claim_nonce: Vec<u8>,
+        initiator_signature: Signature,
+    ) -> Result<Self, MessagingError> {
+        validate_death_verification_request(
+            &initiated_by,
+            required_confirmations,
+            &authorized_trustees,
+            &claim_nonce,
+        )?;
+        let initiator_public_key = *authorized_trustees
+            .get(&initiated_by)
+            .ok_or_else(|| MessagingError::UnauthorizedTrustee(initiated_by.as_str().to_owned()))?;
+        let signing_payload = initial_confirmation_signing_payload(
+            &subject_did,
+            &initiated_by,
+            required_confirmations,
+            &authorized_trustees,
+            &claim_nonce,
+        )?;
+        if !exo_core::crypto::verify(
+            &signing_payload,
+            &initiator_signature,
+            &initiator_public_key,
+        ) {
+            return Err(MessagingError::SignatureVerificationFailed);
+        }
+
         let mut clock = HybridClock::new();
         let now = clock.now();
+        let status = if required_confirmations == 1 {
+            DeathVerificationStatus::Verified
+        } else {
+            DeathVerificationStatus::Pending
+        };
+        let resolved_at = if status == DeathVerificationStatus::Verified {
+            Some(now)
+        } else {
+            None
+        };
 
-        Self {
+        Ok(Self {
             subject_did,
             initiated_by: initiated_by.clone(),
             required_confirmations,
+            authorized_trustees,
+            claim_nonce,
             confirmations: vec![TrusteeConfirmation {
                 trustee_did: initiated_by,
+                public_key: initiator_public_key,
+                signature: initiator_signature,
                 confirmed_at: now,
             }],
-            status: DeathVerificationStatus::Pending,
+            status,
             created: now,
-            resolved_at: None,
-        }
+            resolved_at,
+        })
+    }
+
+    /// Canonical CBOR payload a trustee signs to confirm this death claim.
+    pub fn confirmation_signing_payload(
+        &self,
+        trustee_did: &Did,
+    ) -> Result<Vec<u8>, MessagingError> {
+        confirmation_signing_payload_for(
+            &self.subject_did,
+            &self.initiated_by,
+            self.required_confirmations,
+            &self.authorized_trustees,
+            &self.claim_nonce,
+            trustee_did,
+        )
     }
 
     /// Add a trustee confirmation. Returns `true` if the threshold is now met.
-    pub fn confirm(&mut self, trustee_did: Did) -> Result<bool, MessagingError> {
+    pub fn confirm(
+        &mut self,
+        trustee_did: Did,
+        trustee_public_key: PublicKey,
+        signature: Signature,
+    ) -> Result<bool, MessagingError> {
         if self.status != DeathVerificationStatus::Pending {
             return Err(MessagingError::DeathTriggerAlreadyResolved);
         }
+        let expected_public_key = *self
+            .authorized_trustees
+            .get(&trustee_did)
+            .ok_or_else(|| MessagingError::UnauthorizedTrustee(trustee_did.as_str().to_owned()))?;
 
         // Check for duplicate
         let existing: BTreeSet<String> = self
@@ -84,12 +230,21 @@ impl DeathVerification {
                 trustee_did.as_str().to_owned(),
             ));
         }
+        if expected_public_key != trustee_public_key {
+            return Err(MessagingError::SignatureVerificationFailed);
+        }
+        let signing_payload = self.confirmation_signing_payload(&trustee_did)?;
+        if !exo_core::crypto::verify(&signing_payload, &signature, &expected_public_key) {
+            return Err(MessagingError::SignatureVerificationFailed);
+        }
 
         let mut clock = HybridClock::new();
         let now = clock.now();
 
         self.confirmations.push(TrusteeConfirmation {
             trustee_did,
+            public_key: expected_public_key,
+            signature,
             confirmed_at: now,
         });
 
@@ -132,36 +287,303 @@ impl DeathVerification {
     }
 }
 
+fn validate_death_verification_request(
+    initiated_by: &Did,
+    required_confirmations: u8,
+    authorized_trustees: &BTreeMap<Did, PublicKey>,
+    claim_nonce: &[u8],
+) -> Result<(), MessagingError> {
+    if required_confirmations == 0 {
+        return Err(MessagingError::InvalidDeathVerification(
+            "required_confirmations must be at least 1".to_owned(),
+        ));
+    }
+    if authorized_trustees.is_empty() {
+        return Err(MessagingError::InvalidDeathVerification(
+            "authorized_trustees must not be empty".to_owned(),
+        ));
+    }
+    if usize::from(required_confirmations) > authorized_trustees.len() {
+        return Err(MessagingError::InsufficientConfirmations {
+            need: required_confirmations,
+            got: u8::try_from(authorized_trustees.len()).unwrap_or(u8::MAX),
+        });
+    }
+    if claim_nonce.is_empty() {
+        return Err(MessagingError::InvalidDeathVerification(
+            "claim_nonce must not be empty".to_owned(),
+        ));
+    }
+    if !authorized_trustees.contains_key(initiated_by) {
+        return Err(MessagingError::UnauthorizedTrustee(
+            initiated_by.as_str().to_owned(),
+        ));
+    }
+    Ok(())
+}
+
 // ===========================================================================
 // Tests
 // ===========================================================================
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
+    use exo_core::{
+        PublicKey, Signature,
+        crypto::{KeyPair, sign},
+    };
+
     use super::*;
 
     fn did(name: &str) -> Did {
         Did::new(&format!("did:exo:{name}")).unwrap()
     }
 
+    fn keypair(seed: u8) -> KeyPair {
+        KeyPair::from_secret_bytes([seed; 32]).unwrap()
+    }
+
+    fn authorized_trustees(entries: &[(&Did, &KeyPair)]) -> BTreeMap<Did, PublicKey> {
+        entries
+            .iter()
+            .map(|(trustee_did, keypair)| ((*trustee_did).clone(), *keypair.public_key()))
+            .collect()
+    }
+
+    fn initial_signature(
+        subject: &Did,
+        initiated_by: &Did,
+        required_confirmations: u8,
+        authorized_trustees: &BTreeMap<Did, PublicKey>,
+        claim_nonce: &[u8],
+        keypair: &KeyPair,
+    ) -> Signature {
+        let payload = initial_confirmation_signing_payload(
+            subject,
+            initiated_by,
+            required_confirmations,
+            authorized_trustees,
+            claim_nonce,
+        )
+        .unwrap();
+        sign(&payload, keypair.secret_key())
+    }
+
+    fn signed_verification(
+        subject: &Did,
+        initiated_by: &Did,
+        required_confirmations: u8,
+        authorized_trustees: BTreeMap<Did, PublicKey>,
+        claim_nonce: Vec<u8>,
+        keypair: &KeyPair,
+    ) -> DeathVerification {
+        let signature = initial_signature(
+            subject,
+            initiated_by,
+            required_confirmations,
+            &authorized_trustees,
+            &claim_nonce,
+            keypair,
+        );
+        DeathVerification::new(
+            subject.clone(),
+            initiated_by.clone(),
+            required_confirmations,
+            authorized_trustees,
+            claim_nonce,
+            signature,
+        )
+        .unwrap()
+    }
+
+    fn confirmation_signature(
+        verification: &DeathVerification,
+        trustee_did: &Did,
+        keypair: &KeyPair,
+    ) -> Signature {
+        let payload = verification
+            .confirmation_signing_payload(trustee_did)
+            .unwrap();
+        sign(&payload, keypair.secret_key())
+    }
+
     #[test]
-    fn new_verification_has_initiator_confirmation() {
-        let dv = DeathVerification::new(did("alice"), did("bob"), 3);
+    fn initiator_confirmation_requires_valid_signature() {
+        let subject = did("alice");
+        let bob = did("bob");
+        let carol = did("carol");
+        let bob_key = keypair(1);
+        let carol_key = keypair(2);
+        let authorized = authorized_trustees(&[(&bob, &bob_key), (&carol, &carol_key)]);
+        let nonce = b"r6-claim-1".to_vec();
+
+        let result = DeathVerification::new(
+            subject.clone(),
+            bob.clone(),
+            2,
+            authorized.clone(),
+            nonce.clone(),
+            Signature::Empty,
+        );
+        assert!(matches!(
+            result,
+            Err(MessagingError::SignatureVerificationFailed)
+        ));
+
+        let signature = initial_signature(&subject, &bob, 2, &authorized, &nonce, &bob_key);
+        let dv =
+            DeathVerification::new(subject, bob.clone(), 2, authorized, nonce, signature).unwrap();
         assert_eq!(dv.confirmations.len(), 1);
         assert_eq!(dv.confirmations[0].trustee_did, did("bob"));
+        assert_eq!(dv.confirmations[0].public_key, *bob_key.public_key());
         assert_eq!(dv.status, DeathVerificationStatus::Pending);
-        assert_eq!(dv.confirmations_remaining(), 2);
+        assert_eq!(dv.confirmations_remaining(), 1);
+    }
+
+    #[test]
+    fn unknown_trustee_confirmation_rejected() {
+        let subject = did("alice");
+        let bob = did("bob");
+        let carol = did("carol");
+        let mallory = did("mallory");
+        let bob_key = keypair(1);
+        let carol_key = keypair(2);
+        let mallory_key = keypair(9);
+        let authorized = authorized_trustees(&[(&bob, &bob_key), (&carol, &carol_key)]);
+        let mut dv = signed_verification(
+            &subject,
+            &bob,
+            2,
+            authorized,
+            b"r6-claim-2".to_vec(),
+            &bob_key,
+        );
+
+        let result = dv.confirm(mallory.clone(), *mallory_key.public_key(), Signature::Empty);
+        assert!(matches!(
+            result,
+            Err(MessagingError::UnauthorizedTrustee(trustee)) if trustee == mallory.as_str()
+        ));
+    }
+
+    #[test]
+    fn wrong_key_confirmation_rejected() {
+        let subject = did("alice");
+        let bob = did("bob");
+        let carol = did("carol");
+        let bob_key = keypair(1);
+        let carol_key = keypair(2);
+        let wrong_key = keypair(9);
+        let authorized = authorized_trustees(&[(&bob, &bob_key), (&carol, &carol_key)]);
+        let mut dv = signed_verification(
+            &subject,
+            &bob,
+            2,
+            authorized,
+            b"r6-claim-3".to_vec(),
+            &bob_key,
+        );
+        let signature = confirmation_signature(&dv, &carol, &wrong_key);
+
+        let result = dv.confirm(carol, *wrong_key.public_key(), signature);
+        assert!(matches!(
+            result,
+            Err(MessagingError::SignatureVerificationFailed)
+        ));
+    }
+
+    #[test]
+    fn replayed_confirmation_for_different_claim_nonce_rejected() {
+        let subject = did("alice");
+        let bob = did("bob");
+        let carol = did("carol");
+        let bob_key = keypair(1);
+        let carol_key = keypair(2);
+        let authorized = authorized_trustees(&[(&bob, &bob_key), (&carol, &carol_key)]);
+        let dv_a = signed_verification(
+            &subject,
+            &bob,
+            2,
+            authorized.clone(),
+            b"r6-claim-a".to_vec(),
+            &bob_key,
+        );
+        let mut dv_b = signed_verification(
+            &subject,
+            &bob,
+            2,
+            authorized,
+            b"r6-claim-b".to_vec(),
+            &bob_key,
+        );
+        let replayed_signature = confirmation_signature(&dv_a, &carol, &carol_key);
+
+        let result = dv_b.confirm(carol, *carol_key.public_key(), replayed_signature);
+        assert!(matches!(
+            result,
+            Err(MessagingError::SignatureVerificationFailed)
+        ));
+    }
+
+    #[test]
+    fn tampered_verification_state_rejects_previous_signature() {
+        let subject = did("alice");
+        let bob = did("bob");
+        let carol = did("carol");
+        let bob_key = keypair(1);
+        let carol_key = keypair(2);
+        let authorized = authorized_trustees(&[(&bob, &bob_key), (&carol, &carol_key)]);
+        let mut dv = signed_verification(
+            &subject,
+            &bob,
+            2,
+            authorized,
+            b"r6-claim-4".to_vec(),
+            &bob_key,
+        );
+        let signature = confirmation_signature(&dv, &carol, &carol_key);
+        dv.subject_did = did("mallory");
+
+        let result = dv.confirm(carol, *carol_key.public_key(), signature);
+        assert!(matches!(
+            result,
+            Err(MessagingError::SignatureVerificationFailed)
+        ));
     }
 
     #[test]
     fn threshold_met_triggers_verified() {
-        let mut dv = DeathVerification::new(did("alice"), did("bob"), 3);
+        let subject = did("alice");
+        let bob = did("bob");
+        let carol = did("carol");
+        let dave = did("dave");
+        let bob_key = keypair(1);
+        let carol_key = keypair(2);
+        let dave_key = keypair(3);
+        let authorized =
+            authorized_trustees(&[(&bob, &bob_key), (&carol, &carol_key), (&dave, &dave_key)]);
+        let mut dv = signed_verification(
+            &subject,
+            &bob,
+            3,
+            authorized,
+            b"r6-claim-5".to_vec(),
+            &bob_key,
+        );
 
-        let met = dv.confirm(did("carol")).unwrap();
+        let carol_signature = confirmation_signature(&dv, &carol, &carol_key);
+        let met = dv
+            .confirm(carol.clone(), *carol_key.public_key(), carol_signature)
+            .unwrap();
         assert!(!met);
         assert_eq!(dv.confirmations_remaining(), 1);
 
-        let met = dv.confirm(did("dave")).unwrap();
+        let dave_signature = confirmation_signature(&dv, &dave, &dave_key);
+        let met = dv
+            .confirm(dave, *dave_key.public_key(), dave_signature)
+            .unwrap();
         assert!(met);
         assert_eq!(dv.status, DeathVerificationStatus::Verified);
         assert!(dv.should_release());
@@ -170,19 +592,59 @@ mod tests {
 
     #[test]
     fn duplicate_confirmation_rejected() {
-        let mut dv = DeathVerification::new(did("alice"), did("bob"), 3);
-        let result = dv.confirm(did("bob"));
+        let subject = did("alice");
+        let bob = did("bob");
+        let carol = did("carol");
+        let dave = did("dave");
+        let bob_key = keypair(1);
+        let carol_key = keypair(2);
+        let dave_key = keypair(3);
+        let authorized =
+            authorized_trustees(&[(&bob, &bob_key), (&carol, &carol_key), (&dave, &dave_key)]);
+        let mut dv = signed_verification(
+            &subject,
+            &bob,
+            3,
+            authorized,
+            b"r6-claim-6".to_vec(),
+            &bob_key,
+        );
+        let signature = confirmation_signature(&dv, &carol, &carol_key);
+        dv.confirm(carol.clone(), *carol_key.public_key(), signature.clone())
+            .unwrap();
+
+        let result = dv.confirm(carol.clone(), *carol_key.public_key(), signature);
         assert!(matches!(
             result,
-            Err(MessagingError::DuplicateConfirmation(_))
+            Err(MessagingError::DuplicateConfirmation(trustee)) if trustee == carol.as_str()
         ));
     }
 
     #[test]
     fn cannot_confirm_after_resolved() {
-        let mut dv = DeathVerification::new(did("alice"), did("bob"), 2);
-        dv.confirm(did("carol")).unwrap(); // threshold met
-        let result = dv.confirm(did("dave"));
+        let subject = did("alice");
+        let bob = did("bob");
+        let carol = did("carol");
+        let dave = did("dave");
+        let bob_key = keypair(1);
+        let carol_key = keypair(2);
+        let dave_key = keypair(3);
+        let authorized =
+            authorized_trustees(&[(&bob, &bob_key), (&carol, &carol_key), (&dave, &dave_key)]);
+        let mut dv = signed_verification(
+            &subject,
+            &bob,
+            2,
+            authorized,
+            b"r6-claim-7".to_vec(),
+            &bob_key,
+        );
+        let carol_signature = confirmation_signature(&dv, &carol, &carol_key);
+        dv.confirm(carol, *carol_key.public_key(), carol_signature)
+            .unwrap();
+
+        let dave_signature = confirmation_signature(&dv, &dave, &dave_key);
+        let result = dv.confirm(dave, *dave_key.public_key(), dave_signature);
         assert!(matches!(
             result,
             Err(MessagingError::DeathTriggerAlreadyResolved)
@@ -191,12 +653,26 @@ mod tests {
 
     #[test]
     fn reject_prevents_further_confirmations() {
-        let mut dv = DeathVerification::new(did("alice"), did("bob"), 3);
+        let subject = did("alice");
+        let bob = did("bob");
+        let carol = did("carol");
+        let bob_key = keypair(1);
+        let carol_key = keypair(2);
+        let authorized = authorized_trustees(&[(&bob, &bob_key), (&carol, &carol_key)]);
+        let mut dv = signed_verification(
+            &subject,
+            &bob,
+            2,
+            authorized,
+            b"r6-claim-8".to_vec(),
+            &bob_key,
+        );
         dv.reject().unwrap();
         assert_eq!(dv.status, DeathVerificationStatus::Rejected);
         assert!(!dv.should_release());
 
-        let result = dv.confirm(did("carol"));
+        let carol_signature = confirmation_signature(&dv, &carol, &carol_key);
+        let result = dv.confirm(carol, *carol_key.public_key(), carol_signature);
         assert!(matches!(
             result,
             Err(MessagingError::DeathTriggerAlreadyResolved)
@@ -205,14 +681,44 @@ mod tests {
 
     #[test]
     fn full_pace_4_trustee_flow() {
-        // Simulates the 3-of-4 PACE trustee death verification
-        let mut dv = DeathVerification::new(did("subject"), did("primary"), 3);
+        let subject = did("subject");
+        let primary = did("primary");
+        let alternate = did("alternate");
+        let contingency = did("contingency");
+        let observer = did("observer");
+        let primary_key = keypair(1);
+        let alternate_key = keypair(2);
+        let contingency_key = keypair(3);
+        let observer_key = keypair(4);
+        let authorized = authorized_trustees(&[
+            (&primary, &primary_key),
+            (&alternate, &alternate_key),
+            (&contingency, &contingency_key),
+            (&observer, &observer_key),
+        ]);
+        let mut dv = signed_verification(
+            &subject,
+            &primary,
+            3,
+            authorized,
+            b"r6-claim-9".to_vec(),
+            &primary_key,
+        );
         assert_eq!(dv.confirmations_remaining(), 2);
 
-        dv.confirm(did("alternate")).unwrap();
+        let alternate_signature = confirmation_signature(&dv, &alternate, &alternate_key);
+        dv.confirm(alternate, *alternate_key.public_key(), alternate_signature)
+            .unwrap();
         assert_eq!(dv.confirmations_remaining(), 1);
 
-        let verified = dv.confirm(did("contingency")).unwrap();
+        let contingency_signature = confirmation_signature(&dv, &contingency, &contingency_key);
+        let verified = dv
+            .confirm(
+                contingency,
+                *contingency_key.public_key(),
+                contingency_signature,
+            )
+            .unwrap();
         assert!(verified);
         assert!(dv.should_release());
         assert_eq!(dv.confirmations_remaining(), 0);

--- a/crates/exo-messaging/src/error.rs
+++ b/crates/exo-messaging/src/error.rs
@@ -15,6 +15,9 @@ pub enum MessagingError {
     #[error("signature verification failed")]
     SignatureVerificationFailed,
 
+    #[error("death-trigger confirmation payload encoding failed: {0}")]
+    DeathConfirmationPayloadEncoding(String),
+
     #[error("invalid envelope: {0}")]
     InvalidEnvelope(String),
 
@@ -24,8 +27,14 @@ pub enum MessagingError {
     #[error("death trigger already resolved")]
     DeathTriggerAlreadyResolved,
 
+    #[error("invalid death verification: {0}")]
+    InvalidDeathVerification(String),
+
     #[error("insufficient confirmations: need {need}, got {got}")]
     InsufficientConfirmations { need: u8, got: u8 },
+
+    #[error("unauthorized death-trigger trustee: {0}")]
+    UnauthorizedTrustee(String),
 
     #[error("duplicate confirmation from: {0}")]
     DuplicateConfirmation(String),

--- a/crates/exochain-wasm/src/core_bindings.rs
+++ b/crates/exochain-wasm/src/core_bindings.rs
@@ -95,6 +95,18 @@ pub fn wasm_sign(message: &[u8], secret_hex: &str) -> Result<String, JsValue> {
 }
 
 #[wasm_bindgen]
+pub fn wasm_ed25519_public_from_secret(secret_hex: &str) -> Result<String, JsValue> {
+    let secret_bytes =
+        hex::decode(secret_hex).map_err(|e| JsValue::from_str(&format!("hex: {e}")))?;
+    let arr: [u8; 32] = secret_bytes
+        .try_into()
+        .map_err(|_| JsValue::from_str("secret key must be 32 bytes"))?;
+    let keypair = exo_core::crypto::KeyPair::from_secret_bytes(arr)
+        .map_err(|e| JsValue::from_str(&format!("keypair: {e}")))?;
+    Ok(hex::encode(keypair.public_key().as_bytes()))
+}
+
+#[wasm_bindgen]
 pub fn wasm_verify(
     message: &[u8],
     signature_json: &str,

--- a/crates/exochain-wasm/src/messaging_bindings.rs
+++ b/crates/exochain-wasm/src/messaging_bindings.rs
@@ -1,8 +1,17 @@
 //! Messaging bindings: X25519 key exchange, message encrypt/decrypt, death verification
 
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
 use wasm_bindgen::prelude::*;
 
 use crate::serde_bridge::*;
+
+#[derive(Deserialize)]
+struct WasmAuthorizedTrustee {
+    did: String,
+    public_key_hex: String,
+}
 
 /// Generate a new X25519 keypair for Diffie-Hellman key exchange.
 /// Returns `{ public_key_hex, secret_key_hex }`.
@@ -159,25 +168,133 @@ pub fn wasm_verify_message_signature(
     ))
 }
 
+fn parse_ed25519_public_key_hex(label: &str, value: &str) -> Result<exo_core::PublicKey, JsValue> {
+    let bytes =
+        hex::decode(value).map_err(|e| JsValue::from_str(&format!("invalid {label} hex: {e}")))?;
+    if bytes.len() != 32 {
+        return Err(JsValue::from_str(&format!("{label} must be 32 bytes")));
+    }
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(&bytes);
+    Ok(exo_core::PublicKey::from_bytes(arr))
+}
+
+fn parse_ed25519_signature_hex(label: &str, value: &str) -> Result<exo_core::Signature, JsValue> {
+    let bytes =
+        hex::decode(value).map_err(|e| JsValue::from_str(&format!("invalid {label} hex: {e}")))?;
+    if bytes.len() != 64 {
+        return Err(JsValue::from_str(&format!("{label} must be 64 bytes")));
+    }
+    let mut arr = [0u8; 64];
+    arr.copy_from_slice(&bytes);
+    Ok(exo_core::Signature::from_bytes(arr))
+}
+
+fn parse_authorized_trustees_json(
+    authorized_trustees_json: &str,
+) -> Result<BTreeMap<exo_core::Did, exo_core::PublicKey>, JsValue> {
+    let trustees: Vec<WasmAuthorizedTrustee> = from_json_str(authorized_trustees_json)?;
+    let mut authorized = BTreeMap::new();
+    for trustee in trustees {
+        let did = exo_core::Did::new(&trustee.did)
+            .map_err(|e| JsValue::from_str(&format!("invalid trustee DID: {e}")))?;
+        let public_key =
+            parse_ed25519_public_key_hex("trustee Ed25519 public key", &trustee.public_key_hex)?;
+        if authorized.insert(did.clone(), public_key).is_some() {
+            return Err(JsValue::from_str(&format!(
+                "duplicate authorized trustee: {}",
+                did.as_str()
+            )));
+        }
+    }
+    Ok(authorized)
+}
+
+/// Compute the canonical death-verification initial confirmation payload.
+///
+/// Returns the CBOR bytes that `initiated_by_did` signs before calling
+/// [`wasm_death_verification_new`].
+#[wasm_bindgen]
+pub fn wasm_death_verification_initial_signing_payload(
+    subject_did: &str,
+    initiated_by_did: &str,
+    required_confirmations: u8,
+    authorized_trustees_json: &str,
+    claim_nonce_hex: &str,
+) -> Result<Vec<u8>, JsValue> {
+    let subject = exo_core::Did::new(subject_did)
+        .map_err(|e| JsValue::from_str(&format!("invalid subject DID: {e}")))?;
+    let initiator = exo_core::Did::new(initiated_by_did)
+        .map_err(|e| JsValue::from_str(&format!("invalid initiator DID: {e}")))?;
+    let authorized_trustees = parse_authorized_trustees_json(authorized_trustees_json)?;
+    let claim_nonce = hex::decode(claim_nonce_hex)
+        .map_err(|e| JsValue::from_str(&format!("invalid claim nonce hex: {e}")))?;
+
+    exo_messaging::death_trigger::initial_confirmation_signing_payload(
+        &subject,
+        &initiator,
+        required_confirmations,
+        &authorized_trustees,
+        &claim_nonce,
+    )
+    .map_err(|e| JsValue::from_str(&format!("death verification signing payload failed: {e}")))
+}
+
 /// Create a new death verification request.
+///
+/// `authorized_trustees_json` must be an array of
+/// `{ "did": "...", "public_key_hex": "..." }` objects. `claim_nonce_hex`
+/// and `initiator_signature_hex` bind the initiator's first confirmation to
+/// this claim instance.
 /// Returns the verification state as JSON.
 #[wasm_bindgen]
 pub fn wasm_death_verification_new(
     subject_did: &str,
     initiated_by_did: &str,
     required_confirmations: u8,
+    authorized_trustees_json: &str,
+    claim_nonce_hex: &str,
+    initiator_signature_hex: &str,
 ) -> Result<JsValue, JsValue> {
     let subject = exo_core::Did::new(subject_did)
         .map_err(|e| JsValue::from_str(&format!("invalid subject DID: {e}")))?;
     let initiator = exo_core::Did::new(initiated_by_did)
         .map_err(|e| JsValue::from_str(&format!("invalid initiator DID: {e}")))?;
+    let authorized_trustees = parse_authorized_trustees_json(authorized_trustees_json)?;
+    let claim_nonce = hex::decode(claim_nonce_hex)
+        .map_err(|e| JsValue::from_str(&format!("invalid claim nonce hex: {e}")))?;
+    let initiator_signature =
+        parse_ed25519_signature_hex("initiator confirmation signature", initiator_signature_hex)?;
 
     let dv = exo_messaging::death_trigger::DeathVerification::new(
         subject,
         initiator,
         required_confirmations,
-    );
+        authorized_trustees,
+        claim_nonce,
+        initiator_signature,
+    )
+    .map_err(|e| JsValue::from_str(&format!("death verification creation failed: {e}")))?;
     to_js_value(&dv)
+}
+
+/// Compute the canonical trustee confirmation payload for an existing claim.
+///
+/// Returns the CBOR bytes that `trustee_did` signs before calling
+/// [`wasm_death_verification_confirm`].
+#[wasm_bindgen]
+pub fn wasm_death_verification_confirmation_signing_payload(
+    state_json: &str,
+    trustee_did: &str,
+) -> Result<Vec<u8>, JsValue> {
+    let dv: exo_messaging::death_trigger::DeathVerification = from_json_str(state_json)?;
+    let trustee = exo_core::Did::new(trustee_did)
+        .map_err(|e| JsValue::from_str(&format!("invalid trustee DID: {e}")))?;
+    dv.confirmation_signing_payload(&trustee).map_err(|e| {
+        JsValue::from_str(&format!(
+            "death verification confirmation payload failed: {e}"
+        ))
+    })
 }
 
 /// Add a trustee confirmation to a death verification.
@@ -186,13 +303,18 @@ pub fn wasm_death_verification_new(
 pub fn wasm_death_verification_confirm(
     state_json: &str,
     trustee_did: &str,
+    trustee_public_key_hex: &str,
+    signature_hex: &str,
 ) -> Result<JsValue, JsValue> {
     let mut dv: exo_messaging::death_trigger::DeathVerification = from_json_str(state_json)?;
     let trustee = exo_core::Did::new(trustee_did)
         .map_err(|e| JsValue::from_str(&format!("invalid trustee DID: {e}")))?;
+    let trustee_public_key =
+        parse_ed25519_public_key_hex("trustee Ed25519 public key", trustee_public_key_hex)?;
+    let signature = parse_ed25519_signature_hex("trustee confirmation signature", signature_hex)?;
 
     let verified = dv
-        .confirm(trustee)
+        .confirm(trustee, trustee_public_key, signature)
         .map_err(|e| JsValue::from_str(&format!("confirmation failed: {e}")))?;
 
     to_js_value(&serde_json::json!({

--- a/demo/apps/vitallock/src/lib/crypto.ts
+++ b/demo/apps/vitallock/src/lib/crypto.ts
@@ -7,11 +7,14 @@
 
 import init, {
   wasm_generate_x25519_keypair,
+  wasm_ed25519_public_from_secret,
   wasm_encrypt_message,
   wasm_decrypt_message,
   wasm_verify_message_signature,
   wasm_shamir_split,
+  wasm_death_verification_initial_signing_payload,
   wasm_death_verification_new,
+  wasm_death_verification_confirmation_signing_payload,
   wasm_death_verification_confirm,
 } from '@/wasm/exochain_wasm';
 
@@ -22,6 +25,11 @@ export async function initCrypto(): Promise<void> {
   if (initialized) return;
   await init();
   initialized = true;
+}
+
+/** Derive an Ed25519 public key hex string from a caller-held secret key. */
+export function ed25519PublicFromSecret(secretKeyHex: string): string {
+  return wasm_ed25519_public_from_secret(secretKeyHex);
 }
 
 /** Check if WASM is initialized. */
@@ -133,23 +141,77 @@ export interface DeathVerificationState {
   subject_did: string;
   initiated_by: string;
   required_confirmations: number;
-  confirmations: Array<{ trustee_did: string; confirmed_at: object }>;
+  authorized_trustees: Record<string, number[]>;
+  claim_nonce: number[];
+  confirmations: Array<{
+    trustee_did: string;
+    public_key: number[];
+    signature: { Ed25519: number[] } | { Hybrid: unknown } | { PostQuantum: number[] } | 'Empty';
+    confirmed_at: object;
+  }>;
   status: 'Pending' | 'Verified' | 'Rejected';
+}
+
+export interface AuthorizedDeathVerificationTrustee {
+  did: string;
+  public_key_hex: string;
+}
+
+/** Compute the bytes the initiating trustee must sign for a death claim. */
+export function deathVerificationInitialSigningPayload(
+  subjectDid: string,
+  initiatedByDid: string,
+  authorizedTrustees: AuthorizedDeathVerificationTrustee[],
+  claimNonceHex: string,
+  requiredConfirmations: number = 3,
+): Uint8Array {
+  return wasm_death_verification_initial_signing_payload(
+    subjectDid,
+    initiatedByDid,
+    requiredConfirmations,
+    JSON.stringify(authorizedTrustees),
+    claimNonceHex,
+  );
 }
 
 /** Create a new death verification request. */
 export function createDeathVerification(
   subjectDid: string,
   initiatedByDid: string,
+  authorizedTrustees: AuthorizedDeathVerificationTrustee[],
+  claimNonceHex: string,
+  initiatorSignatureHex: string,
   requiredConfirmations: number = 3,
 ): DeathVerificationState {
-  return wasm_death_verification_new(subjectDid, initiatedByDid, requiredConfirmations);
+  return wasm_death_verification_new(
+    subjectDid,
+    initiatedByDid,
+    requiredConfirmations,
+    JSON.stringify(authorizedTrustees),
+    claimNonceHex,
+    initiatorSignatureHex,
+  );
+}
+
+/** Compute the bytes a trustee must sign to confirm an existing death claim. */
+export function deathVerificationConfirmationSigningPayload(
+  stateJson: string,
+  trusteeDid: string,
+): Uint8Array {
+  return wasm_death_verification_confirmation_signing_payload(stateJson, trusteeDid);
 }
 
 /** Add a trustee confirmation to a death verification. */
 export function confirmDeathVerification(
   stateJson: string,
   trusteeDid: string,
+  trusteePublicKeyHex: string,
+  signatureHex: string,
 ): { verified: boolean; confirmations_remaining: number; state: DeathVerificationState } {
-  return wasm_death_verification_confirm(stateJson, trusteeDid);
+  return wasm_death_verification_confirm(
+    stateJson,
+    trusteeDid,
+    trusteePublicKeyHex,
+    signatureHex,
+  );
 }

--- a/demo/infra/postgres/init/004_vitallock.sql
+++ b/demo/infra/postgres/init/004_vitallock.sql
@@ -78,6 +78,7 @@ CREATE TABLE IF NOT EXISTS death_verification (
     initiated_by TEXT NOT NULL,
     required_confirmations INTEGER NOT NULL DEFAULT 3,
     trustee_confirmations JSONB DEFAULT '[]',
+    verification_state JSONB NOT NULL DEFAULT '{}',
     status TEXT NOT NULL DEFAULT 'pending'
         CHECK (status IN ('pending','verified','rejected')),
     created_at_ms BIGINT NOT NULL,

--- a/demo/services/vitallock-api/src/index.js
+++ b/demo/services/vitallock-api/src/index.js
@@ -270,28 +270,61 @@ export const server = http.createServer(async (req, res) => {
 
     // ── Initiate death claim ──
     if (url.pathname === '/api/death/initiate' && req.method === 'POST') {
-      const { subject_did, initiated_by_did, required_confirmations } = await parseBody(req);
+      const {
+        subject_did,
+        initiated_by_did,
+        required_confirmations,
+        authorized_trustees,
+        claim_nonce_hex,
+        initiator_signature_hex,
+      } = await parseBody(req);
+
+      if (!Array.isArray(authorized_trustees)) {
+        return json(res, 400, { error: 'authorized_trustees must be an array' });
+      }
+      if (!claim_nonce_hex || !initiator_signature_hex) {
+        return json(res, 400, {
+          error: 'claim_nonce_hex and initiator_signature_hex are required',
+        });
+      }
 
       const state = wasm.wasm_death_verification_new(
-        subject_did, initiated_by_did, required_confirmations || 3
+        subject_did,
+        initiated_by_did,
+        required_confirmations || 3,
+        JSON.stringify(authorized_trustees),
+        claim_nonce_hex,
+        initiator_signature_hex
       );
+      const initialStatus = state.status === 'Verified' ? 'verified' : 'pending';
 
       const id = crypto.randomUUID();
       await pool.query(
         `INSERT INTO death_verification
          (id, subject_did, initiated_by, required_confirmations,
-          trustee_confirmations, status, created_at_ms)
-         VALUES ($1, $2, $3, $4, $5, 'pending', $6)`,
+          trustee_confirmations, verification_state, status, created_at_ms)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
         [id, subject_did, initiated_by_did, required_confirmations || 3,
-         JSON.stringify(state.confirmations || []), nowMs()]
+         JSON.stringify(state.confirmations || []), JSON.stringify(state), initialStatus, nowMs()]
       );
 
-      return json(res, 201, { id, status: 'pending', state });
+      return json(res, 201, { id, status: initialStatus, state });
     }
 
     // ── Confirm death claim ──
     if (url.pathname === '/api/death/confirm' && req.method === 'POST') {
-      const { verification_id, trustee_did } = await parseBody(req);
+      const {
+        verification_id,
+        trustee_did,
+        trustee_public_key_hex,
+        signature_hex,
+      } = await parseBody(req);
+
+      if (!trustee_public_key_hex || !signature_hex) {
+        return json(res, 400, {
+          error: 'trustee_public_key_hex and signature_hex are required',
+        });
+      }
 
       const { rows } = await pool.query(
         'SELECT * FROM death_verification WHERE id = $1',
@@ -303,27 +336,28 @@ export const server = http.createServer(async (req, res) => {
       if (dv.status !== 'pending') {
         return json(res, 400, { error: 'verification already resolved' });
       }
-
-      // Rebuild state and confirm
-      const existingConfirmations = dv.trustee_confirmations || [];
-      if (existingConfirmations.some(c => c.trustee_did === trustee_did)) {
-        return json(res, 400, { error: 'duplicate confirmation' });
+      if (!dv.verification_state || !dv.verification_state.subject_did) {
+        return json(res, 500, { error: 'stored verification_state is invalid' });
       }
 
-      existingConfirmations.push({
-        trustee_did: trustee_did,
-        confirmed_at_ms: nowMs(),
-      });
+      const result = wasm.wasm_death_verification_confirm(
+        JSON.stringify(dv.verification_state),
+        trustee_did,
+        trustee_public_key_hex,
+        signature_hex
+      );
 
-      const verified = existingConfirmations.length >= dv.required_confirmations;
+      const verified = result.verified;
       const newStatus = verified ? 'verified' : 'pending';
 
       await pool.query(
         `UPDATE death_verification
-         SET trustee_confirmations = $1, status = $2, resolved_at_ms = $3
-         WHERE id = $4`,
+         SET trustee_confirmations = $1, verification_state = $2,
+             status = $3, resolved_at_ms = $4
+         WHERE id = $5`,
         [
-          JSON.stringify(existingConfirmations),
+          JSON.stringify(result.state.confirmations || []),
+          JSON.stringify(result.state),
           newStatus,
           verified ? nowMs() : null,
           verification_id,
@@ -341,7 +375,7 @@ export const server = http.createServer(async (req, res) => {
 
       return json(res, 200, {
         verified,
-        confirmations: existingConfirmations.length,
+        confirmations: (result.state.confirmations || []).length,
         required: dv.required_confirmations,
         afterlife_messages_released: verified,
       });

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -1,8 +1,8 @@
 /**
  * Bridge Verification Test — WASM binding smoke-test harness
  *
- * Calls every one of the 110 exported wasm_ functions with valid minimal
- * inputs and verifies each returns without throwing.
+ * Calls the covered exported wasm_ bridge functions with valid minimal inputs
+ * and verifies each returns without throwing.
  *
  * Run:  node packages/exochain-wasm/test/bridge_verification.mjs
  */
@@ -51,11 +51,26 @@ const NOW_NUM       = Number(NOW_MS);
 const NOW_TS        = { physical_ms: NOW_NUM, logical: 0 };  // HLC Timestamp
 const TEXT_BYTES     = new TextEncoder().encode('hello');
 const DUMMY_SECRET_HEX = 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+const DUMMY_SECRET_HEX_2 = '1111111111111111111111111111111111111111111111111111111111111111';
+const DUMMY_SECRET_HEX_3 = '2222222222222222222222222222222222222222222222222222222222222222';
 const UUID_1 = randomUUID();
 const UUID_2 = randomUUID();
 
 // Pre-compute a valid Ed25519 keypair result for reuse
 const ephResult = wasm.wasm_sign_with_ephemeral_key(TEXT_BYTES);
+
+function publicKeyForSecret(secretHex) {
+  return wasm.wasm_ed25519_public_from_secret(secretHex);
+}
+
+function signatureHexFromJson(signatureJson) {
+  const signature = typeof signatureJson === 'string' ? JSON.parse(signatureJson) : signatureJson;
+  const bytes = signature.Ed25519;
+  if (!Array.isArray(bytes) || bytes.length !== 64) {
+    throw new Error('expected Ed25519 signature bytes');
+  }
+  return Buffer.from(bytes).toString('hex');
+}
 
 // =========================================================================
 // Module 1 — BCTS (Bounded-Context Transition System)
@@ -112,6 +127,9 @@ test('wasm_verify', () =>
 test('wasm_sign', () =>
   wasm.wasm_sign(TEXT_BYTES, DUMMY_SECRET_HEX));
 
+test('wasm_ed25519_public_from_secret', () =>
+  wasm.wasm_ed25519_public_from_secret(DUMMY_SECRET_HEX));
+
 test('wasm_compute_event_id', () =>
   wasm.wasm_compute_event_id());
 
@@ -141,6 +159,101 @@ test('wasm_verify_event', () => {
   if (!signedEvent) throw new Error('skipped -- no signed event from setup');
   const pubKey = signedEvent.public_key || signedEvent.source_public_key || ephResult.public_key;
   return wasm.wasm_verify_event(JSON.stringify(signedEvent), pubKey);
+});
+
+// =========================================================================
+// Module 3b — Messaging / Death Verification
+// =========================================================================
+
+console.log('\n--- Messaging / Death Verification ---');
+
+const initiatorPublicKey = setup(() => publicKeyForSecret(DUMMY_SECRET_HEX_2));
+const trusteePublicKey = setup(() => publicKeyForSecret(DUMMY_SECRET_HEX_3));
+const deathTrusteesJson = setup(() => {
+  if (!initiatorPublicKey || !trusteePublicKey) {
+    throw new Error('missing death-verification public keys');
+  }
+  return JSON.stringify([
+    { did: TEST_DID_2, public_key_hex: initiatorPublicKey },
+    { did: TEST_DID_3, public_key_hex: trusteePublicKey },
+  ]);
+});
+const deathClaimNonceHex = Buffer.from('bridge-death-claim').toString('hex');
+
+test('wasm_death_verification_initial_signing_payload', () => {
+  if (!deathTrusteesJson) throw new Error('skipped -- no trustee set');
+  return wasm.wasm_death_verification_initial_signing_payload(
+    TEST_DID,
+    TEST_DID_2,
+    2,
+    deathTrusteesJson,
+    deathClaimNonceHex
+  );
+});
+
+const deathInitialPayload = setup(() =>
+  deathTrusteesJson && wasm.wasm_death_verification_initial_signing_payload(
+    TEST_DID,
+    TEST_DID_2,
+    2,
+    deathTrusteesJson,
+    deathClaimNonceHex
+  ));
+const deathInitialSignatureHex = setup(() =>
+  deathInitialPayload && signatureHexFromJson(wasm.wasm_sign(deathInitialPayload, DUMMY_SECRET_HEX_2)));
+
+test('wasm_death_verification_new', () => {
+  if (!deathTrusteesJson || !deathInitialSignatureHex) {
+    throw new Error('skipped -- no signed initial payload');
+  }
+  return wasm.wasm_death_verification_new(
+    TEST_DID,
+    TEST_DID_2,
+    2,
+    deathTrusteesJson,
+    deathClaimNonceHex,
+    deathInitialSignatureHex
+  );
+});
+
+const deathState = setup(() =>
+  deathTrusteesJson && deathInitialSignatureHex && wasm.wasm_death_verification_new(
+    TEST_DID,
+    TEST_DID_2,
+    2,
+    deathTrusteesJson,
+    deathClaimNonceHex,
+    deathInitialSignatureHex
+  ));
+
+test('wasm_death_verification_confirmation_signing_payload', () => {
+  if (!deathState) throw new Error('skipped -- no death-verification state');
+  return wasm.wasm_death_verification_confirmation_signing_payload(
+    JSON.stringify(deathState),
+    TEST_DID_3
+  );
+});
+
+const deathConfirmationPayload = setup(() =>
+  deathState && wasm.wasm_death_verification_confirmation_signing_payload(
+    JSON.stringify(deathState),
+    TEST_DID_3
+  ));
+const deathConfirmationSignatureHex = setup(() =>
+  deathConfirmationPayload && signatureHexFromJson(
+    wasm.wasm_sign(deathConfirmationPayload, DUMMY_SECRET_HEX_3)
+  ));
+
+test('wasm_death_verification_confirm', () => {
+  if (!deathState || !trusteePublicKey || !deathConfirmationSignatureHex) {
+    throw new Error('skipped -- no signed confirmation payload');
+  }
+  return wasm.wasm_death_verification_confirm(
+    JSON.stringify(deathState),
+    TEST_DID_3,
+    trusteePublicKey,
+    deathConfirmationSignatureHex
+  );
 });
 
 // =========================================================================


### PR DESCRIPTION
## Summary
- require death-trigger verifications to define authorized trustee public keys and a caller-supplied claim nonce
- bind initiator and trustee confirmations to domain-separated canonical CBOR payloads verified with Ed25519
- update WASM/VitalLock flows so death initiation and confirmation require signed payloads, and cover the new exports in bridge verification

## TDD
- red: `cargo test -p exo-messaging death_trigger --lib` failed on missing signed-confirmation API and authorization errors

## Verification
- `cargo test -p exo-messaging`
- `cargo test -p exochain-wasm`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm`
- `COUNT=$(grep -c "module.exports.wasm_" packages/exochain-wasm/wasm/exochain_wasm.js); test "$COUNT" -eq 140`
- `node packages/exochain-wasm/test/bridge_verification.mjs`
- `npm --prefix demo test`