### PR TITLE
fix(exo-legal): require deterministic legal metadata

### DIFF
--- a/crates/exo-legal/src/ai_transparency.rs
+++ b/crates/exo-legal/src/ai_transparency.rs
@@ -341,7 +341,7 @@ mod tests {
     #[test]
     fn period_filtering_applies() {
         let mut log = McpAuditLog::new();
-        // records will get Timestamp::now_utc() which is >> ts(500)
+        // MCP audit records use caller-supplied HLC timestamps that are beyond ts(500).
         let r = create_record(
             &log,
             McpRule::Mcp001BctsScope,

--- a/crates/exo-legal/src/bundle.rs
+++ b/crates/exo-legal/src/bundle.rs
@@ -729,6 +729,8 @@ pub fn sign(
 mod tests {
     use std::collections::BTreeMap;
 
+    use uuid::Uuid;
+
     use super::*;
     use crate::{cert_902_11::generate_902_11_cert, evidence::create_evidence};
 
@@ -779,7 +781,14 @@ mod tests {
     }
 
     fn make_evidence_item() -> Evidence {
-        create_evidence(b"test-data", &did("bob"), "document", ts(900)).unwrap()
+        create_evidence(
+            Uuid::from_u128(0x900),
+            b"test-data",
+            &did("bob"),
+            "document",
+            ts(900),
+        )
+        .unwrap()
     }
 
     fn make_anchor() -> DagAnchor {

--- a/crates/exo-legal/src/cert_902_11.rs
+++ b/crates/exo-legal/src/cert_902_11.rs
@@ -190,6 +190,7 @@ fn compute_cert_hash(
 #[cfg(test)]
 mod tests {
     use exo_core::{Did, Timestamp};
+    use uuid::Uuid;
 
     use super::*;
     use crate::evidence::create_evidence;
@@ -204,6 +205,7 @@ mod tests {
 
     fn make_evidence() -> Evidence {
         create_evidence(
+            Uuid::from_u128(0x90211),
             b"board-minutes",
             &did("secretary"),
             "board-minutes",
@@ -325,7 +327,14 @@ mod tests {
         let mut ev = make_evidence();
         let cert_before = generate_902_11_cert(&ev, SYSTEM_DESC, 1_000).unwrap();
 
-        transfer_custody(&mut ev, &did("secretary"), &did("counsel")).unwrap();
+        transfer_custody(
+            &mut ev,
+            &did("secretary"),
+            &did("counsel"),
+            real_ts(1_700_000_000_100),
+            "certification transfer",
+        )
+        .unwrap();
         let cert_after = generate_902_11_cert(&ev, SYSTEM_DESC, 2_000).unwrap();
 
         assert_ne!(

--- a/crates/exo-legal/src/conflict_disclosure.rs
+++ b/crates/exo-legal/src/conflict_disclosure.rs
@@ -3,6 +3,8 @@
 use exo_core::{Did, Timestamp};
 use serde::{Deserialize, Serialize};
 
+use crate::error::{LegalError, Result};
+
 /// A conflict-of-interest disclosure filed by a declarant before a governed action.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Disclosure {
@@ -30,15 +32,29 @@ pub fn require_disclosure(_actor: &Did, action: &str) -> bool {
 }
 
 /// Files a new unverified disclosure describing the conflict and the related parties.
-#[must_use]
-pub fn file_disclosure(actor: &Did, nature: &str, related: &[Did]) -> Disclosure {
-    Disclosure {
+pub fn file_disclosure(
+    actor: &Did,
+    nature: &str,
+    related: &[Did],
+    timestamp: Timestamp,
+) -> Result<Disclosure> {
+    if nature.trim().is_empty() {
+        return Err(LegalError::DisclosureRequired {
+            action: "conflict disclosure requires a non-empty nature".into(),
+        });
+    }
+    if timestamp == Timestamp::ZERO {
+        return Err(LegalError::DisclosureRequired {
+            action: "conflict disclosure timestamp must not be Timestamp::ZERO".into(),
+        });
+    }
+    Ok(Disclosure {
         declarant: actor.clone(),
         nature: nature.into(),
         related_parties: related.to_vec(),
-        timestamp: Timestamp::ZERO,
+        timestamp,
         verified: false,
-    }
+    })
 }
 
 /// Marks a previously filed disclosure as verified.
@@ -51,6 +67,22 @@ mod tests {
     use super::*;
     fn did(n: &str) -> Did {
         Did::new(&format!("did:exo:{n}")).unwrap()
+    }
+    fn ts(ms: u64) -> Timestamp {
+        Timestamp::new(ms, 0)
+    }
+
+    #[test]
+    fn file_disclosure_uses_caller_supplied_timestamp() {
+        let disclosure =
+            file_disclosure(&did("a"), "board conflict", &[did("b")], ts(1000)).unwrap();
+        assert_eq!(disclosure.timestamp, ts(1000));
+    }
+
+    #[test]
+    fn file_disclosure_rejects_placeholder_metadata() {
+        assert!(file_disclosure(&did("a"), "board conflict", &[], Timestamp::ZERO).is_err());
+        assert!(file_disclosure(&did("a"), " ", &[], ts(1000)).is_err());
     }
 
     #[test]
@@ -87,24 +119,24 @@ mod tests {
     }
     #[test]
     fn file_basic() {
-        let d = file_disclosure(&did("a"), "financial", &[did("b")]);
+        let d = file_disclosure(&did("a"), "financial", &[did("b")], ts(1000)).unwrap();
         assert_eq!(d.related_parties.len(), 1);
         assert!(!d.verified);
     }
     #[test]
     fn file_empty() {
-        let d = file_disclosure(&did("a"), "x", &[]);
+        let d = file_disclosure(&did("a"), "x", &[], ts(1000)).unwrap();
         assert!(d.related_parties.is_empty());
     }
     #[test]
     fn verify_sets_flag() {
-        let mut d = file_disclosure(&did("a"), "x", &[]);
+        let mut d = file_disclosure(&did("a"), "x", &[], ts(1000)).unwrap();
         verify_disclosure(&mut d);
         assert!(d.verified);
     }
     #[test]
     fn serde() {
-        let d = file_disclosure(&did("a"), "x", &[did("b")]);
+        let d = file_disclosure(&did("a"), "x", &[did("b")], ts(1000)).unwrap();
         let j = serde_json::to_string(&d).unwrap();
         let r: Disclosure = serde_json::from_str(&j).unwrap();
         assert_eq!(r.declarant, did("a"));

--- a/crates/exo-legal/src/dgcl144.rs
+++ b/crates/exo-legal/src/dgcl144.rs
@@ -100,6 +100,7 @@ pub struct FairnessEvidence {
 /// # Errors
 /// Returns `LegalError::InvalidStateTransition` if the timestamp is zero.
 pub fn initiate_safe_harbor(
+    id: Uuid,
     interested_party: &Did,
     counterparty: &Did,
     interest_description: &str,
@@ -107,13 +108,28 @@ pub fn initiate_safe_harbor(
     path: SafeHarborPath,
     now: Timestamp,
 ) -> Result<InterestedTransaction> {
+    if id.is_nil() {
+        return Err(LegalError::InvalidStateTransition {
+            reason: "safe-harbor transaction ID must be caller-supplied and non-nil".into(),
+        });
+    }
+    if interest_description.trim().is_empty() {
+        return Err(LegalError::InvalidStateTransition {
+            reason: "safe-harbor interest description must not be empty".into(),
+        });
+    }
+    if terms_hash == Hash256::ZERO {
+        return Err(LegalError::InvalidStateTransition {
+            reason: "safe-harbor terms hash must not be Hash256::ZERO".into(),
+        });
+    }
     if now == Timestamp::ZERO {
         return Err(LegalError::InvalidStateTransition {
             reason: "safe-harbor initiation requires a real timestamp".into(),
         });
     }
     Ok(InterestedTransaction {
-        id: Uuid::new_v4(),
+        id,
         interested_party: interested_party.clone(),
         interest_description: interest_description.to_string(),
         counterparty: counterparty.clone(),
@@ -263,9 +279,13 @@ mod tests {
     fn ts(ms: u64) -> Timestamp {
         Timestamp::new(ms, 0)
     }
+    fn id(n: u128) -> Uuid {
+        Uuid::from_u128(n)
+    }
 
     fn create_txn(path: SafeHarborPath) -> InterestedTransaction {
         initiate_safe_harbor(
+            id(0x300),
             &did("director-alice"),
             &did("alice-corp"),
             "director has financial interest in counterparty",
@@ -274,6 +294,62 @@ mod tests {
             ts(1000),
         )
         .unwrap()
+    }
+
+    #[test]
+    fn initiate_uses_caller_supplied_id() {
+        let transaction_id = id(0x301);
+        let txn = initiate_safe_harbor(
+            transaction_id,
+            &did("director-alice"),
+            &did("alice-corp"),
+            "director has financial interest in counterparty",
+            Hash256::digest(b"terms"),
+            SafeHarborPath::BoardApproval,
+            ts(1000),
+        )
+        .unwrap();
+        assert_eq!(txn.id, transaction_id);
+    }
+
+    #[test]
+    fn initiate_rejects_placeholder_metadata() {
+        assert!(
+            initiate_safe_harbor(
+                Uuid::nil(),
+                &did("a"),
+                &did("b"),
+                "interest",
+                Hash256::digest(b"terms"),
+                SafeHarborPath::BoardApproval,
+                ts(1000),
+            )
+            .is_err()
+        );
+        assert!(
+            initiate_safe_harbor(
+                id(0x302),
+                &did("a"),
+                &did("b"),
+                "interest",
+                Hash256::ZERO,
+                SafeHarborPath::BoardApproval,
+                ts(1000),
+            )
+            .is_err()
+        );
+        assert!(
+            initiate_safe_harbor(
+                id(0x303),
+                &did("a"),
+                &did("b"),
+                " ",
+                Hash256::digest(b"terms"),
+                SafeHarborPath::BoardApproval,
+                ts(1000),
+            )
+            .is_err()
+        );
     }
 
     // -- Board Approval path --
@@ -401,10 +477,11 @@ mod tests {
     #[test]
     fn initiate_rejects_zero_timestamp() {
         let err = initiate_safe_harbor(
+            id(0x304),
             &did("a"),
             &did("b"),
             "interest",
-            Hash256::ZERO,
+            Hash256::digest(b"terms"),
             SafeHarborPath::BoardApproval,
             Timestamp::ZERO,
         );

--- a/crates/exo-legal/src/ediscovery.rs
+++ b/crates/exo-legal/src/ediscovery.rs
@@ -53,6 +53,8 @@ pub fn search(request: &DiscoveryRequest, corpus: &[Evidence]) -> DiscoveryRespo
 
 #[cfg(test)]
 mod tests {
+    use uuid::Uuid;
+
     use super::*;
     use crate::evidence::create_evidence;
     fn did(n: &str) -> Did {
@@ -60,9 +62,30 @@ mod tests {
     }
     fn corpus() -> Vec<Evidence> {
         let (a, b) = (did("alice"), did("bob"));
-        let e1 = create_evidence(b"contract", &a, "contract", Timestamp::new(100, 0)).unwrap();
-        let e2 = create_evidence(b"email", &b, "email", Timestamp::new(200, 0)).unwrap();
-        let e3 = create_evidence(b"memo", &a, "memo", Timestamp::new(300, 0)).unwrap();
+        let e1 = create_evidence(
+            Uuid::from_u128(0x501),
+            b"contract",
+            &a,
+            "contract",
+            Timestamp::new(100, 0),
+        )
+        .unwrap();
+        let e2 = create_evidence(
+            Uuid::from_u128(0x502),
+            b"email",
+            &b,
+            "email",
+            Timestamp::new(200, 0),
+        )
+        .unwrap();
+        let e3 = create_evidence(
+            Uuid::from_u128(0x503),
+            b"memo",
+            &a,
+            "memo",
+            Timestamp::new(300, 0),
+        )
+        .unwrap();
         vec![e1, e2, e3]
     }
     fn req(custodians: Vec<Did>, terms: Vec<String>, range: (u64, u64)) -> DiscoveryRequest {

--- a/crates/exo-legal/src/evidence.rs
+++ b/crates/exo-legal/src/evidence.rs
@@ -42,11 +42,22 @@ pub struct Evidence {
 /// Returns `LegalError` if the timestamp is `Timestamp::ZERO` (placeholder).
 /// Evidence must carry a real timestamp for litigation-grade provenance.
 pub fn create_evidence(
+    id: Uuid,
     data: &[u8],
     creator: &Did,
     type_tag: &str,
     timestamp: Timestamp,
 ) -> Result<Evidence> {
+    if id.is_nil() {
+        return Err(LegalError::InvalidStateTransition {
+            reason: "evidence ID must be caller-supplied and non-nil".into(),
+        });
+    }
+    if type_tag.trim().is_empty() {
+        return Err(LegalError::InvalidStateTransition {
+            reason: "evidence type_tag must not be empty".into(),
+        });
+    }
     if timestamp == Timestamp::ZERO {
         return Err(LegalError::InvalidStateTransition {
             reason: "evidence timestamp must not be Timestamp::ZERO; provide a real HLC timestamp"
@@ -54,7 +65,7 @@ pub fn create_evidence(
         });
     }
     Ok(Evidence {
-        id: Uuid::new_v4(),
+        id,
         type_tag: type_tag.to_string(),
         hash: Hash256::digest(data),
         creator: creator.clone(),
@@ -65,7 +76,23 @@ pub fn create_evidence(
 }
 
 /// Transfers custody of evidence from the current holder to a new party, appending to the chain.
-pub fn transfer_custody(evidence: &mut Evidence, from: &Did, to: &Did) -> Result<()> {
+pub fn transfer_custody(
+    evidence: &mut Evidence,
+    from: &Did,
+    to: &Did,
+    timestamp: Timestamp,
+    reason: &str,
+) -> Result<()> {
+    if timestamp == Timestamp::ZERO {
+        return Err(LegalError::CustodyTransferFailed {
+            reason: "custody transfer timestamp must not be Timestamp::ZERO".into(),
+        });
+    }
+    if reason.trim().is_empty() {
+        return Err(LegalError::CustodyTransferFailed {
+            reason: "custody transfer reason must not be empty".into(),
+        });
+    }
     let current = evidence
         .chain_of_custody
         .last()
@@ -76,16 +103,23 @@ pub fn transfer_custody(evidence: &mut Evidence, from: &Did, to: &Did) -> Result
             reason: format!("current custodian is {current}, not {from}"),
         });
     }
-    let prev_ms = evidence
+    let previous_timestamp = evidence
         .chain_of_custody
         .last()
-        .map(|t| t.timestamp.physical_ms + 1)
-        .unwrap_or(evidence.timestamp.physical_ms + 1);
+        .map(|t| t.timestamp)
+        .unwrap_or(evidence.timestamp);
+    if timestamp <= previous_timestamp {
+        return Err(LegalError::CustodyTransferFailed {
+            reason: format!(
+                "custody transfer timestamp {timestamp} must be after previous timestamp {previous_timestamp}"
+            ),
+        });
+    }
     evidence.chain_of_custody.push(CustodyTransfer {
         from: from.clone(),
         to: to.clone(),
-        timestamp: Timestamp::new(prev_ms, 0),
-        reason: "custody transfer".to_string(),
+        timestamp,
+        reason: reason.to_string(),
     });
     Ok(())
 }
@@ -111,66 +145,98 @@ mod tests {
     fn ts(ms: u64) -> Timestamp {
         Timestamp::new(ms, 0)
     }
+    fn id(n: u128) -> Uuid {
+        Uuid::from_u128(n)
+    }
+
+    #[test]
+    fn create_uses_caller_supplied_id() {
+        let evidence_id = id(0x100);
+        let ev = create_evidence(evidence_id, b"doc", &did("a"), "contract", ts(1000)).unwrap();
+        assert_eq!(ev.id, evidence_id);
+    }
+
+    #[test]
+    fn create_rejects_nil_id() {
+        let result = create_evidence(Uuid::nil(), b"doc", &did("a"), "contract", ts(1000));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn transfer_uses_caller_supplied_timestamp_and_reason() {
+        let (a, b) = (did("a"), did("b"));
+        let mut ev = create_evidence(id(0x101), b"d", &a, "d", ts(1000)).unwrap();
+        transfer_custody(&mut ev, &a, &b, ts(2000), "signed release").unwrap();
+        assert_eq!(ev.chain_of_custody[0].timestamp, ts(2000));
+        assert_eq!(ev.chain_of_custody[0].reason, "signed release");
+    }
+
+    #[test]
+    fn transfer_rejects_zero_timestamp() {
+        let (a, b) = (did("a"), did("b"));
+        let mut ev = create_evidence(id(0x102), b"d", &a, "d", ts(1000)).unwrap();
+        assert!(transfer_custody(&mut ev, &a, &b, Timestamp::ZERO, "release").is_err());
+    }
 
     #[test]
     fn create_sets_pending() {
-        let ev = create_evidence(b"doc", &did("a"), "contract", ts(1000)).unwrap();
+        let ev = create_evidence(id(0x103), b"doc", &did("a"), "contract", ts(1000)).unwrap();
         assert_eq!(ev.admissibility_status, AdmissibilityStatus::Pending);
         assert_eq!(ev.type_tag, "contract");
         assert!(ev.chain_of_custody.is_empty());
     }
     #[test]
     fn create_hashes_data() {
-        let ev = create_evidence(b"x", &did("a"), "d", ts(1000)).unwrap();
+        let ev = create_evidence(id(0x104), b"x", &did("a"), "d", ts(1000)).unwrap();
         assert_eq!(ev.hash, Hash256::digest(b"x"));
     }
     #[test]
     fn create_rejects_zero_timestamp() {
-        let result = create_evidence(b"d", &did("a"), "d", Timestamp::ZERO);
+        let result = create_evidence(id(0x105), b"d", &did("a"), "d", Timestamp::ZERO);
         assert!(result.is_err());
     }
     #[test]
     fn create_stores_real_timestamp() {
-        let ev = create_evidence(b"d", &did("a"), "d", ts(42000)).unwrap();
+        let ev = create_evidence(id(0x106), b"d", &did("a"), "d", ts(42000)).unwrap();
         assert_eq!(ev.timestamp, ts(42000));
     }
     #[test]
     fn transfer_success() {
         let (a, b) = (did("a"), did("b"));
-        let mut ev = create_evidence(b"d", &a, "d", ts(1000)).unwrap();
-        transfer_custody(&mut ev, &a, &b).unwrap();
+        let mut ev = create_evidence(id(0x107), b"d", &a, "d", ts(1000)).unwrap();
+        transfer_custody(&mut ev, &a, &b, ts(2000), "custody transfer").unwrap();
         assert_eq!(ev.chain_of_custody.len(), 1);
     }
     #[test]
     fn transfer_chain() {
         let (a, b, c) = (did("a"), did("b"), did("c"));
-        let mut ev = create_evidence(b"d", &a, "d", ts(1000)).unwrap();
-        transfer_custody(&mut ev, &a, &b).unwrap();
-        transfer_custody(&mut ev, &b, &c).unwrap();
+        let mut ev = create_evidence(id(0x108), b"d", &a, "d", ts(1000)).unwrap();
+        transfer_custody(&mut ev, &a, &b, ts(2000), "first transfer").unwrap();
+        transfer_custody(&mut ev, &b, &c, ts(3000), "second transfer").unwrap();
         assert_eq!(ev.chain_of_custody.len(), 2);
     }
     #[test]
     fn transfer_wrong_holder() {
         let (a, b, c) = (did("a"), did("b"), did("c"));
-        let mut ev = create_evidence(b"d", &a, "d", ts(1000)).unwrap();
-        assert!(transfer_custody(&mut ev, &c, &b).is_err());
+        let mut ev = create_evidence(id(0x109), b"d", &a, "d", ts(1000)).unwrap();
+        assert!(transfer_custody(&mut ev, &c, &b, ts(2000), "bad transfer").is_err());
     }
     #[test]
     fn verify_empty_ok() {
-        let ev = create_evidence(b"d", &did("a"), "d", ts(1000)).unwrap();
+        let ev = create_evidence(id(0x10a), b"d", &did("a"), "d", ts(1000)).unwrap();
         verify_chain_of_custody(&ev).unwrap();
     }
     #[test]
     fn verify_valid() {
         let (a, b) = (did("a"), did("b"));
-        let mut ev = create_evidence(b"d", &a, "d", ts(1000)).unwrap();
-        transfer_custody(&mut ev, &a, &b).unwrap();
+        let mut ev = create_evidence(id(0x10b), b"d", &a, "d", ts(1000)).unwrap();
+        transfer_custody(&mut ev, &a, &b, ts(2000), "custody transfer").unwrap();
         verify_chain_of_custody(&ev).unwrap();
     }
     #[test]
     fn verify_broken() {
         let (a, b, c) = (did("a"), did("b"), did("c"));
-        let mut ev = create_evidence(b"d", &a, "d", ts(1000)).unwrap();
+        let mut ev = create_evidence(id(0x10c), b"d", &a, "d", ts(1000)).unwrap();
         ev.chain_of_custody.push(CustodyTransfer {
             from: c,
             to: b,
@@ -207,9 +273,9 @@ mod tests {
     #[test]
     fn timestamps_increase() {
         let (a, b, c) = (did("a"), did("b"), did("c"));
-        let mut ev = create_evidence(b"d", &a, "d", ts(1000)).unwrap();
-        transfer_custody(&mut ev, &a, &b).unwrap();
-        transfer_custody(&mut ev, &b, &c).unwrap();
+        let mut ev = create_evidence(id(0x10d), b"d", &a, "d", ts(1000)).unwrap();
+        transfer_custody(&mut ev, &a, &b, ts(2000), "first transfer").unwrap();
+        transfer_custody(&mut ev, &b, &c, ts(3000), "second transfer").unwrap();
         assert!(ev.chain_of_custody[1].timestamp > ev.chain_of_custody[0].timestamp);
     }
 }

--- a/crates/exo-legal/src/fiduciary.rs
+++ b/crates/exo-legal/src/fiduciary.rs
@@ -93,10 +93,21 @@ pub fn create_duty(
     fiduciary: &Did,
     duty_type: DutyType,
     scope: &str,
+    created: Timestamp,
 ) -> Result<FiduciaryDuty> {
     if principal == fiduciary {
         return Err(LegalError::FiduciaryViolation {
             reason: "principal and fiduciary cannot be same".into(),
+        });
+    }
+    if scope.trim().is_empty() {
+        return Err(LegalError::FiduciaryViolation {
+            reason: "fiduciary duty scope must not be empty".into(),
+        });
+    }
+    if created == Timestamp::ZERO {
+        return Err(LegalError::FiduciaryViolation {
+            reason: "fiduciary duty created timestamp must not be Timestamp::ZERO".into(),
         });
     }
     Ok(FiduciaryDuty {
@@ -104,7 +115,7 @@ pub fn create_duty(
         fiduciary_did: fiduciary.clone(),
         duty_type,
         scope: scope.into(),
-        created: Timestamp::ZERO,
+        created,
     })
 }
 
@@ -114,17 +125,33 @@ mod tests {
     fn did(n: &str) -> Did {
         Did::new(&format!("did:exo:{n}")).unwrap()
     }
+    fn ts(ms: u64) -> Timestamp {
+        Timestamp::new(ms, 0)
+    }
     fn entry(actor: &str, action: &str, ben: Option<&str>) -> AuditEntry {
         AuditEntry {
             actor: did(actor),
             action: action.into(),
-            timestamp: Timestamp::ZERO,
+            timestamp: ts(2000),
             beneficiary: ben.map(did),
         }
     }
+
+    #[test]
+    fn create_duty_uses_caller_supplied_timestamp() {
+        let d = create_duty(&did("p"), &did("f"), DutyType::Care, "a", ts(1000)).unwrap();
+        assert_eq!(d.created, ts(1000));
+    }
+
+    #[test]
+    fn create_duty_rejects_placeholder_metadata() {
+        assert!(create_duty(&did("p"), &did("f"), DutyType::Care, "a", Timestamp::ZERO,).is_err());
+        assert!(create_duty(&did("p"), &did("f"), DutyType::Care, " ", ts(1000)).is_err());
+    }
+
     #[test]
     fn care_ok() {
-        let d = create_duty(&did("p"), &did("f"), DutyType::Care, "a").unwrap();
+        let d = create_duty(&did("p"), &did("f"), DutyType::Care, "a", ts(1000)).unwrap();
         assert_eq!(
             check_duty_compliance(&d, &[entry("f", "review", None)]),
             ComplianceResult::Compliant
@@ -132,7 +159,7 @@ mod tests {
     }
     #[test]
     fn care_fail() {
-        let d = create_duty(&did("p"), &did("f"), DutyType::Care, "a").unwrap();
+        let d = create_duty(&did("p"), &did("f"), DutyType::Care, "a", ts(1000)).unwrap();
         assert!(matches!(
             check_duty_compliance(&d, &[]),
             ComplianceResult::Violation { .. }
@@ -140,7 +167,7 @@ mod tests {
     }
     #[test]
     fn loyalty_ok() {
-        let d = create_duty(&did("p"), &did("f"), DutyType::Loyalty, "a").unwrap();
+        let d = create_duty(&did("p"), &did("f"), DutyType::Loyalty, "a", ts(1000)).unwrap();
         assert_eq!(
             check_duty_compliance(&d, &[entry("f", "act", Some("p"))]),
             ComplianceResult::Compliant
@@ -148,7 +175,7 @@ mod tests {
     }
     #[test]
     fn loyalty_fail() {
-        let d = create_duty(&did("p"), &did("f"), DutyType::Loyalty, "a").unwrap();
+        let d = create_duty(&did("p"), &did("f"), DutyType::Loyalty, "a", ts(1000)).unwrap();
         assert!(matches!(
             check_duty_compliance(&d, &[entry("f", "act", Some("x"))]),
             ComplianceResult::Violation { .. }
@@ -156,7 +183,7 @@ mod tests {
     }
     #[test]
     fn good_faith_ok() {
-        let d = create_duty(&did("p"), &did("f"), DutyType::GoodFaith, "a").unwrap();
+        let d = create_duty(&did("p"), &did("f"), DutyType::GoodFaith, "a", ts(1000)).unwrap();
         assert_eq!(
             check_duty_compliance(&d, &[entry("f", "act", None)]),
             ComplianceResult::Compliant
@@ -164,7 +191,7 @@ mod tests {
     }
     #[test]
     fn good_faith_fail() {
-        let d = create_duty(&did("p"), &did("f"), DutyType::GoodFaith, "a").unwrap();
+        let d = create_duty(&did("p"), &did("f"), DutyType::GoodFaith, "a", ts(1000)).unwrap();
         assert!(matches!(
             check_duty_compliance(&d, &[entry("x", "act", None)]),
             ComplianceResult::Violation { .. }
@@ -172,7 +199,7 @@ mod tests {
     }
     #[test]
     fn disclosure_ok() {
-        let d = create_duty(&did("p"), &did("f"), DutyType::Disclosure, "a").unwrap();
+        let d = create_duty(&did("p"), &did("f"), DutyType::Disclosure, "a", ts(1000)).unwrap();
         assert_eq!(
             check_duty_compliance(&d, &[entry("f", "disclose conflict", None)]),
             ComplianceResult::Compliant
@@ -180,7 +207,7 @@ mod tests {
     }
     #[test]
     fn disclosure_fail() {
-        let d = create_duty(&did("p"), &did("f"), DutyType::Disclosure, "a").unwrap();
+        let d = create_duty(&did("p"), &did("f"), DutyType::Disclosure, "a", ts(1000)).unwrap();
         assert!(matches!(
             check_duty_compliance(&d, &[entry("f", "acted", None)]),
             ComplianceResult::Violation { .. }
@@ -188,7 +215,14 @@ mod tests {
     }
     #[test]
     fn confidentiality_ok() {
-        let d = create_duty(&did("p"), &did("f"), DutyType::Confidentiality, "a").unwrap();
+        let d = create_duty(
+            &did("p"),
+            &did("f"),
+            DutyType::Confidentiality,
+            "a",
+            ts(1000),
+        )
+        .unwrap();
         assert_eq!(
             check_duty_compliance(&d, &[entry("f", "reviewed", None)]),
             ComplianceResult::Compliant
@@ -196,7 +230,14 @@ mod tests {
     }
     #[test]
     fn confidentiality_fail_share() {
-        let d = create_duty(&did("p"), &did("f"), DutyType::Confidentiality, "a").unwrap();
+        let d = create_duty(
+            &did("p"),
+            &did("f"),
+            DutyType::Confidentiality,
+            "a",
+            ts(1000),
+        )
+        .unwrap();
         assert!(matches!(
             check_duty_compliance(&d, &[entry("f", "share x", None)]),
             ComplianceResult::Violation { .. }
@@ -204,7 +245,14 @@ mod tests {
     }
     #[test]
     fn confidentiality_fail_publish() {
-        let d = create_duty(&did("p"), &did("f"), DutyType::Confidentiality, "a").unwrap();
+        let d = create_duty(
+            &did("p"),
+            &did("f"),
+            DutyType::Confidentiality,
+            "a",
+            ts(1000),
+        )
+        .unwrap();
         assert!(matches!(
             check_duty_compliance(&d, &[entry("f", "publish x", None)]),
             ComplianceResult::Violation { .. }
@@ -212,7 +260,7 @@ mod tests {
     }
     #[test]
     fn same_entity_fails() {
-        assert!(create_duty(&did("s"), &did("s"), DutyType::Care, "a").is_err());
+        assert!(create_duty(&did("s"), &did("s"), DutyType::Care, "a", ts(1000)).is_err());
     }
     #[test]
     fn duty_type_serde() {

--- a/crates/exo-legal/src/privilege.rs
+++ b/crates/exo-legal/src/privilege.rs
@@ -4,6 +4,8 @@ use exo_core::{Did, Timestamp};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::error::{LegalError, Result};
+
 /// Category of legal privilege that may shield evidence from disclosure.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PrivilegeType {
@@ -42,36 +44,61 @@ pub struct PrivilegeChallenge {
 }
 
 /// Creates a privilege assertion linking an evidence item to a privilege type and legal basis.
-#[must_use]
 pub fn assert_privilege(
     evidence_id: &Uuid,
     privilege_type: PrivilegeType,
     asserter: &Did,
     basis: &str,
-) -> PrivilegeAssertion {
-    PrivilegeAssertion {
+    timestamp: Timestamp,
+) -> Result<PrivilegeAssertion> {
+    if evidence_id.is_nil() {
+        return Err(LegalError::PrivilegeInvalid {
+            reason: "privilege evidence ID must be caller-supplied and non-nil".into(),
+        });
+    }
+    if basis.trim().is_empty() {
+        return Err(LegalError::PrivilegeInvalid {
+            reason: "privilege basis must not be empty".into(),
+        });
+    }
+    if timestamp == Timestamp::ZERO {
+        return Err(LegalError::PrivilegeInvalid {
+            reason: "privilege assertion timestamp must not be Timestamp::ZERO".into(),
+        });
+    }
+    Ok(PrivilegeAssertion {
         evidence_id: *evidence_id,
         privilege_type,
         asserter: asserter.clone(),
         basis: basis.to_string(),
-        timestamp: Timestamp::ZERO,
-    }
+        timestamp,
+    })
 }
 
 /// Files a challenge against an existing privilege assertion with stated grounds.
-#[must_use]
 pub fn challenge_privilege(
     assertion: &PrivilegeAssertion,
     challenger: &Did,
     grounds: &str,
-) -> PrivilegeChallenge {
-    PrivilegeChallenge {
+    timestamp: Timestamp,
+) -> Result<PrivilegeChallenge> {
+    if grounds.trim().is_empty() {
+        return Err(LegalError::PrivilegeInvalid {
+            reason: "privilege challenge grounds must not be empty".into(),
+        });
+    }
+    if timestamp == Timestamp::ZERO {
+        return Err(LegalError::PrivilegeInvalid {
+            reason: "privilege challenge timestamp must not be Timestamp::ZERO".into(),
+        });
+    }
+    Ok(PrivilegeChallenge {
         assertion_evidence_id: assertion.evidence_id,
         challenger: challenger.clone(),
         grounds: grounds.to_string(),
         status: ChallengeStatus::Pending,
-        timestamp: Timestamp::ZERO,
-    }
+        timestamp,
+    })
 }
 
 #[cfg(test)]
@@ -79,6 +106,65 @@ mod tests {
     use super::*;
     fn did(n: &str) -> Did {
         Did::new(&format!("did:exo:{n}")).unwrap()
+    }
+    fn id(n: u128) -> Uuid {
+        Uuid::from_u128(n)
+    }
+    fn ts(ms: u64) -> Timestamp {
+        Timestamp::new(ms, 0)
+    }
+
+    #[test]
+    fn assertion_and_challenge_use_caller_supplied_timestamps() {
+        let assertion = assert_privilege(
+            &id(0x400),
+            PrivilegeType::AttorneyClient,
+            &did("c"),
+            "basis",
+            ts(1000),
+        )
+        .unwrap();
+        assert_eq!(assertion.timestamp, ts(1000));
+
+        let challenge =
+            challenge_privilege(&assertion, &did("o"), "crime-fraud", ts(2000)).unwrap();
+        assert_eq!(challenge.timestamp, ts(2000));
+    }
+
+    #[test]
+    fn assertion_and_challenge_reject_placeholder_metadata() {
+        assert!(
+            assert_privilege(
+                &Uuid::nil(),
+                PrivilegeType::AttorneyClient,
+                &did("c"),
+                "basis",
+                ts(1000),
+            )
+            .is_err()
+        );
+        assert!(
+            assert_privilege(
+                &id(0x401),
+                PrivilegeType::AttorneyClient,
+                &did("c"),
+                "basis",
+                Timestamp::ZERO,
+            )
+            .is_err()
+        );
+        let assertion = assert_privilege(
+            &id(0x402),
+            PrivilegeType::AttorneyClient,
+            &did("c"),
+            "basis",
+            ts(1000),
+        )
+        .unwrap();
+        assert!(challenge_privilege(&assertion, &did("o"), " ", ts(2000)).is_err());
+        assert!(
+            challenge_privilege(&assertion, &did("o"), "crime-fraud", Timestamp::ZERO).is_err()
+        );
     }
 
     #[test]
@@ -89,19 +175,21 @@ mod tests {
             PrivilegeType::Deliberative,
             PrivilegeType::TradeSecret,
         ] {
-            let a = assert_privilege(&Uuid::new_v4(), pt.clone(), &did("c"), "basis");
+            let a = assert_privilege(&id(0x403), pt.clone(), &did("c"), "basis", ts(1000)).unwrap();
             assert_eq!(a.privilege_type, pt);
         }
     }
     #[test]
     fn challenge_pending() {
         let a = assert_privilege(
-            &Uuid::new_v4(),
+            &id(0x404),
             PrivilegeType::AttorneyClient,
             &did("c"),
             "advice",
-        );
-        let ch = challenge_privilege(&a, &did("o"), "crime-fraud");
+            ts(1000),
+        )
+        .unwrap();
+        let ch = challenge_privilege(&a, &did("o"), "crime-fraud", ts(2000)).unwrap();
         assert_eq!(ch.status, ChallengeStatus::Pending);
         assert!(ch.grounds.contains("crime-fraud"));
     }
@@ -132,9 +220,16 @@ mod tests {
     }
     #[test]
     fn assertion_serde() {
-        let a = assert_privilege(&Uuid::nil(), PrivilegeType::WorkProduct, &did("a"), "b");
+        let a = assert_privilege(
+            &id(0x405),
+            PrivilegeType::WorkProduct,
+            &did("a"),
+            "b",
+            ts(1000),
+        )
+        .unwrap();
         let j = serde_json::to_string(&a).unwrap();
         let r: PrivilegeAssertion = serde_json::from_str(&j).unwrap();
-        assert_eq!(r.evidence_id, Uuid::nil());
+        assert_eq!(r.evidence_id, id(0x405));
     }
 }

--- a/crates/exo-legal/src/records.rs
+++ b/crates/exo-legal/src/records.rs
@@ -6,6 +6,8 @@ use exo_core::{Hash256, Timestamp};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::error::{LegalError, Result};
+
 /// Lifecycle state of a legal record under the retention policy.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Disposition {
@@ -70,29 +72,77 @@ pub fn apply_retention(records: &mut [Record], policy: &RetentionPolicy, now: &T
 }
 
 /// Creates a new active record with a content hash and the given retention period.
-#[must_use]
-pub fn create_record(data: &[u8], classification: &str, retention_days: u64) -> Record {
-    Record {
-        id: Uuid::new_v4(),
+pub fn create_record(
+    id: Uuid,
+    data: &[u8],
+    classification: &str,
+    retention_days: u64,
+    created: Timestamp,
+) -> Result<Record> {
+    if id.is_nil() {
+        return Err(LegalError::InvalidStateTransition {
+            reason: "record ID must be caller-supplied and non-nil".into(),
+        });
+    }
+    if classification.trim().is_empty() {
+        return Err(LegalError::InvalidStateTransition {
+            reason: "record classification must not be empty".into(),
+        });
+    }
+    if retention_days == 0 {
+        return Err(LegalError::InvalidStateTransition {
+            reason: "record retention period must be nonzero".into(),
+        });
+    }
+    if created == Timestamp::ZERO {
+        return Err(LegalError::InvalidStateTransition {
+            reason: "record created timestamp must not be Timestamp::ZERO".into(),
+        });
+    }
+    Ok(Record {
+        id,
         content_hash: Hash256::digest(data),
         classification: Classification(classification.into()),
         retention_period_days: retention_days,
-        created: Timestamp::ZERO,
+        created,
         disposition: Disposition::Active,
-    }
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    fn id(n: u128) -> Uuid {
+        Uuid::from_u128(n)
+    }
+    fn ts(ms: u64) -> Timestamp {
+        Timestamp::new(ms, 0)
+    }
+
+    #[test]
+    fn create_uses_caller_supplied_metadata() {
+        let record_id = id(0x200);
+        let r = create_record(record_id, b"d", "g", 365, ts(1000)).unwrap();
+        assert_eq!(r.id, record_id);
+        assert_eq!(r.created, ts(1000));
+    }
+
+    #[test]
+    fn create_rejects_placeholder_metadata() {
+        assert!(create_record(Uuid::nil(), b"d", "g", 365, ts(1000)).is_err());
+        assert!(create_record(id(0x201), b"d", "g", 365, Timestamp::ZERO).is_err());
+        assert!(create_record(id(0x202), b"d", "g", 0, ts(1000)).is_err());
+        assert!(create_record(id(0x203), b"d", " ", 365, ts(1000)).is_err());
+    }
+
     #[test]
     fn create_is_active() {
-        let r = create_record(b"d", "g", 365);
+        let r = create_record(id(0x204), b"d", "g", 365, ts(1000)).unwrap();
         assert_eq!(r.disposition, Disposition::Active);
     }
     #[test]
     fn create_hashes() {
-        let r = create_record(b"x", "g", 30);
+        let r = create_record(id(0x205), b"x", "g", 30, ts(1000)).unwrap();
         assert_eq!(r.content_hash, Hash256::digest(b"x"));
     }
     #[test]
@@ -107,7 +157,7 @@ mod tests {
     }
     #[test]
     fn retention_marks_expired() {
-        let mut r = vec![create_record(b"o", "g", 30)];
+        let mut r = vec![create_record(id(0x206), b"o", "g", 30, ts(1)).unwrap()];
         apply_retention(
             &mut r,
             &RetentionPolicy::new(),
@@ -117,7 +167,7 @@ mod tests {
     }
     #[test]
     fn retention_keeps_fresh() {
-        let mut r = vec![create_record(b"n", "g", 30)];
+        let mut r = vec![create_record(id(0x207), b"n", "g", 30, ts(1)).unwrap()];
         apply_retention(
             &mut r,
             &RetentionPolicy::new(),
@@ -127,7 +177,7 @@ mod tests {
     }
     #[test]
     fn retention_skips_hold() {
-        let mut r = vec![create_record(b"h", "g", 1)];
+        let mut r = vec![create_record(id(0x208), b"h", "g", 1, ts(1)).unwrap()];
         r[0].disposition = Disposition::RetentionHold;
         apply_retention(
             &mut r,
@@ -138,7 +188,7 @@ mod tests {
     }
     #[test]
     fn retention_skips_destroyed() {
-        let mut r = vec![create_record(b"g", "g", 1)];
+        let mut r = vec![create_record(id(0x209), b"g", "g", 1, ts(1)).unwrap()];
         r[0].disposition = Disposition::Destroyed;
         apply_retention(
             &mut r,
@@ -149,7 +199,7 @@ mod tests {
     }
     #[test]
     fn retention_policy_override() {
-        let mut r = vec![create_record(b"d", "legal", 30)];
+        let mut r = vec![create_record(id(0x20a), b"d", "legal", 30, ts(1)).unwrap()];
         let mut p = RetentionPolicy::new();
         p.add_rule(Classification("legal".into()), 365);
         apply_retention(&mut r, &p, &Timestamp::new(31 * MS_PER_DAY, 0));
@@ -170,11 +220,11 @@ mod tests {
     }
     #[test]
     fn boundary() {
-        let mut r = vec![create_record(b"b", "g", 30)];
+        let mut r = vec![create_record(id(0x20b), b"b", "g", 30, ts(1)).unwrap()];
         apply_retention(
             &mut r,
             &RetentionPolicy::new(),
-            &Timestamp::new(30 * MS_PER_DAY, 0),
+            &Timestamp::new(30 * MS_PER_DAY + 1, 0),
         );
         assert_eq!(r[0].disposition, Disposition::PendingDestruction);
     }

--- a/crates/exo-node/src/mcp/tools/legal.rs
+++ b/crates/exo-node/src/mcp/tools/legal.rs
@@ -1,13 +1,40 @@
 //! Legal MCP tools — e-discovery search, privilege assertion, DGCL safe harbor,
 //! and fiduciary duty compliance checking.
 
-use exo_core::{Did, Hash256, Timestamp};
+use exo_core::Did;
 use serde_json::{Value, json};
 
 use crate::mcp::{
     context::NodeContext,
     protocol::{ToolDefinition, ToolResult},
 };
+
+fn required_nonempty_str<'a>(
+    params: &'a Value,
+    name: &str,
+) -> std::result::Result<&'a str, ToolResult> {
+    match params.get(name).and_then(Value::as_str) {
+        Some(value) if !value.trim().is_empty() => Ok(value),
+        Some(_) => Err(ToolResult::error(
+            json!({"error": format!("{name} must not be empty")}).to_string(),
+        )),
+        None => Err(ToolResult::error(
+            json!({"error": format!("missing required parameter: {name}")}).to_string(),
+        )),
+    }
+}
+
+fn required_nonzero_u64(params: &Value, name: &str) -> std::result::Result<u64, ToolResult> {
+    match params.get(name).and_then(Value::as_u64) {
+        Some(value) if value > 0 => Ok(value),
+        Some(_) => Err(ToolResult::error(
+            json!({"error": format!("{name} must be a nonzero integer")}).to_string(),
+        )),
+        None => Err(ToolResult::error(
+            json!({"error": format!("missing required parameter: {name}")}).to_string(),
+        )),
+    }
+}
 
 // ---------------------------------------------------------------------------
 // exochain_ediscovery_search
@@ -37,9 +64,17 @@ pub fn ediscovery_search_definition() -> ToolDefinition {
                 "date_range_end": {
                     "type": "string",
                     "description": "Optional ISO-8601 end date for the search window."
+                },
+                "search_id": {
+                    "type": "string",
+                    "description": "Caller-supplied non-placeholder search ID."
+                },
+                "searched_at_ms": {
+                    "type": "integer",
+                    "description": "Caller-supplied nonzero HLC physical milliseconds for the search."
                 }
             },
-            "required": ["query"],
+            "required": ["query", "search_id", "searched_at_ms"],
             "additionalProperties": false,
         }),
     }
@@ -58,6 +93,14 @@ pub fn execute_ediscovery_search(params: &Value, _context: &NodeContext) -> Tool
     };
 
     let scope = params.get("scope").and_then(Value::as_str).unwrap_or("all");
+    let search_id = match required_nonempty_str(params, "search_id") {
+        Ok(value) => value,
+        Err(result) => return result,
+    };
+    let searched_at_ms = match required_nonzero_u64(params, "searched_at_ms") {
+        Ok(value) => value,
+        Err(result) => return result,
+    };
     let date_range_start = params
         .get("date_range_start")
         .and_then(Value::as_str)
@@ -67,17 +110,8 @@ pub fn execute_ediscovery_search(params: &Value, _context: &NodeContext) -> Tool
         .and_then(Value::as_str)
         .map(String::from);
 
-    let now = Timestamp::now_utc();
-    let search_id = Hash256::digest(
-        format!(
-            "ediscovery:{}:{}:{}:{}",
-            query, scope, now.physical_ms, now.logical
-        )
-        .as_bytes(),
-    );
-
     let response = json!({
-        "search_id": search_id.to_string(),
+        "search_id": search_id,
         "query": query,
         "scope": scope,
         "date_range": {
@@ -87,7 +121,7 @@ pub fn execute_ediscovery_search(params: &Value, _context: &NodeContext) -> Tool
         "results": [],
         "total_matches": 0,
         "status": "completed",
-        "searched_at": format!("{}:{}", now.physical_ms, now.logical),
+        "searched_at": format!("{}:0", searched_at_ms),
         "note": "No evidence corpus is loaded in this node instance.",
     });
     ToolResult::success(response.to_string())
@@ -120,9 +154,17 @@ pub fn assert_privilege_definition() -> ToolDefinition {
                 "asserter_did": {
                     "type": "string",
                     "description": "DID of the person asserting privilege."
+                },
+                "assertion_id": {
+                    "type": "string",
+                    "description": "Caller-supplied non-placeholder privilege assertion ID."
+                },
+                "asserted_at_ms": {
+                    "type": "integer",
+                    "description": "Caller-supplied nonzero HLC physical milliseconds for assertion."
                 }
             },
-            "required": ["evidence_id", "privilege_type", "asserter_did"],
+            "required": ["evidence_id", "privilege_type", "asserter_did", "assertion_id", "asserted_at_ms"],
             "additionalProperties": false,
         }),
     }
@@ -155,6 +197,14 @@ pub fn execute_assert_privilege(params: &Value, _context: &NodeContext) -> ToolR
             );
         }
     };
+    let assertion_id = match required_nonempty_str(params, "assertion_id") {
+        Ok(value) => value,
+        Err(result) => return result,
+    };
+    let asserted_at_ms = match required_nonzero_u64(params, "asserted_at_ms") {
+        Ok(value) => value,
+        Err(result) => return result,
+    };
 
     // Validate privilege type.
     let valid_types = ["attorney_client", "work_product", "deliberative"];
@@ -175,22 +225,13 @@ pub fn execute_assert_privilege(params: &Value, _context: &NodeContext) -> ToolR
         );
     }
 
-    let now = Timestamp::now_utc();
-    let assertion_id = Hash256::digest(
-        format!(
-            "privilege:{}:{}:{}:{}:{}",
-            evidence_id, privilege_type, asserter_did_str, now.physical_ms, now.logical
-        )
-        .as_bytes(),
-    );
-
     let response = json!({
-        "assertion_id": assertion_id.to_string(),
+        "assertion_id": assertion_id,
         "evidence_id": evidence_id,
         "privilege_type": privilege_type,
         "asserter_did": asserter_did_str,
         "status": "asserted",
-        "asserted_at": format!("{}:{}", now.physical_ms, now.logical),
+        "asserted_at": format!("{}:0", asserted_at_ms),
     });
     ToolResult::success(response.to_string())
 }
@@ -220,9 +261,17 @@ pub fn initiate_safe_harbor_definition() -> ToolDefinition {
                     "type": "array",
                     "items": { "type": "string" },
                     "description": "Array of DID strings for the interested parties."
+                },
+                "process_id": {
+                    "type": "string",
+                    "description": "Caller-supplied non-placeholder safe-harbor process ID."
+                },
+                "initiated_at_ms": {
+                    "type": "integer",
+                    "description": "Caller-supplied nonzero HLC physical milliseconds for initiation."
                 }
             },
-            "required": ["initiator_did", "transaction_description", "interested_parties"],
+            "required": ["initiator_did", "transaction_description", "interested_parties", "process_id", "initiated_at_ms"],
             "additionalProperties": false,
         }),
     }
@@ -259,6 +308,14 @@ pub fn execute_initiate_safe_harbor(params: &Value, _context: &NodeContext) -> T
             );
         }
     };
+    let process_id = match required_nonempty_str(params, "process_id") {
+        Ok(value) => value,
+        Err(result) => return result,
+    };
+    let initiated_at_ms = match required_nonzero_u64(params, "initiated_at_ms") {
+        Ok(value) => value,
+        Err(result) => return result,
+    };
 
     // Validate initiator DID.
     if Did::new(initiator_did_str).is_err() {
@@ -289,15 +346,6 @@ pub fn execute_initiate_safe_harbor(params: &Value, _context: &NodeContext) -> T
         }
     }
 
-    let now = Timestamp::now_utc();
-    let process_id = Hash256::digest(
-        format!(
-            "safe_harbor:{}:{}:{}:{}",
-            initiator_did_str, transaction_description, now.physical_ms, now.logical
-        )
-        .as_bytes(),
-    );
-
     let disclosure_requirements: Vec<Value> = party_dids
         .iter()
         .map(|did| {
@@ -310,14 +358,14 @@ pub fn execute_initiate_safe_harbor(params: &Value, _context: &NodeContext) -> T
         .collect();
 
     let response = json!({
-        "process_id": process_id.to_string(),
+        "process_id": process_id,
         "initiator_did": initiator_did_str,
         "transaction_description": transaction_description,
         "interested_parties": party_dids,
         "disclosure_requirements": disclosure_requirements,
         "dgcl_section": "144",
         "status": "initiated",
-        "initiated_at": format!("{}:{}", now.physical_ms, now.logical),
+        "initiated_at": format!("{}:0", initiated_at_ms),
     });
     ToolResult::success(response.to_string())
 }
@@ -346,9 +394,17 @@ pub fn check_fiduciary_duty_definition() -> ToolDefinition {
                 "beneficiary_did": {
                     "type": "string",
                     "description": "DID of the beneficiary owed the fiduciary duty."
+                },
+                "check_id": {
+                    "type": "string",
+                    "description": "Caller-supplied non-placeholder fiduciary check ID."
+                },
+                "checked_at_ms": {
+                    "type": "integer",
+                    "description": "Caller-supplied nonzero HLC physical milliseconds for the check."
                 }
             },
-            "required": ["actor_did", "action", "beneficiary_did"],
+            "required": ["actor_did", "action", "beneficiary_did", "check_id", "checked_at_ms"],
             "additionalProperties": false,
         }),
     }
@@ -381,6 +437,14 @@ pub fn execute_check_fiduciary_duty(params: &Value, _context: &NodeContext) -> T
             );
         }
     };
+    let check_id = match required_nonempty_str(params, "check_id") {
+        Ok(value) => value,
+        Err(result) => return result,
+    };
+    let checked_at_ms = match required_nonzero_u64(params, "checked_at_ms") {
+        Ok(value) => value,
+        Err(result) => return result,
+    };
 
     // Validate DIDs.
     if Did::new(actor_did_str).is_err() {
@@ -393,8 +457,6 @@ pub fn execute_check_fiduciary_duty(params: &Value, _context: &NodeContext) -> T
             json!({"error": format!("invalid DID format: {beneficiary_did_str}")}).to_string(),
         );
     }
-
-    let now = Timestamp::now_utc();
 
     // Assess fiduciary duties: loyalty, care, good faith.
     let duties = vec![
@@ -415,22 +477,14 @@ pub fn execute_check_fiduciary_duty(params: &Value, _context: &NodeContext) -> T
         }),
     ];
 
-    let check_id = Hash256::digest(
-        format!(
-            "fiduciary:{}:{}:{}:{}:{}",
-            actor_did_str, action, beneficiary_did_str, now.physical_ms, now.logical
-        )
-        .as_bytes(),
-    );
-
     let response = json!({
-        "check_id": check_id.to_string(),
+        "check_id": check_id,
         "actor_did": actor_did_str,
         "action": action,
         "beneficiary_did": beneficiary_did_str,
         "duties_assessed": duties,
         "overall_status": "requires_review",
-        "checked_at": format!("{}:{}", now.physical_ms, now.logical),
+        "checked_at": format!("{}:0", checked_at_ms),
         "note": "Automated pre-screening complete. Human review required for final determination.",
     });
     ToolResult::success(response.to_string())
@@ -456,14 +510,18 @@ mod tests {
 
     #[test]
     fn execute_ediscovery_search_success() {
-        let params = json!({"query": "contract breach"});
+        let params = json!({
+            "query": "contract breach",
+            "search_id": "search-001",
+            "searched_at_ms": 1700000000000_u64,
+        });
         let result = execute_ediscovery_search(&params, &NodeContext::empty());
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
         assert_eq!(v["query"], "contract breach");
         assert_eq!(v["scope"], "all");
         assert_eq!(v["status"], "completed");
-        assert!(v["search_id"].as_str().is_some());
+        assert_eq!(v["search_id"], "search-001");
     }
 
     #[test]
@@ -473,6 +531,8 @@ mod tests {
             "scope": "emails",
             "date_range_start": "2025-01-01",
             "date_range_end": "2025-12-31",
+            "search_id": "search-002",
+            "searched_at_ms": 1700000000001_u64,
         });
         let result = execute_ediscovery_search(&params, &NodeContext::empty());
         assert!(!result.is_error);
@@ -482,7 +542,17 @@ mod tests {
 
     #[test]
     fn execute_ediscovery_search_missing_query() {
-        let result = execute_ediscovery_search(&json!({}), &NodeContext::empty());
+        let result = execute_ediscovery_search(
+            &json!({"search_id": "search-003", "searched_at_ms": 1700000000002_u64}),
+            &NodeContext::empty(),
+        );
+        assert!(result.is_error);
+    }
+
+    #[test]
+    fn execute_ediscovery_search_missing_metadata() {
+        let result =
+            execute_ediscovery_search(&json!({"query": "contract breach"}), &NodeContext::empty());
         assert!(result.is_error);
     }
 
@@ -501,13 +571,15 @@ mod tests {
             "evidence_id": "ev123",
             "privilege_type": "attorney_client",
             "asserter_did": "did:exo:counsel",
+            "assertion_id": "assertion-001",
+            "asserted_at_ms": 1700000000010_u64,
         });
         let result = execute_assert_privilege(&params, &NodeContext::empty());
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
         assert_eq!(v["privilege_type"], "attorney_client");
         assert_eq!(v["status"], "asserted");
-        assert!(v["assertion_id"].as_str().is_some());
+        assert_eq!(v["assertion_id"], "assertion-001");
     }
 
     #[test]
@@ -516,6 +588,8 @@ mod tests {
             "evidence_id": "ev123",
             "privilege_type": "invalid_type",
             "asserter_did": "did:exo:counsel",
+            "assertion_id": "assertion-002",
+            "asserted_at_ms": 1700000000011_u64,
         });
         let result = execute_assert_privilege(&params, &NodeContext::empty());
         assert!(result.is_error);
@@ -527,6 +601,8 @@ mod tests {
             "evidence_id": "ev123",
             "privilege_type": "work_product",
             "asserter_did": "bad",
+            "assertion_id": "assertion-003",
+            "asserted_at_ms": 1700000000012_u64,
         });
         let result = execute_assert_privilege(&params, &NodeContext::empty());
         assert!(result.is_error);
@@ -547,12 +623,15 @@ mod tests {
             "initiator_did": "did:exo:alice",
             "transaction_description": "Acquisition of subsidiary",
             "interested_parties": ["did:exo:bob", "did:exo:carol"],
+            "process_id": "safe-harbor-001",
+            "initiated_at_ms": 1700000000020_u64,
         });
         let result = execute_initiate_safe_harbor(&params, &NodeContext::empty());
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
         assert_eq!(v["dgcl_section"], "144");
         assert_eq!(v["status"], "initiated");
+        assert_eq!(v["process_id"], "safe-harbor-001");
         assert_eq!(
             v["interested_parties"].as_array().expect("parties").len(),
             2
@@ -572,6 +651,8 @@ mod tests {
             "initiator_did": "bad",
             "transaction_description": "test",
             "interested_parties": [],
+            "process_id": "safe-harbor-002",
+            "initiated_at_ms": 1700000000021_u64,
         });
         let result = execute_initiate_safe_harbor(&params, &NodeContext::empty());
         assert!(result.is_error);
@@ -583,6 +664,8 @@ mod tests {
             "initiator_did": "did:exo:alice",
             "transaction_description": "test",
             "interested_parties": ["not-a-did"],
+            "process_id": "safe-harbor-003",
+            "initiated_at_ms": 1700000000022_u64,
         });
         let result = execute_initiate_safe_harbor(&params, &NodeContext::empty());
         assert!(result.is_error);
@@ -603,6 +686,8 @@ mod tests {
             "actor_did": "did:exo:director",
             "action": "approve merger with personal interest",
             "beneficiary_did": "did:exo:shareholders",
+            "check_id": "fiduciary-001",
+            "checked_at_ms": 1700000000030_u64,
         });
         let result = execute_check_fiduciary_duty(&params, &NodeContext::empty());
         assert!(!result.is_error);
@@ -610,7 +695,7 @@ mod tests {
         assert_eq!(v["overall_status"], "requires_review");
         let duties = v["duties_assessed"].as_array().expect("duties");
         assert_eq!(duties.len(), 3);
-        assert!(v["check_id"].as_str().is_some());
+        assert_eq!(v["check_id"], "fiduciary-001");
     }
 
     #[test]
@@ -619,6 +704,8 @@ mod tests {
             "actor_did": "bad",
             "action": "something",
             "beneficiary_did": "did:exo:someone",
+            "check_id": "fiduciary-002",
+            "checked_at_ms": 1700000000031_u64,
         });
         let result = execute_check_fiduciary_duty(&params, &NodeContext::empty());
         assert!(result.is_error);

--- a/crates/exo-node/src/mcp/tools/proofs.rs
+++ b/crates/exo-node/src/mcp/tools/proofs.rs
@@ -1,13 +1,25 @@
 //! Proofs MCP tools — evidence creation, chain of custody verification,
 //! Merkle proof generation, and CGR kernel proof verification.
 
-use exo_core::{Did, Hash256, Timestamp};
+use exo_core::{Did, Hash256};
 use serde_json::{Value, json};
 
 use crate::mcp::{
     context::NodeContext,
     protocol::{ToolDefinition, ToolResult},
 };
+
+fn required_nonzero_u64(params: &Value, name: &str) -> std::result::Result<u64, ToolResult> {
+    match params.get(name).and_then(Value::as_u64) {
+        Some(value) if value > 0 => Ok(value),
+        Some(_) => Err(ToolResult::error(
+            json!({"error": format!("{name} must be a nonzero integer")}).to_string(),
+        )),
+        None => Err(ToolResult::error(
+            json!({"error": format!("missing required parameter: {name}")}).to_string(),
+        )),
+    }
+}
 
 // ---------------------------------------------------------------------------
 // exochain_create_evidence
@@ -33,9 +45,17 @@ pub fn create_evidence_definition() -> ToolDefinition {
                 "source_did": {
                     "type": "string",
                     "description": "DID of the evidence source/creator."
+                },
+                "evidence_id": {
+                    "type": "string",
+                    "description": "Caller-supplied non-placeholder evidence ID."
+                },
+                "created_at_ms": {
+                    "type": "integer",
+                    "description": "Caller-supplied nonzero HLC physical milliseconds for creation."
                 }
             },
-            "required": ["description", "evidence_type", "source_did"],
+            "required": ["description", "evidence_type", "source_did", "evidence_id", "created_at_ms"],
             "additionalProperties": false,
         }),
     }
@@ -68,6 +88,23 @@ pub fn execute_create_evidence(params: &Value, _context: &NodeContext) -> ToolRe
             );
         }
     };
+    let evidence_id = match params.get("evidence_id").and_then(Value::as_str) {
+        Some(s) if !s.trim().is_empty() => s,
+        Some(_) => {
+            return ToolResult::error(
+                json!({"error": "evidence_id must not be empty"}).to_string(),
+            );
+        }
+        None => {
+            return ToolResult::error(
+                json!({"error": "missing required parameter: evidence_id"}).to_string(),
+            );
+        }
+    };
+    let created_at_ms = match required_nonzero_u64(params, "created_at_ms") {
+        Ok(value) => value,
+        Err(result) => return result,
+    };
 
     if Did::new(source_did_str).is_err() {
         return ToolResult::error(
@@ -75,15 +112,8 @@ pub fn execute_create_evidence(params: &Value, _context: &NodeContext) -> ToolRe
         );
     }
 
-    let now = Timestamp::now_utc();
-    let hash_input = format!(
-        "evidence:{}:{}:{}:{}:{}",
-        description, evidence_type, source_did_str, now.physical_ms, now.logical
-    );
-    let evidence_id = Hash256::digest(hash_input.as_bytes());
-
     let response = json!({
-        "evidence_id": evidence_id.to_string(),
+        "evidence_id": evidence_id,
         "description": description,
         "evidence_type": evidence_type,
         "source_did": source_did_str,
@@ -91,7 +121,7 @@ pub fn execute_create_evidence(params: &Value, _context: &NodeContext) -> ToolRe
             {
                 "custodian": source_did_str,
                 "action": "created",
-                "timestamp": format!("{}:{}", now.physical_ms, now.logical),
+                "timestamp": format!("{}:0", created_at_ms),
             }
         ],
         "status": "created",
@@ -126,9 +156,13 @@ pub fn verify_chain_of_custody_definition() -> ToolDefinition {
                         }
                     },
                     "description": "Array of custody entries with custodian and action fields."
+                },
+                "verified_at_ms": {
+                    "type": "integer",
+                    "description": "Caller-supplied nonzero HLC physical milliseconds for verification."
                 }
             },
-            "required": ["evidence_id", "chain"],
+            "required": ["evidence_id", "chain", "verified_at_ms"],
             "additionalProperties": false,
         }),
     }
@@ -153,6 +187,10 @@ pub fn execute_verify_chain_of_custody(params: &Value, _context: &NodeContext) -
                     .to_string(),
             );
         }
+    };
+    let verified_at_ms = match required_nonzero_u64(params, "verified_at_ms") {
+        Ok(value) => value,
+        Err(result) => return result,
     };
 
     if chain.is_empty() {
@@ -182,14 +220,13 @@ pub fn execute_verify_chain_of_custody(params: &Value, _context: &NodeContext) -
     }
 
     let valid = issues.is_empty();
-    let now = Timestamp::now_utc();
 
     let response = json!({
         "evidence_id": evidence_id,
         "chain_length": chain.len(),
         "valid": valid,
         "issues": issues,
-        "verified_at": format!("{}:{}", now.physical_ms, now.logical),
+        "verified_at": format!("{}:0", verified_at_ms),
     });
     ToolResult::success(response.to_string())
 }
@@ -353,9 +390,13 @@ pub fn verify_cgr_proof_definition() -> ToolDefinition {
                     "type": "array",
                     "items": { "type": "string" },
                     "description": "List of invariant names that were checked in the proof."
+                },
+                "verified_at_ms": {
+                    "type": "integer",
+                    "description": "Caller-supplied nonzero HLC physical milliseconds for verification."
                 }
             },
-            "required": ["proof_hash", "invariants_checked"],
+            "required": ["proof_hash", "invariants_checked", "verified_at_ms"],
             "additionalProperties": false,
         }),
     }
@@ -381,6 +422,10 @@ pub fn execute_verify_cgr_proof(params: &Value, _context: &NodeContext) -> ToolR
             );
         }
     };
+    let verified_at_ms = match required_nonzero_u64(params, "verified_at_ms") {
+        Ok(value) => value,
+        Err(result) => return result,
+    };
 
     // Validate hex format.
     if hex::decode(proof_hash).is_err() {
@@ -395,8 +440,6 @@ pub fn execute_verify_cgr_proof(params: &Value, _context: &NodeContext) -> ToolR
         .map(String::from)
         .collect();
 
-    let now = Timestamp::now_utc();
-
     // Compute a verification hash to attest we checked this proof.
     let verification_input = format!("cgr_verify:{}:{}", proof_hash, invariant_names.join(","));
     let verification_hash = Hash256::digest(verification_input.as_bytes());
@@ -407,7 +450,7 @@ pub fn execute_verify_cgr_proof(params: &Value, _context: &NodeContext) -> ToolR
         "invariants_checked": invariant_names,
         "invariant_count": invariant_names.len(),
         "verification_hash": verification_hash.to_string(),
-        "verified_at": format!("{}:{}", now.physical_ms, now.logical),
+        "verified_at": format!("{}:0", verified_at_ms),
     });
     ToolResult::success(response.to_string())
 }
@@ -436,11 +479,13 @@ mod tests {
             "description": "Contract PDF",
             "evidence_type": "document",
             "source_did": "did:exo:alice",
+            "evidence_id": "00000000-0000-0000-0000-000000000001",
+            "created_at_ms": 1700000000000_u64,
         });
         let result = execute_create_evidence(&params, &NodeContext::empty());
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
-        assert!(v["evidence_id"].as_str().is_some());
+        assert_eq!(v["evidence_id"], "00000000-0000-0000-0000-000000000001");
         assert_eq!(v["evidence_type"], "document");
         assert_eq!(v["source_did"], "did:exo:alice");
         assert_eq!(v["status"], "created");
@@ -455,6 +500,8 @@ mod tests {
             "description": "test",
             "evidence_type": "document",
             "source_did": "bad",
+            "evidence_id": "00000000-0000-0000-0000-000000000001",
+            "created_at_ms": 1700000000000_u64,
         });
         let result = execute_create_evidence(&params, &NodeContext::empty());
         assert!(result.is_error);
@@ -463,9 +510,25 @@ mod tests {
     #[test]
     fn execute_create_evidence_missing_description() {
         let result = execute_create_evidence(
-            &json!({"evidence_type": "doc", "source_did": "did:exo:a"}),
+            &json!({
+                "evidence_type": "doc",
+                "source_did": "did:exo:a",
+                "evidence_id": "00000000-0000-0000-0000-000000000001",
+                "created_at_ms": 1700000000000_u64
+            }),
             &NodeContext::empty(),
         );
+        assert!(result.is_error);
+    }
+
+    #[test]
+    fn execute_create_evidence_rejects_missing_metadata() {
+        let params = json!({
+            "description": "Contract PDF",
+            "evidence_type": "document",
+            "source_did": "did:exo:alice",
+        });
+        let result = execute_create_evidence(&params, &NodeContext::empty());
         assert!(result.is_error);
     }
 
@@ -486,6 +549,7 @@ mod tests {
                 {"custodian": "did:exo:alice", "action": "created"},
                 {"custodian": "did:exo:bob", "action": "transferred"},
             ],
+            "verified_at_ms": 1700000000001_u64,
         });
         let result = execute_verify_chain_of_custody(&params, &NodeContext::empty());
         assert!(!result.is_error);
@@ -501,6 +565,7 @@ mod tests {
             "chain": [
                 {"custodian": "did:exo:alice", "action": "transferred"},
             ],
+            "verified_at_ms": 1700000000001_u64,
         });
         let result = execute_verify_chain_of_custody(&params, &NodeContext::empty());
         assert!(!result.is_error);
@@ -510,7 +575,8 @@ mod tests {
 
     #[test]
     fn execute_verify_chain_of_custody_empty() {
-        let params = json!({"evidence_id": "abc", "chain": []});
+        let params =
+            json!({"evidence_id": "abc", "chain": [], "verified_at_ms": 1700000000001_u64});
         let result = execute_verify_chain_of_custody(&params, &NodeContext::empty());
         assert!(result.is_error);
     }
@@ -567,6 +633,7 @@ mod tests {
         let params = json!({
             "proof_hash": "abcdef01",
             "invariants_checked": ["consent_required", "no_self_dealing"],
+            "verified_at_ms": 1700000000002_u64,
         });
         let result = execute_verify_cgr_proof(&params, &NodeContext::empty());
         assert!(!result.is_error);
@@ -578,15 +645,17 @@ mod tests {
 
     #[test]
     fn execute_verify_cgr_proof_invalid_hex() {
-        let params = json!({"proof_hash": "zzzz", "invariants_checked": []});
+        let params = json!({"proof_hash": "zzzz", "invariants_checked": [], "verified_at_ms": 1700000000002_u64});
         let result = execute_verify_cgr_proof(&params, &NodeContext::empty());
         assert!(result.is_error);
     }
 
     #[test]
     fn execute_verify_cgr_proof_missing_hash() {
-        let result =
-            execute_verify_cgr_proof(&json!({"invariants_checked": []}), &NodeContext::empty());
+        let result = execute_verify_cgr_proof(
+            &json!({"invariants_checked": [], "verified_at_ms": 1700000000002_u64}),
+            &NodeContext::empty(),
+        );
         assert!(result.is_error);
     }
 }

--- a/crates/exochain-wasm/src/legal_bindings.rs
+++ b/crates/exochain-wasm/src/legal_bindings.rs
@@ -10,12 +10,16 @@ pub fn wasm_create_evidence(
     content: &[u8],
     type_tag: &str,
     creator_did: &str,
+    evidence_id: &str,
+    created_ms: u64,
 ) -> Result<JsValue, JsValue> {
     let creator = exo_core::Did::new(creator_did)
         .map_err(|e| JsValue::from_str(&format!("DID error: {e}")))?;
-    let mut clock = exo_core::hlc::HybridClock::new();
-    let timestamp = clock.now();
-    let evidence = exo_legal::evidence::create_evidence(content, &creator, type_tag, timestamp)
+    let id: uuid::Uuid = evidence_id
+        .parse()
+        .map_err(|e| JsValue::from_str(&format!("UUID error: {e}")))?;
+    let timestamp = exo_core::Timestamp::new(created_ms, 0);
+    let evidence = exo_legal::evidence::create_evidence(id, content, &creator, type_tag, timestamp)
         .map_err(|e| JsValue::from_str(&format!("Evidence error: {e}")))?;
     to_js_value(&evidence)
 }
@@ -57,6 +61,7 @@ pub fn wasm_assert_privilege(
     privilege_type_json: &str,
     asserter_did: &str,
     basis: &str,
+    asserted_at_ms: u64,
 ) -> Result<JsValue, JsValue> {
     let id: uuid::Uuid = evidence_id
         .parse()
@@ -64,7 +69,10 @@ pub fn wasm_assert_privilege(
     let privilege_type: exo_legal::privilege::PrivilegeType = from_json_str(privilege_type_json)?;
     let asserter = exo_core::Did::new(asserter_did)
         .map_err(|e| JsValue::from_str(&format!("DID error: {e}")))?;
-    let assertion = exo_legal::privilege::assert_privilege(&id, privilege_type, &asserter, basis);
+    let asserted_at = exo_core::Timestamp::new(asserted_at_ms, 0);
+    let assertion =
+        exo_legal::privilege::assert_privilege(&id, privilege_type, &asserter, basis, asserted_at)
+            .map_err(|e| JsValue::from_str(&format!("Privilege error: {e}")))?;
     to_js_value(&assertion)
 }
 
@@ -74,11 +82,15 @@ pub fn wasm_challenge_privilege(
     assertion_json: &str,
     challenger_did: &str,
     grounds: &str,
+    challenged_at_ms: u64,
 ) -> Result<JsValue, JsValue> {
     let assertion: exo_legal::privilege::PrivilegeAssertion = from_json_str(assertion_json)?;
     let challenger = exo_core::Did::new(challenger_did)
         .map_err(|e| JsValue::from_str(&format!("DID error: {e}")))?;
-    let challenge = exo_legal::privilege::challenge_privilege(&assertion, &challenger, grounds);
+    let challenged_at = exo_core::Timestamp::new(challenged_at_ms, 0);
+    let challenge =
+        exo_legal::privilege::challenge_privilege(&assertion, &challenger, grounds, challenged_at)
+            .map_err(|e| JsValue::from_str(&format!("Privilege error: {e}")))?;
     to_js_value(&challenge)
 }
 
@@ -90,8 +102,16 @@ pub fn wasm_create_record(
     data: &[u8],
     classification: &str,
     retention_days: u64,
+    record_id: &str,
+    created_ms: u64,
 ) -> Result<JsValue, JsValue> {
-    let record = exo_legal::records::create_record(data, classification, retention_days);
+    let id: uuid::Uuid = record_id
+        .parse()
+        .map_err(|e| JsValue::from_str(&format!("UUID error: {e}")))?;
+    let created = exo_core::Timestamp::new(created_ms, 0);
+    let record =
+        exo_legal::records::create_record(id, data, classification, retention_days, created)
+            .map_err(|e| JsValue::from_str(&format!("Record error: {e}")))?;
     to_js_value(&record)
 }
 
@@ -117,6 +137,7 @@ pub fn wasm_apply_retention(
 /// Initiate a DGCL §144 safe harbor process for an interested-party transaction.
 #[wasm_bindgen]
 pub fn wasm_initiate_safe_harbor(
+    transaction_id: &str,
     interested_party_did: &str,
     counterparty_did: &str,
     interest_description: &str,
@@ -124,6 +145,9 @@ pub fn wasm_initiate_safe_harbor(
     path_json: &str,
     now_ms: u64,
 ) -> Result<JsValue, JsValue> {
+    let id: uuid::Uuid = transaction_id
+        .parse()
+        .map_err(|e| JsValue::from_str(&format!("UUID error: {e}")))?;
     let interested_party = exo_core::Did::new(interested_party_did)
         .map_err(|e| JsValue::from_str(&format!("DID error: {e}")))?;
     let counterparty = exo_core::Did::new(counterparty_did)
@@ -137,6 +161,7 @@ pub fn wasm_initiate_safe_harbor(
     let path: exo_legal::dgcl144::SafeHarborPath = from_json_str(path_json)?;
     let now = exo_core::types::Timestamp::new(now_ms, 0);
     let txn = exo_legal::dgcl144::initiate_safe_harbor(
+        id,
         &interested_party,
         &counterparty,
         interest_description,

--- a/crates/exochain-wasm/tests/wasm_bindings_test.rs
+++ b/crates/exochain-wasm/tests/wasm_bindings_test.rs
@@ -411,8 +411,14 @@ fn test_create_emergency_action_round_trip() {
 
 #[wasm_bindgen_test]
 fn test_create_record_active_disposition() {
-    let result = exochain_wasm::wasm_create_record(b"document contents", "Confidential", 365)
-        .expect("create_record");
+    let result = exochain_wasm::wasm_create_record(
+        b"document contents",
+        "Confidential",
+        365,
+        "00000000-0000-0000-0000-000000000365",
+        1_700_000_000_000,
+    )
+    .expect("create_record");
     let json = js_to_json(result);
     assert_eq!(json["retention_period_days"].as_u64().unwrap(), 365);
     assert_eq!(json["disposition"].as_str().unwrap(), "Active");

--- a/demo/packages/exochain-wasm/test.mjs
+++ b/demo/packages/exochain-wasm/test.mjs
@@ -253,7 +253,9 @@ test('create_evidence produces evidence object', () => {
   const evidence = wasm.wasm_create_evidence(
     new Uint8Array([10, 20, 30]),
     'document',
-    'did:exo:creator'
+    'did:exo:creator',
+    '00000000-0000-0000-0000-000000000010',
+    BigInt(1700000000000)
   );
   assert(evidence, 'should return evidence');
 });

--- a/demo/services/provenance-writer/src/index.js
+++ b/demo/services/provenance-writer/src/index.js
@@ -33,11 +33,16 @@ export const server = http.createServer(async (req, res) => {
 
     // ── Create Evidence ──
     if (url.pathname === '/api/evidence/create' && req.method === 'POST') {
-      const { content, type_tag, creator_did } = await parseBody(req);
+      const { content, type_tag, creator_did, evidence_id, created_ms } = await parseBody(req);
+      if (!evidence_id || created_ms === undefined || created_ms === null) {
+        return json(res, 400, { error: 'evidence_id and created_ms are required' });
+      }
       const evidence = wasm.wasm_create_evidence(
         new Uint8Array(Buffer.from(content || '')),
         type_tag || 'document',
-        creator_did
+        creator_did,
+        evidence_id,
+        BigInt(created_ms)
       );
       return json(res, 201, evidence);
     }

--- a/demo/services/provenance-writer/src/index.test.js
+++ b/demo/services/provenance-writer/src/index.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vites
 import supertest from 'supertest';
 
 const mockWasm = vi.hoisted(() => ({
-  wasm_create_evidence: vi.fn((_content, typeTag, creator) => ({ id: 'ev-001', type_tag: typeTag, creator_did: creator, content_hash: 'e'.repeat(64), chain_of_custody: [{ actor: creator, timestamp_ms: Date.now(), action: 'Created' }], created_at_ms: Date.now() })),
+  wasm_create_evidence: vi.fn((_content, typeTag, creator, id, createdMs) => ({ id, type_tag: typeTag, creator_did: creator, content_hash: 'e'.repeat(64), chain_of_custody: [{ actor: creator, timestamp_ms: Number(createdMs), action: 'Created' }], created_at_ms: Number(createdMs) })),
   wasm_verify_chain_of_custody: vi.fn((evidenceJson) => ({ valid: true, evidence: JSON.parse(evidenceJson), chain_length: JSON.parse(evidenceJson).chain_of_custody?.length || 0 })),
   wasm_check_fiduciary_duty: vi.fn((_duty, actionsJson) => ({ compliant: true, actions_reviewed: JSON.parse(actionsJson).length, violations: [] })),
   wasm_ediscovery_search: vi.fn((requestJson) => ({ query: JSON.parse(requestJson).query, results: [], result_count: 0, format: 'EDRM' })),
@@ -29,9 +29,9 @@ describe('GET /health', () => {
 
 describe('POST /api/evidence/create', () => {
   it('creates evidence entry with chain-of-custody', async () => {
-    const res = await request.post('/api/evidence/create').send({ content: 'doc', type_tag: 'document', creator_did: 'did:exo:alice' });
+    const res = await request.post('/api/evidence/create').send({ content: 'doc', type_tag: 'document', creator_did: 'did:exo:alice', evidence_id: '00000000-0000-0000-0000-000000000001', created_ms: 1700000000000 });
     expect(res.status).toBe(201);
-    expect(res.body).toHaveProperty('id', 'ev-001');
+    expect(res.body).toHaveProperty('id', '00000000-0000-0000-0000-000000000001');
     expect(res.body.type_tag).toBe('document');
     expect(res.body.creator_did).toBe('did:exo:alice');
     expect(res.body).toHaveProperty('content_hash');
@@ -39,9 +39,15 @@ describe('POST /api/evidence/create', () => {
   });
 
   it('defaults type_tag to document', async () => {
-    const res = await request.post('/api/evidence/create').send({ content: 'x', creator_did: 'did:exo:bob' });
+    const res = await request.post('/api/evidence/create').send({ content: 'x', creator_did: 'did:exo:bob', evidence_id: '00000000-0000-0000-0000-000000000002', created_ms: 1700000000001 });
     expect(res.status).toBe(201);
     expect(res.body.type_tag).toBe('document');
+  });
+
+  it('requires caller-supplied deterministic metadata', async () => {
+    const res = await request.post('/api/evidence/create').send({ content: 'x', creator_did: 'did:exo:bob' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('evidence_id');
   });
 });
 

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -8,7 +8,6 @@
  */
 
 import { createRequire } from 'node:module';
-import { randomUUID }    from 'node:crypto';
 const require = createRequire(import.meta.url);
 const wasm = require('../wasm/exochain_wasm.js');
 
@@ -42,6 +41,7 @@ function setup(fn) {
 
 // Convenience constants
 const ZERO_32_HEX   = '0'.repeat(64);
+const NONZERO_32_HEX = '11'.repeat(32);
 const ZERO_32_BYTES = Array.from({ length: 32 }, () => 0);
 const EVIDENCE_32_BYTES = Array.from({ length: 32 }, () => 0xee);
 const TEST_DID      = 'did:exo:test-actor';
@@ -54,8 +54,10 @@ const TEXT_BYTES     = new TextEncoder().encode('hello');
 const DUMMY_SECRET_HEX = 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
 const DUMMY_SECRET_HEX_2 = '1111111111111111111111111111111111111111111111111111111111111111';
 const DUMMY_SECRET_HEX_3 = '2222222222222222222222222222222222222222222222222222222222222222';
-const UUID_1 = randomUUID();
-const UUID_2 = randomUUID();
+const UUID_1 = '00000000-0000-0000-0000-000000000001';
+const UUID_2 = '00000000-0000-0000-0000-000000000002';
+const UUID_3 = '00000000-0000-0000-0000-000000000003';
+const UUID_4 = '00000000-0000-0000-0000-000000000004';
 
 // Pre-compute a valid Ed25519 keypair result for reuse
 const ephResult = wasm.wasm_sign_with_ephemeral_key(TEXT_BYTES);
@@ -264,10 +266,10 @@ test('wasm_death_verification_confirm', () => {
 console.log('\n--- Legal / Records / Evidence ---');
 
 test('wasm_create_record', () =>
-  wasm.wasm_create_record(TEXT_BYTES, 'Confidential', BigInt(365)));
+  wasm.wasm_create_record(TEXT_BYTES, 'Confidential', BigInt(365), UUID_1, NOW_MS));
 
 test('wasm_apply_retention', () => {
-  const rec = wasm.wasm_create_record(TEXT_BYTES, 'Confidential', BigInt(365));
+  const rec = wasm.wasm_create_record(TEXT_BYTES, 'Confidential', BigInt(365), UUID_2, NOW_MS);
   const policy = {
     default_retention_days: 365,
     rules: { Confidential: 365 }
@@ -280,24 +282,25 @@ test('wasm_apply_retention', () => {
 });
 
 test('wasm_create_evidence', () =>
-  wasm.wasm_create_evidence(TEXT_BYTES, 'Document', TEST_DID));
+  wasm.wasm_create_evidence(TEXT_BYTES, 'Document', TEST_DID, UUID_3, NOW_MS));
 
 const evidence = setup(() =>
-  wasm.wasm_create_evidence(TEXT_BYTES, 'Document', TEST_DID));
+  wasm.wasm_create_evidence(TEXT_BYTES, 'Document', TEST_DID, UUID_3, NOW_MS));
 
 test('wasm_verify_chain_of_custody', () => {
   if (!evidence) throw new Error('skipped -- no evidence from setup');
   return wasm.wasm_verify_chain_of_custody(JSON.stringify(evidence));
 });
 
-const evidenceId = (evidence && evidence.evidence_id) || UUID_1;
+const evidenceId = (evidence && evidence.id) || UUID_3;
 
 test('wasm_assert_privilege', () =>
   wasm.wasm_assert_privilege(
     evidenceId,
     JSON.stringify('AttorneyClient'),
     TEST_DID,
-    'Legal advice communication'
+    'Legal advice communication',
+    NOW_MS
   ));
 
 const assertion = setup(() =>
@@ -305,7 +308,8 @@ const assertion = setup(() =>
     evidenceId,
     JSON.stringify('AttorneyClient'),
     TEST_DID,
-    'Legal advice communication'
+    'Legal advice communication',
+    NOW_MS
   ));
 
 test('wasm_challenge_privilege', () => {
@@ -313,7 +317,8 @@ test('wasm_challenge_privilege', () => {
   return wasm.wasm_challenge_privilege(
     JSON.stringify(assertion),
     TEST_DID_2,
-    'Crime-fraud exception'
+    'Crime-fraud exception',
+    NOW_MS
   );
 });
 
@@ -356,20 +361,22 @@ console.log('\n--- Safe Harbor ---');
 
 test('wasm_initiate_safe_harbor', () =>
   wasm.wasm_initiate_safe_harbor(
+    UUID_4,
     TEST_DID,
     TEST_DID_2,
     'Board member is counterparty',
-    ZERO_32_HEX,
+    NONZERO_32_HEX,
     JSON.stringify('BoardApproval'),
     NOW_MS
   ));
 
 const shTxn = setup(() =>
   wasm.wasm_initiate_safe_harbor(
+    UUID_4,
     TEST_DID,
     TEST_DID_2,
     'Board member is counterparty',
-    ZERO_32_HEX,
+    NONZERO_32_HEX,
     JSON.stringify('BoardApproval'),
     NOW_MS
   ));


### PR DESCRIPTION
## Summary

- require caller-supplied IDs and HLC timestamps for externally meaningful exo-legal constructors
- reject nil IDs, zero timestamps, zero hashes, empty legal labels/reasons, and zero retention metadata
- propagate deterministic metadata requirements through WASM bindings, node MCP legal/proofs tools, JS bridge verification, and provenance-writer service tests

## TDD / Verification

- `cargo test -p exo-legal --lib`
- `cargo test -p exo-legal`
- `cargo test -p exochain-wasm --lib`
- `cargo test -p exochain-wasm`
- `cargo test -p exo-node mcp::tools::legal`
- `cargo test -p exo-node mcp::tools::proofs`
- `cargo test -p exo-node`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm --out-name exochain_wasm`
- `wasm-pack build crates/exochain-wasm --target nodejs --release --out-dir ../../demo/packages/exochain-wasm/wasm --out-name exochain_wasm`
- `node packages/exochain-wasm/test/bridge_verification.mjs` (116/116)
- `npm --prefix demo run test:services` (139 tests)
- `cargo +nightly fmt --all -- --check`
- `git diff --check`

## Note

`node demo/packages/exochain-wasm/test.mjs` still has unrelated pre-existing smoke failures around old WASM keypair/signing/invariant expectations; the updated legal `create_evidence` path passes in that smoke run.
