### PR TITLE
fix(exo-consent): add bailment suspend resume transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 120683 | `wc -l` |
-| Workspace tests | 2,920 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 120904 | `wc -l` |
+| Workspace tests | 2,929 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,920 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,929 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 120683 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 120904 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,920 listed workspace tests
+         cryptographic proofs, 2,929 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-consent/src/bailment.rs
+++ b/crates/exo-consent/src/bailment.rs
@@ -228,6 +228,10 @@ pub fn has_valid_acceptance_proof(bailment: &Bailment) -> bool {
     if bailment.status != BailmentStatus::Active {
         return false;
     }
+    acceptance_proof_verifies(bailment)
+}
+
+fn acceptance_proof_verifies(bailment: &Bailment) -> bool {
     if bailment.signature.is_empty() {
         return false;
     }
@@ -243,6 +247,77 @@ pub fn has_valid_acceptance_proof(bailment: &Bailment) -> bool {
     crypto::verify(&payload, &bailment.signature, &bailee_public_key)
 }
 
+fn require_bailment_party(bailment: &Bailment, actor: &Did) -> Result<(), ConsentError> {
+    if *actor != bailment.bailor_did && *actor != bailment.bailee_did {
+        return Err(ConsentError::Unauthorized(format!(
+            "DID {actor} is neither bailor nor bailee"
+        )));
+    }
+    Ok(())
+}
+
+fn require_bailor(bailment: &Bailment, actor: &Did) -> Result<(), ConsentError> {
+    if *actor != bailment.bailor_did {
+        return Err(ConsentError::Unauthorized(format!(
+            "DID {actor} is not the bailor for bailment {}",
+            bailment.id
+        )));
+    }
+    Ok(())
+}
+
+/// Suspend an active bailment. Either bailor or bailee may pause consent use.
+///
+/// Suspension preserves the original acceptance proof but makes the bailment
+/// inactive until the bailor resumes it. The function verifies the stored
+/// acceptance proof before transitioning so a forged `Active` status bit cannot
+/// be laundered into a legitimate suspended lifecycle state.
+///
+/// # Errors
+/// - `InvalidState` if the bailment is not currently `Active`.
+/// - `Unauthorized` if actor is neither bailor nor bailee.
+/// - `InvalidSignature` if the stored acceptance proof is missing or invalid.
+pub fn suspend(bailment: &mut Bailment, actor: &Did) -> Result<(), ConsentError> {
+    if bailment.status != BailmentStatus::Active {
+        return Err(ConsentError::InvalidState {
+            expected: "Active".into(),
+            actual: bailment.status.to_string(),
+        });
+    }
+    require_bailment_party(bailment, actor)?;
+    if !acceptance_proof_verifies(bailment) {
+        return Err(ConsentError::InvalidSignature);
+    }
+
+    bailment.status = BailmentStatus::Suspended;
+    Ok(())
+}
+
+/// Resume a suspended bailment. Only the bailor may restore consent use.
+///
+/// The bailee's original acceptance signature remains binding; resumption
+/// verifies it again before returning to `Active`.
+///
+/// # Errors
+/// - `InvalidState` if the bailment is not currently `Suspended`.
+/// - `Unauthorized` if actor is not the bailor.
+/// - `InvalidSignature` if the stored acceptance proof is missing or invalid.
+pub fn resume(bailment: &mut Bailment, actor: &Did) -> Result<(), ConsentError> {
+    if bailment.status != BailmentStatus::Suspended {
+        return Err(ConsentError::InvalidState {
+            expected: "Suspended".into(),
+            actual: bailment.status.to_string(),
+        });
+    }
+    require_bailor(bailment, actor)?;
+    if !acceptance_proof_verifies(bailment) {
+        return Err(ConsentError::InvalidSignature);
+    }
+
+    bailment.status = BailmentStatus::Active;
+    Ok(())
+}
+
 /// Terminate a bailment. Either bailor or bailee may terminate.
 ///
 /// # Errors
@@ -255,11 +330,7 @@ pub fn terminate(bailment: &mut Bailment, actor: &Did) -> Result<(), ConsentErro
             actual: bailment.status.to_string(),
         });
     }
-    if *actor != bailment.bailor_did && *actor != bailment.bailee_did {
-        return Err(ConsentError::Unauthorized(format!(
-            "DID {actor} is neither bailor nor bailee"
-        )));
-    }
+    require_bailment_party(bailment, actor)?;
     bailment.status = BailmentStatus::Terminated;
     Ok(())
 }
@@ -302,6 +373,11 @@ mod tests {
         let payload = signing_payload(b).expect("canonical payload");
         let sig = crypto::sign(&payload, &sk);
         (pk, sk, sig)
+    }
+
+    fn accept_test_bailment(b: &mut Bailment) {
+        let (pk, _sk, sig) = sign_as_bailee(b);
+        accept(b, &pk, &sig).expect("test bailment accepts");
     }
 
     fn ts(ms: u64) -> Timestamp {
@@ -568,6 +644,149 @@ mod tests {
     // ================================================================
 
     #[test]
+    fn suspend_active_bailment_by_bailor() {
+        let mut b = propose_test(b"t", BailmentType::Custody);
+        accept_test_bailment(&mut b);
+
+        assert!(suspend(&mut b, &alice()).is_ok());
+
+        assert_eq!(b.status, BailmentStatus::Suspended);
+        assert!(!is_active(&b, &ts(1000)));
+    }
+
+    #[test]
+    fn suspend_active_bailment_by_bailee() {
+        let mut b = propose_test(b"t", BailmentType::Custody);
+        accept_test_bailment(&mut b);
+
+        assert!(suspend(&mut b, &bob()).is_ok());
+
+        assert_eq!(b.status, BailmentStatus::Suspended);
+        assert!(!is_active(&b, &ts(1000)));
+    }
+
+    #[test]
+    fn suspend_rejects_unauthorized_actor() {
+        let mut b = propose_test(b"t", BailmentType::Custody);
+        accept_test_bailment(&mut b);
+
+        assert!(matches!(
+            suspend(&mut b, &charlie()),
+            Err(ConsentError::Unauthorized(_))
+        ));
+        assert_eq!(b.status, BailmentStatus::Active);
+    }
+
+    #[test]
+    fn suspend_rejects_non_active_states() {
+        let mut proposed = propose_test(b"t", BailmentType::Custody);
+        assert_eq!(
+            suspend(&mut proposed, &alice()),
+            Err(ConsentError::InvalidState {
+                expected: "Active".into(),
+                actual: "Proposed".into()
+            })
+        );
+
+        let mut active = propose_test(b"t", BailmentType::Custody);
+        accept_test_bailment(&mut active);
+        suspend(&mut active, &alice()).expect("suspend active bailment");
+        assert_eq!(
+            suspend(&mut active, &alice()),
+            Err(ConsentError::InvalidState {
+                expected: "Active".into(),
+                actual: "Suspended".into()
+            })
+        );
+
+        let mut terminated = propose_test(b"t", BailmentType::Custody);
+        accept_test_bailment(&mut terminated);
+        terminate(&mut terminated, &alice()).expect("terminate active bailment");
+        assert_eq!(
+            suspend(&mut terminated, &alice()),
+            Err(ConsentError::InvalidState {
+                expected: "Active".into(),
+                actual: "Terminated".into()
+            })
+        );
+
+        let mut expired = propose_test(b"t", BailmentType::Custody);
+        expired.status = BailmentStatus::Expired;
+        assert_eq!(
+            suspend(&mut expired, &alice()),
+            Err(ConsentError::InvalidState {
+                expected: "Active".into(),
+                actual: "Expired".into()
+            })
+        );
+    }
+
+    #[test]
+    fn suspend_rejects_status_forged_active_bailment() {
+        let mut b = propose_test(b"t", BailmentType::Custody);
+        b.status = BailmentStatus::Active;
+        b.signature = Signature::from_bytes([0xAB; 64]);
+
+        assert_eq!(
+            suspend(&mut b, &alice()),
+            Err(ConsentError::InvalidSignature)
+        );
+        assert_eq!(b.status, BailmentStatus::Active);
+    }
+
+    #[test]
+    fn resume_suspended_bailment_by_bailor() {
+        let mut b = propose_test(b"t", BailmentType::Custody);
+        accept_test_bailment(&mut b);
+        suspend(&mut b, &bob()).expect("bailee may suspend consent use");
+
+        assert!(resume(&mut b, &alice()).is_ok());
+
+        assert_eq!(b.status, BailmentStatus::Active);
+        assert!(has_valid_acceptance_proof(&b));
+        assert!(is_active(&b, &ts(1000)));
+    }
+
+    #[test]
+    fn resume_rejects_bailee() {
+        let mut b = propose_test(b"t", BailmentType::Custody);
+        accept_test_bailment(&mut b);
+        suspend(&mut b, &alice()).expect("suspend active bailment");
+
+        assert!(matches!(
+            resume(&mut b, &bob()),
+            Err(ConsentError::Unauthorized(_))
+        ));
+        assert_eq!(b.status, BailmentStatus::Suspended);
+    }
+
+    #[test]
+    fn resume_rejects_non_suspended_state() {
+        let mut b = propose_test(b"t", BailmentType::Custody);
+        accept_test_bailment(&mut b);
+
+        assert_eq!(
+            resume(&mut b, &alice()),
+            Err(ConsentError::InvalidState {
+                expected: "Suspended".into(),
+                actual: "Active".into()
+            })
+        );
+    }
+
+    #[test]
+    fn resume_rejects_suspended_without_acceptance_proof() {
+        let mut b = propose_test(b"t", BailmentType::Custody);
+        b.status = BailmentStatus::Suspended;
+
+        assert_eq!(
+            resume(&mut b, &alice()),
+            Err(ConsentError::InvalidSignature)
+        );
+        assert_eq!(b.status, BailmentStatus::Suspended);
+    }
+
+    #[test]
     fn terminate_by_bailor() {
         let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
@@ -627,7 +846,8 @@ mod tests {
     #[test]
     fn terminate_suspended() {
         let mut b = propose_test(b"t", BailmentType::Custody);
-        b.status = BailmentStatus::Suspended;
+        accept_test_bailment(&mut b);
+        suspend(&mut b, &alice()).expect("suspend active bailment");
         assert!(terminate(&mut b, &alice()).is_ok());
     }
 
@@ -708,7 +928,8 @@ mod tests {
     #[test]
     fn not_active_when_suspended() {
         let mut b = propose_test(b"t", BailmentType::Custody);
-        b.status = BailmentStatus::Suspended;
+        accept_test_bailment(&mut b);
+        suspend(&mut b, &alice()).expect("suspend active bailment");
         assert!(!is_active(&b, &ts(1000)));
     }
 

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 120683 lines of Rust under `crates/`, 2,920 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 120904 lines of Rust under `crates/`, 2,929 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,920 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,929 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,920 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,929 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-120683 lines of Rust under `crates/` · 20 workspace packages · 2,920 listed tests · 40 MCP tools · 8 constitutional invariants
+120904 lines of Rust under `crates/` · 20 workspace packages · 2,929 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 120683 lines of Rust under `crates/` | 266 Rust source files | 2,920 listed tests
+> **Codebase:** 20 workspace packages | 120904 lines of Rust under `crates/` | 266 Rust source files | 2,929 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,920 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,929 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 120683 lines of Rust under `crates/` · 2,920 listed tests
+20 workspace packages · 120904 lines of Rust under `crates/` · 2,929 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 
@@ -714,7 +714,7 @@ Bailment-conditioned consent enforcement. Implements the legal foundation of con
 
 ### Test Coverage Summary
 
-54 tests covering: bailment lifecycle transitions (all valid/invalid), consent gate enforcement, policy evaluation, default-deny behavior, emergency bailment time limits, terms hash binding.
+63 tests covering: bailment lifecycle transitions (all valid/invalid), consent gate enforcement, policy evaluation, default-deny behavior, emergency bailment time limits, terms hash binding.
 
 > See also: [[ARCHITECTURE]] Section 4 (Consent Layer), [[THREAT-MODEL]] Threat 7 (Consent Bypass), [[CONSTITUTIONAL-PROOFS]] Proof 4 (Consent Completeness)
 


### PR DESCRIPTION
## Summary
- add explicit bailment suspend/resume transitions for the existing Suspended lifecycle state
- require party authorization, bailor-only resume, and stored acceptance-proof verification before transitions
- add regression tests for valid transitions, unauthorized actors, invalid states, forged Active status, and missing acceptance proof
- refresh repo-truth counts to 120904 Rust LOC / 2,929 listed tests

## TDD / Verification
- RED: cargo test -p exo-consent suspend_active_bailment_by_bailor --lib -- --nocapture failed because suspend()/resume() did not exist
- cargo test -p exo-consent suspend_active_bailment_by_bailor --lib -- --nocapture
- cargo test -p exo-consent resume_suspended_bailment_by_bailor --lib -- --nocapture
- cargo test -p exo-consent --lib -- --nocapture
- cargo test -p exo-consent
- cargo check --workspace
- bash tools/test_repo_truth.sh
- bash tools/test_cr001_status.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_no_orphan_rust_modules.sh
- bash tools/test_railway_entrypoint_args.sh
- cargo +nightly fmt --all -- --check
- git diff --check
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo build --workspace --release
- cargo test --workspace --release
- RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps
- cargo audit --deny unsound --deny unmaintained
- cargo deny check
- cargo machete --with-metadata