### PR TITLE
fix(exo-node): refuse hash-only CGR proof verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 116343 | `wc -l` |
+| Rust LOC | 116344 | `wc -l` |
 | Workspace tests | 2,883 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -57,7 +57,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 116343 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 116344 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 2,883 listed workspace tests
 

--- a/crates/exo-node/src/mcp/tools/proofs.rs
+++ b/crates/exo-node/src/mcp/tools/proofs.rs
@@ -9,6 +9,8 @@ use crate::mcp::{
     protocol::{ToolDefinition, ToolResult},
 };
 
+const MCP_CGR_PROOF_INITIATIVE: &str = "Initiatives/fix-mcp-cgr-proof-verification-stub.md";
+
 fn required_nonzero_u64(params: &Value, name: &str) -> std::result::Result<u64, ToolResult> {
     match params.get(name).and_then(Value::as_u64) {
         Some(value) if value > 0 => Ok(value),
@@ -377,23 +379,22 @@ pub fn execute_generate_merkle_proof(params: &Value, _context: &NodeContext) -> 
 pub fn verify_cgr_proof_definition() -> ToolDefinition {
     ToolDefinition {
         name: "exochain_verify_cgr_proof".to_owned(),
-        description: "Verify a CGR kernel proof by checking the proof hash and invariants."
-            .to_owned(),
+        description: "Fail-closed placeholder for CGR kernel proof verification until proof bytes, public inputs, checkpoint roots, and a production verifier are wired.".to_owned(),
         input_schema: json!({
             "type": "object",
             "properties": {
                 "proof_hash": {
                     "type": "string",
-                    "description": "Hex-encoded hash of the CGR proof to verify."
+                    "description": "Hex-encoded hash claim for the CGR proof. Hash-only verification is refused."
                 },
                 "invariants_checked": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "List of invariant names that were checked in the proof."
+                    "description": "Caller-declared invariant names. These are not accepted as proof of verification."
                 },
                 "verified_at_ms": {
                     "type": "integer",
-                    "description": "Caller-supplied nonzero HLC physical milliseconds for verification."
+                    "description": "Caller-supplied nonzero HLC physical milliseconds for the refusal record."
                 }
             },
             "required": ["proof_hash", "invariants_checked", "verified_at_ms"],
@@ -440,19 +441,18 @@ pub fn execute_verify_cgr_proof(params: &Value, _context: &NodeContext) -> ToolR
         .map(String::from)
         .collect();
 
-    // Compute a verification hash to attest we checked this proof.
-    let verification_input = format!("cgr_verify:{}:{}", proof_hash, invariant_names.join(","));
-    let verification_hash = Hash256::digest(verification_input.as_bytes());
-
-    let response = json!({
-        "proof_hash": proof_hash,
-        "verification_status": "verified",
-        "invariants_checked": invariant_names,
-        "invariant_count": invariant_names.len(),
-        "verification_hash": verification_hash.to_string(),
-        "verified_at": format!("{}:0", verified_at_ms),
-    });
-    ToolResult::success(response.to_string())
+    ToolResult::error(
+        json!({
+            "error": format!(
+                "CGR proof verification is unavailable: exochain_verify_cgr_proof has no proof bytes, public inputs, checkpoint root, validator signature set, or production CGR proof verifier wired; refusing hash-only verification claims. See {MCP_CGR_PROOF_INITIATIVE}."
+            ),
+            "proof_hash": proof_hash,
+            "invariants_requested": invariant_names,
+            "refused_at": format!("{}:0", verified_at_ms),
+            "initiative": MCP_CGR_PROOF_INITIATIVE,
+        })
+        .to_string(),
+    )
 }
 
 // ===========================================================================
@@ -629,18 +629,19 @@ mod tests {
     }
 
     #[test]
-    fn execute_verify_cgr_proof_success() {
+    fn execute_verify_cgr_proof_refuses_hash_only_claims() {
         let params = json!({
             "proof_hash": "abcdef01",
             "invariants_checked": ["consent_required", "no_self_dealing"],
             "verified_at_ms": 1700000000002_u64,
         });
         let result = execute_verify_cgr_proof(&params, &NodeContext::empty());
-        assert!(!result.is_error);
+        assert!(result.is_error);
         let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
-        assert_eq!(v["verification_status"], "verified");
-        assert_eq!(v["invariant_count"], 2);
-        assert!(v["verification_hash"].as_str().is_some());
+        let error = v["error"].as_str().expect("error string");
+        assert!(error.contains("CGR proof verification is unavailable"));
+        assert!(error.contains("fix-mcp-cgr-proof-verification-stub.md"));
+        assert!(!result.content[0].text().contains("verification_status"));
     }
 
     #[test]

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 116343 lines of Rust under `crates/`, 2,883 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 116344 lines of Rust under `crates/`, 2,883 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-116343 lines of Rust under `crates/` · 20 workspace packages · 2,883 listed tests · 40 MCP tools · 8 constitutional invariants
+116344 lines of Rust under `crates/` · 20 workspace packages · 2,883 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 116343 lines of Rust under `crates/` | 266 Rust source files | 2,883 listed tests
+> **Codebase:** 20 workspace packages | 116344 lines of Rust under `crates/` | 266 Rust source files | 2,883 listed tests
 
 ---
 

--- a/docs/guides/ai-agent-guide.md
+++ b/docs/guides/ai-agent-guide.md
@@ -329,11 +329,14 @@ inclusion proofs — for admissibility review.
 3. `tools/call` → `exochain_verify_chain_of_custody` for the
    bundle's custody chain. Every transfer must be signed and
    time-ordered.
-4. `tools/call` → `exochain_verify_cgr_proof` to verify the
-   CGR proof carried by each `PROVEN` event.
+4. Do not treat `exochain_verify_cgr_proof` as a verifier in default
+   builds. It refuses hash-only CGR proof claims until proof bytes,
+   public inputs, checkpoint roots, validator signatures, and a
+   production verifier are wired.
 5. Produce an admissibility statement: either "the bundle is
    self-consistent, signed end-to-end, and verifies against
-   checkpoint X" or a list of specific defects.
+   checkpoint X" or a list of specific defects, including unavailable
+   CGR proof verification when applicable.
 
 ### 5.4 Constitutional audit
 
@@ -357,9 +360,9 @@ against all eight invariants.
 ## 6. Your trust receipts
 
 Every action you take that the kernel adjudicates produces a verdict.
-When that verdict is `Permitted`, a `CgrProof` is attached — a
-cryptographic certificate recording the kernel version, the invariant
-set hash, and the invariants that were evaluated.
+When that verdict is `Permitted`, callers must preserve the signed
+event and any receipt/proof material returned by the adjudication
+path. Default MCP builds do not expose a standalone CGR proof verifier.
 
 These are your **trust receipts**. Keep them. If your work is later
 challenged, the trust receipt is what establishes that you acted
@@ -368,20 +371,10 @@ set.
 
 ### 6.1 How to retrieve a trust receipt
 
-```json
-{
-  "jsonrpc": "2.0",
-  "id":      10,
-  "method":  "tools/call",
-  "params": {
-    "name":      "exochain_verify_cgr_proof",
-    "arguments": { "event_id": "<the event you want the receipt for>" }
-  }
-}
-```
-
-The response includes the `CgrProof` fields: `kernel_hash`,
-`invariants_checked`, `verdict`, `timestamp`, `proof_signature`.
+`exochain_verify_cgr_proof` currently refuses hash-only verification
+claims and names `Initiatives/fix-mcp-cgr-proof-verification-stub.md`
+in the refusal body. Treat that refusal as a missing verification
+surface, not as a negative proof result or a verified trust receipt.
 
 ### 6.2 How to read a trust receipt
 

--- a/docs/guides/architecture-overview.md
+++ b/docs/guides/architecture-overview.md
@@ -399,7 +399,7 @@ dispatches `tools/call` requests to the appropriate handler.
 | Authority      | 3                    | Delegate, verify chain, check permission                         | `tools/authority.rs`                        |
 | Kernel         | 1                    | `exochain_adjudicate_action` — single-call kernel adjudication   | (dispatched to `governance.rs`)             |
 | Ledger         | 4                    | Submit event, get event, inclusion proof, get checkpoint         | `tools/ledger.rs`                           |
-| Proofs         | 4                    | Evidence, chain of custody, Merkle proof, verify CGR proof       | `tools/proofs.rs`                           |
+| Proofs         | 4                    | Evidence, chain of custody, Merkle proof, fail-closed CGR proof verifier placeholder | `tools/proofs.rs`                           |
 | Legal          | 4                    | eDiscovery, privilege, DGCL §144 safe harbour, fiduciary duty    | `tools/legal.rs`                            |
 | Escalation     | 4                    | Evaluate threat, escalate case, triage, feedback                 | `tools/escalation.rs`                       |
 | Messaging      | 3                    | Send encrypted, receive encrypted, configure death trigger       | `tools/messaging.rs`                        |

--- a/docs/guides/mcp-integration.md
+++ b/docs/guides/mcp-integration.md
@@ -298,7 +298,7 @@ Use these at session start to let the agent self-orient.
 | `exochain_create_evidence` | Bundle evidence with a chain-of-custody record. |
 | `exochain_verify_chain_of_custody` | Verify an evidence bundle end-to-end. |
 | `exochain_generate_merkle_proof` | Produce a Merkle inclusion proof for a leaf. |
-| `exochain_verify_cgr_proof` | Verify a CGR verdict proof against the checkpoint root. |
+| `exochain_verify_cgr_proof` | Refuses CGR proof verification until proof bytes, public inputs, checkpoint roots, validator signatures, and a production verifier are wired. |
 
 ### Legal (4)
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 116343 lines of Rust under `crates/` · 2,883 listed tests
+20 workspace packages · 116344 lines of Rust under `crates/` · 2,883 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- make `exochain_verify_cgr_proof` fail closed for hash-only CGR proof claims instead of returning `verification_status: verified`
- keep malformed hash input rejected while returning a clear refusal for well-formed but unverifiable claims
- update MCP/agent docs and repo-truth counts to stop describing the tool as a real CGR proof verifier

## TDD red check
- `cargo test -p exo-node mcp::tools::proofs::tests::execute_verify_cgr_proof_refuses_hash_only_claims --bin exochain -- --nocapture` failed before implementation because the tool returned success for arbitrary hash-only input

## Verification
- `cargo test -p exo-node mcp::tools::proofs::tests::execute_verify_cgr_proof_refuses_hash_only_claims --bin exochain -- --nocapture`
- `cargo test -p exo-node mcp::tools::proofs --bin exochain`
- `cargo test -p exo-node --bin exochain`
- `cargo build -p exo-node`
- `cargo clippy -p exo-node --bin exochain -- -D warnings`
- `bash tools/test_repo_truth.sh`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`