### PR TITLE
[codex] Validate MCP ledger Merkle proofs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 114357 | `wc -l` |
-| Workspace tests | 2,811 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 114507 | `wc -l` |
+| Workspace tests | 2,817 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 114357 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 114507 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,811 listed workspace tests
+         cryptographic proofs, 2,817 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          140 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/mcp/tools/ledger.rs
+++ b/crates/exo-node/src/mcp/tools/ledger.rs
@@ -215,18 +215,60 @@ pub fn verify_inclusion_definition() -> ToolDefinition {
                 "root_hash": {
                     "type": "string",
                     "description": "Hex-encoded expected Merkle root hash."
+                },
+                "target_index": {
+                    "type": "integer",
+                    "description": "Zero-based index of the event hash in the original Merkle tree."
                 }
             },
-            "required": ["event_hash", "proof_hashes", "root_hash"],
+            "required": ["event_hash", "proof_hashes", "root_hash", "target_index"],
             "additionalProperties": false,
         }),
     }
 }
 
+fn decode_hash256_hex(field: &str, value: &str) -> Result<Hash256, String> {
+    let bytes =
+        hex::decode(value).map_err(|_| format!("invalid {field}: not valid hexadecimal"))?;
+    if bytes.len() != 32 {
+        return Err(format!(
+            "invalid {field}: expected 32-byte hash (64 hex chars), got {} bytes",
+            bytes.len()
+        ));
+    }
+
+    let mut hash_bytes = [0u8; 32];
+    hash_bytes.copy_from_slice(&bytes);
+    Ok(Hash256::from_bytes(hash_bytes))
+}
+
+fn hash_merkle_pair(left: &Hash256, right: &Hash256) -> Hash256 {
+    let mut combined = [0u8; 64];
+    combined[..32].copy_from_slice(left.as_bytes());
+    combined[32..].copy_from_slice(right.as_bytes());
+    Hash256::digest(&combined)
+}
+
+fn derive_merkle_root_from_proof(leaf: &Hash256, proof: &[Hash256], index: usize) -> Hash256 {
+    let mut current = *leaf;
+    let mut idx = index;
+
+    for sibling in proof {
+        current = if idx % 2 == 0 {
+            hash_merkle_pair(&current, sibling)
+        } else {
+            hash_merkle_pair(sibling, &current)
+        };
+        idx /= 2;
+    }
+
+    current
+}
+
 /// Execute the `exochain_verify_inclusion` tool.
 #[must_use]
 pub fn execute_verify_inclusion(params: &Value, _context: &NodeContext) -> ToolResult {
-    let event_hash = match params.get("event_hash").and_then(Value::as_str) {
+    let event_hash_raw = match params.get("event_hash").and_then(Value::as_str) {
         Some(s) => s,
         None => {
             return ToolResult::error(
@@ -243,7 +285,7 @@ pub fn execute_verify_inclusion(params: &Value, _context: &NodeContext) -> ToolR
             );
         }
     };
-    let root_hash = match params.get("root_hash").and_then(Value::as_str) {
+    let root_hash_raw = match params.get("root_hash").and_then(Value::as_str) {
         Some(s) => s,
         None => {
             return ToolResult::error(
@@ -251,30 +293,40 @@ pub fn execute_verify_inclusion(params: &Value, _context: &NodeContext) -> ToolR
             );
         }
     };
+    let target_index = match params.get("target_index").and_then(Value::as_u64) {
+        Some(n) => match usize::try_from(n) {
+            Ok(index) => index,
+            Err(_) => {
+                return ToolResult::error(
+                    json!({"error": "invalid target_index: value does not fit usize"}).to_string(),
+                );
+            }
+        },
+        None => {
+            return ToolResult::error(
+                json!({"error": "missing required parameter: target_index"}).to_string(),
+            );
+        }
+    };
 
-    // Validate all hex values.
-    if hex::decode(event_hash).is_err() {
-        return ToolResult::error(
-            json!({"error": "invalid event_hash: not valid hexadecimal"}).to_string(),
-        );
-    }
-    if hex::decode(root_hash).is_err() {
-        return ToolResult::error(
-            json!({"error": "invalid root_hash: not valid hexadecimal"}).to_string(),
-        );
-    }
+    let event_hash = match decode_hash256_hex("event_hash", event_hash_raw) {
+        Ok(hash) => hash,
+        Err(error) => return ToolResult::error(json!({"error": error}).to_string()),
+    };
+    let root_hash = match decode_hash256_hex("root_hash", root_hash_raw) {
+        Ok(hash) => hash,
+        Err(error) => return ToolResult::error(json!({"error": error}).to_string()),
+    };
 
-    let mut proof_strings: Vec<String> = Vec::new();
+    let mut proof: Vec<Hash256> = Vec::new();
     for (i, ph) in proof_hashes.iter().enumerate() {
         match ph.as_str() {
-            Some(s) => {
-                if hex::decode(s).is_err() {
-                    return ToolResult::error(
-                        json!({"error": format!("invalid proof_hash at index {i}: not valid hexadecimal")}).to_string(),
-                    );
+            Some(s) => match decode_hash256_hex(&format!("proof_hash at index {i}"), s) {
+                Ok(hash) => proof.push(hash),
+                Err(error) => {
+                    return ToolResult::error(json!({"error": error}).to_string());
                 }
-                proof_strings.push(s.to_owned());
-            }
+            },
             None => {
                 return ToolResult::error(
                     json!({"error": format!("proof_hash at index {i} is not a string")})
@@ -284,25 +336,16 @@ pub fn execute_verify_inclusion(params: &Value, _context: &NodeContext) -> ToolR
         }
     }
 
-    // Walk the Merkle path: start with event_hash, combine with each proof
-    // hash in order to compute the derived root.
-    let mut current = Hash256::digest(&hex::decode(event_hash).unwrap_or_default());
-    for sibling_hex in &proof_strings {
-        let sibling_bytes = hex::decode(sibling_hex).unwrap_or_default();
-        let mut combined = current.as_bytes().to_vec();
-        combined.extend_from_slice(&sibling_bytes);
-        current = Hash256::digest(&combined);
-    }
-
-    let computed_root = current.to_string();
+    let computed_root = derive_merkle_root_from_proof(&event_hash, &proof, target_index);
     let verified = computed_root == root_hash;
 
     let response = json!({
-        "event_hash": event_hash,
-        "root_hash": root_hash,
-        "computed_root": computed_root,
+        "event_hash": event_hash.to_string(),
+        "root_hash": root_hash.to_string(),
+        "computed_root": computed_root.to_string(),
         "verified": verified,
-        "proof_depth": proof_strings.len(),
+        "proof_depth": proof.len(),
+        "target_index": target_index,
     });
     ToolResult::success(response.to_string())
 }
@@ -397,7 +440,16 @@ pub fn execute_get_checkpoint(params: &Value, context: &NodeContext) -> ToolResu
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
+    use exo_core::hash::{merkle_proof, merkle_root};
+
     use super::*;
+
+    fn test_hash_pair(left: &Hash256, right: &Hash256) -> Hash256 {
+        let mut combined = [0u8; 64];
+        combined[..32].copy_from_slice(left.as_bytes());
+        combined[32..].copy_from_slice(right.as_bytes());
+        Hash256::digest(&combined)
+    }
 
     // -- submit_event ---------------------------------------------------------
 
@@ -514,19 +566,15 @@ mod tests {
 
     #[test]
     fn execute_verify_inclusion_valid_proof() {
-        // Compute the expected root manually.
-        let event_hash_bytes = hex::decode("abcd").unwrap();
-        let h0 = Hash256::digest(&event_hash_bytes);
-        let sibling_hex = "1234";
-        let sibling_bytes = hex::decode(sibling_hex).unwrap();
-        let mut combined = h0.as_bytes().to_vec();
-        combined.extend_from_slice(&sibling_bytes);
-        let expected_root = Hash256::digest(&combined);
+        let event_hash = Hash256::digest(b"event-left");
+        let sibling = Hash256::digest(b"event-right");
+        let expected_root = test_hash_pair(&event_hash, &sibling);
 
         let params = json!({
-            "event_hash": "abcd",
-            "proof_hashes": [sibling_hex],
+            "event_hash": event_hash.to_string(),
+            "proof_hashes": [sibling.to_string()],
             "root_hash": expected_root.to_string(),
+            "target_index": 0,
         });
         let result = execute_verify_inclusion(&params, &NodeContext::empty());
         assert!(!result.is_error);
@@ -535,11 +583,58 @@ mod tests {
     }
 
     #[test]
-    fn execute_verify_inclusion_invalid_proof() {
+    fn execute_verify_inclusion_valid_right_hand_proof() {
+        let left_hash = Hash256::digest(b"event-left");
+        let right_hash = Hash256::digest(b"event-right");
+        let expected_root = test_hash_pair(&left_hash, &right_hash);
+
         let params = json!({
-            "event_hash": "abcd",
-            "proof_hashes": ["1234"],
-            "root_hash": "0000",
+            "event_hash": right_hash.to_string(),
+            "proof_hashes": [left_hash.to_string()],
+            "root_hash": expected_root.to_string(),
+            "target_index": 1,
+        });
+        let result = execute_verify_inclusion(&params, &NodeContext::empty());
+        assert!(!result.is_error);
+        let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
+        assert_eq!(v["verified"], true);
+        assert_eq!(v["target_index"], 1);
+    }
+
+    #[test]
+    fn execute_verify_inclusion_accepts_core_merkle_proof() {
+        let leaves = [
+            Hash256::digest(b"event-0"),
+            Hash256::digest(b"event-1"),
+            Hash256::digest(b"event-2"),
+        ];
+        let target_index = 2;
+        let root = merkle_root(&leaves);
+        let proof = merkle_proof(&leaves, target_index).expect("core proof");
+        let proof_hashes: Vec<String> = proof.iter().map(ToString::to_string).collect();
+
+        let params = json!({
+            "event_hash": leaves[target_index].to_string(),
+            "proof_hashes": proof_hashes,
+            "root_hash": root.to_string(),
+            "target_index": target_index,
+        });
+        let result = execute_verify_inclusion(&params, &NodeContext::empty());
+        assert!(!result.is_error);
+        let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
+        assert_eq!(v["verified"], true);
+        assert_eq!(v["computed_root"], root.to_string());
+    }
+
+    #[test]
+    fn execute_verify_inclusion_invalid_proof() {
+        let event_hash = Hash256::digest(b"event-left");
+        let sibling = Hash256::digest(b"event-right");
+        let params = json!({
+            "event_hash": event_hash.to_string(),
+            "proof_hashes": [sibling.to_string()],
+            "root_hash": Hash256::digest(b"wrong-root").to_string(),
+            "target_index": 0,
         });
         let result = execute_verify_inclusion(&params, &NodeContext::empty());
         assert!(!result.is_error);
@@ -553,9 +648,64 @@ mod tests {
             "event_hash": "zzzz",
             "proof_hashes": [],
             "root_hash": "0000",
+            "target_index": 0,
         });
         let result = execute_verify_inclusion(&params, &NodeContext::empty());
         assert!(result.is_error);
+    }
+
+    #[test]
+    fn execute_verify_inclusion_rejects_short_event_hash() {
+        let params = json!({
+            "event_hash": "abcd",
+            "proof_hashes": [],
+            "root_hash": Hash256::digest(b"root").to_string(),
+            "target_index": 0,
+        });
+        let result = execute_verify_inclusion(&params, &NodeContext::empty());
+        assert!(result.is_error);
+        assert!(result.content[0].text().contains("event_hash"));
+        assert!(result.content[0].text().contains("32-byte"));
+    }
+
+    #[test]
+    fn execute_verify_inclusion_rejects_short_root_hash() {
+        let params = json!({
+            "event_hash": Hash256::digest(b"event").to_string(),
+            "proof_hashes": [],
+            "root_hash": "0000",
+            "target_index": 0,
+        });
+        let result = execute_verify_inclusion(&params, &NodeContext::empty());
+        assert!(result.is_error);
+        assert!(result.content[0].text().contains("root_hash"));
+        assert!(result.content[0].text().contains("32-byte"));
+    }
+
+    #[test]
+    fn execute_verify_inclusion_rejects_short_proof_hash() {
+        let params = json!({
+            "event_hash": Hash256::digest(b"event").to_string(),
+            "proof_hashes": ["1234"],
+            "root_hash": Hash256::digest(b"root").to_string(),
+            "target_index": 0,
+        });
+        let result = execute_verify_inclusion(&params, &NodeContext::empty());
+        assert!(result.is_error);
+        assert!(result.content[0].text().contains("proof_hash at index 0"));
+        assert!(result.content[0].text().contains("32-byte"));
+    }
+
+    #[test]
+    fn execute_verify_inclusion_requires_target_index() {
+        let params = json!({
+            "event_hash": Hash256::digest(b"event").to_string(),
+            "proof_hashes": [],
+            "root_hash": Hash256::digest(b"root").to_string(),
+        });
+        let result = execute_verify_inclusion(&params, &NodeContext::empty());
+        assert!(result.is_error);
+        assert!(result.content[0].text().contains("target_index"));
     }
 
     // -- get_checkpoint -------------------------------------------------------


### PR DESCRIPTION
## Summary

- require `target_index` for `exochain_verify_inclusion` so proof folding respects leaf side
- parse event, root, and proof hashes as exact 32-byte `Hash256` values instead of accepting arbitrary hex
- add regressions for short hashes, missing target index, left/right proofs, wrong roots, and compatibility with `exo_core::hash::merkle_proof`
- refresh README repo-truth counts

## Root cause

`exochain_verify_inclusion` previously decoded hex loosely and used `unwrap_or_default()` while deriving the proof root. It also lacked leaf index information, so it always folded proof siblings as if the target leaf were on the left. That made malformed hashes fail open as proof material and made valid right-hand inclusion proofs unverifiable.

## Validation

- `cargo test -p exo-node mcp::tools::ledger::tests::execute_verify_inclusion --bin exochain`
- `cargo test -p exo-node mcp::tools::ledger::tests --bin exochain`
- `cargo test -p exo-node --bin exochain`
- `bash tools/repo_truth.sh --json`
- `bash tools/test_repo_truth.sh`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit --deny unsound --deny unmaintained`
- `cargo deny check`
- `cargo machete --with-metadata`