### PR TITLE
Fail closed on ExoForge dashboard serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 120111 | `wc -l` |
-| Workspace tests | 2,902 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 120145 | `wc -l` |
+| Workspace tests | 2,903 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,902 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,903 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 120111 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 120145 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,902 listed workspace tests
+         cryptographic proofs, 2,903 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/exoforge.rs
+++ b/crates/exo-node/src/exoforge.rs
@@ -116,6 +116,20 @@ pub struct ForgeState {
     clock: HybridClock,
 }
 
+fn serialize_dashboard_json<T: Serialize>(
+    field: &'static str,
+    value: &T,
+) -> Result<String, StatusCode> {
+    serde_json::to_string(value).map_err(|error| {
+        tracing::error!(
+            field,
+            err = %error,
+            "failed to serialize ExoForge dashboard state"
+        );
+        StatusCode::INTERNAL_SERVER_ERROR
+    })
+}
+
 // ─── Request / Response bodies ──────────────────────────────────────
 
 /// Request body for updating a task's status.
@@ -939,9 +953,9 @@ async fn serve_dashboard(
         tracing::error!("ForgeState mutex poisoned in serve_dashboard");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
-    let tasks_json = serde_json::to_string(&s.tasks).unwrap_or_default();
-    let stats_json = serde_json::to_string(&s.stats()).unwrap_or_default();
-    let log_json = serde_json::to_string(&s.activity_log).unwrap_or_default();
+    let tasks_json = serialize_dashboard_json("tasks", &s.tasks)?;
+    let stats_json = serialize_dashboard_json("stats", &s.stats())?;
+    let log_json = serialize_dashboard_json("activity_log", &s.activity_log)?;
     drop(s);
 
     Ok(Html(format!(
@@ -1618,6 +1632,25 @@ mod tests {
         );
     }
 
+    struct FailingSerialize;
+
+    impl Serialize for FailingSerialize {
+        fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            Err(serde::ser::Error::custom(
+                "intentional dashboard serialization failure",
+            ))
+        }
+    }
+
+    #[test]
+    fn dashboard_json_serialization_fails_closed() {
+        let result = serialize_dashboard_json("tasks", &FailingSerialize);
+        assert_eq!(result, Err(StatusCode::INTERNAL_SERVER_ERROR));
+    }
+
     #[test]
     fn production_source_has_no_float_wall_clock_or_hashset_escape_hatches() {
         let source = include_str!("exoforge.rs");
@@ -1629,6 +1662,7 @@ mod tests {
         assert!(!production.contains("float_arithmetic"));
         assert!(!production.contains("f64"));
         assert!(!production.contains("SystemTime::now"));
+        assert!(!production.contains("unwrap_or_default()"));
         let hash_set = "Hash".to_owned() + "Set";
         assert!(!source.contains(&hash_set));
     }

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 120111 lines of Rust under `crates/`, 2,902 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 120145 lines of Rust under `crates/`, 2,903 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,902 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,903 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,902 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,903 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-120111 lines of Rust under `crates/` · 20 workspace packages · 2,902 listed tests · 40 MCP tools · 8 constitutional invariants
+120145 lines of Rust under `crates/` · 20 workspace packages · 2,903 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 120111 lines of Rust under `crates/` | 266 Rust source files | 2,902 listed tests
+> **Codebase:** 20 workspace packages | 120145 lines of Rust under `crates/` | 266 Rust source files | 2,903 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,901 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,903 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 120111 lines of Rust under `crates/` · 2,902 listed tests
+20 workspace packages · 120145 lines of Rust under `crates/` · 2,903 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- Replace ExoForge dashboard JSON `unwrap_or_default()` fallbacks with a fail-closed serializer that returns HTTP 500 and emits structured error logging.
- Add a focused failing-serializer regression test and extend the ExoForge production source guard against future dashboard JSON fallbacks.
- Refresh repo-truth counts to 120145 Rust LOC / 2,903 listed tests.

## TDD
- Red: `cargo test -p exo-node exoforge::tests::dashboard_json_serialization_fails_closed --bin exochain -- --nocapture` failed before the helper existed.
- Green: same focused test passed after implementation.

## Verification
- `cargo test -p exo-node exoforge::tests::dashboard_json_serialization_fails_closed --bin exochain -- --nocapture`
- `cargo test -p exo-node exoforge::tests::production_source_has_no_float_wall_clock_or_hashset_escape_hatches --bin exochain -- --nocapture`
- `cargo test -p exo-node exoforge::tests --bin exochain -- --nocapture`
- `cargo test -p exo-node --bin exochain`
- `cargo test -p exo-node`
- `cargo build -p exo-node`
- `cargo clippy -p exo-node --bin exochain -- -D warnings`
- `cargo clippy -p exo-node --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `bash tools/test_repo_truth.sh`
- `bash tools/repo_truth.sh --json`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check`
