### PR TITLE
fix(exo-core): propagate event signing serialization errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 120145 | `wc -l` |
-| Workspace tests | 2,903 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 120197 | `wc -l` |
+| Workspace tests | 2,904 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,903 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,904 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 120145 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 120197 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,903 listed workspace tests
+         cryptographic proofs, 2,904 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-core/src/events.rs
+++ b/crates/exo-core/src/events.rs
@@ -4,6 +4,8 @@
 //! be verified independently.  Events carry a CBOR-encoded payload and are
 //! attributed to a DID via an Ed25519 signature.
 
+use std::io::Write;
+
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -72,8 +74,11 @@ impl Event {
     ///
     /// The signed content is: `id || timestamp || event_type || payload || source_did`
     /// serialized as CBOR.
-    #[must_use]
-    pub fn signable_bytes(&self) -> Vec<u8> {
+    ///
+    /// # Errors
+    ///
+    /// Returns `ExoError::SerializationError` if CBOR encoding fails.
+    pub fn write_signable_bytes<W: Write>(&self, writer: W) -> crate::Result<()> {
         #[derive(Serialize)]
         struct Signable<'a> {
             id: &'a CorrelationId,
@@ -89,23 +94,39 @@ impl Event {
             payload: &self.payload,
             source_did: &self.source_did,
         };
+        ciborium::into_writer(&s, writer)?;
+        Ok(())
+    }
+
+    /// Construct the canonical bytes that are signed.
+    ///
+    /// The signed content is: `id || timestamp || event_type || payload || source_did`
+    /// serialized as CBOR.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ExoError::SerializationError` if CBOR encoding fails.
+    pub fn signable_bytes(&self) -> crate::Result<Vec<u8>> {
         let mut buf = Vec::new();
-        // CBOR encoding of simple struct types cannot fail in practice,
-        // but we handle the error path defensively rather than panicking.
-        #[allow(clippy::expect_used)] // Infallible for flat serde structs; defensive only
-        ciborium::into_writer(&s, &mut buf).unwrap_or_else(|_| buf.clear());
-        buf
+        self.write_signable_bytes(&mut buf)?;
+        Ok(buf)
     }
 }
 
 /// Verify that an event's signature is valid for the given public key.
 #[must_use]
 pub fn verify_event(event: &Event, public_key: &PublicKey) -> bool {
-    let bytes = event.signable_bytes();
+    let Ok(bytes) = event.signable_bytes() else {
+        return false;
+    };
     crypto::verify(&bytes, &event.signature, public_key)
 }
 
 /// Helper: create a signed event.
+///
+/// # Errors
+///
+/// Returns `ExoError::SerializationError` if canonical event serialization fails.
 pub fn create_signed_event(
     id: CorrelationId,
     timestamp: Timestamp,
@@ -113,7 +134,7 @@ pub fn create_signed_event(
     payload: Vec<u8>,
     source_did: Did,
     secret_key: &crate::types::SecretKey,
-) -> Event {
+) -> crate::Result<Event> {
     // Build a temporary event with a dummy signature to compute signable bytes
     let mut event = Event {
         id,
@@ -123,9 +144,9 @@ pub fn create_signed_event(
         source_did,
         signature: Signature::from_bytes([0u8; 64]),
     };
-    let bytes = event.signable_bytes();
+    let bytes = event.signable_bytes()?;
     event.signature = crypto::sign(&bytes, secret_key);
-    event
+    Ok(event)
 }
 
 // ---------------------------------------------------------------------------
@@ -297,6 +318,7 @@ mod tests {
             did,
             kp.secret_key(),
         )
+        .expect("sign event")
     }
 
     #[test]
@@ -377,9 +399,29 @@ mod tests {
     fn signable_bytes_deterministic() {
         let kp = KeyPair::generate();
         let event = make_event(&kp);
-        let b1 = event.signable_bytes();
-        let b2 = event.signable_bytes();
+        let b1 = event.signable_bytes().expect("serialize signable bytes");
+        let b2 = event.signable_bytes().expect("serialize signable bytes");
         assert_eq!(b1, b2);
+    }
+
+    #[test]
+    fn signable_bytes_writer_error_is_returned() {
+        struct FailingWriter;
+
+        impl std::io::Write for FailingWriter {
+            fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::other("intentional signable writer failure"))
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let kp = KeyPair::generate();
+        let event = make_event(&kp);
+        let error = event.write_signable_bytes(FailingWriter).unwrap_err();
+        assert!(matches!(error, crate::ExoError::SerializationError { .. }));
     }
 
     #[test]
@@ -410,7 +452,8 @@ mod tests {
             Vec::new(),
             did,
             kp.secret_key(),
-        );
+        )
+        .expect("sign event");
         assert!(verify_event(&event, kp.public_key()));
     }
 
@@ -426,7 +469,8 @@ mod tests {
             payload,
             did,
             kp.secret_key(),
-        );
+        )
+        .expect("sign event");
         assert!(verify_event(&event, kp.public_key()));
     }
 

--- a/crates/exo-core/tests/chain_of_custody.rs
+++ b/crates/exo-core/tests/chain_of_custody.rs
@@ -76,7 +76,8 @@ fn multi_actor_signed_event_chain_with_merkle_proof() {
         t1.receipt_hash.as_bytes().to_vec(),
         actors.proposer.0.clone(),
         actors.proposer.1.secret_key(),
-    );
+    )
+    .expect("sign event");
     assert!(verify_event(&event1, actors.proposer.1.public_key()));
 
     // Phase 2: Identity resolution by reviewer1
@@ -90,7 +91,8 @@ fn multi_actor_signed_event_chain_with_merkle_proof() {
         t2.receipt_hash.as_bytes().to_vec(),
         actors.reviewer1.0.clone(),
         actors.reviewer1.1.secret_key(),
-    );
+    )
+    .expect("sign event");
     assert!(verify_event(&event2, actors.reviewer1.1.public_key()));
 
     // Phase 3: Consent validation by reviewer2
@@ -104,7 +106,8 @@ fn multi_actor_signed_event_chain_with_merkle_proof() {
         t3.receipt_hash.as_bytes().to_vec(),
         actors.reviewer2.0.clone(),
         actors.reviewer2.1.secret_key(),
-    );
+    )
+    .expect("sign event");
     assert!(verify_event(&event3, actors.reviewer2.1.public_key()));
 
     // Phase 4: Deliberation by steward
@@ -118,7 +121,8 @@ fn multi_actor_signed_event_chain_with_merkle_proof() {
         t4.receipt_hash.as_bytes().to_vec(),
         actors.steward.0.clone(),
         actors.steward.1.secret_key(),
-    );
+    )
+    .expect("sign event");
     assert!(verify_event(&event4, actors.steward.1.public_key()));
 
     // Verify receipt chain integrity
@@ -190,7 +194,8 @@ fn denial_remediation_resubmission_with_full_proof_chain() {
             t.receipt_hash.as_bytes().to_vec(),
             actor.clone(),
             kp.secret_key(),
-        );
+        )
+        .expect("sign event");
         assert!(verify_event(&event, kp.public_key()));
         events.push(event);
     }
@@ -343,7 +348,8 @@ fn escalation_path_proof() {
         t_esc.receipt_hash.as_bytes().to_vec(),
         actor.clone(),
         kp.secret_key(),
-    );
+    )
+    .expect("sign event");
     assert!(verify_event(&event, kp.public_key()));
     tx.verify_receipt_chain().expect("chain valid");
     assert_eq!(tx.state(), BctsState::Escalated);

--- a/crates/exo-core/tests/integration.rs
+++ b/crates/exo-core/tests/integration.rs
@@ -50,7 +50,8 @@ fn full_bcts_lifecycle_with_signed_events() {
             transition.receipt_hash.as_bytes().to_vec(),
             actor.clone(),
             kp.secret_key(),
-        );
+        )
+        .expect("sign event");
         assert!(verify_event(&event, kp.public_key()));
     }
 

--- a/crates/exochain-wasm/src/core_bindings.rs
+++ b/crates/exochain-wasm/src/core_bindings.rs
@@ -292,6 +292,7 @@ pub fn wasm_create_signed_event(
     let ts = caller_timestamp(timestamp_physical_ms, timestamp_logical, "event timestamp")?;
 
     let event =
-        exo_core::events::create_signed_event(corr, ts, event_type, payload.to_vec(), did, &secret);
+        exo_core::events::create_signed_event(corr, ts, event_type, payload.to_vec(), did, &secret)
+            .map_err(|e| JsValue::from_str(&format!("event signing error: {e}")))?;
     to_js_value(&event)
 }

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 120145 lines of Rust under `crates/`, 2,903 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 120197 lines of Rust under `crates/`, 2,904 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,903 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,904 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,903 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,904 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-120145 lines of Rust under `crates/` · 20 workspace packages · 2,903 listed tests · 40 MCP tools · 8 constitutional invariants
+120197 lines of Rust under `crates/` · 20 workspace packages · 2,904 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 120145 lines of Rust under `crates/` | 266 Rust source files | 2,903 listed tests
+> **Codebase:** 20 workspace packages | 120197 lines of Rust under `crates/` | 266 Rust source files | 2,904 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,903 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,904 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 120145 lines of Rust under `crates/` · 2,903 listed tests
+20 workspace packages · 120197 lines of Rust under `crates/` · 2,904 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- make exo-core event signable-byte serialization return Result instead of clearing the buffer on CBOR writer errors
- make create_signed_event propagate serialization failures and keep verify_event fail-closed
- surface WASM event signing failures to JS and refresh repo-truth counts to 120197 LOC / 2,904 listed tests

## TDD
- added signable_bytes_writer_error_is_returned, first observed red because Event::write_signable_bytes did not exist

## Verification
- cargo test -p exo-core signable_bytes_writer_error_is_returned --lib -- --nocapture
- cargo test -p exo-core signable_bytes_deterministic --lib -- --nocapture
- cargo test -p exo-core create_and_verify_event --lib -- --nocapture
- cargo test -p exo-core
- cargo test -p exochain-wasm
- cargo build -p exo-core
- cargo build -p exochain-wasm
- cargo clippy -p exo-core --all-targets -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo clippy -p exochain-wasm --all-targets -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo +nightly fmt --all -- --check
- bash tools/test_repo_truth.sh
- bash tools/test_cr001_status.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_no_orphan_rust_modules.sh
- bash tools/test_railway_entrypoint_args.sh
- git diff --check
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo build --workspace --release
- cargo test --workspace --release
- RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps
- cargo audit --deny unsound --deny unmaintained (existing allowed yanked core2 warning)
- cargo deny check (existing duplicate/yanked/unused-allowance warnings)
- cargo machete --with-metadata