### PR TITLE
fix(exo-consensus): require structured deliberation evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 116643 | `wc -l` |
-| Workspace tests | 2,891 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 117115 | `wc -l` |
+| Workspace tests | 2,897 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,891 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,897 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 116643 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 117115 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,891 listed workspace tests
+         cryptographic proofs, 2,897 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-consensus/src/advocate.rs
+++ b/crates/exo-consensus/src/advocate.rs
@@ -1,11 +1,3 @@
-/// Designates logic to determine if a challenge is serious.
-pub fn is_serious_challenge(challenge_text: &str) -> bool {
-    // A mock heuristic for whether the devil's advocate found a serious issue.
-    // Real implementation uses another model call or structural analysis.
-    challenge_text.to_lowercase().contains("serious")
-        || challenge_text.to_lowercase().contains("fatal")
-}
-
 /// Generates a prompt for the devil's advocate based on the synthesized consensus.
 pub fn generate_advocate_prompt(question: &str, consensus: &str) -> String {
     format!(

--- a/crates/exo-consensus/src/commitment.rs
+++ b/crates/exo-consensus/src/commitment.rs
@@ -1,4 +1,10 @@
-use exo_core::types::Hash256;
+use exo_core::{hash::hash_structured, types::Hash256};
+use serde::Serialize;
+
+use crate::{
+    error::{ConsensusError, Result},
+    round::ModelDeliberationResponse,
+};
 
 /// Cryptographically commits to a position before revealing it.
 /// Uses BLAKE3 under the hood.
@@ -9,4 +15,37 @@ pub fn commit(position_text: &str) -> Hash256 {
 /// Verifies that a revealed position matches its prior commitment.
 pub fn verify_commitment(position_text: &str, commitment: &Hash256) -> bool {
     commit(position_text) == *commitment
+}
+
+/// Cryptographically commits to the structured response evidence before reveal.
+pub fn commit_response(response: &ModelDeliberationResponse) -> Result<Hash256> {
+    #[derive(Serialize)]
+    struct CommitmentPayload<'a> {
+        domain: &'static str,
+        schema_version: &'static str,
+        position_text: &'a str,
+        key_claims: &'a [String],
+        confidence_bps: u64,
+    }
+
+    let payload = CommitmentPayload {
+        domain: "exo.consensus.model_response.commitment.v1",
+        schema_version: "1",
+        position_text: &response.position_text,
+        key_claims: &response.key_claims,
+        confidence_bps: response.confidence_bps,
+    };
+
+    hash_structured(&payload).map_err(|source| ConsensusError::HashSerialization {
+        context: "structured consensus model response commitment",
+        source,
+    })
+}
+
+/// Verifies that revealed structured response evidence matches its commitment.
+pub fn verify_response_commitment(
+    response: &ModelDeliberationResponse,
+    commitment: &Hash256,
+) -> Result<bool> {
+    Ok(commit_response(response)? == *commitment)
 }

--- a/crates/exo-consensus/src/lib.rs
+++ b/crates/exo-consensus/src/lib.rs
@@ -8,13 +8,16 @@ pub mod round;
 pub mod scoring;
 pub mod session;
 
-pub use commitment::{commit, verify_commitment};
+pub use commitment::{commit, commit_response, verify_commitment, verify_response_commitment};
 pub use error::{ConsensusError, Result};
 pub use panel::{ModelProvider, ModelRole, Panel, PanelModel};
 pub use record::DeliberationResult;
 pub use report::MinorityReport;
-pub use round::{DeliberationRound, ModelPosition};
-pub use scoring::{PanelConfidenceInputs, calculate_convergence, calculate_panel_confidence};
+pub use round::{DeliberationRound, DevilAdvocateReview, ModelDeliberationResponse, ModelPosition};
+pub use scoring::{
+    PanelConfidenceInputs, calculate_convergence, calculate_panel_confidence, canonical_claim_set,
+    consensus_claims_at_threshold,
+};
 pub use session::{
     DeliberationSession, DeterministicResponseProvider, FinalizationTiming, RoundExecutionTiming,
 };
@@ -42,22 +45,67 @@ mod tests {
         }
     }
 
-    fn routine_response_provider(response: &str) -> DeterministicResponseProvider {
-        DeterministicResponseProvider::new(routine_panel_responses(response))
+    fn response(text: &str, claims: &[&str]) -> ModelDeliberationResponse {
+        ModelDeliberationResponse {
+            position_text: text.to_string(),
+            key_claims: claims.iter().map(|claim| (*claim).to_string()).collect(),
+            confidence_bps: 8000,
+        }
     }
 
-    fn operational_response_provider(response: &str) -> DeterministicResponseProvider {
-        DeterministicResponseProvider::new(BTreeMap::from([
-            ("claude-3-5-sonnet".to_string(), response.to_string()),
-            ("gpt-4o".to_string(), response.to_string()),
-            ("gemini-1.5-pro".to_string(), response.to_string()),
-        ]))
+    fn routine_response_provider(
+        response_text: &str,
+        claims: &[&str],
+    ) -> DeterministicResponseProvider {
+        DeterministicResponseProvider::with_positions(routine_panel_responses(
+            response_text,
+            claims,
+        ))
+    }
+
+    fn operational_response_provider(
+        response_text: &str,
+        claims: &[&str],
+    ) -> DeterministicResponseProvider {
+        DeterministicResponseProvider::new(
+            BTreeMap::from([
+                (
+                    "claude-3-5-sonnet".to_string(),
+                    response(response_text, claims),
+                ),
+                ("gpt-4o".to_string(), response(response_text, claims)),
+                (
+                    "gemini-1.5-pro".to_string(),
+                    response(response_text, claims),
+                ),
+            ]),
+            BTreeMap::from([("gpt-4o".to_string(), neutral_review())]),
+        )
+    }
+
+    fn neutral_review() -> DevilAdvocateReview {
+        DevilAdvocateReview {
+            review_text: "No threshold objection found.".to_string(),
+            serious_objection: false,
+            reasons: Vec::new(),
+        }
     }
 
     // 1. test_convergence_identical_positions
     #[test]
     fn test_convergence_identical_positions() {
-        let pos = vec!["claim1, claim2, claim3", "claim1, claim2, claim3"];
+        let pos = vec![
+            vec![
+                "claim1".to_string(),
+                "claim2".to_string(),
+                "claim3".to_string(),
+            ],
+            vec![
+                "claim1".to_string(),
+                "claim2".to_string(),
+                "claim3".to_string(),
+            ],
+        ];
         let score = calculate_convergence(&pos);
         assert_eq!(score, 10000);
     }
@@ -65,7 +113,10 @@ mod tests {
     // 2. test_convergence_zero_overlap
     #[test]
     fn test_convergence_zero_overlap() {
-        let pos = vec!["claim1, claim2", "claim3, claim4"];
+        let pos = vec![
+            vec!["claim1".to_string(), "claim2".to_string()],
+            vec!["claim3".to_string(), "claim4".to_string()],
+        ];
         let score = calculate_convergence(&pos);
         assert_eq!(score, 0);
     }
@@ -75,7 +126,10 @@ mod tests {
     fn test_convergence_partial_overlap() {
         // "claim1" is shared, "claim2", "claim3", "claim4", "claim5" are not. Total unique: 5.
         // Shared: 1. Wait, let's just make it simple:
-        let pos = vec!["A, B", "A, C"];
+        let pos = vec![
+            vec!["A".to_string(), "B".to_string()],
+            vec!["A".to_string(), "C".to_string()],
+        ];
         let score = calculate_convergence(&pos);
         // Unique claims: a, b, c (3). Shared: a (1).
         // Score = 1/3 * 10000 = 3333.
@@ -83,7 +137,15 @@ mod tests {
         assert_eq!(score, 3333);
 
         // For exactly 50%: "A, B", "A, B, C, D" => Wait.
-        let pos2 = vec!["A, B", "A, B, C, D"];
+        let pos2 = vec![
+            vec!["A".to_string(), "B".to_string()],
+            vec![
+                "A".to_string(),
+                "B".to_string(),
+                "C".to_string(),
+                "D".to_string(),
+            ],
+        ];
         let score2 = calculate_convergence(&pos2);
         // unique: a, b, c, d (4). Shared: a, b (2).
         // 2/4 = 5000
@@ -190,12 +252,44 @@ mod tests {
             positions: BTreeMap::new(),
             synthesis: None,
             convergence_score_bps: 10000,
-            devil_advocate_challenge: None,
+            devil_advocate_review: None,
             round_hash: exo_core::types::Hash256::ZERO,
         };
         let h1 = round.compute_hash().expect("round hash");
         let h2 = round.compute_hash().expect("round hash");
         assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn structured_response_commitment_binds_claims_and_confidence() {
+        let original = response("same prose", &["claim-a", "claim-b"]);
+        let same = response("same prose", &["claim-a", "claim-b"]);
+        let changed_claims = response("same prose", &["claim-a", "claim-c"]);
+        let mut changed_confidence = response("same prose", &["claim-a", "claim-b"]);
+        changed_confidence.confidence_bps = 7000;
+
+        let original_hash = commit_response(&original).expect("structured response hash");
+
+        assert_eq!(
+            original_hash,
+            commit_response(&same).expect("same structured response hash")
+        );
+        assert_ne!(
+            original_hash,
+            commit_response(&changed_claims).expect("changed claims hash")
+        );
+        assert_ne!(
+            original_hash,
+            commit_response(&changed_confidence).expect("changed confidence hash")
+        );
+        assert!(
+            verify_response_commitment(&original, &original_hash)
+                .expect("verify structured commitment")
+        );
+        assert!(
+            !verify_response_commitment(&changed_claims, &original_hash)
+                .expect("reject changed structured claims")
+        );
     }
 
     // 10. test_result_hash_deterministic
@@ -243,7 +337,7 @@ mod tests {
     #[test]
     fn test_deterministic_session_single_round() {
         let panel = Panel::default_panel(DecisionClass::Routine);
-        let provider = routine_response_provider("A, B, C");
+        let provider = routine_response_provider("A, B, C", &["a", "b", "c"]);
 
         let mut session =
             DeliberationSession::new("test".into(), panel, "What is X?".into(), provider);
@@ -259,7 +353,7 @@ mod tests {
     #[test]
     fn test_deterministic_session_converges() {
         let panel = Panel::default_panel(DecisionClass::Operational);
-        let provider = operational_response_provider("identical claim");
+        let provider = operational_response_provider("identical claim", &["identical claim"]);
 
         let mut session =
             DeliberationSession::new("test".into(), panel, "What is X?".into(), provider);
@@ -289,8 +383,8 @@ mod tests {
     #[test]
     fn session_uses_caller_supplied_hlc_inputs() {
         let panel = Panel::default_panel(DecisionClass::Routine);
-        let responses = routine_panel_responses("A, B, C");
-        let provider = DeterministicResponseProvider::new(responses);
+        let responses = routine_panel_responses("A, B, C", &["a", "b", "c"]);
+        let provider = DeterministicResponseProvider::with_positions(responses);
         let submitted_at = Timestamp::new(42_000, 7);
         let revealed_at = Timestamp::new(42_000, 8);
         let completed_at = Timestamp::new(42_001, 0);
@@ -317,9 +411,9 @@ mod tests {
     #[test]
     fn missing_deterministic_response_is_rejected_without_placeholder_text() {
         let panel = Panel::default_panel(DecisionClass::Routine);
-        let mut responses = routine_panel_responses("A, B, C");
+        let mut responses = routine_panel_responses("A, B, C", &["a", "b", "c"]);
         responses.remove("gpt-4o-mini");
-        let provider = DeterministicResponseProvider::new(responses);
+        let provider = DeterministicResponseProvider::with_positions(responses);
         let mut session =
             DeliberationSession::new("test".into(), panel, "What is X?".into(), provider);
 
@@ -351,7 +445,7 @@ mod tests {
             positions: &'a BTreeMap<String, ModelPosition>,
             synthesis: &'a Option<String>,
             convergence_score_bps: u64,
-            devil_advocate_challenge: &'a Option<String>,
+            devil_advocate_review: &'a Option<DevilAdvocateReview>,
         }
         let expected = exo_core::hash::hash_structured(&ExpectedRoundHashPayload {
             domain: "exo.consensus.deliberation_round.v1",
@@ -361,7 +455,7 @@ mod tests {
             positions: &round.positions,
             synthesis: &round.synthesis,
             convergence_score_bps: round.convergence_score_bps,
-            devil_advocate_challenge: &round.devil_advocate_challenge,
+            devil_advocate_review: &round.devil_advocate_review,
         })
         .expect("expected CBOR hash");
 
@@ -425,6 +519,19 @@ mod tests {
     }
 
     #[test]
+    fn production_session_source_has_no_raw_text_consensus_heuristics() {
+        let source = production_source("src/session.rs");
+        assert!(
+            !source.contains(".split([',', '\\n', ';'])"),
+            "production session code must not derive structured claims by splitting raw prose"
+        );
+        assert!(
+            !source.contains("is_serious_challenge"),
+            "production session code must not derive serious objections from keyword heuristics"
+        );
+    }
+
+    #[test]
     fn production_hashing_source_has_no_json_or_silent_default_fallback() {
         for file in ["src/round.rs", "src/record.rs"] {
             let source = production_source(file);
@@ -439,11 +546,20 @@ mod tests {
         }
     }
 
-    fn routine_panel_responses(response: &str) -> BTreeMap<String, String> {
+    fn routine_panel_responses(
+        response_text: &str,
+        claims: &[&str],
+    ) -> BTreeMap<String, ModelDeliberationResponse> {
         BTreeMap::from([
-            ("claude-3-haiku".to_string(), response.to_string()),
-            ("gpt-4o-mini".to_string(), response.to_string()),
-            ("gemini-1.5-flash".to_string(), response.to_string()),
+            (
+                "claude-3-haiku".to_string(),
+                response(response_text, claims),
+            ),
+            ("gpt-4o-mini".to_string(), response(response_text, claims)),
+            (
+                "gemini-1.5-flash".to_string(),
+                response(response_text, claims),
+            ),
         ])
     }
 
@@ -455,7 +571,12 @@ mod tests {
             ModelPosition {
                 model_id: "claude-3-haiku".to_string(),
                 round: 1,
-                position_hash: commit(&position_text),
+                position_hash: commit_response(&ModelDeliberationResponse {
+                    position_text: position_text.clone(),
+                    key_claims: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+                    confidence_bps: 8000,
+                })
+                .expect("structured commitment"),
                 position_text,
                 key_claims: vec!["a".to_string(), "b".to_string(), "c".to_string()],
                 confidence_bps: 8000,
@@ -467,9 +588,9 @@ mod tests {
             round_number: 1,
             question: "What is X?".to_string(),
             positions,
-            synthesis: Some("Synthesized consensus from 1 models.".to_string()),
+            synthesis: Some("Structured consensus claims: a; b; c.".to_string()),
             convergence_score_bps: 10000,
-            devil_advocate_challenge: None,
+            devil_advocate_review: None,
             round_hash: exo_core::types::Hash256::ZERO,
         }
     }
@@ -479,7 +600,7 @@ mod tests {
             session_id: "test".to_string(),
             question: "What is X?".to_string(),
             rounds: vec![sample_round()],
-            final_consensus: "Synthesized consensus from 1 models.".to_string(),
+            final_consensus: "Structured consensus claims: a; b; c.".to_string(),
             minority_reports: Vec::new(),
             panel_confidence_index_bps: 10000,
             rounds_to_convergence: 1,

--- a/crates/exo-consensus/src/report.rs
+++ b/crates/exo-consensus/src/report.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::round::ModelPosition;
+use crate::{round::ModelPosition, scoring::canonical_claim_set};
 
 /// A minority report from a dissenting model.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -14,33 +14,22 @@ pub struct MinorityReport {
 
 pub fn is_minority_report(
     position: &ModelPosition,
-    _consensus_claims: &[String],
+    consensus_claims: &[String],
     threshold_bps: u64,
 ) -> bool {
-    // A simplistic implementation: if convergence is poor, trigger report.
-    // Real implementation would calculate overlap of position claims vs consensus claims.
-    // For test purposes, let's say if the mock text implies low overlap, return true.
-    // Since we don't have full LLM synthesis here, let's just use the threshold.
-    // For now we'll mock this by checking if the confidence_bps is below threshold
-    // or if divergence is somehow known. Let's return false by default unless
-    // specifically triggered. Wait, let's calculate divergence based on key claims.
-
-    // Divergence score: how many consensus claims are MISSING from the model's claims.
-    // If consensus has 0 claims, no divergence.
-    if _consensus_claims.is_empty() {
+    let consensus_claims = canonical_claim_set(consensus_claims);
+    if consensus_claims.is_empty() {
         return false;
     }
 
-    let mut missing = 0;
-    for c in _consensus_claims {
-        if !position.key_claims.contains(c) {
-            missing += 1;
-        }
-    }
+    let position_claims = canonical_claim_set(&position.key_claims);
+    let present = consensus_claims
+        .iter()
+        .filter(|claim| position_claims.contains(claim))
+        .count();
 
-    let overlap_bps = (u64::try_from(_consensus_claims.len() - missing).unwrap_or(0) * 10000)
-        / u64::try_from(_consensus_claims.len()).unwrap_or(1);
+    let overlap_bps = (u64::try_from(present).unwrap_or(0) * 10000)
+        / u64::try_from(consensus_claims.len()).unwrap_or(1);
 
-    // Dissenting if overlap is less than threshold
     overlap_bps < threshold_bps
 }

--- a/crates/exo-consensus/src/round.rs
+++ b/crates/exo-consensus/src/round.rs
@@ -8,6 +8,22 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{ConsensusError, Result};
 
+/// Structured deterministic response from one panel model.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModelDeliberationResponse {
+    pub position_text: String,
+    pub key_claims: Vec<String>,
+    pub confidence_bps: u64,
+}
+
+/// Structured deterministic devil's advocate review.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DevilAdvocateReview {
+    pub review_text: String,
+    pub serious_objection: bool,
+    pub reasons: Vec<String>,
+}
+
 /// A single position submitted by a model in a round.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelPosition {
@@ -29,7 +45,7 @@ pub struct DeliberationRound {
     pub positions: BTreeMap<String, ModelPosition>,
     pub synthesis: Option<String>,
     pub convergence_score_bps: u64,
-    pub devil_advocate_challenge: Option<String>,
+    pub devil_advocate_review: Option<DevilAdvocateReview>,
     pub round_hash: Hash256,
 }
 
@@ -50,7 +66,7 @@ pub fn hash_round(round: &DeliberationRound) -> Result<Hash256> {
         pub positions: &'a BTreeMap<String, ModelPosition>,
         pub synthesis: &'a Option<String>,
         pub convergence_score_bps: u64,
-        pub devil_advocate_challenge: &'a Option<String>,
+        pub devil_advocate_review: &'a Option<DevilAdvocateReview>,
     }
 
     let input = HashInput {
@@ -61,7 +77,7 @@ pub fn hash_round(round: &DeliberationRound) -> Result<Hash256> {
         positions: &round.positions,
         synthesis: &round.synthesis,
         convergence_score_bps: round.convergence_score_bps,
-        devil_advocate_challenge: &round.devil_advocate_challenge,
+        devil_advocate_review: &round.devil_advocate_review,
     };
 
     hash_structured(&input).map_err(|source| ConsensusError::HashSerialization {

--- a/crates/exo-consensus/src/scoring.rs
+++ b/crates/exo-consensus/src/scoring.rs
@@ -10,77 +10,46 @@ pub struct PanelConfidenceInputs {
     pub minority_reports_count: u32,
 }
 
-/// Calculate convergence between a set of positions (in bps, 0–10000).
-/// This extracts mock "key claims" by splitting the text by lines or using provided claims
-/// but for the real system we expect structured claims. Here we simulate it by comparing
-/// the sets of words or using the actual key_claims array if we can pass it.
-/// Actually, the prompt says:
-/// `calculate_convergence(positions: &[&str]) -> u64`
-/// "Use categorical comparison: count matching key claims across positions divided by total unique claims."
-/// We'll assume the positions string represents a comma-separated or line-separated list of claims if it's raw text,
-/// but let's implement it robustly: tokenize and find overlap.
-pub fn calculate_convergence(positions: &[&str]) -> u64 {
-    if positions.is_empty() {
+/// Return a canonical deterministic claim set: trimmed, lowercased, sorted, and
+/// deduplicated. Empty claims are removed.
+pub fn canonical_claim_set(claims: &[String]) -> Vec<String> {
+    claims
+        .iter()
+        .map(|claim| claim.trim().to_lowercase())
+        .filter(|claim| !claim.is_empty())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+/// Calculate convergence between structured key-claim sets (in bps, 0-10000).
+/// Free-form text is not parsed here; callers must provide explicit claim
+/// evidence for each model position.
+pub fn calculate_convergence(claim_sets: &[Vec<String>]) -> u64 {
+    if claim_sets.is_empty() {
         return 0;
     }
-    if positions.len() == 1 {
-        return 10000;
-    }
 
-    // A simple categorical extraction: split by common delimiters and trim.
-    // In production, these would be structured key_claims provided to the function.
     let mut all_claims = BTreeSet::new();
     let mut model_claims = Vec::new();
 
-    for pos in positions {
-        let mut claims = BTreeSet::new();
-        // Extract claims by splitting on commas or newlines for simplistic proxy
-        let parts: Vec<&str> = pos.split([',', '\n', ';']).collect();
-        for p in parts {
-            let clean = p.trim().to_lowercase();
-            if !clean.is_empty() {
-                claims.insert(clean.clone());
-                all_claims.insert(clean);
-            }
+    for claims in claim_sets {
+        let canonical = canonical_claim_set(claims);
+        let set = canonical.into_iter().collect::<BTreeSet<_>>();
+        for claim in &set {
+            all_claims.insert(claim.clone());
         }
-        model_claims.push(claims);
+        model_claims.push(set);
     }
 
     if all_claims.is_empty() {
-        return 10000; // If they all submitted empty, they agree.
+        return 0;
     }
-
-    let _match_score = 0;
-    let total_unique = u64::try_from(all_claims.len()).unwrap_or(0);
-
-    for claim in &all_claims {
-        let _count =
-            u64::try_from(model_claims.iter().filter(|c| c.contains(claim)).count()).unwrap_or(0);
-        // The more models share the claim, the more "matching" it is.
-        // A claim shared by ALL models is a perfect match (worth 1).
-        // Here we just say: if a claim is shared by more than half, it's a majority claim.
-        // Let's use a simple ratio: sum(count) / (total_unique * num_models)
-        // match_score += count; // Keeping for reference if needed
-    }
-
-    let max_possible_score = total_unique * u64::try_from(positions.len()).unwrap_or(0);
-    // Invariant chain: positions.len() >= 2 (early-returned 0/1 above) and
-    // all_claims.len() >= 1 (early-returned empty above). u64::try_from only
-    // fails for usize > 2^64, impossible for in-memory collections. Guard
-    // remains for defense-in-depth against pathological platforms.
-    if max_possible_score == 0 {
+    if claim_sets.len() == 1 {
         return 10000;
     }
 
-    // If we want identical positions to be 10000 and 0 overlap to be 0:
-    // This formula works: match_score / max_possible_score
-    // Example: 2 positions. "A, B" and "A, C".
-    // all_claims: A, B, C.
-    // A count = 2. B count = 1. C count = 1.
-    // match_score = 4. max_possible_score = 3 * 2 = 6.
-    // 4 / 6 = 66%. Wait, 50% overlap.
-    // Let's refine based on "matching key claims across positions divided by total unique claims".
-    // A matching claim means it's present in ALL positions.
+    let total_unique = u64::try_from(all_claims.len()).unwrap_or(0);
     let shared_claims = u64::try_from(
         all_claims
             .iter()
@@ -90,6 +59,50 @@ pub fn calculate_convergence(positions: &[&str]) -> u64 {
     .unwrap_or(0);
 
     (shared_claims * 10000) / total_unique
+}
+
+/// Return claims whose support across models meets the configured threshold.
+pub fn consensus_claims_at_threshold(
+    claim_sets: &[Vec<String>],
+    threshold_bps: u64,
+) -> Vec<String> {
+    if claim_sets.is_empty() {
+        return Vec::new();
+    }
+
+    let canonical_sets = claim_sets
+        .iter()
+        .map(|claims| {
+            canonical_claim_set(claims)
+                .into_iter()
+                .collect::<BTreeSet<_>>()
+        })
+        .collect::<Vec<_>>();
+    let mut all_claims = BTreeSet::new();
+    for claims in &canonical_sets {
+        for claim in claims {
+            all_claims.insert(claim.clone());
+        }
+    }
+
+    let model_count = u64::try_from(canonical_sets.len()).unwrap_or(0);
+    if model_count == 0 {
+        return Vec::new();
+    }
+
+    all_claims
+        .into_iter()
+        .filter(|claim| {
+            let support = u64::try_from(
+                canonical_sets
+                    .iter()
+                    .filter(|claims| claims.contains(claim))
+                    .count(),
+            )
+            .unwrap_or(0);
+            (support * 10000) / model_count >= threshold_bps
+        })
+        .collect()
 }
 
 /// Calculate Panel Confidence Index in bps (0–10000).
@@ -153,17 +166,18 @@ mod proptests {
         /// `calculate_convergence` must never panic on arbitrary input and
         /// must always return a score within the valid bps range.
         #[test]
-        fn convergence_never_panics_and_bounded(positions in proptest::collection::vec(".*", 0..20)) {
-            let refs: Vec<&str> = positions.iter().map(String::as_str).collect();
-            let score = calculate_convergence(&refs);
+        fn convergence_never_panics_and_bounded(positions in proptest::collection::vec(proptest::collection::vec(".*", 0..10), 0..20)) {
+            let score = calculate_convergence(&positions);
             prop_assert!(score <= 10000, "score {score} out of range");
         }
 
         /// Identical positions must always score 10000 (perfect convergence),
         /// regardless of claim shape.
         #[test]
-        fn identical_positions_always_ten_thousand(pos in ".+") {
-            let refs = vec![pos.as_str(); 5];
+        fn identical_positions_always_ten_thousand(
+            pos in proptest::collection::vec("[A-Za-z0-9][A-Za-z0-9 _-]{0,32}", 1..10)
+        ) {
+            let refs = vec![pos; 5];
             let score = calculate_convergence(&refs);
             prop_assert_eq!(score, 10000);
         }
@@ -202,21 +216,25 @@ mod proptests {
     /// Boundary: single position returns 10000 (trivially self-consistent).
     #[test]
     fn single_position_returns_ten_thousand() {
-        assert_eq!(calculate_convergence(&["only one"]), 10000);
+        assert_eq!(calculate_convergence(&[vec!["only one".into()]]), 10000);
     }
 
-    /// Boundary: all-empty strings should not panic and should yield 10000
-    /// (no claims to disagree on).
+    /// Boundary: all-empty claim sets should not panic and should yield 0
+    /// because no explicit claim evidence exists.
     #[test]
     fn all_empty_strings_do_not_panic() {
-        let score = calculate_convergence(&["", "", ""]);
-        assert_eq!(score, 10000);
+        let score = calculate_convergence(&[Vec::new(), Vec::new(), Vec::new()]);
+        assert_eq!(score, 0);
     }
 
     /// Boundary: single-claim positions with disjoint claims score zero.
     #[test]
     fn disjoint_single_claims_score_zero() {
-        let score = calculate_convergence(&["A", "B", "C"]);
+        let score = calculate_convergence(&[
+            vec!["A".to_string()],
+            vec!["B".to_string()],
+            vec!["C".to_string()],
+        ]);
         assert_eq!(score, 0);
     }
 }

--- a/crates/exo-consensus/src/session.rs
+++ b/crates/exo-consensus/src/session.rs
@@ -3,32 +3,56 @@ use std::collections::BTreeMap;
 use exo_core::types::{Hash256, Timestamp};
 
 use crate::{
-    advocate::is_serious_challenge,
-    commitment::{commit, verify_commitment},
+    commitment::{commit_response, verify_response_commitment},
     error::{ConsensusError, Result},
     panel::{ModelRole, Panel},
     record::DeliberationResult,
     report::{MinorityReport, is_minority_report},
-    round::{DeliberationRound, ModelPosition},
-    scoring::{PanelConfidenceInputs, calculate_convergence, calculate_panel_confidence},
+    round::{DeliberationRound, DevilAdvocateReview, ModelDeliberationResponse, ModelPosition},
+    scoring::{
+        PanelConfidenceInputs, calculate_convergence, calculate_panel_confidence,
+        canonical_claim_set, consensus_claims_at_threshold,
+    },
 };
 
 #[derive(Debug, Clone)]
 pub struct DeterministicResponseProvider {
-    responses: BTreeMap<String, String>,
+    positions: BTreeMap<String, ModelDeliberationResponse>,
+    devil_advocate_reviews: BTreeMap<String, DevilAdvocateReview>,
 }
 
 impl DeterministicResponseProvider {
-    pub fn new(responses: BTreeMap<String, String>) -> Self {
-        Self { responses }
+    pub fn new(
+        positions: BTreeMap<String, ModelDeliberationResponse>,
+        devil_advocate_reviews: BTreeMap<String, DevilAdvocateReview>,
+    ) -> Self {
+        Self {
+            positions,
+            devil_advocate_reviews,
+        }
     }
 
-    fn response_for(&self, model_id: &str) -> Result<String> {
-        self.responses.get(model_id).cloned().ok_or_else(|| {
+    pub fn with_positions(positions: BTreeMap<String, ModelDeliberationResponse>) -> Self {
+        Self::new(positions, BTreeMap::new())
+    }
+
+    fn position_for(&self, model_id: &str) -> Result<ModelDeliberationResponse> {
+        self.positions.get(model_id).cloned().ok_or_else(|| {
             ConsensusError::ProviderError(format!(
-                "missing deterministic response for model {model_id}"
+                "missing structured deterministic response for model {model_id}"
             ))
         })
+    }
+
+    fn devil_advocate_review_for(&self, model_id: &str) -> Result<DevilAdvocateReview> {
+        self.devil_advocate_reviews
+            .get(model_id)
+            .cloned()
+            .ok_or_else(|| {
+                ConsensusError::ProviderError(format!(
+                    "missing structured devil's advocate review for model {model_id}"
+                ))
+            })
     }
 }
 
@@ -103,39 +127,31 @@ impl DeliberationSession {
         timing.validate()?;
 
         let mut positions = BTreeMap::new();
-        let mut raw_texts = Vec::new();
 
         // 1. Commitment Phase
         let mut commitments = BTreeMap::new();
         for model in &self.panel.models {
             if model.role == ModelRole::Panelist {
-                let text = self.response_provider.response_for(&model.model_id)?;
-                let position_hash = commit(&text);
-                commitments.insert(model.model_id.clone(), (text, position_hash));
+                let response = self.response_provider.position_for(&model.model_id)?;
+                let response = validate_model_response(&model.model_id, response)?;
+                let position_hash = commit_response(&response)?;
+                commitments.insert(model.model_id.clone(), (response, position_hash));
             }
         }
 
         // 2. Reveal & Verify Phase
-        for (model_id, (text, position_hash)) in commitments {
-            if !verify_commitment(&text, &position_hash) {
+        for (model_id, (response, position_hash)) in commitments {
+            if !verify_response_commitment(&response, &position_hash)? {
                 return Err(ConsensusError::CommitmentMismatch { model_id });
             }
-
-            let key_claims: Vec<String> = text
-                .split([',', '\n', ';'])
-                .map(|s| s.trim().to_lowercase())
-                .filter(|s| !s.is_empty())
-                .collect();
-
-            raw_texts.push(text.clone());
 
             let pos = ModelPosition {
                 model_id: model_id.clone(),
                 round: self.current_round,
                 position_hash,
-                position_text: text,
-                key_claims,
-                confidence_bps: 8000,
+                position_text: response.position_text,
+                key_claims: response.key_claims,
+                confidence_bps: response.confidence_bps,
                 submitted_at: timing.submitted_at,
                 revealed_at: Some(timing.revealed_at),
             };
@@ -143,21 +159,23 @@ impl DeliberationSession {
             positions.insert(model_id, pos);
         }
 
-        // 3. Synthesis
-        let synthesis_text = format!("Synthesized consensus from {} models.", positions.len());
+        // 3. Scoring
+        let claim_sets = position_claim_sets(&positions);
+        let convergence_score_bps = calculate_convergence(&claim_sets);
+        let consensus_claims =
+            consensus_claims_at_threshold(&claim_sets, self.panel.convergence_threshold_bps);
 
-        // 4. Scoring
-        let texts: Vec<&str> = raw_texts.iter().map(|s| s.as_str()).collect();
-        let convergence_score_bps = calculate_convergence(&texts);
+        // 4. Synthesis
+        let synthesis_text = consensus_summary(&consensus_claims);
 
         // 5. Devil's Advocate (only if converging well or on final round)
-        let mut devil_advocate_challenge = None;
+        let mut devil_advocate_review = None;
         if convergence_score_bps >= self.panel.convergence_threshold_bps
             || self.current_round == self.panel.max_rounds
         {
             if let Some(da_id) = &self.panel.devil_advocate_model {
-                let challenge = self.response_provider.response_for(da_id)?;
-                devil_advocate_challenge = Some(challenge);
+                let review = self.response_provider.devil_advocate_review_for(da_id)?;
+                devil_advocate_review = Some(validate_devil_advocate_review(da_id, review)?);
             }
         }
 
@@ -167,7 +185,7 @@ impl DeliberationSession {
             positions,
             synthesis: Some(synthesis_text),
             convergence_score_bps,
-            devil_advocate_challenge,
+            devil_advocate_review,
             round_hash: Hash256::ZERO,
         };
 
@@ -202,32 +220,31 @@ impl DeliberationSession {
         };
         let mut minority_reports = Vec::new();
 
-        // Determine consensus claims to check for minority reports
-        let mut consensus_claims = Vec::new();
-        for pos in last_round.positions.values() {
-            consensus_claims.extend(pos.key_claims.clone());
-        }
-        // Very rough naive deduplication
-        consensus_claims.sort();
-        consensus_claims.dedup();
+        let claim_sets = position_claim_sets(&last_round.positions);
+        let consensus_claims =
+            consensus_claims_at_threshold(&claim_sets, self.panel.convergence_threshold_bps);
 
         for pos in last_round.positions.values() {
             if is_minority_report(pos, &consensus_claims, self.panel.convergence_threshold_bps) {
+                let missing_claims = missing_consensus_claims(pos, &consensus_claims);
                 minority_reports.push(MinorityReport {
                     model_id: pos.model_id.clone(),
                     round: pos.round,
                     dissenting_position: pos.position_text.clone(),
-                    reasons: vec!["Diverged from consensus key claims".into()],
-                    divergence_score_bps: 10000 - last_round.convergence_score_bps, // proxy
+                    reasons: vec![format!(
+                        "Missing structured consensus claims: {}",
+                        missing_claims.join(", ")
+                    )],
+                    divergence_score_bps: 10000 - last_round.convergence_score_bps,
                 });
             }
         }
 
         let mut da_summary = None;
         let mut serious_objection = false;
-        if let Some(challenge) = &last_round.devil_advocate_challenge {
-            da_summary = Some(challenge.clone());
-            serious_objection = is_serious_challenge(challenge);
+        if let Some(review) = &last_round.devil_advocate_review {
+            da_summary = Some(review.review_text.clone());
+            serious_objection = review.serious_objection;
         }
 
         let panelists_count = u32::try_from(
@@ -270,6 +287,87 @@ impl DeliberationSession {
     }
 }
 
+fn validate_model_response(
+    model_id: &str,
+    response: ModelDeliberationResponse,
+) -> Result<ModelDeliberationResponse> {
+    let position_text = response.position_text.trim().to_string();
+    if position_text.is_empty() {
+        return Err(ConsensusError::ProviderError(format!(
+            "structured deterministic response for model {model_id} has empty position_text"
+        )));
+    }
+    if response.confidence_bps > 10000 {
+        return Err(ConsensusError::ProviderError(format!(
+            "structured deterministic response for model {model_id} has confidence_bps above 10000"
+        )));
+    }
+    let key_claims = canonical_claim_set(&response.key_claims);
+    if key_claims.is_empty() {
+        return Err(ConsensusError::ProviderError(format!(
+            "structured deterministic response for model {model_id} must include explicit key_claims"
+        )));
+    }
+
+    Ok(ModelDeliberationResponse {
+        position_text,
+        key_claims,
+        confidence_bps: response.confidence_bps,
+    })
+}
+
+fn validate_devil_advocate_review(
+    model_id: &str,
+    review: DevilAdvocateReview,
+) -> Result<DevilAdvocateReview> {
+    let review_text = review.review_text.trim().to_string();
+    if review_text.is_empty() {
+        return Err(ConsensusError::ProviderError(format!(
+            "structured devil's advocate review for model {model_id} has empty review_text"
+        )));
+    }
+
+    let reasons = canonical_claim_set(&review.reasons);
+    if review.serious_objection && reasons.is_empty() {
+        return Err(ConsensusError::ProviderError(format!(
+            "structured devil's advocate review for model {model_id} marks serious_objection without reasons"
+        )));
+    }
+
+    Ok(DevilAdvocateReview {
+        review_text,
+        serious_objection: review.serious_objection,
+        reasons,
+    })
+}
+
+fn position_claim_sets(positions: &BTreeMap<String, ModelPosition>) -> Vec<Vec<String>> {
+    positions
+        .values()
+        .map(|position| position.key_claims.clone())
+        .collect()
+}
+
+fn consensus_summary(consensus_claims: &[String]) -> String {
+    if consensus_claims.is_empty() {
+        "No structured consensus claims met threshold.".to_string()
+    } else {
+        format!(
+            "Structured consensus claims: {}.",
+            consensus_claims.join("; ")
+        )
+    }
+}
+
+fn missing_consensus_claims(position: &ModelPosition, consensus_claims: &[String]) -> Vec<String> {
+    let position_claims = canonical_claim_set(&position.key_claims);
+    consensus_claims
+        .iter()
+        .filter(|claim| !position_claims.contains(claim))
+        .cloned()
+        .collect()
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -277,12 +375,37 @@ mod tests {
 
     use super::*;
 
-    fn routine_responses(response: &str) -> BTreeMap<String, String> {
+    fn response(text: &str, claims: &[&str]) -> ModelDeliberationResponse {
+        ModelDeliberationResponse {
+            position_text: text.to_string(),
+            key_claims: claims.iter().map(|claim| (*claim).to_string()).collect(),
+            confidence_bps: 8000,
+        }
+    }
+
+    fn routine_responses(
+        response_text: &str,
+        claims: &[&str],
+    ) -> BTreeMap<String, ModelDeliberationResponse> {
         BTreeMap::from([
-            ("claude-3-haiku".to_string(), response.to_string()),
-            ("gpt-4o-mini".to_string(), response.to_string()),
-            ("gemini-1.5-flash".to_string(), response.to_string()),
+            (
+                "claude-3-haiku".to_string(),
+                response(response_text, claims),
+            ),
+            ("gpt-4o-mini".to_string(), response(response_text, claims)),
+            (
+                "gemini-1.5-flash".to_string(),
+                response(response_text, claims),
+            ),
         ])
+    }
+
+    fn neutral_review() -> DevilAdvocateReview {
+        DevilAdvocateReview {
+            review_text: "No threshold objection found.".to_string(),
+            serious_objection: false,
+            reasons: Vec::new(),
+        }
     }
 
     fn timing(round: u64) -> RoundExecutionTiming {
@@ -302,7 +425,8 @@ mod tests {
     #[test]
     fn execute_round_returns_round_limit_exceeded_when_current_round_exceeds_max() {
         let panel = Panel::default_panel(DecisionClass::Routine); // max_rounds = 1
-        let provider = DeterministicResponseProvider::new(routine_responses("A, B"));
+        let provider =
+            DeterministicResponseProvider::with_positions(routine_responses("A, B", &["a", "b"]));
         let mut session = DeliberationSession::new("s".into(), panel, "Q?".into(), provider);
         // First round succeeds; second should be rejected because current_round (2) > max_rounds (1).
         let first = session.execute_round(timing(1)).expect("first round ok");
@@ -323,10 +447,16 @@ mod tests {
         // Operational panel: threshold 7500, 3 panelists. Distinct responses => convergence 0.
         let panel = Panel::default_panel(DecisionClass::Operational);
         let mut responses = BTreeMap::new();
-        responses.insert("claude-3-5-sonnet".into(), "alpha".into());
-        responses.insert("gpt-4o".into(), "beta".into());
-        responses.insert("gemini-1.5-pro".into(), "gamma".into());
-        let provider = DeterministicResponseProvider::new(responses);
+        responses.insert(
+            "claude-3-5-sonnet".into(),
+            response("alpha position", &["alpha"]),
+        );
+        responses.insert("gpt-4o".into(), response("beta position", &["beta"]));
+        responses.insert(
+            "gemini-1.5-pro".into(),
+            response("gamma position", &["gamma"]),
+        );
+        let provider = DeterministicResponseProvider::with_positions(responses);
         let mut session = DeliberationSession::new("s".into(), panel, "Q?".into(), provider);
         let round = session.execute_round(timing(1)).unwrap();
         // Zero overlap across three distinct claims => 0 bps, clearly below the 7500 threshold.
@@ -338,7 +468,7 @@ mod tests {
     #[test]
     fn is_converged_false_when_no_rounds() {
         let panel = Panel::default_panel(DecisionClass::Routine);
-        let provider = DeterministicResponseProvider::new(BTreeMap::new());
+        let provider = DeterministicResponseProvider::with_positions(BTreeMap::new());
         let session = DeliberationSession::new("s".into(), panel, "Q?".into(), provider);
         assert!(!session.is_converged());
     }
@@ -347,7 +477,7 @@ mod tests {
     #[test]
     fn finalize_errors_with_state_error_when_rounds_empty() {
         let panel = Panel::default_panel(DecisionClass::Routine);
-        let provider = DeterministicResponseProvider::new(BTreeMap::new());
+        let provider = DeterministicResponseProvider::with_positions(BTreeMap::new());
         let session = DeliberationSession::new("s".into(), panel, "Q?".into(), provider);
         let err = session
             .finalize(finalization_timing())
@@ -363,6 +493,49 @@ mod tests {
         }
     }
 
+    #[test]
+    fn execute_round_rejects_text_only_response_without_structured_claims() {
+        let panel = Panel::default_panel(DecisionClass::Routine);
+        let provider = DeterministicResponseProvider::with_positions(routine_responses(
+            "raw text has commas, but no structured claims",
+            &[],
+        ));
+        let mut session = DeliberationSession::new("s".into(), panel, "Q?".into(), provider);
+
+        let err = session
+            .execute_round(timing(1))
+            .expect_err("text-only model response must fail closed");
+
+        match err {
+            ConsensusError::ProviderError(message) => {
+                assert!(message.contains("explicit key_claims"));
+            }
+            other => panic!("expected ProviderError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn execute_round_rejects_out_of_range_model_confidence() {
+        let panel = Panel::default_panel(DecisionClass::Routine);
+        let mut responses = routine_responses("claim text", &["claim"]);
+        let mut invalid = response("claim text", &["claim"]);
+        invalid.confidence_bps = 10001;
+        responses.insert("gpt-4o-mini".to_string(), invalid);
+        let provider = DeterministicResponseProvider::with_positions(responses);
+        let mut session = DeliberationSession::new("s".into(), panel, "Q?".into(), provider);
+
+        let err = session
+            .execute_round(timing(1))
+            .expect_err("confidence above 10000 bps must fail closed");
+
+        match err {
+            ConsensusError::ProviderError(message) => {
+                assert!(message.contains("confidence_bps above 10000"));
+            }
+            other => panic!("expected ProviderError, got {other:?}"),
+        }
+    }
+
     // Covers line 100 true branch: devil's advocate runs on final round even when convergence is low.
     #[test]
     fn devil_advocate_runs_on_final_round_even_without_convergence() {
@@ -370,17 +543,26 @@ mod tests {
         let panel = Panel::default_panel(DecisionClass::Operational);
         let mut responses = BTreeMap::new();
         // Distinct responses so convergence < threshold in both rounds.
-        responses.insert("claude-3-5-sonnet".into(), "alpha".into());
-        responses.insert("gpt-4o".into(), "beta".into());
-        responses.insert("gemini-1.5-pro".into(), "gamma".into());
-        let provider = DeterministicResponseProvider::new(responses);
+        responses.insert(
+            "claude-3-5-sonnet".into(),
+            response("alpha position", &["alpha"]),
+        );
+        responses.insert("gpt-4o".into(), response("beta position", &["beta"]));
+        responses.insert(
+            "gemini-1.5-pro".into(),
+            response("gamma position", &["gamma"]),
+        );
+        let provider = DeterministicResponseProvider::new(
+            responses,
+            BTreeMap::from([("gpt-4o".to_string(), neutral_review())]),
+        );
         let mut session = DeliberationSession::new("s".into(), panel, "Q?".into(), provider);
 
         // Round 1: not final, convergence below threshold -> DA does NOT run.
         let r1 = session.execute_round(timing(1)).unwrap();
         assert!(r1.convergence_score_bps < 7500);
         assert!(
-            r1.devil_advocate_challenge.is_none(),
+            r1.devil_advocate_review.is_none(),
             "DA should not run when neither converged nor on the final round"
         );
 
@@ -389,7 +571,7 @@ mod tests {
         assert_eq!(r2.round_number, 2);
         assert!(r2.convergence_score_bps < 7500);
         assert!(
-            r2.devil_advocate_challenge.is_some(),
+            r2.devil_advocate_review.is_some(),
             "DA must trigger on the final round even without convergence"
         );
 
@@ -398,18 +580,133 @@ mod tests {
         assert!(result.devil_advocate_summary.is_some());
     }
 
+    #[test]
+    fn devil_advocate_keyword_text_is_not_binding_without_serious_flag() {
+        let panel = Panel::default_panel(DecisionClass::Operational);
+        let positions = BTreeMap::from([
+            (
+                "claude-3-5-sonnet".to_string(),
+                response("shared position", &["shared claim"]),
+            ),
+            (
+                "gpt-4o".to_string(),
+                response("shared position", &["shared claim"]),
+            ),
+            (
+                "gemini-1.5-pro".to_string(),
+                response("shared position", &["shared claim"]),
+            ),
+        ]);
+        let reviews = BTreeMap::from([(
+            "gpt-4o".to_string(),
+            DevilAdvocateReview {
+                review_text: "The prose says serious and fatal but the structured flag is false."
+                    .to_string(),
+                serious_objection: false,
+                reasons: Vec::new(),
+            },
+        )]);
+        let provider = DeterministicResponseProvider::new(positions, reviews);
+        let mut session = DeliberationSession::new("s".into(), panel, "Q?".into(), provider);
+
+        session.execute_round(timing(1)).unwrap();
+        let result = session.finalize(finalization_timing()).unwrap();
+
+        assert_eq!(result.panel_confidence_index_bps, 10000);
+        assert_eq!(
+            result.devil_advocate_summary.as_deref(),
+            Some("The prose says serious and fatal but the structured flag is false.")
+        );
+    }
+
+    #[test]
+    fn devil_advocate_serious_objection_requires_reasons_and_penalizes_panel_confidence() {
+        let panel = Panel::default_panel(DecisionClass::Operational);
+        let positions = BTreeMap::from([
+            (
+                "claude-3-5-sonnet".to_string(),
+                response("shared position", &["shared claim"]),
+            ),
+            (
+                "gpt-4o".to_string(),
+                response("shared position", &["shared claim"]),
+            ),
+            (
+                "gemini-1.5-pro".to_string(),
+                response("shared position", &["shared claim"]),
+            ),
+        ]);
+        let reviews = BTreeMap::from([(
+            "gpt-4o".to_string(),
+            DevilAdvocateReview {
+                review_text: "Structured objection accepted.".to_string(),
+                serious_objection: true,
+                reasons: vec!["missing safety bound".to_string()],
+            },
+        )]);
+        let provider = DeterministicResponseProvider::new(positions, reviews);
+        let mut session = DeliberationSession::new("s".into(), panel, "Q?".into(), provider);
+
+        session.execute_round(timing(1)).unwrap();
+        let result = session.finalize(finalization_timing()).unwrap();
+
+        assert_eq!(result.panel_confidence_index_bps, 8000);
+
+        let invalid_positions = BTreeMap::from([
+            (
+                "claude-3-5-sonnet".to_string(),
+                response("shared position", &["shared claim"]),
+            ),
+            (
+                "gpt-4o".to_string(),
+                response("shared position", &["shared claim"]),
+            ),
+            (
+                "gemini-1.5-pro".to_string(),
+                response("shared position", &["shared claim"]),
+            ),
+        ]);
+        let invalid_reviews = BTreeMap::from([(
+            "gpt-4o".to_string(),
+            DevilAdvocateReview {
+                review_text: "Structured objection lacks reasons.".to_string(),
+                serious_objection: true,
+                reasons: Vec::new(),
+            },
+        )]);
+        let provider = DeterministicResponseProvider::new(invalid_positions, invalid_reviews);
+        let mut session = DeliberationSession::new(
+            "s2".into(),
+            Panel::default_panel(DecisionClass::Operational),
+            "Q?".into(),
+            provider,
+        );
+        let err = session
+            .execute_round(timing(1))
+            .expect_err("serious objection without reasons must fail closed");
+        match err {
+            ConsensusError::ProviderError(message) => {
+                assert!(message.contains("marks serious_objection without reasons"));
+            }
+            other => panic!("expected ProviderError, got {other:?}"),
+        }
+    }
+
     // Covers the DA-skipped branch when the panel has no devil_advocate_model configured.
     #[test]
     fn devil_advocate_skipped_when_panel_has_no_da_model_even_on_converged_final_round() {
         // Routine panel: max_rounds = 1 (final), devil_advocate_model = None.
         let panel = Panel::default_panel(DecisionClass::Routine);
         assert!(panel.devil_advocate_model.is_none());
-        let provider = DeterministicResponseProvider::new(routine_responses("same claim"));
+        let provider = DeterministicResponseProvider::with_positions(routine_responses(
+            "same claim",
+            &["same claim"],
+        ));
         let mut session = DeliberationSession::new("s".into(), panel, "Q?".into(), provider);
         let round = session.execute_round(timing(1)).unwrap();
         // Convergence is 10000 (all identical) and we are at the final round,
         // but devil_advocate_model is None => the inner `if let Some(..)` is false.
         assert_eq!(round.convergence_score_bps, 10000);
-        assert!(round.devil_advocate_challenge.is_none());
+        assert!(round.devil_advocate_review.is_none());
     }
 }

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 116643 lines of Rust under `crates/`, 2,891 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 117115 lines of Rust under `crates/`, 2,897 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,891 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,897 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,891 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,897 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-116643 lines of Rust under `crates/` · 20 workspace packages · 2,891 listed tests · 40 MCP tools · 8 constitutional invariants
+117115 lines of Rust under `crates/` · 20 workspace packages · 2,897 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 116643 lines of Rust under `crates/` | 266 Rust source files | 2,891 listed tests
+> **Codebase:** 20 workspace packages | 117115 lines of Rust under `crates/` | 266 Rust source files | 2,897 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,891 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,897 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 116643 lines of Rust under `crates/` · 2,891 listed tests
+20 workspace packages · 117115 lines of Rust under `crates/` · 2,897 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- replace raw string consensus responses with structured model response evidence and explicit devil's advocate reviews
- commit to model response text, structured key claims, and confidence via canonical CBOR
- score convergence and minority reports from structured claim sets only; remove keyword serious-objection detection
- refresh repo-truth counts to 117115 Rust LOC and 2,897 listed tests

## TDD
- red check: `cargo test -p exo-consensus production_session_source_has_no_raw_text_consensus_heuristics --lib -- --nocapture` initially failed because production `session.rs` split raw prose into claims
- added regressions for text-only response refusal, out-of-range confidence refusal, structured response commitment binding, keyword text not binding serious objections, and serious objections requiring reasons

## Verification
- `cargo test -p exo-consensus --lib -- --nocapture`
- `cargo test -p exo-consensus`
- `cargo build -p exo-consensus`
- `cargo clippy -p exo-consensus --lib -- -D warnings`
- `cargo clippy -p exo-consensus --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `bash tools/repo_truth.sh --json`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit --deny unsound --deny unmaintained` (existing allowed yanked core2 warning)
- `cargo deny check` (existing duplicate/yanked/unused-allowance warnings)