### PR TITLE
fix(exo-escalation): require challenge provenance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,6 +1408,7 @@ dependencies = [
 name = "exo-escalation"
 version = "0.1.0-beta"
 dependencies = [
+ "ciborium",
  "exo-core",
  "exo-gatekeeper",
  "exo-governance",

--- a/crates/exo-escalation/Cargo.toml
+++ b/crates/exo-escalation/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 exo-core = { path = "../exo-core" }
 exo-identity = { path = "../exo-identity" }
 exo-governance = { path = "../exo-governance" }
+ciborium = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }

--- a/crates/exo-escalation/src/challenge.rs
+++ b/crates/exo-escalation/src/challenge.rs
@@ -8,7 +8,7 @@
 //! `AdjudicationContext`, causing the kernel to return `Verdict::Escalated`
 //! rather than `Verdict::Denied`.
 
-use exo_core::Timestamp;
+use exo_core::{Did, PublicKey, SecretKey, Signature, Timestamp, crypto};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -69,6 +69,36 @@ pub enum ContestStatus {
 }
 
 // ---------------------------------------------------------------------------
+// Challenge admission provenance
+// ---------------------------------------------------------------------------
+
+/// Canonical domain for Ed25519 signatures admitting Sybil challenges.
+pub const CHALLENGE_ADMISSION_DOMAIN: &str = "exo.escalation.challenge.admission.v1";
+
+/// The signable, deterministic challenge-admission payload.
+///
+/// A caller supplies every piece of identity, timing, and authority context.
+/// This module only verifies the signed payload and materializes the hold.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChallengeAdmission {
+    pub hold_id: Uuid,
+    pub action_id: [u8; 32],
+    pub ground: SybilChallengeGround,
+    pub admitted_at: Timestamp,
+    pub admitted_by: Did,
+    pub admitter_public_key: PublicKey,
+    pub evidence_hash: [u8; 32],
+    pub authority_chain_hash: [u8; 32],
+}
+
+/// A challenge admission plus the admitting actor's Ed25519 signature.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignedChallengeAdmission {
+    pub admission: ChallengeAdmission,
+    pub admission_signature: Signature,
+}
+
+// ---------------------------------------------------------------------------
 // ContestHold
 // ---------------------------------------------------------------------------
 
@@ -83,6 +113,11 @@ pub struct ContestHold {
     pub ground: SybilChallengeGround,
     pub status: ContestStatus,
     pub admitted_at: Timestamp,
+    pub admitted_by: Did,
+    pub admitter_public_key: PublicKey,
+    pub evidence_hash: [u8; 32],
+    pub authority_chain_hash: [u8; 32],
+    pub admission_signature: Signature,
     /// Append-only audit trail of status transitions.
     pub audit_log: Vec<String>,
 }
@@ -103,7 +138,113 @@ impl ContestHold {
 // Challenge admission
 // ---------------------------------------------------------------------------
 
-/// Admit a credible Sybil challenge and return a `ContestHold` in
+/// Build the canonical CBOR payload signed for challenge admission.
+///
+/// # Errors
+/// Returns `EscalationError::SerializationFailed` if canonical CBOR encoding
+/// fails.
+pub fn challenge_admission_payload(
+    admission: &ChallengeAdmission,
+) -> Result<Vec<u8>, EscalationError> {
+    let payload = (
+        CHALLENGE_ADMISSION_DOMAIN,
+        &admission.hold_id,
+        &admission.action_id,
+        &admission.ground,
+        &admission.admitted_at,
+        &admission.admitted_by,
+        &admission.admitter_public_key,
+        &admission.evidence_hash,
+        &admission.authority_chain_hash,
+    );
+    let mut encoded = Vec::new();
+    ciborium::into_writer(&payload, &mut encoded).map_err(|e| {
+        EscalationError::SerializationFailed {
+            context: "challenge admission payload".into(),
+            reason: e.to_string(),
+        }
+    })?;
+    Ok(encoded)
+}
+
+/// Sign a challenge admission with the admitting actor's Ed25519 key.
+///
+/// # Errors
+/// Returns an error if required provenance fields are placeholders or if the
+/// canonical payload cannot be serialized.
+pub fn sign_challenge_admission(
+    admission: ChallengeAdmission,
+    secret_key: &SecretKey,
+) -> Result<SignedChallengeAdmission, EscalationError> {
+    validate_challenge_admission_metadata(&admission)?;
+    let payload = challenge_admission_payload(&admission)?;
+    Ok(SignedChallengeAdmission {
+        admission,
+        admission_signature: crypto::sign(&payload, secret_key),
+    })
+}
+
+/// Verify a signed Sybil challenge admission.
+///
+/// # Errors
+/// Returns an error if provenance metadata is placeholder-like, if the
+/// signature is empty/zero, or if Ed25519 verification fails.
+pub fn verify_challenge_admission(
+    signed: &SignedChallengeAdmission,
+) -> Result<(), EscalationError> {
+    validate_challenge_admission_metadata(&signed.admission)?;
+    if signed.admission_signature.is_empty() {
+        return Err(EscalationError::InvalidSignature {
+            signer: signed.admission.admitted_by.to_string(),
+            reason: "challenge admission signature is empty or all-zero".into(),
+        });
+    }
+    let payload = challenge_admission_payload(&signed.admission)?;
+    if !crypto::verify(
+        &payload,
+        &signed.admission_signature,
+        &signed.admission.admitter_public_key,
+    ) {
+        return Err(EscalationError::InvalidSignature {
+            signer: signed.admission.admitted_by.to_string(),
+            reason: "challenge admission signature does not verify".into(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_challenge_admission_metadata(
+    admission: &ChallengeAdmission,
+) -> Result<(), EscalationError> {
+    if admission.hold_id == Uuid::nil() {
+        return Err(EscalationError::InvalidProvenance {
+            reason: "challenge hold id must be caller-supplied and non-nil".into(),
+        });
+    }
+    if admission.action_id == [0u8; 32] {
+        return Err(EscalationError::InvalidProvenance {
+            reason: "challenge action id must be non-zero".into(),
+        });
+    }
+    if admission.evidence_hash == [0u8; 32] {
+        return Err(EscalationError::InvalidProvenance {
+            reason: "challenge admission requires non-zero evidence hash".into(),
+        });
+    }
+    if admission.authority_chain_hash == [0u8; 32] {
+        return Err(EscalationError::InvalidProvenance {
+            reason: "challenge admission requires non-zero authority chain hash".into(),
+        });
+    }
+    if admission.admitter_public_key == PublicKey::from_bytes([0u8; 32]) {
+        return Err(EscalationError::InvalidProvenance {
+            reason: "challenge admission requires a non-zero Ed25519 public key".into(),
+        });
+    }
+    Ok(())
+}
+
+/// Admit a credible, signed Sybil challenge and return a `ContestHold` in
 /// `PauseEligible` status.
 ///
 /// The caller is responsible for:
@@ -113,22 +254,32 @@ impl ContestHold {
 ///    returns `Verdict::Escalated` (not `Verdict::Denied`) while review is
 ///    pending.
 ///
-/// `admitted_at` is supplied by the caller to avoid internal clock calls.
-#[must_use]
-pub fn admit_challenge(
-    action_id: &[u8; 32],
-    ground: SybilChallengeGround,
-    admitted_at: Timestamp,
-) -> ContestHold {
-    let entry = format!("admitted at {admitted_at:?}: ground {ground}");
-    ContestHold {
-        id: Uuid::new_v4(),
-        action_id: *action_id,
-        ground,
+/// The hold id and `admitted_at` are supplied by the caller to avoid internal
+/// randomness or clock calls.
+///
+/// # Errors
+/// Returns an error if the admission signature or provenance metadata is
+/// invalid.
+pub fn admit_challenge(signed: SignedChallengeAdmission) -> Result<ContestHold, EscalationError> {
+    verify_challenge_admission(&signed)?;
+    let admission = signed.admission;
+    let entry = format!(
+        "admitted at {:?}: ground {} by {} evidence {:?}",
+        admission.admitted_at, admission.ground, admission.admitted_by, admission.evidence_hash
+    );
+    Ok(ContestHold {
+        id: admission.hold_id,
+        action_id: admission.action_id,
+        ground: admission.ground,
         status: ContestStatus::PauseEligible,
-        admitted_at,
+        admitted_at: admission.admitted_at,
+        admitted_by: admission.admitted_by,
+        admitter_public_key: admission.admitter_public_key,
+        evidence_hash: admission.evidence_hash,
+        authority_chain_hash: admission.authority_chain_hash,
+        admission_signature: signed.admission_signature,
         audit_log: vec![entry],
-    }
+    })
 }
 
 /// Advance a contest hold to `UnderReview`.
@@ -199,27 +350,181 @@ mod tests {
     fn ts(ms: u64) -> Timestamp {
         Timestamp::new(ms, 0)
     }
+    fn did(n: &str) -> Did {
+        Did::new(&format!("did:exo:{n}")).unwrap()
+    }
+    fn uuid(byte: u8) -> Uuid {
+        Uuid::from_bytes([byte; 16])
+    }
+    fn keypair(seed: u8) -> exo_core::crypto::KeyPair {
+        exo_core::crypto::KeyPair::from_secret_bytes([seed; 32]).unwrap()
+    }
+    fn admission_with(
+        hold_id: Uuid,
+        ground: SybilChallengeGround,
+        keypair: &exo_core::crypto::KeyPair,
+    ) -> ChallengeAdmission {
+        ChallengeAdmission {
+            hold_id,
+            action_id: action_id(),
+            ground,
+            admitted_at: ts(1000),
+            admitted_by: did("reviewer"),
+            admitter_public_key: *keypair.public_key(),
+            evidence_hash: [0xEEu8; 32],
+            authority_chain_hash: [0xACu8; 32],
+        }
+    }
+    fn signed_admission() -> SignedChallengeAdmission {
+        let keypair = keypair(7);
+        sign_challenge_admission(
+            admission_with(
+                uuid(1),
+                SybilChallengeGround::ConcealedCommonControl,
+                &keypair,
+            ),
+            keypair.secret_key(),
+        )
+        .unwrap()
+    }
 
     #[test]
     fn admit_creates_pause_eligible_hold() {
-        let hold = admit_challenge(
-            &action_id(),
-            SybilChallengeGround::ConcealedCommonControl,
-            ts(1000),
-        );
+        let hold = admit_challenge(signed_admission()).unwrap();
         assert_eq!(hold.status, ContestStatus::PauseEligible);
         assert_eq!(hold.ground, SybilChallengeGround::ConcealedCommonControl);
         assert_eq!(hold.action_id, action_id());
+        assert_eq!(hold.id, uuid(1));
+        assert_eq!(hold.admitted_by, did("reviewer"));
+        assert_eq!(hold.evidence_hash, [0xEEu8; 32]);
+        assert_eq!(hold.authority_chain_hash, [0xACu8; 32]);
+        assert!(!hold.admission_signature.is_empty());
         assert!(!hold.audit_log.is_empty());
     }
 
     #[test]
-    fn escalation_reason_contains_ground() {
-        let hold = admit_challenge(
-            &action_id(),
-            SybilChallengeGround::CoordinatedManipulation,
-            ts(1000),
+    fn admit_challenge_is_deterministic_for_same_input() {
+        let signed = signed_admission();
+        let first = admit_challenge(signed.clone()).unwrap();
+        let second = admit_challenge(signed).unwrap();
+
+        assert_eq!(first.id, second.id);
+        assert_eq!(first.admitted_at, second.admitted_at);
+        assert_eq!(first.admission_signature, second.admission_signature);
+    }
+
+    #[test]
+    fn verify_challenge_admission_accepts_valid_signature() {
+        let signed = signed_admission();
+        assert!(verify_challenge_admission(&signed).is_ok());
+    }
+
+    #[test]
+    fn verify_challenge_admission_rejects_empty_and_zero_signatures() {
+        let mut signed = signed_admission();
+        signed.admission_signature = Signature::Empty;
+        assert!(verify_challenge_admission(&signed).is_err());
+
+        signed.admission_signature = Signature::Ed25519([0u8; 64]);
+        assert!(verify_challenge_admission(&signed).is_err());
+    }
+
+    #[test]
+    fn verify_challenge_admission_rejects_fake_non_empty_signature() {
+        let mut signed = signed_admission();
+        signed.admission_signature = Signature::Ed25519([0xABu8; 64]);
+        assert!(verify_challenge_admission(&signed).is_err());
+        assert!(admit_challenge(signed).is_err());
+    }
+
+    #[test]
+    fn verify_challenge_admission_rejects_wrong_key() {
+        let signer_keypair = keypair(7);
+        let wrong_keypair = keypair(8);
+        let mut signed = sign_challenge_admission(
+            admission_with(
+                uuid(2),
+                SybilChallengeGround::CoordinatedManipulation,
+                &signer_keypair,
+            ),
+            signer_keypair.secret_key(),
+        )
+        .unwrap();
+        signed.admission.admitter_public_key = *wrong_keypair.public_key();
+        assert!(verify_challenge_admission(&signed).is_err());
+    }
+
+    #[test]
+    fn verify_challenge_admission_rejects_tampered_payload() {
+        let mut signed = signed_admission();
+        signed.admission.evidence_hash = [0xFEu8; 32];
+        assert!(verify_challenge_admission(&signed).is_err());
+    }
+
+    #[test]
+    fn verify_challenge_admission_rejects_replay_to_other_action() {
+        let mut signed = signed_admission();
+        signed.admission.action_id = [0x99u8; 32];
+        assert!(verify_challenge_admission(&signed).is_err());
+    }
+
+    #[test]
+    fn challenge_admission_payload_is_domain_separated_and_deterministic() {
+        let keypair = keypair(7);
+        let admission = admission_with(
+            uuid(3),
+            SybilChallengeGround::SyntheticHumanMisrepresentation,
+            &keypair,
         );
+        let first = challenge_admission_payload(&admission).unwrap();
+        let second = challenge_admission_payload(&admission).unwrap();
+        assert_eq!(first, second);
+        assert_ne!(first, action_id().to_vec());
+        assert!(
+            first
+                .windows(CHALLENGE_ADMISSION_DOMAIN.len())
+                .any(|window| window == CHALLENGE_ADMISSION_DOMAIN.as_bytes())
+        );
+    }
+
+    #[test]
+    fn admit_challenge_rejects_placeholder_provenance() {
+        let keypair = keypair(7);
+        let mut admission = admission_with(
+            Uuid::nil(),
+            SybilChallengeGround::ConcealedCommonControl,
+            &keypair,
+        );
+        assert!(sign_challenge_admission(admission.clone(), keypair.secret_key()).is_err());
+
+        admission.hold_id = uuid(4);
+        admission.action_id = [0u8; 32];
+        assert!(sign_challenge_admission(admission.clone(), keypair.secret_key()).is_err());
+
+        admission.action_id = action_id();
+        admission.evidence_hash = [0u8; 32];
+        assert!(sign_challenge_admission(admission.clone(), keypair.secret_key()).is_err());
+
+        admission.evidence_hash = [0xEEu8; 32];
+        admission.authority_chain_hash = [0u8; 32];
+        assert!(sign_challenge_admission(admission, keypair.secret_key()).is_err());
+    }
+
+    #[test]
+    fn escalation_reason_contains_ground() {
+        let keypair = keypair(7);
+        let hold = admit_challenge(
+            sign_challenge_admission(
+                admission_with(
+                    uuid(5),
+                    SybilChallengeGround::CoordinatedManipulation,
+                    &keypair,
+                ),
+                keypair.secret_key(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
         let reason = hold.escalation_reason();
         assert!(reason.contains("CoordinatedManipulation"));
         assert!(reason.contains("SybilChallenge"));
@@ -227,11 +532,15 @@ mod tests {
 
     #[test]
     fn begin_review_transitions_from_pause_eligible() {
+        let keypair = keypair(7);
         let mut hold = admit_challenge(
-            &action_id(),
-            SybilChallengeGround::QuorumContamination,
-            ts(1000),
-        );
+            sign_challenge_admission(
+                admission_with(uuid(6), SybilChallengeGround::QuorumContamination, &keypair),
+                keypair.secret_key(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
         assert!(begin_review(&mut hold, ts(2000)).is_ok());
         assert_eq!(hold.status, ContestStatus::UnderReview);
         assert_eq!(hold.audit_log.len(), 2);
@@ -239,33 +548,33 @@ mod tests {
 
     #[test]
     fn begin_review_fails_if_not_pause_eligible() {
-        let mut hold = admit_challenge(
-            &action_id(),
-            SybilChallengeGround::QuorumContamination,
-            ts(1000),
-        );
+        let mut hold = admit_challenge(signed_admission()).unwrap();
         hold.status = ContestStatus::Resolved;
         assert!(begin_review(&mut hold, ts(2000)).is_err());
     }
 
     #[test]
     fn resolve_hold_from_pause_eligible() {
+        let keypair = keypair(7);
         let mut hold = admit_challenge(
-            &action_id(),
-            SybilChallengeGround::SyntheticHumanMisrepresentation,
-            ts(1000),
-        );
+            sign_challenge_admission(
+                admission_with(
+                    uuid(7),
+                    SybilChallengeGround::SyntheticHumanMisrepresentation,
+                    &keypair,
+                ),
+                keypair.secret_key(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
         assert!(resolve_hold(&mut hold, ts(3000), "challenge sustained").is_ok());
         assert_eq!(hold.status, ContestStatus::Resolved);
     }
 
     #[test]
     fn resolve_hold_from_under_review() {
-        let mut hold = admit_challenge(
-            &action_id(),
-            SybilChallengeGround::ConcealedCommonControl,
-            ts(1000),
-        );
+        let mut hold = admit_challenge(signed_admission()).unwrap();
         begin_review(&mut hold, ts(2000)).unwrap();
         assert!(resolve_hold(&mut hold, ts(3000), "action reversed").is_ok());
         assert_eq!(hold.status, ContestStatus::Resolved);
@@ -273,46 +582,64 @@ mod tests {
 
     #[test]
     fn dismiss_hold_unblocks_action() {
+        let keypair = keypair(7);
         let mut hold = admit_challenge(
-            &action_id(),
-            SybilChallengeGround::CoordinatedManipulation,
-            ts(1000),
-        );
+            sign_challenge_admission(
+                admission_with(
+                    uuid(8),
+                    SybilChallengeGround::CoordinatedManipulation,
+                    &keypair,
+                ),
+                keypair.secret_key(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
         assert!(dismiss_hold(&mut hold, ts(2000), "insufficient evidence").is_ok());
         assert_eq!(hold.status, ContestStatus::Dismissed);
     }
 
     #[test]
     fn dismiss_after_resolved_fails() {
+        let keypair = keypair(7);
         let mut hold = admit_challenge(
-            &action_id(),
-            SybilChallengeGround::QuorumContamination,
-            ts(1000),
-        );
+            sign_challenge_admission(
+                admission_with(uuid(9), SybilChallengeGround::QuorumContamination, &keypair),
+                keypair.secret_key(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
         resolve_hold(&mut hold, ts(2000), "done").unwrap();
         assert!(dismiss_hold(&mut hold, ts(3000), "late").is_err());
     }
 
     #[test]
     fn all_four_grounds_admissible() {
+        let keypair = keypair(7);
+        let mut hold_id_marker = 10u8;
         for ground in [
             SybilChallengeGround::ConcealedCommonControl,
             SybilChallengeGround::CoordinatedManipulation,
             SybilChallengeGround::QuorumContamination,
             SybilChallengeGround::SyntheticHumanMisrepresentation,
         ] {
-            let hold = admit_challenge(&action_id(), ground.clone(), ts(1000));
+            let hold = admit_challenge(
+                sign_challenge_admission(
+                    admission_with(uuid(hold_id_marker), ground.clone(), &keypair),
+                    keypair.secret_key(),
+                )
+                .unwrap(),
+            )
+            .unwrap();
             assert_eq!(hold.status, ContestStatus::PauseEligible);
+            hold_id_marker = hold_id_marker.saturating_add(1);
         }
     }
 
     #[test]
     fn audit_log_grows_with_transitions() {
-        let mut hold = admit_challenge(
-            &action_id(),
-            SybilChallengeGround::ConcealedCommonControl,
-            ts(1000),
-        );
+        let mut hold = admit_challenge(signed_admission()).unwrap();
         assert_eq!(hold.audit_log.len(), 1);
         begin_review(&mut hold, ts(2000)).unwrap();
         assert_eq!(hold.audit_log.len(), 2);

--- a/crates/exo-escalation/src/completeness.rs
+++ b/crates/exo-escalation/src/completeness.rs
@@ -79,6 +79,7 @@ pub fn check_completeness(case: &EscalationCase) -> CompletenessResult {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use exo_core::Timestamp;
+    use uuid::Uuid;
 
     use super::*;
     use crate::{detector::*, escalation::*};
@@ -92,16 +93,27 @@ mod tests {
             timestamp: Timestamp::new(1000, 0),
         }
     }
+    fn uuid(byte: u8) -> Uuid {
+        Uuid::from_bytes([byte; 16])
+    }
+    fn case_input(id_marker: u8, confidence: u8, path: EscalationPath) -> EscalationCaseInput {
+        EscalationCaseInput {
+            id: uuid(id_marker),
+            created: Timestamp::new(2000, 0),
+            signal: signal(confidence),
+            path,
+        }
+    }
 
     #[test]
     fn standard_case_complete() {
-        let c = escalate(&signal(50), &EscalationPath::Standard);
+        let c = escalate(case_input(1, 50, EscalationPath::Standard)).unwrap();
         assert_eq!(check_completeness(&c), CompletenessResult::Complete);
     }
 
     #[test]
     fn sybil_case_incomplete_initially() {
-        let c = escalate(&signal(75), &EscalationPath::SybilAdjudication);
+        let c = escalate(case_input(2, 75, EscalationPath::SybilAdjudication)).unwrap();
         match check_completeness(&c) {
             CompletenessResult::Incomplete { missing } => {
                 assert!(missing.iter().any(|m| m.contains("Triage")));
@@ -113,7 +125,7 @@ mod tests {
 
     #[test]
     fn sybil_case_complete_after_all_stages() {
-        let mut c = escalate(&signal(75), &EscalationPath::SybilAdjudication);
+        let mut c = escalate(case_input(3, 75, EscalationPath::SybilAdjudication)).unwrap();
         c.assignee = Some(exo_core::Did::new("did:exo:reviewer").expect("ok"));
         for stage in [
             SybilStage::Triage,
@@ -130,7 +142,7 @@ mod tests {
 
     #[test]
     fn resolved_without_assignee_incomplete() {
-        let mut c = escalate(&signal(50), &EscalationPath::Standard);
+        let mut c = escalate(case_input(4, 50, EscalationPath::Standard)).unwrap();
         c.status = CaseStatus::Resolved;
         match check_completeness(&c) {
             CompletenessResult::Incomplete { missing } => {
@@ -142,19 +154,19 @@ mod tests {
 
     #[test]
     fn emergency_case_complete() {
-        let c = escalate(&signal(95), &EscalationPath::Emergency);
+        let c = escalate(case_input(5, 95, EscalationPath::Emergency)).unwrap();
         assert_eq!(check_completeness(&c), CompletenessResult::Complete);
     }
 
     #[test]
     fn constitutional_case_complete() {
-        let c = escalate(&signal(60), &EscalationPath::Constitutional);
+        let c = escalate(case_input(6, 60, EscalationPath::Constitutional)).unwrap();
         assert_eq!(check_completeness(&c), CompletenessResult::Complete);
     }
 
     #[test]
     fn no_evidence_incomplete() {
-        let mut c = escalate(&signal(50), &EscalationPath::Standard);
+        let mut c = escalate(case_input(7, 50, EscalationPath::Standard)).unwrap();
         c.evidence.clear();
         match check_completeness(&c) {
             CompletenessResult::Incomplete { missing } => {

--- a/crates/exo-escalation/src/error.rs
+++ b/crates/exo-escalation/src/error.rs
@@ -17,6 +17,15 @@ pub enum EscalationError {
     #[error("invalid signal: {0}")]
     InvalidSignal(String),
 
+    #[error("invalid provenance: {reason}")]
+    InvalidProvenance { reason: String },
+
+    #[error("invalid signature from {signer}: {reason}")]
+    InvalidSignature { signer: String, reason: String },
+
+    #[error("serialization failed for {context}: {reason}")]
+    SerializationFailed { context: String, reason: String },
+
     #[error("column not found: {0}")]
     ColumnNotFound(String),
 }

--- a/crates/exo-escalation/src/escalation.rs
+++ b/crates/exo-escalation/src/escalation.rs
@@ -59,33 +59,70 @@ pub struct EscalationCase {
     pub created: Timestamp,
 }
 
+/// Deterministic input for opening an escalation case.
+///
+/// The case id and creation timestamp are supplied by the caller from the
+/// surrounding HLC/provenance context. Escalation case creation never reads
+/// randomness or wall-clock time internally.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EscalationCaseInput {
+    pub id: Uuid,
+    pub created: Timestamp,
+    pub signal: DetectionSignal,
+    pub path: EscalationPath,
+}
+
 /// Escalate a detection signal along a specific path.
-#[must_use]
-pub fn escalate(signal: &DetectionSignal, path: &EscalationPath) -> EscalationCase {
-    let priority = match signal.confidence {
+///
+/// # Errors
+/// Returns an error when caller-supplied provenance fields are placeholders or
+/// the detection signal is outside its documented bounds.
+pub fn escalate(input: EscalationCaseInput) -> Result<EscalationCase, EscalationError> {
+    if input.id == Uuid::nil() {
+        return Err(EscalationError::InvalidProvenance {
+            reason: "escalation case id must be caller-supplied and non-nil".into(),
+        });
+    }
+    if input.signal.source.trim().is_empty() {
+        return Err(EscalationError::InvalidSignal(
+            "detection signal source must not be empty".into(),
+        ));
+    }
+    if input.signal.confidence > 100 {
+        return Err(EscalationError::InvalidSignal(
+            "detection signal confidence must be between 0 and 100".into(),
+        ));
+    }
+    if input.signal.evidence_hash == [0u8; 32] {
+        return Err(EscalationError::InvalidProvenance {
+            reason: "escalation case requires a non-zero evidence hash".into(),
+        });
+    }
+
+    let priority = match input.signal.confidence {
         0..=30 => CasePriority::Low,
         31..=60 => CasePriority::Medium,
         61..=85 => CasePriority::High,
         _ => CasePriority::Critical,
     };
 
-    let initial_stage = match path {
+    let initial_stage = match &input.path {
         EscalationPath::SybilAdjudication => SybilStage::Detection.to_string(),
         EscalationPath::Emergency => "emergency_activated".to_string(),
         EscalationPath::Constitutional => "constitutional_review".to_string(),
         EscalationPath::Standard => "intake".to_string(),
     };
 
-    EscalationCase {
-        id: Uuid::new_v4(),
-        path: path.clone(),
+    Ok(EscalationCase {
+        id: input.id,
+        path: input.path,
         status: CaseStatus::Open,
         priority,
         stages_completed: vec![initial_stage],
-        evidence: vec![signal.evidence_hash],
+        evidence: vec![input.signal.evidence_hash],
         assignee: None,
-        created: Timestamp::now_utc(),
-    }
+        created: input.created,
+    })
 }
 
 /// Advance a Sybil adjudication case to the next stage.
@@ -156,35 +193,107 @@ mod tests {
             timestamp: Timestamp::new(1000, 0),
         }
     }
+    fn uuid(byte: u8) -> Uuid {
+        Uuid::from_bytes([byte; 16])
+    }
+    fn case_input(
+        id_marker: u8,
+        confidence: u8,
+        st: SignalType,
+        path: EscalationPath,
+    ) -> EscalationCaseInput {
+        EscalationCaseInput {
+            id: uuid(id_marker),
+            created: Timestamp::new(2000, 0),
+            signal: signal(confidence, st),
+            path,
+        }
+    }
 
     #[test]
     fn escalate_standard() {
-        let s = signal(40, SignalType::AnomalousPattern);
-        let c = escalate(&s, &EscalationPath::Standard);
+        let c = escalate(case_input(
+            1,
+            40,
+            SignalType::AnomalousPattern,
+            EscalationPath::Standard,
+        ))
+        .unwrap();
         assert_eq!(c.path, EscalationPath::Standard);
         assert_eq!(c.status, CaseStatus::Open);
         assert_eq!(c.priority, CasePriority::Medium);
         assert!(c.stages_completed.contains(&"intake".to_string()));
         assert_eq!(c.evidence, vec![[1u8; 32]]);
+        assert_eq!(c.id, uuid(1));
+        assert_eq!(c.created, Timestamp::new(2000, 0));
     }
+
+    #[test]
+    fn escalate_is_deterministic_for_same_input() {
+        let input = case_input(
+            2,
+            40,
+            SignalType::AnomalousPattern,
+            EscalationPath::Standard,
+        );
+        let first = escalate(input.clone()).unwrap();
+        let second = escalate(input).unwrap();
+
+        assert_eq!(first.id, second.id);
+        assert_eq!(first.created, second.created);
+        assert_eq!(first.stages_completed, second.stages_completed);
+        assert_eq!(first.evidence, second.evidence);
+    }
+
+    #[test]
+    fn escalate_rejects_placeholder_provenance() {
+        let mut input = case_input(
+            3,
+            40,
+            SignalType::AnomalousPattern,
+            EscalationPath::Standard,
+        );
+        input.id = Uuid::nil();
+        assert!(escalate(input.clone()).is_err());
+
+        input.id = uuid(3);
+        input.signal.evidence_hash = [0u8; 32];
+        assert!(escalate(input).is_err());
+    }
+
     #[test]
     fn escalate_sybil() {
-        let s = signal(75, SignalType::SybilSuspicion);
-        let c = escalate(&s, &EscalationPath::SybilAdjudication);
+        let c = escalate(case_input(
+            4,
+            75,
+            SignalType::SybilSuspicion,
+            EscalationPath::SybilAdjudication,
+        ))
+        .unwrap();
         assert_eq!(c.path, EscalationPath::SybilAdjudication);
         assert_eq!(c.priority, CasePriority::High);
         assert!(c.stages_completed.contains(&"Detection".to_string()));
     }
     #[test]
     fn escalate_emergency() {
-        let s = signal(95, SignalType::EmergencyCondition);
-        let c = escalate(&s, &EscalationPath::Emergency);
+        let c = escalate(case_input(
+            5,
+            95,
+            SignalType::EmergencyCondition,
+            EscalationPath::Emergency,
+        ))
+        .unwrap();
         assert_eq!(c.priority, CasePriority::Critical);
     }
     #[test]
     fn escalate_constitutional() {
-        let s = signal(60, SignalType::ConsentViolation);
-        let c = escalate(&s, &EscalationPath::Constitutional);
+        let c = escalate(case_input(
+            6,
+            60,
+            SignalType::ConsentViolation,
+            EscalationPath::Constitutional,
+        ))
+        .unwrap();
         assert!(
             c.stages_completed
                 .contains(&"constitutional_review".to_string())
@@ -193,42 +302,59 @@ mod tests {
     #[test]
     fn priority_from_confidence() {
         assert_eq!(
-            escalate(
-                &signal(20, SignalType::AnomalousPattern),
-                &EscalationPath::Standard
-            )
+            escalate(case_input(
+                7,
+                20,
+                SignalType::AnomalousPattern,
+                EscalationPath::Standard
+            ))
+            .unwrap()
             .priority,
             CasePriority::Low
         );
         assert_eq!(
-            escalate(
-                &signal(50, SignalType::AnomalousPattern),
-                &EscalationPath::Standard
-            )
+            escalate(case_input(
+                8,
+                50,
+                SignalType::AnomalousPattern,
+                EscalationPath::Standard
+            ))
+            .unwrap()
             .priority,
             CasePriority::Medium
         );
         assert_eq!(
-            escalate(
-                &signal(70, SignalType::AnomalousPattern),
-                &EscalationPath::Standard
-            )
+            escalate(case_input(
+                9,
+                70,
+                SignalType::AnomalousPattern,
+                EscalationPath::Standard
+            ))
+            .unwrap()
             .priority,
             CasePriority::High
         );
         assert_eq!(
-            escalate(
-                &signal(90, SignalType::AnomalousPattern),
-                &EscalationPath::Standard
-            )
+            escalate(case_input(
+                10,
+                90,
+                SignalType::AnomalousPattern,
+                EscalationPath::Standard
+            ))
+            .unwrap()
             .priority,
             CasePriority::Critical
         );
     }
     #[test]
     fn advance_sybil_stages() {
-        let s = signal(75, SignalType::SybilSuspicion);
-        let mut c = escalate(&s, &EscalationPath::SybilAdjudication);
+        let mut c = escalate(case_input(
+            11,
+            75,
+            SignalType::SybilSuspicion,
+            EscalationPath::SybilAdjudication,
+        ))
+        .unwrap();
         assert!(advance_sybil_stage(&mut c, SybilStage::Triage).is_ok());
         assert_eq!(c.status, CaseStatus::InProgress);
         assert!(advance_sybil_stage(&mut c, SybilStage::Quarantine).is_ok());
@@ -241,16 +367,26 @@ mod tests {
     }
     #[test]
     fn advance_non_sybil_fails() {
-        let s = signal(50, SignalType::AnomalousPattern);
-        let mut c = escalate(&s, &EscalationPath::Standard);
+        let mut c = escalate(case_input(
+            12,
+            50,
+            SignalType::AnomalousPattern,
+            EscalationPath::Standard,
+        ))
+        .unwrap();
         assert!(advance_sybil_stage(&mut c, SybilStage::Triage).is_err());
     }
 
     // ── reinstate() tests ──────────────────────────────────────────────────────
 
     fn sybil_case_at_clearance_downgrade() -> EscalationCase {
-        let s = signal(80, SignalType::SybilSuspicion);
-        let mut c = escalate(&s, &EscalationPath::SybilAdjudication);
+        let mut c = escalate(case_input(
+            13,
+            80,
+            SignalType::SybilSuspicion,
+            EscalationPath::SybilAdjudication,
+        ))
+        .unwrap();
         for stage in [
             SybilStage::Triage,
             SybilStage::Quarantine,
@@ -279,8 +415,13 @@ mod tests {
 
     #[test]
     fn reinstate_fails_on_non_sybil_path() {
-        let s = signal(50, SignalType::AnomalousPattern);
-        let mut c = escalate(&s, &EscalationPath::Standard);
+        let mut c = escalate(case_input(
+            14,
+            50,
+            SignalType::AnomalousPattern,
+            EscalationPath::Standard,
+        ))
+        .unwrap();
         assert!(reinstate(&mut c, [0xAAu8; 32]).is_err());
     }
     #[test]

--- a/crates/exo-escalation/src/feedback.rs
+++ b/crates/exo-escalation/src/feedback.rs
@@ -103,9 +103,13 @@ pub fn apply_learnings(feedbacks: &[FeedbackEntry]) -> Vec<PolicyRecommendation>
 mod tests {
     use super::*;
 
+    fn uuid(byte: u8) -> Uuid {
+        Uuid::from_bytes([byte; 16])
+    }
+
     fn entry(outcome: FeedbackOutcome, recs: &[&str]) -> FeedbackEntry {
         FeedbackEntry {
-            case_id: Uuid::new_v4(),
+            case_id: uuid(1),
             outcome,
             lessons_learned: "lesson".into(),
             policy_recommendations: recs.iter().map(|s| s.to_string()).collect(),

--- a/crates/exo-escalation/src/kanban.rs
+++ b/crates/exo-escalation/src/kanban.rs
@@ -97,8 +97,19 @@ mod tests {
             source: "test".into(),
             signal_type: SignalType::AnomalousPattern,
             confidence,
-            evidence_hash: [0u8; 32],
+            evidence_hash: [0xE1u8; 32],
             timestamp: Timestamp::new(1000, 0),
+        }
+    }
+    fn uuid(byte: u8) -> Uuid {
+        Uuid::from_bytes([byte; 16])
+    }
+    fn case_input(id_marker: u8, confidence: u8) -> EscalationCaseInput {
+        EscalationCaseInput {
+            id: uuid(id_marker),
+            created: Timestamp::new(2000, 0),
+            signal: signal(confidence),
+            path: EscalationPath::Standard,
         }
     }
 
@@ -111,7 +122,7 @@ mod tests {
     #[test]
     fn add_case_to_backlog() {
         let mut b = KanbanBoard::new();
-        let c = escalate(&signal(50), &EscalationPath::Standard);
+        let c = escalate(case_input(1, 50)).unwrap();
         b.add_case(c);
         assert_eq!(b.total_cases(), 1);
         assert_eq!(b.columns[&KanbanColumn::Backlog].len(), 1);
@@ -119,7 +130,7 @@ mod tests {
     #[test]
     fn move_case_between_columns() {
         let mut b = KanbanBoard::new();
-        let c = escalate(&signal(50), &EscalationPath::Standard);
+        let c = escalate(case_input(2, 50)).unwrap();
         let id = c.id;
         b.add_case(c);
         assert!(move_case(&mut b, &id, KanbanColumn::InProgress).is_ok());
@@ -129,12 +140,12 @@ mod tests {
     #[test]
     fn move_nonexistent_case_fails() {
         let mut b = KanbanBoard::new();
-        assert!(move_case(&mut b, &Uuid::new_v4(), KanbanColumn::InProgress).is_err());
+        assert!(move_case(&mut b, &uuid(0xFE), KanbanColumn::InProgress).is_err());
     }
     #[test]
     fn move_through_all_columns() {
         let mut b = KanbanBoard::new();
-        let c = escalate(&signal(50), &EscalationPath::Standard);
+        let c = escalate(case_input(3, 50)).unwrap();
         let id = c.id;
         b.add_case(c);
         assert!(move_case(&mut b, &id, KanbanColumn::InProgress).is_ok());
@@ -146,9 +157,9 @@ mod tests {
     #[test]
     fn cases_by_priority_sorted() {
         let mut b = KanbanBoard::new();
-        b.add_case(escalate(&signal(20), &EscalationPath::Standard)); // Low
-        b.add_case(escalate(&signal(90), &EscalationPath::Standard)); // Critical
-        b.add_case(escalate(&signal(50), &EscalationPath::Standard)); // Medium
+        b.add_case(escalate(case_input(4, 20)).unwrap()); // Low
+        b.add_case(escalate(case_input(5, 90)).unwrap()); // Critical
+        b.add_case(escalate(case_input(6, 50)).unwrap()); // Medium
         let sorted = cases_by_priority(&b);
         assert_eq!(sorted.len(), 3);
         assert_eq!(sorted[0].priority, CasePriority::Critical);

--- a/crates/exo-escalation/tests/sybil_adjudication.rs
+++ b/crates/exo-escalation/tests/sybil_adjudication.rs
@@ -12,10 +12,15 @@
 
 use exo_core::{Did, Timestamp};
 use exo_escalation::{
-    challenge::{ContestStatus, SybilChallengeGround, admit_challenge, begin_review, resolve_hold},
+    challenge::{
+        ChallengeAdmission, ContestStatus, SignedChallengeAdmission, SybilChallengeGround,
+        admit_challenge, begin_review, resolve_hold, sign_challenge_admission,
+    },
     completeness::{CompletenessResult, check_completeness},
     detector::{DetectionSignal, Severity, SignalType, evaluate_signals},
-    escalation::{EscalationPath, SybilStage, advance_sybil_stage, escalate, reinstate},
+    escalation::{
+        EscalationCaseInput, EscalationPath, SybilStage, advance_sybil_stage, escalate, reinstate,
+    },
     triage::{TriageLevel, triage},
 };
 use exo_gatekeeper::{
@@ -39,6 +44,51 @@ fn did(s: &str) -> Did {
 
 fn ts(ms: u64) -> Timestamp {
     Timestamp::new(ms, 0)
+}
+
+fn uuid(byte: u8) -> uuid::Uuid {
+    uuid::Uuid::from_bytes([byte; 16])
+}
+
+fn keypair(seed: u8) -> exo_core::crypto::KeyPair {
+    exo_core::crypto::KeyPair::from_secret_bytes([seed; 32]).expect("valid keypair")
+}
+
+fn escalation_input(
+    id_marker: u8,
+    signal: DetectionSignal,
+    path: EscalationPath,
+    created_ms: u64,
+) -> EscalationCaseInput {
+    EscalationCaseInput {
+        id: uuid(id_marker),
+        created: ts(created_ms),
+        signal,
+        path,
+    }
+}
+
+fn signed_challenge(
+    hold_marker: u8,
+    action_id: [u8; 32],
+    ground: SybilChallengeGround,
+    admitted_at: Timestamp,
+) -> SignedChallengeAdmission {
+    let keypair = keypair(7);
+    sign_challenge_admission(
+        ChallengeAdmission {
+            hold_id: uuid(hold_marker),
+            action_id,
+            ground,
+            admitted_at,
+            admitted_by: did("did:exo:reviewer"),
+            admitter_public_key: *keypair.public_key(),
+            evidence_hash: [0xEEu8; 32],
+            authority_chain_hash: [0xACu8; 32],
+        },
+        keypair.secret_key(),
+    )
+    .expect("valid challenge admission")
 }
 
 /// Build a fully valid `AdjudicationContext`.  Pass `Some(reason)` to inject
@@ -116,7 +166,13 @@ fn full_detection_to_reinstatement_flow() {
     );
 
     // ── Open escalation case (Detection stage logged) ─────────────────────────
-    let mut case = escalate(&signal, &EscalationPath::SybilAdjudication);
+    let mut case = escalate(escalation_input(
+        1,
+        signal.clone(),
+        EscalationPath::SybilAdjudication,
+        1_050,
+    ))
+    .unwrap();
     assert!(case.stages_completed.contains(&"Detection".to_string()));
 
     // ── Stage 2 (case): Triage ────────────────────────────────────────────────
@@ -124,11 +180,13 @@ fn full_detection_to_reinstatement_flow() {
 
     // ── Stage 3: Quarantine — admit challenge hold ────────────────────────────
     let action_id = [0x01u8; 32];
-    let mut hold = admit_challenge(
-        &action_id,
+    let mut hold = admit_challenge(signed_challenge(
+        2,
+        action_id,
         SybilChallengeGround::ConcealedCommonControl,
         ts(1_100),
-    );
+    ))
+    .unwrap();
     assert_eq!(hold.status, ContestStatus::PauseEligible);
     advance_sybil_stage(&mut case, SybilStage::Quarantine).unwrap();
 
@@ -194,11 +252,13 @@ fn quarantine_pauses_contested_actions_via_kernel() {
 
     // Admit challenge → derive escalation reason
     let action_id = [0x02u8; 32];
-    let hold = admit_challenge(
-        &action_id,
+    let hold = admit_challenge(signed_challenge(
+        3,
+        action_id,
         SybilChallengeGround::QuorumContamination,
         ts(2_000),
-    );
+    ))
+    .unwrap();
     let reason = hold.escalation_reason();
     assert!(reason.contains("SybilChallenge"));
 
@@ -238,7 +298,13 @@ fn reinstatement_refuses_zero_hash_evidence() {
         evidence_hash: [0x01u8; 32],
         timestamp: ts(3_000),
     };
-    let mut case = escalate(&signal, &EscalationPath::SybilAdjudication);
+    let mut case = escalate(escalation_input(
+        4,
+        signal,
+        EscalationPath::SybilAdjudication,
+        3_100,
+    ))
+    .unwrap();
     for stage in [
         SybilStage::Triage,
         SybilStage::Quarantine,

--- a/crates/exo-node/src/challenges.rs
+++ b/crates/exo-node/src/challenges.rs
@@ -27,7 +27,7 @@ use axum::{
     routing::{get, post},
 };
 use exo_core::types::Timestamp;
-use exo_escalation::challenge::{self, ContestHold, SybilChallengeGround};
+use exo_escalation::challenge::{self, ContestHold, SignedChallengeAdmission};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -88,6 +88,10 @@ pub struct ChallengeResponse {
     pub ground: String,
     pub status: String,
     pub admitted_at_ms: u64,
+    pub admitted_by: String,
+    pub evidence_hash: String,
+    pub authority_chain_hash: String,
+    pub admission_signature_algorithm: String,
     pub audit_log: Vec<String>,
 }
 
@@ -99,61 +103,38 @@ impl From<&ContestHold> for ChallengeResponse {
             ground: hold.ground.to_string(),
             status: format!("{:?}", hold.status),
             admitted_at_ms: hold.admitted_at.physical_ms,
+            admitted_by: hold.admitted_by.to_string(),
+            evidence_hash: hex::encode(hold.evidence_hash),
+            authority_chain_hash: hex::encode(hold.authority_chain_hash),
+            admission_signature_algorithm: hold.admission_signature.algorithm().to_string(),
             audit_log: hold.audit_log.clone(),
         }
     }
 }
 
-/// Request body for filing a new challenge.
+/// Request body for beginning review.
 #[derive(Debug, Deserialize)]
-pub struct FileChallengeRequest {
-    /// Hex-encoded 32-byte action identifier being challenged.
-    pub action_id_hex: String,
-    /// Challenge ground: one of "ConcealedCommonControl",
-    /// "CoordinatedManipulation", "QuorumContamination",
-    /// "SyntheticHumanMisrepresentation".
-    pub ground: String,
+pub struct ReviewChallengeRequest {
+    pub at: Timestamp,
 }
 
 /// Request body for resolving a challenge.
 #[derive(Debug, Deserialize)]
 pub struct ResolveChallengeRequest {
+    pub at: Timestamp,
     pub outcome: String,
 }
 
 /// Request body for dismissing a challenge.
 #[derive(Debug, Deserialize)]
 pub struct DismissChallengeRequest {
+    pub at: Timestamp,
     pub reason: String,
 }
 
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
-
-fn parse_ground(s: &str) -> Result<SybilChallengeGround, String> {
-    match s {
-        "ConcealedCommonControl" => Ok(SybilChallengeGround::ConcealedCommonControl),
-        "CoordinatedManipulation" => Ok(SybilChallengeGround::CoordinatedManipulation),
-        "QuorumContamination" => Ok(SybilChallengeGround::QuorumContamination),
-        "SyntheticHumanMisrepresentation" => {
-            Ok(SybilChallengeGround::SyntheticHumanMisrepresentation)
-        }
-        other => Err(format!("unknown challenge ground: {other}")),
-    }
-}
-
-fn now_timestamp() -> Timestamp {
-    #[allow(clippy::as_conversions)]
-    let ms = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as u64;
-    Timestamp {
-        physical_ms: ms,
-        logical: 0,
-    }
-}
 
 /// `GET /api/v1/challenges` — list all challenge holds.
 async fn handle_list(
@@ -195,22 +176,10 @@ async fn handle_get(
 /// `POST /api/v1/challenges` — file a new Sybil challenge.
 async fn handle_file(
     State(store): State<SharedChallengeStore>,
-    Json(req): Json<FileChallengeRequest>,
+    Json(req): Json<SignedChallengeAdmission>,
 ) -> Result<(StatusCode, Json<ChallengeResponse>), (StatusCode, String)> {
-    let action_bytes = hex::decode(&req.action_id_hex)
-        .map_err(|e| (StatusCode::BAD_REQUEST, format!("invalid hex: {e}")))?;
-    if action_bytes.len() != 32 {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            format!("action_id must be 32 bytes, got {}", action_bytes.len()),
-        ));
-    }
-    let mut action_id = [0u8; 32];
-    action_id.copy_from_slice(&action_bytes);
-
-    let ground = parse_ground(&req.ground).map_err(|e| (StatusCode::BAD_REQUEST, e))?;
-
-    let hold = challenge::admit_challenge(&action_id, ground, now_timestamp());
+    let hold =
+        challenge::admit_challenge(req).map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
     let resp = ChallengeResponse::from(&hold);
 
     {
@@ -230,6 +199,7 @@ async fn handle_file(
 async fn handle_begin_review(
     State(store): State<SharedChallengeStore>,
     Path(id_str): Path<String>,
+    Json(req): Json<ReviewChallengeRequest>,
 ) -> Result<Json<ChallengeResponse>, (StatusCode, String)> {
     let id = Uuid::parse_str(&id_str)
         .map_err(|e| (StatusCode::BAD_REQUEST, format!("invalid UUID: {e}")))?;
@@ -244,8 +214,7 @@ async fn handle_begin_review(
         .get_mut(&id)
         .ok_or_else(|| (StatusCode::NOT_FOUND, "challenge not found".into()))?;
 
-    challenge::begin_review(hold, now_timestamp())
-        .map_err(|e| (StatusCode::CONFLICT, e.to_string()))?;
+    challenge::begin_review(hold, req.at).map_err(|e| (StatusCode::CONFLICT, e.to_string()))?;
 
     Ok(Json(ChallengeResponse::from(&*hold)))
 }
@@ -269,7 +238,7 @@ async fn handle_resolve(
         .get_mut(&id)
         .ok_or_else(|| (StatusCode::NOT_FOUND, "challenge not found".into()))?;
 
-    challenge::resolve_hold(hold, now_timestamp(), &req.outcome)
+    challenge::resolve_hold(hold, req.at, &req.outcome)
         .map_err(|e| (StatusCode::CONFLICT, e.to_string()))?;
 
     Ok(Json(ChallengeResponse::from(&*hold)))
@@ -294,7 +263,7 @@ async fn handle_dismiss(
         .get_mut(&id)
         .ok_or_else(|| (StatusCode::NOT_FOUND, "challenge not found".into()))?;
 
-    challenge::dismiss_hold(hold, now_timestamp(), &req.reason)
+    challenge::dismiss_hold(hold, req.at, &req.reason)
         .map_err(|e| (StatusCode::CONFLICT, e.to_string()))?;
 
     Ok(Json(ChallengeResponse::from(&*hold)))
@@ -324,6 +293,10 @@ pub fn challenge_router(store: SharedChallengeStore) -> Router {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use axum::{body::Body, http::Request};
+    use exo_core::{Did, Signature};
+    use exo_escalation::challenge::{
+        ChallengeAdmission, SybilChallengeGround, sign_challenge_admission,
+    };
     use tower::ServiceExt;
 
     use super::*;
@@ -332,8 +305,47 @@ mod tests {
         Arc::new(Mutex::new(ChallengeStore::new()))
     }
 
-    fn action_id_hex() -> String {
-        hex::encode([7u8; 32])
+    fn action_id(byte: u8) -> [u8; 32] {
+        [byte; 32]
+    }
+
+    fn ts(ms: u64) -> Timestamp {
+        Timestamp::new(ms, 0)
+    }
+
+    fn did(s: &str) -> Did {
+        Did::new(s).unwrap()
+    }
+
+    fn uuid(byte: u8) -> Uuid {
+        Uuid::from_bytes([byte; 16])
+    }
+
+    fn keypair(seed: u8) -> exo_core::crypto::KeyPair {
+        exo_core::crypto::KeyPair::from_secret_bytes([seed; 32]).unwrap()
+    }
+
+    fn signed_challenge(
+        hold_marker: u8,
+        action_id: [u8; 32],
+        ground: SybilChallengeGround,
+        admitted_at: Timestamp,
+    ) -> SignedChallengeAdmission {
+        let keypair = keypair(7);
+        sign_challenge_admission(
+            ChallengeAdmission {
+                hold_id: uuid(hold_marker),
+                action_id,
+                ground,
+                admitted_at,
+                admitted_by: did("did:exo:reviewer"),
+                admitter_public_key: *keypair.public_key(),
+                evidence_hash: [0xEEu8; 32],
+                authority_chain_hash: [0xACu8; 32],
+            },
+            keypair.secret_key(),
+        )
+        .unwrap()
     }
 
     #[tokio::test]
@@ -362,10 +374,12 @@ mod tests {
         let store = test_store();
         let app = challenge_router(Arc::clone(&store));
 
-        let body = serde_json::json!({
-            "action_id_hex": action_id_hex(),
-            "ground": "QuorumContamination",
-        });
+        let body = signed_challenge(
+            1,
+            action_id(7),
+            SybilChallengeGround::QuorumContamination,
+            ts(1000),
+        );
 
         let resp = app
             .oneshot(
@@ -384,6 +398,9 @@ mod tests {
         let result: ChallengeResponse = serde_json::from_slice(&body_bytes).unwrap();
         assert_eq!(result.ground, "QuorumContamination");
         assert_eq!(result.status, "PauseEligible");
+        assert_eq!(result.id, uuid(1).to_string());
+        assert_eq!(result.admitted_by, "did:exo:reviewer");
+        assert_eq!(result.admission_signature_algorithm, "Ed25519");
         assert!(!result.audit_log.is_empty());
 
         // Retrieve it by ID.
@@ -405,11 +422,13 @@ mod tests {
         let store = test_store();
 
         // File challenge.
-        let hold = challenge::admit_challenge(
-            &[1u8; 32],
+        let hold = challenge::admit_challenge(signed_challenge(
+            2,
+            action_id(1),
             SybilChallengeGround::ConcealedCommonControl,
-            Timestamp::new(1000, 0),
-        );
+            ts(1000),
+        ))
+        .unwrap();
         let hold_id = hold.id;
         {
             let mut st = store.lock().unwrap();
@@ -418,13 +437,14 @@ mod tests {
 
         // Begin review.
         let app = challenge_router(Arc::clone(&store));
+        let review_body = serde_json::json!({ "at": ts(1100) });
         let resp = app
             .oneshot(
                 Request::builder()
                     .method("POST")
                     .uri(&format!("/api/v1/challenges/{hold_id}/review"))
                     .header("content-type", "application/json")
-                    .body(Body::empty())
+                    .body(Body::from(serde_json::to_string(&review_body).unwrap()))
                     .unwrap(),
             )
             .await
@@ -436,7 +456,7 @@ mod tests {
 
         // Resolve.
         let app2 = challenge_router(Arc::clone(&store));
-        let resolve_body = serde_json::json!({ "outcome": "challenge sustained" });
+        let resolve_body = serde_json::json!({ "at": ts(1200), "outcome": "challenge sustained" });
         let resp2 = app2
             .oneshot(
                 Request::builder()
@@ -458,11 +478,13 @@ mod tests {
     #[tokio::test]
     async fn dismiss_challenge() {
         let store = test_store();
-        let hold = challenge::admit_challenge(
-            &[2u8; 32],
+        let hold = challenge::admit_challenge(signed_challenge(
+            3,
+            action_id(2),
             SybilChallengeGround::SyntheticHumanMisrepresentation,
-            Timestamp::new(500, 0),
-        );
+            ts(500),
+        ))
+        .unwrap();
         let hold_id = hold.id;
         {
             let mut st = store.lock().unwrap();
@@ -470,7 +492,7 @@ mod tests {
         }
 
         let app = challenge_router(Arc::clone(&store));
-        let body = serde_json::json!({ "reason": "insufficient evidence" });
+        let body = serde_json::json!({ "at": ts(600), "reason": "insufficient evidence" });
         let resp = app
             .oneshot(
                 Request::builder()
@@ -489,14 +511,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn invalid_ground_rejected() {
+    async fn invalid_signature_rejected() {
         let store = test_store();
         let app = challenge_router(store);
 
-        let body = serde_json::json!({
-            "action_id_hex": action_id_hex(),
-            "ground": "InvalidGround",
-        });
+        let mut body = signed_challenge(
+            4,
+            action_id(7),
+            SybilChallengeGround::QuorumContamination,
+            ts(1000),
+        );
+        body.admission_signature = Signature::Ed25519([0xABu8; 64]);
 
         let resp = app
             .oneshot(
@@ -516,7 +541,7 @@ mod tests {
     async fn get_nonexistent_returns_404() {
         let store = test_store();
         let app = challenge_router(store);
-        let fake_id = Uuid::new_v4();
+        let fake_id = uuid(0xFE);
 
         let resp = app
             .oneshot(
@@ -533,20 +558,22 @@ mod tests {
     #[tokio::test]
     async fn resolve_already_resolved_conflicts() {
         let store = test_store();
-        let mut hold = challenge::admit_challenge(
-            &[3u8; 32],
+        let mut hold = challenge::admit_challenge(signed_challenge(
+            5,
+            action_id(3),
             SybilChallengeGround::CoordinatedManipulation,
-            Timestamp::new(100, 0),
-        );
+            ts(100),
+        ))
+        .unwrap();
         let hold_id = hold.id;
-        challenge::resolve_hold(&mut hold, Timestamp::new(200, 0), "done").unwrap();
+        challenge::resolve_hold(&mut hold, ts(200), "done").unwrap();
         {
             let mut st = store.lock().unwrap();
             st.insert(hold);
         }
 
         let app = challenge_router(store);
-        let body = serde_json::json!({ "outcome": "again" });
+        let body = serde_json::json!({ "at": ts(300), "outcome": "again" });
         let resp = app
             .oneshot(
                 Request::builder()

--- a/crates/exo-node/src/telegram.rs
+++ b/crates/exo-node/src/telegram.rs
@@ -895,16 +895,28 @@ mod tests {
 
     #[test]
     fn challenges_message_with_hold() {
-        use exo_escalation::challenge::{self, SybilChallengeGround};
+        use exo_escalation::challenge::{
+            self, ChallengeAdmission, SybilChallengeGround, sign_challenge_admission,
+        };
 
         let store: SharedChallengeStore = Arc::new(Mutex::new(ChallengeStore::new()));
         {
             let mut st = store.lock().unwrap();
+            let keypair = exo_core::crypto::KeyPair::from_secret_bytes([7u8; 32]).unwrap();
+            let admission = ChallengeAdmission {
+                hold_id: uuid::Uuid::from_bytes([1u8; 16]),
+                action_id: [1u8; 32],
+                ground: SybilChallengeGround::QuorumContamination,
+                admitted_at: exo_core::types::Timestamp::new(1000, 0),
+                admitted_by: Did::new("did:exo:reviewer").unwrap(),
+                admitter_public_key: *keypair.public_key(),
+                evidence_hash: [0xEEu8; 32],
+                authority_chain_hash: [0xACu8; 32],
+            };
             let hold = challenge::admit_challenge(
-                &[1u8; 32],
-                SybilChallengeGround::QuorumContamination,
-                exo_core::types::Timestamp::new(1000, 0),
-            );
+                sign_challenge_admission(admission, keypair.secret_key()).unwrap(),
+            )
+            .unwrap();
             st.insert(hold);
         }
         let (text, _) = build_challenges_message(&store);

--- a/crates/exochain-wasm/src/escalation_bindings.rs
+++ b/crates/exochain-wasm/src/escalation_bindings.rs
@@ -12,12 +12,15 @@ pub fn wasm_evaluate_signals(signals_json: &str) -> Result<JsValue, JsValue> {
     to_js_value(&assessment)
 }
 
-/// Escalate a detection signal to create a case
+/// Escalate a detection signal to create a case.
+///
+/// The input JSON must be an `EscalationCaseInput` so the caller supplies the
+/// case id and HLC creation timestamp explicitly.
 #[wasm_bindgen]
-pub fn wasm_escalate(signal_json: &str, path_json: &str) -> Result<JsValue, JsValue> {
-    let signal: exo_escalation::detector::DetectionSignal = from_json_str(signal_json)?;
-    let path: exo_escalation::escalation::EscalationPath = from_json_str(path_json)?;
-    let case = exo_escalation::escalation::escalate(&signal, &path);
+pub fn wasm_escalate(input_json: &str) -> Result<JsValue, JsValue> {
+    let input: exo_escalation::escalation::EscalationCaseInput = from_json_str(input_json)?;
+    let case = exo_escalation::escalation::escalate(input)
+        .map_err(|e| JsValue::from_str(&e.to_string()))?;
     to_js_value(&case)
 }
 

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -43,6 +43,7 @@ function setup(fn) {
 // Convenience constants
 const ZERO_32_HEX   = '0'.repeat(64);
 const ZERO_32_BYTES = Array.from({ length: 32 }, () => 0);
+const EVIDENCE_32_BYTES = Array.from({ length: 32 }, () => 0xee);
 const TEST_DID      = 'did:exo:test-actor';
 const TEST_DID_2    = 'did:exo:test-actor-2';
 const TEST_DID_3    = 'did:exo:test-actor-3';
@@ -607,12 +608,16 @@ test('wasm_escalate', () => {
     source: TEST_DID,
     signal_type: 'AnomalousPattern',
     confidence: 80,
-    evidence_hash: ZERO_32_BYTES,
+    evidence_hash: EVIDENCE_32_BYTES,
     timestamp: NOW_TS
   };
-  // EscalationPath is an enum: Standard, SybilAdjudication, Emergency, Constitutional
-  const path = JSON.stringify('Standard');
-  return wasm.wasm_escalate(JSON.stringify(signal), path);
+  const input = {
+    id: '11111111-1111-1111-1111-111111111111',
+    created: NOW_TS,
+    signal,
+    path: 'Standard'
+  };
+  return wasm.wasm_escalate(JSON.stringify(input));
 });
 
 const escCase = setup(() => {
@@ -620,12 +625,16 @@ const escCase = setup(() => {
     source: TEST_DID,
     signal_type: 'AnomalousPattern',
     confidence: 80,
-    evidence_hash: ZERO_32_BYTES,
+    evidence_hash: EVIDENCE_32_BYTES,
     timestamp: NOW_TS
   };
-  // EscalationPath is an enum: Standard, SybilAdjudication, Emergency, Constitutional
-  const path = JSON.stringify('Standard');
-  return wasm.wasm_escalate(JSON.stringify(signal), path);
+  const input = {
+    id: '22222222-2222-2222-2222-222222222222',
+    created: NOW_TS,
+    signal,
+    path: 'Standard'
+  };
+  return wasm.wasm_escalate(JSON.stringify(input));
 });
 
 test('wasm_check_completeness', () => {


### PR DESCRIPTION
## Summary
- require signed canonical-CBOR Sybil challenge admissions with caller DID, public key, evidence hash, authority-chain hash, and supplied hold ID/HLC
- replace internally generated escalation case IDs/timestamps with caller-supplied EscalationCaseInput
- update exo-node challenge routes and WASM escalation binding to use the verified input shapes

## TDD red checks
- `cargo test -p exo-escalation challenge::tests::admit_challenge_is_deterministic_for_same_input --lib` initially failed on random hold IDs
- `cargo test -p exo-escalation escalation::tests::escalate_is_deterministic_for_same_input --lib` initially failed on random case IDs

## Verification
- `cargo test -p exo-escalation --lib`
- `cargo test -p exo-escalation --test sybil_adjudication`
- `cargo test -p exo-escalation`
- `cargo test -p exo-node --bins challenges`
- `cargo build -p exochain-wasm`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo +nightly fmt --all -- --check`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm --out-name exochain_wasm`
- `node packages/exochain-wasm/test/bridge_verification.mjs`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `git diff --check`
