### PR TITLE
fix(governance): reconcile CR-001 status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,8 @@ jobs:
           echo "✓ No GAP stubs remaining in code"
       - name: Repo truth and public claims
         run: bash tools/test_repo_truth.sh
+      - name: CR-001 status consistency
+        run: bash tools/test_cr001_status.sh
 
   # -----------------------------------------------------------------------
   # Gate 10: SBOM (dry-run generation — no upload, validates toolchain)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Layer 5: ExoForge           (exoforge/)
 1. **Identity Adjudication** — Decentralized identity with cryptographic proof, not administrative fiat.
 2. **Data Sovereignty** — Data belongs to its subject; consent is explicit, revocable, and auditable.
 3. **Deterministic Finality** — Every operation is reproducible and verifiable; no floating-point arithmetic permitted.
-4. **Constitutional Governance** — All system behavior is governed by ratified resolutions (CR-001 AEGIS/SYBIL framework).
+4. **Constitutional Governance** — System behavior is governed by the constitutional specification and draft CR-001 AEGIS/SYBIL framework pending council ratification.
 5. **Authentic Plurality** — Sybil-resistant participation ensuring one-entity-one-voice integrity.
 
 ## Repository Structure
@@ -118,7 +118,7 @@ Layer 5: ExoForge           (exoforge/)
 
 * **`governance/`** — Council resolutions, sub-agent charters, traceability matrices, quality gates
 * **`docs/`** — Architecture, guides, council panel reports, proofs, reference documentation
-* **`.github/workflows/`** — CI pipeline (16 quality gates), release workflow, ExoForge triage
+* **`.github/workflows/`** — CI pipeline (20 numbered quality gates plus required aggregator), release workflow, ExoForge triage
 
 ## Governance & Compliance
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -159,7 +159,7 @@ tags: [exochain, documentation, index]
 
 ## CI/CD
 
-- `.github/workflows/ci.yml` — 9 quality gates per CR-001 §8.8.
+- `.github/workflows/ci.yml` — 20 numbered quality gates plus required aggregator per CR-001 §8.8.
 - `.github/workflows/release.yml` — Release with manual approval + provenance attestation.
 - `.github/workflows/exoforge-triage.yml` — Automatic ExoForge triage for GitHub issues.
 - `.github/ISSUE_TEMPLATE/` — Structured issue templates (bug report, feature request).

--- a/docs/adr/ADR-001-authority-of-text.md
+++ b/docs/adr/ADR-001-authority-of-text.md
@@ -4,7 +4,7 @@ status: accepted
 created: 2026-03-30
 authors: [Governance/Constitutional Engineer]
 tags: [adr, normative, aegis, sybil, spec-harmonization]
-mandated-by: "CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY §3 (Immediate Order)"
+tracked-against: "CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY §3 (Immediate Order)"
 ---
 
 # ADR-001: Authority of Text — Normative Specification Hierarchy
@@ -15,14 +15,14 @@ EXOCHAIN adopts a four-tier document hierarchy. In any conflict the higher tier 
 
 | Rank | Document | Filename / Identifier | Role |
 |------|----------|-----------------------|------|
-| **1** | Council Resolutions | `governance/resolutions/CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY.md` (and any future ratified resolutions) | Highest constitutional authority |
+| **1** | Ratified Council Resolutions | Future ratified council resolutions; CR-001 is currently draft | Highest constitutional authority once ratified |
 | **2** | EXOCHAIN Specification v2.2 | `EXOCHAIN_Specification_v2.2.pdf` | **Normative specification** — the reference all implementation code MUST cite |
 | **3** | EXOCHAIN Fabric Platform v2.1 | `EXOCHAIN-FABRIC-PLATFORM.md` | **Engineering-operational elaboration** — authoritative for implementation detail that does not conflict with tiers 1–2 |
 | **4** | Repository governance artifacts | `governance/quality_gates.md`, `docs/architecture/THREAT-MODEL.md`, `docs/architecture/ARCHITECTURE.md`, `docs/proofs/CONSTITUTIONAL-PROOFS.md`, traceability matrices | Implementation-control documents; no superior constitutional meaning |
 
 ## Status of EXOCHAIN-FABRIC-PLATFORM.md
 
-`EXOCHAIN-FABRIC-PLATFORM.md` version 2.1 labels itself *"Authoritative Source of Truth"* and states it *"Supersedes all prior EXOCHAIN documentation."* That self-description was correct before the ratification of CR-001. **After CR-001 it is incorrect as a constitutional claim.** The document is retained as the authoritative engineering elaboration (tier 3) but is NOT a normative constitutional source. Code comments and documentation MUST NOT cite it as the normative authority for AEGIS, SYBIL, or invariant definitions.
+`EXOCHAIN-FABRIC-PLATFORM.md` version 2.1 labels itself *"Authoritative Source of Truth"* and states it *"Supersedes all prior EXOCHAIN documentation."* Under the CR-001 draft hierarchy, that self-description is treated as an engineering claim rather than a constitutional claim. The document is retained as the authoritative engineering elaboration (tier 3) but is NOT a normative constitutional source. Code comments and documentation MUST NOT cite it as the normative authority for AEGIS, SYBIL, or invariant definitions.
 
 ## Artifacts That Inherit Authority from the Normative Spec (Tier 2)
 
@@ -47,13 +47,13 @@ AEGIS = *Autonomous Entity Governance & Invariant System* (canonical definition:
 
 | Clause | Location | Status |
 |--------|----------|--------|
-| Canonical constitutional definition of AEGIS | CR-001 §4 | **Normative** (tier 1) |
+| Canonical constitutional definition of AEGIS | CR-001 §4 | **Draft normative** pending ratification (tier 1 once ratified) |
 | AEGIS as constitutional framework overview | `EXOCHAIN-FABRIC-PLATFORM.md` §3A.1 | **Explanatory** (tier 3) |
-| Separation of Powers model (Legislative / Executive / Judicial) | Platform §3A.2; Architecture §2 | **Explanatory** — implementation detail for normative CR-001 §6 |
+| Separation of Powers model (Legislative / Executive / Judicial) | Platform §3A.2; Architecture §2 | **Explanatory** — implementation detail for draft CR-001 §6 |
 | Constitutional governance flow diagram | Platform §3A.2.4 | **Explanatory** |
 | CGR Kernel architecture and INV-001 through INV-008 invariants | Platform §3A.3; `exo-gatekeeper/src/invariants.rs` | **Normative in code** (`invariants.rs` is authoritative implementation) |
 | Constitutional Amendment Process | Platform §3A.3.2 | **Pending** — process described, not yet tested end-to-end (CR-001 §8 gap) |
-| AEGIS surface mapping (crate assignments) | CR-001 §7 | **Normative** (tier 1) |
+| AEGIS surface mapping (crate assignments) | CR-001 §7 | **Draft normative** pending ratification (tier 1 once ratified) |
 | INV-008 kernel + registry immutability | Platform §2.1 refinement; `exo-gatekeeper/src/invariants.rs` | **Normative in code** |
 | NIST AI RMF alignment | `NIST_AI_RMF_MAPPING.toml` | **Explanatory** |
 
@@ -63,7 +63,7 @@ SYBIL = adversarial/synthetic condition manufacturing counterfeit plurality (can
 
 | Clause | Location | Status |
 |--------|----------|--------|
-| Canonical constitutional definition of SYBIL | CR-001 §5 | **Normative** (tier 1) |
+| Canonical constitutional definition of SYBIL | CR-001 §5 | **Draft normative** pending ratification (tier 1 once ratified) |
 | Six Sybil sub-threat family (Identity, Review, Quorum, Delegation, Mesh, Synthetic-Opinion) | `docs/architecture/THREAT-MODEL.md` §Sybil Family (Threats 1–6) | **Normative** — aligned with CR-001 §8.2 |
 | Anti-Sybil architecture overview | `docs/architecture/ARCHITECTURE.md` §6 | **Explanatory** |
 | Independence-aware quorum computation | `exo-governance/src/quorum.rs` | **Normative in code** |
@@ -112,9 +112,9 @@ For AEGIS or SYBIL constitutional definitions, cite the Council Resolution:
 
 ## Consequence
 
-This ADR satisfies CR-001 §3 Immediate Order. It does not supersede the platform document; it subordinates it within the hierarchy. Future specification updates must increment the version in `EXOCHAIN_Specification_v2.2.pdf` (or a successor file) and update this ADR's tier-2 entry.
+This ADR tracks CR-001 §3 Immediate Order while CR-001 remains draft. It does not supersede the platform document; it subordinates it within the draft hierarchy. Future specification updates must increment the version in `EXOCHAIN_Specification_v2.2.pdf` (or a successor file) and update this ADR's tier-2 entry.
 
 ---
 
 *Authored by the Governance/Constitutional Engineer under [APE-41](/APE/issues/APE-41) (WO-001: Spec Harmonization).*
-*Mandated by [CR-001](/APE/issues/APE-39) §3 Immediate Order.*
+*Tracked against [CR-001](/APE/issues/APE-39) §3 Immediate Order.*

--- a/docs/guides/GETTING-STARTED.md
+++ b/docs/guides/GETTING-STARTED.md
@@ -252,7 +252,7 @@ A new operation type must be:
 
 ## Running the full quality gate locally
 
-Before pushing, run all 8 gates CI enforces per [[CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY]] §8.8:
+Before pushing, run the core local checks behind the CI gates tracked against [[CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY]] §8.8:
 
 ```bash
 cargo build --workspace --release

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -450,7 +450,7 @@ CR-001:
 |---------------------------------------------------------|---------------------------------------------------------|
 | [`../../governance/traceability_matrix.md`](../../governance/traceability_matrix.md) | 87 requirements, each mapped to crate/module/tests/status |
 | [`../../governance/threat_matrix.md`](../../governance/threat_matrix.md) | 14 threats with mitigation references                    |
-| [`../../governance/quality_gates.md`](../../governance/quality_gates.md) | The 16 CI-enforced gates                                 |
+| [`../../governance/quality_gates.md`](../../governance/quality_gates.md) | The 20 numbered CI gates plus required aggregator         |
 | [`../../governance/resolutions/CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY.md`](../../governance/resolutions/CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY.md) | The AEGIS / SYBIL resolution (draft, pending ratification) |
 | [`../../governance/sub_agents.md`](../../governance/sub_agents.md) | 11 sub-agent charters with ownership boundaries          |
 | [`../../governance/EXOCHAIN-REFACTOR-PLAN.md`](../../governance/EXOCHAIN-REFACTOR-PLAN.md) | Active refactor roadmap                                  |

--- a/governance/EXOCHAIN-REFACTOR-PLAN.md
+++ b/governance/EXOCHAIN-REFACTOR-PLAN.md
@@ -1,8 +1,7 @@
 ---
 title: "EXOCHAIN Council-Driven Refactor Plan"
-status: complete
+status: historical-partial
 created: 2026-03-18
-completed: 2026-03-19
 tags: [exochain, refactor, council, syntaxis-builder]
 links:
   - "[[CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY]]"
@@ -11,7 +10,7 @@ links:
 
 # EXOCHAIN Council-Driven Refactor Plan
 
-**Status: ALL PHASES COMPLETE** (2026-03-19)
+**Status: HISTORICAL / PARTIALLY SUPERSEDED BY BASALT** (reconciled 2026-04-26)
 
 ## Objective
 
@@ -49,11 +48,11 @@ All refactor work flows through the Syntaxis Builder system:
 ## Phase 1: Assessment — COMPLETE
 
 - [x] Run council assessment: exo innovations vs exochain gaps
-- [x] Ratify CR-001 (AEGIS/SYBIL resolution)
+- [ ] Complete formal council ratification of CR-001 (AEGIS/SYBIL resolution)
 - [x] Identify abstractions needed for self-development capability
 - [x] Map exo improvements to exochain crate surfaces
 
-> **Completion notes**: Council assessment documented in `governance/COUNCIL-ASSESSMENT-EXO-VS-EXOCHAIN.md`. CR-001 ratified 2026-03-18. 5-panel reports published in `docs/council/`.
+> **Completion notes**: Council assessment documented in `governance/COUNCIL-ASSESSMENT-EXO-VS-EXOCHAIN.md`. CR-001 remains DRAFT pending council ratification evidence. 5-panel reports published in `docs/council/`.
 
 ## Phase 2: Abstraction Layer — COMPLETE
 
@@ -66,11 +65,11 @@ All refactor work flows through the Syntaxis Builder system:
 ## Phase 3: Assimilation — COMPLETE
 
 - [x] Port validated exo patterns through council-approved work orders
-- [x] Implement Section 8 work orders from CR-001
-- [x] Achieve release-blocking acceptance standard (CR-001 Section 9)
+- [ ] Complete Section 8 work orders from CR-001
+- [ ] Achieve release-blocking acceptance standard (CR-001 Section 9)
 
-> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 111606 Rust LOC under `crates/`, 2,687 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
+> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 111606 Rust LOC under `crates/`, 2,687 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
 
 ## Active Resolutions
 
-- [[CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY]] — RATIFIED (fully implemented)
+- [[CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY]] — DRAFT (partial implementation evidence; Section 9 acceptance criteria remain open)

--- a/governance/quality_gates.md
+++ b/governance/quality_gates.md
@@ -42,7 +42,7 @@ All gates are automated in `.github/workflows/ci.yml`. PRs cannot merge until al
 
 ### CR-001 Section 8.8 Release-Blocking Gates
 
-The following gates are release-blocking per the ratified CR-001 resolution:
+The following gates are release-blocking per the draft CR-001 release-blocking criteria:
 
 * 90% minimum line coverage across all crates
 * Zero test failures across the full workspace

--- a/governance/resolutions/CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY.md
+++ b/governance/resolutions/CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY.md
@@ -189,12 +189,12 @@ Upon adoption, this Resolution shall serve as the canonical Council interpretati
 
 | Work Order | Owner | Status | Evidence |
 |-----------|-------|--------|----------|
-| 8.1 Spec harmonization | SPEC_GUARDIAN | ⬜ NOT STARTED | |
-| 8.2 Threat expansion | SECURITY_THREATS_AGENT | ⬜ NOT STARTED | |
-| 8.3 Provenance enforcement | Council | ⬜ NOT STARTED | |
-| 8.4 Clearance hardening | Council | ⬜ NOT STARTED | |
-| 8.5 Challenge path hardening | Council | ⬜ NOT STARTED | |
-| 8.6 Escalation pathway | Council | ⬜ NOT STARTED | |
-| 8.7 Traceability completion | QA_TDD_AGENT + SPEC_GUARDIAN | ⬜ NOT STARTED | |
-| 8.8 Release gating | DEVOPS_RELEASE_AGENT | ⬜ NOT STARTED | |
-| 8.9 No-admin preservation | Council | ⬜ NOT STARTED | |
+| 8.1 Spec harmonization | SPEC_GUARDIAN | 🟡 PARTIAL | `docs/adr/ADR-001-authority-of-text.md`; Basalt R2 keeps CR-001 draft until ratification evidence exists. |
+| 8.2 Threat expansion | SECURITY_THREATS_AGENT | 🟡 PARTIAL | `governance/threat_matrix.md`; `docs/architecture/THREAT-MODEL.md`; Basalt R3 will reconcile registry truth. |
+| 8.3 Provenance enforcement | Council | 🟡 PARTIAL | Provenance surfaces exist across governance and legal crates, but recent Council waves still found unsigned trust-boundary paths. |
+| 8.4 Clearance hardening | Council | 🟡 PARTIAL | Independence-aware quorum/clearance code exists, but open governance-bypass work remains tracked outside this resolution. |
+| 8.5 Challenge path hardening | Council | 🟡 PARTIAL | Challenge paths exist in `exo-governance` and `exo-escalation`; end-to-end auth/admissibility review remains open. |
+| 8.6 Escalation pathway | Council | 🟡 PARTIAL | `exo-escalation` implements the pathway shape; Clause-expansion left residual authority-chain evidence questions. |
+| 8.7 Traceability completion | QA_TDD_AGENT + SPEC_GUARDIAN | 🟡 PARTIAL | Current matrix is 83 implemented / 1 partial / 2 planned rows. |
+| 8.8 Release gating | DEVOPS_RELEASE_AGENT | ✅ IMPLEMENTED | `.github/workflows/ci.yml` defines 20 numbered gates plus the required aggregator. |
+| 8.9 No-admin preservation | Council | 🟡 PARTIAL | `docs/audit/WO-009-no-admin-bypass-audit.md`; design-deferred governance-bypass initiative remains open. |

--- a/governance/resolutions/INDEX.md
+++ b/governance/resolutions/INDEX.md
@@ -7,7 +7,7 @@ tags: [council, governance, index]
 
 | ID | Title | Status | Date | Implemented |
 |----|-------|--------|------|-------------|
-| [[CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY\|CR-001]] | AEGIS, SYBIL, Authentic Plurality & Constitutional Enforcement | RATIFIED | 2026-03-18 | 2026-03-19 |
+| [[CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY\|CR-001]] | AEGIS, SYBIL, Authentic Plurality & Constitutional Enforcement | DRAFT | 2026-03-18 | - |
 | [[CR-002-AUTONOMOUS-RECURSIVE-IMPROVEMENT-INFRASTRUCTURE\|CR-002]] | Autonomous Recursive Self-Improvement Governance and Deployment | DRAFT | 2026-04-25 | - |
 
 ## Resolution Lifecycle

--- a/tools/test_cr001_status.sh
+++ b/tools/test_cr001_status.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Guard the authoritative CR-001 status across public and governance docs.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+fail() {
+  echo "CR-001 status test failed: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file=$1
+  local pattern=$2
+  if ! grep -Eq "$pattern" "$file"; then
+    fail "$file missing required pattern: $pattern"
+  fi
+}
+
+assert_lacks() {
+  local file=$1
+  local pattern=$2
+  if grep -nE "$pattern" "$file"; then
+    fail "$file contains forbidden pattern: $pattern"
+  fi
+}
+
+resolution=governance/resolutions/CR-001-AEGIS-SYBIL-AUTHENTIC-PLURALITY.md
+index=governance/resolutions/INDEX.md
+refactor=governance/EXOCHAIN-REFACTOR-PLAN.md
+quality=governance/quality_gates.md
+adr=docs/adr/ADR-001-authority-of-text.md
+onboarding=docs/guides/developer-onboarding.md
+
+assert_contains "$resolution" '^status: draft$'
+assert_contains "$resolution" '^\*\*Status:\*\* DRAFT .+ Pending Council Ratification$'
+assert_contains "$resolution" '^- \[ \] Quality gates pass without exception$'
+
+assert_contains "$index" 'CR-001.*\| DRAFT \| 2026-03-18 \| - \|'
+
+assert_contains README.md 'CR-001 \(AEGIS/SYBIL/Authentic Plurality\) is \*\*DRAFT .+ pending council ratification\*\*'
+assert_contains README.md 'Council Resolutions.*CR-001 DRAFT'
+assert_lacks README.md 'CR-001[^[:cntrl:]]*ratified|ratified resolutions \(CR-001|CR-001[^[:cntrl:]]*fully implemented'
+
+assert_contains "$refactor" 'CR-001 remains DRAFT'
+assert_contains "$refactor" 'Section 9 acceptance criteria remain open'
+assert_lacks "$refactor" '\[x\] Ratify CR-001|CR-001 ratified|CR-001[^[:cntrl:]]*RATIFIED|CR-001[^[:cntrl:]]*fully implemented'
+
+assert_contains "$quality" 'draft CR-001 release-blocking criteria'
+assert_lacks "$quality" 'ratified CR-001 resolution'
+
+assert_contains "$adr" 'CR-001 draft hierarchy'
+assert_lacks "$adr" 'ratification of CR-001|After CR-001 it is incorrect|Mandated by \[CR-001\]'
+
+assert_contains "$onboarding" 'resolution \(draft, pending ratification\)'
+
+echo "CR-001 status test passed"


### PR DESCRIPTION
## Summary
- add a Gate 9 CR-001 status consistency guard
- align active governance/public docs on CR-001 as DRAFT pending ratification evidence
- replace fully implemented/ratified claims with partial implementation evidence and open Section 9 criteria

## TDD / Verification
- RED: `bash tools/test_cr001_status.sh` failed before doc reconciliation on the CR-001 index row
- `bash tools/test_cr001_status.sh`
- `bash tools/test_repo_truth.sh`
- `bash -n tools/test_cr001_status.sh tools/test_repo_truth.sh tools/repo_truth.sh`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::unwrap_used -A clippy::expect_used`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`

## Basalt R2
CR-001 remains draft because the resolution itself has draft frontmatter, pending visible status, open Section 9 criteria, and no ratification artifact in the repo. This PR makes that the single active claim until Bob/Council ratification evidence exists.