### PR TITLE
fix(exo-node): gate MCP governance state lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 119140 | `wc -l` |
-| Workspace tests | 2,902 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 119221 | `wc -l` |
+| Workspace tests | 2,900 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,902 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,900 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 119140 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 119221 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,902 listed workspace tests
+         cryptographic proofs, 2,900 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/mcp/middleware.rs
+++ b/crates/exo-node/src/mcp/middleware.rs
@@ -27,14 +27,13 @@
 //! at fields the caller supplies (`is_self_grant`, `modifies_kernel`,
 //! `actor_roles`).
 //!
-//! **Current blast radius: bounded by the gate on RED #2.** The three
-//! mutating MCP tools (`exochain_create_decision`, `exochain_cast_vote`,
-//! `exochain_propose_amendment`) refuse by default behind the
-//! `unaudited-mcp-simulation-tools` feature flag. Read-only tools
-//! (`exochain_check_quorum`, `exochain_get_decision_status`,
-//! `exochain_list_invariants`, etc.) are the only callers the
-//! middleware currently rubber-stamps, and they can't mutate
-//! governance fabric.
+//! **Current blast radius: bounded by the gate on RED #2.** Governance MCP
+//! tools that would otherwise simulate decisions, votes, quorum, decision
+//! status, or amendments refuse by default behind the
+//! `unaudited-mcp-simulation-tools` feature flag. Non-synthetic read-only
+//! tools (`exochain_list_invariants`, etc.) are the only callers the
+//! middleware currently rubber-stamps, and they can't mutate governance
+//! fabric.
 //!
 //! **When RED #2 is resolved (real reactor wiring), this middleware
 //! MUST be promoted from node-level authority to live delegated authority.**

--- a/crates/exo-node/src/mcp/prompts/governance_review.rs
+++ b/crates/exo-node/src/mcp/prompts/governance_review.rs
@@ -78,6 +78,10 @@ Before answering, call the following MCP tools to gather context:
 - `exochain_verify_authority_chain` on the proposer DID
 - `exochain_list_invariants` to re-load the current invariant set
 
+If a tool returns `mcp_simulation_tool_disabled`, cite that refusal as missing
+evidence. Do not infer quorum, decision status, or authority validity from
+synthetic or absent MCP state.
+
 Produce your review in this exact structure:
 
 1. **Stakeholders** — who is affected (by branch: legislative / executive / judicial)
@@ -133,6 +137,8 @@ mod tests {
         let text = result.messages[0].content.text();
         assert!(text.contains("dec-123"));
         assert!(text.contains("Expand BCTS scope"));
+        assert!(text.contains("mcp_simulation_tool_disabled"));
+        assert!(text.contains("Do not infer quorum"));
     }
 
     #[test]

--- a/crates/exo-node/src/mcp/resources/readme.rs
+++ b/crates/exo-node/src/mcp/resources/readme.rs
@@ -34,8 +34,9 @@ MCP rules and 8 kernel invariants on every action. Read this document first.
   terminate consent. `ConsentRequired` (invariant #2) means nothing works
   without active consent.
 - **governance (5)** — Create decisions, cast votes, check quorum, inspect
-  status, propose amendments. `QuorumLegitimate` (invariant #7) enforces
-  2/3 threshold evidence.
+  status, propose amendments. These tools refuse by default unless
+  `unaudited-mcp-simulation-tools` is enabled, because they are not wired to
+  the live governance store/reactor yet.
 - **authority (4)** — Delegate authority, verify chains, check permissions,
   run kernel adjudication. `AuthorityChainValid` (invariant #6) is checked
   here.
@@ -161,5 +162,6 @@ mod tests {
         assert!(text.contains("# EXOCHAIN MCP Server"));
         assert!(text.contains("exochain://constitution"));
         assert!(text.contains("MCP-001"));
+        assert!(text.contains("unaudited-mcp-simulation-tools"));
     }
 }

--- a/crates/exo-node/src/mcp/tools/governance.rs
+++ b/crates/exo-node/src/mcp/tools/governance.rs
@@ -3,11 +3,10 @@
 //!
 //! # Simulation gate (Onyx pass 3, RED #2)
 //!
-//! The mutating tools (`exochain_create_decision`, `exochain_cast_vote`,
-//! `exochain_propose_amendment`) currently synthesize response JSON
-//! without persisting to any store or touching the reactor. Behind
-//! the scenes, they don't actually create decisions, record votes,
-//! or register amendments on-chain.
+//! The governance tools currently synthesize response JSON without a backing
+//! governance store or reactor. Behind the scenes, they don't actually create
+//! decisions, record votes, register amendments on-chain, or query persisted
+//! quorum/status state.
 //!
 //! Until these are wired to the real governance flow (see
 //! `Initiatives/fix-mcp-simulation-tools.md`), they are gated behind
@@ -328,37 +327,52 @@ pub fn check_quorum_definition() -> ToolDefinition {
 /// Execute the `exochain_check_quorum` tool.
 #[must_use]
 pub fn execute_check_quorum(params: &Value, _context: &NodeContext) -> ToolResult {
-    let decision_id = match params.get("decision_id").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: decision_id"}).to_string(),
-            );
-        }
-    };
-    let threshold = match params.get("threshold").and_then(Value::as_u64) {
-        Some(n) => n,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing or invalid required parameter: threshold (must be a positive integer)"}).to_string(),
-            );
-        }
-    };
-
-    if decision_id.is_empty() {
-        return ToolResult::error(json!({"error": "decision_id must not be empty"}).to_string());
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    {
+        let _ = params;
+        return simulation_refused("exochain_check_quorum");
     }
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
+    {
+        tracing::warn!(
+            "UNAUDITED MCP simulation tool in use: exochain_check_quorum. \
+             Returns synthetic zero-vote quorum data without querying a \
+             governance store. Gated by `unaudited-mcp-simulation-tools` \
+             feature."
+        );
+        let decision_id = match params.get("decision_id").and_then(Value::as_str) {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: decision_id"}).to_string(),
+                );
+            }
+        };
+        let threshold = match params.get("threshold").and_then(Value::as_u64) {
+            Some(n) => n,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing or invalid required parameter: threshold (must be a positive integer)"}).to_string(),
+                );
+            }
+        };
 
-    // No persistent vote registry yet — always report zero votes.
-    let response = json!({
-        "decision_id": decision_id,
-        "threshold": threshold,
-        "total_votes": 0,
-        "authentic_approvals": 0,
-        "synthetic_excluded": 0,
-        "quorum_met": false,
-    });
-    ToolResult::success(response.to_string())
+        if decision_id.is_empty() {
+            return ToolResult::error(
+                json!({"error": "decision_id must not be empty"}).to_string(),
+            );
+        }
+
+        let response = json!({
+            "decision_id": decision_id,
+            "threshold": threshold,
+            "total_votes": 0,
+            "authentic_approvals": 0,
+            "synthetic_excluded": 0,
+            "quorum_met": false,
+        });
+        ToolResult::success(response.to_string())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -388,25 +402,40 @@ pub fn get_decision_status_definition() -> ToolDefinition {
 /// Execute the `exochain_get_decision_status` tool.
 #[must_use]
 pub fn execute_get_decision_status(params: &Value, _context: &NodeContext) -> ToolResult {
-    let decision_id = match params.get("decision_id").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    {
+        let _ = params;
+        return simulation_refused("exochain_get_decision_status");
+    }
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
+    {
+        tracing::warn!(
+            "UNAUDITED MCP simulation tool in use: exochain_get_decision_status. \
+             Returns synthetic unknown status without querying a governance \
+             store. Gated by `unaudited-mcp-simulation-tools` feature."
+        );
+        let decision_id = match params.get("decision_id").and_then(Value::as_str) {
+            Some(s) => s,
+            None => {
+                return ToolResult::error(
+                    json!({"error": "missing required parameter: decision_id"}).to_string(),
+                );
+            }
+        };
+
+        if decision_id.is_empty() {
             return ToolResult::error(
-                json!({"error": "missing required parameter: decision_id"}).to_string(),
+                json!({"error": "decision_id must not be empty"}).to_string(),
             );
         }
-    };
 
-    if decision_id.is_empty() {
-        return ToolResult::error(json!({"error": "decision_id must not be empty"}).to_string());
+        let response = json!({
+            "decision_id": decision_id,
+            "status": "unknown",
+            "message": "Decision not found in local state",
+        });
+        ToolResult::success(response.to_string())
     }
-
-    let response = json!({
-        "decision_id": decision_id,
-        "status": "unknown",
-        "message": "Decision not found in local state",
-    });
-    ToolResult::success(response.to_string())
 }
 
 // ---------------------------------------------------------------------------
@@ -683,6 +712,7 @@ mod tests {
         assert!(!def.description.is_empty());
     }
 
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_check_quorum_success() {
         let result = execute_check_quorum(
@@ -700,6 +730,7 @@ mod tests {
         assert_eq!(v["total_votes"], 0);
     }
 
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_check_quorum_missing_threshold() {
         let result = execute_check_quorum(&json!({"decision_id": "abc123"}), &NodeContext::empty());
@@ -715,6 +746,7 @@ mod tests {
         assert!(!def.description.is_empty());
     }
 
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_get_decision_status_success() {
         let result =
@@ -725,6 +757,7 @@ mod tests {
         assert_eq!(v["status"], "unknown");
     }
 
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_get_decision_status_empty_id() {
         let result =
@@ -858,6 +891,47 @@ mod tests {
         let text = result.content[0].text();
         assert!(text.contains("mcp_simulation_tool_disabled"));
         assert!(text.contains("exochain_cast_vote"));
+    }
+
+    /// Same refusal for check_quorum — no synthesized zero-vote tally.
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    #[test]
+    fn execute_check_quorum_refused_without_feature_flag() {
+        let result = execute_check_quorum(
+            &json!({
+                "decision_id": "abc",
+                "threshold": 3,
+            }),
+            &NodeContext::empty(),
+        );
+        assert!(result.is_error);
+        let text = result.content[0].text();
+        assert!(text.contains("mcp_simulation_tool_disabled"));
+        assert!(text.contains("exochain_check_quorum"));
+        assert!(text.contains("unaudited-mcp-simulation-tools"));
+        assert!(text.contains("Initiatives/fix-mcp-simulation-tools.md"));
+        assert!(
+            text.contains("governance store"),
+            "refusal body must explain the missing backing store, got: {text}"
+        );
+    }
+
+    /// Same refusal for get_decision_status — no synthesized unknown status.
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    #[test]
+    fn execute_get_decision_status_refused_without_feature_flag() {
+        let result =
+            execute_get_decision_status(&json!({"decision_id": "abc"}), &NodeContext::empty());
+        assert!(result.is_error);
+        let text = result.content[0].text();
+        assert!(text.contains("mcp_simulation_tool_disabled"));
+        assert!(text.contains("exochain_get_decision_status"));
+        assert!(text.contains("unaudited-mcp-simulation-tools"));
+        assert!(text.contains("Initiatives/fix-mcp-simulation-tools.md"));
+        assert!(
+            text.contains("governance store"),
+            "refusal body must explain the missing backing store, got: {text}"
+        );
     }
 
     /// Same refusal for propose_amendment — no synthesized amendment_id.

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 119140 lines of Rust under `crates/`, 2,902 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 119221 lines of Rust under `crates/`, 2,900 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,902 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,900 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,902 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,900 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-119140 lines of Rust under `crates/` · 20 workspace packages · 2,902 listed tests · 40 MCP tools · 8 constitutional invariants
+119221 lines of Rust under `crates/` · 20 workspace packages · 2,900 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 119140 lines of Rust under `crates/` | 266 Rust source files | 2,902 listed tests
+> **Codebase:** 20 workspace packages | 119221 lines of Rust under `crates/` | 266 Rust source files | 2,900 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,902 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,900 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 119140 lines of Rust under `crates/` · 2,902 listed tests
+20 workspace packages · 119221 lines of Rust under `crates/` · 2,900 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- Gate `exochain_check_quorum` and `exochain_get_decision_status` behind `unaudited-mcp-simulation-tools` in the default build.
- Preserve the legacy synthetic zero-vote/unknown-status behavior only when that explicit simulation feature is enabled.
- Update MCP middleware docs, the governance review prompt, and the MCP readme so agents treat simulation refusals as missing evidence rather than quorum/status truth.

## Root Cause
The mutating governance MCP tools already failed closed by default, but the read-style governance tools still returned synthetic local state without querying a governance store. That could cause an agent to infer false negative quorum/status evidence during reviews.

## Validation
- `cargo test -p exo-node mcp::tools::governance --bin exochain -- --nocapture`
- `cargo test -p exo-node --features unaudited-mcp-simulation-tools mcp::tools::governance --bin exochain -- --nocapture`
- `cargo test -p exo-node mcp --bin exochain -- --nocapture`
- `cargo test -p exo-node --features unaudited-mcp-simulation-tools mcp --bin exochain -- --nocapture`
- `cargo test -p exo-node --bin exochain`
- `cargo test -p exo-node --features unaudited-mcp-simulation-tools --bin exochain`
- `cargo build -p exo-node`
- `cargo build -p exo-node --features unaudited-mcp-simulation-tools`
- `cargo clippy -p exo-node --bin exochain -- -D warnings`
- `cargo clippy -p exo-node --features unaudited-mcp-simulation-tools --bin exochain -- -D warnings`
- `cargo clippy -p exo-node --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`