### PR TITLE
fix(exo-legal): require signed conflict disclosure verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 116344 | `wc -l` |
-| Workspace tests | 2,883 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 116643 | `wc -l` |
+| Workspace tests | 2,891 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,883 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,891 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 116344 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 116643 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,883 listed workspace tests
+         cryptographic proofs, 2,891 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-legal/src/conflict_disclosure.rs
+++ b/crates/exo-legal/src/conflict_disclosure.rs
@@ -1,6 +1,6 @@
 //! Conflict of interest disclosure requirements.
 
-use exo_core::{Did, Timestamp};
+use exo_core::{Did, PublicKey, Signature, Timestamp, crypto};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{LegalError, Result};
@@ -13,6 +13,17 @@ pub struct Disclosure {
     pub related_parties: Vec<Did>,
     pub timestamp: Timestamp,
     pub verified: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verification: Option<DisclosureVerification>,
+}
+
+/// Cryptographic evidence that a third-party verifier reviewed a disclosure.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DisclosureVerification {
+    pub verifier: Did,
+    pub verified_at: Timestamp,
+    pub verifier_public_key: PublicKey,
+    pub signature: Signature,
 }
 
 const REQUIRED_ACTIONS: &[&str] = &[
@@ -48,28 +59,124 @@ pub fn file_disclosure(
             action: "conflict disclosure timestamp must not be Timestamp::ZERO".into(),
         });
     }
+    let mut related_parties = related.to_vec();
+    related_parties.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+    related_parties.dedup_by(|a, b| a.as_str() == b.as_str());
+
     Ok(Disclosure {
         declarant: actor.clone(),
         nature: nature.into(),
-        related_parties: related.to_vec(),
+        related_parties,
         timestamp,
         verified: false,
+        verification: None,
     })
 }
 
-/// Marks a previously filed disclosure as verified.
-pub fn verify_disclosure(d: &mut Disclosure) {
-    d.verified = true;
+/// Domain-separated canonical CBOR payload signed to verify a disclosure.
+///
+/// The payload excludes `verified` and `verification` so the signature binds
+/// the filed disclosure content and verifier metadata, not the output field
+/// being produced.
+pub fn disclosure_verification_payload(
+    disclosure: &Disclosure,
+    verifier: &Did,
+    verified_at: &Timestamp,
+) -> Result<Vec<u8>> {
+    let related_parties: Vec<String> = disclosure
+        .related_parties
+        .iter()
+        .map(|did| did.as_str().to_string())
+        .collect();
+    let payload = (
+        "exo.legal.conflict_disclosure.verification.v1",
+        disclosure.declarant.as_str(),
+        disclosure.nature.as_str(),
+        related_parties,
+        disclosure.timestamp.physical_ms,
+        disclosure.timestamp.logical,
+        verifier.as_str(),
+        verified_at.physical_ms,
+        verified_at.logical,
+    );
+    let mut encoded = Vec::new();
+    ciborium::ser::into_writer(&payload, &mut encoded).map_err(|e| {
+        LegalError::DisclosureVerificationInvalid {
+            reason: format!("canonical verification payload encoding failed: {e}"),
+        }
+    })?;
+    Ok(encoded)
+}
+
+/// Marks a previously filed disclosure as verified only with signed evidence.
+pub fn verify_disclosure(
+    disclosure: &mut Disclosure,
+    verification: DisclosureVerification,
+) -> Result<()> {
+    if disclosure.verified || disclosure.verification.is_some() {
+        return Err(LegalError::DisclosureVerificationInvalid {
+            reason: "disclosure is already verified".into(),
+        });
+    }
+    if verification.verified_at == Timestamp::ZERO {
+        return Err(LegalError::DisclosureVerificationInvalid {
+            reason: "verification timestamp must be caller-supplied and non-zero".into(),
+        });
+    }
+    if verification.verifier == disclosure.declarant {
+        return Err(LegalError::DisclosureVerificationInvalid {
+            reason: "self-verification is not permitted for conflict disclosures".into(),
+        });
+    }
+    if verification.signature.is_empty() {
+        return Err(LegalError::DisclosureVerificationInvalid {
+            reason: "verification signature must be non-empty Ed25519 evidence".into(),
+        });
+    }
+
+    let payload = disclosure_verification_payload(
+        disclosure,
+        &verification.verifier,
+        &verification.verified_at,
+    )?;
+    if !crypto::verify(
+        &payload,
+        &verification.signature,
+        &verification.verifier_public_key,
+    ) {
+        return Err(LegalError::DisclosureVerificationInvalid {
+            reason: "verification signature does not match the disclosure payload".into(),
+        });
+    }
+
+    disclosure.verified = true;
+    disclosure.verification = Some(verification);
+    Ok(())
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
+    use exo_core::{Signature, crypto};
+
     use super::*;
+
     fn did(n: &str) -> Did {
         Did::new(&format!("did:exo:{n}")).unwrap()
     }
     fn ts(ms: u64) -> Timestamp {
         Timestamp::new(ms, 0)
+    }
+
+    fn signed_verification(
+        disclosure: &Disclosure,
+        verifier: &Did,
+        verified_at: Timestamp,
+        secret_key: &exo_core::SecretKey,
+    ) -> Signature {
+        let payload = disclosure_verification_payload(disclosure, verifier, &verified_at)
+            .expect("canonical verification payload");
+        crypto::sign(&payload, secret_key)
     }
 
     #[test]
@@ -129,10 +236,199 @@ mod tests {
         assert!(d.related_parties.is_empty());
     }
     #[test]
-    fn verify_sets_flag() {
+    fn verify_disclosure_requires_signed_verification_evidence() {
         let mut d = file_disclosure(&did("a"), "x", &[], ts(1000)).unwrap();
-        verify_disclosure(&mut d);
+        let verifier = did("ethics");
+        let (pk, sk) = crypto::generate_keypair();
+        let verified_at = ts(2000);
+        let signature = signed_verification(&d, &verifier, verified_at, &sk);
+
+        verify_disclosure(
+            &mut d,
+            DisclosureVerification {
+                verifier: verifier.clone(),
+                verified_at,
+                verifier_public_key: pk,
+                signature,
+            },
+        )
+        .expect("signed verification evidence");
+
         assert!(d.verified);
+        assert_eq!(
+            d.verification
+                .as_ref()
+                .expect("verification evidence")
+                .verifier,
+            verifier
+        );
+    }
+
+    #[test]
+    fn verify_disclosure_rejects_empty_signature() {
+        let mut d = file_disclosure(&did("a"), "x", &[], ts(1000)).unwrap();
+        let verifier = did("ethics");
+        let (pk, _sk) = crypto::generate_keypair();
+
+        let err = verify_disclosure(
+            &mut d,
+            DisclosureVerification {
+                verifier,
+                verified_at: ts(2000),
+                verifier_public_key: pk,
+                signature: Signature::Empty,
+            },
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("signature"));
+        assert!(!d.verified);
+    }
+
+    #[test]
+    fn verify_disclosure_rejects_all_zero_signature() {
+        let mut d = file_disclosure(&did("a"), "x", &[], ts(1000)).unwrap();
+        let verifier = did("ethics");
+        let (pk, _sk) = crypto::generate_keypair();
+
+        let err = verify_disclosure(
+            &mut d,
+            DisclosureVerification {
+                verifier,
+                verified_at: ts(2000),
+                verifier_public_key: pk,
+                signature: Signature::from_bytes([0u8; 64]),
+            },
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("signature"));
+        assert!(!d.verified);
+    }
+
+    #[test]
+    fn verify_disclosure_rejects_wrong_key_signature() {
+        let mut d = file_disclosure(&did("a"), "x", &[], ts(1000)).unwrap();
+        let verifier = did("ethics");
+        let (_signer_pk, signer_sk) = crypto::generate_keypair();
+        let (wrong_pk, _wrong_sk) = crypto::generate_keypair();
+        let verified_at = ts(2000);
+        let signature = signed_verification(&d, &verifier, verified_at, &signer_sk);
+
+        let err = verify_disclosure(
+            &mut d,
+            DisclosureVerification {
+                verifier,
+                verified_at,
+                verifier_public_key: wrong_pk,
+                signature,
+            },
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("signature"));
+        assert!(!d.verified);
+    }
+
+    #[test]
+    fn verify_disclosure_rejects_tampered_disclosure_content() {
+        let mut d = file_disclosure(&did("a"), "x", &[], ts(1000)).unwrap();
+        let verifier = did("ethics");
+        let (pk, sk) = crypto::generate_keypair();
+        let verified_at = ts(2000);
+        let signature = signed_verification(&d, &verifier, verified_at, &sk);
+        d.nature = "changed after signing".into();
+
+        let err = verify_disclosure(
+            &mut d,
+            DisclosureVerification {
+                verifier,
+                verified_at,
+                verifier_public_key: pk,
+                signature,
+            },
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("signature"));
+        assert!(!d.verified);
+    }
+
+    #[test]
+    fn verify_disclosure_rejects_self_verification() {
+        let mut d = file_disclosure(&did("a"), "x", &[], ts(1000)).unwrap();
+        let verifier = did("a");
+        let (pk, sk) = crypto::generate_keypair();
+        let verified_at = ts(2000);
+        let signature = signed_verification(&d, &verifier, verified_at, &sk);
+
+        let err = verify_disclosure(
+            &mut d,
+            DisclosureVerification {
+                verifier,
+                verified_at,
+                verifier_public_key: pk,
+                signature,
+            },
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("self"));
+        assert!(!d.verified);
+    }
+
+    #[test]
+    fn verify_disclosure_rejects_zero_timestamp() {
+        let mut d = file_disclosure(&did("a"), "x", &[], ts(1000)).unwrap();
+        let verifier = did("ethics");
+        let (pk, sk) = crypto::generate_keypair();
+        let signature = signed_verification(&d, &verifier, Timestamp::ZERO, &sk);
+
+        let err = verify_disclosure(
+            &mut d,
+            DisclosureVerification {
+                verifier,
+                verified_at: Timestamp::ZERO,
+                verifier_public_key: pk,
+                signature,
+            },
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("timestamp"));
+        assert!(!d.verified);
+    }
+
+    #[test]
+    fn verify_disclosure_rejects_replay_over_already_verified_disclosure() {
+        let mut d = file_disclosure(&did("a"), "x", &[], ts(1000)).unwrap();
+        let verifier = did("ethics");
+        let (pk, sk) = crypto::generate_keypair();
+        let verified_at = ts(2000);
+        let signature = signed_verification(&d, &verifier, verified_at, &sk);
+        let verification = DisclosureVerification {
+            verifier,
+            verified_at,
+            verifier_public_key: pk,
+            signature,
+        };
+
+        verify_disclosure(&mut d, verification.clone()).expect("first verification");
+        let err = verify_disclosure(&mut d, verification).unwrap_err();
+
+        assert!(err.to_string().contains("already verified"));
+    }
+
+    #[test]
+    fn disclosure_verification_payload_is_deterministic() {
+        let d = file_disclosure(&did("a"), "x", &[did("b")], ts(1000)).unwrap();
+        let verifier = did("ethics");
+        let verified_at = ts(2000);
+
+        assert_eq!(
+            disclosure_verification_payload(&d, &verifier, &verified_at).unwrap(),
+            disclosure_verification_payload(&d, &verifier, &verified_at).unwrap()
+        );
     }
     #[test]
     fn serde() {

--- a/crates/exo-legal/src/error.rs
+++ b/crates/exo-legal/src/error.rs
@@ -26,6 +26,8 @@ pub enum LegalError {
     RetentionViolation { reason: String },
     #[error("disclosure required for action: {action}")]
     DisclosureRequired { action: String },
+    #[error("disclosure verification invalid: {reason}")]
+    DisclosureVerificationInvalid { reason: String },
     #[error("conflict of interest: {reason}")]
     ConflictOfInterest { reason: String },
     #[error("record not found: {0}")]
@@ -57,6 +59,7 @@ mod tests {
             Box::new(LegalError::DisclosureRequired {
                 action: "vote".into(),
             }),
+            Box::new(LegalError::DisclosureVerificationInvalid { reason: "x".into() }),
             Box::new(LegalError::ConflictOfInterest { reason: "x".into() }),
             Box::new(LegalError::RecordNotFound(id)),
             Box::new(LegalError::InvalidStateTransition { reason: "x".into() }),

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 116344 lines of Rust under `crates/`, 2,883 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 116643 lines of Rust under `crates/`, 2,891 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,883 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,891 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,883 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,891 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-116344 lines of Rust under `crates/` · 20 workspace packages · 2,883 listed tests · 40 MCP tools · 8 constitutional invariants
+116643 lines of Rust under `crates/` · 20 workspace packages · 2,891 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 116344 lines of Rust under `crates/` | 266 Rust source files | 2,883 listed tests
+> **Codebase:** 20 workspace packages | 116643 lines of Rust under `crates/` | 266 Rust source files | 2,891 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,883 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,891 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 116344 lines of Rust under `crates/` · 2,883 listed tests
+20 workspace packages · 116643 lines of Rust under `crates/` · 2,891 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- replace boolean-only conflict-disclosure verification with signed Ed25519 verification evidence
- add domain-separated canonical CBOR verification payloads and store verifier/timestamp/public-key/signature evidence
- reject empty, all-zero, wrong-key, tampered, self-verification, zero-timestamp, and replay attempts
- refresh repo-truth counts to 116643 Rust LOC and 2,891 listed tests

## TDD / Verification
- RED: `cargo test -p exo-legal conflict_disclosure::tests::verify_disclosure_requires_signed_verification_evidence --lib -- --nocapture` failed before implementation because the proof API did not exist and `verify_disclosure` only flipped a bool
- `cargo test -p exo-legal conflict_disclosure::tests --lib`
- `cargo test -p exo-legal`
- `cargo build -p exo-legal`
- `cargo clippy -p exo-legal --lib -- -D warnings`
- `cargo clippy -p exo-legal --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`