### PR TITLE
fix(docs): guard repo truth claims

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,8 @@ jobs:
             exit 1
           fi
           echo "✓ No GAP stubs remaining in code"
+      - name: Repo truth and public claims
+        run: bash tools/test_repo_truth.sh
 
   # -----------------------------------------------------------------------
   # Gate 10: SBOM (dry-run generation — no upload, validates toolchain)

--- a/README.md
+++ b/README.md
@@ -16,20 +16,20 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 273 | `find crates -name '*.rs'` |
-| Rust LOC | 97,681 | `wc -l` |
-| Workspace tests | 1,603 passing, 0 failing | `cargo test --workspace` |
-| CI quality gates | 16 | `.github/workflows/ci.yml` |
+| Rust LOC | 111606 | `wc -l` |
+| Workspace tests | 2,687 listed | `cargo test --workspace -- --list` |
+| CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
 | Live node | https://exochain.io | Fly.io deployment |
 
 ### What is verified today
 
-- **1,603 workspace tests pass** with zero failures (`cargo test --workspace`)
+- **2,687 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
-- **16 CI quality gates** defined and enforced (build, test, coverage, lint, format, audit, deny, doc, hygiene, SBOM, machete, integration, DB integration, consensus integration, sync/join, cross-platform)
+- **20 numbered CI quality gates** plus the required "All Constitutional Gates" aggregator are defined and enforced
 - **Traceability matrix** maps 87 requirements — see `governance/traceability_matrix.md`
 - **Threat model** covers 14 threats tracked: 14 mitigated, 0 partial, 0 planned — see `governance/threat_matrix.md`
 - **Constitutional invariants** enforced via the CGR kernel in all governance paths
@@ -57,13 +57,12 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 16 crates, ~75K LOC)
+Layer 1: CGR Kernel         (Rust, 20 crates, 111606 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 1,846 tests passing
+         cryptographic proofs, 2,687 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
-         110 exported functions — Rust → WebAssembly → JavaScript
-         Zero stubs. Every function calls real crate logic.
+         140 verified bridge exports — Rust → WebAssembly → JavaScript
 
 Layer 3: CommandBase.ai     (command-base/)
          Operational hypervisor for cognitiveplane.ai
@@ -76,8 +75,8 @@ Layer 4: Decision Forum     (web/)
          React/Vite — decisions, delegations, audit, constitution
 
 Layer 5: ExoForge           (exoforge/)
-         Autonomous implementation engine
-         Triage → Council Review → Implementation → Constitutional Validation
+         Governance triage, planning, validation, and monitoring tools
+         Triage → Council-style heuristic review → Plan → Constitutional Validation
 ```
 
 ## The Five Axioms
@@ -90,7 +89,7 @@ Layer 5: ExoForge           (exoforge/)
 
 ## Repository Structure
 
-### Core Crates (16)
+### Core Crates (20)
 
 | Crate | Description |
 |-------|-------------|
@@ -110,6 +109,10 @@ Layer 5: ExoForge           (exoforge/)
 | `decision-forum` | Governance application: council-driven decision making |
 | `exochain-wasm` | WASM compilation target for browser/Node.js integration |
 | `exo-node` | Distributed P2P node: BFT consensus, networking, governance API, live dashboard |
+| `exo-catapult` | Franchise/NewCo spawn, budgets, goals, agents, receipts, and autonomous corporation scaffolding |
+| `exo-messaging` | Encrypted messaging envelopes, death-trigger checks, and compose/open flows |
+| `exo-consensus` | Multi-model consensus session, scoring, commitment, and report primitives |
+| `exochain-sdk` | Rust SDK facade for identity, consent, authority, governance, and kernel calls |
 
 ### Governance & Infrastructure
 
@@ -125,7 +128,7 @@ This repository is managed under strict **Judicial Build Governance**. All contr
 
 * [Traceability Matrix](governance/traceability_matrix.md) — 87 requirements tracked
 * [Threat Model](governance/threat_matrix.md) — 14 mitigated, 0 partial, 0 planned
-* [Quality Gates](governance/quality_gates.md) — 16 CI-enforced gates
+* [Quality Gates](governance/quality_gates.md) — 20 numbered CI gates plus required aggregator
 * [Sub-Agent Charters](governance/sub_agents.md) — 11 agent charters documented
 * [Council Resolutions](governance/resolutions/INDEX.md) — CR-001 DRAFT
 * [Tier-One Readiness Audit](docs/audit/TIER-ONE-READINESS-AUDIT.md) — capability model, gap analysis, exit checklist
@@ -161,15 +164,15 @@ cd demo && npm install && npm run dev
 
 See [demo/README.md](demo/README.md) for full setup instructions.
 
-## ExoForge (Autonomous Implementation Engine)
+## ExoForge
 
-[ExoForge](https://github.com/exochain/exoforge) is the autonomous implementation engine that establishes a **perpetual self-improvement cycle** for ExoChain:
+[ExoForge](exoforge/) provides governance triage, planning, validation, and monitoring tools for ExoChain:
 
 ```
-Widget AI Help → Feedback Ingestion → Triage → AI-IRB Council Review → Implementation → Constitutional Validation → PR → Deploy
+Widget AI Help → Feedback Ingestion → Triage → Council-Style Heuristic Review → Implementation Plan → Constitutional Validation
 ```
 
-- **7 Archon commands** — Triage, council review, Syntaxis generation, PRD generation, implementation, bug fixing, constitutional validation
+- **7 Archon commands** — Triage, council-style review, Syntaxis generation, PRD generation, implementation planning, bug-fix planning, constitutional validation
 - **4 DAG workflows** — Self-improvement cycle, client onboarding, issue fixing, continuous governance monitoring
 - **5×5 discipline matrix** — 5 council panels × 5 artifact properties (Storable, Diffable, Transferable, Auditable, Contestable)
 - **GitHub Issues integration** — Issues labeled `exoforge:triage` automatically enter the self-improvement cycle
@@ -189,8 +192,8 @@ See [docs/guides/ARCHON-INTEGRATION.md](docs/guides/ARCHON-INTEGRATION.md) for s
 # Build all crates
 cargo build --workspace --all-targets
 
-# Run all library tests
-cargo test --workspace --lib
+# Run the workspace test gate
+cargo test --workspace
 
 # Lint (strict — no warnings allowed)
 cargo clippy --workspace --lib --bins -- -D warnings

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 16 Rust crates, 18,705 lines of code, 1,846 tests, and a formal proof chain demonstrating that its governance properties hold under all conditions.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 111606 lines of Rust under `crates/`, 2,687 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -247,4 +247,4 @@ EXOCHAIN is our answer.
 | Council Assessment | `governance/COUNCIL-ASSESSMENT-EXO-VS-EXOCHAIN.md` | 5-panel exo vs exochain |
 | Refactor Plan | `governance/EXOCHAIN-REFACTOR-PLAN.md` | Master plan |
 | AGENTS.md | Root `AGENTS.md` | AI development instructions |
-| CI Pipeline | `.github/workflows/ci.yml` | 8 quality gates |
+| CI Pipeline | `.github/workflows/ci.yml` | 20 numbered gates plus required aggregator |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-~31,000 lines of Rust · 16 crates · 1,846 tests · 0 failures · 40 MCP tools · 8 constitutional invariants
+111606 lines of Rust under `crates/` · 20 workspace packages · 2,687 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 
@@ -45,7 +45,7 @@ tags: [exochain, documentation, index]
 
 ## Reference
 
-- [[CRATE-REFERENCE]] — Complete API reference for all 16 crates (types, traits, functions, invariants).
+- [[CRATE-REFERENCE]] — API reference for the workspace crates (types, traits, functions, invariants).
 
 ## Proofs
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 16 crates | 18,705 lines of Rust | 111 source files | 1,846 tests | 0 failures
+> **Codebase:** 20 workspace packages | 111606 lines of Rust under `crates/` | 273 Rust source files | 2,687 listed tests
 
 ---
 

--- a/docs/audit/REPO-TRUTH-BASELINE.md
+++ b/docs/audit/REPO-TRUTH-BASELINE.md
@@ -1,5 +1,9 @@
 # EXOCHAIN Repository Truth Baseline
 
+> Superseded numerically by `tools/repo_truth.sh` as updated in Wave E Basalt
+> on 2026-04-26. This file is retained as a historical audit baseline, not as
+> the current source of repo counts.
+
 Generated: 2026-03-20
 Branch: `feat/platform-hardening` @ `bf38f9f`
 Method: Manual audit + automated verification

--- a/docs/audit/TIER-ONE-READINESS-AUDIT.md
+++ b/docs/audit/TIER-ONE-READINESS-AUDIT.md
@@ -1,5 +1,9 @@
 # EXOCHAIN Tier-One Readiness Audit
 
+> Historical readiness audit. Numeric repo facts in this document predate Wave E
+> Basalt; use `tools/repo_truth.sh` and `README.md` for current crate, LOC, test,
+> and CI-gate counts.
+
 **Date**: 2026-04-04
 **Auditor**: ExoForge Council (automated via exochain.io governance API)
 **Live Node**: https://exochain.io (consensus round 14,845 at time of audit)

--- a/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
+++ b/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
@@ -46,9 +46,9 @@ decision.forum is a constitutional trust fabric for AI-era governance. Not a fra
 
 The numbers, verified as of this writing:
 
-- **29,587 lines of Rust** -- not Python, not JavaScript. Rust. For determinism.
-- **16 crates** covering identity, consent, authority, governance, escalation, legal infrastructure, cryptographic proofs, and more
-- **1,846 tests. Zero failures.**
+- **111606 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
+- **20 workspace packages** covering identity, consent, authority, governance, escalation, legal infrastructure, cryptographic proofs, and more
+- **2,687 listed tests** exercised by the workspace test gate.
 - **10 formal proofs** demonstrating that constitutional properties hold under all reachable system states
 - Built and reviewed through a **5-panel council process** (Governance, Legal, Architecture, Security, Operations)
 
@@ -270,7 +270,7 @@ The question is whether we will build it before we need it.
 
 *Bob Stewart is the architect of EXOCHAIN and decision.forum, and the author of The ASI Report on LinkedIn, where he writes about the infrastructure required for safe superintelligence. His work focuses on the intersection of constitutional governance, cryptographic enforcement, and AI safety -- the premise that alignment is necessary but insufficient, and that enforceable structural constraints are the missing complement.*
 
-*The decision.forum codebase -- 29,587 lines of Rust, 16 crates, 1,846 tests, 10 formal proofs -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
+*The EXOCHAIN workspace -- 111606 lines of Rust under `crates/`, 20 packages, 2,687 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
 
 ---
 

--- a/docs/decision-forum/SYSTEM-DOCUMENTATION.md
+++ b/docs/decision-forum/SYSTEM-DOCUMENTATION.md
@@ -6,7 +6,7 @@ created: 2026-03-19
 publication: "The ASI Report — LinkedIn Newsletter"
 tags: [decision-forum, governance, constitutional, asi-safety, exochain]
 status: publication-ready
-codebase: "16 crates | 29,587 LOC Rust | 136 source files | 1,846 tests | 0 failures"
+codebase: "20 workspace packages | 111606 LOC Rust under crates/ | 273 source files | 2,687 listed tests"
 ---
 
 # decision.forum — System Documentation
@@ -19,11 +19,11 @@ This document is the exhaustive technical reference for the decision.forum gover
 
 | Metric | Value |
 |--------|-------|
-| Total crates | 14 |
-| Total Rust LOC | 29,587 |
-| Total source files | 136 |
-| Total tests | 1,182 |
-| Test failures | 0 |
+| Workspace packages | 20 |
+| Rust LOC under `crates/` | 111606 |
+| Rust source files | 273 |
+| Listed workspace tests | 2,687 |
+| Test gate | `cargo test --workspace` in CI Gate 2 |
 | decision-forum crate LOC | 3,800 |
 | decision-forum tests | 131 |
 | decision-forum modules | 15 |

--- a/docs/guides/GETTING-STARTED.md
+++ b/docs/guides/GETTING-STARTED.md
@@ -102,13 +102,13 @@ cargo install cargo-audit
 ## Build, test, lint
 
 ```bash
-# Build all 16 crates (debug)
+# Build the full workspace (debug)
 cargo build --workspace
 
 # Build in release mode (LTO, may take longer)
 cargo build --workspace --release
 
-# Run all 1,846 tests
+# Run the workspace test gate
 cargo test --workspace
 
 # Run tests for a specific crate
@@ -123,10 +123,12 @@ cargo tarpaulin --workspace --out html
 open tarpaulin-report.html
 ```
 
-A clean build produces zero errors and zero warnings. All 1,846 tests should pass with 0 failures:
+A clean build produces zero errors and zero warnings. The current workspace
+inventory lists 2,687 tests; the exact executed count can change as doctests and
+integration targets evolve. What matters is zero failures:
 
 ```
-test result: ok. 1846 passed; 0 failed; 0 ignored
+test result: ok. ... passed; 0 failed; 0 ignored
 ```
 
 ---
@@ -150,7 +152,7 @@ Draft -> Submitted -> IdentityResolved -> ConsentValidated -> Deliberated
 
 Each transition emits a cryptographic receipt; the receipt chain is verifiable end-to-end.
 
-All 16 crates depend on `exo-core`. The full dependency graph is in [[ARCHITECTURE]]; the complete API surface in [[CRATE-REFERENCE]]; the 10 formal proofs that the invariants hold in [[CONSTITUTIONAL-PROOFS]].
+All workspace crates depend directly or indirectly on `exo-core`. The full dependency graph is in [[ARCHITECTURE]]; the API surface is in [[CRATE-REFERENCE]]; the formal proof material is in [[CONSTITUTIONAL-PROOFS]].
 
 ---
 

--- a/docs/guides/architecture-overview.md
+++ b/docs/guides/architecture-overview.md
@@ -19,8 +19,8 @@ From the top-level `README.md`, EXOCHAIN is organised in five layers.
 
 ```
 ┌──────────────────────────────────────────────────────────────────────┐
-│ Layer 5  ExoForge                    Autonomous implementation engine │
-│          (exoforge/)                 Triage → Council Review → Impl   │
+│ Layer 5  ExoForge                    Governance triage/planning tools │
+│          (exoforge/)                 Triage → Heuristic Review → Plan │
 │                                      → Constitutional Validation      │
 ├──────────────────────────────────────────────────────────────────────┤
 │ Layer 4  Decision Forum              Governance deliberation UI       │
@@ -30,18 +30,18 @@ From the top-level `README.md`, EXOCHAIN is organised in five layers.
 │          (command-base/)             cognitiveplane.ai                │
 │                                      Express + SQLite + WebSocket     │
 ├──────────────────────────────────────────────────────────────────────┤
-│ Layer 2  WASM Bridge                 110 exported functions           │
+│ Layer 2  WASM Bridge                 140 verified bridge exports      │
 │          (packages/exochain-wasm,    Rust → WebAssembly → JS          │
-│           crates/exochain-wasm)      Zero stubs, every fn real logic  │
+│           crates/exochain-wasm)      Export sync checked in CI        │
 ├──────────────────────────────────────────────────────────────────────┤
-│ Layer 1  CGR Kernel                  Rust, 16 crates                  │
+│ Layer 1  CGR Kernel                  Rust, 20 workspace packages      │
 │          (crates/)                   Constitutional governance runtime │
 │                                      Deterministic, no floats, tests  │
 └──────────────────────────────────────────────────────────────────────┘
 ```
 
 The layers are directional: higher layers depend on lower ones, never
-the reverse. Layer 1 (the kernel and its 16 crates) is the load-bearing
+the reverse. Layer 1 (the kernel and its workspace crates) is the load-bearing
 substance. The rest are presentation and orchestration surfaces over
 the same primitives.
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -89,11 +89,10 @@ cargo test --workspace
 Expected output tail:
 
 ```
-test result: ok. 1603 passed; 0 failed; 0 ignored; ...
+test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The baseline is currently **1,603 tests passing, 0 failures**. The
-number grows as new crates land; consult
+The current workspace inventory lists **2,687 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 
@@ -177,11 +176,9 @@ violation.
 The workspace root is a plain Cargo workspace. The pieces that matter
 for first-week work:
 
-### 3.1 The 17 Rust crates in `crates/`
+### 3.1 The 20 Rust workspace packages in `crates/`
 
-> There are currently 16 production crates and one SDK crate (17
-> directory entries in `crates/`). The README repo-truth table tracks
-> the production count.
+> The README repo-truth table tracks the current package and source-file counts.
 
 | Crate                | One-line purpose                                                                        |
 |----------------------|-----------------------------------------------------------------------------------------|
@@ -203,7 +200,7 @@ for first-week work:
 | `exo-catapult`       | Event ingestion acceleration / batching                                                 |
 | `exo-node`           | The `exochain` binary: P2P, BFT, reactor, API, dashboard, CLI, MCP server               |
 | `exochain-sdk`       | In-process Rust SDK: ergonomic wrappers for kernel, identity, consent, authority        |
-| `exochain-wasm`      | WebAssembly bindings (the 110-function bridge)                                          |
+| `exochain-wasm`      | WebAssembly bindings (140 verified bridge exports)                                      |
 | `decision-forum`     | Deliberative decision-making forum protocol and voting engine                           |
 
 ### 3.2 SDK and bindings in `packages/`
@@ -241,7 +238,7 @@ for first-week work:
 |-------------------|------------------------------------------------------------------------|
 | `docs/`           | Architecture, guides, ADRs, reference, council panel reports           |
 | `command-base/`   | CommandBase.ai operational hypervisor (Node/Express + SQLite)          |
-| `exoforge/`       | Autonomous implementation engine (triage → council → implement → validate) |
+| `exoforge/`       | Governance triage, implementation planning, validation, and monitoring tools |
 | `web/`            | Decision Forum React UI                                                |
 | `demo/`           | Standalone demo stack (Node microservices + React + Postgres)          |
 | `tla/`            | TLA+ specifications for core protocols                                 |
@@ -364,36 +361,14 @@ Three sources, in priority order:
    been triaged by ExoForge and include a council review. These tend
    to have the clearest acceptance criteria.
 
-### 6.2 The 16 CI quality gates
+### 6.2 The CI quality gates
 
-Every PR runs the `.github/workflows/ci.yml` pipeline. The gates fall
-into three groups:
-
-**Pull-request gates (8, must pass to merge)**
-
-1. Compilation — `cargo build --workspace --all-targets`
-2. Testing — `cargo test --workspace --lib` (≥1,116 tests, 100% pass)
-3. Coverage — `tarpaulin` / `llvm-cov` ≥ 90% line coverage
-4. Formatting — `cargo fmt --all -- --check`
-5. Linting — `cargo clippy --workspace --all-targets -- -D warnings`
-6. Security audit — `cargo audit`, zero CVSS>0 vulnerabilities
-7. Dependency check — `cargo deny check`
-8. Doc check — `cargo doc --workspace --no-deps`
-
-**Release gates (additional)**
-
-9. Cross-implementation hash test — `tools/cross-impl-test/compare.sh`
-10. Benchmark regression — `cargo bench`, no ≥10% regression
-11. Fuzz smoke — 5-minute run, 0 crashes
-12. Changelog — `CHANGELOG.md` updated with conventional commits
-13. Post-quantum roundtrip — all three `Signature` enum variants
-14. Constitutional invariant verification — all AEGIS/SYBIL invariants
-    verified against CR-001
-
-**Meta gates**
-
-15. SBOM generation
-16. `cargo machete` (no unused deps)
+Every PR runs the `.github/workflows/ci.yml` pipeline. It currently defines 20
+numbered gates plus the required "All Constitutional Gates" aggregator. The
+gates cover build, debug/release tests, coverage, clippy, format, audit, deny,
+docs, repo hygiene, SBOM dry-run, unused dependency checks, gateway/DB/consensus
+integration, state sync, cross-platform builds, 0dentity coverage, WASM build,
+bridge verification, and WASM/JS export sync.
 
 See [`../../governance/quality_gates.md`](../../governance/quality_gates.md)
 for the authoritative list.

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -7,9 +7,9 @@ tags: [exochain, reference, api, crates]
 
 # Crate Reference
 
-**Complete API reference for the 16 crates composing the EXOCHAIN constitutional trust fabric.**
+**API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-16 crates · 18,705 lines of Rust · 1,846 tests · 0 failures
+20 workspace packages · 111606 lines of Rust under `crates/` · 2,687 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 

--- a/governance/EXOCHAIN-REFACTOR-PLAN.md
+++ b/governance/EXOCHAIN-REFACTOR-PLAN.md
@@ -69,7 +69,7 @@ All refactor work flows through the Syntaxis Builder system:
 - [x] Implement Section 8 work orders from CR-001
 - [x] Achieve release-blocking acceptance standard (CR-001 Section 9)
 
-> **Completion notes**: All CR-001 Section 8 work orders implemented. 16 crates, 29,587 LOC, 1,846 tests, 0 failures. Traceability matrix 75/75 complete. Threat matrix 13/13 mitigated. 90% coverage target enforced via CI. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) implemented.
+> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 111606 Rust LOC under `crates/`, 2,687 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
 
 ## Active Resolutions
 

--- a/governance/quality_gates.md
+++ b/governance/quality_gates.md
@@ -4,20 +4,32 @@ These gates are enforced by the `DEVOPS_RELEASE_AGENT` via the CI pipeline at `.
 
 Coverage target: **90%** per CR-001 Section 8.8.
 
-## Pull Request Gates (8 Gates — Must Pass to Merge)
+## Pull Request Gates (20 Numbered Gates + Aggregator — Must Pass to Merge)
 
-1. **Compilation**: `cargo build --workspace --all-targets` succeeds.
-2. **Testing**: `cargo test --workspace --lib` passes (100% pass rate, 1,116 tests).
-3. **Coverage**: `tarpaulin` or `llvm-cov` report shows **>= 90% line coverage** (CR-001 Section 8.8).
-4. **Formatting**: `cargo fmt --all -- --check` passes.
-5. **Linting**: `cargo clippy --workspace --all-targets -- -D warnings` (zero warnings).
-6. **Security Audit**: `cargo audit` finds **0** vulnerabilities with `cvss > 0.0` (strict).
-7. **Dependency Check**: `cargo deny check` passes (license compliance, advisory database, banned crates).
-8. **Doc Check**: `cargo doc --no-deps` succeeds.
+1. **Build**: `cargo build --workspace --release` succeeds.
+2. **Test**: `cargo test --workspace` and `cargo test --workspace --release` pass.
+3. **Coverage**: `cargo tarpaulin` reports **>= 90% line coverage** for the configured workspace scope.
+4. **Clippy**: `cargo clippy --workspace --all-targets -- -D warnings` passes.
+5. **Format**: `cargo +nightly fmt --all -- --check` passes.
+6. **Audit**: `cargo audit` passes.
+7. **Deny**: `cargo deny check` passes.
+8. **Documentation**: `cargo doc --workspace --no-deps` passes.
+9. **Repo Hygiene**: generated artifacts, tracked secrets, license drift, GAP stubs, and repo-truth drift are rejected.
+10. **SBOM Dry-Run**: CycloneDX generation path is validated.
+11. **Unused Dependencies**: `cargo machete` passes.
+12. **Gateway Integration**: gateway route tests pass when relevant.
+13. **DB Integration**: production-db integration tests and migrations pass.
+14. **Consensus Integration**: multi-node consensus test passes.
+15. **State Sync & Join**: state sync/join test passes.
+16. **Cross-Platform Build**: Linux x86_64, Linux aarch64, and macOS aarch64 build targets pass.
+17. **0dentity Coverage**: 0dentity module coverage meets the configured threshold.
+20. **WASM Build**: wasm-pack build passes.
+21. **Bridge Verification**: JS bridge verification passes.
+22. **WASM/JS Export Sync**: Rust exports and JS bridge coverage remain synchronized.
 
 ### CI Pipeline Reference
 
-All gates are automated in `.github/workflows/ci.yml`. PRs cannot merge until all 8 gates pass.
+All gates are automated in `.github/workflows/ci.yml`. PRs cannot merge until all numbered gates and the "All Constitutional Gates" aggregator pass.
 
 ## Release Gates (Must Pass to Ship)
 
@@ -26,7 +38,7 @@ All gates are automated in `.github/workflows/ci.yml`. PRs cannot merge until al
 3. **Fuzzing Smoke**: Fuzz targets run for 5 mins with 0 crashes.
 4. **Changelog**: `CHANGELOG.md` updated with conventional commits.
 5. **Post-Quantum Signature Validation**: All three `Signature` enum variants (Ed25519, PostQuantum, Hybrid) pass roundtrip sign/verify tests.
-6. **Constitutional Invariant Verification**: All AEGIS/SYBIL invariants verified against CR-001 requirements; traceability matrix 75/75 complete.
+6. **Constitutional Invariant Verification**: AEGIS/SYBIL invariants verified against current traceability and threat matrices; planned or partial rows remain release-blocking for claims of constitutional completeness.
 
 ### CR-001 Section 8.8 Release-Blocking Gates
 
@@ -34,8 +46,8 @@ The following gates are release-blocking per the ratified CR-001 resolution:
 
 * 90% minimum line coverage across all crates
 * Zero test failures across the full workspace
-* All 13 threat model mitigations verified
-* All 75 traceability matrix requirements mapped and tested
+* All current threat model mitigations verified
+* All traceability matrix requirements mapped and tested, with no planned or partial rows for release-complete claims
 * Constitutional invariant proofs pass verification
 * Post-quantum signature scheme validation complete
 

--- a/governance/sub_agents.md
+++ b/governance/sub_agents.md
@@ -1,6 +1,6 @@
 # Sub-Agent Charters
 
-All 11 sub-agent missions are **COMPLETE**. Status updated 2026-03-19.
+Historical 2026-03-19 sub-agent completion record. Numeric status claims are superseded by `tools/repo_truth.sh` and the Wave E Basalt audit.
 
 ## A) SPEC_GUARDIAN (Legislative) — DONE
 
@@ -8,7 +8,7 @@ All 11 sub-agent missions are **COMPLETE**. Status updated 2026-03-19.
 * **Inputs**: `EXOCHAIN_Specification_v2.2.pdf`, `EXOCHAIN-FABRIC-PLATFORM.md`.
 * **Outputs**: `traceability_matrix.md`, ADR reviews, "Non-negotiable invariants checklist".
 * **Definition of Done**: Traceability matrix maps every Spec section to code/tests; no unmapped requirements.
-* **Status**: **DONE** — Traceability matrix complete: 75/75 requirements mapped and implemented.
+* **Status**: **DONE, needs Basalt refresh** — Current traceability rows are 83 implemented, 1 partial, and 2 planned.
 
 ## B) ARCHITECTURE_AGENT (Legislative) — DONE
 
@@ -16,7 +16,7 @@ All 11 sub-agent missions are **COMPLETE**. Status updated 2026-03-19.
 * **Inputs**: Spec Phases, Rust Ecosystem Best Practices.
 * **Outputs**: Repo layout, `Cargo.toml` workspace, crate boundaries.
 * **Definition of Done**: Use of `workspace` pattern, circular dependency check pass, clear API boundaries.
-* **Status**: **DONE** — 16 crates established in workspace `Cargo.toml` with clean dependency graph.
+* **Status**: **DONE** — 20 workspace packages are established in `Cargo.toml` / `cargo metadata`.
 
 ## C) CRYPTO_CANONICAL_AGENT (Judicial) — DONE
 
@@ -64,7 +64,7 @@ All 11 sub-agent missions are **COMPLETE**. Status updated 2026-03-19.
 * **Inputs**: Spec Section 13 (Threat Model).
 * **Outputs**: `threat_matrix.md`, fuzzing targets, `cargo-audit` config.
 * **Definition of Done**: Every threat in Section 13 has > 1 corresponding test case.
-* **Status**: **DONE** — 13/13 threats implemented with test coverage and mitigations verified.
+* **Status**: **DONE** — Current threat matrix tracks 14 threats, all marked implemented.
 
 ## I) QA_TDD_AGENT (Judicial) — DONE
 
@@ -72,7 +72,7 @@ All 11 sub-agent missions are **COMPLETE**. Status updated 2026-03-19.
 * **Inputs**: Spec Section 16 (Acceptance Criteria).
 * **Outputs**: Test harnesses, Integration tests, Fuzz targets.
 * **Definition of Done**: Section 16 Acceptance Criteria are automated and passing.
-* **Status**: **DONE** — 1,846 tests, 0 failures across 16 crates and 136 source files.
+* **Status**: **DONE** — Current workspace inventory lists 2,687 tests across 20 packages and 273 Rust files.
 
 ## J) DEVOPS_RELEASE_AGENT (Judicial) — DONE
 
@@ -80,7 +80,7 @@ All 11 sub-agent missions are **COMPLETE**. Status updated 2026-03-19.
 * **Inputs**: Quality Gate Policies.
 * **Outputs**: `.github/workflows/ci.yml`, Release scripts, `deny.toml`.
 * **Definition of Done**: CI pipeline enforces coverage, formatting, and audit checks.
-* **Status**: **DONE** — CI pipeline at `.github/workflows/ci.yml` with 8 quality gates, `cargo deny` integration, 90% coverage enforcement per CR-001 Section 8.8.
+* **Status**: **DONE** — CI pipeline at `.github/workflows/ci.yml` with 20 numbered gates plus the required aggregator, `cargo deny` integration, and coverage enforcement per CR-001 Section 8.8.
 
 ## K) DOCS_OSS_GOVERNANCE_AGENT (Legislative) — DONE
 

--- a/governance/traceability_matrix.md
+++ b/governance/traceability_matrix.md
@@ -158,9 +158,9 @@ Updated 2026-03-20 after EXOCHAIN-REM-009 — continuous governance monitoring a
 | Legal (§15) | 7 | 7 | 0 | 0 |
 | ZK Proofs (§12.5) | 5 | 5 | 0 | 0 |
 | P2P/API/Gateway/Tenant (§16–17) | 4 | 4 | 0 | 0 |
-| Decision Forum (GOV/TNC/M) | 16 | 16 | 0 | 0 |
+| Decision Forum (GOV/TNC/M) | 15 | 15 | 0 | 0 |
 | Governance Monitoring (MON) | 12 | 9 | 1 | 2 |
-| **TOTAL** | **87** | **84** | **1** | **2** |
+| **TOTAL** | **86** | **83** | **1** | **2** |
 
-**Coverage: 84/87 requirements traced to code (97%). 2 planned (ExoForge scheduling + React dashboard). 1 partial (T-14 Rust attestation verification).**
-**Workspace: 1,846 tests, 0 failures across 16 crates (monitoring requirements covered by integration tests — see MON-009).**
+**Coverage: 83/86 requirements traced to code (97%). 2 planned (ExoForge scheduling + React dashboard). 1 partial (T-14 Rust attestation verification).**
+**Workspace inventory: 2,687 listed tests across 20 packages and 273 Rust files.**

--- a/tools/repo_truth.sh
+++ b/tools/repo_truth.sh
@@ -127,7 +127,7 @@ RESOLUTION_COUNT=$(ls governance/resolutions/*.md 2>/dev/null | grep -v INDEX | 
 GOVERNANCE_DOCS=$(ls governance/*.md 2>/dev/null | wc -l | tr -d ' ')
 
 # ── Build checks (quick, no full rebuild) ──
-FMT_OK=$(cargo +nightly fmt --all -- --check 2>&1 && echo "true" || echo "false")
+FMT_OK=$(cargo +nightly fmt --all -- --check >/dev/null 2>&1 && echo "true" || echo "false")
 
 # ── Output ──
 TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)

--- a/tools/repo_truth.sh
+++ b/tools/repo_truth.sh
@@ -3,43 +3,114 @@
 # Produces machine-verifiable facts about the repository state.
 # Used to validate public claims in README.md and docs.
 #
-# Usage: bash tools/repo_truth.sh [--json]
+# Usage: bash tools/repo_truth.sh [--json] [--skip-tests|--list-tests|--run-tests]
 
 set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
 JSON_MODE=false
-if [[ "${1:-}" == "--json" ]]; then
-  JSON_MODE=true
-fi
+TEST_MODE="list"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json)
+      JSON_MODE=true
+      ;;
+    --skip-tests)
+      TEST_MODE="skip"
+      ;;
+    --list-tests)
+      TEST_MODE="list"
+      ;;
+    --run-tests)
+      TEST_MODE="run"
+      ;;
+    --help|-h)
+      sed -n '1,12p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
 
 # ── Counts ──
-CRATE_COUNT=$(ls -d crates/*/ 2>/dev/null | wc -l | tr -d ' ')
-RS_FILE_COUNT=$(find crates -name '*.rs' 2>/dev/null | wc -l | tr -d ' ')
-RS_LOC=$(find crates -name '*.rs' -exec cat {} + 2>/dev/null | wc -l | tr -d ' ')
-TLA_COUNT=$(find tla -name '*.tla' 2>/dev/null | wc -l | tr -d ' ')
+CRATE_COUNT=$(cargo metadata --no-deps --format-version 1 | jq '.packages | length')
+RS_FILE_COUNT=$(git ls-files 'crates/**/*.rs' | wc -l | tr -d ' ')
+RS_LOC=$(git ls-files 'crates/**/*.rs' | xargs wc -l | tail -1 | awk '{print $1}')
+TLA_COUNT=$(git ls-files | grep -E '^tla/.*\.tla$' | wc -l | tr -d ' ')
+CI_GATE_COUNT=$(grep -E 'name: "Gate [0-9]+' .github/workflows/ci.yml \
+  | sed -E 's/.*Gate ([0-9]+).*/\1/' \
+  | sort -n \
+  | uniq \
+  | wc -l \
+  | tr -d ' ')
 
-# ── Test count (parse from last cargo test or run fresh) ──
-TEST_OUTPUT=$(cargo test --workspace --lib 2>&1 || true)
-TESTS_PASSED=$(echo "$TEST_OUTPUT" | grep '^test result:' | awk '{sum+=$4} END {print sum+0}')
-TESTS_FAILED=$(echo "$TEST_OUTPUT" | grep '^test result:' | awk '{sum+=$6} END {print sum+0}')
+# ── Test inventory / result count ──
+TESTS_LISTED=null
+TESTS_PASSED=null
+TESTS_FAILED=null
+TEST_EXIT=0
+TEST_MODE_LABEL=$TEST_MODE
+
+case "$TEST_MODE" in
+  skip)
+    TEST_MODE_LABEL="skipped"
+    ;;
+  list)
+    TEST_OUTPUT=$(cargo test --workspace -- --list 2>&1)
+    TESTS_LISTED=$(printf '%s\n' "$TEST_OUTPUT" | grep -c ': test$' | tr -d ' ')
+    ;;
+  run)
+    set +e
+    TEST_OUTPUT=$(cargo test --workspace 2>&1)
+    TEST_EXIT=$?
+    set -e
+    TESTS_PASSED=$(printf '%s\n' "$TEST_OUTPUT" | awk '/^test result:/ {sum+=$4} END {print sum+0}')
+    TESTS_FAILED=$(printf '%s\n' "$TEST_OUTPUT" | awk '/^test result:/ {sum+=$6} END {print sum+0}')
+    ;;
+esac
+
+count_status_rows() {
+  local file=$1
+  local marker=$2
+  awk -F'|' -v marker="$marker" '
+    /^\|/ {
+      label = $2
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", label)
+      if (label ~ /^(---|Spec|Req|Category)$/) {
+        next
+      }
+      status = $(NF - 1)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", status)
+      if (index(status, marker) == 1) {
+        count += 1
+      }
+    }
+    END { print count + 0 }
+  ' "$file"
+}
 
 # ── Traceability ──
-TRACE_GREEN=$(grep -c '🟢' governance/traceability_matrix.md 2>/dev/null || echo 0)
-TRACE_YELLOW=$(grep -c '🟡' governance/traceability_matrix.md 2>/dev/null || echo 0)
-TRACE_RED=$(grep -c '🔴' governance/traceability_matrix.md 2>/dev/null || echo 0)
+TRACE_GREEN=$(count_status_rows governance/traceability_matrix.md '🟢')
+TRACE_YELLOW=$(count_status_rows governance/traceability_matrix.md '🟡')
+TRACE_RED=$(count_status_rows governance/traceability_matrix.md '🔴')
 TRACE_TOTAL=$((TRACE_GREEN + TRACE_YELLOW + TRACE_RED))
 
 # ── Threat model ──
-THREAT_GREEN=$(grep -c '🟢' governance/threat_matrix.md 2>/dev/null || echo 0)
-THREAT_YELLOW=$(grep -c '🟡' governance/threat_matrix.md 2>/dev/null || echo 0)
-THREAT_RED=$(grep -c '🔴' governance/threat_matrix.md 2>/dev/null || echo 0)
+THREAT_GREEN=$(count_status_rows governance/threat_matrix.md '🟢')
+THREAT_YELLOW=$(count_status_rows governance/threat_matrix.md '🟡')
+THREAT_RED=$(count_status_rows governance/threat_matrix.md '🔴')
 THREAT_TOTAL=$((THREAT_GREEN + THREAT_YELLOW + THREAT_RED))
 
 # ── License ──
 CARGO_LICENSE=$(grep '^license' Cargo.toml | head -1 | sed 's/license = "//;s/"//')
 LICENSE_FILE=$(head -1 LICENSE 2>/dev/null || echo "MISSING")
-README_LICENSE=$(grep -oP 'Apache-2\.0|AGPL-3\.0|MIT' README.md | head -1 || echo "NONE")
+README_LICENSE=$(grep -Eo 'Apache-2\.0|AGPL-3\.0|MIT' README.md | head -1 || true)
+README_LICENSE=${README_LICENSE:-NONE}
 
 # ── Release state ──
 TAG_COUNT=$(git tag -l | wc -l | tr -d ' ')
@@ -71,8 +142,11 @@ cat <<JEOF
   "rust_source_files": $RS_FILE_COUNT,
   "rust_loc": $RS_LOC,
   "tla_specs": $TLA_COUNT,
+  "tests": { "mode": "$TEST_MODE_LABEL", "listed": $TESTS_LISTED, "passed": $TESTS_PASSED, "failed": $TESTS_FAILED, "exit_code": $TEST_EXIT },
+  "tests_listed": $TESTS_LISTED,
   "tests_passed": $TESTS_PASSED,
   "tests_failed": $TESTS_FAILED,
+  "ci_gates": { "numbered": $CI_GATE_COUNT, "required_aggregator": "All Constitutional Gates" },
   "traceability": { "implemented": $TRACE_GREEN, "partial": $TRACE_YELLOW, "planned": $TRACE_RED, "total": $TRACE_TOTAL },
   "threats": { "mitigated": $THREAT_GREEN, "partial": $THREAT_YELLOW, "planned": $THREAT_RED, "total": $THREAT_TOTAL },
   "license": { "cargo_toml": "$CARGO_LICENSE", "license_file": "$LICENSE_FILE", "readme": "$README_LICENSE" },
@@ -92,8 +166,12 @@ Rust source files:   $RS_FILE_COUNT
 Rust LOC:            $RS_LOC
 TLA+ specs:          $TLA_COUNT
 
+Test mode:           $TEST_MODE_LABEL
+Tests listed:        $TESTS_LISTED
 Tests passed:        $TESTS_PASSED
 Tests failed:        $TESTS_FAILED
+
+CI gates:            $CI_GATE_COUNT numbered gate jobs + All Constitutional Gates aggregator
 
 Traceability:        $TRACE_GREEN implemented / $TRACE_YELLOW partial / $TRACE_RED planned (of $TRACE_TOTAL)
 Threats:             $THREAT_GREEN mitigated / $THREAT_YELLOW partial / $THREAT_RED planned (of $THREAT_TOTAL)

--- a/tools/test_repo_truth.sh
+++ b/tools/test_repo_truth.sh
@@ -18,7 +18,10 @@ fi
 
 err_file=$(mktemp)
 json_file=$(mktemp)
-trap 'rm -f "$err_file" "$json_file" /tmp/repo_truth_portability.txt' EXIT
+fake_err_file=$(mktemp)
+fake_json_file=$(mktemp)
+fake_bin_dir=$(mktemp -d)
+trap 'rm -f "$err_file" "$json_file" "$fake_err_file" "$fake_json_file" /tmp/repo_truth_portability.txt; rm -rf "$fake_bin_dir"' EXIT
 
 if ! bash tools/repo_truth.sh --json --skip-tests >"$json_file" 2>"$err_file"; then
   cat "$err_file" >&2
@@ -31,6 +34,32 @@ if [ -s "$err_file" ]; then
 fi
 
 jq -e . "$json_file" >/dev/null
+
+real_cargo=$(command -v cargo)
+cat >"$fake_bin_dir/cargo" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = "+nightly" ] && [ "\${2:-}" = "fmt" ]; then
+  echo "nightly formatter unavailable"
+  echo "rustup formatter error" >&2
+  exit 1
+fi
+exec "$real_cargo" "\$@"
+EOF
+chmod +x "$fake_bin_dir/cargo"
+
+if ! PATH="$fake_bin_dir:$PATH" bash tools/repo_truth.sh --json --skip-tests >"$fake_json_file" 2>"$fake_err_file"; then
+  cat "$fake_err_file" >&2
+  fail "tools/repo_truth.sh must still emit JSON when formatter check fails"
+fi
+
+if [ -s "$fake_err_file" ]; then
+  cat "$fake_err_file" >&2
+  fail "formatter check output must not leak to stderr in JSON mode"
+fi
+
+jq -e . "$fake_json_file" >/dev/null
+fake_fmt_clean=$(jq -r '.fmt_clean' "$fake_json_file")
+[ "$fake_fmt_clean" = "false" ] || fail "formatter failure should report fmt_clean=false, got $fake_fmt_clean"
 
 expected_crates=$(cargo metadata --no-deps --format-version 1 | jq '.packages | length')
 actual_crates=$(jq '.crates' "$json_file")

--- a/tools/test_repo_truth.sh
+++ b/tools/test_repo_truth.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Fast regression checks for the repo-truth generator and the README claims that
+# are supposed to be derived from it.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+fail() {
+  echo "repo-truth test failed: $*" >&2
+  exit 1
+}
+
+if grep -n -- 'grep -oP' tools/repo_truth.sh >/tmp/repo_truth_portability.txt; then
+  cat /tmp/repo_truth_portability.txt >&2
+  fail "tools/repo_truth.sh must not use grep -P; macOS grep does not support it"
+fi
+
+err_file=$(mktemp)
+json_file=$(mktemp)
+trap 'rm -f "$err_file" "$json_file" /tmp/repo_truth_portability.txt' EXIT
+
+if ! bash tools/repo_truth.sh --json --skip-tests >"$json_file" 2>"$err_file"; then
+  cat "$err_file" >&2
+  fail "tools/repo_truth.sh --json --skip-tests exited non-zero"
+fi
+
+if [ -s "$err_file" ]; then
+  cat "$err_file" >&2
+  fail "tools/repo_truth.sh --json --skip-tests must not write stderr"
+fi
+
+jq -e . "$json_file" >/dev/null
+
+expected_crates=$(cargo metadata --no-deps --format-version 1 | jq '.packages | length')
+actual_crates=$(jq '.crates' "$json_file")
+[ "$actual_crates" = "$expected_crates" ] || fail "crate count $actual_crates != $expected_crates"
+
+expected_rs_files=$(git ls-files 'crates/**/*.rs' | wc -l | tr -d ' ')
+actual_rs_files=$(jq '.rust_source_files' "$json_file")
+[ "$actual_rs_files" = "$expected_rs_files" ] || fail "Rust source file count $actual_rs_files != $expected_rs_files"
+
+expected_rs_loc=$(git ls-files 'crates/**/*.rs' | xargs wc -l | tail -1 | awk '{print $1}')
+actual_rs_loc=$(jq '.rust_loc' "$json_file")
+[ "$actual_rs_loc" = "$expected_rs_loc" ] || fail "Rust LOC $actual_rs_loc != $expected_rs_loc"
+
+expected_gates=$(grep -E 'name: "Gate [0-9]+' .github/workflows/ci.yml | sed -E 's/.*Gate ([0-9]+).*/\1/' | sort -n | uniq | wc -l | tr -d ' ')
+actual_gates=$(jq '.ci_gates.numbered' "$json_file")
+[ "$actual_gates" = "$expected_gates" ] || fail "CI gate count $actual_gates != $expected_gates"
+
+test_mode=$(jq -r '.tests.mode' "$json_file")
+[ "$test_mode" = "skipped" ] || fail "--skip-tests should report tests.mode=skipped, got $test_mode"
+
+grep -F "| Rust crates | $expected_crates |" README.md >/dev/null || fail "README crate count is not repo-truth derived"
+grep -F "| Rust source files | $expected_rs_files |" README.md >/dev/null || fail "README Rust source file count is not repo-truth derived"
+grep -F "| Rust LOC | $expected_rs_loc |" README.md >/dev/null || fail "README Rust LOC is not repo-truth derived"
+grep -F "| CI quality gates | $expected_gates |" README.md >/dev/null || fail "README CI gate count is not repo-truth derived"
+
+if grep -nE 'Autonomous implementation engine|Core Crates \(16\)|16 crates|1,846 tests|1,603 workspace tests' README.md; then
+  fail "README contains stale Basalt truth claims"
+fi
+
+echo "repo-truth test passed"


### PR DESCRIPTION
## Summary
- make tools/repo_truth.sh portable and explicit about skip/list/run test modes
- add tools/test_repo_truth.sh and wire it into Gate 9 repo hygiene
- refresh README and core public/governance docs to current measured counts and ExoForge planning/triage framing

## Verification
- bash -n tools/repo_truth.sh tools/test_repo_truth.sh
- bash tools/test_repo_truth.sh
- bash tools/repo_truth.sh --json --skip-tests | jq .
- bash tools/repo_truth.sh --list-tests
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace -- -D warnings
- cargo +nightly fmt --all -- --check
- git diff --check