### PR TITLE
fix(exo-core): require caller-supplied correlation ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 121231 | `wc -l` |
+| Rust LOC | 121272 | `wc -l` |
 | Workspace tests | 2,933 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -57,7 +57,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 121231 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 121272 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 2,933 listed workspace tests
 

--- a/crates/exo-core/src/bcts.rs
+++ b/crates/exo-core/src/bcts.rs
@@ -264,6 +264,12 @@ impl BailmentTransaction for Transaction {
 mod tests {
     use super::*;
 
+    macro_rules! correlation_id {
+        () => {
+            CorrelationId::from_uuid(uuid::Uuid::from_u128(u128::from(line!())))
+        };
+    }
+
     fn test_clock() -> HybridClock {
         let counter = std::sync::atomic::AtomicU64::new(1000);
         HybridClock::with_wall_clock(move || {
@@ -402,7 +408,7 @@ mod tests {
 
     #[test]
     fn new_transaction_is_draft() {
-        let cid = CorrelationId::new();
+        let cid = correlation_id!();
         let tx = Transaction::new(cid);
         assert_eq!(tx.state(), BctsState::Draft);
         assert!(tx.receipt_chain().is_empty());
@@ -414,7 +420,7 @@ mod tests {
     fn happy_path_full_lifecycle() {
         let mut clock = test_clock();
         let actor = test_did();
-        let mut tx = Transaction::new(CorrelationId::new());
+        let mut tx = Transaction::new(correlation_id!());
 
         let steps = [
             BctsState::Submitted,
@@ -446,7 +452,7 @@ mod tests {
     fn invalid_transition_from_draft_to_closed() {
         let mut clock = test_clock();
         let actor = test_did();
-        let mut tx = Transaction::new(CorrelationId::new());
+        let mut tx = Transaction::new(correlation_id!());
 
         let err = tx
             .transition(BctsState::Closed, &actor, &mut clock)
@@ -460,7 +466,7 @@ mod tests {
     fn invalid_transition_from_closed() {
         let mut clock = test_clock();
         let actor = test_did();
-        let mut tx = Transaction::new(CorrelationId::new());
+        let mut tx = Transaction::new(correlation_id!());
 
         // Go to Closed via happy path
         for &s in &[
@@ -489,7 +495,7 @@ mod tests {
     fn denial_path() {
         let mut clock = test_clock();
         let actor = test_did();
-        let mut tx = Transaction::new(CorrelationId::new());
+        let mut tx = Transaction::new(correlation_id!());
 
         tx.transition(BctsState::Submitted, &actor, &mut clock)
             .expect("ok");
@@ -503,7 +509,7 @@ mod tests {
     fn escalation_path() {
         let mut clock = test_clock();
         let actor = test_did();
-        let mut tx = Transaction::new(CorrelationId::new());
+        let mut tx = Transaction::new(correlation_id!());
 
         for &s in &[
             BctsState::Submitted,
@@ -524,7 +530,7 @@ mod tests {
     fn remediation_path() {
         let mut clock = test_clock();
         let actor = test_did();
-        let mut tx = Transaction::new(CorrelationId::new());
+        let mut tx = Transaction::new(correlation_id!());
 
         tx.transition(BctsState::Submitted, &actor, &mut clock)
             .expect("ok");
@@ -542,7 +548,7 @@ mod tests {
     fn receipt_chain_grows_monotonically() {
         let mut clock = test_clock();
         let actor = test_did();
-        let mut tx = Transaction::new(CorrelationId::new());
+        let mut tx = Transaction::new(correlation_id!());
 
         tx.transition(BctsState::Submitted, &actor, &mut clock)
             .expect("ok");
@@ -560,7 +566,7 @@ mod tests {
     fn transition_records_correct_actor() {
         let mut clock = test_clock();
         let actor = Did::new("did:exo:alice").expect("valid");
-        let mut tx = Transaction::new(CorrelationId::new());
+        let mut tx = Transaction::new(correlation_id!());
 
         let t = tx
             .transition(BctsState::Submitted, &actor, &mut clock)
@@ -572,7 +578,7 @@ mod tests {
     fn transition_timestamps_are_monotonic() {
         let mut clock = test_clock();
         let actor = test_did();
-        let mut tx = Transaction::new(CorrelationId::new());
+        let mut tx = Transaction::new(correlation_id!());
 
         tx.transition(BctsState::Submitted, &actor, &mut clock)
             .expect("ok");
@@ -587,7 +593,7 @@ mod tests {
     fn verify_receipt_chain_detects_tampering() {
         let mut clock = test_clock();
         let actor = test_did();
-        let mut tx = Transaction::new(CorrelationId::new());
+        let mut tx = Transaction::new(correlation_id!());
 
         tx.transition(BctsState::Submitted, &actor, &mut clock)
             .expect("ok");
@@ -604,7 +610,7 @@ mod tests {
     fn transaction_serde_roundtrip() {
         let mut clock = test_clock();
         let actor = test_did();
-        let mut tx = Transaction::new(CorrelationId::new());
+        let mut tx = Transaction::new(correlation_id!());
         tx.transition(BctsState::Submitted, &actor, &mut clock)
             .expect("ok");
 
@@ -657,7 +663,7 @@ mod tests {
     fn escalated_to_denied_to_remediated_to_submitted() {
         let mut clock = test_clock();
         let actor = test_did();
-        let mut tx = Transaction::new(CorrelationId::new());
+        let mut tx = Transaction::new(correlation_id!());
 
         for &s in &[
             BctsState::Submitted,
@@ -679,7 +685,7 @@ mod tests {
     fn escalated_to_remediated() {
         let mut clock = test_clock();
         let actor = test_did();
-        let mut tx = Transaction::new(CorrelationId::new());
+        let mut tx = Transaction::new(correlation_id!());
 
         for &s in &[
             BctsState::Submitted,

--- a/crates/exo-core/src/events.rs
+++ b/crates/exo-core/src/events.rs
@@ -338,10 +338,16 @@ mod tests {
         types::{CorrelationId, Did, Timestamp},
     };
 
+    macro_rules! correlation_id {
+        () => {
+            CorrelationId::from_uuid(uuid::Uuid::from_u128(u128::from(line!())))
+        };
+    }
+
     fn make_event(kp: &KeyPair) -> Event {
         let did = Did::new("did:exo:test-source").expect("valid");
         create_signed_event(
-            CorrelationId::new(),
+            correlation_id!(),
             Timestamp::new(1000, 0),
             EventType::AuditEntry,
             b"test payload".to_vec(),
@@ -353,7 +359,7 @@ mod tests {
 
     fn make_unsigned_event(source_did: Did) -> Event {
         Event {
-            id: CorrelationId::new(),
+            id: correlation_id!(),
             timestamp: Timestamp::new(1000, 0),
             event_type: EventType::AuditEntry,
             payload: b"test payload".to_vec(),
@@ -569,7 +575,7 @@ mod tests {
         let kp = KeyPair::generate();
         let did = Did::new("did:exo:empty-payload").expect("valid");
         let event = create_signed_event(
-            CorrelationId::new(),
+            correlation_id!(),
             Timestamp::new(500, 1),
             EventType::Custom("empty".into()),
             Vec::new(),
@@ -586,7 +592,7 @@ mod tests {
         let did = Did::new("did:exo:large-payload").expect("valid");
         let payload = vec![0xab_u8; 10_000];
         let event = create_signed_event(
-            CorrelationId::new(),
+            correlation_id!(),
             Timestamp::new(500, 1),
             EventType::AuditEntry,
             payload,

--- a/crates/exo-core/src/types.rs
+++ b/crates/exo-core/src/types.rs
@@ -613,12 +613,6 @@ impl fmt::Display for Did {
 pub struct CorrelationId(Uuid);
 
 impl CorrelationId {
-    /// Generate a new random correlation ID.
-    #[must_use]
-    pub fn new() -> Self {
-        Self(Uuid::new_v4())
-    }
-
     /// Wrap an existing UUID.
     #[must_use]
     pub const fn from_uuid(uuid: Uuid) -> Self {
@@ -629,12 +623,6 @@ impl CorrelationId {
     #[must_use]
     pub const fn as_uuid(&self) -> &Uuid {
         &self.0
-    }
-}
-
-impl Default for CorrelationId {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -1547,27 +1535,40 @@ mod tests {
     // -- CorrelationId -----------------------------------------------------
 
     #[test]
-    fn correlation_id_new() {
-        let c1 = CorrelationId::new();
-        let c2 = CorrelationId::new();
+    fn correlation_id_production_api_does_not_generate_random_ids() {
+        let source = include_str!("types.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production source section exists");
+
+        assert!(
+            !production.contains("Uuid::new_v4()"),
+            "CorrelationId must be caller-supplied, not generated from UUID v4 randomness"
+        );
+        assert!(
+            !production.contains("impl Default for CorrelationId"),
+            "CorrelationId must not provide a random Default implementation"
+        );
+    }
+
+    #[test]
+    fn correlation_id_requires_explicit_uuid() {
+        let c1 = CorrelationId::from_uuid(Uuid::from_u128(1));
+        let c2 = CorrelationId::from_uuid(Uuid::from_u128(2));
         assert_ne!(c1, c2);
     }
 
     #[test]
-    fn correlation_id_default() {
-        let _c = CorrelationId::default();
-    }
-
-    #[test]
     fn correlation_id_from_uuid() {
-        let uuid = Uuid::new_v4();
+        let uuid = Uuid::from_u128(42);
         let c = CorrelationId::from_uuid(uuid);
         assert_eq!(*c.as_uuid(), uuid);
     }
 
     #[test]
     fn correlation_id_display_debug() {
-        let c = CorrelationId::new();
+        let c = CorrelationId::from_uuid(Uuid::from_u128(7));
         let disp = c.to_string();
         assert!(!disp.is_empty());
         let dbg = format!("{c:?}");
@@ -1583,7 +1584,7 @@ mod tests {
 
     #[test]
     fn correlation_id_serde() {
-        let c = CorrelationId::new();
+        let c = CorrelationId::from_uuid(Uuid::from_u128(9));
         let json = serde_json::to_string(&c).expect("ser");
         let c2: CorrelationId = serde_json::from_str(&json).expect("de");
         assert_eq!(c, c2);

--- a/crates/exo-core/tests/chain_of_custody.rs
+++ b/crates/exo-core/tests/chain_of_custody.rs
@@ -21,6 +21,20 @@ use exo_core::{
     },
 };
 
+macro_rules! correlation_id {
+    () => {
+        CorrelationId::from_uuid(uuid::Uuid::from_u128(u128::from(line!())))
+    };
+}
+
+fn indexed_correlation_id(base: u128, index: usize) -> CorrelationId {
+    let offset = match u128::try_from(index) {
+        Ok(value) => value,
+        Err(_) => panic!("test correlation index must fit in u128"),
+    };
+    CorrelationId::from_uuid(uuid::Uuid::from_u128(base + offset))
+}
+
 // ---------------------------------------------------------------------------
 // Helper: multi-actor governance scenario
 // ---------------------------------------------------------------------------
@@ -63,14 +77,14 @@ impl GovernanceActors {
 fn multi_actor_signed_event_chain_with_merkle_proof() {
     let actors = GovernanceActors::new();
     let mut clock = HybridClock::new();
-    let mut tx = Transaction::new(CorrelationId::new());
+    let mut tx = Transaction::new(correlation_id!());
 
     // Phase 1: Proposer submits
     let t1 = tx
         .transition(BctsState::Submitted, &actors.proposer.0, &mut clock)
         .expect("submit ok");
     let event1 = create_signed_event(
-        CorrelationId::new(),
+        correlation_id!(),
         t1.timestamp,
         EventType::TransactionStateChanged,
         t1.receipt_hash.as_bytes().to_vec(),
@@ -85,7 +99,7 @@ fn multi_actor_signed_event_chain_with_merkle_proof() {
         .transition(BctsState::IdentityResolved, &actors.reviewer1.0, &mut clock)
         .expect("identity ok");
     let event2 = create_signed_event(
-        CorrelationId::new(),
+        correlation_id!(),
         t2.timestamp,
         EventType::TransactionStateChanged,
         t2.receipt_hash.as_bytes().to_vec(),
@@ -100,7 +114,7 @@ fn multi_actor_signed_event_chain_with_merkle_proof() {
         .transition(BctsState::ConsentValidated, &actors.reviewer2.0, &mut clock)
         .expect("consent ok");
     let event3 = create_signed_event(
-        CorrelationId::new(),
+        correlation_id!(),
         t3.timestamp,
         EventType::TransactionStateChanged,
         t3.receipt_hash.as_bytes().to_vec(),
@@ -115,7 +129,7 @@ fn multi_actor_signed_event_chain_with_merkle_proof() {
         .transition(BctsState::Deliberated, &actors.steward.0, &mut clock)
         .expect("deliberation ok");
     let event4 = create_signed_event(
-        CorrelationId::new(),
+        correlation_id!(),
         t4.timestamp,
         EventType::TransactionStateChanged,
         t4.receipt_hash.as_bytes().to_vec(),
@@ -163,7 +177,7 @@ fn denial_remediation_resubmission_with_full_proof_chain() {
     let kp = KeyPair::generate();
     let actor = Did::new("did:exo:lifecycle-actor").expect("valid");
     let mut clock = HybridClock::new();
-    let mut tx = Transaction::new(CorrelationId::new());
+    let mut tx = Transaction::new(correlation_id!());
 
     // Submit → Deny → Remediate → Re-submit → Continue to Approved
     let transitions = [
@@ -183,12 +197,12 @@ fn denial_remediation_resubmission_with_full_proof_chain() {
     ];
 
     let mut events = Vec::new();
-    for &target in &transitions {
+    for (index, &target) in transitions.iter().enumerate() {
         let t = tx
             .transition(target, &actor, &mut clock)
             .expect("transition ok");
         let event = create_signed_event(
-            CorrelationId::new(),
+            indexed_correlation_id(2_000, index),
             t.timestamp,
             EventType::TransactionStateChanged,
             t.receipt_hash.as_bytes().to_vec(),
@@ -245,7 +259,7 @@ fn hybrid_crypto_custody_chain() {
     // Sign each transition receipt with hybrid crypto
     let actor = Did::new("did:exo:hybrid-actor").expect("valid");
     let mut clock = HybridClock::new();
-    let mut tx = Transaction::new(CorrelationId::new());
+    let mut tx = Transaction::new(correlation_id!());
 
     let states = [
         BctsState::Submitted,
@@ -299,7 +313,7 @@ fn pq_only_custody_chain() {
     let pq_kp = PqKeyPair::generate();
     let actor = Did::new("did:exo:pq-actor").expect("valid");
     let mut clock = HybridClock::new();
-    let mut tx = Transaction::new(CorrelationId::new());
+    let mut tx = Transaction::new(correlation_id!());
 
     for &s in &[
         BctsState::Submitted,
@@ -326,7 +340,7 @@ fn escalation_path_proof() {
     let actor = Did::new("did:exo:escalation-actor").expect("valid");
     let mut clock = HybridClock::new();
     let kp = KeyPair::generate();
-    let mut tx = Transaction::new(CorrelationId::new());
+    let mut tx = Transaction::new(correlation_id!());
 
     // Submit → IdentityResolved → ConsentValidated → Deliberated → Escalated
     tx.transition(BctsState::Submitted, &actor, &mut clock)
@@ -342,7 +356,7 @@ fn escalation_path_proof() {
         .expect("escalation ok");
 
     let event = create_signed_event(
-        CorrelationId::new(),
+        correlation_id!(),
         t_esc.timestamp,
         EventType::TransactionStateChanged,
         t_esc.receipt_hash.as_bytes().to_vec(),
@@ -363,7 +377,7 @@ fn escalation_path_proof() {
 fn receipt_chain_tamper_detection() {
     let actor = Did::new("did:exo:tamper-actor").expect("valid");
     let mut clock = HybridClock::new();
-    let mut tx = Transaction::new(CorrelationId::new());
+    let mut tx = Transaction::new(correlation_id!());
 
     for &s in &[
         BctsState::Submitted,
@@ -399,8 +413,8 @@ fn concurrent_transactions_hlc_ordering() {
     let mut clock = HybridClock::new();
     let actors = GovernanceActors::new();
 
-    let mut tx_a = Transaction::new(CorrelationId::new());
-    let mut tx_b = Transaction::new(CorrelationId::new());
+    let mut tx_a = Transaction::new(correlation_id!());
+    let mut tx_b = Transaction::new(correlation_id!());
 
     let t_a1 = tx_a
         .transition(BctsState::Submitted, &actors.proposer.0, &mut clock)
@@ -506,7 +520,7 @@ fn pq_keypair_accessors_and_debug() {
 fn invalid_transition_rejected() {
     let actor = Did::new("did:exo:invalid-actor").expect("valid");
     let mut clock = HybridClock::new();
-    let mut tx = Transaction::new(CorrelationId::new());
+    let mut tx = Transaction::new(correlation_id!());
 
     // Draft → Approved (skipping required states) should fail
     let result = tx.transition(BctsState::Approved, &actor, &mut clock);
@@ -698,7 +712,7 @@ fn bailment_transaction_lifecycle() {
     let actor = Did::new("did:exo:bailment-actor").expect("valid");
     let mut clock = HybridClock::new();
 
-    let mut tx = Transaction::new(CorrelationId::new());
+    let mut tx = Transaction::new(correlation_id!());
     assert_eq!(tx.state(), BctsState::Draft);
     assert!(tx.receipt_chain().is_empty());
 

--- a/crates/exo-core/tests/integration.rs
+++ b/crates/exo-core/tests/integration.rs
@@ -15,6 +15,20 @@ use exo_core::{
     types::{CorrelationId, DeterministicMap, Did, Hash256, Timestamp, Version},
 };
 
+macro_rules! correlation_id {
+    () => {
+        CorrelationId::from_uuid(uuid::Uuid::from_u128(u128::from(line!())))
+    };
+}
+
+fn indexed_correlation_id(base: u128, index: usize) -> CorrelationId {
+    let offset = match u128::try_from(index) {
+        Ok(value) => value,
+        Err(_) => panic!("test correlation index must fit in u128"),
+    };
+    CorrelationId::from_uuid(uuid::Uuid::from_u128(base + offset))
+}
+
 // ---------------------------------------------------------------------------
 // Full BCTS lifecycle with crypto + events
 // ---------------------------------------------------------------------------
@@ -24,7 +38,7 @@ fn full_bcts_lifecycle_with_signed_events() {
     let kp = KeyPair::generate();
     let actor = Did::new("did:exo:integration-actor").expect("valid");
     let mut clock = HybridClock::new();
-    let mut tx = Transaction::new(CorrelationId::new());
+    let mut tx = Transaction::new(correlation_id!());
 
     let steps = [
         BctsState::Submitted,
@@ -39,12 +53,12 @@ fn full_bcts_lifecycle_with_signed_events() {
         BctsState::Closed,
     ];
 
-    for &target in &steps {
+    for (index, &target) in steps.iter().enumerate() {
         let transition = tx.transition(target, &actor, &mut clock).expect("ok");
 
         // Create a signed event for each transition
         let event = create_signed_event(
-            CorrelationId::new(),
+            indexed_correlation_id(1_000, index),
             transition.timestamp,
             EventType::TransactionStateChanged,
             transition.receipt_hash.as_bytes().to_vec(),
@@ -67,7 +81,7 @@ fn full_bcts_lifecycle_with_signed_events() {
 fn receipt_chain_merkle_tree() {
     let actor = Did::new("did:exo:merkle-actor").expect("valid");
     let mut clock = HybridClock::new();
-    let mut tx = Transaction::new(CorrelationId::new());
+    let mut tx = Transaction::new(correlation_id!());
 
     for &s in &[
         BctsState::Submitted,
@@ -189,12 +203,12 @@ fn hlc_ordering_across_transactions() {
     let mut clock = HybridClock::new();
     let actor = Did::new("did:exo:hlc-actor").expect("valid");
 
-    let mut tx1 = Transaction::new(CorrelationId::new());
+    let mut tx1 = Transaction::new(correlation_id!());
     let t1 = tx1
         .transition(BctsState::Submitted, &actor, &mut clock)
         .expect("ok");
 
-    let mut tx2 = Transaction::new(CorrelationId::new());
+    let mut tx2 = Transaction::new(correlation_id!());
     let t2 = tx2
         .transition(BctsState::Submitted, &actor, &mut clock)
         .expect("ok");
@@ -211,7 +225,7 @@ fn hlc_ordering_across_transactions() {
 #[test]
 fn re_exports_available() {
     // These types should be available from the crate root
-    let _cid = CorrelationId::new();
+    let _cid = correlation_id!();
     let _ts = Timestamp::new(0, 0);
     let _v = Version::ZERO;
     let _h = Hash256::ZERO;
@@ -227,7 +241,7 @@ fn re_exports_available() {
 fn denial_remediation_resubmission() {
     let mut clock = HybridClock::new();
     let actor = Did::new("did:exo:cycle-actor").expect("valid");
-    let mut tx = Transaction::new(CorrelationId::new());
+    let mut tx = Transaction::new(correlation_id!());
 
     // Submit -> Deny -> Remediate -> Resubmit -> succeed
     tx.transition(BctsState::Submitted, &actor, &mut clock)

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 121231 lines of Rust under `crates/`, 2,933 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 121272 lines of Rust under `crates/`, 2,933 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-121231 lines of Rust under `crates/` · 20 workspace packages · 2,933 listed tests · 40 MCP tools · 8 constitutional invariants
+121272 lines of Rust under `crates/` · 20 workspace packages · 2,933 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 121231 lines of Rust under `crates/` | 266 Rust source files | 2,933 listed tests
+> **Codebase:** 20 workspace packages | 121272 lines of Rust under `crates/` | 266 Rust source files | 2,933 listed tests
 
 ---
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 121231 lines of Rust under `crates/` · 2,933 listed tests
+20 workspace packages · 121272 lines of Rust under `crates/` · 2,933 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- remove random `CorrelationId::new()` and random `Default` construction from exo-core
- keep `CorrelationId` construction caller-supplied through `from_uuid`
- add a production source guard against reintroducing UUID v4/default randomness
- update exo-core tests to use deterministic caller-supplied correlation IDs, including unique indexed IDs in event loops

## TDD
- `cargo test -p exo-core correlation_id_production_api_does_not_generate_random_ids --lib -- --nocapture` failed first while production still contained `Uuid::new_v4()` and `impl Default for CorrelationId`

## Verification
- `cargo test -p exo-core correlation_id_production_api_does_not_generate_random_ids --lib -- --nocapture`
- `cargo test -p exo-core`
- `cargo build -p exo-core`
- `cargo clippy -p exo-core --lib --bins -- -D warnings`
- `cargo clippy -p exo-core --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace`