### PR TITLE
fix(exo-node): gate MCP default simulation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 112962 | `wc -l` |
+| Rust LOC | 113423 | `wc -l` |
 | Workspace tests | 2,777 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -57,7 +57,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 112962 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 113423 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 2,777 listed workspace tests
 

--- a/crates/exo-node/Cargo.toml
+++ b/crates/exo-node/Cargo.toml
@@ -117,15 +117,13 @@ default = []
 # quorum or on-chain record."
 unaudited-admin-governance-shortcut = []
 
-# GAP (Onyx pass 3, RED #2): several MCP governance tools
-# (exochain_create_decision, exochain_cast_vote,
-# exochain_propose_amendment) return `{"recorded": true, ...}` /
-# `{"decision_id": <hash>}` responses without persisting to any
-# store, without invoking the reactor, without any network
-# broadcast — pure simulation. Combined with the MCP middleware's
-# hardcoded-true constitutional context, this means AI agents
-# calling these tools get "success" signals for actions that have
-# zero governance-fabric effect.
+# GAP (Onyx pass 3, RED #2 and follow-on trust-surface scans): several
+# MCP tools return truthy-shaped responses without persisting to any
+# store, invoking the reactor, appending to the DAG, delivering a
+# message, or recording consent/escalation state — pure simulation.
+# Combined with the MCP middleware's hardcoded-true constitutional
+# context, this means AI agents calling these tools get "success"
+# signals for actions that have zero governance-fabric effect.
 #
 # Mitigation: tools don't mutate real state, so blast radius is
 # "AI agents acting on false success signals" — not state

--- a/crates/exo-node/src/mcp/tools/authority.rs
+++ b/crates/exo-node/src/mcp/tools/authority.rs
@@ -6,8 +6,10 @@
 // mutually-exclusive `#[cfg(feature = "...")]` branch.
 #![allow(clippy::needless_return)]
 
+#[cfg(test)]
+use exo_core::Hash256;
 #[cfg_attr(not(feature = "unaudited-mcp-simulation-tools"), allow(unused_imports))]
-use exo_core::{Did, Hash256, Timestamp};
+use exo_core::{Did, hash::hash_structured};
 use exo_gatekeeper::{
     invariants::{
         ConstitutionalInvariant, InvariantContext, InvariantEngine, InvariantSet, enforce_all,
@@ -426,16 +428,27 @@ pub fn execute_delegate_authority(params: &Value, _context: &NodeContext) -> Too
             );
         }
 
-        let now = Timestamp::now_utc();
-        let id_input = format!("{grantor_str}:{grantee_str}:{}", now.physical_ms);
-        let delegation_id = Hash256::digest(id_input.as_bytes()).to_string();
+        let delegation_id = match hash_structured(&(
+            "exo.mcp.authority.delegation.v1",
+            grantor_str,
+            grantee_str,
+            &permissions,
+        )) {
+            Ok(hash) => hash.to_string(),
+            Err(e) => {
+                return ToolResult::error(
+                    json!({"error": format!("failed to hash delegation payload: {e}")}).to_string(),
+                );
+            }
+        };
 
         let response = json!({
             "delegation_id": delegation_id,
             "grantor": grantor_str,
             "grantee": grantee_str,
             "permissions": permissions,
-            "created_at": format!("{}:{}", now.physical_ms, now.logical),
+            "created_at": null,
+            "created_at_source": "simulation_no_persistence_timestamp",
         });
         ToolResult::success(response.to_string())
     }
@@ -918,20 +931,27 @@ mod tests {
     #[test]
     #[cfg(feature = "unaudited-mcp-simulation-tools")]
     fn execute_delegate_authority_success() {
-        let result = execute_delegate_authority(
-            &json!({
+        let params = json!({
                 "grantor_did": "did:exo:root",
                 "grantee_did": "did:exo:alice",
                 "permissions": ["read", "write"],
-            }),
-            &NodeContext::empty(),
-        );
+        });
+        let result = execute_delegate_authority(&params, &NodeContext::empty());
+        let repeat = execute_delegate_authority(&params, &NodeContext::empty());
         assert!(!result.is_error);
+        assert!(!repeat.is_error);
         let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
+        let repeat_v: Value = serde_json::from_str(repeat.content[0].text()).expect("valid JSON");
         assert_eq!(v["grantor"], "did:exo:root");
         assert_eq!(v["grantee"], "did:exo:alice");
         assert_eq!(v["permissions"].as_array().expect("perms").len(), 2);
         assert!(!v["delegation_id"].as_str().expect("id").is_empty());
+        assert_eq!(v["delegation_id"], repeat_v["delegation_id"]);
+        assert!(v["created_at"].is_null());
+        assert_eq!(
+            v["created_at_source"],
+            "simulation_no_persistence_timestamp"
+        );
     }
 
     #[test]

--- a/crates/exo-node/src/mcp/tools/consent.rs
+++ b/crates/exo-node/src/mcp/tools/consent.rs
@@ -1,7 +1,9 @@
 //! Consent MCP tools — bailment proposal, consent checking, bailment listing,
 //! and bailment termination.
 
-use exo_core::{Did, Hash256, Timestamp};
+use exo_core::Did;
+#[cfg(feature = "unaudited-mcp-simulation-tools")]
+use exo_core::hash::hash_structured;
 use serde_json::{Value, json};
 
 use crate::mcp::{
@@ -35,7 +37,8 @@ pub fn propose_bailment_definition() -> ToolDefinition {
                     "description": "Data scope for the bailment (e.g. \"data:medical:records\")."
                 },
                 "duration_hours": {
-                    "type": "number",
+                    "type": "integer",
+                    "minimum": 1,
                     "description": "Duration in hours before the bailment expires (default: 24)."
                 }
             },
@@ -48,66 +51,95 @@ pub fn propose_bailment_definition() -> ToolDefinition {
 /// Execute the `exochain_propose_bailment` tool.
 #[must_use]
 pub fn execute_propose_bailment(params: &Value, _context: &NodeContext) -> ToolResult {
-    let bailor_str = match params.get("bailor_did").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: bailor_did"}).to_string(),
-            );
-        }
-    };
-    let bailee_str = match params.get("bailee_did").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: bailee_did"}).to_string(),
-            );
-        }
-    };
-    let scope = match params.get("scope").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: scope"}).to_string(),
-            );
-        }
-    };
-
-    if Did::new(bailor_str).is_err() {
-        return ToolResult::error(
-            json!({"error": format!("invalid bailor DID format: {bailor_str}")}).to_string(),
-        );
-    }
-    if Did::new(bailee_str).is_err() {
-        return ToolResult::error(
-            json!({"error": format!("invalid bailee DID format: {bailee_str}")}).to_string(),
-        );
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    {
+        let _ = params;
+        super::simulation_tool_refused(
+            "exochain_propose_bailment",
+            "Initiatives/fix-mcp-default-simulation-gates.md",
+            "This MCP tool currently returns a simulated bailment proposal without \
+             persisting consent state. Build with `unaudited-mcp-simulation-tools` \
+             only for explicit dev simulation.",
+        )
     }
 
-    let duration_hours = params
-        .get("duration_hours")
-        .and_then(Value::as_f64)
-        .unwrap_or(24.0) as u64;
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
+    {
+        let bailor_str = match params.get("bailor_did").and_then(Value::as_str) {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: bailor_did"}).to_string(),
+                );
+            }
+        };
+        let bailee_str = match params.get("bailee_did").and_then(Value::as_str) {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: bailee_did"}).to_string(),
+                );
+            }
+        };
+        let scope = match params.get("scope").and_then(Value::as_str) {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: scope"}).to_string(),
+                );
+            }
+        };
 
-    let now = Timestamp::now_utc();
+        if Did::new(bailor_str).is_err() {
+            return ToolResult::error(
+                json!({"error": format!("invalid bailor DID format: {bailor_str}")}).to_string(),
+            );
+        }
+        if Did::new(bailee_str).is_err() {
+            return ToolResult::error(
+                json!({"error": format!("invalid bailee DID format: {bailee_str}")}).to_string(),
+            );
+        }
 
-    // Generate a deterministic proposal ID from the inputs.
-    let id_input = format!("{bailor_str}:{bailee_str}:{scope}:{}", now.physical_ms);
-    let proposal_id = Hash256::digest(id_input.as_bytes()).to_string();
+        let duration_hours = match params.get("duration_hours") {
+            Some(value) => match value.as_u64() {
+                Some(hours) if hours > 0 => hours,
+                _ => {
+                    return ToolResult::error(
+                        json!({"error": "duration_hours must be a positive integer"}).to_string(),
+                    );
+                }
+            },
+            None => 24,
+        };
 
-    let expires_ms = now
-        .physical_ms
-        .saturating_add(duration_hours.saturating_mul(3_600_000));
+        let proposal_id = match hash_structured(&(
+            "exo.mcp.consent.proposal.v1",
+            bailor_str,
+            bailee_str,
+            scope,
+            duration_hours,
+        )) {
+            Ok(hash) => hash.to_string(),
+            Err(e) => {
+                return ToolResult::error(
+                    json!({"error": format!("proposal ID serialization failed: {e}")}).to_string(),
+                );
+            }
+        };
 
-    let response = json!({
-        "proposal_id": proposal_id,
-        "bailor": bailor_str,
-        "bailee": bailee_str,
-        "scope": scope,
-        "status": "proposed",
-        "expires_at": format!("{expires_ms}:0"),
-    });
-    ToolResult::success(response.to_string())
+        let response = json!({
+            "proposal_id": proposal_id,
+            "bailor": bailor_str,
+            "bailee": bailee_str,
+            "scope": scope,
+            "status": "proposed",
+            "expires_at": Value::Null,
+            "expires_at_source": "simulation_no_start_timestamp",
+            "expires_after_hours": duration_hours,
+        });
+        ToolResult::success(response.to_string())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -275,39 +307,55 @@ pub fn terminate_bailment_definition() -> ToolDefinition {
 /// Execute the `exochain_terminate_bailment` tool.
 #[must_use]
 pub fn execute_terminate_bailment(params: &Value, _context: &NodeContext) -> ToolResult {
-    let bailment_id = match params.get("bailment_id").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: bailment_id"}).to_string(),
-            );
-        }
-    };
-    let reason = match params.get("reason").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: reason"}).to_string(),
-            );
-        }
-    };
-
-    if bailment_id.is_empty() {
-        return ToolResult::error(json!({"error": "bailment_id must not be empty"}).to_string());
-    }
-    if reason.is_empty() {
-        return ToolResult::error(json!({"error": "reason must not be empty"}).to_string());
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    {
+        let _ = params;
+        super::simulation_tool_refused(
+            "exochain_terminate_bailment",
+            "Initiatives/fix-mcp-default-simulation-gates.md",
+            "This MCP tool currently returns a simulated bailment termination \
+             without mutating consent state. Build with \
+             `unaudited-mcp-simulation-tools` only for explicit dev simulation.",
+        )
     }
 
-    let now = Timestamp::now_utc();
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
+    {
+        let bailment_id = match params.get("bailment_id").and_then(Value::as_str) {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: bailment_id"}).to_string(),
+                );
+            }
+        };
+        let reason = match params.get("reason").and_then(Value::as_str) {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: reason"}).to_string(),
+                );
+            }
+        };
 
-    let response = json!({
-        "bailment_id": bailment_id,
-        "status": "terminated",
-        "reason": reason,
-        "terminated_at": format!("{}:{}", now.physical_ms, now.logical),
-    });
-    ToolResult::success(response.to_string())
+        if bailment_id.is_empty() {
+            return ToolResult::error(
+                json!({"error": "bailment_id must not be empty"}).to_string(),
+            );
+        }
+        if reason.is_empty() {
+            return ToolResult::error(json!({"error": "reason must not be empty"}).to_string());
+        }
+
+        let response = json!({
+            "bailment_id": bailment_id,
+            "status": "terminated",
+            "reason": reason,
+            "terminated_at": Value::Null,
+            "terminated_at_source": "simulation_no_persistence_timestamp",
+        });
+        ToolResult::success(response.to_string())
+    }
 }
 
 // ===========================================================================
@@ -327,6 +375,7 @@ mod tests {
         assert!(!def.description.is_empty());
     }
 
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_propose_bailment_success() {
         let result = execute_propose_bailment(
@@ -344,7 +393,26 @@ mod tests {
         assert_eq!(v["scope"], "data:medical");
         assert_eq!(v["status"], "proposed");
         assert!(!v["proposal_id"].as_str().expect("id").is_empty());
-        assert!(v["expires_at"].as_str().is_some());
+        assert!(v["expires_at"].is_null());
+        assert_eq!(v["expires_after_hours"], 24);
+    }
+
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    #[test]
+    fn execute_propose_bailment_refuses_by_default() {
+        let result = execute_propose_bailment(
+            &json!({
+                "bailor_did": "did:exo:alice",
+                "bailee_did": "did:exo:bob",
+                "scope": "data:medical",
+            }),
+            &NodeContext::empty(),
+        );
+        assert!(result.is_error);
+        let text = result.content[0].text();
+        assert!(text.contains("mcp_simulation_tool_disabled"));
+        assert!(text.contains("unaudited-mcp-simulation-tools"));
+        assert!(text.contains("fix-mcp-default-simulation-gates.md"));
     }
 
     #[test]
@@ -474,6 +542,7 @@ mod tests {
         assert!(!def.description.is_empty());
     }
 
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_terminate_bailment_success() {
         let result = execute_terminate_bailment(
@@ -488,7 +557,24 @@ mod tests {
         assert_eq!(v["bailment_id"], "abc123");
         assert_eq!(v["status"], "terminated");
         assert_eq!(v["reason"], "data access no longer needed");
-        assert!(v["terminated_at"].as_str().is_some());
+        assert!(v["terminated_at"].is_null());
+    }
+
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    #[test]
+    fn execute_terminate_bailment_refuses_by_default() {
+        let result = execute_terminate_bailment(
+            &json!({
+                "bailment_id": "abc123",
+                "reason": "data access no longer needed",
+            }),
+            &NodeContext::empty(),
+        );
+        assert!(result.is_error);
+        let text = result.content[0].text();
+        assert!(text.contains("mcp_simulation_tool_disabled"));
+        assert!(text.contains("unaudited-mcp-simulation-tools"));
+        assert!(text.contains("fix-mcp-default-simulation-gates.md"));
     }
 
     #[test]

--- a/crates/exo-node/src/mcp/tools/escalation.rs
+++ b/crates/exo-node/src/mcp/tools/escalation.rs
@@ -1,7 +1,7 @@
 //! Escalation MCP tools — threat evaluation, case escalation, triage,
 //! and feedback recording for the detection-to-response pipeline.
 
-use exo_core::{Hash256, Timestamp};
+use exo_core::hash::hash_structured;
 use serde_json::{Value, json};
 
 use crate::mcp::{
@@ -68,6 +68,7 @@ pub fn execute_evaluate_threat(params: &Value, _context: &NodeContext) -> ToolRe
     let mut total_severity: i64 = 0;
     let mut max_severity: i64 = 0;
     let mut signal_summaries: Vec<Value> = Vec::new();
+    let mut signal_inputs: Vec<(String, i64, String)> = Vec::new();
 
     for (i, signal) in signals.iter().enumerate() {
         let signal_type = match signal.get("type").and_then(Value::as_str) {
@@ -112,6 +113,7 @@ pub fn execute_evaluate_threat(params: &Value, _context: &NodeContext) -> ToolRe
             "severity": severity,
             "source": source,
         }));
+        signal_inputs.push((signal_type.to_owned(), severity, source.to_owned()));
     }
 
     // Integer average: truncated division is fine for a threat bucket.
@@ -129,17 +131,20 @@ pub fn execute_evaluate_threat(params: &Value, _context: &NodeContext) -> ToolRe
         "low"
     };
 
-    let now = Timestamp::now_utc();
-    let assessment_id = Hash256::digest(
-        format!(
-            "threat:{}:{}:{}:{}",
-            signals.len(),
-            max_severity,
-            now.physical_ms,
-            now.logical
-        )
-        .as_bytes(),
-    );
+    let assessment_id = match hash_structured(&(
+        "exo.mcp.escalation.threat.v1",
+        &signal_inputs,
+        avg_severity,
+        max_severity,
+        threat_level,
+    )) {
+        Ok(hash) => hash,
+        Err(e) => {
+            return ToolResult::error(
+                json!({"error": format!("assessment ID serialization failed: {e}")}).to_string(),
+            );
+        }
+    };
 
     let response = json!({
         "assessment_id": assessment_id.to_string(),
@@ -148,7 +153,8 @@ pub fn execute_evaluate_threat(params: &Value, _context: &NodeContext) -> ToolRe
         "aggregate_severity": avg_severity,
         "max_severity": max_severity,
         "threat_level": threat_level,
-        "assessed_at": format!("{}:{}", now.physical_ms, now.logical),
+        "assessed_at": Value::Null,
+        "assessed_at_source": "unavailable_no_escalation_store",
     });
     ToolResult::success(response.to_string())
 }
@@ -191,60 +197,83 @@ pub fn escalate_case_definition() -> ToolDefinition {
 /// Execute the `exochain_escalate_case` tool.
 #[must_use]
 pub fn execute_escalate_case(params: &Value, _context: &NodeContext) -> ToolResult {
-    let threat_assessment_id = match params.get("threat_assessment_id").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: threat_assessment_id"}).to_string(),
-            );
-        }
-    };
-    let escalation_reason = match params.get("escalation_reason").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: escalation_reason"}).to_string(),
-            );
-        }
-    };
-    let priority = match params.get("priority").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: priority"}).to_string(),
-            );
-        }
-    };
-
-    let valid_priorities = ["low", "medium", "high", "critical"];
-    if !valid_priorities.contains(&priority) {
-        return ToolResult::error(
-            json!({"error": format!(
-                "invalid priority '{}': must be one of {:?}",
-                priority, valid_priorities
-            )})
-            .to_string(),
-        );
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    {
+        let _ = params;
+        super::simulation_tool_refused(
+            "exochain_escalate_case",
+            "Initiatives/fix-mcp-default-simulation-gates.md",
+            "This MCP tool currently returns a simulated escalation case without \
+             persisting escalation state. Build with \
+             `unaudited-mcp-simulation-tools` only for explicit dev simulation.",
+        )
     }
 
-    let now = Timestamp::now_utc();
-    let case_id = Hash256::digest(
-        format!(
-            "case:{}:{}:{}:{}",
-            threat_assessment_id, priority, now.physical_ms, now.logical
-        )
-        .as_bytes(),
-    );
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
+    {
+        let threat_assessment_id = match params.get("threat_assessment_id").and_then(Value::as_str)
+        {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: threat_assessment_id"})
+                        .to_string(),
+                );
+            }
+        };
+        let escalation_reason = match params.get("escalation_reason").and_then(Value::as_str) {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: escalation_reason"}).to_string(),
+                );
+            }
+        };
+        let priority = match params.get("priority").and_then(Value::as_str) {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: priority"}).to_string(),
+                );
+            }
+        };
 
-    let response = json!({
-        "case_id": case_id.to_string(),
-        "threat_assessment_id": threat_assessment_id,
-        "escalation_reason": escalation_reason,
-        "priority": priority,
-        "status": "open",
-        "escalated_at": format!("{}:{}", now.physical_ms, now.logical),
-    });
-    ToolResult::success(response.to_string())
+        let valid_priorities = ["low", "medium", "high", "critical"];
+        if !valid_priorities.contains(&priority) {
+            return ToolResult::error(
+                json!({"error": format!(
+                    "invalid priority '{}': must be one of {:?}",
+                    priority, valid_priorities
+                )})
+                .to_string(),
+            );
+        }
+
+        let case_id = match hash_structured(&(
+            "exo.mcp.escalation.case.v1",
+            threat_assessment_id,
+            escalation_reason,
+            priority,
+        )) {
+            Ok(hash) => hash,
+            Err(e) => {
+                return ToolResult::error(
+                    json!({"error": format!("case ID serialization failed: {e}")}).to_string(),
+                );
+            }
+        };
+
+        let response = json!({
+            "case_id": case_id.to_string(),
+            "threat_assessment_id": threat_assessment_id,
+            "escalation_reason": escalation_reason,
+            "priority": priority,
+            "status": "open",
+            "escalated_at": Value::Null,
+            "escalated_at_source": "simulation_no_persistence_timestamp",
+        });
+        ToolResult::success(response.to_string())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -284,50 +313,71 @@ pub fn triage_definition() -> ToolDefinition {
 /// Execute the `exochain_triage` tool.
 #[must_use]
 pub fn execute_triage(params: &Value, _context: &NodeContext) -> ToolResult {
-    let case_id = match params.get("case_id").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: case_id"}).to_string(),
-            );
-        }
-    };
-    let assessment = match params.get("assessment").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: assessment"}).to_string(),
-            );
-        }
-    };
-    let recommended_action = match params.get("recommended_action").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: recommended_action"}).to_string(),
-            );
-        }
-    };
-
-    let now = Timestamp::now_utc();
-    let triage_id = Hash256::digest(
-        format!(
-            "triage:{}:{}:{}:{}",
-            case_id, recommended_action, now.physical_ms, now.logical
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    {
+        let _ = params;
+        super::simulation_tool_refused(
+            "exochain_triage",
+            "Initiatives/fix-mcp-default-simulation-gates.md",
+            "This MCP tool currently returns a simulated triage decision without \
+             persisting escalation state. Build with \
+             `unaudited-mcp-simulation-tools` only for explicit dev simulation.",
         )
-        .as_bytes(),
-    );
+    }
 
-    let response = json!({
-        "triage_id": triage_id.to_string(),
-        "case_id": case_id,
-        "assessment": assessment,
-        "recommended_action": recommended_action,
-        "decision": "action_approved",
-        "status": "triaged",
-        "triaged_at": format!("{}:{}", now.physical_ms, now.logical),
-    });
-    ToolResult::success(response.to_string())
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
+    {
+        let case_id = match params.get("case_id").and_then(Value::as_str) {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: case_id"}).to_string(),
+                );
+            }
+        };
+        let assessment = match params.get("assessment").and_then(Value::as_str) {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: assessment"}).to_string(),
+                );
+            }
+        };
+        let recommended_action = match params.get("recommended_action").and_then(Value::as_str) {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: recommended_action"}).to_string(),
+                );
+            }
+        };
+
+        let triage_id = match hash_structured(&(
+            "exo.mcp.escalation.triage.v1",
+            case_id,
+            assessment,
+            recommended_action,
+        )) {
+            Ok(hash) => hash,
+            Err(e) => {
+                return ToolResult::error(
+                    json!({"error": format!("triage ID serialization failed: {e}")}).to_string(),
+                );
+            }
+        };
+
+        let response = json!({
+            "triage_id": triage_id.to_string(),
+            "case_id": case_id,
+            "assessment": assessment,
+            "recommended_action": recommended_action,
+            "decision": "action_approved",
+            "status": "triaged",
+            "triaged_at": Value::Null,
+            "triaged_at_source": "simulation_no_persistence_timestamp",
+        });
+        ToolResult::success(response.to_string())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -367,54 +417,72 @@ pub fn record_feedback_definition() -> ToolDefinition {
 /// Execute the `exochain_record_feedback` tool.
 #[must_use]
 pub fn execute_record_feedback(params: &Value, _context: &NodeContext) -> ToolResult {
-    let case_id = match params.get("case_id").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: case_id"}).to_string(),
-            );
-        }
-    };
-    let outcome = match params.get("outcome").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: outcome"}).to_string(),
-            );
-        }
-    };
-
-    let valid_outcomes = ["true_positive", "false_positive", "inconclusive"];
-    if !valid_outcomes.contains(&outcome) {
-        return ToolResult::error(
-            json!({"error": format!(
-                "invalid outcome '{}': must be one of {:?}",
-                outcome, valid_outcomes
-            )})
-            .to_string(),
-        );
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    {
+        let _ = params;
+        super::simulation_tool_refused(
+            "exochain_record_feedback",
+            "Initiatives/fix-mcp-default-simulation-gates.md",
+            "This MCP tool currently returns simulated feedback recording without \
+             persisting escalation state. Build with \
+             `unaudited-mcp-simulation-tools` only for explicit dev simulation.",
+        )
     }
 
-    let notes = params.get("notes").and_then(Value::as_str).unwrap_or("");
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
+    {
+        let case_id = match params.get("case_id").and_then(Value::as_str) {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: case_id"}).to_string(),
+                );
+            }
+        };
+        let outcome = match params.get("outcome").and_then(Value::as_str) {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: outcome"}).to_string(),
+                );
+            }
+        };
 
-    let now = Timestamp::now_utc();
-    let feedback_id = Hash256::digest(
-        format!(
-            "feedback:{}:{}:{}:{}",
-            case_id, outcome, now.physical_ms, now.logical
-        )
-        .as_bytes(),
-    );
+        let valid_outcomes = ["true_positive", "false_positive", "inconclusive"];
+        if !valid_outcomes.contains(&outcome) {
+            return ToolResult::error(
+                json!({"error": format!(
+                    "invalid outcome '{}': must be one of {:?}",
+                    outcome, valid_outcomes
+                )})
+                .to_string(),
+            );
+        }
 
-    let response = json!({
-        "feedback_id": feedback_id.to_string(),
-        "case_id": case_id,
-        "outcome": outcome,
-        "notes": notes,
-        "status": "recorded",
-        "recorded_at": format!("{}:{}", now.physical_ms, now.logical),
-    });
-    ToolResult::success(response.to_string())
+        let notes = params.get("notes").and_then(Value::as_str).unwrap_or("");
+
+        let feedback_id =
+            match hash_structured(&("exo.mcp.escalation.feedback.v1", case_id, outcome, notes)) {
+                Ok(hash) => hash,
+                Err(e) => {
+                    return ToolResult::error(
+                        json!({"error": format!("feedback ID serialization failed: {e}")})
+                            .to_string(),
+                    );
+                }
+            };
+
+        let response = json!({
+            "feedback_id": feedback_id.to_string(),
+            "case_id": case_id,
+            "outcome": outcome,
+            "notes": notes,
+            "status": "recorded",
+            "recorded_at": Value::Null,
+            "recorded_at_source": "simulation_no_persistence_timestamp",
+        });
+        ToolResult::success(response.to_string())
+    }
 }
 
 // ===========================================================================
@@ -450,6 +518,7 @@ mod tests {
         assert_eq!(v["max_severity"], 7);
         assert_eq!(v["threat_level"], "high");
         assert!(v["assessment_id"].as_str().is_some());
+        assert!(v["assessed_at"].is_null());
     }
 
     #[test]
@@ -463,6 +532,25 @@ mod tests {
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
         assert_eq!(v["threat_level"], "critical");
+    }
+
+    #[test]
+    fn execute_evaluate_threat_is_deterministic() {
+        let params = json!({
+            "signals": [
+                {"type": "anomaly", "severity": 7, "source": "ids"},
+                {"type": "policy_violation", "severity": 3, "source": "audit_log"},
+            ],
+        });
+        let first = execute_evaluate_threat(&params, &NodeContext::empty());
+        let second = execute_evaluate_threat(&params, &NodeContext::empty());
+        assert!(!first.is_error);
+        assert!(!second.is_error);
+        let first_json: Value = serde_json::from_str(first.content[0].text()).expect("valid JSON");
+        let second_json: Value =
+            serde_json::from_str(second.content[0].text()).expect("valid JSON");
+        assert_eq!(first_json["assessment_id"], second_json["assessment_id"]);
+        assert_eq!(first_json["assessed_at"], second_json["assessed_at"]);
     }
 
     #[test]
@@ -486,6 +574,7 @@ mod tests {
         assert!(!def.description.is_empty());
     }
 
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_escalate_case_success() {
         let params = json!({
@@ -499,6 +588,22 @@ mod tests {
         assert_eq!(v["priority"], "high");
         assert_eq!(v["status"], "open");
         assert!(v["case_id"].as_str().is_some());
+    }
+
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    #[test]
+    fn execute_escalate_case_refuses_by_default() {
+        let params = json!({
+            "threat_assessment_id": "ta_abc123",
+            "escalation_reason": "Multiple high-severity signals detected",
+            "priority": "high",
+        });
+        let result = execute_escalate_case(&params, &NodeContext::empty());
+        assert!(result.is_error);
+        let text = result.content[0].text();
+        assert!(text.contains("mcp_simulation_tool_disabled"));
+        assert!(text.contains("unaudited-mcp-simulation-tools"));
+        assert!(text.contains("fix-mcp-default-simulation-gates.md"));
     }
 
     #[test]
@@ -530,6 +635,7 @@ mod tests {
         assert!(!def.description.is_empty());
     }
 
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_triage_success() {
         let params = json!({
@@ -544,6 +650,22 @@ mod tests {
         assert_eq!(v["decision"], "action_approved");
         assert_eq!(v["status"], "triaged");
         assert!(v["triage_id"].as_str().is_some());
+    }
+
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    #[test]
+    fn execute_triage_refuses_by_default() {
+        let params = json!({
+            "case_id": "case_abc",
+            "assessment": "Confirmed unauthorized access attempt",
+            "recommended_action": "block_source_ip",
+        });
+        let result = execute_triage(&params, &NodeContext::empty());
+        assert!(result.is_error);
+        let text = result.content[0].text();
+        assert!(text.contains("mcp_simulation_tool_disabled"));
+        assert!(text.contains("unaudited-mcp-simulation-tools"));
+        assert!(text.contains("fix-mcp-default-simulation-gates.md"));
     }
 
     #[test]
@@ -564,6 +686,7 @@ mod tests {
         assert!(!def.description.is_empty());
     }
 
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_record_feedback_success() {
         let params = json!({
@@ -579,6 +702,22 @@ mod tests {
         assert!(v["feedback_id"].as_str().is_some());
     }
 
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    #[test]
+    fn execute_record_feedback_refuses_by_default() {
+        let params = json!({
+            "case_id": "case_abc",
+            "outcome": "true_positive",
+            "notes": "Confirmed breach via log analysis",
+        });
+        let result = execute_record_feedback(&params, &NodeContext::empty());
+        assert!(result.is_error);
+        let text = result.content[0].text();
+        assert!(text.contains("mcp_simulation_tool_disabled"));
+        assert!(text.contains("unaudited-mcp-simulation-tools"));
+        assert!(text.contains("fix-mcp-default-simulation-gates.md"));
+    }
+
     #[test]
     fn execute_record_feedback_invalid_outcome() {
         let params = json!({"case_id": "case_abc", "outcome": "maybe"});
@@ -586,6 +725,7 @@ mod tests {
         assert!(result.is_error);
     }
 
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_record_feedback_no_notes() {
         let params = json!({"case_id": "case_abc", "outcome": "false_positive"});

--- a/crates/exo-node/src/mcp/tools/governance.rs
+++ b/crates/exo-node/src/mcp/tools/governance.rs
@@ -24,7 +24,7 @@
 #![allow(clippy::needless_return)]
 
 #[cfg_attr(not(feature = "unaudited-mcp-simulation-tools"), allow(unused_imports))]
-use exo_core::{Did, Hash256, Timestamp};
+use exo_core::{Did, hash::hash_structured};
 use serde_json::{Value, json};
 
 use crate::mcp::{
@@ -149,22 +149,35 @@ pub fn execute_create_decision(params: &Value, _context: &NodeContext) -> ToolRe
             );
         }
 
-        let _decision_class = params
+        let decision_class = params
             .get("decision_class")
             .and_then(Value::as_str)
             .unwrap_or("standard");
 
-        let now = Timestamp::now_utc();
-        let id_input = format!("{title}:{proposer_str}:{}", now.physical_ms);
-        let decision_id = Hash256::digest(id_input.as_bytes()).to_string();
+        let decision_id = match hash_structured(&(
+            "exo.mcp.governance.decision.v1",
+            title,
+            description,
+            proposer_str,
+            decision_class,
+        )) {
+            Ok(hash) => hash.to_string(),
+            Err(e) => {
+                return ToolResult::error(
+                    json!({"error": format!("failed to hash decision payload: {e}")}).to_string(),
+                );
+            }
+        };
 
         let response = json!({
             "decision_id": decision_id,
             "title": title,
             "description": description,
             "proposer": proposer_str,
+            "decision_class": decision_class,
             "status": "proposed",
-            "created_at": format!("{}:{}", now.physical_ms, now.logical),
+            "created_at": null,
+            "created_at_source": "simulation_no_persistence_timestamp",
         });
         ToolResult::success(response.to_string())
     } // end cfg(feature = "unaudited-mcp-simulation-tools") block
@@ -495,9 +508,20 @@ pub fn execute_propose_amendment(params: &Value, _context: &NodeContext) -> Tool
         );
         }
 
-        let now = Timestamp::now_utc();
-        let id_input = format!("amendment:{title}:{proposer_str}:{}", now.physical_ms);
-        let amendment_id = Hash256::digest(id_input.as_bytes()).to_string();
+        let amendment_id = match hash_structured(&(
+            "exo.mcp.governance.amendment.v1",
+            title,
+            description,
+            proposer_str,
+            target,
+        )) {
+            Ok(hash) => hash.to_string(),
+            Err(e) => {
+                return ToolResult::error(
+                    json!({"error": format!("failed to hash amendment payload: {e}")}).to_string(),
+                );
+            }
+        };
 
         let response = json!({
             "amendment_id": amendment_id,
@@ -513,6 +537,8 @@ pub fn execute_propose_amendment(params: &Value, _context: &NodeContext) -> Tool
                 "security_audit_required": true,
             },
             "status": "draft",
+            "proposed_at": null,
+            "proposed_at_source": "simulation_no_persistence_timestamp",
             "warning": "Constitutional amendments require the highest governance threshold. See spec \u{00a7}3A.3.2.",
         });
         ToolResult::success(response.to_string())
@@ -539,20 +565,27 @@ mod tests {
     #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_create_decision_success() {
-        let result = execute_create_decision(
-            &json!({
+        let params = json!({
                 "title": "Approve data sharing policy",
                 "description": "Allow cross-org medical data sharing under bailment.",
                 "proposer_did": "did:exo:alice",
-            }),
-            &NodeContext::empty(),
-        );
+        });
+        let result = execute_create_decision(&params, &NodeContext::empty());
+        let repeat = execute_create_decision(&params, &NodeContext::empty());
         assert!(!result.is_error);
+        assert!(!repeat.is_error);
         let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
+        let repeat_v: Value = serde_json::from_str(repeat.content[0].text()).expect("valid JSON");
         assert_eq!(v["title"], "Approve data sharing policy");
         assert_eq!(v["proposer"], "did:exo:alice");
         assert_eq!(v["status"], "proposed");
         assert!(!v["decision_id"].as_str().expect("id").is_empty());
+        assert_eq!(v["decision_id"], repeat_v["decision_id"]);
+        assert!(v["created_at"].is_null());
+        assert_eq!(
+            v["created_at_source"],
+            "simulation_no_persistence_timestamp"
+        );
     }
 
     #[cfg(feature = "unaudited-mcp-simulation-tools")]
@@ -711,20 +744,27 @@ mod tests {
     #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_propose_amendment_success() {
-        let result = execute_propose_amendment(
-            &json!({
+        let params = json!({
                 "title": "Add quantum-safe threshold signatures",
                 "description": "Extend the constitutional invariant set to require ML-DSA-65 for kernel modification quorum.",
                 "proposer_did": "did:exo:alice",
                 "target": "constitution",
-            }),
-            &NodeContext::empty(),
-        );
+        });
+        let result = execute_propose_amendment(&params, &NodeContext::empty());
+        let repeat = execute_propose_amendment(&params, &NodeContext::empty());
         assert!(!result.is_error);
+        assert!(!repeat.is_error);
         let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
+        let repeat_v: Value = serde_json::from_str(repeat.content[0].text()).expect("valid JSON");
         assert_eq!(v["target"], "constitution");
         assert_eq!(v["status"], "draft");
         assert!(!v["amendment_id"].as_str().expect("id").is_empty());
+        assert_eq!(v["amendment_id"], repeat_v["amendment_id"]);
+        assert!(v["proposed_at"].is_null());
+        assert_eq!(
+            v["proposed_at_source"],
+            "simulation_no_persistence_timestamp"
+        );
         assert_eq!(v["requirements"]["validator_consensus"], "unanimous");
         assert_eq!(v["requirements"]["formal_proof_required"], true);
         assert!(

--- a/crates/exo-node/src/mcp/tools/identity.rs
+++ b/crates/exo-node/src/mcp/tools/identity.rs
@@ -1,7 +1,7 @@
 //! Identity MCP tools — DID creation, resolution, risk assessment, signature
 //! verification, and agent passport retrieval.
 
-use exo_core::{Did, Hash256, Timestamp, crypto};
+use exo_core::{Did, Hash256, crypto};
 use serde_json::{Value, json};
 
 use crate::mcp::{
@@ -195,13 +195,13 @@ pub fn execute_assess_risk(params: &Value, _context: &NodeContext) -> ToolResult
         })
         .collect();
 
-    let now = Timestamp::now_utc();
     let response = json!({
         "did": did_str,
         "risk_score": risk_score,
         "risk_level": risk_level,
         "factors": factors,
-        "assessed_at": format!("{}:{}", now.physical_ms, now.logical),
+        "assessed_at": Value::Null,
+        "assessed_at_source": "unavailable_no_risk_store",
     });
     ToolResult::success(response.to_string())
 }
@@ -479,6 +479,8 @@ mod tests {
         assert_eq!(v["risk_score"], 750);
         assert_eq!(v["risk_level"], "high");
         assert_eq!(v["factors"].as_array().expect("factors").len(), 0);
+        assert!(v["assessed_at"].is_null());
+        assert_eq!(v["assessed_at_source"], "unavailable_no_risk_store");
     }
 
     #[test]

--- a/crates/exo-node/src/mcp/tools/ledger.rs
+++ b/crates/exo-node/src/mcp/tools/ledger.rs
@@ -1,7 +1,9 @@
 //! Ledger MCP tools — event submission, retrieval, Merkle inclusion
 //! verification, and checkpoint queries against the DAG.
 
-use exo_core::{Did, Hash256, Timestamp};
+use exo_core::Hash256;
+#[cfg(feature = "unaudited-mcp-simulation-tools")]
+use exo_core::{Did, hash::hash_structured};
 use serde_json::{Value, json};
 
 use crate::mcp::{
@@ -44,62 +46,83 @@ pub fn submit_event_definition() -> ToolDefinition {
 /// Execute the `exochain_submit_event` tool.
 #[must_use]
 pub fn execute_submit_event(params: &Value, _context: &NodeContext) -> ToolResult {
-    let event_type = match params.get("event_type").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: event_type"}).to_string(),
-            );
-        }
-    };
-    let payload_hex = match params.get("payload_hex").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: payload_hex"}).to_string(),
-            );
-        }
-    };
-    let author_did_str = match params.get("author_did").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: author_did"}).to_string(),
-            );
-        }
-    };
-
-    // Validate DID format.
-    if Did::new(author_did_str).is_err() {
-        return ToolResult::error(
-            json!({"error": format!("invalid DID format: {author_did_str}")}).to_string(),
-        );
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    {
+        let _ = params;
+        super::simulation_tool_refused(
+            "exochain_submit_event",
+            "Initiatives/fix-mcp-default-simulation-gates.md",
+            "This MCP tool currently returns simulated DAG acceptance without \
+             appending an event to a live store. Build with \
+             `unaudited-mcp-simulation-tools` only for explicit dev simulation.",
+        )
     }
 
-    // Validate hex payload.
-    if hex::decode(payload_hex).is_err() {
-        return ToolResult::error(
-            json!({"error": "invalid payload_hex: not valid hexadecimal"}).to_string(),
-        );
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
+    {
+        let event_type = match params.get("event_type").and_then(Value::as_str) {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: event_type"}).to_string(),
+                );
+            }
+        };
+        let payload_hex = match params.get("payload_hex").and_then(Value::as_str) {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: payload_hex"}).to_string(),
+                );
+            }
+        };
+        let author_did_str = match params.get("author_did").and_then(Value::as_str) {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: author_did"}).to_string(),
+                );
+            }
+        };
+
+        // Validate DID format.
+        if Did::new(author_did_str).is_err() {
+            return ToolResult::error(
+                json!({"error": format!("invalid DID format: {author_did_str}")}).to_string(),
+            );
+        }
+
+        // Validate hex payload.
+        if hex::decode(payload_hex).is_err() {
+            return ToolResult::error(
+                json!({"error": "invalid payload_hex: not valid hexadecimal"}).to_string(),
+            );
+        }
+
+        let event_id = match hash_structured(&(
+            "exo.mcp.ledger.submit_event.v1",
+            event_type,
+            payload_hex,
+            author_did_str,
+        )) {
+            Ok(hash) => hash,
+            Err(e) => {
+                return ToolResult::error(
+                    json!({"error": format!("event ID serialization failed: {e}")}).to_string(),
+                );
+            }
+        };
+
+        let response = json!({
+            "event_id": event_id.to_string(),
+            "event_type": event_type,
+            "author_did": author_did_str,
+            "status": "accepted",
+            "submitted_at": Value::Null,
+            "submitted_at_source": "simulation_no_persistence_timestamp",
+        });
+        ToolResult::success(response.to_string())
     }
-
-    let now = Timestamp::now_utc();
-
-    // Generate event_id via BLAKE3 hash of type+payload+author+timestamp.
-    let hash_input = format!(
-        "{}:{}:{}:{}:{}",
-        event_type, payload_hex, author_did_str, now.physical_ms, now.logical
-    );
-    let event_id = Hash256::digest(hash_input.as_bytes());
-
-    let response = json!({
-        "event_id": event_id.to_string(),
-        "event_type": event_type,
-        "author_did": author_did_str,
-        "status": "accepted",
-        "submitted_at": format!("{}:{}", now.physical_ms, now.logical),
-    });
-    ToolResult::success(response.to_string())
 }
 
 // ---------------------------------------------------------------------------
@@ -146,16 +169,13 @@ pub fn execute_get_event(params: &Value, context: &NodeContext) -> ToolResult {
     }
 
     // When a DAG store is attached, we differentiate the response so
-    // callers know the lookup was attempted against real state. Full
-    // event retrieval wiring lands in a subsequent change — for now we
-    // surface that a store is available but the lookup path is not yet
-    // implemented.
+    // callers know the lookup was attempted against real state.
     if context.has_store() {
         let response = json!({
             "event_hash": event_hash,
             "found": false,
             "status": "known_store_but_lookup_not_yet_implemented",
-            "suggestion": "Store is attached; direct event retrieval will be wired in a future change.",
+            "suggestion": "Store is attached; this MCP tool cannot retrieve event bodies.",
         });
         return ToolResult::success(response.to_string());
     }
@@ -312,8 +332,6 @@ pub fn get_checkpoint_definition() -> ToolDefinition {
 pub fn execute_get_checkpoint(params: &Value, context: &NodeContext) -> ToolResult {
     let _ = params; // No required params.
 
-    let now = Timestamp::now_utc();
-
     // Prefer live store-reported height if we have one.
     if let Some(store) = context.store.as_ref() {
         let height = match store.lock() {
@@ -346,7 +364,8 @@ pub fn execute_get_checkpoint(params: &Value, context: &NodeContext) -> ToolResu
             "round": round,
             "validator_count": validator_count,
             "status": "live",
-            "last_finalized_at": format!("{}:{}", now.physical_ms, now.logical),
+            "last_finalized_at": Value::Null,
+            "last_finalized_at_source": "unavailable_from_attached_store",
         });
         return ToolResult::success(response.to_string());
     }
@@ -356,8 +375,9 @@ pub fn execute_get_checkpoint(params: &Value, context: &NodeContext) -> ToolResu
         "round": 0,
         "validator_count": 0,
         "status": "no_store_available",
-        "last_finalized_at": format!("{}:{}", now.physical_ms, now.logical),
-        "note": "No DAG store attached to this MCP server. Returning genesis-style template.",
+        "last_finalized_at": Value::Null,
+        "last_finalized_at_source": "unavailable_no_store",
+        "note": "No DAG store attached to this MCP server. Returning non-finalized status.",
     });
     ToolResult::success(response.to_string())
 }
@@ -380,6 +400,7 @@ mod tests {
         assert!(!def.description.is_empty());
     }
 
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_submit_event_success() {
         let params = json!({
@@ -394,6 +415,22 @@ mod tests {
         assert_eq!(v["event_type"], "transfer");
         assert_eq!(v["author_did"], "did:exo:alice");
         assert_eq!(v["status"], "accepted");
+    }
+
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    #[test]
+    fn execute_submit_event_refuses_by_default() {
+        let params = json!({
+            "event_type": "transfer",
+            "payload_hex": "deadbeef",
+            "author_did": "did:exo:alice",
+        });
+        let result = execute_submit_event(&params, &NodeContext::empty());
+        assert!(result.is_error);
+        let text = result.content[0].text();
+        assert!(text.contains("mcp_simulation_tool_disabled"));
+        assert!(text.contains("unaudited-mcp-simulation-tools"));
+        assert!(text.contains("fix-mcp-default-simulation-gates.md"));
     }
 
     #[test]
@@ -531,5 +568,14 @@ mod tests {
         assert_eq!(v["round"], 0);
         assert_eq!(v["validator_count"], 0);
         assert_eq!(v["status"], "no_store_available");
+    }
+
+    #[test]
+    fn execute_get_checkpoint_no_store_does_not_fabricate_timestamp() {
+        let result = execute_get_checkpoint(&json!({}), &NodeContext::empty());
+        assert!(!result.is_error);
+        let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
+        assert!(v["last_finalized_at"].is_null());
+        assert_eq!(v["last_finalized_at_source"], "unavailable_no_store");
     }
 }

--- a/crates/exo-node/src/mcp/tools/messaging.rs
+++ b/crates/exo-node/src/mcp/tools/messaging.rs
@@ -1,7 +1,9 @@
 //! Messaging MCP tools — encrypted message sending, receiving, and
 //! afterlife (death trigger) message configuration.
 
-use exo_core::{Did, Hash256, Timestamp};
+use exo_core::Did;
+#[cfg(feature = "unaudited-mcp-simulation-tools")]
+use exo_core::{Hash256, hash::hash_structured};
 use serde_json::{Value, json};
 
 use crate::mcp::{
@@ -48,76 +50,96 @@ pub fn send_encrypted_definition() -> ToolDefinition {
 /// Execute the `exochain_send_encrypted` tool.
 #[must_use]
 pub fn execute_send_encrypted(params: &Value, _context: &NodeContext) -> ToolResult {
-    let sender_did_str = match params.get("sender_did").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: sender_did"}).to_string(),
-            );
-        }
-    };
-    let recipient_did_str = match params.get("recipient_did").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: recipient_did"}).to_string(),
-            );
-        }
-    };
-    let plaintext = match params.get("plaintext").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: plaintext"}).to_string(),
-            );
-        }
-    };
-
-    let content_type = params
-        .get("content_type")
-        .and_then(Value::as_str)
-        .unwrap_or("text/plain");
-
-    // Validate DIDs.
-    if Did::new(sender_did_str).is_err() {
-        return ToolResult::error(
-            json!({"error": format!("invalid DID format: {sender_did_str}")}).to_string(),
-        );
-    }
-    if Did::new(recipient_did_str).is_err() {
-        return ToolResult::error(
-            json!({"error": format!("invalid DID format: {recipient_did_str}")}).to_string(),
-        );
-    }
-
-    let now = Timestamp::now_utc();
-
-    // Generate envelope ID from sender+recipient+content+timestamp.
-    let envelope_id = Hash256::digest(
-        format!(
-            "envelope:{}:{}:{}:{}:{}",
-            sender_did_str, recipient_did_str, plaintext, now.physical_ms, now.logical
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    {
+        let _ = params;
+        super::simulation_tool_refused(
+            "exochain_send_encrypted",
+            "Initiatives/fix-mcp-default-simulation-gates.md",
+            "This MCP tool currently simulates encrypted delivery by hashing \
+             plaintext without sending or storing an envelope. Build with \
+             `unaudited-mcp-simulation-tools` only for explicit dev simulation.",
         )
-        .as_bytes(),
-    );
+    }
 
-    // Simulate encryption by hashing the plaintext (not real encryption).
-    let ciphertext_hash = Hash256::digest(plaintext.as_bytes());
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
+    {
+        let sender_did_str = match params.get("sender_did").and_then(Value::as_str) {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: sender_did"}).to_string(),
+                );
+            }
+        };
+        let recipient_did_str = match params.get("recipient_did").and_then(Value::as_str) {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: recipient_did"}).to_string(),
+                );
+            }
+        };
+        let plaintext = match params.get("plaintext").and_then(Value::as_str) {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: plaintext"}).to_string(),
+                );
+            }
+        };
 
-    let response = json!({
-        "envelope_id": envelope_id.to_string(),
-        "sender_did": sender_did_str,
-        "recipient_did": recipient_did_str,
-        "content_type": content_type,
-        "encryption": {
-            "algorithm": "X25519-XSalsa20-Poly1305",
-            "ciphertext_hash": ciphertext_hash.to_string(),
-            "plaintext_length": plaintext.len(),
-        },
-        "status": "sent",
-        "sent_at": format!("{}:{}", now.physical_ms, now.logical),
-    });
-    ToolResult::success(response.to_string())
+        let content_type = params
+            .get("content_type")
+            .and_then(Value::as_str)
+            .unwrap_or("text/plain");
+
+        // Validate DIDs.
+        if Did::new(sender_did_str).is_err() {
+            return ToolResult::error(
+                json!({"error": format!("invalid DID format: {sender_did_str}")}).to_string(),
+            );
+        }
+        if Did::new(recipient_did_str).is_err() {
+            return ToolResult::error(
+                json!({"error": format!("invalid DID format: {recipient_did_str}")}).to_string(),
+            );
+        }
+
+        let envelope_id = match hash_structured(&(
+            "exo.mcp.messaging.envelope.v1",
+            sender_did_str,
+            recipient_did_str,
+            content_type,
+            plaintext,
+        )) {
+            Ok(hash) => hash,
+            Err(e) => {
+                return ToolResult::error(
+                    json!({"error": format!("envelope ID serialization failed: {e}")}).to_string(),
+                );
+            }
+        };
+
+        // Simulate encryption by hashing the plaintext (not real encryption).
+        let ciphertext_hash = Hash256::digest(plaintext.as_bytes());
+
+        let response = json!({
+            "envelope_id": envelope_id.to_string(),
+            "sender_did": sender_did_str,
+            "recipient_did": recipient_did_str,
+            "content_type": content_type,
+            "encryption": {
+                "algorithm": "X25519-XSalsa20-Poly1305",
+                "ciphertext_hash": ciphertext_hash.to_string(),
+                "plaintext_length": plaintext.len(),
+            },
+            "status": "sent",
+            "sent_at": Value::Null,
+            "sent_at_source": "simulation_no_delivery_timestamp",
+        });
+        ToolResult::success(response.to_string())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -175,8 +197,6 @@ pub fn execute_receive_encrypted(params: &Value, _context: &NodeContext) -> Tool
         );
     }
 
-    let now = Timestamp::now_utc();
-
     // In the current state we don't have a message store, so return a
     // structured "not found" response.
     let response = json!({
@@ -184,7 +204,8 @@ pub fn execute_receive_encrypted(params: &Value, _context: &NodeContext) -> Tool
         "recipient_did": recipient_did_str,
         "decryption_status": "envelope_not_found",
         "verified": false,
-        "checked_at": format!("{}:{}", now.physical_ms, now.logical),
+        "checked_at": Value::Null,
+        "checked_at_source": "unavailable_no_message_store",
         "note": "No message store is available in this node instance.",
     });
     ToolResult::success(response.to_string())
@@ -234,89 +255,112 @@ pub fn configure_death_trigger_definition() -> ToolDefinition {
 /// Execute the `exochain_configure_death_trigger` tool.
 #[must_use]
 pub fn execute_configure_death_trigger(params: &Value, _context: &NodeContext) -> ToolResult {
-    let owner_did_str = match params.get("owner_did").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: owner_did"}).to_string(),
-            );
-        }
-    };
-    let recipient_did_str = match params.get("recipient_did").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: recipient_did"}).to_string(),
-            );
-        }
-    };
-    let message = match params.get("message").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: message"}).to_string(),
-            );
-        }
-    };
-    let trigger_type = match params.get("trigger_type").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: trigger_type"}).to_string(),
-            );
-        }
-    };
-
-    // Validate trigger type.
-    let valid_types = ["inactivity", "explicit", "date"];
-    if !valid_types.contains(&trigger_type) {
-        return ToolResult::error(
-            json!({"error": format!(
-                "invalid trigger_type '{}': must be one of {:?}",
-                trigger_type, valid_types
-            )})
-            .to_string(),
-        );
-    }
-
-    // Validate DIDs.
-    if Did::new(owner_did_str).is_err() {
-        return ToolResult::error(
-            json!({"error": format!("invalid DID format: {owner_did_str}")}).to_string(),
-        );
-    }
-    if Did::new(recipient_did_str).is_err() {
-        return ToolResult::error(
-            json!({"error": format!("invalid DID format: {recipient_did_str}")}).to_string(),
-        );
-    }
-
-    let trigger_params = params.get("trigger_params").cloned().unwrap_or(json!({}));
-
-    let now = Timestamp::now_utc();
-    let trigger_id = Hash256::digest(
-        format!(
-            "death_trigger:{}:{}:{}:{}:{}",
-            owner_did_str, recipient_did_str, trigger_type, now.physical_ms, now.logical
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    {
+        let _ = params;
+        super::simulation_tool_refused(
+            "exochain_configure_death_trigger",
+            "Initiatives/fix-mcp-default-simulation-gates.md",
+            "This MCP tool currently returns simulated death-trigger configuration \
+             without storing a trigger or sealed envelope. Build with \
+             `unaudited-mcp-simulation-tools` only for explicit dev simulation.",
         )
-        .as_bytes(),
-    );
+    }
 
-    // Hash the message for the sealed envelope.
-    let message_hash = Hash256::digest(message.as_bytes());
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
+    {
+        let owner_did_str = match params.get("owner_did").and_then(Value::as_str) {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: owner_did"}).to_string(),
+                );
+            }
+        };
+        let recipient_did_str = match params.get("recipient_did").and_then(Value::as_str) {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: recipient_did"}).to_string(),
+                );
+            }
+        };
+        let message = match params.get("message").and_then(Value::as_str) {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: message"}).to_string(),
+                );
+            }
+        };
+        let trigger_type = match params.get("trigger_type").and_then(Value::as_str) {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: trigger_type"}).to_string(),
+                );
+            }
+        };
 
-    let response = json!({
-        "trigger_id": trigger_id.to_string(),
-        "owner_did": owner_did_str,
-        "recipient_did": recipient_did_str,
-        "trigger_type": trigger_type,
-        "trigger_params": trigger_params,
-        "message_hash": message_hash.to_string(),
-        "message_length": message.len(),
-        "status": "configured",
-        "configured_at": format!("{}:{}", now.physical_ms, now.logical),
-    });
-    ToolResult::success(response.to_string())
+        // Validate trigger type.
+        let valid_types = ["inactivity", "explicit", "date"];
+        if !valid_types.contains(&trigger_type) {
+            return ToolResult::error(
+                json!({"error": format!(
+                    "invalid trigger_type '{}': must be one of {:?}",
+                    trigger_type, valid_types
+                )})
+                .to_string(),
+            );
+        }
+
+        // Validate DIDs.
+        if Did::new(owner_did_str).is_err() {
+            return ToolResult::error(
+                json!({"error": format!("invalid DID format: {owner_did_str}")}).to_string(),
+            );
+        }
+        if Did::new(recipient_did_str).is_err() {
+            return ToolResult::error(
+                json!({"error": format!("invalid DID format: {recipient_did_str}")}).to_string(),
+            );
+        }
+
+        let trigger_params = params.get("trigger_params").cloned().unwrap_or(json!({}));
+
+        let trigger_id = match hash_structured(&(
+            "exo.mcp.messaging.death_trigger.v1",
+            owner_did_str,
+            recipient_did_str,
+            trigger_type,
+            &trigger_params,
+            message,
+        )) {
+            Ok(hash) => hash,
+            Err(e) => {
+                return ToolResult::error(
+                    json!({"error": format!("trigger ID serialization failed: {e}")}).to_string(),
+                );
+            }
+        };
+
+        // Hash the message for the sealed envelope.
+        let message_hash = Hash256::digest(message.as_bytes());
+
+        let response = json!({
+            "trigger_id": trigger_id.to_string(),
+            "owner_did": owner_did_str,
+            "recipient_did": recipient_did_str,
+            "trigger_type": trigger_type,
+            "trigger_params": trigger_params,
+            "message_hash": message_hash.to_string(),
+            "message_length": message.len(),
+            "status": "configured",
+            "configured_at": Value::Null,
+            "configured_at_source": "simulation_no_persistence_timestamp",
+        });
+        ToolResult::success(response.to_string())
+    }
 }
 
 // ===========================================================================
@@ -337,6 +381,7 @@ mod tests {
         assert!(!def.description.is_empty());
     }
 
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_send_encrypted_success() {
         let params = json!({
@@ -355,6 +400,23 @@ mod tests {
         assert_eq!(v["encryption"]["algorithm"], "X25519-XSalsa20-Poly1305");
     }
 
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    #[test]
+    fn execute_send_encrypted_refuses_by_default() {
+        let params = json!({
+            "sender_did": "did:exo:alice",
+            "recipient_did": "did:exo:bob",
+            "plaintext": "Hello, Bob!",
+        });
+        let result = execute_send_encrypted(&params, &NodeContext::empty());
+        assert!(result.is_error);
+        let text = result.content[0].text();
+        assert!(text.contains("mcp_simulation_tool_disabled"));
+        assert!(text.contains("unaudited-mcp-simulation-tools"));
+        assert!(text.contains("fix-mcp-default-simulation-gates.md"));
+    }
+
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_send_encrypted_with_content_type() {
         let params = json!({
@@ -409,6 +471,8 @@ mod tests {
         let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
         assert_eq!(v["envelope_id"], "env_abc123");
         assert_eq!(v["decryption_status"], "envelope_not_found");
+        assert!(v["checked_at"].is_null());
+        assert_eq!(v["checked_at_source"], "unavailable_no_message_store");
     }
 
     #[test]
@@ -439,6 +503,7 @@ mod tests {
         assert!(!def.description.is_empty());
     }
 
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_configure_death_trigger_success() {
         let params = json!({
@@ -456,6 +521,24 @@ mod tests {
         assert!(v["trigger_id"].as_str().is_some());
         assert!(v["message_hash"].as_str().is_some());
         assert_eq!(v["trigger_params"]["inactivity_days"], 365);
+    }
+
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    #[test]
+    fn execute_configure_death_trigger_refuses_by_default() {
+        let params = json!({
+            "owner_did": "did:exo:alice",
+            "recipient_did": "did:exo:bob",
+            "message": "If you are reading this, I am gone.",
+            "trigger_type": "inactivity",
+            "trigger_params": {"inactivity_days": 365},
+        });
+        let result = execute_configure_death_trigger(&params, &NodeContext::empty());
+        assert!(result.is_error);
+        let text = result.content[0].text();
+        assert!(text.contains("mcp_simulation_tool_disabled"));
+        assert!(text.contains("unaudited-mcp-simulation-tools"));
+        assert!(text.contains("fix-mcp-default-simulation-gates.md"));
     }
 
     #[test]
@@ -482,6 +565,7 @@ mod tests {
         assert!(result.is_error);
     }
 
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_configure_death_trigger_no_params() {
         let params = json!({

--- a/crates/exo-node/src/mcp/tools/mod.rs
+++ b/crates/exo-node/src/mcp/tools/mod.rs
@@ -19,6 +19,24 @@ use super::{
     protocol::{ToolDefinition, ToolResult},
 };
 
+#[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+pub(crate) fn simulation_tool_refused(
+    tool_name: &str,
+    initiative: &str,
+    reason: &str,
+) -> ToolResult {
+    ToolResult::error(
+        serde_json::json!({
+            "error": "mcp_simulation_tool_disabled",
+            "tool": tool_name,
+            "message": reason,
+            "feature_flag": "unaudited-mcp-simulation-tools",
+            "initiative": initiative,
+        })
+        .to_string(),
+    )
+}
+
 /// Registry of available MCP tools.
 ///
 /// Stores tool definitions and dispatches calls to the appropriate handler.
@@ -262,5 +280,30 @@ mod tests {
     fn registry_empty_has_no_tools() {
         let registry = ToolRegistry::new();
         assert!(registry.list().is_empty());
+    }
+
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    #[test]
+    fn default_mcp_operational_tools_do_not_fabricate_local_time() {
+        for path in [
+            "src/mcp/tools/authority.rs",
+            "src/mcp/tools/consent.rs",
+            "src/mcp/tools/ledger.rs",
+            "src/mcp/tools/escalation.rs",
+            "src/mcp/tools/governance.rs",
+            "src/mcp/tools/messaging.rs",
+            "src/mcp/tools/identity.rs",
+        ] {
+            let src = std::fs::read_to_string(path).expect("MCP tool source readable");
+            let operational_src = src.split("#[cfg(test)]").next().expect("source prefix");
+            assert!(
+                !operational_src.contains("Timestamp::now_utc"),
+                "{path} must not read local wall-clock time in MCP tool handlers"
+            );
+            assert!(
+                !operational_src.contains(".as_f64()"),
+                "{path} must not parse floating-point request values"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- gates remaining write-like MCP simulation tools behind `unaudited-mcp-simulation-tools` by default
- replaces local timestamp-derived simulation IDs with domain-separated canonical structured hashes
- removes fabricated local timestamps from no-store MCP read responses and adds source guards
- refreshes README repo-truth LOC to 113423

## TDD red checks

- `cargo test -p exo-node execute_propose_bailment_refuses_by_default --bin exochain` failed before the default-off gate because the bailment proposal tool returned synthetic success.
- `cargo test -p exo-node mcp::tools::authority::tests::execute_delegate_authority_success --bin exochain --features unaudited-mcp-simulation-tools` failed after adding deterministic feature-mode assertions because timestamp-derived IDs differed across identical inputs.

## Verification

- `cargo test -p exo-node mcp::tools --bin exochain`
- `cargo test -p exo-node mcp::tools --bin exochain --features unaudited-mcp-simulation-tools`
- `cargo test -p exo-node`
- `cargo build -p exo-node`
- `cargo clippy -p exo-node --bins -- -D warnings`
- `cargo clippy -p exo-node --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo clippy -p exo-node --bin exochain --features unaudited-mcp-simulation-tools -- -D warnings`
- `cargo clippy -p exo-node --tests --features unaudited-mcp-simulation-tools -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `bash tools/repo_truth.sh --json`
- `bash tools/test_repo_truth.sh`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`