### PR TITLE
fix(exo-messaging): require deterministic envelope metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 110732 | `wc -l` |
-| Workspace tests | 2,722 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 110868 | `wc -l` |
+| Workspace tests | 2,726 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,722 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,726 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 110732 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 110868 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,722 listed workspace tests
+         cryptographic proofs, 2,726 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          140 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-messaging/src/compose.rs
+++ b/crates/exo-messaging/src/compose.rs
@@ -4,7 +4,7 @@
 //! public key, derives a symmetric key via HKDF, encrypts the plaintext with
 //! XChaCha20-Poly1305, and signs the envelope with the sender's Ed25519 key.
 
-use exo_core::{Did, Hash256, SecretKey, hlc::HybridClock};
+use exo_core::{Did, Hash256, SecretKey, Timestamp};
 use exo_identity::vault::VaultEncryptor;
 use uuid::Uuid;
 
@@ -17,6 +17,32 @@ use crate::{
 /// The HKDF context string for message encryption key derivation.
 const MESSAGE_KEX_CONTEXT: &[u8] = b"vitallock-message-v1";
 
+/// Caller-supplied provenance metadata for an encrypted envelope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ComposeMetadata {
+    /// Unique message ID assigned by the caller's deterministic boundary.
+    pub id: Uuid,
+    /// Non-zero HLC timestamp assigned by the caller's deterministic boundary.
+    pub created: Timestamp,
+}
+
+impl ComposeMetadata {
+    /// Validate caller-supplied envelope metadata.
+    pub fn new(id: Uuid, created: Timestamp) -> Result<Self, MessagingError> {
+        if id.is_nil() {
+            return Err(MessagingError::InvalidEnvelope(
+                "message id must be caller-supplied and non-nil".into(),
+            ));
+        }
+        if created == Timestamp::ZERO {
+            return Err(MessagingError::InvalidEnvelope(
+                "message timestamp must be caller-supplied and non-zero".into(),
+            ));
+        }
+        Ok(Self { id, created })
+    }
+}
+
 /// Lock & Send: encrypt a message for a specific recipient.
 ///
 /// # Arguments
@@ -27,6 +53,7 @@ const MESSAGE_KEX_CONTEXT: &[u8] = b"vitallock-message-v1";
 /// * `recipient_did` — The recipient's DID.
 /// * `sender_signing_key` — The sender's Ed25519 secret key for signing.
 /// * `recipient_x25519_public` — The recipient's X25519 public key.
+/// * `metadata` — Caller-supplied non-nil ID and non-zero HLC timestamp.
 /// * `release_on_death` — Whether to release after sender's death.
 /// * `release_delay_hours` — Hours to wait after death verification.
 ///
@@ -47,6 +74,7 @@ pub fn lock_and_send(
     recipient_did: &Did,
     sender_signing_key: &SecretKey,
     recipient_x25519_public: &X25519PublicKey,
+    metadata: ComposeMetadata,
     release_on_death: bool,
     release_delay_hours: u32,
 ) -> Result<EncryptedEnvelope, MessagingError> {
@@ -70,14 +98,9 @@ pub fn lock_and_send(
     // 4. Hash plaintext for post-decrypt integrity check
     let plaintext_hash = Hash256::digest(plaintext);
 
-    // 5. Generate message ID and timestamp
-    let id = Uuid::new_v4().to_string();
-    let mut clock = HybridClock::new();
-    let created = clock.now();
-
-    // 6. Build envelope (without signature first)
+    // 5. Build envelope (without signature first)
     let mut envelope = EncryptedEnvelope {
-        id,
+        id: metadata.id.to_string(),
         sender_did: sender_did.clone(),
         recipient_did: recipient_did.clone(),
         ephemeral_public_key: ephemeral.public.0,
@@ -87,10 +110,10 @@ pub fn lock_and_send(
         plaintext_hash,
         release_on_death,
         release_delay_hours,
-        created,
+        created: metadata.created,
     };
 
-    // 7. Sign the envelope
+    // 6. Sign the envelope
     let signable = envelope.signable_bytes();
     let signature = exo_core::crypto::sign(&signable, sender_signing_key);
     envelope.signature = signature;
@@ -104,9 +127,18 @@ pub fn lock_and_send(
 
 #[cfg(test)]
 mod tests {
-    use exo_core::crypto::generate_keypair;
+    use exo_core::{Timestamp, crypto::generate_keypair};
+    use uuid::Uuid;
 
     use super::*;
+
+    fn metadata() -> ComposeMetadata {
+        ComposeMetadata::new(
+            Uuid::parse_str("018f7a96-8ad0-7c4f-8e0f-111111111111").unwrap(),
+            Timestamp::new(7_000, 2),
+        )
+        .expect("valid compose metadata")
+    }
 
     #[test]
     fn lock_and_send_produces_valid_envelope() {
@@ -114,6 +146,7 @@ mod tests {
         let recipient_did = Did::new("did:exo:bob").unwrap();
         let (_, sender_sk) = generate_keypair();
         let recipient_kp = kex::X25519KeyPair::generate();
+        let metadata = metadata();
 
         let envelope = lock_and_send(
             b"my secret password: hunter2",
@@ -122,11 +155,17 @@ mod tests {
             &recipient_did,
             &sender_sk,
             &recipient_kp.public,
+            metadata,
             false,
             0,
         )
         .expect("lock_and_send");
 
+        assert_eq!(
+            envelope.id,
+            "018f7a96-8ad0-7c4f-8e0f-111111111111".to_string()
+        );
+        assert_eq!(envelope.created, Timestamp::new(7_000, 2));
         assert_eq!(envelope.sender_did, sender_did);
         assert_eq!(envelope.recipient_did, recipient_did);
         assert_eq!(envelope.content_type, ContentType::Password);
@@ -141,6 +180,7 @@ mod tests {
         let recipient_did = Did::new("did:exo:bob").unwrap();
         let (_, sender_sk) = generate_keypair();
         let recipient_kp = kex::X25519KeyPair::generate();
+        let metadata = metadata();
 
         let envelope = lock_and_send(
             b"Read this after I'm gone",
@@ -149,6 +189,7 @@ mod tests {
             &recipient_did,
             &sender_sk,
             &recipient_kp.public,
+            metadata,
             true,
             72,
         )
@@ -157,5 +198,45 @@ mod tests {
         assert!(envelope.release_on_death);
         assert_eq!(envelope.release_delay_hours, 72);
         assert_eq!(envelope.content_type, ContentType::AfterlifeMessage);
+    }
+
+    #[test]
+    fn compose_metadata_rejects_nil_message_id() {
+        let result = ComposeMetadata::new(Uuid::nil(), Timestamp::new(7_000, 2));
+
+        assert!(
+            matches!(result, Err(MessagingError::InvalidEnvelope(reason)) if reason.contains("message id"))
+        );
+    }
+
+    #[test]
+    fn compose_metadata_rejects_zero_timestamp() {
+        let result = ComposeMetadata::new(
+            Uuid::parse_str("018f7a96-8ad0-7c4f-8e0f-222222222222").unwrap(),
+            Timestamp::ZERO,
+        );
+
+        assert!(
+            matches!(result, Err(MessagingError::InvalidEnvelope(reason)) if reason.contains("timestamp"))
+        );
+    }
+
+    #[test]
+    fn compose_path_does_not_fabricate_envelope_metadata() {
+        let source = include_str!("compose.rs");
+        let production = source
+            .split("// ===========================================================================")
+            .next()
+            .expect("production section");
+
+        assert!(
+            !production.contains("Uuid::new_v4"),
+            "compose production path must not fabricate message IDs"
+        );
+        let forbidden_clock = ["HybridClock", "::new()"].concat();
+        assert!(
+            !production.contains(&forbidden_clock),
+            "compose production path must not fabricate HLC timestamps"
+        );
     }
 }

--- a/crates/exo-messaging/src/lib.rs
+++ b/crates/exo-messaging/src/lib.rs
@@ -15,7 +15,7 @@ pub mod error;
 pub mod kex;
 pub mod open;
 
-pub use compose::lock_and_send;
+pub use compose::{ComposeMetadata, lock_and_send};
 pub use envelope::{ContentType, EncryptedEnvelope};
 pub use error::MessagingError;
 pub use kex::{X25519KeyPair, X25519PublicKey, X25519SecretKey};

--- a/crates/exo-messaging/src/open.rs
+++ b/crates/exo-messaging/src/open.rs
@@ -70,10 +70,20 @@ pub fn unlock(
 
 #[cfg(test)]
 mod tests {
-    use exo_core::{Did, crypto::generate_keypair};
+    use exo_core::{Did, Timestamp, crypto::generate_keypair};
+    use uuid::Uuid;
 
     use super::*;
-    use crate::{compose::lock_and_send, envelope::ContentType, kex::X25519KeyPair};
+    use crate::{
+        compose::{ComposeMetadata, lock_and_send},
+        envelope::ContentType,
+        kex::X25519KeyPair,
+    };
+
+    fn metadata(suffix: u128) -> ComposeMetadata {
+        ComposeMetadata::new(Uuid::from_u128(suffix), Timestamp::new(8_000, 0))
+            .expect("valid compose metadata")
+    }
 
     #[test]
     fn encrypt_decrypt_round_trip() {
@@ -91,6 +101,7 @@ mod tests {
             &recipient_did,
             &sender_sk,
             &recipient_kp.public,
+            metadata(0x018f_7a96_8ad0_7c4f_8e0f_1111_1111_1101),
             false,
             0,
         )
@@ -116,6 +127,7 @@ mod tests {
             &recipient_did,
             &sender_sk,
             &recipient_kp.public,
+            metadata(0x018f_7a96_8ad0_7c4f_8e0f_1111_1111_1102),
             false,
             0,
         )
@@ -140,6 +152,7 @@ mod tests {
             &recipient_did,
             &sender_sk,
             &recipient_kp.public,
+            metadata(0x018f_7a96_8ad0_7c4f_8e0f_1111_1111_1103),
             false,
             0,
         )
@@ -168,6 +181,7 @@ mod tests {
             &recipient_did,
             &sender_sk,
             &recipient_kp.public,
+            metadata(0x018f_7a96_8ad0_7c4f_8e0f_1111_1111_1104),
             true,
             72,
         )
@@ -194,6 +208,7 @@ mod tests {
             &recipient_did,
             &sender_sk,
             &recipient_kp.public,
+            metadata(0x018f_7a96_8ad0_7c4f_8e0f_1111_1111_1105),
             false,
             0,
         )
@@ -219,6 +234,7 @@ mod tests {
             &recipient_did,
             &sender_sk,
             &recipient_kp.public,
+            metadata(0x018f_7a96_8ad0_7c4f_8e0f_1111_1111_1106),
             false,
             0,
         )

--- a/crates/exochain-wasm/src/lib.rs
+++ b/crates/exochain-wasm/src/lib.rs
@@ -91,4 +91,30 @@ mod source_guard_tests {
             );
         }
     }
+
+    #[test]
+    fn wasm_messaging_bridge_requires_caller_supplied_envelope_metadata() {
+        let source = include_str!("messaging_bindings.rs");
+        assert!(
+            source.contains("message_id") && source.contains("created_physical_ms"),
+            "messaging WASM encryption must expose caller-supplied envelope metadata"
+        );
+        assert!(
+            source.contains("ComposeMetadata::new"),
+            "messaging WASM encryption must validate caller-supplied envelope metadata"
+        );
+
+        let forbidden = [
+            format!("{}{}", "Timestamp::", "now_utc()"),
+            format!("{}{}", "Uuid::", "new_v4()"),
+            "HybridClock::new()".to_string(),
+        ];
+
+        for pattern in forbidden {
+            assert!(
+                !source.contains(&pattern),
+                "messaging WASM bindings must receive caller-supplied IDs and HLC timestamps"
+            );
+        }
+    }
 }

--- a/crates/exochain-wasm/src/messaging_bindings.rs
+++ b/crates/exochain-wasm/src/messaging_bindings.rs
@@ -45,6 +45,9 @@ pub fn wasm_x25519_public_from_secret(secret_hex: &str) -> Result<JsValue, JsVal
 /// - `recipient_did`: Recipient's DID string
 /// - `sender_signing_key_hex`: Sender's Ed25519 secret key (hex)
 /// - `recipient_x25519_public_hex`: Recipient's X25519 public key (hex)
+/// - `message_id`: Caller-supplied non-nil message UUID
+/// - `created_physical_ms`: Caller-supplied non-zero HLC physical milliseconds
+/// - `created_logical`: Caller-supplied HLC logical counter
 /// - `release_on_death`: Whether to release after sender's death
 /// - `release_delay_hours`: Hours to wait after death verification
 ///
@@ -52,10 +55,9 @@ pub fn wasm_x25519_public_from_secret(secret_hex: &str) -> Result<JsValue, JsVal
 /// The encrypted envelope as JSON.
 #[wasm_bindgen]
 #[allow(clippy::too_many_arguments)]
-// Mirrors `exo_messaging::compose::lock_and_send` — 8 args is
-// the irreducible envelope spec. WASM boundary cannot take a
-// struct directly; each arg is serialized across the JS/Rust
-// boundary independently.
+// Mirrors `exo_messaging::compose::lock_and_send`; the WASM boundary
+// cannot take Rust structs directly, so envelope metadata crosses as
+// primitive fields and is validated before encryption.
 pub fn wasm_encrypt_message(
     plaintext: &str,
     content_type_json: &str,
@@ -63,6 +65,9 @@ pub fn wasm_encrypt_message(
     recipient_did: &str,
     sender_signing_key_hex: &str,
     recipient_x25519_public_hex: &str,
+    message_id: &str,
+    created_physical_ms: u64,
+    created_logical: u32,
     release_on_death: bool,
     release_delay_hours: u32,
 ) -> Result<JsValue, JsValue> {
@@ -84,6 +89,13 @@ pub fn wasm_encrypt_message(
 
     let recipient_pub = exo_messaging::X25519PublicKey::from_hex(recipient_x25519_public_hex)
         .map_err(|e| JsValue::from_str(&format!("invalid recipient X25519 key: {e}")))?;
+    let message_uuid = uuid::Uuid::parse_str(message_id)
+        .map_err(|e| JsValue::from_str(&format!("invalid message id: {e}")))?;
+    let metadata = exo_messaging::ComposeMetadata::new(
+        message_uuid,
+        exo_core::Timestamp::new(created_physical_ms, created_logical),
+    )
+    .map_err(|e| JsValue::from_str(&format!("invalid envelope metadata: {e}")))?;
 
     let envelope = exo_messaging::lock_and_send(
         plaintext.as_bytes(),
@@ -92,6 +104,7 @@ pub fn wasm_encrypt_message(
         &recipient,
         &sender_sk,
         &recipient_pub,
+        metadata,
         release_on_death,
         release_delay_hours,
     )

--- a/demo/apps/vitallock/src/lib/crypto.ts
+++ b/demo/apps/vitallock/src/lib/crypto.ts
@@ -76,6 +76,9 @@ export function encryptMessage(
   recipientDid: string,
   senderSigningKeyHex: string,
   recipientX25519PublicHex: string,
+  messageId: string,
+  createdPhysicalMs: bigint,
+  createdLogical: number,
   releaseOnDeath: boolean = false,
   releaseDelayHours: number = 0,
 ): EncryptedEnvelope {
@@ -86,6 +89,9 @@ export function encryptMessage(
     recipientDid,
     senderSigningKeyHex,
     recipientX25519PublicHex,
+    messageId,
+    createdPhysicalMs,
+    createdLogical,
     releaseOnDeath,
     releaseDelayHours,
   );

--- a/demo/apps/vitallock/src/pages/Compose.tsx
+++ b/demo/apps/vitallock/src/pages/Compose.tsx
@@ -36,6 +36,10 @@ export default function Compose() {
     mutationFn: async () => {
       if (!isCryptoReady()) throw new Error('WASM not initialized');
 
+      const messageId = crypto.randomUUID();
+      const createdPhysicalMs = BigInt(Date.now());
+      const createdLogical = 0;
+
       // Encrypt client-side — plaintext never leaves the browser
       const envelope = encryptMessage(
         body,
@@ -44,6 +48,9 @@ export default function Compose() {
         recipientDid,
         auth!.ed25519SecretHex,
         recipientX25519,
+        messageId,
+        createdPhysicalMs,
+        createdLogical,
         releaseOnDeath,
         releaseDelay,
       );

--- a/demo/packages/exochain-wasm/test.mjs
+++ b/demo/packages/exochain-wasm/test.mjs
@@ -180,6 +180,9 @@ test('check_conflicts with no declarations', () => {
 test('audit_append creates entry', () => {
   const evidenceHash = '0'.repeat(64);
   const result = wasm.wasm_audit_append(
+    '018f7a96-8ad0-7c4f-8e0f-111111111301',
+    7200n,
+    0,
     'did:exo:alice',
     'create_decision',
     'success',
@@ -275,7 +278,9 @@ test('propose_bailment creates bailment', () => {
     'did:exo:bailor',
     'did:exo:bailee',
     new Uint8Array([1, 2, 3]),
-    '"Processing"'
+    '"Processing"',
+    '018f7a96-8ad0-7c4f-8e0f-111111111302',
+    JSON.stringify({ physical_ms: 7300, logical: 0 })
   );
   assert(bailment, 'should return bailment');
 });

--- a/demo/services/vitallock-api/src/index.js
+++ b/demo/services/vitallock-api/src/index.js
@@ -66,8 +66,15 @@ export const server = http.createServer(async (req, res) => {
         const {
           plaintext, content_type, sender_did, recipient_did,
           sender_signing_key_hex, recipient_x25519_public_hex,
+          message_id, created_physical_ms, created_logical,
           release_on_death, release_delay_hours,
         } = body;
+
+        if (!message_id || created_physical_ms === undefined || created_logical === undefined) {
+          return json(res, 400, {
+            error: 'message_id, created_physical_ms, and created_logical are required for server-side encryption',
+          });
+        }
 
         envelope = wasm.wasm_encrypt_message(
           plaintext,
@@ -76,6 +83,9 @@ export const server = http.createServer(async (req, res) => {
           recipient_did,
           sender_signing_key_hex,
           recipient_x25519_public_hex,
+          message_id,
+          BigInt(created_physical_ms),
+          created_logical,
           release_on_death || false,
           release_delay_hours || 0,
         );

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -216,6 +216,9 @@ test('wasm_encrypt_message', () => {
     TEST_DID_2,
     DUMMY_SECRET_HEX,
     recipientKex.public_key_hex,
+    '018f7a96-8ad0-7c4f-8e0f-111111111201',
+    7000n,
+    0,
     false,
     0
   );
@@ -233,6 +236,9 @@ const encryptedEnvelope = setup(() =>
     TEST_DID_2,
     DUMMY_SECRET_HEX,
     recipientKex.public_key_hex,
+    '018f7a96-8ad0-7c4f-8e0f-111111111202',
+    7001n,
+    0,
     false,
     0
   ));


### PR DESCRIPTION
## Summary
- require caller-supplied non-nil UUID and non-zero HLC timestamp for exo-messaging encrypted envelopes
- update WASM, bridge verification, and VitalLock callers to supply explicit envelope metadata
- add regression/source-guard tests preventing internal UUID/HLC fabrication in the compose path

## TDD red check
- cargo test -p exo-messaging compose_metadata_rejects_nil_message_id --lib initially failed before ComposeMetadata and the new lock_and_send signature existed

## Verification
- cargo test -p exo-messaging compose_metadata_rejects_nil_message_id --lib
- cargo test -p exo-messaging --lib
- cargo test -p exo-messaging
- cargo test -p exochain-wasm
- cargo clippy -p exo-messaging --lib --bins -- -D warnings
- cargo clippy -p exo-messaging --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo clippy -p exochain-wasm --lib -- -D warnings
- cargo clippy -p exochain-wasm --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- wasm-pack build crates/exochain-wasm --target nodejs --release --out-dir ../../packages/exochain-wasm/wasm
- node packages/exochain-wasm/test/bridge_verification.mjs
- wasm-pack build crates/exochain-wasm --target nodejs --release --out-dir ../../demo/packages/exochain-wasm/wasm
- npm run test:wasm from demo/
- node --check services/vitallock-api/src/index.js from demo/
- bash tools/repo_truth.sh --json
- cargo +nightly fmt --all -- --check
- git diff --check
- bash tools/test_repo_truth.sh
- bash tools/test_cr001_status.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_no_orphan_rust_modules.sh
- bash tools/test_railway_entrypoint_args.sh
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo build --workspace --release
- cargo test --workspace --release
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
- cargo audit --deny unsound --deny unmaintained
- cargo deny check
- cargo machete --with-metadata