### PR TITLE
fix(exo-gateway): require deterministic vote audit timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 110618 | `wc -l` |
-| Workspace tests | 2,718 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 110732 | `wc -l` |
+| Workspace tests | 2,722 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,718 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,722 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 110618 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 110732 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,718 listed workspace tests
+         cryptographic proofs, 2,722 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          140 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-gateway/src/handlers.rs
+++ b/crates/exo-gateway/src/handlers.rs
@@ -10,7 +10,7 @@ use decision_forum::{
     decision_object::{ActorKind, DecisionObject, Vote, VoteChoice},
     quorum::{QuorumCheckResult, QuorumRegistry, check_quorum, verify_quorum_precondition},
 };
-use exo_core::{Timestamp, hlc::HybridClock, types::Hash256};
+use exo_core::{Timestamp, types::Hash256};
 use exo_gatekeeper::{
     kernel::{ActionRequest as GatekeeperActionRequest, Verdict},
     types::{Permission, PermissionSet},
@@ -80,6 +80,10 @@ fn build_audit_entry(
     timestamp: Timestamp,
     payload: &Value,
 ) -> Result<AuditEntryRecord, String> {
+    if timestamp == Timestamp::ZERO {
+        return Err("audit timestamp must be caller-supplied and non-zero".to_owned());
+    }
+
     let sequence = match last {
         Some(row) => row
             .sequence
@@ -129,6 +133,7 @@ async fn write_audit(
     actor: &str,
     tenant_id: &str,
     decision_id: &str,
+    timestamp: Timestamp,
     payload: &Value,
 ) -> Result<(), String> {
     let db = state.require_db().map_err(|e| e.to_string())?;
@@ -144,14 +149,13 @@ async fn write_audit(
     .fetch_optional(&mut *tx)
     .await
     .map_err(|e| e.to_string())?;
-    let mut clock = HybridClock::new();
     let entry = build_audit_entry(
         last.as_ref(),
         event_type,
         actor,
         tenant_id,
         decision_id,
-        clock.now(),
+        timestamp,
         payload,
     )?;
     sqlx::query(
@@ -185,6 +189,18 @@ pub struct VoteRequest {
     pub choice: VoteChoice,
     pub actor_kind: ActorKind,
     pub rationale: Option<String>,
+    pub timestamp_physical_ms: u64,
+    pub timestamp_logical: u32,
+}
+
+impl VoteRequest {
+    fn caller_supplied_timestamp(&self) -> Result<Timestamp, String> {
+        let timestamp = Timestamp::new(self.timestamp_physical_ms, self.timestamp_logical);
+        if timestamp == Timestamp::ZERO {
+            return Err("vote timestamp must be caller-supplied and non-zero".to_owned());
+        }
+        Ok(timestamp)
+    }
 }
 
 /// Handle a vote submission with conflict-of-interest and authority chain checks.
@@ -363,9 +379,17 @@ pub async fn vote_handler(
         }
     }
 
-    // Build the typed Vote using HLC for deterministic timestamp (AGENTS.md §1).
-    let mut clock = HybridClock::new();
-    let timestamp = clock.now();
+    // Build the typed Vote with caller-supplied HLC metadata (AGENTS.md §1).
+    let timestamp = match body.caller_supplied_timestamp() {
+        Ok(timestamp) => timestamp,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": e})),
+            )
+                .into_response();
+        }
+    };
     let sig_input = format!("{}:{}:{:?}", body.voter_did, body.decision_id, body.choice);
     let signature_hash = Hash256::digest(sig_input.as_bytes());
     let vote = Vote {
@@ -430,6 +454,8 @@ pub async fn vote_handler(
         "tenant_id": tenant_id.as_str(),
         "voter": body.voter_did.as_str(),
         "choice": body.choice,
+        "timestamp_physical_ms": timestamp.physical_ms,
+        "timestamp_logical": timestamp.logical,
     });
     if let Err(e) = write_audit(
         &state,
@@ -437,6 +463,7 @@ pub async fn vote_handler(
         &body.voter_did,
         &tenant_id,
         &body.decision_id,
+        timestamp,
         &audit_payload,
     )
     .await
@@ -642,6 +669,89 @@ mod tests {
         );
     }
 
+    #[test]
+    fn gateway_vote_audit_path_does_not_create_hlc_clock_internally() {
+        let source = include_str!("handlers.rs");
+        let forbidden = ["HybridClock", "::new()"].concat();
+        assert!(
+            !source.contains(&forbidden),
+            "gateway vote/audit path must use caller-supplied HLC timestamps"
+        );
+    }
+
+    #[test]
+    fn audit_entry_rejects_zero_timestamp() {
+        let payload = serde_json::json!({"event": "vote_recorded", "decision_id": "decision-1"});
+        let err = build_audit_entry(
+            None,
+            "VoteCast",
+            "did:exo:alice",
+            "tenant-a",
+            "decision-1",
+            exo_core::Timestamp::ZERO,
+            &payload,
+        )
+        .expect_err("zero audit timestamp must be rejected");
+
+        assert!(
+            err.contains("timestamp"),
+            "error should identify the invalid audit timestamp"
+        );
+    }
+
+    #[test]
+    fn vote_request_requires_caller_supplied_timestamp() {
+        let without_timestamp = serde_json::json!({
+            "decision_id": "decision-1",
+            "voter_did": "did:exo:alice",
+            "choice": "Approve",
+            "actor_kind": "Human",
+            "rationale": null
+        });
+        assert!(
+            serde_json::from_value::<VoteRequest>(without_timestamp).is_err(),
+            "vote requests must not deserialize without explicit HLC timestamp metadata"
+        );
+
+        let with_timestamp = serde_json::json!({
+            "decision_id": "decision-1",
+            "voter_did": "did:exo:alice",
+            "choice": "Approve",
+            "actor_kind": "Human",
+            "rationale": null,
+            "timestamp_physical_ms": 7000,
+            "timestamp_logical": 2
+        });
+        let request: VoteRequest =
+            serde_json::from_value(with_timestamp).expect("timestamped vote request");
+
+        assert_eq!(
+            request
+                .caller_supplied_timestamp()
+                .expect("non-zero timestamp"),
+            exo_core::Timestamp::new(7000, 2)
+        );
+    }
+
+    #[test]
+    fn vote_request_rejects_zero_timestamp() {
+        let request: VoteRequest = serde_json::from_value(serde_json::json!({
+            "decision_id": "decision-1",
+            "voter_did": "did:exo:alice",
+            "choice": "Approve",
+            "actor_kind": "Human",
+            "rationale": null,
+            "timestamp_physical_ms": 0,
+            "timestamp_logical": 0
+        }))
+        .expect("request shape is valid");
+
+        assert!(
+            request.caller_supplied_timestamp().is_err(),
+            "zero vote timestamp must be rejected"
+        );
+    }
+
     #[cfg(feature = "production-db")]
     #[tokio::test]
     async fn vote_audit_write_is_read_by_audit_route_from_migrated_schema() {
@@ -691,6 +801,7 @@ mod tests {
             voter,
             "tenant-r4",
             decision_id,
+            exo_core::Timestamp::new(9000, 0),
             &payload,
         )
         .await
@@ -701,6 +812,7 @@ mod tests {
             voter,
             "tenant-r4",
             decision_id,
+            exo_core::Timestamp::new(9001, 0),
             &payload,
         )
         .await

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -1969,6 +1969,8 @@ mod tests {
             "choice": "Approve",
             "actor_kind": "Human",
             "rationale": null,
+            "timestamp_physical_ms": 7000,
+            "timestamp_logical": 0,
         }))
         .unwrap();
         let app = build_router(state());


### PR DESCRIPTION
## Summary
- require REST vote requests to carry explicit HLC timestamp metadata
- use the caller-supplied timestamp for both the decision-forum vote and the persistent gateway audit entry
- reject zero HLC placeholders in vote requests and audit-entry construction
- refresh README repo-truth counts after adding regression tests

## TDD red check
- `cargo test -p exo-gateway gateway_vote_audit_path_does_not_create_hlc_clock_internally --lib` initially failed because the new tests referenced the intended timestamp API before implementation and the source still contained `HybridClock::new()`

## Verification
- `cargo test -p exo-gateway gateway_vote_audit_path_does_not_create_hlc_clock_internally --lib`
- `cargo test -p exo-gateway audit_entry_rejects_zero_timestamp --lib`
- `cargo test -p exo-gateway vote_request_requires_caller_supplied_timestamp --lib`
- `cargo test -p exo-gateway vote_request_rejects_zero_timestamp --lib`
- `cargo test -p exo-gateway handlers::tests --lib`
- `cargo test -p exo-gateway --test decision_forum_integration`
- `cargo test -p exo-gateway --lib`
- `cargo test -p exo-gateway`
- `cargo clippy -p exo-gateway --lib --bins -- -D warnings`
- `cargo clippy -p exo-gateway --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `bash tools/repo_truth.sh --json` -> 110732 Rust LOC, 2722 listed tests
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit --deny unsound --deny unmaintained` (existing allowed yanked core2 warning)
- `cargo deny check` (existing duplicate/yanked/unused-allowance warnings)
- `cargo machete --with-metadata`