### PR TITLE
fix(exo-node): sign zerodentity attestation claim evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 115686 | `wc -l` |
-| Workspace tests | 2,841 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 115855 | `wc -l` |
+| Workspace tests | 2,843 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,841 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,843 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 115686 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 115855 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,841 listed workspace tests
+         cryptographic proofs, 2,843 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          140 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/zerodentity/api.rs
+++ b/crates/exo-node/src/zerodentity/api.rs
@@ -24,7 +24,7 @@ use axum::{
 };
 use exo_core::{
     crypto,
-    types::{Did, Hash256, PublicKey, Signature},
+    types::{Did, Hash256, PublicKey, Signature, Timestamp},
 };
 use serde::{Deserialize, Serialize};
 
@@ -32,7 +32,7 @@ use super::{
     DEVICE_BEHAVIORAL_AXES_FEATURE, DEVICE_BEHAVIORAL_AXES_INITIATIVE,
     attestation::{
         CreateAttestationInput, attester_score_impact, build_target_claim, create_attestation,
-        target_score_impact, validate_attestation,
+        target_claim_hash, target_claim_id, target_score_impact, validate_attestation,
     },
     device_behavioral_axes_enabled,
     session_auth::{public_key_from_session_bytes, request_signing_payload, signature_from_hex},
@@ -675,25 +675,21 @@ pub async fn create_peer_attestation(
     let attester_public_key = parse_public_key(req.attester_public_key.as_deref())?;
     let signature = parse_signature(req.signature.as_deref())?;
 
-    // Validate
-    let (attester_claims, already_exists) = {
-        let store = state.store.lock().map_err(|_| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": "lock poisoned"})),
-            )
-        })?;
-        let claims: Vec<IdentityClaim> = store
-            .get_claims(&attester_did)
-            .unwrap_or_default()
-            .into_iter()
-            .map(|(_, c)| c)
-            .collect();
-        let exists = store
-            .attestation_exists(&attester_did, &target_did)
-            .unwrap_or(false);
-        (claims, exists)
-    };
+    let mut store = state.store.lock().map_err(|_| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "lock poisoned"})),
+        )
+    })?;
+    let attester_claims: Vec<IdentityClaim> = store
+        .get_claims(&attester_did)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(_, c)| c)
+        .collect();
+    let already_exists = store
+        .attestation_exists(&attester_did, &target_did)
+        .unwrap_or(false);
 
     validate_attestation(&attester_did, &target_did, &attester_claims, already_exists).map_err(
         |e| {
@@ -704,10 +700,20 @@ pub async fn create_peer_attestation(
         },
     )?;
 
-    // Synthetic DAG node hash
-    let dag_node_hash = Hash256::digest(
-        format!("attest:{}:{}", attester_did.as_str(), target_did.as_str()).as_bytes(),
-    );
+    let target_claim_hash = target_claim_hash(&attester_did, &target_did).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e.to_string()})),
+        )
+    })?;
+    let dag_node_hash = store
+        .next_claim_dag_node_hash(target_claim_hash, Timestamp::new(now, 0))
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": format!("Store error: {e}")})),
+            )
+        })?;
 
     let attestation = create_attestation(CreateAttestationInput {
         attester_did: &attester_did,
@@ -725,32 +731,39 @@ pub async fn create_peer_attestation(
             Json(serde_json::json!({"error": e.to_string()})),
         )
     })?;
-
-    // Persist attestation
-    {
-        let mut store = state.store.lock().map_err(|_| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": "lock poisoned"})),
-            )
-        })?;
-        store.insert_attestation(&attestation).map_err(|e| {
+    let target_claim = build_target_claim(&attestation, dag_node_hash, now).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e.to_string()})),
+        )
+    })?;
+    let claim_id = target_claim_id(&attestation).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e.to_string()})),
+        )
+    })?;
+    let evidence = store
+        .save_claim_with_evidence(&claim_id, &target_claim)
+        .map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::json!({"error": format!("Store error: {e}")})),
             )
         })?;
-
-        // Add PeerAttestation claim to target's claim set
-        let target_claim = build_target_claim(&attestation, dag_node_hash, now);
-        let claim_id = uuid::Uuid::new_v4().to_string();
-        let _ = store.insert_claim(&claim_id, &target_claim);
-    }
-
-    let receipt_hash = hex::encode(
-        Hash256::digest(format!("attest-receipt:{}", &attestation.attestation_id).as_bytes())
-            .as_bytes(),
-    );
+    store.insert_attestation(&attestation).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": format!("Store error: {e}")})),
+        )
+    })?;
+    let receipt_hash = evidence.receipt_hash.ok_or_else(|| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "Store error: verified attestation claim did not emit a trust receipt"})),
+        )
+    })?;
+    let receipt_hash = hex::encode(receipt_hash.as_bytes());
 
     let att_id = attestation.attestation_id.clone();
 
@@ -883,6 +896,23 @@ mod tests {
         ApiState {
             store: Arc::new(Mutex::new(test_store())),
         }
+    }
+
+    #[test]
+    fn attestation_write_path_does_not_fabricate_claim_ids_or_receipts() {
+        let source = include_str!("api.rs");
+        let production = source
+            .split("// ---------------------------------------------------------------------------\n// Tests")
+            .next()
+            .unwrap();
+
+        let uuid_new_v4 = format!("{}{}", "Uuid::", "new_v4()");
+        let qualified_uuid_new_v4 = format!("{}{}", "uuid::Uuid::", "new_v4()");
+        let fabricated_receipt = format!("{}{}", "attest-", "receipt");
+
+        assert!(!production.contains(&uuid_new_v4));
+        assert!(!production.contains(&qualified_uuid_new_v4));
+        assert!(!production.contains(&fabricated_receipt));
     }
 
     fn test_keypair(seed: u8) -> KeyPair {

--- a/crates/exo-node/src/zerodentity/attestation.rs
+++ b/crates/exo-node/src/zerodentity/attestation.rs
@@ -11,6 +11,7 @@ use exo_core::{
     crypto,
     types::{Did, Hash256, PublicKey, Signature},
 };
+use serde::Serialize;
 use thiserror::Error;
 
 use super::types::{AttestationType, ClaimStatus, ClaimType, IdentityClaim, PeerAttestation};
@@ -31,6 +32,8 @@ pub enum AttestationError {
     InvalidSignature,
     #[error("Attestation signing payload encoding failed: {reason}")]
     SigningPayloadEncoding { reason: String },
+    #[error("Attestation target claim encoding failed: {reason}")]
+    TargetClaimEncoding { reason: String },
 }
 
 pub struct CreateAttestationInput<'a> {
@@ -104,6 +107,16 @@ pub fn attestation_signing_payload(
     let mut buf = Vec::new();
     ciborium::ser::into_writer(&tuple, &mut buf).map_err(|e| {
         AttestationError::SigningPayloadEncoding {
+            reason: e.to_string(),
+        }
+    })?;
+    Ok(buf)
+}
+
+fn canonical_cbor<T: Serialize>(value: &T) -> Result<Vec<u8>, AttestationError> {
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(value, &mut buf).map_err(|e| {
+        AttestationError::TargetClaimEncoding {
             reason: e.to_string(),
         }
     })?;
@@ -207,14 +220,9 @@ pub fn build_target_claim(
     attestation: &PeerAttestation,
     dag_node_hash: Hash256,
     now_ms: u64,
-) -> IdentityClaim {
-    let payload = format!(
-        "attestation:{}:{}",
-        attestation.attester_did.as_str(),
-        attestation.target_did.as_str()
-    );
-    IdentityClaim {
-        claim_hash: Hash256::digest(payload.as_bytes()),
+) -> Result<IdentityClaim, AttestationError> {
+    Ok(IdentityClaim {
+        claim_hash: target_claim_hash(&attestation.attester_did, &attestation.target_did)?,
         subject_did: attestation.target_did.clone(),
         claim_type: ClaimType::PeerAttestation {
             attester_did: attestation.attester_did.clone(),
@@ -225,7 +233,33 @@ pub fn build_target_claim(
         expires_ms: None,
         signature: attestation.signature.clone(),
         dag_node_hash,
-    }
+    })
+}
+
+/// Deterministic content hash for the target's derived peer-attestation claim.
+pub fn target_claim_hash(
+    attester_did: &Did,
+    target_did: &Did,
+) -> Result<Hash256, AttestationError> {
+    let payload = (
+        "exo.zerodentity.target_claim.v1",
+        attester_did.as_str(),
+        target_did.as_str(),
+    );
+    Ok(Hash256::digest(&canonical_cbor(&payload)?))
+}
+
+/// Deterministic store ID for the target's derived peer-attestation claim.
+pub fn target_claim_id(attestation: &PeerAttestation) -> Result<String, AttestationError> {
+    let payload = (
+        "exo.zerodentity.target_claim_id.v1",
+        attestation.attestation_id.as_str(),
+        attestation.attester_did.as_str(),
+        attestation.target_did.as_str(),
+    );
+    Ok(hex::encode(
+        Hash256::digest(&canonical_cbor(&payload)?).as_bytes(),
+    ))
 }
 
 // ---------------------------------------------------------------------------
@@ -402,7 +436,7 @@ mod tests {
             signature: signature.clone(),
         })
         .expect("attestation");
-        let claim = build_target_claim(&att, hash(b"dag2"), 600);
+        let claim = build_target_claim(&att, hash(b"dag2"), 600).expect("target claim");
         assert_eq!(claim.subject_did.as_str(), target.as_str());
         assert_eq!(claim.status, ClaimStatus::Verified);
         assert_eq!(claim.signature, signature);
@@ -410,6 +444,39 @@ mod tests {
             claim.claim_type,
             ClaimType::PeerAttestation { .. }
         ));
+    }
+
+    #[test]
+    fn target_claim_id_is_deterministic_and_attestation_bound() {
+        let attester = did("did:exo:attester");
+        let target = did("did:exo:target");
+        let (public_key, secret_key) = keypair(17);
+        let signature = signed_attestation_signature(
+            &attester,
+            &target,
+            &AttestationType::Identity,
+            None,
+            700,
+            &secret_key,
+        );
+        let att = create_attestation(CreateAttestationInput {
+            attester_did: &attester,
+            target_did: &target,
+            attestation_type: AttestationType::Identity,
+            message_hash: None,
+            dag_node_hash: hash(b"dag-a"),
+            created_ms: 700,
+            attester_public_key: public_key,
+            signature,
+        })
+        .expect("attestation");
+        let same = target_claim_id(&att).expect("claim id");
+
+        let mut different = att.clone();
+        different.attestation_id = "different-attestation-id".to_owned();
+
+        assert_eq!(target_claim_id(&att).expect("claim id"), same);
+        assert_ne!(target_claim_id(&different).expect("claim id"), same);
     }
 
     #[test]

--- a/crates/exo-node/src/zerodentity/store.rs
+++ b/crates/exo-node/src/zerodentity/store.rs
@@ -56,6 +56,12 @@ impl fmt::Debug for ReceiptSigningContext {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClaimSaveEvidence {
+    pub dag_node_hash: Hash256,
+    pub receipt_hash: Option<Hash256>,
+}
+
 // ---------------------------------------------------------------------------
 // ZerodentityStore
 // ---------------------------------------------------------------------------
@@ -160,6 +166,29 @@ impl ZerodentityStore {
         ))
     }
 
+    fn next_dag_parents(&self) -> Vec<Hash256> {
+        self.dag_nodes
+            .last()
+            .map_or_else(Vec::new, |parent| vec![parent.hash])
+    }
+
+    /// Compute the next claim DAG node hash without mutating the store.
+    pub fn next_claim_dag_node_hash(
+        &self,
+        payload_hash: Hash256,
+        timestamp: Timestamp,
+    ) -> anyhow::Result<Hash256> {
+        let Some(context) = &self.receipt_signing else {
+            anyhow::bail!("0dentity DAG node signer is not configured");
+        };
+        Ok(compute_node_hash(
+            &self.next_dag_parents(),
+            &payload_hash,
+            &context.actor_did,
+            &timestamp,
+        ))
+    }
+
     fn signed_dag_node(
         &self,
         payload_hash: Hash256,
@@ -168,10 +197,7 @@ impl ZerodentityStore {
         let Some(context) = &self.receipt_signing else {
             anyhow::bail!("0dentity DAG node signer is not configured");
         };
-        let parents = self
-            .dag_nodes
-            .last()
-            .map_or_else(Vec::new, |parent| vec![parent.hash]);
+        let parents = self.next_dag_parents();
         let hash = compute_node_hash(&parents, &payload_hash, &context.actor_did, &timestamp);
         let signature = (context.signer)(hash.as_bytes());
         if signature.is_empty() {
@@ -289,6 +315,16 @@ impl ZerodentityStore {
         );
         self.attestations.insert(key, att.clone());
         Ok(())
+    }
+
+    /// Return a stored peer attestation by attester and target.
+    pub fn get_attestation(
+        &self,
+        attester: &Did,
+        target: &Did,
+    ) -> anyhow::Result<Option<PeerAttestation>> {
+        let key = (attester.as_str().to_owned(), target.as_str().to_owned());
+        Ok(self.attestations.get(&key).cloned())
     }
 
     // -----------------------------------------------------------------------
@@ -425,8 +461,7 @@ impl ZerodentityStore {
 
     /// Return `true` if an attestation from `attester` to `target` already exists.
     pub fn attestation_exists(&self, attester: &Did, target: &Did) -> anyhow::Result<bool> {
-        let key = (attester.as_str().to_owned(), target.as_str().to_owned());
-        Ok(self.attestations.contains_key(&key))
+        Ok(self.get_attestation(attester, target)?.is_some())
     }
 
     // -----------------------------------------------------------------------
@@ -484,6 +519,15 @@ impl ZerodentityStore {
     ///   `self.trust_receipts` when `claim.status == Verified`.
     #[allow(dead_code)]
     pub fn save_claim(&mut self, claim_id: &str, claim: &IdentityClaim) -> anyhow::Result<()> {
+        self.save_claim_with_evidence(claim_id, claim).map(|_| ())
+    }
+
+    /// Persist a claim and return the signed DAG / receipt evidence produced.
+    pub fn save_claim_with_evidence(
+        &mut self,
+        claim_id: &str,
+        claim: &IdentityClaim,
+    ) -> anyhow::Result<ClaimSaveEvidence> {
         let node = self.signed_dag_node(claim.claim_hash, Timestamp::new(claim.created_ms, 0))?;
         let receipt = if claim.status == ClaimStatus::Verified {
             let verified_ms = claim.verified_ms.unwrap_or(claim.created_ms);
@@ -498,14 +542,19 @@ impl ZerodentityStore {
         };
 
         self.insert_claim(claim_id, claim)?;
+        let dag_node_hash = node.hash;
         self.dag_nodes.push(node);
 
         // Emit TrustReceipt for verified claims.
+        let receipt_hash = receipt.as_ref().map(|receipt| receipt.receipt_hash);
         if let Some(receipt) = receipt {
             self.trust_receipts.push(receipt);
         }
 
-        Ok(())
+        Ok(ClaimSaveEvidence {
+            dag_node_hash,
+            receipt_hash,
+        })
     }
 
     /// Persist an OTP challenge (APE-72 alias for `insert_otp_challenge`).

--- a/crates/exo-node/src/zerodentity/tests.rs
+++ b/crates/exo-node/src/zerodentity/tests.rs
@@ -28,7 +28,7 @@ mod tests {
         ClaimStatus, ClaimType, IdentityClaim, IdentitySession, OTP_MAX_ATTEMPTS, OtpChallenge,
         OtpChannel, OtpState, PolarAxes, ZerodentityScore,
         api::{ApiState, zerodentity_api_router},
-        attestation::attestation_signing_payload,
+        attestation::{attestation_signing_payload, target_claim_id},
         onboarding::{OnboardingState, onboarding_router},
         scoring::compute_symmetry,
         store::{SharedZerodentityStore, ZerodentityStore, new_shared_store},
@@ -1587,7 +1587,30 @@ mod tests {
                 .as_str()
                 .is_some_and(|s| !s.is_empty())
         );
+        let attestation_id = body["attestation_id"].as_str().unwrap();
         assert!(body["receipt_hash"].as_str().is_some_and(|s| s.len() == 64));
+
+        let guard = store.lock().unwrap();
+        let target_claims = guard.get_claims(&target).unwrap();
+        assert_eq!(target_claims.len(), 1);
+        let (claim_id, target_claim) = &target_claims[0];
+        let saved_attestation = guard
+            .get_attestation(&attester, &target)
+            .unwrap()
+            .expect("attestation stored");
+        assert_eq!(saved_attestation.attestation_id, attestation_id);
+        assert_eq!(claim_id, &target_claim_id(&saved_attestation).unwrap());
+        assert_eq!(target_claim.dag_node_hash, guard.dag_nodes()[0].hash);
+
+        let receipts = guard.trust_receipts();
+        assert_eq!(receipts.len(), 1);
+        let receipt = &receipts[0];
+        assert_eq!(receipt.action_type, "zerodentity.claim_verified");
+        assert_eq!(receipt.action_hash, target_claim.claim_hash);
+        assert_eq!(
+            body["receipt_hash"].as_str().unwrap(),
+            hex::encode(receipt.receipt_hash.as_bytes())
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- derive 0dentity peer-attestation target-claim IDs from canonical CBOR instead of UUIDs
- persist derived target claims through signed DAG node + node-signed trust receipt evidence
- return the actual emitted trust receipt hash from `POST /api/v1/0dentity/:did/attest`
- add source guards against reintroducing `Uuid::new_v4()` or fabricated `attest-receipt` hashes in the production attestation write path
- refresh README repo-truth counts to 115855 Rust LOC and 2843 listed workspace tests

## TDD

Red checks first:

- `cargo test -p exo-node zerodentity::tests::tests::attest_valid_creates_attestation_201 --bin exochain`
- `cargo test -p exo-node zerodentity::api::tests::attestation_write_path_does_not_fabricate_claim_ids_or_receipts --bin exochain`

## Verification

- `cargo test -p exo-node zerodentity::attestation::tests::target_claim_id_is_deterministic_and_attestation_bound --bin exochain`
- `cargo test -p exo-node zerodentity::tests::tests::attest_valid_creates_attestation_201 --bin exochain`
- `cargo test -p exo-node zerodentity::api::tests::attestation_write_path_does_not_fabricate_claim_ids_or_receipts --bin exochain`
- `cargo test -p exo-node zerodentity::attestation::tests --bin exochain`
- `cargo test -p exo-node zerodentity::api::tests --bin exochain`
- `cargo test -p exo-node zerodentity::tests::tests --bin exochain`
- `cargo test -p exo-node zerodentity::store::tests --bin exochain`
- `cargo test -p exo-node --features unaudited-zerodentity-first-touch-onboarding --bin exochain zerodentity::tests::tests::attest_valid_creates_attestation_201`
- `cargo test -p exo-node --bin exochain`
- `cargo clippy -p exo-node --bin exochain -- -D warnings`
- `cargo clippy -p exo-node --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build -p exo-node`
- `cargo test -p exo-node`
- `bash tools/repo_truth.sh --json`
- `bash tools/test_repo_truth.sh`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit --deny unsound --deny unmaintained` (passes with existing allowed yanked `core2` warning)
- `cargo deny check` (passes with existing duplicate/yanked/license warnings)
- `cargo machete --with-metadata`
