### PR TITLE
fix(exo-node): return signed zerodentity erasure receipt evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 115855 | `wc -l` |
-| Workspace tests | 2,843 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 115927 | `wc -l` |
+| Workspace tests | 2,846 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,843 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,846 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 115855 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 115927 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,843 listed workspace tests
+         cryptographic proofs, 2,846 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          140 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/zerodentity/api.rs
+++ b/crates/exo-node/src/zerodentity/api.rs
@@ -815,14 +815,14 @@ pub async fn delete_identity(
     let request_path = path_and_query(&uri);
     let _token = verify_signed_write(&state, &headers, &did, "DELETE", &request_path, &body)?;
 
-    let claims_revoked = {
+    let erasure_evidence = {
         let mut store = state.store.lock().map_err(|_| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::json!({"error": "lock poisoned"})),
             )
         })?;
-        store.erase_did(&did).map_err(|e| {
+        store.erase_did_with_evidence(&did).map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::json!({"error": format!("Erasure failed: {e}")})),
@@ -830,13 +830,11 @@ pub async fn delete_identity(
         })?
     };
 
-    let receipt_hash = hex::encode(
-        Hash256::digest(format!("erasure-receipt:{}", did.as_str()).as_bytes()).as_bytes(),
-    );
+    let receipt_hash = hex::encode(erasure_evidence.receipt_hash.as_bytes());
 
     Ok(Json(ErasureResponse {
         subject_did: did.to_string(),
-        claims_revoked,
+        claims_revoked: erasure_evidence.claims_revoked,
         receipt_hash,
         message: "Identity erased. All sessions revoked, claims marked Revoked, scores zeroed, fingerprints removed, DAG nodes tombstoned.".into(),
     }))
@@ -912,6 +910,18 @@ mod tests {
 
         assert!(!production.contains(&uuid_new_v4));
         assert!(!production.contains(&qualified_uuid_new_v4));
+        assert!(!production.contains(&fabricated_receipt));
+    }
+
+    #[test]
+    fn erasure_write_path_does_not_fabricate_receipt_hashes() {
+        let source = include_str!("api.rs");
+        let production = source
+            .split("// ---------------------------------------------------------------------------\n// Tests")
+            .next()
+            .unwrap();
+        let fabricated_receipt = format!("{}{}", "erasure-", "receipt");
+
         assert!(!production.contains(&fabricated_receipt));
     }
 
@@ -1466,6 +1476,7 @@ mod tests {
         let keypair = test_keypair(43);
         let state =
             make_state_with_signed_session_and_claim("tok-alice", "did:exo:alice", &keypair);
+        let store = state.store.clone();
         let app = zerodentity_api_router(state);
         let resp = signed_delete(
             app,
@@ -1480,6 +1491,17 @@ mod tests {
         let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(result["claims_revoked"], 1);
         assert!(result["receipt_hash"].as_str().is_some());
+        let guard = store.lock().unwrap();
+        let receipts = guard.trust_receipts();
+        let receipt = receipts
+            .iter()
+            .find(|receipt| receipt.action_type == "zerodentity.identity_erased")
+            .expect("erasure receipt");
+        assert_eq!(
+            result["receipt_hash"].as_str().unwrap(),
+            hex::encode(receipt.receipt_hash.as_bytes())
+        );
+        assert!(receipt.verify_hash());
         assert!(
             result["message"]
                 .as_str()

--- a/crates/exo-node/src/zerodentity/store.rs
+++ b/crates/exo-node/src/zerodentity/store.rs
@@ -20,6 +20,7 @@ use std::{
 
 use exo_core::types::{Did, Hash256, ReceiptOutcome, Signature, Timestamp, TrustReceipt};
 use exo_dag::dag::{DagNode, compute_node_hash};
+use serde::Serialize;
 
 use super::types::{
     BehavioralSample, ClaimStatus, DeviceFingerprint, IdentityClaim, IdentitySession, OtpChallenge,
@@ -60,6 +61,14 @@ impl fmt::Debug for ReceiptSigningContext {
 pub struct ClaimSaveEvidence {
     pub dag_node_hash: Hash256,
     pub receipt_hash: Option<Hash256>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ErasureEvidence {
+    pub claims_revoked: u32,
+    pub dag_node_hash: Hash256,
+    pub action_hash: Hash256,
+    pub receipt_hash: Hash256,
 }
 
 // ---------------------------------------------------------------------------
@@ -593,7 +602,8 @@ impl ZerodentityStore {
     // Write — erasure (§11.4 Right to Erasure)
     // -----------------------------------------------------------------------
 
-    /// Erase all data associated with a DID.
+    /// Erase all stored 0dentity data for `did` and return the signed evidence
+    /// emitted for the erasure.
     ///
     /// Implements §11.4 — right to erasure:
     /// 1. Revoke all sessions for this DID.
@@ -603,9 +613,7 @@ impl ZerodentityStore {
     /// 5. Remove OTP challenges belonging to this DID.
     /// 6. Tombstone DAG nodes — zero payload hash, keep structural links.
     /// 7. Emit an erasure receipt.
-    ///
-    /// Returns the number of claims revoked.
-    pub fn erase_did(&mut self, did: &Did) -> anyhow::Result<u32> {
+    pub fn erase_did_with_evidence(&mut self, did: &Did) -> anyhow::Result<ErasureEvidence> {
         if self.receipt_signing.is_none() {
             anyhow::bail!("0dentity trust receipt signer is not configured");
         }
@@ -647,7 +655,7 @@ impl ZerodentityStore {
         // existing claim nodes remain append-only; erasure is represented as a
         // new tombstone event.
         let now_ms = crate::sentinels::now_ms();
-        let erasure_hash = Hash256::digest(format!("erase:{}", did.as_str()).as_bytes());
+        let erasure_hash = erasure_action_hash(did)?;
         let receipt = self.trust_receipt(
             "zerodentity.identity_erased",
             erasure_hash,
@@ -655,10 +663,17 @@ impl ZerodentityStore {
             Timestamp::new(now_ms, 0),
         )?;
         let erasure_node = self.signed_dag_node(erasure_hash, Timestamp::new(now_ms, 0))?;
+        let dag_node_hash = erasure_node.hash;
+        let receipt_hash = receipt.receipt_hash;
         self.dag_nodes.push(erasure_node);
         self.trust_receipts.push(receipt);
 
-        Ok(revoked_count)
+        Ok(ErasureEvidence {
+            claims_revoked: revoked_count,
+            dag_node_hash,
+            action_hash: erasure_hash,
+            receipt_hash,
+        })
     }
 
     // -----------------------------------------------------------------------
@@ -694,6 +709,18 @@ pub type SharedZerodentityStore = Arc<Mutex<ZerodentityStore>>;
 #[allow(dead_code)]
 pub fn new_shared_store() -> SharedZerodentityStore {
     Arc::new(Mutex::new(ZerodentityStore::new()))
+}
+
+fn canonical_cbor<T: Serialize>(value: &T) -> anyhow::Result<Vec<u8>> {
+    let mut encoded = Vec::new();
+    ciborium::ser::into_writer(value, &mut encoded)?;
+    Ok(encoded)
+}
+
+/// Domain-separated canonical action hash for a 0dentity erasure event.
+pub fn erasure_action_hash(did: &Did) -> anyhow::Result<Hash256> {
+    let payload = ("exo.zerodentity.identity_erased.v1", did.as_str());
+    Ok(Hash256::digest(&canonical_cbor(&payload)?))
 }
 
 // ---------------------------------------------------------------------------
@@ -766,6 +793,29 @@ mod tests {
             signature: Signature::Empty,
             dag_node_hash: h(),
         }
+    }
+
+    #[test]
+    fn erasure_action_hash_is_deterministic_and_did_bound() {
+        let did_a = did("did:exo:erase-a");
+        let did_b = did("did:exo:erase-b");
+
+        let first = erasure_action_hash(&did_a).expect("erasure hash");
+
+        assert_eq!(erasure_action_hash(&did_a).expect("erasure hash"), first);
+        assert_ne!(erasure_action_hash(&did_b).expect("erasure hash"), first);
+    }
+
+    #[test]
+    fn erasure_path_does_not_use_ad_hoc_format_hashes() {
+        let source = include_str!("store.rs");
+        let production = source
+            .split("// ---------------------------------------------------------------------------\n// Tests")
+            .next()
+            .unwrap();
+        let ad_hoc_erasure_hash = format!("{}{}", "format!(\"erase", ":");
+
+        assert!(!production.contains(&ad_hoc_erasure_hash));
     }
 
     #[test]
@@ -956,7 +1006,7 @@ mod tests {
         store.save_claim("apg-dag-erasure-001", &c).unwrap();
         let claim_node = store.dag_nodes()[0].clone();
 
-        store.erase_did(&d).unwrap();
+        store.erase_did_with_evidence(&d).unwrap();
 
         let nodes = store.dag_nodes();
         assert_eq!(nodes.len(), 2);
@@ -1070,8 +1120,8 @@ mod tests {
             .unwrap();
 
         // Erase
-        let revoked = store.erase_did(&d).unwrap();
-        assert_eq!(revoked, 2);
+        let evidence = store.erase_did_with_evidence(&d).unwrap();
+        assert_eq!(evidence.claims_revoked, 2);
 
         // Score gone
         assert!(store.get_score(&d).is_none());
@@ -1103,8 +1153,8 @@ mod tests {
         let d = did("did:exo:signed-erase");
         store.put_claim(claim(&d, ClaimType::Email));
 
-        let revoked = store.erase_did(&d).unwrap();
-        assert_eq!(revoked, 1);
+        let evidence = store.erase_did_with_evidence(&d).unwrap();
+        assert_eq!(evidence.claims_revoked, 1);
 
         let receipt = store
             .trust_receipts()
@@ -1150,7 +1200,7 @@ mod tests {
         assert!(!store.get_fingerprints(&d).unwrap().is_empty());
         assert!(!store.get_behavioral_samples(&d).unwrap().is_empty());
 
-        store.erase_did(&d).unwrap();
+        store.erase_did_with_evidence(&d).unwrap();
 
         assert!(store.get_fingerprints(&d).unwrap().is_empty());
         assert!(store.get_behavioral_samples(&d).unwrap().is_empty());
@@ -1164,7 +1214,7 @@ mod tests {
         store.save_claim("dag-001", &c).unwrap();
 
         let claim_node = store.dag_nodes()[0].clone();
-        store.erase_did(&d).unwrap();
+        store.erase_did_with_evidence(&d).unwrap();
         assert_eq!(store.dag_nodes().len(), 2);
         assert_eq!(store.dag_nodes()[0], claim_node);
         assert_eq!(store.dag_nodes()[1].parents, vec![claim_node.hash]);


### PR DESCRIPTION
## Summary
- return the actual node-signed zerodentity erasure receipt hash from DELETE /api/v1/0dentity/:did
- add ErasureEvidence and canonical CBOR/domain-separated erasure action hashing
- add regression/source-guard tests for fabricated erasure receipts and ad hoc erase hashes
- refresh README repo-truth counts to 115927 Rust LOC and 2,846 listed tests

## TDD / Verification
- cargo test -p exo-node zerodentity::api::tests::delete_identity_success_returns_erasure_receipt --bin exochain
- cargo test -p exo-node zerodentity::api::tests::erasure_write_path_does_not_fabricate_receipt_hashes --bin exochain
- cargo test -p exo-node zerodentity::store::tests::erasure_action_hash_is_deterministic_and_did_bound --bin exochain
- cargo test -p exo-node zerodentity::store::tests::erasure_path_does_not_use_ad_hoc_format_hashes --bin exochain
- cargo test -p exo-node zerodentity::api::tests --bin exochain
- cargo test -p exo-node zerodentity::store::tests --bin exochain
- cargo test -p exo-node zerodentity::tests::tests --bin exochain
- cargo test -p exo-node zerodentity::attestation::tests --bin exochain
- cargo test -p exo-node --bin exochain
- cargo clippy -p exo-node --bin exochain -- -D warnings
- cargo clippy -p exo-node --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo build -p exo-node
- cargo test -p exo-node
- bash tools/test_repo_truth.sh
- cargo +nightly fmt --all -- --check
- git diff --check
- bash tools/test_cr001_status.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_no_orphan_rust_modules.sh
- bash tools/test_railway_entrypoint_args.sh
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo build --workspace --release
- cargo test --workspace --release
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
- cargo audit --deny unsound --deny unmaintained
- cargo deny check
- cargo machete --with-metadata