### PR TITLE
fix(exo-catapult): require deterministic spawn metadata

### DIFF
--- a/crates/exo-catapult/src/error.rs
+++ b/crates/exo-catapult/src/error.rs
@@ -38,6 +38,10 @@ pub enum CatapultError {
     FranchiseAlreadyExists(Uuid),
     #[error("newco already exists: {0}")]
     NewcoAlreadyExists(Uuid),
+    #[error("invalid franchise blueprint: {reason}")]
+    InvalidFranchiseBlueprint { reason: String },
+    #[error("invalid newco: {reason}")]
+    InvalidNewco { reason: String },
     #[error("invalid franchise receipt: {reason}")]
     InvalidReceipt { reason: String },
     #[error("franchise receipt serialization failed: {reason}")]
@@ -80,6 +84,12 @@ mod tests {
             CatapultError::DuplicateGoal(Uuid::nil()),
             CatapultError::FranchiseAlreadyExists(Uuid::nil()),
             CatapultError::NewcoAlreadyExists(Uuid::nil()),
+            CatapultError::InvalidFranchiseBlueprint {
+                reason: "bad blueprint".into(),
+            },
+            CatapultError::InvalidNewco {
+                reason: "bad newco".into(),
+            },
             CatapultError::InvalidReceipt {
                 reason: "bad receipt".into(),
             },

--- a/crates/exo-catapult/src/franchise.rs
+++ b/crates/exo-catapult/src/franchise.rs
@@ -13,6 +13,10 @@ use crate::{
     oda::OdaSlot,
 };
 
+/// Domain tag for franchise blueprint content hashing.
+pub const FRANCHISE_BLUEPRINT_HASH_DOMAIN: &str = "exo.catapult.franchise_blueprint.v1";
+const FRANCHISE_BLUEPRINT_SCHEMA_VERSION: &str = "1.0.0";
+
 /// The business model classification for a franchise.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum BusinessModel {
@@ -49,6 +53,192 @@ pub struct FranchiseBlueprint {
     pub content_hash: Hash256,
 }
 
+/// Caller-supplied deterministic metadata for a franchise blueprint.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FranchiseBlueprintInput {
+    pub id: Uuid,
+    pub name: String,
+    pub version: Version,
+    pub description: String,
+    pub business_model: BusinessModel,
+    pub constitution_hash: Hash256,
+    pub required_slots: Vec<OdaSlot>,
+    pub budget_template: BudgetTemplate,
+    pub goal_template: GoalTemplate,
+    pub created: Timestamp,
+}
+
+impl FranchiseBlueprint {
+    /// Build a franchise blueprint from caller-supplied deterministic metadata.
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] if the blueprint contains placeholder metadata
+    /// or if canonical CBOR hashing fails.
+    pub fn new(input: FranchiseBlueprintInput) -> Result<Self> {
+        validate_blueprint_input(&input)?;
+        let content_hash = franchise_blueprint_content_hash(&input)?;
+        Ok(Self {
+            id: input.id,
+            name: input.name,
+            version: input.version,
+            description: input.description,
+            business_model: input.business_model,
+            constitution_hash: input.constitution_hash,
+            required_slots: input.required_slots,
+            budget_template: input.budget_template,
+            goal_template: input.goal_template,
+            created: input.created,
+            content_hash,
+        })
+    }
+
+    /// Recompute and compare this blueprint's canonical content hash.
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] if the blueprint metadata is invalid or if
+    /// canonical CBOR hashing fails.
+    pub fn verify_content_hash(&self) -> Result<bool> {
+        let expected = franchise_blueprint_content_hash(&self.input())?;
+        Ok(self.content_hash == expected)
+    }
+
+    fn validate(&self) -> Result<()> {
+        validate_blueprint_input(&self.input())?;
+        if self.content_hash == Hash256::ZERO {
+            return Err(CatapultError::InvalidFranchiseBlueprint {
+                reason: "blueprint content hash must not be zero".into(),
+            });
+        }
+        if !self.verify_content_hash()? {
+            return Err(CatapultError::InvalidFranchiseBlueprint {
+                reason: format!(
+                    "blueprint {} content hash does not match canonical payload",
+                    self.id
+                ),
+            });
+        }
+        Ok(())
+    }
+
+    fn input(&self) -> FranchiseBlueprintInput {
+        FranchiseBlueprintInput {
+            id: self.id,
+            name: self.name.clone(),
+            version: self.version,
+            description: self.description.clone(),
+            business_model: self.business_model.clone(),
+            constitution_hash: self.constitution_hash,
+            required_slots: self.required_slots.clone(),
+            budget_template: self.budget_template.clone(),
+            goal_template: self.goal_template.clone(),
+            created: self.created,
+        }
+    }
+}
+
+/// Compute the canonical content hash for a franchise blueprint input.
+///
+/// # Errors
+/// Returns [`CatapultError`] if the input is invalid or canonical CBOR hashing
+/// fails.
+pub fn franchise_blueprint_content_hash(input: &FranchiseBlueprintInput) -> Result<Hash256> {
+    validate_blueprint_input(input)?;
+    exo_core::hash::hash_structured(&FranchiseBlueprintHashPayload::from_input(input)).map_err(
+        |e| CatapultError::InvalidFranchiseBlueprint {
+            reason: format!("blueprint hash CBOR serialization failed: {e}"),
+        },
+    )
+}
+
+#[derive(Serialize)]
+struct FranchiseBlueprintHashPayload<'a> {
+    domain: &'static str,
+    schema_version: &'static str,
+    id: Uuid,
+    name: &'a str,
+    version: Version,
+    description: &'a str,
+    business_model: &'a BusinessModel,
+    constitution_hash: Hash256,
+    required_slots: &'a [OdaSlot],
+    budget_template: &'a BudgetTemplate,
+    goal_template: &'a GoalTemplate,
+    created: Timestamp,
+}
+
+impl<'a> FranchiseBlueprintHashPayload<'a> {
+    fn from_input(input: &'a FranchiseBlueprintInput) -> Self {
+        Self {
+            domain: FRANCHISE_BLUEPRINT_HASH_DOMAIN,
+            schema_version: FRANCHISE_BLUEPRINT_SCHEMA_VERSION,
+            id: input.id,
+            name: &input.name,
+            version: input.version,
+            description: &input.description,
+            business_model: &input.business_model,
+            constitution_hash: input.constitution_hash,
+            required_slots: &input.required_slots,
+            budget_template: &input.budget_template,
+            goal_template: &input.goal_template,
+            created: input.created,
+        }
+    }
+}
+
+fn validate_blueprint_input(input: &FranchiseBlueprintInput) -> Result<()> {
+    if input.id.is_nil() {
+        return Err(CatapultError::InvalidFranchiseBlueprint {
+            reason: "blueprint id must be caller-supplied and non-nil".into(),
+        });
+    }
+    if input.name.trim().is_empty() {
+        return Err(CatapultError::InvalidFranchiseBlueprint {
+            reason: "blueprint name must not be empty".into(),
+        });
+    }
+    if input.version == Version::ZERO {
+        return Err(CatapultError::InvalidFranchiseBlueprint {
+            reason: "blueprint version must be greater than zero".into(),
+        });
+    }
+    if input.description.trim().is_empty() {
+        return Err(CatapultError::InvalidFranchiseBlueprint {
+            reason: "blueprint description must not be empty".into(),
+        });
+    }
+    if let BusinessModel::Custom { description } = &input.business_model
+        && description.trim().is_empty()
+    {
+        return Err(CatapultError::InvalidFranchiseBlueprint {
+            reason: "custom business-model description must not be empty".into(),
+        });
+    }
+    if input.constitution_hash == Hash256::ZERO {
+        return Err(CatapultError::InvalidFranchiseBlueprint {
+            reason: "blueprint constitution hash must not be zero".into(),
+        });
+    }
+    if input.required_slots.is_empty() {
+        return Err(CatapultError::InvalidFranchiseBlueprint {
+            reason: "blueprint required slots must not be empty".into(),
+        });
+    }
+    let mut canonical_slots = input.required_slots.clone();
+    canonical_slots.sort();
+    canonical_slots.dedup();
+    if canonical_slots != input.required_slots {
+        return Err(CatapultError::InvalidFranchiseBlueprint {
+            reason: "blueprint required slots must be sorted and unique".into(),
+        });
+    }
+    if input.created == Timestamp::ZERO {
+        return Err(CatapultError::InvalidFranchiseBlueprint {
+            reason: "blueprint created timestamp must be caller-supplied HLC".into(),
+        });
+    }
+    Ok(())
+}
+
 /// In-memory registry of published franchise blueprints.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct FranchiseRegistry {
@@ -66,6 +256,7 @@ impl FranchiseRegistry {
 
     /// Publish a new franchise blueprint.
     pub fn publish(&mut self, blueprint: FranchiseBlueprint) -> Result<Uuid> {
+        blueprint.validate()?;
         let id = blueprint.id;
         if self.blueprints.contains_key(&id) {
             return Err(CatapultError::FranchiseAlreadyExists(id));
@@ -104,20 +295,90 @@ mod tests {
     use super::*;
     use crate::{budget::BudgetTemplate, goal::GoalTemplate};
 
-    fn test_blueprint() -> FranchiseBlueprint {
-        FranchiseBlueprint {
-            id: Uuid::new_v4(),
+    fn test_uuid(byte: u8) -> Uuid {
+        Uuid::from_bytes([byte; 16])
+    }
+
+    fn test_hash(label: &str) -> Hash256 {
+        Hash256::digest(label.as_bytes())
+    }
+
+    fn test_timestamp() -> Timestamp {
+        Timestamp {
+            physical_ms: 1_765_000_000_000,
+            logical: 7,
+        }
+    }
+
+    fn test_blueprint_input() -> FranchiseBlueprintInput {
+        FranchiseBlueprintInput {
+            id: test_uuid(1),
             name: "Test SaaS Franchise".into(),
             version: Version::ZERO.next(),
-            description: "A test SaaS franchise blueprint".into(),
+            description: "A governed SaaS franchise blueprint".into(),
             business_model: BusinessModel::SaaS,
-            constitution_hash: Hash256::ZERO,
+            constitution_hash: test_hash("constitution"),
             required_slots: OdaSlot::ALL.to_vec(),
             budget_template: BudgetTemplate::default(),
             goal_template: GoalTemplate::default(),
-            created: Timestamp::ZERO,
-            content_hash: Hash256::ZERO,
+            created: test_timestamp(),
         }
+    }
+
+    fn test_blueprint() -> FranchiseBlueprint {
+        FranchiseBlueprint::new(test_blueprint_input()).unwrap()
+    }
+
+    #[test]
+    fn blueprint_new_computes_and_verifies_canonical_hash() {
+        let blueprint = FranchiseBlueprint::new(test_blueprint_input()).unwrap();
+
+        assert_ne!(blueprint.content_hash, Hash256::ZERO);
+        assert!(blueprint.verify_content_hash().unwrap());
+
+        let same = FranchiseBlueprint::new(test_blueprint_input()).unwrap();
+        assert_eq!(blueprint.content_hash, same.content_hash);
+
+        let mut changed = test_blueprint_input();
+        changed.required_slots = vec![OdaSlot::HrPeopleOps1];
+        let changed = FranchiseBlueprint::new(changed).unwrap();
+        assert_ne!(blueprint.content_hash, changed.content_hash);
+    }
+
+    #[test]
+    fn blueprint_rejects_placeholder_metadata() {
+        let mut input = test_blueprint_input();
+        input.id = Uuid::nil();
+        assert!(FranchiseBlueprint::new(input).is_err());
+
+        let mut input = test_blueprint_input();
+        input.name = "   ".into();
+        assert!(FranchiseBlueprint::new(input).is_err());
+
+        let mut input = test_blueprint_input();
+        input.version = Version::ZERO;
+        assert!(FranchiseBlueprint::new(input).is_err());
+
+        let mut input = test_blueprint_input();
+        input.constitution_hash = Hash256::ZERO;
+        assert!(FranchiseBlueprint::new(input).is_err());
+
+        let mut input = test_blueprint_input();
+        input.created = Timestamp::ZERO;
+        assert!(FranchiseBlueprint::new(input).is_err());
+    }
+
+    #[test]
+    fn publish_rejects_tampered_or_placeholder_blueprint_hash() {
+        let mut reg = FranchiseRegistry::new();
+        let mut blueprint = test_blueprint();
+        blueprint.content_hash = test_hash("tampered");
+
+        assert!(reg.publish(blueprint).is_err());
+
+        let mut blueprint = test_blueprint();
+        blueprint.id = Uuid::nil();
+        assert!(reg.publish(blueprint).is_err());
     }
 
     #[test]
@@ -143,7 +404,10 @@ mod tests {
     fn list() {
         let mut reg = FranchiseRegistry::new();
         reg.publish(test_blueprint()).unwrap();
-        reg.publish(test_blueprint()).unwrap();
+        let mut second = test_blueprint_input();
+        second.id = test_uuid(2);
+        reg.publish(FranchiseBlueprint::new(second).unwrap())
+            .unwrap();
         assert_eq!(reg.list().len(), 2);
     }
 

--- a/crates/exo-catapult/src/integration.rs
+++ b/crates/exo-catapult/src/integration.rs
@@ -125,21 +125,30 @@ mod tests {
     use exo_core::{Hash256, Timestamp};
 
     use super::*;
-    use crate::agent::{AgentStatus, CatapultAgent};
+    use crate::{
+        agent::{AgentStatus, CatapultAgent},
+        newco::NewcoInput,
+    };
 
     fn test_did(name: &str) -> Did {
         Did::new(&format!("did:exo:test-{name}")).unwrap()
     }
 
     fn make_newco() -> Newco {
-        Newco::new(
-            "Test Co".into(),
-            Uuid::new_v4(),
-            Uuid::new_v4(),
-            Hash256::ZERO,
-            test_did("root"),
-            Timestamp::ZERO,
-        )
+        Newco::new(NewcoInput {
+            id: Uuid::from_bytes([1; 16]),
+            name: "Test Co".into(),
+            franchise_id: Uuid::from_bytes([2; 16]),
+            tenant_id: Uuid::from_bytes([3; 16]),
+            constitution_hash: Hash256::digest(b"constitution"),
+            authority_chain_root: test_did("root"),
+            dag_anchor: Hash256::digest(b"dag-anchor"),
+            created: Timestamp {
+                physical_ms: 1_765_000_000_000,
+                logical: 1,
+            },
+        })
+        .unwrap()
     }
 
     fn make_agent(slot: OdaSlot, name: &str) -> CatapultAgent {

--- a/crates/exo-catapult/src/lib.rs
+++ b/crates/exo-catapult/src/lib.rs
@@ -33,10 +33,12 @@ pub mod receipt;
 pub use agent::{AgentRoster, AgentStatus, CatapultAgent};
 pub use budget::{BudgetLedger, BudgetPolicy, BudgetScope, BudgetVerdict, CostEvent};
 pub use error::{CatapultError, Result};
-pub use franchise::{BusinessModel, FranchiseBlueprint, FranchiseRegistry};
+pub use franchise::{
+    BusinessModel, FranchiseBlueprint, FranchiseBlueprintInput, FranchiseRegistry,
+};
 pub use goal::{Goal, GoalLevel, GoalStatus, GoalTree};
 pub use heartbeat::{HeartbeatMonitor, HeartbeatRecord, HeartbeatStatus};
-pub use newco::{Newco, NewcoStatus};
+pub use newco::{Newco, NewcoInput, NewcoStatus};
 pub use oda::{MosCode, OdaSlot};
 pub use phase::OperationalPhase;
 pub use receipt::{FranchiseOperation, FranchiseReceipt, FranchiseReceiptInput, ReceiptChain};

--- a/crates/exo-catapult/src/newco.rs
+++ b/crates/exo-catapult/src/newco.rs
@@ -60,33 +60,71 @@ pub struct Newco {
     pub status: NewcoStatus,
 }
 
+/// Caller-supplied deterministic metadata for creating a newco.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NewcoInput {
+    pub id: Uuid,
+    pub name: String,
+    pub franchise_id: Uuid,
+    pub tenant_id: Uuid,
+    pub constitution_hash: Hash256,
+    pub authority_chain_root: Did,
+    pub dag_anchor: Hash256,
+    pub created: Timestamp,
+}
+
 impl Newco {
     /// Create a new newco in Assessment phase.
-    #[must_use]
-    pub fn new(
-        name: String,
-        franchise_id: Uuid,
-        tenant_id: Uuid,
-        constitution_hash: Hash256,
-        authority_chain_root: Did,
-        created: Timestamp,
-    ) -> Self {
-        Self {
-            id: Uuid::new_v4(),
-            name,
-            franchise_id,
-            tenant_id,
-            constitution_hash,
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] if the input contains placeholder metadata.
+    pub fn new(input: NewcoInput) -> Result<Self> {
+        validate_newco_input(&input)?;
+        Ok(Self {
+            id: input.id,
+            name: input.name,
+            franchise_id: input.franchise_id,
+            tenant_id: input.tenant_id,
+            constitution_hash: input.constitution_hash,
             phase: OperationalPhase::Assessment,
             roster: AgentRoster::new(),
             budget: BudgetLedger::new(),
             goals: GoalTree::new(),
-            authority_chain_root,
-            dag_anchor: Hash256::ZERO,
-            created,
-            last_heartbeat: created,
+            authority_chain_root: input.authority_chain_root,
+            dag_anchor: input.dag_anchor,
+            created: input.created,
+            last_heartbeat: input.created,
             status: NewcoStatus::Provisioning,
+        })
+    }
+
+    /// Validate externally supplied or deserialized newco metadata.
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] when the newco contains placeholder identity,
+    /// timestamp, or provenance metadata.
+    pub fn validate(&self) -> Result<()> {
+        validate_newco_input(&NewcoInput {
+            id: self.id,
+            name: self.name.clone(),
+            franchise_id: self.franchise_id,
+            tenant_id: self.tenant_id,
+            constitution_hash: self.constitution_hash,
+            authority_chain_root: self.authority_chain_root.clone(),
+            dag_anchor: self.dag_anchor,
+            created: self.created,
+        })?;
+        if self.last_heartbeat == Timestamp::ZERO {
+            return Err(CatapultError::InvalidNewco {
+                reason: "newco last heartbeat must not be zero".into(),
+            });
         }
+        if self.last_heartbeat < self.created {
+            return Err(CatapultError::InvalidNewco {
+                reason: "newco last heartbeat must not precede creation timestamp".into(),
+            });
+        }
+        Ok(())
     }
 
     /// Advance to the next operational phase.
@@ -184,6 +222,7 @@ impl NewcoRegistry {
 
     /// Register a new newco.
     pub fn register(&mut self, newco: Newco) -> Result<Uuid> {
+        newco.validate()?;
         let id = newco.id;
         if self.newcos.contains_key(&id) {
             return Err(CatapultError::NewcoAlreadyExists(id));
@@ -236,24 +275,137 @@ impl NewcoRegistry {
     }
 }
 
+fn validate_newco_input(input: &NewcoInput) -> Result<()> {
+    if input.id.is_nil() {
+        return Err(CatapultError::InvalidNewco {
+            reason: "newco id must be caller-supplied and non-nil".into(),
+        });
+    }
+    if input.name.trim().is_empty() {
+        return Err(CatapultError::InvalidNewco {
+            reason: "newco name must not be empty".into(),
+        });
+    }
+    if input.franchise_id.is_nil() {
+        return Err(CatapultError::InvalidNewco {
+            reason: "newco franchise id must be non-nil".into(),
+        });
+    }
+    if input.tenant_id.is_nil() {
+        return Err(CatapultError::InvalidNewco {
+            reason: "newco tenant id must be non-nil".into(),
+        });
+    }
+    if input.constitution_hash == Hash256::ZERO {
+        return Err(CatapultError::InvalidNewco {
+            reason: "newco constitution hash must not be zero".into(),
+        });
+    }
+    if input.dag_anchor == Hash256::ZERO {
+        return Err(CatapultError::InvalidNewco {
+            reason: "newco DAG anchor must not be zero".into(),
+        });
+    }
+    if input.created == Timestamp::ZERO {
+        return Err(CatapultError::InvalidNewco {
+            reason: "newco created timestamp must be caller-supplied HLC".into(),
+        });
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::agent::AgentStatus;
 
+    fn test_uuid(byte: u8) -> Uuid {
+        Uuid::from_bytes([byte; 16])
+    }
+
+    fn test_hash(label: &str) -> Hash256 {
+        Hash256::digest(label.as_bytes())
+    }
+
+    fn test_timestamp() -> Timestamp {
+        Timestamp {
+            physical_ms: 1_765_000_000_000,
+            logical: 4,
+        }
+    }
+
     fn test_did() -> Did {
         Did::new("did:exo:test-root").unwrap()
     }
 
+    fn test_newco_input() -> NewcoInput {
+        NewcoInput {
+            id: test_uuid(1),
+            name: "Test Co".into(),
+            franchise_id: test_uuid(2),
+            tenant_id: test_uuid(3),
+            constitution_hash: test_hash("constitution"),
+            authority_chain_root: test_did(),
+            dag_anchor: test_hash("dag-anchor"),
+            created: test_timestamp(),
+        }
+    }
+
     fn make_newco() -> Newco {
-        Newco::new(
-            "Test Co".into(),
-            Uuid::new_v4(),
-            Uuid::new_v4(),
-            Hash256::ZERO,
-            test_did(),
-            Timestamp::ZERO,
-        )
+        Newco::new(test_newco_input()).unwrap()
+    }
+
+    #[test]
+    fn newco_new_requires_caller_supplied_identity_and_provenance() {
+        let newco = Newco::new(test_newco_input()).unwrap();
+
+        assert_eq!(newco.id, test_uuid(1));
+        assert_eq!(newco.franchise_id, test_uuid(2));
+        assert_eq!(newco.tenant_id, test_uuid(3));
+        assert_ne!(newco.constitution_hash, Hash256::ZERO);
+        assert_ne!(newco.dag_anchor, Hash256::ZERO);
+        assert_ne!(newco.created, Timestamp::ZERO);
+        assert_eq!(newco.last_heartbeat, newco.created);
+    }
+
+    #[test]
+    fn newco_rejects_placeholder_metadata() {
+        let mut input = test_newco_input();
+        input.id = Uuid::nil();
+        assert!(Newco::new(input).is_err());
+
+        let mut input = test_newco_input();
+        input.name = " ".into();
+        assert!(Newco::new(input).is_err());
+
+        let mut input = test_newco_input();
+        input.franchise_id = Uuid::nil();
+        assert!(Newco::new(input).is_err());
+
+        let mut input = test_newco_input();
+        input.tenant_id = Uuid::nil();
+        assert!(Newco::new(input).is_err());
+
+        let mut input = test_newco_input();
+        input.constitution_hash = Hash256::ZERO;
+        assert!(Newco::new(input).is_err());
+
+        let mut input = test_newco_input();
+        input.dag_anchor = Hash256::ZERO;
+        assert!(Newco::new(input).is_err());
+
+        let mut input = test_newco_input();
+        input.created = Timestamp::ZERO;
+        assert!(Newco::new(input).is_err());
+    }
+
+    #[test]
+    fn registry_register_rejects_direct_placeholder_newco() {
+        let mut reg = NewcoRegistry::new();
+        let mut newco = make_newco();
+        newco.dag_anchor = Hash256::ZERO;
+
+        assert!(reg.register(newco).is_err());
     }
 
     fn make_agent(slot: OdaSlot) -> CatapultAgent {

--- a/crates/exochain-wasm/src/catapult_bindings.rs
+++ b/crates/exochain-wasm/src/catapult_bindings.rs
@@ -4,6 +4,61 @@ use wasm_bindgen::prelude::*;
 
 use crate::serde_bridge::*;
 
+fn parse_uuid(value: &str, label: &str) -> Result<uuid::Uuid, JsValue> {
+    let id: uuid::Uuid = value
+        .parse()
+        .map_err(|e| JsValue::from_str(&format!("{label} UUID error: {e}")))?;
+    if id.is_nil() {
+        return Err(JsValue::from_str(&format!(
+            "{label} UUID must be caller-supplied and non-nil"
+        )));
+    }
+    Ok(id)
+}
+
+fn parse_hash_hex(value: &str, label: &str) -> Result<exo_core::Hash256, JsValue> {
+    let hash_bytes =
+        hex::decode(value).map_err(|e| JsValue::from_str(&format!("{label} hex: {e}")))?;
+    let hash_arr: [u8; 32] = hash_bytes
+        .try_into()
+        .map_err(|_| JsValue::from_str(&format!("{label} hash must be 32 bytes")))?;
+    let hash = exo_core::Hash256::from_bytes(hash_arr);
+    if hash.as_bytes().iter().all(|byte| *byte == 0) {
+        return Err(JsValue::from_str(&format!(
+            "{label} hash must be caller-supplied and nonzero"
+        )));
+    }
+    Ok(hash)
+}
+
+fn parse_timestamp(
+    physical_ms: u64,
+    logical: u32,
+    label: &str,
+) -> Result<exo_core::Timestamp, JsValue> {
+    if physical_ms == 0 && logical == 0 {
+        return Err(JsValue::from_str(&format!(
+            "{label} timestamp must be caller-supplied HLC"
+        )));
+    }
+    Ok(exo_core::Timestamp {
+        physical_ms,
+        logical,
+    })
+}
+
+#[derive(serde::Deserialize)]
+struct WasmNewcoInstantiationInput {
+    name: String,
+    newco_id: String,
+    tenant_id: String,
+    dag_anchor_hex: String,
+    created_physical_ms: u64,
+    created_logical: u32,
+    hr_did: String,
+    researcher_did: String,
+}
+
 // ---------------------------------------------------------------------------
 // Franchise Blueprints
 // ---------------------------------------------------------------------------
@@ -14,28 +69,26 @@ pub fn wasm_create_franchise_blueprint(
     name: &str,
     business_model_json: &str,
     constitution_hash_hex: &str,
+    blueprint_id: &str,
+    description: &str,
+    created_physical_ms: u64,
+    created_logical: u32,
 ) -> Result<JsValue, JsValue> {
     let business_model: exo_catapult::BusinessModel = from_json_str(business_model_json)?;
-    let hash_bytes =
-        hex::decode(constitution_hash_hex).map_err(|e| JsValue::from_str(&format!("hex: {e}")))?;
-    let hash_arr: [u8; 32] = hash_bytes
-        .try_into()
-        .map_err(|_| JsValue::from_str("constitution hash must be 32 bytes"))?;
-    let constitution_hash = exo_core::Hash256::from_bytes(hash_arr);
-
-    let blueprint = exo_catapult::FranchiseBlueprint {
-        id: uuid::Uuid::new_v4(),
+    let constitution_hash = parse_hash_hex(constitution_hash_hex, "constitution")?;
+    let blueprint = exo_catapult::FranchiseBlueprint::new(exo_catapult::FranchiseBlueprintInput {
+        id: parse_uuid(blueprint_id, "blueprint")?,
         name: name.to_owned(),
         version: exo_core::Version::ZERO.next(),
-        description: String::new(),
+        description: description.to_owned(),
         business_model,
         constitution_hash,
         required_slots: exo_catapult::OdaSlot::ALL.to_vec(),
         budget_template: exo_catapult::budget::BudgetTemplate::default(),
         goal_template: exo_catapult::goal::GoalTemplate::default(),
-        created: exo_core::Timestamp::ZERO,
-        content_hash: exo_core::Hash256::ZERO,
-    };
+        created: parse_timestamp(created_physical_ms, created_logical, "blueprint created")?,
+    })
+    .map_err(|e| JsValue::from_str(&format!("Blueprint error: {e}")))?;
     to_js_value(&blueprint)
 }
 
@@ -53,26 +106,38 @@ pub fn wasm_list_franchise_blueprints(registry_json: &str) -> Result<JsValue, Js
 
 /// Instantiate a new company from a franchise blueprint with founding agents.
 #[wasm_bindgen]
-pub fn wasm_instantiate_newco(
-    blueprint_json: &str,
-    name: &str,
-    hr_did: &str,
-    researcher_did: &str,
-) -> Result<JsValue, JsValue> {
+pub fn wasm_instantiate_newco(blueprint_json: &str, input_json: &str) -> Result<JsValue, JsValue> {
     let blueprint: exo_catapult::FranchiseBlueprint = from_json_str(blueprint_json)?;
-    let hr =
-        exo_core::Did::new(hr_did).map_err(|e| JsValue::from_str(&format!("HR DID error: {e}")))?;
-    let researcher = exo_core::Did::new(researcher_did)
+    let input: WasmNewcoInstantiationInput = from_json_str(input_json)?;
+    if !blueprint
+        .verify_content_hash()
+        .map_err(|e| JsValue::from_str(&format!("Blueprint verification error: {e}")))?
+    {
+        return Err(JsValue::from_str(
+            "Blueprint content hash does not match canonical payload",
+        ));
+    }
+    let hr = exo_core::Did::new(&input.hr_did)
+        .map_err(|e| JsValue::from_str(&format!("HR DID error: {e}")))?;
+    let researcher = exo_core::Did::new(&input.researcher_did)
         .map_err(|e| JsValue::from_str(&format!("Researcher DID error: {e}")))?;
+    let created = parse_timestamp(
+        input.created_physical_ms,
+        input.created_logical,
+        "newco created",
+    )?;
 
-    let mut newco = exo_catapult::newco::Newco::new(
-        name.to_owned(),
-        blueprint.id,
-        uuid::Uuid::new_v4(),
-        blueprint.constitution_hash,
-        hr.clone(),
-        exo_core::Timestamp::ZERO,
-    );
+    let mut newco = exo_catapult::newco::Newco::new(exo_catapult::newco::NewcoInput {
+        id: parse_uuid(&input.newco_id, "newco")?,
+        name: input.name,
+        franchise_id: blueprint.id,
+        tenant_id: parse_uuid(&input.tenant_id, "tenant")?,
+        constitution_hash: blueprint.constitution_hash,
+        authority_chain_root: hr.clone(),
+        dag_anchor: parse_hash_hex(&input.dag_anchor_hex, "DAG anchor")?,
+        created,
+    })
+    .map_err(|e| JsValue::from_str(&format!("Newco error: {e}")))?;
 
     // Hire founding agents
     let hr_agent = exo_catapult::CatapultAgent {
@@ -81,10 +146,10 @@ pub fn wasm_instantiate_newco(
         display_name: "HR / People Ops 1".into(),
         capabilities: vec!["assessment".into(), "selection".into(), "talent".into()],
         status: exo_catapult::AgentStatus::Active,
-        last_heartbeat: exo_core::Timestamp::ZERO,
+        last_heartbeat: created,
         budget_spent_cents: 0,
         budget_limit_cents: 1_000_000,
-        hired_at: exo_core::Timestamp::ZERO,
+        hired_at: created,
         hired_by: hr.clone(),
         commandbase_profile: None,
     };
@@ -102,10 +167,10 @@ pub fn wasm_instantiate_newco(
             "market-research".into(),
         ],
         status: exo_catapult::AgentStatus::Active,
-        last_heartbeat: exo_core::Timestamp::ZERO,
+        last_heartbeat: created,
         budget_spent_cents: 0,
         budget_limit_cents: 1_000_000,
-        hired_at: exo_core::Timestamp::ZERO,
+        hired_at: created,
         hired_by: hr,
         commandbase_profile: None,
     };
@@ -340,4 +405,27 @@ pub fn wasm_verify_franchise_receipt_chain(chain_json: &str) -> Result<bool, JsV
     chain
         .verify_chain()
         .map_err(|e| JsValue::from_str(&format!("Receipt chain verification error: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn catapult_exports_do_not_fabricate_spawn_metadata() {
+        let source = std::fs::read_to_string("src/catapult_bindings.rs").unwrap_or_else(|_| {
+            std::fs::read_to_string("crates/exochain-wasm/src/catapult_bindings.rs")
+                .expect("catapult bindings source must be readable")
+        });
+        let forbidden = [
+            concat!("Uuid", "::", "new_v4"),
+            concat!("Timestamp", "::", "ZERO"),
+            concat!("Hash256", "::", "ZERO"),
+        ];
+
+        for pattern in forbidden {
+            assert!(
+                !source.contains(pattern),
+                "Catapult WASM exports must not fabricate placeholder metadata: {pattern}"
+            );
+        }
+    }
 }

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -75,6 +75,20 @@ function signatureHexFromJson(signatureJson) {
   return Buffer.from(bytes).toString('hex');
 }
 
+function hashBytes(hashValue) {
+  if (Array.isArray(hashValue)) return hashValue;
+  if (hashValue && Array.isArray(hashValue[0])) return hashValue[0];
+  if (hashValue && Array.isArray(hashValue.bytes)) return hashValue.bytes;
+  throw new Error('expected serialized Hash256 bytes');
+}
+
+function assertNonZeroHash(hashValue, label) {
+  const bytes = hashBytes(hashValue);
+  if (bytes.length !== 32 || bytes.every((byte) => byte === 0)) {
+    throw new Error(`${label} must be a nonzero Hash256`);
+  }
+}
+
 // =========================================================================
 // Module 1 — BCTS (Bounded-Context Transition System)
 // =========================================================================
@@ -528,6 +542,63 @@ test('wasm_pace_resolve', () => {
     JSON.stringify(config),
     JSON.stringify('Normal')
   );
+});
+
+// =========================================================================
+// Module 8b — Catapult
+// =========================================================================
+
+console.log('\n--- Catapult ---');
+
+test('wasm_create_franchise_blueprint', () => {
+  const blueprint = wasm.wasm_create_franchise_blueprint(
+    'Bridge Franchise',
+    JSON.stringify('SaaS'),
+    NONZERO_32_HEX,
+    UUID_4,
+    'Bridge-test franchise blueprint',
+    NOW_MS,
+    1
+  );
+  if (blueprint.id !== UUID_4) throw new Error('blueprint id must be caller-supplied');
+  assertNonZeroHash(blueprint.content_hash, 'blueprint content_hash');
+  return blueprint;
+});
+
+const catapultBlueprint = setup(() =>
+  wasm.wasm_create_franchise_blueprint(
+    'Bridge Franchise',
+    JSON.stringify('SaaS'),
+    NONZERO_32_HEX,
+    UUID_4,
+    'Bridge-test franchise blueprint',
+    NOW_MS,
+    1
+  ));
+
+test('wasm_instantiate_newco', () => {
+  if (!catapultBlueprint) throw new Error('skipped -- no Catapult blueprint from setup');
+  const newco = wasm.wasm_instantiate_newco(
+    JSON.stringify(catapultBlueprint),
+    JSON.stringify({
+      name: 'Bridge Newco',
+      newco_id: UUID_1,
+      tenant_id: UUID_2,
+      dag_anchor_hex: '22'.repeat(32),
+      created_physical_ms: NOW_NUM,
+      created_logical: 2,
+      hr_did: TEST_DID,
+      researcher_did: TEST_DID_2
+    })
+  );
+  if (newco.id !== UUID_1) throw new Error('newco id must be caller-supplied');
+  if (newco.tenant_id !== UUID_2) throw new Error('tenant id must be caller-supplied');
+  assertNonZeroHash(newco.constitution_hash, 'newco constitution_hash');
+  assertNonZeroHash(newco.dag_anchor, 'newco dag_anchor');
+  if (newco.created.physical_ms !== NOW_NUM || newco.created.logical !== 2) {
+    throw new Error('newco created timestamp must be caller-supplied HLC');
+  }
+  return newco;
 });
 
 // =========================================================================


### PR DESCRIPTION
## Summary
- add deterministic `FranchiseBlueprintInput` and `NewcoInput` constructors for Catapult spawn-boundary objects
- compute and verify franchise blueprint content hashes with domain-separated canonical CBOR
- reject placeholder IDs, zero hashes, zero timestamps, tampered blueprint hashes, and direct placeholder newcos before registry acceptance
- change Catapult WASM exports to require caller-supplied spawn metadata and add JS bridge coverage for blueprint/newco creation

## TDD
- Red check: `cargo test -p exo-catapult newco_new_requires_caller_supplied_identity_and_provenance --lib` failed before implementation because deterministic input types, constructors, content-hash verification, and registry guards did not exist

## Tests
- `cargo test -p exo-catapult newco_new_requires_caller_supplied_identity_and_provenance --lib`
- `cargo test -p exo-catapult blueprint_new_computes_and_verifies_canonical_hash --lib`
- `cargo test -p exochain-wasm catapult_exports_do_not_fabricate_spawn_metadata --lib`
- `cargo test -p exo-catapult`
- `cargo test -p exochain-wasm`
- `cargo build -p exo-catapult`
- `cargo build -p exochain-wasm`
- `cargo clippy -p exo-catapult --lib -- -D warnings`
- `cargo clippy -p exo-catapult --tests -- -D warnings -A clippy::unwrap_used -A clippy::expect_used`
- `cargo clippy -p exochain-wasm --lib -- -D warnings`
- `cargo clippy -p exochain-wasm --tests -- -D warnings -A clippy::unwrap_used -A clippy::expect_used`
- `wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm --out-name exochain_wasm`
- `wasm-pack build crates/exochain-wasm --target nodejs --release --out-dir ../../demo/packages/exochain-wasm/wasm --out-name exochain_wasm`
- `node packages/exochain-wasm/test/bridge_verification.mjs` (118/118)
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo build --workspace --release`
- `cargo test --workspace --release`

Post-rebase sanity:
- `cargo test -p exo-catapult`
- `cargo test -p exochain-wasm`
- `node packages/exochain-wasm/test/bridge_verification.mjs`
- `cargo +nightly fmt --all -- --check`
- `git diff --check origin/main...HEAD`

## Tracking
- Added `Initiatives/fix-scaffold-r2-catapult-deterministic-spawn-boundary.md`
- Updated `_EXECUTION-LEDGER.md` with the Scaffold R1 merge and Scaffold R2 acceptance checklist