### PR TITLE
fix(exo-node): consume zerodentity otp resend challenges

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 121481 | `wc -l` |
-| Workspace tests | 2,939 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 121680 | `wc -l` |
+| Workspace tests | 2,944 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,939 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,944 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 121481 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 121680 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,939 listed workspace tests
+         cryptographic proofs, 2,944 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -714,9 +714,8 @@ async fn start_node(
     };
 
     // Build 0dentity routers.
-    let zd_onboarding_state = zerodentity::onboarding::OnboardingState {
-        store: std::sync::Arc::clone(&zerodentity_store),
-    };
+    let zd_onboarding_state =
+        zerodentity::onboarding::OnboardingState::new(std::sync::Arc::clone(&zerodentity_store));
     let zd_api_state = zerodentity::api::ApiState {
         store: std::sync::Arc::clone(&zerodentity_store),
     };

--- a/crates/exo-node/src/zerodentity/onboarding.rs
+++ b/crates/exo-node/src/zerodentity/onboarding.rs
@@ -14,11 +14,16 @@ use axum::{Json, Router, extract::State, http::StatusCode, routing::post};
 use exo_core::types::{Did, Hash256};
 use exo_core::{
     crypto,
+    hlc::HybridClock,
     types::{PublicKey, Signature},
 };
+#[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
 use getrandom::getrandom;
+use hmac::{Hmac, Mac};
+#[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
 use rand::{SeedableRng, rngs::StdRng};
 use serde::{Deserialize, Serialize};
+use sha2::Sha256;
 
 #[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
 use super::session_auth::claim_submission_signing_payload;
@@ -31,8 +36,12 @@ use super::{
         session_token_from_bootstrap, signature_from_hex,
     },
     store::ZerodentityStore,
-    types::{ClaimType, IdentitySession, OtpChallenge, ZerodentityScore},
+    types::{ClaimType, IdentitySession, OtpChallenge, OtpState, ZerodentityScore},
 };
+
+type HmacSha256 = Hmac<Sha256>;
+
+const OTP_RESEND_DERIVATION_DOMAIN: &[u8] = b"exo.zerodentity.otp.resend.v1";
 
 // ---------------------------------------------------------------------------
 // Shared state
@@ -42,6 +51,30 @@ use super::{
 #[derive(Clone)]
 pub struct OnboardingState {
     pub store: Arc<Mutex<ZerodentityStore>>,
+    clock: Arc<Mutex<HybridClock>>,
+}
+
+impl OnboardingState {
+    #[must_use]
+    pub fn new(store: Arc<Mutex<ZerodentityStore>>) -> Self {
+        Self::new_with_clock(store, HybridClock::new())
+    }
+
+    #[must_use]
+    pub fn new_with_clock(store: Arc<Mutex<ZerodentityStore>>, clock: HybridClock) -> Self {
+        Self {
+            store,
+            clock: Arc::new(Mutex::new(clock)),
+        }
+    }
+
+    fn now_ms(&self) -> Result<u64, (StatusCode, Json<serde_json::Value>)> {
+        let mut clock = self
+            .clock
+            .lock()
+            .map_err(|_| json_error(StatusCode::INTERNAL_SERVER_ERROR, "Clock lock error"))?;
+        Ok(clock.now().physical_ms)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -137,10 +170,7 @@ const FIRST_TOUCH_ONBOARDING_FEATURE: &str = "unaudited-zerodentity-first-touch-
 #[cfg(not(feature = "unaudited-zerodentity-first-touch-onboarding"))]
 const FIRST_TOUCH_ONBOARDING_INITIATIVE: &str = "fix-onyx-4-r1-onboarding-auth.md";
 
-fn now_ms() -> u64 {
-    exo_core::hlc::HybridClock::new().now().physical_ms
-}
-
+#[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
 fn build_rng() -> StdRng {
     let mut seed = [0u8; 32];
     let _ = getrandom(&mut seed);
@@ -171,6 +201,31 @@ fn lock_store(
         .store
         .lock()
         .map_err(|_| json_error(StatusCode::INTERNAL_SERVER_ERROR, "Store lock error"))
+}
+
+fn derive_resend_secret(
+    challenge: &OtpChallenge,
+    now_ms: u64,
+) -> Result<[u8; 32], (StatusCode, Json<serde_json::Value>)> {
+    let mut mac = HmacSha256::new_from_slice(&challenge.hmac_secret).map_err(|_| {
+        json_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "OTP resend secret derivation failed",
+        )
+    })?;
+    mac.update(OTP_RESEND_DERIVATION_DOMAIN);
+    mac.update(challenge.challenge_id.as_bytes());
+    mac.update(challenge.subject_did.as_str().as_bytes());
+    mac.update(match challenge.channel {
+        super::types::OtpChannel::Email => b"email",
+        super::types::OtpChannel::Sms => b"sms",
+    });
+    mac.update(&now_ms.to_le_bytes());
+
+    let bytes = mac.finalize().into_bytes();
+    let mut secret = [0u8; 32];
+    secret.copy_from_slice(&bytes);
+    Ok(secret)
 }
 
 struct VerifiedBootstrap {
@@ -451,7 +506,7 @@ pub async fn verify_otp(
     State(state): State<OnboardingState>,
     Json(req): Json<VerifyOtpRequest>,
 ) -> Result<Json<VerifyOtpResponse>, (StatusCode, Json<serde_json::Value>)> {
-    let now = now_ms();
+    let now = state.now_ms()?;
     let mut store = lock_store(&state)?;
     let mut challenge = store
         .get_otp_challenge(&req.challenge_id)
@@ -559,30 +614,22 @@ pub async fn resend_otp(
     State(state): State<OnboardingState>,
     Json(req): Json<ResendOtpRequest>,
 ) -> Result<Json<ResendOtpResponse>, (StatusCode, Json<serde_json::Value>)> {
-    let now = now_ms();
-
-    let challenge = {
-        let store = state.store.lock().map_err(|_| {
+    let now = state.now_ms()?;
+    let mut store = lock_store(&state)?;
+    let mut challenge = store
+        .get_otp_challenge(&req.challenge_id)
+        .map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": "Store lock error"})),
+                Json(serde_json::json!({"error": format!("Store error: {e}")})),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": "Challenge not found"})),
             )
         })?;
-        store
-            .get_otp_challenge(&req.challenge_id)
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({"error": format!("Store error: {e}")})),
-                )
-            })?
-            .ok_or_else(|| {
-                (
-                    StatusCode::NOT_FOUND,
-                    Json(serde_json::json!({"error": "Challenge not found"})),
-                )
-            })?
-    };
 
     if !challenge.can_resend(now) {
         return Err((
@@ -591,13 +638,12 @@ pub async fn resend_otp(
         ));
     }
 
-    // Create a fresh challenge
-    let mut rng = build_rng();
-    let (new_challenge, _code) = OtpChallenge::new(
+    let resend_secret = derive_resend_secret(&challenge, now)?;
+    let (new_challenge, _code) = OtpChallenge::from_secret(
         &challenge.subject_did,
         challenge.channel.clone(),
         now,
-        &mut rng,
+        resend_secret,
     )
     .map_err(|_| {
         (
@@ -608,16 +654,19 @@ pub async fn resend_otp(
 
     let ttl = new_challenge.ttl_ms;
     let new_id = new_challenge.challenge_id.clone();
-
-    {
-        let mut store = state.store.lock().map_err(|_| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": "Store lock error"})),
-            )
-        })?;
-        let _ = store.insert_otp_challenge(&new_challenge);
-    }
+    challenge.state = OtpState::Expired;
+    store.update_otp_challenge(&challenge).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": format!("Store error: {e}")})),
+        )
+    })?;
+    store.insert_otp_challenge(&new_challenge).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": format!("Store error: {e}")})),
+        )
+    })?;
 
     Ok(Json(ResendOtpResponse {
         challenge_id: new_id,
@@ -731,6 +780,29 @@ mod tests {
         assert_eq!(
             lock_count, 1,
             "OTP verification, challenge consumption, and session insertion must be one critical section"
+        );
+    }
+
+    #[test]
+    fn resend_otp_does_not_generate_runtime_rng_or_global_clock() {
+        let source = include_str!("onboarding.rs");
+        let resend = source
+            .split("pub async fn resend_otp")
+            .nth(1)
+            .and_then(|section| section.split("// Router").next())
+            .expect("resend_otp must have an explicit function body");
+
+        assert!(
+            !resend.contains("build_rng()"),
+            "resend must derive replacement challenge material from existing challenge evidence"
+        );
+        assert!(
+            !resend.contains("OtpChallenge::new("),
+            "resend must not depend on runtime RNG challenge construction"
+        );
+        assert!(
+            !resend.contains("let now = now_ms()"),
+            "resend must read time through OnboardingState's injected HLC"
         );
     }
 

--- a/crates/exo-node/src/zerodentity/otp.rs
+++ b/crates/exo-node/src/zerodentity/otp.rs
@@ -11,6 +11,7 @@
 
 use exo_core::types::{Did, Hash256};
 use hmac::{Hmac, Mac};
+#[cfg(any(test, feature = "unaudited-zerodentity-first-touch-onboarding"))]
 use rand::RngCore;
 use sha2::Sha256;
 use thiserror::Error;
@@ -60,6 +61,8 @@ pub enum OtpResult {
 pub enum OtpError {
     #[error("HMAC key length invalid")]
     InvalidKeyLength,
+    #[error("OTP HMAC secret must not be all zero")]
+    InvalidSecret,
 }
 
 // ---------------------------------------------------------------------------
@@ -76,6 +79,7 @@ impl OtpChallenge {
     /// - `channel`: delivery channel (email or SMS)
     /// - `now_ms`: current epoch time in milliseconds (from HLC)
     /// - `rng`: caller-provided RNG (must not be `SystemRng` in test contexts)
+    #[cfg(any(test, feature = "unaudited-zerodentity-first-touch-onboarding"))]
     pub fn new(
         subject_did: &Did,
         channel: OtpChannel,
@@ -86,14 +90,31 @@ impl OtpChallenge {
         let mut secret = [0u8; 32];
         rng.fill_bytes(&mut secret);
 
-        let code = derive_code(&secret, subject_did.as_str(), now_ms)?;
+        Self::from_secret(subject_did, channel, now_ms, secret)
+    }
+
+    /// Create an OTP challenge from caller-supplied HMAC secret material.
+    ///
+    /// This is the deterministic constructor for trust-boundary callers that
+    /// derive challenge entropy from already verified evidence.
+    pub fn from_secret(
+        subject_did: &Did,
+        channel: OtpChannel,
+        now_ms: u64,
+        hmac_secret: [u8; 32],
+    ) -> Result<(Self, String), OtpError> {
+        if hmac_secret == [0u8; 32] {
+            return Err(OtpError::InvalidSecret);
+        }
+
+        let code = derive_code(&hmac_secret, subject_did.as_str(), now_ms)?;
         let code_str = format!("{code:06}");
 
         // Derive challenge_id from BLAKE3 of (subject_did || now_ms || secret)
         let mut id_input = Vec::with_capacity(100);
         id_input.extend_from_slice(subject_did.as_str().as_bytes());
         id_input.extend_from_slice(&now_ms.to_le_bytes());
-        id_input.extend_from_slice(&secret);
+        id_input.extend_from_slice(&hmac_secret);
         let id_hash = Hash256::digest(&id_input);
         let challenge_id = hex::encode(id_hash.as_bytes());
         let ttl_ms = channel.ttl_ms();
@@ -102,7 +123,7 @@ impl OtpChallenge {
             challenge_id,
             subject_did: subject_did.clone(),
             channel,
-            hmac_secret: secret,
+            hmac_secret,
             dispatched_ms: now_ms,
             ttl_ms,
             attempts: 0,
@@ -279,6 +300,33 @@ mod tests {
             code.chars().all(|c| c.is_ascii_digit()),
             "code must be digits"
         );
+    }
+
+    #[test]
+    fn from_secret_is_deterministic_and_uses_supplied_secret() {
+        let did = test_did();
+        let secret = [7u8; 32];
+        let (first, first_code) =
+            OtpChallenge::from_secret(&did, OtpChannel::Email, 42_000, secret).expect("new ok");
+        let (second, second_code) =
+            OtpChallenge::from_secret(&did, OtpChannel::Email, 42_000, secret).expect("new ok");
+
+        assert_eq!(first.challenge_id, second.challenge_id);
+        assert_eq!(first_code, second_code);
+
+        let (different, different_code) =
+            OtpChallenge::from_secret(&did, OtpChannel::Email, 42_000, [8u8; 32]).expect("new ok");
+        assert_ne!(first.challenge_id, different.challenge_id);
+        assert_ne!(first_code, different_code);
+    }
+
+    #[test]
+    fn from_secret_rejects_zero_secret() {
+        let did = test_did();
+        let err = OtpChallenge::from_secret(&did, OtpChannel::Email, 42_000, [0u8; 32])
+            .expect_err("zero secret must fail");
+
+        assert!(matches!(err, OtpError::InvalidSecret));
     }
 
     #[test]

--- a/crates/exo-node/src/zerodentity/tests.rs
+++ b/crates/exo-node/src/zerodentity/tests.rs
@@ -18,6 +18,7 @@ mod tests {
     };
     use exo_core::{
         crypto::{self, KeyPair},
+        hlc::HybridClock,
         types::{Did, Hash256, PublicKey, SecretKey, Signature},
     };
     use rand::{SeedableRng, rngs::StdRng};
@@ -279,7 +280,14 @@ mod tests {
     }
 
     fn onboarding_app(store: SharedZerodentityStore) -> Router {
-        onboarding_router(OnboardingState { store })
+        onboarding_router(OnboardingState::new(store))
+    }
+
+    fn onboarding_app_with_fixed_clock(store: SharedZerodentityStore, now_ms: u64) -> Router {
+        onboarding_router(OnboardingState::new_with_clock(
+            store,
+            HybridClock::with_wall_clock(move || now_ms),
+        ))
     }
 
     fn api_app(store: SharedZerodentityStore) -> Router {
@@ -1354,6 +1362,78 @@ mod tests {
         let new_cid = body["challenge_id"].as_str().unwrap().to_owned();
         assert_ne!(new_cid, cid, "resend must return a fresh challenge_id");
         assert!(body["ttl_ms"].as_u64().unwrap() > 0);
+    }
+
+    #[tokio::test]
+    async fn resend_otp_after_cooldown_consumes_original_challenge() {
+        let store = new_shared_store();
+        let app = onboarding_app_with_fixed_clock(store.clone(), 120_000);
+        let did = td("otp-resend-consumes-original");
+
+        let mut rng = seeded_rng(0xBEEF_0103);
+        let (challenge, _) = OtpChallenge::new(&did, OtpChannel::Email, 1, &mut rng).unwrap();
+        let cid = challenge.challenge_id.clone();
+        store
+            .lock()
+            .unwrap()
+            .insert_otp_challenge(&challenge)
+            .unwrap();
+
+        let resp = post_json(
+            &app,
+            "/api/v1/0dentity/verify/resend",
+            serde_json::json!({
+                "challenge_id": cid
+            }),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let new_cid = body["challenge_id"].as_str().unwrap();
+
+        let guard = store.lock().unwrap();
+        let original = guard.get_otp_challenge(&cid).unwrap().unwrap();
+        let replacement = guard.get_otp_challenge(new_cid).unwrap().unwrap();
+        assert_eq!(original.state, OtpState::Expired);
+        assert_eq!(replacement.state, OtpState::Pending);
+    }
+
+    #[tokio::test]
+    async fn resend_otp_uses_injected_hlc_timestamp() {
+        let store = new_shared_store();
+        let app = onboarding_app_with_fixed_clock(store.clone(), 180_000);
+        let did = td("otp-resend-clock");
+
+        let mut rng = seeded_rng(0xBEEF_0104);
+        let (challenge, _) = OtpChallenge::new(&did, OtpChannel::Email, 1, &mut rng).unwrap();
+        let cid = challenge.challenge_id.clone();
+        store
+            .lock()
+            .unwrap()
+            .insert_otp_challenge(&challenge)
+            .unwrap();
+
+        let resp = post_json(
+            &app,
+            "/api/v1/0dentity/verify/resend",
+            serde_json::json!({
+                "challenge_id": cid
+            }),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        let new_cid = body["challenge_id"].as_str().unwrap();
+        let replacement = store
+            .lock()
+            .unwrap()
+            .get_otp_challenge(new_cid)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(replacement.dispatched_ms, 180_000);
     }
 
     #[tokio::test]

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 121481 lines of Rust under `crates/`, 2,939 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 121680 lines of Rust under `crates/`, 2,944 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,939 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,944 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,939 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,944 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-121481 lines of Rust under `crates/` · 20 workspace packages · 2,939 listed tests · 40 MCP tools · 8 constitutional invariants
+121680 lines of Rust under `crates/` · 20 workspace packages · 2,944 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 121481 lines of Rust under `crates/` | 266 Rust source files | 2,939 listed tests
+> **Codebase:** 20 workspace packages | 121680 lines of Rust under `crates/` | 266 Rust source files | 2,944 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,939 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,944 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 121481 lines of Rust under `crates/` · 2,939 listed tests
+20 workspace packages · 121680 lines of Rust under `crates/` · 2,944 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- expire the original 0dentity OTP challenge when `/verify/resend` issues a replacement
- route resend and verify timestamps through `OnboardingState`'s injected HLC
- derive resend challenge material from the prior challenge evidence instead of runtime RNG/global clock helpers
- refresh repo-truth counts

## TDD / Verification
- red first: `cargo test -p exo-node resend_otp_after_cooldown_consumes_original_challenge --bin exochain -- --nocapture`
- `cargo test -p exo-node zerodentity:: --bin exochain -- --nocapture`
- `cargo test -p exo-node --features unaudited-zerodentity-first-touch-onboarding zerodentity:: --bin exochain -- --nocapture`
- `cargo test -p exo-node`
- `cargo build -p exo-node`
- `cargo clippy -p exo-node --bin exochain -- -D warnings`
- `cargo clippy -p exo-node --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit` (existing allowed yanked `core2` warning)
- `cargo deny check` (existing duplicate/yanked/unused-allowance warnings)
- `cargo machete --with-metadata`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`