### PR TITLE
fix(exo-dag): clarify deterministic DAG clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 119592 | `wc -l` |
-| Workspace tests | 2,895 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 119616 | `wc -l` |
+| Workspace tests | 2,896 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,895 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,896 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 119592 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 119616 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,895 listed workspace tests
+         cryptographic proofs, 2,896 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-dag/benches/append_normative.rs
+++ b/crates/exo-dag/benches/append_normative.rs
@@ -19,7 +19,7 @@ use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_ma
 use exo_core::types::{Did, Hash256, Signature};
 use exo_dag::{
     consensus::{ConsensusConfig, ConsensusState, Vote, check_commit, commit, propose, vote},
-    dag::{Dag, HybridClock, ancestors, append, tips},
+    dag::{Dag, DeterministicDagClock, ancestors, append, tips},
     store::MemoryStore,
 };
 
@@ -43,7 +43,7 @@ fn creator() -> Did {
 fn linear_dag(depth: usize) -> (Dag, Hash256) {
     let c = creator();
     let mut dag = Dag::new();
-    let mut clock = HybridClock::new();
+    let mut clock = DeterministicDagClock::new();
     let genesis = append(&mut dag, &[], b"genesis", &c, &sign_fn, &mut clock).expect("genesis");
     let mut tip = genesis.hash;
     for i in 0..depth {
@@ -76,7 +76,7 @@ fn bench_dag_append(c: &mut Criterion) {
             |b, &n| {
                 b.iter(|| {
                     let mut dag = Dag::new();
-                    let mut clock = HybridClock::new();
+                    let mut clock = DeterministicDagClock::new();
                     let genesis = append(&mut dag, &[], b"genesis", &cr, &sign_fn, &mut clock)
                         .expect("genesis");
                     let mut tip = genesis.hash;
@@ -96,7 +96,7 @@ fn bench_dag_append(c: &mut Criterion) {
     group.bench_function("diamond_merge", |b| {
         b.iter(|| {
             let mut dag = Dag::new();
-            let mut clock = HybridClock::new();
+            let mut clock = DeterministicDagClock::new();
             let g = append(&mut dag, &[], b"g", &cr, &sign_fn, &mut clock).expect("g");
             let left =
                 append(&mut dag, &[g.hash], b"left", &cr, &sign_fn, &mut clock).expect("left");
@@ -162,7 +162,7 @@ fn bench_store_checkpoint(c: &mut Criterion) {
         // Pre-build nodes outside the timed section.
         let nodes: Vec<_> = {
             let mut dag = Dag::new();
-            let mut clock = HybridClock::new();
+            let mut clock = DeterministicDagClock::new();
             let genesis =
                 append(&mut dag, &[], b"genesis", &cr, &sign_fn, &mut clock).expect("genesis");
             let mut tip = genesis.hash;
@@ -230,7 +230,7 @@ fn bench_consensus_rounds(c: &mut Criterion) {
         // Build a genesis DAG node to propose.
         let cr = creator();
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let node = append(&mut dag, &[], b"genesis", &cr, &sign_fn, &mut clock).expect("genesis");
 
         group.bench_with_input(
@@ -260,7 +260,7 @@ fn bench_consensus_rounds(c: &mut Criterion) {
         // Multi-round: advance through 10 rounds, each with a fresh proposal.
         let nodes: Vec<_> = {
             let mut d = Dag::new();
-            let mut clk = HybridClock::new();
+            let mut clk = DeterministicDagClock::new();
             let g = append(&mut d, &[], b"r0", &cr, &sign_fn, &mut clk).expect("g");
             let mut tip = g.hash;
             let mut out = vec![g];

--- a/crates/exo-dag/src/append.rs
+++ b/crates/exo-dag/src/append.rs
@@ -109,7 +109,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        dag::{Dag, DagNode, HybridClock, append},
+        dag::{Dag, DagNode, DeterministicDagClock, append},
         store::MemoryStore,
     };
 
@@ -130,7 +130,7 @@ mod tests {
 
     fn make_test_node() -> DagNode {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = test_did();
         let sign_fn = make_sign_fn();
         append(&mut dag, &[], b"genesis", &creator, &*sign_fn, &mut clock).expect("genesis")
@@ -138,7 +138,7 @@ mod tests {
 
     fn make_child_node(parent: &DagNode) -> DagNode {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = test_did();
         let sign_fn = make_sign_fn();
 

--- a/crates/exo-dag/src/consensus.rs
+++ b/crates/exo-dag/src/consensus.rs
@@ -511,7 +511,7 @@ pub fn is_finalized(state: &ConsensusState, hash: &Hash256) -> bool {
 #[allow(deprecated)]
 mod tests {
     use super::*;
-    use crate::dag::{Dag, HybridClock, append};
+    use crate::dag::{Dag, DeterministicDagClock, append};
 
     type SignFn = Box<dyn Fn(&[u8]) -> Signature>;
 
@@ -541,7 +541,7 @@ mod tests {
 
     fn setup_dag_with_node() -> (Dag, DagNode) {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = Did::new("did:exo:proposer").expect("valid");
         let sign_fn = make_sign_fn();
         let node = append(&mut dag, &[], b"genesis", &creator, &*sign_fn, &mut clock).unwrap();
@@ -764,7 +764,7 @@ mod tests {
         let mut state = ConsensusState::new(config);
 
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = Did::new("did:exo:proposer").expect("valid");
         let sign_fn = make_sign_fn();
 
@@ -819,7 +819,7 @@ mod tests {
         let mut state = ConsensusState::new(config);
 
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = Did::new("did:exo:proposer").expect("valid");
         let sign_fn = make_sign_fn();
 
@@ -869,7 +869,7 @@ mod tests {
         let mut state = ConsensusState::new(config);
 
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = Did::new("did:exo:proposer").expect("valid");
         let sign_fn = make_sign_fn();
 
@@ -918,7 +918,7 @@ mod tests {
         let mut state = ConsensusState::new(config);
 
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = Did::new("did:exo:proposer").expect("valid");
         let sign_fn = make_sign_fn();
 
@@ -950,7 +950,7 @@ mod tests {
     /// not depend on signing details.
     fn make_node(seed: &str) -> (DagNode, (), ()) {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let did = Did::new("did:exo:proposer").unwrap();
         let sf = make_sign_fn();
         let node = append(&mut dag, &[], seed.as_bytes(), &did, &*sf, &mut clock)

--- a/crates/exo-dag/src/dag.rs
+++ b/crates/exo-dag/src/dag.rs
@@ -13,16 +13,21 @@ use serde::{Deserialize, Serialize};
 use crate::error::{DagError, Result};
 
 // ---------------------------------------------------------------------------
-// HybridClock — monotonic logical clock for deterministic timestamps
+// DeterministicDagClock — logical clock for deterministic DAG append tests
 // ---------------------------------------------------------------------------
 
-/// Hybrid Logical Clock for deterministic, monotonic timestamps.
+/// Deterministic logical clock for DAG append operations.
+///
+/// This is intentionally not `exo_core::hlc::HybridClock`: DAG append tests and
+/// deterministic constructors need caller-controlled timestamps without reading
+/// a wall clock. Runtime paths that need network HLC drift handling should use
+/// `exo_core::hlc::HybridClock` before calling into the DAG layer.
 #[derive(Debug, Clone)]
-pub struct HybridClock {
+pub struct DeterministicDagClock {
     latest: Timestamp,
 }
 
-impl HybridClock {
+impl DeterministicDagClock {
     /// Create a new clock starting at time zero.
     #[must_use]
     pub fn new() -> Self {
@@ -54,7 +59,7 @@ impl HybridClock {
     }
 }
 
-impl Default for HybridClock {
+impl Default for DeterministicDagClock {
     fn default() -> Self {
         Self::new()
     }
@@ -75,7 +80,7 @@ pub struct DagNode {
     pub payload_hash: Hash256,
     /// DID of the creator.
     pub creator_did: Did,
-    /// Deterministic timestamp from hybrid clock.
+    /// Deterministic timestamp supplied by the DAG append clock.
     pub timestamp: Timestamp,
     /// Signature over the node hash.
     pub signature: Signature,
@@ -155,7 +160,7 @@ pub fn append(
     payload: &[u8],
     creator: &Did,
     sign_fn: &dyn Fn(&[u8]) -> Signature,
-    clock: &mut HybridClock,
+    clock: &mut DeterministicDagClock,
 ) -> Result<DagNode> {
     // Genesis node can have empty parents only when DAG is empty
     if parents.is_empty() && !dag.is_empty() {
@@ -365,6 +370,25 @@ mod tests {
     type SignFn = Box<dyn Fn(&[u8]) -> Signature>;
     type VerifyFn = Box<dyn Fn(&[u8], &Signature) -> bool>;
 
+    #[test]
+    fn dag_module_does_not_define_local_hybrid_clock() {
+        let source = include_str!("dag.rs");
+        let production = source
+            .split("// ---------------------------------------------------------------------------\n// Tests")
+            .next()
+            .expect("production section exists");
+
+        assert!(
+            !production.contains("pub struct HybridClock")
+                && !production.contains("impl HybridClock"),
+            "exo-dag must not define a local HybridClock that name-collides with exo_core::hlc::HybridClock"
+        );
+        assert!(
+            production.contains("pub struct DeterministicDagClock"),
+            "exo-dag append tests/helpers should use an explicitly deterministic DAG clock type"
+        );
+    }
+
     fn test_did(name: &str) -> Did {
         Did::new(name).expect("valid DID")
     }
@@ -398,7 +422,7 @@ mod tests {
     #[test]
     fn genesis_node() {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = test_did("did:exo:alice");
         let sign_fn = make_sign_fn();
 
@@ -412,7 +436,7 @@ mod tests {
     #[test]
     fn append_with_parents() {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = test_did("did:exo:alice");
         let sign_fn = make_sign_fn();
 
@@ -434,7 +458,7 @@ mod tests {
     #[test]
     fn empty_parents_non_genesis_rejected() {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = test_did("did:exo:alice");
         let sign_fn = make_sign_fn();
 
@@ -446,7 +470,7 @@ mod tests {
     #[test]
     fn orphan_parent_rejected() {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = test_did("did:exo:alice");
         let sign_fn = make_sign_fn();
 
@@ -466,7 +490,7 @@ mod tests {
     #[test]
     fn parents_sorted_and_deduped() {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = test_did("did:exo:alice");
         let sign_fn = make_sign_fn();
 
@@ -486,7 +510,7 @@ mod tests {
     #[test]
     fn get_node() {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = test_did("did:exo:alice");
         let sign_fn = make_sign_fn();
 
@@ -498,7 +522,7 @@ mod tests {
     #[test]
     fn tips_computation() {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = test_did("did:exo:alice");
         let sign_fn = make_sign_fn();
 
@@ -529,7 +553,7 @@ mod tests {
     #[test]
     fn ancestors_topological() {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = test_did("did:exo:alice");
         let sign_fn = make_sign_fn();
 
@@ -547,7 +571,7 @@ mod tests {
     #[test]
     fn ancestors_empty_for_genesis() {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = test_did("did:exo:alice");
         let sign_fn = make_sign_fn();
 
@@ -564,7 +588,7 @@ mod tests {
     #[test]
     fn verify_node_valid() {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = test_did("did:exo:alice");
         let sign_fn = make_sign_fn();
         let verify_fn = make_verify_fn();
@@ -576,7 +600,7 @@ mod tests {
     #[test]
     fn verify_node_bad_signature() {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = test_did("did:exo:alice");
         let sign_fn = make_sign_fn();
 
@@ -593,7 +617,7 @@ mod tests {
     #[test]
     fn verify_node_bad_hash() {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = test_did("did:exo:alice");
         let sign_fn = make_sign_fn();
         let verify_fn = make_verify_fn();
@@ -609,7 +633,7 @@ mod tests {
     #[test]
     fn verify_node_unsorted_parents() {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = test_did("did:exo:alice");
         let sign_fn = make_sign_fn();
         let verify_fn = make_verify_fn();
@@ -627,7 +651,7 @@ mod tests {
     #[test]
     fn diamond_dag() {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = test_did("did:exo:alice");
         let sign_fn = make_sign_fn();
 
@@ -652,8 +676,8 @@ mod tests {
     }
 
     #[test]
-    fn hybrid_clock_monotonic() {
-        let mut clock = HybridClock::new();
+    fn deterministic_dag_clock_monotonic() {
+        let mut clock = DeterministicDagClock::new();
         let t1 = clock.tick();
         let t2 = clock.tick();
         let t3 = clock.tick();
@@ -662,8 +686,8 @@ mod tests {
     }
 
     #[test]
-    fn hybrid_clock_advance() {
-        let mut clock = HybridClock::with_time(100);
+    fn deterministic_dag_clock_advance() {
+        let mut clock = DeterministicDagClock::with_time(100);
         let t1 = clock.advance(200);
         assert_eq!(t1.physical_ms, 200);
         assert_eq!(t1.logical, 1);
@@ -674,8 +698,8 @@ mod tests {
     }
 
     #[test]
-    fn hybrid_clock_default() {
-        let clock = HybridClock::default();
+    fn deterministic_dag_clock_default() {
+        let clock = DeterministicDagClock::default();
         assert_eq!(clock.latest, Timestamp::ZERO);
     }
 
@@ -738,7 +762,7 @@ mod tests {
     #[test]
     fn multiple_creators() {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let alice = test_did("did:exo:alice");
         let bob = test_did("did:exo:bob");
         let sign_fn = make_sign_fn();

--- a/crates/exo-dag/src/pg_store.rs
+++ b/crates/exo-dag/src/pg_store.rs
@@ -249,7 +249,7 @@ impl DagStore for PostgresStore {
 mod tests {
     use super::*;
     use crate::{
-        dag::{Dag, HybridClock, append},
+        dag::{Dag, DeterministicDagClock, append},
         store::MemoryStore,
     };
 
@@ -266,7 +266,7 @@ mod tests {
 
     fn make_test_node() -> DagNode {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = Did::new("did:exo:test").expect("valid");
         let sign_fn = make_sign_fn();
         append(&mut dag, &[], b"genesis", &creator, &*sign_fn, &mut clock).unwrap()
@@ -382,7 +382,7 @@ mod tests {
         let mut store = PostgresStore::new(pool).await.unwrap();
 
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = Did::new("did:exo:test").expect("valid");
         let sign_fn = make_sign_fn();
 
@@ -410,7 +410,7 @@ mod tests {
         let mut store = PostgresStore::new(pool).await.unwrap();
 
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = Did::new("did:exo:test").expect("valid");
         let sign_fn = make_sign_fn();
 
@@ -492,7 +492,7 @@ mod tests {
         let mut store = PostgresStore::new(pool).await.unwrap();
 
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = Did::new("did:exo:test").expect("valid");
         let sign_fn = make_sign_fn();
 
@@ -561,7 +561,7 @@ mod tests {
         let mut mem_store = MemoryStore::new();
 
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = Did::new("did:exo:test").expect("valid");
         let sign_fn = make_sign_fn();
 

--- a/crates/exo-dag/src/store.rs
+++ b/crates/exo-dag/src/store.rs
@@ -154,7 +154,7 @@ mod tests {
     use exo_core::types::{Did, Signature};
 
     use super::*;
-    use crate::dag::{Dag, HybridClock, append};
+    use crate::dag::{Dag, DeterministicDagClock, append};
 
     type SignFn = Box<dyn Fn(&[u8]) -> Signature>;
 
@@ -169,7 +169,7 @@ mod tests {
 
     fn make_test_node() -> DagNode {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = Did::new("did:exo:test").expect("valid");
         let sign_fn = make_sign_fn();
         append(&mut dag, &[], b"genesis", &creator, &*sign_fn, &mut clock).unwrap()
@@ -234,7 +234,7 @@ mod tests {
     #[tokio::test]
     async fn tips_with_children() {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = Did::new("did:exo:test").expect("valid");
         let sign_fn = make_sign_fn();
 
@@ -269,7 +269,7 @@ mod tests {
         assert_eq!(store.committed_height().await.unwrap(), 1);
 
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = Did::new("did:exo:test2").expect("valid");
         let sign_fn = make_sign_fn();
         let node2 = append(&mut dag, &[], b"other", &creator, &*sign_fn, &mut clock).unwrap();
@@ -288,7 +288,7 @@ mod tests {
     #[tokio::test]
     async fn multiple_tips() {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = Did::new("did:exo:test").expect("valid");
         let sign_fn = make_sign_fn();
 

--- a/crates/exo-node/src/provenance.rs
+++ b/crates/exo-node/src/provenance.rs
@@ -150,7 +150,7 @@ pub fn provenance_router(state: Arc<ProvenanceState>) -> Router {
 mod tests {
     use axum::{body::Body, http::Request};
     use exo_core::types::{Did, Signature};
-    use exo_dag::dag::{Dag, HybridClock, append};
+    use exo_dag::dag::{Dag, DeterministicDagClock, append};
     use tower::ServiceExt;
 
     use super::*;
@@ -169,7 +169,7 @@ mod tests {
         let mut store = SqliteDagStore::open(dir.path()).unwrap();
 
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = Did::new("did:exo:test").unwrap();
         let sign_fn = make_sign_fn();
 

--- a/crates/exo-node/src/reactor.rs
+++ b/crates/exo-node/src/reactor.rs
@@ -46,7 +46,7 @@ use exo_core::{
 };
 use exo_dag::{
     consensus::{self, CommitCertificate, ConsensusConfig, ConsensusState, Vote},
-    dag::{Dag, DagNode, HybridClock, append},
+    dag::{Dag, DagNode, DeterministicDagClock, append},
 };
 use tokio::sync::mpsc;
 
@@ -122,9 +122,9 @@ pub struct ReactorState {
     /// The local DAG — used by submit_proposal via struct destructuring.
     #[allow(dead_code)]
     pub dag: Dag,
-    /// The hybrid logical clock — used by submit_proposal via struct destructuring.
+    /// The deterministic DAG append clock — used by submit_proposal via struct destructuring.
     #[allow(dead_code)]
-    pub clock: HybridClock,
+    pub clock: DeterministicDagClock,
     /// This node's DID.
     pub node_did: Did,
     /// Whether this node is a validator.
@@ -197,7 +197,7 @@ pub fn create_reactor_state(
                 return Arc::new(Mutex::new(ReactorState {
                     consensus: consensus_state,
                     dag: Dag::new(),
-                    clock: HybridClock::new(),
+                    clock: DeterministicDagClock::new(),
                     node_did: config.node_did.clone(),
                     is_validator: config.is_validator,
                     sign_fn,
@@ -258,7 +258,7 @@ pub fn create_reactor_state(
     Arc::new(Mutex::new(ReactorState {
         consensus: consensus_state,
         dag: Dag::new(),
-        clock: HybridClock::new(),
+        clock: DeterministicDagClock::new(),
         node_did: config.node_did.clone(),
         is_validator: config.is_validator,
         sign_fn,
@@ -1074,7 +1074,7 @@ mod tests {
         let store = Arc::new(Mutex::new(SqliteDagStore::open(dir.path()).unwrap()));
 
         let mut dag = Dag::new();
-        let mut clock = HybridClock::with_time(42_000);
+        let mut clock = DeterministicDagClock::with_time(42_000);
         let node = append(
             &mut dag,
             &[],
@@ -1131,7 +1131,7 @@ mod tests {
         let config = ConsensusConfig::new(validators.clone(), 5000);
         let mut consensus_state = ConsensusState::new(config);
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
 
         // Create a DAG node
         let node = append(
@@ -1211,9 +1211,9 @@ mod tests {
         let mut state = ConsensusState::new(config); // quorum = 5
 
         let mut honest_dag = Dag::new();
-        let mut honest_clock = HybridClock::new();
+        let mut honest_clock = DeterministicDagClock::new();
         let mut byzantine_dag = Dag::new();
-        let mut byzantine_clock = HybridClock::new();
+        let mut byzantine_clock = DeterministicDagClock::new();
 
         let honest_node = append(
             &mut honest_dag,
@@ -1277,7 +1277,7 @@ mod tests {
     fn make_node_for_test() -> exo_dag::dag::DagNode {
         use exo_dag::dag::{Dag, append};
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let did = Did::new("did:exo:v0").unwrap();
         let sf = make_sign_fn();
         append(&mut dag, &[], b"x", &did, &*sf, &mut clock).unwrap()

--- a/crates/exo-node/src/store.rs
+++ b/crates/exo-node/src/store.rs
@@ -699,7 +699,7 @@ mod tests {
     use std::collections::BTreeSet;
 
     use exo_core::types::{Did, Signature};
-    use exo_dag::dag::{Dag, HybridClock, append};
+    use exo_dag::dag::{Dag, DeterministicDagClock, append};
 
     use super::*;
 
@@ -716,7 +716,7 @@ mod tests {
 
     fn make_test_node() -> DagNode {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = Did::new("did:exo:test").expect("valid");
         let sign_fn = make_sign_fn();
         append(&mut dag, &[], b"genesis", &creator, &*sign_fn, &mut clock).unwrap()
@@ -774,7 +774,7 @@ mod tests {
     #[test]
     fn tips_with_children() {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = Did::new("did:exo:test").expect("valid");
         let sign_fn = make_sign_fn();
 
@@ -1294,7 +1294,7 @@ mod tests {
     #[test]
     fn multiple_tips() {
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let creator = Did::new("did:exo:test").expect("valid");
         let sign_fn = make_sign_fn();
 

--- a/crates/exo-node/src/sync.rs
+++ b/crates/exo-node/src/sync.rs
@@ -536,7 +536,7 @@ pub async fn run_sync_engine(mut engine: SyncEngine, mut net_events: mpsc::Recei
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use exo_core::types::{Did, Signature};
-    use exo_dag::dag::{Dag, HybridClock, append};
+    use exo_dag::dag::{Dag, DeterministicDagClock, append};
     use tokio::sync::mpsc;
 
     use super::*;
@@ -564,7 +564,7 @@ mod tests {
         let did = test_did();
 
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
         let mut hashes = Vec::new();
 
         let mut parents = vec![];
@@ -726,7 +726,7 @@ mod tests {
         let sign_fn = make_sign_fn();
         let did = test_did();
         let mut dag = Dag::new();
-        let mut clock = HybridClock::new();
+        let mut clock = DeterministicDagClock::new();
 
         let node1 = append(&mut dag, &[], b"synced-1", &did, &*sign_fn, &mut clock).unwrap();
         let node2 = append(

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 119592 lines of Rust under `crates/`, 2,895 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 119616 lines of Rust under `crates/`, 2,896 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,895 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,896 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,895 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,896 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-119592 lines of Rust under `crates/` · 20 workspace packages · 2,895 listed tests · 40 MCP tools · 8 constitutional invariants
+119616 lines of Rust under `crates/` · 20 workspace packages · 2,896 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 119592 lines of Rust under `crates/` | 266 Rust source files | 2,895 listed tests
+> **Codebase:** 20 workspace packages | 119616 lines of Rust under `crates/` | 266 Rust source files | 2,896 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,895 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,896 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 119592 lines of Rust under `crates/` · 2,895 listed tests
+20 workspace packages · 119616 lines of Rust under `crates/` · 2,896 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- rename the exo-dag-local `HybridClock` helper to `DeterministicDagClock` so it no longer name-collides with `exo_core::hlc::HybridClock`
- document that the DAG append clock is caller-controlled and intentionally avoids wall-clock reads
- update exo-dag, exo-node, and benchmark call sites, plus repo truth counts

## TDD
- red: `cargo test -p exo-dag dag_module_does_not_define_local_hybrid_clock --lib` failed while `pub struct HybridClock` still existed
- green: added the source-guard regression and renamed call sites

## Verification
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `cargo machete --with-metadata`
- `cargo test -p exo-dag dag_module_does_not_define_local_hybrid_clock --lib`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `cargo audit --deny unsound --deny unmaintained`
- `cargo deny check`

Note: `cargo audit` and `cargo deny` exit clean; existing warning-only yanked/duplicate dependency noise remains outside this remediation scope.