### PR TITLE
fix(exo-proofs): canonicalize verifier bundles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,6 +1609,7 @@ name = "exo-proofs"
 version = "0.1.0-beta"
 dependencies = [
  "blake3",
+ "ciborium",
  "exo-core",
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 119502 | `wc -l` |
-| Workspace tests | 2,894 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 119592 | `wc -l` |
+| Workspace tests | 2,895 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,894 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,895 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 119502 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 119592 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,894 listed workspace tests
+         cryptographic proofs, 2,895 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-proofs/Cargo.toml
+++ b/crates/exo-proofs/Cargo.toml
@@ -27,6 +27,9 @@ serde = { workspace = true }
 blake3 = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
+ciborium = { workspace = true }
+
+[dev-dependencies]
 serde_json = { workspace = true }
 
 [package.metadata.cargo-machete]

--- a/crates/exo-proofs/src/verifier.rs
+++ b/crates/exo-proofs/src/verifier.rs
@@ -1,6 +1,6 @@
 //! Unified proof verifier -- dispatches to the appropriate proof system.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use crate::{
     error::{ProofError, Result},
@@ -51,8 +51,8 @@ pub struct ZkmlBundle {
 
 /// Verify any proof type given its serialized form and public inputs.
 ///
-/// The `proof_bytes` should be a JSON-encoded bundle appropriate for the
-/// proof type. The `public_inputs_bytes` contains the JSON-encoded public inputs.
+/// The `proof_bytes` must be a canonical CBOR bundle appropriate for the proof
+/// type. The `public_inputs_bytes` contains canonical CBOR public inputs.
 pub fn verify_any(
     proof_type: ProofType,
     proof_bytes: &[u8],
@@ -65,29 +65,28 @@ pub fn verify_any(
     }
 }
 
-fn verify_snark(proof_bytes: &[u8], public_inputs_bytes: &[u8]) -> Result<bool> {
-    let bundle: SnarkBundle = serde_json::from_slice(proof_bytes)
-        .map_err(|e| ProofError::DeserializationError(e.to_string()))?;
+fn decode_cbor<T: DeserializeOwned>(bytes: &[u8], label: &'static str) -> Result<T> {
+    ciborium::from_reader(bytes).map_err(|e| {
+        ProofError::DeserializationError(format!("{label}: canonical CBOR decode failed: {e}"))
+    })
+}
 
-    let public_inputs: Vec<u64> = serde_json::from_slice(public_inputs_bytes)
-        .map_err(|e| ProofError::DeserializationError(e.to_string()))?;
+fn verify_snark(proof_bytes: &[u8], public_inputs_bytes: &[u8]) -> Result<bool> {
+    let bundle: SnarkBundle = decode_cbor(proof_bytes, "snark proof bundle")?;
+    let public_inputs: Vec<u64> = decode_cbor(public_inputs_bytes, "snark public inputs")?;
 
     snark::verify(&bundle.vk, &bundle.proof, &public_inputs)
 }
 
 fn verify_stark(proof_bytes: &[u8], public_inputs_bytes: &[u8]) -> Result<bool> {
-    let bundle: StarkBundle = serde_json::from_slice(proof_bytes)
-        .map_err(|e| ProofError::DeserializationError(e.to_string()))?;
-
-    let public_inputs: Vec<u64> = serde_json::from_slice(public_inputs_bytes)
-        .map_err(|e| ProofError::DeserializationError(e.to_string()))?;
+    let bundle: StarkBundle = decode_cbor(proof_bytes, "stark proof bundle")?;
+    let public_inputs: Vec<u64> = decode_cbor(public_inputs_bytes, "stark public inputs")?;
 
     stark::verify_stark(&bundle.proof, &public_inputs)
 }
 
 fn verify_zkml(proof_bytes: &[u8]) -> Result<bool> {
-    let bundle: ZkmlBundle = serde_json::from_slice(proof_bytes)
-        .map_err(|e| ProofError::DeserializationError(e.to_string()))?;
+    let bundle: ZkmlBundle = decode_cbor(proof_bytes, "zkml proof bundle")?;
 
     zkml::verify_inference(&bundle.proof)
 }
@@ -95,6 +94,27 @@ fn verify_zkml(proof_bytes: &[u8]) -> Result<bool> {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod canonical_encoding_contract_tests {
+    #[test]
+    fn verify_any_uses_canonical_cbor_not_json() {
+        let source = include_str!("verifier.rs");
+        let production = source
+            .split("// ---------------------------------------------------------------------------\n// Tests")
+            .next()
+            .expect("production section exists");
+
+        assert!(
+            !production.contains("serde_json::from_slice"),
+            "proof verifier must not decode proof bundles or public inputs as JSON"
+        );
+        assert!(
+            production.contains("ciborium::from_reader"),
+            "proof verifier must decode proof bundles and public inputs as canonical CBOR"
+        );
+    }
+}
 
 #[cfg(all(test, feature = "unaudited-pedagogical-proofs"))]
 mod tests {
@@ -107,6 +127,12 @@ mod tests {
         stark::StarkConfig,
         zkml::{self, ModelCommitment},
     };
+
+    fn cbor_bytes<T: Serialize>(value: &T) -> Vec<u8> {
+        let mut encoded = Vec::new();
+        ciborium::into_writer(value, &mut encoded).expect("canonical CBOR encode");
+        encoded
+    }
 
     /// x * y = z
     #[derive(Debug)]
@@ -142,11 +168,73 @@ mod tests {
         let proof = snark::prove(&pk, &circuit, &[3, 4, 12]).unwrap();
 
         let bundle = SnarkBundle { vk, proof };
-        let proof_bytes = serde_json::to_vec(&bundle).unwrap();
-        let public_inputs_bytes = serde_json::to_vec(&vec![3u64, 12u64]).unwrap();
+        let proof_bytes = cbor_bytes(&bundle);
+        let public_inputs_bytes = cbor_bytes(&vec![3u64, 12u64]);
 
         let result = verify_any(ProofType::Snark, &proof_bytes, &public_inputs_bytes).unwrap();
         assert!(result);
+    }
+
+    #[test]
+    fn verify_any_snark_accepts_canonical_cbor() {
+        let circuit = MulCircuit {
+            x: Some(3),
+            y: Some(4),
+            z: Some(12),
+        };
+        let (pk, vk) = snark::setup(&circuit).unwrap();
+        let proof = snark::prove(&pk, &circuit, &[3, 4, 12]).unwrap();
+
+        let bundle = SnarkBundle { vk, proof };
+        let proof_bytes = cbor_bytes(&bundle);
+        let public_inputs_bytes = cbor_bytes(&vec![3u64, 12u64]);
+
+        let result = verify_any(ProofType::Snark, &proof_bytes, &public_inputs_bytes).unwrap();
+        assert!(result);
+    }
+
+    #[test]
+    fn verify_any_rejects_json_snark_bundle() {
+        let circuit = MulCircuit {
+            x: Some(3),
+            y: Some(4),
+            z: Some(12),
+        };
+        let (pk, vk) = snark::setup(&circuit).unwrap();
+        let proof = snark::prove(&pk, &circuit, &[3, 4, 12]).unwrap();
+
+        let bundle = SnarkBundle { vk, proof };
+        let proof_bytes = serde_json::to_vec(&bundle).unwrap();
+        let public_inputs_bytes = serde_json::to_vec(&vec![3u64, 12u64]).unwrap();
+
+        let err = verify_any(ProofType::Snark, &proof_bytes, &public_inputs_bytes).unwrap_err();
+        assert!(matches!(err, ProofError::DeserializationError(_)));
+    }
+
+    #[test]
+    fn verify_any_rejects_json_stark_bundle() {
+        let config = StarkConfig::default_config();
+        let trace: Vec<Vec<u64>> = vec![vec![1, 2], vec![3, 4], vec![5, 6]];
+        let proof = crate::stark::prove_stark(&trace, &[], &config).unwrap();
+
+        let bundle = StarkBundle { proof };
+        let proof_bytes = serde_json::to_vec(&bundle).unwrap();
+        let public_inputs_bytes = cbor_bytes(&vec![1u64, 2u64]);
+
+        let err = verify_any(ProofType::Stark, &proof_bytes, &public_inputs_bytes).unwrap_err();
+        assert!(matches!(err, ProofError::DeserializationError(_)));
+    }
+
+    #[test]
+    fn verify_any_rejects_json_zkml_bundle() {
+        let model = ModelCommitment::new(b"arch", b"weights", 1);
+        let proof = zkml::prove_inference(&model, b"input", b"output").unwrap();
+
+        let bundle = ZkmlBundle { proof };
+        let proof_bytes = serde_json::to_vec(&bundle).unwrap();
+
+        let err = verify_any(ProofType::Zkml, &proof_bytes, b"[]").unwrap_err();
+        assert!(matches!(err, ProofError::DeserializationError(_)));
     }
 
     #[test]
@@ -160,8 +248,8 @@ mod tests {
         let proof = snark::prove(&pk, &circuit, &[3, 4, 12]).unwrap();
 
         let bundle = SnarkBundle { vk, proof };
-        let proof_bytes = serde_json::to_vec(&bundle).unwrap();
-        let wrong_inputs = serde_json::to_vec(&vec![3u64, 13u64]).unwrap();
+        let proof_bytes = cbor_bytes(&bundle);
+        let wrong_inputs = cbor_bytes(&vec![3u64, 13u64]);
 
         let result = verify_any(ProofType::Snark, &proof_bytes, &wrong_inputs).unwrap();
         assert!(!result);
@@ -174,8 +262,8 @@ mod tests {
         let proof = crate::stark::prove_stark(&trace, &[], &config).unwrap();
 
         let bundle = StarkBundle { proof };
-        let proof_bytes = serde_json::to_vec(&bundle).unwrap();
-        let public_inputs_bytes = serde_json::to_vec(&vec![1u64, 2u64]).unwrap();
+        let proof_bytes = cbor_bytes(&bundle);
+        let public_inputs_bytes = cbor_bytes(&vec![1u64, 2u64]);
 
         let result = verify_any(ProofType::Stark, &proof_bytes, &public_inputs_bytes).unwrap();
         assert!(result);
@@ -187,7 +275,7 @@ mod tests {
         let proof = zkml::prove_inference(&model, b"input", b"output").unwrap();
 
         let bundle = ZkmlBundle { proof };
-        let proof_bytes = serde_json::to_vec(&bundle).unwrap();
+        let proof_bytes = cbor_bytes(&bundle);
 
         let result = verify_any(ProofType::Zkml, &proof_bytes, b"[]").unwrap();
         assert!(result);
@@ -200,7 +288,7 @@ mod tests {
         proof.output_hash = exo_core::types::Hash256::ZERO;
 
         let bundle = ZkmlBundle { proof };
-        let proof_bytes = serde_json::to_vec(&bundle).unwrap();
+        let proof_bytes = cbor_bytes(&bundle);
 
         let result = verify_any(ProofType::Zkml, &proof_bytes, b"[]").unwrap();
         assert!(!result);
@@ -208,7 +296,7 @@ mod tests {
 
     #[test]
     fn verify_any_bad_proof_bytes() {
-        let err = verify_any(ProofType::Snark, b"not json", b"[]").unwrap_err();
+        let err = verify_any(ProofType::Snark, b"not cbor", b"[]").unwrap_err();
         assert!(matches!(err, ProofError::DeserializationError(_)));
     }
 
@@ -223,9 +311,10 @@ mod tests {
         let proof = snark::prove(&pk, &circuit, &[3, 4, 12]).unwrap();
 
         let bundle = SnarkBundle { vk, proof };
-        let proof_bytes = serde_json::to_vec(&bundle).unwrap();
+        let proof_bytes = cbor_bytes(&bundle);
+        let legacy_json_inputs = serde_json::to_vec(&vec![3u64, 12u64]).unwrap();
 
-        let err = verify_any(ProofType::Snark, &proof_bytes, b"not json").unwrap_err();
+        let err = verify_any(ProofType::Snark, &proof_bytes, &legacy_json_inputs).unwrap_err();
         assert!(matches!(err, ProofError::DeserializationError(_)));
     }
 
@@ -248,7 +337,7 @@ mod tests {
 
     #[test]
     fn verify_any_stark_bad_proof_bytes() {
-        let err = verify_any(ProofType::Stark, b"not json", b"[]").unwrap_err();
+        let err = verify_any(ProofType::Stark, b"not cbor", b"[]").unwrap_err();
         assert!(matches!(err, ProofError::DeserializationError(_)));
     }
 
@@ -258,14 +347,15 @@ mod tests {
         let trace: Vec<Vec<u64>> = vec![vec![1, 2], vec![3, 4]];
         let proof = crate::stark::prove_stark(&trace, &[], &config).unwrap();
         let bundle = StarkBundle { proof };
-        let proof_bytes = serde_json::to_vec(&bundle).unwrap();
-        let err = verify_any(ProofType::Stark, &proof_bytes, b"not json").unwrap_err();
+        let proof_bytes = cbor_bytes(&bundle);
+        let legacy_json_inputs = serde_json::to_vec(&vec![1u64, 2u64]).unwrap();
+        let err = verify_any(ProofType::Stark, &proof_bytes, &legacy_json_inputs).unwrap_err();
         assert!(matches!(err, ProofError::DeserializationError(_)));
     }
 
     #[test]
     fn verify_any_zkml_bad_proof_bytes() {
-        let err = verify_any(ProofType::Zkml, b"not json", b"[]").unwrap_err();
+        let err = verify_any(ProofType::Zkml, b"not cbor", b"[]").unwrap_err();
         assert!(matches!(err, ProofError::DeserializationError(_)));
     }
 }

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 119502 lines of Rust under `crates/`, 2,894 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 119592 lines of Rust under `crates/`, 2,895 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,894 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,895 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,894 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,895 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-119502 lines of Rust under `crates/` · 20 workspace packages · 2,894 listed tests · 40 MCP tools · 8 constitutional invariants
+119592 lines of Rust under `crates/` · 20 workspace packages · 2,895 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 119502 lines of Rust under `crates/` | 266 Rust source files | 2,894 listed tests
+> **Codebase:** 20 workspace packages | 119592 lines of Rust under `crates/` | 266 Rust source files | 2,895 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,894 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,895 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 119502 lines of Rust under `crates/` · 2,894 listed tests
+20 workspace packages · 119592 lines of Rust under `crates/` · 2,895 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- replace JSON decoding in `exo-proofs::verifier::verify_any()` with canonical CBOR decoding for SNARK/STARK/ZKML bundles
- decode SNARK/STARK public inputs as canonical CBOR
- add source and regression tests rejecting legacy JSON proof bundles
- move `serde_json` to dev-dependencies and add `ciborium` as the production verifier dependency
- refresh repo-truth public counts to 119592 Rust LOC and 2,895 listed tests

## TDD red checks
- `cargo test -p exo-proofs verify_any_uses_canonical_cbor_not_json --lib` initially failed while production code still used `serde_json::from_slice`
- `cargo test -p exo-proofs --features unaudited-pedagogical-proofs verify_any_snark_accepts_canonical_cbor --lib` initially failed because CBOR bytes were decoded as JSON
- `cargo test -p exo-proofs --features unaudited-pedagogical-proofs verify_any_rejects_json_snark_bundle --lib` initially failed because the legacy all-JSON SNARK path returned `Ok(true)`

## Verification
- `cargo test -p exo-proofs`
- `cargo test -p exo-proofs --features unaudited-pedagogical-proofs`
- `cargo build -p exo-proofs`
- `cargo build -p exo-proofs --features unaudited-pedagogical-proofs`
- `cargo clippy -p exo-proofs --lib -- -D warnings`
- `cargo clippy -p exo-proofs --features unaudited-pedagogical-proofs --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `bash tools/repo_truth.sh --json`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `cargo machete --with-metadata`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `cargo audit --deny unsound --deny unmaintained` (existing allowed yanked `core2` warning only)
- `cargo deny check` (existing duplicate/yanked/unused-allowance warnings only)