### PR TITLE
fix(exo-core): use canonical trust receipt hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 120368 | `wc -l` |
-| Workspace tests | 2,912 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 120536 | `wc -l` |
+| Workspace tests | 2,914 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,912 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,914 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 120368 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 120536 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,912 listed workspace tests
+         cryptographic proofs, 2,914 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-core/src/types.rs
+++ b/crates/exo-core/src/types.rs
@@ -15,6 +15,7 @@ use zeroize::Zeroize;
 use crate::{
     crypto,
     error::{ExoError, Result},
+    hash::hash_structured,
 };
 
 // ---------------------------------------------------------------------------
@@ -915,16 +916,16 @@ struct TrustReceiptSigningPayload<'a> {
 }
 
 impl TrustReceipt {
-    fn payload_for_signature(
-        actor_did: &Did,
-        authority_chain_hash: &Hash256,
-        consent_reference: Option<&Hash256>,
-        action_type: &str,
-        action_hash: &Hash256,
-        outcome: &ReceiptOutcome,
-        timestamp: &Timestamp,
-    ) -> Vec<u8> {
-        let payload = TrustReceiptSigningPayload {
+    fn signing_payload_fields<'a>(
+        actor_did: &'a Did,
+        authority_chain_hash: &'a Hash256,
+        consent_reference: Option<&'a Hash256>,
+        action_type: &'a str,
+        action_hash: &'a Hash256,
+        outcome: &'a ReceiptOutcome,
+        timestamp: &'a Timestamp,
+    ) -> TrustReceiptSigningPayload<'a> {
+        TrustReceiptSigningPayload {
             domain: TRUST_RECEIPT_SIGNING_DOMAIN,
             actor_did: actor_did.as_str(),
             authority_chain_hash,
@@ -933,12 +934,57 @@ impl TrustReceipt {
             action_hash,
             outcome,
             timestamp,
-        };
-        let mut encoded = Vec::new();
-        if ciborium::into_writer(&payload, &mut encoded).is_err() {
-            panic!("TrustReceipt signing payload CBOR serialization failed");
         }
-        encoded
+    }
+
+    fn payload_for_signature(
+        actor_did: &Did,
+        authority_chain_hash: &Hash256,
+        consent_reference: Option<&Hash256>,
+        action_type: &str,
+        action_hash: &Hash256,
+        outcome: &ReceiptOutcome,
+        timestamp: &Timestamp,
+    ) -> Result<Vec<u8>> {
+        let payload = Self::signing_payload_fields(
+            actor_did,
+            authority_chain_hash,
+            consent_reference,
+            action_type,
+            action_hash,
+            outcome,
+            timestamp,
+        );
+        let mut encoded = Vec::new();
+        ciborium::into_writer(&payload, &mut encoded).map_err(|e| {
+            ExoError::SerializationError {
+                reason: format!("trust receipt signing payload CBOR serialization failed: {e:?}"),
+            }
+        })?;
+        Ok(encoded)
+    }
+
+    fn receipt_hash_for_content(
+        actor_did: &Did,
+        authority_chain_hash: &Hash256,
+        consent_reference: Option<&Hash256>,
+        action_type: &str,
+        action_hash: &Hash256,
+        outcome: &ReceiptOutcome,
+        timestamp: &Timestamp,
+    ) -> Result<Hash256> {
+        let payload = Self::signing_payload_fields(
+            actor_did,
+            authority_chain_hash,
+            consent_reference,
+            action_type,
+            action_hash,
+            outcome,
+            timestamp,
+        );
+        hash_structured(&payload).map_err(|e| ExoError::SerializationError {
+            reason: format!("trust receipt hash payload CBOR serialization failed: {e}"),
+        })
     }
 
     /// Create a new trust receipt and compute its content-addressed hash.
@@ -955,7 +1001,7 @@ impl TrustReceipt {
         outcome: ReceiptOutcome,
         timestamp: Timestamp,
         sign_fn: &dyn Fn(&[u8]) -> Signature,
-    ) -> Self {
+    ) -> Result<Self> {
         let payload = Self::payload_for_signature(
             &actor_did,
             &authority_chain_hash,
@@ -964,12 +1010,20 @@ impl TrustReceipt {
             &action_hash,
             &outcome,
             &timestamp,
-        );
+        )?;
 
         let signature = sign_fn(&payload);
-        let receipt_hash = Hash256::digest(&payload);
+        let receipt_hash = Self::receipt_hash_for_content(
+            &actor_did,
+            &authority_chain_hash,
+            consent_reference.as_ref(),
+            &action_type,
+            &action_hash,
+            &outcome,
+            &timestamp,
+        )?;
 
-        Self {
+        Ok(Self {
             receipt_hash,
             actor_did,
             authority_chain_hash,
@@ -980,19 +1034,34 @@ impl TrustReceipt {
             timestamp,
             signature,
             challenge_reference: None,
-        }
+        })
     }
 
     /// Verify that the receipt hash matches the content.
-    #[must_use]
-    pub fn verify_hash(&self) -> bool {
-        let payload = self.signing_payload();
-        Hash256::digest(&payload) == self.receipt_hash
+    ///
+    /// # Errors
+    ///
+    /// Returns `ExoError::SerializationError` if canonical receipt hashing
+    /// fails.
+    pub fn verify_hash(&self) -> Result<bool> {
+        Ok(Self::receipt_hash_for_content(
+            &self.actor_did,
+            &self.authority_chain_hash,
+            self.consent_reference.as_ref(),
+            &self.action_type,
+            &self.action_hash,
+            &self.outcome,
+            &self.timestamp,
+        )? == self.receipt_hash)
     }
 
     /// Return the exact payload signed by the actor for this receipt.
-    #[must_use]
-    pub fn signing_payload(&self) -> Vec<u8> {
+    ///
+    /// # Errors
+    ///
+    /// Returns `ExoError::SerializationError` if canonical receipt encoding
+    /// fails.
+    pub fn signing_payload(&self) -> Result<Vec<u8>> {
         Self::payload_for_signature(
             &self.actor_did,
             &self.authority_chain_hash,
@@ -1005,12 +1074,20 @@ impl TrustReceipt {
     }
 
     /// Verify the actor signature over this receipt's signable payload.
-    #[must_use]
-    pub fn verify_signature(&self, public_key: &PublicKey) -> bool {
+    ///
+    /// # Errors
+    ///
+    /// Returns `ExoError::SerializationError` if canonical receipt encoding
+    /// fails.
+    pub fn verify_signature(&self, public_key: &PublicKey) -> Result<bool> {
         if self.signature.is_empty() {
-            return false;
+            return Ok(false);
         }
-        crypto::verify(&self.signing_payload(), &self.signature, public_key)
+        Ok(crypto::verify(
+            &self.signing_payload()?,
+            &self.signature,
+            public_key,
+        ))
     }
 }
 
@@ -1659,9 +1736,10 @@ mod tests {
             ReceiptOutcome::Executed,
             Timestamp::new(1_700_000_000_000, 0),
             &test_sign_fn,
-        );
+        )
+        .expect("trust receipt should encode");
 
-        assert!(receipt.verify_hash());
+        assert!(receipt.verify_hash().expect("verify hash"));
         assert!(!receipt.signature.is_empty());
         assert_eq!(receipt.actor_did.to_string(), "did:exo:actor1");
         assert_eq!(receipt.action_type, "governance.propose");
@@ -1696,10 +1774,12 @@ mod tests {
             ReceiptOutcome::Executed,
             timestamp,
             &test_sign_fn,
-        );
+        )
+        .expect("trust receipt should encode");
 
+        let signing_payload = receipt.signing_payload().expect("signing payload");
         let payload: DecodedTrustReceiptSigningPayload =
-            ciborium::from_reader(&receipt.signing_payload()[..]).expect("decode payload");
+            ciborium::from_reader(&signing_payload[..]).expect("decode payload");
         assert_eq!(payload.domain, TRUST_RECEIPT_SIGNING_DOMAIN);
         assert_eq!(payload.actor_did, "did:exo:actor-cbor");
         assert_eq!(payload.authority_chain_hash, authority_chain_hash);
@@ -1708,6 +1788,55 @@ mod tests {
         assert_eq!(payload.action_hash, action_hash);
         assert_eq!(payload.outcome, ReceiptOutcome::Executed);
         assert_eq!(payload.timestamp, timestamp);
+    }
+
+    #[test]
+    fn trust_receipt_hash_matches_structured_cbor_contract() {
+        let actor_did = Did::new("did:exo:actor-hash-contract").unwrap();
+        let authority_chain_hash = Hash256::digest(b"authority-chain");
+        let consent_reference = Hash256::digest(b"consent-ref");
+        let action_type = "governance.propose";
+        let action_hash = Hash256::digest(b"action-payload");
+        let outcome = ReceiptOutcome::Executed;
+        let timestamp = Timestamp::new(1_700_000_000_456, 9);
+        let receipt = TrustReceipt::new(
+            actor_did.clone(),
+            authority_chain_hash,
+            Some(consent_reference),
+            action_type.into(),
+            action_hash,
+            outcome.clone(),
+            timestamp,
+            &test_sign_fn,
+        )
+        .expect("trust receipt should encode");
+        let expected_hash = crate::hash::hash_structured(&TrustReceiptSigningPayload {
+            domain: TRUST_RECEIPT_SIGNING_DOMAIN,
+            actor_did: actor_did.as_str(),
+            authority_chain_hash: &authority_chain_hash,
+            consent_reference: Some(&consent_reference),
+            action_type,
+            action_hash: &action_hash,
+            outcome: &outcome,
+            timestamp: &timestamp,
+        })
+        .expect("structured trust receipt hash");
+
+        assert_eq!(receipt.receipt_hash, expected_hash);
+        assert!(receipt.verify_hash().expect("verify hash"));
+    }
+
+    #[test]
+    fn trust_receipt_hash_path_uses_hash_structured_helper() {
+        let source = std::fs::read_to_string("src/types.rs").expect("read types source");
+        let impl_start = source.find("impl TrustReceipt").expect("TrustReceipt impl");
+        let display_start = source[impl_start..]
+            .find("impl fmt::Display for TrustReceipt")
+            .expect("TrustReceipt display impl");
+        let trust_receipt_impl = &source[impl_start..impl_start + display_start];
+
+        assert!(trust_receipt_impl.contains("hash_structured(&payload)"));
+        assert!(!trust_receipt_impl.contains("Hash256::digest(&payload)"));
     }
 
     #[test]
@@ -1723,9 +1852,14 @@ mod tests {
             ReceiptOutcome::Executed,
             Timestamp::new(1_700_000_003_000, 0),
             &|payload| keypair.sign(payload),
-        );
+        )
+        .expect("trust receipt should encode");
 
-        assert!(receipt.verify_signature(&public_key));
+        assert!(
+            receipt
+                .verify_signature(&public_key)
+                .expect("verify signature")
+        );
     }
 
     #[test]
@@ -1743,17 +1877,30 @@ mod tests {
             ReceiptOutcome::Executed,
             Timestamp::new(1_700_000_003_000, 0),
             &|payload| keypair.sign(payload),
-        );
+        )
+        .expect("trust receipt should encode");
 
-        assert!(!receipt.verify_signature(&wrong_public_key));
+        assert!(
+            !receipt
+                .verify_signature(&wrong_public_key)
+                .expect("verify signature")
+        );
 
         let signature = receipt.signature.clone();
         receipt.signature = Signature::Empty;
-        assert!(!receipt.verify_signature(&public_key));
+        assert!(
+            !receipt
+                .verify_signature(&public_key)
+                .expect("verify signature")
+        );
 
         receipt.signature = signature;
         receipt.action_type = "governance.escalate".into();
-        assert!(!receipt.verify_signature(&public_key));
+        assert!(
+            !receipt
+                .verify_signature(&public_key)
+                .expect("verify signature")
+        );
     }
 
     #[test]
@@ -1767,7 +1914,8 @@ mod tests {
             ReceiptOutcome::Pending,
             Timestamp::new(1_700_000_001_000, 5),
             &test_sign_fn,
-        );
+        )
+        .expect("trust receipt should encode");
 
         let json = serde_json::to_string(&receipt).expect("serialize");
         let deserialized: TrustReceipt = serde_json::from_str(&json).expect("deserialize");
@@ -1777,7 +1925,7 @@ mod tests {
         assert_eq!(receipt.action_type, deserialized.action_type);
         assert_eq!(receipt.outcome, deserialized.outcome);
         assert_eq!(receipt.consent_reference, deserialized.consent_reference);
-        assert!(deserialized.verify_hash());
+        assert!(deserialized.verify_hash().expect("verify hash"));
     }
 
     #[test]
@@ -1791,11 +1939,12 @@ mod tests {
             ReceiptOutcome::Executed,
             Timestamp::new(1_700_000_002_000, 0),
             &test_sign_fn,
-        );
+        )
+        .expect("trust receipt should encode");
 
         // Tamper with the action type.
         receipt.action_type = "governance.escalate".into();
-        assert!(!receipt.verify_hash());
+        assert!(!receipt.verify_hash().expect("verify hash"));
     }
 
     #[test]
@@ -1817,7 +1966,8 @@ mod tests {
             ReceiptOutcome::Executed,
             Timestamp::now_utc(),
             &test_sign_fn,
-        );
+        )
+        .expect("trust receipt should encode");
 
         let display = format!("{receipt}");
         assert!(display.contains("TrustReceipt("));

--- a/crates/exo-node/src/api.rs
+++ b/crates/exo-node/src/api.rs
@@ -788,6 +788,7 @@ mod tests {
             },
             &*sign_fn,
         )
+        .expect("test trust receipt should encode")
     }
 
     #[tokio::test]

--- a/crates/exo-node/src/reactor.rs
+++ b/crates/exo-node/src/reactor.rs
@@ -85,7 +85,7 @@ fn commit_receipt_from_certificate(
         .lock()
         .map_err(|_| "Reactor state mutex poisoned while building commit receipt".to_string())?;
 
-    Ok(TrustReceipt::new(
+    TrustReceipt::new(
         s.node_did.clone(),
         authority_hash,
         None,
@@ -94,7 +94,8 @@ fn commit_receipt_from_certificate(
         ReceiptOutcome::Executed,
         timestamp,
         &*s.sign_fn,
-    ))
+    )
+    .map_err(|e| format!("build commit trust receipt: {e}"))
 }
 
 fn sign_proposal(

--- a/crates/exo-node/src/store.rs
+++ b/crates/exo-node/src/store.rs
@@ -1161,7 +1161,8 @@ mod tests {
                 logical: 0,
             },
             &*sign_fn,
-        );
+        )
+        .expect("test trust receipt should encode");
 
         let hash = receipt.receipt_hash;
         store.save_receipt(&receipt).unwrap();
@@ -1192,7 +1193,8 @@ mod tests {
                 logical: 0,
             },
             &|_| Signature::Empty,
-        );
+        )
+        .expect("test trust receipt should encode");
 
         let err = store.save_receipt(&receipt).unwrap_err();
 
@@ -1217,7 +1219,8 @@ mod tests {
                 logical: 0,
             },
             &*sign_fn,
-        );
+        )
+        .expect("test trust receipt should encode");
 
         let err = store.save_receipt(&receipt).unwrap_err();
 
@@ -1251,7 +1254,8 @@ mod tests {
                     logical: 0,
                 },
                 &*sign_fn,
-            );
+            )
+            .expect("test trust receipt should encode");
             store.save_receipt(&receipt).unwrap();
         }
 
@@ -1268,7 +1272,8 @@ mod tests {
                 logical: 0,
             },
             &*sign_fn,
-        );
+        )
+        .expect("test trust receipt should encode");
         store.save_receipt(&other).unwrap();
 
         // Query actor-a — should get 3 receipts.

--- a/crates/exo-node/src/zerodentity/api.rs
+++ b/crates/exo-node/src/zerodentity/api.rs
@@ -1593,7 +1593,7 @@ mod tests {
         let nodes = guard.dag_nodes();
         let erasure_node = nodes.last().expect("erasure dag node");
         assert_eq!(erasure_node.timestamp.physical_ms, 7_777_000);
-        assert!(receipt.verify_hash());
+        assert!(receipt.verify_hash().expect("verify trust receipt hash"));
         assert!(
             result["message"]
                 .as_str()

--- a/crates/exo-node/src/zerodentity/store.rs
+++ b/crates/exo-node/src/zerodentity/store.rs
@@ -212,7 +212,7 @@ impl ZerodentityStore {
             outcome,
             timestamp,
             &*context.signer,
-        ))
+        )?)
     }
 
     fn next_dag_parents(&self) -> Vec<Hash256> {
@@ -1087,7 +1087,10 @@ mod tests {
         assert_eq!(r.actor_did, node_did);
         assert_eq!(r.action_hash, c.claim_hash);
         assert_eq!(r.action_type, "zerodentity.claim_verified");
-        assert!(r.verify_signature(&node_public_key));
+        assert!(
+            r.verify_signature(&node_public_key)
+                .expect("verify trust receipt signature")
+        );
     }
 
     #[test]
@@ -1102,8 +1105,12 @@ mod tests {
         assert_eq!(receipt.action_hash, c.claim_hash);
         assert_eq!(receipt.action_type, "zerodentity.claim_verified");
         assert!(!receipt.signature.is_empty());
-        assert!(receipt.verify_hash());
-        assert!(receipt.verify_signature(&node_public_key));
+        assert!(receipt.verify_hash().expect("verify trust receipt hash"));
+        assert!(
+            receipt
+                .verify_signature(&node_public_key)
+                .expect("verify trust receipt signature")
+        );
     }
 
     #[test]
@@ -1220,8 +1227,12 @@ mod tests {
             .unwrap();
         assert_eq!(receipt.actor_did, node_did);
         assert!(!receipt.signature.is_empty());
-        assert!(receipt.verify_hash());
-        assert!(receipt.verify_signature(&node_public_key));
+        assert!(receipt.verify_hash().expect("verify trust receipt hash"));
+        assert!(
+            receipt
+                .verify_signature(&node_public_key)
+                .expect("verify trust receipt signature")
+        );
     }
 
     #[test]

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 120368 lines of Rust under `crates/`, 2,912 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 120536 lines of Rust under `crates/`, 2,914 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,912 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,914 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,912 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,914 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-120368 lines of Rust under `crates/` · 20 workspace packages · 2,912 listed tests · 40 MCP tools · 8 constitutional invariants
+120536 lines of Rust under `crates/` · 20 workspace packages · 2,914 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 120368 lines of Rust under `crates/` | 266 Rust source files | 2,912 listed tests
+> **Codebase:** 20 workspace packages | 120536 lines of Rust under `crates/` | 266 Rust source files | 2,914 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,912 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,914 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 120368 lines of Rust under `crates/` · 2,912 listed tests
+20 workspace packages · 120536 lines of Rust under `crates/` · 2,914 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- make TrustReceipt construction/hash/signature verification fallible instead of panicking on CBOR encoding failure
- compute TrustReceipt receipt_hash with the shared structured-CBOR hashing helper instead of hashing the signable byte vector directly
- update exo-node consumers and docs truth counts for the current workspace state

## Tests
- cargo test -p exo-core trust_receipt_creation_and_hash_verification --lib -- --nocapture
- cargo test -p exo-core trust_receipt --lib -- --nocapture
- cargo check --workspace
- cargo test -p exo-node receipt --bin exochain -- --nocapture
- cargo test -p exo-core --lib
- cargo test --workspace -- --list
- bash tools/test_repo_truth.sh
- bash tools/test_cr001_status.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_no_orphan_rust_modules.sh
- bash tools/test_railway_entrypoint_args.sh
- cargo +nightly fmt --all -- --check
- git diff --check
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo build --workspace --release
- cargo test --workspace --release
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
- cargo audit --deny unsound --deny unmaintained
- cargo deny check
- cargo machete --with-metadata