### PR TITLE
fix(decision-forum): enforce human quorum preconditions

### DIFF
--- a/crates/decision-forum/src/quorum.rs
+++ b/crates/decision-forum/src/quorum.rs
@@ -153,16 +153,18 @@ pub fn check_quorum(
 }
 
 /// Verify quorum preconditions BEFORE a vote is initiated (TNC-07).
-/// Returns true if enough eligible voters exist to potentially meet quorum.
+/// Returns true if enough eligible voters and eligible human voters exist to
+/// potentially meet quorum.
 pub fn verify_quorum_precondition(
     registry: &QuorumRegistry,
     class: DecisionClass,
     eligible_voters: usize,
+    eligible_human_voters: usize,
 ) -> Result<bool> {
     let req = registry
         .requirement_for(class)
         .ok_or(ForumError::QuorumPolicyMissing)?;
-    Ok(eligible_voters >= req.min_votes)
+    Ok(eligible_voters >= req.min_votes && eligible_human_voters >= req.min_human_votes)
 }
 
 #[cfg(test)]
@@ -319,9 +321,30 @@ mod tests {
     #[test]
     fn verify_precondition() {
         let reg = QuorumRegistry::with_defaults();
-        assert!(verify_quorum_precondition(&reg, DecisionClass::Routine, 1).expect("ok"));
-        assert!(!verify_quorum_precondition(&reg, DecisionClass::Operational, 2).expect("ok"));
-        assert!(verify_quorum_precondition(&reg, DecisionClass::Operational, 3).expect("ok"));
+        assert!(verify_quorum_precondition(&reg, DecisionClass::Routine, 1, 0).expect("ok"));
+        assert!(!verify_quorum_precondition(&reg, DecisionClass::Operational, 2, 1).expect("ok"));
+        assert!(!verify_quorum_precondition(&reg, DecisionClass::Operational, 3, 0).expect("ok"));
+        assert!(verify_quorum_precondition(&reg, DecisionClass::Operational, 3, 1).expect("ok"));
+    }
+
+    #[test]
+    fn strategic_precondition_rejects_when_human_floor_is_impossible() {
+        let reg = QuorumRegistry::with_defaults();
+
+        assert!(
+            !verify_quorum_precondition(&reg, DecisionClass::Strategic, 5, 0).expect("ok"),
+            "strategic class requires three eligible human voters"
+        );
+    }
+
+    #[test]
+    fn constitutional_precondition_rejects_when_human_floor_is_impossible() {
+        let reg = QuorumRegistry::with_defaults();
+
+        assert!(
+            !verify_quorum_precondition(&reg, DecisionClass::Constitutional, 7, 4).expect("ok"),
+            "constitutional class requires five eligible human voters"
+        );
     }
 
     #[test]

--- a/crates/exo-gateway/src/handlers.rs
+++ b/crates/exo-gateway/src/handlers.rs
@@ -330,15 +330,22 @@ pub async fn vote_handler(
     }
 
     // Verify quorum precondition (TNC-07): enough eligible voters must exist
-    // before accepting the vote. Use the registered DID count as the eligible
-    // voter count since the gateway does not maintain a separate voter registry.
+    // before accepting the vote. This gateway registry currently stores
+    // voter DIDs, so its cardinality is both the total and human-eligible
+    // count supplied to the decision-forum precondition.
     let registry = QuorumRegistry::with_defaults();
     let eligible_voters = state
         .registry
         .read()
         .unwrap_or_else(|e| e.into_inner())
         .len();
-    match verify_quorum_precondition(&registry, decision.class, eligible_voters) {
+    let eligible_human_voters = eligible_voters;
+    match verify_quorum_precondition(
+        &registry,
+        decision.class,
+        eligible_voters,
+        eligible_human_voters,
+    ) {
         Ok(true) => { /* enough eligible voters — proceed */ }
         Ok(false) => {
             return (

--- a/crates/exo-gateway/tests/decision_forum_integration.rs
+++ b/crates/exo-gateway/tests/decision_forum_integration.rs
@@ -71,7 +71,7 @@ fn vote_accepted_quorum_status_met() {
 
     // Verify precondition: 1 eligible voter satisfies Routine (min 1).
     let precondition_ok =
-        verify_quorum_precondition(&registry, decision.class, 1).expect("precondition ok");
+        verify_quorum_precondition(&registry, decision.class, 1, 1).expect("precondition ok");
     assert!(
         precondition_ok,
         "precondition should pass with 1 eligible voter"

--- a/crates/exochain-wasm/src/decision_forum_bindings.rs
+++ b/crates/exochain-wasm/src/decision_forum_bindings.rs
@@ -552,11 +552,17 @@ pub fn wasm_verify_quorum_precondition(
     registry_json: &str,
     class_json: &str,
     eligible_voters: usize,
+    eligible_human_voters: usize,
 ) -> Result<bool, JsValue> {
     let registry: decision_forum::quorum::QuorumRegistry = from_json_str(registry_json)?;
     let class: decision_forum::decision_object::DecisionClass = from_json_str(class_json)?;
-    decision_forum::quorum::verify_quorum_precondition(&registry, class, eligible_voters)
-        .map_err(|e| JsValue::from_str(&format!("Precondition error: {e}")))
+    decision_forum::quorum::verify_quorum_precondition(
+        &registry,
+        class,
+        eligible_voters,
+        eligible_human_voters,
+    )
+    .map_err(|e| JsValue::from_str(&format!("Precondition error: {e}")))
 }
 
 // ── Emergency Protocol ───────────────────────────────────────────

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -1313,7 +1313,8 @@ test('wasm_verify_quorum_precondition', () => {
   return wasm.wasm_verify_quorum_precondition(
     JSON.stringify(registry),
     JSON.stringify('Operational'),
-    3
+    3,
+    1
   );
 });
 


### PR DESCRIPTION
## Summary
- add eligible_human_voters to verify_quorum_precondition so preflight checks match check_quorum human-vote floors
- add regression coverage for operational, strategic, and constitutional classes where total voters exist but human quorum is impossible
- update gateway and WASM bridge callers so the exported contract requires both total and human eligibility counts

## TDD red check
- cargo test -p decision-forum quorum::tests::verify_precondition --lib initially failed with E0061 because the test called the intended four-argument API before implementation

## Verification
- cargo test -p decision-forum quorum::tests --lib
- cargo test -p exo-gateway --test decision_forum_integration
- cargo test -p exochain-wasm
- wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm
- node packages/exochain-wasm/test/bridge_verification.mjs
- cargo +nightly fmt --all -- --check
- git diff --check
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace -- -D warnings
- cargo build --workspace --release
- cargo test --workspace --release