### PR TITLE
fix(exo-consent): differentiate classification clause terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 120904 | `wc -l` |
-| Workspace tests | 2,929 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 121163 | `wc -l` |
+| Workspace tests | 2,931 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,929 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,931 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 120904 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 121163 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,929 listed workspace tests
+         cryptographic proofs, 2,931 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-consent/src/contract.rs
+++ b/crates/exo-consent/src/contract.rs
@@ -127,6 +127,108 @@ impl std::fmt::Display for DataClassification {
     }
 }
 
+impl DataClassification {
+    fn custody_obligations(self) -> &'static str {
+        match self {
+            Self::Public => {
+                "Public data may be stored with baseline integrity controls and publication-safe provenance tracking."
+            }
+            Self::Internal => {
+                "Internal data requires organization-scoped access controls and non-public distribution records."
+            }
+            Self::Confidential => {
+                "Confidential data requires least-privilege access, encrypted storage, encrypted transfer, and access logging."
+            }
+            Self::Restricted => {
+                "Restricted data requires documented need-to-know approval, segregated storage, encrypted transfer, and dual-control access for export."
+            }
+            Self::Regulated => {
+                "Regulated data requires statutory control mapping, jurisdiction-specific handling, audit-ready access logs, and retention policy enforcement."
+            }
+        }
+    }
+
+    fn processing_obligations(self) -> &'static str {
+        match self {
+            Self::Public => {
+                "Public data processing is limited to authorized use, attribution preservation, and integrity checks."
+            }
+            Self::Internal => {
+                "Internal data processing is limited to personnel, services, and agents operating under the bailee's internal authorization boundary."
+            }
+            Self::Confidential => {
+                "Confidential data processing requires purpose-bound authorization and prohibits secondary use without signed amendment."
+            }
+            Self::Restricted => {
+                "Restricted data processing is limited to named workflows and named operators; sub-processing requires explicit bailor approval."
+            }
+            Self::Regulated => {
+                "Regulated data processing is limited to enumerated legal bases and auditable processing records."
+            }
+        }
+    }
+
+    fn breach_notice_obligations(self) -> &'static str {
+        match self {
+            Self::Public => {
+                "Public classification breaches require notice within 10 business days when integrity or attribution is affected."
+            }
+            Self::Internal => {
+                "Internal classification breaches require notice within 5 business days."
+            }
+            Self::Confidential => {
+                "Confidential classification breaches require notice within 72 hours."
+            }
+            Self::Restricted => {
+                "Restricted classification breaches require notice within 24 hours."
+            }
+            Self::Regulated => {
+                "Regulated classification breaches require notice within the shortest applicable legal window, not exceeding 24 hours."
+            }
+        }
+    }
+
+    fn liability_obligations(self) -> &'static str {
+        match self {
+            Self::Public => {
+                "Public data liability remains limited to integrity, availability, and attribution failures."
+            }
+            Self::Internal => {
+                "Internal data liability includes unauthorized internal disclosure and unauthorized retention."
+            }
+            Self::Confidential => {
+                "Confidential data liability includes unauthorized disclosure, unauthorized processing, and control failure."
+            }
+            Self::Restricted => {
+                "Restricted data liability includes unauthorized access, export, delegation, or segregation failure."
+            }
+            Self::Regulated => {
+                "Regulated data liability includes regulatory reporting failure, unlawful processing, and retention violation."
+            }
+        }
+    }
+
+    fn termination_obligations(self) -> &'static str {
+        match self {
+            Self::Public => {
+                "Public data must be returned, deleted, or left published according to the bailor's written instruction."
+            }
+            Self::Internal => {
+                "Internal data must be returned or deleted with an internal access revocation record."
+            }
+            Self::Confidential => {
+                "Confidential data must be returned or destroyed with verifiable destruction evidence."
+            }
+            Self::Restricted => {
+                "Restricted data must be quarantined immediately on termination until return or destruction is receipt-backed."
+            }
+            Self::Regulated => {
+                "Regulated data must follow the governing retention schedule and produce a compliance evidence package on termination."
+            }
+        }
+    }
+}
+
 /// A fully composed contract with all parameters bound and hash computed.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ComposedContract {
@@ -582,6 +684,26 @@ fn substitute_params(body: &str, params: &ContractParams) -> String {
         &params.data_classification.to_string(),
     );
     result = result.replace(
+        "{{classification_custody_obligations}}",
+        params.data_classification.custody_obligations(),
+    );
+    result = result.replace(
+        "{{classification_processing_obligations}}",
+        params.data_classification.processing_obligations(),
+    );
+    result = result.replace(
+        "{{classification_breach_notice}}",
+        params.data_classification.breach_notice_obligations(),
+    );
+    result = result.replace(
+        "{{classification_liability_obligations}}",
+        params.data_classification.liability_obligations(),
+    );
+    result = result.replace(
+        "{{classification_termination_obligations}}",
+        params.data_classification.termination_obligations(),
+    );
+    result = result.replace(
         "{{liability_cap_bps}}",
         &params.liability_cap_bps.to_string(),
     );
@@ -602,7 +724,7 @@ fn custody_clauses() -> Vec<Clause> {
             id: "custody-data-custody".to_string(),
             category: ClauseCategory::DataCustody,
             title: "Data Custody".to_string(),
-            body: "{{bailee_name}} shall hold {{bailor_name}}'s data in secure custody without modification. Data classification: {{data_classification}}.".to_string(),
+            body: "{{bailee_name}} shall hold {{bailor_name}}'s data in secure custody without modification. Data classification: {{data_classification}}. {{classification_custody_obligations}}".to_string(),
             required: true,
             jurisdiction: None,
         },
@@ -610,7 +732,7 @@ fn custody_clauses() -> Vec<Clause> {
             id: "custody-processing-rights".to_string(),
             category: ClauseCategory::ProcessingRights,
             title: "Processing Rights".to_string(),
-            body: "No processing rights are granted. {{bailee_name}} may only store and return data to {{bailor_name}}.".to_string(),
+            body: "No processing rights are granted. {{bailee_name}} may only store and return data to {{bailor_name}}. Any handling must satisfy: {{classification_processing_obligations}}".to_string(),
             required: true,
             jurisdiction: None,
         },
@@ -618,7 +740,7 @@ fn custody_clauses() -> Vec<Clause> {
             id: "custody-breach-remedies".to_string(),
             category: ClauseCategory::BreachRemedies,
             title: "Breach Remedies".to_string(),
-            body: "Upon breach, {{bailor_name}} shall receive notice within 5 days. Material breaches trigger a 30-day cure period.".to_string(),
+            body: "Upon breach, {{bailor_name}} shall receive notice under the classification-specific notice rule. {{classification_breach_notice}} Material breaches trigger a 30-day cure period.".to_string(),
             required: true,
             jurisdiction: None,
         },
@@ -626,7 +748,7 @@ fn custody_clauses() -> Vec<Clause> {
             id: "custody-liability-caps".to_string(),
             category: ClauseCategory::LiabilityCaps,
             title: "Liability Caps".to_string(),
-            body: "Total liability capped at {{liability_cap_bps}} basis points of assessed value.".to_string(),
+            body: "Total liability capped at {{liability_cap_bps}} basis points of assessed value. {{classification_liability_obligations}}".to_string(),
             required: true,
             jurisdiction: None,
         },
@@ -642,7 +764,7 @@ fn custody_clauses() -> Vec<Clause> {
             id: "custody-termination".to_string(),
             category: ClauseCategory::Termination,
             title: "Termination".to_string(),
-            body: "Either party may terminate with 30 days written notice. Data must be returned or destroyed within 15 days of termination.".to_string(),
+            body: "Either party may terminate with 30 days written notice. Data must be returned or destroyed within 15 days of termination. {{classification_termination_obligations}}".to_string(),
             required: true,
             jurisdiction: None,
         },
@@ -672,7 +794,7 @@ fn processing_clauses() -> Vec<Clause> {
             id: "processing-data-custody".to_string(),
             category: ClauseCategory::DataCustody,
             title: "Data Custody".to_string(),
-            body: "{{bailee_name}} shall hold {{bailor_name}}'s data in secure custody. Data classification: {{data_classification}}.".to_string(),
+            body: "{{bailee_name}} shall hold {{bailor_name}}'s data in secure custody. Data classification: {{data_classification}}. {{classification_custody_obligations}}".to_string(),
             required: true,
             jurisdiction: None,
         },
@@ -680,7 +802,7 @@ fn processing_clauses() -> Vec<Clause> {
             id: "processing-processing-rights".to_string(),
             category: ClauseCategory::ProcessingRights,
             title: "Processing Rights".to_string(),
-            body: "{{bailee_name}} may process {{bailor_name}}'s data for purposes defined in this agreement. Processing scope limited to {{data_classification}} tier data.".to_string(),
+            body: "{{bailee_name}} may process {{bailor_name}}'s data for purposes defined in this agreement. Processing scope limited to {{data_classification}} tier data. {{classification_processing_obligations}}".to_string(),
             required: true,
             jurisdiction: None,
         },
@@ -688,7 +810,7 @@ fn processing_clauses() -> Vec<Clause> {
             id: "processing-breach-remedies".to_string(),
             category: ClauseCategory::BreachRemedies,
             title: "Breach Remedies".to_string(),
-            body: "Upon breach, {{bailor_name}} shall receive notice within 3 days. Unauthorized processing constitutes a material breach.".to_string(),
+            body: "Upon breach, {{bailor_name}} shall receive notice under the classification-specific notice rule. {{classification_breach_notice}} Unauthorized processing constitutes a material breach.".to_string(),
             required: true,
             jurisdiction: None,
         },
@@ -696,7 +818,7 @@ fn processing_clauses() -> Vec<Clause> {
             id: "processing-liability-caps".to_string(),
             category: ClauseCategory::LiabilityCaps,
             title: "Liability Caps".to_string(),
-            body: "Total liability capped at {{liability_cap_bps}} basis points of assessed value.".to_string(),
+            body: "Total liability capped at {{liability_cap_bps}} basis points of assessed value. {{classification_liability_obligations}}".to_string(),
             required: true,
             jurisdiction: None,
         },
@@ -712,7 +834,7 @@ fn processing_clauses() -> Vec<Clause> {
             id: "processing-termination".to_string(),
             category: ClauseCategory::Termination,
             title: "Termination".to_string(),
-            body: "Either party may terminate with 30 days written notice. All processing must cease immediately upon termination notice.".to_string(),
+            body: "Either party may terminate with 30 days written notice. All processing must cease immediately upon termination notice. {{classification_termination_obligations}}".to_string(),
             required: true,
             jurisdiction: None,
         },
@@ -742,7 +864,7 @@ fn delegation_clauses() -> Vec<Clause> {
             id: "delegation-data-custody".to_string(),
             category: ClauseCategory::DataCustody,
             title: "Data Custody".to_string(),
-            body: "{{bailee_name}} shall hold {{bailor_name}}'s data and may delegate custody to sub-bailees under equivalent terms. Data classification: {{data_classification}}.".to_string(),
+            body: "{{bailee_name}} shall hold {{bailor_name}}'s data and may delegate custody to sub-bailees under equivalent terms. Data classification: {{data_classification}}. {{classification_custody_obligations}}".to_string(),
             required: true,
             jurisdiction: None,
         },
@@ -750,7 +872,7 @@ fn delegation_clauses() -> Vec<Clause> {
             id: "delegation-processing-rights".to_string(),
             category: ClauseCategory::ProcessingRights,
             title: "Processing Rights".to_string(),
-            body: "{{bailee_name}} may process and delegate processing of {{bailor_name}}'s data. Sub-bailees must maintain equivalent or stricter terms.".to_string(),
+            body: "{{bailee_name}} may process and delegate processing of {{bailor_name}}'s data. Sub-bailees must maintain equivalent or stricter terms. {{classification_processing_obligations}}".to_string(),
             required: true,
             jurisdiction: None,
         },
@@ -758,7 +880,7 @@ fn delegation_clauses() -> Vec<Clause> {
             id: "delegation-breach-remedies".to_string(),
             category: ClauseCategory::BreachRemedies,
             title: "Breach Remedies".to_string(),
-            body: "Upon breach by {{bailee_name}} or any sub-bailee, {{bailor_name}} shall receive notice within 3 days. {{bailee_name}} remains liable for sub-bailee breaches.".to_string(),
+            body: "Upon breach by {{bailee_name}} or any sub-bailee, {{bailor_name}} shall receive notice under the classification-specific notice rule. {{classification_breach_notice}} {{bailee_name}} remains liable for sub-bailee breaches.".to_string(),
             required: true,
             jurisdiction: None,
         },
@@ -766,7 +888,7 @@ fn delegation_clauses() -> Vec<Clause> {
             id: "delegation-liability-caps".to_string(),
             category: ClauseCategory::LiabilityCaps,
             title: "Liability Caps".to_string(),
-            body: "Total liability capped at {{liability_cap_bps}} basis points. {{bailee_name}} bears full liability for sub-bailee actions.".to_string(),
+            body: "Total liability capped at {{liability_cap_bps}} basis points. {{bailee_name}} bears full liability for sub-bailee actions. {{classification_liability_obligations}}".to_string(),
             required: true,
             jurisdiction: None,
         },
@@ -782,7 +904,7 @@ fn delegation_clauses() -> Vec<Clause> {
             id: "delegation-termination".to_string(),
             category: ClauseCategory::Termination,
             title: "Termination".to_string(),
-            body: "Either party may terminate with 30 days written notice. All sub-bailments must be terminated within 15 days of primary termination.".to_string(),
+            body: "Either party may terminate with 30 days written notice. All sub-bailments must be terminated within 15 days of primary termination. {{classification_termination_obligations}}".to_string(),
             required: true,
             jurisdiction: None,
         },
@@ -812,7 +934,7 @@ fn emergency_clauses() -> Vec<Clause> {
             id: "emergency-data-custody".to_string(),
             category: ClauseCategory::DataCustody,
             title: "Emergency Data Custody".to_string(),
-            body: "{{bailee_name}} granted emergency access to {{bailor_name}}'s data. Access expires {{expiry_date}}. Justification required for all access. Data classification: {{data_classification}}.".to_string(),
+            body: "{{bailee_name}} granted emergency access to {{bailor_name}}'s data. Access expires {{expiry_date}}. Justification required for all access. Data classification: {{data_classification}}. {{classification_custody_obligations}}".to_string(),
             required: true,
             jurisdiction: None,
         },
@@ -820,7 +942,7 @@ fn emergency_clauses() -> Vec<Clause> {
             id: "emergency-processing-rights".to_string(),
             category: ClauseCategory::ProcessingRights,
             title: "Emergency Processing Rights".to_string(),
-            body: "{{bailee_name}} may process data only as necessary for emergency resolution. Processing scope: {{data_classification}} tier data. All processing must be logged.".to_string(),
+            body: "{{bailee_name}} may process data only as necessary for emergency resolution. Processing scope: {{data_classification}} tier data. All processing must be logged. {{classification_processing_obligations}}".to_string(),
             required: true,
             jurisdiction: None,
         },
@@ -828,7 +950,7 @@ fn emergency_clauses() -> Vec<Clause> {
             id: "emergency-breach-remedies".to_string(),
             category: ClauseCategory::BreachRemedies,
             title: "Breach Remedies".to_string(),
-            body: "Upon breach, {{bailor_name}} shall receive immediate notice. Emergency access revoked instantly upon breach detection.".to_string(),
+            body: "Upon breach, {{bailor_name}} shall receive immediate notice and the classification-specific notice rule applies. {{classification_breach_notice}} Emergency access revoked instantly upon breach detection.".to_string(),
             required: true,
             jurisdiction: None,
         },
@@ -836,7 +958,7 @@ fn emergency_clauses() -> Vec<Clause> {
             id: "emergency-liability-caps".to_string(),
             category: ClauseCategory::LiabilityCaps,
             title: "Liability Caps".to_string(),
-            body: "Total liability capped at {{liability_cap_bps}} basis points. Emergency access carries elevated liability.".to_string(),
+            body: "Total liability capped at {{liability_cap_bps}} basis points. Emergency access carries elevated liability. {{classification_liability_obligations}}".to_string(),
             required: true,
             jurisdiction: None,
         },
@@ -852,7 +974,7 @@ fn emergency_clauses() -> Vec<Clause> {
             id: "emergency-termination".to_string(),
             category: ClauseCategory::Termination,
             title: "Termination".to_string(),
-            body: "Emergency access automatically terminates at {{expiry_date}}. Either party may terminate immediately with written notice.".to_string(),
+            body: "Emergency access automatically terminates at {{expiry_date}}. Either party may terminate immediately with written notice. {{classification_termination_obligations}}".to_string(),
             required: true,
             jurisdiction: None,
         },
@@ -908,6 +1030,12 @@ mod tests {
         }
     }
 
+    fn test_params_with_classification(data_classification: DataClassification) -> ContractParams {
+        let mut params = test_params();
+        params.data_classification = data_classification;
+        params
+    }
+
     fn ts(ms: u64) -> Timestamp {
         Timestamp::new(ms, 0)
     }
@@ -958,6 +1086,15 @@ mod tests {
     fn compose_custody() -> ComposedContract {
         let template = default_template(BailmentType::Custody);
         compose_test(&template, &test_params())
+    }
+
+    fn rendered_contract_body(contract: &ComposedContract) -> String {
+        contract
+            .rendered_clauses
+            .iter()
+            .map(|clause| clause.rendered_body.clone())
+            .collect::<Vec<_>>()
+            .join(" ")
     }
 
     #[test]
@@ -1172,6 +1309,128 @@ mod tests {
             !all_bodies.contains("{{"),
             "Unsubstituted placeholders remain"
         );
+    }
+
+    #[test]
+    fn data_classification_renders_tier_specific_obligations() {
+        let template = default_template(BailmentType::Processing);
+        let cases = [
+            (
+                DataClassification::Public,
+                "Public data may be stored with baseline integrity controls",
+                "Public data processing is limited to authorized use",
+                "Public classification breaches require notice within 10 business days",
+                "Public data liability remains limited to integrity, availability, and attribution failures",
+                "Public data must be returned, deleted, or left published according to the bailor's written instruction",
+            ),
+            (
+                DataClassification::Internal,
+                "Internal data requires organization-scoped access controls",
+                "Internal data processing is limited to personnel, services, and agents operating under the bailee's internal authorization boundary",
+                "Internal classification breaches require notice within 5 business days",
+                "Internal data liability includes unauthorized internal disclosure and unauthorized retention",
+                "Internal data must be returned or deleted with an internal access revocation record",
+            ),
+            (
+                DataClassification::Confidential,
+                "Confidential data requires least-privilege access, encrypted storage, encrypted transfer, and access logging",
+                "Confidential data processing requires purpose-bound authorization and prohibits secondary use without signed amendment",
+                "Confidential classification breaches require notice within 72 hours",
+                "Confidential data liability includes unauthorized disclosure, unauthorized processing, and control failure",
+                "Confidential data must be returned or destroyed with verifiable destruction evidence",
+            ),
+            (
+                DataClassification::Restricted,
+                "Restricted data requires documented need-to-know approval, segregated storage, encrypted transfer, and dual-control access for export",
+                "Restricted data processing is limited to named workflows and named operators",
+                "Restricted classification breaches require notice within 24 hours",
+                "Restricted data liability includes unauthorized access, export, delegation, or segregation failure",
+                "Restricted data must be quarantined immediately on termination until return or destruction is receipt-backed",
+            ),
+            (
+                DataClassification::Regulated,
+                "Regulated data requires statutory control mapping, jurisdiction-specific handling, audit-ready access logs, and retention policy enforcement",
+                "Regulated data processing is limited to enumerated legal bases and auditable processing records",
+                "Regulated classification breaches require notice within the shortest applicable legal window, not exceeding 24 hours",
+                "Regulated data liability includes regulatory reporting failure, unlawful processing, and retention violation",
+                "Regulated data must follow the governing retention schedule and produce a compliance evidence package on termination",
+            ),
+        ];
+
+        let mut rendered_bodies = Vec::new();
+        for (
+            classification,
+            custody_obligation,
+            processing_obligation,
+            breach_obligation,
+            liability_obligation,
+            termination_obligation,
+        ) in cases
+        {
+            let contract =
+                compose_test(&template, &test_params_with_classification(classification));
+            let body = rendered_contract_body(&contract);
+            assert!(
+                body.contains(custody_obligation),
+                "{classification:?} custody obligation missing"
+            );
+            assert!(
+                body.contains(processing_obligation),
+                "{classification:?} processing obligation missing"
+            );
+            assert!(
+                body.contains(breach_obligation),
+                "{classification:?} breach obligation missing"
+            );
+            assert!(
+                body.contains(liability_obligation),
+                "{classification:?} liability obligation missing"
+            );
+            assert!(
+                body.contains(termination_obligation),
+                "{classification:?} termination obligation missing"
+            );
+            rendered_bodies.push((classification, body));
+        }
+
+        for (index, (left_classification, left_body)) in rendered_bodies.iter().enumerate() {
+            for (right_classification, right_body) in rendered_bodies.iter().skip(index + 1) {
+                assert_ne!(
+                    left_body, right_body,
+                    "{left_classification:?} and {right_classification:?} rendered identical contract bodies"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn standard_templates_bind_classification_obligation_placeholders() {
+        for bailment_type in [
+            BailmentType::Custody,
+            BailmentType::Processing,
+            BailmentType::Delegation,
+            BailmentType::Emergency,
+        ] {
+            let template = default_template(bailment_type);
+            let template_body = template
+                .clauses
+                .iter()
+                .map(|clause| clause.body.clone())
+                .collect::<Vec<_>>()
+                .join(" ");
+            for placeholder in [
+                "{{classification_custody_obligations}}",
+                "{{classification_processing_obligations}}",
+                "{{classification_breach_notice}}",
+                "{{classification_liability_obligations}}",
+                "{{classification_termination_obligations}}",
+            ] {
+                assert!(
+                    template_body.contains(placeholder),
+                    "{bailment_type:?} standard clauses must bind {placeholder}"
+                );
+            }
+        }
     }
 
     // -- Test 4: compose produces deterministic hash --

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 120904 lines of Rust under `crates/`, 2,929 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 121163 lines of Rust under `crates/`, 2,931 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,929 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,931 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,929 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,931 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-120904 lines of Rust under `crates/` · 20 workspace packages · 2,929 listed tests · 40 MCP tools · 8 constitutional invariants
+121163 lines of Rust under `crates/` · 20 workspace packages · 2,931 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 120904 lines of Rust under `crates/` | 266 Rust source files | 2,929 listed tests
+> **Codebase:** 20 workspace packages | 121163 lines of Rust under `crates/` | 266 Rust source files | 2,931 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,929 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,931 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 120904 lines of Rust under `crates/` · 2,929 listed tests
+20 workspace packages · 121163 lines of Rust under `crates/` · 2,931 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 
@@ -661,9 +661,9 @@ Authority chain verification and delegation management. Tracks delegation of per
 
 | Metric | Value |
 |--------|-------|
-| LOC | 899 |
-| Tests | 54 |
-| Files | 5 |
+| LOC | 3,937 |
+| Tests | 121 |
+| Files | 6 |
 
 ### Purpose
 
@@ -714,7 +714,7 @@ Bailment-conditioned consent enforcement. Implements the legal foundation of con
 
 ### Test Coverage Summary
 
-63 tests covering: bailment lifecycle transitions (all valid/invalid), consent gate enforcement, policy evaluation, default-deny behavior, emergency bailment time limits, terms hash binding.
+121 tests covering: bailment lifecycle transitions (all valid/invalid), consent gate enforcement, policy evaluation, default-deny behavior, emergency bailment time limits, terms hash binding, canonical contract hashing, and classification-specific clause obligations.
 
 > See also: [[ARCHITECTURE]] Section 4 (Consent Layer), [[THREAT-MODEL]] Threat 7 (Consent Bypass), [[CONSTITUTIONAL-PROOFS]] Proof 4 (Consent Completeness)
 
@@ -1155,7 +1155,7 @@ P2P networking and external API types. Provides peer-to-peer protocol message ty
 | exo-identity | 1,533 | 67 | 7 | DID management, risk, Shamir, PACE, keys |
 | exo-governance | 1,236 | 69 | 9 | Quorum, clearance, crosscheck, challenge, audit |
 | exo-authority | 1,235 | 66 | 6 | Authority chains, delegation, permissions |
-| exo-consent | 899 | 54 | 5 | Bailment consent, default-deny |
+| exo-consent | 3,937 | 121 | 6 | Bailment consent, default-deny |
 | exo-escalation | 824 | 43 | 8 | Detection, triage, Sybil adjudication, kanban |
 | exo-legal | 583 | 63 | 8 | Evidence, eDiscovery, privilege, fiduciary, records |
 | exo-gateway | 279 | 27 | 6 | HTTP gateway, auth, consent middleware |


### PR DESCRIPTION
## Summary
- Add classification-specific custody, processing, breach notice, liability, and termination obligations for `DataClassification`.
- Bind those obligations into every standard bailment contract template instead of only rendering the classification label.
- Add regression tests proving all five tiers render distinct obligations and that every standard template binds the classification obligation placeholders.
- Refresh repo-truth docs to `121163` Rust LOC and `2,931` listed workspace tests.

## TDD
- Red: `cargo test -p exo-consent data_classification_renders_tier_specific_obligations --lib -- --nocapture` failed on `Public custody obligation missing` before implementation.
- Red: `cargo test -p exo-consent standard_templates_bind_classification_obligation_placeholders --lib -- --nocapture` failed before templates bound the new placeholders.

## Verification
- `cargo test -p exo-consent data_classification_renders_tier_specific_obligations --lib -- --nocapture`
- `cargo test -p exo-consent standard_templates_bind_classification_obligation_placeholders --lib -- --nocapture`
- `cargo test -p exo-consent --lib -- --nocapture`
- `cargo test -p exo-consent`
- `cargo check --workspace`
- `bash tools/repo_truth.sh --json`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo audit --deny unsound --deny unmaintained` (passes with existing allowed yanked `core2` warning)
- `cargo deny check` (passes with existing duplicate/yanked/unused-allowance warnings)
- `cargo machete --with-metadata`
