### PR TITLE
Fix Clause R1 bundle signature verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,6 +1506,7 @@ name = "exo-legal"
 version = "0.1.0-beta"
 dependencies = [
  "blake3",
+ "ciborium",
  "exo-authority",
  "exo-core",
  "exo-gatekeeper",

--- a/crates/exo-legal/Cargo.toml
+++ b/crates/exo-legal/Cargo.toml
@@ -18,6 +18,7 @@ exo-authority = { path = "../exo-authority" }
 exo-governance = { path = "../exo-governance" }
 exo-gatekeeper = { path = "../exo-gatekeeper" }
 serde = { workspace = true }
+ciborium = { workspace = true }
 blake3 = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }

--- a/crates/exo-legal/src/bundle.rs
+++ b/crates/exo-legal/src/bundle.rs
@@ -6,7 +6,7 @@
 //! verification manifest.  The bundle hash seals all content; signatures
 //! attest to the hash without altering it.
 
-use exo_core::{Did, Hash256, Signature, Timestamp};
+use exo_core::{Did, Hash256, PublicKey, SecretKey, Signature, Timestamp, crypto};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -67,6 +67,24 @@ pub struct EvidenceBundle {
     pub verification: VerificationManifest,
     pub bundle_hash: Hash256,
     pub signatures: Vec<BundleSignature>,
+}
+
+/// Deterministic assembly input for an evidence bundle.
+///
+/// Bundle IDs and creation timestamps are part of the bundle hash, so callers
+/// must supply them from the surrounding HLC/provenance context instead of this
+/// module consulting wall-clock time or randomness.
+#[derive(Debug, Clone)]
+pub struct BundleAssemblyInput {
+    pub id: String,
+    pub created_at: Timestamp,
+    pub subject: BundleSubject,
+    pub events: Vec<BundleEvent>,
+    pub evidence_items: Vec<Evidence>,
+    pub consent_records: Vec<ConsentSummary>,
+    pub contract_summary: Option<ContractSummary>,
+    pub certification: Option<Cert902_11>,
+    pub dag_anchor: DagAnchor,
 }
 
 /// What a bundle is about.
@@ -197,12 +215,27 @@ pub struct SignatureCheck {
     pub valid: bool,
 }
 
+/// Resolves a bundle signer DID to the Ed25519 public key authorized to sign.
+pub trait BundleSignerKeyResolver {
+    fn public_key_for(&self, signer: &Did) -> Option<PublicKey>;
+}
+
+impl<F> BundleSignerKeyResolver for F
+where
+    F: Fn(&Did) -> Option<PublicKey>,
+{
+    fn public_key_for(&self, signer: &Did) -> Option<PublicKey> {
+        self(signer)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
 const BUNDLE_VERSION: u32 = 1;
 const BUNDLE_DOMAIN: &[u8] = b"exo:bundle:v1:";
+const BUNDLE_SIGNATURE_DOMAIN: &str = "exo.legal.bundle.signature.v1";
 
 /// Safe usize → u64 conversion (infallible on ≤64-bit platforms).
 #[allow(clippy::as_conversions)]
@@ -227,40 +260,35 @@ fn idx_u32(n: usize) -> u32 {
 ///
 /// # Errors
 /// - `InvalidStateTransition` if events are empty, mis-ordered, or violate causal ordering.
-pub fn assemble(
-    subject: BundleSubject,
-    events: Vec<BundleEvent>,
-    evidence: Vec<Evidence>,
-    consents: Vec<ConsentSummary>,
-    contract: Option<ContractSummary>,
-    cert: Option<Cert902_11>,
-    anchor: DagAnchor,
-) -> Result<EvidenceBundle> {
-    let cert_snapshot = cert.as_ref().map(CertSnapshot::from_cert);
+pub fn assemble(input: BundleAssemblyInput) -> Result<EvidenceBundle> {
+    if input.id.trim().is_empty() {
+        return Err(LegalError::InvalidStateTransition {
+            reason: "bundle id must not be empty".into(),
+        });
+    }
+
+    let cert_snapshot = input.certification.as_ref().map(CertSnapshot::from_cert);
     // Validate events
-    if events.is_empty() {
+    if input.events.is_empty() {
         return Err(LegalError::InvalidStateTransition {
             reason: "bundle must contain at least one event".into(),
         });
     }
-    validate_event_ordering(&events)?;
-    validate_causal_chain(&events)?;
+    validate_event_ordering(&input.events)?;
+    validate_causal_chain(&input.events)?;
 
-    let id = uuid::Uuid::new_v4().to_string();
-    let created_at = Timestamp::now_utc();
-
-    // Build a placeholder bundle to compute the hash
+    // Build the initial bundle value before computing its content hash.
     let mut bundle = EvidenceBundle {
-        id,
+        id: input.id,
         version: BUNDLE_VERSION,
-        created_at,
-        subject,
-        events,
-        evidence_items: evidence,
-        consent_records: consents,
-        contract_summary: contract,
+        created_at: input.created_at,
+        subject: input.subject,
+        events: input.events,
+        evidence_items: input.evidence_items,
+        consent_records: input.consent_records,
+        contract_summary: input.contract_summary,
         certification: cert_snapshot,
-        dag_anchor: anchor,
+        dag_anchor: input.dag_anchor,
         verification: VerificationManifest {
             format_version: BUNDLE_VERSION,
             hash_algorithm: "BLAKE3".into(),
@@ -469,12 +497,38 @@ fn build_verification_steps(bundle: &EvidenceBundle) -> Vec<VerificationStep> {
 // ---------------------------------------------------------------------------
 
 /// Verify a bundle offline: recompute hash, check event ordering, causal
-/// chain, and signatures.
+/// chain, and fail closed for any signatures that cannot be checked without a
+/// signer key resolver.
 ///
 /// # Errors
 /// Returns `LegalError` only for structural failures (e.g. event ordering).
 /// Hash mismatches are reported in the `VerificationResult`, not as errors.
 pub fn verify(bundle: &EvidenceBundle) -> Result<VerificationResult> {
+    verify_inner(bundle, None)
+}
+
+/// Verify a bundle offline with Ed25519 signer keys.
+///
+/// Every signature is checked against a domain-separated canonical CBOR payload
+/// binding the bundle hash, signer DID, signer role, and signed timestamp.
+///
+/// # Errors
+/// Returns `LegalError` only for structural failures (e.g. event ordering) or
+/// canonical payload encoding failure.
+pub fn verify_with_signer_keys<R>(
+    bundle: &EvidenceBundle,
+    resolver: &R,
+) -> Result<VerificationResult>
+where
+    R: BundleSignerKeyResolver,
+{
+    verify_inner(bundle, Some(resolver))
+}
+
+fn verify_inner(
+    bundle: &EvidenceBundle,
+    resolver: Option<&dyn BundleSignerKeyResolver>,
+) -> Result<VerificationResult> {
     let recomputed = compute_bundle_hash(bundle);
     let hash_valid = recomputed == bundle.bundle_hash;
 
@@ -485,10 +539,9 @@ pub fn verify(bundle: &EvidenceBundle) -> Result<VerificationResult> {
         .signatures
         .iter()
         .map(|sig| {
-            // In v1 we check that the signature is non-empty.
-            // Full cryptographic verification requires a key registry and
-            // is deferred to the production verifier in exo-proofs.
-            let valid = !sig.signature.is_empty();
+            let valid = resolver
+                .and_then(|r| r.public_key_for(&sig.signer_did))
+                .is_some_and(|public_key| verify_bundle_signature(bundle, sig, &public_key));
             SignatureCheck {
                 signer: sig.signer_did.clone(),
                 role: sig.signer_role.clone(),
@@ -507,6 +560,25 @@ pub fn verify(bundle: &EvidenceBundle) -> Result<VerificationResult> {
         signatures_valid,
         overall,
     })
+}
+
+fn verify_bundle_signature(
+    bundle: &EvidenceBundle,
+    sig: &BundleSignature,
+    public_key: &PublicKey,
+) -> bool {
+    if sig.signer_role.trim().is_empty() || sig.signature.is_empty() {
+        return false;
+    }
+    let Ok(payload) = bundle_signature_payload(
+        &bundle.bundle_hash,
+        &sig.signer_did,
+        &sig.signer_role,
+        sig.signed_at,
+    ) else {
+        return false;
+    };
+    crypto::verify(&payload, &sig.signature, public_key)
 }
 
 // ---------------------------------------------------------------------------
@@ -588,28 +660,63 @@ pub fn render_markdown_summary(bundle: &EvidenceBundle) -> String {
 // Signing
 // ---------------------------------------------------------------------------
 
-/// Add a signature to the bundle.
+/// Canonical CBOR payload signed by a bundle signer.
+///
+/// # Errors
+/// Returns `LegalError` if canonical payload serialization fails.
+pub fn bundle_signature_payload(
+    bundle_hash: &Hash256,
+    signer: &Did,
+    role: &str,
+    signed_at: Timestamp,
+) -> Result<Vec<u8>> {
+    let payload = (
+        BUNDLE_SIGNATURE_DOMAIN,
+        bundle_hash,
+        signer,
+        role,
+        signed_at,
+    );
+    let mut encoded = Vec::new();
+    ciborium::into_writer(&payload, &mut encoded).map_err(|e| {
+        LegalError::InvalidStateTransition {
+            reason: format!("bundle signature payload CBOR serialization failed: {e}"),
+        }
+    })?;
+    Ok(encoded)
+}
+
+/// Add an Ed25519 signature to the bundle.
 ///
 /// Signatures attest to the `bundle_hash` and do not change it.
 ///
 /// # Errors
-/// Returns `LegalError` if the role string is empty.
+/// Returns `LegalError` if the role string is empty, the bundle hash is stale,
+/// or the signing payload cannot be serialized.
 pub fn sign(
     bundle: &mut EvidenceBundle,
     signer: &Did,
     role: &str,
-    signature: Signature,
+    signed_at: Timestamp,
+    secret_key: &SecretKey,
 ) -> Result<()> {
-    if role.is_empty() {
+    if role.trim().is_empty() {
         return Err(LegalError::InvalidStateTransition {
             reason: "signer role must not be empty".into(),
         });
     }
+    if compute_bundle_hash(bundle) != bundle.bundle_hash {
+        return Err(LegalError::InvalidStateTransition {
+            reason: "bundle hash must be current before signing".into(),
+        });
+    }
+    let payload = bundle_signature_payload(&bundle.bundle_hash, signer, role, signed_at)?;
+    let signature = crypto::sign(&payload, secret_key);
     bundle.signatures.push(BundleSignature {
         signer_did: signer.clone(),
         signer_role: role.to_string(),
         signature,
-        signed_at: Timestamp::now_utc(),
+        signed_at,
     });
     Ok(())
 }
@@ -620,6 +727,8 @@ pub fn sign(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
     use crate::{cert_902_11::generate_902_11_cert, evidence::create_evidence};
 
@@ -631,6 +740,28 @@ mod tests {
 
     fn ts(ms: u64) -> Timestamp {
         Timestamp::new(ms, 0)
+    }
+
+    fn keypair(seed: u8) -> exo_core::crypto::KeyPair {
+        exo_core::crypto::KeyPair::from_secret_bytes([seed; 32]).unwrap()
+    }
+
+    #[derive(Default)]
+    struct StaticResolver {
+        keys: BTreeMap<Did, PublicKey>,
+    }
+
+    impl StaticResolver {
+        fn with(mut self, did: Did, public_key: PublicKey) -> Self {
+            self.keys.insert(did, public_key);
+            self
+        }
+    }
+
+    impl BundleSignerKeyResolver for StaticResolver {
+        fn public_key_for(&self, signer: &Did) -> Option<PublicKey> {
+            self.keys.get(signer).copied()
+        }
     }
 
     fn make_event(seq: u32, parents: Vec<Hash256>) -> BundleEvent {
@@ -697,18 +828,23 @@ mod tests {
         }
     }
 
+    fn make_assembly_input(id: &str, events: Vec<BundleEvent>) -> BundleAssemblyInput {
+        BundleAssemblyInput {
+            id: id.to_string(),
+            created_at: ts(2500),
+            subject: make_subject(),
+            events,
+            evidence_items: vec![make_evidence_item()],
+            consent_records: vec![],
+            contract_summary: None,
+            certification: None,
+            dag_anchor: make_anchor(),
+        }
+    }
+
     fn assemble_minimal() -> EvidenceBundle {
         let e0 = make_event(0, vec![]);
-        assemble(
-            make_subject(),
-            vec![e0],
-            vec![make_evidence_item()],
-            vec![],
-            None,
-            None,
-            make_anchor(),
-        )
-        .unwrap()
+        assemble(make_assembly_input("bundle-minimal", vec![e0])).unwrap()
     }
 
     fn assemble_full() -> EvidenceBundle {
@@ -720,16 +856,12 @@ mod tests {
         let cert =
             generate_902_11_cert(&ev, "EXOCHAIN decision.forum v1.0", 1_700_000_001_000).unwrap();
 
-        assemble(
-            make_subject(),
-            vec![e0, e1, e2],
-            vec![ev],
-            vec![make_consent()],
-            Some(make_contract()),
-            Some(cert),
-            make_anchor(),
-        )
-        .unwrap()
+        let mut input = make_assembly_input("bundle-full", vec![e0, e1, e2]);
+        input.evidence_items = vec![ev];
+        input.consent_records = vec![make_consent()];
+        input.contract_summary = Some(make_contract());
+        input.certification = Some(cert);
+        assemble(input).unwrap()
     }
 
     // -- Tests ------------------------------------------------------------
@@ -756,6 +888,25 @@ mod tests {
         assert!(bundle.contract_summary.is_some());
         assert!(bundle.certification.is_some());
         assert_ne!(bundle.bundle_hash, Hash256::ZERO);
+    }
+
+    #[test]
+    fn test_assemble_uses_supplied_metadata() {
+        let bundle = assemble(make_assembly_input(
+            "bundle-explicit-metadata",
+            vec![make_event(0, vec![])],
+        ))
+        .unwrap();
+        assert_eq!(bundle.id, "bundle-explicit-metadata");
+        assert_eq!(bundle.created_at, ts(2500));
+    }
+
+    #[test]
+    fn test_assemble_rejects_empty_id() {
+        let mut input = make_assembly_input("bundle-empty-id", vec![make_event(0, vec![])]);
+        input.id = "  ".into();
+        let err = assemble(input).unwrap_err();
+        assert!(err.to_string().contains("id"));
     }
 
     #[test]
@@ -874,15 +1025,7 @@ mod tests {
         let mut e1 = make_event(1, vec![e0.event_hash]);
         e1.sequence = 5; // wrong
 
-        let result = assemble(
-            make_subject(),
-            vec![e0, e1],
-            vec![make_evidence_item()],
-            vec![],
-            None,
-            None,
-            make_anchor(),
-        );
+        let result = assemble(make_assembly_input("bad-order", vec![e0, e1]));
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("sequence"));
     }
@@ -893,15 +1036,7 @@ mod tests {
         let e0 = make_event(0, vec![]);
         let e1 = make_event(1, vec![Hash256::digest(b"nonexistent")]);
 
-        let result = assemble(
-            make_subject(),
-            vec![e0, e1],
-            vec![make_evidence_item()],
-            vec![],
-            None,
-            None,
-            make_anchor(),
-        );
+        let result = assemble(make_assembly_input("bad-causal-chain", vec![e0, e1]));
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("parent hash"));
     }
@@ -936,31 +1071,57 @@ mod tests {
     #[test]
     fn test_sign_adds_signature() {
         let mut bundle = assemble_minimal();
+        let signer_key = keypair(11);
+        let signed_at = ts(3000);
         assert!(bundle.signatures.is_empty());
         sign(
             &mut bundle,
             &did("officer"),
             "organization",
-            Signature::from_bytes([0xbb; 64]),
+            signed_at,
+            signer_key.secret_key(),
         )
         .unwrap();
         assert_eq!(bundle.signatures.len(), 1);
         assert_eq!(bundle.signatures[0].signer_did, did("officer"));
         assert_eq!(bundle.signatures[0].signer_role, "organization");
+        assert_eq!(bundle.signatures[0].signed_at, signed_at);
+        assert!(matches!(
+            bundle.signatures[0].signature,
+            Signature::Ed25519(_)
+        ));
     }
 
     #[test]
     fn test_sign_preserves_hash() {
         let mut bundle = assemble_minimal();
+        let signer_key = keypair(12);
         let hash_before = bundle.bundle_hash;
         sign(
             &mut bundle,
             &did("officer"),
             "organization",
-            Signature::from_bytes([0xcc; 64]),
+            ts(3000),
+            signer_key.secret_key(),
         )
         .unwrap();
         assert_eq!(bundle.bundle_hash, hash_before);
+    }
+
+    #[test]
+    fn test_sign_rejects_stale_bundle_hash() {
+        let mut bundle = assemble_minimal();
+        bundle.subject.title = "tampered after hash".into();
+        let err = sign(
+            &mut bundle,
+            &did("officer"),
+            "organization",
+            ts(3000),
+            keypair(16).secret_key(),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("current"));
+        assert!(bundle.signatures.is_empty());
     }
 
     #[test]
@@ -977,16 +1138,8 @@ mod tests {
 
         // They affect the hash: removing them changes the hash
         let e0 = make_event(0, vec![]);
-        let bundle_without = assemble(
-            make_subject(),
-            vec![e0],
-            vec![make_evidence_item()],
-            vec![], // no consents
-            None,   // no contract
-            None,
-            make_anchor(),
-        )
-        .unwrap();
+        let bundle_without =
+            assemble(make_assembly_input("bundle-without-contract", vec![e0])).unwrap();
 
         // The hashes will differ because the bundles have different IDs and
         // timestamps. Instead, directly verify the consent/contract are hashed
@@ -1079,16 +1232,7 @@ mod tests {
     // Covers assemble() rejecting an empty events vector.
     #[test]
     fn test_assemble_rejects_empty_events() {
-        let err = assemble(
-            make_subject(),
-            vec![],
-            vec![make_evidence_item()],
-            vec![],
-            None,
-            None,
-            make_anchor(),
-        )
-        .unwrap_err();
+        let err = assemble(make_assembly_input("empty-events", vec![])).unwrap_err();
         assert!(err.to_string().contains("at least one event"));
     }
 
@@ -1099,37 +1243,142 @@ mod tests {
             parent_hashes: vec![Hash256::digest(b"phantom-parent")],
             ..make_event(0, vec![])
         };
-        let err = assemble(
-            make_subject(),
-            vec![bad_genesis],
-            vec![make_evidence_item()],
-            vec![],
-            None,
-            None,
-            make_anchor(),
-        )
-        .unwrap_err();
+        let err = assemble(make_assembly_input("bad-genesis", vec![bad_genesis])).unwrap_err();
         assert!(err.to_string().contains("genesis"));
     }
 
-    // Covers the signature-check closure inside verify() for a non-empty, valid signature.
+    // Covers fail-closed verification for a non-empty but unauthenticated signature.
     #[test]
-    fn test_verify_reports_valid_signatures() {
+    fn test_verify_rejects_fake_non_empty_signature() {
         let mut bundle = assemble_minimal();
-        sign(
-            &mut bundle,
-            &did("officer"),
-            "organization",
-            Signature::from_bytes([0xab; 64]),
-        )
-        .unwrap();
+        bundle.signatures.push(BundleSignature {
+            signer_did: did("officer"),
+            signer_role: "organization".into(),
+            signature: Signature::from_bytes([0xab; 64]),
+            signed_at: ts(3000),
+        });
         let result = verify(&bundle).unwrap();
         assert_eq!(result.signatures_valid.len(), 1);
         let check = &result.signatures_valid[0];
         assert_eq!(check.signer, did("officer"));
         assert_eq!(check.role, "organization");
-        assert!(check.valid);
+        assert!(!check.valid);
+        assert!(!result.overall);
+    }
+
+    #[test]
+    fn test_bundle_signature_payload_is_deterministic_and_domain_separated() {
+        let bundle = assemble_minimal();
+        let signer = did("officer");
+        let first =
+            bundle_signature_payload(&bundle.bundle_hash, &signer, "organization", ts(3000))
+                .unwrap();
+        let second =
+            bundle_signature_payload(&bundle.bundle_hash, &signer, "organization", ts(3000))
+                .unwrap();
+        let different_role =
+            bundle_signature_payload(&bundle.bundle_hash, &signer, "legal", ts(3000)).unwrap();
+        assert_eq!(first, second);
+        assert_ne!(first, different_role);
+    }
+
+    #[test]
+    fn test_verify_with_signer_keys_accepts_valid_signature() {
+        let signer = did("officer");
+        let signer_key = keypair(21);
+        let mut bundle = assemble_minimal();
+        sign(
+            &mut bundle,
+            &signer,
+            "organization",
+            ts(3000),
+            signer_key.secret_key(),
+        )
+        .unwrap();
+        let resolver = StaticResolver::default().with(signer.clone(), *signer_key.public_key());
+
+        let result = verify_with_signer_keys(&bundle, &resolver).unwrap();
+
+        assert!(result.hash_valid);
+        assert_eq!(result.signatures_valid.len(), 1);
+        assert!(result.signatures_valid[0].valid);
         assert!(result.overall);
+    }
+
+    #[test]
+    fn test_verify_with_signer_keys_rejects_wrong_key() {
+        let signer = did("officer");
+        let signer_key = keypair(22);
+        let wrong_key = keypair(23);
+        let mut bundle = assemble_minimal();
+        sign(
+            &mut bundle,
+            &signer,
+            "organization",
+            ts(3000),
+            signer_key.secret_key(),
+        )
+        .unwrap();
+        let resolver = StaticResolver::default().with(signer, *wrong_key.public_key());
+
+        let result = verify_with_signer_keys(&bundle, &resolver).unwrap();
+
+        assert_eq!(result.signatures_valid.len(), 1);
+        assert!(!result.signatures_valid[0].valid);
+        assert!(!result.overall);
+    }
+
+    #[test]
+    fn test_verify_with_signer_keys_rejects_replayed_signature() {
+        let signer = did("officer");
+        let signer_key = keypair(24);
+        let mut signed_bundle = assemble_minimal();
+        sign(
+            &mut signed_bundle,
+            &signer,
+            "organization",
+            ts(3000),
+            signer_key.secret_key(),
+        )
+        .unwrap();
+
+        let mut replay_target = assemble(make_assembly_input(
+            "bundle-replay-target",
+            vec![make_event(0, vec![])],
+        ))
+        .unwrap();
+        replay_target.signatures = signed_bundle.signatures.clone();
+        let resolver = StaticResolver::default().with(signer, *signer_key.public_key());
+
+        let result = verify_with_signer_keys(&replay_target, &resolver).unwrap();
+
+        assert!(result.hash_valid);
+        assert_eq!(result.signatures_valid.len(), 1);
+        assert!(!result.signatures_valid[0].valid);
+        assert!(!result.overall);
+    }
+
+    #[test]
+    fn test_verify_with_signer_keys_rejects_tampered_bundle() {
+        let signer = did("officer");
+        let signer_key = keypair(25);
+        let mut bundle = assemble_minimal();
+        sign(
+            &mut bundle,
+            &signer,
+            "organization",
+            ts(3000),
+            signer_key.secret_key(),
+        )
+        .unwrap();
+        bundle.events[0].payload_summary = "tampered after signature".into();
+        let resolver = StaticResolver::default().with(signer, *signer_key.public_key());
+
+        let result = verify_with_signer_keys(&bundle, &resolver).unwrap();
+
+        assert!(!result.hash_valid);
+        assert!(result.signatures_valid[0].valid);
+        assert!(!result.overall);
     }
 
     // Covers the signature-check closure flagging an empty (all-zero) signature as invalid.
@@ -1153,18 +1402,22 @@ mod tests {
     #[test]
     fn test_render_markdown_includes_signatures_section() {
         let mut bundle = assemble_minimal();
+        let officer_key = keypair(13);
+        let counsel_key = keypair(14);
         sign(
             &mut bundle,
             &did("officer"),
             "organization",
-            Signature::from_bytes([0xdd; 64]),
+            ts(3000),
+            officer_key.secret_key(),
         )
         .unwrap();
         sign(
             &mut bundle,
             &did("counsel"),
             "legal",
-            Signature::from_bytes([0xee; 64]),
+            ts(3100),
+            counsel_key.secret_key(),
         )
         .unwrap();
         let md = render_markdown_summary(&bundle);
@@ -1183,7 +1436,8 @@ mod tests {
             &mut bundle,
             &did("officer"),
             "",
-            Signature::from_bytes([0xff; 64]),
+            ts(3000),
+            keypair(15).secret_key(),
         )
         .unwrap_err();
         assert!(err.to_string().contains("role"));


### PR DESCRIPTION
## Summary

- Replace non-empty bundle signature checks with fail-closed verification unless signer keys are supplied.
- Add domain-separated canonical CBOR bundle signature payloads and Ed25519 signing/verification.
- Make bundle assembly/signing deterministic by requiring caller-supplied bundle metadata and signed timestamps instead of calling wall-clock time or random UUID generation.

## TDD

- Red check: `cargo test -p exo-legal bundle::tests::test_verify_rejects_fake_non_empty_signature --lib` initially failed because `[0xab; 64]` was accepted as valid.
- Added regression coverage for fake non-empty signatures, empty/zero signatures, valid signatures, wrong keys, replayed signatures, tampered bundles, stale bundle hashes, deterministic payloads, and explicit assembly metadata.

## Verification

- `cargo test -p exo-legal bundle::tests:: --lib`
- `cargo test -p exo-legal`
- `cargo build -p exo-legal`
- `cargo clippy -p exo-legal --lib --bins -- -D warnings`
- `cargo clippy -p exo-legal --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
