### PR TITLE
fix(exo-governance): require deterministic constructor metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,7 +1361,6 @@ dependencies = [
  "ciborium",
  "exo-core",
  "serde",
- "serde_json",
  "thiserror 2.0.17",
 ]
 
@@ -1412,7 +1411,6 @@ dependencies = [
  "exo-gatekeeper",
  "exo-governance",
  "exo-identity",
- "proptest",
  "serde",
  "thiserror 2.0.17",
  "uuid",
@@ -1473,7 +1471,6 @@ dependencies = [
  "exo-consent",
  "exo-core",
  "exo-identity",
- "proptest",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -1511,7 +1508,6 @@ dependencies = [
  "exo-gatekeeper",
  "exo-governance",
  "exo-identity",
- "proptest",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -1586,7 +1582,6 @@ version = "0.1.0-beta"
 dependencies = [
  "blake3",
  "exo-core",
- "proptest",
  "serde",
  "serde_json",
  "sha2",

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 110304 | `wc -l` |
-| Workspace tests | 2,706 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 110618 | `wc -l` |
+| Workspace tests | 2,718 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,706 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,718 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 110304 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 110618 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,706 listed workspace tests
+         cryptographic proofs, 2,718 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          140 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-consent/Cargo.toml
+++ b/crates/exo-consent/Cargo.toml
@@ -18,8 +18,5 @@ blake3 = { workspace = true }
 thiserror = { workspace = true }
 ciborium = { workspace = true }
 
-[dev-dependencies]
-serde_json = { workspace = true }
-
 [package.metadata.cargo-machete]
 ignored = ["blake3"]

--- a/crates/exo-escalation/Cargo.toml
+++ b/crates/exo-escalation/Cargo.toml
@@ -22,7 +22,6 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 exo-gatekeeper = { path = "../exo-gatekeeper" }
-proptest = { workspace = true }
 
 [package.metadata.cargo-machete]
 # Pre-existing workspace dep used via re-exports.

--- a/crates/exo-governance/Cargo.toml
+++ b/crates/exo-governance/Cargo.toml
@@ -23,10 +23,6 @@ thiserror = { workspace = true }
 uuid = { workspace = true }
 serde_json = { workspace = true }
 
-[dev-dependencies]
-proptest = { workspace = true }
-serde_json = { workspace = true }
-
 [package.metadata.cargo-machete]
 # Pre-existing workspace deps used via re-exports or trait bounds.
 ignored = ["exo-authority", "exo-consent", "exo-identity"]

--- a/crates/exo-governance/src/audit.rs
+++ b/crates/exo-governance/src/audit.rs
@@ -95,23 +95,37 @@ pub fn verify_chain(log: &AuditLog) -> Result<(), GovernanceError> {
 }
 
 /// Create a new audit entry chained to the current log head, ready for appending.
-#[must_use]
 pub fn create_entry(
     log: &AuditLog,
+    id: Uuid,
+    timestamp: Timestamp,
     actor: Did,
     action: String,
     result: String,
     evidence_hash: [u8; 32],
-) -> AuditEntry {
-    AuditEntry {
-        id: Uuid::new_v4(),
-        timestamp: Timestamp::now_utc(),
+) -> Result<AuditEntry, GovernanceError> {
+    if id.is_nil() {
+        return Err(GovernanceError::InvalidGovernanceMetadata {
+            field: "audit_entry.id".into(),
+            reason: "must be caller-supplied and non-nil".into(),
+        });
+    }
+    if timestamp == Timestamp::ZERO {
+        return Err(GovernanceError::InvalidGovernanceMetadata {
+            field: "audit_entry.timestamp".into(),
+            reason: "must be caller-supplied and non-zero".into(),
+        });
+    }
+
+    Ok(AuditEntry {
+        id,
+        timestamp,
         actor,
         action,
         result,
         evidence_hash,
         chain_hash: log.head_hash(),
-    }
+    })
 }
 
 #[cfg(test)]
@@ -121,8 +135,51 @@ mod tests {
         Did::new(&format!("did:exo:{n}")).expect("ok")
     }
 
+    fn entry_id(n: u128) -> Uuid {
+        Uuid::from_u128(n)
+    }
+
+    fn ts(ms: u64) -> Timestamp {
+        Timestamp::new(ms, 0)
+    }
+
+    fn create_entry_source() -> &'static str {
+        let source = include_str!("audit.rs");
+        let start = source
+            .find("pub fn create_entry(")
+            .expect("create_entry source must exist");
+        let end = source[start..]
+            .find("#[cfg(test)]")
+            .expect("tests marker must exist");
+        &source[start..start + end]
+    }
+
+    #[test]
+    fn create_entry_has_no_internal_entropy_or_wall_clock() {
+        let source = create_entry_source();
+        assert!(
+            !source.contains("Uuid::new_v4"),
+            "governance audit entries must not fabricate UUIDs internally"
+        );
+        assert!(
+            !source.contains("Timestamp::now_utc"),
+            "governance audit entries must not read wall-clock time internally"
+        );
+    }
+
     fn make_and_append(log: &mut AuditLog, act: &str) {
-        let e = create_entry(log, did("auditor"), act.into(), "ok".into(), [0u8; 32]);
+        let offset = u128::try_from(log.len()).expect("log length fits u128");
+        let timestamp_offset = u64::try_from(log.len()).expect("log length fits u64");
+        let e = create_entry(
+            log,
+            entry_id(0xA000 + offset),
+            ts(10_000 + timestamp_offset),
+            did("auditor"),
+            act.into(),
+            "ok".into(),
+            [0u8; 32],
+        )
+        .expect("deterministic audit entry");
         append(log, e).expect("append failed");
     }
 
@@ -163,8 +220,8 @@ mod tests {
         let mut log = AuditLog::new();
         make_and_append(&mut log, "a1");
         let bad = AuditEntry {
-            id: Uuid::new_v4(),
-            timestamp: Timestamp::new(2000, 0),
+            id: entry_id(0xB001),
+            timestamp: ts(2000),
             actor: did("x"),
             action: "bad".into(),
             result: "bad".into(),
@@ -193,5 +250,63 @@ mod tests {
             chain_hash: [0u8; 32],
         };
         assert_eq!(hash_entry(&e), hash_entry(&e));
+    }
+
+    #[test]
+    fn create_entry_preserves_caller_supplied_metadata() {
+        let log = AuditLog::new();
+        let id = entry_id(0xC001);
+        let timestamp = ts(20_000);
+        let entry = create_entry(
+            &log,
+            id,
+            timestamp,
+            did("auditor"),
+            "act".into(),
+            "ok".into(),
+            [0u8; 32],
+        )
+        .expect("deterministic audit entry");
+
+        assert_eq!(entry.id, id);
+        assert_eq!(entry.timestamp, timestamp);
+    }
+
+    #[test]
+    fn create_entry_rejects_nil_id() {
+        let err = create_entry(
+            &AuditLog::new(),
+            Uuid::nil(),
+            ts(20_001),
+            did("auditor"),
+            "act".into(),
+            "ok".into(),
+            [0u8; 32],
+        )
+        .expect_err("nil audit entry id must be rejected");
+
+        assert!(matches!(
+            err,
+            GovernanceError::InvalidGovernanceMetadata { .. }
+        ));
+    }
+
+    #[test]
+    fn create_entry_rejects_zero_timestamp() {
+        let err = create_entry(
+            &AuditLog::new(),
+            entry_id(0xC002),
+            Timestamp::ZERO,
+            did("auditor"),
+            "act".into(),
+            "ok".into(),
+            [0u8; 32],
+        )
+        .expect_err("zero audit entry timestamp must be rejected");
+
+        assert!(matches!(
+            err,
+            GovernanceError::InvalidGovernanceMetadata { .. }
+        ));
     }
 }

--- a/crates/exo-governance/src/challenge.rs
+++ b/crates/exo-governance/src/challenge.rs
@@ -56,33 +56,56 @@ pub struct PauseOrder {
 }
 
 /// File a new governance challenge against a target action with the given ground and evidence.
-#[must_use]
 pub fn file_challenge(
+    id: Uuid,
+    created: Timestamp,
     challenger: &Did,
     target: &[u8; 32],
     ground: ChallengeGround,
     evidence: &[u8],
-) -> Challenge {
-    Challenge {
-        id: Uuid::new_v4(),
+) -> Result<Challenge, GovernanceError> {
+    if id.is_nil() {
+        return Err(GovernanceError::InvalidGovernanceMetadata {
+            field: "challenge.id".into(),
+            reason: "must be caller-supplied and non-nil".into(),
+        });
+    }
+    if created == Timestamp::ZERO {
+        return Err(GovernanceError::InvalidGovernanceMetadata {
+            field: "challenge.created".into(),
+            reason: "must be caller-supplied and non-zero".into(),
+        });
+    }
+
+    Ok(Challenge {
+        id,
         challenger_did: challenger.clone(),
         target_action_id: *target,
         ground,
         evidence: evidence.to_vec(),
         status: ChallengeStatus::Filed,
-        created: Timestamp::now_utc(),
-    }
+        created,
+    })
 }
 
 /// Issue a pause order that halts the challenged action pending adjudication.
-#[must_use]
-pub fn pause_action(challenge: &Challenge) -> PauseOrder {
-    PauseOrder {
+pub fn pause_action(
+    challenge: &Challenge,
+    issued: Timestamp,
+) -> Result<PauseOrder, GovernanceError> {
+    if issued == Timestamp::ZERO {
+        return Err(GovernanceError::InvalidGovernanceMetadata {
+            field: "pause_order.issued".into(),
+            reason: "must be caller-supplied and non-zero".into(),
+        });
+    }
+
+    Ok(PauseOrder {
         challenge_id: challenge.id,
         target_action_id: challenge.target_action_id,
         reason: format!("challenged on ground: {:?}", challenge.ground),
-        issued: Timestamp::now_utc(),
-    }
+        issued,
+    })
 }
 
 /// Resolve a challenge by applying the given verdict, transitioning it to a terminal state.
@@ -129,125 +152,177 @@ mod tests {
         Did::new("did:exo:challenger").expect("ok")
     }
 
+    fn challenge_id(n: u128) -> Uuid {
+        Uuid::from_u128(n)
+    }
+
+    fn ts(ms: u64) -> Timestamp {
+        Timestamp::new(ms, 0)
+    }
+
+    fn challenge_constructor_source() -> &'static str {
+        let source = include_str!("challenge.rs");
+        let start = source
+            .find("pub fn file_challenge(")
+            .expect("file_challenge source must exist");
+        let end = source[start..]
+            .find("#[cfg(test)]")
+            .expect("tests marker must exist");
+        &source[start..start + end]
+    }
+
+    #[test]
+    fn challenge_constructors_have_no_internal_entropy_or_wall_clock() {
+        let source = challenge_constructor_source();
+        assert!(
+            !source.contains("Uuid::new_v4"),
+            "governance challenges must not fabricate UUIDs internally"
+        );
+        assert!(
+            !source.contains("Timestamp::now_utc"),
+            "governance challenges and pause orders must not read wall-clock time internally"
+        );
+    }
+
+    fn make_challenge(ground: ChallengeGround, evidence: &[u8]) -> Challenge {
+        make_challenge_with_id(0xC001, ground, evidence)
+    }
+
+    fn make_challenge_with_id(id: u128, ground: ChallengeGround, evidence: &[u8]) -> Challenge {
+        file_challenge(
+            challenge_id(id),
+            ts(10_000),
+            &challenger(),
+            &target(),
+            ground,
+            evidence,
+        )
+        .expect("deterministic challenge")
+    }
+
     #[test]
     fn file_creates_filed() {
+        let id = challenge_id(0xC010);
+        let created = ts(10_010);
         let c = file_challenge(
+            id,
+            created,
             &challenger(),
             &target(),
             ChallengeGround::QuorumViolation,
             b"ev",
-        );
+        )
+        .expect("deterministic challenge");
+        assert_eq!(c.id, id);
+        assert_eq!(c.created, created);
         assert_eq!(c.status, ChallengeStatus::Filed);
         assert_eq!(c.ground, ChallengeGround::QuorumViolation);
     }
     #[test]
     fn pause_order() {
-        let c = file_challenge(
-            &challenger(),
-            &target(),
-            ChallengeGround::SybilAllegation,
-            b"",
-        );
-        let o = pause_action(&c);
+        let c = make_challenge(ChallengeGround::SybilAllegation, b"");
+        let issued = ts(10_011);
+        let o = pause_action(&c, issued).expect("deterministic pause order");
         assert_eq!(o.challenge_id, c.id);
+        assert_eq!(o.issued, issued);
         assert!(o.reason.contains("SybilAllegation"));
     }
     #[test]
-    fn adjudicate_sustain() {
-        let mut c = file_challenge(
+    fn file_rejects_nil_id() {
+        let err = file_challenge(
+            Uuid::nil(),
+            ts(10_012),
             &challenger(),
             &target(),
-            ChallengeGround::ProceduralError,
-            b"",
-        );
+            ChallengeGround::QuorumViolation,
+            b"ev",
+        )
+        .expect_err("nil challenge id must be rejected");
+
+        assert!(matches!(
+            err,
+            GovernanceError::InvalidGovernanceMetadata { .. }
+        ));
+    }
+    #[test]
+    fn file_rejects_zero_created_timestamp() {
+        let err = file_challenge(
+            challenge_id(0xC012),
+            Timestamp::ZERO,
+            &challenger(),
+            &target(),
+            ChallengeGround::QuorumViolation,
+            b"ev",
+        )
+        .expect_err("zero challenge created timestamp must be rejected");
+
+        assert!(matches!(
+            err,
+            GovernanceError::InvalidGovernanceMetadata { .. }
+        ));
+    }
+    #[test]
+    fn pause_rejects_zero_issued_timestamp() {
+        let c = make_challenge(ChallengeGround::SybilAllegation, b"");
+        let err = pause_action(&c, Timestamp::ZERO)
+            .expect_err("zero pause-order issued timestamp must be rejected");
+
+        assert!(matches!(
+            err,
+            GovernanceError::InvalidGovernanceMetadata { .. }
+        ));
+    }
+    #[test]
+    fn adjudicate_sustain() {
+        let mut c = make_challenge(ChallengeGround::ProceduralError, b"");
         assert!(adjudicate(&mut c, ChallengeVerdict::Sustain).is_ok());
         assert_eq!(c.status, ChallengeStatus::Sustained);
     }
     #[test]
     fn adjudicate_overrule() {
-        let mut c = file_challenge(
-            &challenger(),
-            &target(),
-            ChallengeGround::ConsentViolation,
-            b"",
-        );
+        let mut c = make_challenge(ChallengeGround::ConsentViolation, b"");
         assert!(adjudicate(&mut c, ChallengeVerdict::Overrule).is_ok());
         assert_eq!(c.status, ChallengeStatus::Overruled);
     }
     #[test]
     fn adjudicate_from_under_review() {
-        let mut c = file_challenge(
-            &challenger(),
-            &target(),
-            ChallengeGround::UndisclosedConflict,
-            b"",
-        );
+        let mut c = make_challenge(ChallengeGround::UndisclosedConflict, b"");
         c.status = ChallengeStatus::UnderReview;
         assert!(adjudicate(&mut c, ChallengeVerdict::Sustain).is_ok());
     }
     #[test]
     fn adjudicate_from_sustained_fails() {
-        let mut c = file_challenge(
-            &challenger(),
-            &target(),
-            ChallengeGround::AuthorityChainInvalid,
-            b"",
-        );
+        let mut c = make_challenge(ChallengeGround::AuthorityChainInvalid, b"");
         c.status = ChallengeStatus::Sustained;
         assert!(adjudicate(&mut c, ChallengeVerdict::Overrule).is_err());
     }
     #[test]
     fn adjudicate_from_overruled_fails() {
-        let mut c = file_challenge(
-            &challenger(),
-            &target(),
-            ChallengeGround::AuthorityChainInvalid,
-            b"",
-        );
+        let mut c = make_challenge(ChallengeGround::AuthorityChainInvalid, b"");
         c.status = ChallengeStatus::Overruled;
         assert!(adjudicate(&mut c, ChallengeVerdict::Sustain).is_err());
     }
     #[test]
     fn adjudicate_from_withdrawn_fails() {
-        let mut c = file_challenge(
-            &challenger(),
-            &target(),
-            ChallengeGround::AuthorityChainInvalid,
-            b"",
-        );
+        let mut c = make_challenge(ChallengeGround::AuthorityChainInvalid, b"");
         c.status = ChallengeStatus::Withdrawn;
         assert!(adjudicate(&mut c, ChallengeVerdict::Sustain).is_err());
     }
     #[test]
     fn withdraw_from_filed() {
-        let mut c = file_challenge(
-            &challenger(),
-            &target(),
-            ChallengeGround::QuorumViolation,
-            b"",
-        );
+        let mut c = make_challenge(ChallengeGround::QuorumViolation, b"");
         assert!(withdraw(&mut c).is_ok());
         assert_eq!(c.status, ChallengeStatus::Withdrawn);
     }
     #[test]
     fn withdraw_from_under_review() {
-        let mut c = file_challenge(
-            &challenger(),
-            &target(),
-            ChallengeGround::QuorumViolation,
-            b"",
-        );
+        let mut c = make_challenge(ChallengeGround::QuorumViolation, b"");
         c.status = ChallengeStatus::UnderReview;
         assert!(withdraw(&mut c).is_ok());
     }
     #[test]
     fn withdraw_from_sustained_fails() {
-        let mut c = file_challenge(
-            &challenger(),
-            &target(),
-            ChallengeGround::QuorumViolation,
-            b"",
-        );
+        let mut c = make_challenge(ChallengeGround::QuorumViolation, b"");
         c.status = ChallengeStatus::Sustained;
         assert!(withdraw(&mut c).is_err());
     }
@@ -261,10 +336,7 @@ mod tests {
             ChallengeGround::SybilAllegation,
             ChallengeGround::ConsentViolation,
         ] {
-            assert_eq!(
-                file_challenge(&challenger(), &target(), g, b"").status,
-                ChallengeStatus::Filed
-            );
+            assert_eq!(make_challenge(g, b"").status, ChallengeStatus::Filed);
         }
     }
 
@@ -274,12 +346,7 @@ mod tests {
     /// confirm the challenge is terminal (no further transitions allowed).
     #[test]
     fn under_review_to_overruled() {
-        let mut c = file_challenge(
-            &challenger(),
-            &target(),
-            ChallengeGround::QuorumViolation,
-            b"",
-        );
+        let mut c = make_challenge(ChallengeGround::QuorumViolation, b"");
         c.status = ChallengeStatus::UnderReview;
         assert!(adjudicate(&mut c, ChallengeVerdict::Overrule).is_ok());
         assert_eq!(c.status, ChallengeStatus::Overruled);
@@ -292,15 +359,10 @@ mod tests {
     /// verify all further transitions are correctly rejected.
     #[test]
     fn full_lifecycle_filed_under_review_sustained() {
-        let mut c = file_challenge(
-            &challenger(),
-            &target(),
-            ChallengeGround::SybilAllegation,
-            b"strong evidence",
-        );
+        let mut c = make_challenge(ChallengeGround::SybilAllegation, b"strong evidence");
         // Stage 1: Filed
         assert_eq!(c.status, ChallengeStatus::Filed);
-        let _ = pause_action(&c); // pause order issued on filing
+        let _ = pause_action(&c, ts(10_013)).expect("deterministic pause order");
 
         // Stage 2: Under review
         c.status = ChallengeStatus::UnderReview;
@@ -328,7 +390,7 @@ mod tests {
             ChallengeGround::SybilAllegation,
             ChallengeGround::ConsentViolation,
         ] {
-            let mut c = file_challenge(&challenger(), &target(), g, b"evidence");
+            let mut c = make_challenge(g, b"evidence");
             assert_eq!(c.status, ChallengeStatus::Filed);
 
             c.status = ChallengeStatus::UnderReview;

--- a/crates/exo-governance/src/deliberation.rs
+++ b/crates/exo-governance/src/deliberation.rs
@@ -64,16 +64,33 @@ pub enum DeliberationResult {
 }
 
 /// Open a new deliberation for the given proposal bytes and participant list.
-#[must_use]
-pub fn open_deliberation(proposal: &[u8], participants: &[Did]) -> Deliberation {
-    Deliberation {
-        id: Uuid::new_v4(),
+pub fn open_deliberation(
+    id: Uuid,
+    created: Timestamp,
+    proposal: &[u8],
+    participants: &[Did],
+) -> Result<Deliberation, GovernanceError> {
+    if id.is_nil() {
+        return Err(GovernanceError::InvalidGovernanceMetadata {
+            field: "deliberation.id".into(),
+            reason: "must be caller-supplied and non-nil".into(),
+        });
+    }
+    if created == Timestamp::ZERO {
+        return Err(GovernanceError::InvalidGovernanceMetadata {
+            field: "deliberation.created".into(),
+            reason: "must be caller-supplied and non-zero".into(),
+        });
+    }
+
+    Ok(Deliberation {
+        id,
         proposal_hash: *blake3::hash(proposal).as_bytes(),
         participants: participants.to_vec(),
         votes: Vec::new(),
         status: DeliberationStatus::Open,
-        created: Timestamp::now_utc(),
-    }
+        created,
+    })
 }
 
 /// Record a vote in an open deliberation, rejecting duplicates and closed sessions.
@@ -162,6 +179,24 @@ mod tests {
     fn did(name: &str) -> Did {
         Did::new(&format!("did:exo:{name}")).expect("ok")
     }
+
+    fn delib_id(n: u128) -> Uuid {
+        Uuid::from_u128(n)
+    }
+
+    fn ts(ms: u64) -> Timestamp {
+        Timestamp::new(ms, 0)
+    }
+
+    fn open(proposal: &[u8], participants: &[Did]) -> Deliberation {
+        open_with_id(0xD001, proposal, participants)
+    }
+
+    fn open_with_id(id: u128, proposal: &[u8], participants: &[Did]) -> Deliberation {
+        open_deliberation(delib_id(id), ts(10_000), proposal, participants)
+            .expect("deterministic deliberation")
+    }
+
     fn vote(name: &str, pos: Position) -> Vote {
         Vote {
             voter_did: did(name),
@@ -179,22 +214,76 @@ mod tests {
         }
     }
 
+    fn open_deliberation_source() -> &'static str {
+        let source = include_str!("deliberation.rs");
+        let start = source
+            .find("pub fn open_deliberation(")
+            .expect("open_deliberation source must exist");
+        let end = source[start..]
+            .find("/// Record a vote")
+            .expect("cast vote marker must exist");
+        &source[start..start + end]
+    }
+
+    #[test]
+    fn open_deliberation_has_no_internal_entropy_or_wall_clock() {
+        let source = open_deliberation_source();
+        assert!(
+            !source.contains("Uuid::new_v4"),
+            "governance deliberations must not fabricate UUIDs internally"
+        );
+        assert!(
+            !source.contains("Timestamp::now_utc"),
+            "governance deliberations must not read wall-clock time internally"
+        );
+    }
+
     #[test]
     fn open_creates_open_status() {
-        let d = open_deliberation(b"proposal", &[did("alice"), did("bob")]);
+        let id = delib_id(0xD010);
+        let created = ts(10_010);
+        let d = open_deliberation(id, created, b"proposal", &[did("alice"), did("bob")])
+            .expect("deterministic deliberation");
+        assert_eq!(d.id, id);
+        assert_eq!(d.created, created);
         assert_eq!(d.status, DeliberationStatus::Open);
         assert_eq!(d.participants.len(), 2);
         assert!(d.votes.is_empty());
     }
     #[test]
+    fn open_rejects_nil_id() {
+        let err = open_deliberation(Uuid::nil(), ts(10_011), b"proposal", &[did("alice")])
+            .expect_err("nil deliberation id must be rejected");
+
+        assert!(matches!(
+            err,
+            GovernanceError::InvalidGovernanceMetadata { .. }
+        ));
+    }
+    #[test]
+    fn open_rejects_zero_created_timestamp() {
+        let err = open_deliberation(
+            delib_id(0xD011),
+            Timestamp::ZERO,
+            b"proposal",
+            &[did("alice")],
+        )
+        .expect_err("zero deliberation timestamp must be rejected");
+
+        assert!(matches!(
+            err,
+            GovernanceError::InvalidGovernanceMetadata { .. }
+        ));
+    }
+    #[test]
     fn cast_vote_succeeds() {
-        let mut d = open_deliberation(b"p", &[did("alice")]);
+        let mut d = open(b"p", &[did("alice")]);
         assert!(cast_vote(&mut d, vote("alice", Position::For)).is_ok());
         assert_eq!(d.votes.len(), 1);
     }
     #[test]
     fn duplicate_vote_rejected() {
-        let mut d = open_deliberation(b"p", &[did("alice")]);
+        let mut d = open(b"p", &[did("alice")]);
         cast_vote(&mut d, vote("alice", Position::For)).unwrap();
         assert!(matches!(
             cast_vote(&mut d, vote("alice", Position::Against)).unwrap_err(),
@@ -203,7 +292,7 @@ mod tests {
     }
     #[test]
     fn vote_on_closed_rejected() {
-        let mut d = open_deliberation(b"p", &[did("alice")]);
+        let mut d = open(b"p", &[did("alice")]);
         d.status = DeliberationStatus::Closed;
         assert!(matches!(
             cast_vote(&mut d, vote("alice", Position::For)).unwrap_err(),
@@ -212,7 +301,7 @@ mod tests {
     }
     #[test]
     fn close_approved() {
-        let mut d = open_deliberation(b"p", &[did("a"), did("b"), did("c")]);
+        let mut d = open(b"p", &[did("a"), did("b"), did("c")]);
         cast_vote(&mut d, vote("a", Position::For)).unwrap();
         cast_vote(&mut d, vote("b", Position::For)).unwrap();
         cast_vote(&mut d, vote("c", Position::Against)).unwrap();
@@ -227,7 +316,7 @@ mod tests {
     }
     #[test]
     fn close_rejected() {
-        let mut d = open_deliberation(b"p", &[did("a"), did("b"), did("c")]);
+        let mut d = open(b"p", &[did("a"), did("b"), did("c")]);
         cast_vote(&mut d, vote("a", Position::For)).unwrap();
         cast_vote(&mut d, vote("b", Position::Against)).unwrap();
         cast_vote(&mut d, vote("c", Position::Against)).unwrap();
@@ -238,7 +327,7 @@ mod tests {
     }
     #[test]
     fn close_no_quorum() {
-        let mut d = open_deliberation(b"p", &[did("a")]);
+        let mut d = open(b"p", &[did("a")]);
         cast_vote(&mut d, vote("a", Position::For)).unwrap();
         assert!(matches!(
             close(&mut d, &policy(3)),
@@ -247,7 +336,7 @@ mod tests {
     }
     #[test]
     fn abstentions_counted() {
-        let mut d = open_deliberation(b"p", &[did("a"), did("b"), did("c")]);
+        let mut d = open(b"p", &[did("a"), did("b"), did("c")]);
         cast_vote(&mut d, vote("a", Position::For)).unwrap();
         cast_vote(&mut d, vote("b", Position::For)).unwrap();
         cast_vote(&mut d, vote("c", Position::Abstain)).unwrap();
@@ -262,18 +351,18 @@ mod tests {
     }
     #[test]
     fn cancelled_rejects_votes() {
-        let mut d = open_deliberation(b"p", &[did("a")]);
+        let mut d = open(b"p", &[did("a")]);
         d.status = DeliberationStatus::Cancelled;
         assert!(cast_vote(&mut d, vote("a", Position::For)).is_err());
     }
     #[test]
     fn proposal_hash_deterministic() {
-        let d1 = open_deliberation(b"same", &[]);
-        let d2 = open_deliberation(b"same", &[]);
+        let d1 = open_with_id(0xD101, b"same", &[]);
+        let d2 = open_with_id(0xD102, b"same", &[]);
         assert_eq!(d1.proposal_hash, d2.proposal_hash);
         assert_ne!(
             d1.proposal_hash,
-            open_deliberation(b"diff", &[]).proposal_hash
+            open_with_id(0xD103, b"diff", &[]).proposal_hash
         );
     }
 }

--- a/crates/exo-governance/src/errors.rs
+++ b/crates/exo-governance/src/errors.rs
@@ -112,4 +112,8 @@ pub enum GovernanceError {
     // --- Crypto errors ---
     #[error("Signature verification failed")]
     SignatureVerificationFailed,
+
+    // --- Deterministic metadata errors ---
+    #[error("Invalid governance metadata for {field}: {reason}")]
+    InvalidGovernanceMetadata { field: String, reason: String },
 }

--- a/crates/exo-governance/src/quorum.rs
+++ b/crates/exo-governance/src/quorum.rs
@@ -533,6 +533,30 @@ mod tests {
         did("challenger")
     }
 
+    fn challenge_id(n: u128) -> uuid::Uuid {
+        uuid::Uuid::from_u128(n)
+    }
+
+    fn challenge_ts(ms: u64) -> Timestamp {
+        Timestamp::new(ms, 0)
+    }
+
+    fn make_challenge(
+        id: u128,
+        ground: ChallengeGround,
+        evidence: &[u8],
+    ) -> crate::challenge::Challenge {
+        file_challenge(
+            challenge_id(id),
+            challenge_ts(20_000),
+            &challenger_did(),
+            &target(),
+            ground,
+            evidence,
+        )
+        .expect("deterministic challenge")
+    }
+
     #[test]
     fn open_challenge_blocks_quorum() {
         let approvals = vec![
@@ -540,9 +564,8 @@ mod tests {
             make_approval("bob", Role::Reviewer, true),
             make_approval("carol", Role::Contributor, true),
         ];
-        let ch = file_challenge(
-            &challenger_did(),
-            &target(),
+        let ch = make_challenge(
+            0x9001,
             ChallengeGround::SybilAllegation,
             b"coordinated approvers suspected",
         );
@@ -559,12 +582,7 @@ mod tests {
             make_approval("bob", Role::Reviewer, true),
             make_approval("carol", Role::Contributor, true),
         ];
-        let mut ch = file_challenge(
-            &challenger_did(),
-            &target(),
-            ChallengeGround::QuorumViolation,
-            b"",
-        );
+        let mut ch = make_challenge(0x9002, ChallengeGround::QuorumViolation, b"");
         ch.status = ChallengeStatus::UnderReview;
         assert!(matches!(
             compute_quorum_with_challenges(&approvals, &default_policy(), &[&ch]),
@@ -579,12 +597,7 @@ mod tests {
             make_approval("bob", Role::Reviewer, true),
             make_approval("carol", Role::Contributor, true),
         ];
-        let mut ch = file_challenge(
-            &challenger_did(),
-            &target(),
-            ChallengeGround::SybilAllegation,
-            b"",
-        );
+        let mut ch = make_challenge(0x9003, ChallengeGround::SybilAllegation, b"");
         ch.status = ChallengeStatus::Overruled;
         assert!(matches!(
             compute_quorum_with_challenges(&approvals, &default_policy(), &[&ch]),
@@ -612,12 +625,7 @@ mod tests {
             make_approval("bob", Role::Reviewer, true),
             make_approval("carol", Role::Contributor, true),
         ];
-        let mut ch = file_challenge(
-            &challenger_did(),
-            &target(),
-            ChallengeGround::SybilAllegation,
-            b"",
-        );
+        let mut ch = make_challenge(0x9004, ChallengeGround::SybilAllegation, b"");
         ch.status = ChallengeStatus::Withdrawn;
         assert!(matches!(
             compute_quorum_with_challenges(&approvals, &default_policy(), &[&ch]),
@@ -636,9 +644,8 @@ mod tests {
             make_approval("bob", Role::Reviewer, true),
             make_approval("carol", Role::Contributor, true),
         ];
-        let mut ch = file_challenge(
-            &challenger_did(),
-            &target(),
+        let mut ch = make_challenge(
+            0x9005,
             ChallengeGround::SybilAllegation,
             b"coordinated approvers suspected",
         );
@@ -674,12 +681,7 @@ mod tests {
             make_approval("bob", Role::Reviewer, true),
             make_approval("carol", Role::Contributor, true),
         ];
-        let mut ch = file_challenge(
-            &challenger_did(),
-            &target(),
-            ChallengeGround::QuorumViolation,
-            b"",
-        );
+        let mut ch = make_challenge(0x9006, ChallengeGround::QuorumViolation, b"");
         adjudicate(&mut ch, ChallengeVerdict::Sustain).expect("adjudicate ok");
         assert_eq!(ch.status, ChallengeStatus::Sustained);
         assert!(matches!(
@@ -697,18 +699,8 @@ mod tests {
             make_approval("bob", Role::Reviewer, true),
             make_approval("carol", Role::Contributor, true),
         ];
-        let ch1 = file_challenge(
-            &challenger_did(),
-            &target(),
-            ChallengeGround::SybilAllegation,
-            b"sybil evidence",
-        );
-        let ch2 = file_challenge(
-            &challenger_did(),
-            &target(),
-            ChallengeGround::QuorumViolation,
-            b"quorum evidence",
-        );
+        let ch1 = make_challenge(0x9007, ChallengeGround::SybilAllegation, b"sybil evidence");
+        let ch2 = make_challenge(0x9008, ChallengeGround::QuorumViolation, b"quorum evidence");
         assert!(matches!(
             compute_quorum_with_challenges(&approvals, &default_policy(), &[&ch1, &ch2]),
             QuorumResult::Contested { .. }
@@ -723,20 +715,10 @@ mod tests {
             make_approval("bob", Role::Reviewer, true),
             make_approval("carol", Role::Contributor, true),
         ];
-        let mut resolved = file_challenge(
-            &challenger_did(),
-            &target(),
-            ChallengeGround::SybilAllegation,
-            b"",
-        );
+        let mut resolved = make_challenge(0x9009, ChallengeGround::SybilAllegation, b"");
         adjudicate(&mut resolved, ChallengeVerdict::Overrule).expect("adjudicate ok");
 
-        let open = file_challenge(
-            &challenger_did(),
-            &target(),
-            ChallengeGround::ProceduralError,
-            b"",
-        );
+        let open = make_challenge(0x9010, ChallengeGround::ProceduralError, b"");
 
         // resolved first in slice — open challenge must still block
         assert!(matches!(
@@ -1099,12 +1081,7 @@ mod tests {
         let resolver = move |d: &Did| -> Option<PublicKey> {
             if *d == d_alice { Some(pk_alice) } else { None }
         };
-        let ch = file_challenge(
-            &challenger_did(),
-            &target(),
-            ChallengeGround::SybilAllegation,
-            b"evidence",
-        );
+        let ch = make_challenge(0x9011, ChallengeGround::SybilAllegation, b"evidence");
         match compute_quorum_with_challenges_verified(&approvals, &policy, &[&ch], &resolver) {
             QuorumResult::Contested { challenge } => {
                 assert!(challenge.contains("unresolved independence challenge"));
@@ -1136,12 +1113,7 @@ mod tests {
         let resolver = move |d: &Did| -> Option<PublicKey> {
             if *d == d_alice { Some(pk_alice) } else { None }
         };
-        let mut ch = file_challenge(
-            &challenger_did(),
-            &target(),
-            ChallengeGround::QuorumViolation,
-            b"",
-        );
+        let mut ch = make_challenge(0x9012, ChallengeGround::QuorumViolation, b"");
         ch.status = ChallengeStatus::UnderReview;
         assert!(matches!(
             compute_quorum_with_challenges_verified(&approvals, &policy, &[&ch], &resolver),
@@ -1202,12 +1174,7 @@ mod tests {
         let resolver = move |d: &Did| -> Option<PublicKey> {
             if *d == d_alice { Some(pk_alice) } else { None }
         };
-        let mut ch = file_challenge(
-            &challenger_did(),
-            &target(),
-            ChallengeGround::SybilAllegation,
-            b"",
-        );
+        let mut ch = make_challenge(0x9013, ChallengeGround::SybilAllegation, b"");
         ch.status = ChallengeStatus::Overruled;
         assert!(matches!(
             compute_quorum_with_challenges_verified(&approvals, &policy, &[&ch], &resolver),

--- a/crates/exo-legal/Cargo.toml
+++ b/crates/exo-legal/Cargo.toml
@@ -24,10 +24,6 @@ thiserror = { workspace = true }
 uuid = { workspace = true }
 serde_json = { workspace = true }
 
-[dev-dependencies]
-proptest = { workspace = true }
-serde_json = { workspace = true }
-
 [package.metadata.cargo-machete]
 # Pre-existing workspace dep used via re-exports.
 ignored = ["exo-identity"]

--- a/crates/exo-legal/src/nist_compliance_tests.rs
+++ b/crates/exo-legal/src/nist_compliance_tests.rs
@@ -146,20 +146,26 @@ mod nist_compliance {
         let mut audit_log = AuditLog::new();
         let e1 = gov_audit::create_entry(
             &audit_log,
+            audit_id(0xE100),
+            ts(40_000),
             actor.clone(),
             "human_override_check".into(),
             "pass".into(),
             [0u8; 32],
-        );
+        )
+        .expect("deterministic governance audit entry");
         gov_audit::append(&mut audit_log, e1).expect("audit append");
 
         let e2 = gov_audit::create_entry(
             &audit_log,
+            audit_id(0xE101),
+            ts(40_001),
             actor,
             "human_override_check".into(),
             "VIOLATION: human_override_preserved=false".into(),
             [0u8; 32],
-        );
+        )
+        .expect("deterministic governance audit entry");
         gov_audit::append(&mut audit_log, e2).expect("audit append");
 
         // 5. Chain integrity must hold — satisfies tamper-evidence requirement.

--- a/crates/exo-proofs/Cargo.toml
+++ b/crates/exo-proofs/Cargo.toml
@@ -29,8 +29,5 @@ sha2 = { workspace = true }
 thiserror = { workspace = true }
 serde_json = { workspace = true }
 
-[dev-dependencies]
-proptest = { workspace = true }
-
 [package.metadata.cargo-machete]
 ignored = ["sha2"]

--- a/crates/exochain-wasm/src/governance_bindings.rs
+++ b/crates/exochain-wasm/src/governance_bindings.rs
@@ -4,6 +4,34 @@ use wasm_bindgen::prelude::*;
 
 use crate::serde_bridge::*;
 
+fn parse_uuid(value: &str, label: &str) -> Result<uuid::Uuid, JsValue> {
+    let id: uuid::Uuid = value
+        .parse()
+        .map_err(|e| JsValue::from_str(&format!("{label} UUID error: {e}")))?;
+    if id.is_nil() {
+        return Err(JsValue::from_str(&format!(
+            "{label} UUID must be caller-supplied and non-nil"
+        )));
+    }
+    Ok(id)
+}
+
+fn parse_timestamp(
+    physical_ms: u64,
+    logical: u32,
+    label: &str,
+) -> Result<exo_core::Timestamp, JsValue> {
+    if physical_ms == 0 && logical == 0 {
+        return Err(JsValue::from_str(&format!(
+            "{label} timestamp must be caller-supplied HLC"
+        )));
+    }
+    Ok(exo_core::Timestamp {
+        physical_ms,
+        logical,
+    })
+}
+
 /// Compute quorum result from approvals and policy
 #[wasm_bindgen]
 pub fn wasm_compute_quorum(approvals_json: &str, policy_json: &str) -> Result<JsValue, JsValue> {
@@ -84,6 +112,9 @@ pub fn wasm_check_conflicts(
 /// Append to a hash-chained audit log
 #[wasm_bindgen]
 pub fn wasm_audit_append(
+    entry_id: &str,
+    timestamp_physical_ms: u64,
+    timestamp_logical: u32,
     actor_did: &str,
     action: &str,
     result: &str,
@@ -100,11 +131,14 @@ pub fn wasm_audit_append(
     let mut log = exo_governance::audit::AuditLog::new();
     let entry = exo_governance::audit::create_entry(
         &log,
+        parse_uuid(entry_id, "audit entry")?,
+        parse_timestamp(timestamp_physical_ms, timestamp_logical, "audit entry")?,
         actor,
         action.to_string(),
         result.to_string(),
         arr,
-    );
+    )
+    .map_err(|e| JsValue::from_str(&format!("Audit error: {e}")))?;
     exo_governance::audit::append(&mut log, entry)
         .map_err(|e| JsValue::from_str(&format!("Audit error: {e}")))?;
     // AuditLog doesn't derive Serialize, return summary
@@ -139,6 +173,9 @@ pub fn wasm_audit_verify(entries_json: &str) -> Result<JsValue, JsValue> {
 /// `participants_json` — JSON array of DID strings.
 #[wasm_bindgen]
 pub fn wasm_open_deliberation(
+    deliberation_id: &str,
+    created_physical_ms: u64,
+    created_logical: u32,
     proposal_hex: &str,
     participants_json: &str,
 ) -> Result<JsValue, JsValue> {
@@ -151,7 +188,13 @@ pub fn wasm_open_deliberation(
             exo_core::Did::new(s).map_err(|e| JsValue::from_str(&format!("DID error: {e}")))?,
         );
     }
-    let delib = exo_governance::deliberation::open_deliberation(&proposal, &participants);
+    let delib = exo_governance::deliberation::open_deliberation(
+        parse_uuid(deliberation_id, "deliberation")?,
+        parse_timestamp(created_physical_ms, created_logical, "deliberation")?,
+        &proposal,
+        &participants,
+    )
+    .map_err(|e| JsValue::from_str(&format!("Deliberation error: {e}")))?;
     to_js_value(&delib)
 }
 
@@ -336,6 +379,9 @@ pub fn wasm_detect_coordination(actions_json: &str) -> Result<JsValue, JsValue> 
 /// File a governance challenge
 #[wasm_bindgen]
 pub fn wasm_file_governance_challenge(
+    challenge_id: &str,
+    created_physical_ms: u64,
+    created_logical: u32,
     challenger_did: &str,
     target_hash_hex: &str,
     ground_json: &str,
@@ -349,7 +395,15 @@ pub fn wasm_file_governance_challenge(
         .try_into()
         .map_err(|_| JsValue::from_str("target must be 32 bytes"))?;
     let ground: exo_governance::challenge::ChallengeGround = from_json_str(ground_json)?;
-    let challenge = exo_governance::challenge::file_challenge(&challenger, &arr, ground, evidence);
+    let challenge = exo_governance::challenge::file_challenge(
+        parse_uuid(challenge_id, "challenge")?,
+        parse_timestamp(created_physical_ms, created_logical, "challenge")?,
+        &challenger,
+        &arr,
+        ground,
+        evidence,
+    )
+    .map_err(|e| JsValue::from_str(&format!("Challenge error: {e}")))?;
     to_js_value(&challenge)
 }
 

--- a/crates/exochain-wasm/src/lib.rs
+++ b/crates/exochain-wasm/src/lib.rs
@@ -74,4 +74,21 @@ mod source_guard_tests {
             );
         }
     }
+
+    #[test]
+    fn wasm_governance_bridge_requires_caller_supplied_metadata() {
+        let source = include_str!("governance_bindings.rs");
+        let forbidden = [
+            format!("{}{}", "Timestamp::", "now_utc()"),
+            format!("{}{}", "Uuid::", "new_v4()"),
+            "HybridClock::new()".to_string(),
+        ];
+
+        for pattern in forbidden {
+            assert!(
+                !source.contains(&pattern),
+                "governance WASM bindings must receive caller-supplied IDs and HLC timestamps"
+            );
+        }
+    }
 }

--- a/docs/proofs/CONSTITUTIONAL-PROOFS.md
+++ b/docs/proofs/CONSTITUTIONAL-PROOFS.md
@@ -762,34 +762,36 @@ Any credible challenge can pause a contested action, and no mechanism within EXO
 
 In a court of law, if there is credible evidence of wrongdoing, a judge can issue an injunction -- a legally binding order that pauses the contested activity until it is reviewed. The person being investigated cannot cancel the injunction. They cannot hide it. They cannot pretend it does not exist.
 
-EXOCHAIN implements a digital version of this principle. If any actor files a challenge against a governance action, and the challenge meets the validity criteria (it cites a recognized ground and provides evidence), the challenged action is automatically paused. The actor whose action is being challenged cannot dismiss the challenge, cannot override the pause, and cannot proceed as if the challenge was never filed. The challenge must be resolved through the adjudication process before the action can resume.
+EXOCHAIN implements a digital version of this principle. If any actor files a challenge against a governance action, and the challenge meets the validity criteria (it carries caller-supplied non-placeholder metadata and cites a recognized typed ground), a pause order can be issued for the challenged action. The actor whose action is being challenged cannot dismiss the challenge, cannot override the pause, and cannot proceed as if the challenge was never filed. The challenge must be resolved through the adjudication process before the action can resume.
 
 ### Formal Proof
 
 **Definitions.**
 
-Let `Ch: A x ActionId x Ground x Evidence -> {Accepted, Rejected}` be the challenge function.
+Let `Ch: Metadata x A x ActionId x Ground x Evidence -> {Accepted, Rejected}` be the challenge function.
+
+Let `Metadata` contain caller-supplied challenge ID and HLC timestamp fields.
 
 Let `ValidGrounds` be the set of recognized challenge grounds (authority-chain violation, quorum contamination, consent violation, Sybil allegation, etc.).
 
 Let `Paused(action)` be the state where `action` is suspended pending adjudication.
 
-**Invariant (INV-CL).** For all actors `a`, actions `action`, grounds `g`, and evidence `e`:
+**Invariant (INV-CL).** For all metadata `m`, actors `a`, actions `action`, grounds `g`, and evidence `e`:
 
 ```
-g in ValidGrounds AND e != empty_set
-  => Ch(a, action, g, e) = Accepted
-  AND action enters Paused state
+m is caller_supplied_non_placeholder AND g in ValidGrounds
+  => Ch(m, a, action, g, e) = Accepted
+  AND a pause order can be issued for action
 ```
 
 **Proof.**
 
-1. The `file_challenge()` function in `exo-governance` accepts a challenge containing an actor, a target action, a ground, and evidence.
-2. The function first validates `g in ValidGrounds`. `ValidGrounds` is defined in the kernel ([[#Proof 5 Kernel Immutability|immutable per Proof 5]]) and cannot be reduced by any actor.
-3. The function then checks `e != empty_set` (evidence is non-empty).
-4. If both conditions hold, the challenge is recorded in the audit log (tamper-evident per [[#Proof 8 Receipt Chain Integrity Tamper Evidence|Proof 8]]).
-5. The `pause_action()` function is then invoked, which sets the target action's state to `Paused`.
-6. The `Paused` state can only be exited through adjudication by the judicial branch (per [[#Proof 1 Separation of Powers|Proof 1]], a different actor than the one whose action is challenged).
+1. The `file_challenge()` function in `exo-governance` accepts caller-supplied challenge metadata, an actor DID, a target action hash, a typed ground, and evidence bytes.
+2. The function rejects fabricated placeholder metadata: challenge IDs must be non-nil UUIDs, and creation timestamps must be caller-supplied non-zero HLC timestamps.
+3. The ground is represented by the closed `ChallengeGround` enum; callers cannot submit unrecognized string grounds.
+4. If metadata and typed inputs are valid, the challenge is recorded as `Filed` with the supplied evidence bytes.
+5. The `pause_action()` function is then invoked with caller-supplied non-zero HLC metadata, which produces a pause order for the challenged action.
+6. The paused action can only be resolved through adjudication by the judicial branch (per [[#Proof 1 Separation of Powers|Proof 1]], a different actor than the one whose action is challenged).
 7. There is no `dismiss_challenge()` function callable by the challenged actor. Challenge dismissal requires judicial adjudication.
 8. Therefore, any challenge meeting the validity criteria succeeds, and no mechanism can suppress it. **QED.**
 
@@ -801,37 +803,42 @@ g in ValidGrounds AND e != empty_set
 
 ```rust
 pub fn file_challenge(
-    challenger: &ActorId,
-    target: ActionId,
+    id: Uuid,
+    created: Timestamp,
+    challenger: &Did,
+    target: &[u8; 32],
     ground: ChallengeGround,
-    evidence: &[Evidence],
-) -> Result<ChallengeId, ChallengeError> {
-    // Ground must be recognized
-    if !VALID_GROUNDS.contains(&ground) {
-        return Err(ChallengeError::InvalidGround(ground));
+    evidence: &[u8],
+) -> Result<Challenge, GovernanceError> {
+    if id.is_nil() {
+        return Err(GovernanceError::InvalidGovernanceMetadata { /* ... */ });
+    }
+    if created == Timestamp::ZERO {
+        return Err(GovernanceError::InvalidGovernanceMetadata { /* ... */ });
     }
 
-    // Evidence must be non-empty
-    if evidence.is_empty() {
-        return Err(ChallengeError::NoEvidence);
-    }
-
-    // Record the challenge (tamper-evident via receipt chain)
-    let challenge_id = record_challenge(challenger, target, ground, evidence)?;
-
-    // Pause the contested action — mandatory, not discretionary
-    pause_action(target)?;
-
-    Ok(challenge_id)
+    Ok(Challenge {
+        id,
+        challenger_did: challenger.clone(),
+        target_action_id: *target,
+        ground,
+        evidence: evidence.to_vec(),
+        status: ChallengeStatus::Filed,
+        created,
+    })
 }
 
-pub fn pause_action(action: ActionId) -> Result<(), PauseError> {
-    let mut action_state = load_action_state(action)?;
-    action_state.status = ActionStatus::Paused {
-        reason: PauseReason::ChallengeReceived,
-    };
-    persist_action_state(action_state)?;
-    Ok(())
+pub fn pause_action(challenge: &Challenge, issued: Timestamp) -> Result<PauseOrder, GovernanceError> {
+    if issued == Timestamp::ZERO {
+        return Err(GovernanceError::InvalidGovernanceMetadata { /* ... */ });
+    }
+
+    Ok(PauseOrder {
+        challenge_id: challenge.id,
+        target_action_id: challenge.target_action_id,
+        reason: format!("challenged on ground: {:?}", challenge.ground),
+        issued,
+    })
 }
 ```
 

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -1214,10 +1214,10 @@ test('wasm_activate_succession', () => {
 console.log('\n--- Audit ---');
 
 test('wasm_audit_append', () =>
-  wasm.wasm_audit_append(TEST_DID, 'create', 'success', ZERO_32_HEX));
+  wasm.wasm_audit_append(UUID_1, NOW_MS, 0, TEST_DID, 'create', 'success', ZERO_32_HEX));
 
 const auditEntry = setup(() =>
-  wasm.wasm_audit_append(TEST_DID, 'create', 'success', ZERO_32_HEX));
+  wasm.wasm_audit_append(UUID_1, NOW_MS, 0, TEST_DID, 'create', 'success', ZERO_32_HEX));
 
 test('wasm_audit_verify', () => {
   const entry = {
@@ -1252,12 +1252,18 @@ console.log('\n--- Deliberation / Voting ---');
 
 test('wasm_open_deliberation', () =>
   wasm.wasm_open_deliberation(
+    UUID_1,
+    NOW_MS,
+    0,
     Buffer.from('test proposal').toString('hex'),
     JSON.stringify([TEST_DID, TEST_DID_2])
   ));
 
 const deliberation = setup(() =>
   wasm.wasm_open_deliberation(
+    UUID_1,
+    NOW_MS,
+    0,
     Buffer.from('test proposal').toString('hex'),
     JSON.stringify([TEST_DID, TEST_DID_2])
   ));
@@ -1359,6 +1365,9 @@ console.log('\n--- Governance Challenges ---');
 
 test('wasm_file_governance_challenge', () =>
   wasm.wasm_file_governance_challenge(
+    UUID_1,
+    NOW_MS,
+    0,
     TEST_DID,
     ZERO_32_HEX,
     JSON.stringify('ProceduralError'),


### PR DESCRIPTION
## Summary
- require caller-supplied non-nil UUIDs and non-zero HLC timestamps for governance audit entries, challenges, pause orders, and deliberations
- update WASM governance bindings and JS bridge smoke tests to pass deterministic metadata instead of relying on Rust-side fabrication
- add source guard/regression tests, refresh repo truth counts, update stale proof docs, and remove stale unused manifest dependencies

## TDD red check
- `cargo test -p exo-governance internal_entropy --lib` initially failed because the constructors still contained `Uuid::new_v4()` / `Timestamp::now_utc()` and call sites still used the old signatures

## Verification
- `cargo test -p exo-governance internal_entropy --lib`
- `cargo test -p exo-governance --lib`
- `cargo test -p exo-legal test_human_oversight_nist_compliance --lib`
- `cargo test -p exo-legal --lib`
- `cargo test -p exochain-wasm source_guard_tests --lib`
- `cargo test -p exochain-wasm`
- `wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm --out-name exochain_wasm`
- `node packages/exochain-wasm/test/bridge_verification.mjs` (140/140)
- `bash tools/repo_truth.sh --json` -> 110618 Rust LOC, 2718 listed tests
- `bash tools/test_repo_truth.sh`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo machete --with-metadata`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit --deny unsound --deny unmaintained` (existing allowed yanked core2 warning)
- `cargo deny check` (existing duplicate/yanked/unused-allowance warnings)
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`