### PR TITLE
fix(governance): reconcile GAP registry truth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,8 @@ jobs:
         run: bash tools/test_repo_truth.sh
       - name: CR-001 status consistency
         run: bash tools/test_cr001_status.sh
+      - name: GAP registry truth
+        run: bash tools/test_gap_registry_truth.sh
 
   # -----------------------------------------------------------------------
   # Gate 10: SBOM (dry-run generation — no upload, validates toolchain)

--- a/GAP-REGISTRY.md
+++ b/GAP-REGISTRY.md
@@ -1,8 +1,22 @@
 # EXOCHAIN Gap Registry — Honest Audit
 
 **Generated:** 2026-04-15
-**Last Updated:** 2026-04-15 21:15 EDT
+**Last Updated:** 2026-04-26 08:25 EDT
+**Current ULTRAPLAN files:** 9
 **Rule:** No gap closes until tests pass and the stub is deleted. Re-audit after each completion.
+
+---
+
+## Basalt reconciliation
+
+Wave E Basalt reconciles this registry against the current repository and Council remediation ledger. The earlier Phase 0 handoff mentioned 53 ULTRAPLAN files; the current repository has 9 `gap/ULTRAPLAN-*.md` files. Treat 9 as the current audited inventory unless new artifacts are restored in a later PR.
+
+| GAP | Reconciliation |
+|-----|----------------|
+| GAP-002 | Closed claim remains valid, but the implementation is stronger than the old registry text: `verify_with_signer_keys` verifies Ed25519 signatures with resolver-supplied signer keys over a domain-separated canonical CBOR payload. |
+| GAP-004 | GAP-004 closure is retained only with Onyx-4 remediation PRs #117-#124 applied. The 0dentity subsystem is no longer represented as unqualified-complete; first-touch onboarding, infrastructure Holons, and device/behavioral axes are default-off or gated where unaudited. |
+| GAP-007 | Closed claim remains scoped to LiveSafe integration tests and production-resolver wiring. Test-only helpers are not production fallback behavior. |
+| GAP-011 | GAP-011 closure is retained with a caveat: ExoForge task registry and onboarding collectors were reconciled, while 0dentity device/behavioral scoring remains feature-gated unaudited axes until Bob approves ship-ingestion vs delete/reduce-to-6-axes. |
 
 ---
 
@@ -14,7 +28,8 @@
 
 ### ✅ GAP-002: Evidence Bundle Export — CLOSED `0685ded`
 - **Closed:** 2026-04-15
-- **What was built:** `crates/exo-legal/src/bundle.rs` — `EvidenceBundle` with `assemble()`, `verify()`, `render_json()`, `render_markdown_summary()`, `sign()`, `compute_bundle_hash()`. Offline-verifiable BLAKE3 hash chain. FRE 901/803(6)/902(13/14)/Daubert compliant. 16 tests, 126 total in exo-legal.
+- **Basalt-reconciled:** 2026-04-26
+- **What was built:** `crates/exo-legal/src/bundle.rs` — `EvidenceBundle` with `assemble()`, `verify()`, `verify_with_signer_keys()`, `render_json()`, `render_markdown_summary()`, `sign()`, and `compute_bundle_hash()`. Offline structural verification covers BLAKE3 hash chain, event order, and causal order. Signer-key verification validates Ed25519 signatures against resolver-supplied public keys over a domain-separated canonical CBOR payload. Current `exo-legal` inventory lists 159 tests.
 
 ### ✅ GAP-003: Multi-Model AI Consensus Engine — CLOSED `789c324`
 - **Closed:** 2026-04-15
@@ -22,7 +37,9 @@
 
 ### ✅ GAP-004: Identity Verification (0dentity) — CLOSED `7746c2a`
 - **Closed:** 2026-04-15
-- **What was built:** `crates/exo-identity/src/registry.rs` (`LocalDidRegistry`) + `crates/exo-identity/src/verification.rs` (`VerificationCeremony`, `IdentityProof`, `calculate_risk_score()`). Stub comments removed from `zerodentity/store.rs`. 12 tests.
+- **Basalt-reconciled:** 2026-04-26
+- **What was built:** `crates/exo-identity/src/registry.rs` (`LocalDidRegistry`) + `crates/exo-identity/src/verification.rs` (`VerificationCeremony`, `IdentityProof`, `calculate_risk_score()`). Stub comments removed from `zerodentity/store.rs`.
+- **Council reconciliation:** Onyx-4 later found RED trust-boundary holes in `exo-node::zerodentity`. GAP-004 remains closed only with Onyx-4 remediation PRs #117-#124 applied: server-key fabrication removed, peer attestations signed, trust receipts signed, sessions bound to public keys, first-touch onboarding default-off, infrastructure Holons gated, device/behavioral axes gated, and AMBER hygiene landed. Current `cargo test -p exo-node zerodentity -- --list` inventory lists 193 zerodentity tests.
 
 ### ✅ GAP-005: Gateway Authentication & Authorization — CLOSED `34ce160`
 - **Closed:** 2026-04-15
@@ -35,10 +52,13 @@
 ### ✅ GAP-007: LiveSafe Integration — CLOSED `8fb0a2a`
 - **Closed:** 2026-04-15
 - **What was built:** Production resolvers now require real `PgPool` — mock fallback is a compile error, not a silent return. 12 PACE integration tests rewritten against current API (PaceConfig, state transitions, escalation, Shamir split/reconstruct). Mock functions retained as `FOR TESTING ONLY`.
+- **Basalt-reconciled:** 2026-04-26 — closure remains scoped to production resolver wiring and PACE integration tests; test-only helpers are not production fallback behavior.
 
 ### ✅ GAP-011: ExoForge Signal Collection & Onboarding — CLOSED `8ec43c6`
 - **Closed:** 2026-04-15
+- **Basalt-reconciled:** 2026-04-26
 - **What was built:** Behavioral JS collector implemented (keystroke dynamics, mouse velocity, touch pressure, scroll histograms). Fingerprint collector expanded from 8 to all 15 `FingerprintSignal` variants (AudioContext, CanvasRendering, WebGL, WebRTC, FontEnumeration, BatteryStatus, + originals). ExoForge task registry updated to reflect actual completion. Phase 4/5 stubs removed.
+- **Council reconciliation:** Onyx-4 R3 later established that Rust fingerprint/behavioral helpers and UI collection existed without a complete default-on ingestion/scoring trust boundary. PR #123 keeps those feature-gated unaudited axes behind `unaudited-zerodentity-device-behavioral-axes` until Bob approves ship-ingestion vs delete/reduce-to-6-axes.
 
 ---
 

--- a/gap/ULTRAPLAN-GAP-002-EVIDENCE-BUNDLE.md
+++ b/gap/ULTRAPLAN-GAP-002-EVIDENCE-BUNDLE.md
@@ -1,6 +1,6 @@
 # ULTRAPLAN — GAP-002: Evidence Bundle Export
 
-**Status:** Active  
+**Status:** Closed — Basalt reconciled 2026-04-26
 **Crate:** `exo-legal`  
 **File:** `crates/exo-legal/src/bundle.rs`  
 **Author:** Aeon (Chief-of-Staff AI)  
@@ -41,7 +41,7 @@ Offline verification requires zero network access:
 1. **Recompute Hash** — Feed all content fields through the same BLAKE3 pipeline. Compare to `bundle_hash`. If mismatch → tampered.
 2. **Validate Event Ordering** — Confirm `sequence` numbers are 0, 1, 2, … with no gaps.
 3. **Validate Causal Chain** — For each event at position i > 0, confirm all `parent_hashes` appear as `event_hash` values in events at positions < i. Event 0 must have empty `parent_hashes` (genesis).
-4. **Check Signatures** — For each `BundleSignature`, verify the signature is non-empty (placeholder for full cryptographic verification against a key registry). Production systems will resolve signer DIDs to public keys and verify Ed25519/PQ signatures over the `bundle_hash`.
+4. **Check Signatures** — Use `verify_with_signer_keys()` with a `BundleSignerKeyResolver`. For each `BundleSignature`, resolve the signer DID to a public key and verify the Ed25519 signature over the domain-separated canonical CBOR signing payload that binds `bundle_hash`, signer DID, signer role, and signed timestamp. A missing signer key, empty signature, wrong key, replayed signature, or tampered bundle fails closed.
 5. **Result** — `VerificationResult` reports `hash_valid`, `event_chain_valid`, `causal_order_valid`, per-signature `SignatureCheck` results, and an `overall` boolean (all checks pass).
 
 ## 4. Legal Admissibility Mapping
@@ -108,4 +108,4 @@ The `decision-forum` crate can call `bundle::render_markdown_summary()` and embe
 
 ---
 
-**Implementation:** `crates/exo-legal/src/bundle.rs` — all types, assembly, verification, rendering, signing, and 16 tests.
+**Implementation:** `crates/exo-legal/src/bundle.rs` — all types, assembly, structural verification, signer-key verification, rendering, signing, and regression tests for valid signatures, wrong keys, replay, tampering, and empty signatures.

--- a/tools/test_gap_registry_truth.sh
+++ b/tools/test_gap_registry_truth.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Guard GAP-REGISTRY.md and closed GAP ULTRAPLANs against stale closure claims.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+fail() {
+  echo "GAP registry truth test failed: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file=$1
+  local pattern=$2
+  if ! grep -Eq "$pattern" "$file"; then
+    fail "$file missing required pattern: $pattern"
+  fi
+}
+
+assert_lacks() {
+  local file=$1
+  local pattern=$2
+  if grep -nE "$pattern" "$file"; then
+    fail "$file contains forbidden pattern: $pattern"
+  fi
+}
+
+ultraplan_count=$(find gap -maxdepth 1 -name 'ULTRAPLAN-*.md' | wc -l | tr -d ' ')
+
+assert_contains GAP-REGISTRY.md "\\*\\*Current ULTRAPLAN files:\\*\\* $ultraplan_count"
+assert_contains GAP-REGISTRY.md "Basalt reconciliation"
+assert_contains GAP-REGISTRY.md "GAP-004.*Onyx-4 remediation PRs #117-#124"
+assert_contains GAP-REGISTRY.md "GAP-011.*feature-gated unaudited axes"
+
+assert_contains gap/ULTRAPLAN-GAP-002-EVIDENCE-BUNDLE.md "verify_with_signer_keys"
+assert_lacks gap/ULTRAPLAN-GAP-002-EVIDENCE-BUNDLE.md \
+  "placeholder for full cryptographic verification|Production systems will resolve signer DIDs|signature is non-empty"
+
+assert_lacks GAP-REGISTRY.md "GAP-002:[^\\n]*16 tests|GAP-002:[^\\n]*offline-verifiable signatures"
+
+echo "GAP registry truth test passed"


### PR DESCRIPTION
## Summary
- add a Gate 9 truth guard for GAP registry and ULTRAPLAN status claims
- reconcile GAP-REGISTRY.md against the current 9 ULTRAPLAN files and Onyx-4 remediation state
- update GAP-002 ULTRAPLAN text to reflect signer-key Ed25519 verification instead of stale placeholder language

## TDD / Verification
- Red: bash tools/test_gap_registry_truth.sh failed before reconciliation on missing current ULTRAPLAN inventory
- Green: bash tools/test_gap_registry_truth.sh
- bash tools/test_repo_truth.sh
- bash tools/test_cr001_status.sh
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::unwrap_used -A clippy::expect_used
- cargo build --workspace --release
- cargo doc --workspace --no-deps
- cargo +nightly fmt --all -- --check
- git diff --check