### PR TITLE
fix(exo-consent): verify active bailment proofs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 114241 | `wc -l` |
-| Workspace tests | 2,807 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 114357 | `wc -l` |
+| Workspace tests | 2,811 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 114241 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 114357 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,807 listed workspace tests
+         cryptographic proofs, 2,811 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          140 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-consent/src/bailment.rs
+++ b/crates/exo-consent/src/bailment.rs
@@ -55,6 +55,8 @@ pub struct Bailment {
     pub expires: Option<Timestamp>,
     pub status: BailmentStatus,
     pub signature: Signature,
+    #[serde(default)]
+    pub bailee_public_key: Option<PublicKey>,
 }
 
 /// Propose a new bailment. Returns a bailment in `Proposed` status.
@@ -87,6 +89,7 @@ pub fn propose(
         expires: None,
         status: BailmentStatus::Proposed,
         signature: Signature::empty(),
+        bailee_public_key: None,
     })
 }
 
@@ -188,8 +191,34 @@ pub fn accept(
     }
 
     bailment.signature = bailee_signature.clone();
+    bailment.bailee_public_key = Some(*bailee_public_key);
     bailment.status = BailmentStatus::Active;
     Ok(())
+}
+
+/// Verify that an active bailment carries a cryptographic acceptance proof.
+///
+/// A status bit alone is not consent. Active bailments must retain the bailee
+/// public key used at acceptance and the stored signature must still verify
+/// over the canonical acceptance payload.
+#[must_use]
+pub fn has_valid_acceptance_proof(bailment: &Bailment) -> bool {
+    if bailment.status != BailmentStatus::Active {
+        return false;
+    }
+    if bailment.signature.is_empty() {
+        return false;
+    }
+    if bailment.signature.as_bytes().iter().all(|b| *b == 0) {
+        return false;
+    }
+    let Some(bailee_public_key) = bailment.bailee_public_key else {
+        return false;
+    };
+    let Ok(payload) = signing_payload(bailment) else {
+        return false;
+    };
+    crypto::verify(&payload, &bailment.signature, &bailee_public_key)
 }
 
 /// Terminate a bailment. Either bailor or bailee may terminate.
@@ -217,6 +246,9 @@ pub fn terminate(bailment: &mut Bailment, actor: &Did) -> Result<(), ConsentErro
 #[must_use]
 pub fn is_active(bailment: &Bailment, now: &Timestamp) -> bool {
     if bailment.status != BailmentStatus::Active {
+        return false;
+    }
+    if !has_valid_acceptance_proof(bailment) {
         return false;
     }
     match &bailment.expires {
@@ -307,6 +339,7 @@ mod tests {
         assert_eq!(b.id, "bailment-explicit");
         assert_eq!(b.created, ts(1234));
         assert!(b.signature.is_empty());
+        assert!(b.bailee_public_key.is_none());
         assert!(b.expires.is_none());
     }
 
@@ -360,6 +393,8 @@ mod tests {
         assert!(accept(&mut b, &pk, &sig).is_ok());
         assert_eq!(b.status, BailmentStatus::Active);
         assert!(!b.signature.is_empty());
+        assert_eq!(b.bailee_public_key, Some(pk));
+        assert!(has_valid_acceptance_proof(&b));
     }
 
     #[test]
@@ -572,6 +607,30 @@ mod tests {
         accept(&mut b, &pk, &sig).ok();
         b.expires = Some(ts(1000));
         assert!(!is_active(&b, &ts(5000)));
+    }
+
+    #[test]
+    fn is_active_rejects_status_forged_empty_signature() {
+        let mut b = propose_test(b"t", BailmentType::Custody);
+        b.status = BailmentStatus::Active;
+        b.signature = Signature::Empty;
+
+        assert!(
+            !is_active(&b, &ts(1000)),
+            "active bailments must not be trusted without a verifiable acceptance signature"
+        );
+    }
+
+    #[test]
+    fn is_active_rejects_status_forged_junk_signature() {
+        let mut b = propose_test(b"t", BailmentType::Custody);
+        b.status = BailmentStatus::Active;
+        b.signature = Signature::from_bytes([0xAB; 64]);
+
+        assert!(
+            !is_active(&b, &ts(1000)),
+            "active bailments must not trust non-empty signatures without the bailee key proof"
+        );
     }
 
     #[test]

--- a/crates/exo-consent/src/gatekeeper.rs
+++ b/crates/exo-consent/src/gatekeeper.rs
@@ -266,6 +266,31 @@ mod tests {
     }
 
     #[test]
+    fn check_denies_status_forged_active_bailment() {
+        let mut g = ConsentGate::new(strict_policy());
+        let mut b = bailment::propose(
+            &alice(),
+            &bob(),
+            b"gt",
+            BailmentType::Custody,
+            "forged",
+            ts(1000),
+        )
+        .expect("test bailment proposal");
+        b.status = bailment::BailmentStatus::Active;
+        b.signature = exo_core::Signature::from_bytes([0xAB; 64]);
+        g.register_consent(&bob(), "read", "data-owner", 1, b);
+
+        assert!(
+            matches!(
+                g.check(&bob(), "read", &now()),
+                ConsentDecision::Denied { .. }
+            ),
+            "ConsentGate must not grant on a status-forged active bailment"
+        );
+    }
+
+    #[test]
     fn policy_accessor() {
         let g = ConsentGate::new(strict_policy());
         assert_eq!(g.policy().id, "strict");

--- a/crates/exo-consent/src/policy.rs
+++ b/crates/exo-consent/src/policy.rs
@@ -337,6 +337,38 @@ mod tests {
     }
 
     #[test]
+    fn forged_active_bailment_does_not_satisfy_policy() {
+        let e = PolicyEngine::new();
+        let mut b = bailment::propose(
+            &alice(),
+            &bob(),
+            b"terms",
+            BailmentType::Custody,
+            "forged-active",
+            ts(1000),
+        )
+        .expect("test bailment proposal");
+        b.status = bailment::BailmentStatus::Active;
+        b.signature = exo_core::Signature::from_bytes([0xAB; 64]);
+        let c = vec![consent(&alice(), "read", "data-owner", 1, b)];
+
+        let d = e.evaluate(
+            &read_policy(),
+            &c,
+            &ActionRequest {
+                actor: bob(),
+                action_type: "read".into(),
+            },
+            &now(),
+        );
+
+        assert!(
+            matches!(d, ConsentDecision::Denied { .. }),
+            "policy must deny forged active bailments without verified acceptance proof"
+        );
+    }
+
+    #[test]
     fn grant_no_requirements_permissive() {
         let e = PolicyEngine::new();
         let p = ConsentPolicy {


### PR DESCRIPTION
## Summary
- persist the verified bailee public key on bailment acceptance
- require active bailments to re-verify the stored canonical acceptance signature before they can satisfy consent
- add regressions proving status-forged active bailments do not pass is_active, policy, or ConsentGate checks
- refresh README repo-truth counts to 114357 Rust LOC and 2811 listed tests

## TDD red checks
- cargo test -p exo-consent is_active_rejects_status_forged --lib failed before implementation
- cargo test -p exo-consent forged_active_bailment --lib failed before implementation

## Verification
- cargo test -p exo-consent
- cargo build -p exo-consent
- cargo clippy -p exo-consent --all-targets -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo test -p exochain-wasm
- wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm
- node packages/exochain-wasm/test/bridge_verification.mjs
- bash tools/repo_truth.sh --json
- bash tools/test_repo_truth.sh
- cargo +nightly fmt --all -- --check
- git diff --check
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo build --workspace --release
- cargo test --workspace --release
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
- cargo audit --deny unsound --deny unmaintained
- cargo deny check
- cargo machete --with-metadata
- bash tools/test_cr001_status.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_no_orphan_rust_modules.sh
- bash tools/test_railway_entrypoint_args.sh