### PR TITLE
fix(exo-legal): require verified AI delegation revocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 117978 | `wc -l` |
-| Workspace tests | 2,907 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 118694 | `wc -l` |
+| Workspace tests | 2,915 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,907 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,915 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 117978 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 118694 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,907 listed workspace tests
+         cryptographic proofs, 2,915 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-authority/src/delegation.rs
+++ b/crates/exo-authority/src/delegation.rs
@@ -10,6 +10,10 @@ use crate::{
     permission::Permission,
 };
 
+/// Domain tag for authority delegation revocation signatures.
+pub const AUTHORITY_REVOCATION_SIGNING_DOMAIN: &str = "exo.authority.revocation.v1";
+const AUTHORITY_REVOCATION_SIGNING_SCHEMA_VERSION: u16 = 1;
+
 /// Registry of all active delegations.
 #[derive(Debug, Default)]
 pub struct DelegationRegistry {
@@ -30,6 +34,192 @@ pub struct DelegationGrant<'a> {
     pub now: &'a Timestamp,
     pub delegatee_kind: DelegateeKind,
     pub delegator_public_key: &'a PublicKey,
+}
+
+/// Caller-supplied fields for a signed delegation revocation.
+pub struct DelegationRevocationGrant<'a> {
+    pub link_id: &'a Hash256,
+    pub revoker: &'a Did,
+    pub revoked_at: &'a Timestamp,
+    pub revoker_public_key: &'a PublicKey,
+}
+
+#[derive(serde::Serialize)]
+struct AuthorityRevocationSigningPayload<'a> {
+    domain: &'static str,
+    schema_version: u16,
+    revoked_link_hash: &'a Hash256,
+    revoker_did: &'a Did,
+    revoked_at: &'a Timestamp,
+}
+
+/// Signed evidence that an authority link was revoked by its delegator.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct AuthorityRevocation {
+    pub revoked_link: AuthorityLink,
+    pub revoked_link_hash: Hash256,
+    pub revoker_did: Did,
+    pub revoked_at: Timestamp,
+    pub signature: Signature,
+}
+
+impl AuthorityRevocation {
+    /// Create and verify a signed revocation artifact for an authority link.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthorityError`] when the revoker is not the original
+    /// delegator, the revocation timestamp is invalid, canonical payload
+    /// encoding fails, or the revocation signature does not verify.
+    pub fn for_link(
+        revoked_link: AuthorityLink,
+        revoker: &Did,
+        revoked_at: &Timestamp,
+        revoker_public_key: &PublicKey,
+        sign_fn: impl FnOnce(&[u8]) -> Signature,
+    ) -> Result<Self, AuthorityError> {
+        let revoked_link_hash = revoked_link.id()?;
+        let mut revocation = Self {
+            revoked_link,
+            revoked_link_hash,
+            revoker_did: revoker.clone(),
+            revoked_at: *revoked_at,
+            signature: Signature::empty(),
+        };
+
+        revocation.validate_structure()?;
+        let payload = revocation.signing_payload()?;
+        let signature = sign_fn(&payload);
+        if signature.is_empty() {
+            return Err(AuthorityError::InvalidSignature { index: 0 });
+        }
+        if !crypto::verify(&payload, &signature, revoker_public_key) {
+            return Err(AuthorityError::InvalidSignature { index: 0 });
+        }
+        revocation.signature = signature;
+        Ok(revocation)
+    }
+
+    /// Compute the deterministic ID for this revocation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthorityError::SigningPayloadEncoding`] if canonical CBOR
+    /// encoding of the signed payload fails.
+    pub fn id(&self) -> Result<Hash256, AuthorityError> {
+        Ok(Hash256::digest(&self.signing_payload()?))
+    }
+
+    /// Canonical revocation payload signed by the revoker.
+    ///
+    /// The payload is domain-separated CBOR and excludes the signature itself.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthorityError::SigningPayloadEncoding`] if canonical CBOR
+    /// encoding fails.
+    pub fn signing_payload(&self) -> Result<Vec<u8>, AuthorityError> {
+        let payload = AuthorityRevocationSigningPayload {
+            domain: AUTHORITY_REVOCATION_SIGNING_DOMAIN,
+            schema_version: AUTHORITY_REVOCATION_SIGNING_SCHEMA_VERSION,
+            revoked_link_hash: &self.revoked_link_hash,
+            revoker_did: &self.revoker_did,
+            revoked_at: &self.revoked_at,
+        };
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&payload, &mut buf).map_err(|e| {
+            AuthorityError::SigningPayloadEncoding {
+                reason: e.to_string(),
+            }
+        })?;
+        Ok(buf)
+    }
+
+    /// Verify this revocation and the revoked authority link.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthorityError`] when the artifact is structurally invalid,
+    /// the revocation signature is missing or forged, or the revoked link's
+    /// original delegation signature cannot be verified.
+    pub fn verify<F>(&self, resolve_key: F) -> Result<(), AuthorityError>
+    where
+        F: Fn(&Did) -> Option<PublicKey>,
+    {
+        self.validate_structure()?;
+
+        if self.signature.is_empty() {
+            return Err(AuthorityError::InvalidSignature { index: 0 });
+        }
+        let revoker_public_key =
+            resolve_key(&self.revoker_did).ok_or(AuthorityError::InvalidSignature { index: 0 })?;
+        let payload = self.signing_payload()?;
+        if !crypto::verify(&payload, &self.signature, &revoker_public_key) {
+            return Err(AuthorityError::InvalidSignature { index: 0 });
+        }
+
+        if self.revoked_link.signature.is_empty() {
+            return Err(AuthorityError::InvalidSignature {
+                index: self.revoked_link.depth,
+            });
+        }
+        let delegator_public_key = resolve_key(&self.revoked_link.delegator_did).ok_or(
+            AuthorityError::InvalidSignature {
+                index: self.revoked_link.depth,
+            },
+        )?;
+        let link_payload = self.revoked_link.signing_payload()?;
+        if !crypto::verify(
+            &link_payload,
+            &self.revoked_link.signature,
+            &delegator_public_key,
+        ) {
+            return Err(AuthorityError::InvalidSignature {
+                index: self.revoked_link.depth,
+            });
+        }
+
+        Ok(())
+    }
+
+    fn validate_structure(&self) -> Result<(), AuthorityError> {
+        if self.revoked_at == Timestamp::ZERO {
+            return Err(AuthorityError::InvalidDelegation {
+                reason: "revocation timestamp must be non-zero".into(),
+            });
+        }
+        if self.revoked_at < self.revoked_link.created {
+            return Err(AuthorityError::InvalidDelegation {
+                reason: "revocation timestamp must not precede delegation creation".into(),
+            });
+        }
+        if let Some(expires) = &self.revoked_link.expires {
+            if expires.is_expired(&self.revoked_at) {
+                return Err(AuthorityError::ExpiredLink {
+                    index: self.revoked_link.depth,
+                });
+            }
+        }
+        if self.revoker_did != self.revoked_link.delegator_did {
+            return Err(AuthorityError::PermissionDenied(format!(
+                "revoker {} is not delegator {} for revoked link",
+                self.revoker_did.as_str(),
+                self.revoked_link.delegator_did.as_str()
+            )));
+        }
+
+        let computed_link_hash = self.revoked_link.id()?;
+        if computed_link_hash != self.revoked_link_hash {
+            return Err(AuthorityError::InvalidDelegation {
+                reason: format!(
+                    "revoked link hash mismatch: expected {}, computed {}",
+                    self.revoked_link_hash, computed_link_hash
+                ),
+            });
+        }
+
+        Ok(())
+    }
 }
 
 impl DelegationRegistry {
@@ -142,6 +332,37 @@ impl DelegationRegistry {
         }
 
         Ok(())
+    }
+
+    /// Revoke a delegation by its link ID and return signed revocation evidence.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthorityError::NotFound`] if the link does not exist, or
+    /// signature/validation errors when the revocation artifact cannot be
+    /// verified before removal.
+    pub fn revoke_delegation_signed(
+        &mut self,
+        grant: DelegationRevocationGrant<'_>,
+        sign_fn: impl FnOnce(&[u8]) -> Signature,
+    ) -> Result<AuthorityRevocation, AuthorityError> {
+        let DelegationRevocationGrant {
+            link_id,
+            revoker,
+            revoked_at,
+            revoker_public_key,
+        } = grant;
+
+        let link = self
+            .links
+            .get(link_id)
+            .cloned()
+            .ok_or_else(|| AuthorityError::NotFound(format!("{link_id:?}")))?;
+
+        let revocation =
+            AuthorityRevocation::for_link(link, revoker, revoked_at, revoker_public_key, sign_fn)?;
+        self.revoke_delegation(link_id)?;
+        Ok(revocation)
     }
 
     /// Find a delegation chain from `from` to `to`.
@@ -487,6 +708,97 @@ mod tests {
         let id = link.id().unwrap();
         assert!(reg.revoke_delegation(&id).is_ok());
         assert_eq!(reg.len(), 0);
+    }
+
+    #[test]
+    fn signed_revoke_delegation_returns_verifiable_revocation() {
+        let mut reg = DelegationRegistry::new();
+        let alice_key = KeyPair::generate();
+        let alice = did("alice");
+        let alice_public_key = public_key(&alice_key);
+        let link =
+            signed_delegate(&mut reg, "alice", "bob", &[Permission::Read], &alice_key).unwrap();
+        let id = link.id().unwrap();
+
+        let revocation = reg
+            .revoke_delegation_signed(
+                DelegationRevocationGrant {
+                    link_id: &id,
+                    revoker: &alice,
+                    revoked_at: &ts(6_000),
+                    revoker_public_key: &alice_public_key,
+                },
+                |payload| alice_key.sign(payload),
+            )
+            .unwrap();
+
+        assert_eq!(revocation.revoked_link_hash, id);
+        assert!(!revocation.signature.is_empty());
+        assert_eq!(reg.len(), 0);
+        assert!(
+            revocation
+                .verify(|did| {
+                    if did == &alice {
+                        Some(alice_public_key)
+                    } else {
+                        None
+                    }
+                })
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn signed_revoke_delegation_rejects_wrong_key_signature() {
+        let mut reg = DelegationRegistry::new();
+        let alice_key = KeyPair::generate();
+        let wrong_key = KeyPair::generate();
+        let alice = did("alice");
+        let alice_public_key = public_key(&alice_key);
+        let link =
+            signed_delegate(&mut reg, "alice", "bob", &[Permission::Read], &alice_key).unwrap();
+        let id = link.id().unwrap();
+
+        let result = reg.revoke_delegation_signed(
+            DelegationRevocationGrant {
+                link_id: &id,
+                revoker: &alice,
+                revoked_at: &ts(6_000),
+                revoker_public_key: &alice_public_key,
+            },
+            |payload| wrong_key.sign(payload),
+        );
+
+        assert!(matches!(
+            result,
+            Err(AuthorityError::InvalidSignature { index: 0 })
+        ));
+        assert_eq!(reg.len(), 1);
+    }
+
+    #[test]
+    fn signed_revoke_delegation_rejects_non_delegator_revoker() {
+        let mut reg = DelegationRegistry::new();
+        let alice_key = KeyPair::generate();
+        let bob_key = KeyPair::generate();
+        let bob = did("bob");
+        let bob_public_key = public_key(&bob_key);
+        let link =
+            signed_delegate(&mut reg, "alice", "bob", &[Permission::Read], &alice_key).unwrap();
+        let id = link.id().unwrap();
+
+        let result = reg.revoke_delegation_signed(
+            DelegationRevocationGrant {
+                link_id: &id,
+                revoker: &bob,
+                revoked_at: &ts(6_000),
+                revoker_public_key: &bob_public_key,
+            },
+            |payload| bob_key.sign(payload),
+        );
+
+        assert!(matches!(result, Err(AuthorityError::PermissionDenied(_))));
+        assert_eq!(reg.len(), 1);
     }
 
     #[test]

--- a/crates/exo-authority/src/lib.rs
+++ b/crates/exo-authority/src/lib.rs
@@ -11,6 +11,6 @@ pub mod permission;
 
 pub use cache::ChainCache;
 pub use chain::{AuthorityChain, AuthorityLink, DelegateeKind};
-pub use delegation::DelegationRegistry;
+pub use delegation::{AuthorityRevocation, DelegationRegistry, DelegationRevocationGrant};
 pub use error::AuthorityError;
 pub use permission::{Permission, PermissionSet};

--- a/crates/exo-legal/src/ai_transparency.rs
+++ b/crates/exo-legal/src/ai_transparency.rs
@@ -12,7 +12,7 @@
 //! which verifies the requesting actor's authority chain before any report
 //! can be generated.
 
-use exo_authority::{AuthorityChain, AuthorityLink, DelegateeKind, chain};
+use exo_authority::{AuthorityChain, AuthorityLink, AuthorityRevocation, DelegateeKind, chain};
 use exo_core::{Did, PublicKey, Timestamp, hash::hash_structured};
 use exo_gatekeeper::mcp_audit::{
     McpAuditLog, McpEnforcementOutcome, verify_chain as verify_mcp_audit_chain,
@@ -25,6 +25,9 @@ const AUTHORITY_CLEARANCE_DOMAIN: &str = "exo.legal.ai_transparency.authority_cl
 const AUTHORITY_CLEARANCE_SCHEMA_VERSION: u16 = 1;
 const AI_DELEGATION_GRANT_DOMAIN: &str = "exo.legal.ai_transparency.ai_delegation_grant.v1";
 const AI_DELEGATION_GRANT_SCHEMA_VERSION: u16 = 1;
+const AI_DELEGATION_REVOCATION_DOMAIN: &str =
+    "exo.legal.ai_transparency.ai_delegation_revocation.v1";
+const AI_DELEGATION_REVOCATION_SCHEMA_VERSION: u16 = 1;
 
 // ---------------------------------------------------------------------------
 // Report structures
@@ -88,6 +91,42 @@ impl VerifiedAiDelegationGrant {
     }
 }
 
+/// Summary of a verified AI agent delegation revocation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AiDelegationRevocationEvent {
+    pub delegator: Did,
+    pub delegatee: Did,
+    /// The model identifier — may be redacted in compliance reports.
+    pub model_id: String,
+    pub granted_at: Timestamp,
+    pub expires_at: Option<Timestamp>,
+    pub revoked_at: Timestamp,
+    pub revoker: Did,
+    pub depth: usize,
+    pub authority_chain_root: Did,
+    pub authority_chain_leaf: Did,
+    pub authority_chain_depth: usize,
+    pub authority_chain_hash: [u8; 32],
+    pub authority_link_hash: [u8; 32],
+    pub revocation_hash: [u8; 32],
+}
+
+/// Verified AI delegation revocation artifact that can only be created by
+/// authority-chain and signed-revocation verification through
+/// [`verify_ai_delegation_revocation`].
+#[derive(Debug, Clone)]
+pub struct VerifiedAiDelegationRevocation {
+    event: AiDelegationRevocationEvent,
+}
+
+impl VerifiedAiDelegationRevocation {
+    /// Return the serializable event evidence captured after verification.
+    #[must_use]
+    pub fn event(&self) -> &AiDelegationRevocationEvent {
+        &self.event
+    }
+}
+
 /// Per-rule MCP enforcement outcome summary.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpOutcomeSummary {
@@ -114,8 +153,8 @@ pub struct AiTransparencyReport {
     pub ai_agent_action_count: u64,
     /// Verified AI delegation grants recorded during the period.
     pub ai_delegation_grants: Vec<AiDelegationEvent>,
-    /// Count of AI delegation revocations during the period.
-    pub ai_delegation_revocations: u64,
+    /// Verified AI delegation revocations recorded during the period.
+    pub ai_delegation_revocations: Vec<AiDelegationRevocationEvent>,
     /// Per-rule breakdown of MCP enforcement outcomes.
     pub mcp_rule_outcomes: Vec<McpOutcomeSummary>,
     /// Head hash of the MCP audit log after full-chain verification.
@@ -138,7 +177,8 @@ pub struct ReportParams<'a> {
     pub mcp_log: &'a McpAuditLog,
     /// Verified AI delegation grants admitted through signed authority chains.
     pub ai_delegation_grants: Vec<VerifiedAiDelegationGrant>,
-    pub ai_delegation_revocations: u64,
+    /// Verified AI delegation revocations admitted through signed revocation artifacts.
+    pub ai_delegation_revocations: Vec<VerifiedAiDelegationRevocation>,
     /// Verified authority-chain clearance for the actor generating the report.
     pub authority_clearance: &'a VerifiedAuthorityClearance,
 }
@@ -193,7 +233,10 @@ pub fn generate_report(params: ReportParams<'_>) -> Result<AiTransparencyReport>
             .into_iter()
             .map(|grant| grant.event().clone())
             .collect(),
-        ai_delegation_revocations,
+        ai_delegation_revocations: ai_delegation_revocations
+            .into_iter()
+            .map(|revocation| revocation.event().clone())
+            .collect(),
         mcp_rule_outcomes,
         mcp_audit_head_hash: mcp_log.head_hash(),
         authority_clearance: authority_clearance.evidence().clone(),
@@ -340,6 +383,114 @@ where
     }))
 }
 
+/// Verify an authority chain and signed revocation artifact, then extract an
+/// AI delegation revocation from the chain leaf.
+///
+/// Returns `Ok(None)` after successful chain and revocation verification when
+/// the revoked leaf delegatee is not an AI agent. This keeps human and legacy
+/// delegation revocations out of AI transparency lists without trusting caller
+/// supplied flags or counts.
+///
+/// # Errors
+///
+/// Returns [`LegalError::InvalidStateTransition`] if the verification timestamp
+/// is zero, the revocation is in the future relative to verification, the
+/// authority chain is empty or invalid at the revocation time, the signed
+/// revocation artifact is invalid, the revocation does not bind to the chain
+/// leaf, or the event evidence cannot be canonicalized.
+pub fn verify_ai_delegation_revocation<F>(
+    authority_chain: &AuthorityChain,
+    revocation: &AuthorityRevocation,
+    verified_at: Timestamp,
+    resolve_key: F,
+) -> Result<Option<VerifiedAiDelegationRevocation>>
+where
+    F: Fn(&Did) -> Option<PublicKey>,
+{
+    if verified_at == Timestamp::ZERO {
+        return Err(LegalError::InvalidStateTransition {
+            reason: "AI delegation revocation verification timestamp must be non-zero".into(),
+        });
+    }
+    if revocation.revoked_at > verified_at {
+        return Err(LegalError::InvalidStateTransition {
+            reason: "AI delegation revocation must not be in the future relative to verification"
+                .into(),
+        });
+    }
+
+    chain::verify_chain(authority_chain, &revocation.revoked_at, &resolve_key).map_err(|e| {
+        LegalError::InvalidStateTransition {
+            reason: format!("AI delegation revocation authority chain verification failed: {e}"),
+        }
+    })?;
+    revocation
+        .verify(&resolve_key)
+        .map_err(|e| LegalError::InvalidStateTransition {
+            reason: format!("AI delegation revocation signature verification failed: {e}"),
+        })?;
+
+    let chain_root =
+        authority_chain
+            .root()
+            .cloned()
+            .ok_or_else(|| LegalError::InvalidStateTransition {
+                reason: "AI delegation revocation authority chain must not be empty".into(),
+            })?;
+    let chain_leaf =
+        authority_chain
+            .leaf()
+            .cloned()
+            .ok_or_else(|| LegalError::InvalidStateTransition {
+                reason: "AI delegation revocation authority chain must not be empty".into(),
+            })?;
+    let leaf_link =
+        authority_chain
+            .links
+            .last()
+            .ok_or_else(|| LegalError::InvalidStateTransition {
+                reason: "AI delegation revocation authority chain must not be empty".into(),
+            })?;
+
+    if &revocation.revoked_link != leaf_link {
+        return Err(LegalError::InvalidStateTransition {
+            reason: "AI delegation revocation artifact does not match authority chain leaf".into(),
+        });
+    }
+    if revocation.revoked_link_hash
+        != AuthorityLink::id(leaf_link).map_err(|e| LegalError::InvalidStateTransition {
+            reason: format!("AI delegation revocation leaf hash failed: {e}"),
+        })?
+    {
+        return Err(LegalError::InvalidStateTransition {
+            reason: "AI delegation revocation hash does not match authority chain leaf".into(),
+        });
+    }
+
+    let DelegateeKind::AiAgent { model_id } = &leaf_link.delegatee_kind else {
+        return Ok(None);
+    };
+
+    Ok(Some(VerifiedAiDelegationRevocation {
+        event: AiDelegationRevocationEvent {
+            delegator: leaf_link.delegator_did.clone(),
+            delegatee: leaf_link.delegate_did.clone(),
+            model_id: model_id.clone(),
+            granted_at: leaf_link.created,
+            expires_at: leaf_link.expires,
+            revoked_at: revocation.revoked_at,
+            revoker: revocation.revoker_did.clone(),
+            depth: leaf_link.depth,
+            authority_chain_root: chain_root,
+            authority_chain_leaf: chain_leaf,
+            authority_chain_depth: authority_chain.depth(),
+            authority_chain_hash: hash_ai_delegation_revocation_chain(authority_chain)?,
+            authority_link_hash: hash_authority_link(leaf_link)?,
+            revocation_hash: hash_authority_revocation(revocation)?,
+        },
+    }))
+}
+
 fn aggregate_mcp_outcomes(
     log: &McpAuditLog,
     period_start: Timestamp,
@@ -388,6 +539,13 @@ struct AiDelegationGrantHashPayload<'a> {
     authority_chain: &'a AuthorityChain,
 }
 
+#[derive(Serialize)]
+struct AiDelegationRevocationHashPayload<'a> {
+    domain: &'static str,
+    schema_version: u16,
+    authority_chain: &'a AuthorityChain,
+}
+
 fn hash_authority_clearance_chain(authority_chain: &AuthorityChain) -> Result<[u8; 32]> {
     let payload = AuthorityClearanceHashPayload {
         domain: AUTHORITY_CLEARANCE_DOMAIN,
@@ -414,11 +572,33 @@ fn hash_ai_delegation_chain(authority_chain: &AuthorityChain) -> Result<[u8; 32]
         })
 }
 
+fn hash_ai_delegation_revocation_chain(authority_chain: &AuthorityChain) -> Result<[u8; 32]> {
+    let payload = AiDelegationRevocationHashPayload {
+        domain: AI_DELEGATION_REVOCATION_DOMAIN,
+        schema_version: AI_DELEGATION_REVOCATION_SCHEMA_VERSION,
+        authority_chain,
+    };
+    hash_structured(&payload)
+        .map(|hash| *hash.as_bytes())
+        .map_err(|e| LegalError::InvalidStateTransition {
+            reason: format!("AI delegation revocation canonical CBOR hash failed: {e}"),
+        })
+}
+
 fn hash_authority_link(link: &AuthorityLink) -> Result<[u8; 32]> {
     link.id()
         .map(|hash| *hash.as_bytes())
         .map_err(|e| LegalError::InvalidStateTransition {
             reason: format!("AI delegation authority link hash failed: {e}"),
+        })
+}
+
+fn hash_authority_revocation(revocation: &AuthorityRevocation) -> Result<[u8; 32]> {
+    revocation
+        .id()
+        .map(|hash| *hash.as_bytes())
+        .map_err(|e| LegalError::InvalidStateTransition {
+            reason: format!("AI delegation authority revocation hash failed: {e}"),
         })
 }
 
@@ -525,6 +705,44 @@ mod tests {
         .expect("AI delegation grant is present")
     }
 
+    fn verified_ai_revocation() -> VerifiedAiDelegationRevocation {
+        let root = did("revocation-root");
+        let agent = did("agent-revoked");
+        let root_key = KeyPair::generate();
+        let link = signed_authority_link(
+            &root,
+            &agent,
+            DelegateeKind::AiAgent {
+                model_id: "claude-sonnet-4-6-revoked".into(),
+            },
+            &root_key,
+            0,
+            Some(ts(3_000)),
+        );
+        let revocation = AuthorityRevocation::for_link(
+            link.clone(),
+            &root,
+            &ts(2_000),
+            root_key.public_key(),
+            |payload| root_key.sign(payload),
+        )
+        .expect("authority revocation signs");
+        let chain = AuthorityChain {
+            links: vec![link],
+            max_depth: 5,
+        };
+
+        verify_ai_delegation_revocation(&chain, &revocation, ts(2_500), |did| {
+            if did == &root {
+                Some(*root_key.public_key())
+            } else {
+                None
+            }
+        })
+        .expect("AI delegation revocation verification succeeds")
+        .expect("AI delegation revocation is present")
+    }
+
     fn make_log_with_records() -> McpAuditLog {
         let mut log = McpAuditLog::new();
         let r1 = create_record(
@@ -566,7 +784,7 @@ mod tests {
             legal_jurisdiction: "EU-AI-ACT",
             mcp_log: &log,
             ai_delegation_grants: vec![],
-            ai_delegation_revocations: 0,
+            ai_delegation_revocations: vec![],
             authority_clearance: &clearance,
         });
 
@@ -612,6 +830,27 @@ mod tests {
         assert!(
             !report_params.contains("ai_delegation_grants: Vec<AiDelegationEvent>"),
             "ReportParams must require verified AI delegation grant artifacts, not raw events"
+        );
+    }
+
+    #[test]
+    fn generate_report_source_does_not_accept_raw_ai_delegation_revocation_count() {
+        let source = include_str!("ai_transparency.rs");
+        let production = source
+            .split("// ===========================================================================")
+            .next()
+            .expect("tests section marker present");
+        let report_params = production
+            .split("pub struct ReportParams<'a>")
+            .nth(1)
+            .expect("ReportParams definition present")
+            .split("/// Generate an AI transparency report for the given tenant and time period.")
+            .next()
+            .expect("ReportParams definition boundary present");
+
+        assert!(
+            !report_params.contains("ai_delegation_revocations: u64"),
+            "ReportParams must require verified AI delegation revocation artifacts, not raw counts"
         );
     }
 
@@ -663,7 +902,7 @@ mod tests {
             legal_jurisdiction: "EU-AI-ACT",
             mcp_log: &log,
             ai_delegation_grants: vec![],
-            ai_delegation_revocations: 0,
+            ai_delegation_revocations: vec![],
             authority_clearance: &clearance,
         })
         .expect("report generation should succeed");
@@ -685,7 +924,7 @@ mod tests {
             legal_jurisdiction: "NIST-AI-RMF",
             mcp_log: &log,
             ai_delegation_grants: vec![],
-            ai_delegation_revocations: 0,
+            ai_delegation_revocations: vec![],
             authority_clearance: &clearance,
         })
         .expect("ok");
@@ -774,6 +1013,104 @@ mod tests {
     }
 
     #[test]
+    fn verify_ai_delegation_revocation_from_ai_link_returns_verified_event() {
+        let revocation = verified_ai_revocation();
+        let event = revocation.event();
+        assert_eq!(event.model_id, "claude-sonnet-4-6-revoked");
+        assert_eq!(event.depth, 0);
+        assert_eq!(event.revoked_at, ts(2_000));
+        assert_eq!(event.revoker, did("revocation-root"));
+        assert_eq!(event.authority_chain_root, did("revocation-root"));
+        assert_eq!(event.authority_chain_leaf, did("agent-revoked"));
+        assert_eq!(event.authority_chain_depth, 1);
+        assert_ne!(event.authority_chain_hash, [0u8; 32]);
+        assert_ne!(event.authority_link_hash, [0u8; 32]);
+        assert_ne!(event.revocation_hash, [0u8; 32]);
+    }
+
+    #[test]
+    fn verify_ai_delegation_revocation_from_human_link_returns_none() {
+        let root = did("human-revocation-root");
+        let human = did("human-revoked");
+        let root_key = KeyPair::generate();
+        let link = signed_authority_link(
+            &root,
+            &human,
+            DelegateeKind::Human,
+            &root_key,
+            0,
+            Some(ts(3_000)),
+        );
+        let revocation = AuthorityRevocation::for_link(
+            link.clone(),
+            &root,
+            &ts(2_000),
+            root_key.public_key(),
+            |payload| root_key.sign(payload),
+        )
+        .expect("authority revocation signs");
+        let chain = AuthorityChain {
+            links: vec![link],
+            max_depth: 5,
+        };
+
+        let result = verify_ai_delegation_revocation(&chain, &revocation, ts(2_500), |did| {
+            if did == &root {
+                Some(*root_key.public_key())
+            } else {
+                None
+            }
+        })
+        .expect("human revocation authority chain still verifies");
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn verify_ai_delegation_revocation_rejects_tampered_signature() {
+        let root = did("tampered-revocation-root");
+        let agent = did("tampered-agent");
+        let root_key = KeyPair::generate();
+        let wrong_key = KeyPair::generate();
+        let link = signed_authority_link(
+            &root,
+            &agent,
+            DelegateeKind::AiAgent {
+                model_id: "tampered-model".into(),
+            },
+            &root_key,
+            0,
+            Some(ts(3_000)),
+        );
+        let mut revocation = AuthorityRevocation::for_link(
+            link.clone(),
+            &root,
+            &ts(2_000),
+            root_key.public_key(),
+            |payload| root_key.sign(payload),
+        )
+        .expect("authority revocation signs");
+        let payload = revocation
+            .signing_payload()
+            .expect("revocation signing payload");
+        revocation.signature = wrong_key.sign(&payload);
+        let chain = AuthorityChain {
+            links: vec![link],
+            max_depth: 5,
+        };
+
+        let result = verify_ai_delegation_revocation(&chain, &revocation, ts(2_500), |did| {
+            if did == &root {
+                Some(*root_key.public_key())
+            } else {
+                None
+            }
+        });
+
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn generate_report_with_verified_ai_delegation_grant_succeeds() {
         let log = McpAuditLog::new();
         let tenant = did("tenant");
@@ -788,7 +1125,7 @@ mod tests {
             legal_jurisdiction: "EU-AI-ACT",
             mcp_log: &log,
             ai_delegation_grants: vec![grant],
-            ai_delegation_revocations: 0,
+            ai_delegation_revocations: vec![],
             authority_clearance: &clearance,
         })
         .expect("verified AI delegation grant should be accepted");
@@ -797,6 +1134,33 @@ mod tests {
         assert_eq!(
             report.ai_delegation_grants[0].authority_chain_hash,
             expected_chain_hash
+        );
+    }
+
+    #[test]
+    fn generate_report_with_verified_ai_delegation_revocation_succeeds() {
+        let log = McpAuditLog::new();
+        let tenant = did("tenant");
+        let clearance = verified_clearance(&tenant);
+        let revocation = verified_ai_revocation();
+        let expected_revocation_hash = revocation.event().revocation_hash;
+
+        let report = generate_report(ReportParams {
+            tenant_id: &tenant,
+            period_start: ts(0),
+            period_end: ts(u64::MAX),
+            legal_jurisdiction: "EU-AI-ACT",
+            mcp_log: &log,
+            ai_delegation_grants: vec![],
+            ai_delegation_revocations: vec![revocation],
+            authority_clearance: &clearance,
+        })
+        .expect("verified AI delegation revocation should be accepted");
+
+        assert_eq!(report.ai_delegation_revocations.len(), 1);
+        assert_eq!(
+            report.ai_delegation_revocations[0].revocation_hash,
+            expected_revocation_hash
         );
     }
 
@@ -826,7 +1190,7 @@ mod tests {
             legal_jurisdiction: "EU-AI-ACT",
             mcp_log: &log,
             ai_delegation_grants: vec![],
-            ai_delegation_revocations: 0,
+            ai_delegation_revocations: vec![],
             authority_clearance: &clearance,
         })
         .expect("ok");

--- a/crates/exo-legal/src/compliance_report.rs
+++ b/crates/exo-legal/src/compliance_report.rs
@@ -254,7 +254,7 @@ fn derive_status_and_evidence(
                     report.authority_clearance.chain_depth,
                     hex_encode(&report.authority_clearance.chain_hash),
                     ai_grants,
-                    report.ai_delegation_revocations
+                    report.ai_delegation_revocations.len()
                 ),
             )
         }
@@ -407,7 +407,7 @@ mod tests {
             legal_jurisdiction: "EU-AI-ACT",
             mcp_log: &McpAuditLog::new(),
             ai_delegation_grants: vec![],
-            ai_delegation_revocations: 0,
+            ai_delegation_revocations: vec![],
             authority_clearance: &clearance,
         })
         .expect("ok")

--- a/crates/exo-legal/src/nist_compliance_tests.rs
+++ b/crates/exo-legal/src/nist_compliance_tests.rs
@@ -8,7 +8,7 @@
 mod nist_compliance {
     use exo_authority::{
         AuthorityChain as ReportAuthorityChain, AuthorityLink as ReportAuthorityLink,
-        DelegateeKind, Permission as ReportPermission,
+        AuthorityRevocation, DelegateeKind, Permission as ReportPermission,
     };
     use exo_core::{Did, Hash256, Signature, Timestamp, crypto::KeyPair};
     use exo_gatekeeper::{
@@ -25,8 +25,9 @@ mod nist_compliance {
 
     use crate::{
         ai_transparency::{
-            ReportParams, VerifiedAiDelegationGrant, VerifiedAuthorityClearance, generate_report,
-            verify_ai_delegation_grant, verify_authority_clearance,
+            ReportParams, VerifiedAiDelegationGrant, VerifiedAiDelegationRevocation,
+            VerifiedAuthorityClearance, generate_report, verify_ai_delegation_grant,
+            verify_ai_delegation_revocation, verify_authority_clearance,
         },
         compliance_report::{
             AttestationStatus, ComplianceReportMode, build_report, redact_model_id,
@@ -129,6 +130,44 @@ mod nist_compliance {
         })
         .expect("AI delegation chain must verify")
         .expect("AI delegation grant must be present")
+    }
+
+    fn verified_ai_delegation_revocation(model_id: &str) -> VerifiedAiDelegationRevocation {
+        let root = did("ai-revocation-root");
+        let agent = did("ai-agent-revoked");
+        let root_key = KeyPair::generate();
+        let link = signed_report_authority_link(
+            &root,
+            &agent,
+            DelegateeKind::AiAgent {
+                model_id: model_id.to_owned(),
+            },
+            &root_key,
+            0,
+            Some(ts(2_500)),
+        );
+        let revocation = AuthorityRevocation::for_link(
+            link.clone(),
+            &root,
+            &ts(2_000),
+            root_key.public_key(),
+            |payload| root_key.sign(payload),
+        )
+        .expect("AI delegation revocation must sign");
+        let chain = ReportAuthorityChain {
+            links: vec![link],
+            max_depth: 5,
+        };
+
+        verify_ai_delegation_revocation(&chain, &revocation, ts(2_250), |did| {
+            if did == &root {
+                Some(*root_key.public_key())
+            } else {
+                None
+            }
+        })
+        .expect("AI delegation revocation chain must verify")
+        .expect("AI delegation revocation must be present")
     }
 
     fn signed_authority_link(grantor: &Did, grantee: &Did) -> AuthorityLink {
@@ -390,7 +429,7 @@ mod nist_compliance {
             legal_jurisdiction: "EU-AI-ACT",
             mcp_log: &mcp_log,
             ai_delegation_grants: vec![],
-            ai_delegation_revocations: 0,
+            ai_delegation_revocations: vec![],
             authority_clearance: &clearance,
         })
         .expect("transparency report generation must succeed");
@@ -524,6 +563,7 @@ mod nist_compliance {
         let tenant = did("tenant-beta");
         let mcp_log = McpAuditLog::new();
         let clearance = verified_report_clearance(&tenant);
+        let ai_revocation = verified_ai_delegation_revocation(model_id);
         let report = generate_report(ReportParams {
             tenant_id: &tenant,
             period_start: ts(0),
@@ -531,12 +571,12 @@ mod nist_compliance {
             legal_jurisdiction: "NIST-AI-RMF",
             mcp_log: &mcp_log,
             ai_delegation_grants: vec![ai_grant],
-            ai_delegation_revocations: 1,
+            ai_delegation_revocations: vec![ai_revocation],
             authority_clearance: &clearance,
         })
         .expect("transparency report must succeed");
         assert_eq!(report.ai_delegation_grants.len(), 1);
-        assert_eq!(report.ai_delegation_revocations, 1);
+        assert_eq!(report.ai_delegation_revocations.len(), 1);
 
         // 5. Full mode preserves plaintext model_id.
         let result_full = redact_model_id(&tenant, model_id, &ComplianceReportMode::Full);

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 117978 lines of Rust under `crates/`, 2,907 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 118694 lines of Rust under `crates/`, 2,915 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,907 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,915 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,907 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,915 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-117978 lines of Rust under `crates/` · 20 workspace packages · 2,907 listed tests · 40 MCP tools · 8 constitutional invariants
+118694 lines of Rust under `crates/` · 20 workspace packages · 2,915 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 117978 lines of Rust under `crates/` | 266 Rust source files | 2,907 listed tests
+> **Codebase:** 20 workspace packages | 118694 lines of Rust under `crates/` | 266 Rust source files | 2,915 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,907 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,915 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 117978 lines of Rust under `crates/` · 2,907 listed tests
+20 workspace packages · 118694 lines of Rust under `crates/` · 2,915 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- adds signed `AuthorityRevocation` evidence to `exo-authority` with canonical CBOR signing payloads and verification
- changes AI transparency revocations from caller-supplied counts to verified revocation event artifacts
- updates NIST/report tests and repo-truth documentation counts

## Validation
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo build --workspace --release
- cargo test --workspace --release
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
- cargo audit --deny unsound --deny unmaintained
- cargo deny check
- cargo machete --with-metadata
- cargo +nightly fmt --all -- --check
- git diff --check
- bash tools/test_repo_truth.sh
