### PR TITLE
fix(exo-gatekeeper): reject synthetic hardware TEE attestations

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 114507 | `wc -l` |
-| Workspace tests | 2,817 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 114603 | `wc -l` |
+| Workspace tests | 2,821 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,807 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,821 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 114507 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 114603 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,817 listed workspace tests
+         cryptographic proofs, 2,821 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          140 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-gatekeeper/src/tee.rs
+++ b/crates/exo-gatekeeper/src/tee.rs
@@ -136,8 +136,9 @@ fn is_platform_allowed(platform: &TeePlatform, policy: &TeePolicy) -> bool {
 
 /// Generate an attestation for the given platform and measurement.
 ///
-/// In production, this would interface with the actual TEE hardware.
-/// For now, it produces a deterministic attestation with a blake3-based signature.
+/// This creates deterministic simulated attestation fixtures. Hardware TEE
+/// platforms require platform quote verification and are not accepted by
+/// `verify_attestation` when carrying this synthetic signature.
 #[must_use]
 pub fn generate_attestation(
     platform: &TeePlatform,
@@ -146,18 +147,44 @@ pub fn generate_attestation(
 ) -> TeeAttestation {
     let measurement_hash = *blake3::hash(measurement).as_bytes();
 
-    // Deterministic signature: hash(measurement_hash || timestamp || platform).
-    let mut sig_input = Vec::new();
-    sig_input.extend_from_slice(&measurement_hash);
-    sig_input.extend_from_slice(&timestamp.to_le_bytes());
-    sig_input.extend_from_slice(format!("{:?}", platform).as_bytes());
-    let signature = blake3::hash(&sig_input).as_bytes().to_vec();
-
     TeeAttestation {
         platform: *platform,
         measurement_hash,
         timestamp,
-        signature,
+        signature: synthetic_attestation_signature(platform, &measurement_hash, timestamp),
+    }
+}
+
+/// Deterministic signature used only for simulated TEE test fixtures.
+fn synthetic_attestation_signature(
+    platform: &TeePlatform,
+    measurement_hash: &[u8; 32],
+    timestamp: u64,
+) -> Vec<u8> {
+    let mut sig_input = Vec::new();
+    sig_input.extend_from_slice(measurement_hash);
+    sig_input.extend_from_slice(&timestamp.to_le_bytes());
+    sig_input.extend_from_slice(format!("{:?}", platform).as_bytes());
+    blake3::hash(&sig_input).as_bytes().to_vec()
+}
+
+fn synthetic_signature_allowed(attestation: &TeeAttestation, policy: &TeePolicy) -> bool {
+    if attestation.platform != TeePlatform::Simulated {
+        return false;
+    }
+
+    if policy.environment == TeeEnvironment::Testing {
+        return true;
+    }
+
+    #[cfg(feature = "allow-simulated-tee")]
+    {
+        policy.environment == TeeEnvironment::Production
+    }
+
+    #[cfg(not(feature = "allow-simulated-tee"))]
+    {
+        false
     }
 }
 
@@ -207,20 +234,31 @@ pub fn verify_attestation(
         }
     }
 
-    // Verify deterministic signature.
-    let mut sig_input = Vec::new();
-    sig_input.extend_from_slice(&attestation.measurement_hash);
-    sig_input.extend_from_slice(&attestation.timestamp.to_le_bytes());
-    sig_input.extend_from_slice(format!("{:?}", attestation.platform).as_bytes());
-    let expected_sig = blake3::hash(&sig_input).as_bytes().to_vec();
+    let synthetic_sig = synthetic_attestation_signature(
+        &attestation.platform,
+        &attestation.measurement_hash,
+        attestation.timestamp,
+    );
 
-    if attestation.signature != expected_sig {
+    if attestation.signature == synthetic_sig {
+        if synthetic_signature_allowed(attestation, policy) {
+            return Ok(());
+        }
         return Err(GatekeeperError::TeeError(
-            "Attestation signature verification failed".into(),
+            "synthetic TEE attestation signatures are only accepted for simulated TEEs in explicitly allowed environments".into(),
         ));
     }
 
-    Ok(())
+    if attestation.platform == TeePlatform::Simulated {
+        return Err(GatekeeperError::TeeError(
+            "simulated TEE attestation signature verification failed".into(),
+        ));
+    }
+
+    Err(GatekeeperError::TeeError(format!(
+        "Hardware TEE attestation for platform {:?} requires a platform quote verifier",
+        attestation.platform
+    )))
 }
 
 // ===========================================================================
@@ -295,24 +333,30 @@ mod tests {
     }
 
     #[test]
-    fn verify_passes_for_sgx_attestation() {
+    fn verify_rejects_synthetic_sgx_attestation() {
         let att = generate_attestation(&TeePlatform::Sgx, MEASUREMENT, TIMESTAMP);
         let policy = permissive_policy();
-        assert!(verify_attestation(&att, &policy).is_ok());
+        let result = verify_attestation(&att, &policy);
+        assert!(result.is_err());
+        assert!(format!("{}", result.unwrap_err()).contains("synthetic"));
     }
 
     #[test]
-    fn verify_passes_for_trustzone_attestation() {
+    fn verify_rejects_synthetic_trustzone_attestation() {
         let att = generate_attestation(&TeePlatform::TrustZone, MEASUREMENT, TIMESTAMP);
         let policy = permissive_policy();
-        assert!(verify_attestation(&att, &policy).is_ok());
+        let result = verify_attestation(&att, &policy);
+        assert!(result.is_err());
+        assert!(format!("{}", result.unwrap_err()).contains("synthetic"));
     }
 
     #[test]
-    fn verify_passes_for_sev_attestation() {
+    fn verify_rejects_synthetic_sev_attestation() {
         let att = generate_attestation(&TeePlatform::Sev, MEASUREMENT, TIMESTAMP);
         let policy = permissive_policy();
-        assert!(verify_attestation(&att, &policy).is_ok());
+        let result = verify_attestation(&att, &policy);
+        assert!(result.is_err());
+        assert!(format!("{}", result.unwrap_err()).contains("synthetic"));
     }
 
     // --- Verification: platform rejection ---
@@ -484,35 +528,87 @@ mod tests {
     }
 
     #[test]
-    fn sgx_accepted_in_production() {
+    fn synthetic_sgx_attestation_rejected_in_production() {
         let att = generate_attestation(&TeePlatform::Sgx, MEASUREMENT, TIMESTAMP);
         let mut policy = TeePolicy::production();
         policy.current_time_ms = TIMESTAMP;
-        assert!(verify_attestation(&att, &policy).is_ok());
+        let result = verify_attestation(&att, &policy);
+        assert!(result.is_err());
+        assert!(format!("{}", result.unwrap_err()).contains("synthetic"));
     }
 
     #[test]
-    fn sgx_accepted_in_testing() {
-        let att = generate_attestation(&TeePlatform::Sgx, MEASUREMENT, TIMESTAMP);
-        let mut policy = TeePolicy::testing();
-        policy.current_time_ms = TIMESTAMP;
-        assert!(verify_attestation(&att, &policy).is_ok());
-    }
-
-    #[test]
-    fn trustzone_accepted_in_production() {
+    fn synthetic_trustzone_attestation_rejected_in_production() {
         let att = generate_attestation(&TeePlatform::TrustZone, MEASUREMENT, TIMESTAMP);
         let mut policy = TeePolicy::production();
         policy.current_time_ms = TIMESTAMP;
-        assert!(verify_attestation(&att, &policy).is_ok());
+        let result = verify_attestation(&att, &policy);
+        assert!(result.is_err());
+        assert!(format!("{}", result.unwrap_err()).contains("synthetic"));
     }
 
     #[test]
-    fn sev_accepted_in_production() {
+    fn synthetic_sev_attestation_rejected_in_production() {
         let att = generate_attestation(&TeePlatform::Sev, MEASUREMENT, TIMESTAMP);
         let mut policy = TeePolicy::production();
         policy.current_time_ms = TIMESTAMP;
-        assert!(verify_attestation(&att, &policy).is_ok());
+        let result = verify_attestation(&att, &policy);
+        assert!(result.is_err());
+        assert!(format!("{}", result.unwrap_err()).contains("synthetic"));
+    }
+
+    #[test]
+    fn synthetic_hardware_attestation_rejected_in_testing() {
+        let att = generate_attestation(&TeePlatform::Sgx, MEASUREMENT, TIMESTAMP);
+        let mut policy = TeePolicy::testing();
+        policy.current_time_ms = TIMESTAMP;
+        let result = verify_attestation(&att, &policy);
+        assert!(result.is_err());
+        assert!(format!("{}", result.unwrap_err()).contains("synthetic"));
+    }
+
+    #[test]
+    fn sgx_non_synthetic_signature_rejected_without_quote_verifier_in_production() {
+        let mut att = generate_attestation(&TeePlatform::Sgx, MEASUREMENT, TIMESTAMP);
+        att.signature = vec![0xA5; 64];
+        let mut policy = TeePolicy::production();
+        policy.current_time_ms = TIMESTAMP;
+        let result = verify_attestation(&att, &policy);
+        assert!(result.is_err());
+        assert!(format!("{}", result.unwrap_err()).contains("quote verifier"));
+    }
+
+    #[test]
+    fn sgx_non_synthetic_signature_rejected_without_quote_verifier_in_testing() {
+        let mut att = generate_attestation(&TeePlatform::Sgx, MEASUREMENT, TIMESTAMP);
+        att.signature = vec![0xA5; 64];
+        let mut policy = TeePolicy::testing();
+        policy.current_time_ms = TIMESTAMP;
+        let result = verify_attestation(&att, &policy);
+        assert!(result.is_err());
+        assert!(format!("{}", result.unwrap_err()).contains("quote verifier"));
+    }
+
+    #[test]
+    fn trustzone_non_synthetic_signature_rejected_without_quote_verifier() {
+        let mut att = generate_attestation(&TeePlatform::TrustZone, MEASUREMENT, TIMESTAMP);
+        att.signature = vec![0xA5; 64];
+        let mut policy = TeePolicy::production();
+        policy.current_time_ms = TIMESTAMP;
+        let result = verify_attestation(&att, &policy);
+        assert!(result.is_err());
+        assert!(format!("{}", result.unwrap_err()).contains("quote verifier"));
+    }
+
+    #[test]
+    fn sev_non_synthetic_signature_rejected_without_quote_verifier() {
+        let mut att = generate_attestation(&TeePlatform::Sev, MEASUREMENT, TIMESTAMP);
+        att.signature = vec![0xA5; 64];
+        let mut policy = TeePolicy::production();
+        policy.current_time_ms = TIMESTAMP;
+        let result = verify_attestation(&att, &policy);
+        assert!(result.is_err());
+        assert!(format!("{}", result.unwrap_err()).contains("quote verifier"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reject deterministic BLAKE3 fixture signatures when claimed as SGX, TrustZone, or SEV hardware TEE attestations
- keep synthetic signatures accepted only for simulated TEEs in explicitly allowed environments
- fail closed for hardware platform claims unless a platform quote verifier is present at the verification boundary
- refresh README repo-truth counters

## TDD

Red before implementation:

```bash
cargo test -p exo-gatekeeper tee::tests::synthetic_ --lib
```

The red run showed synthetic SGX, TrustZone, and SEV attestations were accepted.

## Verification

```bash
cargo test -p exo-gatekeeper tee::tests::synthetic_ --lib
cargo test -p exo-gatekeeper tee::tests --lib
cargo test -p exo-gatekeeper --lib
bash tools/repo_truth.sh --json
bash tools/test_repo_truth.sh
cargo +nightly fmt --all -- --check
git diff --check
cargo test -p exo-gatekeeper
cargo clippy -p exo-gatekeeper --lib -- -D warnings
cargo clippy -p exo-gatekeeper --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
bash tools/test_cr001_status.sh
bash tools/test_gap_registry_truth.sh
bash tools/test_no_orphan_rust_modules.sh
bash tools/test_railway_entrypoint_args.sh
cargo build --workspace
cargo test --workspace
cargo clippy --workspace --lib --bins -- -D warnings
cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
cargo build --workspace --release
cargo test --workspace --release
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
cargo audit --deny unsound --deny unmaintained
cargo deny check
cargo machete --with-metadata
```

`cargo audit` passed with the existing allowed `core2` yanked warning. `cargo deny check` passed with existing duplicate/yanked/license warnings.
