### PR TITLE
fix(exo-catapult): sign franchise receipts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,6 +1330,7 @@ dependencies = [
 name = "exo-catapult"
 version = "0.1.0-beta"
 dependencies = [
+ "ciborium",
  "exo-authority",
  "exo-consent",
  "exo-core",

--- a/crates/exo-catapult/Cargo.toml
+++ b/crates/exo-catapult/Cargo.toml
@@ -18,6 +18,7 @@ exo-consent = { path = "../exo-consent" }
 exo-authority = { path = "../exo-authority" }
 exo-tenant = { path = "../exo-tenant" }
 exo-escalation = { path = "../exo-escalation" }
+ciborium = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }

--- a/crates/exo-catapult/src/error.rs
+++ b/crates/exo-catapult/src/error.rs
@@ -38,6 +38,12 @@ pub enum CatapultError {
     FranchiseAlreadyExists(Uuid),
     #[error("newco already exists: {0}")]
     NewcoAlreadyExists(Uuid),
+    #[error("invalid franchise receipt: {reason}")]
+    InvalidReceipt { reason: String },
+    #[error("franchise receipt serialization failed: {reason}")]
+    ReceiptSerializationFailed { reason: String },
+    #[error("franchise receipt chain broken at index {index}")]
+    ReceiptChainBroken { index: usize },
 }
 
 /// Convenience alias for results with [`CatapultError`].
@@ -74,6 +80,13 @@ mod tests {
             CatapultError::DuplicateGoal(Uuid::nil()),
             CatapultError::FranchiseAlreadyExists(Uuid::nil()),
             CatapultError::NewcoAlreadyExists(Uuid::nil()),
+            CatapultError::InvalidReceipt {
+                reason: "bad receipt".into(),
+            },
+            CatapultError::ReceiptSerializationFailed {
+                reason: "bad cbor".into(),
+            },
+            CatapultError::ReceiptChainBroken { index: 3 },
         ];
         for e in &es {
             assert!(!e.to_string().is_empty());

--- a/crates/exo-catapult/src/lib.rs
+++ b/crates/exo-catapult/src/lib.rs
@@ -39,4 +39,4 @@ pub use heartbeat::{HeartbeatMonitor, HeartbeatRecord, HeartbeatStatus};
 pub use newco::{Newco, NewcoStatus};
 pub use oda::{MosCode, OdaSlot};
 pub use phase::OperationalPhase;
-pub use receipt::{FranchiseOperation, FranchiseReceipt};
+pub use receipt::{FranchiseOperation, FranchiseReceipt, FranchiseReceiptInput, ReceiptChain};

--- a/crates/exo-catapult/src/receipt.rs
+++ b/crates/exo-catapult/src/receipt.rs
@@ -3,11 +3,19 @@
 //! Every material Catapult operation produces a cryptographically chained
 //! receipt anchored in the ExoChain DAG for immutable provenance.
 
-use exo_core::{Did, Hash256, Signature, Timestamp};
+use exo_core::{Did, Hash256, PublicKey, SecretKey, Signature, Timestamp, crypto};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{oda::OdaSlot, phase::OperationalPhase};
+use crate::{
+    error::{CatapultError, Result},
+    oda::OdaSlot,
+    phase::OperationalPhase,
+};
+
+/// Domain tag for Catapult franchise receipt signatures.
+pub const FRANCHISE_RECEIPT_SIGNATURE_DOMAIN: &str = "exo.catapult.franchise_receipt.v1";
+const FRANCHISE_RECEIPT_SCHEMA_VERSION: &str = "1.0.0";
 
 /// A franchise operation that produces a trust receipt.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -72,47 +80,77 @@ pub struct FranchiseReceipt {
     pub signature: Signature,
 }
 
+/// Caller-supplied content for a signed franchise receipt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FranchiseReceiptInput {
+    pub id: Uuid,
+    pub newco_id: Uuid,
+    pub operation: FranchiseOperation,
+    pub actor_did: Did,
+    pub timestamp: Timestamp,
+    pub state_hash: Hash256,
+    pub prev_receipt: Hash256,
+}
+
 impl FranchiseReceipt {
-    /// Create a new receipt (unsigned — signature is `Empty` until signed).
-    #[must_use]
-    pub fn new(
-        newco_id: Uuid,
-        operation: FranchiseOperation,
-        actor_did: Did,
-        timestamp: Timestamp,
-        state_hash: Hash256,
-        prev_receipt: Hash256,
-    ) -> Self {
-        Self {
-            id: Uuid::new_v4(),
-            newco_id,
-            operation,
-            actor_did,
-            timestamp,
-            state_hash,
-            prev_receipt,
-            signature: Signature::empty(),
-        }
+    /// Create a signed receipt from caller-supplied deterministic metadata.
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] if the receipt contains placeholder metadata
+    /// or if canonical CBOR serialization fails.
+    pub fn signed(input: FranchiseReceiptInput, secret_key: &SecretKey) -> Result<Self> {
+        validate_receipt_input(&input)?;
+        let payload = franchise_receipt_signing_payload(&input)?;
+        Ok(Self {
+            id: input.id,
+            newco_id: input.newco_id,
+            operation: input.operation,
+            actor_did: input.actor_did,
+            timestamp: input.timestamp,
+            state_hash: input.state_hash,
+            prev_receipt: input.prev_receipt,
+            signature: crypto::sign(&payload, secret_key),
+        })
     }
 
     /// Compute the content hash of this receipt (excluding the signature).
-    #[must_use]
-    pub fn content_hash(&self) -> Hash256 {
-        // Serialize the content fields deterministically
-        let mut data = Vec::new();
-        data.extend_from_slice(self.id.as_bytes());
-        data.extend_from_slice(self.newco_id.as_bytes());
-        data.extend_from_slice(self.state_hash.as_bytes());
-        data.extend_from_slice(self.prev_receipt.as_bytes());
-        data.extend_from_slice(&self.timestamp.physical_ms.to_le_bytes());
-        data.extend_from_slice(&self.timestamp.logical.to_le_bytes());
-        Hash256::digest(&data)
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] if canonical CBOR hashing fails.
+    pub fn content_hash(&self) -> Result<Hash256> {
+        receipt_content_hash(&self.input())
     }
 
     /// Whether this receipt has been signed.
     #[must_use]
     pub fn is_signed(&self) -> bool {
         !self.signature.is_empty()
+    }
+
+    /// Verify this receipt's Ed25519 signature against the actor public key.
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] if canonical CBOR serialization fails.
+    pub fn verify_signature(&self, public_key: &PublicKey) -> Result<bool> {
+        if self.signature.is_empty() {
+            return Ok(false);
+        }
+        let input = self.input();
+        validate_receipt_input(&input)?;
+        let payload = franchise_receipt_signing_payload(&input)?;
+        Ok(crypto::verify(&payload, &self.signature, public_key))
+    }
+
+    fn input(&self) -> FranchiseReceiptInput {
+        FranchiseReceiptInput {
+            id: self.id,
+            newco_id: self.newco_id,
+            operation: self.operation.clone(),
+            actor_did: self.actor_did.clone(),
+            timestamp: self.timestamp,
+            state_hash: self.state_hash,
+            prev_receipt: self.prev_receipt,
+        }
     }
 }
 
@@ -131,18 +169,42 @@ impl ReceiptChain {
         }
     }
 
-    /// Append a receipt to the chain. The receipt's `prev_receipt` should
-    /// match the last receipt's content hash (or `Hash256::ZERO` for the first).
-    pub fn append(&mut self, receipt: FranchiseReceipt) {
+    /// Append a receipt after verifying its signature and hash-chain linkage.
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] if the signature is invalid or the previous
+    /// receipt hash does not match the current tip.
+    pub fn append(
+        &mut self,
+        receipt: FranchiseReceipt,
+        actor_public_key: &PublicKey,
+    ) -> Result<()> {
+        if !receipt.verify_signature(actor_public_key)? {
+            return Err(CatapultError::InvalidReceipt {
+                reason: format!(
+                    "receipt {} signature does not verify for actor {}",
+                    receipt.id, receipt.actor_did
+                ),
+            });
+        }
+        let expected_prev = self.tip_hash()?;
+        if receipt.prev_receipt != expected_prev {
+            return Err(CatapultError::ReceiptChainBroken {
+                index: self.receipts.len(),
+            });
+        }
         self.receipts.push(receipt);
+        Ok(())
     }
 
     /// The hash of the most recent receipt, or `Hash256::ZERO` if empty.
-    #[must_use]
-    pub fn tip_hash(&self) -> Hash256 {
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] if canonical CBOR hashing fails.
+    pub fn tip_hash(&self) -> Result<Hash256> {
         self.receipts
             .last()
-            .map_or(Hash256::ZERO, |r| r.content_hash())
+            .map_or(Ok(Hash256::ZERO), |r| r.content_hash())
     }
 
     /// Number of receipts in the chain.
@@ -158,21 +220,171 @@ impl ReceiptChain {
     }
 
     /// Verify the hash chain integrity.
-    #[must_use]
-    pub fn verify_chain(&self) -> bool {
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] if canonical CBOR hashing fails.
+    pub fn verify_chain(&self) -> Result<bool> {
         let mut expected_prev = Hash256::ZERO;
         for receipt in &self.receipts {
             if receipt.prev_receipt != expected_prev {
-                return false;
+                return Ok(false);
             }
-            expected_prev = receipt.content_hash();
+            expected_prev = receipt.content_hash()?;
         }
-        true
+        Ok(true)
     }
 
     /// Iterate over all receipts in order.
     pub fn iter(&self) -> impl Iterator<Item = &FranchiseReceipt> {
         self.receipts.iter()
+    }
+}
+
+/// Compute the canonical content hash for a receipt input.
+///
+/// # Errors
+/// Returns [`CatapultError`] if canonical CBOR hashing fails.
+pub fn receipt_content_hash(input: &FranchiseReceiptInput) -> Result<Hash256> {
+    validate_receipt_input(input)?;
+    exo_core::hash::hash_structured(&FranchiseReceiptHashPayload::from_input(input)).map_err(|e| {
+        CatapultError::ReceiptSerializationFailed {
+            reason: format!("franchise receipt hash CBOR serialization failed: {e}"),
+        }
+    })
+}
+
+/// Build the canonical CBOR signing payload for a franchise receipt.
+///
+/// # Errors
+/// Returns [`CatapultError`] if canonical CBOR serialization fails.
+pub fn franchise_receipt_signing_payload(input: &FranchiseReceiptInput) -> Result<Vec<u8>> {
+    validate_receipt_input(input)?;
+    let payload = FranchiseReceiptHashPayload::from_input(input);
+    let mut encoded = Vec::new();
+    ciborium::into_writer(&payload, &mut encoded).map_err(|e| {
+        CatapultError::ReceiptSerializationFailed {
+            reason: format!("franchise receipt signing payload CBOR serialization failed: {e}"),
+        }
+    })?;
+    Ok(encoded)
+}
+
+#[derive(Serialize)]
+struct FranchiseReceiptHashPayload<'a> {
+    domain: &'static str,
+    schema_version: &'static str,
+    id: Uuid,
+    newco_id: Uuid,
+    operation: &'a FranchiseOperation,
+    actor_did: &'a Did,
+    timestamp: Timestamp,
+    state_hash: Hash256,
+    prev_receipt: Hash256,
+}
+
+impl<'a> FranchiseReceiptHashPayload<'a> {
+    fn from_input(input: &'a FranchiseReceiptInput) -> Self {
+        Self {
+            domain: FRANCHISE_RECEIPT_SIGNATURE_DOMAIN,
+            schema_version: FRANCHISE_RECEIPT_SCHEMA_VERSION,
+            id: input.id,
+            newco_id: input.newco_id,
+            operation: &input.operation,
+            actor_did: &input.actor_did,
+            timestamp: input.timestamp,
+            state_hash: input.state_hash,
+            prev_receipt: input.prev_receipt,
+        }
+    }
+}
+
+fn validate_receipt_input(input: &FranchiseReceiptInput) -> Result<()> {
+    if input.id.is_nil() {
+        return Err(CatapultError::InvalidReceipt {
+            reason: "receipt id must be caller-supplied and non-nil".into(),
+        });
+    }
+    if input.newco_id.is_nil() {
+        return Err(CatapultError::InvalidReceipt {
+            reason: "receipt newco id must be non-nil".into(),
+        });
+    }
+    if input.timestamp == Timestamp::ZERO {
+        return Err(CatapultError::InvalidReceipt {
+            reason: "receipt timestamp must be caller-supplied HLC".into(),
+        });
+    }
+    if input.state_hash == Hash256::ZERO {
+        return Err(CatapultError::InvalidReceipt {
+            reason: "receipt state hash must not be zero".into(),
+        });
+    }
+    validate_operation(&input.operation)
+}
+
+fn validate_operation(operation: &FranchiseOperation) -> Result<()> {
+    let invalid_uuid = |name: &str| CatapultError::InvalidReceipt {
+        reason: format!("receipt operation {name} must be non-nil"),
+    };
+    match operation {
+        FranchiseOperation::BlueprintPublished { blueprint_id } if blueprint_id.is_nil() => {
+            Err(invalid_uuid("blueprint_id"))
+        }
+        FranchiseOperation::NewcoCreated { franchise_id } if franchise_id.is_nil() => {
+            Err(invalid_uuid("franchise_id"))
+        }
+        FranchiseOperation::BudgetPolicyUpdated { policy_id } if policy_id.is_nil() => {
+            Err(invalid_uuid("policy_id"))
+        }
+        FranchiseOperation::CostRecorded {
+            event_id,
+            amount_cents,
+        } => {
+            if event_id.is_nil() {
+                return Err(invalid_uuid("event_id"));
+            }
+            if *amount_cents == 0 {
+                return Err(CatapultError::InvalidReceipt {
+                    reason: "receipt cost amount must be greater than zero".into(),
+                });
+            }
+            Ok(())
+        }
+        FranchiseOperation::GoalCreated { goal_id }
+        | FranchiseOperation::GoalCompleted { goal_id }
+            if goal_id.is_nil() =>
+        {
+            Err(invalid_uuid("goal_id"))
+        }
+        FranchiseOperation::FranchiseReplicated {
+            source_newco_id,
+            target_newco_id,
+        } => {
+            if source_newco_id.is_nil() {
+                return Err(invalid_uuid("source_newco_id"));
+            }
+            if target_newco_id.is_nil() {
+                return Err(invalid_uuid("target_newco_id"));
+            }
+            if source_newco_id == target_newco_id {
+                return Err(CatapultError::InvalidReceipt {
+                    reason: "franchise replication source and target must differ".into(),
+                });
+            }
+            Ok(())
+        }
+        FranchiseOperation::PaceEscalation {
+            from_level,
+            to_level,
+        } => {
+            if from_level.trim().is_empty() || to_level.trim().is_empty() {
+                return Err(CatapultError::InvalidReceipt {
+                    reason: "PACE escalation levels must not be empty".into(),
+                });
+            }
+            Ok(())
+        }
+        _ => Ok(()),
     }
 }
 
@@ -184,87 +396,288 @@ mod tests {
         Did::new("did:exo:test-actor").unwrap()
     }
 
-    fn make_receipt(newco_id: Uuid, op: FranchiseOperation, prev: Hash256) -> FranchiseReceipt {
-        FranchiseReceipt::new(
+    fn uuid(value: u128) -> Uuid {
+        Uuid::from_u128(value)
+    }
+
+    fn ts(ms: u64) -> Timestamp {
+        Timestamp::new(ms, 0)
+    }
+
+    fn keypair(seed: u8) -> exo_core::crypto::KeyPair {
+        exo_core::crypto::KeyPair::from_secret_bytes([seed; 32]).unwrap()
+    }
+
+    fn receipt_input(
+        id: Uuid,
+        newco_id: Uuid,
+        op: FranchiseOperation,
+        prev: Hash256,
+    ) -> FranchiseReceiptInput {
+        FranchiseReceiptInput {
+            id,
             newco_id,
-            op,
-            test_did(),
-            Timestamp::ZERO,
-            Hash256::digest(b"state"),
-            prev,
-        )
+            operation: op,
+            actor_did: test_did(),
+            timestamp: ts(1000),
+            state_hash: Hash256::digest(b"state"),
+            prev_receipt: prev,
+        }
     }
 
     #[test]
-    fn receipt_creation() {
-        let r = make_receipt(
-            Uuid::nil(),
+    fn signed_receipt_verifies_with_actor_key() {
+        let signer = keypair(1);
+        let receipt = FranchiseReceipt::signed(
+            receipt_input(
+                uuid(1),
+                uuid(10),
+                FranchiseOperation::NewcoCreated {
+                    franchise_id: uuid(20),
+                },
+                Hash256::ZERO,
+            ),
+            signer.secret_key(),
+        )
+        .unwrap();
+
+        assert!(receipt.is_signed());
+        assert_ne!(receipt.content_hash().unwrap(), Hash256::ZERO);
+        assert!(receipt.verify_signature(signer.public_key()).unwrap());
+    }
+
+    #[test]
+    fn signed_receipt_rejects_wrong_key_and_tamper() {
+        let signer = keypair(2);
+        let wrong = keypair(3);
+        let mut receipt = FranchiseReceipt::signed(
+            receipt_input(
+                uuid(2),
+                uuid(10),
+                FranchiseOperation::AgentHired {
+                    slot: OdaSlot::HrPeopleOps1,
+                    agent_did: test_did(),
+                },
+                Hash256::ZERO,
+            ),
+            signer.secret_key(),
+        )
+        .unwrap();
+
+        assert!(!receipt.verify_signature(wrong.public_key()).unwrap());
+
+        receipt.operation = FranchiseOperation::AgentReleased {
+            slot: OdaSlot::HrPeopleOps1,
+            agent_did: test_did(),
+        };
+        assert!(!receipt.verify_signature(signer.public_key()).unwrap());
+    }
+
+    #[test]
+    fn receipt_content_hash_covers_actor_and_operation() {
+        let base = receipt_input(
+            uuid(3),
+            uuid(10),
             FranchiseOperation::NewcoCreated {
-                franchise_id: Uuid::nil(),
+                franchise_id: uuid(20),
             },
             Hash256::ZERO,
         );
-        assert!(!r.is_signed());
-        assert_ne!(r.content_hash(), Hash256::ZERO);
+        let actor_changed = FranchiseReceiptInput {
+            actor_did: Did::new("did:exo:other-actor").unwrap(),
+            ..base.clone()
+        };
+        let operation_changed = FranchiseReceiptInput {
+            operation: FranchiseOperation::GoalCompleted { goal_id: uuid(30) },
+            ..base.clone()
+        };
+
+        assert_ne!(
+            receipt_content_hash(&base).unwrap(),
+            receipt_content_hash(&actor_changed).unwrap()
+        );
+        assert_ne!(
+            receipt_content_hash(&base).unwrap(),
+            receipt_content_hash(&operation_changed).unwrap()
+        );
     }
 
     #[test]
-    fn chain_integrity() {
-        let newco_id = Uuid::new_v4();
+    fn receipt_rejects_placeholder_metadata() {
+        let signer = keypair(4);
+        assert!(
+            FranchiseReceipt::signed(
+                receipt_input(
+                    Uuid::nil(),
+                    uuid(10),
+                    FranchiseOperation::NewcoCreated {
+                        franchise_id: uuid(20),
+                    },
+                    Hash256::ZERO,
+                ),
+                signer.secret_key(),
+            )
+            .is_err()
+        );
+        assert!(
+            FranchiseReceipt::signed(
+                receipt_input(
+                    uuid(4),
+                    Uuid::nil(),
+                    FranchiseOperation::NewcoCreated {
+                        franchise_id: uuid(20),
+                    },
+                    Hash256::ZERO,
+                ),
+                signer.secret_key(),
+            )
+            .is_err()
+        );
+        assert!(
+            FranchiseReceipt::signed(
+                receipt_input(
+                    uuid(5),
+                    uuid(10),
+                    FranchiseOperation::NewcoCreated {
+                        franchise_id: Uuid::nil(),
+                    },
+                    Hash256::ZERO,
+                ),
+                signer.secret_key(),
+            )
+            .is_err()
+        );
+        let mut input = receipt_input(
+            uuid(6),
+            uuid(10),
+            FranchiseOperation::NewcoCreated {
+                franchise_id: uuid(20),
+            },
+            Hash256::ZERO,
+        );
+        input.timestamp = Timestamp::ZERO;
+        assert!(FranchiseReceipt::signed(input, signer.secret_key()).is_err());
+    }
+
+    #[test]
+    fn chain_append_requires_valid_signature_and_prev_hash() {
+        let signer = keypair(5);
+        let wrong = keypair(6);
+        let newco_id = uuid(10);
         let mut chain = ReceiptChain::new();
         assert!(chain.is_empty());
-        assert_eq!(chain.tip_hash(), Hash256::ZERO);
+        assert_eq!(chain.tip_hash().unwrap(), Hash256::ZERO);
 
-        let r1 = make_receipt(
-            newco_id,
-            FranchiseOperation::NewcoCreated {
-                franchise_id: Uuid::nil(),
-            },
-            Hash256::ZERO,
-        );
-        let r1_hash = r1.content_hash();
-        chain.append(r1);
+        let r1 = FranchiseReceipt::signed(
+            receipt_input(
+                uuid(7),
+                newco_id,
+                FranchiseOperation::NewcoCreated {
+                    franchise_id: uuid(20),
+                },
+                Hash256::ZERO,
+            ),
+            signer.secret_key(),
+        )
+        .unwrap();
+        let r1_hash = r1.content_hash().unwrap();
+        chain.append(r1, signer.public_key()).unwrap();
 
-        let r2 = make_receipt(
-            newco_id,
-            FranchiseOperation::AgentHired {
-                slot: OdaSlot::HrPeopleOps1,
-                agent_did: test_did(),
-            },
-            r1_hash,
-        );
-        chain.append(r2);
+        let r2 = FranchiseReceipt::signed(
+            receipt_input(
+                uuid(8),
+                newco_id,
+                FranchiseOperation::AgentHired {
+                    slot: OdaSlot::HrPeopleOps1,
+                    agent_did: test_did(),
+                },
+                r1_hash,
+            ),
+            signer.secret_key(),
+        )
+        .unwrap();
+        assert!(chain.append(r2.clone(), wrong.public_key()).is_err());
+        chain.append(r2, signer.public_key()).unwrap();
 
         assert_eq!(chain.len(), 2);
-        assert!(chain.verify_chain());
+        assert!(chain.verify_chain().unwrap());
     }
 
     #[test]
-    fn chain_broken() {
-        let newco_id = Uuid::new_v4();
+    fn chain_append_rejects_replayed_receipt() {
+        let signer = keypair(7);
+        let newco_id = uuid(10);
         let mut chain = ReceiptChain::new();
+        let r1 = FranchiseReceipt::signed(
+            receipt_input(
+                uuid(9),
+                newco_id,
+                FranchiseOperation::NewcoCreated {
+                    franchise_id: uuid(20),
+                },
+                Hash256::ZERO,
+            ),
+            signer.secret_key(),
+        )
+        .unwrap();
+        chain.append(r1.clone(), signer.public_key()).unwrap();
+        assert!(chain.append(r1, signer.public_key()).is_err());
+    }
 
-        let r1 = make_receipt(
-            newco_id,
+    #[test]
+    fn chain_verify_detects_broken_prev_hash() {
+        let signer = keypair(8);
+        let newco_id = uuid(10);
+        let mut chain = ReceiptChain::new();
+        let r1 = FranchiseReceipt::signed(
+            receipt_input(
+                uuid(11),
+                newco_id,
+                FranchiseOperation::NewcoCreated {
+                    franchise_id: uuid(20),
+                },
+                Hash256::ZERO,
+            ),
+            signer.secret_key(),
+        )
+        .unwrap();
+        let r2 = FranchiseReceipt::signed(
+            receipt_input(
+                uuid(12),
+                newco_id,
+                FranchiseOperation::PhaseTransition {
+                    from: OperationalPhase::Assessment,
+                    to: OperationalPhase::Selection,
+                },
+                Hash256::ZERO,
+            ),
+            signer.secret_key(),
+        )
+        .unwrap();
+        chain.receipts.push(r1);
+        chain.receipts.push(r2);
+
+        assert!(!chain.verify_chain().unwrap());
+    }
+
+    #[test]
+    fn signing_payload_is_domain_separated_and_deterministic() {
+        let input = receipt_input(
+            uuid(13),
+            uuid(10),
             FranchiseOperation::NewcoCreated {
-                franchise_id: Uuid::nil(),
+                franchise_id: uuid(20),
             },
             Hash256::ZERO,
         );
-        chain.append(r1);
-
-        // Wrong prev_receipt — should break chain
-        let r2 = make_receipt(
-            newco_id,
-            FranchiseOperation::PhaseTransition {
-                from: OperationalPhase::Assessment,
-                to: OperationalPhase::Selection,
-            },
-            Hash256::ZERO, // Wrong — should be r1's hash
+        let first = franchise_receipt_signing_payload(&input).unwrap();
+        let second = franchise_receipt_signing_payload(&input).unwrap();
+        assert_eq!(first, second);
+        assert!(
+            first
+                .windows(FRANCHISE_RECEIPT_SIGNATURE_DOMAIN.len())
+                .any(|window| window == FRANCHISE_RECEIPT_SIGNATURE_DOMAIN.as_bytes())
         );
-        chain.append(r2);
-
-        assert!(!chain.verify_chain());
     }
 
     #[test]

--- a/crates/exochain-wasm/src/catapult_bindings.rs
+++ b/crates/exochain-wasm/src/catapult_bindings.rs
@@ -323,31 +323,21 @@ pub fn wasm_goal_alignment_score(tree_json: &str) -> Result<u32, JsValue> {
 /// Generate a franchise trust receipt for an operation.
 #[wasm_bindgen]
 pub fn wasm_generate_franchise_receipt(
-    newco_id: &str,
-    operation_json: &str,
-    actor_did: &str,
+    _newco_id: &str,
+    _operation_json: &str,
+    _actor_did: &str,
 ) -> Result<JsValue, JsValue> {
-    let id: uuid::Uuid = newco_id
-        .parse()
-        .map_err(|e| JsValue::from_str(&format!("UUID error: {e}")))?;
-    let operation: exo_catapult::FranchiseOperation = from_json_str(operation_json)?;
-    let actor =
-        exo_core::Did::new(actor_did).map_err(|e| JsValue::from_str(&format!("DID error: {e}")))?;
-
-    let receipt = exo_catapult::FranchiseReceipt::new(
-        id,
-        operation,
-        actor,
-        exo_core::Timestamp::ZERO,
-        exo_core::Hash256::digest(b"state"),
-        exo_core::Hash256::ZERO,
-    );
-    to_js_value(&receipt)
+    Err(JsValue::from_str(
+        "wasm_generate_franchise_receipt requires a server-side Ed25519 signer \
+         and is disabled by default; see Initiatives/fix-scaffold-r1-catapult-receipt-signing.md",
+    ))
 }
 
 /// Verify a franchise receipt chain's integrity.
 #[wasm_bindgen]
 pub fn wasm_verify_franchise_receipt_chain(chain_json: &str) -> Result<bool, JsValue> {
     let chain: exo_catapult::receipt::ReceiptChain = from_json_str(chain_json)?;
-    Ok(chain.verify_chain())
+    chain
+        .verify_chain()
+        .map_err(|e| JsValue::from_str(&format!("Receipt chain verification error: {e}")))
 }


### PR DESCRIPTION
## Summary
- replace unsigned/random Catapult franchise receipt creation with caller-supplied signed receipt inputs
- hash and sign domain-separated canonical CBOR over full receipt content, including operation, actor DID, HLC timestamp, state hash, and previous receipt hash
- require receipt-chain append to verify Ed25519 signatures and previous-hash linkage
- make WASM receipt generation fail closed instead of emitting unsigned placeholder receipts

## TDD
- Red check: `cargo test -p exo-catapult receipt::tests::signed_receipt_verifies_with_actor_key --lib` failed before implementation because signed receipt construction, canonical payloads, content hashing, signature verification, and verified chain append did not exist

## Tests
- `cargo test -p exo-catapult receipt::tests --lib`
- `cargo test -p exo-catapult`
- `cargo test -p exochain-wasm`
- `cargo build -p exo-catapult`
- `cargo build -p exochain-wasm`
- `cargo clippy -p exo-catapult --lib -- -D warnings`
- `cargo clippy -p exo-catapult --tests -- -D warnings -A clippy::unwrap_used -A clippy::expect_used`
- `cargo clippy -p exochain-wasm --lib -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm --out-name exochain_wasm`
- `wasm-pack build crates/exochain-wasm --target nodejs --release --out-dir ../../demo/packages/exochain-wasm/wasm --out-name exochain_wasm`

## Tracking
- Added `Initiatives/fix-scaffold-r1-catapult-receipt-signing.md`
- Updated `_EXECUTION-LEDGER.md` with the Scaffold R1 acceptance checklist