### PR TITLE
Require cryptographic invariant context

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 114913 | `wc -l` |
-| Workspace tests | 2,829 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 115527 | `wc -l` |
+| Workspace tests | 2,835 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,829 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,835 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 114913 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 115527 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,829 listed workspace tests
+         cryptographic proofs, 2,835 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          140 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/decision-forum/tests/governance_kernel_integration.rs
+++ b/crates/decision-forum/tests/governance_kernel_integration.rs
@@ -62,6 +62,58 @@ fn did(s: &str) -> Did {
     Did::new(s).expect("valid DID")
 }
 
+fn signed_authority_link(grantee: &Did) -> GkAuthorityLink {
+    let (pk, sk) = exo_core::crypto::generate_keypair();
+    let grantor = did("did:exo:governance-root");
+    let permissions = PermissionSet::new(vec![Permission::new("enact:decision")]);
+
+    let mut payload = Vec::new();
+    payload.extend_from_slice(grantor.as_str().as_bytes());
+    payload.push(0x00);
+    payload.extend_from_slice(grantee.as_str().as_bytes());
+    payload.push(0x00);
+    for permission in &permissions.permissions {
+        payload.extend_from_slice(permission.0.as_bytes());
+        payload.push(0x00);
+    }
+    let message = Hash256::digest(&payload);
+    let signature = exo_core::crypto::sign(message.as_bytes(), &sk);
+
+    GkAuthorityLink {
+        grantor,
+        grantee: grantee.clone(),
+        permissions,
+        signature: signature.to_bytes().to_vec(),
+        grantor_public_key: Some(pk.as_bytes().to_vec()),
+    }
+}
+
+fn signed_provenance(actor: &Did) -> Provenance {
+    let (pk, sk) = exo_core::crypto::generate_keypair();
+    let timestamp = "2026-03-30T00:00:00Z".to_owned();
+    let action_hash = vec![0x01, 0x02, 0x03];
+
+    let mut payload = Vec::new();
+    payload.extend_from_slice(actor.as_str().as_bytes());
+    payload.push(0x00);
+    payload.extend_from_slice(&action_hash);
+    payload.push(0x00);
+    payload.extend_from_slice(timestamp.as_bytes());
+    let message = Hash256::digest(&payload);
+    let signature = exo_core::crypto::sign(message.as_bytes(), &sk);
+
+    Provenance {
+        actor: actor.clone(),
+        timestamp,
+        action_hash,
+        signature: signature.to_bytes().to_vec(),
+        public_key: Some(pk.as_bytes().to_vec()),
+        voice_kind: None,
+        independence: None,
+        review_order: None,
+    }
+}
+
 fn test_kernel() -> Kernel {
     Kernel::new(CONSTITUTION, InvariantSet::all())
 }
@@ -127,7 +179,7 @@ fn make_approved_decision(class: DecisionClass, clock: &mut HybridClock) -> Deci
 /// - CP-5: `modifies_kernel` = false (set on ActionRequest)
 /// - CP-6: valid single-link authority chain ending at actor
 /// - CP-7: `quorum_evidence` = None (invariant skips when None)
-/// - CP-8: provenance present, actor matches, non-empty signature
+/// - CP-8: provenance present, actor matches, Ed25519 signature verifies
 fn valid_adj_context(actor: &Did) -> AdjudicationContext {
     AdjudicationContext {
         actor_roles: vec![Role {
@@ -135,13 +187,7 @@ fn valid_adj_context(actor: &Did) -> AdjudicationContext {
             branch: GovernmentBranch::Judicial,
         }],
         authority_chain: AuthorityChain {
-            links: vec![GkAuthorityLink {
-                grantor: did("did:exo:governance-root"),
-                grantee: actor.clone(),
-                permissions: PermissionSet::new(vec![Permission::new("enact:decision")]),
-                signature: vec![0xAB, 0xCD, 0xEF],
-                grantor_public_key: None,
-            }],
+            links: vec![signed_authority_link(actor)],
         },
         consent_records: vec![ConsentRecord {
             subject: did("did:exo:bailor"),
@@ -156,16 +202,7 @@ fn valid_adj_context(actor: &Did) -> AdjudicationContext {
         },
         human_override_preserved: true,
         actor_permissions: PermissionSet::new(vec![Permission::new("enact:decision")]),
-        provenance: Some(Provenance {
-            actor: actor.clone(),
-            timestamp: "2026-03-30T00:00:00Z".into(),
-            action_hash: vec![0x01, 0x02, 0x03],
-            signature: vec![0x04, 0x05, 0x06],
-            public_key: None,
-            voice_kind: None,
-            independence: None,
-            review_order: None,
-        }),
+        provenance: Some(signed_provenance(actor)),
         quorum_evidence: None,
         active_challenge_reason: None,
     }

--- a/crates/exo-escalation/tests/sybil_adjudication.rs
+++ b/crates/exo-escalation/tests/sybil_adjudication.rs
@@ -10,7 +10,7 @@
 //! - Reinstatement refuses zero-hash clearance evidence
 //! - `check_completeness` returns `Complete` after all seven stages
 
-use exo_core::{Did, Timestamp};
+use exo_core::{Did, Hash256, Timestamp};
 use exo_escalation::{
     challenge::{
         ChallengeAdmission, ContestStatus, SignedChallengeAdmission, SybilChallengeGround,
@@ -91,6 +91,58 @@ fn signed_challenge(
     .expect("valid challenge admission")
 }
 
+fn signed_authority_link(grantee: &Did) -> AuthorityLink {
+    let keypair = keypair(11);
+    let grantor = did("did:exo:root");
+    let permissions = PermissionSet::new(vec![Permission::new("read")]);
+
+    let mut payload = Vec::new();
+    payload.extend_from_slice(grantor.as_str().as_bytes());
+    payload.push(0x00);
+    payload.extend_from_slice(grantee.as_str().as_bytes());
+    payload.push(0x00);
+    for permission in &permissions.permissions {
+        payload.extend_from_slice(permission.0.as_bytes());
+        payload.push(0x00);
+    }
+    let message = Hash256::digest(&payload);
+    let signature = exo_core::crypto::sign(message.as_bytes(), keypair.secret_key());
+
+    AuthorityLink {
+        grantor,
+        grantee: grantee.clone(),
+        permissions,
+        signature: signature.to_bytes().to_vec(),
+        grantor_public_key: Some(keypair.public_key().as_bytes().to_vec()),
+    }
+}
+
+fn signed_provenance(actor: &Did) -> Provenance {
+    let keypair = keypair(12);
+    let timestamp = "2026-03-30T00:00:00Z".to_owned();
+    let action_hash = vec![0xAA, 0xBB, 0xCC];
+
+    let mut payload = Vec::new();
+    payload.extend_from_slice(actor.as_str().as_bytes());
+    payload.push(0x00);
+    payload.extend_from_slice(&action_hash);
+    payload.push(0x00);
+    payload.extend_from_slice(timestamp.as_bytes());
+    let message = Hash256::digest(&payload);
+    let signature = exo_core::crypto::sign(message.as_bytes(), keypair.secret_key());
+
+    Provenance {
+        actor: actor.clone(),
+        timestamp,
+        action_hash,
+        signature: signature.to_bytes().to_vec(),
+        public_key: Some(keypair.public_key().as_bytes().to_vec()),
+        voice_kind: None,
+        independence: None,
+        review_order: None,
+    }
+}
+
 /// Build a fully valid `AdjudicationContext`.  Pass `Some(reason)` to inject
 /// an active Sybil challenge hold so the kernel returns `Verdict::Escalated`.
 fn valid_kernel_context(actor: &Did, challenge_reason: Option<String>) -> AdjudicationContext {
@@ -100,13 +152,7 @@ fn valid_kernel_context(actor: &Did, challenge_reason: Option<String>) -> Adjudi
             branch: GovernmentBranch::Judicial,
         }],
         authority_chain: AuthorityChain {
-            links: vec![AuthorityLink {
-                grantor: did("did:exo:root"),
-                grantee: actor.clone(),
-                permissions: PermissionSet::new(vec![Permission::new("read")]),
-                signature: vec![1, 2, 3],
-                grantor_public_key: None,
-            }],
+            links: vec![signed_authority_link(actor)],
         },
         consent_records: vec![ConsentRecord {
             subject: did("did:exo:bailor"),
@@ -121,16 +167,7 @@ fn valid_kernel_context(actor: &Did, challenge_reason: Option<String>) -> Adjudi
         },
         human_override_preserved: true,
         actor_permissions: PermissionSet::new(vec![Permission::new("read")]),
-        provenance: Some(Provenance {
-            actor: actor.clone(),
-            timestamp: "2026-03-30T00:00:00Z".into(),
-            action_hash: vec![0xAA, 0xBB, 0xCC],
-            signature: vec![0x01, 0x02, 0x03],
-            public_key: None,
-            voice_kind: None,
-            independence: None,
-            review_order: None,
-        }),
+        provenance: Some(signed_provenance(actor)),
         quorum_evidence: None,
         active_challenge_reason: challenge_reason,
     }

--- a/crates/exo-gatekeeper/src/holon.rs
+++ b/crates/exo-gatekeeper/src/holon.rs
@@ -157,6 +157,8 @@ pub fn resume(holon: &mut Holon, checkpoint: &Checkpoint) -> Result<(), Gatekeep
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
+    use exo_core::Hash256;
+
     use super::*;
     use crate::{
         combinator::{Predicate, TransformFn},
@@ -167,6 +169,58 @@ mod tests {
     fn did(s: &str) -> Did {
         Did::new(s).expect("valid DID")
     }
+
+    fn signed_link(grantor_str: &str, grantee: &Did) -> AuthorityLink {
+        let (pk, sk) = exo_core::crypto::generate_keypair();
+        let grantor = did(grantor_str);
+        let permissions = PermissionSet::new(vec![Permission::new("read")]);
+
+        let mut payload = Vec::new();
+        payload.extend_from_slice(grantor.as_str().as_bytes());
+        payload.push(0x00);
+        payload.extend_from_slice(grantee.as_str().as_bytes());
+        payload.push(0x00);
+        for permission in &permissions.permissions {
+            payload.extend_from_slice(permission.0.as_bytes());
+            payload.push(0x00);
+        }
+        let message = Hash256::digest(&payload);
+        let signature = exo_core::crypto::sign(message.as_bytes(), &sk);
+
+        AuthorityLink {
+            grantor,
+            grantee: grantee.clone(),
+            permissions,
+            signature: signature.to_bytes().to_vec(),
+            grantor_public_key: Some(pk.as_bytes().to_vec()),
+        }
+    }
+
+    fn signed_provenance(actor: &Did) -> Provenance {
+        let (pk, sk) = exo_core::crypto::generate_keypair();
+        let timestamp = "2025-01-01T00:00:00Z".to_owned();
+        let action_hash = vec![1];
+        let mut payload = Vec::new();
+        payload.extend_from_slice(actor.as_str().as_bytes());
+        payload.push(0x00);
+        payload.extend_from_slice(&action_hash);
+        payload.push(0x00);
+        payload.extend_from_slice(timestamp.as_bytes());
+        let message = Hash256::digest(&payload);
+        let signature = exo_core::crypto::sign(message.as_bytes(), &sk);
+
+        Provenance {
+            actor: actor.clone(),
+            timestamp,
+            action_hash,
+            signature: signature.to_bytes().to_vec(),
+            public_key: Some(pk.as_bytes().to_vec()),
+            voice_kind: None,
+            independence: None,
+            review_order: None,
+        }
+    }
+
     fn test_kernel() -> Kernel {
         Kernel::new(b"constitution", InvariantSet::all())
     }
@@ -186,13 +240,7 @@ mod tests {
                 branch: GovernmentBranch::Executive,
             }],
             authority_chain: AuthorityChain {
-                links: vec![AuthorityLink {
-                    grantor: did("did:exo:root"),
-                    grantee: actor.clone(),
-                    permissions: PermissionSet::new(vec![Permission::new("read")]),
-                    signature: vec![1, 2, 3],
-                    grantor_public_key: None,
-                }],
+                links: vec![signed_link("did:exo:root", actor)],
             },
             consent_records: vec![ConsentRecord {
                 subject: did("did:exo:owner"),
@@ -207,16 +255,7 @@ mod tests {
             },
             human_override_preserved: true,
             actor_permissions: PermissionSet::new(vec![Permission::new("read")]),
-            provenance: Some(Provenance {
-                actor: actor.clone(),
-                timestamp: "t".into(),
-                action_hash: vec![1],
-                signature: vec![4, 5, 6],
-                public_key: None,
-                voice_kind: None,
-                independence: None,
-                review_order: None,
-            }),
+            provenance: Some(signed_provenance(actor)),
             quorum_evidence: None,
             active_challenge_reason: None,
         }

--- a/crates/exo-gatekeeper/src/invariants.rs
+++ b/crates/exo-gatekeeper/src/invariants.rs
@@ -281,75 +281,67 @@ fn check_authority_chain_valid(ctx: &InvariantContext) -> Result<(), InvariantVi
         }
     }
 
-    // TNC-01: Cryptographic signature verification (if grantor_public_key is provided).
-    // For each link that carries a public key, verify the Ed25519 signature over the
+    // TNC-01: Cryptographic signature verification.
+    // Every link must carry the grantor public key and verify the Ed25519 signature over the
     // canonical payload: Hash256(grantor_bytes || 0x00 || grantee_bytes || 0x00 ||
-    // permission_bytes).  Links without a public key fall back to non-emptiness check.
+    // permission_bytes).
     for (idx, link) in links.iter().enumerate() {
-        match &link.grantor_public_key {
-            Some(pk_bytes) => {
-                // Validate key length.
-                let pk_arr: [u8; 32] =
-                    pk_bytes
-                        .as_slice()
-                        .try_into()
-                        .map_err(|_| InvariantViolation {
-                            invariant: ConstitutionalInvariant::AuthorityChainValid,
-                            description: format!("link[{idx}] grantor_public_key is not 32 bytes"),
-                            evidence: vec![format!("key_len: {}", pk_bytes.len())],
-                        })?;
+        let pk_bytes = link
+            .grantor_public_key
+            .as_ref()
+            .ok_or_else(|| InvariantViolation {
+                invariant: ConstitutionalInvariant::AuthorityChainValid,
+                description: format!("link[{idx}] missing grantor_public_key"),
+                evidence: vec![format!("grantor: {}", link.grantor)],
+            })?;
 
-                // Validate signature length.
-                let sig_arr: [u8; 64] =
-                    link.signature
-                        .as_slice()
-                        .try_into()
-                        .map_err(|_| InvariantViolation {
-                            invariant: ConstitutionalInvariant::AuthorityChainValid,
-                            description: format!(
-                                "link[{idx}] signature is not 64 bytes (required for Ed25519)"
-                            ),
-                            evidence: vec![format!("sig_len: {}", link.signature.len())],
-                        })?;
+        // Validate key length.
+        let pk_arr: [u8; 32] = pk_bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| InvariantViolation {
+                invariant: ConstitutionalInvariant::AuthorityChainValid,
+                description: format!("link[{idx}] grantor_public_key is not 32 bytes"),
+                evidence: vec![format!("key_len: {}", pk_bytes.len())],
+            })?;
 
-                // Compute canonical payload.
-                let mut payload = Vec::new();
-                payload.extend_from_slice(link.grantor.as_str().as_bytes());
-                payload.push(0x00);
-                payload.extend_from_slice(link.grantee.as_str().as_bytes());
-                payload.push(0x00);
-                for perm in &link.permissions.permissions {
-                    payload.extend_from_slice(perm.0.as_bytes());
-                    payload.push(0x00);
-                }
-                let message = Hash256::digest(&payload);
+        // Validate signature length.
+        let sig_arr: [u8; 64] =
+            link.signature
+                .as_slice()
+                .try_into()
+                .map_err(|_| InvariantViolation {
+                    invariant: ConstitutionalInvariant::AuthorityChainValid,
+                    description: format!(
+                        "link[{idx}] signature is not 64 bytes (required for Ed25519)"
+                    ),
+                    evidence: vec![format!("sig_len: {}", link.signature.len())],
+                })?;
 
-                let pubkey = exo_core::PublicKey::from_bytes(pk_arr);
-                let sig = exo_core::Signature::from_bytes(sig_arr);
+        // Compute canonical payload.
+        let mut payload = Vec::new();
+        payload.extend_from_slice(link.grantor.as_str().as_bytes());
+        payload.push(0x00);
+        payload.extend_from_slice(link.grantee.as_str().as_bytes());
+        payload.push(0x00);
+        for perm in &link.permissions.permissions {
+            payload.extend_from_slice(perm.0.as_bytes());
+            payload.push(0x00);
+        }
+        let message = Hash256::digest(&payload);
 
-                if !exo_core::crypto::verify(message.as_bytes(), &sig, &pubkey) {
-                    return Err(InvariantViolation {
-                        invariant: ConstitutionalInvariant::AuthorityChainValid,
-                        description: format!(
-                            "link[{idx}] Ed25519 signature is cryptographically invalid"
-                        ),
-                        evidence: vec![
-                            format!("grantor: {}", link.grantor),
-                            format!("grantee: {}", link.grantee),
-                        ],
-                    });
-                }
-            }
-            None => {
-                // Legacy: at minimum the signature must be non-empty.
-                if link.signature.is_empty() {
-                    return Err(InvariantViolation {
-                        invariant: ConstitutionalInvariant::AuthorityChainValid,
-                        description: format!("link[{idx}] has empty signature"),
-                        evidence: vec![format!("grantor: {}", link.grantor)],
-                    });
-                }
-            }
+        let pubkey = exo_core::PublicKey::from_bytes(pk_arr);
+        let sig = exo_core::Signature::from_bytes(sig_arr);
+
+        if !exo_core::crypto::verify(message.as_bytes(), &sig, &pubkey) {
+            return Err(InvariantViolation {
+                invariant: ConstitutionalInvariant::AuthorityChainValid,
+                description: format!("link[{idx}] Ed25519 signature is cryptographically invalid"),
+                evidence: vec![
+                    format!("grantor: {}", link.grantor),
+                    format!("grantee: {}", link.grantee),
+                ],
+            });
         }
     }
 
@@ -407,58 +399,46 @@ fn check_provenance_verifiable(ctx: &InvariantContext) -> Result<(), InvariantVi
                     ],
                 });
             }
-            match &prov.public_key {
-                Some(pk_bytes) => {
-                    // Full Ed25519 verification path (closes GAP-02).
-                    let pk_arr: [u8; 32] =
-                        pk_bytes
-                            .as_slice()
-                            .try_into()
-                            .map_err(|_| InvariantViolation {
-                                invariant: ConstitutionalInvariant::ProvenanceVerifiable,
-                                description: "Provenance public_key is not 32 bytes".into(),
-                                evidence: vec![format!("key_len: {}", pk_bytes.len())],
-                            })?;
-                    let sig_arr: [u8; 64] =
-                        prov.signature
-                            .as_slice()
-                            .try_into()
-                            .map_err(|_| InvariantViolation {
-                                invariant: ConstitutionalInvariant::ProvenanceVerifiable,
-                                description:
-                                    "Provenance signature is not 64 bytes (required for Ed25519)"
-                                        .into(),
-                                evidence: vec![format!("sig_len: {}", prov.signature.len())],
-                            })?;
-                    // Canonical payload: actor || 0x00 || action_hash || 0x00 || timestamp
-                    let mut payload = Vec::new();
-                    payload.extend_from_slice(prov.actor.as_str().as_bytes());
-                    payload.push(0x00);
-                    payload.extend_from_slice(&prov.action_hash);
-                    payload.push(0x00);
-                    payload.extend_from_slice(prov.timestamp.as_bytes());
-                    let message = Hash256::digest(&payload);
-                    let pubkey = exo_core::PublicKey::from_bytes(pk_arr);
-                    let sig = exo_core::Signature::from_bytes(sig_arr);
-                    if !exo_core::crypto::verify(message.as_bytes(), &sig, &pubkey) {
-                        return Err(InvariantViolation {
-                            invariant: ConstitutionalInvariant::ProvenanceVerifiable,
-                            description:
-                                "Provenance Ed25519 signature is cryptographically invalid".into(),
-                            evidence: vec![format!("actor: {}", prov.actor)],
-                        });
-                    }
-                }
-                None => {
-                    // Legacy path: signature must be non-empty.
-                    if !prov.is_signed() {
-                        return Err(InvariantViolation {
-                            invariant: ConstitutionalInvariant::ProvenanceVerifiable,
-                            description: "Provenance metadata is not signed".into(),
-                            evidence: vec![format!("actor: {}", prov.actor)],
-                        });
-                    }
-                }
+            let pk_bytes = prov.public_key.as_ref().ok_or_else(|| InvariantViolation {
+                invariant: ConstitutionalInvariant::ProvenanceVerifiable,
+                description: "Provenance public_key is required for Ed25519 verification".into(),
+                evidence: vec![format!("actor: {}", prov.actor)],
+            })?;
+            let pk_arr: [u8; 32] =
+                pk_bytes
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| InvariantViolation {
+                        invariant: ConstitutionalInvariant::ProvenanceVerifiable,
+                        description: "Provenance public_key is not 32 bytes".into(),
+                        evidence: vec![format!("key_len: {}", pk_bytes.len())],
+                    })?;
+            let sig_arr: [u8; 64] =
+                prov.signature
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| InvariantViolation {
+                        invariant: ConstitutionalInvariant::ProvenanceVerifiable,
+                        description: "Provenance signature is not 64 bytes (required for Ed25519)"
+                            .into(),
+                        evidence: vec![format!("sig_len: {}", prov.signature.len())],
+                    })?;
+            // Canonical payload: actor || 0x00 || action_hash || 0x00 || timestamp
+            let mut payload = Vec::new();
+            payload.extend_from_slice(prov.actor.as_str().as_bytes());
+            payload.push(0x00);
+            payload.extend_from_slice(&prov.action_hash);
+            payload.push(0x00);
+            payload.extend_from_slice(prov.timestamp.as_bytes());
+            let message = Hash256::digest(&payload);
+            let pubkey = exo_core::PublicKey::from_bytes(pk_arr);
+            let sig = exo_core::Signature::from_bytes(sig_arr);
+            if !exo_core::crypto::verify(message.as_bytes(), &sig, &pubkey) {
+                return Err(InvariantViolation {
+                    invariant: ConstitutionalInvariant::ProvenanceVerifiable,
+                    description: "Provenance Ed25519 signature is cryptographically invalid".into(),
+                    evidence: vec![format!("actor: {}", prov.actor)],
+                });
             }
             Ok(())
         }
@@ -484,6 +464,8 @@ mod tests {
 
     fn passing_context() -> InvariantContext {
         let actor = did("did:exo:actor1");
+        let (authority_link, _) = signed_link("did:exo:root", actor.as_str());
+        let (provenance, _, _) = signed_provenance(actor.as_str());
         InvariantContext {
             actor: actor.clone(),
             actor_roles: vec![Role {
@@ -502,28 +484,13 @@ mod tests {
                 active: true,
             }],
             authority_chain: AuthorityChain {
-                links: vec![AuthorityLink {
-                    grantor: did("did:exo:root"),
-                    grantee: actor.clone(),
-                    permissions: PermissionSet::new(vec![Permission::new("read")]),
-                    signature: vec![1, 2, 3],
-                    grantor_public_key: None,
-                }],
+                links: vec![authority_link],
             },
             is_self_grant: false,
             human_override_preserved: true,
             kernel_modification_attempted: false,
             quorum_evidence: None,
-            provenance: Some(Provenance {
-                actor: actor.clone(),
-                timestamp: "2025-01-01T00:00:00Z".into(),
-                action_hash: vec![1, 2, 3],
-                signature: vec![4, 5, 6],
-                public_key: None,
-                voice_kind: None,
-                independence: None,
-                review_order: None,
-            }),
+            provenance: Some(provenance),
             actor_permissions: PermissionSet::new(vec![Permission::new("read")]),
             requested_permissions: PermissionSet::default(),
         }
@@ -771,23 +738,10 @@ mod tests {
             ConstitutionalInvariant::AuthorityChainValid,
         ]));
         let mut ctx = passing_context();
+        let (link1, _) = signed_link("did:exo:root", "did:exo:mid");
+        let (link2, _) = signed_link("did:exo:mid", "did:exo:actor1");
         ctx.authority_chain = AuthorityChain {
-            links: vec![
-                AuthorityLink {
-                    grantor: did("did:exo:root"),
-                    grantee: did("did:exo:mid"),
-                    permissions: PermissionSet::default(),
-                    signature: vec![1],
-                    grantor_public_key: None,
-                },
-                AuthorityLink {
-                    grantor: did("did:exo:mid"),
-                    grantee: ctx.actor.clone(),
-                    permissions: PermissionSet::default(),
-                    signature: vec![2],
-                    grantor_public_key: None,
-                },
-            ],
+            links: vec![link1, link2],
         };
         assert!(enforce_all(&engine, &ctx).is_ok());
     }
@@ -868,17 +822,39 @@ mod tests {
             ConstitutionalInvariant::ProvenanceVerifiable,
         ]));
         let mut ctx = passing_context();
+        let (pk, _) = exo_core::crypto::generate_keypair();
         ctx.provenance = Some(Provenance {
             actor: ctx.actor.clone(),
             timestamp: "t".into(),
             action_hash: vec![1],
             signature: vec![],
-            public_key: None,
+            public_key: Some(pk.as_bytes().to_vec()),
             voice_kind: None,
             independence: None,
             review_order: None,
         });
         assert!(enforce_all(&engine, &ctx).is_err());
+    }
+
+    #[test]
+    fn provenance_fails_without_public_key_even_with_non_empty_signature() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::ProvenanceVerifiable,
+        ]));
+        let mut ctx = passing_context();
+        ctx.provenance = Some(Provenance {
+            actor: ctx.actor.clone(),
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            action_hash: vec![1],
+            signature: vec![7u8; 64],
+            public_key: None,
+            voice_kind: None,
+            independence: None,
+            review_order: None,
+        });
+
+        let err = enforce_all(&engine, &ctx).unwrap_err();
+        assert!(err[0].description.contains("public_key"));
     }
 
     #[test]
@@ -1249,7 +1225,20 @@ mod tests {
     }
 
     #[test]
-    fn authority_chain_fails_empty_signature_no_key() {
+    fn authority_chain_fails_empty_signature_with_public_key() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::AuthorityChainValid,
+        ]));
+        let mut ctx = passing_context();
+        let (mut link, _) = signed_link("did:exo:root", "did:exo:actor1");
+        link.signature.clear();
+        ctx.authority_chain = AuthorityChain { links: vec![link] };
+        let err = enforce_all(&engine, &ctx).unwrap_err();
+        assert!(err[0].description.contains("not 64 bytes"));
+    }
+
+    #[test]
+    fn authority_chain_fails_without_grantor_public_key_even_with_non_empty_signature() {
         let engine = InvariantEngine::new(InvariantSet::with(vec![
             ConstitutionalInvariant::AuthorityChainValid,
         ]));
@@ -1258,13 +1247,14 @@ mod tests {
             links: vec![AuthorityLink {
                 grantor: did("did:exo:root"),
                 grantee: did("did:exo:actor1"),
-                permissions: PermissionSet::default(),
-                signature: vec![], // empty — legacy check fails
+                permissions: PermissionSet::new(vec![Permission::new("read")]),
+                signature: vec![7u8; 64],
                 grantor_public_key: None,
             }],
         };
+
         let err = enforce_all(&engine, &ctx).unwrap_err();
-        assert!(err[0].description.contains("empty signature"));
+        assert!(err[0].description.contains("grantor_public_key"));
     }
 
     #[test]

--- a/crates/exo-gatekeeper/src/kernel.rs
+++ b/crates/exo-gatekeeper/src/kernel.rs
@@ -159,6 +159,8 @@ impl Kernel {
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
+    use exo_core::Hash256;
+
     use super::*;
     use crate::types::{AuthorityLink, GovernmentBranch, Permission, QuorumVote};
 
@@ -167,6 +169,58 @@ mod tests {
     fn did(s: &str) -> Did {
         Did::new(s).expect("valid DID")
     }
+
+    fn signed_link(grantor_str: &str, grantee: &Did) -> AuthorityLink {
+        let (pk, sk) = exo_core::crypto::generate_keypair();
+        let grantor = did(grantor_str);
+        let permissions = PermissionSet::new(vec![Permission::new("read")]);
+
+        let mut payload = Vec::new();
+        payload.extend_from_slice(grantor.as_str().as_bytes());
+        payload.push(0x00);
+        payload.extend_from_slice(grantee.as_str().as_bytes());
+        payload.push(0x00);
+        for permission in &permissions.permissions {
+            payload.extend_from_slice(permission.0.as_bytes());
+            payload.push(0x00);
+        }
+        let message = Hash256::digest(&payload);
+        let signature = exo_core::crypto::sign(message.as_bytes(), &sk);
+
+        AuthorityLink {
+            grantor,
+            grantee: grantee.clone(),
+            permissions,
+            signature: signature.to_bytes().to_vec(),
+            grantor_public_key: Some(pk.as_bytes().to_vec()),
+        }
+    }
+
+    fn signed_provenance(actor: &Did) -> Provenance {
+        let (pk, sk) = exo_core::crypto::generate_keypair();
+        let timestamp = "2025-01-01T00:00:00Z".to_owned();
+        let action_hash = vec![1, 2, 3];
+        let mut payload = Vec::new();
+        payload.extend_from_slice(actor.as_str().as_bytes());
+        payload.push(0x00);
+        payload.extend_from_slice(&action_hash);
+        payload.push(0x00);
+        payload.extend_from_slice(timestamp.as_bytes());
+        let message = Hash256::digest(&payload);
+        let signature = exo_core::crypto::sign(message.as_bytes(), &sk);
+
+        Provenance {
+            actor: actor.clone(),
+            timestamp,
+            action_hash,
+            signature: signature.to_bytes().to_vec(),
+            public_key: Some(pk.as_bytes().to_vec()),
+            voice_kind: None,
+            independence: None,
+            review_order: None,
+        }
+    }
+
     fn test_kernel() -> Kernel {
         Kernel::new(CONSTITUTION, InvariantSet::all())
     }
@@ -188,13 +242,7 @@ mod tests {
                 branch: GovernmentBranch::Judicial,
             }],
             authority_chain: AuthorityChain {
-                links: vec![AuthorityLink {
-                    grantor: did("did:exo:root"),
-                    grantee: actor.clone(),
-                    permissions: PermissionSet::new(vec![Permission::new("read")]),
-                    signature: vec![1, 2, 3],
-                    grantor_public_key: None,
-                }],
+                links: vec![signed_link("did:exo:root", actor)],
             },
             consent_records: vec![ConsentRecord {
                 subject: did("did:exo:bailor"),
@@ -209,16 +257,7 @@ mod tests {
             },
             human_override_preserved: true,
             actor_permissions: PermissionSet::new(vec![Permission::new("read")]),
-            provenance: Some(Provenance {
-                actor: actor.clone(),
-                timestamp: "2025-01-01T00:00:00Z".into(),
-                action_hash: vec![1, 2, 3],
-                signature: vec![4, 5, 6],
-                public_key: None,
-                voice_kind: None,
-                independence: None,
-                review_order: None,
-            }),
+            provenance: Some(signed_provenance(actor)),
             quorum_evidence: None,
             active_challenge_reason: None,
         }

--- a/crates/exo-gatekeeper/src/types.rs
+++ b/crates/exo-gatekeeper/src/types.rs
@@ -129,10 +129,9 @@ pub struct AuthorityLink {
     pub signature: Vec<u8>,
     /// Ed25519 public key (32 bytes) of the grantor.
     ///
-    /// When present, `check_authority_chain_valid` performs full cryptographic
-    /// Ed25519 signature verification over the canonical link payload
-    /// (grantor || grantee || permissions). When absent, only non-emptiness of
-    /// `signature` is checked (legacy path for links without embedded keys).
+    /// `check_authority_chain_valid` requires this key and performs Ed25519
+    /// signature verification over the canonical link payload
+    /// (grantor || grantee || permissions). Links without this key fail closed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub grantor_public_key: Option<Vec<u8>>,
 }
@@ -250,10 +249,10 @@ pub struct Provenance {
     pub signature: Vec<u8>,
     /// Ed25519 public key (32 bytes) of the actor.
     ///
-    /// When present, `check_provenance_verifiable` performs full cryptographic
-    /// Ed25519 signature verification over the canonical provenance payload:
+    /// `check_provenance_verifiable` requires this key and performs Ed25519
+    /// signature verification over the canonical provenance payload:
     /// `Hash256(actor_bytes || 0x00 || action_hash || 0x00 || timestamp_bytes)`.
-    /// When absent, only non-emptiness of `signature` is checked (legacy path).
+    /// Provenance without this key fails closed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub public_key: Option<Vec<u8>>,
     /// Whether this actor is human, synthetic (AI), or a system process.

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -3047,6 +3047,31 @@ mod tests {
     /// all non-provenance invariants.  Mirrors the context that
     /// `build_adjudication_context_from_db` would produce for an actor with
     /// a single role, one active consent record, and a one-link authority chain.
+    fn signed_authority_link(grantor: &Did, grantee: &Did) -> AuthorityLink {
+        let (public_key, secret_key) = generate_keypair();
+        let permissions = PermissionSet::new(vec![Permission::new("vote")]);
+
+        let mut payload = Vec::new();
+        payload.extend_from_slice(grantor.as_str().as_bytes());
+        payload.push(0x00);
+        payload.extend_from_slice(grantee.as_str().as_bytes());
+        payload.push(0x00);
+        for permission in &permissions.permissions {
+            payload.extend_from_slice(permission.0.as_bytes());
+            payload.push(0x00);
+        }
+        let message = Hash256::digest(&payload);
+        let signature = sign(message.as_bytes(), &secret_key);
+
+        AuthorityLink {
+            grantor: grantor.clone(),
+            grantee: grantee.clone(),
+            permissions,
+            signature: signature.to_bytes().to_vec(),
+            grantor_public_key: Some(public_key.as_bytes().to_vec()),
+        }
+    }
+
     fn valid_db_context(actor: &Did) -> AdjudicationContext {
         let root = Did::new("did:exo:root-grantor").unwrap();
         AdjudicationContext {
@@ -3055,14 +3080,7 @@ mod tests {
                 branch: GovernmentBranch::Executive,
             }],
             authority_chain: AuthorityChain {
-                links: vec![AuthorityLink {
-                    grantor: root.clone(),
-                    grantee: actor.clone(),
-                    permissions: PermissionSet::new(vec![Permission::new("vote")]),
-                    // Non-empty signature satisfies the legacy (no-public-key) path.
-                    signature: vec![0xAB; 8],
-                    grantor_public_key: None,
-                }],
+                links: vec![signed_authority_link(&root, actor)],
             },
             consent_records: vec![ConsentRecord {
                 subject: root.clone(),

--- a/crates/exo-gateway/tests/adjudication_db_integration.rs
+++ b/crates/exo-gateway/tests/adjudication_db_integration.rs
@@ -20,7 +20,7 @@
 
 use std::sync::{Arc, RwLock};
 
-use exo_core::Did;
+use exo_core::{Did, Hash256};
 use exo_gatekeeper::{
     ActionRequest, AdjudicationContext, Kernel,
     invariants::{ConstitutionalInvariant, InvariantSet},
@@ -72,6 +72,31 @@ fn vote_action(actor: &Did) -> ActionRequest {
     }
 }
 
+fn signed_authority_link(grantor: &Did, grantee: &Did) -> AuthorityLink {
+    let (public_key, secret_key) = exo_core::crypto::generate_keypair();
+    let permissions = PermissionSet::new(vec![Permission::new("vote")]);
+
+    let mut payload = Vec::new();
+    payload.extend_from_slice(grantor.as_str().as_bytes());
+    payload.push(0x00);
+    payload.extend_from_slice(grantee.as_str().as_bytes());
+    payload.push(0x00);
+    for permission in &permissions.permissions {
+        payload.extend_from_slice(permission.0.as_bytes());
+        payload.push(0x00);
+    }
+    let message = Hash256::digest(&payload);
+    let signature = exo_core::crypto::sign(message.as_bytes(), &secret_key);
+
+    AuthorityLink {
+        grantor: grantor.clone(),
+        grantee: grantee.clone(),
+        permissions,
+        signature: signature.to_bytes().to_vec(),
+        grantor_public_key: Some(public_key.as_bytes().to_vec()),
+    }
+}
+
 /// Construct a fully-valid `AdjudicationContext` that mirrors what
 /// `build_adjudication_context_from_db` would produce when the actor has a
 /// role, active consent, and a one-link authority chain.
@@ -83,13 +108,7 @@ fn full_db_context(actor: &Did) -> AdjudicationContext {
             branch: GovernmentBranch::Executive,
         }],
         authority_chain: AuthorityChain {
-            links: vec![AuthorityLink {
-                grantor: grantor.clone(),
-                grantee: actor.clone(),
-                permissions: PermissionSet::new(vec![Permission::new("vote")]),
-                signature: vec![0xAB; 8], // non-empty: satisfies legacy path
-                grantor_public_key: None,
-            }],
+            links: vec![signed_authority_link(&grantor, actor)],
         },
         consent_records: vec![ConsentRecord {
             subject: grantor.clone(),
@@ -241,13 +260,7 @@ fn revoked_consent_denies() {
             branch: GovernmentBranch::Executive,
         }],
         authority_chain: AuthorityChain {
-            links: vec![AuthorityLink {
-                grantor: grantor.clone(),
-                grantee: actor.clone(),
-                permissions: PermissionSet::new(vec![Permission::new("vote")]),
-                signature: vec![0xAB; 8],
-                grantor_public_key: None,
-            }],
+            links: vec![signed_authority_link(&grantor, &actor)],
         },
         consent_records: vec![ConsentRecord {
             subject: grantor.clone(),
@@ -309,7 +322,7 @@ fn cross_branch_roles_denies() {
 mod db_roundtrip {
     use std::sync::{Arc, RwLock};
 
-    use exo_core::Did;
+    use exo_core::{Did, Hash256};
     use exo_gatekeeper::{
         ActionRequest, Kernel,
         invariants::{ConstitutionalInvariant, InvariantSet},
@@ -345,6 +358,31 @@ mod db_roundtrip {
             required_permissions: PermissionSet::new(vec![Permission::new("vote")]),
             is_self_grant: false,
             modifies_kernel: false,
+        }
+    }
+
+    fn signed_authority_link(grantor: &Did, grantee: &Did) -> AuthorityLink {
+        let (public_key, secret_key) = exo_core::crypto::generate_keypair();
+        let permissions = PermissionSet::new(vec![Permission::new("vote")]);
+
+        let mut payload = Vec::new();
+        payload.extend_from_slice(grantor.as_str().as_bytes());
+        payload.push(0x00);
+        payload.extend_from_slice(grantee.as_str().as_bytes());
+        payload.push(0x00);
+        for permission in &permissions.permissions {
+            payload.extend_from_slice(permission.0.as_bytes());
+            payload.push(0x00);
+        }
+        let message = Hash256::digest(&payload);
+        let signature = exo_core::crypto::sign(message.as_bytes(), &secret_key);
+
+        AuthorityLink {
+            grantor: grantor.clone(),
+            grantee: grantee.clone(),
+            permissions,
+            signature: signature.to_bytes().to_vec(),
+            grantor_public_key: Some(public_key.as_bytes().to_vec()),
         }
     }
 
@@ -407,13 +445,7 @@ mod db_roundtrip {
         let actor = did(actor_did);
         let grantor = did(grantor_did);
         let chain = AuthorityChain {
-            links: vec![AuthorityLink {
-                grantor: grantor.clone(),
-                grantee: actor.clone(),
-                permissions: PermissionSet::new(vec![Permission::new("vote")]),
-                signature: vec![0xAB; 8], // non-empty: satisfies legacy path
-                grantor_public_key: None,
-            }],
+            links: vec![signed_authority_link(&grantor, &actor)],
         };
         let chain_json = serde_json::to_value(&chain).unwrap();
         sqlx::query(

--- a/crates/exo-legal/src/nist_compliance_tests.rs
+++ b/crates/exo-legal/src/nist_compliance_tests.rs
@@ -7,7 +7,7 @@
 #[cfg(test)]
 mod nist_compliance {
     use exo_authority::DelegateeKind;
-    use exo_core::{Did, Timestamp};
+    use exo_core::{Did, Hash256, Timestamp};
     use exo_gatekeeper::{
         InvariantEngine, McpRule,
         invariants::{ConstitutionalInvariant, InvariantContext, enforce_all},
@@ -44,8 +44,60 @@ mod nist_compliance {
         Uuid::from_u128(n)
     }
 
+    fn signed_authority_link(grantor: &Did, grantee: &Did) -> AuthorityLink {
+        let (public_key, secret_key) = exo_core::crypto::generate_keypair();
+        let permissions = PermissionSet::new(vec![Permission::new("read")]);
+
+        let mut payload = Vec::new();
+        payload.extend_from_slice(grantor.as_str().as_bytes());
+        payload.push(0x00);
+        payload.extend_from_slice(grantee.as_str().as_bytes());
+        payload.push(0x00);
+        for permission in &permissions.permissions {
+            payload.extend_from_slice(permission.0.as_bytes());
+            payload.push(0x00);
+        }
+        let message = Hash256::digest(&payload);
+        let signature = exo_core::crypto::sign(message.as_bytes(), &secret_key);
+
+        AuthorityLink {
+            grantor: grantor.clone(),
+            grantee: grantee.clone(),
+            permissions,
+            signature: signature.to_bytes().to_vec(),
+            grantor_public_key: Some(public_key.as_bytes().to_vec()),
+        }
+    }
+
+    fn signed_provenance(actor: &Did) -> Provenance {
+        let (public_key, secret_key) = exo_core::crypto::generate_keypair();
+        let timestamp = "2026-03-20T00:00:00Z".to_owned();
+        let action_hash = vec![1, 2, 3];
+
+        let mut payload = Vec::new();
+        payload.extend_from_slice(actor.as_str().as_bytes());
+        payload.push(0x00);
+        payload.extend_from_slice(&action_hash);
+        payload.push(0x00);
+        payload.extend_from_slice(timestamp.as_bytes());
+        let message = Hash256::digest(&payload);
+        let signature = exo_core::crypto::sign(message.as_bytes(), &secret_key);
+
+        Provenance {
+            actor: actor.clone(),
+            timestamp,
+            action_hash,
+            signature: signature.to_bytes().to_vec(),
+            public_key: Some(public_key.as_bytes().to_vec()),
+            voice_kind: None,
+            independence: None,
+            review_order: None,
+        }
+    }
+
     /// Build a passing InvariantContext matching the pattern in invariants.rs tests.
     fn passing_context(actor: &Did) -> InvariantContext {
+        let root = did("root");
         InvariantContext {
             actor: actor.clone(),
             actor_roles: vec![Role {
@@ -64,28 +116,13 @@ mod nist_compliance {
                 active: true,
             }],
             authority_chain: AuthorityChain {
-                links: vec![AuthorityLink {
-                    grantor: did("root"),
-                    grantee: actor.clone(),
-                    permissions: PermissionSet::new(vec![Permission::new("read")]),
-                    signature: vec![1, 2, 3],
-                    grantor_public_key: None,
-                }],
+                links: vec![signed_authority_link(&root, actor)],
             },
             is_self_grant: false,
             human_override_preserved: true,
             kernel_modification_attempted: false,
             quorum_evidence: None,
-            provenance: Some(Provenance {
-                actor: actor.clone(),
-                timestamp: "2026-03-20T00:00:00Z".into(),
-                action_hash: vec![1, 2, 3],
-                signature: vec![4, 5, 6],
-                public_key: None,
-                voice_kind: None,
-                independence: None,
-                review_order: None,
-            }),
+            provenance: Some(signed_provenance(actor)),
             actor_permissions: PermissionSet::new(vec![Permission::new("read")]),
             requested_permissions: PermissionSet::default(),
         }

--- a/crates/exo-node/src/holons.rs
+++ b/crates/exo-node/src/holons.rs
@@ -12,15 +12,14 @@
 //!
 //! # Audit status — Onyx-4 R5 (default-off runtime)
 //!
-//! The current infrastructure Holon adjudication context still uses sentinel
-//! authority and provenance signatures (`vec![1, 2, 3]`) with no Ed25519 public
-//! key. That means `ProvenanceVerifiable` can only confirm that bytes are
-//! present, not that the action was signed by a real infrastructure authority.
+//! The infrastructure Holon adjudication context now requires a configured
+//! Ed25519 authority key and signer. The authority chain and provenance are
+//! signed over the same canonical payloads enforced by `exo-gatekeeper`.
 //!
 //! The runtime background manager is therefore disabled by default behind the
 //! `unaudited-infrastructure-holons` feature flag. Enabling the feature means
-//! the operator accepts the recommendation-only Holon runtime while the real
-//! signed authority/provenance context is tracked in
+//! the operator accepts the recommendation-only Holon runtime while the
+//! product decision for shipping infrastructure Holons is tracked in
 //! `Initiatives/fix-onyx-4-r5-holons-stub-context.md`.
 //!
 //! ## Holons
@@ -37,9 +36,9 @@
 #![allow(clippy::expect_used, clippy::as_conversions, clippy::single_match)]
 #![cfg_attr(not(feature = "unaudited-infrastructure-holons"), allow(dead_code))]
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
-use exo_core::types::Did;
+use exo_core::{Hash256, PublicKey, Signature, types::Did};
 use exo_gatekeeper::{
     combinator::{Combinator, CombinatorInput, Predicate, TransformFn},
     holon::{self, Holon, HolonState},
@@ -118,12 +117,16 @@ pub enum HealthStatus {
 // ---------------------------------------------------------------------------
 
 /// Configuration for infrastructure Holons.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct HolonManagerConfig {
     /// This node's DID.
     pub node_did: Did,
     /// Root authority DID for the authority chain.
     pub root_did: Did,
+    /// Ed25519 public key for `root_did`.
+    pub root_public_key: PublicKey,
+    /// Signs canonical authority/provenance payload hashes for infrastructure Holon context.
+    pub root_signer: Arc<dyn Fn(&[u8]) -> Signature + Send + Sync>,
     /// How often to run the topology optimizer (seconds).
     pub topology_interval_secs: u64,
     /// How often to run the scaling advisor (seconds).
@@ -132,11 +135,32 @@ pub struct HolonManagerConfig {
     pub health_interval_secs: u64,
 }
 
+impl std::fmt::Debug for HolonManagerConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HolonManagerConfig")
+            .field("node_did", &self.node_did)
+            .field("root_did", &self.root_did)
+            .field("root_public_key", &self.root_public_key)
+            .field("topology_interval_secs", &self.topology_interval_secs)
+            .field("scaling_interval_secs", &self.scaling_interval_secs)
+            .field("health_interval_secs", &self.health_interval_secs)
+            .finish_non_exhaustive()
+    }
+}
+
 impl Default for HolonManagerConfig {
     fn default() -> Self {
+        let keypair = exo_core::crypto::KeyPair::from_secret_bytes([0x48; 32])
+            .expect("default infrastructure Holon key seed");
+        let root_public_key = *keypair.public_key();
+        let root_secret_key = keypair.secret_key().clone();
         Self {
             node_did: Did::new("did:exo:node-default").expect("default DID"),
             root_did: Did::new("did:exo:root").expect("root DID"),
+            root_public_key,
+            root_signer: Arc::new(move |message: &[u8]| {
+                exo_core::crypto::sign(message, &root_secret_key)
+            }),
             topology_interval_secs: 60,
             scaling_interval_secs: 300,
             health_interval_secs: 30,
@@ -260,6 +284,62 @@ pub fn create_infrastructure_kernel() -> Kernel {
 /// Infrastructure Holons operate under the Executive branch with
 /// read-only + recommend permissions. They cannot self-grant or
 /// modify the kernel.
+fn authority_link_message(grantor: &Did, grantee: &Did, permissions: &PermissionSet) -> Hash256 {
+    let mut payload = Vec::new();
+    payload.extend_from_slice(grantor.as_str().as_bytes());
+    payload.push(0x00);
+    payload.extend_from_slice(grantee.as_str().as_bytes());
+    payload.push(0x00);
+    for permission in &permissions.permissions {
+        payload.extend_from_slice(permission.0.as_bytes());
+        payload.push(0x00);
+    }
+    Hash256::digest(&payload)
+}
+
+fn provenance_message(actor: &Did, action_hash: &[u8], timestamp: &str) -> Hash256 {
+    let mut payload = Vec::new();
+    payload.extend_from_slice(actor.as_str().as_bytes());
+    payload.push(0x00);
+    payload.extend_from_slice(action_hash);
+    payload.push(0x00);
+    payload.extend_from_slice(timestamp.as_bytes());
+    Hash256::digest(&payload)
+}
+
+fn signed_authority_link(holon: &Holon, config: &HolonManagerConfig) -> AuthorityLink {
+    let message = authority_link_message(&config.root_did, &holon.id, &holon.capabilities);
+    let signature = (config.root_signer)(message.as_bytes());
+
+    AuthorityLink {
+        grantor: config.root_did.clone(),
+        grantee: holon.id.clone(),
+        permissions: holon.capabilities.clone(),
+        signature: signature.to_bytes().to_vec(),
+        grantor_public_key: Some(config.root_public_key.as_bytes().to_vec()),
+    }
+}
+
+fn signed_provenance(holon: &Holon, config: &HolonManagerConfig) -> Provenance {
+    let timestamp = "2026-04-27T00:00:00Z".to_owned();
+    let action_hash = Hash256::digest(format!("infrastructure-holon-step:{}", holon.id).as_bytes())
+        .as_bytes()
+        .to_vec();
+    let message = provenance_message(&holon.id, &action_hash, &timestamp);
+    let signature = (config.root_signer)(message.as_bytes());
+
+    Provenance {
+        actor: holon.id.clone(),
+        timestamp,
+        action_hash,
+        signature: signature.to_bytes().to_vec(),
+        public_key: Some(config.root_public_key.as_bytes().to_vec()),
+        voice_kind: None,
+        independence: None,
+        review_order: None,
+    }
+}
+
 pub fn build_holon_adjudication_context(
     holon: &Holon,
     config: &HolonManagerConfig,
@@ -270,13 +350,7 @@ pub fn build_holon_adjudication_context(
             branch: GovernmentBranch::Executive,
         }],
         authority_chain: AuthorityChain {
-            links: vec![AuthorityLink {
-                grantor: config.root_did.clone(),
-                grantee: holon.id.clone(),
-                permissions: holon.capabilities.clone(),
-                signature: vec![1, 2, 3], // Placeholder — real system uses Ed25519
-                grantor_public_key: None,
-            }],
+            links: vec![signed_authority_link(holon, config)],
         },
         consent_records: vec![ConsentRecord {
             subject: config.root_did.clone(),
@@ -291,16 +365,7 @@ pub fn build_holon_adjudication_context(
         },
         human_override_preserved: true,
         actor_permissions: holon.capabilities.clone(),
-        provenance: Some(Provenance {
-            actor: holon.id.clone(),
-            timestamp: "0".into(),
-            action_hash: vec![0; 32],
-            signature: vec![1, 2, 3], // Non-empty for ProvenanceVerifiable invariant
-            public_key: None,
-            voice_kind: None,
-            independence: None,
-            review_order: None,
-        }),
+        provenance: Some(signed_provenance(holon, config)),
         quorum_evidence: None,
         active_challenge_reason: None,
     }
@@ -694,10 +759,10 @@ mod tests {
     fn test_config() -> HolonManagerConfig {
         HolonManagerConfig {
             node_did: test_did(),
-            root_did: Did::new("did:exo:root").unwrap(),
             topology_interval_secs: 60,
             scaling_interval_secs: 300,
             health_interval_secs: 30,
+            ..HolonManagerConfig::default()
         }
     }
 
@@ -717,8 +782,8 @@ mod tests {
             "module doc must point at the R5 initiative"
         );
         assert!(
-            src.contains("vec![1, 2, 3]"),
-            "module doc must call out the sentinel adjudication signatures"
+            src.contains("Ed25519 authority key"),
+            "module doc must call out the signed adjudication authority"
         );
     }
 
@@ -948,12 +1013,12 @@ mod tests {
         let (event_tx, mut event_rx) = mpsc::channel(32);
         let config = HolonManagerConfig {
             node_did: test_did(),
-            root_did: Did::new("did:exo:root").unwrap(),
             // Health fires quickly; topology/scaling fire slowly to avoid
             // blocked peer_count() calls (no network loop in test).
             topology_interval_secs: 3600,
             scaling_interval_secs: 3600,
             health_interval_secs: 1,
+            ..HolonManagerConfig::default()
         };
 
         // Spawn a background task to drain network commands (prevents hangs).

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -397,9 +397,15 @@ async fn start_node(
     // --- Infrastructure Holons ---
     #[cfg(feature = "unaudited-infrastructure-holons")]
     {
+        let holon_identity = identity::load_or_create(data_dir)?;
+        let holon_authority_did = holon_identity.did.clone();
+        let holon_authority_public_key = *holon_identity.public_key();
+        let holon_authority_signer = Arc::new(move |message: &[u8]| holon_identity.sign(message));
         let holon_config = HolonManagerConfig {
             node_did: node_identity.did.clone(),
-            root_did: Did::new("did:exo:root").unwrap_or_else(|_| node_identity.did.clone()),
+            root_did: holon_authority_did,
+            root_public_key: holon_authority_public_key,
+            root_signer: holon_authority_signer,
             topology_interval_secs: 60,
             scaling_interval_secs: 300,
             health_interval_secs: 30,
@@ -502,7 +508,7 @@ async fn start_node(
         enabled = holons::infrastructure_holons_enabled(),
         feature_flag = holons::INFRASTRUCTURE_HOLONS_FEATURE,
         initiative = holons::INFRASTRUCTURE_HOLONS_INITIATIVE,
-        "Infrastructure Holons disabled: adjudication context still uses sentinel signatures"
+        "Infrastructure Holons disabled pending product disposition"
     );
 
     // NOTE: /health and /ready are provided by the gateway (exo-gateway)
@@ -829,6 +835,15 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             } else {
                 node_identity.did.clone()
             };
+            if did != node_identity.did {
+                return Err(anyhow::anyhow!(
+                    "MCP actor DID must match the local node identity DID for signed adjudication"
+                ));
+            }
+            let node_identity_for_log = node_identity.did.clone();
+            let mcp_authority_did = node_identity.did.clone();
+            let mcp_authority_public_key = *node_identity.public_key();
+            let mcp_authority_signer = Arc::new(move |message: &[u8]| node_identity.sign(message));
 
             // The standalone `exochain mcp` command does NOT connect to a
             // running node, so we spin up the MCP server with an empty
@@ -840,17 +855,22 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             // context)` where `context` carries the `SharedReactorState`
             // and the `Arc<Mutex<SqliteDagStore>>` so tools return real
             // runtime data.
-            let server = mcp::McpServer::new(did);
+            let server = mcp::McpServer::with_authority(
+                did,
+                mcp_authority_did,
+                mcp_authority_public_key,
+                mcp_authority_signer,
+            );
 
             if let Some(bind) = sse {
                 eprintln!("[exochain-mcp] Starting MCP server on SSE at {bind}...");
-                eprintln!("[exochain-mcp] Node identity: {}", node_identity.did);
+                eprintln!("[exochain-mcp] Node identity: {}", node_identity_for_log);
                 mcp::serve_sse(server, &bind)
                     .await
                     .map_err(|e| anyhow::anyhow!("MCP SSE server error: {e}"))
             } else {
                 eprintln!("[exochain-mcp] Starting MCP server on stdio...");
-                eprintln!("[exochain-mcp] Node identity: {}", node_identity.did);
+                eprintln!("[exochain-mcp] Node identity: {}", node_identity_for_log);
                 mcp::serve_stdio(server)
                     .await
                     .map_err(|e| anyhow::anyhow!("MCP stdio server error: {e}"))

--- a/crates/exo-node/src/mcp/handler.rs
+++ b/crates/exo-node/src/mcp/handler.rs
@@ -5,9 +5,9 @@
 //! constitutional constraints through the middleware, and returns properly
 //! formatted JSON-RPC responses.
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::Arc};
 
-use exo_core::Did;
+use exo_core::{Did, PublicKey, Signature};
 use serde_json::Value;
 
 use super::{
@@ -39,21 +39,25 @@ pub struct McpServer {
 }
 
 impl McpServer {
-    /// Create a new MCP server for the given actor DID.
-    ///
-    /// Initializes the tool registry with all built-in tools and creates
-    /// a constitutional middleware instance with the full kernel. The
-    /// runtime context is empty — tools that query live node state will
-    /// fall back to template responses. Use `with_context` to bind a
-    /// running node's reactor and DAG store.
+    /// Create a new MCP server with a configured authority signer for
+    /// constitutional adjudication.
     #[must_use]
-    pub fn new(actor_did: Did) -> Self {
+    pub fn with_authority(
+        actor_did: Did,
+        authority_did: Did,
+        authority_public_key: PublicKey,
+        authority_signer: Arc<dyn Fn(&[u8]) -> Signature + Send + Sync>,
+    ) -> Self {
         Self {
             actor_did,
             registry: ToolRegistry::default(),
             resources: ResourceRegistry::default(),
             prompts: PromptRegistry::default(),
-            middleware: ConstitutionalMiddleware::new(),
+            middleware: ConstitutionalMiddleware::with_authority(
+                authority_did,
+                authority_public_key,
+                authority_signer,
+            ),
             context: NodeContext::empty(),
         }
     }
@@ -73,6 +77,30 @@ impl McpServer {
             resources: ResourceRegistry::default(),
             prompts: PromptRegistry::default(),
             middleware: ConstitutionalMiddleware::new(),
+            context,
+        }
+    }
+
+    /// Create a context-bound MCP server with a configured authority signer.
+    #[must_use]
+    #[allow(dead_code)]
+    pub fn with_context_and_authority(
+        actor_did: Did,
+        context: NodeContext,
+        authority_did: Did,
+        authority_public_key: PublicKey,
+        authority_signer: Arc<dyn Fn(&[u8]) -> Signature + Send + Sync>,
+    ) -> Self {
+        Self {
+            actor_did,
+            registry: ToolRegistry::default(),
+            resources: ResourceRegistry::default(),
+            prompts: PromptRegistry::default(),
+            middleware: ConstitutionalMiddleware::with_authority(
+                authority_did,
+                authority_public_key,
+                authority_signer,
+            ),
             context,
         }
     }
@@ -425,7 +453,16 @@ mod tests {
     use super::*;
 
     fn test_server() -> McpServer {
-        McpServer::new(Did::new("did:exo:test-ai-agent").expect("valid DID"))
+        let did = Did::new("did:exo:test-ai-agent").expect("valid DID");
+        let keypair = exo_core::crypto::KeyPair::from_secret_bytes([0x4D; 32]).unwrap();
+        let public_key = *keypair.public_key();
+        let secret_key = keypair.secret_key().clone();
+        McpServer::with_authority(
+            did.clone(),
+            did,
+            public_key,
+            Arc::new(move |message: &[u8]| exo_core::crypto::sign(message, &secret_key)),
+        )
     }
 
     #[test]

--- a/crates/exo-node/src/mcp/middleware.rs
+++ b/crates/exo-node/src/mcp/middleware.rs
@@ -16,8 +16,8 @@
 //!   - `consent_active: true`
 //!   - `output_marked_ai: true`
 //!   - `human_override_preserved: true`
-//!   - authority chain: synthetic root → actor with `signature: vec![1, 2, 3]`
-//!   - provenance: `action_hash: vec![1, 2, 3]`, `signature: vec![4, 5, 6]`
+//!   - authority chain: configured MCP authority → actor
+//!   - provenance: configured MCP authority signature over the tool action
 //!
 //! These sentinels mean the middleware cannot actually fail on
 //! `ProvenancePresent`, `ConsentRequired`, or `HumanOverride` —
@@ -37,7 +37,8 @@
 //! governance fabric.
 //!
 //! **When RED #2 is resolved (real reactor wiring), this middleware
-//! MUST be rewritten first.** A rewrite must either:
+//! MUST be promoted from node-level authority to live delegated authority.**
+//! A rewrite must either:
 //!   (a) accept real `McpContext` / `AdjudicationContext` from the
 //!       caller and verify the embedded signatures/provenance, or
 //!   (b) decline to adjudicate (return Err) when it cannot construct
@@ -49,7 +50,9 @@
 //! reading the code — DO NOT remove the audit-status section when
 //! adjusting this middleware.
 
-use exo_core::{Did, Hash256, SignerType};
+use std::sync::Arc;
+
+use exo_core::{Did, Hash256, PublicKey, Signature, SignerType};
 use exo_gatekeeper::{
     invariants::InvariantSet,
     kernel::{ActionRequest, AdjudicationContext, Kernel, Verdict},
@@ -68,6 +71,13 @@ use super::error::{McpError, Result};
 /// constitution and all 8 constitutional invariants.
 pub struct ConstitutionalMiddleware {
     kernel: Kernel,
+    authority: Option<McpAuthority>,
+}
+
+struct McpAuthority {
+    did: Did,
+    public_key: PublicKey,
+    signer: Arc<dyn Fn(&[u8]) -> Signature + Send + Sync>,
 }
 
 impl ConstitutionalMiddleware {
@@ -80,17 +90,45 @@ impl ConstitutionalMiddleware {
     #[must_use]
     pub fn new() -> Self {
         tracing::warn!(
-            "mcp::ConstitutionalMiddleware initialized with STUB \
-             adjudication context (has_provenance/consent_active/ \
-             human_override_preserved hardcoded true; signatures are \
-             sentinel vec![1,2,3]/vec![4,5,6]). This middleware only \
-             rubber-stamps read-only MCP tools — mutating tools MUST \
-             be gated separately (see unaudited-mcp-simulation-tools \
-             feature flag). Tracked in \
+            "mcp::ConstitutionalMiddleware initialized without an MCP \
+             authority signer; tool adjudication fails closed until \
+             ConstitutionalMiddleware::with_authority is used."
+        );
+        let kernel = Kernel::new(b"EXOCHAIN Constitutional Trust Fabric", InvariantSet::all());
+        Self {
+            kernel,
+            authority: None,
+        }
+    }
+
+    /// Create middleware bound to a caller-supplied MCP authority signer.
+    ///
+    /// The authority is used to sign the canonical authority/provenance payload
+    /// hashes that the gatekeeper verifies. The surrounding MCP context still
+    /// carries hardcoded consent/provenance booleans until
+    /// `fix-mcp-simulation-tools.md` is resolved.
+    #[must_use]
+    pub fn with_authority(
+        authority_did: Did,
+        authority_public_key: PublicKey,
+        authority_signer: Arc<dyn Fn(&[u8]) -> Signature + Send + Sync>,
+    ) -> Self {
+        tracing::warn!(
+            "mcp::ConstitutionalMiddleware initialized with configured \
+             authority signer but hardcoded MCP context booleans \
+             (has_provenance/consent_active/human_override_preserved). \
+             Mutating tools MUST remain gated separately. Tracked in \
              Initiatives/fix-mcp-simulation-tools.md."
         );
         let kernel = Kernel::new(b"EXOCHAIN Constitutional Trust Fabric", InvariantSet::all());
-        Self { kernel }
+        Self {
+            kernel,
+            authority: Some(McpAuthority {
+                did: authority_did,
+                public_key: authority_public_key,
+                signer: authority_signer,
+            }),
+        }
     }
 
     /// Enforce all 6 MCP rules against the AI actor's context.
@@ -119,6 +157,55 @@ impl ConstitutionalMiddleware {
         })
     }
 
+    fn signed_authority_link(authority: &McpAuthority, grantee: &Did) -> AuthorityLink {
+        let permissions = PermissionSet::new(vec![Permission::new("mcp:tool_call")]);
+
+        let mut payload = Vec::new();
+        payload.extend_from_slice(authority.did.as_str().as_bytes());
+        payload.push(0x00);
+        payload.extend_from_slice(grantee.as_str().as_bytes());
+        payload.push(0x00);
+        for permission in &permissions.permissions {
+            payload.extend_from_slice(permission.0.as_bytes());
+            payload.push(0x00);
+        }
+        let message = Hash256::digest(&payload);
+        let signature = (authority.signer)(message.as_bytes());
+
+        AuthorityLink {
+            grantor: authority.did.clone(),
+            grantee: grantee.clone(),
+            permissions,
+            signature: signature.to_bytes().to_vec(),
+            grantor_public_key: Some(authority.public_key.as_bytes().to_vec()),
+        }
+    }
+
+    fn signed_provenance(authority: &McpAuthority, actor: &Did, action: &str) -> Provenance {
+        let timestamp = "2026-01-01T00:00:00Z".to_owned();
+        let action_hash = Hash256::digest(action.as_bytes()).as_bytes().to_vec();
+
+        let mut payload = Vec::new();
+        payload.extend_from_slice(actor.as_str().as_bytes());
+        payload.push(0x00);
+        payload.extend_from_slice(&action_hash);
+        payload.push(0x00);
+        payload.extend_from_slice(timestamp.as_bytes());
+        let message = Hash256::digest(&payload);
+        let signature = (authority.signer)(message.as_bytes());
+
+        Provenance {
+            actor: actor.clone(),
+            timestamp,
+            action_hash,
+            signature: signature.to_bytes().to_vec(),
+            public_key: Some(authority.public_key.as_bytes().to_vec()),
+            voice_kind: None,
+            independence: None,
+            review_order: None,
+        }
+    }
+
     /// Adjudicate an action against all 8 constitutional invariants.
     ///
     /// Builds an `ActionRequest` and `AdjudicationContext` with reasonable
@@ -134,8 +221,14 @@ impl ConstitutionalMiddleware {
             modifies_kernel: false,
         };
 
-        #[allow(clippy::expect_used)] // Static string is always a valid DID.
-        let root_did = Did::new("did:exo:root").expect("static DID is valid");
+        let authority = self.authority.as_ref().ok_or_else(|| {
+            McpError::ConstitutionalViolation(
+                "MCP authority signer is required for kernel adjudication".into(),
+            )
+        })?;
+        if actor_did != &authority.did {
+            return Err(McpError::AuthenticationRequired);
+        }
 
         let adj_context = AdjudicationContext {
             actor_roles: vec![Role {
@@ -143,37 +236,22 @@ impl ConstitutionalMiddleware {
                 branch: GovernmentBranch::Judicial,
             }],
             authority_chain: AuthorityChain {
-                links: vec![AuthorityLink {
-                    grantor: root_did.clone(),
-                    grantee: actor_did.clone(),
-                    permissions: PermissionSet::new(vec![Permission::new("mcp:tool_call")]),
-                    signature: vec![1, 2, 3],
-                    grantor_public_key: None,
-                }],
+                links: vec![Self::signed_authority_link(authority, actor_did)],
             },
             consent_records: vec![ConsentRecord {
-                subject: root_did.clone(),
+                subject: authority.did.clone(),
                 granted_to: actor_did.clone(),
                 scope: "mcp:tools".into(),
                 active: true,
             }],
             bailment_state: BailmentState::Active {
-                bailor: root_did,
+                bailor: authority.did.clone(),
                 bailee: actor_did.clone(),
                 scope: "mcp:tools".into(),
             },
             human_override_preserved: true,
             actor_permissions: PermissionSet::new(vec![Permission::new("mcp:tool_call")]),
-            provenance: Some(Provenance {
-                actor: actor_did.clone(),
-                timestamp: "2026-01-01T00:00:00Z".into(),
-                action_hash: vec![1, 2, 3],
-                signature: vec![4, 5, 6],
-                public_key: None,
-                voice_kind: None,
-                independence: None,
-                review_order: None,
-            }),
+            provenance: Some(Self::signed_provenance(authority, actor_did, action)),
             quorum_evidence: None,
             active_challenge_reason: None,
         };
@@ -221,9 +299,20 @@ mod tests {
         Did::new("did:exo:ai-agent-mcp").expect("valid DID")
     }
 
+    fn signed_middleware() -> ConstitutionalMiddleware {
+        let keypair = exo_core::crypto::KeyPair::from_secret_bytes([0x4D; 32]).unwrap();
+        let public_key = *keypair.public_key();
+        let secret_key = keypair.secret_key().clone();
+        ConstitutionalMiddleware::with_authority(
+            test_did(),
+            public_key,
+            Arc::new(move |message: &[u8]| exo_core::crypto::sign(message, &secret_key)),
+        )
+    }
+
     #[test]
     fn middleware_permits_valid_action() {
-        let mw = ConstitutionalMiddleware::new();
+        let mw = signed_middleware();
         let did = test_did();
         assert!(mw.enforce(&did, "exochain_node_status").is_ok());
     }
@@ -237,10 +326,17 @@ mod tests {
 
     #[test]
     fn middleware_adjudicate_permits_valid() {
-        let mw = ConstitutionalMiddleware::new();
+        let mw = signed_middleware();
         let did = test_did();
         let verdict = mw.adjudicate(&did, "exochain_node_status").unwrap();
         assert!(verdict.is_permitted());
+    }
+
+    #[test]
+    fn middleware_adjudicate_without_authority_fails_closed() {
+        let mw = ConstitutionalMiddleware::new();
+        let did = test_did();
+        assert!(mw.adjudicate(&did, "exochain_node_status").is_err());
     }
 
     #[test]

--- a/crates/exo-node/src/mcp/mod.rs
+++ b/crates/exo-node/src/mcp/mod.rs
@@ -152,9 +152,16 @@ mod sse_tests {
     use super::*;
 
     fn test_router() -> Router {
+        let did = exo_core::Did::new("did:exo:test").expect("valid DID");
+        let keypair = exo_core::crypto::KeyPair::from_secret_bytes([0x4D; 32]).unwrap();
+        let public_key = *keypair.public_key();
+        let secret_key = keypair.secret_key().clone();
         let state = SseState {
-            server: Arc::new(McpServer::new(
-                exo_core::Did::new("did:exo:test").expect("valid DID"),
+            server: Arc::new(McpServer::with_authority(
+                did.clone(),
+                did,
+                public_key,
+                Arc::new(move |message: &[u8]| exo_core::crypto::sign(message, &secret_key)),
             )),
         };
         build_sse_router(state)

--- a/crates/exochain-sdk/README.md
+++ b/crates/exochain-sdk/README.md
@@ -80,7 +80,8 @@ fn main() -> Result<(), ExoError> {
     assert_eq!(chain.depth, 2);
 
     // 5. Ask the kernel whether bob may perform the action.
-    let kernel = ConstitutionalKernel::new();
+    // The SDK kernel requires caller-supplied authority signing material.
+    let kernel = ConstitutionalKernel::with_authority_identity(root);
     let verdict = kernel.adjudicate(bob.did(), "data:medical:read");
     assert!(verdict.is_permitted());
 
@@ -217,23 +218,26 @@ terminal mismatch.
 
 [`ConstitutionalKernel`](src/kernel.rs) is a simplified wrapper over
 [`exo_gatekeeper::Kernel`]. It initialises the kernel with the default
-EXOCHAIN constitution and all eight invariants, and exposes
-`adjudicate(actor, action)` with reasonable defaults.
+EXOCHAIN constitution and all eight invariants. Adjudication requires
+caller-supplied authority signing material, so the SDK does not fabricate a
+trust root.
 
 ```rust
 use exochain_sdk::kernel::ConstitutionalKernel;
+use exochain_sdk::identity::Identity;
 use exo_core::Did;
 
-let kernel = ConstitutionalKernel::new();
+let authority = Identity::generate("authority");
+let kernel = ConstitutionalKernel::with_authority_identity(authority);
 let actor = Did::new("did:exo:alice").expect("valid");
 
 let verdict = kernel.adjudicate(&actor, "data:medical:read");
 assert!(verdict.is_permitted());
 ```
 
-The SDK supplies a permissive default context (single Judicial role, one-link
-authority chain, active bailment, preserved human override). Targeted helpers
-exercise specific invariants:
+The SDK supplies a minimal signed default context (single Judicial role,
+one-link authority chain, active bailment, preserved human override). Targeted
+helpers exercise specific invariants:
 
 - `adjudicate_self_grant` — enables `NoSelfGrant` enforcement.
 - `adjudicate_kernel_modification` — enables `KernelImmutability` enforcement.

--- a/crates/exochain-sdk/src/kernel.rs
+++ b/crates/exochain-sdk/src/kernel.rs
@@ -10,8 +10,8 @@
 //! [`ConstitutionalKernel`] is a simplified, ergonomic wrapper around
 //! [`exo_gatekeeper::Kernel`]. It initialises the kernel with the default
 //! EXOCHAIN constitution text and the full set of eight constitutional
-//! invariants, and exposes a minimal [`ConstitutionalKernel::adjudicate`]
-//! that supplies reasonable defaults for the adjudication context.
+//! invariants. Adjudication requires caller-supplied authority signing material
+//! so the SDK never fabricates a trust root.
 //!
 //! ## Why use this module
 //!
@@ -29,13 +29,16 @@
 //! use exochain_sdk::kernel::ConstitutionalKernel;
 //! use exo_core::Did;
 //!
-//! let kernel = ConstitutionalKernel::new();
+//! let authority = exochain_sdk::identity::Identity::generate("authority");
+//! let kernel = ConstitutionalKernel::with_authority_identity(authority);
 //! let actor = Did::new("did:exo:alice").expect("valid");
 //! let verdict = kernel.adjudicate(&actor, "data:medical:read");
 //! assert!(verdict.is_permitted());
 //! ```
 
-use exo_core::Did;
+use std::sync::Arc;
+
+use exo_core::{Did, Hash256, PublicKey, Signature};
 use exo_gatekeeper::{
     ActionRequest, AdjudicationContext, InvariantSet, Kernel, Verdict,
     types::{
@@ -136,10 +139,10 @@ impl KernelVerdict {
 /// An ergonomic wrapper around the CGR [`Kernel`].
 ///
 /// Provides a minimal adjudication interface suitable for common SDK use
-/// cases: a single actor performing an action, with default provenance and
-/// an active bailment to a sentinel bailor. Callers needing fine-grained
-/// control over the adjudication context should use [`exo_gatekeeper::Kernel`]
-/// directly.
+/// cases: a single actor performing an action, with caller-supplied authority
+/// signing material, signed provenance, and an active bailment from that
+/// authority. Callers needing fine-grained control over the adjudication
+/// context should use [`exo_gatekeeper::Kernel`] directly.
 ///
 /// # Examples
 ///
@@ -147,7 +150,8 @@ impl KernelVerdict {
 /// use exochain_sdk::kernel::ConstitutionalKernel;
 /// use exo_core::Did;
 ///
-/// let kernel = ConstitutionalKernel::new();
+/// let authority = exochain_sdk::identity::Identity::generate("authority");
+/// let kernel = ConstitutionalKernel::with_authority_identity(authority);
 /// assert!(kernel.verify_integrity());
 /// assert_eq!(kernel.invariant_count(), 8);
 ///
@@ -158,6 +162,15 @@ impl KernelVerdict {
 pub struct ConstitutionalKernel {
     inner: Kernel,
     constitution: Vec<u8>,
+    authority: Option<KernelAuthority>,
+}
+
+type AuthoritySigner = Arc<dyn Fn(&[u8]) -> Signature + Send + Sync>;
+
+struct KernelAuthority {
+    did: Did,
+    public_key: PublicKey,
+    signer: AuthoritySigner,
 }
 
 impl ConstitutionalKernel {
@@ -177,18 +190,87 @@ impl ConstitutionalKernel {
         Self {
             inner: Kernel::new(DEFAULT_CONSTITUTION, InvariantSet::all()),
             constitution: DEFAULT_CONSTITUTION.to_vec(),
+            authority: None,
         }
     }
 
-    /// Adjudicate `action` performed by `actor` using reasonable defaults.
+    /// Construct a new kernel with an authority signing identity.
     ///
-    /// The SDK supplies a permissive default context:
+    /// This is the common SDK path: the identity's DID becomes the authority
+    /// grantor and bailor for the default adjudication context, and its secret
+    /// key signs the canonical authority/provenance payloads that the kernel
+    /// verifies.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use exochain_sdk::{identity::Identity, kernel::ConstitutionalKernel};
+    /// let authority = Identity::generate("authority");
+    /// let kernel = ConstitutionalKernel::with_authority_identity(authority);
+    /// assert!(kernel.verify_integrity());
+    /// ```
+    #[must_use]
+    pub fn with_authority_identity(authority: crate::identity::Identity) -> Self {
+        let authority_did = authority.did().clone();
+        let authority_public_key = *authority.public_key();
+        Self::with_authority(
+            authority_did,
+            authority_public_key,
+            Arc::new(move |message: &[u8]| authority.sign(message)),
+        )
+    }
+
+    /// Construct a new kernel with caller-supplied authority signing material.
+    ///
+    /// The signer must produce an Ed25519 signature over the message bytes it
+    /// receives. The supplied public key is embedded in the adjudication
+    /// context, and the gatekeeper verifies every signature cryptographically.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::sync::Arc;
+    /// # use exochain_sdk::{crypto, kernel::ConstitutionalKernel};
+    /// let authority_did = crypto::Did::new("did:exo:authority").expect("valid");
+    /// let (authority_public_key, authority_secret_key) = crypto::generate_keypair();
+    /// let kernel = ConstitutionalKernel::with_authority(
+    ///     authority_did,
+    ///     authority_public_key,
+    ///     Arc::new(move |message: &[u8]| crypto::sign(message, &authority_secret_key)),
+    /// );
+    /// assert!(kernel.verify_integrity());
+    /// ```
+    #[must_use]
+    pub fn with_authority(
+        authority_did: Did,
+        authority_public_key: PublicKey,
+        authority_signer: AuthoritySigner,
+    ) -> Self {
+        Self {
+            inner: Kernel::new(DEFAULT_CONSTITUTION, InvariantSet::all()),
+            constitution: DEFAULT_CONSTITUTION.to_vec(),
+            authority: Some(KernelAuthority {
+                did: authority_did,
+                public_key: authority_public_key,
+                signer: authority_signer,
+            }),
+        }
+    }
+
+    /// Adjudicate `action` performed by `actor` using the signed SDK context.
+    ///
+    /// The SDK supplies a minimal signed default context:
     /// - A single Judicial role for `actor`.
-    /// - A one-link authority chain `did:exo:root -> actor` granting `read`.
-    /// - An active bailment from `did:exo:sdk-bailor -> actor` scoped to
+    /// - A one-link authority chain from the configured authority to `actor`
+    ///   granting `read`.
+    /// - An active bailment from the configured authority to `actor` scoped to
     ///   `action`.
     /// - Full human-override preservation.
     /// - Signed provenance with timestamp `"sdk"`.
+    ///
+    /// If the kernel was created with [`Self::new`] rather than
+    /// [`Self::with_authority`] or [`Self::with_authority_identity`], this
+    /// method fails closed with a denied verdict.
     ///
     /// Callers needing richer context should reach for
     /// [`exo_gatekeeper::Kernel`] directly.
@@ -206,7 +288,8 @@ impl ConstitutionalKernel {
     /// use exochain_sdk::kernel::ConstitutionalKernel;
     /// use exo_core::Did;
     ///
-    /// let kernel = ConstitutionalKernel::new();
+    /// let authority = exochain_sdk::identity::Identity::generate("authority");
+    /// let kernel = ConstitutionalKernel::with_authority_identity(authority);
     /// let actor = Did::new("did:exo:alice").expect("valid");
     /// let verdict = kernel.adjudicate(&actor, "data:read");
     /// assert!(verdict.is_permitted());
@@ -228,7 +311,8 @@ impl ConstitutionalKernel {
     /// use exochain_sdk::kernel::ConstitutionalKernel;
     /// use exo_core::Did;
     ///
-    /// let kernel = ConstitutionalKernel::new();
+    /// let authority = exochain_sdk::identity::Identity::generate("authority");
+    /// let kernel = ConstitutionalKernel::with_authority_identity(authority);
     /// let actor = Did::new("did:exo:self-granter").expect("valid");
     /// let verdict = kernel.adjudicate_self_grant(&actor, "escalate-self");
     /// assert!(verdict.is_denied());
@@ -247,7 +331,8 @@ impl ConstitutionalKernel {
     /// use exochain_sdk::kernel::ConstitutionalKernel;
     /// use exo_core::Did;
     ///
-    /// let kernel = ConstitutionalKernel::new();
+    /// let authority = exochain_sdk::identity::Identity::generate("authority");
+    /// let kernel = ConstitutionalKernel::with_authority_identity(authority);
     /// let actor = Did::new("did:exo:patcher").expect("valid");
     /// let verdict = kernel.adjudicate_kernel_modification(&actor, "patch-kernel");
     /// assert!(verdict.is_denied());
@@ -266,7 +351,8 @@ impl ConstitutionalKernel {
     /// use exochain_sdk::kernel::ConstitutionalKernel;
     /// use exo_core::Did;
     ///
-    /// let kernel = ConstitutionalKernel::new();
+    /// let authority = exochain_sdk::identity::Identity::generate("authority");
+    /// let kernel = ConstitutionalKernel::with_authority_identity(authority);
     /// let actor = Did::new("did:exo:unauth").expect("valid");
     /// let verdict = kernel.adjudicate_without_bailment(&actor, "read-data");
     /// assert!(verdict.is_denied());
@@ -309,7 +395,57 @@ impl ConstitutionalKernel {
         INVARIANT_COUNT
     }
 
-    #[allow(clippy::expect_used)] // "did:exo:sdk-bailor" and "did:exo:root" are compile-time valid DIDs
+    fn signed_authority_link(
+        authority: &KernelAuthority,
+        grantee: &Did,
+        permissions: &PermissionSet,
+    ) -> AuthorityLink {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(authority.did.as_str().as_bytes());
+        payload.push(0x00);
+        payload.extend_from_slice(grantee.as_str().as_bytes());
+        payload.push(0x00);
+        for permission in &permissions.permissions {
+            payload.extend_from_slice(permission.0.as_bytes());
+            payload.push(0x00);
+        }
+        let message = Hash256::digest(&payload);
+        let signature = (authority.signer)(message.as_bytes());
+
+        AuthorityLink {
+            grantor: authority.did.clone(),
+            grantee: grantee.clone(),
+            permissions: permissions.clone(),
+            signature: signature.to_bytes().to_vec(),
+            grantor_public_key: Some(authority.public_key.as_bytes().to_vec()),
+        }
+    }
+
+    fn signed_provenance(authority: &KernelAuthority, actor: &Did, action: &str) -> Provenance {
+        let timestamp = "sdk".to_owned();
+        let action_hash = Hash256::digest(action.as_bytes()).as_bytes().to_vec();
+
+        let mut payload = Vec::new();
+        payload.extend_from_slice(actor.as_str().as_bytes());
+        payload.push(0x00);
+        payload.extend_from_slice(&action_hash);
+        payload.push(0x00);
+        payload.extend_from_slice(timestamp.as_bytes());
+        let message = Hash256::digest(&payload);
+        let signature = (authority.signer)(message.as_bytes());
+
+        Provenance {
+            actor: actor.clone(),
+            timestamp,
+            action_hash,
+            signature: signature.to_bytes().to_vec(),
+            public_key: Some(authority.public_key.as_bytes().to_vec()),
+            voice_kind: None,
+            independence: None,
+            review_order: None,
+        }
+    }
+
     fn adjudicate_internal(
         &self,
         actor: &Did,
@@ -319,6 +455,14 @@ impl ConstitutionalKernel {
         include_bailment: bool,
         human_override_preserved: bool,
     ) -> KernelVerdict {
+        let Some(authority) = self.authority.as_ref() else {
+            return KernelVerdict::Denied {
+                violations: vec![
+                    "AuthorityChainValid: SDK authority signer is required for adjudication".into(),
+                ],
+            };
+        };
+
         let permissions = PermissionSet::new(vec![Permission::new("read")]);
         let request = ActionRequest {
             actor: actor.clone(),
@@ -328,18 +472,17 @@ impl ConstitutionalKernel {
             modifies_kernel,
         };
 
-        let bailor = Did::new("did:exo:sdk-bailor").expect("sdk-bailor is a well-formed DID");
         let scope = action.to_owned();
 
         let (bailment_state, consent_records) = if include_bailment {
             (
                 BailmentState::Active {
-                    bailor: bailor.clone(),
+                    bailor: authority.did.clone(),
                     bailee: actor.clone(),
                     scope: scope.clone(),
                 },
                 vec![ConsentRecord {
-                    subject: bailor,
+                    subject: authority.did.clone(),
                     granted_to: actor.clone(),
                     scope,
                     active: true,
@@ -355,28 +498,13 @@ impl ConstitutionalKernel {
                 branch: GovernmentBranch::Judicial,
             }],
             authority_chain: AuthorityChain {
-                links: vec![AuthorityLink {
-                    grantor: Did::new("did:exo:root").expect("did:exo:root is a well-formed DID"),
-                    grantee: actor.clone(),
-                    permissions: permissions.clone(),
-                    signature: vec![1],
-                    grantor_public_key: None,
-                }],
+                links: vec![Self::signed_authority_link(authority, actor, &permissions)],
             },
             consent_records,
             bailment_state,
             human_override_preserved,
             actor_permissions: permissions,
-            provenance: Some(Provenance {
-                actor: actor.clone(),
-                timestamp: "sdk".into(),
-                action_hash: vec![1],
-                signature: vec![1],
-                public_key: None,
-                voice_kind: None,
-                independence: None,
-                review_order: None,
-            }),
+            provenance: Some(Self::signed_provenance(authority, actor, action)),
             quorum_evidence: None,
             active_challenge_reason: None,
         };
@@ -421,6 +549,12 @@ mod tests {
         Did::new(s).expect("valid DID")
     }
 
+    fn signed_kernel() -> ConstitutionalKernel {
+        ConstitutionalKernel::with_authority_identity(crate::identity::Identity::generate(
+            "sdk-authority",
+        ))
+    }
+
     #[test]
     fn new_initialises_with_eight_invariants() {
         let k = ConstitutionalKernel::new();
@@ -443,7 +577,7 @@ mod tests {
 
     #[test]
     fn valid_action_permitted() {
-        let k = ConstitutionalKernel::new();
+        let k = signed_kernel();
         let actor = did("did:exo:valid-actor");
         let verdict = k.adjudicate(&actor, "read-medical-record");
         assert!(
@@ -453,8 +587,22 @@ mod tests {
     }
 
     #[test]
-    fn self_grant_denied() {
+    fn adjudicate_without_authority_signer_fails_closed() {
         let k = ConstitutionalKernel::new();
+        let actor = did("did:exo:valid-actor");
+        let verdict = k.adjudicate(&actor, "read-medical-record");
+        assert!(verdict.is_denied(), "expected Denied, got {verdict:?}");
+        match verdict {
+            KernelVerdict::Denied { violations } => {
+                assert!(violations.iter().any(|v| v.contains("authority signer")));
+            }
+            other => panic!("expected Denied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn self_grant_denied() {
+        let k = signed_kernel();
         let actor = did("did:exo:self-granter");
         let verdict = k.adjudicate_self_grant(&actor, "escalate-self");
         assert!(verdict.is_denied(), "expected Denied, got {verdict:?}");
@@ -462,7 +610,7 @@ mod tests {
 
     #[test]
     fn kernel_modification_denied() {
-        let k = ConstitutionalKernel::new();
+        let k = signed_kernel();
         let actor = did("did:exo:patcher");
         let verdict = k.adjudicate_kernel_modification(&actor, "patch-kernel");
         assert!(verdict.is_denied(), "expected Denied, got {verdict:?}");
@@ -470,7 +618,7 @@ mod tests {
 
     #[test]
     fn no_bailment_denied() {
-        let k = ConstitutionalKernel::new();
+        let k = signed_kernel();
         let actor = did("did:exo:unauth");
         let verdict = k.adjudicate_without_bailment(&actor, "read-data");
         assert!(verdict.is_denied(), "expected Denied, got {verdict:?}");

--- a/crates/exochain-sdk/src/lib.rs
+++ b/crates/exochain-sdk/src/lib.rs
@@ -85,7 +85,8 @@
 //! assert_eq!(&chain.terminal, bob.did());
 //!
 //! // 5. Ask the kernel whether bob may perform the action.
-//! let kernel = ConstitutionalKernel::new();
+//! // The SDK kernel requires caller-supplied authority signing material.
+//! let kernel = ConstitutionalKernel::with_authority_identity(root);
 //! let verdict = kernel.adjudicate(bob.did(), "data:medical:read");
 //! assert!(verdict.is_permitted(), "expected Permitted, got {verdict:?}");
 //! # Ok::<(), exochain_sdk::error::ExoError>(())

--- a/crates/exochain-wasm/src/gatekeeper_bindings.rs
+++ b/crates/exochain-wasm/src/gatekeeper_bindings.rs
@@ -185,13 +185,25 @@ mod tests {
             }],
         };
 
-        // Provenance must exist and be signed (non-empty signature).
+        let (provenance_pk, provenance_sk) = exo_core::crypto::generate_keypair();
+        let provenance_actor = actor();
+        let provenance_timestamp = "2026-03-20T00:00:00Z".to_string();
+        let provenance_action_hash = vec![1u8; 32];
+        let mut provenance_payload = Vec::new();
+        provenance_payload.extend_from_slice(provenance_actor.as_str().as_bytes());
+        provenance_payload.push(0x00);
+        provenance_payload.extend_from_slice(&provenance_action_hash);
+        provenance_payload.push(0x00);
+        provenance_payload.extend_from_slice(provenance_timestamp.as_bytes());
+        let provenance_message = exo_core::Hash256::digest(&provenance_payload);
+        let provenance_sig = exo_core::crypto::sign(provenance_message.as_bytes(), &provenance_sk);
+
         let provenance = Some(Provenance {
-            actor: actor(),
-            timestamp: "2026-03-20T00:00:00Z".to_string(),
-            action_hash: vec![1u8; 32],
-            signature: vec![2u8; 64],
-            public_key: None,
+            actor: provenance_actor,
+            timestamp: provenance_timestamp,
+            action_hash: provenance_action_hash,
+            signature: provenance_sig.to_bytes().to_vec(),
+            public_key: Some(provenance_pk.as_bytes().to_vec()),
             voice_kind: None,
             independence: None,
             review_order: None,


### PR DESCRIPTION
## Summary
- require `AuthorityLink.grantor_public_key` and Ed25519 verification for every gatekeeper authority link
- require provenance public keys and Ed25519 verification, removing non-empty-signature fallback acceptance
- update gatekeeper callers, MCP, infrastructure Holons, WASM, SDK, and integration fixtures to provide signed authority/provenance context
- make the SDK facade fail closed unless callers provide authority signing material

## TDD
- added RED regression tests proving non-empty signatures without public keys fail for both `AuthorityChainValid` and `ProvenanceVerifiable`
- added MCP regression coverage for adjudication without configured authority signer
- added SDK regression coverage for fail-closed adjudication without an authority signer

## Verification
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit --deny unsound --deny unmaintained`
- `cargo deny check`
- `cargo machete --with-metadata`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `bash tools/test_repo_truth.sh`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`