### PR TITLE
fix(exo-catapult): guard resource event boundaries

### DIFF
--- a/crates/exo-catapult/src/agent.rs
+++ b/crates/exo-catapult/src/agent.rs
@@ -51,6 +51,67 @@ pub struct CatapultAgent {
     pub commandbase_profile: Option<String>,
 }
 
+/// Caller-supplied deterministic metadata for hiring an agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatapultAgentInput {
+    pub did: Did,
+    pub slot: OdaSlot,
+    pub display_name: String,
+    pub capabilities: Vec<String>,
+    pub status: AgentStatus,
+    pub last_heartbeat: Timestamp,
+    pub budget_spent_cents: u64,
+    pub budget_limit_cents: u64,
+    pub hired_at: Timestamp,
+    pub hired_by: Did,
+    pub commandbase_profile: Option<String>,
+}
+
+impl CatapultAgent {
+    /// Create an agent from caller-supplied lifecycle metadata.
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] when the input contains placeholder
+    /// timestamps, an empty display name, or an unusable budget limit.
+    pub fn new(input: CatapultAgentInput) -> Result<Self> {
+        validate_agent_input(&input)?;
+        Ok(Self {
+            did: input.did,
+            slot: input.slot,
+            display_name: input.display_name,
+            capabilities: input.capabilities,
+            status: input.status,
+            last_heartbeat: input.last_heartbeat,
+            budget_spent_cents: input.budget_spent_cents,
+            budget_limit_cents: input.budget_limit_cents,
+            hired_at: input.hired_at,
+            hired_by: input.hired_by,
+            commandbase_profile: input.commandbase_profile,
+        })
+    }
+
+    /// Validate externally supplied or deserialized agent metadata.
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] when the agent contains placeholder
+    /// lifecycle metadata.
+    pub fn validate(&self) -> Result<()> {
+        validate_agent_input(&CatapultAgentInput {
+            did: self.did.clone(),
+            slot: self.slot,
+            display_name: self.display_name.clone(),
+            capabilities: self.capabilities.clone(),
+            status: self.status,
+            last_heartbeat: self.last_heartbeat,
+            budget_spent_cents: self.budget_spent_cents,
+            budget_limit_cents: self.budget_limit_cents,
+            hired_at: self.hired_at,
+            hired_by: self.hired_by.clone(),
+            commandbase_profile: self.commandbase_profile.clone(),
+        })
+    }
+}
+
 /// The ODA roster — a governed map of slots to agents.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AgentRoster {
@@ -68,6 +129,7 @@ impl AgentRoster {
 
     /// Fill an ODA slot with an agent. Returns an error if the slot is already occupied.
     pub fn fill_slot(&mut self, agent: CatapultAgent) -> Result<()> {
+        agent.validate()?;
         let slot = agent.slot;
         if self.agents.contains_key(&slot) {
             return Err(CatapultError::SlotAlreadyFilled(slot));
@@ -144,6 +206,26 @@ impl AgentRoster {
         self.agents.iter()
     }
 
+    /// Validate every roster entry and the map key-to-slot invariant.
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] when an agent contains placeholder metadata
+    /// or is stored under the wrong ODA slot key.
+    pub fn validate(&self) -> Result<()> {
+        for (slot, agent) in &self.agents {
+            if *slot != agent.slot {
+                return Err(CatapultError::InvalidAgent {
+                    reason: format!(
+                        "agent {} stored under slot {slot:?} but declares slot {:?}",
+                        agent.did, agent.slot
+                    ),
+                });
+            }
+            agent.validate()?;
+        }
+        Ok(())
+    }
+
     /// Generate a unique DID for an agent in this newco.
     ///
     /// Format: `did:exo:catapult:<newco_id>:<slot_name>`
@@ -151,6 +233,35 @@ impl AgentRoster {
         let slot_name = format!("{slot:?}").to_ascii_lowercase();
         Did::new(&format!("did:exo:catapult:{newco_id}:{slot_name}"))
     }
+}
+
+fn validate_agent_input(input: &CatapultAgentInput) -> Result<()> {
+    if input.display_name.trim().is_empty() {
+        return Err(CatapultError::InvalidAgent {
+            reason: "agent display name must not be empty".into(),
+        });
+    }
+    if input.last_heartbeat == Timestamp::ZERO {
+        return Err(CatapultError::InvalidAgent {
+            reason: "agent last heartbeat must be caller-supplied HLC".into(),
+        });
+    }
+    if input.hired_at == Timestamp::ZERO {
+        return Err(CatapultError::InvalidAgent {
+            reason: "agent hired_at must be caller-supplied HLC".into(),
+        });
+    }
+    if input.last_heartbeat < input.hired_at {
+        return Err(CatapultError::InvalidAgent {
+            reason: "agent last heartbeat must not precede hired_at".into(),
+        });
+    }
+    if input.budget_limit_cents == 0 {
+        return Err(CatapultError::InvalidAgent {
+            reason: "agent budget limit must be nonzero".into(),
+        });
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -168,13 +279,51 @@ mod tests {
             display_name: name.into(),
             capabilities: vec!["test".into()],
             status: AgentStatus::Active,
-            last_heartbeat: Timestamp::ZERO,
+            last_heartbeat: Timestamp::new(1_765_000_000_100, 0),
             budget_spent_cents: 0,
             budget_limit_cents: 100_000,
-            hired_at: Timestamp::ZERO,
+            hired_at: Timestamp::new(1_765_000_000_000, 0),
             hired_by: test_did("hr"),
             commandbase_profile: None,
         }
+    }
+
+    #[test]
+    fn agent_new_requires_caller_supplied_lifecycle_metadata() {
+        let agent = CatapultAgent::new(CatapultAgentInput {
+            did: test_did("valid"),
+            slot: OdaSlot::DeepResearcher,
+            display_name: "valid".into(),
+            capabilities: vec!["research".into()],
+            status: AgentStatus::Active,
+            last_heartbeat: Timestamp::new(1_765_000_000_100, 0),
+            budget_spent_cents: 0,
+            budget_limit_cents: 100_000,
+            hired_at: Timestamp::new(1_765_000_000_000, 0),
+            hired_by: test_did("hr"),
+            commandbase_profile: None,
+        })
+        .unwrap();
+
+        assert_eq!(agent.slot, OdaSlot::DeepResearcher);
+        assert_ne!(agent.last_heartbeat, Timestamp::ZERO);
+        assert_ne!(agent.hired_at, Timestamp::ZERO);
+    }
+
+    #[test]
+    fn roster_rejects_placeholder_agent_metadata() {
+        let mut roster = AgentRoster::new();
+        let mut agent = make_agent(OdaSlot::DeepResearcher, "dr1");
+        agent.last_heartbeat = Timestamp::ZERO;
+        assert!(roster.fill_slot(agent).is_err());
+
+        let mut agent = make_agent(OdaSlot::DeepResearcher, "dr1");
+        agent.hired_at = Timestamp::ZERO;
+        assert!(roster.fill_slot(agent).is_err());
+
+        let mut agent = make_agent(OdaSlot::DeepResearcher, "dr1");
+        agent.budget_limit_cents = 0;
+        assert!(roster.fill_slot(agent).is_err());
     }
 
     #[test]

--- a/crates/exo-catapult/src/agent.rs
+++ b/crates/exo-catapult/src/agent.rs
@@ -327,6 +327,40 @@ mod tests {
     }
 
     #[test]
+    fn agent_validation_rejects_empty_name_and_regressive_heartbeat() {
+        let mut agent = make_agent(OdaSlot::DeepResearcher, "dr1");
+        agent.display_name = "   ".into();
+        assert!(agent.validate().is_err());
+
+        let mut agent = make_agent(OdaSlot::DeepResearcher, "dr1");
+        agent.last_heartbeat = Timestamp::new(1, 0);
+        assert!(agent.validate().is_err());
+    }
+
+    #[test]
+    fn roster_validate_detects_deserialized_slot_key_mismatch() {
+        let mut roster = AgentRoster::new();
+        let agent = make_agent(OdaSlot::DeepResearcher, "dr1");
+        roster.agents.insert(OdaSlot::HrPeopleOps1, agent);
+
+        assert!(roster.validate().is_err());
+    }
+
+    #[test]
+    fn active_count_ignores_non_active_agents() {
+        let mut roster = AgentRoster::new();
+        roster
+            .fill_slot(make_agent(OdaSlot::DeepResearcher, "dr1"))
+            .unwrap();
+        let mut suspended = make_agent(OdaSlot::HrPeopleOps1, "hr1");
+        suspended.status = AgentStatus::Suspended;
+        roster.fill_slot(suspended).unwrap();
+
+        assert_eq!(roster.active_count(), 1);
+        assert_eq!(roster.iter().count(), 2);
+    }
+
+    #[test]
     fn fill_and_get() {
         let mut roster = AgentRoster::new();
         let agent = make_agent(OdaSlot::HrPeopleOps1, "hr1");

--- a/crates/exo-catapult/src/budget.rs
+++ b/crates/exo-catapult/src/budget.rs
@@ -538,6 +538,74 @@ mod tests {
     }
 
     #[test]
+    fn policy_and_cost_input_validation_rejects_boundary_placeholders() {
+        let mut policy = valid_policy(BudgetScope::Company, 100_000);
+        policy.warn_threshold_bps = 0;
+        assert!(policy.validate().is_err());
+
+        let mut policy = valid_policy(BudgetScope::Company, 100_000);
+        policy.warn_threshold_bps = 10_001;
+        assert!(policy.validate().is_err());
+
+        let mut input = valid_cost_input(OdaSlot::VentureCommander, 100);
+        input.id = Uuid::nil();
+        assert!(CostEvent::new(input).is_err());
+
+        let mut input = valid_cost_input(OdaSlot::VentureCommander, 100);
+        input.newco_id = Uuid::nil();
+        assert!(CostEvent::new(input).is_err());
+
+        let mut input = valid_cost_input(OdaSlot::VentureCommander, 100);
+        input.amount = 0;
+        assert!(CostEvent::new(input).is_err());
+
+        let mut input = valid_cost_input(OdaSlot::VentureCommander, 100);
+        input.description = "   ".into();
+        assert!(CostEvent::new(input).is_err());
+
+        let mut input = valid_cost_input(OdaSlot::VentureCommander, 100);
+        input.timestamp = Timestamp::ZERO;
+        assert!(CostEvent::new(input).is_err());
+    }
+
+    #[test]
+    fn ledger_rejects_duplicate_ids_from_api_and_deserialized_state() {
+        let mut ledger = BudgetLedger::new();
+        let policy = valid_policy(BudgetScope::Company, 100_000);
+        ledger.add_policy(policy.clone()).unwrap();
+        assert!(ledger.add_policy(policy.clone()).is_err());
+
+        let duplicate_policy_ledger = BudgetLedger {
+            policies: vec![policy.clone(), policy],
+            events: Vec::new(),
+        };
+        assert!(duplicate_policy_ledger.validate().is_err());
+
+        let event = CostEvent::new(valid_cost_input(OdaSlot::VentureCommander, 100)).unwrap();
+        let duplicate_event_ledger = BudgetLedger {
+            policies: Vec::new(),
+            events: vec![event.clone(), event],
+        };
+        assert!(duplicate_event_ledger.validate().is_err());
+    }
+
+    #[test]
+    fn inactive_policy_is_ignored_by_enforcement() {
+        let mut ledger = BudgetLedger::new();
+        let mut policy = make_policy(BudgetScope::Company, 1);
+        policy.is_active = false;
+        ledger.add_policy(policy).unwrap();
+        ledger
+            .record_cost(make_cost(OdaSlot::VentureCommander, 10))
+            .unwrap();
+
+        assert_eq!(
+            ledger.check_enforcement(&BudgetScope::Company),
+            BudgetVerdict::Ok
+        );
+    }
+
+    #[test]
     fn empty_ledger_ok() {
         let ledger = BudgetLedger::new();
         assert_eq!(

--- a/crates/exo-catapult/src/budget.rs
+++ b/crates/exo-catapult/src/budget.rs
@@ -7,7 +7,15 @@ use exo_core::{Did, Hash256, Timestamp};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{oda::OdaSlot, phase::OperationalPhase};
+use crate::{
+    error::{CatapultError, Result},
+    oda::OdaSlot,
+    phase::OperationalPhase,
+};
+
+/// Domain tag for canonical cost-event receipt hashes.
+pub const COST_EVENT_HASH_DOMAIN: &str = "exo.catapult.cost_event.v1";
+const COST_EVENT_HASH_SCHEMA_VERSION: &str = "1.0.0";
 
 /// Scope of a budget policy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -58,6 +66,17 @@ pub struct BudgetPolicy {
     pub is_active: bool,
 }
 
+impl BudgetPolicy {
+    /// Validate externally supplied or deserialized budget policy metadata.
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] when placeholder IDs, zero limits, or invalid
+    /// thresholds are present.
+    pub fn validate(&self) -> Result<()> {
+        validate_budget_policy(self)
+    }
+}
+
 /// A recorded cost event.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CostEvent {
@@ -70,6 +89,84 @@ pub struct CostEvent {
     pub description: String,
     pub timestamp: Timestamp,
     pub receipt_hash: Hash256,
+}
+
+/// Caller-supplied deterministic metadata for creating a cost event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CostEventInput {
+    pub id: Uuid,
+    pub newco_id: Uuid,
+    pub agent_did: Did,
+    pub slot: OdaSlot,
+    pub amount: u64,
+    pub metric: BudgetMetric,
+    pub description: String,
+    pub timestamp: Timestamp,
+}
+
+impl CostEvent {
+    /// Create a cost event with a deterministic canonical receipt hash.
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] if the input contains placeholder metadata
+    /// or canonical hashing fails.
+    pub fn new(input: CostEventInput) -> Result<Self> {
+        validate_cost_event_input(&input)?;
+        let receipt_hash = cost_event_receipt_hash(&input)?;
+        Ok(Self {
+            id: input.id,
+            newco_id: input.newco_id,
+            agent_did: input.agent_did,
+            slot: input.slot,
+            amount: input.amount,
+            metric: input.metric,
+            description: input.description,
+            timestamp: input.timestamp,
+            receipt_hash,
+        })
+    }
+
+    /// Validate externally supplied or deserialized cost event metadata.
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] if placeholders are present or the stored
+    /// receipt hash does not match the canonical event payload.
+    pub fn validate(&self) -> Result<()> {
+        let input = self.input();
+        validate_cost_event_input(&input)?;
+        if self.receipt_hash == Hash256::ZERO {
+            return Err(CatapultError::InvalidCostEvent {
+                reason: "cost event receipt hash must not be zero".into(),
+            });
+        }
+        if !self.verify_receipt_hash()? {
+            return Err(CatapultError::InvalidCostEvent {
+                reason: "cost event receipt hash does not match canonical payload".into(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Verify the stored receipt hash against the canonical payload.
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] if canonical hashing fails.
+    pub fn verify_receipt_hash(&self) -> Result<bool> {
+        Ok(cost_event_receipt_hash(&self.input())? == self.receipt_hash)
+    }
+
+    fn input(&self) -> CostEventInput {
+        CostEventInput {
+            id: self.id,
+            newco_id: self.newco_id,
+            agent_did: self.agent_did.clone(),
+            slot: self.slot,
+            amount: self.amount,
+            metric: self.metric,
+            description: self.description.clone(),
+            timestamp: self.timestamp,
+        }
+    }
 }
 
 /// Result of a budget enforcement check.
@@ -122,13 +219,31 @@ impl BudgetLedger {
     }
 
     /// Add a budget policy.
-    pub fn add_policy(&mut self, policy: BudgetPolicy) {
+    pub fn add_policy(&mut self, policy: BudgetPolicy) -> Result<()> {
+        validate_budget_policy(&policy)?;
+        if self
+            .policies
+            .iter()
+            .any(|existing| existing.id == policy.id)
+        {
+            return Err(CatapultError::InvalidBudgetPolicy {
+                reason: format!("duplicate budget policy id {}", policy.id),
+            });
+        }
         self.policies.push(policy);
+        Ok(())
     }
 
     /// Record a cost event.
-    pub fn record_cost(&mut self, event: CostEvent) {
+    pub fn record_cost(&mut self, event: CostEvent) -> Result<()> {
+        event.validate()?;
+        if self.events.iter().any(|existing| existing.id == event.id) {
+            return Err(CatapultError::InvalidCostEvent {
+                reason: format!("duplicate cost event id {}", event.id),
+            });
+        }
         self.events.push(event);
+        Ok(())
     }
 
     /// Calculate total spent for a given scope and metric.
@@ -192,6 +307,127 @@ impl BudgetLedger {
     pub fn event_count(&self) -> usize {
         self.events.len()
     }
+
+    /// Validate every policy and event in a deserialized ledger.
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] when placeholder metadata or duplicate IDs
+    /// are present.
+    pub fn validate(&self) -> Result<()> {
+        let mut policy_ids = std::collections::BTreeSet::new();
+        for policy in &self.policies {
+            validate_budget_policy(policy)?;
+            if !policy_ids.insert(policy.id) {
+                return Err(CatapultError::InvalidBudgetPolicy {
+                    reason: format!("duplicate budget policy id {}", policy.id),
+                });
+            }
+        }
+
+        let mut event_ids = std::collections::BTreeSet::new();
+        for event in &self.events {
+            event.validate()?;
+            if !event_ids.insert(event.id) {
+                return Err(CatapultError::InvalidCostEvent {
+                    reason: format!("duplicate cost event id {}", event.id),
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Compute the canonical receipt hash for a cost event.
+///
+/// # Errors
+/// Returns [`CatapultError`] if canonical CBOR hashing fails.
+pub fn cost_event_receipt_hash(input: &CostEventInput) -> Result<Hash256> {
+    validate_cost_event_input(input)?;
+    exo_core::hash::hash_structured(&CostEventHashPayload::from_input(input)).map_err(|e| {
+        CatapultError::InvalidCostEvent {
+            reason: format!("cost event canonical hash failed: {e}"),
+        }
+    })
+}
+
+#[derive(Serialize)]
+struct CostEventHashPayload<'a> {
+    domain: &'static str,
+    schema_version: &'static str,
+    id: Uuid,
+    newco_id: Uuid,
+    agent_did: &'a Did,
+    slot: OdaSlot,
+    amount: u64,
+    metric: BudgetMetric,
+    description: &'a str,
+    timestamp: Timestamp,
+}
+
+impl<'a> CostEventHashPayload<'a> {
+    fn from_input(input: &'a CostEventInput) -> Self {
+        Self {
+            domain: COST_EVENT_HASH_DOMAIN,
+            schema_version: COST_EVENT_HASH_SCHEMA_VERSION,
+            id: input.id,
+            newco_id: input.newco_id,
+            agent_did: &input.agent_did,
+            slot: input.slot,
+            amount: input.amount,
+            metric: input.metric,
+            description: &input.description,
+            timestamp: input.timestamp,
+        }
+    }
+}
+
+fn validate_budget_policy(policy: &BudgetPolicy) -> Result<()> {
+    if policy.id.is_nil() {
+        return Err(CatapultError::InvalidBudgetPolicy {
+            reason: "budget policy id must be caller-supplied and non-nil".into(),
+        });
+    }
+    if policy.limit == 0 {
+        return Err(CatapultError::InvalidBudgetPolicy {
+            reason: "budget policy limit must be nonzero".into(),
+        });
+    }
+    if policy.warn_threshold_bps == 0 || policy.warn_threshold_bps > 10_000 {
+        return Err(CatapultError::InvalidBudgetPolicy {
+            reason: "budget policy warning threshold must be 1..=10000 basis points".into(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_cost_event_input(input: &CostEventInput) -> Result<()> {
+    if input.id.is_nil() {
+        return Err(CatapultError::InvalidCostEvent {
+            reason: "cost event id must be caller-supplied and non-nil".into(),
+        });
+    }
+    if input.newco_id.is_nil() {
+        return Err(CatapultError::InvalidCostEvent {
+            reason: "cost event newco id must be non-nil".into(),
+        });
+    }
+    if input.amount == 0 {
+        return Err(CatapultError::InvalidCostEvent {
+            reason: "cost event amount must be nonzero".into(),
+        });
+    }
+    if input.description.trim().is_empty() {
+        return Err(CatapultError::InvalidCostEvent {
+            reason: "cost event description must not be empty".into(),
+        });
+    }
+    if input.timestamp == Timestamp::ZERO {
+        return Err(CatapultError::InvalidCostEvent {
+            reason: "cost event timestamp must be caller-supplied HLC".into(),
+        });
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -202,9 +438,36 @@ mod tests {
         Did::new("did:exo:test-agent").unwrap()
     }
 
+    fn test_uuid(byte: u8) -> Uuid {
+        Uuid::from_bytes([byte; 16])
+    }
+
+    fn uuid_from_u64(value: u64) -> Uuid {
+        let mut bytes = [0u8; 16];
+        bytes[..8].copy_from_slice(&value.to_le_bytes());
+        Uuid::from_bytes(bytes)
+    }
+
+    fn test_timestamp() -> Timestamp {
+        Timestamp::new(1_765_000_000_000, 0)
+    }
+
     fn make_policy(scope: BudgetScope, limit: u64) -> BudgetPolicy {
         BudgetPolicy {
-            id: Uuid::new_v4(),
+            id: uuid_from_u64(limit),
+            scope,
+            metric: BudgetMetric::BilledCents,
+            window: BudgetWindow::Lifetime,
+            limit,
+            warn_threshold_bps: 8000,
+            hard_stop: true,
+            is_active: true,
+        }
+    }
+
+    fn valid_policy(scope: BudgetScope, limit: u64) -> BudgetPolicy {
+        BudgetPolicy {
+            id: test_uuid(1),
             scope,
             metric: BudgetMetric::BilledCents,
             window: BudgetWindow::Lifetime,
@@ -216,17 +479,62 @@ mod tests {
     }
 
     fn make_cost(slot: OdaSlot, amount: u64) -> CostEvent {
-        CostEvent {
-            id: Uuid::new_v4(),
-            newco_id: Uuid::nil(),
+        CostEvent::new(CostEventInput {
+            id: uuid_from_u64(amount),
+            newco_id: test_uuid(4),
             agent_did: test_did(),
             slot,
             amount,
             metric: BudgetMetric::BilledCents,
             description: "test cost".into(),
-            timestamp: Timestamp::ZERO,
-            receipt_hash: Hash256::ZERO,
+            timestamp: test_timestamp(),
+        })
+        .unwrap()
+    }
+
+    fn valid_cost_input(slot: OdaSlot, amount: u64) -> CostEventInput {
+        CostEventInput {
+            id: test_uuid(2),
+            newco_id: test_uuid(3),
+            agent_did: test_did(),
+            slot,
+            amount,
+            metric: BudgetMetric::BilledCents,
+            description: "valid cost".into(),
+            timestamp: test_timestamp(),
         }
+    }
+
+    #[test]
+    fn ledger_rejects_placeholder_budget_policy_and_cost_event() {
+        let mut ledger = BudgetLedger::new();
+
+        let mut policy = valid_policy(BudgetScope::Company, 100_000);
+        policy.id = Uuid::nil();
+        assert!(ledger.add_policy(policy).is_err());
+
+        let mut policy = valid_policy(BudgetScope::Company, 0);
+        policy.limit = 0;
+        assert!(ledger.add_policy(policy).is_err());
+
+        let mut cost = CostEvent::new(valid_cost_input(OdaSlot::VentureCommander, 100)).unwrap();
+        cost.receipt_hash = Hash256::ZERO;
+        assert!(ledger.record_cost(cost).is_err());
+    }
+
+    #[test]
+    fn cost_event_receipt_hash_covers_canonical_payload() {
+        let mut ledger = BudgetLedger::new();
+        let event = CostEvent::new(valid_cost_input(OdaSlot::VentureCommander, 100)).unwrap();
+
+        assert_ne!(event.receipt_hash, Hash256::ZERO);
+        assert!(event.verify_receipt_hash().unwrap());
+        ledger.record_cost(event.clone()).unwrap();
+
+        let mut tampered = event;
+        tampered.amount += 1;
+        assert!(!tampered.verify_receipt_hash().unwrap());
+        assert!(ledger.record_cost(tampered).is_err());
     }
 
     #[test]
@@ -241,8 +549,12 @@ mod tests {
     #[test]
     fn under_budget() {
         let mut ledger = BudgetLedger::new();
-        ledger.add_policy(make_policy(BudgetScope::Company, 100_000));
-        ledger.record_cost(make_cost(OdaSlot::VentureCommander, 50_000));
+        ledger
+            .add_policy(make_policy(BudgetScope::Company, 100_000))
+            .unwrap();
+        ledger
+            .record_cost(make_cost(OdaSlot::VentureCommander, 50_000))
+            .unwrap();
         assert_eq!(
             ledger.check_enforcement(&BudgetScope::Company),
             BudgetVerdict::Ok
@@ -252,9 +564,13 @@ mod tests {
     #[test]
     fn warning_threshold() {
         let mut ledger = BudgetLedger::new();
-        ledger.add_policy(make_policy(BudgetScope::Company, 100_000));
+        ledger
+            .add_policy(make_policy(BudgetScope::Company, 100_000))
+            .unwrap();
         // 85% of budget — exceeds 80% warning threshold
-        ledger.record_cost(make_cost(OdaSlot::VentureCommander, 85_000));
+        ledger
+            .record_cost(make_cost(OdaSlot::VentureCommander, 85_000))
+            .unwrap();
         assert!(matches!(
             ledger.check_enforcement(&BudgetScope::Company),
             BudgetVerdict::Warning { .. }
@@ -264,8 +580,12 @@ mod tests {
     #[test]
     fn hard_stop() {
         let mut ledger = BudgetLedger::new();
-        ledger.add_policy(make_policy(BudgetScope::Company, 100_000));
-        ledger.record_cost(make_cost(OdaSlot::VentureCommander, 100_001));
+        ledger
+            .add_policy(make_policy(BudgetScope::Company, 100_000))
+            .unwrap();
+        ledger
+            .record_cost(make_cost(OdaSlot::VentureCommander, 100_001))
+            .unwrap();
         assert!(matches!(
             ledger.check_enforcement(&BudgetScope::Company),
             BudgetVerdict::HardStop { .. }
@@ -278,12 +598,16 @@ mod tests {
         let scope = BudgetScope::Agent {
             slot: OdaSlot::GrowthEngineer1,
         };
-        ledger.add_policy(make_policy(scope, 10_000));
+        ledger.add_policy(make_policy(scope, 10_000)).unwrap();
         // Cost from a different slot should not count
-        ledger.record_cost(make_cost(OdaSlot::VentureCommander, 50_000));
+        ledger
+            .record_cost(make_cost(OdaSlot::VentureCommander, 50_000))
+            .unwrap();
         assert_eq!(ledger.check_enforcement(&scope), BudgetVerdict::Ok);
         // Cost from the target slot should count
-        ledger.record_cost(make_cost(OdaSlot::GrowthEngineer1, 10_001));
+        ledger
+            .record_cost(make_cost(OdaSlot::GrowthEngineer1, 10_001))
+            .unwrap();
         assert!(matches!(
             ledger.check_enforcement(&scope),
             BudgetVerdict::HardStop { .. }
@@ -293,8 +617,12 @@ mod tests {
     #[test]
     fn total_spent() {
         let mut ledger = BudgetLedger::new();
-        ledger.record_cost(make_cost(OdaSlot::VentureCommander, 100));
-        ledger.record_cost(make_cost(OdaSlot::VentureCommander, 200));
+        ledger
+            .record_cost(make_cost(OdaSlot::VentureCommander, 100))
+            .unwrap();
+        ledger
+            .record_cost(make_cost(OdaSlot::VentureCommander, 200))
+            .unwrap();
         assert_eq!(
             ledger.total_spent(&BudgetScope::Company, &BudgetMetric::BilledCents),
             300

--- a/crates/exo-catapult/src/error.rs
+++ b/crates/exo-catapult/src/error.rs
@@ -38,6 +38,16 @@ pub enum CatapultError {
     FranchiseAlreadyExists(Uuid),
     #[error("newco already exists: {0}")]
     NewcoAlreadyExists(Uuid),
+    #[error("invalid catapult agent: {reason}")]
+    InvalidAgent { reason: String },
+    #[error("invalid budget policy: {reason}")]
+    InvalidBudgetPolicy { reason: String },
+    #[error("invalid cost event: {reason}")]
+    InvalidCostEvent { reason: String },
+    #[error("invalid goal: {reason}")]
+    InvalidGoal { reason: String },
+    #[error("invalid heartbeat record: {reason}")]
+    InvalidHeartbeat { reason: String },
     #[error("invalid franchise blueprint: {reason}")]
     InvalidFranchiseBlueprint { reason: String },
     #[error("invalid newco: {reason}")]
@@ -84,6 +94,21 @@ mod tests {
             CatapultError::DuplicateGoal(Uuid::nil()),
             CatapultError::FranchiseAlreadyExists(Uuid::nil()),
             CatapultError::NewcoAlreadyExists(Uuid::nil()),
+            CatapultError::InvalidAgent {
+                reason: "bad agent".into(),
+            },
+            CatapultError::InvalidBudgetPolicy {
+                reason: "bad policy".into(),
+            },
+            CatapultError::InvalidCostEvent {
+                reason: "bad cost".into(),
+            },
+            CatapultError::InvalidGoal {
+                reason: "bad goal".into(),
+            },
+            CatapultError::InvalidHeartbeat {
+                reason: "bad heartbeat".into(),
+            },
             CatapultError::InvalidFranchiseBlueprint {
                 reason: "bad blueprint".into(),
             },

--- a/crates/exo-catapult/src/franchise.rs
+++ b/crates/exo-catapult/src/franchise.rs
@@ -360,7 +360,29 @@ mod tests {
         assert!(FranchiseBlueprint::new(input).is_err());
 
         let mut input = test_blueprint_input();
+        input.description = " ".into();
+        assert!(FranchiseBlueprint::new(input).is_err());
+
+        let mut input = test_blueprint_input();
+        input.business_model = BusinessModel::Custom {
+            description: " ".into(),
+        };
+        assert!(FranchiseBlueprint::new(input).is_err());
+
+        let mut input = test_blueprint_input();
         input.constitution_hash = Hash256::ZERO;
+        assert!(FranchiseBlueprint::new(input).is_err());
+
+        let mut input = test_blueprint_input();
+        input.required_slots = Vec::new();
+        assert!(FranchiseBlueprint::new(input).is_err());
+
+        let mut input = test_blueprint_input();
+        input.required_slots = vec![OdaSlot::HrPeopleOps1, OdaSlot::DeepResearcher];
+        assert!(FranchiseBlueprint::new(input).is_err());
+
+        let mut input = test_blueprint_input();
+        input.required_slots = vec![OdaSlot::HrPeopleOps1, OdaSlot::HrPeopleOps1];
         assert!(FranchiseBlueprint::new(input).is_err());
 
         let mut input = test_blueprint_input();
@@ -378,6 +400,10 @@ mod tests {
 
         let mut blueprint = test_blueprint();
         blueprint.id = Uuid::nil();
+        assert!(reg.publish(blueprint).is_err());
+
+        let mut blueprint = test_blueprint();
+        blueprint.content_hash = Hash256::ZERO;
         assert!(reg.publish(blueprint).is_err());
     }
 

--- a/crates/exo-catapult/src/goal.rs
+++ b/crates/exo-catapult/src/goal.rs
@@ -53,6 +53,60 @@ pub struct Goal {
     pub updated: Timestamp,
 }
 
+/// Caller-supplied deterministic metadata for creating a goal.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GoalInput {
+    pub id: Uuid,
+    pub title: String,
+    pub description: Option<String>,
+    pub level: GoalLevel,
+    pub status: GoalStatus,
+    pub parent_id: Option<Uuid>,
+    pub owner_slot: Option<OdaSlot>,
+    pub created: Timestamp,
+    pub updated: Timestamp,
+}
+
+impl Goal {
+    /// Create a goal from caller-supplied deterministic metadata.
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] if the input contains placeholder IDs or
+    /// timestamps.
+    pub fn new(input: GoalInput) -> Result<Self> {
+        validate_goal_input(&input)?;
+        Ok(Self {
+            id: input.id,
+            title: input.title,
+            description: input.description,
+            level: input.level,
+            status: input.status,
+            parent_id: input.parent_id,
+            owner_slot: input.owner_slot,
+            created: input.created,
+            updated: input.updated,
+        })
+    }
+
+    /// Validate externally supplied or deserialized goal metadata.
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] if placeholder IDs or timestamps are present.
+    pub fn validate(&self) -> Result<()> {
+        validate_goal_input(&GoalInput {
+            id: self.id,
+            title: self.title.clone(),
+            description: self.description.clone(),
+            level: self.level,
+            status: self.status,
+            parent_id: self.parent_id,
+            owner_slot: self.owner_slot,
+            created: self.created,
+            updated: self.updated,
+        })
+    }
+}
+
 /// Default goal template for franchise blueprints.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GoalTemplate {
@@ -109,9 +163,17 @@ impl GoalTree {
 
     /// Add a goal to the tree.
     pub fn add(&mut self, goal: Goal) -> Result<()> {
+        goal.validate()?;
         let id = goal.id;
         if self.goals.contains_key(&id) {
             return Err(CatapultError::DuplicateGoal(id));
+        }
+        if let Some(parent_id) = goal.parent_id {
+            if !self.goals.contains_key(&parent_id) {
+                return Err(CatapultError::InvalidGoal {
+                    reason: format!("goal parent id {parent_id} does not exist"),
+                });
+            }
         }
         self.goals.insert(id, goal);
         Ok(())
@@ -124,12 +186,19 @@ impl GoalTree {
     }
 
     /// Update the status of a goal.
-    pub fn update_status(&mut self, id: &Uuid, status: GoalStatus) -> Result<()> {
+    pub fn update_status(
+        &mut self,
+        id: &Uuid,
+        status: GoalStatus,
+        updated: Timestamp,
+    ) -> Result<()> {
         let goal = self
             .goals
             .get_mut(id)
             .ok_or(CatapultError::GoalNotFound(*id))?;
+        validate_goal_update_timestamp(goal, updated)?;
         goal.status = status;
+        goal.updated = updated;
         Ok(())
     }
 
@@ -202,6 +271,83 @@ impl GoalTree {
     pub fn iter(&self) -> impl Iterator<Item = (&Uuid, &Goal)> {
         self.goals.iter()
     }
+
+    /// Validate every goal and parent relationship in a deserialized tree.
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] if placeholders, mismatched map keys, or
+    /// orphan parent references are present.
+    pub fn validate(&self) -> Result<()> {
+        for (id, goal) in &self.goals {
+            if *id != goal.id {
+                return Err(CatapultError::InvalidGoal {
+                    reason: format!("goal stored under id {id} but declares id {}", goal.id),
+                });
+            }
+            goal.validate()?;
+            if let Some(parent_id) = goal.parent_id {
+                if !self.goals.contains_key(&parent_id) {
+                    return Err(CatapultError::InvalidGoal {
+                        reason: format!("goal parent id {parent_id} does not exist"),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn validate_goal_input(input: &GoalInput) -> Result<()> {
+    if input.id.is_nil() {
+        return Err(CatapultError::InvalidGoal {
+            reason: "goal id must be caller-supplied and non-nil".into(),
+        });
+    }
+    if input.title.trim().is_empty() {
+        return Err(CatapultError::InvalidGoal {
+            reason: "goal title must not be empty".into(),
+        });
+    }
+    if input.parent_id == Some(input.id) {
+        return Err(CatapultError::InvalidGoal {
+            reason: "goal parent id must not equal goal id".into(),
+        });
+    }
+    if input.created == Timestamp::ZERO {
+        return Err(CatapultError::InvalidGoal {
+            reason: "goal created timestamp must be caller-supplied HLC".into(),
+        });
+    }
+    if input.updated == Timestamp::ZERO {
+        return Err(CatapultError::InvalidGoal {
+            reason: "goal updated timestamp must be caller-supplied HLC".into(),
+        });
+    }
+    if input.updated < input.created {
+        return Err(CatapultError::InvalidGoal {
+            reason: "goal updated timestamp must not precede creation timestamp".into(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_goal_update_timestamp(goal: &Goal, updated: Timestamp) -> Result<()> {
+    if updated == Timestamp::ZERO {
+        return Err(CatapultError::InvalidGoal {
+            reason: "goal status update timestamp must be caller-supplied HLC".into(),
+        });
+    }
+    if updated < goal.updated {
+        return Err(CatapultError::InvalidGoal {
+            reason: "goal status update timestamp must not regress".into(),
+        });
+    }
+    if updated < goal.created {
+        return Err(CatapultError::InvalidGoal {
+            reason: "goal status update timestamp must not precede creation timestamp".into(),
+        });
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -209,17 +355,95 @@ mod tests {
     use super::*;
 
     fn make_goal(title: &str, level: GoalLevel, status: GoalStatus) -> Goal {
-        Goal {
-            id: Uuid::new_v4(),
+        let mut bytes = [0u8; 16];
+        for (index, byte) in title.as_bytes().iter().take(16).enumerate() {
+            bytes[index] = *byte;
+        }
+        if bytes.iter().all(|byte| *byte == 0) {
+            bytes[0] = 1;
+        }
+        Goal::new(GoalInput {
+            id: Uuid::from_bytes(bytes),
             title: title.into(),
             description: None,
             level,
             status,
             parent_id: None,
             owner_slot: None,
-            created: Timestamp::ZERO,
-            updated: Timestamp::ZERO,
-        }
+            created: Timestamp::new(1_765_000_000_000, 0),
+            updated: Timestamp::new(1_765_000_000_000, 0),
+        })
+        .unwrap()
+    }
+
+    fn test_uuid(byte: u8) -> Uuid {
+        Uuid::from_bytes([byte; 16])
+    }
+
+    fn test_timestamp(offset: u64) -> Timestamp {
+        Timestamp::new(1_765_000_000_000 + offset, 0)
+    }
+
+    fn valid_goal(title: &str, level: GoalLevel, status: GoalStatus) -> Goal {
+        Goal::new(GoalInput {
+            id: test_uuid(1),
+            title: title.into(),
+            description: None,
+            level,
+            status,
+            parent_id: None,
+            owner_slot: None,
+            created: test_timestamp(0),
+            updated: test_timestamp(0),
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn add_rejects_placeholder_goal_metadata() {
+        let mut tree = GoalTree::new();
+
+        let mut goal = valid_goal("Test", GoalLevel::Company, GoalStatus::Planned);
+        goal.id = Uuid::nil();
+        assert!(tree.add(goal).is_err());
+
+        let mut goal = valid_goal("Test", GoalLevel::Company, GoalStatus::Planned);
+        goal.created = Timestamp::ZERO;
+        assert!(tree.add(goal).is_err());
+
+        let mut goal = valid_goal("Test", GoalLevel::Company, GoalStatus::Planned);
+        goal.updated = Timestamp::new(1, 0);
+        goal.created = Timestamp::new(2, 0);
+        assert!(tree.add(goal).is_err());
+    }
+
+    #[test]
+    fn add_rejects_orphan_goal_parent() {
+        let mut tree = GoalTree::new();
+        let mut child = valid_goal("Child", GoalLevel::Team, GoalStatus::Planned);
+        child.parent_id = Some(test_uuid(9));
+
+        assert!(tree.add(child).is_err());
+    }
+
+    #[test]
+    fn update_status_requires_caller_supplied_hlc() {
+        let mut tree = GoalTree::new();
+        let goal = valid_goal("Test", GoalLevel::Company, GoalStatus::Planned);
+        let id = goal.id;
+        tree.add(goal).unwrap();
+
+        assert!(
+            tree.update_status(&id, GoalStatus::Completed, Timestamp::ZERO)
+                .is_err()
+        );
+
+        let updated = test_timestamp(100);
+        tree.update_status(&id, GoalStatus::Completed, updated)
+            .unwrap();
+        let goal = tree.get(&id).unwrap();
+        assert_eq!(goal.status, GoalStatus::Completed);
+        assert_eq!(goal.updated, updated);
     }
 
     #[test]
@@ -247,7 +471,8 @@ mod tests {
         let goal = make_goal("Test", GoalLevel::Company, GoalStatus::Planned);
         let id = goal.id;
         tree.add(goal).unwrap();
-        tree.update_status(&id, GoalStatus::Completed).unwrap();
+        tree.update_status(&id, GoalStatus::Completed, test_timestamp(100))
+            .unwrap();
         assert_eq!(tree.get(&id).unwrap().status, GoalStatus::Completed);
     }
 
@@ -255,7 +480,7 @@ mod tests {
     fn update_not_found() {
         let mut tree = GoalTree::new();
         assert!(
-            tree.update_status(&Uuid::nil(), GoalStatus::Active)
+            tree.update_status(&Uuid::nil(), GoalStatus::Active, test_timestamp(100))
                 .is_err()
         );
     }

--- a/crates/exo-catapult/src/goal.rs
+++ b/crates/exo-catapult/src/goal.rs
@@ -427,6 +427,44 @@ mod tests {
     }
 
     #[test]
+    fn goal_validation_rejects_empty_title_self_parent_and_regressive_update() {
+        let mut goal = valid_goal("Test", GoalLevel::Company, GoalStatus::Planned);
+        goal.title = "   ".into();
+        assert!(goal.validate().is_err());
+
+        let mut goal = valid_goal("Test", GoalLevel::Company, GoalStatus::Planned);
+        goal.parent_id = Some(goal.id);
+        assert!(goal.validate().is_err());
+
+        let mut tree = GoalTree::new();
+        let goal = valid_goal("Test", GoalLevel::Company, GoalStatus::Planned);
+        let id = goal.id;
+        tree.add(goal).unwrap();
+        assert!(
+            tree.update_status(&id, GoalStatus::Blocked, test_timestamp(0))
+                .is_ok()
+        );
+        assert!(
+            tree.update_status(&id, GoalStatus::Completed, Timestamp::new(1, 0))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn tree_validate_rejects_deserialized_key_mismatch_and_orphan_parent() {
+        let mut key_mismatch = GoalTree::new();
+        let goal = valid_goal("Mismatch", GoalLevel::Company, GoalStatus::Planned);
+        key_mismatch.goals.insert(test_uuid(9), goal);
+        assert!(key_mismatch.validate().is_err());
+
+        let mut orphan = GoalTree::new();
+        let mut child = valid_goal("Child", GoalLevel::Team, GoalStatus::Planned);
+        child.parent_id = Some(test_uuid(8));
+        orphan.goals.insert(child.id, child);
+        assert!(orphan.validate().is_err());
+    }
+
+    #[test]
     fn update_status_requires_caller_supplied_hlc() {
         let mut tree = GoalTree::new();
         let goal = valid_goal("Test", GoalLevel::Company, GoalStatus::Planned);

--- a/crates/exo-catapult/src/heartbeat.rs
+++ b/crates/exo-catapult/src/heartbeat.rs
@@ -418,6 +418,54 @@ mod tests {
     }
 
     #[test]
+    fn heartbeat_input_validation_rejects_placeholder_and_regressive_time() {
+        let mut input = valid_heartbeat_input(test_did("agent1"), 1000);
+        input.id = Uuid::nil();
+        assert!(HeartbeatRecord::new(input).is_err());
+
+        let mut input = valid_heartbeat_input(test_did("agent1"), 1000);
+        input.newco_id = Uuid::nil();
+        assert!(HeartbeatRecord::new(input).is_err());
+
+        let mut input = valid_heartbeat_input(test_did("agent1"), 1000);
+        input.started = Timestamp::ZERO;
+        assert!(HeartbeatRecord::new(input).is_err());
+
+        let mut input = valid_heartbeat_input(test_did("agent1"), 1000);
+        input.finished = Some(Timestamp::new(999, 0));
+        assert!(HeartbeatRecord::new(input).is_err());
+    }
+
+    #[test]
+    fn monitor_validate_rejects_deserialized_inconsistencies() {
+        let did = test_did("agent1");
+        let record = make_heartbeat(did.clone(), 1000);
+        let mut monitor = HeartbeatMonitor::new();
+        monitor.record(record.clone()).unwrap();
+        assert!(monitor.validate().is_ok());
+
+        let mut mismatched_key = HeartbeatMonitor::new();
+        let other = test_did("other");
+        mismatched_key
+            .last_seen
+            .insert(other.clone(), record.started);
+        mismatched_key.history.insert(other, vec![record.clone()]);
+        assert!(mismatched_key.validate().is_err());
+
+        let mut stale_last_seen = monitor.clone();
+        stale_last_seen
+            .last_seen
+            .insert(did.clone(), Timestamp::new(1, 0));
+        assert!(stale_last_seen.validate().is_err());
+
+        let mut missing_history = HeartbeatMonitor::new();
+        missing_history
+            .last_seen
+            .insert(did, Timestamp::new(1000, 0));
+        assert!(missing_history.validate().is_err());
+    }
+
+    #[test]
     fn record_and_last_seen() {
         let mut monitor = HeartbeatMonitor::new();
         let did = test_did("agent1");

--- a/crates/exo-catapult/src/heartbeat.rs
+++ b/crates/exo-catapult/src/heartbeat.rs
@@ -9,6 +9,12 @@ use exo_core::{Did, Hash256, Timestamp};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::error::{CatapultError, Result};
+
+/// Domain tag for canonical heartbeat receipt hashes.
+pub const HEARTBEAT_HASH_DOMAIN: &str = "exo.catapult.heartbeat_record.v1";
+const HEARTBEAT_HASH_SCHEMA_VERSION: &str = "1.0.0";
+
 /// Status of a heartbeat invocation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum HeartbeatStatus {
@@ -32,6 +38,81 @@ pub struct HeartbeatRecord {
     pub usage: BTreeMap<String, u64>,
     /// Hash of this heartbeat for receipt chaining.
     pub receipt_hash: Hash256,
+}
+
+/// Caller-supplied deterministic metadata for creating a heartbeat record.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HeartbeatRecordInput {
+    pub id: Uuid,
+    pub newco_id: Uuid,
+    pub agent_did: Did,
+    pub status: HeartbeatStatus,
+    pub started: Timestamp,
+    pub finished: Option<Timestamp>,
+    pub usage: BTreeMap<String, u64>,
+}
+
+impl HeartbeatRecord {
+    /// Create a heartbeat record with a deterministic canonical receipt hash.
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] when the input contains placeholder metadata
+    /// or canonical hashing fails.
+    pub fn new(input: HeartbeatRecordInput) -> Result<Self> {
+        validate_heartbeat_input(&input)?;
+        let receipt_hash = heartbeat_record_receipt_hash(&input)?;
+        Ok(Self {
+            id: input.id,
+            newco_id: input.newco_id,
+            agent_did: input.agent_did,
+            status: input.status,
+            started: input.started,
+            finished: input.finished,
+            usage: input.usage,
+            receipt_hash,
+        })
+    }
+
+    /// Validate externally supplied or deserialized heartbeat metadata.
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] when placeholders are present or the stored
+    /// receipt hash does not match the canonical heartbeat payload.
+    pub fn validate(&self) -> Result<()> {
+        let input = self.input();
+        validate_heartbeat_input(&input)?;
+        if self.receipt_hash == Hash256::ZERO {
+            return Err(CatapultError::InvalidHeartbeat {
+                reason: "heartbeat receipt hash must not be zero".into(),
+            });
+        }
+        if !self.verify_receipt_hash()? {
+            return Err(CatapultError::InvalidHeartbeat {
+                reason: "heartbeat receipt hash does not match canonical payload".into(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Verify the stored receipt hash against the canonical payload.
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] if canonical hashing fails.
+    pub fn verify_receipt_hash(&self) -> Result<bool> {
+        Ok(heartbeat_record_receipt_hash(&self.input())? == self.receipt_hash)
+    }
+
+    fn input(&self) -> HeartbeatRecordInput {
+        HeartbeatRecordInput {
+            id: self.id,
+            newco_id: self.newco_id,
+            agent_did: self.agent_did.clone(),
+            status: self.status,
+            started: self.started,
+            finished: self.finished,
+            usage: self.usage.clone(),
+        }
+    }
 }
 
 /// An alert generated when an agent misses their heartbeat window.
@@ -94,11 +175,13 @@ impl HeartbeatMonitor {
     }
 
     /// Record a heartbeat from an agent.
-    pub fn record(&mut self, record: HeartbeatRecord) {
+    pub fn record(&mut self, record: HeartbeatRecord) -> Result<()> {
+        record.validate()?;
         let did = record.agent_did.clone();
         let ts = record.started;
         self.last_seen.insert(did.clone(), ts);
         self.history.entry(did).or_default().push(record);
+        Ok(())
     }
 
     /// Check all agents for heartbeat health at the given time.
@@ -143,12 +226,129 @@ impl HeartbeatMonitor {
     pub fn agent_count(&self) -> usize {
         self.last_seen.len()
     }
+
+    /// Validate a deserialized monitor and all recorded heartbeat history.
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] when heartbeat history contains placeholders
+    /// or a last-seen timestamp disagrees with recorded history.
+    pub fn validate(&self) -> Result<()> {
+        for (did, history) in &self.history {
+            let mut latest = None;
+            for record in history {
+                if record.agent_did != *did {
+                    return Err(CatapultError::InvalidHeartbeat {
+                        reason: format!(
+                            "heartbeat history key {did} does not match record DID {}",
+                            record.agent_did
+                        ),
+                    });
+                }
+                record.validate()?;
+                latest = Some(latest.map_or(record.started, |current: Timestamp| {
+                    current.max(record.started)
+                }));
+            }
+            match (self.last_seen.get(did), latest) {
+                (Some(last_seen), Some(latest_started)) if *last_seen == latest_started => {}
+                (Some(_), Some(latest_started)) => {
+                    return Err(CatapultError::InvalidHeartbeat {
+                        reason: format!(
+                            "heartbeat last_seen for {did} does not match latest record {latest_started}"
+                        ),
+                    });
+                }
+                _ => {
+                    return Err(CatapultError::InvalidHeartbeat {
+                        reason: format!("heartbeat history for {did} has no matching last_seen"),
+                    });
+                }
+            }
+        }
+
+        for did in self.last_seen.keys() {
+            if !self.history.contains_key(did) {
+                return Err(CatapultError::InvalidHeartbeat {
+                    reason: format!("heartbeat last_seen for {did} has no history"),
+                });
+            }
+        }
+        Ok(())
+    }
 }
 
 impl Default for HeartbeatMonitor {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Compute the canonical receipt hash for a heartbeat record.
+///
+/// # Errors
+/// Returns [`CatapultError`] if canonical CBOR hashing fails.
+pub fn heartbeat_record_receipt_hash(input: &HeartbeatRecordInput) -> Result<Hash256> {
+    validate_heartbeat_input(input)?;
+    exo_core::hash::hash_structured(&HeartbeatHashPayload::from_input(input)).map_err(|e| {
+        CatapultError::InvalidHeartbeat {
+            reason: format!("heartbeat canonical hash failed: {e}"),
+        }
+    })
+}
+
+#[derive(Serialize)]
+struct HeartbeatHashPayload<'a> {
+    domain: &'static str,
+    schema_version: &'static str,
+    id: Uuid,
+    newco_id: Uuid,
+    agent_did: &'a Did,
+    status: HeartbeatStatus,
+    started: Timestamp,
+    finished: Option<Timestamp>,
+    usage: &'a BTreeMap<String, u64>,
+}
+
+impl<'a> HeartbeatHashPayload<'a> {
+    fn from_input(input: &'a HeartbeatRecordInput) -> Self {
+        Self {
+            domain: HEARTBEAT_HASH_DOMAIN,
+            schema_version: HEARTBEAT_HASH_SCHEMA_VERSION,
+            id: input.id,
+            newco_id: input.newco_id,
+            agent_did: &input.agent_did,
+            status: input.status,
+            started: input.started,
+            finished: input.finished,
+            usage: &input.usage,
+        }
+    }
+}
+
+fn validate_heartbeat_input(input: &HeartbeatRecordInput) -> Result<()> {
+    if input.id.is_nil() {
+        return Err(CatapultError::InvalidHeartbeat {
+            reason: "heartbeat id must be caller-supplied and non-nil".into(),
+        });
+    }
+    if input.newco_id.is_nil() {
+        return Err(CatapultError::InvalidHeartbeat {
+            reason: "heartbeat newco id must be non-nil".into(),
+        });
+    }
+    if input.started == Timestamp::ZERO {
+        return Err(CatapultError::InvalidHeartbeat {
+            reason: "heartbeat started timestamp must be caller-supplied HLC".into(),
+        });
+    }
+    if let Some(finished) = input.finished {
+        if finished < input.started {
+            return Err(CatapultError::InvalidHeartbeat {
+                reason: "heartbeat finished timestamp must not precede started timestamp".into(),
+            });
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -160,29 +360,68 @@ mod tests {
     }
 
     fn make_heartbeat(did: Did, time_ms: u64) -> HeartbeatRecord {
-        HeartbeatRecord {
-            id: Uuid::new_v4(),
-            newco_id: Uuid::nil(),
+        let mut bytes = [0u8; 16];
+        bytes[..8].copy_from_slice(&time_ms.to_le_bytes());
+        HeartbeatRecord::new(HeartbeatRecordInput {
+            id: Uuid::from_bytes(bytes),
+            newco_id: test_uuid(3),
             agent_did: did,
             status: HeartbeatStatus::Completed,
-            started: Timestamp {
-                physical_ms: time_ms,
-                logical: 0,
-            },
-            finished: Some(Timestamp {
-                physical_ms: time_ms + 100,
-                logical: 0,
-            }),
+            started: Timestamp::new(time_ms, 0),
+            finished: Some(Timestamp::new(time_ms + 100, 0)),
             usage: BTreeMap::new(),
-            receipt_hash: Hash256::ZERO,
+        })
+        .unwrap()
+    }
+
+    fn test_uuid(byte: u8) -> Uuid {
+        Uuid::from_bytes([byte; 16])
+    }
+
+    fn valid_heartbeat_input(did: Did, time_ms: u64) -> HeartbeatRecordInput {
+        HeartbeatRecordInput {
+            id: test_uuid(1),
+            newco_id: test_uuid(2),
+            agent_did: did,
+            status: HeartbeatStatus::Completed,
+            started: Timestamp::new(time_ms, 0),
+            finished: Some(Timestamp::new(time_ms + 100, 0)),
+            usage: BTreeMap::new(),
         }
+    }
+
+    #[test]
+    fn heartbeat_record_new_requires_caller_supplied_provenance() {
+        let record = HeartbeatRecord::new(valid_heartbeat_input(test_did("agent1"), 1000)).unwrap();
+
+        assert_ne!(record.id, Uuid::nil());
+        assert_ne!(record.newco_id, Uuid::nil());
+        assert_ne!(record.started, Timestamp::ZERO);
+        assert_ne!(record.receipt_hash, Hash256::ZERO);
+        assert!(record.verify_receipt_hash().unwrap());
+    }
+
+    #[test]
+    fn monitor_rejects_placeholder_or_tampered_heartbeat_records() {
+        let mut monitor = HeartbeatMonitor::new();
+
+        let mut record =
+            HeartbeatRecord::new(valid_heartbeat_input(test_did("agent1"), 1000)).unwrap();
+        record.receipt_hash = Hash256::ZERO;
+        assert!(monitor.record(record).is_err());
+
+        let mut record =
+            HeartbeatRecord::new(valid_heartbeat_input(test_did("agent1"), 1000)).unwrap();
+        record.status = HeartbeatStatus::Failed;
+        assert!(!record.verify_receipt_hash().unwrap());
+        assert!(monitor.record(record).is_err());
     }
 
     #[test]
     fn record_and_last_seen() {
         let mut monitor = HeartbeatMonitor::new();
         let did = test_did("agent1");
-        monitor.record(make_heartbeat(did.clone(), 1000));
+        monitor.record(make_heartbeat(did.clone(), 1000)).unwrap();
         assert_eq!(monitor.last_seen(&did).unwrap().physical_ms, 1000);
         assert_eq!(monitor.agent_count(), 1);
     }
@@ -191,7 +430,7 @@ mod tests {
     fn no_alerts_when_healthy() {
         let mut monitor = HeartbeatMonitor::new();
         let did = test_did("agent1");
-        monitor.record(make_heartbeat(did, 1000));
+        monitor.record(make_heartbeat(did, 1000)).unwrap();
 
         let now = Timestamp {
             physical_ms: 1500,
@@ -204,7 +443,7 @@ mod tests {
     fn warning_alert() {
         let mut monitor = HeartbeatMonitor::with_thresholds(100, 200);
         let did = test_did("agent1");
-        monitor.record(make_heartbeat(did, 1000));
+        monitor.record(make_heartbeat(did, 1000)).unwrap();
 
         let now = Timestamp {
             physical_ms: 1150,
@@ -219,7 +458,7 @@ mod tests {
     fn critical_alert() {
         let mut monitor = HeartbeatMonitor::with_thresholds(100, 200);
         let did = test_did("agent1");
-        monitor.record(make_heartbeat(did, 1000));
+        monitor.record(make_heartbeat(did, 1000)).unwrap();
 
         let now = Timestamp {
             physical_ms: 1250,
@@ -233,8 +472,8 @@ mod tests {
     #[test]
     fn multiple_agents() {
         let mut monitor = HeartbeatMonitor::with_thresholds(100, 200);
-        monitor.record(make_heartbeat(test_did("a"), 1000));
-        monitor.record(make_heartbeat(test_did("b"), 900));
+        monitor.record(make_heartbeat(test_did("a"), 1000)).unwrap();
+        monitor.record(make_heartbeat(test_did("b"), 900)).unwrap();
 
         let now = Timestamp {
             physical_ms: 1150,
@@ -249,8 +488,8 @@ mod tests {
     fn history_tracking() {
         let mut monitor = HeartbeatMonitor::new();
         let did = test_did("agent1");
-        monitor.record(make_heartbeat(did.clone(), 1000));
-        monitor.record(make_heartbeat(did.clone(), 2000));
+        monitor.record(make_heartbeat(did.clone(), 1000)).unwrap();
+        monitor.record(make_heartbeat(did.clone(), 2000)).unwrap();
         assert_eq!(monitor.history(&did).unwrap().len(), 2);
     }
 

--- a/crates/exo-catapult/src/integration.rs
+++ b/crates/exo-catapult/src/integration.rs
@@ -158,10 +158,10 @@ mod tests {
             display_name: name.into(),
             capabilities: vec![],
             status: AgentStatus::Active,
-            last_heartbeat: Timestamp::ZERO,
+            last_heartbeat: Timestamp::new(1_765_000_000_100, 0),
             budget_spent_cents: 0,
             budget_limit_cents: 100_000,
-            hired_at: Timestamp::ZERO,
+            hired_at: Timestamp::new(1_765_000_000_000, 0),
             hired_by: test_did("hr"),
             commandbase_profile: None,
         }

--- a/crates/exo-catapult/src/lib.rs
+++ b/crates/exo-catapult/src/lib.rs
@@ -30,14 +30,16 @@ pub mod phase;
 pub mod receipt;
 
 // Re-export the most commonly used items at crate root.
-pub use agent::{AgentRoster, AgentStatus, CatapultAgent};
-pub use budget::{BudgetLedger, BudgetPolicy, BudgetScope, BudgetVerdict, CostEvent};
+pub use agent::{AgentRoster, AgentStatus, CatapultAgent, CatapultAgentInput};
+pub use budget::{
+    BudgetLedger, BudgetPolicy, BudgetScope, BudgetVerdict, CostEvent, CostEventInput,
+};
 pub use error::{CatapultError, Result};
 pub use franchise::{
     BusinessModel, FranchiseBlueprint, FranchiseBlueprintInput, FranchiseRegistry,
 };
-pub use goal::{Goal, GoalLevel, GoalStatus, GoalTree};
-pub use heartbeat::{HeartbeatMonitor, HeartbeatRecord, HeartbeatStatus};
+pub use goal::{Goal, GoalInput, GoalLevel, GoalStatus, GoalTree};
+pub use heartbeat::{HeartbeatMonitor, HeartbeatRecord, HeartbeatRecordInput, HeartbeatStatus};
 pub use newco::{Newco, NewcoInput, NewcoStatus};
 pub use oda::{MosCode, OdaSlot};
 pub use phase::OperationalPhase;

--- a/crates/exo-catapult/src/newco.rs
+++ b/crates/exo-catapult/src/newco.rs
@@ -413,6 +413,17 @@ mod tests {
         assert!(reg.register(newco).is_err());
     }
 
+    #[test]
+    fn newco_validate_rejects_deserialized_bad_heartbeat_state() {
+        let mut newco = make_newco();
+        newco.last_heartbeat = Timestamp::ZERO;
+        assert!(newco.validate().is_err());
+
+        let mut newco = make_newco();
+        newco.last_heartbeat = Timestamp::new(1, 0);
+        assert!(newco.validate().is_err());
+    }
+
     fn make_agent(slot: OdaSlot) -> CatapultAgent {
         CatapultAgent {
             did: Did::new(&format!("did:exo:test-{slot:?}").to_ascii_lowercase()).unwrap(),
@@ -519,7 +530,10 @@ mod tests {
 
         assert_eq!(reg.len(), 1);
         assert!(reg.get(&id).is_some());
+        assert!(reg.get_mut(&id).is_some());
         assert!(reg.receipts(&id).is_some());
+        assert!(reg.receipts_mut(&id).is_some());
+        assert_eq!(reg.list().len(), 1);
     }
 
     #[test]

--- a/crates/exo-catapult/src/newco.rs
+++ b/crates/exo-catapult/src/newco.rs
@@ -124,6 +124,9 @@ impl Newco {
                 reason: "newco last heartbeat must not precede creation timestamp".into(),
             });
         }
+        self.roster.validate()?;
+        self.budget.validate()?;
+        self.goals.validate()?;
         Ok(())
     }
 
@@ -131,6 +134,7 @@ impl Newco {
     ///
     /// Validates both the phase transition and roster sufficiency.
     pub fn advance_phase(&mut self, target: OperationalPhase) -> Result<()> {
+        self.validate()?;
         // Validate the phase transition
         if !self.phase.can_transition_to(target) {
             return Err(CatapultError::InvalidPhaseTransition {
@@ -165,6 +169,7 @@ impl Newco {
 
     /// Hire an agent into an ODA slot.
     pub fn hire_agent(&mut self, agent: CatapultAgent) -> Result<()> {
+        self.validate()?;
         self.roster.fill_slot(agent)
     }
 
@@ -415,10 +420,10 @@ mod tests {
             display_name: slot.display_name().into(),
             capabilities: vec![],
             status: AgentStatus::Active,
-            last_heartbeat: Timestamp::ZERO,
+            last_heartbeat: Timestamp::new(1_765_000_000_100, 0),
             budget_spent_cents: 0,
             budget_limit_cents: 100_000,
-            hired_at: Timestamp::ZERO,
+            hired_at: Timestamp::new(1_765_000_000_000, 0),
             hired_by: test_did(),
             commandbase_profile: None,
         }

--- a/crates/exo-catapult/src/receipt.rs
+++ b/crates/exo-catapult/src/receipt.rs
@@ -560,6 +560,81 @@ mod tests {
     }
 
     #[test]
+    fn receipt_rejects_invalid_operation_payloads() {
+        let signer = keypair(9);
+        let invalid_operations = [
+            FranchiseOperation::BlueprintPublished {
+                blueprint_id: Uuid::nil(),
+            },
+            FranchiseOperation::BudgetPolicyUpdated {
+                policy_id: Uuid::nil(),
+            },
+            FranchiseOperation::CostRecorded {
+                event_id: Uuid::nil(),
+                amount_cents: 1,
+            },
+            FranchiseOperation::CostRecorded {
+                event_id: uuid(30),
+                amount_cents: 0,
+            },
+            FranchiseOperation::GoalCreated {
+                goal_id: Uuid::nil(),
+            },
+            FranchiseOperation::GoalCompleted {
+                goal_id: Uuid::nil(),
+            },
+            FranchiseOperation::FranchiseReplicated {
+                source_newco_id: Uuid::nil(),
+                target_newco_id: uuid(31),
+            },
+            FranchiseOperation::FranchiseReplicated {
+                source_newco_id: uuid(31),
+                target_newco_id: Uuid::nil(),
+            },
+            FranchiseOperation::FranchiseReplicated {
+                source_newco_id: uuid(31),
+                target_newco_id: uuid(31),
+            },
+            FranchiseOperation::PaceEscalation {
+                from_level: " ".into(),
+                to_level: "incident command".into(),
+            },
+        ];
+
+        for (index, operation) in invalid_operations.into_iter().enumerate() {
+            let id = uuid(100 + u128::try_from(index).unwrap());
+            assert!(
+                FranchiseReceipt::signed(
+                    receipt_input(id, uuid(10), operation, Hash256::ZERO),
+                    signer.secret_key(),
+                )
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn unsigned_receipt_fails_signature_verification() {
+        let signer = keypair(10);
+        let mut receipt = FranchiseReceipt::signed(
+            receipt_input(
+                uuid(90),
+                uuid(10),
+                FranchiseOperation::HeartbeatRecorded {
+                    agent_did: test_did(),
+                },
+                Hash256::ZERO,
+            ),
+            signer.secret_key(),
+        )
+        .unwrap();
+        receipt.signature = Signature::Empty;
+
+        assert!(!receipt.is_signed());
+        assert!(!receipt.verify_signature(signer.public_key()).unwrap());
+    }
+
+    #[test]
     fn chain_append_requires_valid_signature_and_prev_hash() {
         let signer = keypair(5);
         let wrong = keypair(6);

--- a/crates/exochain-wasm/src/catapult_bindings.rs
+++ b/crates/exochain-wasm/src/catapult_bindings.rs
@@ -222,6 +222,9 @@ pub fn wasm_hire_agent(newco_json: &str, agent_json: &str) -> Result<JsValue, Js
 #[wasm_bindgen]
 pub fn wasm_release_agent(newco_json: &str, slot_json: &str) -> Result<JsValue, JsValue> {
     let mut newco: exo_catapult::newco::Newco = from_json_str(newco_json)?;
+    newco
+        .validate()
+        .map_err(|e| JsValue::from_str(&format!("Newco validation error: {e}")))?;
     let slot: exo_catapult::OdaSlot = from_json_str(slot_json)?;
     let released = newco
         .release_agent(&slot)
@@ -236,6 +239,9 @@ pub fn wasm_release_agent(newco_json: &str, slot_json: &str) -> Result<JsValue, 
 #[wasm_bindgen]
 pub fn wasm_roster_status(newco_json: &str) -> Result<JsValue, JsValue> {
     let newco: exo_catapult::newco::Newco = from_json_str(newco_json)?;
+    newco
+        .validate()
+        .map_err(|e| JsValue::from_str(&format!("Newco validation error: {e}")))?;
     to_js_value(&serde_json::json!({
         "filled": newco.roster.filled_count(),
         "vacancies": newco.roster.vacancy_count(),
@@ -249,6 +255,9 @@ pub fn wasm_roster_status(newco_json: &str) -> Result<JsValue, JsValue> {
 #[wasm_bindgen]
 pub fn wasm_oda_authority_chain(newco_json: &str) -> Result<JsValue, JsValue> {
     let newco: exo_catapult::newco::Newco = from_json_str(newco_json)?;
+    newco
+        .validate()
+        .map_err(|e| JsValue::from_str(&format!("Newco validation error: {e}")))?;
     let pace = exo_catapult::integration::build_pace_config(&newco);
     to_js_value(&serde_json::json!({
         "primary": pace.primary.map(|d| d.to_string()),
@@ -266,8 +275,12 @@ pub fn wasm_oda_authority_chain(newco_json: &str) -> Result<JsValue, JsValue> {
 #[wasm_bindgen]
 pub fn wasm_record_heartbeat(monitor_json: &str, record_json: &str) -> Result<JsValue, JsValue> {
     let mut monitor: exo_catapult::HeartbeatMonitor = from_json_str(monitor_json)?;
-    let record: exo_catapult::HeartbeatRecord = from_json_str(record_json)?;
-    monitor.record(record);
+    let input: exo_catapult::HeartbeatRecordInput = from_json_str(record_json)?;
+    let record = exo_catapult::HeartbeatRecord::new(input)
+        .map_err(|e| JsValue::from_str(&format!("Heartbeat record error: {e}")))?;
+    monitor
+        .record(record)
+        .map_err(|e| JsValue::from_str(&format!("Heartbeat record error: {e}")))?;
     to_js_value(&monitor)
 }
 
@@ -275,10 +288,10 @@ pub fn wasm_record_heartbeat(monitor_json: &str, record_json: &str) -> Result<Js
 #[wasm_bindgen]
 pub fn wasm_check_heartbeat_health(monitor_json: &str, now_ms: u64) -> Result<JsValue, JsValue> {
     let monitor: exo_catapult::HeartbeatMonitor = from_json_str(monitor_json)?;
-    let now = exo_core::Timestamp {
-        physical_ms: now_ms,
-        logical: 0,
-    };
+    monitor
+        .validate()
+        .map_err(|e| JsValue::from_str(&format!("Heartbeat monitor validation error: {e}")))?;
+    let now = parse_timestamp(now_ms, 0, "heartbeat health check")?;
     let alerts = monitor.check_health(&now);
     to_js_value(&serde_json::json!({
         "alerts": alerts.iter().map(|a| serde_json::json!({
@@ -299,8 +312,12 @@ pub fn wasm_check_heartbeat_health(monitor_json: &str, now_ms: u64) -> Result<Js
 #[wasm_bindgen]
 pub fn wasm_record_cost_event(ledger_json: &str, event_json: &str) -> Result<JsValue, JsValue> {
     let mut ledger: exo_catapult::BudgetLedger = from_json_str(ledger_json)?;
-    let event: exo_catapult::CostEvent = from_json_str(event_json)?;
-    ledger.record_cost(event);
+    let input: exo_catapult::CostEventInput = from_json_str(event_json)?;
+    let event = exo_catapult::CostEvent::new(input)
+        .map_err(|e| JsValue::from_str(&format!("Cost event error: {e}")))?;
+    ledger
+        .record_cost(event)
+        .map_err(|e| JsValue::from_str(&format!("Cost event error: {e}")))?;
     to_js_value(&ledger)
 }
 
@@ -308,6 +325,9 @@ pub fn wasm_record_cost_event(ledger_json: &str, event_json: &str) -> Result<JsV
 #[wasm_bindgen]
 pub fn wasm_check_budget_status(ledger_json: &str, scope_json: &str) -> Result<JsValue, JsValue> {
     let ledger: exo_catapult::BudgetLedger = from_json_str(ledger_json)?;
+    ledger
+        .validate()
+        .map_err(|e| JsValue::from_str(&format!("Budget ledger validation error: {e}")))?;
     let scope: exo_catapult::BudgetScope = from_json_str(scope_json)?;
     let verdict = ledger.check_enforcement(&scope);
     let json = match verdict {
@@ -326,6 +346,9 @@ pub fn wasm_check_budget_status(ledger_json: &str, scope_json: &str) -> Result<J
 #[wasm_bindgen]
 pub fn wasm_enforce_budget(newco_json: &str) -> Result<JsValue, JsValue> {
     let newco: exo_catapult::newco::Newco = from_json_str(newco_json)?;
+    newco
+        .validate()
+        .map_err(|e| JsValue::from_str(&format!("Newco validation error: {e}")))?;
     let company_verdict = newco
         .budget
         .check_enforcement(&exo_catapult::BudgetScope::Company);
@@ -351,6 +374,8 @@ pub fn wasm_enforce_budget(newco_json: &str) -> Result<JsValue, JsValue> {
 #[wasm_bindgen]
 pub fn wasm_create_goal(tree_json: &str, goal_json: &str) -> Result<JsValue, JsValue> {
     let mut tree: exo_catapult::GoalTree = from_json_str(tree_json)?;
+    tree.validate()
+        .map_err(|e| JsValue::from_str(&format!("Goal tree validation error: {e}")))?;
     let goal: exo_catapult::Goal = from_json_str(goal_json)?;
     tree.add(goal)
         .map_err(|e| JsValue::from_str(&format!("Goal error: {e}")))?;
@@ -363,13 +388,18 @@ pub fn wasm_update_goal_status(
     tree_json: &str,
     goal_id: &str,
     status_json: &str,
+    updated_physical_ms: u64,
+    updated_logical: u32,
 ) -> Result<JsValue, JsValue> {
     let mut tree: exo_catapult::GoalTree = from_json_str(tree_json)?;
+    tree.validate()
+        .map_err(|e| JsValue::from_str(&format!("Goal tree validation error: {e}")))?;
     let id: uuid::Uuid = goal_id
         .parse()
         .map_err(|e| JsValue::from_str(&format!("UUID error: {e}")))?;
     let status: exo_catapult::GoalStatus = from_json_str(status_json)?;
-    tree.update_status(&id, status)
+    let updated = parse_timestamp(updated_physical_ms, updated_logical, "goal update")?;
+    tree.update_status(&id, status, updated)
         .map_err(|e| JsValue::from_str(&format!("Goal update error: {e}")))?;
     to_js_value(&tree)
 }
@@ -378,6 +408,8 @@ pub fn wasm_update_goal_status(
 #[wasm_bindgen]
 pub fn wasm_goal_alignment_score(tree_json: &str) -> Result<u32, JsValue> {
     let tree: exo_catapult::GoalTree = from_json_str(tree_json)?;
+    tree.validate()
+        .map_err(|e| JsValue::from_str(&format!("Goal tree validation error: {e}")))?;
     Ok(tree.alignment_score())
 }
 

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -601,6 +601,81 @@ test('wasm_instantiate_newco', () => {
   return newco;
 });
 
+test('wasm_record_cost_event', () => {
+  const ledger = wasm.wasm_record_cost_event(
+    JSON.stringify({ policies: [], events: [] }),
+    JSON.stringify({
+      id: UUID_1,
+      newco_id: UUID_2,
+      agent_did: TEST_DID,
+      slot: 'VentureCommander',
+      amount: 1234,
+      metric: 'BilledCents',
+      description: 'Bridge cost event',
+      timestamp: { physical_ms: NOW_NUM + 10, logical: 0 }
+    })
+  );
+  if (ledger.events.length !== 1) throw new Error('cost event was not recorded');
+  assertNonZeroHash(ledger.events[0].receipt_hash, 'cost event receipt_hash');
+  return ledger;
+});
+
+test('wasm_record_heartbeat', () => {
+  const monitor = wasm.wasm_record_heartbeat(
+    JSON.stringify({
+      last_seen: {},
+      history: {},
+      warn_ms: 180000,
+      timeout_ms: 300000
+    }),
+    JSON.stringify({
+      id: UUID_2,
+      newco_id: UUID_3,
+      agent_did: TEST_DID,
+      status: 'Completed',
+      started: { physical_ms: NOW_NUM + 20, logical: 0 },
+      finished: { physical_ms: NOW_NUM + 120, logical: 0 },
+      usage: { tokens: 12 }
+    })
+  );
+  if (monitor.last_seen[TEST_DID].physical_ms !== NOW_NUM + 20) {
+    throw new Error('heartbeat last_seen was not recorded');
+  }
+  assertNonZeroHash(monitor.history[TEST_DID][0].receipt_hash, 'heartbeat receipt_hash');
+  return monitor;
+});
+
+test('wasm_create_goal and wasm_update_goal_status', () => {
+  const tree = wasm.wasm_create_goal(
+    JSON.stringify({ goals: {} }),
+    JSON.stringify({
+      id: UUID_3,
+      title: 'Bridge goal',
+      description: null,
+      level: 'Company',
+      status: 'Planned',
+      parent_id: null,
+      owner_slot: null,
+      created: { physical_ms: NOW_NUM + 30, logical: 0 },
+      updated: { physical_ms: NOW_NUM + 30, logical: 0 }
+    })
+  );
+  const updated = wasm.wasm_update_goal_status(
+    JSON.stringify(tree),
+    UUID_3,
+    JSON.stringify('Completed'),
+    BigInt(NOW_NUM + 40),
+    0
+  );
+  if (updated.goals[UUID_3].status !== 'Completed') {
+    throw new Error('goal status was not updated');
+  }
+  if (updated.goals[UUID_3].updated.physical_ms !== NOW_NUM + 40) {
+    throw new Error('goal updated timestamp was not caller-supplied HLC');
+  }
+  return updated;
+});
+
 // =========================================================================
 // Module 9 — Risk Assessment
 // =========================================================================


### PR DESCRIPTION
## Summary
- add deterministic input constructors and validation for Catapult agents, budget policies/events, goals, and heartbeat records
- canonicalize cost-event and heartbeat receipt hashes with domain-tagged CBOR payloads
- make Catapult resource/event mutation boundaries fail closed on nil IDs, zero HLC timestamps, zero hashes, duplicate IDs, orphan parents, and tampered hashes
- align Catapult WASM cost/heartbeat/goal exports and add JS bridge coverage

## TDD / red check
- `cargo test -p exo-catapult agent_new_requires_caller_supplied_lifecycle_metadata --lib` initially failed because the input constructors, hash verifiers, and Result-returning mutation APIs did not exist

## Verification
- `cargo test -p exo-catapult --lib`
- `cargo test -p exochain-wasm --lib`
- `cargo test -p exo-catapult`
- `cargo test -p exochain-wasm`
- `cargo build -p exo-catapult`
- `cargo build -p exochain-wasm`
- `cargo clippy -p exo-catapult --lib -- -D warnings`
- `cargo clippy -p exo-catapult --tests -- -D warnings -A clippy::unwrap_used -A clippy::expect_used`
- `cargo clippy -p exochain-wasm --lib -- -D warnings`
- `cargo clippy -p exochain-wasm --tests -- -D warnings -A clippy::unwrap_used -A clippy::expect_used`
- `wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm --out-name exochain_wasm`
- `wasm-pack build crates/exochain-wasm --target nodejs --release --out-dir ../../demo/packages/exochain-wasm/wasm --out-name exochain_wasm`
- `node packages/exochain-wasm/test/bridge_verification.mjs` (121/121)
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo build --workspace --release`
- `cargo test --workspace --release`

Ledger: `/Users/bobstewart/obsidian/aeon/exochain/council-intake/_EXECUTION-LEDGER.md`
Initiative: `/Users/bobstewart/obsidian/aeon/Initiatives/fix-scaffold-r3-catapult-resource-event-guards.md`
