### PR TITLE
fix(exo-messaging): require deterministic death trigger metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 111109 | `wc -l` |
-| Workspace tests | 2,734 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 111386 | `wc -l` |
+| Workspace tests | 2,741 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,734 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,741 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 111109 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 111386 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,734 listed workspace tests
+         cryptographic proofs, 2,741 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          140 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-messaging/src/death_trigger.rs
+++ b/crates/exo-messaging/src/death_trigger.rs
@@ -5,7 +5,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use exo_core::{Did, PublicKey, Signature, Timestamp, hlc::HybridClock};
+use exo_core::{Did, PublicKey, Signature, Timestamp};
 use serde::{Deserialize, Serialize};
 
 use crate::error::MessagingError;
@@ -30,6 +30,60 @@ pub struct TrusteeConfirmation {
     pub public_key: PublicKey,
     pub signature: Signature,
     pub confirmed_at: Timestamp,
+}
+
+/// Caller-supplied metadata for initiating a death verification request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeathVerificationCreationMetadata {
+    pub created_at: Timestamp,
+}
+
+impl DeathVerificationCreationMetadata {
+    /// Validate caller-supplied creation metadata.
+    pub fn new(created_at: Timestamp) -> Result<Self, MessagingError> {
+        if created_at == Timestamp::ZERO {
+            return Err(MessagingError::InvalidDeathVerification(
+                "created_at must be caller-supplied and non-zero".to_owned(),
+            ));
+        }
+        Ok(Self { created_at })
+    }
+}
+
+/// Caller-supplied metadata for a trustee confirmation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeathConfirmationMetadata {
+    pub confirmed_at: Timestamp,
+}
+
+impl DeathConfirmationMetadata {
+    /// Validate caller-supplied confirmation metadata.
+    pub fn new(confirmed_at: Timestamp) -> Result<Self, MessagingError> {
+        if confirmed_at == Timestamp::ZERO {
+            return Err(MessagingError::InvalidDeathVerification(
+                "confirmed_at must be caller-supplied and non-zero".to_owned(),
+            ));
+        }
+        Ok(Self { confirmed_at })
+    }
+}
+
+/// Caller-supplied metadata for rejecting a death verification request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeathRejectionMetadata {
+    pub rejected_at: Timestamp,
+}
+
+impl DeathRejectionMetadata {
+    /// Validate caller-supplied rejection metadata.
+    pub fn new(rejected_at: Timestamp) -> Result<Self, MessagingError> {
+        if rejected_at == Timestamp::ZERO {
+            return Err(MessagingError::InvalidDeathVerification(
+                "rejected_at must be caller-supplied and non-zero".to_owned(),
+            ));
+        }
+        Ok(Self { rejected_at })
+    }
 }
 
 /// A death verification request tracking trustee consensus.
@@ -133,6 +187,7 @@ impl DeathVerification {
         authorized_trustees: BTreeMap<Did, PublicKey>,
         claim_nonce: Vec<u8>,
         initiator_signature: Signature,
+        metadata: DeathVerificationCreationMetadata,
     ) -> Result<Self, MessagingError> {
         validate_death_verification_request(
             &initiated_by,
@@ -158,8 +213,7 @@ impl DeathVerification {
             return Err(MessagingError::SignatureVerificationFailed);
         }
 
-        let mut clock = HybridClock::new();
-        let now = clock.now();
+        let now = metadata.created_at;
         let status = if required_confirmations == 1 {
             DeathVerificationStatus::Verified
         } else {
@@ -210,6 +264,7 @@ impl DeathVerification {
         trustee_did: Did,
         trustee_public_key: PublicKey,
         signature: Signature,
+        metadata: DeathConfirmationMetadata,
     ) -> Result<bool, MessagingError> {
         if self.status != DeathVerificationStatus::Pending {
             return Err(MessagingError::DeathTriggerAlreadyResolved);
@@ -238,8 +293,7 @@ impl DeathVerification {
             return Err(MessagingError::SignatureVerificationFailed);
         }
 
-        let mut clock = HybridClock::new();
-        let now = clock.now();
+        let now = metadata.confirmed_at;
 
         self.confirmations.push(TrusteeConfirmation {
             trustee_did,
@@ -260,13 +314,12 @@ impl DeathVerification {
     }
 
     /// Reject the death claim.
-    pub fn reject(&mut self) -> Result<(), MessagingError> {
+    pub fn reject(&mut self, metadata: DeathRejectionMetadata) -> Result<(), MessagingError> {
         if self.status != DeathVerificationStatus::Pending {
             return Err(MessagingError::DeathTriggerAlreadyResolved);
         }
-        let mut clock = HybridClock::new();
         self.status = DeathVerificationStatus::Rejected;
-        self.resolved_at = Some(clock.now());
+        self.resolved_at = Some(metadata.rejected_at);
         Ok(())
     }
 
@@ -345,6 +398,22 @@ mod tests {
         KeyPair::from_secret_bytes([seed; 32]).unwrap()
     }
 
+    fn timestamp(physical_ms: u64) -> Timestamp {
+        Timestamp::new(physical_ms, 0)
+    }
+
+    fn creation_metadata(physical_ms: u64) -> DeathVerificationCreationMetadata {
+        DeathVerificationCreationMetadata::new(timestamp(physical_ms)).unwrap()
+    }
+
+    fn confirmation_metadata(physical_ms: u64) -> DeathConfirmationMetadata {
+        DeathConfirmationMetadata::new(timestamp(physical_ms)).unwrap()
+    }
+
+    fn rejection_metadata(physical_ms: u64) -> DeathRejectionMetadata {
+        DeathRejectionMetadata::new(timestamp(physical_ms)).unwrap()
+    }
+
     fn authorized_trustees(entries: &[(&Did, &KeyPair)]) -> BTreeMap<Did, PublicKey> {
         entries
             .iter()
@@ -394,6 +463,7 @@ mod tests {
             authorized_trustees,
             claim_nonce,
             signature,
+            creation_metadata(1_000),
         )
         .unwrap()
     }
@@ -426,6 +496,7 @@ mod tests {
             authorized.clone(),
             nonce.clone(),
             Signature::Empty,
+            creation_metadata(1_001),
         );
         assert!(matches!(
             result,
@@ -433,8 +504,16 @@ mod tests {
         ));
 
         let signature = initial_signature(&subject, &bob, 2, &authorized, &nonce, &bob_key);
-        let dv =
-            DeathVerification::new(subject, bob.clone(), 2, authorized, nonce, signature).unwrap();
+        let dv = DeathVerification::new(
+            subject,
+            bob.clone(),
+            2,
+            authorized,
+            nonce,
+            signature,
+            creation_metadata(1_002),
+        )
+        .unwrap();
         assert_eq!(dv.confirmations.len(), 1);
         assert_eq!(dv.confirmations[0].trustee_did, did("bob"));
         assert_eq!(dv.confirmations[0].public_key, *bob_key.public_key());
@@ -461,7 +540,12 @@ mod tests {
             &bob_key,
         );
 
-        let result = dv.confirm(mallory.clone(), *mallory_key.public_key(), Signature::Empty);
+        let result = dv.confirm(
+            mallory.clone(),
+            *mallory_key.public_key(),
+            Signature::Empty,
+            confirmation_metadata(2_000),
+        );
         assert!(matches!(
             result,
             Err(MessagingError::UnauthorizedTrustee(trustee)) if trustee == mallory.as_str()
@@ -487,7 +571,12 @@ mod tests {
         );
         let signature = confirmation_signature(&dv, &carol, &wrong_key);
 
-        let result = dv.confirm(carol, *wrong_key.public_key(), signature);
+        let result = dv.confirm(
+            carol,
+            *wrong_key.public_key(),
+            signature,
+            confirmation_metadata(2_001),
+        );
         assert!(matches!(
             result,
             Err(MessagingError::SignatureVerificationFailed)
@@ -520,7 +609,12 @@ mod tests {
         );
         let replayed_signature = confirmation_signature(&dv_a, &carol, &carol_key);
 
-        let result = dv_b.confirm(carol, *carol_key.public_key(), replayed_signature);
+        let result = dv_b.confirm(
+            carol,
+            *carol_key.public_key(),
+            replayed_signature,
+            confirmation_metadata(2_002),
+        );
         assert!(matches!(
             result,
             Err(MessagingError::SignatureVerificationFailed)
@@ -546,7 +640,12 @@ mod tests {
         let signature = confirmation_signature(&dv, &carol, &carol_key);
         dv.subject_did = did("mallory");
 
-        let result = dv.confirm(carol, *carol_key.public_key(), signature);
+        let result = dv.confirm(
+            carol,
+            *carol_key.public_key(),
+            signature,
+            confirmation_metadata(2_003),
+        );
         assert!(matches!(
             result,
             Err(MessagingError::SignatureVerificationFailed)
@@ -575,14 +674,24 @@ mod tests {
 
         let carol_signature = confirmation_signature(&dv, &carol, &carol_key);
         let met = dv
-            .confirm(carol.clone(), *carol_key.public_key(), carol_signature)
+            .confirm(
+                carol.clone(),
+                *carol_key.public_key(),
+                carol_signature,
+                confirmation_metadata(2_004),
+            )
             .unwrap();
         assert!(!met);
         assert_eq!(dv.confirmations_remaining(), 1);
 
         let dave_signature = confirmation_signature(&dv, &dave, &dave_key);
         let met = dv
-            .confirm(dave, *dave_key.public_key(), dave_signature)
+            .confirm(
+                dave,
+                *dave_key.public_key(),
+                dave_signature,
+                confirmation_metadata(2_005),
+            )
             .unwrap();
         assert!(met);
         assert_eq!(dv.status, DeathVerificationStatus::Verified);
@@ -610,10 +719,20 @@ mod tests {
             &bob_key,
         );
         let signature = confirmation_signature(&dv, &carol, &carol_key);
-        dv.confirm(carol.clone(), *carol_key.public_key(), signature.clone())
-            .unwrap();
+        dv.confirm(
+            carol.clone(),
+            *carol_key.public_key(),
+            signature.clone(),
+            confirmation_metadata(2_006),
+        )
+        .unwrap();
 
-        let result = dv.confirm(carol.clone(), *carol_key.public_key(), signature);
+        let result = dv.confirm(
+            carol.clone(),
+            *carol_key.public_key(),
+            signature,
+            confirmation_metadata(2_007),
+        );
         assert!(matches!(
             result,
             Err(MessagingError::DuplicateConfirmation(trustee)) if trustee == carol.as_str()
@@ -640,11 +759,21 @@ mod tests {
             &bob_key,
         );
         let carol_signature = confirmation_signature(&dv, &carol, &carol_key);
-        dv.confirm(carol, *carol_key.public_key(), carol_signature)
-            .unwrap();
+        dv.confirm(
+            carol,
+            *carol_key.public_key(),
+            carol_signature,
+            confirmation_metadata(2_008),
+        )
+        .unwrap();
 
         let dave_signature = confirmation_signature(&dv, &dave, &dave_key);
-        let result = dv.confirm(dave, *dave_key.public_key(), dave_signature);
+        let result = dv.confirm(
+            dave,
+            *dave_key.public_key(),
+            dave_signature,
+            confirmation_metadata(2_009),
+        );
         assert!(matches!(
             result,
             Err(MessagingError::DeathTriggerAlreadyResolved)
@@ -667,12 +796,17 @@ mod tests {
             b"r6-claim-8".to_vec(),
             &bob_key,
         );
-        dv.reject().unwrap();
+        dv.reject(rejection_metadata(3_000)).unwrap();
         assert_eq!(dv.status, DeathVerificationStatus::Rejected);
         assert!(!dv.should_release());
 
         let carol_signature = confirmation_signature(&dv, &carol, &carol_key);
-        let result = dv.confirm(carol, *carol_key.public_key(), carol_signature);
+        let result = dv.confirm(
+            carol,
+            *carol_key.public_key(),
+            carol_signature,
+            confirmation_metadata(2_010),
+        );
         assert!(matches!(
             result,
             Err(MessagingError::DeathTriggerAlreadyResolved)
@@ -707,8 +841,13 @@ mod tests {
         assert_eq!(dv.confirmations_remaining(), 2);
 
         let alternate_signature = confirmation_signature(&dv, &alternate, &alternate_key);
-        dv.confirm(alternate, *alternate_key.public_key(), alternate_signature)
-            .unwrap();
+        dv.confirm(
+            alternate,
+            *alternate_key.public_key(),
+            alternate_signature,
+            confirmation_metadata(2_011),
+        )
+        .unwrap();
         assert_eq!(dv.confirmations_remaining(), 1);
 
         let contingency_signature = confirmation_signature(&dv, &contingency, &contingency_key);
@@ -717,10 +856,126 @@ mod tests {
                 contingency,
                 *contingency_key.public_key(),
                 contingency_signature,
+                confirmation_metadata(2_012),
             )
             .unwrap();
         assert!(verified);
         assert!(dv.should_release());
         assert_eq!(dv.confirmations_remaining(), 0);
+    }
+
+    #[test]
+    fn creation_metadata_rejects_zero_created_at() {
+        let result = DeathVerificationCreationMetadata::new(Timestamp::ZERO);
+
+        assert!(
+            matches!(result, Err(MessagingError::InvalidDeathVerification(reason)) if reason.contains("created_at"))
+        );
+    }
+
+    #[test]
+    fn creation_preserves_caller_supplied_timestamps() {
+        let subject = did("alice");
+        let bob = did("bob");
+        let bob_key = keypair(1);
+        let authorized = authorized_trustees(&[(&bob, &bob_key)]);
+        let nonce = b"r6-claim-single".to_vec();
+        let signature = initial_signature(&subject, &bob, 1, &authorized, &nonce, &bob_key);
+        let metadata = creation_metadata(7_001);
+
+        let dv = DeathVerification::new(subject, bob, 1, authorized, nonce, signature, metadata)
+            .unwrap();
+
+        assert_eq!(dv.created, timestamp(7_001));
+        assert_eq!(dv.confirmations[0].confirmed_at, timestamp(7_001));
+        assert_eq!(dv.resolved_at, Some(timestamp(7_001)));
+    }
+
+    #[test]
+    fn confirmation_metadata_rejects_zero_confirmed_at() {
+        let result = DeathConfirmationMetadata::new(Timestamp::ZERO);
+
+        assert!(
+            matches!(result, Err(MessagingError::InvalidDeathVerification(reason)) if reason.contains("confirmed_at"))
+        );
+    }
+
+    #[test]
+    fn confirm_preserves_caller_supplied_timestamp() {
+        let subject = did("alice");
+        let bob = did("bob");
+        let carol = did("carol");
+        let bob_key = keypair(1);
+        let carol_key = keypair(2);
+        let authorized = authorized_trustees(&[(&bob, &bob_key), (&carol, &carol_key)]);
+        let mut dv = signed_verification(
+            &subject,
+            &bob,
+            2,
+            authorized,
+            b"r6-claim-confirm-time".to_vec(),
+            &bob_key,
+        );
+        let signature = confirmation_signature(&dv, &carol, &carol_key);
+
+        let verified = dv
+            .confirm(
+                carol,
+                *carol_key.public_key(),
+                signature,
+                confirmation_metadata(7_002),
+            )
+            .unwrap();
+
+        assert!(verified);
+        assert_eq!(dv.confirmations[1].confirmed_at, timestamp(7_002));
+        assert_eq!(dv.resolved_at, Some(timestamp(7_002)));
+    }
+
+    #[test]
+    fn rejection_metadata_rejects_zero_rejected_at() {
+        let result = DeathRejectionMetadata::new(Timestamp::ZERO);
+
+        assert!(
+            matches!(result, Err(MessagingError::InvalidDeathVerification(reason)) if reason.contains("rejected_at"))
+        );
+    }
+
+    #[test]
+    fn reject_preserves_caller_supplied_timestamp() {
+        let subject = did("alice");
+        let bob = did("bob");
+        let carol = did("carol");
+        let bob_key = keypair(1);
+        let carol_key = keypair(2);
+        let authorized = authorized_trustees(&[(&bob, &bob_key), (&carol, &carol_key)]);
+        let mut dv = signed_verification(
+            &subject,
+            &bob,
+            2,
+            authorized,
+            b"r6-claim-reject-time".to_vec(),
+            &bob_key,
+        );
+
+        dv.reject(rejection_metadata(7_003)).unwrap();
+
+        assert_eq!(dv.status, DeathVerificationStatus::Rejected);
+        assert_eq!(dv.resolved_at, Some(timestamp(7_003)));
+    }
+
+    #[test]
+    fn death_trigger_path_does_not_fabricate_hlc_metadata() {
+        let source = include_str!("death_trigger.rs");
+        let production = source
+            .split("// ===========================================================================")
+            .next()
+            .unwrap();
+        let forbidden_clock = ["HybridClock", "::new()"].concat();
+
+        assert!(
+            !production.contains(&forbidden_clock),
+            "death-trigger production path must not fabricate HLC timestamps"
+        );
     }
 }

--- a/crates/exochain-wasm/src/lib.rs
+++ b/crates/exochain-wasm/src/lib.rs
@@ -103,6 +103,11 @@ mod source_guard_tests {
             source.contains("ComposeMetadata::new"),
             "messaging WASM encryption must validate caller-supplied envelope metadata"
         );
+        assert!(
+            source.contains("DeathVerificationCreationMetadata::new")
+                && source.contains("DeathConfirmationMetadata::new"),
+            "messaging WASM death verification must validate caller-supplied state metadata"
+        );
 
         let forbidden = [
             format!("{}{}", "Timestamp::", "now_utc()"),

--- a/crates/exochain-wasm/src/messaging_bindings.rs
+++ b/crates/exochain-wasm/src/messaging_bindings.rs
@@ -261,6 +261,10 @@ pub fn wasm_death_verification_initial_signing_payload(
 /// this claim instance.
 /// Returns the verification state as JSON.
 #[wasm_bindgen]
+#[allow(clippy::too_many_arguments)]
+// WASM cannot take Rust metadata structs directly, so the death-verification
+// creation boundary exposes the HLC metadata as primitive fields and validates
+// it before touching the state machine.
 pub fn wasm_death_verification_new(
     subject_did: &str,
     initiated_by_did: &str,
@@ -268,6 +272,8 @@ pub fn wasm_death_verification_new(
     authorized_trustees_json: &str,
     claim_nonce_hex: &str,
     initiator_signature_hex: &str,
+    created_physical_ms: u64,
+    created_logical: u32,
 ) -> Result<JsValue, JsValue> {
     let subject = exo_core::Did::new(subject_did)
         .map_err(|e| JsValue::from_str(&format!("invalid subject DID: {e}")))?;
@@ -278,6 +284,10 @@ pub fn wasm_death_verification_new(
         .map_err(|e| JsValue::from_str(&format!("invalid claim nonce hex: {e}")))?;
     let initiator_signature =
         parse_ed25519_signature_hex("initiator confirmation signature", initiator_signature_hex)?;
+    let metadata = exo_messaging::death_trigger::DeathVerificationCreationMetadata::new(
+        exo_core::Timestamp::new(created_physical_ms, created_logical),
+    )
+    .map_err(|e| JsValue::from_str(&format!("invalid death verification metadata: {e}")))?;
 
     let dv = exo_messaging::death_trigger::DeathVerification::new(
         subject,
@@ -286,6 +296,7 @@ pub fn wasm_death_verification_new(
         authorized_trustees,
         claim_nonce,
         initiator_signature,
+        metadata,
     )
     .map_err(|e| JsValue::from_str(&format!("death verification creation failed: {e}")))?;
     to_js_value(&dv)
@@ -318,6 +329,8 @@ pub fn wasm_death_verification_confirm(
     trustee_did: &str,
     trustee_public_key_hex: &str,
     signature_hex: &str,
+    confirmed_physical_ms: u64,
+    confirmed_logical: u32,
 ) -> Result<JsValue, JsValue> {
     let mut dv: exo_messaging::death_trigger::DeathVerification = from_json_str(state_json)?;
     let trustee = exo_core::Did::new(trustee_did)
@@ -325,9 +338,13 @@ pub fn wasm_death_verification_confirm(
     let trustee_public_key =
         parse_ed25519_public_key_hex("trustee Ed25519 public key", trustee_public_key_hex)?;
     let signature = parse_ed25519_signature_hex("trustee confirmation signature", signature_hex)?;
+    let metadata = exo_messaging::death_trigger::DeathConfirmationMetadata::new(
+        exo_core::Timestamp::new(confirmed_physical_ms, confirmed_logical),
+    )
+    .map_err(|e| JsValue::from_str(&format!("invalid death confirmation metadata: {e}")))?;
 
     let verified = dv
-        .confirm(trustee, trustee_public_key, signature)
+        .confirm(trustee, trustee_public_key, signature, metadata)
         .map_err(|e| JsValue::from_str(&format!("confirmation failed: {e}")))?;
 
     to_js_value(&serde_json::json!({

--- a/demo/apps/vitallock/src/lib/crypto.ts
+++ b/demo/apps/vitallock/src/lib/crypto.ts
@@ -187,6 +187,8 @@ export function createDeathVerification(
   authorizedTrustees: AuthorizedDeathVerificationTrustee[],
   claimNonceHex: string,
   initiatorSignatureHex: string,
+  createdPhysicalMs: bigint,
+  createdLogical: number,
   requiredConfirmations: number = 3,
 ): DeathVerificationState {
   return wasm_death_verification_new(
@@ -196,6 +198,8 @@ export function createDeathVerification(
     JSON.stringify(authorizedTrustees),
     claimNonceHex,
     initiatorSignatureHex,
+    createdPhysicalMs,
+    createdLogical,
   );
 }
 
@@ -213,11 +217,15 @@ export function confirmDeathVerification(
   trusteeDid: string,
   trusteePublicKeyHex: string,
   signatureHex: string,
+  confirmedPhysicalMs: bigint,
+  confirmedLogical: number,
 ): { verified: boolean; confirmations_remaining: number; state: DeathVerificationState } {
   return wasm_death_verification_confirm(
     stateJson,
     trusteeDid,
     trusteePublicKeyHex,
     signatureHex,
+    confirmedPhysicalMs,
+    confirmedLogical,
   );
 }

--- a/demo/services/vitallock-api/src/index.js
+++ b/demo/services/vitallock-api/src/index.js
@@ -287,6 +287,8 @@ export const server = http.createServer(async (req, res) => {
         authorized_trustees,
         claim_nonce_hex,
         initiator_signature_hex,
+        created_physical_ms,
+        created_logical,
       } = await parseBody(req);
 
       if (!Array.isArray(authorized_trustees)) {
@@ -297,6 +299,11 @@ export const server = http.createServer(async (req, res) => {
           error: 'claim_nonce_hex and initiator_signature_hex are required',
         });
       }
+      if (created_physical_ms === undefined || created_logical === undefined) {
+        return json(res, 400, {
+          error: 'created_physical_ms and created_logical are required',
+        });
+      }
 
       const state = wasm.wasm_death_verification_new(
         subject_did,
@@ -304,7 +311,9 @@ export const server = http.createServer(async (req, res) => {
         required_confirmations || 3,
         JSON.stringify(authorized_trustees),
         claim_nonce_hex,
-        initiator_signature_hex
+        initiator_signature_hex,
+        BigInt(created_physical_ms),
+        created_logical
       );
       const initialStatus = state.status === 'Verified' ? 'verified' : 'pending';
 
@@ -315,7 +324,7 @@ export const server = http.createServer(async (req, res) => {
           trustee_confirmations, verification_state, status, created_at_ms)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
         [id, subject_did, initiated_by_did, required_confirmations || 3,
-         JSON.stringify(state.confirmations || []), JSON.stringify(state), initialStatus, nowMs()]
+         JSON.stringify(state.confirmations || []), JSON.stringify(state), initialStatus, created_physical_ms]
       );
 
       return json(res, 201, { id, status: initialStatus, state });
@@ -328,11 +337,18 @@ export const server = http.createServer(async (req, res) => {
         trustee_did,
         trustee_public_key_hex,
         signature_hex,
+        confirmed_physical_ms,
+        confirmed_logical,
       } = await parseBody(req);
 
       if (!trustee_public_key_hex || !signature_hex) {
         return json(res, 400, {
           error: 'trustee_public_key_hex and signature_hex are required',
+        });
+      }
+      if (confirmed_physical_ms === undefined || confirmed_logical === undefined) {
+        return json(res, 400, {
+          error: 'confirmed_physical_ms and confirmed_logical are required',
         });
       }
 
@@ -354,7 +370,9 @@ export const server = http.createServer(async (req, res) => {
         JSON.stringify(dv.verification_state),
         trustee_did,
         trustee_public_key_hex,
-        signature_hex
+        signature_hex,
+        BigInt(confirmed_physical_ms),
+        confirmed_logical
       );
 
       const verified = result.verified;
@@ -369,7 +387,7 @@ export const server = http.createServer(async (req, res) => {
           JSON.stringify(result.state.confirmations || []),
           JSON.stringify(result.state),
           newStatus,
-          verified ? nowMs() : null,
+          verified ? confirmed_physical_ms : null,
           verification_id,
         ]
       );

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -310,14 +310,23 @@ test('wasm_death_verification_new', () => {
   if (!deathTrusteesJson || !deathInitialSignatureHex) {
     throw new Error('skipped -- no signed initial payload');
   }
-  return wasm.wasm_death_verification_new(
+  const state = wasm.wasm_death_verification_new(
     TEST_DID,
     TEST_DID_2,
     2,
     deathTrusteesJson,
     deathClaimNonceHex,
-    deathInitialSignatureHex
+    deathInitialSignatureHex,
+    NOW_MS,
+    0
   );
+  if (state.created.physical_ms !== NOW_NUM || state.created.logical !== 0) {
+    throw new Error('death verification created timestamp must be caller-supplied HLC');
+  }
+  if (state.confirmations[0].confirmed_at.physical_ms !== NOW_NUM) {
+    throw new Error('initial confirmation timestamp must match caller-supplied creation HLC');
+  }
+  return state;
 });
 
 const deathState = setup(() =>
@@ -327,7 +336,9 @@ const deathState = setup(() =>
     2,
     deathTrusteesJson,
     deathClaimNonceHex,
-    deathInitialSignatureHex
+    deathInitialSignatureHex,
+    NOW_MS,
+    0
   ));
 
 test('wasm_death_verification_confirmation_signing_payload', () => {
@@ -352,12 +363,22 @@ test('wasm_death_verification_confirm', () => {
   if (!deathState || !trusteePublicKey || !deathConfirmationSignatureHex) {
     throw new Error('skipped -- no signed confirmation payload');
   }
-  return wasm.wasm_death_verification_confirm(
+  const result = wasm.wasm_death_verification_confirm(
     JSON.stringify(deathState),
     TEST_DID_3,
     trusteePublicKey,
-    deathConfirmationSignatureHex
+    deathConfirmationSignatureHex,
+    BigInt(NOW_NUM + 1),
+    0
   );
+  const confirmation = result.state.confirmations[1];
+  if (confirmation.confirmed_at.physical_ms !== NOW_NUM + 1 || confirmation.confirmed_at.logical !== 0) {
+    throw new Error('trustee confirmation timestamp must be caller-supplied HLC');
+  }
+  if (result.state.resolved_at.physical_ms !== NOW_NUM + 1) {
+    throw new Error('verified death claim resolution timestamp must match confirmation HLC');
+  }
+  return result;
 });
 
 // =========================================================================


### PR DESCRIPTION
## Summary
- require caller-supplied non-zero HLC metadata for death verification creation, trustee confirmation, and rejection
- remove internal HybridClock fabrication from the death-trigger state machine
- carry metadata through WASM and VitalLock callers, with bridge assertions for timestamp preservation
- refresh README repo-truth counts to 111386 Rust LOC and 2,741 listed tests

## Verification
- cargo test -p exo-messaging creation_metadata_rejects_zero_created_at --lib (red before implementation, green after)
- cargo test -p exo-messaging --lib
- cargo test -p exo-messaging
- cargo test -p exochain-wasm
- cargo clippy -p exo-messaging --lib --bins -- -D warnings
- cargo clippy -p exo-messaging --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo clippy -p exochain-wasm --lib -- -D warnings
- cargo clippy -p exochain-wasm --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- wasm-pack build crates/exochain-wasm --target nodejs --release --out-dir ../../packages/exochain-wasm/wasm
- wasm-pack build crates/exochain-wasm --target nodejs --release --out-dir ../../demo/packages/exochain-wasm/wasm
- node packages/exochain-wasm/test/bridge_verification.mjs
- npm run test:wasm (demo)
- npm test (demo)
- node --check demo/services/vitallock-api/src/index.js
- cargo +nightly fmt --all -- --check
- git diff --check
- bash tools/repo_truth.sh --json
- bash tools/test_repo_truth.sh
- bash tools/test_cr001_status.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_no_orphan_rust_modules.sh
- bash tools/test_railway_entrypoint_args.sh
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo build --workspace --release
- cargo test --workspace --release
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
- cargo audit --deny unsound --deny unmaintained
- cargo deny check
- cargo machete --with-metadata

Note: npm run build in demo/apps/vitallock could not run because that app has no local node_modules/tsc installed; root demo tests and wasm bridge tests passed.