### PR TITLE
[codex] fix(exo-consent): require deterministic constructor metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1363,7 +1363,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.17",
- "uuid",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 109708 | `wc -l` |
-| Workspace tests | 2,687 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 110081 | `wc -l` |
+| Workspace tests | 2,699 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,687 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,699 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 109708 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 110081 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,687 listed workspace tests
+         cryptographic proofs, 2,699 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          140 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-consent/Cargo.toml
+++ b/crates/exo-consent/Cargo.toml
@@ -16,7 +16,6 @@ exo-core = { path = "../exo-core" }
 serde = { workspace = true }
 blake3 = { workspace = true }
 thiserror = { workspace = true }
-uuid = { workspace = true }
 ciborium = { workspace = true }
 
 [dev-dependencies]

--- a/crates/exo-consent/src/bailment.rs
+++ b/crates/exo-consent/src/bailment.rs
@@ -5,7 +5,6 @@
 
 use exo_core::{Did, Hash256, PublicKey, Signature, Timestamp, crypto};
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 use crate::error::ConsentError;
 
@@ -59,19 +58,55 @@ pub struct Bailment {
 }
 
 /// Propose a new bailment. Returns a bailment in `Proposed` status.
-#[must_use]
-pub fn propose(bailor: &Did, bailee: &Did, terms: &[u8], bailment_type: BailmentType) -> Bailment {
-    Bailment {
-        id: Uuid::new_v4().to_string(),
+///
+/// Callers must supply the proposal ID and creation timestamp from their
+/// deterministic execution context. The constructor rejects empty IDs and
+/// zero timestamps so consensus/audit-significant bailments cannot silently
+/// carry placeholder metadata.
+///
+/// # Errors
+/// Returns `Denied` if `id` is empty or `created` is [`Timestamp::ZERO`].
+pub fn propose(
+    bailor: &Did,
+    bailee: &Did,
+    terms: &[u8],
+    bailment_type: BailmentType,
+    id: impl Into<String>,
+    created: Timestamp,
+) -> Result<Bailment, ConsentError> {
+    let id = id.into();
+    validate_constructor_metadata("bailment id", &id, "created", &created)?;
+
+    Ok(Bailment {
+        id,
         bailor_did: bailor.clone(),
         bailee_did: bailee.clone(),
         bailment_type,
         terms_hash: Hash256::digest(terms),
-        created: Timestamp::now_utc(),
+        created,
         expires: None,
         status: BailmentStatus::Proposed,
         signature: Signature::empty(),
+    })
+}
+
+fn validate_constructor_metadata(
+    id_label: &str,
+    id: &str,
+    timestamp_label: &str,
+    timestamp: &Timestamp,
+) -> Result<(), ConsentError> {
+    if id.trim().is_empty() {
+        return Err(ConsentError::Denied(format!(
+            "{id_label} must be caller-supplied and non-empty"
+        )));
     }
+    if *timestamp == Timestamp::ZERO {
+        return Err(ConsentError::Denied(format!(
+            "{timestamp_label} must be caller-supplied and non-zero"
+        )));
+    }
+    Ok(())
 }
 
 /// Canonical CBOR signing payload for bailment acceptance.
@@ -219,30 +254,108 @@ mod tests {
         Timestamp::new(ms, 0)
     }
 
+    fn propose_test(terms: &[u8], bailment_type: BailmentType) -> Bailment {
+        propose(
+            &alice(),
+            &bob(),
+            terms,
+            bailment_type,
+            "bailment-test",
+            ts(1000),
+        )
+        .expect("test bailment proposal")
+    }
+
+    fn propose_test_with_metadata(
+        terms: &[u8],
+        bailment_type: BailmentType,
+        id: &str,
+        created: Timestamp,
+    ) -> Bailment {
+        propose(&alice(), &bob(), terms, bailment_type, id, created)
+            .expect("test bailment proposal with metadata")
+    }
+
+    #[test]
+    fn bailment_proposal_constructor_has_no_internal_entropy_or_wall_clock() {
+        let source = include_str!("bailment.rs");
+        let uuid_pattern = format!("{}{}", "Uuid::", "new_v4()");
+        let now_pattern = format!("{}{}", "Timestamp::", "now_utc()");
+
+        assert!(
+            !source.contains(&uuid_pattern),
+            "bailment proposals must receive caller-supplied IDs"
+        );
+        assert!(
+            !source.contains(&now_pattern),
+            "bailment proposals must receive caller-supplied HLC timestamps"
+        );
+    }
+
     #[test]
     fn propose_creates_proposed() {
-        let b = propose(&alice(), &bob(), b"terms", BailmentType::Custody);
+        let b = propose_test_with_metadata(
+            b"terms",
+            BailmentType::Custody,
+            "bailment-explicit",
+            ts(1234),
+        );
         assert_eq!(b.status, BailmentStatus::Proposed);
         assert_eq!(b.bailor_did, alice());
         assert_eq!(b.bailee_did, bob());
         assert_eq!(b.bailment_type, BailmentType::Custody);
+        assert_eq!(b.id, "bailment-explicit");
+        assert_eq!(b.created, ts(1234));
         assert!(b.signature.is_empty());
         assert!(b.expires.is_none());
-        assert!(!b.id.is_empty());
+    }
+
+    #[test]
+    fn propose_rejects_empty_id() {
+        let err = propose(
+            &alice(),
+            &bob(),
+            b"terms",
+            BailmentType::Custody,
+            " ",
+            ts(1000),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            ConsentError::Denied("bailment id must be caller-supplied and non-empty".into())
+        );
+    }
+
+    #[test]
+    fn propose_rejects_zero_created_timestamp() {
+        let err = propose(
+            &alice(),
+            &bob(),
+            b"terms",
+            BailmentType::Custody,
+            "bailment-explicit",
+            Timestamp::ZERO,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            ConsentError::Denied("created must be caller-supplied and non-zero".into())
+        );
     }
 
     #[test]
     fn propose_hashes_terms_deterministically() {
-        let a = propose(&alice(), &bob(), b"terms-a", BailmentType::Processing);
-        let b = propose(&alice(), &bob(), b"terms-b", BailmentType::Processing);
+        let a = propose_test(b"terms-a", BailmentType::Processing);
+        let b = propose_test(b"terms-b", BailmentType::Processing);
         assert_ne!(a.terms_hash, b.terms_hash);
-        let c = propose(&alice(), &bob(), b"terms-a", BailmentType::Processing);
+        let c = propose_test(b"terms-a", BailmentType::Processing);
         assert_eq!(a.terms_hash, c.terms_hash);
     }
 
     #[test]
     fn accept_transitions_to_active() {
-        let mut b = propose(&alice(), &bob(), b"t", BailmentType::Custody);
+        let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
         assert!(accept(&mut b, &pk, &sig).is_ok());
         assert_eq!(b.status, BailmentStatus::Active);
@@ -251,7 +364,7 @@ mod tests {
 
     #[test]
     fn accept_rejects_non_proposed() {
-        let mut b = propose(&alice(), &bob(), b"t", BailmentType::Custody);
+        let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
         b.status = BailmentStatus::Active;
         assert_eq!(
@@ -265,7 +378,7 @@ mod tests {
 
     #[test]
     fn accept_rejects_empty_signature() {
-        let mut b = propose(&alice(), &bob(), b"t", BailmentType::Custody);
+        let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk) = crypto::generate_keypair();
         assert_eq!(
             accept(&mut b, &pk, &Signature::empty()),
@@ -280,7 +393,7 @@ mod tests {
     /// accepted.
     #[test]
     fn accept_rejects_non_empty_but_invalid_signature() {
-        let mut b = propose(&alice(), &bob(), b"t", BailmentType::Custody);
+        let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk) = crypto::generate_keypair();
         // Non-empty junk bytes — the kind of signature the old code let
         // through unchecked.
@@ -298,7 +411,7 @@ mod tests {
     /// point; EXOCHAIN must not.
     #[test]
     fn accept_rejects_zero_byte_signature() {
-        let mut b = propose(&alice(), &bob(), b"t", BailmentType::Custody);
+        let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk) = crypto::generate_keypair();
         let zeros = Signature::from_bytes([0u8; 64]);
         assert_eq!(
@@ -313,7 +426,7 @@ mod tests {
     /// bound to the bailee's public key.
     #[test]
     fn accept_rejects_signature_by_wrong_key() {
-        let mut b = propose(&alice(), &bob(), b"t", BailmentType::Custody);
+        let mut b = propose_test(b"t", BailmentType::Custody);
         let (_pk_a, sk_a) = crypto::generate_keypair();
         let (pk_b, _sk_b) = crypto::generate_keypair();
         let payload = signing_payload(&b).unwrap();
@@ -330,8 +443,8 @@ mod tests {
     /// authenticate this bailment (replay protection).
     #[test]
     fn accept_rejects_signature_over_different_bailment() {
-        let mut b1 = propose(&alice(), &bob(), b"t1", BailmentType::Custody);
-        let b2 = propose(&alice(), &bob(), b"t2", BailmentType::Custody);
+        let mut b1 = propose_test(b"t1", BailmentType::Custody);
+        let b2 = propose_test(b"t2", BailmentType::Custody);
         let (pk, sk) = crypto::generate_keypair();
         let payload2 = signing_payload(&b2).unwrap();
         let sig_on_b2 = crypto::sign(&payload2, &sk);
@@ -346,7 +459,7 @@ mod tests {
     /// before acceptance is processed must invalidate the signature.
     #[test]
     fn accept_rejects_tampered_bailment() {
-        let mut b = propose(&alice(), &bob(), b"t", BailmentType::Custody);
+        let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
         // Attacker changes the bailee to themselves after the real
         // bailee signed. Should be rejected.
@@ -360,7 +473,7 @@ mod tests {
 
     #[test]
     fn accept_rejects_tampered_terms() {
-        let mut b = propose(&alice(), &bob(), b"t-original", BailmentType::Custody);
+        let mut b = propose_test(b"t-original", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
         b.terms_hash = Hash256::digest(b"t-swapped");
         assert_eq!(
@@ -373,7 +486,7 @@ mod tests {
 
     #[test]
     fn terminate_by_bailor() {
-        let mut b = propose(&alice(), &bob(), b"t", BailmentType::Custody);
+        let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
         accept(&mut b, &pk, &sig).ok();
         assert!(terminate(&mut b, &alice()).is_ok());
@@ -382,7 +495,7 @@ mod tests {
 
     #[test]
     fn terminate_by_bailee() {
-        let mut b = propose(&alice(), &bob(), b"t", BailmentType::Custody);
+        let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
         accept(&mut b, &pk, &sig).ok();
         assert!(terminate(&mut b, &bob()).is_ok());
@@ -391,7 +504,7 @@ mod tests {
 
     #[test]
     fn terminate_rejects_unauthorized() {
-        let mut b = propose(&alice(), &bob(), b"t", BailmentType::Custody);
+        let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
         accept(&mut b, &pk, &sig).ok();
         assert!(matches!(
@@ -402,7 +515,7 @@ mod tests {
 
     #[test]
     fn terminate_rejects_already_terminated() {
-        let mut b = propose(&alice(), &bob(), b"t", BailmentType::Custody);
+        let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
         accept(&mut b, &pk, &sig).ok();
         terminate(&mut b, &alice()).ok();
@@ -414,7 +527,7 @@ mod tests {
 
     #[test]
     fn terminate_rejects_expired() {
-        let mut b = propose(&alice(), &bob(), b"t", BailmentType::Custody);
+        let mut b = propose_test(b"t", BailmentType::Custody);
         b.status = BailmentStatus::Expired;
         assert!(matches!(
             terminate(&mut b, &alice()),
@@ -424,20 +537,20 @@ mod tests {
 
     #[test]
     fn terminate_proposed() {
-        let mut b = propose(&alice(), &bob(), b"t", BailmentType::Custody);
+        let mut b = propose_test(b"t", BailmentType::Custody);
         assert!(terminate(&mut b, &alice()).is_ok());
     }
 
     #[test]
     fn terminate_suspended() {
-        let mut b = propose(&alice(), &bob(), b"t", BailmentType::Custody);
+        let mut b = propose_test(b"t", BailmentType::Custody);
         b.status = BailmentStatus::Suspended;
         assert!(terminate(&mut b, &alice()).is_ok());
     }
 
     #[test]
     fn is_active_with_no_expiry() {
-        let mut b = propose(&alice(), &bob(), b"t", BailmentType::Custody);
+        let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
         accept(&mut b, &pk, &sig).ok();
         assert!(is_active(&b, &ts(5000)));
@@ -445,7 +558,7 @@ mod tests {
 
     #[test]
     fn is_active_before_expiry() {
-        let mut b = propose(&alice(), &bob(), b"t", BailmentType::Custody);
+        let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
         accept(&mut b, &pk, &sig).ok();
         b.expires = Some(ts(10000));
@@ -454,7 +567,7 @@ mod tests {
 
     #[test]
     fn not_active_after_expiry() {
-        let mut b = propose(&alice(), &bob(), b"t", BailmentType::Custody);
+        let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
         accept(&mut b, &pk, &sig).ok();
         b.expires = Some(ts(1000));
@@ -463,7 +576,7 @@ mod tests {
 
     #[test]
     fn not_active_at_exact_expiry() {
-        let mut b = propose(&alice(), &bob(), b"t", BailmentType::Custody);
+        let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
         accept(&mut b, &pk, &sig).ok();
         b.expires = Some(ts(5000));
@@ -472,13 +585,13 @@ mod tests {
 
     #[test]
     fn not_active_when_proposed() {
-        let b = propose(&alice(), &bob(), b"t", BailmentType::Custody);
+        let b = propose_test(b"t", BailmentType::Custody);
         assert!(!is_active(&b, &ts(1000)));
     }
 
     #[test]
     fn not_active_when_terminated() {
-        let mut b = propose(&alice(), &bob(), b"t", BailmentType::Custody);
+        let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
         accept(&mut b, &pk, &sig).ok();
         terminate(&mut b, &alice()).ok();
@@ -487,14 +600,14 @@ mod tests {
 
     #[test]
     fn not_active_when_suspended() {
-        let mut b = propose(&alice(), &bob(), b"t", BailmentType::Custody);
+        let mut b = propose_test(b"t", BailmentType::Custody);
         b.status = BailmentStatus::Suspended;
         assert!(!is_active(&b, &ts(1000)));
     }
 
     #[test]
     fn not_active_when_expired_status() {
-        let mut b = propose(&alice(), &bob(), b"t", BailmentType::Custody);
+        let mut b = propose_test(b"t", BailmentType::Custody);
         b.status = BailmentStatus::Expired;
         assert!(!is_active(&b, &ts(1000)));
     }

--- a/crates/exo-consent/src/contract.rs
+++ b/crates/exo-consent/src/contract.rs
@@ -15,7 +15,6 @@
 
 use exo_core::{DeterministicMap, Did, Hash256, Timestamp, hash::hash_structured};
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 use crate::{bailment::BailmentType, error::ConsentError};
 
@@ -281,7 +280,12 @@ pub fn default_template(bailment_type: BailmentType) -> ContractTemplate {
 pub fn compose(
     template: &ContractTemplate,
     params: &ContractParams,
+    id: impl Into<String>,
+    composed_at: Timestamp,
 ) -> Result<ComposedContract, ConsentError> {
+    let id = id.into();
+    validate_constructor_metadata("contract id", &id, "composed_at", &composed_at)?;
+
     // Filter clauses by jurisdiction
     let mut filtered_clauses = Vec::new();
     for clause in &template.clauses {
@@ -327,11 +331,11 @@ pub fn compose(
         hash_structured(&payload).map_err(|e| ConsentError::Denied(format!("Hash error: {e}")))?;
 
     Ok(ComposedContract {
-        id: Uuid::new_v4().to_string(),
+        id,
         template_id,
         params: params.clone(),
         rendered_clauses,
-        composed_at: Timestamp::now_utc(),
+        composed_at,
         contract_hash,
         version,
         parent_contract_id: None,
@@ -403,7 +407,10 @@ pub fn assess_breach(
     contract: &ComposedContract,
     breached_clause_ids: &[&str],
     severity: BreachSeverity,
+    assessed_at: Timestamp,
 ) -> Result<BreachAssessment, ConsentError> {
+    validate_constructor_metadata("contract id", &contract.id, "assessed_at", &assessed_at)?;
+
     // Validate all clause IDs exist
     for clause_id in breached_clause_ids {
         if !contract
@@ -440,7 +447,7 @@ pub fn assess_breach(
         breached_clauses: breached_clause_ids.iter().map(|s| s.to_string()).collect(),
         liability_assessment_bps: liability_bps,
         recommended_remedy: remedy,
-        assessed_at: Timestamp::now_utc(),
+        assessed_at,
     })
 }
 
@@ -457,7 +464,12 @@ pub fn amend(
     original: &ComposedContract,
     new_params: &ContractParams,
     amended_clauses: &[(String, Clause)],
+    id: impl Into<String>,
+    composed_at: Timestamp,
 ) -> Result<ComposedContract, ConsentError> {
+    let id = id.into();
+    validate_constructor_metadata("contract id", &id, "composed_at", &composed_at)?;
+
     // Start with original rendered clauses
     let mut clauses: Vec<RenderedClause> = original.rendered_clauses.clone();
 
@@ -498,11 +510,11 @@ pub fn amend(
         hash_structured(&payload).map_err(|e| ConsentError::Denied(format!("Hash error: {e}")))?;
 
     Ok(ComposedContract {
-        id: Uuid::new_v4().to_string(),
+        id,
         template_id: original.template_id.clone(),
         params: new_params.clone(),
         rendered_clauses: clauses,
-        composed_at: Timestamp::now_utc(),
+        composed_at,
         contract_hash,
         version: new_version,
         parent_contract_id: Some(original.id.clone()),
@@ -525,6 +537,25 @@ pub fn verify_hash(contract: &ComposedContract) -> bool {
         Ok(computed) => computed == contract.contract_hash,
         Err(_) => false,
     }
+}
+
+fn validate_constructor_metadata(
+    id_label: &str,
+    id: &str,
+    timestamp_label: &str,
+    timestamp: &Timestamp,
+) -> Result<(), ConsentError> {
+    if id.trim().is_empty() {
+        return Err(ConsentError::Denied(format!(
+            "{id_label} must be caller-supplied and non-empty"
+        )));
+    }
+    if *timestamp == Timestamp::ZERO {
+        return Err(ConsentError::Denied(format!(
+            "{timestamp_label} must be caller-supplied and non-zero"
+        )));
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -877,9 +908,181 @@ mod tests {
         }
     }
 
+    fn ts(ms: u64) -> Timestamp {
+        Timestamp::new(ms, 0)
+    }
+
+    fn compose_test(template: &ContractTemplate, params: &ContractParams) -> ComposedContract {
+        compose(template, params, "contract-test", ts(1_700_000_000_100))
+            .expect("test contract composition")
+    }
+
+    fn compose_test_with_metadata(
+        template: &ContractTemplate,
+        params: &ContractParams,
+        id: &str,
+        composed_at: Timestamp,
+    ) -> ComposedContract {
+        compose(template, params, id, composed_at).expect("test contract composition metadata")
+    }
+
+    fn assess_breach_test(
+        contract: &ComposedContract,
+        breached_clause_ids: &[&str],
+        severity: BreachSeverity,
+    ) -> BreachAssessment {
+        assess_breach(
+            contract,
+            breached_clause_ids,
+            severity,
+            ts(1_700_000_000_200),
+        )
+        .expect("test breach assessment")
+    }
+
+    fn amend_test(
+        original: &ComposedContract,
+        new_params: &ContractParams,
+        amended_clauses: &[(String, Clause)],
+    ) -> ComposedContract {
+        amend(
+            original,
+            new_params,
+            amended_clauses,
+            "contract-amendment-test",
+            ts(1_700_000_000_300),
+        )
+        .expect("test amendment")
+    }
+
     fn compose_custody() -> ComposedContract {
         let template = default_template(BailmentType::Custody);
-        compose(&template, &test_params()).unwrap()
+        compose_test(&template, &test_params())
+    }
+
+    #[test]
+    fn contract_constructors_have_no_internal_entropy_or_wall_clock() {
+        let source = include_str!("contract.rs");
+        let uuid_pattern = format!("{}{}", "Uuid::", "new_v4()");
+        let now_pattern = format!("{}{}", "Timestamp::", "now_utc()");
+
+        assert!(
+            !source.contains(&uuid_pattern),
+            "contract constructors must receive caller-supplied IDs"
+        );
+        assert!(
+            !source.contains(&now_pattern),
+            "contract constructors must receive caller-supplied HLC timestamps"
+        );
+    }
+
+    #[test]
+    fn compose_uses_caller_supplied_metadata() {
+        let template = default_template(BailmentType::Custody);
+        let contract =
+            compose_test_with_metadata(&template, &test_params(), "contract-explicit", ts(4321));
+
+        assert_eq!(contract.id, "contract-explicit");
+        assert_eq!(contract.composed_at, ts(4321));
+        assert_eq!(contract.version, 1);
+        assert_eq!(contract.parent_contract_id, None);
+    }
+
+    #[test]
+    fn compose_rejects_empty_id() {
+        let template = default_template(BailmentType::Custody);
+        let err = compose(&template, &test_params(), " ", ts(1000)).unwrap_err();
+
+        assert_eq!(
+            err,
+            ConsentError::Denied("contract id must be caller-supplied and non-empty".into())
+        );
+    }
+
+    #[test]
+    fn compose_rejects_zero_composed_at() {
+        let template = default_template(BailmentType::Custody);
+        let err = compose(
+            &template,
+            &test_params(),
+            "contract-explicit",
+            Timestamp::ZERO,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            err,
+            ConsentError::Denied("composed_at must be caller-supplied and non-zero".into())
+        );
+    }
+
+    #[test]
+    fn assess_breach_uses_caller_supplied_timestamp() {
+        let contract = compose_custody();
+        let clause_id = contract.rendered_clauses[0].clause_id.as_str();
+        let assessment = assess_breach(&contract, &[clause_id], BreachSeverity::Minor, ts(4567))
+            .expect("breach assessment");
+
+        assert_eq!(assessment.assessed_at, ts(4567));
+    }
+
+    #[test]
+    fn assess_breach_rejects_zero_timestamp() {
+        let contract = compose_custody();
+        let clause_id = contract.rendered_clauses[0].clause_id.as_str();
+        let err = assess_breach(
+            &contract,
+            &[clause_id],
+            BreachSeverity::Minor,
+            Timestamp::ZERO,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            err,
+            ConsentError::Denied("assessed_at must be caller-supplied and non-zero".into())
+        );
+    }
+
+    #[test]
+    fn amend_uses_caller_supplied_metadata() {
+        let original = compose_custody();
+        let amended = amend(
+            &original,
+            &test_params(),
+            &[],
+            "contract-amendment-explicit",
+            ts(5678),
+        )
+        .expect("amendment");
+
+        assert_eq!(amended.id, "contract-amendment-explicit");
+        assert_eq!(amended.composed_at, ts(5678));
+        assert_eq!(amended.parent_contract_id, Some(original.id.clone()));
+    }
+
+    #[test]
+    fn amend_rejects_placeholder_metadata() {
+        let original = compose_custody();
+
+        let empty_id = amend(&original, &test_params(), &[], " ", ts(5678)).unwrap_err();
+        assert_eq!(
+            empty_id,
+            ConsentError::Denied("contract id must be caller-supplied and non-empty".into())
+        );
+
+        let zero_time = amend(
+            &original,
+            &test_params(),
+            &[],
+            "contract-amendment-explicit",
+            Timestamp::ZERO,
+        )
+        .unwrap_err();
+        assert_eq!(
+            zero_time,
+            ConsentError::Denied("composed_at must be caller-supplied and non-zero".into())
+        );
     }
 
     // All 8 clause categories
@@ -978,11 +1181,12 @@ mod tests {
         let template = default_template(BailmentType::Custody);
         let params = test_params();
 
-        let c1 = compose(&template, &params).unwrap();
-        let c2 = compose(&template, &params).unwrap();
+        let c1 = compose_test(&template, &params);
+        let c2 = compose_test(&template, &params);
 
-        // IDs differ (UUID), but hashes must be identical
-        assert_ne!(c1.id, c2.id);
+        // Caller-supplied metadata is stable, and content hash is stable.
+        assert_eq!(c1.id, c2.id);
+        assert_eq!(c1.composed_at, c2.composed_at);
         assert_eq!(c1.contract_hash, c2.contract_hash);
     }
 
@@ -995,8 +1199,8 @@ mod tests {
         let mut params2 = test_params();
         params2.liability_cap_bps = 9999;
 
-        let c1 = compose(&template, &params1).unwrap();
-        let c2 = compose(&template, &params2).unwrap();
+        let c1 = compose_test(&template, &params1);
+        let c2 = compose_test(&template, &params2);
 
         assert_ne!(c1.contract_hash, c2.contract_hash);
     }
@@ -1060,7 +1264,7 @@ mod tests {
         let contract = compose_custody();
         let clause_id = contract.rendered_clauses[0].clause_id.as_str();
 
-        let assessment = assess_breach(&contract, &[clause_id], BreachSeverity::Minor).unwrap();
+        let assessment = assess_breach_test(&contract, &[clause_id], BreachSeverity::Minor);
 
         assert_eq!(assessment.breach_severity, BreachSeverity::Minor);
         assert_eq!(assessment.recommended_remedy, Remedy::Notice);
@@ -1074,7 +1278,7 @@ mod tests {
         let contract = compose_custody();
         let clause_id = contract.rendered_clauses[0].clause_id.as_str();
 
-        let assessment = assess_breach(&contract, &[clause_id], BreachSeverity::Material).unwrap();
+        let assessment = assess_breach_test(&contract, &[clause_id], BreachSeverity::Material);
 
         assert_eq!(assessment.breach_severity, BreachSeverity::Material);
         assert_eq!(
@@ -1093,8 +1297,7 @@ mod tests {
         let contract = compose_custody();
         let clause_id = contract.rendered_clauses[0].clause_id.as_str();
 
-        let assessment =
-            assess_breach(&contract, &[clause_id], BreachSeverity::Fundamental).unwrap();
+        let assessment = assess_breach_test(&contract, &[clause_id], BreachSeverity::Fundamental);
 
         assert_eq!(assessment.breach_severity, BreachSeverity::Fundamental);
         assert_eq!(
@@ -1110,7 +1313,12 @@ mod tests {
     fn test_breach_invalid_clause_id() {
         let contract = compose_custody();
 
-        let result = assess_breach(&contract, &["nonexistent-clause"], BreachSeverity::Minor);
+        let result = assess_breach(
+            &contract,
+            &["nonexistent-clause"],
+            BreachSeverity::Minor,
+            ts(1_700_000_000_200),
+        );
 
         assert!(result.is_err());
         match result {
@@ -1128,7 +1336,7 @@ mod tests {
         let original = compose_custody();
         let new_params = test_params();
 
-        let amended = amend(&original, &new_params, &[]).unwrap();
+        let amended = amend_test(&original, &new_params, &[]);
 
         assert_eq!(amended.version, original.version + 1);
         assert_eq!(amended.parent_contract_id, Some(original.id.clone()));
@@ -1145,7 +1353,7 @@ mod tests {
         let mut new_params = test_params();
         new_params.liability_cap_bps = 9000;
 
-        let _amended = amend(&original, &new_params, &[]).unwrap();
+        let _amended = amend_test(&original, &new_params, &[]);
 
         // Original's hash is unchanged
         assert_eq!(original.contract_hash, original_hash);
@@ -1181,7 +1389,7 @@ mod tests {
 
         // Breach assessment also uses u64
         let clause_id = contract.rendered_clauses[0].clause_id.as_str();
-        let assessment = assess_breach(&contract, &[clause_id], BreachSeverity::Material).unwrap();
+        let assessment = assess_breach_test(&contract, &[clause_id], BreachSeverity::Material);
         let _liability: u64 = assessment.liability_assessment_bps;
         assert_eq!(assessment.liability_assessment_bps, 2500u64);
 
@@ -1225,7 +1433,7 @@ mod tests {
     #[test]
     fn test_compose_delegation_template_succeeds() {
         let template = default_template(BailmentType::Delegation);
-        let contract = compose(&template, &test_params()).unwrap();
+        let contract = compose_test(&template, &test_params());
         assert!(!contract.rendered_clauses.is_empty());
         assert_ne!(contract.contract_hash, Hash256::ZERO);
         // Section numbering is monotonic from 1.
@@ -1239,7 +1447,7 @@ mod tests {
     #[test]
     fn test_compose_emergency_template_succeeds() {
         let template = default_template(BailmentType::Emergency);
-        let contract = compose(&template, &test_params()).unwrap();
+        let contract = compose_test(&template, &test_params());
         assert!(!contract.rendered_clauses.is_empty());
         assert_ne!(contract.contract_hash, Hash256::ZERO);
     }
@@ -1260,7 +1468,7 @@ mod tests {
             jurisdiction: Some("EU-DE".to_string()),
         });
 
-        let contract = compose(&template, &test_params()).unwrap();
+        let contract = compose_test(&template, &test_params());
         assert!(
             contract
                 .rendered_clauses
@@ -1285,7 +1493,12 @@ mod tests {
         });
 
         // test_params() uses "US-DE" — the required EU clause cannot apply.
-        let result = compose(&template, &test_params());
+        let result = compose(
+            &template,
+            &test_params(),
+            "contract-test",
+            ts(1_700_000_000_100),
+        );
         match result {
             Err(ConsentError::Denied(msg)) => {
                 assert!(msg.contains("required-eu-only"));
@@ -1310,7 +1523,7 @@ mod tests {
             jurisdiction: Some("US-DE".to_string()),
         });
 
-        let contract = compose(&template, &test_params()).unwrap();
+        let contract = compose_test(&template, &test_params());
         assert!(
             contract
                 .rendered_clauses
@@ -1342,6 +1555,8 @@ mod tests {
             &original,
             &test_params(),
             &[(target_id.clone(), replacement.clone())],
+            "contract-amendment-test",
+            ts(1_700_000_000_300),
         )
         .unwrap();
 
@@ -1400,6 +1615,8 @@ mod tests {
             &original,
             &test_params(),
             &[("NON-EXISTENT-CLAUSE-ID".to_string(), new_clause)],
+            "contract-amendment-test",
+            ts(1_700_000_000_300),
         )
         .unwrap();
 
@@ -1452,6 +1669,8 @@ mod tests {
                 (target_id, replacement),
                 ("UNKNOWN-ID".to_string(), addition),
             ],
+            "contract-amendment-test",
+            ts(1_700_000_000_300),
         )
         .unwrap();
 
@@ -1479,7 +1698,7 @@ mod tests {
     #[test]
     fn test_amend_changes_contract_hash() {
         let original = compose_custody();
-        let amended = amend(&original, &test_params(), &[]).unwrap();
+        let amended = amend_test(&original, &test_params(), &[]);
         // Version differs (original = 1, amended = 2), so payload differs,
         // so hash must differ.
         assert_ne!(amended.contract_hash, original.contract_hash);
@@ -1492,7 +1711,7 @@ mod tests {
         let template = default_template(BailmentType::Custody);
         let mut params = test_params();
         params.expiry_date = None;
-        let contract = compose(&template, &params).unwrap();
+        let contract = compose_test(&template, &params);
 
         let md = render_markdown(&contract);
         assert!(
@@ -1547,7 +1766,7 @@ mod tests {
     fn test_compose_includes_all_jurisdiction_neutral_required_clauses() {
         let template = default_template(BailmentType::Custody);
         // Default template clauses all have jurisdiction: None.
-        let contract = compose(&template, &test_params()).unwrap();
+        let contract = compose_test(&template, &test_params());
         assert_eq!(contract.rendered_clauses.len(), template.clauses.len());
     }
 
@@ -1559,7 +1778,7 @@ mod tests {
         let id0 = contract.rendered_clauses[0].clause_id.clone();
         let id1 = contract.rendered_clauses[1].clause_id.clone();
 
-        let a = assess_breach(&contract, &[&id0, &id1], BreachSeverity::Material).unwrap();
+        let a = assess_breach_test(&contract, &[&id0, &id1], BreachSeverity::Material);
         assert_eq!(a.breached_clauses.len(), 2);
         assert!(a.breached_clauses.contains(&id0));
         assert!(a.breached_clauses.contains(&id1));

--- a/crates/exo-consent/src/gatekeeper.rs
+++ b/crates/exo-consent/src/gatekeeper.rs
@@ -157,7 +157,8 @@ mod tests {
         bt: BailmentType,
         exp: Option<Timestamp>,
     ) -> Bailment {
-        let mut b = bailment::propose(bailor, bailee, b"gt", bt);
+        let mut b = bailment::propose(bailor, bailee, b"gt", bt, "gatekeeper-test", ts(1000))
+            .expect("test bailment proposal");
         // Produce a valid bailee signature for the GAP-012-verified accept().
         let (pk, sk) = exo_core::crypto::generate_keypair();
         let payload = bailment::signing_payload(&b).expect("canonical payload");

--- a/crates/exo-consent/src/policy.rs
+++ b/crates/exo-consent/src/policy.rs
@@ -164,7 +164,8 @@ mod tests {
         btype: BailmentType,
         exp: Option<Timestamp>,
     ) -> Bailment {
-        let mut b = bailment::propose(bailor, bailee, b"terms", btype);
+        let mut b = bailment::propose(bailor, bailee, b"terms", btype, "policy-test", ts(1000))
+            .expect("test bailment proposal");
         // Produce a valid bailee signature for the GAP-012-verified accept().
         let (pk, sk) = exo_core::crypto::generate_keypair();
         let payload = bailment::signing_payload(&b).expect("canonical payload");

--- a/crates/exochain-wasm/src/consent_bindings.rs
+++ b/crates/exochain-wasm/src/consent_bindings.rs
@@ -11,22 +11,32 @@ pub fn wasm_propose_bailment(
     bailee_did: &str,
     terms: &[u8],
     bailment_type_json: &str,
+    bailment_id: &str,
+    created_json: &str,
 ) -> Result<JsValue, JsValue> {
     let bailor = exo_core::Did::new(bailor_did)
         .map_err(|e| JsValue::from_str(&format!("DID error: {e}")))?;
     let bailee = exo_core::Did::new(bailee_did)
         .map_err(|e| JsValue::from_str(&format!("DID error: {e}")))?;
     let bailment_type: exo_consent::BailmentType = from_json_str(bailment_type_json)?;
-    let bailment = exo_consent::bailment::propose(&bailor, &bailee, terms, bailment_type);
+    let created: exo_core::Timestamp = from_json_str(created_json)?;
+    let bailment = exo_consent::bailment::propose(
+        &bailor,
+        &bailee,
+        terms,
+        bailment_type,
+        bailment_id,
+        created,
+    )
+    .map_err(|e| JsValue::from_str(&format!("Propose error: {e}")))?;
     to_js_value(&bailment)
 }
 
 /// Check if a bailment is currently active
 #[wasm_bindgen]
-pub fn wasm_bailment_is_active(bailment_json: &str) -> Result<bool, JsValue> {
+pub fn wasm_bailment_is_active(bailment_json: &str, now_json: &str) -> Result<bool, JsValue> {
     let bailment: exo_consent::Bailment = from_json_str(bailment_json)?;
-    let mut clock = exo_core::hlc::HybridClock::new();
-    let now = clock.now();
+    let now: exo_core::Timestamp = from_json_str(now_json)?;
     Ok(exo_consent::bailment::is_active(&bailment, &now))
 }
 

--- a/crates/exochain-wasm/src/lib.rs
+++ b/crates/exochain-wasm/src/lib.rs
@@ -57,4 +57,21 @@ mod source_guard_tests {
             );
         }
     }
+
+    #[test]
+    fn wasm_consent_bridge_requires_caller_supplied_time() {
+        let source = include_str!("consent_bindings.rs");
+        let forbidden = [
+            format!("{}{}", "Timestamp::", "now_utc()"),
+            format!("{}{}", "Uuid::", "new_v4()"),
+            "HybridClock::new()".to_string(),
+        ];
+
+        for pattern in forbidden {
+            assert!(
+                !source.contains(&pattern),
+                "consent WASM bindings must receive caller-supplied IDs and HLC timestamps"
+            );
+        }
+    }
 }

--- a/crates/exochain-wasm/tests/wasm_bindings_test.rs
+++ b/crates/exochain-wasm/tests/wasm_bindings_test.rs
@@ -26,6 +26,8 @@ fn js_str(val: JsValue) -> String {
     val.as_string().expect("expected string JsValue")
 }
 
+const TEST_TS_JSON: &str = r#"{"physical_ms":1700000000000,"logical":0}"#;
+
 // ── Core: Hashing ─────────────────────────────────────────────────────────────
 
 #[wasm_bindgen_test]
@@ -411,10 +413,17 @@ fn test_propose_bailment_creates_proposed_status() {
         "did:exo:bailee",
         b"data sharing terms v1",
         r#""Custody""#,
+        "bailment-wasm-test",
+        TEST_TS_JSON,
     )
     .expect("propose_bailment");
     let json = js_to_json(result);
     assert_eq!(json["status"].as_str().unwrap(), "Proposed");
+    assert_eq!(json["id"].as_str().unwrap(), "bailment-wasm-test");
+    assert_eq!(
+        json["created"]["physical_ms"].as_u64().unwrap(),
+        1700000000000
+    );
 }
 
 #[wasm_bindgen_test]
@@ -425,10 +434,13 @@ fn test_bailment_not_active_when_proposed() {
             "did:exo:bailee",
             b"terms",
             r#""Processing""#,
+            "bailment-wasm-test",
+            TEST_TS_JSON,
         )
         .expect("propose"),
     );
-    let active = exochain_wasm::wasm_bailment_is_active(&bailment_json).expect("is_active");
+    let active =
+        exochain_wasm::wasm_bailment_is_active(&bailment_json, TEST_TS_JSON).expect("is_active");
     assert!(!active);
 }
 

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -520,7 +520,9 @@ test('wasm_propose_bailment', () =>
     TEST_DID,
     TEST_DID_2,
     TEXT_BYTES,
-    JSON.stringify('Custody')
+    JSON.stringify('Custody'),
+    UUID_1,
+    JSON.stringify(NOW_TS)
   ));
 
 const bailment = setup(() =>
@@ -528,12 +530,14 @@ const bailment = setup(() =>
     TEST_DID,
     TEST_DID_2,
     TEXT_BYTES,
-    JSON.stringify('Custody')
+    JSON.stringify('Custody'),
+    UUID_1,
+    JSON.stringify(NOW_TS)
   ));
 
 test('wasm_bailment_is_active', () => {
   if (!bailment) throw new Error('skipped -- no bailment from setup');
-  return wasm.wasm_bailment_is_active(JSON.stringify(bailment));
+  return wasm.wasm_bailment_is_active(JSON.stringify(bailment), JSON.stringify(NOW_TS));
 });
 
 // Build the canonical bailment signing payload and sign it with a


### PR DESCRIPTION
## Summary
- Require caller-supplied deterministic IDs and HLC timestamps for exo-consent bailment and contract constructors.
- Reject empty IDs and zero timestamps so audit-significant consent artifacts cannot carry placeholder metadata.
- Update WASM consent bindings and JS bridge verification to pass explicit metadata, and remove exo-consent's direct uuid dependency.
- Refresh README repo-truth counts after the added tests.

## TDD red checks
- `cargo test -p exo-consent bailment_proposal_constructor_has_no_internal_entropy_or_wall_clock --lib` failed before implementation because bailment proposals used `Uuid::new_v4()`.
- `cargo test -p exo-consent contract_constructors_have_no_internal_entropy_or_wall_clock --lib` failed before implementation because contract constructors used `Uuid::new_v4()`.

## Verification
- `cargo test -p exo-consent --lib`
- `cargo test -p exo-consent`
- `cargo test -p exochain-wasm`
- `wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm`
- `node packages/exochain-wasm/test/bridge_verification.mjs`
- `cargo clippy -p exo-consent -p exochain-wasm --lib --bins -- -D warnings`
- `cargo clippy -p exo-consent -p exochain-wasm --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo machete`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `cargo doc --workspace --no-deps`
- `cargo audit` (passed with the existing allowed yanked-core2 advisory warning)
- `cargo deny check` (passed with existing duplicate/yanked/unused-allowance warnings)
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`

## Notes
This is the first deterministic-constructor cleanup item in the resumed remediation docket. Next intrinsic target after merge: scan and remediate remaining production wall-clock/entropy constructors, starting with `exo-dag` append-time handling if still present on main.