### PR TITLE
fix(exo-legal): require verified AI delegation grants

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 117674 | `wc -l` |
-| Workspace tests | 2,904 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 117978 | `wc -l` |
+| Workspace tests | 2,907 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,904 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,907 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 117674 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 117978 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,904 listed workspace tests
+         cryptographic proofs, 2,907 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-legal/src/ai_transparency.rs
+++ b/crates/exo-legal/src/ai_transparency.rs
@@ -12,7 +12,7 @@
 //! which verifies the requesting actor's authority chain before any report
 //! can be generated.
 
-use exo_authority::{AuthorityChain, DelegateeKind, chain};
+use exo_authority::{AuthorityChain, AuthorityLink, DelegateeKind, chain};
 use exo_core::{Did, PublicKey, Timestamp, hash::hash_structured};
 use exo_gatekeeper::mcp_audit::{
     McpAuditLog, McpEnforcementOutcome, verify_chain as verify_mcp_audit_chain,
@@ -23,6 +23,8 @@ use crate::error::{LegalError, Result};
 
 const AUTHORITY_CLEARANCE_DOMAIN: &str = "exo.legal.ai_transparency.authority_clearance.v1";
 const AUTHORITY_CLEARANCE_SCHEMA_VERSION: u16 = 1;
+const AI_DELEGATION_GRANT_DOMAIN: &str = "exo.legal.ai_transparency.ai_delegation_grant.v1";
+const AI_DELEGATION_GRANT_SCHEMA_VERSION: u16 = 1;
 
 // ---------------------------------------------------------------------------
 // Report structures
@@ -64,6 +66,26 @@ pub struct AiDelegationEvent {
     pub granted_at: Timestamp,
     pub expires_at: Option<Timestamp>,
     pub depth: usize,
+    pub authority_chain_root: Did,
+    pub authority_chain_leaf: Did,
+    pub authority_chain_depth: usize,
+    pub authority_chain_hash: [u8; 32],
+    pub authority_link_hash: [u8; 32],
+}
+
+/// Verified AI delegation artifact that can only be created by authority-chain
+/// verification through [`verify_ai_delegation_grant`].
+#[derive(Debug, Clone)]
+pub struct VerifiedAiDelegationGrant {
+    event: AiDelegationEvent,
+}
+
+impl VerifiedAiDelegationGrant {
+    /// Return the serializable event evidence captured after verification.
+    #[must_use]
+    pub fn event(&self) -> &AiDelegationEvent {
+        &self.event
+    }
 }
 
 /// Per-rule MCP enforcement outcome summary.
@@ -90,7 +112,7 @@ pub struct AiTransparencyReport {
     pub legal_jurisdiction: String,
     /// Total number of actions performed by AI agents during the period.
     pub ai_agent_action_count: u64,
-    /// AI delegation grants observed in the MCP audit log during the period.
+    /// Verified AI delegation grants recorded during the period.
     pub ai_delegation_grants: Vec<AiDelegationEvent>,
     /// Count of AI delegation revocations during the period.
     pub ai_delegation_revocations: u64,
@@ -114,7 +136,8 @@ pub struct ReportParams<'a> {
     pub period_end: Timestamp,
     pub legal_jurisdiction: &'a str,
     pub mcp_log: &'a McpAuditLog,
-    pub ai_delegation_grants: Vec<AiDelegationEvent>,
+    /// Verified AI delegation grants admitted through signed authority chains.
+    pub ai_delegation_grants: Vec<VerifiedAiDelegationGrant>,
     pub ai_delegation_revocations: u64,
     /// Verified authority-chain clearance for the actor generating the report.
     pub authority_clearance: &'a VerifiedAuthorityClearance,
@@ -166,7 +189,10 @@ pub fn generate_report(params: ReportParams<'_>) -> Result<AiTransparencyReport>
         period_end,
         legal_jurisdiction: legal_jurisdiction.to_owned(),
         ai_agent_action_count,
-        ai_delegation_grants,
+        ai_delegation_grants: ai_delegation_grants
+            .into_iter()
+            .map(|grant| grant.event().clone())
+            .collect(),
         ai_delegation_revocations,
         mcp_rule_outcomes,
         mcp_audit_head_hash: mcp_log.head_hash(),
@@ -240,29 +266,78 @@ where
     })
 }
 
-/// Build AI delegation events from authority link data.
+/// Verify an authority chain and extract an AI delegation grant from its leaf.
 ///
-/// Filters links where `delegatee_kind` is [`DelegateeKind::AiAgent`].
-#[must_use]
-pub fn ai_delegation_event_from_link(
-    delegator: Did,
-    delegatee: Did,
-    delegatee_kind: &DelegateeKind,
-    granted_at: Timestamp,
-    expires_at: Option<Timestamp>,
-    depth: usize,
-) -> Option<AiDelegationEvent> {
-    match delegatee_kind {
-        DelegateeKind::AiAgent { model_id } => Some(AiDelegationEvent {
-            delegator,
-            delegatee,
-            model_id: model_id.clone(),
-            granted_at,
-            expires_at,
-            depth,
-        }),
-        DelegateeKind::Human | DelegateeKind::Unknown => None,
+/// Returns `Ok(None)` after successful chain verification when the leaf
+/// delegatee is not an AI agent. This keeps human and legacy delegations out of
+/// AI transparency grant lists without trusting caller-supplied flags.
+///
+/// # Errors
+///
+/// Returns [`LegalError::InvalidStateTransition`] if the timestamp is zero, the
+/// chain is empty, the chain fails signature/scope verification, or the grant
+/// evidence cannot be canonicalized.
+pub fn verify_ai_delegation_grant<F>(
+    authority_chain: &AuthorityChain,
+    verified_at: Timestamp,
+    resolve_key: F,
+) -> Result<Option<VerifiedAiDelegationGrant>>
+where
+    F: Fn(&Did) -> Option<PublicKey>,
+{
+    if verified_at == Timestamp::ZERO {
+        return Err(LegalError::InvalidStateTransition {
+            reason: "AI delegation grant verification timestamp must be non-zero".into(),
+        });
     }
+
+    chain::verify_chain(authority_chain, &verified_at, resolve_key).map_err(|e| {
+        LegalError::InvalidStateTransition {
+            reason: format!("AI delegation authority chain verification failed: {e}"),
+        }
+    })?;
+
+    let chain_root =
+        authority_chain
+            .root()
+            .cloned()
+            .ok_or_else(|| LegalError::InvalidStateTransition {
+                reason: "AI delegation authority chain must not be empty".into(),
+            })?;
+    let chain_leaf =
+        authority_chain
+            .leaf()
+            .cloned()
+            .ok_or_else(|| LegalError::InvalidStateTransition {
+                reason: "AI delegation authority chain must not be empty".into(),
+            })?;
+    let leaf_link =
+        authority_chain
+            .links
+            .last()
+            .ok_or_else(|| LegalError::InvalidStateTransition {
+                reason: "AI delegation authority chain must not be empty".into(),
+            })?;
+
+    let DelegateeKind::AiAgent { model_id } = &leaf_link.delegatee_kind else {
+        return Ok(None);
+    };
+
+    Ok(Some(VerifiedAiDelegationGrant {
+        event: AiDelegationEvent {
+            delegator: leaf_link.delegator_did.clone(),
+            delegatee: leaf_link.delegate_did.clone(),
+            model_id: model_id.clone(),
+            granted_at: leaf_link.created,
+            expires_at: leaf_link.expires,
+            depth: leaf_link.depth,
+            authority_chain_root: chain_root,
+            authority_chain_leaf: chain_leaf,
+            authority_chain_depth: authority_chain.depth(),
+            authority_chain_hash: hash_ai_delegation_chain(authority_chain)?,
+            authority_link_hash: hash_authority_link(leaf_link)?,
+        },
+    }))
 }
 
 fn aggregate_mcp_outcomes(
@@ -306,6 +381,13 @@ struct AuthorityClearanceHashPayload<'a> {
     authority_chain: &'a AuthorityChain,
 }
 
+#[derive(Serialize)]
+struct AiDelegationGrantHashPayload<'a> {
+    domain: &'static str,
+    schema_version: u16,
+    authority_chain: &'a AuthorityChain,
+}
+
 fn hash_authority_clearance_chain(authority_chain: &AuthorityChain) -> Result<[u8; 32]> {
     let payload = AuthorityClearanceHashPayload {
         domain: AUTHORITY_CLEARANCE_DOMAIN,
@@ -316,6 +398,27 @@ fn hash_authority_clearance_chain(authority_chain: &AuthorityChain) -> Result<[u
         .map(|hash| *hash.as_bytes())
         .map_err(|e| LegalError::InvalidStateTransition {
             reason: format!("authority clearance canonical CBOR hash failed: {e}"),
+        })
+}
+
+fn hash_ai_delegation_chain(authority_chain: &AuthorityChain) -> Result<[u8; 32]> {
+    let payload = AiDelegationGrantHashPayload {
+        domain: AI_DELEGATION_GRANT_DOMAIN,
+        schema_version: AI_DELEGATION_GRANT_SCHEMA_VERSION,
+        authority_chain,
+    };
+    hash_structured(&payload)
+        .map(|hash| *hash.as_bytes())
+        .map_err(|e| LegalError::InvalidStateTransition {
+            reason: format!("AI delegation grant canonical CBOR hash failed: {e}"),
+        })
+}
+
+fn hash_authority_link(link: &AuthorityLink) -> Result<[u8; 32]> {
+    link.id()
+        .map(|hash| *hash.as_bytes())
+        .map_err(|e| LegalError::InvalidStateTransition {
+            reason: format!("AI delegation authority link hash failed: {e}"),
         })
 }
 
@@ -350,20 +453,8 @@ mod tests {
     fn verified_clearance(requester: &Did) -> VerifiedAuthorityClearance {
         let root = did("root-authority");
         let root_key = KeyPair::generate();
-        let mut link = AuthorityLink {
-            delegator_did: root.clone(),
-            delegate_did: requester.clone(),
-            scope: vec![Permission::Read],
-            created: ts(1_000),
-            expires: None,
-            signature: Signature::empty(),
-            depth: 0,
-            delegatee_kind: DelegateeKind::Human,
-        };
-        let payload = link
-            .signing_payload()
-            .expect("authority link signing payload");
-        link.signature = root_key.sign(&payload);
+        let link =
+            signed_authority_link(&root, requester, DelegateeKind::Human, &root_key, 0, None);
 
         let chain = AuthorityChain {
             links: vec![link],
@@ -377,6 +468,61 @@ mod tests {
             }
         })
         .expect("authority clearance must verify")
+    }
+
+    fn signed_authority_link(
+        delegator: &Did,
+        delegate: &Did,
+        delegatee_kind: DelegateeKind,
+        signing_key: &KeyPair,
+        depth: usize,
+        expires: Option<Timestamp>,
+    ) -> AuthorityLink {
+        let mut link = AuthorityLink {
+            delegator_did: delegator.clone(),
+            delegate_did: delegate.clone(),
+            scope: vec![Permission::Read],
+            created: ts(1_000),
+            expires,
+            signature: Signature::empty(),
+            depth,
+            delegatee_kind,
+        };
+        let payload = link
+            .signing_payload()
+            .expect("authority link signing payload");
+        link.signature = signing_key.sign(&payload);
+        link
+    }
+
+    fn verified_ai_grant() -> VerifiedAiDelegationGrant {
+        let root = did("grant-root");
+        let agent = did("agent-1");
+        let root_key = KeyPair::generate();
+        let link = signed_authority_link(
+            &root,
+            &agent,
+            DelegateeKind::AiAgent {
+                model_id: "claude-sonnet-4-6".into(),
+            },
+            &root_key,
+            0,
+            Some(ts(3_000)),
+        );
+        let chain = AuthorityChain {
+            links: vec![link],
+            max_depth: 5,
+        };
+
+        verify_ai_delegation_grant(&chain, ts(2_000), |did| {
+            if did == &root {
+                Some(*root_key.public_key())
+            } else {
+                None
+            }
+        })
+        .expect("AI delegation grant verification succeeds")
+        .expect("AI delegation grant is present")
     }
 
     fn make_log_with_records() -> McpAuditLog {
@@ -445,6 +591,27 @@ mod tests {
         assert!(
             !production.contains("if !clearance_verified"),
             "report generation must not trust a naked clearance boolean"
+        );
+    }
+
+    #[test]
+    fn generate_report_source_does_not_accept_raw_ai_delegation_event_vector() {
+        let source = include_str!("ai_transparency.rs");
+        let production = source
+            .split("// ===========================================================================")
+            .next()
+            .expect("tests section marker present");
+        let report_params = production
+            .split("pub struct ReportParams<'a>")
+            .nth(1)
+            .expect("ReportParams definition present")
+            .split("/// Generate an AI transparency report for the given tenant and time period.")
+            .next()
+            .expect("ReportParams definition boundary present");
+
+        assert!(
+            !report_params.contains("ai_delegation_grants: Vec<AiDelegationEvent>"),
+            "ReportParams must require verified AI delegation grant artifacts, not raw events"
         );
     }
 
@@ -539,33 +706,98 @@ mod tests {
     }
 
     #[test]
-    fn ai_delegation_event_from_human_link_returns_none() {
-        let result = ai_delegation_event_from_link(
-            did("alice"),
-            did("bob"),
-            &DelegateeKind::Human,
-            ts(100),
-            None,
-            0,
-        );
+    fn verify_ai_delegation_grant_from_human_link_returns_none() {
+        let root = did("grant-root");
+        let human = did("human-bob");
+        let root_key = KeyPair::generate();
+        let link = signed_authority_link(&root, &human, DelegateeKind::Human, &root_key, 0, None);
+        let chain = AuthorityChain {
+            links: vec![link],
+            max_depth: 5,
+        };
+
+        let result = verify_ai_delegation_grant(&chain, ts(2_000), |did| {
+            if did == &root {
+                Some(*root_key.public_key())
+            } else {
+                None
+            }
+        })
+        .expect("human authority chain still verifies");
+
         assert!(result.is_none());
     }
 
     #[test]
-    fn ai_delegation_event_from_ai_link_returns_some() {
-        let result = ai_delegation_event_from_link(
-            did("alice"),
-            did("agent-1"),
-            &DelegateeKind::AiAgent {
+    fn verify_ai_delegation_grant_from_ai_link_returns_verified_event() {
+        let grant = verified_ai_grant();
+        let event = grant.event();
+        assert_eq!(event.model_id, "claude-sonnet-4-6");
+        assert_eq!(event.depth, 0);
+        assert_eq!(event.authority_chain_root, did("grant-root"));
+        assert_eq!(event.authority_chain_leaf, did("agent-1"));
+        assert_eq!(event.authority_chain_depth, 1);
+        assert_ne!(event.authority_chain_hash, [0u8; 32]);
+        assert_ne!(event.authority_link_hash, [0u8; 32]);
+    }
+
+    #[test]
+    fn verify_ai_delegation_grant_rejects_tampered_signature() {
+        let root = did("grant-root");
+        let agent = did("agent-1");
+        let root_key = KeyPair::generate();
+        let mut link = signed_authority_link(
+            &root,
+            &agent,
+            DelegateeKind::AiAgent {
                 model_id: "claude-sonnet-4-6".into(),
             },
-            ts(100),
-            Some(ts(200)),
-            1,
+            &root_key,
+            0,
+            None,
         );
-        let event = result.expect("AI link must produce an event");
-        assert_eq!(event.model_id, "claude-sonnet-4-6");
-        assert_eq!(event.depth, 1);
+        link.signature = Signature::from_bytes([0xA5; 64]);
+        let chain = AuthorityChain {
+            links: vec![link],
+            max_depth: 5,
+        };
+
+        let result = verify_ai_delegation_grant(&chain, ts(2_000), |did| {
+            if did == &root {
+                Some(*root_key.public_key())
+            } else {
+                None
+            }
+        });
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn generate_report_with_verified_ai_delegation_grant_succeeds() {
+        let log = McpAuditLog::new();
+        let tenant = did("tenant");
+        let clearance = verified_clearance(&tenant);
+        let grant = verified_ai_grant();
+        let expected_chain_hash = grant.event().authority_chain_hash;
+
+        let report = generate_report(ReportParams {
+            tenant_id: &tenant,
+            period_start: ts(0),
+            period_end: ts(u64::MAX),
+            legal_jurisdiction: "EU-AI-ACT",
+            mcp_log: &log,
+            ai_delegation_grants: vec![grant],
+            ai_delegation_revocations: 0,
+            authority_clearance: &clearance,
+        })
+        .expect("verified AI delegation grant should be accepted");
+
+        assert_eq!(report.ai_delegation_grants.len(), 1);
+        assert_eq!(
+            report.ai_delegation_grants[0].authority_chain_hash,
+            expected_chain_hash
+        );
     }
 
     #[test]

--- a/crates/exo-legal/src/compliance_report.rs
+++ b/crates/exo-legal/src/compliance_report.rs
@@ -246,7 +246,7 @@ fn derive_status_and_evidence(
                 format!(
                     "Report generation authorized by verified authority clearance for requester {}. \
                      Chain root {}, leaf {}, depth {}, hash {}. \
-                     {} AI agent delegation grants recorded (DelegateeKind::AiAgent tagged). \
+                     {} AI agent delegation grants recorded from verified authority-chain artifacts. \
                      {} revocations. GDPR Art. 5(2) accountability chain evidence present.",
                     report.authority_clearance.requester.as_str(),
                     report.authority_clearance.chain_root.as_str(),

--- a/crates/exo-legal/src/nist_compliance_tests.rs
+++ b/crates/exo-legal/src/nist_compliance_tests.rs
@@ -25,8 +25,8 @@ mod nist_compliance {
 
     use crate::{
         ai_transparency::{
-            ReportParams, VerifiedAuthorityClearance, ai_delegation_event_from_link,
-            generate_report, verify_authority_clearance,
+            ReportParams, VerifiedAiDelegationGrant, VerifiedAuthorityClearance, generate_report,
+            verify_ai_delegation_grant, verify_authority_clearance,
         },
         compliance_report::{
             AttestationStatus, ComplianceReportMode, build_report, redact_model_id,
@@ -53,20 +53,14 @@ mod nist_compliance {
     fn verified_report_clearance(requester: &Did) -> VerifiedAuthorityClearance {
         let root = did("report-root");
         let root_key = KeyPair::generate();
-        let mut link = ReportAuthorityLink {
-            delegator_did: root.clone(),
-            delegate_did: requester.clone(),
-            scope: vec![ReportPermission::Read],
-            created: ts(1_000),
-            expires: None,
-            signature: Signature::empty(),
-            depth: 0,
-            delegatee_kind: DelegateeKind::Human,
-        };
-        let payload = link
-            .signing_payload()
-            .expect("authority link signing payload");
-        link.signature = root_key.sign(&payload);
+        let link = signed_report_authority_link(
+            &root,
+            requester,
+            DelegateeKind::Human,
+            &root_key,
+            0,
+            None,
+        );
 
         let chain = ReportAuthorityChain {
             links: vec![link],
@@ -80,6 +74,61 @@ mod nist_compliance {
             }
         })
         .expect("report authority clearance must verify")
+    }
+
+    fn signed_report_authority_link(
+        delegator: &Did,
+        delegate: &Did,
+        delegatee_kind: DelegateeKind,
+        signing_key: &KeyPair,
+        depth: usize,
+        expires: Option<Timestamp>,
+    ) -> ReportAuthorityLink {
+        let mut link = ReportAuthorityLink {
+            delegator_did: delegator.clone(),
+            delegate_did: delegate.clone(),
+            scope: vec![ReportPermission::Read],
+            created: ts(1_000),
+            expires,
+            signature: Signature::empty(),
+            depth,
+            delegatee_kind,
+        };
+        let payload = link
+            .signing_payload()
+            .expect("authority link signing payload");
+        link.signature = signing_key.sign(&payload);
+        link
+    }
+
+    fn verified_ai_delegation_grant(model_id: &str) -> VerifiedAiDelegationGrant {
+        let root = did("ai-delegation-root");
+        let agent = did("ai-agent-42");
+        let root_key = KeyPair::generate();
+        let link = signed_report_authority_link(
+            &root,
+            &agent,
+            DelegateeKind::AiAgent {
+                model_id: model_id.to_owned(),
+            },
+            &root_key,
+            0,
+            Some(ts(2_000)),
+        );
+        let chain = ReportAuthorityChain {
+            links: vec![link],
+            max_depth: 5,
+        };
+
+        verify_ai_delegation_grant(&chain, ts(1_500), |did| {
+            if did == &root {
+                Some(*root_key.public_key())
+            } else {
+                None
+            }
+        })
+        .expect("AI delegation chain must verify")
+        .expect("AI delegation grant must be present")
     }
 
     fn signed_authority_link(grantor: &Did, grantee: &Did) -> AuthorityLink {
@@ -406,45 +455,68 @@ mod nist_compliance {
             "AuthorityChainValid mapping must reference GDPR Art. 5(2) (accountability)"
         );
 
-        // 2. AI delegation events are extracted from AiAgent links.
+        // 2. AI delegation events are extracted only after signed authority
+        //    chain verification of AiAgent links.
         let model_id = "claude-sonnet-4-6";
-        let ai_event = ai_delegation_event_from_link(
-            did("principal"),
-            did("ai-agent-42"),
-            &DelegateeKind::AiAgent {
-                model_id: model_id.to_owned(),
-            },
-            ts(1000),
-            Some(ts(2000)),
-            1,
-        )
-        .expect("AiAgent link must produce a delegation event");
-        assert_eq!(ai_event.model_id, model_id);
-        assert_eq!(ai_event.depth, 1);
+        let ai_grant = verified_ai_delegation_grant(model_id);
+        assert_eq!(ai_grant.event().model_id, model_id);
+        assert_eq!(ai_grant.event().depth, 0);
+        assert_ne!(ai_grant.event().authority_chain_hash, [0u8; 32]);
+        assert_ne!(ai_grant.event().authority_link_hash, [0u8; 32]);
 
-        // 3. Human and Unknown links produce no AI delegation events.
-        assert!(
-            ai_delegation_event_from_link(
-                did("principal"),
-                did("human-bob"),
-                &DelegateeKind::Human,
-                ts(1000),
-                None,
+        // 3. Human and Unknown links verify structurally but produce no AI
+        //    delegation grants.
+        let human_root = did("human-root");
+        let human = did("human-bob");
+        let human_key = KeyPair::generate();
+        let human_chain = ReportAuthorityChain {
+            links: vec![signed_report_authority_link(
+                &human_root,
+                &human,
+                DelegateeKind::Human,
+                &human_key,
                 0,
-            )
-            .is_none(),
+                None,
+            )],
+            max_depth: 5,
+        };
+        let human_result = verify_ai_delegation_grant(&human_chain, ts(1_500), |did| {
+            if did == &human_root {
+                Some(*human_key.public_key())
+            } else {
+                None
+            }
+        })
+        .expect("human authority chain must verify");
+        assert!(
+            human_result.is_none(),
             "Human delegation must not appear in AI delegation events"
         );
-        assert!(
-            ai_delegation_event_from_link(
-                did("principal"),
-                did("legacy"),
-                &DelegateeKind::Unknown,
-                ts(1000),
-                None,
+
+        let unknown_root = did("unknown-root");
+        let unknown = did("legacy");
+        let unknown_key = KeyPair::generate();
+        let unknown_chain = ReportAuthorityChain {
+            links: vec![signed_report_authority_link(
+                &unknown_root,
+                &unknown,
+                DelegateeKind::Unknown,
+                &unknown_key,
                 0,
-            )
-            .is_none(),
+                None,
+            )],
+            max_depth: 5,
+        };
+        let unknown_result = verify_ai_delegation_grant(&unknown_chain, ts(1_500), |did| {
+            if did == &unknown_root {
+                Some(*unknown_key.public_key())
+            } else {
+                None
+            }
+        })
+        .expect("unknown authority chain must verify");
+        assert!(
+            unknown_result.is_none(),
             "Unknown delegation must not appear in AI delegation events"
         );
 
@@ -458,7 +530,7 @@ mod nist_compliance {
             period_end: ts(u64::MAX),
             legal_jurisdiction: "NIST-AI-RMF",
             mcp_log: &mcp_log,
-            ai_delegation_grants: vec![ai_event],
+            ai_delegation_grants: vec![ai_grant],
             ai_delegation_revocations: 1,
             authority_clearance: &clearance,
         })

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 117674 lines of Rust under `crates/`, 2,904 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 117978 lines of Rust under `crates/`, 2,907 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,904 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,907 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,904 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,907 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-117674 lines of Rust under `crates/` · 20 workspace packages · 2,904 listed tests · 40 MCP tools · 8 constitutional invariants
+117978 lines of Rust under `crates/` · 20 workspace packages · 2,907 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 117674 lines of Rust under `crates/` | 266 Rust source files | 2,904 listed tests
+> **Codebase:** 20 workspace packages | 117978 lines of Rust under `crates/` | 266 Rust source files | 2,907 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,904 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,907 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 117674 lines of Rust under `crates/` · 2,904 listed tests
+20 workspace packages · 117978 lines of Rust under `crates/` · 2,907 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary

- requires AI delegation grants in legal transparency reports to come from `VerifiedAiDelegationGrant` artifacts rather than raw caller-supplied `AiDelegationEvent` structs
- verifies signed `exo_authority` chains before admitting AI-agent delegation grants, while excluding human/unknown delegatees after structural verification
- binds grant evidence into reports with authority-chain root/leaf/depth, canonical CBOR chain hash, and authority-link hash
- updates NIST delegation governance tests to use real signed AI delegation chains
- refreshes repo-truth counts to 117978 Rust LOC and 2,907 listed workspace tests

## TDD red checks

- `cargo test -p exo-legal ai_transparency::tests::generate_report_rejects_synthetic_ai_delegation_event_without_verified_chain --lib -- --nocapture` initially failed because a synthetic `AiDelegationEvent` was accepted
- `cargo test -p exo-legal ai_transparency::tests::generate_report_source_does_not_accept_raw_ai_delegation_event_vector --lib -- --nocapture` initially failed because `ReportParams` accepted `Vec<AiDelegationEvent>`

## Verification

- `cargo test -p exo-legal ai_transparency::tests --lib -- --nocapture`
- `cargo test -p exo-legal`
- `cargo build -p exo-legal`
- `cargo clippy -p exo-legal --lib -- -D warnings`
- `cargo clippy -p exo-legal --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit --deny unsound --deny unmaintained` (existing allowed yanked `core2` warning only)
- `cargo deny check` (existing duplicate/yanked/unused-allowance warnings only)
- `cargo machete --with-metadata`
