### PR TITLE
fix(exo-node): use HLC for runtime clocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 115569 | `wc -l` |
-| Workspace tests | 2,837 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 115631 | `wc -l` |
+| Workspace tests | 2,839 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,837 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,839 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 115569 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 115631 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,837 listed workspace tests
+         cryptographic proofs, 2,839 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          140 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/metrics.rs
+++ b/crates/exo-node/src/metrics.rs
@@ -15,13 +15,12 @@
 //! - `exochain_uptime_seconds` — node uptime in seconds
 //! - `exochain_sync_in_progress` — whether state sync is active (0 or 1)
 
-use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
-    time::Instant,
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicU64, Ordering},
 };
+
+use exo_core::{Timestamp, hlc::HybridClock};
 
 /// Thread-safe metrics registry for the node.
 #[derive(Debug)]
@@ -41,13 +40,22 @@ pub struct NodeMetrics {
     /// Whether state sync is in progress.
     pub sync_in_progress: AtomicU64,
     /// When the node started.
-    start_time: Instant,
+    start_time: Timestamp,
+    /// HLC source used to render deterministic uptime.
+    clock: Mutex<HybridClock>,
 }
 
 impl NodeMetrics {
     /// Create a new metrics registry.
     #[must_use]
     pub fn new() -> Self {
+        Self::new_with_clock(HybridClock::new())
+    }
+
+    /// Create a new metrics registry with an explicit HLC source.
+    #[must_use]
+    pub fn new_with_clock(mut clock: HybridClock) -> Self {
+        let start_time = clock.now();
         Self {
             peer_count: AtomicU64::new(0),
             consensus_round: AtomicU64::new(0),
@@ -56,14 +64,31 @@ impl NodeMetrics {
             validator_count: AtomicU64::new(0),
             is_validator: AtomicU64::new(0),
             sync_in_progress: AtomicU64::new(0),
-            start_time: Instant::now(),
+            start_time,
+            clock: Mutex::new(clock),
+        }
+    }
+
+    fn uptime_seconds(&self) -> u64 {
+        match self.clock.lock() {
+            Ok(mut clock) => {
+                clock
+                    .now()
+                    .physical_ms
+                    .saturating_sub(self.start_time.physical_ms)
+                    / 1000
+            }
+            Err(_) => {
+                tracing::error!("NodeMetrics HLC mutex poisoned while rendering uptime");
+                0
+            }
         }
     }
 
     /// Render all metrics in Prometheus exposition format.
     #[must_use]
     pub fn render(&self) -> String {
-        let uptime = self.start_time.elapsed().as_secs();
+        let uptime = self.uptime_seconds();
 
         format!(
             "# HELP exochain_peer_count Number of connected P2P peers.\n\
@@ -131,6 +156,8 @@ pub fn create_metrics() -> SharedMetrics {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
+    use exo_core::hlc::HybridClock;
+
     use super::*;
 
     #[test]
@@ -163,6 +190,20 @@ mod tests {
     }
 
     #[test]
+    fn metrics_uptime_uses_injected_hlc_source() {
+        let wall = Arc::new(AtomicU64::new(42_000));
+        let wall_for_clock = Arc::clone(&wall);
+        let metrics = NodeMetrics::new_with_clock(HybridClock::with_wall_clock(move || {
+            wall_for_clock.load(Ordering::Relaxed)
+        }));
+
+        wall.store(45_000, Ordering::Relaxed);
+        let output = metrics.render();
+
+        assert!(output.contains("exochain_uptime_seconds 3"));
+    }
+
+    #[test]
     fn metrics_atomic_updates() {
         let metrics = Arc::new(NodeMetrics::new());
 
@@ -185,5 +226,21 @@ mod tests {
         .unwrap();
 
         assert_eq!(metrics.peer_count.load(Ordering::Relaxed), 42);
+    }
+
+    #[test]
+    fn default_runtime_sources_do_not_read_wall_clock_directly() {
+        let metrics_source = include_str!("metrics.rs")
+            .split("// ---------------------------------------------------------------------------\n// Tests")
+            .next()
+            .expect("metrics tests marker present");
+        let sentinels_source = include_str!("sentinels.rs")
+            .split("// ---------------------------------------------------------------------------\n// Tests")
+            .next()
+            .expect("sentinels tests marker present");
+
+        assert!(!metrics_source.contains("Instant::now"));
+        assert!(!metrics_source.contains("time::Instant"));
+        assert!(!sentinels_source.contains("SystemTime::now"));
     }
 }

--- a/crates/exo-node/src/sentinels.rs
+++ b/crates/exo-node/src/sentinels.rs
@@ -16,11 +16,12 @@
 //! | ScoreIntegrity | 0dentity scores are deterministically reproducible | 60s |
 
 use std::{
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, OnceLock},
     time::Duration,
 };
 
 use axum::{Json, Router, extract::State, http::StatusCode, routing::get};
+use exo_core::hlc::HybridClock;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 
@@ -104,12 +105,16 @@ pub type SharedSentinelState = Arc<Mutex<Vec<SentinelStatus>>>;
 pub type AlertSender = mpsc::Sender<SentinelAlert>;
 pub type AlertReceiver = mpsc::Receiver<SentinelAlert>;
 
-#[allow(clippy::as_conversions)]
 pub(crate) fn now_ms() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as u64
+    static SENTINEL_CLOCK: OnceLock<Mutex<HybridClock>> = OnceLock::new();
+    let clock = SENTINEL_CLOCK.get_or_init(|| Mutex::new(HybridClock::new()));
+    match clock.lock() {
+        Ok(mut clock) => clock.now().physical_ms,
+        Err(_) => {
+            tracing::error!("Sentinel HLC mutex poisoned while reading timestamp");
+            0
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- replace default-on sentinel timestamp reads with an HLC-backed process clock
- replace metrics Instant uptime with Timestamp + injectable HybridClock state
- add deterministic uptime coverage and source guards against direct wall-clock reads returning
- refresh README repo-truth counts to 115631 Rust LOC / 2839 listed tests

## TDD red
- cargo test -p exo-node metrics::tests::metrics_uptime_uses_injected_hlc_source --bin exochain failed before implementation because NodeMetrics::new_with_clock did not exist

## Verification
- cargo test -p exo-node metrics::tests::metrics_uptime_uses_injected_hlc_source --bin exochain
- cargo test -p exo-node metrics::tests::default_runtime_sources_do_not_read_wall_clock_directly --bin exochain
- cargo test -p exo-node metrics::tests --bin exochain
- cargo test -p exo-node sentinels::tests --bin exochain
- cargo build -p exo-node
- cargo clippy -p exo-node --bin exochain -- -D warnings
- cargo test -p exo-node --bin exochain
- cargo clippy -p exo-node --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo test -p exo-node
- bash tools/repo_truth.sh --json
- bash tools/test_repo_truth.sh
- bash tools/test_cr001_status.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_no_orphan_rust_modules.sh
- bash tools/test_railway_entrypoint_args.sh
- cargo +nightly fmt --all -- --check
- git diff --check
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo build --workspace --release
- cargo test --workspace --release
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
- cargo audit --deny unsound --deny unmaintained
- cargo deny check
- cargo machete --with-metadata