### PR TITLE
docs: add CommandBase foundation starter package

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -149,6 +149,7 @@ tags: [exochain, documentation, index]
 
 - [ExoForge Repository](https://github.com/exochain/exoforge) — Archon-based autonomous coding platform.
 - [[ARCHON-INTEGRATION]] — Integration guide (commands, workflows, council review, governance gate).
+- [CommandBase Foundation Starter](commandbase-foundation/README.md) — portable starter package for the first ExoChain-powered operating business.
 
 ## Development
 

--- a/docs/commandbase-foundation/AGENTS.md
+++ b/docs/commandbase-foundation/AGENTS.md
@@ -1,0 +1,128 @@
+# AGENTS.md - CommandBase Starter
+
+Never stub, never skip, never postpone, never synthesize production behavior.
+Always test first, keep tenant boundaries explicit, and preserve the trust
+boundary between CommandBase and ExoChain.
+
+## Product Boundary
+
+CommandBase is the operational control plane for the AVC fractional CTO
+collective and its client engagements.
+
+ExoChain is the trust substrate. CommandBase may display, request, and cache
+trust facts, but ExoChain must verify and record audit-critical facts.
+
+ExoForge is a governed build engine. It may propose, implement, test, and open
+PRs. It may not approve itself.
+
+Decision Forum is the deliberation layer. It should be embedded in CommandBase
+first, then launched standalone after it proves itself.
+
+## Session Start Protocol
+
+Every session starts by recording:
+
+```text
+Date:
+Repo:
+Branch:
+Open PRs:
+Changed files:
+Current objective:
+Authority level:
+Risk classification:
+Expected receipts:
+Tests to run:
+Rollback plan:
+```
+
+Append that record to `docs/execution-ledger/YYYY-MM-DD-commandbase.md`.
+
+## Engineering Constraints
+
+- Every domain object must be tenant-scoped.
+- Every mutating action must identify actor, authority, tenant, object, risk,
+  evidence, and expected receipt.
+- Every agent action must be attributable to an agent passport.
+- Every client-visible decision must be reviewable in Decision Forum.
+- Every audit-critical action must have an ExoChain receipt or an explicit
+  "receipt pending" state that blocks completion.
+- Do not allow direct mutation of receipts or evidence records.
+- Do not add cross-tenant queries without tests proving isolation.
+- Do not let ExoForge merge or deploy without the staged authority policy.
+
+## TDD Expectations
+
+Before implementation, write or update tests for:
+
+- tenant isolation
+- role and authority enforcement
+- approval gates
+- receipt request and verification paths
+- agent budget and tool restrictions
+- API contract behavior
+- UI critical flows
+- deployment smoke checks
+
+Required checks before handoff:
+
+```bash
+pnpm -r typecheck
+pnpm test:run
+pnpm build
+pnpm test:e2e
+```
+
+If a command cannot run, state why and what risk remains.
+
+## Default Human Approval Gates
+
+Human approval is required for:
+
+- creating or modifying agents
+- granting authority
+- accessing client data
+- using sensitive or regulated data
+- client-facing communication
+- merge to main
+- production deployment
+- auth, billing, tenant, or permission changes
+- budget increases
+- legal or compliance claims
+- destructive actions
+- governance overrides
+- health, safety, security, or regulated-domain recommendations
+
+## ExoForge Authority
+
+Phase 1:
+
+- may create issues, plans, branches, PRs, tests, and proposed fixes
+- may not merge, deploy, alter secrets, or approve itself
+
+Phase 2:
+
+- may merge only after human approval, green tests, receipt issuance, and
+  rollback documentation
+
+Phase 3:
+
+- may deploy low-risk changes only after receipt-backed approval, smoke tests,
+  canary or rollback confirmation, and environment classification
+
+## First Build Target
+
+Build CommandBase for AVC Customer Zero:
+
+1. Setup AVC
+2. Invite CTOs
+3. Create client
+4. Create engagement
+5. Define governance model
+6. Add agent roster
+7. Create first project
+8. Open decision
+9. Assign agent task
+10. Review output
+11. Issue receipt
+12. Generate weekly client brief

--- a/docs/commandbase-foundation/README.md
+++ b/docs/commandbase-foundation/README.md
@@ -1,0 +1,115 @@
+# CommandBase Foundation Starter
+
+Status: portable planning package
+Created: 2026-04-26
+Intended destination: a new `commandbase.ai` product repository
+
+## Purpose
+
+This folder is a starter package for standing up CommandBase as the first
+operating business powered by ExoChain.
+
+The intended direction is:
+
+- CommandBase is the first operating business and product control plane.
+- ExoChain is the trust substrate.
+- ExoForge is the governed build engine.
+- Decision Forum is the governance and deliberation layer.
+- Crosschecked is the verification and evidence product.
+- VitalLock and LiveSafe come later after identity, consent, health, safety,
+  and evidence workflows are hardened.
+
+## Recommended Repo Shape
+
+CommandBase should be a separate product monorepo seeded from a clean Paperclip
+fork, with upstream mergeability preserved. It should not live permanently
+inside `exochain/exochain`.
+
+```text
+commandbase/
+  AGENTS.md
+  apps/
+    web/
+    api/
+    worker/
+  packages/
+    exochain-client/
+    tenant/
+    auth/
+    ui/
+    brand-config/
+    receipts/
+    decision-forum/
+  upstream/
+    paperclip-compat/
+  docs/
+    architecture/
+    governance/
+    execution-ledger/
+    product/
+```
+
+Keep the trust boundary explicit:
+
+- `exochain/exochain`: constitutional trust fabric, identity, consent,
+  authority, signed receipts, provenance, audit-critical facts.
+- `commandbase.ai`: product workflows, client portal, CTO operations, agent
+  roster, reporting, user-facing UX.
+- `exoforge`: governed SDLC automation that observes, proposes, implements,
+  tests, and submits.
+- `decision.forum`: deliberation and approval UX, embedded first and standalone
+  later.
+- `crosschecked.ai`: claim and evidence verification.
+
+## Files To Copy First
+
+- `AGENTS.md` - project operating instructions for humans and AI agents.
+- `architecture.md` - portfolio and CommandBase system architecture.
+- `authority-model.md` - actor, tenant, and authority model.
+- `human-approval-policy.md` - gates for agents, production, client trust, and
+  sensitive operations.
+- `receipt-taxonomy.md` - receipt classes and human-readable receipt format.
+- `mvp-scope.md` - Customer Zero scope and out-of-scope boundaries.
+- `avc-customer-zero-workflows.md` - first workflows for the AVC collective.
+- `exoforge-session-protocol.md` - governed AI development session protocol.
+- `execution-ledger-template.md` - per-session ledger template.
+
+## Doctrine
+
+Every exoapp should follow this operational doctrine:
+
+```text
+Intent
+-> Authority Check
+-> Risk Classification
+-> Execution
+-> Evidence Capture
+-> ExoChain Receipt
+-> Decision Review
+-> ExoForge Improvement Loop
+```
+
+## First Commercial Wedge
+
+The first paid offer should be the AVC Governed Intelligence Accelerator, also
+usable as the Governed Automation Accelerator:
+
+```text
+8-12 week engagement
+-> AI governance assessment
+-> workflow selection
+-> governed automation implementation
+-> agent-assisted delivery
+-> evidence and receipt layer
+-> executive reporting
+-> handoff or retainer
+```
+
+CommandBase should support selling and delivering that offer before attempting
+to sell an abstract autonomous business launcher.
+
+## Source Context
+
+- Paperclip: https://github.com/paperclipai/paperclip
+- ExoForge: https://github.com/exochain/exoforge
+- ExoChain: https://github.com/exochain/exochain

--- a/docs/commandbase-foundation/architecture.md
+++ b/docs/commandbase-foundation/architecture.md
@@ -1,0 +1,184 @@
+# CommandBase Architecture Plan
+
+Status: starter architecture
+Created: 2026-04-26
+
+## Product Order
+
+Build in this order:
+
+1. CommandBase.ai
+2. Decision Forum embedded module
+3. Crosschecked.ai embedded verification workflows
+4. Decision.Forum standalone
+5. VitalLock
+6. LiveSafe
+
+VitalLock and LiveSafe should not be first because they will likely involve
+higher-risk health, safety, sensitive identity, consent, and evidence workflows.
+
+## System Roles
+
+```text
+CommandBase
+  product shell, UX, client operations, CTO workflows, agent dashboard
+
+ExoChain
+  identity, authority, consent, signed receipts, provenance, audit truth
+
+ExoForge
+  governed software development loop, PR creation, validation, deployment
+  proposal
+
+Decision Forum
+  deliberation, approvals, council views, contestability
+
+Crosschecked
+  claim, evidence, panel review, confidence, receipt
+```
+
+## Tenant Model
+
+Use this schema as the product spine:
+
+```text
+Portfolio
+  -> Venture/App
+    -> Customer Org
+      -> Workspace
+        -> Engagement
+          -> Project
+            -> Goal
+              -> Decision
+              -> Task
+              -> Agent
+              -> Evidence
+              -> Receipt
+```
+
+Every table should be scoped to the narrowest relevant tenant boundary and
+should include enough lineage to audit cross-object relationships.
+
+## First Customer Org
+
+Customer Zero is AVC, the fractional CTO and governed AI implementation
+collective.
+
+```text
+Portfolio: ExoChain Ecosystem
+Venture/App: CommandBase.ai
+Customer Org: Apex Velocity Catalysts / AVC Collective
+Workspace: Enterprise AVC Command Center
+```
+
+## Shared Account Strategy
+
+User-facing identity should be neutral: ExoID or `exo.id`.
+
+Phase 1:
+
+- email login
+- passkeys
+- Google, Microsoft, GitHub OAuth
+- organization invitations
+- role-based access control
+- ExoChain DID generated or bound silently underneath
+
+Phase 2:
+
+- user-visible ExoChain identity
+- actor DID on receipts
+- visible authority chains
+- portable consent artifacts
+
+Phase 3:
+
+- DID-first for advanced users, auditors, governance participants, and
+  cross-app identity
+
+## Deployment Strategy
+
+Use one portfolio Railway project for beta:
+
+```text
+Railway project: exoapps-beta
+Environments:
+  development
+  staging
+  production
+
+Services:
+  commandbase-web
+  commandbase-api
+  commandbase-worker
+  exochain-client-gateway
+  shared-auth
+  postgres
+  redis
+```
+
+Later split high-risk apps into dedicated production projects:
+
+```text
+commandbase-prod
+decisionforum-prod
+crosschecked-prod
+vitallock-prod
+livesafe-prod
+```
+
+Production CommandBase should use Postgres before real client data. SQLite or
+embedded storage is acceptable only for local development and prototypes.
+
+## Trust Boundary
+
+CommandBase can store product state:
+
+- dashboards
+- workflows
+- client records
+- notifications
+- UI state
+- local drafts
+- reporting views
+
+ExoChain must verify and record:
+
+- identity
+- authority
+- consent
+- signed receipts
+- provenance
+- constitutional decisions
+- audit-critical facts
+- governance outcomes
+
+CommandBase should never become the source of truth for audit-critical facts.
+
+## First Screens
+
+AVC command center:
+
+- portfolio overview
+- clients
+- engagements
+- CTOs
+- agents
+- decisions
+- receipts
+- evidence
+- risks
+- budgets
+- deployments
+- escalations
+
+Client portal:
+
+- current work
+- decisions needing approval
+- shipped value
+- risks and blockers
+- evidence
+- receipts
+- budget consumed
+- next actions

--- a/docs/commandbase-foundation/authority-model.md
+++ b/docs/commandbase-foundation/authority-model.md
@@ -1,0 +1,108 @@
+# Authority Model
+
+Status: starter governance model
+Created: 2026-04-26
+
+## Operating Structure
+
+Model AVC as a governed fractional CTO collective and AI transformation studio:
+
+```text
+Founder / Principal Governor
+  -> AVC Collective
+    -> Named CTOs / Operating Partners
+      -> Client Portfolios
+        -> Client Orgs
+          -> Engagements
+            -> Projects
+              -> Agents / Tasks / Decisions / Evidence / Receipts
+```
+
+Do not hard-code one legal structure. Use both legal and operating entities.
+
+## Core Entities
+
+- ExoChain Foundation / Ecosystem: doctrine, substrate, trust fabric.
+- AVC / Apex Velocity Catalysts: commercial fractional CTO and governed AI
+  implementation business.
+- CommandBase.ai: control plane product.
+- Client organizations: customers receiving services.
+- CTO members: operators with delegated authority.
+- Agents: non-human actors operating under explicit authority.
+- Auditors and observers: evidence reviewers.
+
+## MVP Roles
+
+| Role | Description | MVP |
+|---|---|---|
+| Founder Governor | Bob-level authority across portfolio | Yes |
+| Platform Admin | Manages tenants, auth, billing, integrations | Yes |
+| AVC CTO Member | Fractional CTO/operator delivering outcomes | Yes |
+| Client Executive Sponsor | Reviews roadmap, decisions, risks, outcomes | Yes |
+| Client Technical Owner | Reviews technical work, approvals, evidence | Yes |
+| Autonomous Agent | Executes scoped tasks under authority | Yes |
+| Auditor / Evidence Reviewer | Reviews receipts and evidence | Yes |
+| Client Engineer | Participates in implementation | Later |
+| Investor / Board Observer | Portfolio progress and governance visibility | Later |
+| Public User | Public Decision Forum / Crosschecked modes | Later |
+
+## Authority Claim Shape
+
+Every mutating action should resolve to this shape:
+
+```json
+{
+  "actor_id": "usr_or_agent_...",
+  "actor_type": "human|agent|service",
+  "tenant_id": "org_...",
+  "workspace_id": "wrk_...",
+  "authority_source": "role|delegation|decision|emergency_override",
+  "authority_scope": ["task:create", "decision:propose"],
+  "target_type": "task|decision|agent|receipt|evidence|deployment",
+  "target_id": "object_...",
+  "risk_tier": "low|medium|high|critical",
+  "approval_requirement": "none|ctomember|founder|council|client",
+  "evidence_refs": [],
+  "receipt_expected": true
+}
+```
+
+## Agent Passport
+
+Every autonomous agent needs an agent passport:
+
+```text
+Agent ID
+Name
+Role
+Model/provider
+Runtime
+Authority scope
+Budget
+Allowed tools
+Forbidden actions
+Human supervisor
+Risk tier
+Receipt history
+Performance history
+Revocation status
+```
+
+Agents cannot act outside their passport. Passport changes require human
+approval and an ExoChain receipt.
+
+## Revocation
+
+Authority must be revocable at these levels:
+
+- user membership
+- role assignment
+- delegation
+- agent passport
+- tool permission
+- integration credential
+- engagement access
+- client org access
+
+Revocation should be receipt-backed and should invalidate pending work where
+the revoked authority was required.

--- a/docs/commandbase-foundation/avc-customer-zero-workflows.md
+++ b/docs/commandbase-foundation/avc-customer-zero-workflows.md
@@ -1,0 +1,106 @@
+# AVC Customer Zero Workflows
+
+Status: starter workflow plan
+Created: 2026-04-26
+
+## Workflow 1: Governed AI Assessment To Engagement
+
+Purpose: turn a prospect or client into a governed implementation roadmap.
+
+```text
+Client Intake
+-> AI Landscape Inventory
+-> Risk / Compliance / Opportunity Map
+-> Recommended Workflows
+-> Governance Baseline
+-> Engagement Plan
+-> Signed Decision / Receipt
+```
+
+Minimum product support:
+
+- client intake form
+- systems inventory
+- risk register
+- opportunity map
+- recommended automation candidates
+- decision proposal
+- evidence attachments
+- receipt request
+
+## Workflow 2: Agent-Assisted Delivery Loop
+
+Purpose: make CTO delivery work faster without losing control.
+
+```text
+Client Goal
+-> Project
+-> Task
+-> Agent Assignment
+-> Work Product
+-> CTO Review
+-> Client Approval if needed
+-> ExoChain Receipt
+-> Deployment / Handoff
+```
+
+Minimum product support:
+
+- project and goal tracking
+- agent passport and task assignment
+- task checkout semantics
+- work product upload/linking
+- review queue
+- approval gate
+- receipt state
+- deployment or handoff status
+
+## Workflow 3: Executive Governance Reporting
+
+Purpose: show the client what happened, why it happened, who approved it, what
+evidence exists, and what risks remain.
+
+```text
+Weekly Executive Brief
+-> Decisions Made
+-> Work Completed
+-> Risks / Blockers
+-> Receipts Issued
+-> Budget Consumed
+-> Next Actions
+```
+
+Minimum product support:
+
+- weekly brief generator
+- decision summary
+- completed work summary
+- evidence links
+- receipt list
+- risk and blocker rollup
+- budget summary
+- next action list
+
+## First Real Engagement Shape
+
+The first engagement should involve:
+
+- one client org
+- one executive sponsor
+- one technical owner
+- one AVC CTO
+- Bob as founder governor
+- two to four agents
+- one governed AI assessment
+- one implementation project
+- one executive report cycle
+
+## Success Criteria
+
+CommandBase succeeds for Customer Zero when:
+
+- Bob can see all active engagements and escalations.
+- A CTO can run a client engagement from intake to weekly report.
+- A client sponsor can approve decisions without seeing internal complexity.
+- An agent can receive scoped work and cannot exceed its passport.
+- Every material client-facing action has evidence and a receipt state.

--- a/docs/commandbase-foundation/execution-ledger-template.md
+++ b/docs/commandbase-foundation/execution-ledger-template.md
@@ -1,0 +1,91 @@
+# CommandBase Execution Ledger Template
+
+Date:
+Session:
+Repo:
+Branch:
+Operator:
+
+## Objective
+
+Describe the concrete goal for this session.
+
+## Authority
+
+Authority level:
+Risk classification:
+Human approver:
+Expected receipt:
+
+## Starting State
+
+Current branch:
+Open PRs:
+Changed files:
+Relevant docs read:
+Relevant issues:
+
+## Plan
+
+1.
+2.
+3.
+
+## Tests First
+
+Failing tests to add:
+
+- 
+
+Expected verification:
+
+```bash
+pnpm -r typecheck
+pnpm test:run
+pnpm build
+pnpm test:e2e
+```
+
+## Execution Notes
+
+Record important decisions, commands, failures, fixes, and links.
+
+## Verification
+
+Commands run:
+
+- 
+
+Results:
+
+- 
+
+## Deployment
+
+Environment:
+Railway project:
+Service:
+Deployment id:
+Commit:
+Public URL:
+Health URL:
+Smoke test result:
+
+## Receipts
+
+Expected:
+Issued:
+Pending:
+Failed:
+
+## Rollback
+
+Rollback command or procedure:
+Rollback owner:
+Known risks:
+
+## Handoff
+
+Summary:
+Next priority:
+Open questions:

--- a/docs/commandbase-foundation/exoforge-session-protocol.md
+++ b/docs/commandbase-foundation/exoforge-session-protocol.md
@@ -1,0 +1,112 @@
+# ExoForge Session Protocol
+
+Status: starter protocol
+Created: 2026-04-26
+
+## Purpose
+
+ExoForge should govern software delivery without becoming an unchecked
+constitutional authority.
+
+Its job is:
+
+```text
+Observe -> Propose -> Implement -> Test -> Submit -> Explain
+```
+
+It should not approve itself, rewrite policy, or deploy high-risk changes
+without receipt-backed human authorization.
+
+## Session Header
+
+Every ExoForge session starts with:
+
+```text
+Date:
+Repo:
+Branch:
+Open PRs:
+Changed files:
+Objective:
+Authority level:
+Risk classification:
+Expected receipts:
+Tests to run:
+Rollback plan:
+```
+
+## Work Item Lifecycle
+
+```text
+Issue or feedback
+-> triage
+-> risk classification
+-> council/CTO review if required
+-> implementation plan
+-> failing test
+-> code change
+-> verification
+-> PR
+-> human approval
+-> merge
+-> deploy if authorized
+-> smoke test
+-> receipt
+-> ledger update
+```
+
+## Required Evidence
+
+Every PR opened by ExoForge should include:
+
+- issue or objective
+- risk tier
+- authority basis
+- changed files
+- tests added or changed
+- commands run
+- rollback plan
+- receipt expectation
+- remaining risk
+
+## Merge Policy
+
+Phase 1:
+
+- ExoForge opens PRs only.
+- Humans merge.
+
+Phase 2:
+
+- ExoForge may merge after explicit human approval, green CI, receipt issuance,
+  and rollback path.
+
+Phase 3:
+
+- ExoForge may deploy low-risk changes after receipt-backed approval, smoke
+  tests, canary or rollback confirmation, and environment classification.
+
+## Blockers
+
+If blocked, ExoForge must not synthesize success. It must record:
+
+- blocker
+- evidence
+- attempted remediation
+- owner required
+- risk of proceeding
+- next safe action
+
+## Deployment Smoke Checks
+
+For Railway deployments:
+
+```bash
+railway status --json
+railway logs --service <service> --build --lines 200 --json
+railway logs --service <service> --lines 200 --json
+curl -i https://<domain>/health
+```
+
+Do not report deployment success until the platform status is successful and
+the public health endpoint returns a healthy response.

--- a/docs/commandbase-foundation/human-approval-policy.md
+++ b/docs/commandbase-foundation/human-approval-policy.md
@@ -1,0 +1,108 @@
+# Human Approval Policy
+
+Status: starter policy
+Created: 2026-04-26
+
+## Default Posture
+
+Start conservative. Autonomy expands only after evidence proves the system can
+operate safely.
+
+Human approval is required for anything involving authority, money, production,
+client trust, sensitive data, external communication, safety, or regulated
+workflows.
+
+## Approval Gates
+
+| Action | Approval Required |
+|---|---|
+| Create or modify an agent | Yes |
+| Grant new authority to an agent | Yes |
+| Access client data | Yes |
+| Use sensitive or regulated data | Yes |
+| Send client-facing communication | Yes |
+| Merge to main | Yes |
+| Deploy to production | Yes |
+| Change auth, billing, tenant, or permissions | Yes |
+| Spend over budget threshold | Yes |
+| Create legal or compliance claims | Yes |
+| Delete data | Yes |
+| Modify receipts or evidence | Never directly allowed |
+| Override governance control | Yes, escalated receipt |
+| Health, safety, medical, or security recommendations | Yes |
+| Change ExoChain trust, consent, authority, or receipt code | Highest level |
+
+## Risk Tiers
+
+Low risk:
+
+- draft notes
+- local UI copy
+- internal task updates
+- non-client-visible summaries
+
+Medium risk:
+
+- client work planning
+- agent task assignment
+- decision proposals
+- internal evidence classification
+
+High risk:
+
+- client-facing deliverables
+- production-impacting changes
+- tenant permission changes
+- material budget changes
+- security-sensitive recommendations
+
+Critical risk:
+
+- production deploy
+- deletion
+- authority expansion
+- legal, compliance, health, safety, or regulated claims
+- ExoChain trust substrate changes
+
+## ExoForge Authority Ladder
+
+Phase 1 - PR only:
+
+- may create issues
+- may draft plans
+- may create branches
+- may open PRs
+- may run tests
+- may propose fixes
+- may not merge
+- may not deploy
+- may not alter production secrets
+- may not approve itself
+
+Phase 2 - supervised merge:
+
+- may merge only after green tests, CTO approval, receipt issuance, and rollback
+  path documentation
+
+Phase 3 - controlled deploy:
+
+- may deploy low-risk changes only after policy check, receipt verification,
+  smoke tests, canary or rollback confirmation, and environment classification
+
+Phase 4 - continuous governed development:
+
+- allowed only after repeated successful evidence-backed operation
+
+## Emergency Override
+
+Emergency override must:
+
+- identify the human actor
+- state reason and scope
+- define expiry
+- preserve evidence
+- create an escalated receipt
+- notify affected stakeholders
+- create a follow-up review item
+
+Emergency override cannot directly mutate receipts or delete evidence.

--- a/docs/commandbase-foundation/mvp-scope.md
+++ b/docs/commandbase-foundation/mvp-scope.md
@@ -1,0 +1,127 @@
+# CommandBase MVP Scope
+
+Status: starter MVP plan
+Created: 2026-04-26
+
+## Objective
+
+Build CommandBase for Enterprise AVC first. The MVP should make the AVC
+fractional CTO collective more effective at selling and delivering governed AI
+implementation work.
+
+The MVP should not attempt to become a generic autonomous business launcher.
+
+## First Paid Offer
+
+Governed Intelligence Accelerator, also usable as Governed Automation
+Accelerator.
+
+```text
+8-12 week engagement
+-> AI governance assessment
+-> workflow selection
+-> governed automation implementation
+-> agent-assisted delivery
+-> evidence and receipt layer
+-> executive reporting
+-> handoff or retainer
+```
+
+## MVP Screens
+
+1. Setup AVC
+2. Invite CTOs
+3. Create client
+4. Create engagement
+5. Define governance model
+6. Add agent roster
+7. Create first project
+8. Open decision
+9. Assign agent task
+10. Review output
+11. Issue receipt
+12. Generate weekly client brief
+
+## MVP Capabilities
+
+Tenant and identity:
+
+- create portfolio, venture, customer org, workspace
+- invite users
+- assign roles
+- bind or generate ExoChain DID in background
+
+Engagement operations:
+
+- create client org
+- create engagement
+- create project
+- create goals
+- create tasks
+- assign CTO and agents
+
+Governance:
+
+- decision log
+- approval requests
+- evidence attachments
+- receipt status
+- human approval gates
+
+Agent operations:
+
+- agent passport
+- budget
+- allowed tools
+- forbidden actions
+- task assignment
+- status and heartbeat
+
+Reporting:
+
+- weekly client brief
+- decisions made
+- work completed
+- risks and blockers
+- receipts issued
+- budget consumed
+- next actions
+
+## Out Of Scope For MVP
+
+- autonomous production deploys
+- DID-first login UX
+- public marketplace
+- public Decision Forum network
+- Crosschecked standalone
+- VitalLock
+- LiveSafe
+- health or safety workflows
+- regulated data workflows
+- self-approving ExoForge automation
+
+## Definition Of Done
+
+The MVP is done when AVC can run one real engagement through CommandBase:
+
+```text
+Client created
+-> engagement created
+-> governance model selected
+-> agent roster created
+-> first decision opened
+-> first agent task assigned
+-> output reviewed
+-> receipt issued or receipt-pending state blocks completion
+-> weekly client brief generated
+```
+
+Required checks:
+
+- unit tests
+- API contract tests
+- tenant isolation tests
+- role and approval gate tests
+- receipt verification path tests
+- Playwright flow for the end-to-end MVP path
+- Railway deployment smoke tests

--- a/docs/commandbase-foundation/receipt-taxonomy.md
+++ b/docs/commandbase-foundation/receipt-taxonomy.md
@@ -1,0 +1,98 @@
+# Receipt Taxonomy
+
+Status: starter taxonomy
+Created: 2026-04-26
+
+## Purpose
+
+Receipts make actions legible to clients, CTOs, auditors, agents, and the
+ExoChain trust substrate.
+
+Each receipt should have:
+
+- a machine-verifiable form
+- a human-readable form
+- evidence references
+- actor and authority context
+- tenant context
+- risk classification
+
+## Receipt Classes
+
+| Class | Purpose |
+|---|---|
+| Identity Receipt | Actor identity created, bound, rotated, or revoked |
+| Authority Receipt | Role, delegation, scope, or agent passport changed |
+| Consent Receipt | Client or user consent granted, narrowed, revoked, or expired |
+| Decision Receipt | Decision proposed, reviewed, approved, rejected, or amended |
+| Evidence Receipt | Evidence captured, classified, linked, or sealed |
+| Agent Action Receipt | Agent performed a scoped action |
+| Work Product Receipt | Artifact created or changed |
+| Review Receipt | Human or council review completed |
+| Deployment Receipt | Environment deployment attempted, succeeded, failed, or rolled back |
+| Override Receipt | Human override invoked |
+| Incident Receipt | Security, reliability, or governance incident logged |
+| Crosscheck Receipt | Claim checked against evidence and confidence assigned |
+
+## Machine Form
+
+```json
+{
+  "receipt_type": "agent_action",
+  "receipt_version": "commandbase.receipt.v1",
+  "tenant_id": "org_...",
+  "workspace_id": "wrk_...",
+  "actor": {
+    "id": "agent_...",
+    "type": "agent",
+    "did": "did:exo:..."
+  },
+  "authority": {
+    "source": "agent_passport",
+    "scope": ["task:update"],
+    "delegated_by": "usr_...",
+    "expires_at": null
+  },
+  "action": {
+    "verb": "created",
+    "object_type": "implementation_plan",
+    "object_id": "plan_..."
+  },
+  "risk": {
+    "tier": "medium",
+    "approval_required": true,
+    "approval_state": "pending"
+  },
+  "evidence": [
+    {
+      "type": "document",
+      "id": "ev_...",
+      "hash": "..."
+    }
+  ],
+  "timestamp": "2026-04-26T00:00:00Z",
+  "signature": "..."
+}
+```
+
+## Human Form
+
+```text
+On April 26, 2026, Agent X created a proposed implementation plan for Client Y
+under authority delegated by CTO Z. The action was classified as medium risk,
+requires CTO review, and is not approved for deployment.
+```
+
+## Receipt States
+
+- pending: action expects a receipt, but verification is not complete
+- issued: receipt exists and is stored
+- verified: signature and payload match
+- contested: receipt is under review
+- superseded: newer receipt narrows, revokes, or replaces it
+- invalid: receipt failed verification
+
+## Product Rule
+
+CommandBase may display and cache receipt summaries, but ExoChain should be the
+source of truth for audit-critical receipts.


### PR DESCRIPTION
## Summary
- add a portable CommandBase foundation starter package under docs/commandbase-foundation
- include starter AGENTS.md, architecture, authority model, approval policy, receipt taxonomy, MVP scope, Customer Zero workflows, ExoForge session protocol, and execution ledger template
- link the package from docs/INDEX.md

## Verification
- git diff --check

## Notes
Docs-only planning package. Intended to be copied into the first CommandBase product repo to kick off Customer Zero subsystem development.