### PR TITLE
fix(exo-node): fail closed on MCP serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 120060 | `wc -l` |
-| Workspace tests | 2,901 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 120111 | `wc -l` |
+| Workspace tests | 2,902 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,901 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,902 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 120060 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 120111 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,901 listed workspace tests
+         cryptographic proofs, 2,902 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/mcp/handler.rs
+++ b/crates/exo-node/src/mcp/handler.rs
@@ -25,6 +25,18 @@ use super::{
     tools::ToolRegistry,
 };
 
+fn serialize_json_rpc_response(response: &JsonRpcResponse) -> String {
+    match serde_json::to_string(response) {
+        Ok(serialized) => serialized,
+        Err(error) => {
+            tracing::error!(err = %error, "failed to serialize JSON-RPC response");
+            format!(
+                "{{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{{\"code\":{INTERNAL_ERROR},\"message\":\"internal error: failed to serialize JSON-RPC response\"}}}}"
+            )
+        }
+    }
+}
+
 /// MCP server that processes JSON-RPC messages from AI clients.
 ///
 /// Each server instance is bound to a specific actor DID, ensuring that
@@ -134,7 +146,7 @@ impl McpServer {
             Ok(req) => req,
             Err(e) => {
                 let resp = JsonRpcResponse::error(None, PARSE_ERROR, format!("parse error: {e}"));
-                return Some(serde_json::to_string(&resp).unwrap_or_default());
+                return Some(serialize_json_rpc_response(&resp));
             }
         };
 
@@ -143,7 +155,7 @@ impl McpServer {
         request.id.as_ref()?;
 
         let response = self.dispatch(&request);
-        Some(serde_json::to_string(&response).unwrap_or_default())
+        Some(serialize_json_rpc_response(&response))
     }
 
     /// Dispatch a parsed JSON-RPC request to the appropriate handler.
@@ -214,12 +226,19 @@ impl McpServer {
 
     /// Handle `tools/list` — returns all registered tools.
     fn handle_tools_list(&self, request: &JsonRpcRequest) -> JsonRpcResponse {
-        let tools: Vec<Value> = self
-            .registry
-            .list()
-            .into_iter()
-            .filter_map(|t| serde_json::to_value(t).ok())
-            .collect();
+        let mut tools: Vec<Value> = Vec::new();
+        for tool in self.registry.list() {
+            match serde_json::to_value(tool) {
+                Ok(value) => tools.push(value),
+                Err(e) => {
+                    return JsonRpcResponse::error(
+                        request.id.clone(),
+                        INTERNAL_ERROR,
+                        format!("tool definition serialization error: {e}"),
+                    );
+                }
+            }
+        }
 
         JsonRpcResponse::success(request.id.clone(), serde_json::json!({ "tools": tools }))
     }
@@ -318,12 +337,19 @@ impl McpServer {
 
     /// Handle `resources/list` — return all registered resource definitions.
     fn handle_resources_list(&self, request: &JsonRpcRequest) -> JsonRpcResponse {
-        let resources: Vec<Value> = self
-            .resources
-            .list()
-            .into_iter()
-            .filter_map(|r| serde_json::to_value(r).ok())
-            .collect();
+        let mut resources: Vec<Value> = Vec::new();
+        for resource in self.resources.list() {
+            match serde_json::to_value(resource) {
+                Ok(value) => resources.push(value),
+                Err(e) => {
+                    return JsonRpcResponse::error(
+                        request.id.clone(),
+                        INTERNAL_ERROR,
+                        format!("resource definition serialization error: {e}"),
+                    );
+                }
+            }
+        }
 
         JsonRpcResponse::success(
             request.id.clone(),
@@ -377,12 +403,19 @@ impl McpServer {
 
     /// Handle `prompts/list` — return all registered prompt definitions.
     fn handle_prompts_list(&self, request: &JsonRpcRequest) -> JsonRpcResponse {
-        let prompts: Vec<Value> = self
-            .prompts
-            .list()
-            .into_iter()
-            .filter_map(|p| serde_json::to_value(p).ok())
-            .collect();
+        let mut prompts: Vec<Value> = Vec::new();
+        for prompt in self.prompts.list() {
+            match serde_json::to_value(prompt) {
+                Ok(value) => prompts.push(value),
+                Err(e) => {
+                    return JsonRpcResponse::error(
+                        request.id.clone(),
+                        INTERNAL_ERROR,
+                        format!("prompt definition serialization error: {e}"),
+                    );
+                }
+            }
+        }
 
         JsonRpcResponse::success(
             request.id.clone(),
@@ -591,6 +624,24 @@ mod tests {
         let parsed: JsonRpcResponse = serde_json::from_str(&response).unwrap();
         assert!(parsed.error.is_some());
         assert_eq!(parsed.error.unwrap().code, PARSE_ERROR);
+    }
+
+    #[test]
+    fn handler_production_source_fails_closed_on_serialization_errors() {
+        let source = include_str!("handler.rs");
+        let production = source
+            .split("// ===========================================================================\n// Tests")
+            .next()
+            .expect("handler production section must be present");
+
+        assert!(
+            !production.contains("unwrap_or_default()"),
+            "MCP handler must not hide JSON-RPC serialization failures behind empty strings"
+        );
+        assert!(
+            !production.contains(".filter_map(|"),
+            "MCP handler list endpoints must not silently drop unserializable entries"
+        );
     }
 
     #[test]

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 120060 lines of Rust under `crates/`, 2,901 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 120111 lines of Rust under `crates/`, 2,902 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,901 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,902 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,901 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,902 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-120060 lines of Rust under `crates/` · 20 workspace packages · 2,901 listed tests · 40 MCP tools · 8 constitutional invariants
+120111 lines of Rust under `crates/` · 20 workspace packages · 2,902 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 120060 lines of Rust under `crates/` | 266 Rust source files | 2,901 listed tests
+> **Codebase:** 20 workspace packages | 120111 lines of Rust under `crates/` | 266 Rust source files | 2,902 listed tests
 
 ---
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 120060 lines of Rust under `crates/` · 2,901 listed tests
+20 workspace packages · 120111 lines of Rust under `crates/` · 2,902 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- fail closed when JSON-RPC response serialization cannot be emitted
- return explicit MCP internal errors instead of silently dropping unserializable tools/resources/prompts
- add a source guard test against the two production fail-open patterns
- refresh repo-truth LOC/test counts after adding the guard test

## TDD
- red: added `handler_production_source_fails_closed_on_serialization_errors`; it failed while production still used `unwrap_or_default()`
- green: replaced silent defaults/drops with explicit internal-error responses and a hardcoded fallback JSON-RPC error string

## Verification
- `cargo test -p exo-node mcp::handler::tests::handler_production_source_fails_closed_on_serialization_errors --bin exochain -- --nocapture`
- `cargo test -p exo-node mcp::handler::tests::handler_invalid_json --bin exochain -- --nocapture`
- `cargo test -p exo-node mcp::handler::tests --bin exochain -- --nocapture`
- `cargo test -p exo-node --bin exochain`
- `cargo test -p exo-node`
- `cargo build -p exo-node`
- `cargo clippy -p exo-node --bin exochain -- -D warnings`
- `cargo clippy -p exo-node --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `bash tools/test_repo_truth.sh`
- `bash tools/repo_truth.sh --json`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo doc --workspace --no-deps`
- `cargo audit` (green; existing allowed yanked warning)
- `cargo deny check` (green; existing allowed warnings)
- `cargo test --workspace --release`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash tools/repo_truth.sh --json --skip-tests`
