### PR TITLE
[codex] fix(exo-gatekeeper): require deterministic MCP audit metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 110161 | `wc -l` |
-| Workspace tests | 2,702 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 110304 | `wc -l` |
+| Workspace tests | 2,706 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,702 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,706 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 110161 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 110304 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,702 listed workspace tests
+         cryptographic proofs, 2,706 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          140 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-gatekeeper/src/error.rs
+++ b/crates/exo-gatekeeper/src/error.rs
@@ -37,6 +37,9 @@ pub enum GatekeeperError {
 
     #[error("MCP audit chain broken at index {index}")]
     McpAuditChainBroken { index: usize },
+
+    #[error("MCP audit record invalid: {reason}")]
+    McpAuditInvalidRecord { reason: String },
 }
 
 impl From<exo_core::ExoError> for GatekeeperError {
@@ -68,6 +71,12 @@ mod tests {
             (GatekeeperError::Timeout(500), "500"),
             (GatekeeperError::CheckpointError("ckpt".into()), "ckpt"),
             (GatekeeperError::Core("core".into()), "core"),
+            (
+                GatekeeperError::McpAuditInvalidRecord {
+                    reason: "missing deterministic metadata".into(),
+                },
+                "missing deterministic metadata",
+            ),
         ];
         for (err, fragment) in cases {
             assert!(err.to_string().contains(fragment), "{err}");

--- a/crates/exo-gatekeeper/src/mcp_audit.rs
+++ b/crates/exo-gatekeeper/src/mcp_audit.rs
@@ -144,23 +144,35 @@ pub fn verify_chain(log: &McpAuditLog) -> Result<(), GatekeeperError> {
 }
 
 /// Build a new record linked to the current log head.
-#[must_use]
 pub fn create_record(
     log: &McpAuditLog,
+    id: Uuid,
+    timestamp: Timestamp,
     rule: McpRule,
     actor: Did,
     outcome: McpEnforcementOutcome,
     data_residency_region: Option<String>,
-) -> McpAuditRecord {
-    McpAuditRecord {
-        id: Uuid::new_v4(),
-        timestamp: Timestamp::now_utc(),
+) -> Result<McpAuditRecord, GatekeeperError> {
+    if id.is_nil() {
+        return Err(GatekeeperError::McpAuditInvalidRecord {
+            reason: "record id must be caller-supplied and non-nil".into(),
+        });
+    }
+    if timestamp == Timestamp::ZERO {
+        return Err(GatekeeperError::McpAuditInvalidRecord {
+            reason: "timestamp must be caller-supplied and non-zero".into(),
+        });
+    }
+
+    Ok(McpAuditRecord {
+        id,
+        timestamp,
         rule,
         actor,
         outcome,
         data_residency_region,
         chain_hash: log.head_hash(),
-    }
+    })
 }
 
 // ===========================================================================
@@ -178,8 +190,51 @@ mod tests {
         Did::new(&format!("did:exo:{s}")).expect("valid DID")
     }
 
+    fn record_id(n: u128) -> Uuid {
+        Uuid::from_u128(n)
+    }
+
+    fn ts(ms: u64) -> Timestamp {
+        Timestamp::new(ms, 0)
+    }
+
+    fn create_record_source() -> &'static str {
+        let source = include_str!("mcp_audit.rs");
+        let start = source
+            .find("pub fn create_record(")
+            .expect("create_record source must exist");
+        let end = source[start..]
+            .find("// ===========================================================================")
+            .expect("tests section marker must exist");
+        &source[start..start + end]
+    }
+
+    #[test]
+    fn create_record_has_no_internal_entropy_or_wall_clock() {
+        let source = create_record_source();
+        assert!(
+            !source.contains("Uuid::new_v4"),
+            "MCP audit records must not fabricate nondeterministic UUIDs internally"
+        );
+        assert!(
+            !source.contains("Timestamp::now_utc"),
+            "MCP audit records must not read wall-clock time internally"
+        );
+    }
+
     fn append_ok(log: &mut McpAuditLog, rule: McpRule, outcome: McpEnforcementOutcome) {
-        let r = create_record(log, rule, did("agent"), outcome, None);
+        let offset = u128::try_from(log.len()).expect("log length fits u128");
+        let timestamp_offset = u64::try_from(log.len()).expect("log length fits u64");
+        let r = create_record(
+            log,
+            record_id(0xA000 + offset),
+            ts(10_000 + timestamp_offset),
+            rule,
+            did("agent"),
+            outcome,
+            None,
+        )
+        .expect("deterministic MCP audit record");
         append(log, r).expect("append failed");
     }
 
@@ -230,8 +285,8 @@ mod tests {
             McpEnforcementOutcome::Allowed,
         );
         let bad = McpAuditRecord {
-            id: Uuid::new_v4(),
-            timestamp: Timestamp::new(9000, 0),
+            id: record_id(0xB001),
+            timestamp: ts(9000),
             rule: McpRule::Mcp002NoSelfEscalation,
             actor: did("agent"),
             outcome: McpEnforcementOutcome::Blocked,
@@ -273,14 +328,69 @@ mod tests {
         let mut log = McpAuditLog::new();
         let r = create_record(
             &log,
+            record_id(0xC001),
+            ts(20_000),
             McpRule::Mcp001BctsScope,
             did("agent"),
             McpEnforcementOutcome::Allowed,
             Some("EU-WEST-1".into()),
-        );
+        )
+        .expect("deterministic MCP audit record");
         assert_eq!(r.data_residency_region, Some("EU-WEST-1".into()));
         append(&mut log, r).expect("append ok");
         assert!(verify_chain(&log).is_ok());
+    }
+
+    #[test]
+    fn create_record_preserves_caller_supplied_metadata() {
+        let log = McpAuditLog::new();
+        let id = record_id(0xC002);
+        let timestamp = ts(21_000);
+        let record = create_record(
+            &log,
+            id,
+            timestamp,
+            McpRule::Mcp001BctsScope,
+            did("agent"),
+            McpEnforcementOutcome::Allowed,
+            None,
+        )
+        .expect("deterministic MCP audit record");
+
+        assert_eq!(record.id, id);
+        assert_eq!(record.timestamp, timestamp);
+    }
+
+    #[test]
+    fn create_record_rejects_nil_id() {
+        let err = create_record(
+            &McpAuditLog::new(),
+            Uuid::nil(),
+            ts(21_001),
+            McpRule::Mcp001BctsScope,
+            did("agent"),
+            McpEnforcementOutcome::Allowed,
+            None,
+        )
+        .expect_err("nil record IDs must be rejected");
+
+        assert!(matches!(err, GatekeeperError::McpAuditInvalidRecord { .. }));
+    }
+
+    #[test]
+    fn create_record_rejects_zero_timestamp() {
+        let err = create_record(
+            &McpAuditLog::new(),
+            record_id(0xC003),
+            Timestamp::ZERO,
+            McpRule::Mcp001BctsScope,
+            did("agent"),
+            McpEnforcementOutcome::Allowed,
+            None,
+        )
+        .expect_err("zero timestamps must be rejected");
+
+        assert!(matches!(err, GatekeeperError::McpAuditInvalidRecord { .. }));
     }
 
     #[test]

--- a/crates/exo-legal/src/ai_transparency.rs
+++ b/crates/exo-legal/src/ai_transparency.rs
@@ -212,6 +212,7 @@ mod tests {
         McpRule,
         mcp_audit::{McpAuditLog, McpEnforcementOutcome, append, create_record},
     };
+    use uuid::Uuid;
 
     use super::*;
 
@@ -223,24 +224,34 @@ mod tests {
         Timestamp::new(ms, 0)
     }
 
+    fn audit_id(n: u128) -> Uuid {
+        Uuid::from_u128(n)
+    }
+
     fn make_log_with_records() -> McpAuditLog {
         let mut log = McpAuditLog::new();
         let r1 = create_record(
             &log,
+            audit_id(0xE001),
+            ts(10_000),
             McpRule::Mcp001BctsScope,
             did("agent"),
             McpEnforcementOutcome::Allowed,
             None,
-        );
-        append(&mut log, r1).ok();
+        )
+        .expect("deterministic MCP audit record");
+        append(&mut log, r1).expect("append deterministic MCP audit record");
         let r2 = create_record(
             &log,
+            audit_id(0xE002),
+            ts(10_001),
             McpRule::Mcp002NoSelfEscalation,
             did("agent"),
             McpEnforcementOutcome::Blocked,
             None,
-        );
-        append(&mut log, r2).ok();
+        )
+        .expect("deterministic MCP audit record");
+        append(&mut log, r2).expect("append deterministic MCP audit record");
         log
     }
 
@@ -341,15 +352,18 @@ mod tests {
     #[test]
     fn period_filtering_applies() {
         let mut log = McpAuditLog::new();
-        // MCP audit records use caller-supplied HLC timestamps that are beyond ts(500).
+        // MCP audit records use caller-supplied HLC timestamps beyond this report window.
         let r = create_record(
             &log,
+            audit_id(0xE003),
+            ts(500),
             McpRule::Mcp001BctsScope,
             did("agent"),
             McpEnforcementOutcome::Allowed,
             None,
-        );
-        append(&mut log, r).ok();
+        )
+        .expect("deterministic MCP audit record");
+        append(&mut log, r).expect("append deterministic MCP audit record");
 
         // Period that excludes the record (past epoch)
         let report = generate_report(ReportParams {

--- a/crates/exo-legal/src/nist_compliance_tests.rs
+++ b/crates/exo-legal/src/nist_compliance_tests.rs
@@ -18,6 +18,7 @@ mod nist_compliance {
         },
     };
     use exo_governance::audit::{self as gov_audit, AuditLog};
+    use uuid::Uuid;
 
     use crate::{
         ai_transparency::{ReportParams, ai_delegation_event_from_link, generate_report},
@@ -37,6 +38,10 @@ mod nist_compliance {
 
     fn ts(ms: u64) -> Timestamp {
         Timestamp::new(ms, 0)
+    }
+
+    fn audit_id(n: u128) -> Uuid {
+        Uuid::from_u128(n)
     }
 
     /// Build a passing InvariantContext matching the pattern in invariants.rs tests.
@@ -206,14 +211,19 @@ mod nist_compliance {
         //    satisfies MS.2 "AI risk measurement via documentation".
         let actor = did("ai-agent-1");
         let mut mcp_log = McpAuditLog::new();
-        for rule in McpRule::all() {
+        for (index, rule) in McpRule::all().into_iter().enumerate() {
+            let offset = u128::try_from(index).expect("rule index fits u128");
+            let timestamp_offset = u64::try_from(index).expect("rule index fits u64");
             let r = create_record(
                 &mcp_log,
+                audit_id(0xD000 + offset),
+                ts(30_000 + timestamp_offset),
                 rule,
                 actor.clone(),
                 McpEnforcementOutcome::Allowed,
                 Some("EU-WEST-1".into()),
-            );
+            )
+            .expect("deterministic MCP audit record");
             append(&mut mcp_log, r).expect("MCP audit append");
         }
         verify_chain(&mcp_log).expect("MCP audit chain must be intact after 6 records");

--- a/docs/guides/cgr-developer-guide.md
+++ b/docs/guides/cgr-developer-guide.md
@@ -530,16 +530,20 @@ All MCP enforcement outcomes must be recorded in a hash-chained audit log:
 ```rust
 use exo_gatekeeper::{McpAuditLog, McpEnforcementOutcome};
 use exo_gatekeeper::mcp_audit::{create_record, append};
+use exo_core::Timestamp;
+use uuid::Uuid;
 
 let mut log = McpAuditLog::new();
 
 let record = create_record(
     &log,
+    Uuid::from_u128(0xA11D17),
+    Timestamp::new(1_800_000_000_000, 0),
     McpRule::Mcp001BctsScope,
     actor_did.clone(),
     McpEnforcementOutcome::Allowed,
     Some("EU".into()), // data residency region (GDPR Chapter V)
-);
+)?;
 append(&mut log, record)?;
 
 // Verify chain integrity at any point


### PR DESCRIPTION
## Summary
- require caller-supplied UUID and HLC timestamp metadata when creating MCP audit records
- reject nil audit record IDs and zero timestamps before records enter the hash chain
- update downstream legal transparency tests, NIST compliance tests, developer guide sample, and repo-truth counts

## Root cause
`mcp_audit::create_record` previously fabricated `Uuid::new_v4()` and read `Timestamp::now_utc()` internally, which made audit-record construction nondeterministic and hid provenance metadata from the caller.

## TDD
- added `create_record_has_no_internal_entropy_or_wall_clock` first and confirmed it failed against the existing `Uuid::new_v4()` implementation
- added regression coverage for preserving caller metadata and rejecting nil/zero metadata

## Validation
- `cargo test -p exo-gatekeeper create_record --lib`
- `cargo test -p exo-gatekeeper mcp_audit --lib`
- `cargo test -p exo-legal test_transparency_accountability_nist_compliance --lib`
- `cargo test -p exo-legal ai_transparency::tests --lib`
- `cargo test -p exo-gatekeeper`
- `cargo test -p exo-legal`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `cargo clippy -p exo-gatekeeper -p exo-legal --lib --bins -- -D warnings`
- `cargo clippy -p exo-gatekeeper -p exo-legal --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check`
- `cargo machete`
- `cargo build --workspace --release`
- `cargo test --workspace --release`