### PR TITLE
fix(exo-identity): require explicit key rotation timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 120574 | `wc -l` |
-| Workspace tests | 2,916 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 120635 | `wc -l` |
+| Workspace tests | 2,918 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,916 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,918 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 120574 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 120635 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,916 listed workspace tests
+         cryptographic proofs, 2,918 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-identity/src/did.rs
+++ b/crates/exo-identity/src/did.rs
@@ -254,7 +254,8 @@ mod tests {
 
         let (new_pk, _new_sk) = generate_keypair();
         let proof = sign(new_pk.as_bytes(), &sk);
-        reg.rotate_key(&did, &new_pk, &proof).unwrap();
+        reg.rotate_key(&did, &new_pk, &proof, Timestamp::new(1001, 0))
+            .unwrap();
 
         let resolved = reg.resolve(&did).unwrap();
         assert_eq!(resolved.public_keys.len(), 2);
@@ -269,7 +270,9 @@ mod tests {
         let proof = sign(new_pk.as_bytes(), &sk);
 
         let mut reg = LocalDidRegistry::new();
-        let err = reg.rotate_key(&did, &new_pk, &proof).unwrap_err();
+        let err = reg
+            .rotate_key(&did, &new_pk, &proof, Timestamp::new(1001, 0))
+            .unwrap_err();
         assert!(matches!(err, IdentityError::DidNotFound(_)));
     }
 
@@ -290,7 +293,9 @@ mod tests {
 
         let (new_pk, _) = generate_keypair();
         let proof = sign(new_pk.as_bytes(), &sk);
-        let err = reg.rotate_key(&did, &new_pk, &proof).unwrap_err();
+        let err = reg
+            .rotate_key(&did, &new_pk, &proof, Timestamp::new(1001, 0))
+            .unwrap_err();
         assert!(matches!(err, IdentityError::DidRevoked(_)));
     }
 
@@ -306,7 +311,9 @@ mod tests {
         let (new_pk, _) = generate_keypair();
         let (_other_pk, other_sk) = generate_keypair();
         let bad_proof = sign(new_pk.as_bytes(), &other_sk);
-        let err = reg.rotate_key(&did, &new_pk, &bad_proof).unwrap_err();
+        let err = reg
+            .rotate_key(&did, &new_pk, &bad_proof, Timestamp::new(1001, 0))
+            .unwrap_err();
         assert!(matches!(err, IdentityError::InvalidSignature));
     }
 

--- a/crates/exo-identity/src/error.rs
+++ b/crates/exo-identity/src/error.rs
@@ -1,6 +1,6 @@
 //! Identity-specific error types for the EXOCHAIN identity subsystem.
 
-use exo_core::Did;
+use exo_core::{Did, Timestamp};
 
 /// Errors that can occur during identity operations.
 #[derive(Debug, thiserror::Error)]
@@ -16,6 +16,13 @@ pub enum IdentityError {
 
     #[error("invalid signature")]
     InvalidSignature,
+
+    #[error("non-monotonic timestamp for DID {did}: current={current}, proposed={proposed}")]
+    NonMonotonicTimestamp {
+        did: Did,
+        current: Timestamp,
+        proposed: Timestamp,
+    },
 
     #[error("invalid revocation proof for DID: {0}")]
     InvalidRevocationProof(Did),

--- a/crates/exo-identity/src/registry.rs
+++ b/crates/exo-identity/src/registry.rs
@@ -19,11 +19,16 @@ pub trait DidRegistry {
     fn revoke(&mut self, did: &Did, proof: &RevocationProof) -> Result<(), IdentityError>;
 
     /// Rotate the key for a DID after verifying the proof.
+    ///
+    /// `updated` must be supplied by the caller's deterministic execution
+    /// context, normally an `exo_core::hlc::HybridClock`, and must advance
+    /// past the current document timestamp.
     fn rotate_key(
         &mut self,
         did: &Did,
         new_key: &PublicKey,
         proof: &Signature,
+        updated: Timestamp,
     ) -> Result<(), IdentityError>;
 }
 
@@ -93,6 +98,7 @@ impl DidRegistry for LocalDidRegistry {
         did: &Did,
         new_key: &PublicKey,
         proof: &Signature,
+        updated: Timestamp,
     ) -> Result<(), IdentityError> {
         let doc = self
             .documents
@@ -113,8 +119,16 @@ impl DidRegistry for LocalDidRegistry {
             return Err(IdentityError::InvalidSignature);
         }
 
+        if updated <= doc.updated {
+            return Err(IdentityError::NonMonotonicTimestamp {
+                did: did.clone(),
+                current: doc.updated,
+                proposed: updated,
+            });
+        }
+
         doc.public_keys.push(*new_key);
-        doc.updated = Timestamp::new(doc.updated.physical_ms + 1, 0);
+        doc.updated = updated;
         Ok(())
     }
 }
@@ -189,10 +203,43 @@ mod tests {
         let (new_pk, _) = generate_keypair();
         let proof = sign(new_pk.as_bytes(), &sk);
 
-        reg.rotate_key(&did, &new_pk, &proof).unwrap();
+        reg.rotate_key(&did, &new_pk, &proof, Timestamp::new(1001, 0))
+            .unwrap();
 
         let resolved = reg.resolve(&did).unwrap();
         assert_eq!(resolved.public_keys.len(), 2);
+        assert_eq!(resolved.updated, Timestamp::new(1001, 0));
+    }
+
+    #[test]
+    fn rotate_key_rejects_non_advancing_updated_timestamp() {
+        let (pk, sk) = generate_keypair();
+        let did = make_did("dora");
+        let doc = make_doc(did.clone(), pk);
+
+        let mut reg = LocalDidRegistry::new();
+        reg.register(doc).unwrap();
+
+        let (new_pk, _) = generate_keypair();
+        let proof = sign(new_pk.as_bytes(), &sk);
+        let err = reg
+            .rotate_key(&did, &new_pk, &proof, Timestamp::new(1000, 0))
+            .unwrap_err();
+
+        assert!(matches!(err, IdentityError::NonMonotonicTimestamp { .. }));
+        let resolved = reg.resolve(&did).unwrap();
+        assert_eq!(resolved.public_keys, vec![pk]);
+        assert_eq!(resolved.updated, Timestamp::new(1000, 0));
+    }
+
+    #[test]
+    fn rotate_key_does_not_fabricate_timestamp_from_existing_document() {
+        let source = std::fs::read_to_string("src/registry.rs").expect("read registry source");
+        let forbidden = ["physical_ms", " + ", "1"].concat();
+        assert!(
+            !source.contains(&forbidden),
+            "DID key rotation must use a caller-supplied HLC timestamp"
+        );
     }
 
     #[test]

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 120574 lines of Rust under `crates/`, 2,916 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 120635 lines of Rust under `crates/`, 2,918 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,916 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,918 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,916 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,918 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-120574 lines of Rust under `crates/` · 20 workspace packages · 2,916 listed tests · 40 MCP tools · 8 constitutional invariants
+120635 lines of Rust under `crates/` · 20 workspace packages · 2,918 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 120574 lines of Rust under `crates/` | 266 Rust source files | 2,916 listed tests
+> **Codebase:** 20 workspace packages | 120635 lines of Rust under `crates/` | 266 Rust source files | 2,918 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,916 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,918 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 120574 lines of Rust under `crates/` · 2,916 listed tests
+20 workspace packages · 120635 lines of Rust under `crates/` · 2,918 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- Require DidRegistry::rotate_key callers to supply a monotonic update timestamp from their deterministic execution context.
- Reject non-advancing key-rotation timestamps without mutating DID documents.
- Add a source guard against the old physical_ms + 1 timestamp fabrication and refresh repo-truth docs to 120631 Rust LOC / 2,918 listed tests.

## TDD / Verification
- Red first: cargo test -p exo-identity rotate_key_rejects_non_advancing_updated_timestamp --lib -- --nocapture failed before the API/error existed.
- cargo test -p exo-identity registry::tests --lib -- --nocapture
- cargo test -p exo-identity --lib -- --nocapture
- cargo test -p exo-identity
- cargo check --workspace
- cargo test --workspace -- --list
- bash tools/repo_truth.sh --json
- bash tools/test_repo_truth.sh
- bash tools/test_cr001_status.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_no_orphan_rust_modules.sh
- bash tools/test_railway_entrypoint_args.sh
- cargo +nightly fmt --all -- --check
- git diff --check
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo build --workspace --release
- cargo test --workspace --release
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps
- cargo audit --deny unsound --deny unmaintained (existing allowed yanked core2 warning)
- cargo deny check (existing duplicate/yanked/unused allowance warnings)
- cargo machete --with-metadata
- RUSTDOCFLAGS=-D warnings cargo doc -p exo-identity --no-deps