### PR TITLE
fix(exo-authority): sign delegation registry grants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,6 +1319,7 @@ name = "exo-authority"
 version = "0.1.0-beta"
 dependencies = [
  "blake3",
+ "ciborium",
  "ed25519-dalek",
  "exo-core",
  "exo-identity",

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 112221 | `wc -l` |
-| Workspace tests | 2,762 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 112451 | `wc -l` |
+| Workspace tests | 2,772 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,762 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,772 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 112221 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 112451 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,762 listed workspace tests
+         cryptographic proofs, 2,772 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          140 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-authority/Cargo.toml
+++ b/crates/exo-authority/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+ciborium = { workspace = true }
 exo-core = { path = "../exo-core" }
 exo-identity = { path = "../exo-identity" }
 serde = { workspace = true }

--- a/crates/exo-authority/src/cache.rs
+++ b/crates/exo-authority/src/cache.rs
@@ -151,7 +151,7 @@ mod tests {
                 scope: vec![Permission::Read],
                 created: ts(1000),
                 expires: None,
-                signature: Signature::from_bytes([1u8; 64]),
+                signature: Signature::from_bytes([0xA5u8; 64]),
                 depth: 0,
                 delegatee_kind: crate::chain::DelegateeKind::Human,
             }],

--- a/crates/exo-authority/src/chain.rs
+++ b/crates/exo-authority/src/chain.rs
@@ -13,6 +13,22 @@ use crate::{
 
 /// Default maximum delegation depth.
 pub const DEFAULT_MAX_DEPTH: usize = 5;
+/// Domain tag for authority delegation signatures.
+pub const AUTHORITY_LINK_SIGNING_DOMAIN: &str = "exo.authority.delegation.v1";
+const AUTHORITY_LINK_SIGNING_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Serialize)]
+struct AuthorityLinkSigningPayload<'a> {
+    domain: &'static str,
+    schema_version: u16,
+    delegator_did: &'a Did,
+    delegate_did: &'a Did,
+    scope: &'a [Permission],
+    created: &'a Timestamp,
+    expires: &'a Option<Timestamp>,
+    depth: usize,
+    delegatee_kind: &'a DelegateeKind,
+}
 
 /// Distinguishes human delegatees from AI agent delegatees.
 ///
@@ -56,32 +72,48 @@ pub struct AuthorityLink {
 
 impl AuthorityLink {
     /// Compute a deterministic ID for this link.
-    #[must_use]
-    pub fn id(&self) -> Hash256 {
-        Hash256::digest(&self.signable_payload())
+    ///
+    /// # Errors
+    ///
+    /// Returns `AuthorityError::SigningPayloadEncoding` if canonical CBOR
+    /// encoding of the signed payload fails.
+    pub fn id(&self) -> Result<Hash256, AuthorityError> {
+        Ok(Hash256::digest(&self.signing_payload()?))
     }
 
     /// The canonical payload that must be signed by the delegator.
-    /// This is the deterministic byte representation of the link's content
-    /// (excluding the signature itself).
-    #[must_use]
-    pub fn signable_payload(&self) -> Vec<u8> {
-        let mut data = Vec::new();
-        data.extend_from_slice(self.delegator_did.as_str().as_bytes());
-        data.extend_from_slice(self.delegate_did.as_str().as_bytes());
-        for p in &self.scope {
-            data.extend_from_slice(format!("{p:?}").as_bytes());
-        }
-        data.extend_from_slice(&self.created.physical_ms.to_le_bytes());
-        data.extend_from_slice(&self.created.logical.to_le_bytes());
-        data.extend_from_slice(&self.depth.to_le_bytes());
-        if let Some(exp) = &self.expires {
-            data.extend_from_slice(&exp.physical_ms.to_le_bytes());
-            data.extend_from_slice(&exp.logical.to_le_bytes());
-        }
-        // Include delegatee kind so it is cryptographically bound to the grant.
-        data.extend_from_slice(format!("{:?}", self.delegatee_kind).as_bytes());
-        data
+    ///
+    /// The payload is domain-separated canonical CBOR and excludes the
+    /// signature itself. Permissions are represented as a deterministic set so
+    /// caller ordering cannot alter the grant identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns `AuthorityError::SigningPayloadEncoding` if canonical CBOR
+    /// encoding fails.
+    pub fn signing_payload(&self) -> Result<Vec<u8>, AuthorityError> {
+        let scope: Vec<Permission> = PermissionSet::from_permissions(&self.scope)
+            .iter()
+            .copied()
+            .collect();
+        let payload = AuthorityLinkSigningPayload {
+            domain: AUTHORITY_LINK_SIGNING_DOMAIN,
+            schema_version: AUTHORITY_LINK_SIGNING_SCHEMA_VERSION,
+            delegator_did: &self.delegator_did,
+            delegate_did: &self.delegate_did,
+            scope: &scope,
+            created: &self.created,
+            expires: &self.expires,
+            depth: self.depth,
+            delegatee_kind: &self.delegatee_kind,
+        };
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&payload, &mut buf).map_err(|e| {
+            AuthorityError::SigningPayloadEncoding {
+                reason: e.to_string(),
+            }
+        })?;
+        Ok(buf)
     }
 }
 
@@ -213,7 +245,7 @@ where
         // Real Ed25519 signature verification
         let pub_key = resolve_key(&link.delegator_did)
             .ok_or(AuthorityError::InvalidSignature { index: i })?;
-        let payload = link.signable_payload();
+        let payload = link.signing_payload()?;
         if !exo_core::crypto::verify(&payload, &link.signature, &pub_key) {
             return Err(AuthorityError::InvalidSignature { index: i });
         }
@@ -316,7 +348,7 @@ mod tests {
             depth,
             delegatee_kind: DelegateeKind::Human,
         };
-        let payload = link.signable_payload();
+        let payload = link.signing_payload().expect("canonical signing payload");
         let kp = registry
             .keys
             .get(&format!("did:exo:{from}"))
@@ -339,7 +371,7 @@ mod tests {
             scope,
             created: ts(1000),
             expires: exp,
-            signature: Signature::from_bytes([1u8; 64]),
+            signature: Signature::from_bytes([0xA5u8; 64]),
             depth,
             delegatee_kind: DelegateeKind::Human,
         }
@@ -505,7 +537,7 @@ mod tests {
             depth: 0,
             delegatee_kind: DelegateeKind::Human,
         };
-        let payload = link.signable_payload();
+        let payload = link.signing_payload().expect("canonical signing payload");
         // Sign with alice's key (wrong key for root)
         let alice_kp = reg.keys.get("did:exo:alice").unwrap();
         link.signature = alice_kp.sign(&payload);
@@ -659,15 +691,35 @@ mod tests {
     #[test]
     fn link_id_deterministic() {
         let l = fake_link("root", "alice", vec![Permission::Read], 0, None);
-        let id1 = l.id();
-        let id2 = l.id();
+        let id1 = l.id().expect("canonical link id");
+        let id2 = l.id().expect("canonical link id");
         assert_eq!(id1, id2);
     }
 
     #[test]
-    fn signable_payload_deterministic() {
+    fn signing_payload_deterministic() {
         let l = fake_link("root", "alice", vec![Permission::Read], 0, None);
-        assert_eq!(l.signable_payload(), l.signable_payload());
+        assert_eq!(
+            l.signing_payload().expect("canonical signing payload"),
+            l.signing_payload().expect("canonical signing payload")
+        );
+    }
+
+    #[test]
+    fn authority_link_signing_payload_is_domain_tagged_cbor() {
+        #[derive(Deserialize)]
+        struct DecodedPayload {
+            domain: String,
+            schema_version: u16,
+        }
+
+        let link = fake_link("root", "alice", vec![Permission::Read], 0, None);
+        let payload = link.signing_payload().expect("canonical signing payload");
+        let decoded: DecodedPayload =
+            ciborium::from_reader(payload.as_slice()).expect("decode authority payload");
+
+        assert_eq!(decoded.domain, AUTHORITY_LINK_SIGNING_DOMAIN);
+        assert_eq!(decoded.schema_version, 1);
     }
 
     #[test]

--- a/crates/exo-authority/src/delegation.rs
+++ b/crates/exo-authority/src/delegation.rs
@@ -1,8 +1,8 @@
 //! Delegation management — tracks active delegations and resolves chains.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
-use exo_core::{Did, Hash256, Signature, Timestamp};
+use exo_core::{Did, Hash256, PublicKey, Signature, Timestamp, crypto};
 
 use crate::{
     chain::{self, AuthorityChain, AuthorityLink, DEFAULT_MAX_DEPTH, DelegateeKind},
@@ -21,6 +21,17 @@ pub struct DelegationRegistry {
     by_delegate: BTreeMap<String, Vec<Hash256>>,
 }
 
+/// Caller-supplied fields for a signed delegation grant.
+pub struct DelegationGrant<'a> {
+    pub from: &'a Did,
+    pub to: &'a Did,
+    pub scope: &'a [Permission],
+    pub expires: Timestamp,
+    pub now: &'a Timestamp,
+    pub delegatee_kind: DelegateeKind,
+    pub delegator_public_key: &'a PublicKey,
+}
+
 impl DelegationRegistry {
     #[must_use]
     pub fn new() -> Self {
@@ -33,13 +44,19 @@ impl DelegationRegistry {
     /// Returns `CircularDelegation` if this would create a cycle.
     pub fn delegate(
         &mut self,
-        from: &Did,
-        to: &Did,
-        scope: &[Permission],
-        expires: Timestamp,
-        now: &Timestamp,
-        delegatee_kind: DelegateeKind,
+        grant: DelegationGrant<'_>,
+        sign_fn: impl FnOnce(&[u8]) -> Signature,
     ) -> Result<AuthorityLink, AuthorityError> {
+        let DelegationGrant {
+            from,
+            to,
+            scope,
+            expires,
+            now,
+            delegatee_kind,
+            delegator_public_key,
+        } = grant;
+
         // Detect circular: if `to` already delegates (directly or transitively) to `from`
         if self.has_path(to, from) {
             return Err(AuthorityError::CircularDelegation(format!(
@@ -48,20 +65,52 @@ impl DelegationRegistry {
             )));
         }
 
+        if *now == Timestamp::ZERO {
+            return Err(AuthorityError::InvalidDelegation {
+                reason: "created timestamp must be non-zero".into(),
+            });
+        }
+        if expires <= *now {
+            return Err(AuthorityError::InvalidDelegation {
+                reason: "expiration must be later than created timestamp".into(),
+            });
+        }
+        if let DelegateeKind::AiAgent { model_id } = &delegatee_kind {
+            if model_id.trim().is_empty() {
+                return Err(AuthorityError::InvalidDelegation {
+                    reason: "AI-agent delegatee kind requires a non-empty model_id".into(),
+                });
+            }
+        }
+
+        let scope = canonical_scope(scope)?;
         let depth = self.compute_depth(from);
 
-        let link = AuthorityLink {
+        let mut link = AuthorityLink {
             delegator_did: from.clone(),
             delegate_did: to.clone(),
-            scope: scope.to_vec(),
+            scope,
             created: *now,
             expires: Some(expires),
-            signature: Signature::from_bytes([1u8; 64]), // placeholder
+            signature: Signature::empty(),
             depth,
             delegatee_kind,
         };
 
-        let id = link.id();
+        let payload = link.signing_payload()?;
+        let signature = sign_fn(&payload);
+        if signature.is_empty() || signature_is_all_zero(&signature) {
+            return Err(AuthorityError::InvalidSignature { index: depth });
+        }
+        if !crypto::verify(&payload, &signature, delegator_public_key) {
+            return Err(AuthorityError::InvalidSignature { index: depth });
+        }
+        link.signature = signature;
+
+        let id = link.id()?;
+        if self.links.contains_key(&id) {
+            return Err(AuthorityError::DuplicateDelegation { id: id.to_string() });
+        }
         self.links.insert(id, link.clone());
         self.by_delegator
             .entry(from.as_str().to_owned())
@@ -194,8 +243,28 @@ impl DelegationRegistry {
     }
 }
 
+fn canonical_scope(scope: &[Permission]) -> Result<Vec<Permission>, AuthorityError> {
+    let scope: BTreeSet<Permission> = scope.iter().copied().collect();
+    if scope.is_empty() {
+        return Err(AuthorityError::InvalidDelegation {
+            reason: "scope must contain at least one permission".into(),
+        });
+    }
+    Ok(scope.into_iter().collect())
+}
+
+fn signature_is_all_zero(signature: &Signature) -> bool {
+    let raw = signature.as_bytes();
+    !raw.is_empty() && raw.iter().all(|b| *b == 0)
+}
+
 #[cfg(test)]
 mod tests {
+    use exo_core::{
+        PublicKey,
+        crypto::{self, KeyPair},
+    };
+
     use super::*;
 
     fn did(name: &str) -> Did {
@@ -207,18 +276,173 @@ mod tests {
     fn now() -> Timestamp {
         ts(5000)
     }
+    fn public_key(keypair: &KeyPair) -> PublicKey {
+        *keypair.public_key()
+    }
+    fn signed_delegate(
+        reg: &mut DelegationRegistry,
+        from: &str,
+        to: &str,
+        scope: &[Permission],
+        signer: &KeyPair,
+    ) -> Result<AuthorityLink, AuthorityError> {
+        let public_key = public_key(signer);
+        let from = did(from);
+        let to = did(to);
+        reg.delegate(
+            DelegationGrant {
+                from: &from,
+                to: &to,
+                scope,
+                expires: ts(10000),
+                now: &now(),
+                delegatee_kind: DelegateeKind::Human,
+                delegator_public_key: &public_key,
+            },
+            |payload| signer.sign(payload),
+        )
+    }
+
+    #[test]
+    fn delegate_signs_link_with_delegator_key() {
+        let mut reg = DelegationRegistry::new();
+        let keypair = KeyPair::generate();
+        let public_key = public_key(&keypair);
+        let link =
+            signed_delegate(&mut reg, "alice", "bob", &[Permission::Read], &keypair).unwrap();
+
+        assert!(!link.signature.is_empty());
+        let payload = link.signing_payload().unwrap();
+        assert!(crypto::verify(&payload, &link.signature, &public_key));
+    }
+
+    #[test]
+    fn delegate_rejects_wrong_key_signature() {
+        let mut reg = DelegationRegistry::new();
+        let signer = KeyPair::generate();
+        let wrong_key = KeyPair::generate();
+        let wrong_public_key = public_key(&wrong_key);
+        let from = did("alice");
+        let to = did("bob");
+
+        let result = reg.delegate(
+            DelegationGrant {
+                from: &from,
+                to: &to,
+                scope: &[Permission::Read],
+                expires: ts(10000),
+                now: &now(),
+                delegatee_kind: DelegateeKind::Human,
+                delegator_public_key: &wrong_public_key,
+            },
+            |payload| signer.sign(payload),
+        );
+
+        assert!(matches!(
+            result,
+            Err(AuthorityError::InvalidSignature { index: 0 })
+        ));
+    }
+
+    #[test]
+    fn delegate_rejects_empty_signature() {
+        let mut reg = DelegationRegistry::new();
+        let keypair = KeyPair::generate();
+        let public_key = public_key(&keypair);
+        let from = did("alice");
+        let to = did("bob");
+
+        let result = reg.delegate(
+            DelegationGrant {
+                from: &from,
+                to: &to,
+                scope: &[Permission::Read],
+                expires: ts(10000),
+                now: &now(),
+                delegatee_kind: DelegateeKind::Human,
+                delegator_public_key: &public_key,
+            },
+            |_payload| Signature::Empty,
+        );
+
+        assert!(matches!(
+            result,
+            Err(AuthorityError::InvalidSignature { index: 0 })
+        ));
+    }
+
+    #[test]
+    fn delegate_rejects_all_zero_signature() {
+        let mut reg = DelegationRegistry::new();
+        let keypair = KeyPair::generate();
+        let public_key = public_key(&keypair);
+        let from = did("alice");
+        let to = did("bob");
+
+        let result = reg.delegate(
+            DelegationGrant {
+                from: &from,
+                to: &to,
+                scope: &[Permission::Read],
+                expires: ts(10000),
+                now: &now(),
+                delegatee_kind: DelegateeKind::Human,
+                delegator_public_key: &public_key,
+            },
+            |_payload| Signature::from_bytes([0u8; 64]),
+        );
+
+        assert!(matches!(
+            result,
+            Err(AuthorityError::InvalidSignature { index: 0 })
+        ));
+    }
+
+    #[test]
+    fn delegate_rejects_duplicate_grant() {
+        let mut reg = DelegationRegistry::new();
+        let keypair = KeyPair::generate();
+        signed_delegate(&mut reg, "alice", "bob", &[Permission::Read], &keypair).unwrap();
+
+        let result = signed_delegate(&mut reg, "alice", "bob", &[Permission::Read], &keypair);
+
+        assert!(matches!(
+            result,
+            Err(AuthorityError::DuplicateDelegation { .. })
+        ));
+    }
+
+    #[test]
+    fn find_chain_returns_cryptographically_valid_chain() {
+        let mut reg = DelegationRegistry::new();
+        let alice_key = KeyPair::generate();
+        let bob_key = KeyPair::generate();
+        signed_delegate(
+            &mut reg,
+            "alice",
+            "bob",
+            &[Permission::Read, Permission::Write],
+            &alice_key,
+        )
+        .unwrap();
+        signed_delegate(&mut reg, "bob", "charlie", &[Permission::Read], &bob_key).unwrap();
+
+        let chain = reg
+            .find_chain(&did("alice"), &did("charlie"))
+            .expect("chain should resolve");
+        let keys = std::collections::BTreeMap::from([
+            (did("alice").as_str().to_owned(), public_key(&alice_key)),
+            (did("bob").as_str().to_owned(), public_key(&bob_key)),
+        ]);
+
+        assert!(chain::verify_chain(&chain, &now(), |did| keys.get(did.as_str()).copied()).is_ok());
+    }
 
     #[test]
     fn delegate_creates_link() {
         let mut reg = DelegationRegistry::new();
-        let link = reg.delegate(
-            &did("alice"),
-            &did("bob"),
-            &[Permission::Read],
-            ts(10000),
-            &now(),
-            DelegateeKind::Human,
-        );
+        let alice_key = KeyPair::generate();
+        let link = signed_delegate(&mut reg, "alice", "bob", &[Permission::Read], &alice_key);
         assert!(link.is_ok());
         let l = link.unwrap();
         assert_eq!(l.delegator_did, did("alice"));
@@ -229,54 +453,27 @@ mod tests {
     #[test]
     fn delegate_detects_circular() {
         let mut reg = DelegationRegistry::new();
-        reg.delegate(
-            &did("alice"),
-            &did("bob"),
-            &[Permission::Read],
-            ts(10000),
-            &now(),
-            DelegateeKind::Human,
-        )
-        .ok();
-        let result = reg.delegate(
-            &did("bob"),
-            &did("alice"),
-            &[Permission::Read],
-            ts(10000),
-            &now(),
-            DelegateeKind::Human,
-        );
+        let alice_key = KeyPair::generate();
+        let bob_key = KeyPair::generate();
+        signed_delegate(&mut reg, "alice", "bob", &[Permission::Read], &alice_key).ok();
+        let result = signed_delegate(&mut reg, "bob", "alice", &[Permission::Read], &bob_key);
         assert!(matches!(result, Err(AuthorityError::CircularDelegation(_))));
     }
 
     #[test]
     fn delegate_detects_transitive_circular() {
         let mut reg = DelegationRegistry::new();
-        reg.delegate(
-            &did("alice"),
-            &did("bob"),
+        let alice_key = KeyPair::generate();
+        let bob_key = KeyPair::generate();
+        let charlie_key = KeyPair::generate();
+        signed_delegate(&mut reg, "alice", "bob", &[Permission::Read], &alice_key).ok();
+        signed_delegate(&mut reg, "bob", "charlie", &[Permission::Read], &bob_key).ok();
+        let result = signed_delegate(
+            &mut reg,
+            "charlie",
+            "alice",
             &[Permission::Read],
-            ts(10000),
-            &now(),
-            DelegateeKind::Human,
-        )
-        .ok();
-        reg.delegate(
-            &did("bob"),
-            &did("charlie"),
-            &[Permission::Read],
-            ts(10000),
-            &now(),
-            DelegateeKind::Human,
-        )
-        .ok();
-        let result = reg.delegate(
-            &did("charlie"),
-            &did("alice"),
-            &[Permission::Read],
-            ts(10000),
-            &now(),
-            DelegateeKind::Human,
+            &charlie_key,
         );
         assert!(matches!(result, Err(AuthorityError::CircularDelegation(_))));
     }
@@ -284,17 +481,10 @@ mod tests {
     #[test]
     fn revoke_delegation() {
         let mut reg = DelegationRegistry::new();
-        let link = reg
-            .delegate(
-                &did("alice"),
-                &did("bob"),
-                &[Permission::Read],
-                ts(10000),
-                &now(),
-                DelegateeKind::Human,
-            )
-            .unwrap();
-        let id = link.id();
+        let alice_key = KeyPair::generate();
+        let link =
+            signed_delegate(&mut reg, "alice", "bob", &[Permission::Read], &alice_key).unwrap();
+        let id = link.id().unwrap();
         assert!(reg.revoke_delegation(&id).is_ok());
         assert_eq!(reg.len(), 0);
     }
@@ -312,15 +502,8 @@ mod tests {
     #[test]
     fn find_chain_direct() {
         let mut reg = DelegationRegistry::new();
-        reg.delegate(
-            &did("alice"),
-            &did("bob"),
-            &[Permission::Read],
-            ts(10000),
-            &now(),
-            DelegateeKind::Human,
-        )
-        .ok();
+        let alice_key = KeyPair::generate();
+        signed_delegate(&mut reg, "alice", "bob", &[Permission::Read], &alice_key).ok();
         let chain = reg.find_chain(&did("alice"), &did("bob"));
         assert!(chain.is_some());
         assert_eq!(chain.unwrap().depth(), 1);
@@ -329,24 +512,17 @@ mod tests {
     #[test]
     fn find_chain_transitive() {
         let mut reg = DelegationRegistry::new();
-        reg.delegate(
-            &did("alice"),
-            &did("bob"),
+        let alice_key = KeyPair::generate();
+        let bob_key = KeyPair::generate();
+        signed_delegate(
+            &mut reg,
+            "alice",
+            "bob",
             &[Permission::Read, Permission::Write],
-            ts(10000),
-            &now(),
-            DelegateeKind::Human,
+            &alice_key,
         )
         .ok();
-        reg.delegate(
-            &did("bob"),
-            &did("charlie"),
-            &[Permission::Read],
-            ts(10000),
-            &now(),
-            DelegateeKind::Human,
-        )
-        .ok();
+        signed_delegate(&mut reg, "bob", "charlie", &[Permission::Read], &bob_key).ok();
         let chain = reg.find_chain(&did("alice"), &did("charlie"));
         assert!(chain.is_some());
         assert_eq!(chain.unwrap().depth(), 2);
@@ -361,15 +537,8 @@ mod tests {
     #[test]
     fn find_chain_no_path() {
         let mut reg = DelegationRegistry::new();
-        reg.delegate(
-            &did("alice"),
-            &did("bob"),
-            &[Permission::Read],
-            ts(10000),
-            &now(),
-            DelegateeKind::Human,
-        )
-        .ok();
+        let alice_key = KeyPair::generate();
+        signed_delegate(&mut reg, "alice", "bob", &[Permission::Read], &alice_key).ok();
         assert!(reg.find_chain(&did("alice"), &did("charlie")).is_none());
     }
 
@@ -383,17 +552,9 @@ mod tests {
     #[test]
     fn revoke_cleans_indexes() {
         let mut reg = DelegationRegistry::new();
-        let l = reg
-            .delegate(
-                &did("alice"),
-                &did("bob"),
-                &[Permission::Read],
-                ts(10000),
-                &now(),
-                DelegateeKind::Human,
-            )
-            .unwrap();
-        reg.revoke_delegation(&l.id()).ok();
+        let alice_key = KeyPair::generate();
+        let l = signed_delegate(&mut reg, "alice", "bob", &[Permission::Read], &alice_key).unwrap();
+        reg.revoke_delegation(&l.id().unwrap()).ok();
         // After revocation, chain should not be found
         assert!(reg.find_chain(&did("alice"), &did("bob")).is_none());
     }
@@ -401,22 +562,14 @@ mod tests {
     #[test]
     fn multiple_delegations_from_same_source() {
         let mut reg = DelegationRegistry::new();
-        reg.delegate(
-            &did("alice"),
-            &did("bob"),
-            &[Permission::Read],
-            ts(10000),
-            &now(),
-            DelegateeKind::Human,
-        )
-        .ok();
-        reg.delegate(
-            &did("alice"),
-            &did("charlie"),
+        let alice_key = KeyPair::generate();
+        signed_delegate(&mut reg, "alice", "bob", &[Permission::Read], &alice_key).ok();
+        signed_delegate(
+            &mut reg,
+            "alice",
+            "charlie",
             &[Permission::Write],
-            ts(10000),
-            &now(),
-            DelegateeKind::Human,
+            &alice_key,
         )
         .ok();
         assert_eq!(reg.len(), 2);
@@ -427,14 +580,8 @@ mod tests {
     #[test]
     fn self_delegation_detected_as_circular() {
         let mut reg = DelegationRegistry::new();
-        let result = reg.delegate(
-            &did("alice"),
-            &did("alice"),
-            &[Permission::Read],
-            ts(10000),
-            &now(),
-            DelegateeKind::Human,
-        );
+        let alice_key = KeyPair::generate();
+        let result = signed_delegate(&mut reg, "alice", "alice", &[Permission::Read], &alice_key);
         assert!(matches!(result, Err(AuthorityError::CircularDelegation(_))));
     }
 }

--- a/crates/exo-authority/src/error.rs
+++ b/crates/exo-authority/src/error.rs
@@ -20,6 +20,15 @@ pub enum AuthorityError {
     #[error("invalid signature at index {index}")]
     InvalidSignature { index: usize },
 
+    #[error("delegation signing payload encoding failed: {reason}")]
+    SigningPayloadEncoding { reason: String },
+
+    #[error("invalid delegation: {reason}")]
+    InvalidDelegation { reason: String },
+
+    #[error("duplicate delegation: {id}")]
+    DuplicateDelegation { id: String },
+
     #[error("circular delegation detected: {0}")]
     CircularDelegation(String),
 
@@ -72,6 +81,28 @@ mod tests {
     fn error_display_invalid_signature() {
         let e = AuthorityError::InvalidSignature { index: 3 };
         assert!(e.to_string().contains("3"));
+    }
+
+    #[test]
+    fn error_display_signing_payload_encoding() {
+        let e = AuthorityError::SigningPayloadEncoding {
+            reason: "writer".into(),
+        };
+        assert!(e.to_string().contains("writer"));
+    }
+
+    #[test]
+    fn error_display_invalid_delegation() {
+        let e = AuthorityError::InvalidDelegation {
+            reason: "empty scope".into(),
+        };
+        assert!(e.to_string().contains("empty scope"));
+    }
+
+    #[test]
+    fn error_display_duplicate_delegation() {
+        let e = AuthorityError::DuplicateDelegation { id: "abc".into() };
+        assert!(e.to_string().contains("abc"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- require DelegationRegistry grants to be signed by the delegator key
- replace synthetic authority-link IDs with canonical CBOR signing payload hashes
- reject empty, all-zero, wrong-key, duplicate, and invalid delegation grants
- refresh repo truth counts after the new authority tests

## Verification
- cargo test -p exo-authority delegate_signs_link_with_delegator_key --lib
- cargo test -p exo-authority --lib
- cargo test -p exo-authority
- cargo build -p exo-authority
- cargo clippy -p exo-authority --lib -- -D warnings
- cargo clippy -p exo-authority --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- bash tools/repo_truth.sh --json
- bash tools/test_repo_truth.sh
- cargo +nightly fmt --all -- --check
- git diff --check