### PR TITLE
fix(exo-gateway): fail closed conflict declaration checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 117115 | `wc -l` |
-| Workspace tests | 2,897 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 117316 | `wc -l` |
+| Workspace tests | 2,901 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,897 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,901 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 117115 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 117316 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,897 listed workspace tests
+         cryptographic proofs, 2,901 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-gateway/migrations/20260427000001_create_conflict_declarations.sql
+++ b/crates/exo-gateway/migrations/20260427000001_create_conflict_declarations.sql
@@ -1,0 +1,20 @@
+-- Conflict-of-interest declarations backing vote recusal checks.
+--
+-- Vote handling must fail closed if this register cannot be read. The JSONB
+-- payload stores the canonical `exo_governance::conflict::ConflictDeclaration`
+-- shape while indexed scalar columns keep the lookup deterministic.
+CREATE TABLE IF NOT EXISTS conflict_declarations (
+    id_hash TEXT PRIMARY KEY,
+    declarant_did TEXT NOT NULL,
+    nature TEXT NOT NULL,
+    related_dids JSONB NOT NULL,
+    timestamp_physical_ms BIGINT NOT NULL CHECK (timestamp_physical_ms > 0),
+    timestamp_logical INTEGER NOT NULL DEFAULT 0 CHECK (timestamp_logical >= 0),
+    payload JSONB NOT NULL,
+    CHECK (length(trim(nature)) > 0),
+    CHECK (jsonb_typeof(related_dids) = 'array'),
+    CHECK (jsonb_array_length(related_dids) > 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_conflict_declarations_declarant
+    ON conflict_declarations(declarant_did);

--- a/crates/exo-gateway/src/db.rs
+++ b/crates/exo-gateway/src/db.rs
@@ -327,6 +327,25 @@ pub async fn update_decision(
     Ok(())
 }
 
+/// Load conflict declaration payloads for a declarant, oldest first.
+pub async fn list_conflict_declaration_payloads_db(
+    pool: &PgPool,
+    declarant_did: &str,
+) -> Result<Vec<JsonValue>, sqlx::Error> {
+    let rows = sqlx::query(
+        "SELECT payload FROM conflict_declarations
+         WHERE declarant_did = $1
+         ORDER BY timestamp_physical_ms, timestamp_logical, id_hash",
+    )
+    .bind(declarant_did)
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter()
+        .map(|row| row.try_get::<JsonValue, _>("payload"))
+        .collect()
+}
+
 /// Row representation of a governance decision from the `decisions` table.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct DecisionRow {

--- a/crates/exo-gateway/src/handlers.rs
+++ b/crates/exo-gateway/src/handlers.rs
@@ -1,7 +1,7 @@
 //! HTTP route handlers — axum handler functions for all gateway endpoints.
 //!
 //! CONSTITUTIONAL REQUIREMENTS (do not remove):
-//!   1. Vote handler MUST call `check_conflicts` + `must_recuse` (ConflictAdjudication)
+//!   1. Vote handler MUST call `check_conflicts` + `check_and_block` (ConflictAdjudication)
 //!   2. Vote handler MUST call `Kernel::adjudicate` and gate on `Verdict::Permitted` (TNC-01)
 //!   3. `write_audit` MUST use `ciborium::into_writer` before blake3, not serde_json (TransparencyAccountability)
 
@@ -10,13 +10,13 @@ use decision_forum::{
     decision_object::{ActorKind, DecisionObject, Vote, VoteChoice},
     quorum::{QuorumCheckResult, QuorumRegistry, check_quorum, verify_quorum_precondition},
 };
-use exo_core::{Timestamp, types::Hash256};
+use exo_core::{Did, Timestamp, types::Hash256};
 use exo_gatekeeper::{
     kernel::{ActionRequest as GatekeeperActionRequest, Verdict},
     types::{Permission, PermissionSet},
 };
 use exo_governance::conflict::{
-    ActionRequest as ConflictActionRequest, check_conflicts, must_recuse,
+    ActionRequest as ConflictActionRequest, check_and_block, check_conflicts,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -186,6 +186,7 @@ async fn write_audit(
 pub struct VoteRequest {
     pub decision_id: String,
     pub voter_did: String,
+    pub affected_dids: Vec<String>,
     pub choice: VoteChoice,
     pub actor_kind: ActorKind,
     pub rationale: Option<String>,
@@ -200,6 +201,17 @@ impl VoteRequest {
             return Err("vote timestamp must be caller-supplied and non-zero".to_owned());
         }
         Ok(timestamp)
+    }
+
+    fn caller_supplied_affected_dids(&self) -> Result<Vec<Did>, String> {
+        if self.affected_dids.is_empty() {
+            return Err("affected_dids must contain at least one DID".to_owned());
+        }
+
+        self.affected_dids
+            .iter()
+            .map(|raw| Did::new(raw).map_err(|e| format!("invalid affected DID `{raw}`: {e}")))
+            .collect()
     }
 }
 
@@ -218,24 +230,46 @@ pub async fn vote_handler(
                 .into_response();
         }
     };
+    let affected_dids = match body.caller_supplied_affected_dids() {
+        Ok(dids) => dids,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": e})),
+            )
+                .into_response();
+        }
+    };
 
     // ── VIOLATION 1 FIX: ConflictAdjudication ───────────────────────────
     // Check if voter has a declared conflict of interest on this decision.
-    let declarations = state
-        .load_conflict_declarations(&voter_did)
-        .await
-        .unwrap_or_default();
+    let declarations = match state.load_conflict_declarations(&voter_did).await {
+        Ok(declarations) => declarations,
+        Err(e) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({
+                    "error": "conflict register unavailable",
+                    "details": e.to_string()
+                })),
+            )
+                .into_response();
+        }
+    };
     let conflict_action = ConflictActionRequest {
         action_id: body.decision_id.clone(),
         actor_did: voter_did.clone(),
-        affected_dids: vec![],
+        affected_dids,
         description: format!("Vote on {}", body.decision_id),
     };
     let conflicts = check_conflicts(&voter_did, &conflict_action, &declarations);
-    if must_recuse(&conflicts) {
+    if let Err(err) = check_and_block(&voter_did, &conflicts) {
         return (
             StatusCode::FORBIDDEN,
-            Json(serde_json::json!({"error": "must recuse due to conflict of interest"})),
+            Json(serde_json::json!({
+                "error": "must recuse due to conflict of interest",
+                "reason": err.to_string()
+            })),
         )
             .into_response();
     }
@@ -716,6 +750,7 @@ mod tests {
         let with_timestamp = serde_json::json!({
             "decision_id": "decision-1",
             "voter_did": "did:exo:alice",
+            "affected_dids": ["did:exo:tenant-a"],
             "choice": "Approve",
             "actor_kind": "Human",
             "rationale": null,
@@ -738,6 +773,7 @@ mod tests {
         let request: VoteRequest = serde_json::from_value(serde_json::json!({
             "decision_id": "decision-1",
             "voter_did": "did:exo:alice",
+            "affected_dids": ["did:exo:tenant-a"],
             "choice": "Approve",
             "actor_kind": "Human",
             "rationale": null,
@@ -749,6 +785,62 @@ mod tests {
         assert!(
             request.caller_supplied_timestamp().is_err(),
             "zero vote timestamp must be rejected"
+        );
+    }
+
+    #[test]
+    fn vote_request_requires_affected_dids_for_conflict_adjudication() {
+        let without_affected_dids = serde_json::json!({
+            "decision_id": "decision-1",
+            "voter_did": "did:exo:alice",
+            "choice": "Approve",
+            "actor_kind": "Human",
+            "rationale": null,
+            "timestamp_physical_ms": 7000,
+            "timestamp_logical": 2
+        });
+        assert!(
+            serde_json::from_value::<VoteRequest>(without_affected_dids).is_err(),
+            "vote requests must provide affected DIDs so conflict checks are not vacuous"
+        );
+
+        let empty_affected_dids: VoteRequest = serde_json::from_value(serde_json::json!({
+            "decision_id": "decision-1",
+            "voter_did": "did:exo:alice",
+            "affected_dids": [],
+            "choice": "Approve",
+            "actor_kind": "Human",
+            "rationale": null,
+            "timestamp_physical_ms": 7000,
+            "timestamp_logical": 2
+        }))
+        .expect("request shape is valid");
+        assert!(
+            empty_affected_dids.caller_supplied_affected_dids().is_err(),
+            "affected_dids must not be an explicitly empty conflict context"
+        );
+    }
+
+    #[test]
+    fn vote_handler_source_does_not_default_conflict_adjudication() {
+        let source = include_str!("handlers.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("test module marker present");
+        assert!(
+            !production.contains(
+                ".load_conflict_declarations(&voter_did)\n        .await\n        .unwrap_or_default()"
+            ),
+            "vote handler must fail closed when the conflict register cannot be loaded"
+        );
+        assert!(
+            !production.contains("affected_dids: vec![]"),
+            "vote handler must not adjudicate conflicts against an empty affected-DID set"
+        );
+        assert!(
+            production.contains("check_and_block(&voter_did, &conflicts)"),
+            "vote handler must use the enforcing conflict gate, not advisory-only recusal checks"
         );
     }
 

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -174,17 +174,23 @@ impl AppState {
         })
     }
 
-    /// Load conflict declarations for an actor.
-    ///
-    /// Currently returns an empty list until the DB schema includes a
-    /// `conflict_declarations` table.  Handlers should call
-    /// `.await.unwrap_or_default()` for graceful degradation.
+    /// Load conflict declarations for an actor from the DB-backed standing
+    /// conflict register.
     pub async fn load_conflict_declarations(
         &self,
-        _actor: &Did,
+        actor: &Did,
     ) -> std::result::Result<Vec<ConflictDeclaration>, GatewayError> {
-        // TODO: query `conflict_declarations` table when DB is available
-        Ok(vec![])
+        let pool = self.require_db()?;
+        let payloads = db::list_conflict_declaration_payloads_db(pool, actor.as_str())
+            .await
+            .map_err(|e| {
+                GatewayError::Internal(format!("failed to load conflict declarations: {e}"))
+            })?;
+
+        payloads
+            .into_iter()
+            .map(|payload| decode_conflict_declaration_payload(actor, payload))
+            .collect()
     }
 
     /// Build an adjudication context for the given actor.
@@ -234,6 +240,44 @@ impl AppState {
             active_challenge_reason: None,
         }
     }
+}
+
+fn decode_conflict_declaration_payload(
+    actor: &Did,
+    payload: serde_json::Value,
+) -> std::result::Result<ConflictDeclaration, GatewayError> {
+    let declaration: ConflictDeclaration = serde_json::from_value(payload).map_err(|e| {
+        GatewayError::Internal(format!("invalid stored conflict declaration payload: {e}"))
+    })?;
+    validate_conflict_declaration(actor, declaration)
+}
+
+fn validate_conflict_declaration(
+    actor: &Did,
+    declaration: ConflictDeclaration,
+) -> std::result::Result<ConflictDeclaration, GatewayError> {
+    if &declaration.declarant_did != actor {
+        return Err(GatewayError::Internal(format!(
+            "stored conflict declaration for {} was returned while loading {}",
+            declaration.declarant_did, actor
+        )));
+    }
+    if declaration.nature.trim().is_empty() {
+        return Err(GatewayError::Internal(
+            "stored conflict declaration has empty nature".into(),
+        ));
+    }
+    if declaration.related_dids.is_empty() {
+        return Err(GatewayError::Internal(
+            "stored conflict declaration has no related DIDs".into(),
+        ));
+    }
+    if declaration.timestamp == Timestamp::ZERO {
+        return Err(GatewayError::Internal(
+            "stored conflict declaration has zero timestamp".into(),
+        ));
+    }
+    Ok(declaration)
 }
 
 const GATEWAY_SERVER_METADATA_INITIATIVE: &str =
@@ -1989,6 +2033,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn conflict_declaration_loader_fails_closed_without_db_pool() {
+        let state = state();
+        let actor = Did::new("did:exo:alice").expect("valid DID");
+        let err = state
+            .load_conflict_declarations(&actor)
+            .await
+            .expect_err("missing conflict register must fail closed");
+        assert!(
+            err.to_string().contains("database"),
+            "error should identify missing DB-backed conflict register, got: {err}"
+        );
+    }
+
+    #[test]
+    fn conflict_declaration_payload_validation_rejects_wrong_actor_and_placeholders() {
+        let actor = Did::new("did:exo:alice").expect("valid DID");
+        let related = Did::new("did:exo:tenant-a").expect("valid DID");
+
+        let valid = serde_json::json!({
+            "declarant_did": actor,
+            "nature": "financial ownership",
+            "related_dids": [related],
+            "timestamp": { "physical_ms": 7000, "logical": 0 }
+        });
+        let decoded =
+            decode_conflict_declaration_payload(&actor, valid).expect("valid declaration payload");
+        assert_eq!(decoded.declarant_did, actor);
+
+        let wrong_actor = serde_json::json!({
+            "declarant_did": "did:exo:bob",
+            "nature": "financial ownership",
+            "related_dids": ["did:exo:tenant-a"],
+            "timestamp": { "physical_ms": 7000, "logical": 0 }
+        });
+        assert!(decode_conflict_declaration_payload(&actor, wrong_actor).is_err());
+
+        let zero_timestamp = serde_json::json!({
+            "declarant_did": actor,
+            "nature": "financial ownership",
+            "related_dids": ["did:exo:tenant-a"],
+            "timestamp": { "physical_ms": 0, "logical": 0 }
+        });
+        assert!(decode_conflict_declaration_payload(&actor, zero_timestamp).is_err());
+    }
+
+    #[tokio::test]
     async fn gateway_global_concurrency_limit_queues_excess_requests() {
         #[derive(Clone)]
         struct HoldState {
@@ -2535,10 +2625,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn vote_route_without_authority_returns_403() {
+    async fn vote_route_without_conflict_register_returns_503() {
         let body = serde_json::to_string(&serde_json::json!({
             "decision_id": "d1",
             "voter_did": "did:exo:alice",
+            "affected_dids": ["did:exo:tenant-a"],
             "choice": "Approve",
             "actor_kind": "Human",
             "rationale": null,
@@ -2558,11 +2649,10 @@ mod tests {
             )
             .await
             .unwrap();
-        // The Kernel adjudicates before the DB check.  The dev-scaffold context
-        // has BailmentState::None (fails ConsentRequired) and an empty authority
-        // chain (fails AuthorityChainValid), so the Kernel correctly returns 403
-        // before we ever reach the DB-pool check.
-        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        // Conflict adjudication is a required vote precondition. Without a
+        // DB-backed standing conflict register, the route fails closed before
+        // reaching kernel adjudication.
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
     // --- Identity score endpoint tests ---

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 117115 lines of Rust under `crates/`, 2,897 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 117316 lines of Rust under `crates/`, 2,901 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,897 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,901 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,897 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,901 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-117115 lines of Rust under `crates/` · 20 workspace packages · 2,897 listed tests · 40 MCP tools · 8 constitutional invariants
+117316 lines of Rust under `crates/` · 20 workspace packages · 2,901 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 117115 lines of Rust under `crates/` | 266 Rust source files | 2,897 listed tests
+> **Codebase:** 20 workspace packages | 117316 lines of Rust under `crates/` | 266 Rust source files | 2,901 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,897 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,901 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 117115 lines of Rust under `crates/` · 2,897 listed tests
+20 workspace packages · 117316 lines of Rust under `crates/` · 2,901 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary

- Require vote requests to provide a non-empty affected-DID set before conflict adjudication.
- Fail closed with `503 Service Unavailable` when the gateway cannot load the conflict declaration register.
- Load persisted conflict declarations from the production database, validate them before use, and enforce voting conflicts with `check_and_block`.
- Add the `conflict_declarations` migration and update repo-truth counts to `117316` Rust LOC / `2,901` listed tests.

## TDD Red Checks

- `cargo test -p exo-gateway vote_request_requires_affected_dids_for_conflict_adjudication --lib -- --nocapture` initially failed because missing `affected_dids` was accepted.
- `cargo test -p exo-gateway vote_handler_source_does_not_default_conflict_adjudication --lib -- --nocapture` initially failed because the handler used `unwrap_or_default` and empty affected DID sets.
- `cargo test -p exo-gateway conflict_declaration_loader_fails_closed_without_db_pool --lib -- --nocapture` initially failed because the loader returned `Ok([])`.

## Verification

- `cargo test -p exo-gateway --lib`
- `cargo test -p exo-gateway`
- `cargo test -p exo-gateway --features production-db`
- `cargo build -p exo-gateway`
- `cargo clippy -p exo-gateway --lib --bins -- -D warnings`
- `cargo clippy -p exo-gateway --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit --deny unsound --deny unmaintained` passed with the existing allowed yanked `core2` warning.
- `cargo deny check` passed with existing duplicate/yanked/unused-allowance warnings.

## Initiative

`/Users/bobstewart/obsidian/aeon/Initiatives/fix-gateway-conflict-declaration-enforcement.md`
