### PR TITLE
fix(exo-gateway): use HLC for server runtime clocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 115631 | `wc -l` |
-| Workspace tests | 2,839 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 115686 | `wc -l` |
+| Workspace tests | 2,841 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,839 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,841 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 115631 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 115686 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,839 listed workspace tests
+         cryptographic proofs, 2,841 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          140 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -1,5 +1,5 @@
 //! HTTP server skeleton — gateway configuration, lifecycle, and axum routing.
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 
 use axum::{
     Router,
@@ -8,7 +8,7 @@ use axum::{
     response::{IntoResponse, Json},
     routing::{get, post},
 };
-use exo_core::{Did, Hash256, Signature, Timestamp};
+use exo_core::{Did, Hash256, Signature, Timestamp, hlc::HybridClock};
 use exo_gatekeeper::{
     invariants::InvariantSet,
     kernel::{ActionRequest as GkActionRequest, AdjudicationContext, Kernel, Verdict},
@@ -106,26 +106,49 @@ pub struct AppState {
     pub registry: Arc<RwLock<LocalDidRegistry>>,
     /// Constitutional kernel — enforces the 8 invariants on every action.
     pub kernel: Arc<Kernel>,
-    /// Wall-clock milliseconds at server start, used to compute uptime.
-    start_ms: u64,
+    /// HLC timestamp captured at server start, used to compute uptime.
+    start_time: Timestamp,
+    /// HLC source used for default-on gateway runtime timestamps.
+    clock: Arc<Mutex<HybridClock>>,
 }
 
 impl AppState {
     /// Create a new `AppState` with an optional database pool and a shared DID registry.
     pub fn new(pool: Option<sqlx::PgPool>, registry: Arc<RwLock<LocalDidRegistry>>) -> Self {
+        Self::new_with_clock(pool, registry, HybridClock::new())
+    }
+
+    /// Create a new `AppState` with an explicit HLC source.
+    pub fn new_with_clock(
+        pool: Option<sqlx::PgPool>,
+        registry: Arc<RwLock<LocalDidRegistry>>,
+        mut clock: HybridClock,
+    ) -> Self {
         // Bootstrap kernel with the all-invariants set.
         // constitution bytes are hashed for immutability verification.
         let kernel = Kernel::new(b"exochain-constitution-v1", InvariantSet::all());
+        let start_time = clock.now();
         Self {
             pool,
             registry,
             kernel: Arc::new(kernel),
-            start_ms: now_ms(),
+            start_time,
+            clock: Arc::new(Mutex::new(clock)),
+        }
+    }
+
+    fn now_ms(&self) -> u64 {
+        match self.clock.lock() {
+            Ok(mut clock) => clock.now().physical_ms,
+            Err(_) => {
+                tracing::error!("Gateway AppState HLC mutex poisoned while reading timestamp");
+                0
+            }
         }
     }
 
     fn uptime_seconds(&self) -> u64 {
-        now_ms().saturating_sub(self.start_ms) / 1000
+        self.now_ms().saturating_sub(self.start_time.physical_ms) / 1000
     }
 
     /// Return the DB pool or a 503 if none is configured.
@@ -169,7 +192,8 @@ impl AppState {
         // Production path — compiled only when the feature flag is set.
         #[cfg(feature = "production-db")]
         if let Some(pool) = &self.pool {
-            match build_adjudication_context_from_db(pool, actor).await {
+            let now = i64::try_from(self.now_ms()).unwrap_or(i64::MAX);
+            match build_adjudication_context_from_db(pool, actor, now).await {
                 Ok(ctx) => return ctx,
                 Err(e) => {
                     tracing::warn!(
@@ -194,10 +218,6 @@ impl AppState {
             active_challenge_reason: None,
         }
     }
-}
-
-fn now_ms() -> u64 {
-    exo_core::Timestamp::now_utc().physical_ms
 }
 
 const GATEWAY_SERVER_METADATA_INITIATIVE: &str =
@@ -500,13 +520,13 @@ fn generate_session_token() -> Result<String> {
 async fn build_adjudication_context_from_db(
     pool: &sqlx::PgPool,
     actor: &Did,
+    now: i64,
 ) -> Result<AdjudicationContext> {
     use exo_gatekeeper::types::{
         AuthorityChain as GkChain, BailmentState as GkBailment, ConsentRecord, GovernmentBranch,
         Role,
     };
 
-    let now = i64::try_from(now_ms()).unwrap_or(i64::MAX);
     let actor_str = actor.as_str();
 
     let role_rows = crate::db::load_agent_roles(pool, actor_str, now)
@@ -1823,10 +1843,13 @@ pub async fn serve_with_extra_routes(
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
     use axum::{body::Body, http::Request};
     use exo_core::{
         Timestamp,
         crypto::{generate_keypair, sign},
+        hlc::HybridClock,
     };
     use exo_identity::did::{DidDocument, VerificationMethod};
     use tower::ServiceExt;
@@ -1835,6 +1858,38 @@ mod tests {
 
     fn state() -> AppState {
         AppState::new(None, Arc::new(RwLock::new(LocalDidRegistry::new())))
+    }
+
+    #[test]
+    fn gateway_uptime_uses_injected_hlc_source() {
+        let wall = Arc::new(AtomicU64::new(80_000));
+        let wall_for_clock = Arc::clone(&wall);
+        let state = AppState::new_with_clock(
+            None,
+            Arc::new(RwLock::new(LocalDidRegistry::new())),
+            HybridClock::with_wall_clock(move || wall_for_clock.load(Ordering::Relaxed)),
+        );
+
+        wall.store(86_000, Ordering::Relaxed);
+
+        assert_eq!(state.uptime_seconds(), 6);
+    }
+
+    #[test]
+    fn gateway_server_runtime_sources_do_not_read_wall_clock_directly() {
+        let source = include_str!("server.rs");
+        let production = source
+            .split("// ---------------------------------------------------------------------------\n// Tests")
+            .next()
+            .expect("tests marker present");
+
+        let timestamp_now = format!("{}{}", "Timestamp::", "now_utc()");
+        let system_time_now = format!("{}{}", "SystemTime::", "now()");
+        let instant_now = format!("{}{}", "Instant::", "now()");
+
+        assert!(!production.contains(&timestamp_now));
+        assert!(!production.contains(&system_time_now));
+        assert!(!production.contains(&instant_now));
     }
 
     /// Build a minimal DidDocument for use in registration tests.


### PR DESCRIPTION
## Summary
- replace default-on exo-gateway server runtime clock reads with an AppState-owned HLC
- add deterministic AppState::new_with_clock injection and uptime regression coverage
- pass HLC-derived milliseconds into production DB adjudication context loading
- refresh README repo-truth counts to 115686 Rust LOC / 2841 listed tests

## TDD red
- cargo test -p exo-gateway server::tests::gateway_uptime_uses_injected_hlc_source --lib initially failed because AppState::new_with_clock did not exist

## Verification
- cargo test -p exo-gateway server::tests::gateway_uptime_uses_injected_hlc_source --lib
- cargo test -p exo-gateway server::tests::gateway_server_runtime_sources_do_not_read_wall_clock_directly --lib
- cargo test -p exo-gateway server::tests --lib
- cargo test -p exo-gateway --features production-db
- cargo test -p exo-gateway --test spline_amber_hygiene --features production-db
- cargo build -p exo-gateway --features production-db
- cargo clippy -p exo-gateway --lib --bins -- -D warnings
- cargo clippy -p exo-gateway --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo clippy -p exo-gateway --all-targets --features production-db -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo test -p exo-gateway
- cargo build -p exo-gateway
- bash tools/repo_truth.sh --json
- bash tools/test_repo_truth.sh
- cargo +nightly fmt --all -- --check
- git diff --check
- bash tools/test_cr001_status.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_no_orphan_rust_modules.sh
- bash tools/test_railway_entrypoint_args.sh
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo build --workspace --release
- cargo test --workspace --release
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
- cargo audit --deny unsound --deny unmaintained
- cargo deny check
- cargo machete --with-metadata