### PR TITLE
fix(exo-messaging): canonicalize envelope signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 121680 | `wc -l` |
-| Workspace tests | 2,944 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 121820 | `wc -l` |
+| Workspace tests | 2,946 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,944 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,946 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 121680 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 121820 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,944 listed workspace tests
+         cryptographic proofs, 2,946 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-messaging/src/compose.rs
+++ b/crates/exo-messaging/src/compose.rs
@@ -114,7 +114,7 @@ pub fn lock_and_send(
     };
 
     // 6. Sign the envelope
-    let signable = envelope.signable_bytes();
+    let signable = envelope.signing_payload()?;
     let signature = exo_core::crypto::sign(&signable, sender_signing_key);
     envelope.signature = signature;
 

--- a/crates/exo-messaging/src/envelope.rs
+++ b/crates/exo-messaging/src/envelope.rs
@@ -7,6 +7,28 @@
 use exo_core::{Did, Hash256, Signature, Timestamp};
 use serde::{Deserialize, Serialize};
 
+use crate::error::MessagingError;
+
+/// Domain tag for encrypted-envelope signatures.
+pub const ENVELOPE_SIGNING_DOMAIN: &str = "exo.messaging.envelope.v1";
+const ENVELOPE_SIGNING_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Serialize)]
+struct EnvelopeSigningPayload<'a> {
+    domain: &'static str,
+    schema_version: u16,
+    id: &'a str,
+    sender_did: &'a Did,
+    recipient_did: &'a Did,
+    ephemeral_public_key: &'a [u8; 32],
+    ciphertext: &'a [u8],
+    content_type: u8,
+    plaintext_hash: &'a Hash256,
+    release_on_death: bool,
+    release_delay_hours: u32,
+    created: &'a Timestamp,
+}
+
 /// The type of content in the encrypted message.
 ///
 /// `#[repr(u8)]` with explicit discriminants so the wire-format byte
@@ -74,27 +96,40 @@ pub struct EncryptedEnvelope {
 }
 
 impl EncryptedEnvelope {
-    /// Compute the canonical bytes for signing (everything except the signature field).
-    #[must_use]
-    pub fn signable_bytes(&self) -> Vec<u8> {
+    /// Compute the domain-separated canonical CBOR payload for signing.
+    ///
+    /// The payload covers every envelope field except the signature itself.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MessagingError::EnvelopeSigningPayloadEncoding`] if the CBOR
+    /// encoder rejects the payload.
+    pub fn signing_payload(&self) -> Result<Vec<u8>, MessagingError> {
+        let payload = EnvelopeSigningPayload {
+            domain: ENVELOPE_SIGNING_DOMAIN,
+            schema_version: ENVELOPE_SIGNING_SCHEMA_VERSION,
+            id: &self.id,
+            sender_did: &self.sender_did,
+            recipient_did: &self.recipient_did,
+            ephemeral_public_key: &self.ephemeral_public_key,
+            ciphertext: &self.ciphertext,
+            content_type: u8::from(self.content_type),
+            plaintext_hash: &self.plaintext_hash,
+            release_on_death: self.release_on_death,
+            release_delay_hours: self.release_delay_hours,
+            created: &self.created,
+        };
         let mut buf = Vec::new();
-        buf.extend_from_slice(self.id.as_bytes());
-        buf.extend_from_slice(self.sender_did.as_str().as_bytes());
-        buf.extend_from_slice(self.recipient_did.as_str().as_bytes());
-        buf.extend_from_slice(&self.ephemeral_public_key);
-        buf.extend_from_slice(&self.ciphertext);
-        buf.extend_from_slice(&[u8::from(self.content_type)]);
-        buf.extend_from_slice(self.plaintext_hash.as_bytes());
-        buf.extend_from_slice(&[u8::from(self.release_on_death)]);
-        buf.extend_from_slice(&self.release_delay_hours.to_le_bytes());
-        buf.extend_from_slice(&self.created.physical_ms.to_le_bytes());
-        buf.extend_from_slice(&self.created.logical.to_le_bytes());
-        buf
+        ciborium::ser::into_writer(&payload, &mut buf)
+            .map_err(|e| MessagingError::EnvelopeSigningPayloadEncoding(e.to_string()))?;
+        Ok(buf)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use serde::Deserialize;
+
     use super::*;
 
     #[test]
@@ -111,5 +146,60 @@ mod tests {
             let recovered: ContentType = serde_json::from_str(&json).unwrap();
             assert_eq!(ct, recovered);
         }
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct DecodedEnvelopeSigningPayload {
+        domain: String,
+        schema_version: u16,
+        id: String,
+        sender_did: Did,
+        recipient_did: Did,
+        ephemeral_public_key: [u8; 32],
+        ciphertext: Vec<u8>,
+        content_type: u8,
+        plaintext_hash: Hash256,
+        release_on_death: bool,
+        release_delay_hours: u32,
+        created: Timestamp,
+    }
+
+    fn sample_envelope() -> EncryptedEnvelope {
+        EncryptedEnvelope {
+            id: "018f7a96-8ad0-7c4f-8e0f-111111111199".to_string(),
+            sender_did: Did::new("did:exo:alice").unwrap(),
+            recipient_did: Did::new("did:exo:bob").unwrap(),
+            ephemeral_public_key: [7; 32],
+            ciphertext: vec![1, 1, 2, 3, 5, 8],
+            content_type: ContentType::Secret,
+            signature: Signature::empty(),
+            plaintext_hash: Hash256::digest(b"plaintext"),
+            release_on_death: true,
+            release_delay_hours: 72,
+            created: Timestamp::new(9_000, 3),
+        }
+    }
+
+    #[test]
+    fn envelope_signing_payload_is_domain_separated_cbor() {
+        let envelope = sample_envelope();
+        let payload = envelope
+            .signing_payload()
+            .expect("canonical envelope signing payload");
+        let decoded: DecodedEnvelopeSigningPayload =
+            ciborium::from_reader(&payload[..]).expect("decode envelope signing payload");
+
+        assert_eq!(decoded.domain, "exo.messaging.envelope.v1");
+        assert_eq!(decoded.schema_version, 1);
+        assert_eq!(decoded.id, envelope.id);
+        assert_eq!(decoded.sender_did, envelope.sender_did);
+        assert_eq!(decoded.recipient_did, envelope.recipient_did);
+        assert_eq!(decoded.ephemeral_public_key, envelope.ephemeral_public_key);
+        assert_eq!(decoded.ciphertext, envelope.ciphertext);
+        assert_eq!(decoded.content_type, u8::from(envelope.content_type));
+        assert_eq!(decoded.plaintext_hash, envelope.plaintext_hash);
+        assert_eq!(decoded.release_on_death, envelope.release_on_death);
+        assert_eq!(decoded.release_delay_hours, envelope.release_delay_hours);
+        assert_eq!(decoded.created, envelope.created);
     }
 }

--- a/crates/exo-messaging/src/error.rs
+++ b/crates/exo-messaging/src/error.rs
@@ -18,6 +18,9 @@ pub enum MessagingError {
     #[error("death-trigger confirmation payload encoding failed: {0}")]
     DeathConfirmationPayloadEncoding(String),
 
+    #[error("envelope signing payload encoding failed: {0}")]
+    EnvelopeSigningPayloadEncoding(String),
+
     #[error("invalid envelope: {0}")]
     InvalidEnvelope(String),
 

--- a/crates/exo-messaging/src/open.rs
+++ b/crates/exo-messaging/src/open.rs
@@ -33,7 +33,7 @@ pub fn unlock(
     sender_ed25519_public: &PublicKey,
 ) -> Result<Vec<u8>, MessagingError> {
     // 1. Verify the sender's signature
-    let signable = envelope.signable_bytes();
+    let signable = envelope.signing_payload()?;
     if !crypto::verify(&signable, &envelope.signature, sender_ed25519_public) {
         return Err(MessagingError::SignatureVerificationFailed);
     }
@@ -76,13 +76,29 @@ mod tests {
     use super::*;
     use crate::{
         compose::{ComposeMetadata, lock_and_send},
-        envelope::ContentType,
+        envelope::{ContentType, EncryptedEnvelope},
         kex::X25519KeyPair,
     };
 
     fn metadata(suffix: u128) -> ComposeMetadata {
         ComposeMetadata::new(Uuid::from_u128(suffix), Timestamp::new(8_000, 0))
             .expect("valid compose metadata")
+    }
+
+    fn legacy_signable_bytes(envelope: &EncryptedEnvelope) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(envelope.id.as_bytes());
+        buf.extend_from_slice(envelope.sender_did.as_str().as_bytes());
+        buf.extend_from_slice(envelope.recipient_did.as_str().as_bytes());
+        buf.extend_from_slice(&envelope.ephemeral_public_key);
+        buf.extend_from_slice(&envelope.ciphertext);
+        buf.extend_from_slice(&[u8::from(envelope.content_type)]);
+        buf.extend_from_slice(envelope.plaintext_hash.as_bytes());
+        buf.extend_from_slice(&[u8::from(envelope.release_on_death)]);
+        buf.extend_from_slice(&envelope.release_delay_hours.to_le_bytes());
+        buf.extend_from_slice(&envelope.created.physical_ms.to_le_bytes());
+        buf.extend_from_slice(&envelope.created.logical.to_le_bytes());
+        buf
     }
 
     #[test]
@@ -162,6 +178,35 @@ mod tests {
         assert!(
             matches!(result, Err(MessagingError::SignatureVerificationFailed)),
             "wrong sender key should fail signature verification"
+        );
+    }
+
+    #[test]
+    fn unlock_rejects_legacy_byte_concat_signature() {
+        let sender_did = Did::new("did:exo:alice").unwrap();
+        let recipient_did = Did::new("did:exo:bob").unwrap();
+        let (sender_pk, sender_sk) = generate_keypair();
+        let recipient_kp = X25519KeyPair::generate();
+
+        let mut envelope = lock_and_send(
+            b"secret",
+            ContentType::Secret,
+            &sender_did,
+            &recipient_did,
+            &sender_sk,
+            &recipient_kp.public,
+            metadata(0x018f_7a96_8ad0_7c4f_8e0f_1111_1111_1121),
+            false,
+            0,
+        )
+        .expect("lock_and_send");
+
+        envelope.signature = exo_core::crypto::sign(&legacy_signable_bytes(&envelope), &sender_sk);
+
+        let result = unlock(&envelope, &recipient_kp.secret, &sender_pk);
+        assert!(
+            matches!(result, Err(MessagingError::SignatureVerificationFailed)),
+            "legacy byte-concat signatures must not verify"
         );
     }
 

--- a/crates/exochain-wasm/src/messaging_bindings.rs
+++ b/crates/exochain-wasm/src/messaging_bindings.rs
@@ -173,7 +173,9 @@ pub fn wasm_verify_message_signature(
     pk_arr.copy_from_slice(&pk_bytes);
     let sender_pk = exo_core::PublicKey::from_bytes(pk_arr);
 
-    let signable = envelope.signable_bytes();
+    let signable = envelope
+        .signing_payload()
+        .map_err(|e| JsValue::from_str(&format!("signature payload failed: {e}")))?;
     Ok(exo_core::crypto::verify(
         &signable,
         &envelope.signature,

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 121680 lines of Rust under `crates/`, 2,944 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 121820 lines of Rust under `crates/`, 2,946 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,944 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,946 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,944 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,946 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-121680 lines of Rust under `crates/` · 20 workspace packages · 2,944 listed tests · 40 MCP tools · 8 constitutional invariants
+121820 lines of Rust under `crates/` · 20 workspace packages · 2,946 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 121680 lines of Rust under `crates/` | 266 Rust source files | 2,944 listed tests
+> **Codebase:** 20 workspace packages | 121820 lines of Rust under `crates/` | 266 Rust source files | 2,946 listed tests
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,944 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,946 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 121680 lines of Rust under `crates/` · 2,944 listed tests
+20 workspace packages · 121820 lines of Rust under `crates/` · 2,946 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 


### PR DESCRIPTION
## Summary
- replace encrypted-envelope byte-concat signatures with domain-separated canonical CBOR payloads
- update compose, unlock, and WASM signature verification to use the canonical payload
- add regressions for legacy byte-concat rejection and decoded domain/schema payload shape
- refresh repo-truth counts to 121819 Rust LOC and 2,946 listed tests

## TDD red checks
- `cargo test -p exo-messaging unlock_rejects_legacy_byte_concat_signature --lib -- --nocapture` failed first because legacy byte-concat signatures still verified
- `cargo test -p exo-messaging envelope_signing_payload_is_domain_separated_cbor --lib -- --nocapture` failed first because `EncryptedEnvelope::signing_payload` did not exist

## Verification
- `cargo test -p exo-messaging --lib`
- `cargo test -p exo-messaging`
- `cargo build -p exo-messaging`
- `cargo clippy -p exo-messaging --lib --bins -- -D warnings`
- `cargo clippy -p exo-messaging --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo test -p exochain-wasm`
- `cargo build -p exochain-wasm`
- `cargo clippy -p exochain-wasm --lib --bins -- -D warnings`
- `cargo clippy -p exochain-wasm --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --no-deps`
- `cargo audit` (existing allowed yanked core2 warning)
- `cargo deny check` (existing duplicate/yanked/unused-allowance warnings)
- `cargo machete --with-metadata`
- repo-truth, CR-001, GAP registry, orphan module, Railway entrypoint, fmt, and diff guards