### PR TITLE
fix(exo-dag): canonicalize node hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 119436 | `wc -l` |
-| Workspace tests | 2,893 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 119502 | `wc -l` |
+| Workspace tests | 2,894 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,893 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,894 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 119436 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 119502 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,893 listed workspace tests
+         cryptographic proofs, 2,894 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-dag/src/append.rs
+++ b/crates/exo-dag/src/append.rs
@@ -93,7 +93,7 @@ pub async fn verify_stored_integrity(store: &impl DagStore, hash: &Hash256) -> R
         &node.payload_hash,
         &node.creator_did,
         &node.timestamp,
-    );
+    )?;
 
     Ok(recomputed == node.hash)
 }
@@ -152,7 +152,7 @@ mod tests {
             parent.timestamp.physical_ms + 1,
             parent.timestamp.logical + 1,
         );
-        let hash = compute_node_hash(&[parent.hash], &payload_hash, &creator, &timestamp);
+        let hash = compute_node_hash(&[parent.hash], &payload_hash, &creator, &timestamp).unwrap();
         let signature = (*sign_fn)(hash.as_bytes());
 
         DagNode {
@@ -168,7 +168,7 @@ mod tests {
     fn make_node_at(timestamp: Timestamp) -> DagNode {
         let creator = test_did();
         let payload_hash = Hash256::digest(b"timestamped-node");
-        let hash = compute_node_hash(&[], &payload_hash, &creator, &timestamp);
+        let hash = compute_node_hash(&[], &payload_hash, &creator, &timestamp).unwrap();
         let sign_fn = make_sign_fn();
         let signature = (*sign_fn)(hash.as_bytes());
 
@@ -242,7 +242,7 @@ mod tests {
         let creator = test_did();
         let payload_hash = Hash256::digest(b"bad-child");
         let timestamp = Timestamp::new(0, 0); // Before genesis
-        let hash = compute_node_hash(&[genesis.hash], &payload_hash, &creator, &timestamp);
+        let hash = compute_node_hash(&[genesis.hash], &payload_hash, &creator, &timestamp).unwrap();
         let sign_fn = make_sign_fn();
         let signature = (*sign_fn)(hash.as_bytes());
 

--- a/crates/exo-dag/src/dag.rs
+++ b/crates/exo-dag/src/dag.rs
@@ -4,7 +4,10 @@
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
-use exo_core::types::{Did, Hash256, Signature, Timestamp};
+use exo_core::{
+    hash::hash_structured,
+    types::{Did, Hash256, Signature, Timestamp},
+};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{DagError, Result};
@@ -64,7 +67,7 @@ impl Default for HybridClock {
 /// A node in the append-only DAG.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DagNode {
-    /// Blake3 hash of (sorted parents || payload_hash || creator_did || timestamp).
+    /// Domain-tagged canonical CBOR hash of the node's identity fields.
     pub hash: Hash256,
     /// Parent node hashes, sorted for determinism.
     pub parents: Vec<Hash256>,
@@ -78,23 +81,36 @@ pub struct DagNode {
     pub signature: Signature,
 }
 
+const DAG_NODE_HASH_DOMAIN: &str = "exo.dag.node.v1";
+
+#[derive(Serialize)]
+struct DagNodeHashPayload<'a> {
+    domain: &'static str,
+    parents: &'a [Hash256],
+    payload_hash: &'a Hash256,
+    creator_did: &'a Did,
+    timestamp: &'a Timestamp,
+}
+
 /// Compute the canonical hash of a DAG node from its fields.
-#[must_use]
+///
+/// # Errors
+///
+/// Returns [`DagError::Serialization`] if canonical CBOR encoding fails.
 pub fn compute_node_hash(
     parents: &[Hash256],
     payload_hash: &Hash256,
     creator_did: &Did,
     timestamp: &Timestamp,
-) -> Hash256 {
-    let mut hasher = blake3::Hasher::new();
-    for p in parents {
-        hasher.update(p.as_bytes());
-    }
-    hasher.update(payload_hash.as_bytes());
-    hasher.update(creator_did.as_str().as_bytes());
-    hasher.update(&timestamp.physical_ms.to_le_bytes());
-    hasher.update(&timestamp.logical.to_le_bytes());
-    Hash256::from_bytes(*hasher.finalize().as_bytes())
+) -> Result<Hash256> {
+    hash_structured(&DagNodeHashPayload {
+        domain: DAG_NODE_HASH_DOMAIN,
+        parents,
+        payload_hash,
+        creator_did,
+        timestamp,
+    })
+    .map_err(|e| DagError::Serialization(format!("dag node canonical CBOR hash failed: {e}")))
 }
 
 // ---------------------------------------------------------------------------
@@ -160,7 +176,7 @@ pub fn append(
 
     let payload_hash = Hash256::digest(payload);
     let timestamp = clock.tick();
-    let hash = compute_node_hash(&sorted_parents, &payload_hash, creator, &timestamp);
+    let hash = compute_node_hash(&sorted_parents, &payload_hash, creator, &timestamp)?;
 
     // Check for duplicate
     if dag.nodes.contains_key(&hash) {
@@ -309,7 +325,7 @@ pub fn verify_node(
         &node.payload_hash,
         &node.creator_did,
         &node.timestamp,
-    );
+    )?;
     if expected_hash != node.hash {
         return Err(DagError::InvalidSignature(node.hash));
     }
@@ -368,6 +384,15 @@ mod tests {
             let h = blake3::hash(data);
             sig.as_bytes()[..32] == *h.as_bytes()
         })
+    }
+
+    #[derive(Serialize)]
+    struct ExpectedNodeHashPayload<'a> {
+        domain: &'static str,
+        parents: &'a [Hash256],
+        payload_hash: &'a Hash256,
+        creator_did: &'a Did,
+        timestamp: &'a Timestamp,
     }
 
     #[test]
@@ -661,9 +686,47 @@ mod tests {
         let creator = test_did("did:exo:test");
         let ts = Timestamp::new(1000, 1);
 
-        let h1 = compute_node_hash(&parents, &payload, &creator, &ts);
-        let h2 = compute_node_hash(&parents, &payload, &creator, &ts);
+        let h1 = compute_node_hash(&parents, &payload, &creator, &ts).expect("hash ok");
+        let h2 = compute_node_hash(&parents, &payload, &creator, &ts).expect("hash ok");
         assert_eq!(h1, h2);
+        let expected = exo_core::hash::hash_structured(&ExpectedNodeHashPayload {
+            domain: DAG_NODE_HASH_DOMAIN,
+            parents: &parents,
+            payload_hash: &payload,
+            creator_did: &creator,
+            timestamp: &ts,
+        })
+        .expect("canonical node hash payload");
+        assert_eq!(h1, expected);
+    }
+
+    #[test]
+    fn compute_node_hash_uses_canonical_cbor_not_byte_concat() {
+        let source = include_str!("dag.rs");
+        let body = source
+            .split("pub fn compute_node_hash")
+            .nth(1)
+            .expect("compute_node_hash exists")
+            .split("// ---------------------------------------------------------------------------\n// Dag")
+            .next()
+            .expect("compute_node_hash body exists");
+
+        assert!(
+            !body.contains("blake3::Hasher::new"),
+            "compute_node_hash must not hash byte-concat fields directly"
+        );
+        assert!(
+            !body.contains("hasher.update"),
+            "compute_node_hash must not hash byte-concat fields directly"
+        );
+        assert!(
+            !body.contains("to_le_bytes"),
+            "compute_node_hash must not hash platform byte-order encodings directly"
+        );
+        assert!(
+            body.contains("hash_structured") || body.contains("ciborium::"),
+            "compute_node_hash must use canonical CBOR"
+        );
     }
 
     #[test]

--- a/crates/exo-dag/src/error.rs
+++ b/crates/exo-dag/src/error.rs
@@ -41,6 +41,9 @@ pub enum DagError {
     #[error("mmr error: {0}")]
     MmrError(String),
 
+    #[error("serialization error: {0}")]
+    Serialization(String),
+
     #[error("store error: {0}")]
     StoreError(String),
 }

--- a/crates/exo-dag/src/pg_store.rs
+++ b/crates/exo-dag/src/pg_store.rs
@@ -534,7 +534,7 @@ mod tests {
         // All-0xFF payload hash
         let payload_hash = Hash256::from_bytes([0xFF; 32]);
         let timestamp = Timestamp::new(1000, 1);
-        let hash = crate::dag::compute_node_hash(&[], &payload_hash, &creator, &timestamp);
+        let hash = crate::dag::compute_node_hash(&[], &payload_hash, &creator, &timestamp).unwrap();
         let signature = (*sign_fn)(hash.as_bytes());
 
         let node = DagNode {

--- a/crates/exo-node/src/zerodentity/store.rs
+++ b/crates/exo-node/src/zerodentity/store.rs
@@ -235,7 +235,7 @@ impl ZerodentityStore {
             &payload_hash,
             &context.actor_did,
             &timestamp,
-        ))
+        )?)
     }
 
     fn signed_dag_node(
@@ -247,7 +247,7 @@ impl ZerodentityStore {
             anyhow::bail!("0dentity DAG node signer is not configured");
         };
         let parents = self.next_dag_parents();
-        let hash = compute_node_hash(&parents, &payload_hash, &context.actor_did, &timestamp);
+        let hash = compute_node_hash(&parents, &payload_hash, &context.actor_did, &timestamp)?;
         let signature = (context.signer)(hash.as_bytes());
         if signature.is_empty() {
             anyhow::bail!("0dentity DAG node signer produced an empty signature");

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 119436 lines of Rust under `crates/`, 2,893 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 119502 lines of Rust under `crates/`, 2,894 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,893 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,894 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,893 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,894 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-119436 lines of Rust under `crates/` · 20 workspace packages · 2,893 listed tests · 40 MCP tools · 8 constitutional invariants
+119502 lines of Rust under `crates/` · 20 workspace packages · 2,894 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 119436 lines of Rust under `crates/` | 266 Rust source files | 2,893 listed tests
+> **Codebase:** 20 workspace packages | 119502 lines of Rust under `crates/` | 266 Rust source files | 2,894 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,893 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,894 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 119436 lines of Rust under `crates/` · 2,893 listed tests
+20 workspace packages · 119502 lines of Rust under `crates/` · 2,894 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- Replace exo-dag node byte-concat hashing with domain-tagged canonical CBOR via exo_core::hash::hash_structured.
- Make compute_node_hash fallible with DagError::Serialization and propagate errors through append, verify_node, stored-integrity verification, and 0dentity DAG node construction.
- Add regression coverage proving compute_node_hash does not return to direct BLAKE3 byte concatenation, hasher.update, or to_le_bytes timestamp encodings.
- Refresh repo-truth docs to 119502 Rust LOC and 2,894 listed workspace tests.

## TDD red check
- cargo test -p exo-dag compute_node_hash_uses_canonical_cbor_not_byte_concat --lib initially failed because DAG_NODE_HASH_DOMAIN did not exist and compute_node_hash still returned infallible Hash256.

## Verification
- cargo test -p exo-dag compute_node_hash_uses_canonical_cbor_not_byte_concat --lib
- cargo test -p exo-dag deterministic_hash --lib
- cargo test -p exo-dag
- cargo build -p exo-dag
- cargo clippy -p exo-dag --lib -- -D warnings
- cargo clippy -p exo-dag --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo test -p exo-node zerodentity::store --bin exochain
- cargo test --workspace -- --list
- bash tools/repo_truth.sh --json
- cargo +nightly fmt --all -- --check
- git diff --check
- bash tools/test_repo_truth.sh
- bash tools/test_cr001_status.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_no_orphan_rust_modules.sh
- bash tools/test_railway_entrypoint_args.sh
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps
- cargo build --workspace --release
- cargo test --workspace --release
- cargo audit --deny unsound --deny unmaintained (passes with existing allowed yanked core2 warning)
- cargo deny check (passes with existing duplicate/yanked/unused-allowance warnings)
- cargo machete --with-metadata