### PR TITLE
fix(exo-governance): canonicalize constitution hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 119392 | `wc -l` |
-| Workspace tests | 2,892 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 119436 | `wc -l` |
+| Workspace tests | 2,893 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,892 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,893 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 119392 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 119436 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,892 listed workspace tests
+         cryptographic proofs, 2,893 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-governance/src/constitution.rs
+++ b/crates/exo-governance/src/constitution.rs
@@ -4,6 +4,7 @@
 
 use exo_core::{
     Did,
+    hash::hash_structured,
     types::{Hash256, Timestamp},
 };
 use serde::{Deserialize, Serialize};
@@ -190,6 +191,14 @@ pub struct Constitution {
     pub signatures: Vec<GovernanceSignature>,
 }
 
+const CONSTITUTION_HASH_DOMAIN: &str = "exo.governance.constitution.v1";
+
+#[derive(Serialize)]
+struct ConstitutionHashPayload<'a> {
+    domain: &'static str,
+    documents: &'a [ConstitutionalDocument],
+}
+
 /// Result of evaluating a constraint.
 #[derive(Clone, Debug)]
 pub struct ConstraintResult {
@@ -202,9 +211,13 @@ pub struct ConstraintResult {
 impl Constitution {
     /// Compute the content hash of this constitution.
     pub fn compute_hash(&self) -> Result<Hash256, GovernanceError> {
-        let canonical = serde_json::to_vec(&self.documents)
-            .map_err(|_| GovernanceError::Serialization("failed to encode constitution".into()))?;
-        Ok(Hash256::digest(&canonical))
+        hash_structured(&ConstitutionHashPayload {
+            domain: CONSTITUTION_HASH_DOMAIN,
+            documents: &self.documents,
+        })
+        .map_err(|e| {
+            GovernanceError::Serialization(format!("constitution canonical CBOR hash failed: {e}"))
+        })
     }
 
     /// Evaluate all constraints against a proposed action (TNC-04: synchronous).
@@ -655,6 +668,12 @@ mod tests {
         }
     }
 
+    #[derive(serde::Serialize)]
+    struct ExpectedConstitutionHashPayload<'a> {
+        domain: &'static str,
+        documents: &'a [ConstitutionalDocument],
+    }
+
     // compute_hash success path: deterministic digest of documents
     #[test]
     fn test_compute_hash_is_deterministic_and_content_addressed() {
@@ -665,8 +684,33 @@ mod tests {
         let c2 = constitution_with(vec![]);
         let h3 = c2.compute_hash().expect("hash ok");
         assert_ne!(h1, h3, "different documents must hash differently");
-        let expected = Hash256::digest(&serde_json::to_vec(&c.documents).unwrap());
+        let expected = exo_core::hash::hash_structured(&ExpectedConstitutionHashPayload {
+            domain: CONSTITUTION_HASH_DOMAIN,
+            documents: &c.documents,
+        })
+        .expect("canonical constitution hash payload");
         assert_eq!(h1, expected);
+    }
+
+    #[test]
+    fn compute_hash_uses_canonical_cbor_not_json() {
+        let source = include_str!("constitution.rs");
+        let body = source
+            .split("pub fn compute_hash")
+            .nth(1)
+            .expect("compute_hash exists")
+            .split("pub fn evaluate_constraints")
+            .next()
+            .expect("compute_hash body exists");
+
+        assert!(
+            !body.contains("serde_json::to_vec"),
+            "Constitution::compute_hash must not hash JSON bytes"
+        );
+        assert!(
+            body.contains("hash_structured") || body.contains("ciborium::"),
+            "Constitution::compute_hash must use canonical CBOR"
+        );
     }
 
     // RequireHumanGate satisfied branch: message "Human gate satisfied"

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 119392 lines of Rust under `crates/`, 2,892 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 119436 lines of Rust under `crates/`, 2,893 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,892 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,893 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,892 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,893 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-119392 lines of Rust under `crates/` · 20 workspace packages · 2,892 listed tests · 40 MCP tools · 8 constitutional invariants
+119436 lines of Rust under `crates/` · 20 workspace packages · 2,893 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 119392 lines of Rust under `crates/` | 266 Rust source files | 2,892 listed tests
+> **Codebase:** 20 workspace packages | 119436 lines of Rust under `crates/` | 266 Rust source files | 2,893 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,892 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,893 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 119392 lines of Rust under `crates/` · 2,892 listed tests
+20 workspace packages · 119436 lines of Rust under `crates/` · 2,893 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- replace Constitution::compute_hash JSON-byte hashing with domain-tagged canonical CBOR via exo_core::hash::hash_structured
- add regression coverage proving compute_hash does not use serde_json::to_vec
- refresh repo-truth documentation to 119436 Rust LOC / 2,893 listed tests

## Verification
- cargo test -p exo-governance
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps
- cargo build --workspace --release
- cargo test --workspace --release
- cargo audit --deny unsound --deny unmaintained
- cargo deny check
- cargo machete --with-metadata
- cargo +nightly fmt --all -- --check
- git diff --check
- bash tools/test_cr001_status.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_no_orphan_rust_modules.sh
- bash tools/test_repo_truth.sh
- bash tools/test_railway_entrypoint_args.sh