### PR TITLE
fix(exo-identity): canonicalize risk attestation signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1510,6 +1510,7 @@ dependencies = [
  "blake3",
  "bs58",
  "chacha20poly1305",
+ "ciborium",
  "exo-core",
  "getrandom 0.2.16",
  "hkdf",

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 121820 | `wc -l` |
-| Workspace tests | 2,946 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 122001 | `wc -l` |
+| Workspace tests | 2,951 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,946 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,951 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 121820 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 122001 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,946 listed workspace tests
+         cryptographic proofs, 2,951 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-identity/Cargo.toml
+++ b/crates/exo-identity/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 exo-core = { path = "../exo-core" }
 serde = { workspace = true }
+ciborium = { workspace = true }
 blake3 = { workspace = true }
 bs58 = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/exo-identity/src/error.rs
+++ b/crates/exo-identity/src/error.rs
@@ -60,6 +60,17 @@ pub enum IdentityError {
     #[error("risk attestation expired")]
     AttestationExpired,
 
+    #[error("risk attestation signing payload encoding failed: {reason}")]
+    RiskAttestationSigningPayloadEncoding { reason: String },
+
+    #[error(
+        "risk attestation expiry overflow: now_physical_ms={now_physical_ms}, validity_ms={validity_ms}"
+    )]
+    RiskAttestationExpiryOverflow {
+        now_physical_ms: u64,
+        validity_ms: u64,
+    },
+
     #[error("duplicate DID across PACE levels: {0}")]
     DuplicatePaceDid(Did),
 

--- a/crates/exo-identity/src/risk.rs
+++ b/crates/exo-identity/src/risk.rs
@@ -3,6 +3,13 @@
 use exo_core::{Did, PublicKey, SecretKey, Signature, Timestamp, crypto};
 use serde::{Deserialize, Serialize};
 
+use crate::error::IdentityError;
+
+/// Domain tag for signed risk-attestation payloads.
+pub const RISK_ATTESTATION_SIGNING_DOMAIN: &str = "exo.identity.risk_attestation.v1";
+
+const RISK_ATTESTATION_SIGNING_SCHEMA_VERSION: u16 = 1;
+
 /// Discrete risk severity levels for identity adjudication, ordered from least to most severe.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum RiskLevel {
@@ -39,25 +46,55 @@ impl From<RiskLevel> for u8 {
     }
 }
 
-impl RiskAttestation {
-    #[must_use]
-    fn signing_payload(
-        subject_did: &Did,
-        attester_did: &Did,
-        level: RiskLevel,
-        evidence_hash: &[u8; 32],
-        timestamp: Timestamp,
-        expiry: Timestamp,
-    ) -> Vec<u8> {
-        let mut payload = Vec::new();
-        payload.extend_from_slice(subject_did.as_str().as_bytes());
-        payload.extend_from_slice(attester_did.as_str().as_bytes());
-        payload.extend_from_slice(&[u8::from(level)]);
-        payload.extend_from_slice(evidence_hash);
-        payload.extend_from_slice(&timestamp.physical_ms.to_le_bytes());
-        payload.extend_from_slice(&expiry.physical_ms.to_le_bytes());
-        payload
-    }
+/// Canonical CBOR payload signed by risk attesters.
+///
+/// The domain tag prevents cross-protocol signature reuse. The schema version
+/// allows future payload changes without accepting legacy byte-concat
+/// signatures.
+pub fn risk_attestation_signing_payload(
+    subject_did: &Did,
+    attester_did: &Did,
+    level: RiskLevel,
+    evidence_hash: &[u8; 32],
+    timestamp: Timestamp,
+    expiry: Timestamp,
+) -> Result<Vec<u8>, IdentityError> {
+    let payload = (
+        RISK_ATTESTATION_SIGNING_DOMAIN,
+        RISK_ATTESTATION_SIGNING_SCHEMA_VERSION,
+        subject_did,
+        attester_did,
+        level,
+        evidence_hash,
+        timestamp,
+        expiry,
+    );
+    let mut encoded = Vec::new();
+    ciborium::ser::into_writer(&payload, &mut encoded).map_err(|e| {
+        IdentityError::RiskAttestationSigningPayloadEncoding {
+            reason: e.to_string(),
+        }
+    })?;
+    Ok(encoded)
+}
+
+#[cfg(test)]
+fn legacy_risk_attestation_signing_payload(
+    subject_did: &Did,
+    attester_did: &Did,
+    level: RiskLevel,
+    evidence_hash: &[u8; 32],
+    timestamp: Timestamp,
+    expiry: Timestamp,
+) -> Vec<u8> {
+    let mut payload = Vec::new();
+    payload.extend_from_slice(subject_did.as_str().as_bytes());
+    payload.extend_from_slice(attester_did.as_str().as_bytes());
+    payload.extend_from_slice(&[u8::from(level)]);
+    payload.extend_from_slice(evidence_hash);
+    payload.extend_from_slice(&timestamp.physical_ms.to_le_bytes());
+    payload.extend_from_slice(&expiry.physical_ms.to_le_bytes());
+    payload
 }
 
 /// Input parameters for producing a risk attestation.
@@ -99,27 +136,34 @@ impl RiskPolicy {
 }
 
 /// Create a signed risk attestation for a subject DID using the given context and attester key.
-#[must_use]
 pub fn assess_risk(
     subject: &Did,
     context: &RiskContext,
     attester_key: &SecretKey,
-) -> RiskAttestation {
+) -> Result<RiskAttestation, IdentityError> {
     let evidence_hash: [u8; 32] = *blake3::hash(&context.evidence).as_bytes();
-    let expiry = Timestamp::new(context.now.physical_ms + context.validity_ms, 0);
+    let expiry_physical_ms = context
+        .now
+        .physical_ms
+        .checked_add(context.validity_ms)
+        .ok_or(IdentityError::RiskAttestationExpiryOverflow {
+            now_physical_ms: context.now.physical_ms,
+            validity_ms: context.validity_ms,
+        })?;
+    let expiry = Timestamp::new(expiry_physical_ms, 0);
 
-    let payload = RiskAttestation::signing_payload(
+    let payload = risk_attestation_signing_payload(
         subject,
         &context.attester_did,
         context.level,
         &evidence_hash,
         context.now,
         expiry,
-    );
+    )?;
 
     let signature = crypto::sign(&payload, attester_key);
 
-    RiskAttestation {
+    Ok(RiskAttestation {
         subject_did: subject.clone(),
         attester_did: context.attester_did.clone(),
         level: context.level,
@@ -127,20 +171,25 @@ pub fn assess_risk(
         timestamp: context.now,
         expiry,
         signature,
-    }
+    })
 }
 
 /// Verify the cryptographic signature on a risk attestation against the attester's public key.
 #[must_use]
 pub fn verify_attestation(attestation: &RiskAttestation, attester_key: &PublicKey) -> bool {
-    let payload = RiskAttestation::signing_payload(
+    if attestation.signature.is_empty() || attestation.signature.ed25519_component_is_zero() {
+        return false;
+    }
+    let Ok(payload) = risk_attestation_signing_payload(
         &attestation.subject_did,
         &attestation.attester_did,
         attestation.level,
         &attestation.evidence_hash,
         attestation.timestamp,
         attestation.expiry,
-    );
+    ) else {
+        return false;
+    };
     crypto::verify(&payload, &attestation.signature, attester_key)
 }
 
@@ -177,7 +226,7 @@ mod tests {
         let subject_did = make_did("subject");
         let ctx = make_context(attester_did, RiskLevel::Low);
 
-        let att = assess_risk(&subject_did, &ctx, &sk);
+        let att = assess_risk(&subject_did, &ctx, &sk).expect("risk attestation");
         assert_eq!(att.level, RiskLevel::Low);
         assert_eq!(att.subject_did, subject_did);
         assert!(verify_attestation(&att, &pk));
@@ -190,9 +239,60 @@ mod tests {
         let subject_did = make_did("subject2");
         let ctx = make_context(attester_did, RiskLevel::Medium);
 
-        let att = assess_risk(&subject_did, &ctx, &sk);
+        let att = assess_risk(&subject_did, &ctx, &sk).expect("risk attestation");
         let (wrong_pk, _) = generate_keypair();
         assert!(!verify_attestation(&att, &wrong_pk));
+    }
+
+    #[test]
+    fn verify_rejects_empty_and_zero_signatures() {
+        let (pk, sk) = generate_keypair();
+        let attester_did = make_did("attester-empty");
+        let subject_did = make_did("subject-empty");
+        let ctx = make_context(attester_did, RiskLevel::Low);
+        let mut att = assess_risk(&subject_did, &ctx, &sk).expect("risk attestation");
+
+        att.signature = Signature::Empty;
+        assert!(!verify_attestation(&att, &pk));
+
+        att.signature = Signature::Ed25519([0u8; 64]);
+        assert!(!verify_attestation(&att, &pk));
+    }
+
+    #[test]
+    fn verify_rejects_tampered_attestation() {
+        let (pk, sk) = generate_keypair();
+        let attester_did = make_did("attester-tamper");
+        let subject_did = make_did("subject-tamper");
+        let ctx = make_context(attester_did, RiskLevel::Low);
+        let mut att = assess_risk(&subject_did, &ctx, &sk).expect("risk attestation");
+
+        att.level = RiskLevel::Critical;
+
+        assert!(!verify_attestation(&att, &pk));
+    }
+
+    #[test]
+    fn assess_risk_rejects_expiry_overflow() {
+        let (_pk, sk) = generate_keypair();
+        let attester_did = make_did("attester-overflow");
+        let subject_did = make_did("subject-overflow");
+        let ctx = RiskContext {
+            attester_did,
+            evidence: b"test evidence data".to_vec(),
+            now: Timestamp::new(u64::MAX, 0),
+            validity_ms: 1,
+            level: RiskLevel::Low,
+        };
+
+        let err = assess_risk(&subject_did, &ctx, &sk).expect_err("expiry overflow");
+        assert!(matches!(
+            err,
+            crate::error::IdentityError::RiskAttestationExpiryOverflow {
+                now_physical_ms: u64::MAX,
+                validity_ms: 1
+            }
+        ));
     }
 
     #[test]
@@ -202,7 +302,7 @@ mod tests {
         let subject_did = make_did("subject3");
         let ctx = make_context(attester_did, RiskLevel::Minimal);
 
-        let att = assess_risk(&subject_did, &ctx, &sk);
+        let att = assess_risk(&subject_did, &ctx, &sk).expect("risk attestation");
         assert!(!is_expired(&att, &Timestamp::new(14_999, 0)));
         assert!(is_expired(&att, &Timestamp::new(15_000, 0)));
         assert!(is_expired(&att, &Timestamp::new(20_000, 0)));
@@ -250,7 +350,7 @@ mod tests {
         ] {
             let subject = make_did("target");
             let ctx = make_context(attester_did.clone(), level);
-            let att = assess_risk(&subject, &ctx, &sk);
+            let att = assess_risk(&subject, &ctx, &sk).expect("risk attestation");
             assert_eq!(att.level, level);
             assert!(verify_attestation(&att, &pk));
         }
@@ -263,8 +363,77 @@ mod tests {
         let subject = make_did("target2");
         let ctx = make_context(attester_did, RiskLevel::Low);
 
-        let att1 = assess_risk(&subject, &ctx, &sk);
-        let att2 = assess_risk(&subject, &ctx, &sk);
+        let att1 = assess_risk(&subject, &ctx, &sk).expect("risk attestation");
+        let att2 = assess_risk(&subject, &ctx, &sk).expect("risk attestation");
         assert_eq!(att1.evidence_hash, att2.evidence_hash);
+    }
+
+    #[test]
+    fn risk_attestation_signing_payload_is_domain_separated_cbor() {
+        let subject_did = make_did("payload-subject");
+        let attester_did = make_did("payload-attester");
+        let evidence_hash = [7u8; 32];
+
+        let payload = risk_attestation_signing_payload(
+            &subject_did,
+            &attester_did,
+            RiskLevel::High,
+            &evidence_hash,
+            Timestamp::new(12_000, 3),
+            Timestamp::new(18_000, 4),
+        )
+        .expect("canonical risk payload");
+
+        assert!(
+            payload
+                .windows(b"exo.identity.risk_attestation.v1".len())
+                .any(|window| window == b"exo.identity.risk_attestation.v1"),
+            "domain tag must be encoded inside the signed payload"
+        );
+
+        let payload_again = risk_attestation_signing_payload(
+            &subject_did,
+            &attester_did,
+            RiskLevel::High,
+            &evidence_hash,
+            Timestamp::new(12_000, 3),
+            Timestamp::new(18_000, 4),
+        )
+        .expect("canonical risk payload");
+        assert_eq!(payload, payload_again);
+    }
+
+    #[test]
+    fn verify_rejects_legacy_raw_concat_signature() {
+        let (pk, sk) = generate_keypair();
+        let subject_did = make_did("legacy-subject");
+        let attester_did = make_did("legacy-attester");
+        let evidence_hash = [9u8; 32];
+        let timestamp = Timestamp::new(21_000, 1);
+        let expiry = Timestamp::new(27_000, 2);
+        let legacy_payload = legacy_risk_attestation_signing_payload(
+            &subject_did,
+            &attester_did,
+            RiskLevel::Critical,
+            &evidence_hash,
+            timestamp,
+            expiry,
+        );
+        let legacy_signature = crypto::sign(&legacy_payload, &sk);
+
+        let attestation = RiskAttestation {
+            subject_did,
+            attester_did,
+            level: RiskLevel::Critical,
+            evidence_hash,
+            timestamp,
+            expiry,
+            signature: legacy_signature,
+        };
+
+        assert!(
+            !verify_attestation(&attestation, &pk),
+            "legacy byte-concat signatures must not verify"
+        );
     }
 }

--- a/crates/exo-identity/src/verification.rs
+++ b/crates/exo-identity/src/verification.rs
@@ -17,6 +17,8 @@ pub enum VerificationCeremonyError {
     InsufficientScore { score: u32 },
     #[error("Invalid attester DID: {0}")]
     InvalidAttesterDid(String),
+    #[error("risk attestation failed: {0}")]
+    RiskAttestation(#[from] crate::error::IdentityError),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -167,12 +169,10 @@ impl VerificationCeremony {
             level,
         };
 
-        let attestation = assess_risk(&self.target_did, &ctx, attester_key);
+        let attestation = assess_risk(&self.target_did, &ctx, attester_key)?;
 
         // Only flip the finalized flag once the real attestation has been
-        // produced successfully. (assess_risk is infallible in this build,
-        // but keeping the ordering explicit guards against future changes
-        // that might make signing fallible.)
+        // produced successfully.
         self.finalized = true;
 
         // Sanity: the returned attestation must verify under the public

--- a/crates/exochain-wasm/src/identity_bindings.rs
+++ b/crates/exochain-wasm/src/identity_bindings.rs
@@ -150,7 +150,8 @@ pub fn wasm_assess_risk(
         level,
     };
 
-    let attestation = exo_identity::risk::assess_risk(&subject, &context, &secret_key);
+    let attestation = exo_identity::risk::assess_risk(&subject, &context, &secret_key)
+        .map_err(|e| JsValue::from_str(&format!("risk attestation error: {e}")))?;
     to_js_value(&attestation)
 }
 

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 121820 lines of Rust under `crates/`, 2,946 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 122001 lines of Rust under `crates/`, 2,951 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,946 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,951 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,946 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,951 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-121820 lines of Rust under `crates/` · 20 workspace packages · 2,946 listed tests · 40 MCP tools · 8 constitutional invariants
+122001 lines of Rust under `crates/` · 20 workspace packages · 2,951 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 121820 lines of Rust under `crates/` | 266 Rust source files | 2,946 listed tests
+> **Codebase:** 20 workspace packages | 122001 lines of Rust under `crates/` | 266 Rust source files | 2,951 listed tests
 
 ---
 

--- a/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
+++ b/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
@@ -46,9 +46,9 @@ decision.forum is a constitutional trust fabric for AI-era governance. Not a fra
 
 The numbers, verified as of this writing:
 
-- **111606 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
+- **122001 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
 - **20 workspace packages** covering identity, consent, authority, governance, escalation, legal infrastructure, cryptographic proofs, and more
-- **2,687 listed tests** exercised by the workspace test gate.
+- **2,951 listed tests** exercised by the workspace test gate.
 - **10 formal proofs** demonstrating that constitutional properties hold under all reachable system states
 - Built and reviewed through a **5-panel council process** (Governance, Legal, Architecture, Security, Operations)
 
@@ -270,7 +270,7 @@ The question is whether we will build it before we need it.
 
 *Bob Stewart is the architect of EXOCHAIN and decision.forum, and the author of The ASI Report on LinkedIn, where he writes about the infrastructure required for safe superintelligence. His work focuses on the intersection of constitutional governance, cryptographic enforcement, and AI safety -- the premise that alignment is necessary but insufficient, and that enforceable structural constraints are the missing complement.*
 
-*The EXOCHAIN workspace -- 111606 lines of Rust under `crates/`, 20 packages, 2,687 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
+*The EXOCHAIN workspace -- 122001 lines of Rust under `crates/`, 20 packages, 2,951 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
 
 ---
 

--- a/docs/decision-forum/SYSTEM-DOCUMENTATION.md
+++ b/docs/decision-forum/SYSTEM-DOCUMENTATION.md
@@ -6,7 +6,7 @@ created: 2026-03-19
 publication: "The ASI Report — LinkedIn Newsletter"
 tags: [decision-forum, governance, constitutional, asi-safety, exochain]
 status: publication-ready
-codebase: "20 workspace packages | 111606 LOC Rust under crates/ | 273 source files | 2,687 listed tests"
+codebase: "20 workspace packages | 122001 LOC Rust under crates/ | 266 source files | 2,951 listed tests"
 ---
 
 # decision.forum — System Documentation
@@ -20,9 +20,9 @@ This document is the exhaustive technical reference for the decision.forum gover
 | Metric | Value |
 |--------|-------|
 | Workspace packages | 20 |
-| Rust LOC under `crates/` | 111606 |
+| Rust LOC under `crates/` | 122001 |
 | Rust source files | 273 |
-| Listed workspace tests | 2,687 |
+| Listed workspace tests | 2,951 |
 | Test gate | `cargo test --workspace` in CI Gate 2 |
 | decision-forum crate LOC | 3,800 |
 | decision-forum tests | 131 |

--- a/docs/guides/GETTING-STARTED.md
+++ b/docs/guides/GETTING-STARTED.md
@@ -124,7 +124,7 @@ open tarpaulin-report.html
 ```
 
 A clean build produces zero errors and zero warnings. The current workspace
-inventory lists 2,687 tests; the exact executed count can change as doctests and
+inventory lists 2,951 tests; the exact executed count can change as doctests and
 integration targets evolve. What matters is zero failures:
 
 ```

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,946 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,951 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 121820 lines of Rust under `crates/` · 2,946 listed tests
+20 workspace packages · 122001 lines of Rust under `crates/` · 2,951 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 

--- a/governance/EXOCHAIN-REFACTOR-PLAN.md
+++ b/governance/EXOCHAIN-REFACTOR-PLAN.md
@@ -68,7 +68,7 @@ All refactor work flows through the Syntaxis Builder system:
 - [ ] Complete Section 8 work orders from CR-001
 - [ ] Achieve release-blocking acceptance standard (CR-001 Section 9)
 
-> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 109708 Rust LOC under `crates/`, 2,687 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
+> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 122001 Rust LOC under `crates/`, 2,951 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
 
 ## Active Resolutions
 

--- a/governance/sub_agents.md
+++ b/governance/sub_agents.md
@@ -72,7 +72,7 @@ Historical 2026-03-19 sub-agent completion record. Numeric status claims are sup
 * **Inputs**: Spec Section 16 (Acceptance Criteria).
 * **Outputs**: Test harnesses, Integration tests, Fuzz targets.
 * **Definition of Done**: Section 16 Acceptance Criteria are automated and passing.
-* **Status**: **DONE** — Current workspace inventory lists 2,687 tests across 20 packages and 273 Rust files.
+* **Status**: **DONE** — Current workspace inventory lists 2,951 tests across 20 packages and 266 Rust files.
 
 ## J) DEVOPS_RELEASE_AGENT (Judicial) — DONE
 

--- a/governance/traceability_matrix.md
+++ b/governance/traceability_matrix.md
@@ -21,7 +21,7 @@ Updated 2026-03-20 after EXOCHAIN-REM-009 — continuous governance monitoring a
 | **9.4** | **Merkle Mountain Range** | `exo-dag::mmr` | `exo-dag/src/mmr.rs` (mod tests) | 23 | 🟢 |
 | 9.4 | Sparse Merkle Tree | `exo-dag::smt` | `exo-dag/src/smt.rs` (mod tests) | 20 | 🟢 |
 | 9.4 | DAG store + checkpoints | `exo-dag::store` | `exo-dag/src/store.rs` (mod tests) | 10 | 🟢 |
-| **9.5** | **RiskAttestation** | `exo-identity::risk` | `exo-identity/src/risk.rs` (mod tests) | 8 | 🟢 |
+| **9.5** | **RiskAttestation** | `exo-identity::risk` | `exo-identity/src/risk.rs` (mod tests) | 13 | 🟢 |
 
 ## Identity & Key Management (Spec §10)
 
@@ -163,4 +163,4 @@ Updated 2026-03-20 after EXOCHAIN-REM-009 — continuous governance monitoring a
 | **TOTAL** | **86** | **83** | **1** | **2** |
 
 **Coverage: 83/86 requirements traced to code (97%). 2 planned (ExoForge scheduling + React dashboard). 1 partial (T-14 Rust attestation verification).**
-**Workspace inventory: 2,687 listed tests across 20 packages and 266 Rust files.**
+**Workspace inventory: 2,951 listed tests across 20 packages and 266 Rust files.**


### PR DESCRIPTION
## Summary
- replace exo-identity risk-attestation raw byte-concat signatures with domain-separated canonical CBOR under `exo.identity.risk_attestation.v1`
- make `assess_risk` fallible for CBOR encoding and expiry-overflow errors
- reject empty, zero, wrong-key, tampered, and legacy raw-concat risk-attestation signatures
- update verification ceremony, WASM binding propagation, and repo-truth docs to 122001 Rust LOC / 2,951 listed tests

## TDD
- Red: `cargo test -p exo-identity risk_attestation_signing_payload_is_domain_separated_cbor --lib -- --nocapture` failed before the canonical payload API existed
- Red: `cargo test -p exo-identity verify_rejects_legacy_raw_concat_signature --lib -- --nocapture` failed because the old verifier accepted legacy byte-concat signatures

## Verification
- `cargo test -p exo-identity risk::tests:: --lib -- --nocapture`
- `cargo test -p exo-identity`
- `cargo build -p exo-identity`
- `cargo clippy -p exo-identity --lib --bins -- -D warnings`
- `cargo clippy -p exo-identity --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo test -p exochain-wasm`
- `cargo clippy -p exochain-wasm --lib --bins -- -D warnings`
- `cargo clippy -p exochain-wasm --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `bash tools/repo_truth.sh --json`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit` (existing allowed yanked `core2` warning only)
- `cargo deny check` (existing duplicate/yanked/unused-allowance warnings only)
- `cargo machete --with-metadata`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`