### PR TITLE
fix(exo-node): canonicalize zerodentity evidence order

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 116067 | `wc -l` |
-| Workspace tests | 2,851 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 116283 | `wc -l` |
+| Workspace tests | 2,855 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,851 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,855 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 116067 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 116283 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,851 listed workspace tests
+         cryptographic proofs, 2,855 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          140 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/zerodentity/store.rs
+++ b/crates/exo-node/src/zerodentity/store.rs
@@ -8,6 +8,7 @@
 //! the integration path for SQLite persistence remains available.
 //!
 //! All inner maps use `BTreeMap` (never `HashMap`) for deterministic iteration.
+//! Evidence vectors are canonicalized on read before callers perform scoring.
 //!
 //! Spec reference: §9, §12.1.
 
@@ -69,6 +70,45 @@ pub struct ErasureEvidence {
     pub dag_node_hash: Hash256,
     pub action_hash: Hash256,
     pub receipt_hash: Hash256,
+}
+
+fn canonicalize_claim_entries(claims: &mut [(String, IdentityClaim)]) {
+    claims.sort_by(|(left_id, left), (right_id, right)| {
+        left.created_ms
+            .cmp(&right.created_ms)
+            .then(left.verified_ms.cmp(&right.verified_ms))
+            .then(left.claim_hash.as_bytes().cmp(right.claim_hash.as_bytes()))
+            .then(left_id.cmp(right_id))
+    });
+}
+
+fn canonicalize_fingerprints(fingerprints: &mut [DeviceFingerprint]) {
+    fingerprints.sort_by(|left, right| {
+        left.captured_ms
+            .cmp(&right.captured_ms)
+            .then(
+                left.composite_hash
+                    .as_bytes()
+                    .cmp(right.composite_hash.as_bytes()),
+            )
+            .then(left.consistency_score_bp.cmp(&right.consistency_score_bp))
+    });
+}
+
+fn canonicalize_behavioral_samples(samples: &mut [BehavioralSample]) {
+    samples.sort_by(|left, right| {
+        left.captured_ms
+            .cmp(&right.captured_ms)
+            .then(
+                left.sample_hash
+                    .as_bytes()
+                    .cmp(right.sample_hash.as_bytes()),
+            )
+            .then(
+                left.baseline_similarity_bp
+                    .cmp(&right.baseline_similarity_bp),
+            )
+    });
 }
 
 // ---------------------------------------------------------------------------
@@ -369,7 +409,9 @@ impl ZerodentityStore {
     ///
     /// Returns an empty `Vec` (not an error) when the DID has no claims.
     pub fn get_claims(&self, did: &Did) -> anyhow::Result<Vec<(String, IdentityClaim)>> {
-        Ok(self.claims.get(did.as_str()).cloned().unwrap_or_default())
+        let mut claims = self.claims.get(did.as_str()).cloned().unwrap_or_default();
+        canonicalize_claim_entries(&mut claims);
+        Ok(claims)
     }
 
     /// Return all claims for a DID as a plain slice (no claim IDs).
@@ -379,9 +421,8 @@ impl ZerodentityStore {
     #[must_use]
     #[allow(dead_code)]
     pub fn get_claims_slice(&self, did: &Did) -> Vec<IdentityClaim> {
-        self.claims
-            .get(did.as_str())
-            .map(|v| v.iter().map(|(_, c)| c.clone()).collect())
+        self.get_claims(did)
+            .map(|entries| entries.into_iter().map(|(_, c)| c).collect())
             .unwrap_or_default()
     }
 
@@ -391,20 +432,24 @@ impl ZerodentityStore {
 
     /// Return all device fingerprints for a DID.
     pub fn get_fingerprints(&self, did: &Did) -> anyhow::Result<Vec<DeviceFingerprint>> {
-        Ok(self
+        let mut fingerprints = self
             .fingerprints
             .get(did.as_str())
             .cloned()
-            .unwrap_or_default())
+            .unwrap_or_default();
+        canonicalize_fingerprints(&mut fingerprints);
+        Ok(fingerprints)
     }
 
     /// Return all behavioral samples for a DID.
     pub fn get_behavioral_samples(&self, did: &Did) -> anyhow::Result<Vec<BehavioralSample>> {
-        Ok(self
+        let mut samples = self
             .behavioral
             .get(did.as_str())
             .cloned()
-            .unwrap_or_default())
+            .unwrap_or_default();
+        canonicalize_behavioral_samples(&mut samples);
+        Ok(samples)
     }
 
     // -----------------------------------------------------------------------

--- a/crates/exo-node/src/zerodentity/tests.rs
+++ b/crates/exo-node/src/zerodentity/tests.rs
@@ -32,7 +32,10 @@ mod tests {
         onboarding::{OnboardingState, onboarding_router},
         scoring::compute_symmetry,
         store::{SharedZerodentityStore, ZerodentityStore, new_shared_store},
-        types::AttestationType,
+        types::{
+            AttestationType, BehavioralSample, BehavioralSignalType, DeviceFingerprint,
+            FingerprintSignal,
+        },
     };
 
     // -----------------------------------------------------------------------
@@ -118,6 +121,42 @@ mod tests {
             expires_ms: None,
             signature: Signature::Empty,
             dag_node_hash: h(&format!("dag-{key}")),
+        }
+    }
+
+    fn make_signed_claim(
+        did: &Did,
+        ct: ClaimType,
+        status: ClaimStatus,
+        ms: u64,
+        signature: Signature,
+    ) -> IdentityClaim {
+        let mut claim = make_claim(did, ct, status, ms);
+        claim.signature = signature;
+        claim
+    }
+
+    fn make_fingerprint(tag: &str, captured_ms: u64) -> DeviceFingerprint {
+        let mut signal_hashes = std::collections::BTreeMap::new();
+        signal_hashes.insert(FingerprintSignal::UserAgent, h(&format!("{tag}-ua")));
+        DeviceFingerprint {
+            composite_hash: h(&format!("{tag}-composite")),
+            signal_hashes,
+            captured_ms,
+            consistency_score_bp: Some(8_000),
+        }
+    }
+
+    fn make_behavioral_sample(
+        tag: &str,
+        signal_type: BehavioralSignalType,
+        captured_ms: u64,
+    ) -> BehavioralSample {
+        BehavioralSample {
+            sample_hash: h(&format!("{tag}-sample")),
+            signal_type,
+            captured_ms,
+            baseline_similarity_bp: Some(7_500),
         }
     }
 
@@ -551,6 +590,76 @@ mod tests {
         for ((_, c_t), c_s) in tuples.iter().zip(slice.iter()) {
             assert_eq!(c_t.claim_type, c_s.claim_type);
         }
+    }
+
+    #[test]
+    fn store_get_claims_returns_canonical_created_ms_order() {
+        let did = td("store-claims-canonical-order");
+        let mut store = ZerodentityStore::new();
+
+        store
+            .insert_claim(
+                "newer",
+                &make_claim(&did, ClaimType::Phone, ClaimStatus::Verified, 2_000),
+            )
+            .unwrap();
+        store
+            .insert_claim(
+                "older",
+                &make_claim(&did, ClaimType::Email, ClaimStatus::Verified, 1_000),
+            )
+            .unwrap();
+
+        let claim_ids: Vec<String> = store
+            .get_claims(&did)
+            .unwrap()
+            .into_iter()
+            .map(|(claim_id, _)| claim_id)
+            .collect();
+
+        assert_eq!(claim_ids, vec!["older".to_owned(), "newer".to_owned()]);
+    }
+
+    #[test]
+    fn store_get_fingerprints_returns_canonical_captured_ms_order() {
+        let did = td("store-fingerprints-canonical-order");
+        let mut store = ZerodentityStore::new();
+
+        store.put_fingerprint(&did, make_fingerprint("newer", 2_000));
+        store.put_fingerprint(&did, make_fingerprint("older", 1_000));
+
+        let captured: Vec<u64> = store
+            .get_fingerprints(&did)
+            .unwrap()
+            .into_iter()
+            .map(|fingerprint| fingerprint.captured_ms)
+            .collect();
+
+        assert_eq!(captured, vec![1_000, 2_000]);
+    }
+
+    #[test]
+    fn store_get_behavioral_samples_returns_canonical_captured_ms_order() {
+        let did = td("store-behavioral-canonical-order");
+        let mut store = ZerodentityStore::new();
+
+        store.put_behavioral(
+            &did,
+            make_behavioral_sample("newer", BehavioralSignalType::MouseDynamics, 2_000),
+        );
+        store.put_behavioral(
+            &did,
+            make_behavioral_sample("older", BehavioralSignalType::KeystrokeDynamics, 1_000),
+        );
+
+        let captured: Vec<u64> = store
+            .get_behavioral_samples(&did)
+            .unwrap()
+            .into_iter()
+            .map(|sample| sample.captured_ms)
+            .collect();
+
+        assert_eq!(captured, vec![1_000, 2_000]);
     }
 
     // -----------------------------------------------------------------------
@@ -1129,6 +1238,68 @@ mod tests {
         assert_eq!(
             body["error"].as_str().unwrap(),
             "as_of_ms must be greater than 0"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_score_is_invariant_to_claim_insertion_order() {
+        let did = td("api-score-canonical-order");
+        let older_post_quantum = make_signed_claim(
+            &did,
+            ClaimType::Email,
+            ClaimStatus::Verified,
+            1_000,
+            Signature::PostQuantum(vec![9; 64]),
+        );
+        let newer_ed25519 = make_signed_claim(
+            &did,
+            ClaimType::Phone,
+            ClaimStatus::Verified,
+            2_000,
+            Signature::Ed25519([8; 64]),
+        );
+
+        let ordered_store = new_shared_store();
+        {
+            let mut s = ordered_store.lock().unwrap();
+            s.insert_claim("older", &older_post_quantum).unwrap();
+            s.insert_claim("newer", &newer_ed25519).unwrap();
+        }
+        let ordered_app = api_app(ordered_store);
+
+        let reversed_store = new_shared_store();
+        {
+            let mut s = reversed_store.lock().unwrap();
+            s.insert_claim("newer", &newer_ed25519).unwrap();
+            s.insert_claim("older", &older_post_quantum).unwrap();
+        }
+        let reversed_app = api_app(reversed_store);
+
+        let ordered_resp = get_req(
+            &ordered_app,
+            &format!("/api/v1/0dentity/{}/score", did.as_str()),
+        )
+        .await;
+        let reversed_resp = get_req(
+            &reversed_app,
+            &format!("/api/v1/0dentity/{}/score", did.as_str()),
+        )
+        .await;
+
+        assert_eq!(ordered_resp.status(), StatusCode::OK);
+        assert_eq!(reversed_resp.status(), StatusCode::OK);
+        let ordered_body = body_json(ordered_resp).await;
+        let reversed_body = body_json(reversed_resp).await;
+
+        assert_eq!(
+            ordered_body["axes"]["cryptographic_strength"],
+            reversed_body["axes"]["cryptographic_strength"]
+        );
+        assert_eq!(
+            ordered_body["axes"]["cryptographic_strength"]
+                .as_u64()
+                .unwrap(),
+            4_000
         );
     }
 


### PR DESCRIPTION
## Summary
- canonicalizes 0dentity claim, fingerprint, and behavioral evidence vectors on store reads before scoring
- preserves claim IDs while sorting claims by created_ms/verified_ms/hash/id
- adds regressions proving canonical retrieval and insertion-order invariant score output
- refreshes README repo-truth counts

## TDD red checks
- `cargo test -p exo-node zerodentity::tests::tests::store_get_claims_returns_canonical_created_ms_order --bin exochain` failed before the fix with insertion order `newer, older`
- `cargo test -p exo-node zerodentity::tests::tests::get_score_is_invariant_to_claim_insertion_order --bin exochain` failed before the fix with scores `4000` vs `5000`

## Verification
- `cargo test -p exo-node zerodentity::tests::tests --bin exochain`
- `cargo test -p exo-node zerodentity::store::tests --bin exochain`
- `cargo test -p exo-node --bin exochain`
- `cargo test -p exo-node`
- `cargo clippy -p exo-node --bin exochain -- -D warnings`
- `cargo clippy -p exo-node --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build -p exo-node`
- `bash tools/repo_truth.sh --json`
- `bash tools/test_repo_truth.sh`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit --deny unsound --deny unmaintained`
- `cargo deny check`
- `cargo machete --with-metadata`