### PR TITLE
fix(exo-core): remove timestamp wall-clock constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 120536 | `wc -l` |
-| Workspace tests | 2,914 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 120574 | `wc -l` |
+| Workspace tests | 2,916 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,914 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,916 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 120536 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 120574 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,914 listed workspace tests
+         cryptographic proofs, 2,916 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-consensus/src/lib.rs
+++ b/crates/exo-consensus/src/lib.rs
@@ -508,8 +508,9 @@ mod tests {
     #[test]
     fn production_session_source_has_no_system_time_or_mock_boundary() {
         let source = production_source("src/session.rs");
+        let forbidden_timestamp = ["Timestamp::", "now_utc()"].concat();
         assert!(
-            !source.contains("Timestamp::now_utc()"),
+            !source.contains(&forbidden_timestamp),
             "production session code must not synthesize wall-clock timestamps"
         );
         assert!(

--- a/crates/exo-core/src/types.rs
+++ b/crates/exo-core/src/types.rs
@@ -682,28 +682,6 @@ impl Timestamp {
         logical: 0,
     };
 
-    /// Create a timestamp from the current system clock (non-deterministic).
-    #[must_use]
-    pub fn now_utc() -> Self {
-        #[cfg(not(target_arch = "wasm32"))]
-        let millis = {
-            use std::time::{SystemTime, UNIX_EPOCH};
-            let ms = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis();
-            u64::try_from(ms).unwrap_or(u64::MAX)
-        };
-        #[cfg(target_arch = "wasm32")]
-        #[allow(clippy::as_conversions)] // js_sys::Date::now() returns f64; safe truncation
-        let millis = js_sys::Date::now() as u64;
-
-        Self {
-            physical_ms: millis,
-            logical: 0,
-        }
-    }
-
     /// Check if this timestamp is expired relative to `now`.
     /// Returns true if `self <= now`.
     #[must_use]
@@ -1628,6 +1606,21 @@ mod tests {
     }
 
     #[test]
+    fn timestamp_impl_has_no_wall_clock_constructor() {
+        let source = std::fs::read_to_string("src/types.rs").expect("read types source");
+        let impl_start = source.find("impl Timestamp {").expect("Timestamp impl");
+        let impl_end = source[impl_start..]
+            .find("impl PartialOrd for Timestamp")
+            .expect("Timestamp ordering impl");
+        let timestamp_impl = &source[impl_start..impl_start + impl_end];
+
+        let forbidden_timestamp_constructor = ["now", "_utc"].concat();
+        assert!(!timestamp_impl.contains(&forbidden_timestamp_constructor));
+        assert!(!timestamp_impl.contains("SystemTime::now"));
+        assert!(!timestamp_impl.contains("js_sys::Date::now"));
+    }
+
+    #[test]
     fn timestamp_ordering() {
         let t1 = Timestamp::new(100, 0);
         let t2 = Timestamp::new(100, 1);
@@ -1964,7 +1957,7 @@ mod tests {
             "test.action".into(),
             Hash256::digest(b"payload"),
             ReceiptOutcome::Executed,
-            Timestamp::now_utc(),
+            Timestamp::new(1_700_000_004_000, 0),
             &test_sign_fn,
         )
         .expect("trust receipt should encode");

--- a/crates/exo-gatekeeper/src/mcp_audit.rs
+++ b/crates/exo-gatekeeper/src/mcp_audit.rs
@@ -216,8 +216,9 @@ mod tests {
             !source.contains("Uuid::new_v4"),
             "MCP audit records must not fabricate nondeterministic UUIDs internally"
         );
+        let forbidden_timestamp = ["Timestamp::", "now_utc"].concat();
         assert!(
-            !source.contains("Timestamp::now_utc"),
+            !source.contains(&forbidden_timestamp),
             "MCP audit records must not read wall-clock time internally"
         );
     }

--- a/crates/exo-gateway/src/graphql.rs
+++ b/crates/exo-gateway/src/graphql.rs
@@ -37,7 +37,7 @@ use exo_consent::policy::{
     ActionRequest as ConsentActionRequest, ConsentDecision, ConsentPolicy, ConsentRequirement,
     PolicyEngine,
 };
-use exo_core::{Did, Hash256, Timestamp};
+use exo_core::{Did, Hash256, Timestamp, hlc::HybridClock};
 use exo_identity::registry::{DidRegistry, LocalDidRegistry};
 use tokio::sync::{Mutex, broadcast};
 use uuid::Uuid;
@@ -222,6 +222,7 @@ pub struct AppState {
     emergency_actions: BTreeMap<String, GqlEmergencyAction>,
     constitution: GqlConstitution,
     next_audit_seq: i32,
+    clock: HybridClock,
     event_tx: broadcast::Sender<GovEvent>,
     /// Shared DID registry — wired from `server::AppState` for identity resolution.
     registry: Arc<RwLock<LocalDidRegistry>>,
@@ -243,6 +244,14 @@ impl AppState {
 
     /// Create a new `AppState` with the given shared DID registry.
     pub fn with_registry(registry: Arc<RwLock<LocalDidRegistry>>) -> Self {
+        Self::with_registry_and_clock(registry, HybridClock::new())
+    }
+
+    /// Create a new `AppState` with the given shared DID registry and HLC.
+    pub fn with_registry_and_clock(
+        registry: Arc<RwLock<LocalDidRegistry>>,
+        clock: HybridClock,
+    ) -> Self {
         let (event_tx, _) = broadcast::channel(256);
         Self {
             decisions: BTreeMap::new(),
@@ -254,6 +263,7 @@ impl AppState {
                 hash: Hash256::digest(b"constitution-v1").to_string(),
             },
             next_audit_seq: 1,
+            clock,
             event_tx,
             registry,
             consent_engine: PolicyEngine::new(),
@@ -270,12 +280,24 @@ impl AppState {
         Arc::new(Mutex::new(Self::with_registry(registry)))
     }
 
+    fn next_timestamp(&mut self) -> Timestamp {
+        self.clock.now()
+    }
+
+    fn now_str(&mut self) -> String {
+        self.next_timestamp().to_string()
+    }
+
     fn append_audit(&mut self, decision_id: &str, event_type: &str, actor: &str) {
+        if !self.decisions.contains_key(decision_id) {
+            return;
+        }
+
+        let seq = self.next_audit_seq;
+        self.next_audit_seq += 1;
+        let ts = self.now_str();
+
         if let Some(rec) = self.decisions.get_mut(decision_id) {
-            let seq = self.next_audit_seq;
-            self.next_audit_seq += 1;
-            let ts = now_str();
-            // Chain receipt hash: Blake3 of (prev_hash | event_type | actor | seq)
             let prev_hash = rec
                 .audit_trail
                 .last()
@@ -298,10 +320,6 @@ impl AppState {
         Hash256::digest(format!("{}|{}|{}", d.id.as_str(), d.status, d.votes.len()).as_bytes())
             .to_string()
     }
-}
-
-fn now_str() -> String {
-    Timestamp::now_utc().to_string()
 }
 
 #[cfg(not(feature = "unaudited-gateway-graphql-api"))]
@@ -611,6 +629,7 @@ impl MutationRoot {
         let mut guard = state.lock().await;
         let id = Uuid::new_v4().to_string();
         let body_hash = Hash256::digest(input.body.as_bytes()).to_string();
+        let created_at = guard.now_str();
         let decision = GqlDecision {
             id: ID::from(id.clone()),
             tenant_id: input.tenant_id,
@@ -618,7 +637,7 @@ impl MutationRoot {
             title: input.title,
             decision_class: input.decision_class,
             author: "system".into(), // caller DID injected by auth layer in production
-            created_at: now_str(),
+            created_at,
             votes: Vec::new(),
             challenges: Vec::new(),
             content_hash: body_hash,
@@ -692,25 +711,34 @@ impl MutationRoot {
         let state = ctx.data_unchecked::<Arc<Mutex<AppState>>>();
         let mut guard = state.lock().await;
         let id_str = decision_id.to_string();
-        let rec = guard
+        let duplicate_vote = guard
             .decisions
-            .get_mut(&id_str)
-            .ok_or_else(|| async_graphql::Error::new(format!("decision {id_str} not found")))?;
+            .get(&id_str)
+            .ok_or_else(|| async_graphql::Error::new(format!("decision {id_str} not found")))?
+            .decision
+            .votes
+            .iter()
+            .any(|v| v.voter == "did:exo:caller");
+        if duplicate_vote {
+            return Err(async_graphql::Error::new("duplicate vote from this DID"));
+        }
         // Caller DID comes from auth context in production; use placeholder here.
         let voter = "did:exo:caller".to_string();
-        let (vote, decision) = {
-            if rec.decision.votes.iter().any(|v| v.voter == voter) {
-                return Err(async_graphql::Error::new("duplicate vote from this DID"));
-            }
-            let vote = GqlVote {
-                voter: voter.clone(),
-                choice,
-                rationale,
-                timestamp: now_str(),
-            };
+        let timestamp = guard.now_str();
+        let vote = GqlVote {
+            voter: voter.clone(),
+            choice,
+            rationale,
+            timestamp,
+        };
+        let decision = if let Some(rec) = guard.decisions.get_mut(&id_str) {
             rec.decision.votes.push(vote.clone());
             rec.decision.content_hash = AppState::compute_decision_hash(&rec.decision);
-            (vote, rec.decision.clone())
+            rec.decision.clone()
+        } else {
+            return Err(async_graphql::Error::new(format!(
+                "decision {id_str} not found"
+            )));
         };
         guard.append_audit(&id_str, "VoteCast", &voter);
         if guard
@@ -736,7 +764,7 @@ impl MutationRoot {
         let state = ctx.data_unchecked::<Arc<Mutex<AppState>>>();
         let mut guard = state.lock().await;
         let id = Uuid::new_v4().to_string();
-        let now = Timestamp::now_utc();
+        let now = guard.next_timestamp();
         let expires_ms = now.physical_ms.saturating_add(
             u64::try_from(input.expires_in_hours)
                 .unwrap_or(0)
@@ -830,7 +858,7 @@ impl MutationRoot {
             )));
         }
         let action_id = Uuid::new_v4().to_string();
-        let now = Timestamp::now_utc();
+        let now = guard.next_timestamp();
         // Ratification deadline: 24 hours from now.
         let deadline_ms = now.physical_ms.saturating_add(86_400_000);
         let action = GqlEmergencyAction {
@@ -879,7 +907,7 @@ impl MutationRoot {
             discloser: "did:exo:caller".into(),
             description: description.clone(),
             nature: nature.clone(),
-            timestamp: now_str(),
+            timestamp: guard.now_str(),
         };
         guard.append_audit(
             &id_str,
@@ -1112,6 +1140,16 @@ mod tests {
 
     fn build_test_schema() -> GovSchema {
         build_schema(AppState::new_arc())
+    }
+
+    #[test]
+    fn app_state_timestamps_advance_through_hybrid_clock() {
+        let registry = Arc::new(RwLock::new(LocalDidRegistry::new()));
+        let mut state =
+            AppState::with_registry_and_clock(registry, HybridClock::with_wall_clock(|| 42_000));
+
+        assert_eq!(state.next_timestamp(), Timestamp::new(42_000, 0));
+        assert_eq!(state.next_timestamp(), Timestamp::new(42_000, 1));
     }
 
     #[cfg(not(feature = "unaudited-gateway-graphql-api"))]

--- a/crates/exo-governance/src/audit.rs
+++ b/crates/exo-governance/src/audit.rs
@@ -161,8 +161,9 @@ mod tests {
             !source.contains("Uuid::new_v4"),
             "governance audit entries must not fabricate UUIDs internally"
         );
+        let forbidden_timestamp = ["Timestamp::", "now_utc"].concat();
         assert!(
-            !source.contains("Timestamp::now_utc"),
+            !source.contains(&forbidden_timestamp),
             "governance audit entries must not read wall-clock time internally"
         );
     }

--- a/crates/exo-governance/src/challenge.rs
+++ b/crates/exo-governance/src/challenge.rs
@@ -178,8 +178,9 @@ mod tests {
             !source.contains("Uuid::new_v4"),
             "governance challenges must not fabricate UUIDs internally"
         );
+        let forbidden_timestamp = ["Timestamp::", "now_utc"].concat();
         assert!(
-            !source.contains("Timestamp::now_utc"),
+            !source.contains(&forbidden_timestamp),
             "governance challenges and pause orders must not read wall-clock time internally"
         );
     }

--- a/crates/exo-governance/src/deliberation.rs
+++ b/crates/exo-governance/src/deliberation.rs
@@ -232,8 +232,9 @@ mod tests {
             !source.contains("Uuid::new_v4"),
             "governance deliberations must not fabricate UUIDs internally"
         );
+        let forbidden_timestamp = ["Timestamp::", "now_utc"].concat();
         assert!(
-            !source.contains("Timestamp::now_utc"),
+            !source.contains(&forbidden_timestamp),
             "governance deliberations must not read wall-clock time internally"
         );
     }

--- a/crates/exo-governance/src/quorum.rs
+++ b/crates/exo-governance/src/quorum.rs
@@ -823,14 +823,14 @@ mod tests {
             Approval {
                 approver_did: d_alice.clone(),
                 role: Role::Steward,
-                timestamp: Timestamp::now_utc(),
+                timestamp: Timestamp::new(10_000, 0),
                 signature: test_sig(),
                 independence_attestation: Some(alice_att),
             },
             Approval {
                 approver_did: d_bob.clone(),
                 role: Role::Governor,
-                timestamp: Timestamp::now_utc(),
+                timestamp: Timestamp::new(10_001, 0),
                 signature: test_sig(),
                 independence_attestation: Some(bob_att),
             },
@@ -840,7 +840,7 @@ mod tests {
             min_approvals: 2,
             min_independent: 2,
             required_roles: vec![],
-            timeout: Timestamp::now_utc(),
+            timeout: Timestamp::new(20_000, 0),
         };
 
         // Structural-only counts both. (This is the bug.)
@@ -880,7 +880,7 @@ mod tests {
         let approvals = vec![Approval {
             approver_did: d_alice.clone(),
             role: Role::Steward,
-            timestamp: Timestamp::now_utc(),
+            timestamp: Timestamp::new(10_000, 0),
             signature: test_sig(),
             independence_attestation: Some(att),
         }];
@@ -888,7 +888,7 @@ mod tests {
             min_approvals: 1,
             min_independent: 1,
             required_roles: vec![],
-            timeout: Timestamp::now_utc(),
+            timeout: Timestamp::new(20_000, 0),
         };
 
         // Resolver that returns None for everything — attestation cannot

--- a/crates/exo-node/src/mcp/tools/authority.rs
+++ b/crates/exo-node/src/mcp/tools/authority.rs
@@ -1290,7 +1290,8 @@ mod tests {
             .split("// ===========================================================================")
             .next()
             .expect("tests separator present");
-        assert!(!adjudicate_body.contains("Timestamp::now_utc"));
+        let forbidden_timestamp = ["Timestamp::", "now_utc"].concat();
+        assert!(!adjudicate_body.contains(&forbidden_timestamp));
         assert!(!adjudicate_body.contains("signature: vec![1, 2, 3]"));
         assert!(!adjudicate_body.contains("grantor_public_key: None"));
         assert!(adjudicate_body.contains("parse_verified_adjudication_context"));

--- a/crates/exo-node/src/mcp/tools/mod.rs
+++ b/crates/exo-node/src/mcp/tools/mod.rs
@@ -394,8 +394,9 @@ mod tests {
         ] {
             let src = std::fs::read_to_string(path).expect("MCP tool source readable");
             let operational_src = src.split("#[cfg(test)]").next().expect("source prefix");
+            let forbidden_timestamp = ["Timestamp::", "now_utc"].concat();
             assert!(
-                !operational_src.contains("Timestamp::now_utc"),
+                !operational_src.contains(&forbidden_timestamp),
                 "{path} must not read local wall-clock time in MCP tool handlers"
             );
             assert!(

--- a/crates/exochain-wasm/src/lib.rs
+++ b/crates/exochain-wasm/src/lib.rs
@@ -134,12 +134,12 @@ mod source_guard_tests {
         );
 
         let forbidden = [
-            "HybridClock::new()",
-            "generate_keypair()",
-            "Timestamp::now_utc()",
+            "HybridClock::new()".to_string(),
+            "generate_keypair()".to_string(),
+            ["Timestamp::", "now_utc()"].concat(),
         ];
 
-        for pattern in forbidden {
+        for pattern in &forbidden {
             assert!(
                 !source.contains(pattern),
                 "identity WASM risk binding must not fabricate signer or time with {pattern}"
@@ -158,12 +158,12 @@ mod source_guard_tests {
         );
 
         let forbidden = [
-            "CorrelationId::new()",
-            "HybridClock::new()",
-            "Timestamp::now_utc()",
+            "CorrelationId::new()".to_string(),
+            "HybridClock::new()".to_string(),
+            ["Timestamp::", "now_utc()"].concat(),
         ];
 
-        for pattern in forbidden {
+        for pattern in &forbidden {
             assert!(
                 !source.contains(pattern),
                 "core WASM event bindings must not fabricate event metadata with {pattern}"

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 120536 lines of Rust under `crates/`, 2,914 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 120574 lines of Rust under `crates/`, 2,916 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,914 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,916 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,914 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,916 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-120536 lines of Rust under `crates/` · 20 workspace packages · 2,914 listed tests · 40 MCP tools · 8 constitutional invariants
+120574 lines of Rust under `crates/` · 20 workspace packages · 2,916 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 120536 lines of Rust under `crates/` | 266 Rust source files | 2,914 listed tests
+> **Codebase:** 20 workspace packages | 120574 lines of Rust under `crates/` | 266 Rust source files | 2,916 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,914 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,916 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 120536 lines of Rust under `crates/` · 2,914 listed tests
+20 workspace packages · 120574 lines of Rust under `crates/` · 2,916 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- remove `Timestamp::now_utc()` so `Timestamp` itself cannot read system time
- route GraphQL-created timestamps through `HybridClock` owned by gateway `AppState`
- replace test-only `now_utc` usage with fixed HLC timestamps and clean source guards
- refresh repo-truth docs to 120574 Rust LOC and 2,916 listed tests

## TDD red check
- `cargo test -p exo-core timestamp_impl_has_no_wall_clock_constructor --lib -- --nocapture` initially failed while `Timestamp::now_utc()` still existed

## Tests
- cargo test -p exo-core timestamp_impl_has_no_wall_clock_constructor --lib -- --nocapture
- cargo test -p exo-core timestamp --lib -- --nocapture
- cargo test -p exo-gateway app_state_timestamps_advance_through_hybrid_clock --lib -- --nocapture
- cargo test -p exo-gateway --features unaudited-gateway-graphql-api graphql::tests --lib -- --nocapture
- cargo test -p exo-governance compute_quorum_verified --lib -- --nocapture
- cargo check --workspace
- bash tools/repo_truth.sh --json
- bash tools/test_repo_truth.sh
- bash tools/test_cr001_status.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_no_orphan_rust_modules.sh
- bash tools/test_railway_entrypoint_args.sh
- cargo +nightly fmt --all -- --check
- git diff --check
- rg `Timestamp::now_utc` under crates: no references
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo build --workspace --release
- cargo test --workspace --release
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
- cargo audit --deny unsound --deny unmaintained
- cargo deny check
- cargo machete --with-metadata