### PR TITLE
fix(deploy): repair Railway volume permissions before start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN cargo build --release --bin exochain --bin exo-gateway
 # Stage 2: Runtime
 FROM debian:bookworm-slim
 RUN apt-get update && \
-    apt-get install -y ca-certificates libssl3 && \
+    apt-get install -y ca-certificates libssl3 gosu && \
     rm -rf /var/lib/apt/lists/* && \
     useradd --system --create-home --shell /usr/sbin/nologin exochain && \
     mkdir -p /data && chown exochain:exochain /data && chmod 755 /data
@@ -49,7 +49,8 @@ EXPOSE 4001 4002 8080
 # On Railway, /data is mounted via a Railway volume — do NOT use the
 # Dockerfile VOLUME keyword (Railway bans it).
 # For plain Docker: `docker run -v exochain-data:/data exochain/node`.
-
-USER exochain
+# Keep the container entrypoint as root so mounted volumes can have ownership
+# repaired at startup; deploy/entrypoint.sh drops to the exochain user before
+# launching the node process.
 
 CMD ["/app/entrypoint.sh"]

--- a/deploy/Dockerfile.node
+++ b/deploy/Dockerfile.node
@@ -19,7 +19,7 @@ RUN cargo build --release --bin exochain
 
 FROM debian:bookworm-slim
 RUN apt-get update && \
-    apt-get install -y ca-certificates libssl3 curl && \
+    apt-get install -y ca-certificates libssl3 curl gosu && \
     rm -rf /var/lib/apt/lists/* && \
     useradd --system --create-home --shell /usr/sbin/nologin exochain && \
     mkdir -p /data && chown exochain:exochain /data
@@ -27,7 +27,6 @@ RUN apt-get update && \
 COPY --from=builder /app/target/release/exochain /usr/local/bin/exochain
 COPY deploy/entrypoint.sh /usr/local/bin/entrypoint.sh
 
-USER exochain
 ENV EXOCHAIN_DATA_DIR=/data
 ENV RUST_LOG=info
 

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -11,22 +11,40 @@ API_PORT="${PORT:-${API_PORT:-8080}}"
 # Direct CLI execution keeps the binary's safer 127.0.0.1 default unless this
 # deployment entrypoint is used.
 API_HOST="${API_HOST:-0.0.0.0}"
+RUN_AS_USER="${EXOCHAIN_RUN_AS:-exochain}"
 
 # Build base arguments.
-ARGS="--data-dir ${DATA_DIR} --p2p-port ${P2P_PORT} --api-port ${API_PORT} --api-host ${API_HOST}"
+set -- --data-dir "${DATA_DIR}" --p2p-port "${P2P_PORT}" --api-port "${API_PORT}" --api-host "${API_HOST}"
 
-if [ -n "${VALIDATORS}" ]; then
-    ARGS="${ARGS} --validator --validators ${VALIDATORS}"
-elif [ "${IS_VALIDATOR}" = "true" ]; then
-    ARGS="${ARGS} --validator"
+if [ -n "${VALIDATORS:-}" ]; then
+    set -- "$@" --validator --validators "${VALIDATORS}"
+elif [ "${IS_VALIDATOR:-}" = "true" ]; then
+    set -- "$@" --validator
 fi
 
-if [ -n "${SEED_ADDR}" ]; then
+if [ -n "${SEED_ADDR:-}" ]; then
     echo "Joining network via seed: ${SEED_ADDR}"
-    # shellcheck disable=SC2086
-    exec exochain join --seed "${SEED_ADDR}" ${ARGS}
+    set -- join --seed "${SEED_ADDR}" "$@"
 else
     echo "Starting as seed node"
-    # shellcheck disable=SC2086
-    exec exochain start ${ARGS}
+    set -- start "$@"
 fi
+
+if [ "$(id -u)" = "0" ]; then
+    mkdir -p "${DATA_DIR}"
+    chown "${RUN_AS_USER}:${RUN_AS_USER}" "${DATA_DIR}"
+    chmod 755 "${DATA_DIR}"
+
+    if command -v gosu >/dev/null 2>&1; then
+        exec gosu "${RUN_AS_USER}" exochain "$@"
+    fi
+
+    if command -v runuser >/dev/null 2>&1; then
+        exec runuser -u "${RUN_AS_USER}" -- exochain "$@"
+    fi
+
+    echo "Cannot drop privileges: neither gosu nor runuser is available" >&2
+    exit 127
+fi
+
+exec exochain "$@"

--- a/tools/test_railway_entrypoint_args.sh
+++ b/tools/test_railway_entrypoint_args.sh
@@ -73,4 +73,66 @@ first_arg="$(sed -n '1p' "$args_file")"
 assert_arg_pair "$args_file" "--seed" "seed.example.com:4001"
 assert_arg_pair "$args_file" "--api-host" "127.0.0.1"
 
+cat >"$tmp_dir/id" <<'FAKE'
+#!/usr/bin/env sh
+if [ "${1:-}" = "-u" ]; then
+  echo 0
+else
+  /usr/bin/id "$@"
+fi
+FAKE
+chmod +x "$tmp_dir/id"
+
+cat >"$tmp_dir/mkdir" <<'FAKE'
+#!/usr/bin/env sh
+printf '%s\n' "$@" >"${ENTRYPOINT_MKDIR_ARGS_FILE:?}"
+FAKE
+chmod +x "$tmp_dir/mkdir"
+
+cat >"$tmp_dir/chown" <<'FAKE'
+#!/usr/bin/env sh
+printf '%s\n' "$@" >"${ENTRYPOINT_CHOWN_ARGS_FILE:?}"
+FAKE
+chmod +x "$tmp_dir/chown"
+
+cat >"$tmp_dir/chmod" <<'FAKE'
+#!/usr/bin/env sh
+printf '%s\n' "$@" >"${ENTRYPOINT_CHMOD_ARGS_FILE:?}"
+FAKE
+chmod +x "$tmp_dir/chmod"
+
+cat >"$tmp_dir/gosu" <<'FAKE'
+#!/usr/bin/env sh
+user="$1"
+shift
+printf '%s\n' "$user" >"${ENTRYPOINT_GOSU_USER_FILE:?}"
+exec "$@"
+FAKE
+chmod +x "$tmp_dir/gosu"
+
+args_file="$tmp_dir/root.args"
+env -i \
+  PATH="$tmp_dir:/usr/bin:/bin" \
+  ENTRYPOINT_ARGS_FILE="$args_file" \
+  ENTRYPOINT_MKDIR_ARGS_FILE="$tmp_dir/mkdir.args" \
+  ENTRYPOINT_CHOWN_ARGS_FILE="$tmp_dir/chown.args" \
+  ENTRYPOINT_CHMOD_ARGS_FILE="$tmp_dir/chmod.args" \
+  ENTRYPOINT_GOSU_USER_FILE="$tmp_dir/gosu.user" \
+  EXOCHAIN_DATA_DIR="/data" \
+  PORT="9999" \
+  P2P_PORT="4001" \
+  ./deploy/entrypoint.sh >/dev/null
+
+first_arg="$(sed -n '1p' "$args_file")"
+[ "$first_arg" = "start" ] || fail "expected root path to start node, got '$first_arg'"
+assert_arg_pair "$args_file" "--data-dir" "/data"
+assert_arg_pair "$args_file" "--api-host" "0.0.0.0"
+grep -qx -- "-p" "$tmp_dir/mkdir.args" || fail "root path must ensure data dir exists"
+grep -qx -- "/data" "$tmp_dir/mkdir.args" || fail "root path mkdir must target /data"
+grep -qx -- "exochain:exochain" "$tmp_dir/chown.args" || fail "root path must chown /data to exochain"
+grep -qx -- "/data" "$tmp_dir/chown.args" || fail "root path chown must target /data"
+grep -qx -- "755" "$tmp_dir/chmod.args" || fail "root path must chmod /data to 755"
+grep -qx -- "/data" "$tmp_dir/chmod.args" || fail "root path chmod must target /data"
+grep -qx -- "exochain" "$tmp_dir/gosu.user" || fail "root path must drop to exochain user"
+
 echo "railway entrypoint argument test passed"


### PR DESCRIPTION
## Summary
- Keep container entrypoint as root long enough to repair the mounted /data ownership
- Install gosu and drop privileges to the exochain user before launching the node
- Preserve the Railway/public API host fix and add regression coverage for root-mounted volume startup

## Verification
- bash tools/test_railway_entrypoint_args.sh
- sh -n deploy/entrypoint.sh
- cargo test -p exo-gateway health_returns_200
- cargo build -p exo-node
- cargo clippy -p exo-node --bins -- -D warnings
- cargo fmt --all -- --check
- git diff --check

Local Docker build was attempted but Docker Desktop stalled resolving Docker Hub base-image metadata before reaching this repo's Dockerfile; Railway will validate the Docker build path after merge.