### PR TITLE
fix(exo-node): bind zerodentity attestation claims to signed time

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 115927 | `wc -l` |
-| Workspace tests | 2,846 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 115942 | `wc -l` |
+| Workspace tests | 2,847 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,846 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,847 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 115927 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 115942 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,846 listed workspace tests
+         cryptographic proofs, 2,847 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          140 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/zerodentity/api.rs
+++ b/crates/exo-node/src/zerodentity/api.rs
@@ -649,7 +649,6 @@ pub async fn create_peer_attestation(
     let req: AttestRequest = serde_json::from_slice(&body)
         .map_err(|_| json_error(StatusCode::BAD_REQUEST, "Invalid JSON body"))?;
     let target_did = parse_did(&req.target_did)?;
-    let now = now_ms();
 
     let request_path = path_and_query(&uri);
     let _token = verify_signed_write(
@@ -707,7 +706,7 @@ pub async fn create_peer_attestation(
         )
     })?;
     let dag_node_hash = store
-        .next_claim_dag_node_hash(target_claim_hash, Timestamp::new(now, 0))
+        .next_claim_dag_node_hash(target_claim_hash, Timestamp::new(created_ms, 0))
         .map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -731,12 +730,13 @@ pub async fn create_peer_attestation(
             Json(serde_json::json!({"error": e.to_string()})),
         )
     })?;
-    let target_claim = build_target_claim(&attestation, dag_node_hash, now).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": e.to_string()})),
-        )
-    })?;
+    let target_claim =
+        build_target_claim(&attestation, dag_node_hash, created_ms).map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": e.to_string()})),
+            )
+        })?;
     let claim_id = target_claim_id(&attestation).map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -923,6 +923,18 @@ mod tests {
         let fabricated_receipt = format!("{}{}", "erasure-", "receipt");
 
         assert!(!production.contains(&fabricated_receipt));
+    }
+
+    #[test]
+    fn attestation_write_path_uses_caller_supplied_time() {
+        let source = include_str!("api.rs");
+        let attestation_section = source
+            .split("// POST /api/v1/0dentity/:did/attest\n// ---------------------------------------------------------------------------")
+            .nth(1)
+            .and_then(|section| section.split("// ---------------------------------------------------------------------------").next())
+            .unwrap();
+
+        assert!(!attestation_section.contains("now_ms()"));
     }
 
     fn test_keypair(seed: u8) -> KeyPair {

--- a/crates/exo-node/src/zerodentity/tests.rs
+++ b/crates/exo-node/src/zerodentity/tests.rs
@@ -1563,6 +1563,7 @@ mod tests {
         }
 
         let uri = format!("/api/v1/0dentity/{}/attest", attester.as_str());
+        let signed_created_ms = 1_234_000;
         let resp = post_with_signed_auth(
             &app,
             &uri,
@@ -1573,7 +1574,7 @@ mod tests {
                 &target,
                 AttestationType::Identity,
                 None,
-                1_234_000,
+                signed_created_ms,
                 &public_key,
                 &secret_key,
             ),
@@ -1601,6 +1602,8 @@ mod tests {
         assert_eq!(saved_attestation.attestation_id, attestation_id);
         assert_eq!(claim_id, &target_claim_id(&saved_attestation).unwrap());
         assert_eq!(target_claim.dag_node_hash, guard.dag_nodes()[0].hash);
+        assert_eq!(target_claim.created_ms, signed_created_ms);
+        assert_eq!(target_claim.verified_ms, Some(signed_created_ms));
 
         let receipts = guard.trust_receipts();
         assert_eq!(receipts.len(), 1);


### PR DESCRIPTION
## Summary
- bind the derived 0dentity peer-attestation target claim timestamp to the attester-signed `created_ms`
- remove internal `now_ms()` use from the production peer-attestation write path
- refresh README repo-truth counts to 115,942 Rust LOC and 2,847 listed tests

## TDD red checks
- `cargo test -p exo-node zerodentity::tests::tests::attest_valid_creates_attestation_201 --bin exochain` initially failed because the derived target claim used internal HLC time instead of signed request time
- `cargo test -p exo-node zerodentity::api::tests::attestation_write_path_uses_caller_supplied_time --bin exochain` initially failed against the production `now_ms()` call

## Verification
- `cargo test -p exo-node zerodentity::tests::tests::attest_valid_creates_attestation_201 --bin exochain`
- `cargo test -p exo-node zerodentity::api::tests::attestation_write_path_uses_caller_supplied_time --bin exochain`
- `cargo test -p exo-node zerodentity::api::tests --bin exochain`
- `cargo test -p exo-node zerodentity::tests::tests --bin exochain`
- `cargo test -p exo-node zerodentity::attestation::tests --bin exochain`
- `cargo test -p exo-node --bin exochain`
- `cargo clippy -p exo-node --bin exochain -- -D warnings`
- `cargo clippy -p exo-node --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build -p exo-node`
- `cargo test -p exo-node`
- `bash tools/repo_truth.sh --json`
- `bash tools/test_repo_truth.sh`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit --deny unsound --deny unmaintained`
- `cargo deny check`
- `cargo machete --with-metadata`