### PR TITLE
fix(exo-node): make zerodentity sessions one-shot

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 121321 | `wc -l` |
-| Workspace tests | 2,935 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 121481 | `wc -l` |
+| Workspace tests | 2,939 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,935 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,939 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 121321 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 121481 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,935 listed workspace tests
+         cryptographic proofs, 2,939 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/zerodentity/onboarding.rs
+++ b/crates/exo-node/src/zerodentity/onboarding.rs
@@ -12,11 +12,13 @@ use std::sync::{Arc, Mutex};
 use axum::{Json, Router, extract::State, http::StatusCode, routing::post};
 #[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
 use exo_core::types::{Did, Hash256};
-use exo_core::{crypto, types::PublicKey};
+use exo_core::{
+    crypto,
+    types::{PublicKey, Signature},
+};
 use getrandom::getrandom;
 use rand::{SeedableRng, rngs::StdRng};
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 #[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
 use super::session_auth::claim_submission_signing_payload;
@@ -25,7 +27,8 @@ use super::types::{ClaimStatus, IdentityClaim, OtpChannel};
 use super::{
     otp::OtpResult,
     session_auth::{
-        bootstrap_signing_payload, did_from_public_key, public_key_from_hex, signature_from_hex,
+        bootstrap_signing_payload, did_from_public_key, public_key_from_hex,
+        session_token_from_bootstrap, signature_from_hex,
     },
     store::ZerodentityStore,
     types::{ClaimType, IdentitySession, OtpChallenge, ZerodentityScore},
@@ -170,10 +173,15 @@ fn lock_store(
         .map_err(|_| json_error(StatusCode::INTERNAL_SERVER_ERROR, "Store lock error"))
 }
 
+struct VerifiedBootstrap {
+    public_key: PublicKey,
+    signature: Signature,
+}
+
 fn verify_bootstrap_signature(
     req: &VerifyOtpRequest,
     challenge: &OtpChallenge,
-) -> Result<PublicKey, (StatusCode, Json<serde_json::Value>)> {
+) -> Result<VerifiedBootstrap, (StatusCode, Json<serde_json::Value>)> {
     let public_key_hex = req
         .public_key
         .as_deref()
@@ -212,7 +220,10 @@ fn verify_bootstrap_signature(
         ));
     }
 
-    Ok(public_key)
+    Ok(VerifiedBootstrap {
+        public_key,
+        signature,
+    })
 }
 
 #[cfg_attr(
@@ -441,54 +452,55 @@ pub async fn verify_otp(
     Json(req): Json<VerifyOtpRequest>,
 ) -> Result<Json<VerifyOtpResponse>, (StatusCode, Json<serde_json::Value>)> {
     let now = now_ms();
-
-    let mut challenge = {
-        let store = lock_store(&state)?;
-        store
-            .get_otp_challenge(&req.challenge_id)
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({"error": format!("Store error: {e}")})),
-                )
-            })?
-            .ok_or_else(|| {
-                (
-                    StatusCode::NOT_FOUND,
-                    Json(serde_json::json!({"error": "Challenge not found"})),
-                )
-            })?
-    };
+    let mut store = lock_store(&state)?;
+    let mut challenge = store
+        .get_otp_challenge(&req.challenge_id)
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": format!("Store error: {e}")})),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": "Challenge not found"})),
+            )
+        })?;
 
     let result = challenge.verify(&req.code, now);
 
     match result {
         OtpResult::Success => {
-            let public_key = verify_bootstrap_signature(&req, &challenge)?;
-            let session_token = Uuid::new_v4().to_string();
+            let bootstrap = verify_bootstrap_signature(&req, &challenge)?;
+            let session_token = session_token_from_bootstrap(
+                &challenge.challenge_id,
+                &challenge.subject_did,
+                &bootstrap.public_key,
+                &bootstrap.signature,
+                &challenge.hmac_secret,
+            )
+            .map_err(|e| json_error(StatusCode::INTERNAL_SERVER_ERROR, e))?;
             let session = IdentitySession {
                 session_token: session_token.clone(),
                 subject_did: challenge.subject_did.clone(),
-                public_key: public_key.as_bytes().to_vec(),
+                public_key: bootstrap.public_key.as_bytes().to_vec(),
                 created_ms: now,
                 last_active_ms: now,
                 revoked: false,
             };
-            {
-                let mut store = lock_store(&state)?;
-                store.update_otp_challenge(&challenge).map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(serde_json::json!({"error": format!("Store error: {e}")})),
-                    )
-                })?;
-                store.insert_session(&session).map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(serde_json::json!({"error": format!("Store error: {e}")})),
-                    )
-                })?;
-            }
+            store.update_otp_challenge(&challenge).map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": format!("Store error: {e}")})),
+                )
+            })?;
+            store.insert_session(&session).map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": format!("Store error: {e}")})),
+                )
+            })?;
             Ok(Json(VerifyOtpResponse {
                 verified: true,
                 session_token: Some(session_token),
@@ -496,8 +508,11 @@ pub async fn verify_otp(
                 message: "Verification successful".into(),
             }))
         }
+        OtpResult::AlreadyVerified => Err(json_error(
+            StatusCode::CONFLICT,
+            "Challenge has already been verified",
+        )),
         OtpResult::WrongCode { attempts_remaining } => {
-            let mut store = lock_store(&state)?;
             store.update_otp_challenge(&challenge).map_err(|e| {
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -512,7 +527,6 @@ pub async fn verify_otp(
             }))
         }
         OtpResult::Expired => {
-            let mut store = lock_store(&state)?;
             store.update_otp_challenge(&challenge).map_err(|e| {
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -522,7 +536,6 @@ pub async fn verify_otp(
             Err(json_error(StatusCode::GONE, "Challenge has expired"))
         }
         OtpResult::Locked { .. } => {
-            let mut store = lock_store(&state)?;
             store.update_otp_challenge(&challenge).map_err(|e| {
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -680,6 +693,45 @@ mod tests {
 
         assert!(verifier.contains("did_from_public_key(&public_key)"));
         assert!(verifier.contains("derived_did != challenge.subject_did"));
+    }
+
+    #[test]
+    fn verify_otp_does_not_mint_uuid_session_tokens() {
+        let source = include_str!("onboarding.rs");
+        let verifier = source
+            .split("pub async fn verify_otp")
+            .nth(1)
+            .and_then(|section| {
+                section
+                    .split("// POST /api/v1/0dentity/verify/resend")
+                    .next()
+            })
+            .expect("verify_otp must have an explicit function body");
+
+        assert!(
+            !verifier.contains("Uuid::new_v4()"),
+            "session tokens must be derived from verified bootstrap material, not UUID v4"
+        );
+    }
+
+    #[test]
+    fn verify_otp_consumes_challenge_and_session_in_one_store_lock() {
+        let source = include_str!("onboarding.rs");
+        let verifier = source
+            .split("pub async fn verify_otp")
+            .nth(1)
+            .and_then(|section| {
+                section
+                    .split("// POST /api/v1/0dentity/verify/resend")
+                    .next()
+            })
+            .expect("verify_otp must have an explicit function body");
+        let lock_count = verifier.matches("lock_store(&state)").count();
+
+        assert_eq!(
+            lock_count, 1,
+            "OTP verification, challenge consumption, and session insertion must be one critical section"
+        );
     }
 
     #[test]

--- a/crates/exo-node/src/zerodentity/otp.rs
+++ b/crates/exo-node/src/zerodentity/otp.rs
@@ -41,6 +41,8 @@ pub const OTP_RESEND_COOLDOWN_MS: u64 = 60_000;
 pub enum OtpResult {
     /// Code was correct.
     Success,
+    /// The challenge was already consumed by a successful verification.
+    AlreadyVerified,
     /// Code was wrong; `attempts_remaining` indicates how many more tries before lockout.
     WrongCode { attempts_remaining: u32 },
     /// The challenge TTL has expired.
@@ -122,7 +124,7 @@ impl OtpChallenge {
     pub fn verify(&mut self, code: &str, now_ms: u64) -> OtpResult {
         // Already in a terminal or locked state?
         match self.state {
-            OtpState::Verified => return OtpResult::Success,
+            OtpState::Verified => return OtpResult::AlreadyVerified,
             OtpState::LockedOut => {
                 // Compute when lock expires
                 let locked_until = self.dispatched_ms + self.ttl_ms + OTP_LOCKOUT_MS;
@@ -416,7 +418,7 @@ mod tests {
     // ---- verify: early-return branches for terminal states ----
 
     #[test]
-    fn verify_on_already_verified_returns_success_without_incrementing_attempts() {
+    fn verify_on_already_verified_returns_already_verified_without_incrementing_attempts() {
         let mut rng = test_rng();
         let did = test_did();
         let now = 0u64;
@@ -427,7 +429,7 @@ mod tests {
         assert_eq!(ch.state, OtpState::Verified);
         let attempts_before = ch.attempts;
         // Second verify hits the Verified early-return (line 127)
-        assert_eq!(ch.verify("wrong", now + 2_000), OtpResult::Success);
+        assert_eq!(ch.verify("wrong", now + 2_000), OtpResult::AlreadyVerified);
         assert_eq!(
             ch.attempts, attempts_before,
             "attempts must not change on re-verify"

--- a/crates/exo-node/src/zerodentity/session_auth.rs
+++ b/crates/exo-node/src/zerodentity/session_auth.rs
@@ -11,6 +11,7 @@ pub(crate) const BOOTSTRAP_SIGNING_DOMAIN: &str = "exo.zerodentity.session_boots
 #[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
 pub(crate) const CLAIM_SUBMISSION_SIGNING_DOMAIN: &str = "exo.zerodentity.claim_submission.v1";
 pub(crate) const REQUEST_SIGNING_DOMAIN: &str = "exo.zerodentity.session_request.v1";
+pub(crate) const SESSION_TOKEN_DOMAIN: &str = "exo.zerodentity.session_token.v1";
 
 #[derive(Serialize)]
 struct BootstrapSigningPayload<'a> {
@@ -40,6 +41,16 @@ struct RequestSigningPayload<'a> {
     session_token: &'a str,
     nonce: &'a str,
     body_hash: &'a Hash256,
+}
+
+#[derive(Serialize)]
+struct SessionTokenPayload<'a> {
+    domain: &'static str,
+    challenge_id: &'a str,
+    subject_did: &'a str,
+    public_key: &'a PublicKey,
+    bootstrap_signature: &'a Signature,
+    hmac_secret: &'a [u8; 32],
 }
 
 fn encode_cbor<T: Serialize>(payload: &T) -> Result<Vec<u8>, String> {
@@ -97,6 +108,24 @@ pub(crate) fn request_signing_payload(
         nonce,
         body_hash,
     })
+}
+
+pub(crate) fn session_token_from_bootstrap(
+    challenge_id: &str,
+    subject_did: &Did,
+    public_key: &PublicKey,
+    bootstrap_signature: &Signature,
+    hmac_secret: &[u8; 32],
+) -> Result<String, String> {
+    let encoded = encode_cbor(&SessionTokenPayload {
+        domain: SESSION_TOKEN_DOMAIN,
+        challenge_id,
+        subject_did: subject_did.as_str(),
+        public_key,
+        bootstrap_signature,
+        hmac_secret,
+    })?;
+    Ok(hex::encode(Hash256::digest(&encoded).as_bytes()))
 }
 
 pub(crate) fn public_key_from_hex(value: &str) -> Result<PublicKey, String> {
@@ -249,6 +278,48 @@ mod tests {
 
         assert_ne!(first, different_nonce);
         assert_ne!(first, different_body);
+    }
+
+    #[test]
+    fn session_token_is_deterministic_and_bound_to_bootstrap_material() {
+        let did = did();
+        let public_key = public_key();
+        let signature = Signature::from_bytes([9u8; 64]);
+        let secret = [8u8; 32];
+
+        let first = must(session_token_from_bootstrap(
+            "challenge-1",
+            &did,
+            &public_key,
+            &signature,
+            &secret,
+        ));
+        let second = must(session_token_from_bootstrap(
+            "challenge-1",
+            &did,
+            &public_key,
+            &signature,
+            &secret,
+        ));
+        let different_challenge = must(session_token_from_bootstrap(
+            "challenge-2",
+            &did,
+            &public_key,
+            &signature,
+            &secret,
+        ));
+        let different_signature = must(session_token_from_bootstrap(
+            "challenge-1",
+            &did,
+            &public_key,
+            &Signature::from_bytes([10u8; 64]),
+            &secret,
+        ));
+
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 64);
+        assert_ne!(first, different_challenge);
+        assert_ne!(first, different_signature);
     }
 
     #[test]

--- a/crates/exo-node/src/zerodentity/tests.rs
+++ b/crates/exo-node/src/zerodentity/tests.rs
@@ -1034,6 +1034,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn verify_otp_replay_after_success_returns_conflict() {
+        let store = new_shared_store();
+        let app = onboarding_app(store.clone());
+        let keypair = test_keypair(11);
+        let did = derived_did(&keypair);
+        let dispatched_ms = u64::MAX / 2;
+
+        let mut rng = seeded_rng(0xCAFE_1020);
+        let (challenge, code) =
+            OtpChallenge::new(&did, OtpChannel::Email, dispatched_ms, &mut rng).unwrap();
+        let cid = challenge.challenge_id.clone();
+        store
+            .lock()
+            .unwrap()
+            .insert_otp_challenge(&challenge)
+            .unwrap();
+
+        let first = post_json(
+            &app,
+            "/api/v1/0dentity/verify",
+            bootstrap_verify_body(&cid, &code, &did, &keypair),
+        )
+        .await;
+        let second = post_json(
+            &app,
+            "/api/v1/0dentity/verify",
+            bootstrap_verify_body(&cid, &code, &did, &keypair),
+        )
+        .await;
+
+        assert_eq!(first.status(), StatusCode::OK);
+        assert_eq!(second.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
     async fn verify_otp_success_without_bootstrap_signature_returns_400() {
         let store = new_shared_store();
         let app = onboarding_app(store.clone());

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 121321 lines of Rust under `crates/`, 2,935 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 121481 lines of Rust under `crates/`, 2,939 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,935 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,939 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,935 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,939 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-121321 lines of Rust under `crates/` · 20 workspace packages · 2,935 listed tests · 40 MCP tools · 8 constitutional invariants
+121481 lines of Rust under `crates/` · 20 workspace packages · 2,939 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 121321 lines of Rust under `crates/` | 266 Rust source files | 2,935 listed tests
+> **Codebase:** 20 workspace packages | 121481 lines of Rust under `crates/` | 266 Rust source files | 2,939 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,935 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,939 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 121321 lines of Rust under `crates/` · 2,935 listed tests
+20 workspace packages · 121481 lines of Rust under `crates/` · 2,939 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- reject replayed 0dentity OTP verification attempts with HTTP 409 instead of issuing another session response
- derive session tokens from domain-separated canonical bootstrap material instead of UUID v4 runtime entropy
- keep challenge consumption and session insertion in one store critical section and refresh repo-truth counts

## TDD / Verification
- red: `cargo test -p exo-node verify_otp_replay_after_success_returns_conflict --bin exochain -- --nocapture` initially failed with 200 OK replay
- red: `cargo test -p exo-node verify_otp_does_not_mint_uuid_session_tokens --bin exochain -- --nocapture` initially failed while `Uuid::new_v4()` remained in the verifier
- `cargo test -p exo-node verify_otp_replay_after_success_returns_conflict --bin exochain -- --nocapture`
- `cargo test -p exo-node verify_otp_does_not_mint_uuid_session_tokens --bin exochain -- --nocapture`
- `cargo test -p exo-node session_token_is_deterministic_and_bound_to_bootstrap_material --bin exochain -- --nocapture`
- `cargo test -p exo-node verify_otp_consumes_challenge_and_session_in_one_store_lock --bin exochain -- --nocapture`
- `cargo test -p exo-node zerodentity:: --bin exochain -- --nocapture`
- `cargo test -p exo-node --features unaudited-zerodentity-first-touch-onboarding zerodentity:: --bin exochain -- --nocapture`
- `cargo test -p exo-node`
- `cargo build -p exo-node`
- `cargo clippy -p exo-node --bin exochain -- -D warnings`
- `cargo clippy -p exo-node --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit` (passes with existing allowed yanked `core2` warning)
- `cargo deny check` (passes with existing duplicate/yanked/unused-allowance warnings)
- `cargo machete --with-metadata`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `cargo fmt --all -- --check`
- `git diff --check`