### PR TITLE
fix(exo-core): deprecate signature byte sentinel

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 120320 | `wc -l` |
-| Workspace tests | 2,908 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 120368 | `wc -l` |
+| Workspace tests | 2,912 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,908 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,912 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 120320 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 120368 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,908 listed workspace tests
+         cryptographic proofs, 2,912 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-authority/src/delegation.rs
+++ b/crates/exo-authority/src/delegation.rs
@@ -475,8 +475,7 @@ fn canonical_scope(scope: &[Permission]) -> Result<Vec<Permission>, AuthorityErr
 }
 
 fn signature_is_all_zero(signature: &Signature) -> bool {
-    let raw = signature.as_bytes();
-    !raw.is_empty() && raw.iter().all(|b| *b == 0)
+    signature.ed25519_component_is_zero()
 }
 
 #[cfg(test)]

--- a/crates/exo-consent/src/bailment.rs
+++ b/crates/exo-consent/src/bailment.rs
@@ -181,7 +181,7 @@ pub fn accept(
     // callers who forget to check is_empty() and pass an Ed25519 with
     // all-zero bytes, which some backends treat as a valid point but
     // is a well-known null-signature attack shape.
-    if bailee_signature.as_bytes().iter().all(|b| *b == 0) {
+    if bailee_signature.ed25519_component_is_zero() {
         return Err(ConsentError::InvalidSignature);
     }
 
@@ -209,7 +209,7 @@ pub fn has_valid_acceptance_proof(bailment: &Bailment) -> bool {
     if bailment.signature.is_empty() {
         return false;
     }
-    if bailment.signature.as_bytes().iter().all(|b| *b == 0) {
+    if bailment.signature.ed25519_component_is_zero() {
         return false;
     }
     let Some(bailee_public_key) = bailment.bailee_public_key else {

--- a/crates/exo-core/src/types.rs
+++ b/crates/exo-core/src/types.rs
@@ -270,18 +270,22 @@ impl Signature {
         Self::Ed25519(bytes)
     }
 
-    /// Return the inner bytes for Ed25519 signatures.
-    /// Panics if called on non-Ed25519 variants (use `ed25519_bytes()` for fallible access).
+    /// Return the inner bytes for legacy Ed25519 signatures.
+    ///
+    /// # Panics
+    /// Panics if called on non-Ed25519 variants. Use [`Self::ed25519_bytes`]
+    /// for fallible Ed25519-compatible access or [`Self::to_bytes`] for
+    /// algorithm-agnostic byte serialization.
+    #[deprecated(
+        since = "0.1.0-beta",
+        note = "use ed25519_bytes() for fallible Ed25519-compatible access or to_bytes() for algorithm-agnostic serialization"
+    )]
     #[must_use]
     pub fn as_bytes(&self) -> &[u8; 64] {
         match self {
             Self::Ed25519(b) => b,
-            Self::Hybrid { classical, .. } => classical,
-            Self::PostQuantum(_) | Self::Empty => {
-                // Return a static reference for compatibility; callers should
-                // migrate to ed25519_bytes() for proper handling.
-                static ZEROS: [u8; 64] = [0u8; 64];
-                &ZEROS
+            Self::Hybrid { .. } | Self::PostQuantum(_) | Self::Empty => {
+                panic!("Signature::as_bytes() is only valid for Ed25519 signatures")
             }
         }
     }
@@ -294,6 +298,16 @@ impl Signature {
             Self::Hybrid { classical, .. } => Some(classical),
             Self::PostQuantum(_) | Self::Empty => None,
         }
+    }
+
+    /// Return true when the Ed25519-compatible component is the all-zero sentinel.
+    ///
+    /// This preserves the explicit null-signature guard without relying on
+    /// [`Self::as_bytes`], which is intentionally Ed25519-only.
+    #[must_use]
+    pub fn ed25519_component_is_zero(&self) -> bool {
+        self.ed25519_bytes()
+            .is_some_and(|raw| raw.iter().all(|b| *b == 0))
     }
 
     /// Return all signature bytes as a slice (algorithm-agnostic).
@@ -1204,9 +1218,36 @@ mod tests {
     // -- Signature ---------------------------------------------------------
 
     #[test]
+    #[allow(deprecated)]
     fn signature_from_bytes() {
         let sig = Signature::from_bytes([0xffu8; 64]);
         assert_eq!(sig.as_bytes(), &[0xff; 64]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Signature::as_bytes() is only valid for Ed25519 signatures")]
+    #[allow(deprecated)]
+    fn signature_as_bytes_panics_for_empty_instead_of_returning_zero_sentinel() {
+        let _ = Signature::Empty.as_bytes();
+    }
+
+    #[test]
+    #[should_panic(expected = "Signature::as_bytes() is only valid for Ed25519 signatures")]
+    #[allow(deprecated)]
+    fn signature_as_bytes_panics_for_post_quantum_instead_of_returning_zero_sentinel() {
+        let _ = Signature::PostQuantum(vec![1, 2, 3]).as_bytes();
+    }
+
+    #[test]
+    #[should_panic(expected = "Signature::as_bytes() is only valid for Ed25519 signatures")]
+    #[allow(deprecated)]
+    fn signature_as_bytes_panics_for_hybrid_to_prevent_classical_downgrade() {
+        let signature = Signature::Hybrid {
+            classical: [0xab; 64],
+            pq: vec![1, 2, 3],
+        };
+
+        let _ = signature.as_bytes();
     }
 
     #[test]
@@ -1216,6 +1257,20 @@ mod tests {
         assert_eq!(Signature::Empty.ed25519_bytes(), None);
         let pq = Signature::PostQuantum(vec![1, 2, 3]);
         assert_eq!(pq.ed25519_bytes(), None);
+    }
+
+    #[test]
+    fn signature_ed25519_component_zero_detection_is_explicit() {
+        assert!(Signature::from_bytes([0u8; 64]).ed25519_component_is_zero());
+        assert!(!Signature::from_bytes([1u8; 64]).ed25519_component_is_zero());
+        assert!(!Signature::PostQuantum(vec![1, 2, 3]).ed25519_component_is_zero());
+        assert!(!Signature::Empty.ed25519_component_is_zero());
+
+        let hybrid_zero_classical = Signature::Hybrid {
+            classical: [0u8; 64],
+            pq: vec![1, 2, 3],
+        };
+        assert!(hybrid_zero_classical.ed25519_component_is_zero());
     }
 
     #[test]

--- a/crates/exo-dag/src/consensus.rs
+++ b/crates/exo-dag/src/consensus.rs
@@ -132,8 +132,7 @@ impl Vote {
         if self.signature.is_empty() {
             return false;
         }
-        let raw = self.signature.as_bytes();
-        if !raw.is_empty() && raw.iter().all(|b| *b == 0) {
+        if self.signature.ed25519_component_is_zero() {
             return false;
         }
         let Ok(payload) = self.signing_payload() else {
@@ -169,8 +168,7 @@ impl Proposal {
         if signature.is_empty() {
             return false;
         }
-        let raw = signature.as_bytes();
-        if !raw.is_empty() && raw.iter().all(|b| *b == 0) {
+        if signature.ed25519_component_is_zero() {
             return false;
         }
         let Ok(payload) = self.signing_payload() else {
@@ -1207,17 +1205,15 @@ mod tests {
     // Coverage completion tests — exercise remaining error branches.
     // -----------------------------------------------------------------------
 
-    // Covers Vote::verify_signature line 137: non-empty, all-zero (non-Ed25519) sig.
+    // Covers Vote::verify_signature rejecting a non-Ed25519 signature without
+    // relying on the legacy Signature::as_bytes() zero sentinel.
     #[test]
-    fn vote_verify_signature_rejects_all_zero_postquantum_bytes() {
+    fn vote_verify_signature_rejects_postquantum_signature() {
         let (pk_a, _sk_a) = crypto::generate_keypair();
         let v = Vote {
             voter: Did::new("did:exo:alice").unwrap(),
             round: 0,
             node_hash: Hash256::ZERO,
-            // PostQuantum variant -> is_empty() == false (vec non-empty),
-            // but as_bytes() returns the static ZEROS buffer, exercising
-            // the all-zero sentinel guard.
             signature: Signature::PostQuantum(vec![1u8; 64]),
         };
         assert!(!v.verify_signature(&pk_a));
@@ -1235,17 +1231,16 @@ mod tests {
         assert!(!p.verify_signature(&pk_a, &Signature::empty()));
     }
 
-    // Covers Proposal::verify_signature line 174: non-empty, all-zero sentinel.
+    // Covers Proposal::verify_signature rejecting a non-Ed25519 signature without
+    // relying on the legacy Signature::as_bytes() zero sentinel.
     #[test]
-    fn proposal_verify_signature_rejects_all_zero_postquantum_bytes() {
+    fn proposal_verify_signature_rejects_postquantum_signature() {
         let (pk_a, _sk_a) = crypto::generate_keypair();
         let p = Proposal {
             proposer: Did::new("did:exo:alice").unwrap(),
             round: 0,
             node_hash: Hash256::ZERO,
         };
-        // Same trick as the vote test: non-empty PostQuantum whose
-        // as_bytes() returns the all-zero static buffer.
         let sig = Signature::PostQuantum(vec![1u8; 64]);
         assert!(!p.verify_signature(&pk_a, &sig));
     }

--- a/crates/exo-dag/src/dag.rs
+++ b/crates/exo-dag/src/dag.rs
@@ -406,7 +406,8 @@ mod tests {
     fn make_verify_fn() -> VerifyFn {
         Box::new(|data: &[u8], sig: &Signature| {
             let h = blake3::hash(data);
-            sig.as_bytes()[..32] == *h.as_bytes()
+            sig.ed25519_bytes()
+                .is_some_and(|raw| raw[..32] == *h.as_bytes())
         })
     }
 

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -2814,7 +2814,7 @@ mod tests {
             "authTimestampLogical": timestamp.logical,
             "observedAt": observed_at.physical_ms,
             "observedAtLogical": observed_at.logical,
-            "signature": hex::encode(signature.as_bytes())
+            "signature": hex::encode(signature.to_bytes())
         });
 
         let response = handle_auth_login(

--- a/crates/exo-governance/src/quorum.rs
+++ b/crates/exo-governance/src/quorum.rs
@@ -78,8 +78,7 @@ impl IndependenceAttestation {
             return false;
         };
         // Empty signatures are an explicit "unsigned" sentinel and must not verify.
-        let raw = self.signature.as_bytes();
-        if raw.is_empty() || raw.iter().all(|b| *b == 0) {
+        if self.signature.is_empty() || self.signature.ed25519_component_is_zero() {
             return false;
         }
         crypto::verify(&payload, &self.signature, public_key)
@@ -1200,7 +1199,7 @@ mod tests {
         assert!(PublicKeyResolver::resolve(&resolver, &did("other")).is_none());
     }
 
-    // Covers verify_signature's empty-signature early reject (Signature::Empty → 64 zeros).
+    // Covers verify_signature's empty-signature early reject.
     #[test]
     fn verify_signature_rejects_empty_variant() {
         let (pk, _sk) = crypto::generate_keypair();

--- a/crates/exo-identity/src/verification.rs
+++ b/crates/exo-identity/src/verification.rs
@@ -222,7 +222,7 @@ impl VerificationCeremony {
                 IdentityProof::Signature(sig, pk, msg) => {
                     let mut h = blake3::Hasher::new();
                     h.update(b"proof.signature.v1");
-                    h.update(sig.as_bytes());
+                    h.update(&sig.to_bytes());
                     h.update(pk.as_bytes());
                     h.update(msg);
                     ("Signature", *h.finalize().as_bytes())

--- a/crates/exo-node/src/mcp/tools/identity.rs
+++ b/crates/exo-node/src/mcp/tools/identity.rs
@@ -638,7 +638,7 @@ mod tests {
         let params = json!({
             "public_key_hex": hex::encode(pk.as_bytes()),
             "message_hex": hex::encode(message),
-            "signature_hex": hex::encode(sig.as_bytes()),
+            "signature_hex": hex::encode(sig.to_bytes()),
         });
         let result = execute_verify_signature(&params, &NodeContext::empty());
         assert!(!result.is_error);

--- a/crates/exo-node/src/zerodentity/api.rs
+++ b/crates/exo-node/src/zerodentity/api.rs
@@ -1191,7 +1191,7 @@ mod tests {
             "message_hash": message_hash.map(|h| hex::encode(h.as_bytes())),
             "created_ms": created_ms,
             "attester_public_key": hex::encode(public_key.as_bytes()),
-            "signature": hex::encode(signature.as_bytes())
+            "signature": hex::encode(signature.to_bytes())
         })
     }
 

--- a/crates/exo-node/src/zerodentity/attestation.rs
+++ b/crates/exo-node/src/zerodentity/attestation.rs
@@ -140,8 +140,7 @@ pub fn verify_attestation_signature(
     if signature.is_empty() {
         return false;
     }
-    let raw = signature.as_bytes();
-    if !raw.is_empty() && raw.iter().all(|b| *b == 0) {
+    if signature.ed25519_component_is_zero() {
         return false;
     }
     let Ok(payload) = attestation_signing_payload(

--- a/crates/exo-node/src/zerodentity/tests.rs
+++ b/crates/exo-node/src/zerodentity/tests.rs
@@ -100,7 +100,7 @@ mod tests {
             "message_hash": message_hash.map(|h| hex::encode(h.as_bytes())),
             "created_ms": created_ms,
             "attester_public_key": hex::encode(public_key.as_bytes()),
-            "signature": hex::encode(signature.as_bytes())
+            "signature": hex::encode(signature.to_bytes())
         })
     }
 

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 120320 lines of Rust under `crates/`, 2,908 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 120368 lines of Rust under `crates/`, 2,912 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,908 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,912 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,908 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,912 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-120320 lines of Rust under `crates/` · 20 workspace packages · 2,908 listed tests · 40 MCP tools · 8 constitutional invariants
+120368 lines of Rust under `crates/` · 20 workspace packages · 2,912 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 120320 lines of Rust under `crates/` | 266 Rust source files | 2,908 listed tests
+> **Codebase:** 20 workspace packages | 120368 lines of Rust under `crates/` | 266 Rust source files | 2,912 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,908 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,912 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 120320 lines of Rust under `crates/` · 2,908 listed tests
+20 workspace packages · 120368 lines of Rust under `crates/` · 2,912 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- Deprecate Signature::as_bytes as a legacy Ed25519-only accessor and make it panic for Empty, PostQuantum, and Hybrid instead of returning zero bytes or a classical half.
- Add explicit ed25519_component_is_zero for null-signature guards and migrate verifier call sites away from ambiguous byte access.
- Use algorithm-aware Signature::to_bytes for JSON/evidence serialization helpers and refresh repo-truth docs to 120368 LOC / 2,912 listed tests.

## TDD Red
- cargo test -p exo-core signature_as_bytes_panics_for_empty_instead_of_returning_zero_sentinel --lib -- --nocapture initially failed because Signature::Empty.as_bytes returned the static zero buffer.

## Verification
- cargo test -p exo-core signature_as_bytes --lib -- --nocapture
- cargo test -p exo-core --lib
- cargo test -p exo-consent --lib
- cargo test -p exo-authority --lib
- cargo test -p exo-dag --lib
- cargo test -p exo-governance --lib
- cargo test -p exo-node zerodentity:: --bin exochain
- cargo test -p exo-gateway --lib
- cargo test --workspace -- --list => 2,912 listed tests
- bash tools/test_repo_truth.sh
- bash tools/repo_truth.sh --json
- bash tools/test_cr001_status.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_no_orphan_rust_modules.sh
- bash tools/test_railway_entrypoint_args.sh
- cargo +nightly fmt --all -- --check
- git diff --check
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo build --workspace --release
- cargo test --workspace --release
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps
- cargo audit --deny unsound --deny unmaintained (existing allowed yanked core2 warning only)
- cargo deny check (existing duplicate/yanked/unused-allowance warnings only)
- cargo machete --with-metadata