### PR TITLE
fix(exo-legal): require compliance attestation evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 117316 | `wc -l` |
-| Workspace tests | 2,901 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 117674 | `wc -l` |
+| Workspace tests | 2,904 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,901 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,904 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 117316 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 117674 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,901 listed workspace tests
+         cryptographic proofs, 2,904 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-legal/src/ai_transparency.rs
+++ b/crates/exo-legal/src/ai_transparency.rs
@@ -7,21 +7,52 @@
 //! # Clearance requirement
 //!
 //! [`generate_report`] is a sensitive operation — the report reveals which
-//! AI agents hold delegated authority. Callers must verify that the
-//! requesting actor holds a valid authority chain before calling this
-//! function. The function signature accepts a `clearance_verified: bool`
-//! flag which must be set only after an [`exo_authority`] chain check.
+//! AI agents hold delegated authority. Callers must pass a
+//! [`VerifiedAuthorityClearance`] created by [`verify_authority_clearance`],
+//! which verifies the requesting actor's authority chain before any report
+//! can be generated.
 
-use exo_authority::DelegateeKind;
-use exo_core::{Did, Timestamp};
-use exo_gatekeeper::mcp_audit::{McpAuditLog, McpEnforcementOutcome};
+use exo_authority::{AuthorityChain, DelegateeKind, chain};
+use exo_core::{Did, PublicKey, Timestamp, hash::hash_structured};
+use exo_gatekeeper::mcp_audit::{
+    McpAuditLog, McpEnforcementOutcome, verify_chain as verify_mcp_audit_chain,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{LegalError, Result};
 
+const AUTHORITY_CLEARANCE_DOMAIN: &str = "exo.legal.ai_transparency.authority_clearance.v1";
+const AUTHORITY_CLEARANCE_SCHEMA_VERSION: u16 = 1;
+
 // ---------------------------------------------------------------------------
 // Report structures
 // ---------------------------------------------------------------------------
+
+/// Verified authority-chain evidence authorizing report generation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthorityClearanceEvidence {
+    pub requester: Did,
+    pub verified_at: Timestamp,
+    pub chain_root: Did,
+    pub chain_leaf: Did,
+    pub chain_depth: usize,
+    pub chain_hash: [u8; 32],
+}
+
+/// Authority clearance artifact that can only be created by successful chain
+/// verification through [`verify_authority_clearance`].
+#[derive(Debug, Clone)]
+pub struct VerifiedAuthorityClearance {
+    evidence: AuthorityClearanceEvidence,
+}
+
+impl VerifiedAuthorityClearance {
+    /// Return the serializable evidence captured after verification.
+    #[must_use]
+    pub fn evidence(&self) -> &AuthorityClearanceEvidence {
+        &self.evidence
+    }
+}
 
 /// Summary of a single AI agent delegation event.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -65,6 +96,10 @@ pub struct AiTransparencyReport {
     pub ai_delegation_revocations: u64,
     /// Per-rule breakdown of MCP enforcement outcomes.
     pub mcp_rule_outcomes: Vec<McpOutcomeSummary>,
+    /// Head hash of the MCP audit log after full-chain verification.
+    pub mcp_audit_head_hash: [u8; 32],
+    /// Verified report-generation authority evidence.
+    pub authority_clearance: AuthorityClearanceEvidence,
 }
 
 // ---------------------------------------------------------------------------
@@ -81,22 +116,21 @@ pub struct ReportParams<'a> {
     pub mcp_log: &'a McpAuditLog,
     pub ai_delegation_grants: Vec<AiDelegationEvent>,
     pub ai_delegation_revocations: u64,
-    /// Must only be `true` after the caller has validated the requesting
-    /// actor's authority chain via `exo_authority::chain::verify_chain`.
-    pub clearance_verified: bool,
+    /// Verified authority-chain clearance for the actor generating the report.
+    pub authority_clearance: &'a VerifiedAuthorityClearance,
 }
 
 /// Generate an AI transparency report for the given tenant and time period.
 ///
 /// # Clearance requirement
 ///
-/// `params.clearance_verified` must be `true` only after the caller has
-/// validated the requesting actor's authority chain. Passing `false` returns
-/// [`LegalError::InvalidStateTransition`] immediately without generating data.
+/// `params.authority_clearance` must be created by
+/// [`verify_authority_clearance`], which performs real authority-chain
+/// verification and binds the resulting chain evidence into the report.
 ///
 /// # Errors
 ///
-/// - [`LegalError::InvalidStateTransition`] if clearance is not verified.
+/// - [`LegalError::InvalidStateTransition`] if the MCP audit chain is broken.
 pub fn generate_report(params: ReportParams<'_>) -> Result<AiTransparencyReport> {
     let ReportParams {
         tenant_id,
@@ -106,16 +140,12 @@ pub fn generate_report(params: ReportParams<'_>) -> Result<AiTransparencyReport>
         mcp_log,
         ai_delegation_grants,
         ai_delegation_revocations,
-        clearance_verified,
+        authority_clearance,
     } = params;
 
-    if !clearance_verified {
-        return Err(LegalError::InvalidStateTransition {
-            reason: "AiTransparencyReport requires verified authority chain clearance; \
-                     call exo_authority::chain::verify_chain before generate_report"
-                .into(),
-        });
-    }
+    verify_mcp_audit_chain(mcp_log).map_err(|e| LegalError::InvalidStateTransition {
+        reason: format!("MCP audit chain verification failed before transparency report: {e}"),
+    })?;
 
     // Count total AI agent actions from MCP audit log within period.
     let ai_agent_action_count = u64::try_from(
@@ -139,6 +169,74 @@ pub fn generate_report(params: ReportParams<'_>) -> Result<AiTransparencyReport>
         ai_delegation_grants,
         ai_delegation_revocations,
         mcp_rule_outcomes,
+        mcp_audit_head_hash: mcp_log.head_hash(),
+        authority_clearance: authority_clearance.evidence().clone(),
+    })
+}
+
+/// Verify report-generation authority clearance and return a non-synthesizable
+/// artifact for [`ReportParams`].
+///
+/// # Errors
+///
+/// Returns [`LegalError::InvalidStateTransition`] if the timestamp is zero, the
+/// chain leaf is not the requester, the authority chain fails verification, or
+/// the chain evidence cannot be canonicalized.
+pub fn verify_authority_clearance<F>(
+    requester: &Did,
+    authority_chain: &AuthorityChain,
+    verified_at: Timestamp,
+    resolve_key: F,
+) -> Result<VerifiedAuthorityClearance>
+where
+    F: Fn(&Did) -> Option<PublicKey>,
+{
+    if verified_at == Timestamp::ZERO {
+        return Err(LegalError::InvalidStateTransition {
+            reason: "authority clearance verification timestamp must be non-zero".into(),
+        });
+    }
+
+    let chain_root =
+        authority_chain
+            .root()
+            .cloned()
+            .ok_or_else(|| LegalError::InvalidStateTransition {
+                reason: "authority clearance chain must not be empty".into(),
+            })?;
+    let chain_leaf =
+        authority_chain
+            .leaf()
+            .cloned()
+            .ok_or_else(|| LegalError::InvalidStateTransition {
+                reason: "authority clearance chain must not be empty".into(),
+            })?;
+
+    if &chain_leaf != requester {
+        return Err(LegalError::InvalidStateTransition {
+            reason: format!(
+                "authority clearance requester {} does not match chain leaf {}",
+                requester.as_str(),
+                chain_leaf.as_str()
+            ),
+        });
+    }
+
+    chain::verify_chain(authority_chain, &verified_at, resolve_key).map_err(|e| {
+        LegalError::InvalidStateTransition {
+            reason: format!("authority clearance chain verification failed: {e}"),
+        }
+    })?;
+
+    Ok(VerifiedAuthorityClearance {
+        evidence: AuthorityClearanceEvidence {
+            requester: requester.clone(),
+            verified_at,
+            chain_root,
+            chain_leaf,
+            chain_depth: authority_chain.depth(),
+            chain_hash: hash_authority_clearance_chain(authority_chain)?,
+        },
     })
 }
 
@@ -201,13 +299,34 @@ fn aggregate_mcp_outcomes(
         .collect()
 }
 
+#[derive(Serialize)]
+struct AuthorityClearanceHashPayload<'a> {
+    domain: &'static str,
+    schema_version: u16,
+    authority_chain: &'a AuthorityChain,
+}
+
+fn hash_authority_clearance_chain(authority_chain: &AuthorityChain) -> Result<[u8; 32]> {
+    let payload = AuthorityClearanceHashPayload {
+        domain: AUTHORITY_CLEARANCE_DOMAIN,
+        schema_version: AUTHORITY_CLEARANCE_SCHEMA_VERSION,
+        authority_chain,
+    };
+    hash_structured(&payload)
+        .map(|hash| *hash.as_bytes())
+        .map_err(|e| LegalError::InvalidStateTransition {
+            reason: format!("authority clearance canonical CBOR hash failed: {e}"),
+        })
+}
+
 // ===========================================================================
 // Tests
 // ===========================================================================
 
 #[cfg(test)]
 mod tests {
-    use exo_core::{Did, Timestamp};
+    use exo_authority::{AuthorityChain, AuthorityLink, Permission};
+    use exo_core::{Did, Signature, Timestamp, crypto::KeyPair};
     use exo_gatekeeper::{
         McpRule,
         mcp_audit::{McpAuditLog, McpEnforcementOutcome, append, create_record},
@@ -226,6 +345,38 @@ mod tests {
 
     fn audit_id(n: u128) -> Uuid {
         Uuid::from_u128(n)
+    }
+
+    fn verified_clearance(requester: &Did) -> VerifiedAuthorityClearance {
+        let root = did("root-authority");
+        let root_key = KeyPair::generate();
+        let mut link = AuthorityLink {
+            delegator_did: root.clone(),
+            delegate_did: requester.clone(),
+            scope: vec![Permission::Read],
+            created: ts(1_000),
+            expires: None,
+            signature: Signature::empty(),
+            depth: 0,
+            delegatee_kind: DelegateeKind::Human,
+        };
+        let payload = link
+            .signing_payload()
+            .expect("authority link signing payload");
+        link.signature = root_key.sign(&payload);
+
+        let chain = AuthorityChain {
+            links: vec![link],
+            max_depth: 5,
+        };
+        verify_authority_clearance(requester, &chain, ts(2_000), |did| {
+            if did == &root {
+                Some(*root_key.public_key())
+            } else {
+                None
+            }
+        })
+        .expect("authority clearance must verify")
     }
 
     fn make_log_with_records() -> McpAuditLog {
@@ -256,51 +407,119 @@ mod tests {
     }
 
     #[test]
-    fn generate_report_requires_clearance() {
-        let log = McpAuditLog::new();
+    fn generate_report_rejects_tampered_mcp_audit_chain() {
+        let mut log = make_log_with_records();
+        log.records[1].chain_hash = [0xAA; 32];
+        let tenant = did("tenant");
+        let clearance = verified_clearance(&tenant);
+
         let result = generate_report(ReportParams {
-            tenant_id: &did("tenant"),
+            tenant_id: &tenant,
             period_start: ts(0),
-            period_end: ts(9999),
+            period_end: ts(u64::MAX),
             legal_jurisdiction: "EU-AI-ACT",
             mcp_log: &log,
             ai_delegation_grants: vec![],
             ai_delegation_revocations: 0,
-            clearance_verified: false,
+            authority_clearance: &clearance,
         });
+
+        assert!(
+            result.is_err(),
+            "transparency reports must not aggregate over a broken MCP audit chain"
+        );
+    }
+
+    #[test]
+    fn generate_report_source_does_not_accept_caller_supplied_clearance_boolean() {
+        let source = include_str!("ai_transparency.rs");
+        let production = source
+            .split("// ===========================================================================")
+            .next()
+            .expect("tests section marker present");
+
+        assert!(
+            !production.contains("clearance_verified: bool"),
+            "authority clearance must be a verified artifact, not a caller-supplied boolean"
+        );
+        assert!(
+            !production.contains("if !clearance_verified"),
+            "report generation must not trust a naked clearance boolean"
+        );
+    }
+
+    #[test]
+    fn verify_authority_clearance_requires_requester_to_match_chain_leaf() {
+        let root = did("root-authority");
+        let requester = did("reporter");
+        let other = did("other");
+        let root_key = KeyPair::generate();
+        let mut link = AuthorityLink {
+            delegator_did: root.clone(),
+            delegate_did: other,
+            scope: vec![Permission::Read],
+            created: ts(1_000),
+            expires: None,
+            signature: Signature::empty(),
+            depth: 0,
+            delegatee_kind: DelegateeKind::Human,
+        };
+        let payload = link
+            .signing_payload()
+            .expect("authority link signing payload");
+        link.signature = root_key.sign(&payload);
+
+        let chain = AuthorityChain {
+            links: vec![link],
+            max_depth: 5,
+        };
+        let result = verify_authority_clearance(&requester, &chain, ts(2_000), |did| {
+            if did == &root {
+                Some(*root_key.public_key())
+            } else {
+                None
+            }
+        });
+
         assert!(result.is_err());
     }
 
     #[test]
     fn generate_report_with_clearance_succeeds() {
         let log = make_log_with_records();
+        let tenant = did("tenant");
+        let clearance = verified_clearance(&tenant);
         let report = generate_report(ReportParams {
-            tenant_id: &did("tenant"),
+            tenant_id: &tenant,
             period_start: ts(0),
             period_end: ts(u64::MAX),
             legal_jurisdiction: "EU-AI-ACT",
             mcp_log: &log,
             ai_delegation_grants: vec![],
             ai_delegation_revocations: 0,
-            clearance_verified: true,
+            authority_clearance: &clearance,
         })
         .expect("report generation should succeed");
         assert_eq!(report.ai_agent_action_count, 2);
         assert_eq!(report.legal_jurisdiction, "EU-AI-ACT");
+        assert_eq!(report.authority_clearance.requester, tenant);
+        assert_eq!(report.mcp_audit_head_hash, log.head_hash());
     }
 
     #[test]
     fn mcp_outcomes_aggregated_correctly() {
         let log = make_log_with_records();
+        let tenant = did("tenant");
+        let clearance = verified_clearance(&tenant);
         let report = generate_report(ReportParams {
-            tenant_id: &did("tenant"),
+            tenant_id: &tenant,
             period_start: ts(0),
             period_end: ts(u64::MAX),
             legal_jurisdiction: "NIST-AI-RMF",
             mcp_log: &log,
             ai_delegation_grants: vec![],
             ai_delegation_revocations: 0,
-            clearance_verified: true,
+            authority_clearance: &clearance,
         })
         .expect("ok");
         // One Allowed for Mcp001, one Blocked for Mcp002
@@ -366,15 +585,17 @@ mod tests {
         append(&mut log, r).expect("append deterministic MCP audit record");
 
         // Period that excludes the record (past epoch)
+        let tenant = did("tenant");
+        let clearance = verified_clearance(&tenant);
         let report = generate_report(ReportParams {
-            tenant_id: &did("tenant"),
+            tenant_id: &tenant,
             period_start: ts(0),
             period_end: ts(1), // very narrow window in the past
             legal_jurisdiction: "EU-AI-ACT",
             mcp_log: &log,
             ai_delegation_grants: vec![],
             ai_delegation_revocations: 0,
-            clearance_verified: true,
+            authority_clearance: &clearance,
         })
         .expect("ok");
         // Record's timestamp from now_utc() will not fall in [0, 1ms]

--- a/crates/exo-legal/src/compliance_report.rs
+++ b/crates/exo-legal/src/compliance_report.rs
@@ -215,15 +215,28 @@ fn derive_status_and_evidence(
                 .iter()
                 .map(|o| o.allowed + o.blocked + o.escalated)
                 .sum();
-            (
-                AttestationStatus::Compliant,
-                format!(
-                    "Hash-chained AuditLog provides tamper-evident provenance. \
-                     {} MCP enforcement events recorded this period. \
-                     BLAKE3 chain verified. GDPR Art. 5(1)(f) satisfied.",
-                    mcp_count
-                ),
-            )
+            if mcp_count == 0 {
+                (
+                    AttestationStatus::NotApplicable,
+                    format!(
+                        "No MCP enforcement events recorded this period; no action provenance \
+                         is attested for this invariant. MCP audit log was structurally verified \
+                         before report generation with head hash {}.",
+                        hex_encode(&report.mcp_audit_head_hash)
+                    ),
+                )
+            } else {
+                (
+                    AttestationStatus::Compliant,
+                    format!(
+                        "Hash-chained MCP audit log verified before report generation. \
+                         {} MCP enforcement events recorded this period. \
+                         Verified head hash {}. GDPR Art. 5(1)(f) satisfied.",
+                        mcp_count,
+                        hex_encode(&report.mcp_audit_head_hash)
+                    ),
+                )
+            }
         }
 
         ConstitutionalInvariant::AuthorityChainValid => {
@@ -231,10 +244,17 @@ fn derive_status_and_evidence(
             (
                 AttestationStatus::Compliant,
                 format!(
-                    "Authority chain verified for all actions. \
+                    "Report generation authorized by verified authority clearance for requester {}. \
+                     Chain root {}, leaf {}, depth {}, hash {}. \
                      {} AI agent delegation grants recorded (DelegateeKind::AiAgent tagged). \
-                     {} revocations. GDPR Art. 5(2) accountability chain intact.",
-                    ai_grants, report.ai_delegation_revocations
+                     {} revocations. GDPR Art. 5(2) accountability chain evidence present.",
+                    report.authority_clearance.requester.as_str(),
+                    report.authority_clearance.chain_root.as_str(),
+                    report.authority_clearance.chain_leaf.as_str(),
+                    report.authority_clearance.chain_depth,
+                    hex_encode(&report.authority_clearance.chain_hash),
+                    ai_grants,
+                    report.ai_delegation_revocations
                 ),
             )
         }
@@ -328,11 +348,15 @@ fn hash_report_payload(payload: &ComplianceReportHashPayload<'_>) -> Result<[u8;
 
 #[cfg(test)]
 mod tests {
-    use exo_core::{Did, Timestamp};
+    use exo_authority::{AuthorityChain, AuthorityLink, DelegateeKind, Permission};
+    use exo_core::{Did, Signature, Timestamp, crypto::KeyPair};
     use exo_gatekeeper::mcp_audit::McpAuditLog;
 
     use super::*;
-    use crate::ai_transparency::{AiTransparencyReport, ReportParams, generate_report};
+    use crate::ai_transparency::{
+        AiTransparencyReport, ReportParams, VerifiedAuthorityClearance, generate_report,
+        verify_authority_clearance,
+    };
 
     fn did(s: &str) -> Did {
         Did::new(&format!("did:exo:{s}")).expect("valid DID")
@@ -342,7 +366,40 @@ mod tests {
         Timestamp::new(ms, 0)
     }
 
+    fn verified_clearance(requester: &Did) -> VerifiedAuthorityClearance {
+        let root = did("root-authority");
+        let root_key = KeyPair::generate();
+        let mut link = AuthorityLink {
+            delegator_did: root.clone(),
+            delegate_did: requester.clone(),
+            scope: vec![Permission::Read],
+            created: ts(1_000),
+            expires: None,
+            signature: Signature::empty(),
+            depth: 0,
+            delegatee_kind: DelegateeKind::Human,
+        };
+        let payload = link
+            .signing_payload()
+            .expect("authority link signing payload");
+        link.signature = root_key.sign(&payload);
+        let chain = AuthorityChain {
+            links: vec![link],
+            max_depth: 5,
+        };
+
+        verify_authority_clearance(requester, &chain, ts(2_000), |did| {
+            if did == &root {
+                Some(*root_key.public_key())
+            } else {
+                None
+            }
+        })
+        .expect("authority clearance must verify")
+    }
+
     fn empty_report(tenant: &Did) -> AiTransparencyReport {
+        let clearance = verified_clearance(tenant);
         generate_report(ReportParams {
             tenant_id: tenant,
             period_start: ts(0),
@@ -351,7 +408,7 @@ mod tests {
             mcp_log: &McpAuditLog::new(),
             ai_delegation_grants: vec![],
             ai_delegation_revocations: 0,
-            clearance_verified: true,
+            authority_clearance: &clearance,
         })
         .expect("ok")
     }
@@ -434,18 +491,58 @@ mod tests {
     }
 
     #[test]
-    fn all_attestations_compliant_for_empty_period() {
+    fn static_kernel_attestations_remain_compliant_for_empty_period() {
         let tenant = did("tenant");
         let tr = empty_report(&tenant);
         let report = build_report(&tr, &ComplianceReportMode::Full, ts(10000)).expect("ok");
         for att in &report.attestations {
-            assert_eq!(
-                att.status,
-                AttestationStatus::Compliant,
-                "invariant {} should be Compliant",
-                att.invariant
-            );
+            if att.invariant == "ProvenanceVerifiable" {
+                assert_eq!(att.status, AttestationStatus::NotApplicable);
+            } else {
+                assert_eq!(
+                    att.status,
+                    AttestationStatus::Compliant,
+                    "invariant {} should be Compliant",
+                    att.invariant
+                );
+            }
         }
+    }
+
+    #[test]
+    fn empty_period_does_not_overclaim_provenance_or_authority_compliance() {
+        let tenant = did("tenant");
+        let tr = empty_report(&tenant);
+        let report = build_report(&tr, &ComplianceReportMode::Full, ts(10000)).expect("ok");
+
+        let provenance = report
+            .attestations
+            .iter()
+            .find(|a| a.invariant == "ProvenanceVerifiable")
+            .expect("ProvenanceVerifiable must appear in attestations");
+        assert_ne!(
+            provenance.status,
+            AttestationStatus::Compliant,
+            "an empty report period has no provenance events to verify"
+        );
+        assert!(
+            !provenance
+                .evidence_summary
+                .contains("BLAKE3 chain verified"),
+            "empty evidence must not claim a verified non-empty audit chain"
+        );
+
+        let authority = report
+            .attestations
+            .iter()
+            .find(|a| a.invariant == "AuthorityChainValid")
+            .expect("AuthorityChainValid must appear in attestations");
+        assert!(
+            !authority
+                .evidence_summary
+                .contains("Authority chain verified for all actions"),
+            "authority attestations must name concrete verified evidence, not all-action prose"
+        );
     }
 
     #[test]

--- a/crates/exo-legal/src/nist_compliance_tests.rs
+++ b/crates/exo-legal/src/nist_compliance_tests.rs
@@ -6,8 +6,11 @@
 
 #[cfg(test)]
 mod nist_compliance {
-    use exo_authority::DelegateeKind;
-    use exo_core::{Did, Hash256, Timestamp};
+    use exo_authority::{
+        AuthorityChain as ReportAuthorityChain, AuthorityLink as ReportAuthorityLink,
+        DelegateeKind, Permission as ReportPermission,
+    };
+    use exo_core::{Did, Hash256, Signature, Timestamp, crypto::KeyPair};
     use exo_gatekeeper::{
         InvariantEngine, McpRule,
         invariants::{ConstitutionalInvariant, InvariantContext, enforce_all},
@@ -21,7 +24,10 @@ mod nist_compliance {
     use uuid::Uuid;
 
     use crate::{
-        ai_transparency::{ReportParams, ai_delegation_event_from_link, generate_report},
+        ai_transparency::{
+            ReportParams, VerifiedAuthorityClearance, ai_delegation_event_from_link,
+            generate_report, verify_authority_clearance,
+        },
         compliance_report::{
             AttestationStatus, ComplianceReportMode, build_report, redact_model_id,
         },
@@ -42,6 +48,38 @@ mod nist_compliance {
 
     fn audit_id(n: u128) -> Uuid {
         Uuid::from_u128(n)
+    }
+
+    fn verified_report_clearance(requester: &Did) -> VerifiedAuthorityClearance {
+        let root = did("report-root");
+        let root_key = KeyPair::generate();
+        let mut link = ReportAuthorityLink {
+            delegator_did: root.clone(),
+            delegate_did: requester.clone(),
+            scope: vec![ReportPermission::Read],
+            created: ts(1_000),
+            expires: None,
+            signature: Signature::empty(),
+            depth: 0,
+            delegatee_kind: DelegateeKind::Human,
+        };
+        let payload = link
+            .signing_payload()
+            .expect("authority link signing payload");
+        link.signature = root_key.sign(&payload);
+
+        let chain = ReportAuthorityChain {
+            links: vec![link],
+            max_depth: 5,
+        };
+        verify_authority_clearance(requester, &chain, ts(2_000), |did| {
+            if did == &root {
+                Some(*root_key.public_key())
+            } else {
+                None
+            }
+        })
+        .expect("report authority clearance must verify")
     }
 
     fn signed_authority_link(grantor: &Did, grantee: &Did) -> AuthorityLink {
@@ -295,6 +333,7 @@ mod nist_compliance {
 
         // 5. Transparency report captures MCP enforcement events.
         let tenant = did("tenant-acme");
+        let clearance = verified_report_clearance(&tenant);
         let report = generate_report(ReportParams {
             tenant_id: &tenant,
             period_start: ts(0),
@@ -303,7 +342,7 @@ mod nist_compliance {
             mcp_log: &mcp_log,
             ai_delegation_grants: vec![],
             ai_delegation_revocations: 0,
-            clearance_verified: true,
+            authority_clearance: &clearance,
         })
         .expect("transparency report generation must succeed");
         assert_eq!(
@@ -412,6 +451,7 @@ mod nist_compliance {
         // 4. Transparency report records AI delegation grants and revocations.
         let tenant = did("tenant-beta");
         let mcp_log = McpAuditLog::new();
+        let clearance = verified_report_clearance(&tenant);
         let report = generate_report(ReportParams {
             tenant_id: &tenant,
             period_start: ts(0),
@@ -420,7 +460,7 @@ mod nist_compliance {
             mcp_log: &mcp_log,
             ai_delegation_grants: vec![ai_event],
             ai_delegation_revocations: 1,
-            clearance_verified: true,
+            authority_clearance: &clearance,
         })
         .expect("transparency report must succeed");
         assert_eq!(report.ai_delegation_grants.len(), 1);

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 117316 lines of Rust under `crates/`, 2,901 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 117674 lines of Rust under `crates/`, 2,904 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,901 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,904 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,901 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,904 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-117316 lines of Rust under `crates/` · 20 workspace packages · 2,901 listed tests · 40 MCP tools · 8 constitutional invariants
+117674 lines of Rust under `crates/` · 20 workspace packages · 2,904 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 117316 lines of Rust under `crates/` | 266 Rust source files | 2,901 listed tests
+> **Codebase:** 20 workspace packages | 117674 lines of Rust under `crates/` | 266 Rust source files | 2,904 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,901 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,904 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 117316 lines of Rust under `crates/` · 2,901 listed tests
+20 workspace packages · 117674 lines of Rust under `crates/` · 2,904 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary

- replaces caller-supplied AI transparency report clearance booleans with a `VerifiedAuthorityClearance` artifact created only after authority-chain verification
- verifies MCP audit chains before legal transparency aggregation and binds the verified audit head hash into reports
- changes empty-period compliance evidence from overclaimed `Compliant` to `NotApplicable`, and narrows authority evidence text to verified report-generation clearance
- refreshes repo-truth counts to 117674 Rust LOC and 2,904 listed workspace tests

## TDD red checks

- `cargo test -p exo-legal ai_transparency::tests::generate_report_rejects_tampered_mcp_audit_chain --lib -- --nocapture` initially failed because a tampered MCP chain still generated a report
- `cargo test -p exo-legal ai_transparency::tests::generate_report_source_does_not_accept_caller_supplied_clearance_boolean --lib -- --nocapture` initially failed because production still accepted `clearance_verified: bool`
- `cargo test -p exo-legal compliance_report::tests::empty_period_does_not_overclaim_provenance_or_authority_compliance --lib -- --nocapture` initially failed because empty periods were marked compliant

## Verification

- `cargo test -p exo-legal`
- `cargo build -p exo-legal`
- `cargo clippy -p exo-legal --lib -- -D warnings`
- `cargo clippy -p exo-legal --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit --deny unsound --deny unmaintained` (existing allowed yanked `core2` warning only)
- `cargo deny check` (existing duplicate/yanked/unused-allowance warnings only)
