### PR TITLE
fix(exo-consent): canonicalize bailment terms hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 120635 | `wc -l` |
-| Workspace tests | 2,918 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 120683 | `wc -l` |
+| Workspace tests | 2,920 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,918 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,920 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 120635 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 120683 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,918 listed workspace tests
+         cryptographic proofs, 2,920 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-consent/src/bailment.rs
+++ b/crates/exo-consent/src/bailment.rs
@@ -3,10 +3,13 @@
 //! A bailment is a trust relationship where a bailor entrusts property (data/authority)
 //! to a bailee under specific terms. No action may proceed without an active bailment.
 
-use exo_core::{Did, Hash256, PublicKey, Signature, Timestamp, crypto};
+use exo_core::{Did, Hash256, PublicKey, Signature, Timestamp, crypto, hash::hash_structured};
 use serde::{Deserialize, Serialize};
 
 use crate::error::ConsentError;
+
+/// Domain-separation tag for hashing bailment proposal terms.
+pub const BAILMENT_TERMS_HASH_DOMAIN: &str = "exo.bailment.terms.v1";
 
 /// The type of bailment relationship.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -64,10 +67,13 @@ pub struct Bailment {
 /// Callers must supply the proposal ID and creation timestamp from their
 /// deterministic execution context. The constructor rejects empty IDs and
 /// zero timestamps so consensus/audit-significant bailments cannot silently
-/// carry placeholder metadata.
+/// carry placeholder metadata. The supplied `terms` bytes are never hashed
+/// directly; [`terms_hash`] wraps them in a versioned domain tag and hashes
+/// the canonical CBOR representation.
 ///
 /// # Errors
-/// Returns `Denied` if `id` is empty or `created` is [`Timestamp::ZERO`].
+/// - `Denied` if `id` is empty or `created` is [`Timestamp::ZERO`].
+/// - `Serialization` if canonical CBOR terms hashing fails.
 pub fn propose(
     bailor: &Did,
     bailee: &Did,
@@ -78,18 +84,34 @@ pub fn propose(
 ) -> Result<Bailment, ConsentError> {
     let id = id.into();
     validate_constructor_metadata("bailment id", &id, "created", &created)?;
+    let terms_hash = terms_hash(terms)?;
 
     Ok(Bailment {
         id,
         bailor_did: bailor.clone(),
         bailee_did: bailee.clone(),
         bailment_type,
-        terms_hash: Hash256::digest(terms),
+        terms_hash,
         created,
         expires: None,
         status: BailmentStatus::Proposed,
         signature: Signature::empty(),
         bailee_public_key: None,
+    })
+}
+
+/// Hash bailment proposal terms through a versioned canonical-CBOR boundary.
+///
+/// The input is a byte representation of the proposed terms, but the digest is
+/// computed over `(BAILMENT_TERMS_HASH_DOMAIN, terms)` encoded as CBOR. This
+/// prevents a caller from defining the cryptographic preimage shape implicitly
+/// by choosing arbitrary raw bytes.
+///
+/// # Errors
+/// Returns `Serialization` if canonical CBOR encoding fails.
+pub fn terms_hash(terms: &[u8]) -> Result<Hash256, ConsentError> {
+    hash_structured(&(BAILMENT_TERMS_HASH_DOMAIN, terms)).map_err(|e| {
+        ConsentError::Serialization(format!("bailment terms hash encoding failed: {e}"))
     })
 }
 
@@ -259,7 +281,7 @@ pub fn is_active(bailment: &Bailment, now: &Timestamp) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use exo_core::SecretKey;
+    use exo_core::{SecretKey, hash::hash_structured};
 
     use super::*;
 
@@ -321,6 +343,32 @@ mod tests {
         assert!(
             !source.contains(&now_pattern),
             "bailment proposals must receive caller-supplied HLC timestamps"
+        );
+    }
+
+    #[test]
+    fn bailment_proposal_terms_hash_is_domain_separated_canonical_cbor() {
+        let b = propose_test_with_metadata(
+            b"terms",
+            BailmentType::Custody,
+            "bailment-canonical-terms",
+            ts(1234),
+        );
+        let expected = hash_structured(&(BAILMENT_TERMS_HASH_DOMAIN, b"terms".as_slice()))
+            .expect("canonical terms hash");
+
+        assert_eq!(b.terms_hash, expected);
+        assert_ne!(b.terms_hash, Hash256::digest(b"terms"));
+    }
+
+    #[test]
+    fn bailment_proposal_does_not_digest_terms_as_raw_bytes() {
+        let source = include_str!("bailment.rs");
+        let direct_terms_digest_pattern = format!("{}{}", "Hash256::digest(", "terms)");
+
+        assert!(
+            !source.contains(&direct_terms_digest_pattern),
+            "bailment proposals must hash terms through a domain-separated canonical-CBOR boundary"
         );
     }
 
@@ -510,7 +558,7 @@ mod tests {
     fn accept_rejects_tampered_terms() {
         let mut b = propose_test(b"t-original", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
-        b.terms_hash = Hash256::digest(b"t-swapped");
+        b.terms_hash = terms_hash(b"t-swapped").expect("canonical terms hash");
         assert_eq!(
             accept(&mut b, &pk, &sig),
             Err(ConsentError::InvalidSignature)

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 120635 lines of Rust under `crates/`, 2,918 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 120683 lines of Rust under `crates/`, 2,920 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,918 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,920 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,918 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,920 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-120635 lines of Rust under `crates/` · 20 workspace packages · 2,918 listed tests · 40 MCP tools · 8 constitutional invariants
+120683 lines of Rust under `crates/` · 20 workspace packages · 2,920 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 120635 lines of Rust under `crates/` | 266 Rust source files | 2,918 listed tests
+> **Codebase:** 20 workspace packages | 120683 lines of Rust under `crates/` | 266 Rust source files | 2,920 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,918 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,920 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 120635 lines of Rust under `crates/` · 2,918 listed tests
+20 workspace packages · 120683 lines of Rust under `crates/` · 2,920 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- hash bailment proposal terms through a versioned canonical-CBOR domain boundary
- add public terms_hash helper used by propose and tamper tests
- add red/green regressions proving terms_hash is not raw byte digest
- refresh repo-truth docs to 120683 Rust LOC and 2920 listed tests

## TDD
- red: cargo test -p exo-consent bailment_proposal_terms_hash_is_domain_separated_canonical_cbor --lib -- --nocapture
- red: cargo test -p exo-consent bailment_proposal_does_not_digest_terms_as_raw_bytes --lib -- --nocapture

## Verification
- cargo test -p exo-consent --lib -- --nocapture
- cargo test -p exo-consent
- cargo check --workspace
- cargo test --workspace -- --list
- bash tools/repo_truth.sh --json
- bash tools/test_repo_truth.sh
- bash tools/test_cr001_status.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_no_orphan_rust_modules.sh
- bash tools/test_railway_entrypoint_args.sh
- cargo +nightly fmt --all -- --check
- git diff --check
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo build --workspace --release
- cargo test --workspace --release
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps
- cargo audit --deny unsound --deny unmaintained
- cargo deny check
- cargo machete --with-metadata