### PR TITLE
fix(wasm): require caller event metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 115855 | `wc -l` |
-| Workspace tests | 2,869 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 115919 | `wc -l` |
+| Workspace tests | 2,870 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,869 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,870 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 115855 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 115919 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,869 listed workspace tests
+         cryptographic proofs, 2,870 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exochain-wasm/src/core_bindings.rs
+++ b/crates/exochain-wasm/src/core_bindings.rs
@@ -189,10 +189,48 @@ pub fn wasm_verify_merkle_proof(
 
 // ── Events ─────────────────────────────────────────────────────────
 
-/// Generate a fresh event correlation ID.
+fn deterministic_event_id(seed: &[u8]) -> String {
+    let mut preimage = b"exo.wasm.event_id.v1".to_vec();
+    preimage.extend_from_slice(seed);
+    let digest = exo_core::Hash256::digest(&preimage);
+    let mut bytes = [0u8; 16];
+    bytes.copy_from_slice(&digest.as_bytes()[..16]);
+    // RFC 9562 UUID version 8 with RFC 4122 variant bits, using caller seed
+    // entropy hashed under the domain tag above.
+    bytes[6] = (bytes[6] & 0x0f) | 0x80;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    uuid::Uuid::from_bytes(bytes).to_string()
+}
+
+fn caller_event_id(event_id: &str) -> Result<exo_core::CorrelationId, JsValue> {
+    let uuid = uuid::Uuid::parse_str(event_id)
+        .map_err(|e| JsValue::from_str(&format!("event_id: {e}")))?;
+    if uuid.is_nil() {
+        return Err(JsValue::from_str("event_id must not be the nil UUID"));
+    }
+    Ok(exo_core::CorrelationId::from_uuid(uuid))
+}
+
+fn caller_timestamp(
+    physical_ms: u64,
+    logical: u32,
+    label: &str,
+) -> Result<exo_core::Timestamp, JsValue> {
+    if physical_ms == 0 {
+        return Err(JsValue::from_str(&format!(
+            "{label} physical_ms must be caller-supplied and non-zero"
+        )));
+    }
+    Ok(exo_core::Timestamp::new(physical_ms, logical))
+}
+
+/// Derive an event correlation ID from caller-supplied seed bytes.
 #[wasm_bindgen]
-pub fn wasm_compute_event_id() -> String {
-    exo_core::CorrelationId::new().to_string()
+pub fn wasm_compute_event_id(seed: &[u8]) -> Result<String, JsValue> {
+    if seed.is_empty() {
+        return Err(JsValue::from_str("event_id seed must not be empty"));
+    }
+    Ok(deterministic_event_id(seed))
 }
 
 /// Verify the Ed25519 signature on a signed event.
@@ -236,6 +274,9 @@ pub fn wasm_create_signed_event(
     payload: &[u8],
     source_did: &str,
     secret_hex: &str,
+    event_id: &str,
+    timestamp_physical_ms: u64,
+    timestamp_logical: u32,
 ) -> Result<JsValue, JsValue> {
     let event_type: exo_core::events::EventType = from_json_str(event_type_json)?;
     let did = exo_core::Did::new(source_did)
@@ -247,9 +288,8 @@ pub fn wasm_create_signed_event(
         .map_err(|_| JsValue::from_str("secret key must be 32 bytes"))?;
     let secret = exo_core::SecretKey::from_bytes(arr);
 
-    let mut clock = exo_core::hlc::HybridClock::new();
-    let ts = clock.now();
-    let corr = exo_core::CorrelationId::new();
+    let corr = caller_event_id(event_id)?;
+    let ts = caller_timestamp(timestamp_physical_ms, timestamp_logical, "event timestamp")?;
 
     let event =
         exo_core::events::create_signed_event(corr, ts, event_type, payload.to_vec(), did, &secret);

--- a/crates/exochain-wasm/src/lib.rs
+++ b/crates/exochain-wasm/src/lib.rs
@@ -146,4 +146,28 @@ mod source_guard_tests {
             );
         }
     }
+
+    #[test]
+    fn wasm_core_event_bridge_requires_caller_supplied_metadata() {
+        let source = include_str!("core_bindings.rs");
+        assert!(
+            source.contains("event_id")
+                && source.contains("timestamp_physical_ms")
+                && source.contains("timestamp_logical"),
+            "signed event creation must expose caller-supplied event ID and HLC metadata"
+        );
+
+        let forbidden = [
+            "CorrelationId::new()",
+            "HybridClock::new()",
+            "Timestamp::now_utc()",
+        ];
+
+        for pattern in forbidden {
+            assert!(
+                !source.contains(pattern),
+                "core WASM event bindings must not fabricate event metadata with {pattern}"
+            );
+        }
+    }
 }

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 115855 lines of Rust under `crates/`, 2,869 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 115919 lines of Rust under `crates/`, 2,870 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,868 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,870 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,868 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,870 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-115855 lines of Rust under `crates/` · 20 workspace packages · 2,869 listed tests · 40 MCP tools · 8 constitutional invariants
+115919 lines of Rust under `crates/` · 20 workspace packages · 2,870 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 115855 lines of Rust under `crates/` | 266 Rust source files | 2,869 listed tests
+> **Codebase:** 20 workspace packages | 115919 lines of Rust under `crates/` | 266 Rust source files | 2,870 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,869 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,870 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 115855 lines of Rust under `crates/` · 2,869 listed tests
+20 workspace packages · 115919 lines of Rust under `crates/` · 2,870 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -151,8 +151,16 @@ test('wasm_sign', () =>
 test('wasm_ed25519_public_from_secret', () =>
   wasm.wasm_ed25519_public_from_secret(DUMMY_SECRET_HEX));
 
-test('wasm_compute_event_id', () =>
-  wasm.wasm_compute_event_id());
+const EVENT_SEED = new TextEncoder().encode('event-seed-1');
+const EVENT_ID = wasm.wasm_compute_event_id(EVENT_SEED);
+
+test('wasm_compute_event_id', () => {
+  const again = wasm.wasm_compute_event_id(EVENT_SEED);
+  if (EVENT_ID !== again) {
+    throw new Error('event ID derivation must be deterministic for caller seed');
+  }
+  return EVENT_ID;
+});
 
 // =========================================================================
 // Module 3 — Events
@@ -165,7 +173,10 @@ test('wasm_create_signed_event', () =>
     JSON.stringify('AuditEntry'),
     TEXT_BYTES,
     TEST_DID,
-    DUMMY_SECRET_HEX
+    DUMMY_SECRET_HEX,
+    EVENT_ID,
+    NOW_MS,
+    7
   ));
 
 const signedEvent = setup(() =>
@@ -173,12 +184,21 @@ const signedEvent = setup(() =>
     JSON.stringify('AuditEntry'),
     TEXT_BYTES,
     TEST_DID,
-    DUMMY_SECRET_HEX
+    DUMMY_SECRET_HEX,
+    EVENT_ID,
+    NOW_MS,
+    7
   ));
 
 test('wasm_verify_event', () => {
   if (!signedEvent) throw new Error('skipped -- no signed event from setup');
-  const pubKey = signedEvent.public_key || signedEvent.source_public_key || ephResult.public_key;
+  if (String(signedEvent.id) !== EVENT_ID) {
+    throw new Error('signed event did not preserve caller-supplied event ID');
+  }
+  if (BigInt(signedEvent.timestamp?.physical_ms) !== NOW_MS || signedEvent.timestamp?.logical !== 7) {
+    throw new Error('signed event did not preserve caller-supplied HLC timestamp');
+  }
+  const pubKey = publicKeyForSecret(DUMMY_SECRET_HEX);
   return wasm.wasm_verify_event(JSON.stringify(signedEvent), pubKey);
 });
 


### PR DESCRIPTION
## Summary
- require caller-supplied event IDs and HLC metadata when creating signed events through the WASM bridge
- make `wasm_compute_event_id` deterministic from non-empty caller seed bytes
- add source guards and JS bridge assertions proving the event ID and timestamp are preserved instead of fabricated
- refresh repo-truth documentation counts after the remediation

## Root cause
The WASM signed-event bridge accepted caller payload, DID, and signing material, but generated its own `CorrelationId` and timestamp with runtime constructors. That produced signed events whose durable metadata was not supplied by or bound to the caller's operation context.

## Validation
After rebasing onto `main` following #190:
- `cargo test -p exochain-wasm`
- `node packages/exochain-wasm/test/bridge_verification.mjs`
- `wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm`
- `cargo clippy -p exochain-wasm --lib -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`

Earlier focused TDD checks on this branch:
- `cargo test -p exochain-wasm wasm_core_event_bridge_requires_caller_supplied_metadata --lib -- --nocapture`
- `cargo test -p exochain-wasm --lib source_guard_tests -- --nocapture`
- `bash tools/test_repo_truth.sh`
