### PR TITLE
fix(exo-node): fail closed on sqlite store decodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 113575 | `wc -l` |
-| Workspace tests | 2,780 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 114241 | `wc -l` |
+| Workspace tests | 2,807 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,780 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,807 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 113575 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 114241 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,780 listed workspace tests
+         cryptographic proofs, 2,807 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          140 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -162,7 +162,7 @@ async fn start_node(
 
     // Open local DAG store.
     let dag_store = store::SqliteDagStore::open(data_dir)?;
-    let height = dag_store.committed_height_value();
+    let height = dag_store.committed_height_value()?;
     tracing::info!(height, "DAG store opened");
 
     // Open 0dentity store (shares the same dag.db, applies zerodentity migration).
@@ -805,7 +805,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             let dag_store = store::SqliteDagStore::open(&data_dir)?;
 
             println!("Node:   {}", node_identity.did);
-            println!("Height: {}", dag_store.committed_height_value());
+            println!("Height: {}", dag_store.committed_height_value()?);
             println!("Data:   {}", data_dir.display());
 
             Ok(())

--- a/crates/exo-node/src/mcp/tools/ledger.rs
+++ b/crates/exo-node/src/mcp/tools/ledger.rs
@@ -335,7 +335,15 @@ pub fn execute_get_checkpoint(params: &Value, context: &NodeContext) -> ToolResu
     // Prefer live store-reported height if we have one.
     if let Some(store) = context.store.as_ref() {
         let height = match store.lock() {
-            Ok(guard) => guard.committed_height_value(),
+            Ok(guard) => match guard.committed_height_value() {
+                Ok(height) => height,
+                Err(e) => {
+                    return ToolResult::error(
+                        json!({"error": format!("store committed height unavailable: {e}")})
+                            .to_string(),
+                    );
+                }
+            },
             Err(_) => {
                 return ToolResult::error(json!({"error": "store mutex poisoned"}).to_string());
             }
@@ -577,5 +585,29 @@ mod tests {
         let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
         assert!(v["last_finalized_at"].is_null());
         assert_eq!(v["last_finalized_at_source"], "unavailable_no_store");
+    }
+
+    #[test]
+    fn execute_get_checkpoint_fails_closed_on_store_height_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = crate::store::SqliteDagStore::open(dir.path()).unwrap();
+        let conn = rusqlite::Connection::open(dir.path().join("dag.db")).unwrap();
+        let hash = [0xA5u8; 32];
+        conn.execute(
+            "INSERT INTO committed (hash, height) VALUES (?1, ?2)",
+            rusqlite::params![hash.as_slice(), -1_i64],
+        )
+        .unwrap();
+        let context = NodeContext {
+            store: Some(std::sync::Arc::new(std::sync::Mutex::new(store))),
+            ..NodeContext::empty()
+        };
+
+        let result = execute_get_checkpoint(&json!({}), &context);
+
+        assert!(result.is_error);
+        let text = result.content[0].text();
+        assert!(text.contains("store committed height unavailable"));
+        assert!(text.contains("committed.height"));
     }
 }

--- a/crates/exo-node/src/sentinels.rs
+++ b/crates/exo-node/src/sentinels.rs
@@ -196,7 +196,18 @@ fn check_receipt_integrity(store: &Arc<Mutex<SqliteDagStore>>) -> SentinelStatus
     // We query via a raw SQL since load_receipts_by_actor requires an actor.
     // For the sentinel, we'll check receipts from a known actor or skip if none.
     // Simplified: check committed height is sane as a proxy.
-    let height = st.committed_height_value();
+    let height = match st.committed_height_value() {
+        Ok(height) => height,
+        Err(e) => {
+            tracing::error!(err = %e, "Failed to read committed height in receipt sentinel");
+            return SentinelStatus {
+                check: SentinelCheck::ReceiptIntegrity,
+                healthy: false,
+                message: format!("Receipt store unavailable: {e}"),
+                last_run_ms: now_ms(),
+            };
+        }
+    };
 
     SentinelStatus {
         check: SentinelCheck::ReceiptIntegrity,
@@ -371,8 +382,30 @@ fn check_store_consistency(store: &Arc<Mutex<SqliteDagStore>>) -> SentinelStatus
             };
         }
     };
-    let height = st.committed_height_value();
-    let certs = st.load_certificates().unwrap_or_default();
+    let height = match st.committed_height_value() {
+        Ok(height) => height,
+        Err(e) => {
+            tracing::error!(err = %e, "Failed to read committed height in consistency sentinel");
+            return SentinelStatus {
+                check: SentinelCheck::StoreConsistency,
+                healthy: false,
+                message: format!("Store unavailable: {e}"),
+                last_run_ms: now_ms(),
+            };
+        }
+    };
+    let certs = match st.load_certificates() {
+        Ok(certs) => certs,
+        Err(e) => {
+            tracing::error!(err = %e, "Failed to load commit certificates in consistency sentinel");
+            return SentinelStatus {
+                check: SentinelCheck::StoreConsistency,
+                healthy: false,
+                message: format!("Store certificates unavailable: {e}"),
+                last_run_ms: now_ms(),
+            };
+        }
+    };
 
     let healthy = certs.len() as u64 <= height || height == 0;
     let message = if healthy {
@@ -533,6 +566,20 @@ mod tests {
         Arc::new(Mutex::new(store))
     }
 
+    fn store_with_negative_committed_height() -> Arc<Mutex<SqliteDagStore>> {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SqliteDagStore::open(dir.path()).unwrap();
+        let conn = rusqlite::Connection::open(dir.path().join("dag.db")).unwrap();
+        let hash = [0xA5u8; 32];
+        conn.execute(
+            "INSERT INTO committed (hash, height) VALUES (?1, ?2)",
+            rusqlite::params![hash.as_slice(), -1_i64],
+        )
+        .unwrap();
+        std::mem::forget(dir);
+        Arc::new(Mutex::new(store))
+    }
+
     #[test]
     fn liveness_check_healthy() {
         let reactor = test_reactor();
@@ -578,6 +625,26 @@ mod tests {
         let store = test_store();
         let status = check_receipt_integrity(&store);
         assert!(status.healthy);
+    }
+
+    #[test]
+    fn receipt_integrity_fails_closed_on_store_height_error() {
+        let store = store_with_negative_committed_height();
+        let status = check_receipt_integrity(&store);
+
+        assert!(!status.healthy);
+        assert_eq!(status.check, SentinelCheck::ReceiptIntegrity);
+        assert!(status.message.contains("committed.height"));
+    }
+
+    #[test]
+    fn store_consistency_fails_closed_on_store_height_error() {
+        let store = store_with_negative_committed_height();
+        let status = check_store_consistency(&store);
+
+        assert!(!status.healthy);
+        assert_eq!(status.check, SentinelCheck::StoreConsistency);
+        assert!(status.message.contains("committed.height"));
     }
 
     #[tokio::test]

--- a/crates/exo-node/src/store.rs
+++ b/crates/exo-node/src/store.rs
@@ -8,7 +8,7 @@
 
 use std::{collections::BTreeSet, path::Path};
 
-use exo_core::types::{Did, Hash256};
+use exo_core::types::{Did, Hash256, Signature};
 use exo_dag::{
     consensus::{CommitCertificate, Vote},
     dag::DagNode,
@@ -20,6 +20,90 @@ fn store_err(e: impl std::fmt::Display) -> DagError {
     DagError::StoreError(e.to_string())
 }
 use rusqlite::{Connection, params};
+
+fn sqlite_u64_to_i64(value: u64, field: &str) -> DagResult<i64> {
+    i64::try_from(value)
+        .map_err(|_| store_err(format!("{field} value {value} exceeds SQLite INTEGER max")))
+}
+
+#[allow(clippy::as_conversions)]
+fn sqlite_i64_to_u64(value: i64, field: &str) -> DagResult<u64> {
+    if value < 0 {
+        return Err(store_err(format!("{field} value {value} is negative")));
+    }
+    Ok(value as u64)
+}
+
+fn decode_hash_bytes(bytes: &[u8], field: &str) -> DagResult<Hash256> {
+    let arr: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| store_err(format!("{field} must be 32 bytes, got {}", bytes.len())))?;
+    Ok(Hash256::from_bytes(arr))
+}
+
+fn decode_signature_bytes(bytes: &[u8], field: &str) -> DagResult<Signature> {
+    let arr: [u8; 64] = bytes
+        .try_into()
+        .map_err(|_| store_err(format!("{field} must be 64 bytes, got {}", bytes.len())))?;
+    let signature = Signature::from_bytes(arr);
+    validate_signature(&signature, field)?;
+    Ok(signature)
+}
+
+fn validate_signature(signature: &Signature, field: &str) -> DagResult<()> {
+    if signature.is_empty() {
+        return Err(store_err(format!("{field} must not be empty or all-zero")));
+    }
+    Ok(())
+}
+
+fn validate_ed25519_signature<'a>(
+    signature: &'a Signature,
+    field: &str,
+) -> DagResult<&'a [u8; 64]> {
+    let Signature::Ed25519(bytes) = signature else {
+        return Err(store_err(format!(
+            "{field} must be an Ed25519 signature for consensus persistence"
+        )));
+    };
+    if bytes.iter().all(|b| *b == 0) {
+        return Err(store_err(format!("{field} must not be empty or all-zero")));
+    }
+    Ok(bytes)
+}
+
+fn decode_did(value: &str, field: &str) -> DagResult<Did> {
+    Did::new(value).map_err(|e| store_err(format!("{field} is invalid: {e}")))
+}
+
+fn validate_vote(vote: &Vote, context: &str) -> DagResult<()> {
+    validate_ed25519_signature(&vote.signature, &format!("{context}.signature"))?;
+    Ok(())
+}
+
+fn validate_commit_certificate(cert: &CommitCertificate) -> DagResult<()> {
+    if cert.votes.is_empty() {
+        return Err(store_err("commit_certificates.votes must not be empty"));
+    }
+
+    for (idx, vote) in cert.votes.iter().enumerate() {
+        let context = format!("commit_certificates.votes[{idx}]");
+        if vote.round != cert.round {
+            return Err(store_err(format!(
+                "{context}.round {} does not match certificate round {}",
+                vote.round, cert.round
+            )));
+        }
+        if vote.node_hash != cert.node_hash {
+            return Err(store_err(format!(
+                "{context}.node_hash does not match certificate node_hash"
+            )));
+        }
+        validate_vote(vote, &context)?;
+    }
+
+    Ok(())
+}
 
 /// SQLite-backed DAG store.
 pub struct SqliteDagStore {
@@ -100,9 +184,8 @@ impl SqliteDagStore {
     }
 
     /// Convenience accessor for the current committed height.
-    #[must_use]
-    pub fn committed_height_value(&self) -> u64 {
-        self.committed_height_sync().unwrap_or(0)
+    pub fn committed_height_value(&self) -> DagResult<u64> {
+        self.committed_height_sync()
     }
 
     /// Serialize a `DagNode` to CBOR bytes.
@@ -126,7 +209,8 @@ impl SqliteDagStore {
         from_height: u64,
         to_height: u64,
     ) -> DagResult<Vec<(Hash256, u64)>> {
-        #[allow(clippy::as_conversions)]
+        let from_height = sqlite_u64_to_i64(from_height, "committed.from_height")?;
+        let to_height = sqlite_u64_to_i64(to_height, "committed.to_height")?;
         let mut stmt = self
             .conn
             .prepare_cached(
@@ -136,20 +220,21 @@ impl SqliteDagStore {
             )
             .map_err(store_err)?;
 
-        #[allow(clippy::as_conversions)]
         let rows = stmt
-            .query_map(params![from_height as i64, to_height as i64], |row| {
+            .query_map(params![from_height, to_height], |row| {
                 let bytes: Vec<u8> = row.get(0)?;
                 let height: i64 = row.get(1)?;
-                let mut arr = [0u8; 32];
-                arr.copy_from_slice(&bytes);
-                Ok((Hash256::from_bytes(arr), height as u64))
+                Ok((bytes, height))
             })
             .map_err(store_err)?;
 
         let mut result = Vec::new();
         for row in rows {
-            result.push(row.map_err(store_err)?);
+            let (bytes, height) = row.map_err(store_err)?;
+            result.push((
+                decode_hash_bytes(&bytes, "committed.hash")?,
+                sqlite_i64_to_u64(height, "committed.height")?,
+            ));
         }
         Ok(result)
     }
@@ -179,21 +264,25 @@ impl SqliteDagStore {
         );
         match result {
             Ok(s) => s.parse::<u64>().map_err(store_err),
-            Err(_) => Ok(0),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(0),
+            Err(e) => Err(store_err(e)),
         }
     }
 
     /// Persist a consensus vote.
     pub fn save_vote(&mut self, vote: &Vote) -> DagResult<()> {
-        #[allow(clippy::as_conversions)]
+        let round = sqlite_u64_to_i64(vote.round, "consensus_votes.round")?;
+        validate_vote(vote, "consensus_votes")?;
+        let signature = validate_ed25519_signature(&vote.signature, "consensus_votes.signature")?;
+
         self.conn
             .execute(
                 "INSERT OR IGNORE INTO consensus_votes (round, node_hash, voter_did, signature) VALUES (?1, ?2, ?3, ?4)",
                 params![
-                    vote.round as i64,
+                    round,
                     vote.node_hash.0.as_slice(),
                     vote.voter.to_string(),
-                    vote.signature.as_bytes(),
+                    signature,
                 ],
             )
             .map_err(store_err)?;
@@ -202,7 +291,7 @@ impl SqliteDagStore {
 
     /// Load all votes for a given round.
     pub fn load_votes_for_round(&self, round: u64) -> DagResult<Vec<Vote>> {
-        #[allow(clippy::as_conversions)]
+        let round_i64 = sqlite_u64_to_i64(round, "consensus_votes.round")?;
         let mut stmt = self
             .conn
             .prepare_cached(
@@ -210,51 +299,43 @@ impl SqliteDagStore {
             )
             .map_err(store_err)?;
 
-        #[allow(clippy::as_conversions)]
         let rows = stmt
-            .query_map(params![round as i64], |row| {
+            .query_map(params![round_i64], |row| {
                 let hash_bytes: Vec<u8> = row.get(0)?;
                 let voter_str: String = row.get(1)?;
                 let sig_bytes: Vec<u8> = row.get(2)?;
-
-                let mut hash_arr = [0u8; 32];
-                hash_arr.copy_from_slice(&hash_bytes);
-                let mut sig_arr = [0u8; 64];
-                if sig_bytes.len() == 64 {
-                    sig_arr.copy_from_slice(&sig_bytes);
-                }
-
-                Ok(Vote {
-                    #[allow(clippy::expect_used)] // Hardcoded constant — always valid.
-                    voter: Did::new(&voter_str)
-                        .unwrap_or_else(|_| Did::new("did:exo:unknown").expect("hardcoded DID")),
-                    round,
-                    node_hash: Hash256::from_bytes(hash_arr),
-                    signature: exo_core::types::Signature::from_bytes(sig_arr),
-                })
+                Ok((hash_bytes, voter_str, sig_bytes))
             })
             .map_err(store_err)?;
 
         let mut votes = Vec::new();
         for row in rows {
-            votes.push(row.map_err(store_err)?);
+            let (hash_bytes, voter_str, sig_bytes) = row.map_err(store_err)?;
+            votes.push(Vote {
+                voter: decode_did(&voter_str, "consensus_votes.voter_did")?,
+                round,
+                node_hash: decode_hash_bytes(&hash_bytes, "consensus_votes.node_hash")?,
+                signature: decode_signature_bytes(&sig_bytes, "consensus_votes.signature")?,
+            });
         }
         Ok(votes)
     }
 
     /// Persist a commit certificate.
     pub fn save_certificate(&mut self, cert: &CommitCertificate) -> DagResult<()> {
+        let round = sqlite_u64_to_i64(cert.round, "commit_certificates.round")?;
+        validate_commit_certificate(cert)?;
+
         let mut cbor_buf = Vec::new();
         ciborium::into_writer(cert, &mut cbor_buf)
             .map_err(|e| store_err(format!("CBOR encode certificate: {e}")))?;
 
-        #[allow(clippy::as_conversions)]
         self.conn
             .execute(
                 "INSERT OR IGNORE INTO commit_certificates (node_hash, round, cbor_data) VALUES (?1, ?2, ?3)",
                 params![
                     cert.node_hash.0.as_slice(),
-                    cert.round as i64,
+                    round,
                     cbor_buf,
                 ],
             )
@@ -281,6 +362,7 @@ impl SqliteDagStore {
             let bytes = row.map_err(store_err)?;
             let cert: CommitCertificate = ciborium::from_reader(bytes.as_slice())
                 .map_err(|e| store_err(format!("CBOR decode certificate: {e}")))?;
+            validate_commit_certificate(&cert)?;
             certs.push(cert);
         }
         Ok(certs)
@@ -330,15 +412,18 @@ impl SqliteDagStore {
         let mut set = BTreeSet::new();
         for row in rows {
             let did_str = row.map_err(store_err)?;
-            if let Ok(did) = Did::new(&did_str) {
-                set.insert(did);
-            }
+            let did = decode_did(&did_str, "validators.did")?;
+            set.insert(did);
         }
         Ok(set)
     }
 
     /// Save a trust receipt to the database.
     pub fn save_receipt(&mut self, receipt: &exo_core::types::TrustReceipt) -> DagResult<()> {
+        validate_signature(&receipt.signature, "trust_receipts.signature")?;
+        let timestamp_ms =
+            sqlite_u64_to_i64(receipt.timestamp.physical_ms, "trust_receipts.timestamp_ms")?;
+
         let mut buf = Vec::new();
         ciborium::into_writer(receipt, &mut buf)
             .map_err(|e| store_err(format!("CBOR encode receipt: {e}")))?;
@@ -351,7 +436,7 @@ impl SqliteDagStore {
                     receipt.actor_did.to_string(),
                     receipt.action_type,
                     receipt.outcome.to_string(),
-                    receipt.timestamp.physical_ms as i64,
+                    timestamp_ms,
                     buf,
                 ],
             )
@@ -427,15 +512,14 @@ impl SqliteDagStore {
         let rows = stmt
             .query_map(params![parent_hash.0.as_slice()], |row| {
                 let bytes: Vec<u8> = row.get(0)?;
-                let mut arr = [0u8; 32];
-                arr.copy_from_slice(&bytes);
-                Ok(Hash256::from_bytes(arr))
+                Ok(bytes)
             })
             .map_err(store_err)?;
 
         let mut result = Vec::new();
         for row in rows {
-            result.push(row.map_err(store_err)?);
+            let bytes = row.map_err(store_err)?;
+            result.push(decode_hash_bytes(&bytes, "dag_parents.child_hash")?);
         }
         Ok(result)
     }
@@ -461,11 +545,11 @@ impl SqliteDagStore {
 
         match stmt.query_row(params![hash.0.as_slice()], |row| {
             let h: i64 = row.get(0)?;
-            #[allow(clippy::as_conversions)]
-            Ok(h as u64)
+            Ok(h)
         }) {
-            Ok(h) => Ok(Some(h)),
-            Err(_) => Ok(None),
+            Ok(h) => Ok(Some(sqlite_i64_to_u64(h, "committed.height")?)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(store_err(e)),
         }
     }
 
@@ -562,15 +646,14 @@ impl SqliteDagStore {
         let rows = stmt
             .query_map([], |row| {
                 let bytes: Vec<u8> = row.get(0)?;
-                let mut arr = [0u8; 32];
-                arr.copy_from_slice(&bytes);
-                Ok(Hash256::from_bytes(arr))
+                Ok(bytes)
             })
             .map_err(store_err)?;
 
         let mut tips = Vec::new();
         for row in rows {
-            tips.push(row.map_err(store_err)?);
+            let bytes = row.map_err(store_err)?;
+            tips.push(decode_hash_bytes(&bytes, "dag_nodes.hash")?);
         }
         Ok(tips)
     }
@@ -584,8 +667,7 @@ impl SqliteDagStore {
 
         let height: i64 = stmt.query_row([], |row| row.get(0)).map_err(store_err)?;
 
-        #[allow(clippy::as_conversions)]
-        Ok(height as u64)
+        sqlite_i64_to_u64(height, "committed.height")
     }
 
     /// Sync version of `DagStore::mark_committed`.
@@ -594,11 +676,11 @@ impl SqliteDagStore {
             return Err(DagError::NodeNotFound(*hash));
         }
 
-        #[allow(clippy::as_conversions)]
+        let height = sqlite_u64_to_i64(height, "committed.height")?;
         self.conn
             .execute(
                 "INSERT OR REPLACE INTO committed (hash, height) VALUES (?1, ?2)",
-                params![hash.0.as_slice(), height as i64],
+                params![hash.0.as_slice(), height],
             )
             .map_err(store_err)?;
 
@@ -745,6 +827,16 @@ mod tests {
     }
 
     #[test]
+    fn load_consensus_round_propagates_store_errors() {
+        let store = temp_store();
+        store.conn.execute("DROP TABLE consensus_meta", []).unwrap();
+
+        let err = store.load_consensus_round().unwrap_err();
+
+        assert!(err.to_string().contains("consensus_meta"));
+    }
+
+    #[test]
     fn vote_persistence_roundtrip() {
         use exo_core::types::Signature;
         let mut store = temp_store();
@@ -768,6 +860,125 @@ mod tests {
         // Different round returns empty.
         let empty = store.load_votes_for_round(6).unwrap();
         assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn load_votes_for_round_rejects_short_hash() {
+        let store = temp_store();
+        store
+            .conn
+            .execute(
+                "INSERT INTO consensus_votes (round, node_hash, voter_did, signature)
+                 VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![7_i64, vec![0xABu8; 31], "did:exo:voter1", vec![7u8; 64]],
+            )
+            .unwrap();
+
+        let err = store.load_votes_for_round(7).unwrap_err();
+
+        assert!(err.to_string().contains("consensus_votes.node_hash"));
+    }
+
+    #[test]
+    fn load_votes_for_round_rejects_short_signature() {
+        let store = temp_store();
+        let mut hash = [0u8; 32];
+        hash[0] = 0xAB;
+        store
+            .conn
+            .execute(
+                "INSERT INTO consensus_votes (round, node_hash, voter_did, signature)
+                 VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![7_i64, hash.as_slice(), "did:exo:voter1", vec![7u8; 63]],
+            )
+            .unwrap();
+
+        let err = store.load_votes_for_round(7).unwrap_err();
+
+        assert!(err.to_string().contains("consensus_votes.signature"));
+    }
+
+    #[test]
+    fn load_votes_for_round_rejects_zero_signature() {
+        let store = temp_store();
+        let mut hash = [0u8; 32];
+        hash[0] = 0xAB;
+        store
+            .conn
+            .execute(
+                "INSERT INTO consensus_votes (round, node_hash, voter_did, signature)
+                 VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![7_i64, hash.as_slice(), "did:exo:voter1", vec![0u8; 64]],
+            )
+            .unwrap();
+
+        let err = store.load_votes_for_round(7).unwrap_err();
+
+        assert!(err.to_string().contains("consensus_votes.signature"));
+    }
+
+    #[test]
+    fn load_votes_for_round_rejects_invalid_voter_did() {
+        let store = temp_store();
+        let mut hash = [0u8; 32];
+        hash[0] = 0xAB;
+        store
+            .conn
+            .execute(
+                "INSERT INTO consensus_votes (round, node_hash, voter_did, signature)
+                 VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![7_i64, hash.as_slice(), "not-a-did", vec![7u8; 64]],
+            )
+            .unwrap();
+
+        let err = store.load_votes_for_round(7).unwrap_err();
+
+        assert!(err.to_string().contains("consensus_votes.voter_did"));
+    }
+
+    #[test]
+    fn save_vote_rejects_empty_signature() {
+        let mut store = temp_store();
+        let vote = Vote {
+            voter: Did::new("did:exo:voter1").unwrap(),
+            round: 5,
+            node_hash: Hash256::digest(b"vote-target"),
+            signature: Signature::from_bytes([0u8; 64]),
+        };
+
+        let err = store.save_vote(&vote).unwrap_err();
+
+        assert!(err.to_string().contains("consensus_votes.signature"));
+    }
+
+    #[test]
+    fn save_vote_rejects_signature_variants_that_cannot_roundtrip() {
+        let mut store = temp_store();
+        let vote = Vote {
+            voter: Did::new("did:exo:voter1").unwrap(),
+            round: 5,
+            node_hash: Hash256::digest(b"vote-target"),
+            signature: Signature::PostQuantum(vec![7u8; 64]),
+        };
+
+        let err = store.save_vote(&vote).unwrap_err();
+
+        assert!(err.to_string().contains("consensus_votes.signature"));
+    }
+
+    #[test]
+    fn save_vote_rejects_rounds_that_do_not_fit_sqlite_integer() {
+        let mut store = temp_store();
+        let vote = Vote {
+            voter: Did::new("did:exo:voter1").unwrap(),
+            round: u64::MAX,
+            node_hash: Hash256::digest(b"vote-target"),
+            signature: Signature::from_bytes([7u8; 64]),
+        };
+
+        let err = store.save_vote(&vote).unwrap_err();
+
+        assert!(err.to_string().contains("consensus_votes.round"));
     }
 
     #[test]
@@ -796,6 +1007,105 @@ mod tests {
     }
 
     #[test]
+    fn save_certificate_rejects_empty_vote_signature() {
+        let mut store = temp_store();
+        let hash = Hash256::digest(b"cert-target");
+        let cert = CommitCertificate {
+            node_hash: hash,
+            round: 3,
+            votes: vec![Vote {
+                voter: Did::new("did:exo:v0").unwrap(),
+                round: 3,
+                node_hash: hash,
+                signature: Signature::Empty,
+            }],
+        };
+
+        let err = store.save_certificate(&cert).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("commit_certificates.votes[0].signature")
+        );
+    }
+
+    #[test]
+    fn save_certificate_rejects_signature_variants_that_cannot_verify() {
+        let mut store = temp_store();
+        let hash = Hash256::digest(b"cert-target");
+        let cert = CommitCertificate {
+            node_hash: hash,
+            round: 3,
+            votes: vec![Vote {
+                voter: Did::new("did:exo:v0").unwrap(),
+                round: 3,
+                node_hash: hash,
+                signature: Signature::PostQuantum(vec![7u8; 64]),
+            }],
+        };
+
+        let err = store.save_certificate(&cert).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("commit_certificates.votes[0].signature")
+        );
+    }
+
+    #[test]
+    fn load_certificates_rejects_empty_vote_signature() {
+        let store = temp_store();
+        let hash = Hash256::digest(b"cert-target");
+        let cert = CommitCertificate {
+            node_hash: hash,
+            round: 3,
+            votes: vec![Vote {
+                voter: Did::new("did:exo:v0").unwrap(),
+                round: 3,
+                node_hash: hash,
+                signature: Signature::Empty,
+            }],
+        };
+        let mut cbor = Vec::new();
+        ciborium::into_writer(&cert, &mut cbor).unwrap();
+        store
+            .conn
+            .execute(
+                "INSERT INTO commit_certificates (node_hash, round, cbor_data)
+                 VALUES (?1, ?2, ?3)",
+                rusqlite::params![hash.0.as_slice(), 3_i64, cbor],
+            )
+            .unwrap();
+
+        let err = store.load_certificates().unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("commit_certificates.votes[0].signature")
+        );
+    }
+
+    #[test]
+    fn save_certificate_rejects_rounds_that_do_not_fit_sqlite_integer() {
+        let mut store = temp_store();
+        let hash = Hash256::digest(b"cert-target");
+        let cert = CommitCertificate {
+            node_hash: hash,
+            round: u64::MAX,
+            votes: vec![Vote {
+                voter: Did::new("did:exo:v0").unwrap(),
+                round: u64::MAX,
+                node_hash: hash,
+                signature: Signature::from_bytes([1u8; 64]),
+            }],
+        };
+
+        let err = store.save_certificate(&cert).unwrap_err();
+
+        assert!(err.to_string().contains("commit_certificates.round"));
+    }
+
+    #[test]
     fn validator_set_persistence() {
         let mut store = temp_store();
         let empty = store.load_validator_set().unwrap();
@@ -818,6 +1128,19 @@ mod tests {
         store.save_validator_set(&smaller).unwrap();
         let loaded2 = store.load_validator_set().unwrap();
         assert_eq!(loaded2.len(), 1);
+    }
+
+    #[test]
+    fn load_validator_set_rejects_invalid_did() {
+        let store = temp_store();
+        store
+            .conn
+            .execute("INSERT INTO validators (did) VALUES (?1)", ["not-a-did"])
+            .unwrap();
+
+        let err = store.load_validator_set().unwrap_err();
+
+        assert!(err.to_string().contains("validators.did"));
     }
 
     #[test]
@@ -850,6 +1173,55 @@ mod tests {
         assert_eq!(loaded.actor_did.to_string(), "did:exo:agent-a");
         assert_eq!(loaded.action_type, "dag.commit");
         assert_eq!(loaded.outcome, ReceiptOutcome::Executed);
+    }
+
+    #[test]
+    fn save_receipt_rejects_empty_signature() {
+        use exo_core::types::{ReceiptOutcome, Timestamp, TrustReceipt};
+        let mut store = temp_store();
+
+        let receipt = TrustReceipt::new(
+            Did::new("did:exo:agent-a").unwrap(),
+            Hash256::digest(b"authority"),
+            None,
+            "dag.commit".to_string(),
+            Hash256::digest(b"action-payload"),
+            ReceiptOutcome::Executed,
+            Timestamp {
+                physical_ms: 1_700_000_000_000,
+                logical: 0,
+            },
+            &|_| Signature::Empty,
+        );
+
+        let err = store.save_receipt(&receipt).unwrap_err();
+
+        assert!(err.to_string().contains("trust_receipts.signature"));
+    }
+
+    #[test]
+    fn save_receipt_rejects_timestamps_that_do_not_fit_sqlite_integer() {
+        use exo_core::types::{ReceiptOutcome, Timestamp, TrustReceipt};
+        let mut store = temp_store();
+        let sign_fn = make_sign_fn();
+
+        let receipt = TrustReceipt::new(
+            Did::new("did:exo:agent-a").unwrap(),
+            Hash256::digest(b"authority"),
+            None,
+            "dag.commit".to_string(),
+            Hash256::digest(b"action-payload"),
+            ReceiptOutcome::Executed,
+            Timestamp {
+                physical_ms: u64::MAX,
+                logical: 0,
+            },
+            &*sign_fn,
+        );
+
+        let err = store.save_receipt(&receipt).unwrap_err();
+
+        assert!(err.to_string().contains("trust_receipts.timestamp_ms"));
     }
 
     #[test]
@@ -955,5 +1327,116 @@ mod tests {
         assert_eq!(t.len(), 2);
         assert!(t.contains(&c1.hash));
         assert!(t.contains(&c2.hash));
+    }
+
+    #[test]
+    fn committed_nodes_in_range_rejects_short_hash() {
+        let store = temp_store();
+        store
+            .conn
+            .execute(
+                "INSERT INTO committed (hash, height) VALUES (?1, ?2)",
+                rusqlite::params![vec![0xCDu8; 31], 1_i64],
+            )
+            .unwrap();
+
+        let err = store.committed_nodes_in_range(0, 10).unwrap_err();
+
+        assert!(err.to_string().contains("committed.hash"));
+    }
+
+    #[test]
+    fn committed_height_for_rejects_negative_height() {
+        let store = temp_store();
+        let hash = Hash256::digest(b"committed-node");
+        store
+            .conn
+            .execute(
+                "INSERT INTO committed (hash, height) VALUES (?1, ?2)",
+                rusqlite::params![hash.0.as_slice(), -1_i64],
+            )
+            .unwrap();
+
+        let err = store.committed_height_for(&hash).unwrap_err();
+
+        assert!(err.to_string().contains("committed.height"));
+    }
+
+    #[test]
+    fn committed_height_value_rejects_negative_height() {
+        let store = temp_store();
+        let hash = Hash256::digest(b"committed-node");
+        store
+            .conn
+            .execute(
+                "INSERT INTO committed (hash, height) VALUES (?1, ?2)",
+                rusqlite::params![hash.0.as_slice(), -1_i64],
+            )
+            .unwrap();
+
+        let err = store.committed_height_value().unwrap_err();
+
+        assert!(err.to_string().contains("committed.height"));
+    }
+
+    #[test]
+    fn committed_height_sync_rejects_negative_height() {
+        let store = temp_store();
+        let hash = Hash256::digest(b"committed-node");
+        store
+            .conn
+            .execute(
+                "INSERT INTO committed (hash, height) VALUES (?1, ?2)",
+                rusqlite::params![hash.0.as_slice(), -1_i64],
+            )
+            .unwrap();
+
+        let err = store.committed_height_sync().unwrap_err();
+
+        assert!(err.to_string().contains("committed.height"));
+    }
+
+    #[test]
+    fn mark_committed_rejects_heights_that_do_not_fit_sqlite_integer() {
+        let mut store = temp_store();
+        let node = make_test_node();
+        store.put_sync(node.clone()).unwrap();
+
+        let err = store.mark_committed_sync(&node.hash, u64::MAX).unwrap_err();
+
+        assert!(err.to_string().contains("committed.height"));
+    }
+
+    #[test]
+    fn children_rejects_short_child_hash() {
+        let store = temp_store();
+        let parent = Hash256::digest(b"parent");
+        store
+            .conn
+            .execute(
+                "INSERT INTO dag_parents (child_hash, parent_hash) VALUES (?1, ?2)",
+                rusqlite::params![vec![0xABu8; 31], parent.0.as_slice()],
+            )
+            .unwrap();
+
+        let err = store.children(&parent).unwrap_err();
+
+        assert!(err.to_string().contains("dag_parents.child_hash"));
+    }
+
+    #[test]
+    fn tips_rejects_short_hash() {
+        let store = temp_store();
+        store
+            .conn
+            .execute(
+                "INSERT INTO dag_nodes (hash, cbor_payload) VALUES (?1, ?2)",
+                rusqlite::params![vec![0xABu8; 31], vec![0x00u8]],
+            )
+            .unwrap();
+
+        let err = store.tips_sync().unwrap_err();
+
+        assert!(err.to_string().contains("dag_nodes.hash"));
     }
 }

--- a/crates/exo-node/src/sync.rs
+++ b/crates/exo-node/src/sync.rs
@@ -126,6 +126,7 @@ impl SyncEngine {
                 .lock()
                 .map_err(|_| anyhow::anyhow!("Store mutex poisoned in request_sync"))?;
             st.committed_height_value()
+                .map_err(|e| anyhow::anyhow!("committed height: {e}"))?
         };
 
         tracing::info!(local_height, "Requesting state snapshot from network");
@@ -197,7 +198,13 @@ impl SyncEngine {
                 tracing::error!("Store mutex poisoned in handle_snapshot_request");
                 return;
             };
-            st.committed_height_value()
+            match st.committed_height_value() {
+                Ok(height) => height,
+                Err(e) => {
+                    tracing::warn!(err = %e, "Failed to read committed height for snapshot request");
+                    return;
+                }
+            }
         };
 
         // Only respond if we have data the peer needs.
@@ -345,7 +352,13 @@ impl SyncEngine {
                     tracing::error!("Store mutex poisoned in handle_snapshot_chunk (complete)");
                     return;
                 };
-                st.committed_height_value()
+                match st.committed_height_value() {
+                    Ok(height) => height,
+                    Err(e) => {
+                        tracing::warn!(err = %e, "Failed to read committed height after snapshot");
+                        return;
+                    }
+                }
             };
 
             tracing::info!(committed_height, "State sync complete");
@@ -388,7 +401,13 @@ impl SyncEngine {
             // Get nodes the peer is missing — nodes we have that descend
             // from their tips. For simplicity, we send our committed nodes
             // above the peer's implicit height.
-            let local_height = st.committed_height_value();
+            let local_height = match st.committed_height_value() {
+                Ok(height) => height,
+                Err(e) => {
+                    tracing::warn!(err = %e, "Failed to read committed height for DAG sync");
+                    return;
+                }
+            };
             let max_nodes = msg.max_nodes.min(500) as u64;
             let send_height = if local_height > max_nodes {
                 local_height - max_nodes
@@ -737,7 +756,7 @@ mod tests {
             let st = store.lock().unwrap();
             assert!(st.contains_sync(&node1.hash).unwrap());
             assert!(st.contains_sync(&node2.hash).unwrap());
-            assert_eq!(st.committed_height_value(), 2);
+            assert_eq!(st.committed_height_value().unwrap(), 2);
         }
 
         // Verify sync completed.
@@ -832,6 +851,40 @@ mod tests {
             }
             _ => panic!("Expected Publish command"),
         }
+    }
+
+    #[tokio::test]
+    async fn request_sync_fails_closed_on_store_height_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SqliteDagStore::open(dir.path()).unwrap();
+        let conn = rusqlite::Connection::open(dir.path().join("dag.db")).unwrap();
+        let hash = [0xA5u8; 32];
+        conn.execute(
+            "INSERT INTO committed (hash, height) VALUES (?1, ?2)",
+            rusqlite::params![hash.as_slice(), -1_i64],
+        )
+        .unwrap();
+        let store = Arc::new(Mutex::new(store));
+
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(256);
+        let net_handle = NetworkHandle::new(cmd_tx);
+        let (event_tx, _event_rx) = mpsc::channel(32);
+        let mut engine = SyncEngine::new(
+            SyncConfig {
+                node_did: test_did(),
+                chunk_size: 50,
+                max_sync_nodes: 200,
+            },
+            store,
+            net_handle,
+            event_tx,
+        );
+
+        let err = engine.request_sync().await.unwrap_err();
+
+        assert!(err.to_string().contains("committed.height"));
+        assert!(!engine.needs_sync());
+        assert!(cmd_rx.try_recv().is_err());
     }
 
     #[tokio::test]

--- a/crates/exo-node/src/telegram.rs
+++ b/crates/exo-node/src/telegram.rs
@@ -488,8 +488,18 @@ pub fn build_status_message(
     };
 
     let store_height = match store.lock() {
-        Ok(st) => st.committed_height_value(),
-        Err(_) => 0,
+        Ok(st) => match st.committed_height_value() {
+            Ok(height) => height,
+            Err(e) => {
+                return (format!("\u{274c} Store height unavailable: {e}"), vec![]);
+            }
+        },
+        Err(_) => {
+            return (
+                "\u{274c} Store state temporarily unavailable".to_string(),
+                vec![],
+            );
+        }
     };
 
     let role = if is_validator {
@@ -871,6 +881,27 @@ mod tests {
         assert!(text.contains("Validators:"));
         assert!(text.contains("Validator")); // role
         assert!(!keyboard.is_empty());
+    }
+
+    #[test]
+    fn status_message_fails_closed_on_store_height_error() {
+        let reactor = test_reactor();
+        let dir = tempfile::tempdir().unwrap();
+        let store = SqliteDagStore::open(dir.path()).unwrap();
+        let conn = rusqlite::Connection::open(dir.path().join("dag.db")).unwrap();
+        let hash = [0xA5u8; 32];
+        conn.execute(
+            "INSERT INTO committed (hash, height) VALUES (?1, ?2)",
+            rusqlite::params![hash.as_slice(), -1_i64],
+        )
+        .unwrap();
+        let store = Arc::new(Mutex::new(store));
+
+        let (text, keyboard) = build_status_message(&reactor, &store);
+
+        assert!(text.contains("Store height unavailable"));
+        assert!(text.contains("committed.height"));
+        assert!(keyboard.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fail closed on malformed `exo-node` SQLite DAG/consensus persistence rows instead of panicking, fabricating zero/unknown values, or wrapping integers.
- Add checked hash/signature/DID/integer decoding and consensus vote/certificate validation.
- Propagate committed-height store errors through node startup/status, sentinels, Telegram status, sync, and MCP checkpoint surfaces instead of reporting synthetic height `0`.
- Refresh README repo-truth counts to `114241` Rust LOC and `2807` listed workspace tests.

## TDD / Regression Coverage

- `load_votes_for_round_rejects_short_signature` red-checked before implementation: 63-byte signature reloaded as all-zero Ed25519.
- `save_vote_rejects_signature_variants_that_cannot_roundtrip` red-checked before implementation: non-empty `PostQuantum` vote signature was accepted into fixed Ed25519 BLOB persistence.
- Added coverage for short hashes, short/all-zero signatures, invalid DIDs, invalid signature variants, oversized writes, negative height reads, missing `consensus_meta`, and status/sync/MCP/sentinel fail-closed behavior.

## Verification

- `cargo test -p exo-node load_votes_for_round_rejects_short_signature --bin exochain`
- `cargo test -p exo-node save_vote_rejects_signature_variants_that_cannot_roundtrip --bin exochain`
- `cargo test -p exo-node save_certificate_rejects_signature_variants_that_cannot_verify --bin exochain`
- `cargo test -p exo-node store::tests --bin exochain`
- `cargo test -p exo-node sync::tests --bin exochain`
- `cargo test -p exo-node sentinels::tests --bin exochain`
- `cargo test -p exo-node mcp::tools::ledger::tests --bin exochain`
- `cargo test -p exo-node telegram::tests --bin exochain`
- `cargo test -p exo-node --bin exochain`
- `cargo test -p exo-node`
- `cargo build -p exo-node`
- `cargo clippy -p exo-node --bins -- -D warnings`
- `cargo clippy -p exo-node --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `bash tools/repo_truth.sh --json`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit --deny unsound --deny unmaintained` passed with existing allowed yanked `core2` warning
- `cargo deny check` passed with existing duplicate/yanked/unused-allowance warnings
- `cargo machete --with-metadata`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
