### PR TITLE
fix(exo-core): verify PQ and hybrid event signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 120197 | `wc -l` |
-| Workspace tests | 2,904 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 120320 | `wc -l` |
+| Workspace tests | 2,908 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,904 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,908 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 120197 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 120320 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,904 listed workspace tests
+         cryptographic proofs, 2,908 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-core/src/events.rs
+++ b/crates/exo-core/src/events.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     crypto,
-    types::{CorrelationId, Did, PublicKey, Signature, Timestamp},
+    types::{CorrelationId, Did, PqPublicKey, PublicKey, Signature, Timestamp},
 };
 
 // ---------------------------------------------------------------------------
@@ -120,6 +120,36 @@ pub fn verify_event(event: &Event, public_key: &PublicKey) -> bool {
         return false;
     };
     crypto::verify(&bytes, &event.signature, public_key)
+}
+
+/// Verify that an event's post-quantum signature is valid for the given ML-DSA public key.
+#[must_use]
+pub fn verify_event_pq(event: &Event, public_key: &PqPublicKey) -> bool {
+    let Ok(bytes) = event.signable_bytes() else {
+        return false;
+    };
+    crypto::verify_pq(&bytes, &event.signature, public_key)
+}
+
+/// Verify that an event's hybrid signature is valid for both public keys.
+///
+/// Both Ed25519 and ML-DSA components must verify. Use [`verify_event`] only
+/// for Ed25519-only events.
+#[must_use]
+pub fn verify_event_hybrid(
+    event: &Event,
+    classical_public_key: &PublicKey,
+    pq_public_key: &PqPublicKey,
+) -> bool {
+    let Ok(bytes) = event.signable_bytes() else {
+        return false;
+    };
+    crypto::verify_hybrid(
+        &bytes,
+        &event.signature,
+        classical_public_key,
+        pq_public_key,
+    )
 }
 
 /// Helper: create a signed event.
@@ -304,7 +334,7 @@ pub fn compute_event_id<T: serde::Serialize>(envelope: &T) -> crate::Result<crat
 mod tests {
     use super::*;
     use crate::{
-        crypto::KeyPair,
+        crypto::{self, KeyPair, PqKeyPair},
         types::{CorrelationId, Did, Timestamp},
     };
 
@@ -319,6 +349,17 @@ mod tests {
             kp.secret_key(),
         )
         .expect("sign event")
+    }
+
+    fn make_unsigned_event(source_did: Did) -> Event {
+        Event {
+            id: CorrelationId::new(),
+            timestamp: Timestamp::new(1000, 0),
+            event_type: EventType::AuditEntry,
+            payload: b"test payload".to_vec(),
+            source_did,
+            signature: Signature::Empty,
+        }
     }
 
     #[test]
@@ -358,6 +399,88 @@ mod tests {
         let mut event = make_event(&kp);
         event.event_type = EventType::SybilAlert;
         assert!(!verify_event(&event, kp.public_key()));
+    }
+
+    #[test]
+    fn verify_event_pq_accepts_valid_post_quantum_signature() {
+        let pq = PqKeyPair::generate();
+        let did = Did::new("did:exo:pq-source").expect("valid");
+        let mut event = make_unsigned_event(did);
+        let bytes = event.signable_bytes().expect("serialize signable bytes");
+        event.signature = pq.sign(&bytes).expect("sign pq event");
+
+        assert!(verify_event_pq(&event, pq.public_key()));
+        assert!(
+            !verify_event(&event, &PublicKey::from_bytes([7u8; 32])),
+            "classical verifier must not accept a PQ event signature"
+        );
+    }
+
+    #[test]
+    fn verify_event_pq_rejects_wrong_key_and_tamper() {
+        let pq = PqKeyPair::generate();
+        let wrong_pq = PqKeyPair::generate();
+        let did = Did::new("did:exo:pq-source").expect("valid");
+        let mut event = make_unsigned_event(did);
+        let bytes = event.signable_bytes().expect("serialize signable bytes");
+        event.signature = pq.sign(&bytes).expect("sign pq event");
+
+        assert!(!verify_event_pq(&event, wrong_pq.public_key()));
+
+        event.payload = b"tampered".to_vec();
+        assert!(!verify_event_pq(&event, pq.public_key()));
+    }
+
+    #[test]
+    fn verify_event_hybrid_accepts_valid_dual_signature() {
+        let classical = KeyPair::generate();
+        let (pq_public, pq_secret) = crypto::generate_pq_keypair();
+        let did = Did::new("did:exo:hybrid-source").expect("valid");
+        let mut event = make_unsigned_event(did);
+        let bytes = event.signable_bytes().expect("serialize signable bytes");
+        event.signature = crypto::sign_hybrid(&bytes, classical.secret_key(), &pq_secret)
+            .expect("sign hybrid event");
+
+        assert!(verify_event_hybrid(
+            &event,
+            classical.public_key(),
+            &pq_public
+        ));
+        assert!(
+            !verify_event(&event, classical.public_key()),
+            "classical verifier must not accept a hybrid event signature"
+        );
+    }
+
+    #[test]
+    fn verify_event_hybrid_rejects_wrong_keys_and_tamper() {
+        let classical = KeyPair::generate();
+        let wrong_classical = KeyPair::generate();
+        let (pq_public, pq_secret) = crypto::generate_pq_keypair();
+        let (wrong_pq_public, _) = crypto::generate_pq_keypair();
+        let did = Did::new("did:exo:hybrid-source").expect("valid");
+        let mut event = make_unsigned_event(did);
+        let bytes = event.signable_bytes().expect("serialize signable bytes");
+        event.signature = crypto::sign_hybrid(&bytes, classical.secret_key(), &pq_secret)
+            .expect("sign hybrid event");
+
+        assert!(!verify_event_hybrid(
+            &event,
+            wrong_classical.public_key(),
+            &pq_public
+        ));
+        assert!(!verify_event_hybrid(
+            &event,
+            classical.public_key(),
+            &wrong_pq_public
+        ));
+
+        event.event_type = EventType::SybilAlert;
+        assert!(!verify_event_hybrid(
+            &event,
+            classical.public_key(),
+            &pq_public
+        ));
     }
 
     #[test]

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 120197 lines of Rust under `crates/`, 2,904 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 120320 lines of Rust under `crates/`, 2,908 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,904 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,908 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,904 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,908 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-120197 lines of Rust under `crates/` · 20 workspace packages · 2,904 listed tests · 40 MCP tools · 8 constitutional invariants
+120320 lines of Rust under `crates/` · 20 workspace packages · 2,908 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 120197 lines of Rust under `crates/` | 266 Rust source files | 2,904 listed tests
+> **Codebase:** 20 workspace packages | 120320 lines of Rust under `crates/` | 266 Rust source files | 2,908 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,904 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,908 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 120197 lines of Rust under `crates/` · 2,904 listed tests
+20 workspace packages · 120320 lines of Rust under `crates/` · 2,908 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- add event-level ML-DSA verifier via verify_event_pq
- add event-level hybrid verifier via verify_event_hybrid requiring both Ed25519 and ML-DSA keys
- keep verify_event as Ed25519-only and fail-closed for PQ/hybrid variants
- refresh repo-truth docs to 120320 Rust LOC and 2,908 listed tests

## TDD
- RED: cargo test -p exo-core verify_event_pq_accepts_valid_post_quantum_signature --lib -- --nocapture failed before the new verifier APIs existed
- GREEN: cargo test -p exo-core verify_event_pq_accepts_valid_post_quantum_signature --lib -- --nocapture
- GREEN: cargo test -p exo-core verify_event_hybrid_accepts_valid_dual_signature --lib -- --nocapture
- GREEN: cargo test -p exo-core verify_event_pq_ --lib -- --nocapture
- GREEN: cargo test -p exo-core verify_event_hybrid_ --lib -- --nocapture

## Verification
- cargo test -p exo-core --lib
- cargo test -p exo-core
- cargo build -p exo-core
- cargo clippy -p exo-core --all-targets -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo test --workspace -- --list
- cargo +nightly fmt --all -- --check
- bash tools/test_repo_truth.sh
- bash tools/test_cr001_status.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_no_orphan_rust_modules.sh
- bash tools/test_railway_entrypoint_args.sh
- git diff --check
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo build --workspace --release
- cargo test --workspace --release
- RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps
- cargo audit --deny unsound --deny unmaintained (existing allowed yanked core2 warning)
- cargo deny check (existing duplicate/yanked/unused-allowance warnings)
- cargo machete --with-metadata