### PR TITLE
fix(decision-forum): require deterministic provenance inputs

### DIFF
--- a/crates/decision-forum/src/accountability.rs
+++ b/crates/decision-forum/src/accountability.rs
@@ -48,29 +48,46 @@ pub struct AccountabilityAction {
 pub const SUSPENSION_ENACT_LIMIT_MS: u64 = 60_000; // 60 seconds
 pub const DUE_PROCESS_WINDOW_MS: u64 = 7 * 24 * 60 * 60 * 1000; // 7 days
 
+/// Caller-supplied metadata for proposing an accountability action.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AccountabilityInput {
+    pub id: Uuid,
+    pub action_type: AccountabilityActionType,
+    pub target: Did,
+    pub proposer: Did,
+    pub reason: String,
+    pub evidence_hash: Hash256,
+    pub proposed_at: Timestamp,
+}
+
 /// Propose an accountability action.
-pub fn propose(
-    action_type: AccountabilityActionType,
-    target: &Did,
-    proposer: &Did,
-    reason: &str,
-    evidence_hash: Hash256,
-    timestamp: Timestamp,
-) -> AccountabilityAction {
-    let due_process_deadline_ms = timestamp.physical_ms.saturating_add(DUE_PROCESS_WINDOW_MS);
-    AccountabilityAction {
-        id: Uuid::new_v4(),
-        action_type,
-        target_did: target.clone(),
-        proposer_did: proposer.clone(),
-        reason: reason.to_owned(),
-        evidence_hash,
+pub fn propose(input: AccountabilityInput) -> Result<AccountabilityAction> {
+    validate_uuid(input.id, "accountability action id")?;
+    validate_timestamp(input.proposed_at, "accountability proposed_at")?;
+    validate_hash(input.evidence_hash, "accountability evidence hash")?;
+    if input.reason.trim().is_empty() {
+        return Err(ForumError::InvalidProvenance {
+            reason: "accountability reason must be non-empty".into(),
+        });
+    }
+
+    let due_process_deadline_ms = input
+        .proposed_at
+        .physical_ms
+        .saturating_add(DUE_PROCESS_WINDOW_MS);
+    Ok(AccountabilityAction {
+        id: input.id,
+        action_type: input.action_type,
+        target_did: input.target,
+        proposer_did: input.proposer,
+        reason: input.reason,
+        evidence_hash: input.evidence_hash,
         status: AccountabilityStatus::Proposed,
         decision_id: None,
-        proposed_at: timestamp,
+        proposed_at: input.proposed_at,
         enacted_at: None,
         due_process_deadline: Timestamp::new(due_process_deadline_ms, 0),
-    }
+    })
 }
 
 /// Move an action into due-process status.
@@ -137,6 +154,33 @@ pub fn is_due_process_expired(action: &AccountabilityAction, now: &Timestamp) ->
     action.status == AccountabilityStatus::DueProcess && *now > action.due_process_deadline
 }
 
+fn validate_uuid(id: Uuid, label: &str) -> Result<()> {
+    if id.is_nil() {
+        return Err(ForumError::InvalidProvenance {
+            reason: format!("{label} must not be nil"),
+        });
+    }
+    Ok(())
+}
+
+fn validate_timestamp(timestamp: Timestamp, label: &str) -> Result<()> {
+    if timestamp == Timestamp::ZERO {
+        return Err(ForumError::InvalidProvenance {
+            reason: format!("{label} must be non-zero HLC"),
+        });
+    }
+    Ok(())
+}
+
+fn validate_hash(hash: Hash256, label: &str) -> Result<()> {
+    if hash == Hash256::ZERO {
+        return Err(ForumError::InvalidProvenance {
+            reason: format!("{label} must be non-zero"),
+        });
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -148,44 +192,71 @@ mod tests {
         Timestamp::new(1_000_000, 0)
     }
 
+    fn action_input(id: Uuid, action_type: AccountabilityActionType) -> AccountabilityInput {
+        AccountabilityInput {
+            id,
+            action_type,
+            target: did("target"),
+            proposer: did("proposer"),
+            reason: "misconduct".into(),
+            evidence_hash: Hash256::digest(b"evidence"),
+            proposed_at: ts(),
+        }
+    }
+
+    fn make_action(action_type: AccountabilityActionType) -> AccountabilityAction {
+        propose(action_input(Uuid::from_u128(21), action_type)).expect("valid action")
+    }
+
+    #[test]
+    fn propose_requires_caller_supplied_identity_and_hlc() {
+        let action = propose(action_input(
+            Uuid::from_u128(22),
+            AccountabilityActionType::Censure,
+        ))
+        .expect("valid");
+        assert_eq!(action.id, Uuid::from_u128(22));
+        assert_eq!(action.proposed_at, ts());
+
+        let nil =
+            propose(action_input(Uuid::nil(), AccountabilityActionType::Censure)).unwrap_err();
+        assert!(matches!(nil, ForumError::InvalidProvenance { .. }));
+
+        let zero_time = propose(AccountabilityInput {
+            proposed_at: Timestamp::ZERO,
+            ..action_input(Uuid::from_u128(23), AccountabilityActionType::Censure)
+        })
+        .unwrap_err();
+        assert!(matches!(zero_time, ForumError::InvalidProvenance { .. }));
+
+        let zero_evidence = propose(AccountabilityInput {
+            evidence_hash: Hash256::ZERO,
+            ..action_input(Uuid::from_u128(24), AccountabilityActionType::Censure)
+        })
+        .unwrap_err();
+        assert!(matches!(
+            zero_evidence,
+            ForumError::InvalidProvenance { .. }
+        ));
+    }
+
     #[test]
     fn propose_censure() {
-        let a = propose(
-            AccountabilityActionType::Censure,
-            &did("target"),
-            &did("proposer"),
-            "misconduct",
-            Hash256::digest(b"evidence"),
-            ts(),
-        );
+        let a = make_action(AccountabilityActionType::Censure);
         assert_eq!(a.status, AccountabilityStatus::Proposed);
         assert_eq!(a.action_type, AccountabilityActionType::Censure);
     }
 
     #[test]
     fn due_process_flow() {
-        let mut a = propose(
-            AccountabilityActionType::Recall,
-            &did("target"),
-            &did("proposer"),
-            "reason",
-            Hash256::ZERO,
-            ts(),
-        );
+        let mut a = make_action(AccountabilityActionType::Recall);
         begin_due_process(&mut a).expect("ok");
         assert_eq!(a.status, AccountabilityStatus::DueProcess);
     }
 
     #[test]
     fn enact_after_due_process() {
-        let mut a = propose(
-            AccountabilityActionType::Revocation,
-            &did("target"),
-            &did("proposer"),
-            "reason",
-            Hash256::ZERO,
-            ts(),
-        );
+        let mut a = make_action(AccountabilityActionType::Revocation);
         begin_due_process(&mut a).expect("ok");
         let enact_ts = Timestamp::new(ts().physical_ms + 1000, 0);
         enact(&mut a, Uuid::new_v4(), enact_ts).expect("ok");
@@ -195,14 +266,7 @@ mod tests {
 
     #[test]
     fn suspension_must_be_immediate() {
-        let mut a = propose(
-            AccountabilityActionType::Suspension,
-            &did("target"),
-            &did("proposer"),
-            "urgent",
-            Hash256::ZERO,
-            ts(),
-        );
+        let mut a = make_action(AccountabilityActionType::Suspension);
         // Enact within 60s — should work
         let fast_ts = Timestamp::new(ts().physical_ms + 30_000, 0);
         enact(&mut a, Uuid::new_v4(), fast_ts).expect("ok");
@@ -210,14 +274,7 @@ mod tests {
 
     #[test]
     fn suspension_too_slow_fails() {
-        let mut a = propose(
-            AccountabilityActionType::Suspension,
-            &did("target"),
-            &did("proposer"),
-            "urgent",
-            Hash256::ZERO,
-            ts(),
-        );
+        let mut a = make_action(AccountabilityActionType::Suspension);
         let slow_ts = Timestamp::new(ts().physical_ms + 120_000, 0);
         let err = enact(&mut a, Uuid::new_v4(), slow_ts).unwrap_err();
         assert!(err.to_string().contains("60s"));
@@ -225,14 +282,7 @@ mod tests {
 
     #[test]
     fn reverse_enacted() {
-        let mut a = propose(
-            AccountabilityActionType::Censure,
-            &did("target"),
-            &did("proposer"),
-            "reason",
-            Hash256::ZERO,
-            ts(),
-        );
+        let mut a = make_action(AccountabilityActionType::Censure);
         let enact_ts = Timestamp::new(ts().physical_ms + 100, 0);
         enact(&mut a, Uuid::new_v4(), enact_ts).expect("ok");
         reverse(&mut a).expect("ok");
@@ -241,27 +291,13 @@ mod tests {
 
     #[test]
     fn reverse_not_enacted_fails() {
-        let mut a = propose(
-            AccountabilityActionType::Censure,
-            &did("target"),
-            &did("proposer"),
-            "reason",
-            Hash256::ZERO,
-            ts(),
-        );
+        let mut a = make_action(AccountabilityActionType::Censure);
         assert!(reverse(&mut a).is_err());
     }
 
     #[test]
     fn due_process_expiry() {
-        let mut a = propose(
-            AccountabilityActionType::Recall,
-            &did("target"),
-            &did("proposer"),
-            "reason",
-            Hash256::ZERO,
-            ts(),
-        );
+        let mut a = make_action(AccountabilityActionType::Recall);
         begin_due_process(&mut a).expect("ok");
         let before = Timestamp::new(a.due_process_deadline.physical_ms - 1000, 0);
         assert!(!is_due_process_expired(&a, &before));
@@ -271,14 +307,7 @@ mod tests {
 
     #[test]
     fn double_due_process_fails() {
-        let mut a = propose(
-            AccountabilityActionType::Censure,
-            &did("target"),
-            &did("proposer"),
-            "reason",
-            Hash256::ZERO,
-            ts(),
-        );
+        let mut a = make_action(AccountabilityActionType::Censure);
         begin_due_process(&mut a).expect("ok");
         assert!(begin_due_process(&mut a).is_err());
     }

--- a/crates/decision-forum/src/contestation.rs
+++ b/crates/decision-forum/src/contestation.rs
@@ -34,26 +34,35 @@ pub struct ReversalLink {
     pub reversed_at: Timestamp,
 }
 
+/// Caller-supplied metadata for filing a challenge.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChallengeInput {
+    pub id: Uuid,
+    pub decision_id: Uuid,
+    pub challenger: Did,
+    pub ground: ChallengeGround,
+    pub evidence_hash: Hash256,
+    pub created_at: Timestamp,
+}
+
 /// File a challenge against a decision.
-#[must_use]
-pub fn file_challenge(
-    decision_id: Uuid,
-    challenger: &Did,
-    ground: ChallengeGround,
-    evidence_hash: Hash256,
-    timestamp: Timestamp,
-) -> ChallengeObject {
-    ChallengeObject {
-        id: Uuid::new_v4(),
-        decision_id,
-        challenger_did: challenger.clone(),
-        ground,
-        evidence_hash,
+pub fn file_challenge(input: ChallengeInput) -> Result<ChallengeObject> {
+    validate_uuid(input.id, "challenge id")?;
+    validate_uuid(input.decision_id, "decision id")?;
+    validate_timestamp(input.created_at, "challenge created_at")?;
+    validate_hash(input.evidence_hash, "challenge evidence hash")?;
+
+    Ok(ChallengeObject {
+        id: input.id,
+        decision_id: input.decision_id,
+        challenger_did: input.challenger,
+        ground: input.ground,
+        evidence_hash: input.evidence_hash,
         status: ChallengeStatus::Filed,
-        created_at: timestamp,
+        created_at: input.created_at,
         resolved_at: None,
         resolution_decision_id: None,
-    }
+    })
 }
 
 /// Adjudicate a challenge with a verdict.
@@ -132,6 +141,33 @@ pub fn is_contested(challenges: &[ChallengeObject], decision_id: Uuid) -> bool {
     })
 }
 
+fn validate_uuid(id: Uuid, label: &str) -> Result<()> {
+    if id.is_nil() {
+        return Err(ForumError::InvalidProvenance {
+            reason: format!("{label} must not be nil"),
+        });
+    }
+    Ok(())
+}
+
+fn validate_timestamp(timestamp: Timestamp, label: &str) -> Result<()> {
+    if timestamp == Timestamp::ZERO {
+        return Err(ForumError::InvalidProvenance {
+            reason: format!("{label} must be non-zero HLC"),
+        });
+    }
+    Ok(())
+}
+
+fn validate_hash(hash: Hash256, label: &str) -> Result<()> {
+    if hash == Hash256::ZERO {
+        return Err(ForumError::InvalidProvenance {
+            reason: format!("{label} must be non-zero"),
+        });
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -146,28 +182,62 @@ mod tests {
         Uuid::new_v4()
     }
 
+    fn challenge_input(id: Uuid) -> ChallengeInput {
+        ChallengeInput {
+            id,
+            decision_id: Uuid::from_u128(7),
+            challenger: did(),
+            ground: ChallengeGround::QuorumViolation,
+            evidence_hash: Hash256::digest(b"evidence"),
+            created_at: ts(),
+        }
+    }
+
+    fn make_challenge(ground: ChallengeGround) -> ChallengeObject {
+        file_challenge(ChallengeInput {
+            ground,
+            ..challenge_input(Uuid::from_u128(8))
+        })
+        .expect("valid challenge")
+    }
+
+    #[test]
+    fn file_challenge_requires_caller_supplied_identity_and_hlc() {
+        let challenge = file_challenge(challenge_input(Uuid::from_u128(9))).expect("valid");
+        assert_eq!(challenge.id, Uuid::from_u128(9));
+        assert_eq!(challenge.created_at, ts());
+
+        let nil = file_challenge(challenge_input(Uuid::nil())).unwrap_err();
+        assert!(matches!(nil, ForumError::InvalidProvenance { .. }));
+
+        let zero_time = file_challenge(ChallengeInput {
+            created_at: Timestamp::ZERO,
+            ..challenge_input(Uuid::from_u128(10))
+        })
+        .unwrap_err();
+        assert!(matches!(zero_time, ForumError::InvalidProvenance { .. }));
+
+        let zero_evidence = file_challenge(ChallengeInput {
+            evidence_hash: Hash256::ZERO,
+            ..challenge_input(Uuid::from_u128(11))
+        })
+        .unwrap_err();
+        assert!(matches!(
+            zero_evidence,
+            ForumError::InvalidProvenance { .. }
+        ));
+    }
+
     #[test]
     fn file_challenge_creates_filed() {
-        let c = file_challenge(
-            decision_id(),
-            &did(),
-            ChallengeGround::QuorumViolation,
-            Hash256::ZERO,
-            ts(),
-        );
+        let c = make_challenge(ChallengeGround::QuorumViolation);
         assert_eq!(c.status, ChallengeStatus::Filed);
         assert!(c.resolved_at.is_none());
     }
 
     #[test]
     fn adjudicate_sustain() {
-        let mut c = file_challenge(
-            decision_id(),
-            &did(),
-            ChallengeGround::ProceduralError,
-            Hash256::ZERO,
-            ts(),
-        );
+        let mut c = make_challenge(ChallengeGround::ProceduralError);
         adjudicate(&mut c, ChallengeVerdict::Sustain, Timestamp::new(2000, 0)).expect("ok");
         assert_eq!(c.status, ChallengeStatus::Sustained);
         assert!(c.resolved_at.is_some());
@@ -175,78 +245,42 @@ mod tests {
 
     #[test]
     fn adjudicate_overrule() {
-        let mut c = file_challenge(
-            decision_id(),
-            &did(),
-            ChallengeGround::ConsentViolation,
-            Hash256::ZERO,
-            ts(),
-        );
+        let mut c = make_challenge(ChallengeGround::ConsentViolation);
         adjudicate(&mut c, ChallengeVerdict::Overrule, Timestamp::new(2000, 0)).expect("ok");
         assert_eq!(c.status, ChallengeStatus::Overruled);
     }
 
     #[test]
     fn adjudicate_from_under_review() {
-        let mut c = file_challenge(
-            decision_id(),
-            &did(),
-            ChallengeGround::SybilAllegation,
-            Hash256::ZERO,
-            ts(),
-        );
+        let mut c = make_challenge(ChallengeGround::SybilAllegation);
         begin_review(&mut c).expect("ok");
         adjudicate(&mut c, ChallengeVerdict::Sustain, Timestamp::new(2000, 0)).expect("ok");
     }
 
     #[test]
     fn adjudicate_from_terminal_fails() {
-        let mut c = file_challenge(
-            decision_id(),
-            &did(),
-            ChallengeGround::QuorumViolation,
-            Hash256::ZERO,
-            ts(),
-        );
+        let mut c = make_challenge(ChallengeGround::QuorumViolation);
         adjudicate(&mut c, ChallengeVerdict::Overrule, Timestamp::new(2000, 0)).expect("ok");
         assert!(adjudicate(&mut c, ChallengeVerdict::Sustain, Timestamp::new(3000, 0)).is_err());
     }
 
     #[test]
     fn withdraw_from_filed() {
-        let mut c = file_challenge(
-            decision_id(),
-            &did(),
-            ChallengeGround::UndisclosedConflict,
-            Hash256::ZERO,
-            ts(),
-        );
+        let mut c = make_challenge(ChallengeGround::UndisclosedConflict);
         withdraw(&mut c).expect("ok");
         assert_eq!(c.status, ChallengeStatus::Withdrawn);
     }
 
     #[test]
     fn withdraw_from_sustained_fails() {
-        let mut c = file_challenge(
-            decision_id(),
-            &did(),
-            ChallengeGround::QuorumViolation,
-            Hash256::ZERO,
-            ts(),
-        );
+        let mut c = make_challenge(ChallengeGround::QuorumViolation);
         adjudicate(&mut c, ChallengeVerdict::Sustain, Timestamp::new(2000, 0)).expect("ok");
         assert!(withdraw(&mut c).is_err());
     }
 
     #[test]
     fn create_reversal_ok() {
-        let mut c = file_challenge(
-            decision_id(),
-            &did(),
-            ChallengeGround::AuthorityChainInvalid,
-            Hash256::ZERO,
-            ts(),
-        );
+        let mut c = make_challenge(ChallengeGround::AuthorityChainInvalid);
         adjudicate(&mut c, ChallengeVerdict::Sustain, Timestamp::new(2000, 0)).expect("ok");
         let reversal = create_reversal(&c, Uuid::new_v4(), Timestamp::new(3000, 0)).expect("ok");
         assert_eq!(reversal.challenge_id, c.id);
@@ -255,26 +289,19 @@ mod tests {
 
     #[test]
     fn create_reversal_requires_sustained() {
-        let c = file_challenge(
-            decision_id(),
-            &did(),
-            ChallengeGround::QuorumViolation,
-            Hash256::ZERO,
-            ts(),
-        );
+        let c = make_challenge(ChallengeGround::QuorumViolation);
         assert!(create_reversal(&c, Uuid::new_v4(), ts()).is_err());
     }
 
     #[test]
     fn is_contested_check() {
         let did = decision_id();
-        let c = file_challenge(
-            did,
-            &self::did(),
-            ChallengeGround::ProceduralError,
-            Hash256::ZERO,
-            ts(),
-        );
+        let c = file_challenge(ChallengeInput {
+            decision_id: did,
+            ground: ChallengeGround::ProceduralError,
+            ..challenge_input(Uuid::from_u128(12))
+        })
+        .expect("valid challenge");
         assert!(is_contested(std::slice::from_ref(&c), did));
         let mut c2 = c;
         adjudicate(&mut c2, ChallengeVerdict::Overrule, Timestamp::new(2000, 0)).expect("ok");
@@ -283,13 +310,7 @@ mod tests {
 
     #[test]
     fn begin_review_transitions() {
-        let mut c = file_challenge(
-            decision_id(),
-            &did(),
-            ChallengeGround::QuorumViolation,
-            Hash256::ZERO,
-            ts(),
-        );
+        let mut c = make_challenge(ChallengeGround::QuorumViolation);
         begin_review(&mut c).expect("ok");
         assert_eq!(c.status, ChallengeStatus::UnderReview);
         // Can't begin review again

--- a/crates/decision-forum/src/decision_object.rs
+++ b/crates/decision-forum/src/decision_object.rs
@@ -9,7 +9,6 @@
 use exo_core::{
     bcts::BctsState,
     hash::hash_structured,
-    hlc::HybridClock,
     types::{DeterministicMap, Did, Hash256, Timestamp},
 };
 use serde::{Deserialize, Serialize};
@@ -101,29 +100,46 @@ pub struct DecisionObject {
     pub metadata: DeterministicMap<String, String>,
 }
 
+/// Caller-supplied metadata for constructing a [`DecisionObject`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DecisionObjectInput {
+    pub id: Uuid,
+    pub title: String,
+    pub class: DecisionClass,
+    pub constitutional_hash: Hash256,
+    pub created_at: Timestamp,
+}
+
 impl DecisionObject {
     /// Create a new Decision Object in the Draft state, bound to the given
     /// constitutional hash.
-    #[must_use]
-    pub fn new(
-        title: &str,
-        class: DecisionClass,
-        constitutional_hash: Hash256,
-        clock: &mut HybridClock,
-    ) -> Self {
-        Self {
-            id: Uuid::new_v4(),
-            title: title.to_owned(),
-            class,
-            constitutional_hash,
+    pub fn new(input: DecisionObjectInput) -> Result<Self> {
+        validate_uuid(input.id, "decision id")?;
+        validate_timestamp(input.created_at, "decision created_at")?;
+        if input.title.trim().is_empty() {
+            return Err(ForumError::InvalidProvenance {
+                reason: "decision title must be non-empty".into(),
+            });
+        }
+        if input.constitutional_hash == Hash256::ZERO {
+            return Err(ForumError::InvalidProvenance {
+                reason: "constitutional hash must be non-zero".into(),
+            });
+        }
+
+        Ok(Self {
+            id: input.id,
+            title: input.title,
+            class: input.class,
+            constitutional_hash: input.constitutional_hash,
             state: BctsState::Draft,
             authority_chain: Vec::new(),
             votes: Vec::new(),
             evidence_bundle: Vec::new(),
             receipt_chain: Vec::new(),
-            created_at: clock.now(),
+            created_at: input.created_at,
             metadata: DeterministicMap::new(),
-        }
+        })
     }
 
     /// Returns true if this decision is in a terminal state (Closed or
@@ -134,11 +150,11 @@ impl DecisionObject {
     }
 
     /// Transition the decision to a new BCTS state, recording a receipt.
-    pub fn transition(
+    pub fn transition_at(
         &mut self,
         to: BctsState,
         actor: &Did,
-        clock: &mut HybridClock,
+        timestamp: Timestamp,
     ) -> Result<()> {
         if self.is_terminal() {
             return Err(ForumError::DecisionImmutable);
@@ -149,8 +165,8 @@ impl DecisionObject {
                 to: format!("{to:?}"),
             });
         }
+        self.validate_transition_timestamp(timestamp)?;
 
-        let timestamp = clock.now();
         let receipt_hash = self.compute_receipt_hash(self.state, to, &timestamp, actor)?;
 
         self.receipt_chain.push(LifecycleReceipt {
@@ -161,6 +177,24 @@ impl DecisionObject {
             receipt_hash,
         });
         self.state = to;
+        Ok(())
+    }
+
+    fn validate_transition_timestamp(&self, timestamp: Timestamp) -> Result<()> {
+        validate_timestamp(timestamp, "transition timestamp")?;
+        let floor = self
+            .receipt_chain
+            .last()
+            .map(|r| r.timestamp)
+            .unwrap_or(self.created_at);
+        if timestamp <= floor {
+            return Err(ForumError::InvalidProvenance {
+                reason: format!(
+                    "transition timestamp {:?} must be greater than prior timestamp {:?}",
+                    timestamp, floor
+                ),
+            });
+        }
         Ok(())
     }
 
@@ -255,6 +289,24 @@ impl DecisionObject {
     }
 }
 
+fn validate_uuid(id: Uuid, label: &str) -> Result<()> {
+    if id.is_nil() {
+        return Err(ForumError::InvalidProvenance {
+            reason: format!("{label} must not be nil"),
+        });
+    }
+    Ok(())
+}
+
+fn validate_timestamp(timestamp: Timestamp, label: &str) -> Result<()> {
+    if timestamp == Timestamp::ZERO {
+        return Err(ForumError::InvalidProvenance {
+            reason: format!("{label} must be non-zero HLC"),
+        });
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -273,12 +325,85 @@ mod tests {
     }
 
     fn make_decision(clock: &mut HybridClock) -> DecisionObject {
-        DecisionObject::new(
-            "Test Decision",
-            DecisionClass::Operational,
-            Hash256::digest(b"const-v1"),
-            clock,
+        DecisionObject::new(DecisionObjectInput {
+            id: Uuid::from_u128(1),
+            title: "Test Decision".into(),
+            class: DecisionClass::Operational,
+            constitutional_hash: Hash256::digest(b"const-v1"),
+            created_at: clock.now(),
+        })
+        .expect("valid decision")
+    }
+
+    #[test]
+    fn new_decision_requires_caller_supplied_identity_and_hlc() {
+        let input = DecisionObjectInput {
+            id: Uuid::from_u128(42),
+            title: "Deterministic Decision".into(),
+            class: DecisionClass::Strategic,
+            constitutional_hash: Hash256::digest(b"constitution"),
+            created_at: Timestamp::new(10_000, 0),
+        };
+        let first = DecisionObject::new(input.clone()).expect("valid decision");
+        let second = DecisionObject::new(input).expect("same metadata valid");
+
+        assert_eq!(first.id, Uuid::from_u128(42));
+        assert_eq!(first.created_at, Timestamp::new(10_000, 0));
+        assert_eq!(
+            first.content_hash().expect("hash"),
+            second.content_hash().expect("hash")
+        );
+
+        let nil_id = DecisionObject::new(DecisionObjectInput {
+            id: Uuid::nil(),
+            title: "bad".into(),
+            class: DecisionClass::Routine,
+            constitutional_hash: Hash256::digest(b"constitution"),
+            created_at: Timestamp::new(10_000, 0),
+        })
+        .unwrap_err();
+        assert!(matches!(nil_id, ForumError::InvalidProvenance { .. }));
+
+        let zero_time = DecisionObject::new(DecisionObjectInput {
+            id: Uuid::from_u128(43),
+            title: "bad".into(),
+            class: DecisionClass::Routine,
+            constitutional_hash: Hash256::digest(b"constitution"),
+            created_at: Timestamp::ZERO,
+        })
+        .unwrap_err();
+        assert!(matches!(zero_time, ForumError::InvalidProvenance { .. }));
+    }
+
+    #[test]
+    fn transition_requires_caller_supplied_monotonic_hlc() {
+        let mut clock = test_clock();
+        let actor = test_did();
+        let mut d = make_decision(&mut clock);
+
+        d.transition_at(BctsState::Submitted, &actor, Timestamp::new(10_001, 0))
+            .expect("submitted");
+
+        let zero = d
+            .transition_at(BctsState::IdentityResolved, &actor, Timestamp::ZERO)
+            .unwrap_err();
+        assert!(matches!(zero, ForumError::InvalidProvenance { .. }));
+
+        let regressive = d
+            .transition_at(
+                BctsState::IdentityResolved,
+                &actor,
+                Timestamp::new(10_000, 0),
+            )
+            .unwrap_err();
+        assert!(matches!(regressive, ForumError::InvalidProvenance { .. }));
+
+        d.transition_at(
+            BctsState::IdentityResolved,
+            &actor,
+            Timestamp::new(10_002, 0),
         )
+        .expect("monotonic transition");
     }
 
     #[test]
@@ -297,7 +422,8 @@ mod tests {
     fn transition_draft_to_submitted() {
         let mut clock = test_clock();
         let mut d = make_decision(&mut clock);
-        d.transition(BctsState::Submitted, &test_did(), &mut clock)
+        let ts = clock.now();
+        d.transition_at(BctsState::Submitted, &test_did(), ts)
             .expect("ok");
         assert_eq!(d.state, BctsState::Submitted);
         assert_eq!(d.receipt_chain.len(), 1);
@@ -307,8 +433,9 @@ mod tests {
     fn transition_invalid_rejects() {
         let mut clock = test_clock();
         let mut d = make_decision(&mut clock);
+        let ts = clock.now();
         let err = d
-            .transition(BctsState::Closed, &test_did(), &mut clock)
+            .transition_at(BctsState::Closed, &test_did(), ts)
             .unwrap_err();
         assert!(matches!(err, ForumError::InvalidTransition { .. }));
     }
@@ -331,7 +458,8 @@ mod tests {
             BctsState::Closed,
         ];
         for s in steps {
-            d.transition(s, &actor, &mut clock).expect("ok");
+            let ts = clock.now();
+            d.transition_at(s, &actor, ts).expect("ok");
         }
         assert!(d.is_terminal());
         assert_eq!(d.receipt_chain.len(), 10);
@@ -354,9 +482,11 @@ mod tests {
             BctsState::Recorded,
             BctsState::Closed,
         ] {
-            d.transition(s, &actor, &mut clock).expect("ok");
+            let ts = clock.now();
+            d.transition_at(s, &actor, ts).expect("ok");
         }
-        assert!(d.transition(BctsState::Draft, &actor, &mut clock).is_err());
+        let ts = clock.now();
+        assert!(d.transition_at(BctsState::Draft, &actor, ts).is_err());
         assert!(
             d.add_vote(Vote {
                 voter_did: actor.clone(),
@@ -418,7 +548,8 @@ mod tests {
         let actor = test_did();
         let mut d = make_decision(&mut clock);
         let h1 = d.content_hash().expect("ok");
-        d.transition(BctsState::Submitted, &actor, &mut clock)
+        let ts = clock.now();
+        d.transition_at(BctsState::Submitted, &actor, ts)
             .expect("ok");
         let h2 = d.content_hash().expect("ok");
         assert_ne!(h1, h2);
@@ -429,9 +560,11 @@ mod tests {
         let mut clock = test_clock();
         let actor = test_did();
         let mut d = make_decision(&mut clock);
-        d.transition(BctsState::Submitted, &actor, &mut clock)
+        let ts = clock.now();
+        d.transition_at(BctsState::Submitted, &actor, ts)
             .expect("ok");
-        d.transition(BctsState::IdentityResolved, &actor, &mut clock)
+        let ts = clock.now();
+        d.transition_at(BctsState::IdentityResolved, &actor, ts)
             .expect("ok");
         assert_ne!(
             d.receipt_chain[0].receipt_hash,
@@ -450,7 +583,14 @@ mod tests {
     fn constitutional_hash_bound_at_creation() {
         let mut clock = test_clock();
         let hash = Hash256::digest(b"test-constitution");
-        let d = DecisionObject::new("test", DecisionClass::Routine, hash, &mut clock);
+        let d = DecisionObject::new(DecisionObjectInput {
+            id: Uuid::from_u128(2),
+            title: "test".into(),
+            class: DecisionClass::Routine,
+            constitutional_hash: hash,
+            created_at: clock.now(),
+        })
+        .expect("valid");
         assert_eq!(d.constitutional_hash, hash);
     }
 

--- a/crates/decision-forum/src/emergency.rs
+++ b/crates/decision-forum/src/emergency.rs
@@ -79,45 +79,61 @@ impl Default for EmergencyPolicy {
     }
 }
 
+/// Caller-supplied metadata for creating an emergency action.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmergencyActionInput {
+    pub id: Uuid,
+    pub action_type: EmergencyActionType,
+    pub actor: Did,
+    pub justification: String,
+    pub monetary_cap_cents: u64,
+    pub evidence_hash: Hash256,
+    pub created_at: Timestamp,
+}
+
 /// Create an emergency action, validating against the policy.
 pub fn create_emergency_action(
-    action_type: EmergencyActionType,
-    actor: &Did,
-    justification: &str,
-    monetary_cap_cents: u64,
-    evidence_hash: Hash256,
+    input: EmergencyActionInput,
     policy: &EmergencyPolicy,
-    timestamp: Timestamp,
 ) -> Result<EmergencyAction> {
-    if !policy.allowed_actions.contains(&action_type) {
+    validate_uuid(input.id, "emergency action id")?;
+    validate_timestamp(input.created_at, "emergency created_at")?;
+    validate_hash(input.evidence_hash, "emergency evidence hash")?;
+    if input.justification.trim().is_empty() {
         return Err(ForumError::EmergencyInvalid {
-            reason: format!("{action_type:?} not in allowed actions"),
+            reason: "justification must be non-empty".into(),
         });
     }
-    if monetary_cap_cents > policy.max_monetary_cap_cents {
+    if !policy.allowed_actions.contains(&input.action_type) {
+        return Err(ForumError::EmergencyInvalid {
+            reason: format!("{:?} not in allowed actions", input.action_type),
+        });
+    }
+    if input.monetary_cap_cents > policy.max_monetary_cap_cents {
         return Err(ForumError::EmergencyCapExceeded {
             reason: format!(
-                "cap {monetary_cap_cents} exceeds policy max {}",
-                policy.max_monetary_cap_cents
+                "cap {} exceeds policy max {}",
+                input.monetary_cap_cents, policy.max_monetary_cap_cents
             ),
         });
     }
 
-    let deadline_ms = timestamp
+    let deadline_ms = input
+        .created_at
         .physical_ms
         .saturating_add(policy.ratification_window_ms);
     Ok(EmergencyAction {
-        id: Uuid::new_v4(),
-        action_type,
-        actor_did: actor.clone(),
-        justification: justification.to_owned(),
-        monetary_cap_cents,
+        id: input.id,
+        action_type: input.action_type,
+        actor_did: input.actor,
+        justification: input.justification,
+        monetary_cap_cents: input.monetary_cap_cents,
         actual_cost_cents: 0,
-        created_at: timestamp,
+        created_at: input.created_at,
         ratification_status: RatificationStatus::Required,
         ratification_deadline: Timestamp::new(deadline_ms, 0),
         ratification_decision_id: None,
-        evidence_hash,
+        evidence_hash: input.evidence_hash,
     })
 }
 
@@ -201,6 +217,33 @@ pub fn needs_governance_review(actions: &[EmergencyAction], policy: &EmergencyPo
     active_count > policy.max_per_quarter
 }
 
+fn validate_uuid(id: Uuid, label: &str) -> Result<()> {
+    if id.is_nil() {
+        return Err(ForumError::InvalidProvenance {
+            reason: format!("{label} must not be nil"),
+        });
+    }
+    Ok(())
+}
+
+fn validate_timestamp(timestamp: Timestamp, label: &str) -> Result<()> {
+    if timestamp == Timestamp::ZERO {
+        return Err(ForumError::InvalidProvenance {
+            reason: format!("{label} must be non-zero HLC"),
+        });
+    }
+    Ok(())
+}
+
+fn validate_hash(hash: Hash256, label: &str) -> Result<()> {
+    if hash == Hash256::ZERO {
+        return Err(ForumError::InvalidProvenance {
+            reason: format!("{label} must be non-zero"),
+        });
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -215,18 +258,67 @@ mod tests {
         EmergencyPolicy::default()
     }
 
+    fn emergency_input(id: Uuid, action_type: EmergencyActionType) -> EmergencyActionInput {
+        EmergencyActionInput {
+            id,
+            action_type,
+            actor: did(),
+            justification: "critical outage".into(),
+            monetary_cap_cents: 5_000_000,
+            evidence_hash: Hash256::digest(b"evidence"),
+            created_at: ts(),
+        }
+    }
+
+    fn make_action(action_type: EmergencyActionType) -> EmergencyAction {
+        create_emergency_action(emergency_input(Uuid::from_u128(31), action_type), &policy())
+            .expect("valid emergency")
+    }
+
+    #[test]
+    fn create_action_requires_caller_supplied_identity_and_hlc() {
+        let action = create_emergency_action(
+            emergency_input(Uuid::from_u128(32), EmergencyActionType::SystemHalt),
+            &policy(),
+        )
+        .expect("valid");
+        assert_eq!(action.id, Uuid::from_u128(32));
+        assert_eq!(action.created_at, ts());
+
+        let nil = create_emergency_action(
+            emergency_input(Uuid::nil(), EmergencyActionType::SystemHalt),
+            &policy(),
+        )
+        .unwrap_err();
+        assert!(matches!(nil, ForumError::InvalidProvenance { .. }));
+
+        let zero_time = create_emergency_action(
+            EmergencyActionInput {
+                created_at: Timestamp::ZERO,
+                ..emergency_input(Uuid::from_u128(33), EmergencyActionType::SystemHalt)
+            },
+            &policy(),
+        )
+        .unwrap_err();
+        assert!(matches!(zero_time, ForumError::InvalidProvenance { .. }));
+
+        let zero_evidence = create_emergency_action(
+            EmergencyActionInput {
+                evidence_hash: Hash256::ZERO,
+                ..emergency_input(Uuid::from_u128(34), EmergencyActionType::SystemHalt)
+            },
+            &policy(),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            zero_evidence,
+            ForumError::InvalidProvenance { .. }
+        ));
+    }
+
     #[test]
     fn create_valid_action() {
-        let a = create_emergency_action(
-            EmergencyActionType::SystemHalt,
-            &did(),
-            "critical outage",
-            5_000_000,
-            Hash256::digest(b"evidence"),
-            &policy(),
-            ts(),
-        )
-        .expect("ok");
+        let a = make_action(EmergencyActionType::SystemHalt);
         assert_eq!(a.ratification_status, RatificationStatus::Required);
         assert_eq!(a.action_type, EmergencyActionType::SystemHalt);
     }
@@ -234,13 +326,11 @@ mod tests {
     #[test]
     fn cap_exceeded() {
         let err = create_emergency_action(
-            EmergencyActionType::SystemHalt,
-            &did(),
-            "too expensive",
-            99_999_999,
-            Hash256::ZERO,
+            EmergencyActionInput {
+                monetary_cap_cents: 99_999_999,
+                ..emergency_input(Uuid::from_u128(35), EmergencyActionType::SystemHalt)
+            },
             &policy(),
-            ts(),
         )
         .unwrap_err();
         assert!(matches!(err, ForumError::EmergencyCapExceeded { .. }));
@@ -253,13 +343,8 @@ mod tests {
             ..policy()
         };
         let err = create_emergency_action(
-            EmergencyActionType::RoleEscalation,
-            &did(),
-            "not allowed",
-            0,
-            Hash256::ZERO,
+            emergency_input(Uuid::from_u128(36), EmergencyActionType::RoleEscalation),
             &p,
-            ts(),
         )
         .unwrap_err();
         assert!(matches!(err, ForumError::EmergencyInvalid { .. }));
@@ -267,16 +352,7 @@ mod tests {
 
     #[test]
     fn ratify_ok() {
-        let mut a = create_emergency_action(
-            EmergencyActionType::DataFreeze,
-            &did(),
-            "breach",
-            0,
-            Hash256::ZERO,
-            &policy(),
-            ts(),
-        )
-        .expect("ok");
+        let mut a = make_action(EmergencyActionType::DataFreeze);
         let ratify_ts = Timestamp::new(ts().physical_ms + 1000, 0);
         ratify_emergency(&mut a, Uuid::new_v4(), ratify_ts).expect("ok");
         assert_eq!(a.ratification_status, RatificationStatus::Ratified);
@@ -285,16 +361,7 @@ mod tests {
 
     #[test]
     fn ratify_expired() {
-        let mut a = create_emergency_action(
-            EmergencyActionType::DataFreeze,
-            &did(),
-            "breach",
-            0,
-            Hash256::ZERO,
-            &policy(),
-            ts(),
-        )
-        .expect("ok");
+        let mut a = make_action(EmergencyActionType::DataFreeze);
         let late = Timestamp::new(a.ratification_deadline.physical_ms + 1000, 0);
         let err = ratify_emergency(&mut a, Uuid::new_v4(), late).unwrap_err();
         assert!(matches!(err, ForumError::EmergencyInvalid { .. }));
@@ -303,16 +370,7 @@ mod tests {
 
     #[test]
     fn check_expiry_marks_expired() {
-        let mut a = create_emergency_action(
-            EmergencyActionType::SystemHalt,
-            &did(),
-            "test",
-            0,
-            Hash256::ZERO,
-            &policy(),
-            ts(),
-        )
-        .expect("ok");
+        let mut a = make_action(EmergencyActionType::SystemHalt);
         let before = Timestamp::new(a.ratification_deadline.physical_ms - 1000, 0);
         assert!(!check_expiry(&mut a, &before));
         let after = Timestamp::new(a.ratification_deadline.physical_ms + 1000, 0);
@@ -324,15 +382,13 @@ mod tests {
     fn frequency_monitoring() {
         let p = policy();
         let actions: Vec<EmergencyAction> = (0..4)
-            .map(|_| {
+            .map(|i| {
                 create_emergency_action(
-                    EmergencyActionType::SystemHalt,
-                    &did(),
-                    "test",
-                    0,
-                    Hash256::ZERO,
+                    EmergencyActionInput {
+                        id: Uuid::from_u128(40 + i),
+                        ..emergency_input(Uuid::from_u128(40 + i), EmergencyActionType::SystemHalt)
+                    },
                     &p,
-                    ts(),
                 )
                 .expect("ok")
             })
@@ -353,13 +409,8 @@ mod tests {
     fn per_actor_limit_blocks_second_invocation_same_actor() {
         let p = policy(); // max_per_quarter_per_actor = 1
         let first = create_emergency_action(
-            EmergencyActionType::SystemHalt,
-            &did(),
-            "first",
-            0,
-            Hash256::ZERO,
+            emergency_input(Uuid::from_u128(50), EmergencyActionType::SystemHalt),
             &p,
-            ts(),
         )
         .expect("ok");
         let err = check_per_actor_limit(&[first], &did(), &p).unwrap_err();
@@ -375,13 +426,11 @@ mod tests {
         let actor_a = Did::new("did:exo:actor-a").expect("ok");
         let actor_b = Did::new("did:exo:actor-b").expect("ok");
         let action_a = create_emergency_action(
-            EmergencyActionType::SystemHalt,
-            &actor_a,
-            "actor a",
-            0,
-            Hash256::ZERO,
+            EmergencyActionInput {
+                actor: actor_a,
+                ..emergency_input(Uuid::from_u128(51), EmergencyActionType::SystemHalt)
+            },
             &p,
-            ts(),
         )
         .expect("ok");
         // actor_b is unaffected by actor_a's invocation
@@ -392,13 +441,8 @@ mod tests {
     fn per_actor_limit_excludes_expired_actions() {
         let p = policy(); // max_per_quarter_per_actor = 1
         let mut expired = create_emergency_action(
-            EmergencyActionType::SystemHalt,
-            &did(),
-            "old",
-            0,
-            Hash256::ZERO,
+            emergency_input(Uuid::from_u128(52), EmergencyActionType::SystemHalt),
             &p,
-            ts(),
         )
         .expect("ok");
         // Mark as expired (missed ratification window)
@@ -417,15 +461,10 @@ mod tests {
         };
         // Create many actions for the same actor — all should pass
         let actions: Vec<EmergencyAction> = (0..10)
-            .map(|_| {
+            .map(|i| {
                 create_emergency_action(
-                    EmergencyActionType::SystemHalt,
-                    &did(),
-                    "unlimited",
-                    0,
-                    Hash256::ZERO,
+                    emergency_input(Uuid::from_u128(60 + i), EmergencyActionType::SystemHalt),
                     &p,
-                    ts(),
                 )
                 .expect("ok")
             })
@@ -435,16 +474,7 @@ mod tests {
 
     #[test]
     fn double_ratify_fails() {
-        let mut a = create_emergency_action(
-            EmergencyActionType::SystemHalt,
-            &did(),
-            "test",
-            0,
-            Hash256::ZERO,
-            &policy(),
-            ts(),
-        )
-        .expect("ok");
+        let mut a = make_action(EmergencyActionType::SystemHalt);
         ratify_emergency(
             &mut a,
             Uuid::new_v4(),

--- a/crates/decision-forum/src/error.rs
+++ b/crates/decision-forum/src/error.rs
@@ -51,6 +51,9 @@ pub enum ForumError {
     #[error("invalid state transition: {from} -> {to}")]
     InvalidTransition { from: String, to: String },
 
+    #[error("invalid provenance metadata: {reason}")]
+    InvalidProvenance { reason: String },
+
     // -- Human gate errors -------------------------------------------------
     #[error("human gate required: AI cannot satisfy this approval")]
     HumanGateRequired,
@@ -144,6 +147,9 @@ mod tests {
             ForumError::InvalidTransition {
                 from: "Draft".into(),
                 to: "Closed".into(),
+            },
+            ForumError::InvalidProvenance {
+                reason: "nil id".into(),
             },
             ForumError::HumanGateRequired,
             ForumError::AiCeilingExceeded {

--- a/crates/decision-forum/src/human_gate.rs
+++ b/crates/decision-forum/src/human_gate.rs
@@ -92,7 +92,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::decision_object::VoteChoice;
+    use crate::decision_object::{DecisionObjectInput, VoteChoice};
 
     fn test_clock() -> HybridClock {
         let counter = AtomicU64::new(1000);
@@ -122,11 +122,22 @@ mod tests {
         }
     }
 
+    fn make_decision(class: DecisionClass, clock: &mut HybridClock) -> DecisionObject {
+        DecisionObject::new(DecisionObjectInput {
+            id: uuid::Uuid::from_u128(100),
+            title: "test".into(),
+            class,
+            constitutional_hash: Hash256::digest(b"constitution"),
+            created_at: clock.now(),
+        })
+        .expect("valid decision")
+    }
+
     #[test]
     fn routine_passes_without_human() {
         let mut clock = test_clock();
         let policy = HumanGatePolicy::default();
-        let mut d = DecisionObject::new("test", DecisionClass::Routine, Hash256::ZERO, &mut clock);
+        let mut d = make_decision(DecisionClass::Routine, &mut clock);
         d.add_vote(ai_vote(&mut clock)).expect("ok");
         assert!(enforce_human_gate(&policy, &d).is_ok());
     }
@@ -135,8 +146,7 @@ mod tests {
     fn strategic_requires_human() {
         let mut clock = test_clock();
         let policy = HumanGatePolicy::default();
-        let mut d =
-            DecisionObject::new("test", DecisionClass::Strategic, Hash256::ZERO, &mut clock);
+        let mut d = make_decision(DecisionClass::Strategic, &mut clock);
         d.add_vote(ai_vote(&mut clock)).expect("ok");
         let err = enforce_human_gate(&policy, &d).unwrap_err();
         assert!(matches!(
@@ -149,8 +159,7 @@ mod tests {
     fn strategic_passes_with_human() {
         let mut clock = test_clock();
         let policy = HumanGatePolicy::default();
-        let mut d =
-            DecisionObject::new("test", DecisionClass::Strategic, Hash256::ZERO, &mut clock);
+        let mut d = make_decision(DecisionClass::Strategic, &mut clock);
         d.add_vote(human_vote(&mut clock)).expect("ok");
         assert!(enforce_human_gate(&policy, &d).is_ok());
     }
@@ -159,12 +168,7 @@ mod tests {
     fn constitutional_requires_human() {
         let mut clock = test_clock();
         let policy = HumanGatePolicy::default();
-        let mut d = DecisionObject::new(
-            "test",
-            DecisionClass::Constitutional,
-            Hash256::ZERO,
-            &mut clock,
-        );
+        let mut d = make_decision(DecisionClass::Constitutional, &mut clock);
         d.add_vote(ai_vote(&mut clock)).expect("ok");
         assert!(enforce_human_gate(&policy, &d).is_err());
     }
@@ -174,7 +178,7 @@ mod tests {
         // No votes yet — gate doesn't block (nothing to validate).
         let mut clock = test_clock();
         let policy = HumanGatePolicy::default();
-        let d = DecisionObject::new("test", DecisionClass::Strategic, Hash256::ZERO, &mut clock);
+        let d = make_decision(DecisionClass::Strategic, &mut clock);
         // With no votes, the human gate check for human_required_classes fails
         // because human_count == 0, but we allow empty votes since no approval is claimed.
         let result = enforce_human_gate(&policy, &d);

--- a/crates/decision-forum/src/lib.rs
+++ b/crates/decision-forum/src/lib.rs
@@ -38,3 +38,32 @@ pub mod self_governance;
 pub mod terms;
 pub mod tnc_enforcer;
 pub mod workflow;
+
+#[cfg(test)]
+mod audit_tests {
+    fn production_source(source: &str) -> &str {
+        source.split("#[cfg(test)]").next().unwrap_or(source)
+    }
+
+    #[test]
+    fn scope_r1_constructors_do_not_fabricate_identity_or_clock_metadata() {
+        for (module, source) in [
+            ("decision_object", include_str!("decision_object.rs")),
+            ("contestation", include_str!("contestation.rs")),
+            ("accountability", include_str!("accountability.rs")),
+            ("emergency", include_str!("emergency.rs")),
+            ("self_governance", include_str!("self_governance.rs")),
+            ("workflow", include_str!("workflow.rs")),
+        ] {
+            let production = production_source(source);
+            assert!(
+                !production.contains("Uuid::new_v4"),
+                "{module} production code must not fabricate UUIDs"
+            );
+            assert!(
+                !production.contains("HybridClock::new()"),
+                "{module} production code must not fabricate HLC clocks"
+            );
+        }
+    }
+}

--- a/crates/decision-forum/src/quorum.rs
+++ b/crates/decision-forum/src/quorum.rs
@@ -173,6 +173,7 @@ mod tests {
         hlc::HybridClock,
         types::{Did, Hash256},
     };
+    use uuid::Uuid;
 
     use super::*;
     use crate::decision_object::*;
@@ -215,11 +216,22 @@ mod tests {
         }
     }
 
+    fn make_decision(title: &str, class: DecisionClass, clock: &mut HybridClock) -> DecisionObject {
+        DecisionObject::new(DecisionObjectInput {
+            id: Uuid::from_u128(200),
+            title: title.into(),
+            class,
+            constitutional_hash: Hash256::digest(b"constitution"),
+            created_at: clock.now(),
+        })
+        .expect("valid decision")
+    }
+
     #[test]
     fn routine_quorum_met() {
         let mut clock = test_clock();
         let reg = QuorumRegistry::with_defaults();
-        let mut d = DecisionObject::new("test", DecisionClass::Routine, Hash256::ZERO, &mut clock);
+        let mut d = make_decision("test", DecisionClass::Routine, &mut clock);
         d.add_vote(human_approve_vote("alice", &mut clock))
             .expect("ok");
         match check_quorum(&reg, &d).expect("ok") {
@@ -232,12 +244,7 @@ mod tests {
     fn operational_needs_three_votes() {
         let mut clock = test_clock();
         let reg = QuorumRegistry::with_defaults();
-        let mut d = DecisionObject::new(
-            "test",
-            DecisionClass::Operational,
-            Hash256::ZERO,
-            &mut clock,
-        );
+        let mut d = make_decision("test", DecisionClass::Operational, &mut clock);
         d.add_vote(human_approve_vote("alice", &mut clock))
             .expect("ok");
         match check_quorum(&reg, &d).expect("ok") {
@@ -257,12 +264,7 @@ mod tests {
     fn operational_quorum_met() {
         let mut clock = test_clock();
         let reg = QuorumRegistry::with_defaults();
-        let mut d = DecisionObject::new(
-            "test",
-            DecisionClass::Operational,
-            Hash256::ZERO,
-            &mut clock,
-        );
+        let mut d = make_decision("test", DecisionClass::Operational, &mut clock);
         d.add_vote(human_approve_vote("alice", &mut clock))
             .expect("ok");
         d.add_vote(ai_approve_vote("bot1", &mut clock)).expect("ok");
@@ -284,12 +286,7 @@ mod tests {
     fn insufficient_approval_pct() {
         let mut clock = test_clock();
         let reg = QuorumRegistry::with_defaults();
-        let mut d = DecisionObject::new(
-            "test",
-            DecisionClass::Operational,
-            Hash256::ZERO,
-            &mut clock,
-        );
+        let mut d = make_decision("test", DecisionClass::Operational, &mut clock);
         d.add_vote(human_approve_vote("alice", &mut clock))
             .expect("ok");
         d.add_vote(reject_vote("bob", &mut clock)).expect("ok");
@@ -306,8 +303,7 @@ mod tests {
     fn strategic_needs_human_votes() {
         let mut clock = test_clock();
         let reg = QuorumRegistry::with_defaults();
-        let mut d =
-            DecisionObject::new("test", DecisionClass::Strategic, Hash256::ZERO, &mut clock);
+        let mut d = make_decision("test", DecisionClass::Strategic, &mut clock);
         for i in 0..5 {
             d.add_vote(ai_approve_vote(&format!("bot{i}"), &mut clock))
                 .expect("ok");

--- a/crates/decision-forum/src/self_governance.rs
+++ b/crates/decision-forum/src/self_governance.rs
@@ -7,6 +7,8 @@ use exo_core::types::{Hash256, Timestamp};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::error::{ForumError, Result};
+
 /// A proposed governance change tracked as a self-governance item.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GovernanceProposal {
@@ -116,23 +118,48 @@ impl Default for ComplianceTracker {
     }
 }
 
+/// Caller-supplied metadata for creating a governance proposal.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GovernanceProposalInput {
+    pub id: Uuid,
+    pub title: String,
+    pub description: String,
+    pub change_type: GovernanceChangeType,
+    pub proposed_at: Timestamp,
+}
+
 /// Create a governance proposal.
-#[must_use]
-pub fn create_proposal(
-    title: &str,
-    description: &str,
-    change_type: GovernanceChangeType,
-    timestamp: Timestamp,
-) -> GovernanceProposal {
-    GovernanceProposal {
-        id: Uuid::new_v4(),
-        title: title.to_owned(),
-        description: description.to_owned(),
-        change_type,
+pub fn create_proposal(input: GovernanceProposalInput) -> Result<GovernanceProposal> {
+    if input.id.is_nil() {
+        return Err(ForumError::InvalidProvenance {
+            reason: "governance proposal id must not be nil".into(),
+        });
+    }
+    if input.proposed_at == Timestamp::ZERO {
+        return Err(ForumError::InvalidProvenance {
+            reason: "governance proposal proposed_at must be non-zero HLC".into(),
+        });
+    }
+    if input.title.trim().is_empty() {
+        return Err(ForumError::InvalidProvenance {
+            reason: "governance proposal title must be non-empty".into(),
+        });
+    }
+    if input.description.trim().is_empty() {
+        return Err(ForumError::InvalidProvenance {
+            reason: "governance proposal description must be non-empty".into(),
+        });
+    }
+
+    Ok(GovernanceProposal {
+        id: input.id,
+        title: input.title,
+        description: input.description,
+        change_type: input.change_type,
         decision_id: None,
         simulation_result: None,
-        proposed_at: timestamp,
-    }
+        proposed_at: input.proposed_at,
+    })
 }
 
 #[cfg(test)]
@@ -143,14 +170,61 @@ mod tests {
         Timestamp::new(1_000_000, 0)
     }
 
+    fn proposal_input(
+        id: Uuid,
+        title: &str,
+        change_type: GovernanceChangeType,
+    ) -> GovernanceProposalInput {
+        GovernanceProposalInput {
+            id,
+            title: title.into(),
+            description: "desc".into(),
+            change_type,
+            proposed_at: ts(),
+        }
+    }
+
+    #[test]
+    fn create_proposal_requires_caller_supplied_identity_and_hlc() {
+        let proposal = create_proposal(proposal_input(
+            Uuid::from_u128(70),
+            "Update quorum",
+            GovernanceChangeType::QuorumPolicyChange,
+        ))
+        .expect("valid");
+        assert_eq!(proposal.id, Uuid::from_u128(70));
+
+        let nil = create_proposal(proposal_input(
+            Uuid::nil(),
+            "bad",
+            GovernanceChangeType::QuorumPolicyChange,
+        ))
+        .unwrap_err();
+        assert!(matches!(nil, ForumError::InvalidProvenance { .. }));
+
+        let zero_time = create_proposal(GovernanceProposalInput {
+            proposed_at: Timestamp::ZERO,
+            ..proposal_input(
+                Uuid::from_u128(71),
+                "bad",
+                GovernanceChangeType::QuorumPolicyChange,
+            )
+        })
+        .unwrap_err();
+        assert!(matches!(zero_time, ForumError::InvalidProvenance { .. }));
+    }
+
     #[test]
     fn create_proposal_basic() {
-        let p = create_proposal(
-            "Update quorum",
-            "Change thresholds",
-            GovernanceChangeType::QuorumPolicyChange,
-            ts(),
-        );
+        let p = create_proposal(GovernanceProposalInput {
+            description: "Change thresholds".into(),
+            ..proposal_input(
+                Uuid::from_u128(72),
+                "Update quorum",
+                GovernanceChangeType::QuorumPolicyChange,
+            )
+        })
+        .expect("valid");
         assert_eq!(p.title, "Update quorum");
         assert!(p.decision_id.is_none());
         assert!(p.simulation_result.is_none());
@@ -158,12 +232,12 @@ mod tests {
 
     #[test]
     fn simulate_valid_proposal() {
-        let p = create_proposal(
+        let p = create_proposal(proposal_input(
+            Uuid::from_u128(73),
             "Test",
-            "desc",
             GovernanceChangeType::QuorumPolicyChange,
-            ts(),
-        );
+        ))
+        .expect("valid");
         let result = GovernanceSimulator::simulate(&p, Hash256::ZERO, ts());
         assert!(result.passed);
         assert!(result.issues.is_empty());
@@ -171,12 +245,12 @@ mod tests {
 
     #[test]
     fn simulate_amendment_without_decision() {
-        let p = create_proposal(
+        let p = create_proposal(proposal_input(
+            Uuid::from_u128(74),
             "Amend",
-            "desc",
             GovernanceChangeType::ConstitutionalAmendment,
-            ts(),
-        );
+        ))
+        .expect("valid");
         let result = GovernanceSimulator::simulate(&p, Hash256::ZERO, ts());
         assert!(!result.passed);
         assert!(result.issues.iter().any(|i| i.contains("backing decision")));
@@ -184,9 +258,13 @@ mod tests {
 
     #[test]
     fn simulate_empty_title() {
-        let p = create_proposal("", "desc", GovernanceChangeType::QuorumPolicyChange, ts());
-        let result = GovernanceSimulator::simulate(&p, Hash256::ZERO, ts());
-        assert!(!result.passed);
+        let err = create_proposal(proposal_input(
+            Uuid::from_u128(75),
+            "",
+            GovernanceChangeType::QuorumPolicyChange,
+        ))
+        .unwrap_err();
+        assert!(matches!(err, ForumError::InvalidProvenance { .. }));
     }
 
     #[test]

--- a/crates/decision-forum/src/tnc_enforcer.rs
+++ b/crates/decision-forum/src/tnc_enforcer.rs
@@ -222,6 +222,7 @@ mod tests {
         hlc::HybridClock,
         types::{Did, Hash256},
     };
+    use uuid::Uuid;
 
     use super::*;
     use crate::decision_object::*;
@@ -245,8 +246,19 @@ mod tests {
         }
     }
 
+    fn make_decision(class: DecisionClass, clock: &mut HybridClock) -> DecisionObject {
+        DecisionObject::new(DecisionObjectInput {
+            id: Uuid::from_u128(300),
+            title: "test".into(),
+            class,
+            constitutional_hash: Hash256::digest(b"constitution"),
+            created_at: clock.now(),
+        })
+        .expect("valid decision")
+    }
+
     fn decision_with_authority(clock: &mut HybridClock) -> DecisionObject {
-        let mut d = DecisionObject::new("test", DecisionClass::Operational, Hash256::ZERO, clock);
+        let mut d = make_decision(DecisionClass::Operational, clock);
         let ts = clock.now();
         d.add_authority_link(AuthorityLink {
             actor_did: Did::new("did:exo:root").expect("ok"),
@@ -269,7 +281,7 @@ mod tests {
     #[test]
     fn tnc_01_empty_authority() {
         let mut clock = test_clock();
-        let d = DecisionObject::new("test", DecisionClass::Routine, Hash256::ZERO, &mut clock);
+        let d = make_decision(DecisionClass::Routine, &mut clock);
         let ctx = passing_ctx(&d);
         let err = enforce_tnc_01(&ctx).unwrap_err();
         assert!(matches!(err, ForumError::TncViolation { tnc_id: 1, .. }));
@@ -347,7 +359,8 @@ mod tests {
             BctsState::Recorded,
             BctsState::Closed,
         ] {
-            d.transition(s, &actor, &mut clock).expect("ok");
+            let ts = clock.now();
+            d.transition_at(s, &actor, ts).expect("ok");
         }
         let ctx = passing_ctx(&d);
         let err = enforce_tnc_08(&ctx).unwrap_err();
@@ -357,8 +370,7 @@ mod tests {
     #[test]
     fn tnc_09_ai_ceiling() {
         let mut clock = test_clock();
-        let mut d =
-            DecisionObject::new("test", DecisionClass::Strategic, Hash256::ZERO, &mut clock);
+        let mut d = make_decision(DecisionClass::Strategic, &mut clock);
         d.add_authority_link(AuthorityLink {
             actor_did: Did::new("did:exo:root").expect("ok"),
             actor_kind: ActorKind::Human,
@@ -395,7 +407,7 @@ mod tests {
     #[test]
     fn collect_violations_multiple() {
         let mut clock = test_clock();
-        let d = DecisionObject::new("test", DecisionClass::Routine, Hash256::ZERO, &mut clock);
+        let d = make_decision(DecisionClass::Routine, &mut clock);
         let ctx = TncContext {
             decision: &d,
             constitutional_hash_valid: false,
@@ -429,12 +441,7 @@ mod tests {
         // Without external ceiling verification, an AI signer on an Operational
         // decision must be rejected even if it self-declares Operational ceiling.
         let mut clock = test_clock();
-        let mut d = DecisionObject::new(
-            "test",
-            DecisionClass::Operational,
-            Hash256::ZERO,
-            &mut clock,
-        );
+        let mut d = make_decision(DecisionClass::Operational, &mut clock);
         d.add_authority_link(AuthorityLink {
             actor_did: Did::new("did:exo:human-root").expect("ok"),
             actor_kind: ActorKind::Human,
@@ -467,7 +474,7 @@ mod tests {
     fn test_ai_ceiling_unverified_allows_routine() {
         // Without external verification, AI signers are still allowed on Routine.
         let mut clock = test_clock();
-        let mut d = DecisionObject::new("test", DecisionClass::Routine, Hash256::ZERO, &mut clock);
+        let mut d = make_decision(DecisionClass::Routine, &mut clock);
         d.add_authority_link(AuthorityLink {
             actor_did: Did::new("did:exo:human-root").expect("ok"),
             actor_kind: ActorKind::Human,
@@ -495,12 +502,7 @@ mod tests {
     fn test_ai_ceiling_verified_allows_declared_class() {
         // With external verification, the declared ceiling_class is trusted.
         let mut clock = test_clock();
-        let mut d = DecisionObject::new(
-            "test",
-            DecisionClass::Operational,
-            Hash256::ZERO,
-            &mut clock,
-        );
+        let mut d = make_decision(DecisionClass::Operational, &mut clock);
         d.add_authority_link(AuthorityLink {
             actor_did: Did::new("did:exo:human-root").expect("ok"),
             actor_kind: ActorKind::Human,
@@ -528,8 +530,7 @@ mod tests {
     fn test_ai_self_declared_strategic_blocked_when_verified_ceiling_is_operational() {
         // Even when externally verified, AI cannot exceed its actual registry ceiling.
         let mut clock = test_clock();
-        let mut d =
-            DecisionObject::new("test", DecisionClass::Strategic, Hash256::ZERO, &mut clock);
+        let mut d = make_decision(DecisionClass::Strategic, &mut clock);
         d.add_authority_link(AuthorityLink {
             actor_did: Did::new("did:exo:human-root").expect("ok"),
             actor_kind: ActorKind::Human,

--- a/crates/decision-forum/src/workflow.rs
+++ b/crates/decision-forum/src/workflow.rs
@@ -10,6 +10,8 @@ use exo_core::{
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::error::{ForumError, Result};
+
 /// A workflow stage corresponding to a BCTS state.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkflowStage {
@@ -29,8 +31,12 @@ pub struct WorkflowDefinition {
 
 impl WorkflowDefinition {
     /// Create the standard decision governance workflow.
-    #[must_use]
-    pub fn standard_governance() -> Self {
+    pub fn standard_governance(id: Uuid) -> Result<Self> {
+        if id.is_nil() {
+            return Err(ForumError::InvalidProvenance {
+                reason: "workflow id must not be nil".into(),
+            });
+        }
         let stages = vec![
             WorkflowStage {
                 state: BctsState::Draft,
@@ -99,11 +105,11 @@ impl WorkflowDefinition {
                 requires_receipt: true,
             },
         ];
-        Self {
-            id: Uuid::new_v4(),
+        Ok(Self {
+            id,
             name: "Standard Governance Workflow".into(),
             stages,
-        }
+        })
     }
 
     /// Find the stage definition for a given BCTS state.
@@ -171,34 +177,40 @@ mod tests {
 
     #[test]
     fn standard_workflow_has_all_stages() {
-        let wf = WorkflowDefinition::standard_governance();
+        let wf = WorkflowDefinition::standard_governance(Uuid::from_u128(80)).expect("valid");
         assert_eq!(wf.stage_count(), 11);
         assert!(wf.stage_for(BctsState::Draft).is_some());
         assert!(wf.stage_for(BctsState::Closed).is_some());
     }
 
     #[test]
+    fn standard_workflow_requires_caller_supplied_identity() {
+        let err = WorkflowDefinition::standard_governance(Uuid::nil()).unwrap_err();
+        assert!(matches!(err, ForumError::InvalidProvenance { .. }));
+    }
+
+    #[test]
     fn next_stage() {
-        let wf = WorkflowDefinition::standard_governance();
+        let wf = WorkflowDefinition::standard_governance(Uuid::from_u128(81)).expect("valid");
         let next = wf.next_stage(BctsState::Draft).expect("should exist");
         assert_eq!(next.state, BctsState::Submitted);
     }
 
     #[test]
     fn next_stage_from_closed_is_none() {
-        let wf = WorkflowDefinition::standard_governance();
+        let wf = WorkflowDefinition::standard_governance(Uuid::from_u128(82)).expect("valid");
         assert!(wf.next_stage(BctsState::Closed).is_none());
     }
 
     #[test]
     fn draft_no_receipt() {
-        let wf = WorkflowDefinition::standard_governance();
+        let wf = WorkflowDefinition::standard_governance(Uuid::from_u128(83)).expect("valid");
         assert!(!wf.requires_receipt(BctsState::Draft));
     }
 
     #[test]
     fn submitted_requires_receipt() {
-        let wf = WorkflowDefinition::standard_governance();
+        let wf = WorkflowDefinition::standard_governance(Uuid::from_u128(84)).expect("valid");
         assert!(wf.requires_receipt(BctsState::Submitted));
     }
 
@@ -224,14 +236,14 @@ mod tests {
 
     #[test]
     fn unknown_state_not_found() {
-        let wf = WorkflowDefinition::standard_governance();
+        let wf = WorkflowDefinition::standard_governance(Uuid::from_u128(85)).expect("valid");
         // Escalated is not in the standard workflow
         assert!(wf.stage_for(BctsState::Escalated).is_none());
     }
 
     #[test]
     fn serde_roundtrip() {
-        let wf = WorkflowDefinition::standard_governance();
+        let wf = WorkflowDefinition::standard_governance(Uuid::from_u128(86)).expect("valid");
         let json = serde_json::to_string(&wf).expect("ser");
         let wf2: WorkflowDefinition = serde_json::from_str(&json).expect("de");
         assert_eq!(wf2.stage_count(), wf.stage_count());

--- a/crates/decision-forum/tests/governance_kernel_integration.rs
+++ b/crates/decision-forum/tests/governance_kernel_integration.rs
@@ -26,7 +26,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use decision_forum::{
     decision_object::{
-        ActorKind, AuthorityLink as ForumAuthorityLink, DecisionClass, DecisionObject, EvidenceItem,
+        ActorKind, AuthorityLink as ForumAuthorityLink, DecisionClass, DecisionObject,
+        DecisionObjectInput, EvidenceItem,
     },
     tnc_enforcer::{TncContext, enforce_all as enforce_tnc_all},
 };
@@ -43,6 +44,7 @@ use exo_gatekeeper::{
         GovernmentBranch, Permission, PermissionSet, Provenance, QuorumEvidence, QuorumVote, Role,
     },
 };
+use uuid::Uuid;
 
 // ---------------------------------------------------------------------------
 // Shared constants & helpers
@@ -71,7 +73,14 @@ fn make_approved_decision(class: DecisionClass, clock: &mut HybridClock) -> Deci
     let actor = did("did:exo:governance-author");
     let const_hash = Hash256::digest(CONSTITUTION);
 
-    let mut d = DecisionObject::new("Integration Test Decision", class, const_hash, clock);
+    let mut d = DecisionObject::new(DecisionObjectInput {
+        id: Uuid::from_u128(500),
+        title: "Integration Test Decision".into(),
+        class,
+        constitutional_hash: const_hash,
+        created_at: clock.now(),
+    })
+    .expect("valid decision");
 
     // Attach a human authority link so TNC-01 is satisfied.
     d.add_authority_link(ForumAuthorityLink {
@@ -100,7 +109,8 @@ fn make_approved_decision(class: DecisionClass, clock: &mut HybridClock) -> Deci
         BctsState::Governed,
         BctsState::Approved,
     ] {
-        d.transition(state, &actor, clock)
+        let ts = clock.now();
+        d.transition_at(state, &actor, ts)
             .expect("lifecycle transition");
     }
 
@@ -323,12 +333,14 @@ fn full_lifecycle_adjudicated_at_each_transition() {
     let actor = did("did:exo:lifecycle-actor");
     let const_hash = Hash256::digest(CONSTITUTION);
 
-    let mut d = DecisionObject::new(
-        "Lifecycle Test",
-        DecisionClass::Operational,
-        const_hash,
-        &mut clock,
-    );
+    let mut d = DecisionObject::new(DecisionObjectInput {
+        id: Uuid::from_u128(501),
+        title: "Lifecycle Test".into(),
+        class: DecisionClass::Operational,
+        constitutional_hash: const_hash,
+        created_at: clock.now(),
+    })
+    .expect("valid decision");
     d.add_authority_link(ForumAuthorityLink {
         actor_did: actor.clone(),
         actor_kind: ActorKind::Human,
@@ -360,7 +372,8 @@ fn full_lifecycle_adjudicated_at_each_transition() {
     ];
 
     for state in transitions {
-        d.transition(state, &actor, &mut clock)
+        let ts = clock.now();
+        d.transition_at(state, &actor, ts)
             .expect("lifecycle transition");
         let verdict = kernel.adjudicate(&action, &context);
         assert!(
@@ -562,12 +575,14 @@ fn denied_forum_decision_correlates_with_kernel_denial() {
     let const_hash = Hash256::digest(CONSTITUTION);
 
     // Build a decision that gets denied in the forum layer (transition to Denied).
-    let mut d = DecisionObject::new(
-        "Denied Decision",
-        DecisionClass::Operational,
-        const_hash,
-        &mut clock,
-    );
+    let mut d = DecisionObject::new(DecisionObjectInput {
+        id: Uuid::from_u128(502),
+        title: "Denied Decision".into(),
+        class: DecisionClass::Operational,
+        constitutional_hash: const_hash,
+        created_at: clock.now(),
+    })
+    .expect("valid decision");
     d.add_authority_link(ForumAuthorityLink {
         actor_did: actor.clone(),
         actor_kind: ActorKind::Human,
@@ -575,9 +590,11 @@ fn denied_forum_decision_correlates_with_kernel_denial() {
         timestamp: clock.now(),
     })
     .expect("add link");
-    d.transition(BctsState::Submitted, &actor, &mut clock)
+    let ts = clock.now();
+    d.transition_at(BctsState::Submitted, &actor, ts)
         .expect("submit");
-    d.transition(BctsState::Denied, &actor, &mut clock)
+    let ts = clock.now();
+    d.transition_at(BctsState::Denied, &actor, ts)
         .expect("deny");
     assert_eq!(d.state, BctsState::Denied);
 

--- a/crates/exo-gateway/tests/decision_forum_integration.rs
+++ b/crates/exo-gateway/tests/decision_forum_integration.rs
@@ -12,7 +12,9 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use decision_forum::{
-    decision_object::{ActorKind, DecisionClass, DecisionObject, Vote, VoteChoice},
+    decision_object::{
+        ActorKind, DecisionClass, DecisionObject, DecisionObjectInput, Vote, VoteChoice,
+    },
     quorum::{QuorumCheckResult, QuorumRegistry, check_quorum, verify_quorum_precondition},
 };
 use exo_core::{
@@ -35,12 +37,14 @@ fn did(s: &str) -> Did {
 }
 
 fn routine_decision(clock: &mut HybridClock) -> DecisionObject {
-    DecisionObject::new(
-        "Routine test decision",
-        DecisionClass::Routine,
-        Hash256::digest(b"test-constitution-v1"),
-        clock,
-    )
+    DecisionObject::new(DecisionObjectInput {
+        id: uuid::Uuid::from_u128(400),
+        title: "Routine test decision".into(),
+        class: DecisionClass::Routine,
+        constitutional_hash: Hash256::digest(b"test-constitution-v1"),
+        created_at: clock.now(),
+    })
+    .expect("valid decision")
 }
 
 fn human_approve(name: &str, clock: &mut HybridClock) -> Vote {
@@ -152,8 +156,9 @@ fn terminal_decision_rejects_votes() {
         BctsState::Closed,
     ];
     for state in lifecycle {
+        let ts = clock.now();
         decision
-            .transition(state, &actor, &mut clock)
+            .transition_at(state, &actor, ts)
             .expect("transition ok");
     }
 

--- a/crates/exo-node/src/network.rs
+++ b/crates/exo-node/src/network.rs
@@ -551,12 +551,7 @@ mod tests {
             seed_addrs: vec![],
             node_did: Did::new("did:exo:test").unwrap(),
         };
-        let mut swarm = build_swarm(&config).unwrap();
-
-        // Listen on random ports
-        swarm
-            .listen_on("/ip4/127.0.0.1/tcp/0".parse().unwrap())
-            .unwrap();
+        let swarm = build_swarm(&config).unwrap();
 
         let (cmd_tx, cmd_rx) = mpsc::channel(32);
         let (event_tx, _event_rx) = mpsc::channel(32);
@@ -566,10 +561,8 @@ mod tests {
         // Spawn network loop
         tokio::spawn(run_network_loop(swarm, cmd_rx, event_tx));
 
-        // Small delay for the loop to start
-        tokio::time::sleep(Duration::from_millis(100)).await;
-
-        // Query peer count (should be 0 — no peers connected)
+        // Query peer count before listening so concurrent network tests cannot
+        // connect through loopback/mDNS and make this assertion nondeterministic.
         let count = handle.peer_count().await.unwrap();
         assert_eq!(count, 0);
     }

--- a/crates/exochain-wasm/src/decision_forum_bindings.rs
+++ b/crates/exochain-wasm/src/decision_forum_bindings.rs
@@ -8,21 +8,28 @@ use crate::serde_bridge::*;
 /// Create a new DecisionObject with full BCTS lifecycle
 #[wasm_bindgen]
 pub fn wasm_create_decision(
+    decision_id: &str,
     title: &str,
     class_json: &str,
     constitution_hash_hex: &str,
+    created_at_ms: u64,
+    created_at_logical: u32,
 ) -> Result<JsValue, JsValue> {
+    let id = parse_uuid(decision_id)?;
     let class: decision_forum::decision_object::DecisionClass = from_json_str(class_json)?;
-    let hash_bytes =
-        hex::decode(constitution_hash_hex).map_err(|e| JsValue::from_str(&format!("hex: {e}")))?;
-    let arr: [u8; 32] = hash_bytes
-        .try_into()
-        .map_err(|_| JsValue::from_str("hash must be 32 bytes"))?;
-    let hash = exo_core::Hash256::from_bytes(arr);
+    let hash = parse_hash(constitution_hash_hex, "hash")?;
+    let created_at = exo_core::types::Timestamp::new(created_at_ms, created_at_logical);
 
-    let mut clock = exo_core::hlc::HybridClock::new();
-    let decision =
-        decision_forum::decision_object::DecisionObject::new(title, class, hash, &mut clock);
+    let decision = decision_forum::decision_object::DecisionObject::new(
+        decision_forum::decision_object::DecisionObjectInput {
+            id,
+            title: title.into(),
+            class,
+            constitutional_hash: hash,
+            created_at,
+        },
+    )
+    .map_err(|e| JsValue::from_str(&format!("Decision error: {e}")))?;
     to_js_value(&decision)
 }
 
@@ -32,16 +39,18 @@ pub fn wasm_transition_decision(
     decision_json: &str,
     to_state_json: &str,
     actor_did: &str,
+    timestamp_ms: u64,
+    timestamp_logical: u32,
 ) -> Result<JsValue, JsValue> {
     let mut decision: decision_forum::decision_object::DecisionObject =
         from_json_str(decision_json)?;
     let to_state: exo_core::bcts::BctsState = from_json_str(to_state_json)?;
     let actor =
         exo_core::Did::new(actor_did).map_err(|e| JsValue::from_str(&format!("DID error: {e}")))?;
-    let mut clock = exo_core::hlc::HybridClock::new();
+    let ts = exo_core::types::Timestamp::new(timestamp_ms, timestamp_logical);
 
     decision
-        .transition(to_state, &actor, &mut clock)
+        .transition_at(to_state, &actor, ts)
         .map_err(|e| JsValue::from_str(&format!("Transition error: {e}")))?;
     to_js_value(&decision)
 }
@@ -92,70 +101,73 @@ pub fn wasm_decision_content_hash(decision_json: &str) -> Result<String, JsValue
 /// File a challenge against a decision (contestation - GOV-008)
 #[wasm_bindgen]
 pub fn wasm_file_challenge(
+    challenge_id: &str,
     challenger_did: &str,
     decision_id: &str,
     ground_json: &str,
     evidence_hash_hex: &str,
+    created_at_ms: u64,
+    created_at_logical: u32,
 ) -> Result<JsValue, JsValue> {
+    let challenge_id = parse_uuid(challenge_id)?;
     let challenger = exo_core::Did::new(challenger_did)
         .map_err(|e| JsValue::from_str(&format!("DID error: {e}")))?;
-    let id: uuid::Uuid = decision_id
-        .parse()
-        .map_err(|e| JsValue::from_str(&format!("Invalid UUID: {e}")))?;
+    let decision_id = parse_uuid(decision_id)?;
     let ground: exo_governance::challenge::ChallengeGround = from_json_str(ground_json)?;
-    let evidence_bytes =
-        hex::decode(evidence_hash_hex).map_err(|e| JsValue::from_str(&format!("hex: {e}")))?;
-    let arr: [u8; 32] = evidence_bytes
-        .try_into()
-        .map_err(|_| JsValue::from_str("evidence hash must be 32 bytes"))?;
-    let evidence_hash = exo_core::Hash256::from_bytes(arr);
-
-    let mut clock = exo_core::hlc::HybridClock::new();
-    let timestamp = clock.now();
+    let evidence_hash = parse_hash(evidence_hash_hex, "evidence hash")?;
+    let created_at = exo_core::types::Timestamp::new(created_at_ms, created_at_logical);
 
     let challenge = decision_forum::contestation::file_challenge(
-        id,
-        &challenger,
-        ground,
-        evidence_hash,
-        timestamp,
-    );
+        decision_forum::contestation::ChallengeInput {
+            id: challenge_id,
+            decision_id,
+            challenger,
+            ground,
+            evidence_hash,
+            created_at,
+        },
+    )
+    .map_err(|e| JsValue::from_str(&format!("Challenge error: {e}")))?;
     to_js_value(&challenge)
 }
 
 /// Propose an accountability action (GOV-012)
 #[wasm_bindgen]
+#[allow(clippy::too_many_arguments)]
+// WASM exports cannot accept Rust input structs directly; the explicit
+// metadata fields keep provenance caller-supplied across the JS boundary.
 pub fn wasm_propose_accountability(
+    action_id: &str,
     target_did: &str,
     proposer_did: &str,
     action_type_json: &str,
     reason: &str,
     evidence_hash_hex: &str,
+    proposed_at_ms: u64,
+    proposed_at_logical: u32,
 ) -> Result<JsValue, JsValue> {
+    let action_id = parse_uuid(action_id)?;
     let target = exo_core::Did::new(target_did)
         .map_err(|e| JsValue::from_str(&format!("DID error: {e}")))?;
     let proposer = exo_core::Did::new(proposer_did)
         .map_err(|e| JsValue::from_str(&format!("DID error: {e}")))?;
     let action_type: decision_forum::accountability::AccountabilityActionType =
         from_json_str(action_type_json)?;
-    let evidence_bytes =
-        hex::decode(evidence_hash_hex).map_err(|e| JsValue::from_str(&format!("hex: {e}")))?;
-    let arr: [u8; 32] = evidence_bytes
-        .try_into()
-        .map_err(|_| JsValue::from_str("evidence hash must be 32 bytes"))?;
-    let evidence_hash = exo_core::Hash256::from_bytes(arr);
-
-    let mut clock = exo_core::hlc::HybridClock::new();
-    let timestamp = clock.now();
+    let evidence_hash = parse_hash(evidence_hash_hex, "evidence hash")?;
+    let proposed_at = exo_core::types::Timestamp::new(proposed_at_ms, proposed_at_logical);
 
     let action = decision_forum::accountability::propose(
-        action_type,
-        &target,
-        &proposer,
-        reason,
-        evidence_hash,
-        timestamp,
-    );
+        decision_forum::accountability::AccountabilityInput {
+            id: action_id,
+            action_type,
+            target,
+            proposer,
+            reason: reason.into(),
+            evidence_hash,
+            proposed_at,
+        },
+    )
+    .map_err(|e| JsValue::from_str(&format!("Accountability error: {e}")))?;
     to_js_value(&action)
 }
 
@@ -551,7 +563,11 @@ pub fn wasm_verify_quorum_precondition(
 
 /// Create an emergency action under the given policy.
 #[wasm_bindgen]
+#[allow(clippy::too_many_arguments)]
+// Mirrors the emergency action provenance contract across the JS/Rust
+// boundary without rebuilding IDs or HLC timestamps inside the bridge.
 pub fn wasm_create_emergency_action(
+    action_id: &str,
     action_type_json: &str,
     actor_did: &str,
     justification: &str,
@@ -559,28 +575,28 @@ pub fn wasm_create_emergency_action(
     evidence_hash_hex: &str,
     policy_json: &str,
     timestamp_ms: u64,
+    timestamp_logical: u32,
 ) -> Result<JsValue, JsValue> {
+    let action_id = parse_uuid(action_id)?;
     let action_type: decision_forum::emergency::EmergencyActionType =
         from_json_str(action_type_json)?;
     let actor =
         exo_core::Did::new(actor_did).map_err(|e| JsValue::from_str(&format!("DID error: {e}")))?;
-    let evidence_bytes =
-        hex::decode(evidence_hash_hex).map_err(|e| JsValue::from_str(&format!("hex: {e}")))?;
-    let arr: [u8; 32] = evidence_bytes
-        .try_into()
-        .map_err(|_| JsValue::from_str("evidence hash must be 32 bytes"))?;
-    let evidence_hash = exo_core::Hash256::from_bytes(arr);
+    let evidence_hash = parse_hash(evidence_hash_hex, "evidence hash")?;
     let policy: decision_forum::emergency::EmergencyPolicy = from_json_str(policy_json)?;
-    let ts = exo_core::types::Timestamp::new(timestamp_ms, 0);
+    let ts = exo_core::types::Timestamp::new(timestamp_ms, timestamp_logical);
 
     let action = decision_forum::emergency::create_emergency_action(
-        action_type,
-        &actor,
-        justification,
-        monetary_cap_cents,
-        evidence_hash,
+        decision_forum::emergency::EmergencyActionInput {
+            id: action_id,
+            action_type,
+            actor,
+            justification: justification.into(),
+            monetary_cap_cents,
+            evidence_hash,
+            created_at: ts,
+        },
         &policy,
-        ts,
     )
     .map_err(|e| JsValue::from_str(&format!("Emergency error: {e}")))?;
     to_js_value(&action)
@@ -719,5 +735,40 @@ pub fn wasm_verify_forum_authority(authority_json: &str) -> Result<JsValue, JsVa
     match decision_forum::authority::verify_forum_authority(&authority) {
         Ok(()) => to_js_value(&serde_json::json!({"ok": true})),
         Err(e) => to_js_value(&serde_json::json!({"ok": false, "error": e.to_string()})),
+    }
+}
+
+fn parse_uuid(value: &str) -> Result<uuid::Uuid, JsValue> {
+    value
+        .parse()
+        .map_err(|e| JsValue::from_str(&format!("UUID error: {e}")))
+}
+
+fn parse_hash(value: &str, label: &str) -> Result<exo_core::Hash256, JsValue> {
+    let bytes = hex::decode(value).map_err(|e| JsValue::from_str(&format!("hex: {e}")))?;
+    let arr: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| JsValue::from_str(&format!("{label} must be 32 bytes")))?;
+    Ok(exo_core::Hash256::from_bytes(arr))
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn decision_forum_bridge_does_not_synthesize_clock_metadata() {
+        let source = include_str!("decision_forum_bindings.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production section");
+
+        assert!(
+            !production.contains("HybridClock::new()"),
+            "decision-forum WASM exports must require caller-supplied HLC metadata"
+        );
+        assert!(
+            !production.contains("Uuid::new_v4"),
+            "decision-forum WASM exports must require caller-supplied UUID metadata"
+        );
     }
 }

--- a/crates/exochain-wasm/tests/wasm_bindings_test.rs
+++ b/crates/exochain-wasm/tests/wasm_bindings_test.rs
@@ -172,8 +172,15 @@ fn test_bcts_terminal_states() {
 #[wasm_bindgen_test]
 fn test_create_decision_round_trip() {
     let hash_hex = "a".repeat(64);
-    let result = exochain_wasm::wasm_create_decision("Test proposal", r#""Routine""#, &hash_hex)
-        .expect("create_decision");
+    let result = exochain_wasm::wasm_create_decision(
+        "00000000-0000-0000-0000-000000000101",
+        "Test proposal",
+        r#""Routine""#,
+        &hash_hex,
+        1_700_000_000_000,
+        0,
+    )
+    .expect("create_decision");
     let json = js_to_json(result);
     assert_eq!(json["title"].as_str().unwrap(), "Test proposal");
     assert!(!json["id"].as_str().unwrap().is_empty());
@@ -183,8 +190,15 @@ fn test_create_decision_round_trip() {
 fn test_decision_is_not_terminal_after_creation() {
     let hash_hex = "b".repeat(64);
     let decision_json = js_str(
-        exochain_wasm::wasm_create_decision("Draft dec", r#""Routine""#, &hash_hex)
-            .expect("create"),
+        exochain_wasm::wasm_create_decision(
+            "00000000-0000-0000-0000-000000000102",
+            "Draft dec",
+            r#""Routine""#,
+            &hash_hex,
+            1_700_000_000_000,
+            0,
+        )
+        .expect("create"),
     );
     let terminal = exochain_wasm::wasm_decision_is_terminal(&decision_json).expect("is_terminal");
     assert!(!terminal);
@@ -194,7 +208,15 @@ fn test_decision_is_not_terminal_after_creation() {
 fn test_decision_content_hash_is_deterministic() {
     let hash_hex = "c".repeat(64);
     let decision_json = js_str(
-        exochain_wasm::wasm_create_decision("Stable", r#""Routine""#, &hash_hex).expect("create"),
+        exochain_wasm::wasm_create_decision(
+            "00000000-0000-0000-0000-000000000103",
+            "Stable",
+            r#""Routine""#,
+            &hash_hex,
+            1_700_000_000_000,
+            0,
+        )
+        .expect("create"),
     );
     let h1 = exochain_wasm::wasm_decision_content_hash(&decision_json).expect("h1");
     let h2 = exochain_wasm::wasm_decision_content_hash(&decision_json).expect("h2");
@@ -223,10 +245,13 @@ fn test_workflow_stages_contains_all_14_bcts_states() {
 fn test_file_challenge_creates_filed_status() {
     let evidence_hex = "d".repeat(64);
     let result = exochain_wasm::wasm_file_challenge(
+        "00000000-0000-0000-0000-000000000201",
         "did:exo:challenger",
         "00000000-0000-0000-0000-000000000001",
         r#""ProceduralError""#,
         &evidence_hex,
+        1_700_000_000_000,
+        0,
     )
     .expect("file_challenge");
     let json = js_to_json(result);
@@ -238,10 +263,13 @@ fn test_begin_review_transitions_to_under_review() {
     let evidence_hex = "e".repeat(64);
     let challenge_json = js_str(
         exochain_wasm::wasm_file_challenge(
+            "00000000-0000-0000-0000-000000000202",
             "did:exo:c",
             "00000000-0000-0000-0000-000000000002",
             r#""ProceduralError""#,
             &evidence_hex,
+            1_700_000_000_000,
+            0,
         )
         .expect("file"),
     );
@@ -255,8 +283,16 @@ fn test_is_contested_true_when_filed() {
     let id = "00000000-0000-0000-0000-000000000003";
     let evidence_hex = "f".repeat(64);
     let challenge_json = js_str(
-        exochain_wasm::wasm_file_challenge("did:exo:c", id, r#""ProceduralError""#, &evidence_hex)
-            .expect("file"),
+        exochain_wasm::wasm_file_challenge(
+            "00000000-0000-0000-0000-000000000203",
+            "did:exo:c",
+            id,
+            r#""ProceduralError""#,
+            &evidence_hex,
+            1_700_000_000_000,
+            0,
+        )
+        .expect("file"),
     );
     let challenges_json = format!("[{}]", challenge_json);
     let contested = exochain_wasm::wasm_is_contested(&challenges_json, id).expect("is_contested");
@@ -270,11 +306,14 @@ fn test_begin_due_process_transitions_status() {
     let evidence_hex = "1".repeat(64);
     let action_json = js_str(
         exochain_wasm::wasm_propose_accountability(
+            "00000000-0000-0000-0000-000000000301",
             "did:exo:target",
             "did:exo:proposer",
             r#""Censure""#,
             "Violated transparency policy",
             &evidence_hex,
+            1_700_000_000_000,
+            0,
         )
         .expect("propose"),
     );
@@ -289,7 +328,15 @@ fn test_begin_due_process_transitions_status() {
 fn test_enforce_all_tnc_passes_when_all_flags_set() {
     let hash_hex = "2".repeat(64);
     let decision_json = js_str(
-        exochain_wasm::wasm_create_decision("TNC test", r#""Routine""#, &hash_hex).expect("create"),
+        exochain_wasm::wasm_create_decision(
+            "00000000-0000-0000-0000-000000000501",
+            "TNC test",
+            r#""Routine""#,
+            &hash_hex,
+            1_700_000_000_000,
+            0,
+        )
+        .expect("create"),
     );
     let flags = r#"{
         "constitutional_hash_valid": true,
@@ -310,8 +357,15 @@ fn test_enforce_all_tnc_passes_when_all_flags_set() {
 fn test_collect_tnc_violations_when_flags_clear() {
     let hash_hex = "3".repeat(64);
     let decision_json = js_str(
-        exochain_wasm::wasm_create_decision("Violation test", r#""Routine""#, &hash_hex)
-            .expect("create"),
+        exochain_wasm::wasm_create_decision(
+            "00000000-0000-0000-0000-000000000502",
+            "Violation test",
+            r#""Routine""#,
+            &hash_hex,
+            1_700_000_000_000,
+            0,
+        )
+        .expect("create"),
     );
     let result = exochain_wasm::wasm_collect_tnc_violations(&decision_json, r#"{}"#)
         .expect("collect_violations");
@@ -387,9 +441,11 @@ fn test_create_emergency_action_round_trip() {
         "max_monetary_cap_cents": 1000000,
         "allowed_actions": ["DataFreeze", "SystemHalt"],
         "ratification_window_ms": 3600000,
-        "max_per_quarter": 5
+        "max_per_quarter": 5,
+        "max_per_quarter_per_actor": 1
     }"#;
     let result = exochain_wasm::wasm_create_emergency_action(
+        "00000000-0000-0000-0000-000000000401",
         r#""DataFreeze""#,
         "did:exo:operator",
         "Network anomaly detected",
@@ -397,6 +453,7 @@ fn test_create_emergency_action_round_trip() {
         &evidence_hex,
         policy,
         1_700_000_000_000,
+        0,
     )
     .expect("create_emergency_action");
     let json = js_to_json(result);

--- a/demo/packages/exochain-wasm/test.mjs
+++ b/demo/packages/exochain-wasm/test.mjs
@@ -26,6 +26,9 @@ function assert(condition, msg) {
   if (!condition) throw new Error(msg || 'Assertion failed');
 }
 
+const TEST_DID = 'did:exo:test-actor';
+const DUMMY_SECRET_HEX = 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+
 // ═══════════════════════════════════════════════════════════════
 // CORE BINDINGS
 // ═══════════════════════════════════════════════════════════════
@@ -46,23 +49,22 @@ test('hash_structured produces deterministic hash', () => {
 test('generate_keypair returns pub+secret', () => {
   const kp = wasm.wasm_generate_keypair();
   assert(kp.public_key, 'should have public_key');
-  assert(kp.secret_key, 'should have secret_key');
   assert(kp.public_key.length === 64, `public key should be 64 hex chars, got ${kp.public_key.length}`);
 });
 
 test('sign + verify round-trip', () => {
-  const kp = wasm.wasm_generate_keypair();
+  const publicKey = wasm.wasm_ed25519_public_from_secret(DUMMY_SECRET_HEX);
   const msg = new Uint8Array([72, 101, 108, 108, 111]); // "Hello"
-  const sig = wasm.wasm_sign(msg, kp.secret_key);
-  const valid = wasm.wasm_verify(msg, sig, kp.public_key);
+  const sig = wasm.wasm_sign(msg, DUMMY_SECRET_HEX);
+  const valid = wasm.wasm_verify(msg, sig, publicKey);
   assert(valid === true, 'signature should verify');
 });
 
 test('verify rejects bad signature', () => {
-  const kp = wasm.wasm_generate_keypair();
+  const publicKey = wasm.wasm_ed25519_public_from_secret(DUMMY_SECRET_HEX);
   const msg = new Uint8Array([1, 2, 3]);
-  const sig = wasm.wasm_sign(msg, kp.secret_key);
-  const bad = wasm.wasm_verify(new Uint8Array([4, 5, 6]), sig, kp.public_key);
+  const sig = wasm.wasm_sign(msg, DUMMY_SECRET_HEX);
+  const bad = wasm.wasm_verify(new Uint8Array([4, 5, 6]), sig, publicKey);
   assert(bad === false, 'bad message should not verify');
 });
 
@@ -81,14 +83,13 @@ test('bcts_is_terminal — Closed is terminal', () => {
 });
 
 test('create_signed_event', () => {
-  const kp = wasm.wasm_generate_keypair();
   const evt = wasm.wasm_create_signed_event(
     '"GovernanceDecision"',
     new Uint8Array([1, 2, 3]),
-    'did:exo:test-actor',
-    kp.secret_key,
+    TEST_DID,
+    DUMMY_SECRET_HEX,
   );
-  assert(evt.source_did === 'did:exo:test-actor', `source_did should be did:exo:test-actor, got ${evt.source_did}`);
+  assert(evt.source_did === TEST_DID, `source_did should be ${TEST_DID}, got ${evt.source_did}`);
 });
 
 test('merkle_root computes root from 32-byte hex leaves', () => {
@@ -111,10 +112,28 @@ test('mcp_rules returns rule list', () => {
   assert(rules[0].description, 'each rule should have "description" field');
 });
 
-test('enforce_invariants returns 8 constitutional invariants', () => {
-  const result = wasm.wasm_enforce_invariants('{"test": true}');
-  assert(result.invariants, 'should have invariants');
-  assert(result.invariants.length === 8, `should have 8 invariants, got ${result.invariants.length}`);
+test('enforce_invariants evaluates a structured request', () => {
+  const request = {
+    actor: TEST_DID,
+    actor_roles: [],
+    bailment_state: {
+      Active: {
+        bailor: 'did:exo:bailor',
+        bailee: TEST_DID,
+        scope: 'data',
+      },
+    },
+    consent_records: [{
+      subject: 'did:exo:subject',
+      granted_to: TEST_DID,
+      scope: 'data',
+      active: true,
+    }],
+    authority_chain: { links: [] },
+  };
+  const result = wasm.wasm_enforce_invariants(JSON.stringify(request));
+  assert(result.passed === false, 'empty authority/provenance request should fail');
+  assert(Array.isArray(result.violations), 'should return violations');
 });
 
 test('workflow_stages returns stage list', () => {
@@ -176,26 +195,43 @@ test('audit_append creates entry', () => {
 console.log('\n── Decision Forum Bindings ──');
 
 test('create_decision produces DecisionObject', () => {
-  const constitutionHash = '0'.repeat(64);
+  const constitutionHash = '11'.repeat(32);
   const decision = wasm.wasm_create_decision(
+    '00000000-0000-0000-0000-000000000001',
     'Test Budget Approval',
     '"Operational"',
-    constitutionHash
+    constitutionHash,
+    1000n,
+    0
   );
   assert(decision.title === 'Test Budget Approval', `title should match, got ${decision.title}`);
-  assert(decision.id, 'should have UUID id');
+  assert(decision.id === '00000000-0000-0000-0000-000000000001', `id should match, got ${decision.id}`);
 });
 
 test('decision_is_terminal — new decision is not terminal', () => {
-  const constitutionHash = '0'.repeat(64);
-  const decision = wasm.wasm_create_decision('Test', '"Operational"', constitutionHash);
+  const constitutionHash = '11'.repeat(32);
+  const decision = wasm.wasm_create_decision(
+    '00000000-0000-0000-0000-000000000002',
+    'Test',
+    '"Operational"',
+    constitutionHash,
+    1100n,
+    0
+  );
   const json = JSON.stringify(decision);
   assert(wasm.wasm_decision_is_terminal(json) === false, 'new decision should not be terminal');
 });
 
 test('decision_content_hash produces hash', () => {
-  const constitutionHash = '0'.repeat(64);
-  const decision = wasm.wasm_create_decision('Hash Test', '"Operational"', constitutionHash);
+  const constitutionHash = '11'.repeat(32);
+  const decision = wasm.wasm_create_decision(
+    '00000000-0000-0000-0000-000000000003',
+    'Hash Test',
+    '"Operational"',
+    constitutionHash,
+    1200n,
+    0
+  );
   const hash = wasm.wasm_decision_content_hash(JSON.stringify(decision));
   assert(typeof hash === 'string', 'should return string');
   assert(hash.length === 64, `should be 64-char hex, got length ${hash.length}`);

--- a/demo/services/decision-forge/src/index.js
+++ b/demo/services/decision-forge/src/index.js
@@ -21,6 +21,10 @@ function parseBody(req) {
   });
 }
 
+function missingFields(input, fields) {
+  return fields.filter(field => input[field] === undefined || input[field] === null || input[field] === '');
+}
+
 export const server = http.createServer(async (req, res) => {
   if (req.method === 'OPTIONS') {
     res.writeHead(204, { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': '*', 'Access-Control-Allow-Headers': 'Content-Type' });
@@ -33,9 +37,18 @@ export const server = http.createServer(async (req, res) => {
 
     // ── Create Decision ──
     if (url.pathname === '/api/decision/create' && req.method === 'POST') {
-      const { title, decision_class, constitution_hash } = await parseBody(req);
-      const hash = constitution_hash || '0'.repeat(64);
-      const decision = wasm.wasm_create_decision(title, JSON.stringify(decision_class || 'Operational'), hash);
+      const body = await parseBody(req);
+      const { title, decision_class, constitution_hash, decision_id, created_at_ms, created_at_logical } = body;
+      const missing = missingFields(body, ['constitution_hash', 'decision_id', 'created_at_ms', 'created_at_logical']);
+      if (missing.length) return json(res, 400, { error: 'Missing required deterministic metadata', fields: missing });
+      const decision = wasm.wasm_create_decision(
+        decision_id,
+        title,
+        JSON.stringify(decision_class || 'Operational'),
+        constitution_hash,
+        created_at_ms,
+        created_at_logical
+      );
       return json(res, 201, decision);
     }
 
@@ -55,8 +68,17 @@ export const server = http.createServer(async (req, res) => {
 
     // ── Transition State ──
     if (url.pathname === '/api/decision/transition' && req.method === 'POST') {
-      const { decision_json, to_state, actor_did } = await parseBody(req);
-      const updated = wasm.wasm_transition_decision(JSON.stringify(decision_json), JSON.stringify(to_state), actor_did);
+      const body = await parseBody(req);
+      const { decision_json, to_state, actor_did, timestamp_ms, timestamp_logical } = body;
+      const missing = missingFields(body, ['timestamp_ms', 'timestamp_logical']);
+      if (missing.length) return json(res, 400, { error: 'Missing required deterministic metadata', fields: missing });
+      const updated = wasm.wasm_transition_decision(
+        JSON.stringify(decision_json),
+        JSON.stringify(to_state),
+        actor_did,
+        timestamp_ms,
+        timestamp_logical
+      );
       return json(res, 200, updated);
     }
 
@@ -76,15 +98,38 @@ export const server = http.createServer(async (req, res) => {
 
     // ── File Challenge (Contestation GOV-008) ──
     if (url.pathname === '/api/decision/challenge' && req.method === 'POST') {
-      const { challenger_did, decision_id, ground, evidence_hash } = await parseBody(req);
-      const challenge = wasm.wasm_file_challenge(challenger_did, decision_id, JSON.stringify(ground), evidence_hash);
+      const body = await parseBody(req);
+      const { challenger_did, decision_id, ground, evidence_hash, challenge_id, created_at_ms, created_at_logical } = body;
+      const missing = missingFields(body, ['challenge_id', 'created_at_ms', 'created_at_logical']);
+      if (missing.length) return json(res, 400, { error: 'Missing required deterministic metadata', fields: missing });
+      const challenge = wasm.wasm_file_challenge(
+        challenge_id,
+        challenger_did,
+        decision_id,
+        JSON.stringify(ground),
+        evidence_hash,
+        created_at_ms,
+        created_at_logical
+      );
       return json(res, 200, challenge);
     }
 
     // ── Propose Accountability (GOV-012) ──
     if (url.pathname === '/api/decision/accountability' && req.method === 'POST') {
-      const { target_did, proposer_did, action_type, reason, evidence_hash } = await parseBody(req);
-      const action = wasm.wasm_propose_accountability(target_did, proposer_did, JSON.stringify(action_type), reason, evidence_hash);
+      const body = await parseBody(req);
+      const { target_did, proposer_did, action_type, reason, evidence_hash, action_id, proposed_at_ms, proposed_at_logical } = body;
+      const missing = missingFields(body, ['action_id', 'proposed_at_ms', 'proposed_at_logical']);
+      if (missing.length) return json(res, 400, { error: 'Missing required deterministic metadata', fields: missing });
+      const action = wasm.wasm_propose_accountability(
+        action_id,
+        target_did,
+        proposer_did,
+        JSON.stringify(action_type),
+        reason,
+        evidence_hash,
+        proposed_at_ms,
+        proposed_at_logical
+      );
       return json(res, 200, action);
     }
 

--- a/demo/services/decision-forge/src/index.test.js
+++ b/demo/services/decision-forge/src/index.test.js
@@ -2,16 +2,37 @@ import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vites
 import supertest from 'supertest';
 
 const mockWasm = vi.hoisted(() => ({
-  wasm_create_decision: vi.fn((title, decClass, hash) => ({
+  wasm_create_decision: vi.fn((id, title, decClass, hash, createdAtMs, createdAtLogical) => ({
     id: 'test-dec-001', title, decision_class: JSON.parse(decClass), constitution_hash: hash, status: 'Draft', votes: [], evidence: [],
+    input_id: id, created_at: { physical_ms: createdAtMs, logical: createdAtLogical },
   })),
   wasm_add_vote: vi.fn((decJson, voteJson) => ({ ...JSON.parse(decJson), votes: [...(JSON.parse(decJson).votes || []), JSON.parse(voteJson)] })),
   wasm_add_evidence: vi.fn((decJson, evJson) => ({ ...JSON.parse(decJson), evidence: [...(JSON.parse(decJson).evidence || []), JSON.parse(evJson)] })),
-  wasm_transition_decision: vi.fn((decJson, stateJson) => ({ ...JSON.parse(decJson), status: JSON.parse(stateJson) })),
+  wasm_transition_decision: vi.fn((decJson, stateJson, _actor, timestampMs, timestampLogical) => ({
+    ...JSON.parse(decJson),
+    status: JSON.parse(stateJson),
+    last_transition_at: { physical_ms: timestampMs, logical: timestampLogical },
+  })),
   wasm_decision_content_hash: vi.fn(() => 'c'.repeat(64)),
   wasm_decision_is_terminal: vi.fn(() => false),
-  wasm_file_challenge: vi.fn((challenger, id, ground) => ({ challenger_did: challenger, target_id: id, ground: JSON.parse(ground), challenge_hash: 'd'.repeat(64) })),
-  wasm_propose_accountability: vi.fn((target, proposer, actionType, reason, evidence) => ({ target_did: target, proposer_did: proposer, action_type: JSON.parse(actionType), reason, evidence_hash: evidence })),
+  wasm_file_challenge: vi.fn((challengeId, challenger, id, ground, evidence, createdAtMs, createdAtLogical) => ({
+    id: challengeId,
+    challenger_did: challenger,
+    target_id: id,
+    ground: JSON.parse(ground),
+    evidence_hash: evidence,
+    created_at: { physical_ms: createdAtMs, logical: createdAtLogical },
+    challenge_hash: 'd'.repeat(64),
+  })),
+  wasm_propose_accountability: vi.fn((actionId, target, proposer, actionType, reason, evidence, proposedAtMs, proposedAtLogical) => ({
+    id: actionId,
+    target_did: target,
+    proposer_did: proposer,
+    action_type: JSON.parse(actionType),
+    reason,
+    evidence_hash: evidence,
+    proposed_at: { physical_ms: proposedAtMs, logical: proposedAtLogical },
+  })),
   wasm_workflow_stages: vi.fn(() => ['Draft', 'Review', 'Voting', 'Enacted', 'Withdrawn']),
 }));
 
@@ -39,7 +60,14 @@ describe('GET /health', () => {
 
 describe('POST /api/decision/create', () => {
   it('creates a DecisionObject via WASM', async () => {
-    const res = await request.post('/api/decision/create').send({ title: 'Adopt RFC-42', decision_class: 'Strategic', constitution_hash: 'a'.repeat(64) });
+    const res = await request.post('/api/decision/create').send({
+      title: 'Adopt RFC-42',
+      decision_class: 'Strategic',
+      constitution_hash: 'a'.repeat(64),
+      decision_id: '00000000-0000-0000-0000-000000000001',
+      created_at_ms: 1000,
+      created_at_logical: 0,
+    });
     expect(res.status).toBe(201);
     expect(res.body).toHaveProperty('id', 'test-dec-001');
     expect(res.body.title).toBe('Adopt RFC-42');
@@ -47,9 +75,21 @@ describe('POST /api/decision/create', () => {
   });
 
   it('defaults decision_class to Operational', async () => {
-    const res = await request.post('/api/decision/create').send({ title: 'Simple Decision' });
+    const res = await request.post('/api/decision/create').send({
+      title: 'Simple Decision',
+      constitution_hash: 'a'.repeat(64),
+      decision_id: '00000000-0000-0000-0000-000000000002',
+      created_at_ms: 1100,
+      created_at_logical: 0,
+    });
     expect(res.status).toBe(201);
     expect(res.body.decision_class).toBe('Operational');
+  });
+
+  it('requires caller-supplied deterministic create metadata', async () => {
+    const res = await request.post('/api/decision/create').send({ title: 'Simple Decision' });
+    expect(res.status).toBe(400);
+    expect(res.body.fields).toEqual(['constitution_hash', 'decision_id', 'created_at_ms', 'created_at_logical']);
   });
 });
 
@@ -71,7 +111,13 @@ describe('POST /api/decision/evidence', () => {
 
 describe('POST /api/decision/transition', () => {
   it('transitions decision to new state', async () => {
-    const res = await request.post('/api/decision/transition').send({ decision_json: { id: 'test-dec-001', status: 'Draft' }, to_state: 'Review', actor_did: 'did:exo:alice' });
+    const res = await request.post('/api/decision/transition').send({
+      decision_json: { id: 'test-dec-001', status: 'Draft' },
+      to_state: 'Review',
+      actor_did: 'did:exo:alice',
+      timestamp_ms: 2000,
+      timestamp_logical: 0,
+    });
     expect(res.status).toBe(200);
     expect(res.body.status).toBe('Review');
   });
@@ -95,7 +141,15 @@ describe('POST /api/decision/terminal', () => {
 
 describe('POST /api/decision/challenge', () => {
   it('files a governance challenge', async () => {
-    const res = await request.post('/api/decision/challenge').send({ challenger_did: 'did:exo:carol', decision_id: 'test-dec-001', ground: 'ConstitutionalViolation', evidence_hash: 'e'.repeat(64) });
+    const res = await request.post('/api/decision/challenge').send({
+      challenger_did: 'did:exo:carol',
+      decision_id: 'test-dec-001',
+      ground: 'ConstitutionalViolation',
+      evidence_hash: 'e'.repeat(64),
+      challenge_id: '00000000-0000-0000-0000-000000000003',
+      created_at_ms: 3000,
+      created_at_logical: 0,
+    });
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('challenger_did', 'did:exo:carol');
   });
@@ -103,7 +157,16 @@ describe('POST /api/decision/challenge', () => {
 
 describe('POST /api/decision/accountability', () => {
   it('proposes accountability action', async () => {
-    const res = await request.post('/api/decision/accountability').send({ target_did: 'did:exo:dave', proposer_did: 'did:exo:alice', action_type: 'Censure', reason: 'Violation', evidence_hash: 'f'.repeat(64) });
+    const res = await request.post('/api/decision/accountability').send({
+      target_did: 'did:exo:dave',
+      proposer_did: 'did:exo:alice',
+      action_type: 'Censure',
+      reason: 'Violation',
+      evidence_hash: 'f'.repeat(64),
+      action_id: '00000000-0000-0000-0000-000000000004',
+      proposed_at_ms: 4000,
+      proposed_at_logical: 0,
+    });
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('target_did', 'did:exo:dave');
   });

--- a/demo/services/gateway-api/src/index.js
+++ b/demo/services/gateway-api/src/index.js
@@ -22,6 +22,10 @@ function parseBody(req) {
   });
 }
 
+function missingFields(input, fields) {
+  return fields.filter(field => input[field] === undefined || input[field] === null || input[field] === '');
+}
+
 export const server = http.createServer(async (req, res) => {
   if (req.method === 'OPTIONS') {
     res.writeHead(204, { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': '*', 'Access-Control-Allow-Headers': 'Content-Type' });
@@ -72,7 +76,9 @@ export const server = http.createServer(async (req, res) => {
     // ── Decisions: Create (full WASM pipeline) ──
     if (url.pathname === '/api/decisions' && req.method === 'POST') {
       const body = await parseBody(req);
-      const { title, decision_class, author_did } = body;
+      const { title, decision_class, author_did, decision_id, created_at_ms, created_at_logical } = body;
+      const missing = missingFields(body, ['decision_id', 'created_at_ms', 'created_at_logical']);
+      if (missing.length) return json(res, 400, { error: 'Missing required deterministic metadata', fields: missing });
 
       // 1. Verify author exists
       const { rows: [author] } = await pool.query('SELECT did, roles, pace_status FROM users WHERE did = $1', [author_did]);
@@ -87,12 +93,19 @@ export const server = http.createServer(async (req, res) => {
       const constitutionHash = wasm.wasm_hash_structured(JSON.stringify(constitution.payload));
 
       // 3. Create DecisionObject via WASM
-      const decision = wasm.wasm_create_decision(title, JSON.stringify(decision_class || 'Operational'), constitutionHash);
+      const decision = wasm.wasm_create_decision(
+        decision_id,
+        title,
+        JSON.stringify(decision_class || 'Operational'),
+        constitutionHash,
+        created_at_ms,
+        created_at_logical
+      );
 
       // 4. Persist to DB
       await pool.query(
         'INSERT INTO decisions (id_hash, tenant_id, status, title, decision_class, author, created_at_ms, constitution_version, payload) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)',
-        [decision.id, 'exochain-foundation', 'Draft', title, decision_class || 'Operational', author_did, Date.now(), constitution.version, JSON.stringify(decision)]
+        [decision.id, 'exochain-foundation', 'Draft', title, decision_class || 'Operational', author_did, created_at_ms, constitution.version, JSON.stringify(decision)]
       );
 
       // 5. Audit trail
@@ -136,12 +149,20 @@ export const server = http.createServer(async (req, res) => {
     // ── Decisions: Transition State ──
     if (url.pathname === '/api/decisions/transition' && req.method === 'POST') {
       const body = await parseBody(req);
-      const { decision_id, to_state, actor_did } = body;
+      const { decision_id, to_state, actor_did, timestamp_ms, timestamp_logical } = body;
+      const missing = missingFields(body, ['timestamp_ms', 'timestamp_logical']);
+      if (missing.length) return json(res, 400, { error: 'Missing required deterministic metadata', fields: missing });
 
       const { rows: [row] } = await pool.query('SELECT payload, status FROM decisions WHERE id_hash = $1', [decision_id]);
       if (!row) return json(res, 404, { error: 'Decision not found' });
 
-      const updated = wasm.wasm_transition_decision(JSON.stringify(row.payload), JSON.stringify(to_state), actor_did);
+      const updated = wasm.wasm_transition_decision(
+        JSON.stringify(row.payload),
+        JSON.stringify(to_state),
+        actor_did,
+        timestamp_ms,
+        timestamp_logical
+      );
 
       await pool.query('UPDATE decisions SET payload = $1, status = $2 WHERE id_hash = $3', [JSON.stringify(updated), to_state, decision_id]);
 

--- a/demo/services/gateway-api/src/index.test.js
+++ b/demo/services/gateway-api/src/index.test.js
@@ -15,9 +15,19 @@ const mockWasm = vi.hoisted(() => ({
   wasm_bcts_is_terminal: vi.fn(() => false),
   wasm_check_clearance: vi.fn(() => ({ status: 'Granted' })),
   wasm_check_conflicts: vi.fn(() => ({ must_recuse: false, conflicts: [] })),
-  wasm_create_decision: vi.fn((title) => ({ id: 'test-id-001', title, status: 'Draft', votes: [] })),
+  wasm_create_decision: vi.fn((id, title, _decClass, _hash, createdAtMs, createdAtLogical) => ({
+    id,
+    title,
+    status: 'Draft',
+    created_at: { physical_ms: createdAtMs, logical: createdAtLogical },
+    votes: [],
+  })),
   wasm_add_vote: vi.fn((decJson, voteJson) => ({ ...JSON.parse(decJson), votes: [JSON.parse(voteJson)] })),
-  wasm_transition_decision: vi.fn((decJson, stateJson) => ({ ...JSON.parse(decJson), status: JSON.parse(stateJson) })),
+  wasm_transition_decision: vi.fn((decJson, stateJson, _actor, timestampMs, timestampLogical) => ({
+    ...JSON.parse(decJson),
+    status: JSON.parse(stateJson),
+    last_transition_at: { physical_ms: timestampMs, logical: timestampLogical },
+  })),
   wasm_decision_is_terminal: vi.fn(() => false),
   wasm_shamir_split: vi.fn(() => []),
   wasm_audit_append: vi.fn(() => ({ entries: 1, head_hash: 'f'.repeat(64) })),
@@ -80,9 +90,19 @@ beforeEach(async () => {
   mockWasm.wasm_generate_keypair.mockReturnValue({ public_key: 'c'.repeat(64), secret_key: 'd'.repeat(64) });
   mockWasm.wasm_sign.mockReturnValue('e'.repeat(128));
   mockWasm.wasm_verify.mockReturnValue(true);
-  mockWasm.wasm_create_decision.mockImplementation((title) => ({ id: 'test-id-001', title, status: 'Draft', votes: [] }));
+  mockWasm.wasm_create_decision.mockImplementation((id, title, _decClass, _hash, createdAtMs, createdAtLogical) => ({
+    id,
+    title,
+    status: 'Draft',
+    created_at: { physical_ms: createdAtMs, logical: createdAtLogical },
+    votes: [],
+  }));
   mockWasm.wasm_add_vote.mockImplementation((decJson, voteJson) => ({ ...JSON.parse(decJson), votes: [JSON.parse(voteJson)] }));
-  mockWasm.wasm_transition_decision.mockImplementation((decJson, stateJson) => ({ ...JSON.parse(decJson), status: JSON.parse(stateJson) }));
+  mockWasm.wasm_transition_decision.mockImplementation((decJson, stateJson, _actor, timestampMs, timestampLogical) => ({
+    ...JSON.parse(decJson),
+    status: JSON.parse(stateJson),
+    last_transition_at: { physical_ms: timestampMs, logical: timestampLogical },
+  }));
   mockWasm.wasm_decision_is_terminal.mockReturnValue(false);
   mockWasm.wasm_shamir_split.mockReturnValue([]);
   mockWasm.wasm_audit_append.mockReturnValue({ entries: 1, head_hash: 'f'.repeat(64) });
@@ -133,10 +153,25 @@ describe('POST /api/decisions', () => {
       .mockResolvedValueOnce({ rows: [] });
     const res = await request
       .post('/api/decisions')
-      .send({ title: 'Test Decision', decision_class: 'Operational', author_did: 'did:exo:alice' });
+      .send({
+        title: 'Test Decision',
+        decision_class: 'Operational',
+        author_did: 'did:exo:alice',
+        decision_id: '00000000-0000-0000-0000-000000000001',
+        created_at_ms: 1000,
+        created_at_logical: 0,
+      });
     expect(res.status).toBe(201);
-    expect(res.body.decision).toHaveProperty('id');
+    expect(res.body.decision).toHaveProperty('id', '00000000-0000-0000-0000-000000000001');
     expect(res.body.decision.title).toBe('Test Decision');
+  });
+
+  it('requires caller-supplied deterministic create metadata', async () => {
+    const res = await request
+      .post('/api/decisions')
+      .send({ title: 'Test Decision', decision_class: 'Operational', author_did: 'did:exo:alice' });
+    expect(res.status).toBe(400);
+    expect(res.body.fields).toEqual(['decision_id', 'created_at_ms', 'created_at_logical']);
   });
 
   it('returns 404 when author not found', async () => {
@@ -144,7 +179,13 @@ describe('POST /api/decisions', () => {
     pool.query.mockResolvedValueOnce({ rows: [] });
     const res = await request
       .post('/api/decisions')
-      .send({ title: 'Test', author_did: 'did:exo:unknown' });
+      .send({
+        title: 'Test',
+        author_did: 'did:exo:unknown',
+        decision_id: '00000000-0000-0000-0000-000000000002',
+        created_at_ms: 1100,
+        created_at_logical: 0,
+      });
     expect(res.status).toBe(404);
     expect(res.body.error).toBe('Author not found');
   });
@@ -154,7 +195,13 @@ describe('POST /api/decisions', () => {
     pool.query.mockResolvedValueOnce({ rows: [{ did: 'did:exo:bob', pace_status: 'Pending' }] });
     const res = await request
       .post('/api/decisions')
-      .send({ title: 'Test', author_did: 'did:exo:bob' });
+      .send({
+        title: 'Test',
+        author_did: 'did:exo:bob',
+        decision_id: '00000000-0000-0000-0000-000000000003',
+        created_at_ms: 1200,
+        created_at_logical: 0,
+      });
     expect(res.status).toBe(403);
     expect(res.body.error).toBe('Author not PACE enrolled');
   });
@@ -202,9 +249,23 @@ describe('POST /api/decisions/transition', () => {
       .mockResolvedValueOnce({ rows: [] });
     const res = await request
       .post('/api/decisions/transition')
-      .send({ decision_id: 'test-id-001', to_state: 'Review', actor_did: 'did:exo:alice' });
+      .send({
+        decision_id: 'test-id-001',
+        to_state: 'Review',
+        actor_did: 'did:exo:alice',
+        timestamp_ms: 2000,
+        timestamp_logical: 0,
+      });
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('new_state', 'Review');
+  });
+
+  it('requires caller-supplied transition timestamp metadata', async () => {
+    const res = await request
+      .post('/api/decisions/transition')
+      .send({ decision_id: 'test-id-001', to_state: 'Review', actor_did: 'did:exo:alice' });
+    expect(res.status).toBe(400);
+    expect(res.body.fields).toEqual(['timestamp_ms', 'timestamp_logical']);
   });
 });
 

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -1071,9 +1071,12 @@ console.log('\n--- TNC Enforcement ---');
 
 const minDecision = setup(() =>
   wasm.wasm_create_decision(
+    UUID_1,
     'Test Decision',
     JSON.stringify('Operational'),
-    ZERO_32_HEX
+    NONZERO_32_HEX,
+    NOW_MS,
+    0
   ));
 
 const tncFlags = {
@@ -1152,18 +1155,24 @@ console.log('\n--- Challenge Lifecycle ---');
 
 test('wasm_file_challenge', () =>
   wasm.wasm_file_challenge(
+    UUID_2,
     TEST_DID,
     UUID_1,
     JSON.stringify('ProceduralError'),
-    ZERO_32_HEX
+    NONZERO_32_HEX,
+    NOW_MS,
+    0
   ));
 
 const challenge = setup(() =>
   wasm.wasm_file_challenge(
+    UUID_2,
     TEST_DID,
     UUID_1,
     JSON.stringify('ProceduralError'),
-    ZERO_32_HEX
+    NONZERO_32_HEX,
+    NOW_MS,
+    0
   ));
 
 test('wasm_begin_review', () => {
@@ -1189,16 +1198,22 @@ console.log('\n--- Decision Lifecycle ---');
 
 test('wasm_create_decision', () =>
   wasm.wasm_create_decision(
+    UUID_3,
     'Bridge Test Decision',
     JSON.stringify('Operational'),
-    ZERO_32_HEX
+    NONZERO_32_HEX,
+    NOW_MS,
+    0
   ));
 
 const decision = setup(() =>
   wasm.wasm_create_decision(
+    UUID_3,
     'Bridge Test Decision',
     JSON.stringify('Operational'),
-    ZERO_32_HEX
+    NONZERO_32_HEX,
+    NOW_MS,
+    0
   ));
 
 const decJson = decision ? JSON.stringify(decision) : '{}';
@@ -1235,7 +1250,9 @@ test('wasm_transition_decision', () =>
   wasm.wasm_transition_decision(
     decJson,
     JSON.stringify('Submitted'),
-    TEST_DID
+    TEST_DID,
+    BigInt(NOW_NUM + 1),
+    0
   ));
 
 test('wasm_check_quorum', () => {
@@ -1373,20 +1390,26 @@ console.log('\n--- Accountability ---');
 
 test('wasm_propose_accountability', () =>
   wasm.wasm_propose_accountability(
+    UUID_4,
     TEST_DID_2,
     TEST_DID,
     JSON.stringify('Censure'),
     'Violation of governance protocol',
-    ZERO_32_HEX
+    NONZERO_32_HEX,
+    NOW_MS,
+    0
   ));
 
 const accAction = setup(() =>
   wasm.wasm_propose_accountability(
+    UUID_4,
     TEST_DID_2,
     TEST_DID,
     JSON.stringify('Censure'),
     'Violation of governance protocol',
-    ZERO_32_HEX
+    NONZERO_32_HEX,
+    NOW_MS,
+    0
   ));
 
 test('wasm_begin_due_process', () => {
@@ -1441,24 +1464,28 @@ const emergencyPolicy = {
 
 test('wasm_create_emergency_action', () =>
   wasm.wasm_create_emergency_action(
+    UUID_1,
     JSON.stringify('SystemHalt'),
     TEST_DID,
     'Critical security breach',
     BigInt(50000),
-    ZERO_32_HEX,
+    NONZERO_32_HEX,
     JSON.stringify(emergencyPolicy),
-    NOW_MS
+    NOW_MS,
+    0
   ));
 
 const emergencyAction = setup(() =>
   wasm.wasm_create_emergency_action(
+    UUID_1,
     JSON.stringify('SystemHalt'),
     TEST_DID,
     'Critical security breach',
     BigInt(50000),
-    ZERO_32_HEX,
+    NONZERO_32_HEX,
     JSON.stringify(emergencyPolicy),
-    NOW_MS
+    NOW_MS,
+    0
   ));
 
 test('wasm_check_expiry', () => {


### PR DESCRIPTION
## Summary
- replace decision-forum constructor-local UUID/HLC fabrication with caller-supplied deterministic provenance inputs
- validate nil IDs, zero timestamps, empty provenance text, zero hashes, and regressive state-transition timestamps
- expand WASM/demo decision-forum entrypoints to require the same explicit provenance and add source guards against reintroducing Uuid::new_v4 or HybridClock::new
- stabilize the exo-node peer-count test so full release workspace tests do not race peer discovery

## Verification
- cargo build --workspace
- cargo test --workspace
- cargo build --workspace --release
- cargo test --workspace --release
- cargo clippy --workspace -- -D warnings
- cargo clippy -p exo-node --bin exochain -- -D warnings
- cargo test -p decision-forum
- cargo test -p exochain-wasm
- cargo test -p exo-gateway --test decision_forum_integration
- cargo +nightly fmt --all -- --check
- git diff --check
- node packages/exochain-wasm/test/bridge_verification.mjs
- npm run test:wasm
- npx vitest run services/gateway-api/src/index.test.js services/decision-forge/src/index.test.js

## Notes
- Rebased after PR #140 merged into origin/main.
- The repository still has pre-existing test-target clippy expect/unwrap_err findings under decision-forum when using --all-targets; the production workspace clippy gate listed above is green.