### PR TITLE
fix(deploy): bind Railway entrypoint to public interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,8 @@ jobs:
         run: bash tools/test_gap_registry_truth.sh
       - name: No orphan Rust modules
         run: bash tools/test_no_orphan_rust_modules.sh
+      - name: Railway entrypoint ingress contract
+        run: bash tools/test_railway_entrypoint_args.sh
 
   # -----------------------------------------------------------------------
   # Gate 10: SBOM (dry-run generation — no upload, validates toolchain)

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -7,9 +7,13 @@ DATA_DIR="${EXOCHAIN_DATA_DIR:-/data}"
 P2P_PORT="${P2P_PORT:-4001}"
 # Honor Railway/Heroku-style $PORT first, then $API_PORT, then default 8080.
 API_PORT="${PORT:-${API_PORT:-8080}}"
+# Containers must bind HTTP to all interfaces for Railway/public ingress.
+# Direct CLI execution keeps the binary's safer 127.0.0.1 default unless this
+# deployment entrypoint is used.
+API_HOST="${API_HOST:-0.0.0.0}"
 
 # Build base arguments.
-ARGS="--data-dir ${DATA_DIR} --p2p-port ${P2P_PORT} --api-port ${API_PORT}"
+ARGS="--data-dir ${DATA_DIR} --p2p-port ${P2P_PORT} --api-port ${API_PORT} --api-host ${API_HOST}"
 
 if [ -n "${VALIDATORS}" ]; then
     ARGS="${ARGS} --validator --validators ${VALIDATORS}"

--- a/tools/test_railway_entrypoint_args.sh
+++ b/tools/test_railway_entrypoint_args.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Guard the container entrypoint contract Railway depends on: the HTTP API
+# must bind to all container interfaces while still allowing explicit override.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+fail() {
+  echo "railway entrypoint argument test failed: $*" >&2
+  exit 1
+}
+
+assert_arg_pair() {
+  local file="$1"
+  local flag="$2"
+  local expected="$3"
+  local previous=""
+
+  while IFS= read -r arg; do
+    if [ "$previous" = "$flag" ]; then
+      [ "$arg" = "$expected" ] || fail "$flag expected '$expected', got '$arg'"
+      return 0
+    fi
+    previous="$arg"
+  done <"$file"
+
+  fail "$flag was not passed to exochain"
+}
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fake_bin="$tmp_dir/exochain"
+cat >"$fake_bin" <<'FAKE'
+#!/usr/bin/env sh
+if [ -z "${ENTRYPOINT_ARGS_FILE:-}" ]; then
+  echo "ENTRYPOINT_ARGS_FILE is required" >&2
+  exit 2
+fi
+printf '%s\n' "$@" >"$ENTRYPOINT_ARGS_FILE"
+FAKE
+chmod +x "$fake_bin"
+
+args_file="$tmp_dir/default.args"
+env -i \
+  PATH="$tmp_dir:/usr/bin:/bin" \
+  ENTRYPOINT_ARGS_FILE="$args_file" \
+  EXOCHAIN_DATA_DIR="/data" \
+  PORT="9999" \
+  P2P_PORT="4001" \
+  IS_VALIDATOR="true" \
+  ./deploy/entrypoint.sh >/dev/null
+
+first_arg="$(sed -n '1p' "$args_file")"
+[ "$first_arg" = "start" ] || fail "expected start command, got '$first_arg'"
+assert_arg_pair "$args_file" "--api-port" "9999"
+assert_arg_pair "$args_file" "--api-host" "0.0.0.0"
+assert_arg_pair "$args_file" "--p2p-port" "4001"
+
+args_file="$tmp_dir/override.args"
+env -i \
+  PATH="$tmp_dir:/usr/bin:/bin" \
+  ENTRYPOINT_ARGS_FILE="$args_file" \
+  EXOCHAIN_DATA_DIR="/data" \
+  PORT="9999" \
+  API_HOST="127.0.0.1" \
+  SEED_ADDR="seed.example.com:4001" \
+  ./deploy/entrypoint.sh >/dev/null
+
+first_arg="$(sed -n '1p' "$args_file")"
+[ "$first_arg" = "join" ] || fail "expected join command, got '$first_arg'"
+assert_arg_pair "$args_file" "--seed" "seed.example.com:4001"
+assert_arg_pair "$args_file" "--api-host" "127.0.0.1"
+
+echo "railway entrypoint argument test passed"


### PR DESCRIPTION
## Summary
- Pass --api-host from deploy/entrypoint.sh, defaulting containers to 0.0.0.0 for Railway/public ingress
- Preserve explicit API_HOST override for loopback/private starts
- Add a shell regression test and wire it into CI hygiene

## Verification
- bash tools/test_railway_entrypoint_args.sh
- cargo test -p exo-gateway health_returns_200
- cargo build -p exo-node
- cargo clippy -p exo-node --bins -- -D warnings
- cargo build --release --bin exochain --bin exo-gateway
- cargo fmt --all -- --check
- git diff --check