### PR TITLE
fix(exo-consensus): require synthesis before finalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 118694 | `wc -l` |
-| Workspace tests | 2,915 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 118764 | `wc -l` |
+| Workspace tests | 2,918 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,915 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,918 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 118694 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 118764 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,915 listed workspace tests
+         cryptographic proofs, 2,918 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-consensus/src/lib.rs
+++ b/crates/exo-consensus/src/lib.rs
@@ -532,6 +532,15 @@ mod tests {
     }
 
     #[test]
+    fn production_session_source_has_no_silent_default_final_consensus() {
+        let source = production_source("src/session.rs");
+        assert!(
+            !source.contains("unwrap_or_default"),
+            "production session finalization must fail closed instead of defaulting missing synthesis"
+        );
+    }
+
+    #[test]
     fn production_hashing_source_has_no_json_or_silent_default_fallback() {
         for file in ["src/round.rs", "src/record.rs"] {
             let source = production_source(file);

--- a/crates/exo-consensus/src/session.rs
+++ b/crates/exo-consensus/src/session.rs
@@ -218,6 +218,17 @@ impl DeliberationSession {
                 "Rounds exist but last() failed".into(),
             ));
         };
+        let final_consensus = last_round
+            .synthesis
+            .as_deref()
+            .map(str::trim)
+            .filter(|synthesis| !synthesis.is_empty())
+            .ok_or_else(|| {
+                ConsensusError::StateError(
+                    "Cannot finalize round with missing synthesis evidence".into(),
+                )
+            })?
+            .to_string();
         let mut minority_reports = Vec::new();
 
         let claim_sets = position_claim_sets(&last_round.positions);
@@ -272,7 +283,7 @@ impl DeliberationSession {
             session_id: self.session_id.clone(),
             question: self.question.clone(),
             rounds: self.rounds.clone(),
-            final_consensus: last_round.synthesis.clone().unwrap_or_default(),
+            final_consensus,
             minority_reports,
             panel_confidence_index_bps: pci,
             rounds_to_convergence: u32::try_from(self.rounds.len()).unwrap_or(0),
@@ -488,6 +499,56 @@ mod tests {
                     msg.contains("Cannot finalize without any rounds"),
                     "unexpected state error message: {msg}"
                 );
+            }
+            other => panic!("expected StateError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn finalize_rejects_round_without_synthesis_evidence() {
+        let panel = Panel::default_panel(DecisionClass::Routine);
+        let provider = DeterministicResponseProvider::with_positions(routine_responses(
+            "shared position",
+            &["shared claim"],
+        ));
+        let mut session = DeliberationSession::new("s".into(), panel, "Q?".into(), provider);
+        session
+            .execute_round(timing(1))
+            .expect("round executes with synthesis");
+        session.rounds[0].synthesis = None;
+
+        let err = session
+            .finalize(finalization_timing())
+            .expect_err("missing synthesis evidence must fail closed");
+
+        match err {
+            ConsensusError::StateError(message) => {
+                assert!(message.contains("missing synthesis"));
+            }
+            other => panic!("expected StateError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn finalize_rejects_blank_synthesis_evidence() {
+        let panel = Panel::default_panel(DecisionClass::Routine);
+        let provider = DeterministicResponseProvider::with_positions(routine_responses(
+            "shared position",
+            &["shared claim"],
+        ));
+        let mut session = DeliberationSession::new("s".into(), panel, "Q?".into(), provider);
+        session
+            .execute_round(timing(1))
+            .expect("round executes with synthesis");
+        session.rounds[0].synthesis = Some("   ".to_string());
+
+        let err = session
+            .finalize(finalization_timing())
+            .expect_err("blank synthesis evidence must fail closed");
+
+        match err {
+            ConsensusError::StateError(message) => {
+                assert!(message.contains("missing synthesis"));
             }
             other => panic!("expected StateError, got {other:?}"),
         }

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 118694 lines of Rust under `crates/`, 2,915 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 118764 lines of Rust under `crates/`, 2,918 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,915 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,918 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,915 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,918 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-118694 lines of Rust under `crates/` · 20 workspace packages · 2,915 listed tests · 40 MCP tools · 8 constitutional invariants
+118764 lines of Rust under `crates/` · 20 workspace packages · 2,918 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 118694 lines of Rust under `crates/` | 266 Rust source files | 2,915 listed tests
+> **Codebase:** 20 workspace packages | 118764 lines of Rust under `crates/` | 266 Rust source files | 2,918 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,915 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,918 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 118694 lines of Rust under `crates/` · 2,915 listed tests
+20 workspace packages · 118764 lines of Rust under `crates/` · 2,918 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- fail closed when `DeliberationSession::finalize` sees missing or blank last-round synthesis evidence
- remove the silent `unwrap_or_default()` final-consensus fallback
- add behavioral regressions and a source guard preventing silent defaults in consensus finalization
- refresh repo-truth-derived LOC/test metrics after adding tests

## TDD red checks
- `cargo test -p exo-consensus finalize_rejects_round_without_synthesis_evidence --lib` failed before the fix by returning `final_consensus: ""`
- `cargo test -p exo-consensus finalize_rejects_blank_synthesis_evidence --lib` failed before the fix by returning blank final consensus
- `cargo test -p exo-consensus production_session_source_has_no_silent_default_final_consensus --lib` failed before the fix on `unwrap_or_default()`

## Verification
- `cargo test -p exo-consensus --lib`
- `cargo test -p exo-consensus`
- `cargo build -p exo-consensus`
- `cargo clippy -p exo-consensus --lib -- -D warnings`
- `cargo clippy -p exo-consensus --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit --deny unsound --deny unmaintained` (passes with existing allowed yanked `core2` warning)
- `cargo deny check` (passes with existing duplicate/yanked/unused-allowance warnings)
- `cargo machete --with-metadata`
- `bash tools/test_repo_truth.sh`