### PR TITLE
fix(exo-governance): verify delegation grant signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 114603 | `wc -l` |
-| Workspace tests | 2,821 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 114913 | `wc -l` |
+| Workspace tests | 2,829 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,821 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,829 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 114603 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 114913 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,821 listed workspace tests
+         cryptographic proofs, 2,829 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          140 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-governance/src/delegation.rs
+++ b/crates/exo-governance/src/delegation.rs
@@ -3,7 +3,7 @@
 //! Satisfies: GOV-003, GOV-004, TNC-05, TNC-09
 
 use exo_core::{
-    Did,
+    Did, PublicKey, crypto,
     types::{Hash256, Timestamp},
 };
 use serde::{Deserialize, Serialize};
@@ -85,6 +85,75 @@ pub struct Delegation {
 }
 
 impl Delegation {
+    /// Canonical CBOR payload signed by the delegator when granting authority.
+    ///
+    /// The payload intentionally excludes the mutable `signature` field and
+    /// `revoked_at`; revocation is enforced as current state, while this
+    /// payload proves the original grant.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GovernanceError::Serialization`] if canonical CBOR encoding
+    /// fails.
+    pub fn signing_payload(&self) -> Result<Vec<u8>, GovernanceError> {
+        let payload = (
+            "exo.governance.delegation.v1",
+            &self.id,
+            &self.tenant_id,
+            &self.delegator,
+            &self.delegatee,
+            &self.scope,
+            self.sub_delegation_allowed,
+            &self.sub_delegation_scope_cap,
+            &self.created_at,
+            self.expires_at,
+            &self.constitution_version,
+            &self.parent_delegation,
+        );
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&payload, &mut buf).map_err(|e| {
+            GovernanceError::Serialization(format!(
+                "delegation canonical grant encoding failed: {e}"
+            ))
+        })?;
+        Ok(buf)
+    }
+
+    /// Verify the delegator's signature over this delegation grant.
+    ///
+    /// Returns `false` for empty/all-zero signatures, signer/delegator
+    /// mismatch, zero key versions, impossible signature timestamps, and
+    /// Ed25519 verification failure.
+    #[must_use]
+    pub fn verify_signature(&self, delegator_public_key: &PublicKey) -> bool {
+        if self.signature.signer != self.delegator
+            || self.signature.key_version == 0
+            || self.signature.timestamp == Timestamp::ZERO
+            || self.signature.timestamp.physical_ms < self.created_at.physical_ms
+            || self.signature.timestamp.physical_ms >= self.expires_at
+            || self.signature.signature.is_empty()
+        {
+            return false;
+        }
+
+        if let SignerType::AiAgent {
+            delegation_id,
+            expires_at,
+        } = &self.signature.signer_type
+        {
+            if *delegation_id == Hash256::ZERO
+                || *expires_at <= self.signature.timestamp.physical_ms
+            {
+                return false;
+            }
+        }
+
+        let Ok(payload) = self.signing_payload() else {
+            return false;
+        };
+        crypto::verify(&payload, &self.signature.signature, delegator_public_key)
+    }
+
     /// Check whether this delegation is currently active (not expired, not revoked).
     /// TNC-05: Immediate expiry, no grace period.
     pub fn is_active(&self, current_time_ms: u64) -> bool {
@@ -94,6 +163,16 @@ impl Delegation {
         }
         // Not expired — TNC-05: strict enforcement
         current_time_ms < self.expires_at
+    }
+
+    /// Check whether this delegation is active and cryptographically verified.
+    #[must_use]
+    pub fn is_active_verified(
+        &self,
+        current_time_ms: u64,
+        delegator_public_key: &PublicKey,
+    ) -> bool {
+        self.is_active(current_time_ms) && self.verify_signature(delegator_public_key)
     }
 
     /// Revoke this delegation.
@@ -106,6 +185,7 @@ impl Delegation {
         &self,
         sub_scope: &DelegationScope,
         current_time_ms: u64,
+        delegator_public_key: &PublicKey,
     ) -> Result<(), GovernanceError> {
         // Must be active
         if !self.is_active(current_time_ms) {
@@ -113,6 +193,9 @@ impl Delegation {
                 return Err(GovernanceError::DelegationRevoked(self.id));
             }
             return Err(GovernanceError::DelegationExpired(self.id));
+        }
+        if !self.verify_signature(delegator_public_key) {
+            return Err(GovernanceError::SignatureVerificationFailed);
         }
 
         // Sub-delegation must be permitted
@@ -138,12 +221,16 @@ impl Delegation {
         action: &AuthorizedAction,
         class: &DecisionClass,
         current_time_ms: u64,
+        delegator_public_key: &PublicKey,
     ) -> Result<(), GovernanceError> {
         if !self.is_active(current_time_ms) {
             if self.revoked_at.is_some() {
                 return Err(GovernanceError::DelegationRevoked(self.id));
             }
             return Err(GovernanceError::DelegationExpired(self.id));
+        }
+        if !self.verify_signature(delegator_public_key) {
+            return Err(GovernanceError::SignatureVerificationFailed);
         }
 
         if !self.scope.covers(action, class) {
@@ -157,12 +244,28 @@ impl Delegation {
 
         Ok(())
     }
+
+    /// Alias for call sites that want the verified API name to make the trust
+    /// boundary explicit.
+    pub fn authorizes_verified(
+        &self,
+        action: &AuthorizedAction,
+        class: &DecisionClass,
+        current_time_ms: u64,
+        delegator_public_key: &PublicKey,
+    ) -> Result<(), GovernanceError> {
+        self.authorizes(action, class, current_time_ms, delegator_public_key)
+    }
 }
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
-    use exo_core::types::{Signature, Timestamp};
+    use exo_core::{
+        PublicKey,
+        crypto::{self, KeyPair},
+        types::{Signature, Timestamp},
+    };
 
     use super::*;
 
@@ -209,6 +312,32 @@ mod tests {
             signature: test_signature(),
             parent_delegation: None,
         }
+    }
+
+    fn keypair(seed: u8) -> KeyPair {
+        KeyPair::from_secret_bytes([seed; 32]).expect("deterministic test keypair")
+    }
+
+    fn signed_test_delegation(
+        scope: DelegationScope,
+        expires_at: u64,
+        sub_delegation_allowed: bool,
+        signer: &KeyPair,
+    ) -> Delegation {
+        let mut delegation = test_delegation(scope, expires_at, sub_delegation_allowed);
+        let payload = delegation.signing_payload().expect("canonical payload");
+        delegation.signature = GovernanceSignature {
+            signer: delegation.delegator.clone(),
+            signer_type: SignerType::Human,
+            signature: crypto::sign(&payload, signer.secret_key()),
+            key_version: 1,
+            timestamp: Timestamp::new(1_100, 0),
+        };
+        delegation
+    }
+
+    fn public_key(keypair: &KeyPair) -> PublicKey {
+        *keypair.public_key()
     }
 
     // ---- DelegationScope::covers -------------------------------------
@@ -400,6 +529,109 @@ mod tests {
         assert!(!d.is_active(6_000));
     }
 
+    // ---- Delegation signature verification ---------------------------
+
+    #[test]
+    fn verify_signature_accepts_delegator_signature() {
+        let signer = keypair(11);
+        let d = signed_test_delegation(
+            test_scope(
+                vec![AuthorizedAction::CastVote],
+                vec![DecisionClass::Operational],
+            ),
+            10_000,
+            false,
+            &signer,
+        );
+
+        assert!(d.verify_signature(&public_key(&signer)));
+    }
+
+    #[test]
+    fn verify_signature_rejects_zero_signature() {
+        let signer = keypair(12);
+        let d = test_delegation(
+            test_scope(
+                vec![AuthorizedAction::CastVote],
+                vec![DecisionClass::Operational],
+            ),
+            10_000,
+            false,
+        );
+
+        assert!(!d.verify_signature(&public_key(&signer)));
+    }
+
+    #[test]
+    fn verify_signature_rejects_wrong_key() {
+        let signer = keypair(13);
+        let wrong_key = keypair(14);
+        let d = signed_test_delegation(
+            test_scope(
+                vec![AuthorizedAction::CastVote],
+                vec![DecisionClass::Operational],
+            ),
+            10_000,
+            false,
+            &signer,
+        );
+
+        assert!(!d.verify_signature(&public_key(&wrong_key)));
+    }
+
+    #[test]
+    fn verify_signature_rejects_tampered_scope() {
+        let signer = keypair(15);
+        let mut d = signed_test_delegation(
+            test_scope(
+                vec![AuthorizedAction::CastVote],
+                vec![DecisionClass::Operational],
+            ),
+            10_000,
+            false,
+            &signer,
+        );
+        d.scope.actions.push(AuthorizedAction::GrantDelegation);
+
+        assert!(!d.verify_signature(&public_key(&signer)));
+    }
+
+    #[test]
+    fn verify_signature_rejects_signer_mismatch() {
+        let signer = keypair(16);
+        let mut d = signed_test_delegation(
+            test_scope(
+                vec![AuthorizedAction::CastVote],
+                vec![DecisionClass::Operational],
+            ),
+            10_000,
+            false,
+            &signer,
+        );
+        d.signature.signer = Did::new("did:exo:mallory").expect("valid DID");
+
+        assert!(!d.verify_signature(&public_key(&signer)));
+    }
+
+    #[test]
+    fn verify_signature_rejects_signature_outside_grant_window() {
+        let signer = keypair(17);
+        let mut d = signed_test_delegation(
+            test_scope(
+                vec![AuthorizedAction::CastVote],
+                vec![DecisionClass::Operational],
+            ),
+            10_000,
+            false,
+            &signer,
+        );
+        d.signature.timestamp = Timestamp::new(999, 0);
+        let payload = d.signing_payload().expect("canonical payload");
+        d.signature.signature = crypto::sign(&payload, signer.secret_key());
+
+        assert!(!d.verify_signature(&public_key(&signer)));
+    }
+
     // ---- Delegation::revoke -------------------------------------------
 
     #[test]
@@ -421,6 +653,30 @@ mod tests {
 
     #[test]
     fn authorizes_ok_when_active_and_scope_covers() {
+        let signer = keypair(21);
+        let d = signed_test_delegation(
+            test_scope(
+                vec![AuthorizedAction::CastVote],
+                vec![DecisionClass::Operational],
+            ),
+            10_000,
+            false,
+            &signer,
+        );
+        assert!(
+            d.authorizes_verified(
+                &AuthorizedAction::CastVote,
+                &DecisionClass::Operational,
+                5_000,
+                &public_key(&signer),
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn authorizes_rejects_unsigned_delegation() {
+        let signer = keypair(22);
         let d = test_delegation(
             test_scope(
                 vec![AuthorizedAction::CastVote],
@@ -429,25 +685,28 @@ mod tests {
             10_000,
             false,
         );
-        assert!(
-            d.authorizes(
+        let err = d
+            .authorizes_verified(
                 &AuthorizedAction::CastVote,
                 &DecisionClass::Operational,
-                5_000
+                5_000,
+                &public_key(&signer),
             )
-            .is_ok()
-        );
+            .unwrap_err();
+        assert!(matches!(err, GovernanceError::SignatureVerificationFailed));
     }
 
     #[test]
     fn authorizes_revoked_error_when_revoked() {
-        let mut d = test_delegation(
+        let signer = keypair(23);
+        let mut d = signed_test_delegation(
             test_scope(
                 vec![AuthorizedAction::CastVote],
                 vec![DecisionClass::Operational],
             ),
             10_000,
             false,
+            &signer,
         );
         d.revoke(2_000);
         let err = d
@@ -455,6 +714,7 @@ mod tests {
                 &AuthorizedAction::CastVote,
                 &DecisionClass::Operational,
                 3_000,
+                &public_key(&signer),
             )
             .unwrap_err();
         assert!(matches!(err, GovernanceError::DelegationRevoked(_)));
@@ -462,19 +722,22 @@ mod tests {
 
     #[test]
     fn authorizes_expired_error_when_expired() {
-        let d = test_delegation(
+        let signer = keypair(24);
+        let d = signed_test_delegation(
             test_scope(
                 vec![AuthorizedAction::CastVote],
                 vec![DecisionClass::Operational],
             ),
             10_000,
             false,
+            &signer,
         );
         let err = d
             .authorizes(
                 &AuthorizedAction::CastVote,
                 &DecisionClass::Operational,
                 20_000,
+                &public_key(&signer),
             )
             .unwrap_err();
         assert!(matches!(err, GovernanceError::DelegationExpired(_)));
@@ -482,19 +745,22 @@ mod tests {
 
     #[test]
     fn authorizes_chain_broken_when_scope_does_not_cover() {
-        let d = test_delegation(
+        let signer = keypair(25);
+        let d = signed_test_delegation(
             test_scope(
                 vec![AuthorizedAction::CastVote],
                 vec![DecisionClass::Operational],
             ),
             10_000,
             false,
+            &signer,
         );
         let err = d
             .authorizes(
                 &AuthorizedAction::GrantDelegation,
                 &DecisionClass::Operational,
                 5_000,
+                &public_key(&signer),
             )
             .unwrap_err();
         assert!(matches!(err, GovernanceError::AuthorityChainBroken { .. }));
@@ -504,38 +770,25 @@ mod tests {
 
     #[test]
     fn validate_sub_delegation_ok_when_allowed_and_within_scope() {
+        let signer = keypair(31);
         let parent_scope = test_scope(
             vec![AuthorizedAction::CastVote, AuthorizedAction::CreateDecision],
             vec![DecisionClass::Operational, DecisionClass::Strategic],
         );
-        let d = test_delegation(parent_scope, 10_000, true);
+        let d = signed_test_delegation(parent_scope, 10_000, true, &signer);
         let sub_scope = test_scope(
             vec![AuthorizedAction::CastVote],
             vec![DecisionClass::Operational],
         );
-        assert!(d.validate_sub_delegation(&sub_scope, 5_000).is_ok());
+        assert!(
+            d.validate_sub_delegation(&sub_scope, 5_000, &public_key(&signer))
+                .is_ok()
+        );
     }
 
     #[test]
-    fn validate_sub_delegation_error_when_not_permitted() {
-        let d = test_delegation(
-            test_scope(
-                vec![AuthorizedAction::CastVote],
-                vec![DecisionClass::Operational],
-            ),
-            10_000,
-            false, // sub-delegation NOT allowed
-        );
-        let sub_scope = test_scope(
-            vec![AuthorizedAction::CastVote],
-            vec![DecisionClass::Operational],
-        );
-        let err = d.validate_sub_delegation(&sub_scope, 5_000).unwrap_err();
-        assert!(matches!(err, GovernanceError::SubDelegationNotPermitted(_)));
-    }
-
-    #[test]
-    fn validate_sub_delegation_error_when_exceeds_scope() {
+    fn validate_sub_delegation_rejects_unsigned_parent() {
+        let signer = keypair(32);
         let d = test_delegation(
             test_scope(
                 vec![AuthorizedAction::CastVote],
@@ -543,6 +796,50 @@ mod tests {
             ),
             10_000,
             true,
+        );
+        let sub_scope = test_scope(
+            vec![AuthorizedAction::CastVote],
+            vec![DecisionClass::Operational],
+        );
+        let err = d
+            .validate_sub_delegation(&sub_scope, 5_000, &public_key(&signer))
+            .unwrap_err();
+        assert!(matches!(err, GovernanceError::SignatureVerificationFailed));
+    }
+
+    #[test]
+    fn validate_sub_delegation_error_when_not_permitted() {
+        let signer = keypair(33);
+        let d = signed_test_delegation(
+            test_scope(
+                vec![AuthorizedAction::CastVote],
+                vec![DecisionClass::Operational],
+            ),
+            10_000,
+            false, // sub-delegation NOT allowed
+            &signer,
+        );
+        let sub_scope = test_scope(
+            vec![AuthorizedAction::CastVote],
+            vec![DecisionClass::Operational],
+        );
+        let err = d
+            .validate_sub_delegation(&sub_scope, 5_000, &public_key(&signer))
+            .unwrap_err();
+        assert!(matches!(err, GovernanceError::SubDelegationNotPermitted(_)));
+    }
+
+    #[test]
+    fn validate_sub_delegation_error_when_exceeds_scope() {
+        let signer = keypair(34);
+        let d = signed_test_delegation(
+            test_scope(
+                vec![AuthorizedAction::CastVote],
+                vec![DecisionClass::Operational],
+            ),
+            10_000,
+            true,
+            &signer,
         );
         let sub_scope = test_scope(
             vec![
@@ -551,49 +848,60 @@ mod tests {
             ],
             vec![DecisionClass::Operational],
         );
-        let err = d.validate_sub_delegation(&sub_scope, 5_000).unwrap_err();
+        let err = d
+            .validate_sub_delegation(&sub_scope, 5_000, &public_key(&signer))
+            .unwrap_err();
         assert!(matches!(err, GovernanceError::SubDelegationNotPermitted(_)));
     }
 
     #[test]
     fn validate_sub_delegation_error_when_revoked() {
-        let mut d = test_delegation(
+        let signer = keypair(35);
+        let mut d = signed_test_delegation(
             test_scope(
                 vec![AuthorizedAction::CastVote],
                 vec![DecisionClass::Operational],
             ),
             10_000,
             true,
+            &signer,
         );
         d.revoke(2_000);
         let sub_scope = test_scope(
             vec![AuthorizedAction::CastVote],
             vec![DecisionClass::Operational],
         );
-        let err = d.validate_sub_delegation(&sub_scope, 3_000).unwrap_err();
+        let err = d
+            .validate_sub_delegation(&sub_scope, 3_000, &public_key(&signer))
+            .unwrap_err();
         assert!(matches!(err, GovernanceError::DelegationRevoked(_)));
     }
 
     #[test]
     fn validate_sub_delegation_error_when_expired() {
-        let d = test_delegation(
+        let signer = keypair(36);
+        let d = signed_test_delegation(
             test_scope(
                 vec![AuthorizedAction::CastVote],
                 vec![DecisionClass::Operational],
             ),
             10_000,
             true,
+            &signer,
         );
         let sub_scope = test_scope(
             vec![AuthorizedAction::CastVote],
             vec![DecisionClass::Operational],
         );
-        let err = d.validate_sub_delegation(&sub_scope, 20_000).unwrap_err();
+        let err = d
+            .validate_sub_delegation(&sub_scope, 20_000, &public_key(&signer))
+            .unwrap_err();
         assert!(matches!(err, GovernanceError::DelegationExpired(_)));
     }
 
     #[test]
     fn validate_sub_delegation_uses_explicit_cap_when_set() {
+        let signer = keypair(37);
         // Parent scope is broad; explicit cap is narrower.
         let parent_scope = test_scope(
             vec![AuthorizedAction::CastVote, AuthorizedAction::CreateDecision],
@@ -603,16 +911,18 @@ mod tests {
             vec![AuthorizedAction::CastVote],
             vec![DecisionClass::Operational],
         );
-        let d = Delegation {
-            sub_delegation_scope_cap: Some(narrower_cap),
-            ..test_delegation(parent_scope, 10_000, true)
-        };
+        let mut d = signed_test_delegation(parent_scope, 10_000, true, &signer);
+        d.sub_delegation_scope_cap = Some(narrower_cap);
+        let payload = d.signing_payload().expect("canonical payload");
+        d.signature.signature = crypto::sign(&payload, signer.secret_key());
         // Sub-delegation matches parent but exceeds cap — must be rejected.
         let sub_scope = test_scope(
             vec![AuthorizedAction::CreateDecision],
             vec![DecisionClass::Operational],
         );
-        let err = d.validate_sub_delegation(&sub_scope, 5_000).unwrap_err();
+        let err = d
+            .validate_sub_delegation(&sub_scope, 5_000, &public_key(&signer))
+            .unwrap_err();
         assert!(matches!(err, GovernanceError::SubDelegationNotPermitted(_)));
     }
 }


### PR DESCRIPTION
## Summary
- add domain-separated canonical CBOR signing payloads for exo-governance delegations
- require delegator public-key verification before action authorization or sub-delegation validation
- reject empty/zero signatures, wrong keys, signer mismatch, tampered grants, and impossible signature timestamps
- refresh README repo-truth counts to 114913 Rust LOC and 2829 listed tests

## TDD / verification
- RED: cargo test -p exo-governance delegation::tests::verify_signature_accepts_delegator_signature --lib failed before implementation because signing_payload/verify_signature/verified authorization did not exist
- cargo test -p exo-governance delegation::tests --lib
- cargo test -p exo-governance
- cargo build -p exo-governance
- cargo clippy -p exo-governance --lib -- -D warnings
- cargo clippy -p exo-governance --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo +nightly fmt --all -- --check
- git diff --check
- bash tools/test_repo_truth.sh
- bash tools/test_cr001_status.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_no_orphan_rust_modules.sh
- bash tools/test_railway_entrypoint_args.sh
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo build --workspace --release
- cargo test --workspace --release
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
- cargo audit --deny unsound --deny unmaintained (existing allowed core2 yanked warning)
- cargo deny check (existing duplicate/yanked/license warnings)
- cargo machete --with-metadata