### PR TITLE
fix(exo-node): compile out first-touch legacy path

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 116405 | `wc -l` |
-| Workspace tests | 2,860 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 116444 | `wc -l` |
+| Workspace tests | 2,861 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,860 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,861 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 116405 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 116444 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,860 listed workspace tests
+         cryptographic proofs, 2,861 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          140 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/zerodentity/onboarding.rs
+++ b/crates/exo-node/src/zerodentity/onboarding.rs
@@ -5,29 +5,26 @@
 //!
 //! Spec reference: §7.1.
 
-use std::{
-    str::FromStr,
-    sync::{Arc, Mutex},
-};
+#[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
+use std::str::FromStr;
+use std::sync::{Arc, Mutex};
 
 use axum::{Json, Router, extract::State, http::StatusCode, routing::post};
-use exo_core::{
-    crypto,
-    types::{Did, Hash256, PublicKey, Signature},
-};
+#[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
+use exo_core::types::{Did, Hash256, Signature};
+use exo_core::{crypto, types::PublicKey};
 use getrandom::getrandom;
 use rand::{SeedableRng, rngs::StdRng};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+#[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
+use super::types::{ClaimStatus, IdentityClaim, OtpChannel};
 use super::{
     otp::OtpResult,
     session_auth::{bootstrap_signing_payload, public_key_from_hex, signature_from_hex},
     store::ZerodentityStore,
-    types::{
-        ClaimStatus, ClaimType, IdentityClaim, IdentitySession, OtpChallenge, OtpChannel,
-        ZerodentityScore,
-    },
+    types::{ClaimType, IdentitySession, OtpChallenge, ZerodentityScore},
 };
 
 // ---------------------------------------------------------------------------
@@ -69,6 +66,10 @@ pub fn score_summary_from(score: &ZerodentityScore) -> ScoreSummary {
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Deserialize)]
+#[cfg_attr(
+    not(feature = "unaudited-zerodentity-first-touch-onboarding"),
+    allow(dead_code)
+)]
 pub struct SubmitClaimRequest {
     pub subject_did: String,
     pub claim_type: String,
@@ -118,7 +119,9 @@ pub struct ResendOtpResponse {
 // Helpers
 // ---------------------------------------------------------------------------
 
+#[cfg(not(feature = "unaudited-zerodentity-first-touch-onboarding"))]
 const FIRST_TOUCH_ONBOARDING_FEATURE: &str = "unaudited-zerodentity-first-touch-onboarding";
+#[cfg(not(feature = "unaudited-zerodentity-first-touch-onboarding"))]
 const FIRST_TOUCH_ONBOARDING_INITIATIVE: &str = "fix-onyx-4-r1-onboarding-auth.md";
 
 fn now_ms() -> u64 {
@@ -131,6 +134,7 @@ fn build_rng() -> StdRng {
     StdRng::from_seed(seed)
 }
 
+#[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
 fn parse_did(s: &str) -> Result<Did, (StatusCode, Json<serde_json::Value>)> {
     Did::new(s).map_err(|_| {
         (
@@ -193,6 +197,10 @@ fn verify_bootstrap_signature(
     Ok(public_key)
 }
 
+#[cfg_attr(
+    not(feature = "unaudited-zerodentity-first-touch-onboarding"),
+    allow(dead_code)
+)]
 fn parse_claim_type(ct: &str, provider: Option<&str>) -> Option<ClaimType> {
     match ct {
         "Email" => Some(ClaimType::Email),
@@ -208,6 +216,7 @@ fn parse_claim_type(ct: &str, provider: Option<&str>) -> Option<ClaimType> {
     }
 }
 
+#[cfg(not(feature = "unaudited-zerodentity-first-touch-onboarding"))]
 fn first_touch_onboarding_refusal() -> (StatusCode, Json<serde_json::Value>) {
     tracing::warn!(
         "refusing POST /api/v1/0dentity/claims: first-touch onboarding \
@@ -235,15 +244,21 @@ fn first_touch_onboarding_refusal() -> (StatusCode, Json<serde_json::Value>) {
 // ---------------------------------------------------------------------------
 
 /// `POST /api/v1/0dentity/claims` — submit a new identity claim for verification.
+#[cfg(not(feature = "unaudited-zerodentity-first-touch-onboarding"))]
 pub async fn submit_claim(
     State(state): State<OnboardingState>,
     Json(req): Json<SubmitClaimRequest>,
 ) -> Result<Json<SubmitClaimResponse>, (StatusCode, Json<serde_json::Value>)> {
-    if !cfg!(feature = "unaudited-zerodentity-first-touch-onboarding") {
-        let _ = (state, req);
-        return Err(first_touch_onboarding_refusal());
-    }
+    let _ = (state, req);
+    Err(first_touch_onboarding_refusal())
+}
 
+/// `POST /api/v1/0dentity/claims` — submit a new identity claim for verification.
+#[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
+pub async fn submit_claim(
+    State(state): State<OnboardingState>,
+    Json(req): Json<SubmitClaimRequest>,
+) -> Result<Json<SubmitClaimResponse>, (StatusCode, Json<serde_json::Value>)> {
     let subject_did = parse_did(&req.subject_did)?;
     let now = now_ms();
 
@@ -537,6 +552,30 @@ mod tests {
             parse_claim_type("BiometricLiveness", None),
             Some(ClaimType::BiometricLiveness)
         );
+    }
+
+    #[test]
+    #[cfg(not(feature = "unaudited-zerodentity-first-touch-onboarding"))]
+    fn default_submit_claim_handler_compiles_out_legacy_claim_creation() {
+        let source = include_str!("onboarding.rs");
+        let default_handler = source
+            .split(
+                "#[cfg(not(feature = \"unaudited-zerodentity-first-touch-onboarding\"))]\n\
+                 pub async fn submit_claim",
+            )
+            .nth(1)
+            .and_then(|section| {
+                section
+                    .split("#[cfg(feature = \"unaudited-zerodentity-first-touch-onboarding\")]")
+                    .next()
+            })
+            .expect("default submit_claim handler must have an explicit cfg boundary");
+
+        assert!(default_handler.contains("first_touch_onboarding_refusal"));
+        assert!(!default_handler.contains("now_ms()"));
+        assert!(!default_handler.contains("Uuid::new_v4()"));
+        assert!(!default_handler.contains("Signature::Empty"));
+        assert!(!default_handler.contains("insert_claim"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Split `POST /api/v1/0dentity/claims` into mutually exclusive cfg-specific handlers.
- Keep the default build refusal-only for `unaudited-zerodentity-first-touch-onboarding`, with the R1 initiative named in the body.
- Preserve the legacy first-touch claim flow only behind the explicit unaudited feature.
- Add a source guard proving the default handler excludes `now_ms()`, `Uuid::new_v4()`, `Signature::Empty`, and `insert_claim`.
- Update README repo-truth counts to 116444 Rust LOC and 2,861 listed workspace tests.

## Root Cause
The R1 default-off gate used `cfg!()` at runtime, so the default `exo-node` binary still compiled the legacy claim-creation body even though requests were refused.

## TDD
Red check captured before implementation:
- `cargo test -p exo-node zerodentity::onboarding::tests::default_submit_claim_handler_compiles_out_legacy_claim_creation --bin exochain` failed because the default handler still contained `now_ms()`.

## Verification
- `cargo test -p exo-node zerodentity::onboarding::tests::default_submit_claim_handler_compiles_out_legacy_claim_creation --bin exochain`
- `cargo test -p exo-node zerodentity::onboarding::tests --bin exochain`
- `cargo test -p exo-node zerodentity::tests::tests::submit_claim_refused_without_first_touch_feature_flag --bin exochain`
- `cargo test -p exo-node --features unaudited-zerodentity-first-touch-onboarding --bin exochain zerodentity::tests::tests::submit_claim`
- `cargo test -p exo-node --bin exochain`
- `cargo test -p exo-node`
- `cargo build -p exo-node`
- `cargo clippy -p exo-node --bin exochain -- -D warnings`
- `cargo clippy -p exo-node --features unaudited-zerodentity-first-touch-onboarding --bin exochain -- -D warnings`
- `cargo clippy -p exo-node --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `bash tools/repo_truth.sh --json`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit --deny unsound --deny unmaintained`
- `cargo deny check`
- `cargo machete --with-metadata`