### PR TITLE
fix(exo-node): require signed erasure time

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 116283 | `wc -l` |
-| Workspace tests | 2,855 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 116405 | `wc -l` |
+| Workspace tests | 2,860 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,855 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,860 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 116283 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 116405 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,855 listed workspace tests
+         cryptographic proofs, 2,860 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          140 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/zerodentity/api.rs
+++ b/crates/exo-node/src/zerodentity/api.rs
@@ -828,6 +828,11 @@ pub struct ErasureResponse {
     pub message: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct ErasureRequest {
+    pub erased_ms: Option<u64>,
+}
+
 /// Delete all 0dentity data for a DID.
 ///
 /// Implements the right to erasure (§11.4):
@@ -848,6 +853,14 @@ pub async fn delete_identity(
 
     let request_path = path_and_query(&uri);
     let _token = verify_signed_write(&state, &headers, &did, "DELETE", &request_path, &body)?;
+    let req: ErasureRequest = serde_json::from_slice(&body)
+        .map_err(|_| json_error(StatusCode::BAD_REQUEST, "Invalid JSON body"))?;
+    let erased_ms = req
+        .erased_ms
+        .ok_or_else(|| bad_request("erased_ms is required"))?;
+    if erased_ms == 0 {
+        return Err(bad_request("erased_ms must be greater than 0"));
+    }
 
     let erasure_evidence = {
         let mut store = state.store.lock().map_err(|_| {
@@ -856,12 +869,14 @@ pub async fn delete_identity(
                 Json(serde_json::json!({"error": "lock poisoned"})),
             )
         })?;
-        store.erase_did_with_evidence(&did).map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": format!("Erasure failed: {e}")})),
-            )
-        })?
+        store
+            .erase_did_with_evidence(&did, Timestamp::new(erased_ms, 0))
+            .map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": format!("Erasure failed: {e}")})),
+                )
+            })?
     };
 
     let receipt_hash = hex::encode(erasure_evidence.receipt_hash.as_bytes());
@@ -981,6 +996,18 @@ mod tests {
             .unwrap();
 
         assert!(!score_section.contains("now_ms()"));
+    }
+
+    #[test]
+    fn erasure_write_path_does_not_fabricate_runtime_time() {
+        let source = include_str!("api.rs");
+        let erasure_section = source
+            .split("// DELETE /api/v1/0dentity/:did")
+            .nth(1)
+            .and_then(|section| section.split("// ---------------------------------------------------------------------------\n// Router").next())
+            .unwrap();
+
+        assert!(!erasure_section.contains("now_ms()"));
     }
 
     fn test_keypair(seed: u8) -> KeyPair {
@@ -1114,19 +1141,21 @@ mod tests {
         uri: &str,
         token: &str,
         nonce: &str,
+        body: serde_json::Value,
         keypair: &KeyPair,
     ) -> axum::response::Response {
-        let body = Vec::new();
+        let body = serde_json::to_vec(&body).unwrap();
         let (nonce, signature) =
             request_signature_headers("DELETE", uri, token, nonce, &body, keypair);
         app.oneshot(
             Request::builder()
                 .method("DELETE")
                 .uri(uri)
+                .header("content-type", "application/json")
                 .header("authorization", format!("Bearer {token}"))
                 .header("x-exo-nonce", nonce)
                 .header("x-exo-sig", signature)
-                .body(Body::empty())
+                .body(Body::from(body))
                 .unwrap(),
         )
         .await
@@ -1541,6 +1570,7 @@ mod tests {
             "/api/v1/0dentity/did%3Aexo%3Aalice",
             "tok-alice",
             "nonce-api-delete-1",
+            serde_json::json!({ "erased_ms": 7_777_000 }),
             &keypair,
         )
         .await;
@@ -1559,12 +1589,61 @@ mod tests {
             result["receipt_hash"].as_str().unwrap(),
             hex::encode(receipt.receipt_hash.as_bytes())
         );
+        assert_eq!(receipt.timestamp.physical_ms, 7_777_000);
+        let nodes = guard.dag_nodes();
+        let erasure_node = nodes.last().expect("erasure dag node");
+        assert_eq!(erasure_node.timestamp.physical_ms, 7_777_000);
         assert!(receipt.verify_hash());
         assert!(
             result["message"]
                 .as_str()
                 .unwrap()
                 .contains("Identity erased")
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_identity_requires_erasure_timestamp() {
+        let keypair = test_keypair(44);
+        let state =
+            make_state_with_signed_session_and_claim("tok-alice", "did:exo:alice", &keypair);
+        let app = zerodentity_api_router(state);
+        let resp = signed_delete(
+            app,
+            "/api/v1/0dentity/did%3Aexo%3Aalice",
+            "tok-alice",
+            "nonce-api-delete-missing-time",
+            serde_json::json!({}),
+            &keypair,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["error"].as_str().unwrap(), "erased_ms is required");
+    }
+
+    #[tokio::test]
+    async fn delete_identity_rejects_zero_erasure_timestamp() {
+        let keypair = test_keypair(45);
+        let state =
+            make_state_with_signed_session_and_claim("tok-alice", "did:exo:alice", &keypair);
+        let app = zerodentity_api_router(state);
+        let resp = signed_delete(
+            app,
+            "/api/v1/0dentity/did%3Aexo%3Aalice",
+            "tok-alice",
+            "nonce-api-delete-zero-time",
+            serde_json::json!({ "erased_ms": 0 }),
+            &keypair,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            result["error"].as_str().unwrap(),
+            "erased_ms must be greater than 0"
         );
     }
 

--- a/crates/exo-node/src/zerodentity/store.rs
+++ b/crates/exo-node/src/zerodentity/store.rs
@@ -658,9 +658,16 @@ impl ZerodentityStore {
     /// 5. Remove OTP challenges belonging to this DID.
     /// 6. Tombstone DAG nodes — zero payload hash, keep structural links.
     /// 7. Emit an erasure receipt.
-    pub fn erase_did_with_evidence(&mut self, did: &Did) -> anyhow::Result<ErasureEvidence> {
+    pub fn erase_did_with_evidence(
+        &mut self,
+        did: &Did,
+        timestamp: Timestamp,
+    ) -> anyhow::Result<ErasureEvidence> {
         if self.receipt_signing.is_none() {
             anyhow::bail!("0dentity trust receipt signer is not configured");
+        }
+        if timestamp.physical_ms == 0 {
+            anyhow::bail!("0dentity erasure timestamp must be greater than 0");
         }
 
         let key = did.as_str().to_owned();
@@ -699,15 +706,14 @@ impl ZerodentityStore {
         // 6. Emit erasure receipt and append a signed erasure DAG node. The
         // existing claim nodes remain append-only; erasure is represented as a
         // new tombstone event.
-        let now_ms = crate::sentinels::now_ms();
         let erasure_hash = erasure_action_hash(did)?;
         let receipt = self.trust_receipt(
             "zerodentity.identity_erased",
             erasure_hash,
             ReceiptOutcome::Executed,
-            Timestamp::new(now_ms, 0),
+            timestamp,
         )?;
-        let erasure_node = self.signed_dag_node(erasure_hash, Timestamp::new(now_ms, 0))?;
+        let erasure_node = self.signed_dag_node(erasure_hash, timestamp)?;
         let dag_node_hash = erasure_node.hash;
         let receipt_hash = receipt.receipt_hash;
         self.dag_nodes.push(erasure_node);
@@ -779,7 +785,7 @@ mod tests {
 
     use exo_core::{
         crypto::{KeyPair, verify},
-        types::{Did, Hash256, PublicKey, Signature},
+        types::{Did, Hash256, PublicKey, Signature, Timestamp},
     };
 
     use super::*;
@@ -1051,7 +1057,9 @@ mod tests {
         store.save_claim("apg-dag-erasure-001", &c).unwrap();
         let claim_node = store.dag_nodes()[0].clone();
 
-        store.erase_did_with_evidence(&d).unwrap();
+        store
+            .erase_did_with_evidence(&d, Timestamp::new(6_000, 0))
+            .unwrap();
 
         let nodes = store.dag_nodes();
         assert_eq!(nodes.len(), 2);
@@ -1165,7 +1173,9 @@ mod tests {
             .unwrap();
 
         // Erase
-        let evidence = store.erase_did_with_evidence(&d).unwrap();
+        let evidence = store
+            .erase_did_with_evidence(&d, Timestamp::new(7_000, 0))
+            .unwrap();
         assert_eq!(evidence.claims_revoked, 2);
 
         // Score gone
@@ -1198,7 +1208,9 @@ mod tests {
         let d = did("did:exo:signed-erase");
         store.put_claim(claim(&d, ClaimType::Email));
 
-        let evidence = store.erase_did_with_evidence(&d).unwrap();
+        let evidence = store
+            .erase_did_with_evidence(&d, Timestamp::new(8_000, 0))
+            .unwrap();
         assert_eq!(evidence.claims_revoked, 1);
 
         let receipt = store
@@ -1210,6 +1222,33 @@ mod tests {
         assert!(!receipt.signature.is_empty());
         assert!(receipt.verify_hash());
         assert!(receipt.verify_signature(&node_public_key));
+    }
+
+    #[test]
+    fn erase_did_rejects_zero_timestamp() {
+        let (mut store, _, _) = signed_store(18);
+        let d = did("did:exo:zero-erase");
+        store.put_claim(claim(&d, ClaimType::Email));
+
+        let err = store
+            .erase_did_with_evidence(&d, Timestamp::new(0, 0))
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("erasure timestamp must be greater than 0")
+        );
+    }
+
+    #[test]
+    fn erase_did_write_path_does_not_fabricate_runtime_time() {
+        let source = include_str!("store.rs");
+        let erasure_section = source
+            .split("// Write — erasure")
+            .nth(1)
+            .and_then(|section| section.split("// Read — OTP challenges").next())
+            .unwrap();
+
+        assert!(!erasure_section.contains("now_ms()"));
     }
 
     #[test]
@@ -1245,7 +1284,9 @@ mod tests {
         assert!(!store.get_fingerprints(&d).unwrap().is_empty());
         assert!(!store.get_behavioral_samples(&d).unwrap().is_empty());
 
-        store.erase_did_with_evidence(&d).unwrap();
+        store
+            .erase_did_with_evidence(&d, Timestamp::new(9_000, 0))
+            .unwrap();
 
         assert!(store.get_fingerprints(&d).unwrap().is_empty());
         assert!(store.get_behavioral_samples(&d).unwrap().is_empty());
@@ -1259,7 +1300,9 @@ mod tests {
         store.save_claim("dag-001", &c).unwrap();
 
         let claim_node = store.dag_nodes()[0].clone();
-        store.erase_did_with_evidence(&d).unwrap();
+        store
+            .erase_did_with_evidence(&d, Timestamp::new(10_000, 0))
+            .unwrap();
         assert_eq!(store.dag_nodes().len(), 2);
         assert_eq!(store.dag_nodes()[0], claim_node);
         assert_eq!(store.dag_nodes()[1].parents, vec![claim_node.hash]);


### PR DESCRIPTION

## Summary
- require signed DELETE /api/v1/0dentity/:did requests to include a non-zero erased_ms timestamp
- bind the erasure timestamp to the existing signed request body hash and use it for both the trust receipt and erasure DAG tombstone
- add regression/source-guard tests preventing runtime now_ms fabrication from returning to the erasure path
- update README repo-truth counters after the new tests

## Root Cause
The default-on erasure endpoint verified the caller signature but the store still minted runtime time internally with now_ms() for receipt and DAG evidence. That made an audit-critical erasure fact store-fabricated instead of caller-supplied and signature-bound.

## TDD Red Checks Captured
- cargo test -p exo-node zerodentity::api::tests::delete_identity_requires_erasure_timestamp --bin exochain
- cargo test -p exo-node zerodentity::api::tests::delete_identity_success_returns_erasure_receipt --bin exochain
- cargo test -p exo-node zerodentity::store::tests::erase_did_write_path_does_not_fabricate_runtime_time --bin exochain

## Verification
- cargo test -p exo-node zerodentity::api::tests --bin exochain
- cargo test -p exo-node zerodentity::store::tests --bin exochain
- cargo test -p exo-node zerodentity::tests::tests --bin exochain
- cargo test -p exo-node --bin exochain
- cargo test -p exo-node
- cargo build -p exo-node
- cargo clippy -p exo-node --bin exochain -- -D warnings
- cargo clippy -p exo-node --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- bash tools/repo_truth.sh --json
- cargo +nightly fmt --all -- --check
- git diff --check
- bash tools/test_repo_truth.sh
- bash tools/test_cr001_status.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_no_orphan_rust_modules.sh
- bash tools/test_railway_entrypoint_args.sh
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo build --workspace --release
- cargo test --workspace --release
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
- cargo audit --deny unsound --deny unmaintained
- cargo deny check
- cargo machete --with-metadata
