### PR TITLE
fix(exo-node): make zerodentity score reads deterministic

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 115942 | `wc -l` |
-| Workspace tests | 2,847 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 116067 | `wc -l` |
+| Workspace tests | 2,851 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,847 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,851 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 115942 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 116067 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,847 listed workspace tests
+         cryptographic proofs, 2,851 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          140 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/zerodentity/api.rs
+++ b/crates/exo-node/src/zerodentity/api.rs
@@ -37,7 +37,9 @@ use super::{
     device_behavioral_axes_enabled,
     session_auth::{public_key_from_session_bytes, request_signing_payload, signature_from_hex},
     store::ZerodentityStore,
-    types::{AttestationType, IdentityClaim, ZerodentityScore},
+    types::{
+        AttestationType, BehavioralSample, DeviceFingerprint, IdentityClaim, ZerodentityScore,
+    },
 };
 
 // ---------------------------------------------------------------------------
@@ -60,6 +62,11 @@ pub struct ClaimsQuery {
     pub claim_type: Option<String>,
     pub limit: Option<u64>,
     pub offset: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ScoreQuery {
+    pub as_of_ms: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -375,8 +382,34 @@ fn axes_from_score(s: &ZerodentityScore) -> AxesResponse {
     }
 }
 
-fn now_ms() -> u64 {
-    exo_core::hlc::HybridClock::new().now().physical_ms
+fn score_as_of_ms(
+    claims: &[IdentityClaim],
+    fingerprints: &[DeviceFingerprint],
+    behavioral: &[BehavioralSample],
+    requested_as_of_ms: Option<u64>,
+) -> Result<u64, (StatusCode, Json<serde_json::Value>)> {
+    if let Some(as_of_ms) = requested_as_of_ms {
+        if as_of_ms == 0 {
+            return Err(bad_request("as_of_ms must be greater than 0"));
+        }
+        return Ok(as_of_ms);
+    }
+
+    let mut horizon_ms = 0u64;
+    for claim in claims {
+        horizon_ms = horizon_ms.max(claim.created_ms);
+        if let Some(verified_ms) = claim.verified_ms {
+            horizon_ms = horizon_ms.max(verified_ms);
+        }
+    }
+    for fingerprint in fingerprints {
+        horizon_ms = horizon_ms.max(fingerprint.captured_ms);
+    }
+    for sample in behavioral {
+        horizon_ms = horizon_ms.max(sample.captured_ms);
+    }
+
+    Ok(horizon_ms)
 }
 
 // ---------------------------------------------------------------------------
@@ -387,9 +420,9 @@ fn now_ms() -> u64 {
 pub async fn get_score(
     State(state): State<ApiState>,
     Path(did_str): Path<String>,
+    Query(params): Query<ScoreQuery>,
 ) -> Result<Json<ScoreResponse>, (StatusCode, Json<serde_json::Value>)> {
     let did = parse_did(&did_str)?;
-    let now = now_ms();
 
     let store = state.store.lock().map_err(|_| {
         (
@@ -410,8 +443,9 @@ pub async fn get_score(
     let claims: Vec<IdentityClaim> = claims_raw.into_iter().map(|(_, c)| c).collect();
     let fingerprints = store.get_fingerprints(&did).unwrap_or_default();
     let behavioral = store.get_behavioral_samples(&did).unwrap_or_default();
+    let as_of_ms = score_as_of_ms(&claims, &fingerprints, &behavioral, params.as_of_ms)?;
 
-    let score = ZerodentityScore::compute(&did, &claims, &fingerprints, &behavioral, now);
+    let score = ZerodentityScore::compute(&did, &claims, &fingerprints, &behavioral, as_of_ms);
 
     let history = store
         .get_score_history(&did, None, None)
@@ -935,6 +969,18 @@ mod tests {
             .unwrap();
 
         assert!(!attestation_section.contains("now_ms()"));
+    }
+
+    #[test]
+    fn score_read_path_does_not_fabricate_runtime_time() {
+        let source = include_str!("api.rs");
+        let score_section = source
+            .split("// GET /api/v1/0dentity/:did/score\n// ---------------------------------------------------------------------------")
+            .nth(1)
+            .and_then(|section| section.split("// ---------------------------------------------------------------------------").next())
+            .unwrap();
+
+        assert!(!score_section.contains("now_ms()"));
     }
 
     fn test_keypair(seed: u8) -> KeyPair {

--- a/crates/exo-node/src/zerodentity/tests.rs
+++ b/crates/exo-node/src/zerodentity/tests.rs
@@ -1054,6 +1054,85 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_score_without_as_of_uses_latest_evidence_timestamp() {
+        let store = new_shared_store();
+        let app = api_app(store.clone());
+        let did = td("api-score-evidence-time");
+
+        {
+            let mut s = store.lock().unwrap();
+            s.insert_claim(
+                "e1",
+                &make_claim(&did, ClaimType::Email, ClaimStatus::Verified, 1_000),
+            )
+            .unwrap();
+            s.insert_claim(
+                "p1",
+                &make_claim(&did, ClaimType::Phone, ClaimStatus::Verified, 2_000),
+            )
+            .unwrap();
+        }
+
+        let resp = get_req(&app, &format!("/api/v1/0dentity/{}/score", did.as_str())).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["computed_ms"].as_u64().unwrap(), 2_500);
+    }
+
+    #[tokio::test]
+    async fn get_score_with_as_of_uses_caller_supplied_timestamp() {
+        let store = new_shared_store();
+        let app = api_app(store.clone());
+        let did = td("api-score-explicit-time");
+
+        store
+            .lock()
+            .unwrap()
+            .insert_claim(
+                "c1",
+                &make_claim(&did, ClaimType::DisplayName, ClaimStatus::Verified, 1_000),
+            )
+            .unwrap();
+
+        let resp = get_req(
+            &app,
+            &format!("/api/v1/0dentity/{}/score?as_of_ms=123456", did.as_str()),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["computed_ms"].as_u64().unwrap(), 123_456);
+    }
+
+    #[tokio::test]
+    async fn get_score_rejects_zero_as_of_timestamp() {
+        let store = new_shared_store();
+        let app = api_app(store.clone());
+        let did = td("api-score-zero-time");
+
+        store
+            .lock()
+            .unwrap()
+            .insert_claim(
+                "c1",
+                &make_claim(&did, ClaimType::DisplayName, ClaimStatus::Verified, 1_000),
+            )
+            .unwrap();
+
+        let resp = get_req(
+            &app,
+            &format!("/api/v1/0dentity/{}/score?as_of_ms=0", did.as_str()),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = body_json(resp).await;
+        assert_eq!(
+            body["error"].as_str().unwrap(),
+            "as_of_ms must be greater than 0"
+        );
+    }
+
+    #[tokio::test]
     async fn get_score_includes_dag_state_hash_hex() {
         let store = new_shared_store();
         let app = api_app(store.clone());


### PR DESCRIPTION
## Summary
- adds explicit `as_of_ms` query support to `GET /api/v1/0dentity/:did/score`
- derives the default score `computed_ms` from persisted claim/fingerprint/behavioral evidence instead of runtime HLC time
- rejects explicit `as_of_ms=0` and adds regression/source-guard coverage

## TDD red checks observed
- `cargo test -p exo-node zerodentity::tests::tests::get_score_without_as_of_uses_latest_evidence_timestamp --bin exochain` initially failed because `computed_ms` came from runtime time
- `cargo test -p exo-node zerodentity::tests::tests::get_score_with_as_of_uses_caller_supplied_timestamp --bin exochain` initially failed because the query parameter was not supported
- `cargo test -p exo-node zerodentity::api::tests::score_read_path_does_not_fabricate_runtime_time --bin exochain` initially failed because the score path called `now_ms()`

## Verification
- `cargo test -p exo-node zerodentity::api::tests --bin exochain`
- `cargo test -p exo-node zerodentity::tests::tests --bin exochain`
- `cargo test -p exo-node --bin exochain`
- `cargo build -p exo-node`
- `cargo test -p exo-node`
- `cargo clippy -p exo-node --bin exochain -- -D warnings`
- `cargo clippy -p exo-node --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `bash tools/test_repo_truth.sh`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit --deny unsound --deny unmaintained`
- `cargo deny check`
- `cargo machete --with-metadata`