### PR TITLE
fix(exoforge): label planning and triage contracts

### DIFF
--- a/exoforge/bin/exoforge-council-review.js
+++ b/exoforge/bin/exoforge-council-review.js
@@ -1,13 +1,12 @@
 #!/usr/bin/env node
 
 /**
- * exoforge-council-review — Run a 5-panel council review on a proposal.
+ * exoforge-council-review — Run 5-panel council-style heuristic triage.
  *
  * Accepts a proposal description (as CLI argument or via stdin) and runs
- * it through all 5 governance panels (Governance, Legal, Architecture,
- * Security, Operations). Each panel evaluates the proposal against its
- * criteria and casts a weighted vote. The final verdict is computed using
- * weighted tallying with veto power for Security and Governance panels.
+ * it through all 5 governance panel lenses (Governance, Legal, Architecture,
+ * Security, Operations). The result is non-binding heuristic triage, not an
+ * actual constitutional council decision.
  *
  * Usage:
  *   exoforge-council-review "Add new WASM combinator for delegation"
@@ -16,7 +15,13 @@
  *   exoforge-council-review --json "Modify safe harbor process"
  */
 
-import { getPanels, conductReview, tallyVotes } from '../lib/panels.js';
+import {
+  REVIEW_BINDING,
+  REVIEW_METHOD,
+  getPanels,
+  conductReview,
+  tallyVotes
+} from '../lib/panels.js';
 
 // ── Parse CLI arguments ─────────────────────────────────────────────────────
 
@@ -116,10 +121,12 @@ async function readStdin() {
 function formatTextReport(proposal, assessments, tally) {
   const lines = [];
   lines.push('');
-  lines.push('  ExoForge Council Review');
+  lines.push('  ExoForge Council-Style Triage');
   lines.push(`  ${'='.repeat(50)}`);
   lines.push(`  Proposal: ${proposal.title}`);
   if (proposal.type) lines.push(`  Type: ${proposal.type}`);
+  lines.push(`  Method: ${REVIEW_METHOD}`);
+  lines.push(`  Binding: ${REVIEW_BINDING ? 'YES' : 'NO'}`);
   lines.push('');
 
   // Panel assessments
@@ -230,7 +237,9 @@ async function main() {
         affected_systems: proposal.affectedSystems
       },
       assessments,
-      verdict: tally
+      verdict: tally,
+      review_method: REVIEW_METHOD,
+      binding_review: REVIEW_BINDING
     }, null, 2));
   } else {
     console.log(formatTextReport(proposal, assessments, tally));

--- a/exoforge/bin/exoforge-implement.js
+++ b/exoforge/bin/exoforge-implement.js
@@ -1,22 +1,25 @@
 #!/usr/bin/env node
 
 /**
- * exoforge-implement — Generate an implementation plan from a GitHub issue.
+ * exoforge-implement — Generate an implementation readiness plan from a GitHub issue.
  *
  * Reads the specified issue from GitHub, analyzes its requirements against
  * the 5-panel governance matrix, and produces a structured implementation
  * plan skeleton. The plan includes affected files, governance gates,
- * required reviews, and testing criteria.
- *
- * Actual code implementation requires Claude Code invocation; this tool
- * generates the plan that guides that process.
+ * required reviews, and testing criteria. This command is planning-only.
  *
  * Usage:
  *   exoforge-implement <issue_number> [--repo owner/name] [--json]
  */
 
 import { getIssue } from '../lib/github.js';
-import { getPanels, conductReview, tallyVotes } from '../lib/panels.js';
+import {
+  REVIEW_BINDING,
+  REVIEW_TIMESTAMP_ISO,
+  getPanels,
+  conductReview,
+  tallyVotes
+} from '../lib/panels.js';
 
 const DEFAULT_REPO = 'exochain/exochain';
 
@@ -196,8 +199,7 @@ function determinePhases(issue, panelAssessments) {
       'Create feature branch from main',
       'Implement changes per requirements',
       'Update WASM bindings if Rust crates are modified',
-      'Run cargo test and cargo clippy',
-      'NOTE: Actual implementation requires Claude Code invocation'
+      'Run cargo test and cargo clippy'
     ],
     blocked: false
   });
@@ -304,15 +306,17 @@ async function main() {
         : tally.total_findings > 2 ? 'medium' : 'low',
       requires_wasm_rebuild: affectedFiles.some(f => f.includes('crates/') || f.includes('wasm')),
       requires_council_review: tally.verdict !== 'APPROVED',
-      generated_at: new Date().toISOString(),
-      implementation_note: 'Actual code implementation requires invoking Claude Code with this plan as context.'
+      generated_at: REVIEW_TIMESTAMP_ISO,
+      execution_mode: 'planning_only',
+      binding_review: REVIEW_BINDING,
+      planning_note: 'This command generates an implementation readiness plan; it does not modify files.'
     };
 
     if (args.json) {
       console.log(JSON.stringify(plan, null, 2));
     } else {
       console.log('');
-      console.log('  ExoForge Implementation Plan');
+      console.log('  ExoForge Implementation Readiness Plan');
       console.log(`  ${'='.repeat(50)}`);
       console.log(`  Issue: #${plan.issue.number} — ${plan.issue.title}`);
       console.log(`  URL: ${plan.issue.url}`);
@@ -350,7 +354,7 @@ async function main() {
       if (plan.requires_wasm_rebuild) {
         console.log('  NOTE: This implementation requires a WASM rebuild (wasm-pack build)');
       }
-      console.log(`  NOTE: ${plan.implementation_note}`);
+      console.log(`  NOTE: ${plan.planning_note}`);
       console.log('');
     }
   } catch (err) {

--- a/exoforge/lib/panels.js
+++ b/exoforge/lib/panels.js
@@ -1,10 +1,13 @@
 /**
- * panels.js — 5-panel council review system for ExoForge.
+ * panels.js — 5-panel council triage system for ExoForge.
  *
- * Implements the multi-panel governance review process modeled on
- * ExoChain's three-branch (legislative/executive/judicial) structure.
- * Each panel evaluates proposals within its scope and casts a weighted vote.
+ * Provides deterministic heuristic triage modeled on ExoChain's
+ * three-branch (legislative/executive/judicial) structure.
  */
+
+export const REVIEW_METHOD = 'heuristic_triage';
+export const REVIEW_BINDING = false;
+export const REVIEW_TIMESTAMP_ISO = '2023-11-14T22:13:20.000Z';
 
 /**
  * The 5 standing council panels.
@@ -97,7 +100,7 @@ export function getPanel(name) {
 }
 
 /**
- * Conduct a multi-panel review of a proposal.
+ * Conduct a multi-panel heuristic triage of a proposal.
  *
  * Each panel evaluates the proposal against its criteria and produces
  * a structured assessment. This function returns the raw assessments;
@@ -121,11 +124,10 @@ export function conductReview(panels, proposal) {
 }
 
 /**
- * Evaluate a single panel's review of a proposal.
+ * Evaluate a single panel's heuristic triage of a proposal.
  *
- * Performs heuristic analysis based on the proposal's described impact
- * areas and the panel's criteria. In production, this would invoke
- * Claude Code for deeper semantic analysis.
+ * Performs deterministic keyword analysis based on the proposal's described
+ * impact areas and the panel's criteria. This is not a binding council vote.
  *
  * @param {object} panel - Panel definition
  * @param {object} proposal - Proposal to evaluate
@@ -269,10 +271,12 @@ function evaluatePanel(panel, proposal) {
     weight: panel.weight,
     vote,
     confidence: Math.round(confidence * 100) / 100,
+    review_method: REVIEW_METHOD,
+    binding_review: REVIEW_BINDING,
     findings,
     criteria_met: criteriaMet,
     criteria_failed: criteriaFailed,
-    reviewed_at: new Date().toISOString()
+    reviewed_at: REVIEW_TIMESTAMP_ISO
   };
 }
 
@@ -348,10 +352,12 @@ export function tallyVotes(votes) {
   return {
     verdict,
     score,
+    review_method: REVIEW_METHOD,
+    binding_review: REVIEW_BINDING,
     breakdown,
     vetoed_by: vetoedBy,
     total_findings: totalFindings,
     panels_reviewed: votes.length,
-    reviewed_at: new Date().toISOString()
+    reviewed_at: REVIEW_TIMESTAMP_ISO
   };
 }

--- a/exoforge/package.json
+++ b/exoforge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@exochain/exoforge",
   "version": "0.1.0-beta",
-  "description": "ExoForge — autonomous implementation engine for EXOCHAIN",
+  "description": "ExoForge — governance triage, planning, validation, and monitoring tools for EXOCHAIN",
   "type": "module",
   "scripts": {
     "test": "node --test test/*.test.js"

--- a/exoforge/test/product-contracts.test.js
+++ b/exoforge/test/product-contracts.test.js
@@ -1,0 +1,47 @@
+import { execFile } from 'node:child_process';
+import { test } from 'node:test';
+import { promisify } from 'node:util';
+import { equal, ok } from 'node:assert/strict';
+
+const execFileAsync = promisify(execFile);
+
+async function runJsonCli(script, args = []) {
+  try {
+    const { stdout } = await execFileAsync(process.execPath, [script, ...args], {
+      cwd: new URL('../..', import.meta.url),
+      maxBuffer: 1024 * 1024,
+    });
+    return JSON.parse(stdout);
+  } catch (err) {
+    if (err.stdout) return JSON.parse(err.stdout);
+    throw err;
+  }
+}
+
+test('exoforge-implement identifies itself as a planning-only contract', async () => {
+  const plan = await runJsonCli('exoforge/bin/exoforge-implement.js', [
+    '1',
+    '--dry-run',
+    '--json',
+  ]);
+
+  equal(plan.execution_mode, 'planning_only');
+  equal(plan.binding_review, false);
+  ok(!JSON.stringify(plan).includes('Actual code implementation requires'));
+  ok(!JSON.stringify(plan).includes('requires invoking Claude Code'));
+});
+
+test('exoforge-council-review labels heuristic output as non-binding triage', async () => {
+  const review = await runJsonCli('exoforge/bin/exoforge-council-review.js', [
+    '--json',
+    '--title',
+    'Constitutional change',
+    '--description',
+    'Modify authority chain',
+  ]);
+
+  equal(review.review_method, 'heuristic_triage');
+  equal(review.binding_review, false);
+  equal(review.verdict.review_method, 'heuristic_triage');
+  equal(review.verdict.binding_review, false);
+});


### PR DESCRIPTION
## Summary
- make ExoForge package/product language match current behavior
- mark `exoforge-implement` JSON as `execution_mode: planning_only` and non-binding
- mark council-style output as `heuristic_triage` and non-binding
- remove dynamic timestamps from panel review and implementation plan output
- add product-contract tests

## TDD red check
- `npm test --prefix exoforge` failed before implementation because the planner lacked `execution_mode` and council-review lacked heuristic/non-binding labels

## Verification
- `npm test --prefix exoforge`
- `node exoforge/bin/exoforge-implement.js 1 --dry-run --json`
- `node exoforge/bin/exoforge-council-review.js --json --title "Constitutional change" --description "Modify authority chain"`
- `git diff --check`