### PR TITLE
fix(exo-node): bind 0dentity bootstrap keys to DIDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 121272 | `wc -l` |
-| Workspace tests | 2,933 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 121321 | `wc -l` |
+| Workspace tests | 2,935 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,933 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,935 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 121272 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 121321 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,933 listed workspace tests
+         cryptographic proofs, 2,935 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/zerodentity/onboarding.rs
+++ b/crates/exo-node/src/zerodentity/onboarding.rs
@@ -19,12 +19,14 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 #[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
-use super::session_auth::{claim_submission_signing_payload, did_from_public_key};
+use super::session_auth::claim_submission_signing_payload;
 #[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
 use super::types::{ClaimStatus, IdentityClaim, OtpChannel};
 use super::{
     otp::OtpResult,
-    session_auth::{bootstrap_signing_payload, public_key_from_hex, signature_from_hex},
+    session_auth::{
+        bootstrap_signing_payload, did_from_public_key, public_key_from_hex, signature_from_hex,
+    },
     store::ZerodentityStore,
     types::{ClaimType, IdentitySession, OtpChallenge, ZerodentityScore},
 };
@@ -183,6 +185,14 @@ fn verify_bootstrap_signature(
 
     let public_key =
         public_key_from_hex(public_key_hex).map_err(|e| json_error(StatusCode::BAD_REQUEST, e))?;
+    let derived_did = did_from_public_key(&public_key)
+        .map_err(|e| json_error(StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    if derived_did != challenge.subject_did {
+        return Err(json_error(
+            StatusCode::UNAUTHORIZED,
+            "public_key does not derive the challenged subject_did",
+        ));
+    }
     let signature =
         signature_from_hex(signature_hex).map_err(|e| json_error(StatusCode::BAD_REQUEST, e))?;
     if signature.is_empty() {
@@ -657,6 +667,19 @@ mod tests {
         assert!(!default_handler.contains("Uuid::new_v4()"));
         assert!(!default_handler.contains("Signature::Empty"));
         assert!(!default_handler.contains("insert_claim"));
+    }
+
+    #[test]
+    fn verify_bootstrap_signature_binds_public_key_to_challenged_did() {
+        let source = include_str!("onboarding.rs");
+        let verifier = source
+            .split("fn verify_bootstrap_signature")
+            .nth(1)
+            .and_then(|section| section.split("Ok(public_key)").next())
+            .expect("verify_bootstrap_signature must have an explicit function body");
+
+        assert!(verifier.contains("did_from_public_key(&public_key)"));
+        assert!(verifier.contains("derived_did != challenge.subject_did"));
     }
 
     #[test]

--- a/crates/exo-node/src/zerodentity/session_auth.rs
+++ b/crates/exo-node/src/zerodentity/session_auth.rs
@@ -124,7 +124,6 @@ pub(crate) fn signature_from_hex(value: &str) -> Result<Signature, String> {
     Ok(Signature::from_bytes(signature))
 }
 
-#[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
 pub(crate) fn did_from_public_key(public_key: &PublicKey) -> Result<Did, String> {
     let key_hash = Hash256::digest(public_key.as_bytes());
     let method_specific = bs58::encode(key_hash.as_bytes()).into_string();

--- a/crates/exo-node/src/zerodentity/tests.rs
+++ b/crates/exo-node/src/zerodentity/tests.rs
@@ -205,7 +205,6 @@ mod tests {
         })
     }
 
-    #[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
     fn derived_did(keypair: &KeyPair) -> Did {
         crate::zerodentity::session_auth::did_from_public_key(keypair.public_key()).unwrap()
     }
@@ -994,8 +993,8 @@ mod tests {
     async fn verify_otp_correct_code_returns_verified_and_session_token() {
         let store = new_shared_store();
         let app = onboarding_app(store.clone());
-        let did = td("otp-ok-01");
         let keypair = test_keypair(1);
+        let did = derived_did(&keypair);
         // Far-future dispatched_ms so TTL check won't trigger on wall clock
         let dispatched_ms = u64::MAX / 2;
 
@@ -1068,9 +1067,9 @@ mod tests {
     async fn verify_otp_success_rejects_wrong_bootstrap_key() {
         let store = new_shared_store();
         let app = onboarding_app(store.clone());
-        let did = td("otp-bootstrap-wrong-key");
         let keypair = test_keypair(2);
         let wrong_keypair = test_keypair(3);
+        let did = derived_did(&keypair);
         let dispatched_ms = u64::MAX / 2;
 
         let mut rng = seeded_rng(0xCAFE_1011);
@@ -1100,6 +1099,34 @@ mod tests {
                 "public_key": hex::encode(keypair.public_key().as_bytes()),
                 "bootstrap_signature": hex::encode(wrong_signature.to_bytes())
             }),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn verify_otp_rejects_bootstrap_key_that_does_not_derive_subject_did() {
+        let store = new_shared_store();
+        let app = onboarding_app(store.clone());
+        let did = td("otp-bootstrap-unbound-key");
+        let keypair = test_keypair(4);
+        let dispatched_ms = u64::MAX / 2;
+
+        let mut rng = seeded_rng(0xCAFE_1012);
+        let (challenge, code) =
+            OtpChallenge::new(&did, OtpChannel::Email, dispatched_ms, &mut rng).unwrap();
+        let cid = challenge.challenge_id.clone();
+        store
+            .lock()
+            .unwrap()
+            .insert_otp_challenge(&challenge)
+            .unwrap();
+
+        let resp = post_json(
+            &app,
+            "/api/v1/0dentity/verify",
+            bootstrap_verify_body(&cid, &code, &did, &keypair),
         )
         .await;
 

--- a/crates/exo-node/src/zerodentity/types.rs
+++ b/crates/exo-node/src/zerodentity/types.rs
@@ -413,7 +413,7 @@ pub struct PeerAttestation {
 /// Spec §8.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IdentitySession {
-    /// Opaque session token (UUID v4 in hex).
+    /// Opaque session token issued after verified onboarding bootstrap.
     pub session_token: String,
     /// The DID authenticated by this session.
     pub subject_did: Did,

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 121272 lines of Rust under `crates/`, 2,933 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 121321 lines of Rust under `crates/`, 2,935 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,933 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,935 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,933 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,935 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-121272 lines of Rust under `crates/` · 20 workspace packages · 2,933 listed tests · 40 MCP tools · 8 constitutional invariants
+121321 lines of Rust under `crates/` · 20 workspace packages · 2,935 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 121272 lines of Rust under `crates/` | 266 Rust source files | 2,933 listed tests
+> **Codebase:** 20 workspace packages | 121321 lines of Rust under `crates/` | 266 Rust source files | 2,935 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,933 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,935 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 121272 lines of Rust under `crates/` · 2,933 listed tests
+20 workspace packages · 121321 lines of Rust under `crates/` · 2,935 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- reject 0dentity bootstrap verification when the submitted public key does not derive the challenged subject DID
- keep `did_from_public_key` available in the default build so the verified OTP bootstrap path can enforce DID/key binding
- add regression and source-guard tests for the binding check, and refresh repo-truth doc counts

## TDD
- Red first: `cargo test -p exo-node verify_otp_rejects_bootstrap_key_that_does_not_derive_subject_did --bin exochain -- --nocapture` failed before the fix with `200`, expected `401`
- Green after implementation: same regression passes

## Verification
- `cargo test -p exo-node verify_otp_ --bin exochain -- --nocapture`
- `cargo test -p exo-node verify_bootstrap_signature_binds_public_key_to_challenged_did --bin exochain -- --nocapture`
- `cargo test -p exo-node zerodentity:: --bin exochain -- --nocapture`
- `cargo test -p exo-node --features unaudited-zerodentity-first-touch-onboarding zerodentity:: --bin exochain -- --nocapture`
- `cargo test -p exo-node`
- `cargo build -p exo-node`
- `cargo clippy -p exo-node --bin exochain -- -D warnings`
- `cargo clippy -p exo-node --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `bash tools/repo_truth.sh --json`
- `bash tools/test_repo_truth.sh`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check`