### PR TITLE
fix(exo-node): verify reactor consensus signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 119616 | `wc -l` |
-| Workspace tests | 2,896 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 120060 | `wc -l` |
+| Workspace tests | 2,901 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,896 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,901 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 119616 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 120060 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,896 listed workspace tests
+         cryptographic proofs, 2,901 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/api.rs
+++ b/crates/exo-node/src/api.rs
@@ -33,8 +33,12 @@ use axum::{
 #[cfg(any(test, feature = "unaudited-admin-governance-shortcut"))]
 use exo_core::types::Did;
 use exo_core::types::Hash256;
+#[cfg(feature = "unaudited-admin-governance-shortcut")]
+use exo_core::types::PublicKey;
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "unaudited-admin-governance-shortcut")]
+use crate::identity;
 #[cfg(feature = "unaudited-admin-governance-shortcut")]
 use crate::wire::ValidatorChange;
 use crate::{
@@ -88,6 +92,7 @@ pub struct BroadcastRequest {
 pub struct ValidatorChangeRequest {
     pub action: String, // "add" or "remove"
     pub did: String,
+    pub public_key_hex: Option<String>,
 }
 
 /// Response representing a single trust receipt.
@@ -142,6 +147,25 @@ pub struct NodeStatusResponse {
 // ---------------------------------------------------------------------------
 // Route handlers
 // ---------------------------------------------------------------------------
+
+#[cfg(feature = "unaudited-admin-governance-shortcut")]
+fn parse_validator_public_key_hex(value: &str) -> Result<PublicKey, (StatusCode, String)> {
+    let bytes = hex::decode(value).map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Invalid public_key_hex: {e}"),
+        )
+    })?;
+    if bytes.len() != 32 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("public_key_hex must be 32 bytes, got {}", bytes.len()),
+        ));
+    }
+    let mut public_key = [0u8; 32];
+    public_key.copy_from_slice(&bytes);
+    Ok(PublicKey::from_bytes(public_key))
+}
 
 /// `POST /api/v1/governance/propose` — submit a governance proposal for BFT consensus.
 async fn handle_propose(
@@ -291,6 +315,31 @@ async fn handle_validator_change(
         let did = Did::new(&req.did)
             .map_err(|e| (StatusCode::BAD_REQUEST, format!("Invalid DID: {e}")))?;
 
+        let add_public_key = if req.action == "add" {
+            let public_key_hex = req.public_key_hex.as_deref().ok_or_else(|| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    "public_key_hex is required when adding a validator".to_string(),
+                )
+            })?;
+            let public_key = parse_validator_public_key_hex(public_key_hex)?;
+            let derived_did = identity::did_from_public_key(&public_key).map_err(|e| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    format!("public_key_hex does not derive a valid validator DID: {e}"),
+                )
+            })?;
+            if derived_did != did {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    format!("public_key_hex derives {derived_did}, not {did}"),
+                ));
+            }
+            Some(public_key)
+        } else {
+            None
+        };
+
         let change = match req.action.as_str() {
             "add" => ValidatorChange::AddValidator { did },
             "remove" => ValidatorChange::RemoveValidator { did },
@@ -313,6 +362,9 @@ async fn handle_validator_change(
             match &change {
                 ValidatorChange::AddValidator { did } => {
                     s.consensus.config.validators.insert(did.clone());
+                    if let Some(public_key) = add_public_key {
+                        s.validator_public_keys.insert(did.clone(), public_key);
+                    }
                 }
                 ValidatorChange::RemoveValidator { did } => {
                     if s.consensus.config.validators.len() <= 4 {
@@ -323,6 +375,7 @@ async fn handle_validator_change(
                         ));
                     }
                     s.consensus.config.validators.remove(did);
+                    s.validator_public_keys.remove(did);
                 }
             }
             (
@@ -487,7 +540,7 @@ mod tests {
     };
 
     use axum::{body::Body, http::Request};
-    use exo_core::types::Signature;
+    use exo_core::{crypto::KeyPair, types::Signature};
     use tower::ServiceExt;
 
     use super::*;
@@ -497,12 +550,23 @@ mod tests {
     };
 
     fn make_sign_fn() -> Arc<dyn Fn(&[u8]) -> Signature + Send + Sync> {
-        Arc::new(|data: &[u8]| {
-            let h = blake3::hash(data);
-            let mut sig = [0u8; 64];
-            sig[..32].copy_from_slice(h.as_bytes());
-            Signature::from_bytes(sig)
-        })
+        let keypair = KeyPair::from_secret_bytes([1u8; 32]).unwrap();
+        Arc::new(move |data: &[u8]| keypair.sign(data))
+    }
+
+    fn validator_public_keys(
+        validators: &BTreeSet<Did>,
+    ) -> std::collections::BTreeMap<Did, exo_core::types::PublicKey> {
+        validators
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(idx, did)| {
+                let seed = u8::try_from(idx + 1).unwrap();
+                let keypair = KeyPair::from_secret_bytes([seed; 32]).unwrap();
+                (did, *keypair.public_key())
+            })
+            .collect()
     }
 
     fn test_api_state() -> Arc<NodeApiState> {
@@ -513,6 +577,7 @@ mod tests {
         let config = ReactorConfig {
             node_did: Did::new("did:exo:v0").unwrap(),
             is_validator: true,
+            validator_public_keys: validator_public_keys(&validators),
             validators,
             round_timeout_ms: 5000,
         };
@@ -611,10 +676,13 @@ mod tests {
     async fn validator_add_increases_count() {
         let state = test_api_state();
         let app = governance_router(Arc::clone(&state));
+        let keypair = KeyPair::from_secret_bytes([50u8; 32]).unwrap();
+        let did = crate::identity::did_from_public_key(keypair.public_key()).unwrap();
 
         let body = serde_json::json!({
             "action": "add",
-            "did": "did:exo:new-validator",
+            "did": did.to_string(),
+            "public_key_hex": hex::encode(keypair.public_key().as_bytes()),
         });
 
         let resp = app

--- a/crates/exo-node/src/cli.rs
+++ b/crates/exo-node/src/cli.rs
@@ -52,6 +52,12 @@ pub enum Command {
         /// If not provided, this node's DID is used as the sole validator.
         #[arg(long, value_delimiter = ',')]
         validators: Option<Vec<String>>,
+
+        /// Validator public keys as `did:exo:...=<64 hex bytes>` entries.
+        /// Required for every non-local validator DID because consensus
+        /// proposals/votes/certificates are verified against these keys.
+        #[arg(long = "validator-public-key", value_delimiter = ',')]
+        validator_public_keys: Option<Vec<String>>,
     },
 
     /// Join an existing network via seed node(s).
@@ -84,6 +90,12 @@ pub enum Command {
         /// Validator DIDs for the initial validator set (comma-separated).
         #[arg(long, value_delimiter = ',')]
         validators: Option<Vec<String>>,
+
+        /// Validator public keys as `did:exo:...=<64 hex bytes>` entries.
+        /// Required for every non-local validator DID because consensus
+        /// proposals/votes/certificates are verified against these keys.
+        #[arg(long = "validator-public-key", value_delimiter = ',')]
+        validator_public_keys: Option<Vec<String>>,
     },
 
     /// Show node status.

--- a/crates/exo-node/src/holons.rs
+++ b/crates/exo-node/src/holons.rs
@@ -1001,6 +1001,7 @@ mod tests {
             node_did: test_did(),
             is_validator: true,
             validators,
+            validator_public_keys: std::collections::BTreeMap::new(),
             round_timeout_ms: 5000,
         };
         let sign_fn: Arc<dyn Fn(&[u8]) -> Signature + Send + Sync> =

--- a/crates/exo-node/src/identity.rs
+++ b/crates/exo-node/src/identity.rs
@@ -44,6 +44,17 @@ impl NodeIdentity {
     }
 }
 
+/// Derive the EXOCHAIN DID bound to a raw Ed25519 public key.
+///
+/// The node DID format is `did:exo:<base58(blake3(pubkey))>`. Validator
+/// public-key configuration uses this derivation as a consistency check before
+/// a key can be accepted for consensus signature verification.
+pub fn did_from_public_key(public_key: &PublicKey) -> anyhow::Result<Did> {
+    let hash = blake3::hash(public_key.as_bytes());
+    let encoded = bs58_encode(hash.as_bytes());
+    Did::new(&format!("did:exo:{encoded}")).map_err(Into::into)
+}
+
 /// Load an existing identity from the data directory, or generate a new one.
 pub fn load_or_create(data_dir: &Path) -> anyhow::Result<NodeIdentity> {
     let key_path = data_dir.join("identity.key");
@@ -78,15 +89,11 @@ pub fn load_or_create(data_dir: &Path) -> anyhow::Result<NodeIdentity> {
         let keypair = KeyPair::generate();
         let public_key = *keypair.public_key();
 
-        // DID = did:exo:<base58(blake3(pubkey))>
-        let hash = blake3::hash(&public_key.0);
-        let encoded = bs58_encode(hash.as_bytes());
-        let did_str = format!("did:exo:{encoded}");
-        let did = Did::new(&did_str)?;
+        let did = did_from_public_key(&public_key)?;
 
         // Persist secret key (mode 0600).
         write_secret(&key_path, keypair.secret_key().as_bytes())?;
-        std::fs::write(&did_path, did_str.as_bytes())?;
+        std::fs::write(&did_path, did.as_str().as_bytes())?;
 
         tracing::info!(did = %did, "Generated new node identity");
 
@@ -181,6 +188,17 @@ mod tests {
 
         assert_eq!(first.did, second.did);
         assert_eq!(first.public_key_bytes(), second.public_key_bytes());
+    }
+
+    #[test]
+    fn did_from_public_key_matches_node_identity_derivation() {
+        let dir = tempfile::tempdir().unwrap();
+        let identity = load_or_create(dir.path()).unwrap();
+
+        assert_eq!(
+            did_from_public_key(identity.public_key()).unwrap(),
+            identity.did
+        );
     }
 
     #[test]

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -40,13 +40,13 @@ mod wire;
 mod zerodentity;
 
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     sync::{Arc, Mutex},
 };
 
 use clap::Parser;
 use cli::{Cli, Command};
-use exo_core::types::Did;
+use exo_core::types::{Did, PublicKey};
 #[cfg(feature = "unaudited-infrastructure-holons")]
 use holons::{HolonEvent, HolonManagerConfig};
 use network::{NetworkConfig, NetworkEvent, NetworkHandle};
@@ -84,6 +84,63 @@ fn parse_validator_set(cli_validators: &Option<Vec<String>>, node_did: &Did) -> 
         set.insert(node_did.clone());
         set
     }
+}
+
+fn parse_public_key_hex(value: &str) -> anyhow::Result<PublicKey> {
+    let bytes = hex::decode(value)?;
+    if bytes.len() != 32 {
+        anyhow::bail!("validator public key must be 32 bytes, got {}", bytes.len());
+    }
+    let mut public_key = [0u8; 32];
+    public_key.copy_from_slice(&bytes);
+    Ok(PublicKey::from_bytes(public_key))
+}
+
+fn parse_validator_public_key_entry(entry: &str) -> anyhow::Result<(Did, PublicKey)> {
+    let (did_str, public_key_hex) = entry.split_once('=').ok_or_else(|| {
+        anyhow::anyhow!("validator public key must be did:exo:...=<64 hex bytes>")
+    })?;
+    let did = Did::new(did_str)?;
+    let public_key = parse_public_key_hex(public_key_hex)?;
+    let derived_did = identity::did_from_public_key(&public_key)?;
+    if derived_did != did {
+        anyhow::bail!("validator public key does not derive DID {did}; derived {derived_did}");
+    }
+    Ok((did, public_key))
+}
+
+fn resolve_validator_public_keys(
+    entries: &Option<Vec<String>>,
+    node_identity: &identity::NodeIdentity,
+    validators: &BTreeSet<Did>,
+) -> anyhow::Result<BTreeMap<Did, PublicKey>> {
+    let mut keys = BTreeMap::new();
+    keys.insert(node_identity.did.clone(), node_identity.public_key);
+
+    if let Some(entries) = entries {
+        for entry in entries {
+            let (did, public_key) = parse_validator_public_key_entry(entry)?;
+            if let Some(previous) = keys.insert(did.clone(), public_key) {
+                if previous != public_key {
+                    anyhow::bail!("conflicting public keys supplied for validator {did}");
+                }
+            }
+        }
+    }
+
+    let missing: Vec<String> = validators
+        .iter()
+        .filter(|did| !keys.contains_key(*did))
+        .map(ToString::to_string)
+        .collect();
+    if !missing.is_empty() {
+        anyhow::bail!(
+            "missing public keys for validators: {}. Pass --validator-public-key did:exo:...=<64 hex bytes> for every non-local validator.",
+            missing.join(", ")
+        );
+    }
+
+    Ok(keys)
 }
 
 /// Spawn the event fan-out task that dispatches network events to both
@@ -138,7 +195,7 @@ fn spawn_event_fanout(
 #[allow(clippy::too_many_arguments)]
 // 8 args is the minimum for a node bootstrap entry point:
 // data_dir, api_host, api_port, p2p_port, validator, validators,
-// seed_addrs, is_join. Each is a distinct bootstrap parameter
+// validator_public_keys, seed_addrs, is_join. Each is a distinct bootstrap parameter
 // that came in through CLI parsing; bundling them behind a
 // struct would add a layer of boilerplate with no safety benefit
 // since this is the single call site from `main()`.
@@ -149,6 +206,7 @@ async fn start_node(
     p2p_port: u16,
     validator: bool,
     validators: &Option<Vec<String>>,
+    validator_public_key_entries: &Option<Vec<String>>,
     seed_addrs: Vec<libp2p::Multiaddr>,
     is_join: bool,
 ) -> anyhow::Result<()> {
@@ -226,10 +284,16 @@ async fn start_node(
 
     // --- Consensus reactor ---
     let validator_set = parse_validator_set(validators, &node_identity.did);
+    let validator_public_keys = resolve_validator_public_keys(
+        validator_public_key_entries,
+        &node_identity,
+        &validator_set,
+    )?;
     let reactor_config = ReactorConfig {
         node_did: node_identity.did.clone(),
         is_validator: validator,
         validators: validator_set.clone(),
+        validator_public_keys,
         round_timeout_ms: 5000,
     };
 
@@ -746,6 +810,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             data_dir,
             validator,
             validators,
+            validator_public_keys,
         } => {
             let data_dir = config::resolve_data_dir(data_dir)?;
             let cfg = config::load_or_create(&data_dir)?;
@@ -763,6 +828,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                 p2p_port,
                 validator,
                 &validators,
+                &validator_public_keys,
                 vec![],
                 false,
             )
@@ -777,6 +843,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             data_dir,
             validator,
             validators,
+            validator_public_keys,
         } => {
             let data_dir = config::resolve_data_dir(data_dir)?;
             let cfg = config::load_or_create(&data_dir)?;
@@ -812,6 +879,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                 p2p_port,
                 validator,
                 &validators,
+                &validator_public_keys,
                 seed_addrs,
                 true,
             )

--- a/crates/exo-node/src/mcp/tools/node.rs
+++ b/crates/exo-node/src/mcp/tools/node.rs
@@ -412,6 +412,7 @@ mod tests {
             node_did: this_did.clone(),
             is_validator: true,
             validators,
+            validator_public_keys: std::collections::BTreeMap::new(),
             round_timeout_ms: 5000,
         };
         let sign_fn: Arc<dyn Fn(&[u8]) -> Signature + Send + Sync> =

--- a/crates/exo-node/src/passport.rs
+++ b/crates/exo-node/src/passport.rs
@@ -474,6 +474,7 @@ mod tests {
             node_did: Did::new("did:exo:v0").unwrap(),
             is_validator: true,
             validators,
+            validator_public_keys: std::collections::BTreeMap::new(),
             round_timeout_ms: 5000,
         };
 

--- a/crates/exo-node/src/reactor.rs
+++ b/crates/exo-node/src/reactor.rs
@@ -7,45 +7,31 @@
 //! 4. Broadcasts outbound consensus messages via the network handle
 //! 5. Drives round advancement on timeout
 //!
-//! This module wires the existing fully-tested consensus code (`propose()`,
-//! `vote()`, `check_commit()`, `commit()`) into a network-aware reactor
-//! without modifying the consensus protocol itself.
+//! This module wires the fully-tested verified consensus API
+//! (`propose_verified()`, `vote_verified()`, `check_commit()`,
+//! `commit_verified()`) into a network-aware reactor.
 //!
 //! # GAP-014 note
 //!
-//! The GAP-014 fix (commit 254e8dc) introduced `propose_verified`,
-//! `vote_verified`, and `commit_verified` in `exo_dag::consensus` which
-//! enforce signature verification. This reactor still calls the legacy
-//! `propose` / `vote` / `commit` — wiring the reactor's handle_* paths
-//! to the verified variants requires a `PublicKeyResolver` backed by
-//! the identity registry, which is the follow-up initiative
-//! `exochain-api-migration-gap` (tracked separately).
-//!
-//! Until that wiring lands, the legacy API is permitted here via
-//! `#[allow(deprecated)]`. As defense-in-depth, `validate_proposal` /
-//! `validate_vote` / `validate_commit` below reject all-zero signature
-//! sentinels so a trivial-forge attacker still can't inject bogus
-//! messages through this path.
+//! The reactor keeps an explicit validator DID → Ed25519 public-key map and
+//! rejects proposals, votes, and commit certificates that cannot be verified
+//! against that resolver. Local proposal and self-vote signatures are produced
+//! over the canonical CBOR payloads defined by `exo-dag::consensus`.
 
-#![allow(
-    clippy::as_conversions,
-    clippy::type_complexity,
-    clippy::single_match,
-    deprecated
-)]
+#![allow(clippy::as_conversions, clippy::type_complexity, clippy::single_match)]
 
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     sync::{Arc, Mutex},
     time::Duration,
 };
 
 use exo_core::{
     hash::hash_structured,
-    types::{Did, Hash256, ReceiptOutcome, Signature, Timestamp, TrustReceipt},
+    types::{Did, Hash256, PublicKey, ReceiptOutcome, Signature, Timestamp, TrustReceipt},
 };
 use exo_dag::{
-    consensus::{self, CommitCertificate, ConsensusConfig, ConsensusState, Vote},
+    consensus::{self, CommitCertificate, ConsensusConfig, ConsensusState, Proposal, Vote},
     dag::{Dag, DagNode, DeterministicDagClock, append},
 };
 use tokio::sync::mpsc;
@@ -111,9 +97,84 @@ fn commit_receipt_from_certificate(
     ))
 }
 
+fn sign_proposal(
+    proposal: &Proposal,
+    sign_fn: &(dyn Fn(&[u8]) -> Signature + Send + Sync),
+) -> Result<Signature, String> {
+    let payload = proposal
+        .signing_payload()
+        .map_err(|e| format!("proposal signing payload: {e}"))?;
+    Ok(sign_fn(&payload))
+}
+
+fn signed_vote(
+    voter: Did,
+    round: u64,
+    node_hash: Hash256,
+    sign_fn: &(dyn Fn(&[u8]) -> Signature + Send + Sync),
+) -> Result<Vote, String> {
+    let mut vote = Vote {
+        voter,
+        round,
+        node_hash,
+        signature: Signature::empty(),
+    };
+    let payload = vote
+        .signing_payload()
+        .map_err(|e| format!("vote signing payload: {e}"))?;
+    vote.signature = sign_fn(&payload);
+    Ok(vote)
+}
+
 // ---------------------------------------------------------------------------
 // Reactor state
 // ---------------------------------------------------------------------------
+
+/// Deterministic validator public-key resolver used by the reactor.
+///
+/// Consensus verification must resolve keys from explicit configuration or
+/// persisted governance state; it cannot infer a public key from a DID.
+#[derive(Debug, Clone, Default)]
+pub struct ValidatorPublicKeys {
+    keys: BTreeMap<Did, PublicKey>,
+}
+
+impl ValidatorPublicKeys {
+    #[must_use]
+    pub fn new(keys: BTreeMap<Did, PublicKey>) -> Self {
+        Self { keys }
+    }
+
+    #[must_use]
+    pub fn as_map(&self) -> &BTreeMap<Did, PublicKey> {
+        &self.keys
+    }
+
+    #[cfg_attr(not(feature = "unaudited-admin-governance-shortcut"), allow(dead_code))]
+    pub fn insert(&mut self, did: Did, public_key: PublicKey) {
+        self.keys.insert(did, public_key);
+    }
+
+    #[cfg_attr(not(feature = "unaudited-admin-governance-shortcut"), allow(dead_code))]
+    pub fn remove(&mut self, did: &Did) {
+        self.keys.remove(did);
+    }
+
+    #[must_use]
+    pub fn missing_for(&self, validators: &BTreeSet<Did>) -> Vec<Did> {
+        validators
+            .iter()
+            .filter(|did| !self.keys.contains_key(*did))
+            .cloned()
+            .collect()
+    }
+}
+
+impl consensus::PublicKeyResolver for ValidatorPublicKeys {
+    fn resolve(&self, did: &Did) -> Option<PublicKey> {
+        self.keys.get(did).copied()
+    }
+}
 
 /// Shared state for the consensus reactor, accessible from the API layer.
 pub struct ReactorState {
@@ -131,6 +192,8 @@ pub struct ReactorState {
     pub is_validator: bool,
     /// Sign function using this node's key.
     sign_fn: Arc<dyn Fn(&[u8]) -> Signature + Send + Sync>,
+    /// Public keys for validators in the current consensus set.
+    pub validator_public_keys: ValidatorPublicKeys,
 }
 
 impl std::fmt::Debug for ReactorState {
@@ -139,6 +202,14 @@ impl std::fmt::Debug for ReactorState {
             .field("consensus", &self.consensus)
             .field("node_did", &self.node_did)
             .field("is_validator", &self.is_validator)
+            .field(
+                "validator_public_keys",
+                &self
+                    .validator_public_keys
+                    .as_map()
+                    .keys()
+                    .collect::<Vec<_>>(),
+            )
             .finish_non_exhaustive()
     }
 }
@@ -170,6 +241,8 @@ pub struct ReactorConfig {
     pub is_validator: bool,
     /// Initial validator set DIDs.
     pub validators: BTreeSet<Did>,
+    /// Ed25519 public keys for every validator DID.
+    pub validator_public_keys: BTreeMap<Did, PublicKey>,
     /// Round timeout in milliseconds.
     pub round_timeout_ms: u64,
 }
@@ -187,6 +260,7 @@ pub fn create_reactor_state(
 ) -> SharedReactorState {
     let consensus_config = ConsensusConfig::new(config.validators.clone(), config.round_timeout_ms);
     let mut consensus_state = ConsensusState::new(consensus_config);
+    let validator_public_keys = ValidatorPublicKeys::new(config.validator_public_keys.clone());
 
     // Restore persisted consensus state if a store is provided.
     if let Some(store_arc) = store {
@@ -201,6 +275,7 @@ pub fn create_reactor_state(
                     node_did: config.node_did.clone(),
                     is_validator: config.is_validator,
                     sign_fn,
+                    validator_public_keys,
                 }));
             }
         };
@@ -215,12 +290,39 @@ pub fn create_reactor_state(
             }
         }
 
+        // Restore persisted validator set (may have been changed via governance).
+        if let Ok(persisted_validators) = st.load_validator_set() {
+            if !persisted_validators.is_empty() {
+                consensus_state.config.validators = persisted_validators;
+                tracing::info!(
+                    validators = consensus_state.config.validators.len(),
+                    "Restored validator set from store"
+                );
+            }
+        }
+
+        let missing_public_keys =
+            validator_public_keys.missing_for(&consensus_state.config.validators);
+        if !missing_public_keys.is_empty() {
+            tracing::warn!(
+                missing = ?missing_public_keys,
+                "Consensus validator public-key resolver is incomplete; \
+                 unverifiable restored votes/certificates and network messages will be rejected"
+            );
+        }
+
         // Restore commit certificates.
         if let Ok(certs) = st.load_certificates() {
             let count = certs.len();
             for cert in certs {
                 if !consensus::is_finalized(&consensus_state, &cert.node_hash) {
-                    consensus::commit(&mut consensus_state, cert);
+                    if let Err(e) = consensus::commit_verified(
+                        &mut consensus_state,
+                        cert,
+                        &validator_public_keys,
+                    ) {
+                        tracing::warn!(err = %e, "Skipped unverifiable restored commit certificate");
+                    }
                 }
             }
             if count > 0 {
@@ -232,24 +334,17 @@ pub fn create_reactor_state(
         if let Ok(votes) = st.load_votes_for_round(consensus_state.current_round) {
             let count = votes.len();
             for vote in votes {
-                let _ = consensus::vote(&mut consensus_state, vote);
+                if let Err(e) =
+                    consensus::vote_verified(&mut consensus_state, vote, &validator_public_keys)
+                {
+                    tracing::warn!(err = %e, "Skipped unverifiable restored pending vote");
+                }
             }
             if count > 0 {
                 tracing::info!(
                     count,
                     round = consensus_state.current_round,
                     "Restored pending votes"
-                );
-            }
-        }
-
-        // Restore persisted validator set (may have been changed via governance).
-        if let Ok(persisted_validators) = st.load_validator_set() {
-            if !persisted_validators.is_empty() {
-                consensus_state.config.validators = persisted_validators;
-                tracing::info!(
-                    validators = consensus_state.config.validators.len(),
-                    "Restored validator set from store"
                 );
             }
         }
@@ -262,6 +357,7 @@ pub fn create_reactor_state(
         node_did: config.node_did.clone(),
         is_validator: config.is_validator,
         sign_fn,
+        validator_public_keys,
     }))
 }
 
@@ -353,34 +449,28 @@ pub async fn run_reactor(
 
 /// Validate a consensus proposal before processing.
 ///
-/// Checks: proposer is in the current validator set, the attached
-/// signature is non-empty, is not a zero-byte sentinel, and the
-/// node hash matches the proposal's node_hash.
-///
-/// **Note (GAP-014 defense-in-depth):** This function is a structural
-/// guard only. Until the reactor is wired to a real
-/// `PublicKeyResolver` (see initiative
-/// `fix-gap-014-consensus-sig-verify.md`), the actual cryptographic
-/// verification lives in `consensus::*_verified` but is NOT yet called
-/// from this reactor. This validator does the maximum amount of
-/// structural filtering possible without a resolver: it rejects
-/// empty and all-zero signatures, blocking the most obvious forgery
-/// shapes. It does NOT yet reject forgeries that use arbitrary
-/// non-zero bytes.
-fn validate_proposal(msg: &ConsensusProposalMsg, validators: &BTreeSet<Did>) -> Result<(), String> {
+/// Checks: proposer is in the current validator set, the attached signature
+/// verifies against the configured proposer public key, and the node hash
+/// matches the proposal's node_hash.
+fn validate_proposal<R: consensus::PublicKeyResolver>(
+    msg: &ConsensusProposalMsg,
+    validators: &BTreeSet<Did>,
+    resolver: &R,
+) -> Result<(), String> {
     if !validators.contains(&msg.proposal.proposer) {
         return Err(format!(
             "proposer {} is not in the validator set",
             msg.proposal.proposer
         ));
     }
-    if msg.signature.is_empty() {
-        return Err("proposal carries empty signature".into());
-    }
-    // GAP-014 defense-in-depth: reject the null-signature attack shape.
-    let raw = msg.signature.as_bytes();
-    if !raw.is_empty() && raw.iter().all(|b| *b == 0) {
-        return Err("proposal carries zero-byte signature (null-sig attack shape)".into());
+    let Some(public_key) = resolver.resolve(&msg.proposal.proposer) else {
+        return Err(format!(
+            "proposer {} has no configured public key",
+            msg.proposal.proposer
+        ));
+    };
+    if !msg.proposal.verify_signature(&public_key, &msg.signature) {
+        return Err("proposal carries invalid signature".into());
     }
     if msg.node.hash != msg.proposal.node_hash {
         return Err(format!(
@@ -393,36 +483,41 @@ fn validate_proposal(msg: &ConsensusProposalMsg, validators: &BTreeSet<Did>) -> 
 
 /// Validate a consensus vote before processing.
 ///
-/// Checks: voter is a known validator, signature is non-empty, and
-/// signature is not a zero-byte sentinel.
-///
-/// See `validate_proposal` for the GAP-014 caveat.
-fn validate_vote(msg: &ConsensusVoteMsg, validators: &BTreeSet<Did>) -> Result<(), String> {
+/// Checks: voter is a known validator and the signature verifies against the
+/// configured voter public key.
+fn validate_vote<R: consensus::PublicKeyResolver>(
+    msg: &ConsensusVoteMsg,
+    validators: &BTreeSet<Did>,
+    resolver: &R,
+) -> Result<(), String> {
     if !validators.contains(&msg.vote.voter) {
         return Err(format!(
             "voter {} is not in the validator set",
             msg.vote.voter
         ));
     }
-    if msg.vote.signature.is_empty() {
-        return Err("vote carries empty signature".into());
-    }
-    // GAP-014 defense-in-depth: reject the null-signature attack shape.
-    let raw = msg.vote.signature.as_bytes();
-    if !raw.is_empty() && raw.iter().all(|b| *b == 0) {
-        return Err("vote carries zero-byte signature (null-sig attack shape)".into());
+    let Some(public_key) = resolver.resolve(&msg.vote.voter) else {
+        return Err(format!(
+            "voter {} has no configured public key",
+            msg.vote.voter
+        ));
+    };
+    if !msg.vote.verify_signature(&public_key) {
+        return Err("vote carries invalid signature".into());
     }
     Ok(())
 }
 
 /// Validate a commit certificate before processing.
 ///
-/// Checks: every vote in the certificate is from a known validator,
-/// carries a non-empty, non-zero-sentinel signature, and references
-/// the certificate's node hash.
-///
-/// See `validate_proposal` for the GAP-014 caveat.
-fn validate_commit(msg: &ConsensusCommitMsg, validators: &BTreeSet<Did>) -> Result<(), String> {
+/// Checks: every vote in the certificate is from a known validator, references
+/// the certificate node hash, and verifies against the configured voter public
+/// key.
+fn validate_commit<R: consensus::PublicKeyResolver>(
+    msg: &ConsensusCommitMsg,
+    validators: &BTreeSet<Did>,
+    resolver: &R,
+) -> Result<(), String> {
     for vote in &msg.certificate.votes {
         if !validators.contains(&vote.voter) {
             return Err(format!(
@@ -430,23 +525,21 @@ fn validate_commit(msg: &ConsensusCommitMsg, validators: &BTreeSet<Did>) -> Resu
                 vote.voter
             ));
         }
-        if vote.signature.is_empty() {
-            return Err(format!(
-                "certificate vote from {} has empty signature",
-                vote.voter
-            ));
-        }
-        // GAP-014 defense-in-depth: reject the null-signature attack shape.
-        let raw = vote.signature.as_bytes();
-        if !raw.is_empty() && raw.iter().all(|b| *b == 0) {
-            return Err(format!(
-                "certificate vote from {} has zero-byte signature (null-sig attack shape)",
-                vote.voter
-            ));
-        }
         if vote.node_hash != msg.certificate.node_hash {
             return Err(format!(
                 "certificate vote from {} references wrong node hash",
+                vote.voter
+            ));
+        }
+        let Some(public_key) = resolver.resolve(&vote.voter) else {
+            return Err(format!(
+                "certificate vote from {} has no configured public key",
+                vote.voter
+            ));
+        };
+        if !vote.verify_signature(&public_key) {
+            return Err(format!(
+                "certificate vote from {} has invalid signature",
                 vote.voter
             ));
         }
@@ -501,7 +594,11 @@ async fn handle_proposal(
             tracing::error!("Reactor state mutex poisoned in handle_proposal (validate)");
             return;
         };
-        if let Err(reason) = validate_proposal(&msg, &s.consensus.config.validators) {
+        if let Err(reason) = validate_proposal(
+            &msg,
+            &s.consensus.config.validators,
+            &s.validator_public_keys,
+        ) {
             tracing::warn!(err = %reason, "Rejected invalid proposal from network");
             return;
         }
@@ -526,8 +623,15 @@ async fn handle_proposal(
             }
         }
 
-        // Register the proposal in consensus state.
-        if let Err(e) = consensus::propose(&mut s.consensus, &msg.node, &msg.proposal.proposer) {
+        // Register the proposal in consensus state after cryptographic verification.
+        let resolver = s.validator_public_keys.clone();
+        if let Err(e) = consensus::propose_verified(
+            &mut s.consensus,
+            &msg.node,
+            &msg.proposal.proposer,
+            &msg.signature,
+            &resolver,
+        ) {
             tracing::warn!(err = %e, proposer = %msg.proposal.proposer, "Invalid proposal");
             return;
         }
@@ -541,14 +645,21 @@ async fn handle_proposal(
 
         // If we are a validator, vote for the proposal.
         if s.is_validator {
-            let vote = Vote {
-                voter: s.node_did.clone(),
-                round: s.consensus.current_round,
-                node_hash: msg.node.hash,
-                signature: (s.sign_fn)(msg.node.hash.0.as_slice()),
+            let vote = match signed_vote(
+                s.node_did.clone(),
+                s.consensus.current_round,
+                msg.node.hash,
+                &*s.sign_fn,
+            ) {
+                Ok(vote) => vote,
+                Err(e) => {
+                    tracing::warn!(err = %e, "Failed to sign own consensus vote");
+                    return;
+                }
             };
 
-            if let Err(e) = consensus::vote(&mut s.consensus, vote.clone()) {
+            let resolver = s.validator_public_keys.clone();
+            if let Err(e) = consensus::vote_verified(&mut s.consensus, vote.clone(), &resolver) {
                 tracing::warn!(err = %e, "Failed to cast own vote");
                 return;
             }
@@ -584,7 +695,11 @@ async fn handle_vote(
             tracing::error!("Reactor state mutex poisoned in handle_vote (validate)");
             return;
         };
-        if let Err(reason) = validate_vote(&msg, &s.consensus.config.validators) {
+        if let Err(reason) = validate_vote(
+            &msg,
+            &s.consensus.config.validators,
+            &s.validator_public_keys,
+        ) {
             tracing::warn!(err = %reason, "Rejected invalid vote from network");
             return;
         }
@@ -596,7 +711,8 @@ async fn handle_vote(
             return;
         };
 
-        if let Err(e) = consensus::vote(&mut s.consensus, msg.vote.clone()) {
+        let resolver = s.validator_public_keys.clone();
+        if let Err(e) = consensus::vote_verified(&mut s.consensus, msg.vote.clone(), &resolver) {
             tracing::debug!(
                 err = %e,
                 voter = %msg.vote.voter,
@@ -642,7 +758,11 @@ async fn handle_commit(
             tracing::error!("Reactor state mutex poisoned in handle_commit (validate)");
             return;
         };
-        if let Err(reason) = validate_commit(&msg, &s.consensus.config.validators) {
+        if let Err(reason) = validate_commit(
+            &msg,
+            &s.consensus.config.validators,
+            &s.validator_public_keys,
+        ) {
             tracing::warn!(err = %reason, "Rejected invalid commit certificate from network");
             return;
         }
@@ -660,10 +780,14 @@ async fn handle_commit(
             return;
         }
 
-        // Apply the commit certificate.
+        // Apply the commit certificate after verifying every certificate vote.
         let round = cert.round;
         let hash = cert.node_hash;
-        consensus::commit(&mut s.consensus, cert.clone());
+        let resolver = s.validator_public_keys.clone();
+        if let Err(e) = consensus::commit_verified(&mut s.consensus, cert.clone(), &resolver) {
+            tracing::warn!(err = %e, "Invalid commit certificate");
+            return;
+        }
 
         let height = s.consensus.committed.len() as u64;
         (cert, (hash, height, round))
@@ -748,7 +872,13 @@ async fn check_and_commit(
                 return;
             };
             if !consensus::is_finalized(&s.consensus, &hash) {
-                consensus::commit(&mut s.consensus, cert.clone());
+                let resolver = s.validator_public_keys.clone();
+                if let Err(e) =
+                    consensus::commit_verified(&mut s.consensus, cert.clone(), &resolver)
+                {
+                    tracing::warn!(err = %e, "Failed to verify local commit certificate");
+                    return;
+                }
             }
         }
 
@@ -873,21 +1003,32 @@ pub async fn submit_proposal(
                 .map_err(|e| anyhow::anyhow!("put: {e}"))?;
         }
 
-        // Create the proposal.
+        // Create and sign the proposal over the canonical consensus payload.
         let proposer_did = s.node_did.clone();
-        let proposal = consensus::propose(&mut s.consensus, &node, &proposer_did)
-            .map_err(|e| anyhow::anyhow!("propose: {e}"))?;
-
-        // Vote for our own proposal.
-        let vote = Vote {
-            voter: s.node_did.clone(),
+        let proposal_to_sign = Proposal {
+            proposer: proposer_did.clone(),
             round: s.consensus.current_round,
             node_hash: node.hash,
-            signature: (s.sign_fn)(node.hash.0.as_slice()),
         };
-        consensus::vote(&mut s.consensus, vote).map_err(|e| anyhow::anyhow!("self-vote: {e}"))?;
+        let sig = sign_proposal(&proposal_to_sign, &*s.sign_fn)
+            .map_err(|e| anyhow::anyhow!("proposal signature: {e}"))?;
+        let resolver = s.validator_public_keys.clone();
+        let proposal =
+            consensus::propose_verified(&mut s.consensus, &node, &proposer_did, &sig, &resolver)
+                .map_err(|e| anyhow::anyhow!("propose: {e}"))?;
 
-        let sig = (s.sign_fn)(node.hash.0.as_slice());
+        // Vote for our own proposal.
+        let vote = signed_vote(
+            s.node_did.clone(),
+            s.consensus.current_round,
+            node.hash,
+            &*s.sign_fn,
+        )
+        .map_err(|e| anyhow::anyhow!("self-vote signature: {e}"))?;
+        let resolver = s.validator_public_keys.clone();
+        consensus::vote_verified(&mut s.consensus, vote, &resolver)
+            .map_err(|e| anyhow::anyhow!("self-vote: {e}"))?;
+
         (node, proposal, sig)
     };
 
@@ -942,17 +1083,105 @@ pub async fn broadcast_governance_event(
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used, deprecated)]
 mod tests {
+    use exo_core::crypto::KeyPair;
+
     use super::*;
 
     fn make_sign_fn() -> Arc<dyn Fn(&[u8]) -> Signature + Send + Sync> {
-        Arc::new(|data: &[u8]| {
-            let h = blake3::hash(data);
-            let mut sig = [0u8; 64];
-            sig[..32].copy_from_slice(h.as_bytes());
-            Signature::from_bytes(sig)
-        })
+        let keypair = validator_keypair(0);
+        Arc::new(move |data: &[u8]| keypair.sign(data))
+    }
+
+    fn validator_keypair(index: usize) -> KeyPair {
+        let seed = u8::try_from(index + 1).expect("test validator index fits in u8");
+        KeyPair::from_secret_bytes([seed; 32]).expect("deterministic validator keypair")
+    }
+
+    fn make_validator_public_keys(validators: &BTreeSet<Did>) -> BTreeMap<Did, PublicKey> {
+        validators
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(idx, did)| {
+                let keypair = validator_keypair(idx);
+                (did, *keypair.public_key())
+            })
+            .collect()
+    }
+
+    fn sign_vote_for_index(mut vote: Vote, index: usize) -> Vote {
+        let keypair = validator_keypair(index);
+        let payload = vote.signing_payload().expect("vote payload");
+        vote.signature = keypair.sign(&payload);
+        vote
+    }
+
+    fn sign_proposal_for_index(proposal: &Proposal, index: usize) -> Signature {
+        let keypair = validator_keypair(index);
+        let payload = proposal.signing_payload().expect("proposal payload");
+        keypair.sign(&payload)
+    }
+
+    fn config_for(node_did: Did, is_validator: bool, validators: BTreeSet<Did>) -> ReactorConfig {
+        ReactorConfig {
+            node_did,
+            is_validator,
+            validator_public_keys: make_validator_public_keys(&validators),
+            validators,
+            round_timeout_ms: 5000,
+        }
+    }
+
+    fn vote_for(did: &Did, index: usize, round: u64, node_hash: Hash256) -> Vote {
+        sign_vote_for_index(
+            Vote {
+                voter: did.clone(),
+                round,
+                node_hash,
+                signature: Signature::empty(),
+            },
+            index,
+        )
+    }
+
+    fn proposal_msg_for(
+        proposer: Did,
+        proposer_index: usize,
+        round: u64,
+        node: DagNode,
+    ) -> ConsensusProposalMsg {
+        let proposal = Proposal {
+            proposer,
+            round,
+            node_hash: node.hash,
+        };
+        let signature = sign_proposal_for_index(&proposal, proposer_index);
+        ConsensusProposalMsg {
+            proposal,
+            node,
+            signature,
+        }
+    }
+
+    fn validator_keys_for_single(did: &Did, public_key: PublicKey) -> ValidatorPublicKeys {
+        let mut keys = BTreeMap::new();
+        keys.insert(did.clone(), public_key);
+        ValidatorPublicKeys::new(keys)
+    }
+
+    fn key_for_validator_index(index: usize) -> PublicKey {
+        *validator_keypair(index).public_key()
+    }
+
+    fn sign_with_wrong_key(payload: &[u8]) -> Signature {
+        let wrong_keypair = KeyPair::from_secret_bytes([91u8; 32]).unwrap();
+        wrong_keypair.sign(payload)
+    }
+
+    fn signature_is_invalid_error(err: &str) -> bool {
+        err.contains("invalid signature") || err.contains("empty") || err.contains("zero-byte")
     }
 
     fn make_validators(n: usize) -> BTreeSet<Did> {
@@ -964,12 +1193,7 @@ mod tests {
     #[test]
     fn create_reactor_state_initializes() {
         let validators = make_validators(4);
-        let config = ReactorConfig {
-            node_did: Did::new("did:exo:v0").unwrap(),
-            is_validator: true,
-            validators: validators.clone(),
-            round_timeout_ms: 5000,
-        };
+        let config = config_for(Did::new("did:exo:v0").unwrap(), true, validators.clone());
 
         let state = create_reactor_state(&config, make_sign_fn(), None);
         let s = state.lock().unwrap();
@@ -981,12 +1205,7 @@ mod tests {
 
     #[test]
     fn reactor_state_round_advancement() {
-        let config = ReactorConfig {
-            node_did: Did::new("did:exo:v0").unwrap(),
-            is_validator: true,
-            validators: make_validators(4),
-            round_timeout_ms: 5000,
-        };
+        let config = config_for(Did::new("did:exo:v0").unwrap(), true, make_validators(4));
 
         let state = create_reactor_state(&config, make_sign_fn(), None);
         {
@@ -1000,12 +1219,7 @@ mod tests {
     #[tokio::test]
     async fn submit_proposal_creates_dag_node() {
         let validators = make_validators(4);
-        let config = ReactorConfig {
-            node_did: Did::new("did:exo:v0").unwrap(),
-            is_validator: true,
-            validators,
-            round_timeout_ms: 5000,
-        };
+        let config = config_for(Did::new("did:exo:v0").unwrap(), true, validators);
 
         let state = create_reactor_state(&config, make_sign_fn(), None);
         let dir = tempfile::tempdir().unwrap();
@@ -1035,12 +1249,7 @@ mod tests {
     #[tokio::test]
     async fn submit_proposal_non_validator_rejected() {
         let validators = make_validators(4);
-        let config = ReactorConfig {
-            node_did: Did::new("did:exo:outsider").unwrap(),
-            is_validator: false,
-            validators,
-            round_timeout_ms: 5000,
-        };
+        let config = config_for(Did::new("did:exo:outsider").unwrap(), false, validators);
 
         let state = create_reactor_state(&config, make_sign_fn(), None);
         let dir = tempfile::tempdir().unwrap();
@@ -1062,12 +1271,7 @@ mod tests {
         let validators = make_validators(4);
         let validator_vec: Vec<Did> = validators.iter().cloned().collect();
         let node_did = validator_vec[0].clone();
-        let config = ReactorConfig {
-            node_did: node_did.clone(),
-            is_validator: true,
-            validators,
-            round_timeout_ms: 5000,
-        };
+        let config = config_for(node_did.clone(), true, validators);
         let sign_fn = make_sign_fn();
         let state = create_reactor_state(&config, sign_fn.clone(), None);
         let dir = tempfile::tempdir().unwrap();
@@ -1287,6 +1491,7 @@ mod tests {
     fn validate_proposal_rejects_zero_byte_signature() {
         let validators = make_validators(1);
         let proposer = Did::new("did:exo:v0").unwrap();
+        let resolver = validator_keys_for_single(&proposer, key_for_validator_index(0));
         let node = make_node_for_test();
         let msg = ConsensusProposalMsg {
             proposal: exo_dag::consensus::Proposal {
@@ -1297,17 +1502,29 @@ mod tests {
             node,
             signature: Signature::from_bytes([0u8; 64]),
         };
-        let err = validate_proposal(&msg, &validators).unwrap_err();
+        let err = validate_proposal(&msg, &validators, &resolver).unwrap_err();
         // Signature::Ed25519([0u8; 64]) hits is_empty() first (ex_core types.rs:325)
         // so the "empty" message fires before the explicit null-sig check.
         // Either message proves rejection — both are defense in depth.
-        assert!(err.contains("empty") || err.contains("zero-byte"));
+        assert!(signature_is_invalid_error(&err));
+    }
+
+    #[test]
+    fn validate_proposal_accepts_signed_message() {
+        let validators = make_validators(1);
+        let proposer = Did::new("did:exo:v0").unwrap();
+        let resolver = validator_keys_for_single(&proposer, key_for_validator_index(0));
+        let node = make_node_for_test();
+        let msg = proposal_msg_for(proposer, 0, 0, node);
+
+        validate_proposal(&msg, &validators, &resolver).unwrap();
     }
 
     #[test]
     fn validate_vote_rejects_zero_byte_signature() {
         let validators = make_validators(1);
         let voter = Did::new("did:exo:v0").unwrap();
+        let resolver = validator_keys_for_single(&voter, key_for_validator_index(0));
         let msg = ConsensusVoteMsg {
             vote: exo_dag::consensus::Vote {
                 voter,
@@ -1316,14 +1533,27 @@ mod tests {
                 signature: Signature::from_bytes([0u8; 64]),
             },
         };
-        let err = validate_vote(&msg, &validators).unwrap_err();
-        assert!(err.contains("empty") || err.contains("zero-byte"));
+        let err = validate_vote(&msg, &validators, &resolver).unwrap_err();
+        assert!(signature_is_invalid_error(&err));
+    }
+
+    #[test]
+    fn validate_vote_accepts_signed_vote() {
+        let validators = make_validators(1);
+        let voter = Did::new("did:exo:v0").unwrap();
+        let resolver = validator_keys_for_single(&voter, key_for_validator_index(0));
+        let msg = ConsensusVoteMsg {
+            vote: vote_for(&voter, 0, 0, exo_core::types::Hash256([9u8; 32])),
+        };
+
+        validate_vote(&msg, &validators, &resolver).unwrap();
     }
 
     #[test]
     fn validate_commit_rejects_zero_byte_vote_in_cert() {
         let validators = make_validators(1);
         let voter = Did::new("did:exo:v0").unwrap();
+        let resolver = validator_keys_for_single(&voter, key_for_validator_index(0));
         let hash = exo_core::types::Hash256([7u8; 32]);
         let cert = exo_dag::consensus::CommitCertificate {
             node_hash: hash,
@@ -1336,14 +1566,15 @@ mod tests {
             round: 0,
         };
         let msg = ConsensusCommitMsg { certificate: cert };
-        let err = validate_commit(&msg, &validators).unwrap_err();
-        assert!(err.contains("empty") || err.contains("zero-byte"));
+        let err = validate_commit(&msg, &validators, &resolver).unwrap_err();
+        assert!(signature_is_invalid_error(&err));
     }
 
     #[test]
     fn validate_vote_rejects_empty_signature() {
         let validators = make_validators(1);
         let voter = Did::new("did:exo:v0").unwrap();
+        let resolver = validator_keys_for_single(&voter, key_for_validator_index(0));
         let msg = ConsensusVoteMsg {
             vote: exo_dag::consensus::Vote {
                 voter,
@@ -1352,8 +1583,27 @@ mod tests {
                 signature: Signature::empty(),
             },
         };
-        let err = validate_vote(&msg, &validators).unwrap_err();
-        assert!(err.contains("empty signature"));
+        let err = validate_vote(&msg, &validators, &resolver).unwrap_err();
+        assert!(signature_is_invalid_error(&err));
+    }
+
+    #[test]
+    fn validate_vote_rejects_forged_nonzero_signature() {
+        let validators = make_validators(1);
+        let voter = Did::new("did:exo:v0").unwrap();
+        let resolver = validator_keys_for_single(&voter, key_for_validator_index(0));
+        let mut vote = exo_dag::consensus::Vote {
+            voter,
+            round: 0,
+            node_hash: exo_core::types::Hash256([9u8; 32]),
+            signature: Signature::empty(),
+        };
+        let payload = vote.signing_payload().unwrap();
+        vote.signature = sign_with_wrong_key(&payload);
+
+        let msg = ConsensusVoteMsg { vote };
+        let err = validate_vote(&msg, &validators, &resolver).unwrap_err();
+        assert!(err.contains("signature"));
     }
 
     #[test]
@@ -1364,6 +1614,28 @@ mod tests {
         assert!(
             !source.contains(forbidden),
             "reactor commit receipts must derive timestamps from protocol or stored DAG metadata"
+        );
+    }
+
+    #[test]
+    fn reactor_production_paths_do_not_call_legacy_consensus_api() {
+        let source = include_str!("reactor.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("reactor source has production section");
+
+        assert!(
+            !production.contains("consensus::propose("),
+            "production reactor paths must call propose_verified"
+        );
+        assert!(
+            !production.contains("consensus::vote("),
+            "production reactor paths must call vote_verified"
+        );
+        assert!(
+            !production.contains("consensus::commit("),
+            "production reactor paths must call commit_verified"
         );
     }
 }

--- a/crates/exo-node/src/sentinels.rs
+++ b/crates/exo-node/src/sentinels.rs
@@ -559,6 +559,7 @@ mod tests {
             node_did: Did::new("did:exo:v0").unwrap(),
             is_validator: true,
             validators,
+            validator_public_keys: std::collections::BTreeMap::new(),
             round_timeout_ms: 5000,
         };
         create_reactor_state(&config, make_sign_fn(), None)
@@ -610,6 +611,7 @@ mod tests {
             node_did: Did::new("did:exo:v0").unwrap(),
             is_validator: true,
             validators,
+            validator_public_keys: std::collections::BTreeMap::new(),
             round_timeout_ms: 5000,
         };
         let reactor = create_reactor_state(&config, make_sign_fn(), None);

--- a/crates/exo-node/src/telegram.rs
+++ b/crates/exo-node/src/telegram.rs
@@ -858,6 +858,7 @@ mod tests {
             node_did: Did::new("did:exo:v0").unwrap(),
             is_validator: true,
             validators,
+            validator_public_keys: std::collections::BTreeMap::new(),
             round_timeout_ms: 5000,
         };
         create_reactor_state(&config, make_sign_fn(), None)

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 119616 lines of Rust under `crates/`, 2,896 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 120060 lines of Rust under `crates/`, 2,901 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,896 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,901 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,896 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,901 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-119616 lines of Rust under `crates/` · 20 workspace packages · 2,896 listed tests · 40 MCP tools · 8 constitutional invariants
+120060 lines of Rust under `crates/` · 20 workspace packages · 2,901 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 119616 lines of Rust under `crates/` | 266 Rust source files | 2,896 listed tests
+> **Codebase:** 20 workspace packages | 120060 lines of Rust under `crates/` | 266 Rust source files | 2,901 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,896 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,901 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 119616 lines of Rust under `crates/` · 2,896 listed tests
+20 workspace packages · 120060 lines of Rust under `crates/` · 2,901 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- wire exo-node reactor proposal/vote/commit handling to exo-dag verified consensus APIs
- add explicit validator DID to Ed25519 public-key resolver configuration and CLI/API validation
- sign local proposals and self-votes over canonical consensus CBOR payloads
- refuse unverifiable restored votes/certificates and guard against production legacy consensus calls

## TDD / Verification
- RED: cargo test -p exo-node validate_vote_rejects_forged_nonzero_signature --bin exochain -- --nocapture
- RED: cargo test -p exo-node reactor_production_paths_do_not_call_legacy_consensus_api --bin exochain -- --nocapture
- cargo test -p exo-node reactor::tests --bin exochain -- --nocapture
- cargo test -p exo-node --bin exochain -- --nocapture
- cargo test -p exo-node --features unaudited-admin-governance-shortcut
- cargo build -p exo-node
- cargo clippy -p exo-node --bin exochain -- -D warnings
- cargo clippy -p exo-node --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo +nightly fmt --all -- --check
- git diff --check
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
- cargo build --workspace --release
- cargo test --workspace --release
- cargo audit --deny unsound --deny unmaintained
- cargo deny check
- cargo machete --with-metadata
- bash tools/repo_truth.sh --json
- bash tools/test_repo_truth.sh
- bash tools/test_cr001_status.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_no_orphan_rust_modules.sh
- bash tools/test_railway_entrypoint_args.sh