### PR TITLE
fix(exo-tenant): enforce deterministic tenant isolation

### DIFF
--- a/crates/exo-tenant/src/cold.rs
+++ b/crates/exo-tenant/src/cold.rs
@@ -1,8 +1,12 @@
 //! Cold storage archival for long-term retention.
 
-use chrono::{DateTime, Utc};
+use std::collections::BTreeMap;
+
+use exo_core::{Hash256, Timestamp};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+
+use crate::error::{Result, TenantError};
 
 /// Storage tier for data lifecycle management.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -25,20 +29,30 @@ pub struct ArchivalPolicy {
     pub warm_to_cold_days: u32,
     pub cold_to_archive_days: u32,
     pub retention_years: u32,
-    pub created_at: DateTime<Utc>,
+    pub created_at: Timestamp,
 }
 
 impl ArchivalPolicy {
     /// Create a default 50-year retention policy.
-    pub fn default_50_year(tenant_id: Uuid) -> Self {
-        Self {
+    pub fn default_50_year(tenant_id: Uuid, created_at: Timestamp) -> Result<Self> {
+        if tenant_id == Uuid::nil() {
+            return Err(TenantError::InvalidTenant {
+                reason: "tenant id must not be nil".into(),
+            });
+        }
+        if created_at == Timestamp::ZERO {
+            return Err(TenantError::InvalidTenant {
+                reason: "created timestamp must be caller-supplied HLC".into(),
+            });
+        }
+        Ok(Self {
             tenant_id,
             hot_to_warm_days: 90,
             warm_to_cold_days: 365,
             cold_to_archive_days: 365 * 3,
             retention_years: 50,
-            created_at: Utc::now(),
-        }
+            created_at,
+        })
     }
 
     /// Determine the target tier for data of a given age.
@@ -62,31 +76,42 @@ pub struct ColdStorageRef {
     pub object_key: String,
     pub tier: StorageTier,
     pub size_bytes: u64,
-    pub archived_at: DateTime<Utc>,
-    pub content_hash: exo_core::crypto::Blake3Hash,
+    pub archived_at: Timestamp,
+    pub content_hash: Hash256,
 }
 
 /// Cold storage service (trait for S3/Glacier backends).
 pub struct ColdStorage {
-    refs: Vec<ColdStorageRef>,
+    refs: BTreeMap<(Uuid, String), ColdStorageRef>,
 }
 
 impl ColdStorage {
     /// Create an empty cold storage tracker.
     pub fn new() -> Self {
-        Self { refs: Vec::new() }
+        Self {
+            refs: BTreeMap::new(),
+        }
     }
 
     /// Record an archival operation.
-    pub fn record_archival(&mut self, reference: ColdStorageRef) {
-        self.refs.push(reference);
+    pub fn record_archival(&mut self, reference: ColdStorageRef) -> Result<()> {
+        Self::validate_reference(&reference)?;
+        let key = (reference.tenant_id, reference.object_key.clone());
+        if self.refs.contains_key(&key) {
+            return Err(TenantError::ColdStorageReferenceAlreadyExists {
+                tenant_id: reference.tenant_id,
+                object_key: reference.object_key,
+            });
+        }
+        self.refs.insert(key, reference);
+        Ok(())
     }
 
     /// Get all archived references for a tenant.
     pub fn for_tenant(&self, tenant_id: Uuid) -> Vec<&ColdStorageRef> {
         self.refs
-            .iter()
-            .filter(|r| r.tenant_id == tenant_id)
+            .values()
+            .filter(|reference| reference.tenant_id == tenant_id)
             .collect()
     }
 
@@ -94,8 +119,37 @@ impl ColdStorage {
     pub fn archived_size(&self, tenant_id: Uuid) -> u64 {
         self.for_tenant(tenant_id)
             .iter()
-            .map(|r| r.size_bytes)
+            .map(|reference| reference.size_bytes)
             .sum()
+    }
+
+    fn validate_reference(reference: &ColdStorageRef) -> Result<()> {
+        if reference.tenant_id == Uuid::nil() {
+            return Err(TenantError::StorageError {
+                reason: "tenant id must not be nil".into(),
+            });
+        }
+        if reference.object_key.trim().is_empty() {
+            return Err(TenantError::StorageError {
+                reason: "object key must not be empty".into(),
+            });
+        }
+        if reference.size_bytes == 0 {
+            return Err(TenantError::StorageError {
+                reason: "archived size must be greater than zero".into(),
+            });
+        }
+        if reference.archived_at == Timestamp::ZERO {
+            return Err(TenantError::StorageError {
+                reason: "archived timestamp must be caller-supplied HLC".into(),
+            });
+        }
+        if reference.content_hash == Hash256::ZERO {
+            return Err(TenantError::StorageError {
+                reason: "content hash must not be zero".into(),
+            });
+        }
+        Ok(())
     }
 }
 
@@ -107,12 +161,22 @@ impl Default for ColdStorage {
 
 #[cfg(test)]
 mod tests {
+    use exo_core::{Hash256, Timestamp};
+
     use super::*;
+
+    fn uuid(byte: u8) -> Uuid {
+        Uuid::from_bytes([byte; 16])
+    }
+
+    fn ts(ms: u64) -> Timestamp {
+        Timestamp::new(ms, 0)
+    }
 
     #[test]
     fn test_archival_policy_tier_assignment() {
-        let tenant = Uuid::new_v4();
-        let policy = ArchivalPolicy::default_50_year(tenant);
+        let tenant = uuid(1);
+        let policy = ArchivalPolicy::default_50_year(tenant, ts(1_700_000_000_000)).unwrap();
 
         assert_eq!(policy.tier_for_age_days(30), StorageTier::Hot);
         assert_eq!(policy.tier_for_age_days(100), StorageTier::Warm);
@@ -121,20 +185,86 @@ mod tests {
     }
 
     #[test]
+    fn default_50_year_records_supplied_hlc_timestamp() {
+        let created_at = ts(1_700_000_000_000);
+        let policy = ArchivalPolicy::default_50_year(uuid(1), created_at).unwrap();
+        assert_eq!(policy.created_at, created_at);
+    }
+
+    #[test]
+    fn default_50_year_rejects_nil_tenant() {
+        assert!(ArchivalPolicy::default_50_year(Uuid::nil(), ts(1_700_000_000_000)).is_err());
+    }
+
+    #[test]
+    fn default_50_year_rejects_zero_created_at() {
+        assert!(ArchivalPolicy::default_50_year(uuid(1), Timestamp::ZERO).is_err());
+    }
+
+    #[test]
     fn test_cold_storage_tracking() {
         let mut cold = ColdStorage::new();
-        let tenant = Uuid::new_v4();
+        let tenant = uuid(1);
 
         cold.record_archival(ColdStorageRef {
             tenant_id: tenant,
             object_key: "events/2024/q1.cbor".into(),
             tier: StorageTier::Cold,
             size_bytes: 1024 * 1024,
-            archived_at: Utc::now(),
-            content_hash: exo_core::crypto::Blake3Hash([1u8; 32]),
-        });
+            archived_at: ts(1_700_000_000_000),
+            content_hash: Hash256::digest(b"events/2024/q1.cbor"),
+        })
+        .unwrap();
 
         assert_eq!(cold.for_tenant(tenant).len(), 1);
         assert_eq!(cold.archived_size(tenant), 1024 * 1024);
+    }
+
+    #[test]
+    fn record_archival_rejects_wrong_placeholder_fields() {
+        let mut cold = ColdStorage::new();
+        let valid = ColdStorageRef {
+            tenant_id: uuid(1),
+            object_key: "events/2024/q1.cbor".into(),
+            tier: StorageTier::Cold,
+            size_bytes: 1024,
+            archived_at: ts(1_700_000_000_000),
+            content_hash: Hash256::digest(b"events/2024/q1.cbor"),
+        };
+
+        let mut nil_tenant = valid.clone();
+        nil_tenant.tenant_id = Uuid::nil();
+        assert!(cold.record_archival(nil_tenant).is_err());
+
+        let mut empty_key = valid.clone();
+        empty_key.object_key.clear();
+        assert!(cold.record_archival(empty_key).is_err());
+
+        let mut zero_size = valid.clone();
+        zero_size.size_bytes = 0;
+        assert!(cold.record_archival(zero_size).is_err());
+
+        let mut zero_timestamp = valid.clone();
+        zero_timestamp.archived_at = Timestamp::ZERO;
+        assert!(cold.record_archival(zero_timestamp).is_err());
+
+        let mut zero_hash = valid;
+        zero_hash.content_hash = Hash256::ZERO;
+        assert!(cold.record_archival(zero_hash).is_err());
+    }
+
+    #[test]
+    fn record_archival_rejects_duplicate_tenant_object_key() {
+        let mut cold = ColdStorage::new();
+        let reference = ColdStorageRef {
+            tenant_id: uuid(1),
+            object_key: "events/2024/q1.cbor".into(),
+            tier: StorageTier::Cold,
+            size_bytes: 1024,
+            archived_at: ts(1_700_000_000_000),
+            content_hash: Hash256::digest(b"events/2024/q1.cbor"),
+        };
+        cold.record_archival(reference.clone()).unwrap();
+        assert!(cold.record_archival(reference).is_err());
     }
 }

--- a/crates/exo-tenant/src/cold_storage.rs
+++ b/crates/exo-tenant/src/cold_storage.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 use crate::error::{Result, TenantError};
 
 /// Tiered storage classification for data lifecycle migration.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum StorageTier {
     Hot,
     Warm,
@@ -19,13 +19,14 @@ pub enum StorageTier {
 #[derive(Debug, Clone)]
 pub struct StorageRecord {
     pub id: Uuid,
+    pub tenant_id: Uuid,
     pub tier: StorageTier,
 }
 
 /// Manages storage tier assignments and enforces migration rules.
 #[derive(Debug, Default)]
 pub struct StorageManager {
-    pub records: BTreeMap<Uuid, StorageTier>,
+    records: BTreeMap<(Uuid, Uuid), StorageRecord>,
 }
 
 impl StorageManager {
@@ -37,19 +38,46 @@ impl StorageManager {
         }
     }
 
-    /// Register an item at the specified storage tier.
-    pub fn register(&mut self, id: Uuid, tier: StorageTier) {
-        self.records.insert(id, tier);
+    /// Register an item at the specified storage tier for a tenant.
+    pub fn register(&mut self, tenant_id: Uuid, id: Uuid, tier: StorageTier) -> Result<()> {
+        Self::validate_key(&tenant_id, &id)?;
+        let key = (tenant_id, id);
+        if self.records.contains_key(&key) {
+            return Err(TenantError::StorageRecordAlreadyExists {
+                tenant_id,
+                item_id: id,
+            });
+        }
+        self.records.insert(
+            key,
+            StorageRecord {
+                id,
+                tenant_id,
+                tier,
+            },
+        );
+        Ok(())
     }
 
     /// Migrate an item from one tier to a colder (or equal) tier.
-    pub fn migrate(&mut self, id: &Uuid, from: StorageTier, to: StorageTier) -> Result<()> {
-        let current = self.records.get(id).ok_or(TenantError::StorageError {
-            reason: format!("record {id} not found"),
-        })?;
-        if *current != from {
+    pub fn migrate(
+        &mut self,
+        tenant_id: &Uuid,
+        id: &Uuid,
+        from: StorageTier,
+        to: StorageTier,
+    ) -> Result<()> {
+        Self::validate_key(tenant_id, id)?;
+        let record =
+            self.records
+                .get_mut(&(*tenant_id, *id))
+                .ok_or(TenantError::StorageRecordNotFound {
+                    tenant_id: *tenant_id,
+                    item_id: *id,
+                })?;
+        if record.tier != from {
             return Err(TenantError::MigrationError {
-                reason: format!("expected {from:?}, found {current:?}"),
+                reason: format!("expected {from:?}, found {:?}", record.tier),
             });
         }
         // Can only move to colder or same tier (Hot -> Warm -> Cold -> Archive)
@@ -58,70 +86,133 @@ impl StorageManager {
                 reason: format!("cannot promote from {from:?} to {to:?}"),
             });
         }
-        self.records.insert(*id, to);
+        record.tier = to;
         Ok(())
     }
 
     /// Return the current storage tier for an item, if registered.
     #[must_use]
-    pub fn get_tier(&self, id: &Uuid) -> Option<StorageTier> {
-        self.records.get(id).copied()
+    pub fn get_tier(&self, tenant_id: &Uuid, id: &Uuid) -> Option<StorageTier> {
+        self.records
+            .get(&(*tenant_id, *id))
+            .map(|record| record.tier)
     }
+
     /// Count items currently assigned to the given tier.
     #[must_use]
-    pub fn count_by_tier(&self, tier: StorageTier) -> usize {
-        self.records.values().filter(|t| **t == tier).count()
+    pub fn count_by_tier(&self, tenant_id: &Uuid, tier: StorageTier) -> usize {
+        self.records
+            .values()
+            .filter(|record| record.tenant_id == *tenant_id && record.tier == tier)
+            .count()
+    }
+
+    /// Return `true` if there are no storage records.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    fn validate_key(tenant_id: &Uuid, id: &Uuid) -> Result<()> {
+        if *tenant_id == Uuid::nil() {
+            return Err(TenantError::StorageError {
+                reason: "tenant id must not be nil".into(),
+            });
+        }
+        if *id == Uuid::nil() {
+            return Err(TenantError::StorageError {
+                reason: "item id must not be nil".into(),
+            });
+        }
+        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn uuid(byte: u8) -> Uuid {
+        Uuid::from_bytes([byte; 16])
+    }
+
     #[test]
     fn register_and_get() {
         let mut m = StorageManager::new();
-        let id = Uuid::new_v4();
-        m.register(id, StorageTier::Hot);
-        assert_eq!(m.get_tier(&id), Some(StorageTier::Hot));
+        let tenant_id = uuid(1);
+        let id = uuid(10);
+        m.register(tenant_id, id, StorageTier::Hot).unwrap();
+        assert_eq!(m.get_tier(&tenant_id, &id), Some(StorageTier::Hot));
     }
+
+    #[test]
+    fn register_rejects_nil_tenant_id() {
+        let mut m = StorageManager::new();
+        assert!(m.register(Uuid::nil(), uuid(10), StorageTier::Hot).is_err());
+    }
+
+    #[test]
+    fn register_rejects_nil_item_id() {
+        let mut m = StorageManager::new();
+        assert!(m.register(uuid(1), Uuid::nil(), StorageTier::Hot).is_err());
+    }
+
+    #[test]
+    fn register_rejects_duplicate_tenant_item_key() {
+        let mut m = StorageManager::new();
+        let tenant_id = uuid(1);
+        let id = uuid(10);
+        m.register(tenant_id, id, StorageTier::Hot).unwrap();
+        assert!(m.register(tenant_id, id, StorageTier::Cold).is_err());
+    }
+
     #[test]
     fn migrate_hot_to_warm() {
         let mut m = StorageManager::new();
-        let id = Uuid::new_v4();
-        m.register(id, StorageTier::Hot);
-        m.migrate(&id, StorageTier::Hot, StorageTier::Warm).unwrap();
-        assert_eq!(m.get_tier(&id), Some(StorageTier::Warm));
+        let tenant_id = uuid(1);
+        let id = uuid(10);
+        m.register(tenant_id, id, StorageTier::Hot).unwrap();
+        m.migrate(&tenant_id, &id, StorageTier::Hot, StorageTier::Warm)
+            .unwrap();
+        assert_eq!(m.get_tier(&tenant_id, &id), Some(StorageTier::Warm));
     }
     #[test]
     fn migrate_warm_to_cold() {
         let mut m = StorageManager::new();
-        let id = Uuid::new_v4();
-        m.register(id, StorageTier::Warm);
-        m.migrate(&id, StorageTier::Warm, StorageTier::Cold)
+        let tenant_id = uuid(1);
+        let id = uuid(10);
+        m.register(tenant_id, id, StorageTier::Warm).unwrap();
+        m.migrate(&tenant_id, &id, StorageTier::Warm, StorageTier::Cold)
             .unwrap();
     }
     #[test]
     fn migrate_cold_to_archive() {
         let mut m = StorageManager::new();
-        let id = Uuid::new_v4();
-        m.register(id, StorageTier::Cold);
-        m.migrate(&id, StorageTier::Cold, StorageTier::Archive)
+        let tenant_id = uuid(1);
+        let id = uuid(10);
+        m.register(tenant_id, id, StorageTier::Cold).unwrap();
+        m.migrate(&tenant_id, &id, StorageTier::Cold, StorageTier::Archive)
             .unwrap();
     }
     #[test]
     fn cannot_promote() {
         let mut m = StorageManager::new();
-        let id = Uuid::new_v4();
-        m.register(id, StorageTier::Cold);
-        assert!(m.migrate(&id, StorageTier::Cold, StorageTier::Hot).is_err());
+        let tenant_id = uuid(1);
+        let id = uuid(10);
+        m.register(tenant_id, id, StorageTier::Cold).unwrap();
+        assert!(
+            m.migrate(&tenant_id, &id, StorageTier::Cold, StorageTier::Hot)
+                .is_err()
+        );
     }
     #[test]
     fn wrong_current_tier() {
         let mut m = StorageManager::new();
-        let id = Uuid::new_v4();
-        m.register(id, StorageTier::Hot);
+        let tenant_id = uuid(1);
+        let id = uuid(10);
+        m.register(tenant_id, id, StorageTier::Hot).unwrap();
         assert!(
-            m.migrate(&id, StorageTier::Cold, StorageTier::Archive)
+            m.migrate(&tenant_id, &id, StorageTier::Cold, StorageTier::Archive)
                 .is_err()
         );
     }
@@ -129,18 +220,47 @@ mod tests {
     fn not_found() {
         let mut m = StorageManager::new();
         assert!(
-            m.migrate(&Uuid::nil(), StorageTier::Hot, StorageTier::Warm)
+            m.migrate(&uuid(1), &uuid(10), StorageTier::Hot, StorageTier::Warm)
                 .is_err()
         );
     }
     #[test]
     fn count_by_tier() {
         let mut m = StorageManager::new();
-        m.register(Uuid::new_v4(), StorageTier::Hot);
-        m.register(Uuid::new_v4(), StorageTier::Hot);
-        m.register(Uuid::new_v4(), StorageTier::Cold);
-        assert_eq!(m.count_by_tier(StorageTier::Hot), 2);
-        assert_eq!(m.count_by_tier(StorageTier::Cold), 1);
+        let tenant_id = uuid(1);
+        m.register(tenant_id, uuid(10), StorageTier::Hot).unwrap();
+        m.register(tenant_id, uuid(11), StorageTier::Hot).unwrap();
+        m.register(tenant_id, uuid(12), StorageTier::Cold).unwrap();
+        assert_eq!(m.count_by_tier(&tenant_id, StorageTier::Hot), 2);
+        assert_eq!(m.count_by_tier(&tenant_id, StorageTier::Cold), 1);
+    }
+
+    #[test]
+    fn same_item_id_is_scoped_by_tenant() {
+        let mut m = StorageManager::new();
+        let t1 = uuid(1);
+        let t2 = uuid(2);
+        let id = uuid(10);
+        m.register(t1, id, StorageTier::Hot).unwrap();
+        m.register(t2, id, StorageTier::Cold).unwrap();
+        assert_eq!(m.get_tier(&t1, &id), Some(StorageTier::Hot));
+        assert_eq!(m.get_tier(&t2, &id), Some(StorageTier::Cold));
+        assert_eq!(m.count_by_tier(&t1, StorageTier::Hot), 1);
+        assert_eq!(m.count_by_tier(&t2, StorageTier::Hot), 0);
+    }
+
+    #[test]
+    fn migrate_wrong_tenant_does_not_touch_other_tenant_record() {
+        let mut m = StorageManager::new();
+        let t1 = uuid(1);
+        let t2 = uuid(2);
+        let id = uuid(10);
+        m.register(t1, id, StorageTier::Hot).unwrap();
+        assert!(
+            m.migrate(&t2, &id, StorageTier::Hot, StorageTier::Warm)
+                .is_err()
+        );
+        assert_eq!(m.get_tier(&t1, &id), Some(StorageTier::Hot));
     }
     #[test]
     fn tier_serde() {
@@ -157,14 +277,15 @@ mod tests {
     }
     #[test]
     fn default() {
-        assert!(StorageManager::default().records.is_empty());
+        assert!(StorageManager::default().is_empty());
     }
     #[test]
     fn same_tier_ok() {
         let mut m = StorageManager::new();
-        let id = Uuid::new_v4();
-        m.register(id, StorageTier::Warm);
-        m.migrate(&id, StorageTier::Warm, StorageTier::Warm)
+        let tenant_id = uuid(1);
+        let id = uuid(10);
+        m.register(tenant_id, id, StorageTier::Warm).unwrap();
+        m.migrate(&tenant_id, &id, StorageTier::Warm, StorageTier::Warm)
             .unwrap();
     }
 }

--- a/crates/exo-tenant/src/error.rs
+++ b/crates/exo-tenant/src/error.rs
@@ -9,8 +9,16 @@ pub enum TenantError {
     TenantNotFound(Uuid),
     #[error("tenant already exists: {0}")]
     TenantAlreadyExists(Uuid),
+    #[error("invalid tenant: {reason}")]
+    InvalidTenant { reason: String },
     #[error("invalid state transition: {reason}")]
     InvalidStateTransition { reason: String },
+    #[error("storage record already exists for tenant {tenant_id}, item {item_id}")]
+    StorageRecordAlreadyExists { tenant_id: Uuid, item_id: Uuid },
+    #[error("storage record not found for tenant {tenant_id}, item {item_id}")]
+    StorageRecordNotFound { tenant_id: Uuid, item_id: Uuid },
+    #[error("cold storage reference already exists for tenant {tenant_id}, object {object_key}")]
+    ColdStorageReferenceAlreadyExists { tenant_id: Uuid, object_key: String },
     #[error("shard error: {reason}")]
     ShardError { reason: String },
     #[error("storage error: {reason}")]
@@ -29,7 +37,20 @@ mod tests {
         let es: Vec<TenantError> = vec![
             TenantError::TenantNotFound(Uuid::nil()),
             TenantError::TenantAlreadyExists(Uuid::nil()),
+            TenantError::InvalidTenant { reason: "x".into() },
             TenantError::InvalidStateTransition { reason: "x".into() },
+            TenantError::StorageRecordAlreadyExists {
+                tenant_id: Uuid::nil(),
+                item_id: Uuid::nil(),
+            },
+            TenantError::StorageRecordNotFound {
+                tenant_id: Uuid::nil(),
+                item_id: Uuid::nil(),
+            },
+            TenantError::ColdStorageReferenceAlreadyExists {
+                tenant_id: Uuid::nil(),
+                object_key: "x".into(),
+            },
             TenantError::ShardError { reason: "x".into() },
             TenantError::StorageError { reason: "x".into() },
             TenantError::MigrationError { reason: "x".into() },

--- a/crates/exo-tenant/src/lib.rs
+++ b/crates/exo-tenant/src/lib.rs
@@ -1,6 +1,8 @@
 //! EXOCHAIN constitutional trust fabric — multi-tenant isolation, cold storage, sharding.
+pub mod cold;
 pub mod cold_storage;
 pub mod error;
 pub mod shard;
+pub mod sharding;
 pub mod store;
 pub mod tenant;

--- a/crates/exo-tenant/src/shard.rs
+++ b/crates/exo-tenant/src/shard.rs
@@ -2,6 +2,8 @@
 use exo_core::Hash256;
 use serde::{Deserialize, Serialize};
 
+use crate::error::{Result, TenantError};
+
 /// Configuration for shard count and replication factor.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ShardConfig {
@@ -19,32 +21,64 @@ impl Default for ShardConfig {
 }
 
 /// Deterministic shard assignment: hash mod num_shards.
-#[must_use]
-pub fn assign_shard(key: &Hash256, config: &ShardConfig) -> usize {
+pub fn assign_shard(key: &Hash256, config: &ShardConfig) -> Result<usize> {
+    validate_config(config)?;
     let bytes = key.as_bytes();
     let val = usize::from(bytes[0])
         | (usize::from(bytes[1]) << 8)
         | (usize::from(bytes[2]) << 16)
         | (usize::from(bytes[3]) << 24);
-    val % config.num_shards
+    Ok(val % config.num_shards)
 }
 
 /// Get all replica shards for a given primary shard.
-#[must_use]
-pub fn replica_shards(primary: usize, config: &ShardConfig) -> Vec<usize> {
-    (0..config.replication_factor)
+pub fn replica_shards(primary: usize, config: &ShardConfig) -> Result<Vec<usize>> {
+    validate_config(config)?;
+    if primary >= config.num_shards {
+        return Err(TenantError::ShardError {
+            reason: format!(
+                "primary shard {primary} must be less than configured shard count {}",
+                config.num_shards
+            ),
+        });
+    }
+    Ok((0..config.replication_factor)
         .map(|i| (primary + i) % config.num_shards)
-        .collect()
+        .collect())
 }
 
 /// Compute which shards a key migrates between when shard count changes.
-#[must_use]
 pub fn migration_plan(
     key: &Hash256,
     old_config: &ShardConfig,
     new_config: &ShardConfig,
-) -> (usize, usize) {
-    (assign_shard(key, old_config), assign_shard(key, new_config))
+) -> Result<(usize, usize)> {
+    Ok((
+        assign_shard(key, old_config)?,
+        assign_shard(key, new_config)?,
+    ))
+}
+
+fn validate_config(config: &ShardConfig) -> Result<()> {
+    if config.num_shards == 0 {
+        return Err(TenantError::ShardError {
+            reason: "num_shards must be greater than zero".into(),
+        });
+    }
+    if config.replication_factor == 0 {
+        return Err(TenantError::ShardError {
+            reason: "replication_factor must be greater than zero".into(),
+        });
+    }
+    if config.replication_factor > config.num_shards {
+        return Err(TenantError::ShardError {
+            reason: format!(
+                "replication_factor {} must not exceed num_shards {}",
+                config.replication_factor, config.num_shards
+            ),
+        });
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -54,7 +88,7 @@ mod tests {
     fn assign_deterministic() {
         let h = Hash256::digest(b"key");
         let c = ShardConfig::default();
-        assert_eq!(assign_shard(&h, &c), assign_shard(&h, &c));
+        assert_eq!(assign_shard(&h, &c).unwrap(), assign_shard(&h, &c).unwrap());
     }
     #[test]
     fn assign_in_range() {
@@ -63,7 +97,16 @@ mod tests {
             num_shards: 8,
             replication_factor: 1,
         };
-        assert!(assign_shard(&h, &c) < 8);
+        assert!(assign_shard(&h, &c).unwrap() < 8);
+    }
+    #[test]
+    fn assign_rejects_zero_shards() {
+        let h = Hash256::digest(b"k");
+        let c = ShardConfig {
+            num_shards: 0,
+            replication_factor: 1,
+        };
+        assert!(assign_shard(&h, &c).is_err());
     }
     #[test]
     fn different_keys_may_differ() {
@@ -73,8 +116,8 @@ mod tests {
             num_shards: 1000,
             replication_factor: 1,
         };
-        let s1 = assign_shard(&h1, &c);
-        let s2 = assign_shard(&h2, &c);
+        let s1 = assign_shard(&h1, &c).unwrap();
+        let s2 = assign_shard(&h2, &c).unwrap();
         let _ = (s1, s2); /* may or may not differ */
     }
     #[test]
@@ -85,7 +128,8 @@ mod tests {
                 num_shards: 4,
                 replication_factor: 3,
             },
-        );
+        )
+        .unwrap();
         assert_eq!(r, vec![0, 1, 2]);
     }
     #[test]
@@ -96,8 +140,33 @@ mod tests {
                 num_shards: 4,
                 replication_factor: 3,
             },
-        );
+        )
+        .unwrap();
         assert_eq!(r, vec![3, 0, 1]);
+    }
+    #[test]
+    fn replicas_reject_zero_shards() {
+        let c = ShardConfig {
+            num_shards: 0,
+            replication_factor: 1,
+        };
+        assert!(replica_shards(0, &c).is_err());
+    }
+    #[test]
+    fn replicas_reject_zero_replication_factor() {
+        let c = ShardConfig {
+            num_shards: 4,
+            replication_factor: 0,
+        };
+        assert!(replica_shards(0, &c).is_err());
+    }
+    #[test]
+    fn replicas_reject_more_replicas_than_shards() {
+        let c = ShardConfig {
+            num_shards: 2,
+            replication_factor: 3,
+        };
+        assert!(replica_shards(0, &c).is_err());
     }
     #[test]
     fn migration() {
@@ -110,7 +179,7 @@ mod tests {
             num_shards: 8,
             replication_factor: 1,
         };
-        let (a, b) = migration_plan(&h, &o, &n);
+        let (a, b) = migration_plan(&h, &o, &n).unwrap();
         assert!(a < 4);
         assert!(b < 8);
     }

--- a/crates/exo-tenant/src/sharding.rs
+++ b/crates/exo-tenant/src/sharding.rs
@@ -3,6 +3,8 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::error::{Result, TenantError};
+
 /// Sharding strategy for distributing tenants across storage backends.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ShardStrategy {
@@ -27,20 +29,36 @@ pub struct ShardAssignment {
 
 impl ShardStrategy {
     /// Compute shard ID for a tenant.
-    pub fn assign(&self, tenant_id: Uuid) -> u32 {
+    pub fn assign(&self, tenant_id: Uuid) -> Result<u32> {
+        if tenant_id == Uuid::nil() {
+            return Err(TenantError::ShardError {
+                reason: "tenant id must not be nil".into(),
+            });
+        }
         match self {
             ShardStrategy::HashBased { total_shards } => {
+                if *total_shards == 0 {
+                    return Err(TenantError::ShardError {
+                        reason: "total_shards must be greater than zero".into(),
+                    });
+                }
                 let bytes = tenant_id.as_bytes();
                 let hash = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
-                hash % total_shards
+                Ok(hash % total_shards)
             }
-            ShardStrategy::RangeBased { .. } => {
-                // Range-based would use creation order — simplified to hash
+            ShardStrategy::RangeBased { shard_size } => {
+                if *shard_size == 0 {
+                    return Err(TenantError::ShardError {
+                        reason: "shard_size must be greater than zero".into(),
+                    });
+                }
                 let bytes = tenant_id.as_bytes();
-                u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) % 256
+                let keyspace_position =
+                    u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                Ok(keyspace_position / shard_size)
             }
-            ShardStrategy::Geographic { .. } => 0, // Single region shard
-            ShardStrategy::Single => 0,
+            ShardStrategy::Geographic { .. } => Ok(0), // Single region shard
+            ShardStrategy::Single => Ok(0),
         }
     }
 }
@@ -52,24 +70,47 @@ mod tests {
     #[test]
     fn test_hash_based_sharding() {
         let strategy = ShardStrategy::HashBased { total_shards: 16 };
-        let tenant = Uuid::new_v4();
-        let shard = strategy.assign(tenant);
+        let tenant = Uuid::from_bytes([1u8; 16]);
+        let shard = strategy.assign(tenant).unwrap();
         assert!(shard < 16);
+    }
+
+    #[test]
+    fn hash_based_rejects_zero_total_shards() {
+        let strategy = ShardStrategy::HashBased { total_shards: 0 };
+        assert!(strategy.assign(Uuid::from_bytes([1u8; 16])).is_err());
     }
 
     #[test]
     fn test_deterministic_assignment() {
         let strategy = ShardStrategy::HashBased { total_shards: 8 };
         let tenant = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
-        let shard1 = strategy.assign(tenant);
-        let shard2 = strategy.assign(tenant);
+        let shard1 = strategy.assign(tenant).unwrap();
+        let shard2 = strategy.assign(tenant).unwrap();
         assert_eq!(shard1, shard2);
     }
 
     #[test]
     fn test_single_shard() {
         let strategy = ShardStrategy::Single;
-        let shard = strategy.assign(Uuid::new_v4());
+        let shard = strategy.assign(Uuid::from_bytes([1u8; 16])).unwrap();
         assert_eq!(shard, 0);
+    }
+
+    #[test]
+    fn range_based_rejects_zero_shard_size() {
+        let strategy = ShardStrategy::RangeBased { shard_size: 0 };
+        assert!(strategy.assign(Uuid::from_bytes([1u8; 16])).is_err());
+    }
+
+    #[test]
+    fn range_based_uses_configured_shard_size() {
+        let tenant = Uuid::from_bytes([16u8; 16]);
+        let smaller_ranges = ShardStrategy::RangeBased { shard_size: 16 };
+        let larger_ranges = ShardStrategy::RangeBased { shard_size: 64 };
+        assert_ne!(
+            smaller_ranges.assign(tenant).unwrap(),
+            larger_ranges.assign(tenant).unwrap()
+        );
     }
 }

--- a/crates/exo-tenant/src/store.rs
+++ b/crates/exo-tenant/src/store.rs
@@ -32,15 +32,42 @@ impl TenantStore {
 
     /// Store an item under the given tenant, enforcing tenant-ID consistency.
     pub fn put(&mut self, tenant_id: Uuid, item: TenantData) -> Result<()> {
+        Self::validate_item(&tenant_id, &item)?;
         if item.tenant_id != tenant_id {
             return Err(TenantError::StorageError {
                 reason: "tenant_id mismatch".into(),
             });
         }
-        self.data
-            .entry(tenant_id)
-            .or_default()
-            .insert(item.id, item);
+        let item_id = item.id;
+        let tenant_items = self.data.entry(tenant_id).or_default();
+        if tenant_items.contains_key(&item_id) {
+            return Err(TenantError::StorageRecordAlreadyExists { tenant_id, item_id });
+        }
+        tenant_items.insert(item_id, item);
+        Ok(())
+    }
+
+    fn validate_item(tenant_id: &Uuid, item: &TenantData) -> Result<()> {
+        if *tenant_id == Uuid::nil() {
+            return Err(TenantError::StorageError {
+                reason: "tenant id must not be nil".into(),
+            });
+        }
+        if item.tenant_id == Uuid::nil() {
+            return Err(TenantError::StorageError {
+                reason: "item tenant id must not be nil".into(),
+            });
+        }
+        if item.id == Uuid::nil() {
+            return Err(TenantError::StorageError {
+                reason: "item id must not be nil".into(),
+            });
+        }
+        if item.content_hash == Hash256::ZERO {
+            return Err(TenantError::StorageError {
+                reason: "content hash must not be zero".into(),
+            });
+        }
         Ok(())
     }
 
@@ -55,8 +82,9 @@ impl TenantStore {
         self.data
             .get_mut(tenant_id)
             .and_then(|m| m.remove(item_id))
-            .ok_or(TenantError::StorageError {
-                reason: format!("item {item_id} not found in tenant {tenant_id}"),
+            .ok_or(TenantError::StorageRecordNotFound {
+                tenant_id: *tenant_id,
+                item_id: *item_id,
             })
     }
 
@@ -81,20 +109,25 @@ impl TenantStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    fn td(tid: Uuid) -> TenantData {
+
+    fn uuid(byte: u8) -> Uuid {
+        Uuid::from_bytes([byte; 16])
+    }
+
+    fn td(tid: Uuid, item_id: Uuid) -> TenantData {
         TenantData {
-            id: Uuid::new_v4(),
+            id: item_id,
             tenant_id: tid,
             owner: Did::new("did:exo:owner").unwrap(),
-            content_hash: Hash256::ZERO,
+            content_hash: Hash256::digest(format!("{tid}:{item_id}").as_bytes()),
         }
     }
 
     #[test]
     fn put_and_get() {
         let mut s = TenantStore::new();
-        let tid = Uuid::new_v4();
-        let item = td(tid);
+        let tid = uuid(1);
+        let item = td(tid, uuid(10));
         let iid = item.id;
         s.put(tid, item).unwrap();
         assert!(s.get(&tid, &iid).is_some());
@@ -102,14 +135,44 @@ mod tests {
     #[test]
     fn put_mismatch() {
         let mut s = TenantStore::new();
-        let item = td(Uuid::new_v4());
-        assert!(s.put(Uuid::new_v4(), item).is_err());
+        let item = td(uuid(1), uuid(10));
+        assert!(s.put(uuid(2), item).is_err());
     }
+
+    #[test]
+    fn put_rejects_nil_tenant_id() {
+        let mut s = TenantStore::new();
+        assert!(s.put(Uuid::nil(), td(Uuid::nil(), uuid(10))).is_err());
+    }
+
+    #[test]
+    fn put_rejects_nil_item_id() {
+        let mut s = TenantStore::new();
+        assert!(s.put(uuid(1), td(uuid(1), Uuid::nil())).is_err());
+    }
+
+    #[test]
+    fn put_rejects_zero_content_hash() {
+        let mut s = TenantStore::new();
+        let mut item = td(uuid(1), uuid(10));
+        item.content_hash = Hash256::ZERO;
+        assert!(s.put(uuid(1), item).is_err());
+    }
+
+    #[test]
+    fn put_rejects_duplicate_item_in_same_tenant() {
+        let mut s = TenantStore::new();
+        let tid = uuid(1);
+        let iid = uuid(10);
+        s.put(tid, td(tid, iid)).unwrap();
+        assert!(s.put(tid, td(tid, iid)).is_err());
+    }
+
     #[test]
     fn delete_ok() {
         let mut s = TenantStore::new();
-        let tid = Uuid::new_v4();
-        let item = td(tid);
+        let tid = uuid(1);
+        let item = td(tid, uuid(10));
         let iid = item.id;
         s.put(tid, item).unwrap();
         s.delete(&tid, &iid).unwrap();
@@ -123,18 +186,31 @@ mod tests {
     #[test]
     fn isolation() {
         let mut s = TenantStore::new();
-        let t1 = Uuid::new_v4();
-        let t2 = Uuid::new_v4();
-        let item = td(t1);
+        let t1 = uuid(1);
+        let t2 = uuid(2);
+        let item = td(t1, uuid(10));
         let iid = item.id;
         s.put(t1, item).unwrap();
         assert!(s.get(&t2, &iid).is_none());
     }
+
+    #[test]
+    fn same_item_id_can_exist_in_different_tenants_without_cross_read() {
+        let mut s = TenantStore::new();
+        let t1 = uuid(1);
+        let t2 = uuid(2);
+        let item_id = uuid(10);
+        s.put(t1, td(t1, item_id)).unwrap();
+        s.put(t2, td(t2, item_id)).unwrap();
+        assert_eq!(s.get(&t1, &item_id).unwrap().tenant_id, t1);
+        assert_eq!(s.get(&t2, &item_id).unwrap().tenant_id, t2);
+    }
+
     #[test]
     fn get_isolated() {
         let mut s = TenantStore::new();
-        let tid = Uuid::new_v4();
-        let item = td(tid);
+        let tid = uuid(1);
+        let item = td(tid, uuid(10));
         let iid = item.id;
         s.put(tid, item).unwrap();
         assert!(s.get_isolated(&tid, &iid).is_some());
@@ -142,9 +218,9 @@ mod tests {
     #[test]
     fn count() {
         let mut s = TenantStore::new();
-        let tid = Uuid::new_v4();
-        s.put(tid, td(tid)).unwrap();
-        s.put(tid, td(tid)).unwrap();
+        let tid = uuid(1);
+        s.put(tid, td(tid, uuid(10))).unwrap();
+        s.put(tid, td(tid, uuid(11))).unwrap();
         assert_eq!(s.count(&tid), 2);
     }
     #[test]

--- a/crates/exo-tenant/src/tenant.rs
+++ b/crates/exo-tenant/src/tenant.rs
@@ -40,6 +40,15 @@ pub struct Tenant {
     pub status: TenantStatus,
 }
 
+/// Caller-supplied tenant creation record.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TenantRegistration {
+    pub id: Uuid,
+    pub name: String,
+    pub config: TenantConfig,
+    pub created: Timestamp,
+}
+
 /// In-memory registry of tenants with CRUD and lifecycle operations.
 #[derive(Debug, Clone, Default)]
 pub struct TenantRegistry {
@@ -55,18 +64,51 @@ impl TenantRegistry {
         }
     }
 
-    /// Create a new tenant with the given name and config, returning its UUID.
-    pub fn create(&mut self, name: &str, config: TenantConfig) -> Result<Uuid> {
-        let id = Uuid::new_v4();
+    /// Create a new tenant from caller-supplied identity and HLC metadata.
+    pub fn create(&mut self, registration: TenantRegistration) -> Result<Uuid> {
+        Self::validate_registration(&registration)?;
+        if self.tenants.contains_key(&registration.id) {
+            return Err(TenantError::TenantAlreadyExists(registration.id));
+        }
+        let id = registration.id;
         let t = Tenant {
             id,
-            name: name.into(),
-            config,
-            created: Timestamp::ZERO,
+            name: registration.name,
+            config: registration.config,
+            created: registration.created,
             status: TenantStatus::Active,
         };
         self.tenants.insert(id, t);
         Ok(id)
+    }
+
+    fn validate_registration(registration: &TenantRegistration) -> Result<()> {
+        if registration.id == Uuid::nil() {
+            return Err(TenantError::InvalidTenant {
+                reason: "tenant id must not be nil".into(),
+            });
+        }
+        if registration.name.trim().is_empty() {
+            return Err(TenantError::InvalidTenant {
+                reason: "tenant name must not be empty".into(),
+            });
+        }
+        if registration.created == Timestamp::ZERO {
+            return Err(TenantError::InvalidTenant {
+                reason: "created timestamp must be caller-supplied HLC".into(),
+            });
+        }
+        if registration.config.max_storage_bytes == 0 {
+            return Err(TenantError::InvalidTenant {
+                reason: "max storage bytes must be greater than zero".into(),
+            });
+        }
+        if registration.config.max_users == 0 {
+            return Err(TenantError::InvalidTenant {
+                reason: "max users must be greater than zero".into(),
+            });
+        }
+        Ok(())
     }
 
     /// Look up a tenant by ID.
@@ -129,17 +171,81 @@ impl TenantRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn uuid(byte: u8) -> Uuid {
+        Uuid::from_bytes([byte; 16])
+    }
+
+    fn ts(ms: u64) -> Timestamp {
+        Timestamp::new(ms, 0)
+    }
+
+    fn registration(id: Uuid, name: &str, created: Timestamp) -> TenantRegistration {
+        TenantRegistration {
+            id,
+            name: name.into(),
+            config: TenantConfig::default(),
+            created,
+        }
+    }
+
     #[test]
     fn create_and_get() {
         let mut r = TenantRegistry::new();
-        let id = r.create("t", TenantConfig::default()).unwrap();
+        let id = uuid(1);
+        let created = ts(1_700_000_000_000);
+        let returned = r.create(registration(id, "t", created)).unwrap();
+        assert_eq!(returned, id);
         assert!(r.get(&id).is_some());
+        assert_eq!(r.get(&id).unwrap().created, created);
         assert_eq!(r.len(), 1);
     }
+
+    #[test]
+    fn create_rejects_nil_tenant_id() {
+        let mut r = TenantRegistry::new();
+        assert!(
+            r.create(registration(Uuid::nil(), "tenant", ts(1_700_000_000_000)))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn create_rejects_zero_created_timestamp() {
+        let mut r = TenantRegistry::new();
+        assert!(
+            r.create(registration(uuid(1), "tenant", Timestamp::ZERO))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn create_rejects_empty_name() {
+        let mut r = TenantRegistry::new();
+        assert!(
+            r.create(registration(uuid(1), "   ", ts(1_700_000_000_000)))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn create_rejects_duplicate_tenant_id() {
+        let mut r = TenantRegistry::new();
+        let id = uuid(1);
+        r.create(registration(id, "tenant-a", ts(1_700_000_000_000)))
+            .unwrap();
+        assert!(
+            r.create(registration(id, "tenant-b", ts(1_700_000_000_001)))
+                .is_err()
+        );
+    }
+
     #[test]
     fn delete() {
         let mut r = TenantRegistry::new();
-        let id = r.create("t", TenantConfig::default()).unwrap();
+        let id = r
+            .create(registration(uuid(1), "t", ts(1_700_000_000_000)))
+            .unwrap();
         r.delete(&id).unwrap();
         assert!(r.is_empty());
     }
@@ -151,14 +257,18 @@ mod tests {
     #[test]
     fn suspend() {
         let mut r = TenantRegistry::new();
-        let id = r.create("t", TenantConfig::default()).unwrap();
+        let id = r
+            .create(registration(uuid(1), "t", ts(1_700_000_000_000)))
+            .unwrap();
         r.update_status(&id, TenantStatus::Suspended).unwrap();
         assert_eq!(r.get(&id).unwrap().status, TenantStatus::Suspended);
     }
     #[test]
     fn reactivate() {
         let mut r = TenantRegistry::new();
-        let id = r.create("t", TenantConfig::default()).unwrap();
+        let id = r
+            .create(registration(uuid(1), "t", ts(1_700_000_000_000)))
+            .unwrap();
         r.update_status(&id, TenantStatus::Suspended).unwrap();
         r.update_status(&id, TenantStatus::Active).unwrap();
         assert_eq!(r.get(&id).unwrap().status, TenantStatus::Active);
@@ -166,13 +276,17 @@ mod tests {
     #[test]
     fn archive_from_active() {
         let mut r = TenantRegistry::new();
-        let id = r.create("t", TenantConfig::default()).unwrap();
+        let id = r
+            .create(registration(uuid(1), "t", ts(1_700_000_000_000)))
+            .unwrap();
         r.update_status(&id, TenantStatus::Archived).unwrap();
     }
     #[test]
     fn invalid_transition() {
         let mut r = TenantRegistry::new();
-        let id = r.create("t", TenantConfig::default()).unwrap();
+        let id = r
+            .create(registration(uuid(1), "t", ts(1_700_000_000_000)))
+            .unwrap();
         r.update_status(&id, TenantStatus::Archived).unwrap();
         assert!(r.update_status(&id, TenantStatus::Active).is_err());
     }
@@ -184,8 +298,10 @@ mod tests {
     #[test]
     fn list() {
         let mut r = TenantRegistry::new();
-        r.create("a", TenantConfig::default()).unwrap();
-        r.create("b", TenantConfig::default()).unwrap();
+        r.create(registration(uuid(1), "a", ts(1_700_000_000_000)))
+            .unwrap();
+        r.create(registration(uuid(2), "b", ts(1_700_000_000_001)))
+            .unwrap();
         assert_eq!(r.list().len(), 2);
     }
     #[test]
@@ -207,7 +323,9 @@ mod tests {
     #[test]
     fn tenant_serde() {
         let mut r = TenantRegistry::new();
-        let id = r.create("t", TenantConfig::default()).unwrap();
+        let id = r
+            .create(registration(uuid(1), "t", ts(1_700_000_000_000)))
+            .unwrap();
         let t = r.get(&id).unwrap();
         let j = serde_json::to_string(t).unwrap();
         let rt: Tenant = serde_json::from_str(&j).unwrap();
@@ -216,7 +334,9 @@ mod tests {
     #[test]
     fn get_mut() {
         let mut r = TenantRegistry::new();
-        let id = r.create("t", TenantConfig::default()).unwrap();
+        let id = r
+            .create(registration(uuid(1), "t", ts(1_700_000_000_000)))
+            .unwrap();
         r.get_mut(&id).unwrap().name = "updated".into();
         assert_eq!(r.get(&id).unwrap().name, "updated");
     }


### PR DESCRIPTION
## Summary
- Require caller-supplied tenant UUIDs and HLC timestamps for tenant creation.
- Key storage lifecycle records by tenant plus item, with wrong-tenant migration rejection.
- Compile and harden cold archival and sharding modules; reject invalid placeholder fields and shard configs.

## TDD red check
- cargo test -p exo-tenant initially failed because tests required compiled cold/sharding modules, supplied tenant IDs/HLCs, tenant-scoped lifecycle APIs, and checked shard errors while production still used old signatures and dead modules.

## Verification
- cargo test -p exo-tenant
- cargo test -p exo-tenant --lib
- cargo build -p exo-tenant
- cargo clippy -p exo-tenant --lib -- -D warnings
- cargo clippy -p exo-tenant --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps
- cargo +nightly fmt --all -- --check
- git diff --check
- cargo build --workspace --release
- cargo test --workspace --release