### PR TITLE
fix(exo-node): canonicalize gossipsub message ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 121163 | `wc -l` |
-| Workspace tests | 2,931 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 121231 | `wc -l` |
+| Workspace tests | 2,933 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,931 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,933 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 121163 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 121231 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,931 listed workspace tests
+         cryptographic proofs, 2,933 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/network.rs
+++ b/crates/exo-node/src/network.rs
@@ -9,14 +9,13 @@
     clippy::collapsible_match
 )]
 
-use std::{
-    collections::hash_map::DefaultHasher,
-    hash::{Hash, Hasher},
-    time::Duration,
-};
+use std::time::Duration;
 
 use exo_api::p2p::{PeerId as ExoPeerId, PeerInfo, PeerRegistry, RateLimiter};
-use exo_core::types::{Did, Hash256, Timestamp};
+use exo_core::{
+    hash::hash_structured,
+    types::{Did, Hash256, Timestamp},
+};
 use futures::StreamExt;
 use libp2p::{
     Multiaddr, PeerId, Swarm, SwarmBuilder, gossipsub, identify, kad, mdns, noise, ping,
@@ -26,6 +25,15 @@ use libp2p::{
 use tokio::sync::mpsc;
 
 use crate::wire::{self, WireMessage, topics};
+
+const GOSSIPSUB_MESSAGE_ID_DOMAIN: &str = "exo.node.gossipsub.message-id.v1";
+
+#[derive(serde::Serialize)]
+struct GossipsubMessageIdPayload<'a> {
+    domain: &'static str,
+    topic: &'a str,
+    data: &'a [u8],
+}
 
 // ---------------------------------------------------------------------------
 // Composed network behaviour
@@ -106,12 +114,7 @@ pub fn build_swarm(config: &NetworkConfig) -> anyhow::Result<Swarm<ExochainBehav
         .with_quic()
         .with_behaviour(|keypair| {
             // Gossipsub configuration
-            let message_id_fn = |message: &gossipsub::Message| {
-                let mut hasher = DefaultHasher::new();
-                message.data.hash(&mut hasher);
-                message.topic.hash(&mut hasher);
-                gossipsub::MessageId::from(hasher.finish().to_string())
-            };
+            let message_id_fn = canonical_gossipsub_message_id;
 
             let gossipsub_config = gossipsub::ConfigBuilder::default()
                 .heartbeat_interval(Duration::from_secs(10))
@@ -172,6 +175,33 @@ pub fn build_swarm(config: &NetworkConfig) -> anyhow::Result<Swarm<ExochainBehav
         .build();
 
     Ok(swarm)
+}
+
+fn canonical_gossipsub_message_id(message: &gossipsub::Message) -> gossipsub::MessageId {
+    match canonical_gossipsub_message_id_for_parts(message.topic.as_str(), &message.data) {
+        Ok(id) => id,
+        Err(error) => {
+            tracing::error!(
+                err = %error,
+                "failed to encode canonical gossipsub message id payload"
+            );
+            gossipsub::MessageId::new(b"exo.node.gossipsub.message-id.serialization-error")
+        }
+    }
+}
+
+fn canonical_gossipsub_message_id_for_parts(
+    topic: &str,
+    data: &[u8],
+) -> anyhow::Result<gossipsub::MessageId> {
+    let payload = GossipsubMessageIdPayload {
+        domain: GOSSIPSUB_MESSAGE_ID_DOMAIN,
+        topic,
+        data,
+    };
+    let hash = hash_structured(&payload)
+        .map_err(|error| anyhow::anyhow!("canonical gossipsub message id encoding: {error}"))?;
+    Ok(gossipsub::MessageId::new(hash.as_bytes()))
 }
 
 /// Start listening on configured ports.
@@ -541,6 +571,44 @@ mod tests {
         };
         let swarm = build_swarm(&config);
         assert!(swarm.is_ok());
+    }
+
+    #[test]
+    fn production_gossipsub_message_ids_do_not_use_default_hasher() {
+        let source = include_str!("network.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production source section exists");
+        assert!(
+            !production.contains("DefaultHasher"),
+            "gossipsub message IDs must not use process-seeded DefaultHasher"
+        );
+    }
+
+    #[test]
+    fn gossipsub_message_ids_are_canonical_and_domain_separated() {
+        let id_a = canonical_gossipsub_message_id_for_parts("exo/consensus", b"payload")
+            .expect("canonical message id");
+        let id_b = canonical_gossipsub_message_id_for_parts("exo/consensus", b"payload")
+            .expect("canonical message id");
+        let different_topic =
+            canonical_gossipsub_message_id_for_parts("exo/governance", b"payload")
+                .expect("canonical message id");
+        let different_payload = canonical_gossipsub_message_id_for_parts("exo/consensus", b"other")
+            .expect("canonical message id");
+
+        assert_eq!(id_a, id_b);
+        assert_ne!(id_a, different_topic);
+        assert_ne!(id_a, different_payload);
+
+        let expected = hash_structured(&GossipsubMessageIdPayload {
+            domain: GOSSIPSUB_MESSAGE_ID_DOMAIN,
+            topic: "exo/consensus",
+            data: b"payload",
+        })
+        .expect("canonical hash");
+        assert_eq!(id_a.to_string(), expected.to_string());
     }
 
     #[tokio::test]

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 121163 lines of Rust under `crates/`, 2,931 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 121231 lines of Rust under `crates/`, 2,933 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,931 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,933 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,931 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,933 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-121163 lines of Rust under `crates/` · 20 workspace packages · 2,931 listed tests · 40 MCP tools · 8 constitutional invariants
+121231 lines of Rust under `crates/` · 20 workspace packages · 2,933 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 121163 lines of Rust under `crates/` | 266 Rust source files | 2,931 listed tests
+> **Codebase:** 20 workspace packages | 121231 lines of Rust under `crates/` | 266 Rust source files | 2,933 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,931 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,933 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 121163 lines of Rust under `crates/` · 2,931 listed tests
+20 workspace packages · 121231 lines of Rust under `crates/` · 2,933 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- replace the gossipsub message-id callback's process-seeded `DefaultHasher` with domain-separated canonical structured hashing
- cover topic and payload in `exo.node.gossipsub.message-id.v1` canonical CBOR before deriving the `MessageId`
- add regression coverage proving production no longer uses `DefaultHasher` and message IDs are stable, topic-sensitive, and payload-sensitive
- refresh repo-truth LOC/test counters

## TDD / Verification
- RED first: `cargo test -p exo-node production_gossipsub_message_ids_do_not_use_default_hasher --bin exochain -- --nocapture` failed while production used `DefaultHasher`
- `cargo test -p exo-node production_gossipsub_message_ids_do_not_use_default_hasher --bin exochain -- --nocapture`
- `cargo test -p exo-node gossipsub_message_ids_are_canonical_and_domain_separated --bin exochain -- --nocapture`
- `cargo test -p exo-node network::tests --bin exochain -- --nocapture`
- `cargo test -p exo-node`
- `cargo build -p exo-node`
- `cargo clippy -p exo-node --bins -- -D warnings`
- `cargo clippy -p exo-node --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `bash tools/repo_truth.sh --json`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit --deny unsound --deny unmaintained`
- `cargo deny check`
- `cargo machete --with-metadata`
