### PR TITLE
fix(exo-legal): canonicalize bundle hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 122001 | `wc -l` |
-| Workspace tests | 2,951 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 122130 | `wc -l` |
+| Workspace tests | 2,955 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,951 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,955 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 122001 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 122130 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,951 listed workspace tests
+         cryptographic proofs, 2,955 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-legal/src/bundle.rs
+++ b/crates/exo-legal/src/bundle.rs
@@ -234,14 +234,13 @@ where
 // ---------------------------------------------------------------------------
 
 const BUNDLE_VERSION: u32 = 1;
+#[cfg(test)]
 const BUNDLE_DOMAIN: &[u8] = b"exo:bundle:v1:";
+const BUNDLE_HASH_DOMAIN: &str = "exo.legal.bundle.hash.v1";
+const BUNDLE_HASH_SCHEMA_VERSION: u32 = 1;
+const BUNDLE_EVENT_CHAIN_DOMAIN: &str = "exo.legal.bundle.event_chain.v1";
+const BUNDLE_EVIDENCE_HASHES_DOMAIN: &str = "exo.legal.bundle.evidence_hashes.v1";
 const BUNDLE_SIGNATURE_DOMAIN: &str = "exo.legal.bundle.signature.v1";
-
-/// Safe usize → u64 conversion (infallible on ≤64-bit platforms).
-#[allow(clippy::as_conversions)]
-fn len_u64(n: usize) -> u64 {
-    n as u64
-}
 
 /// Safe usize → u32 conversion (saturating for safety).
 #[allow(clippy::as_conversions)]
@@ -299,9 +298,9 @@ pub fn assemble(input: BundleAssemblyInput) -> Result<EvidenceBundle> {
     };
 
     // Compute hash and build verification steps
-    let hash = compute_bundle_hash(&bundle);
+    let hash = compute_bundle_hash(&bundle)?;
     bundle.bundle_hash = hash;
-    bundle.verification.verification_steps = build_verification_steps(&bundle);
+    bundle.verification.verification_steps = build_verification_steps(&bundle)?;
 
     Ok(bundle)
 }
@@ -351,126 +350,71 @@ fn validate_causal_chain(events: &[BundleEvent]) -> Result<()> {
 // Hashing
 // ---------------------------------------------------------------------------
 
-/// Compute the deterministic BLAKE3 root hash of a bundle.
+/// Canonical CBOR payload hashed to produce a bundle root.
 ///
-/// Covers all content fields except `bundle_hash` and `signatures`.
-#[must_use]
-pub fn compute_bundle_hash(bundle: &EvidenceBundle) -> Hash256 {
-    let mut hasher = blake3::Hasher::new();
-    hasher.update(BUNDLE_DOMAIN);
-
-    // Identity
-    hasher.update(bundle.id.as_bytes());
-    hasher.update(&bundle.version.to_le_bytes());
-    hasher.update(&bundle.created_at.physical_ms.to_le_bytes());
-    hasher.update(&bundle.created_at.logical.to_le_bytes());
-
-    // Subject
-    hasher.update(bundle.subject.subject_type.as_tag().as_bytes());
-    hasher.update(bundle.subject.subject_id.as_bytes());
-    hasher.update(bundle.subject.title.as_bytes());
-    hasher.update(bundle.subject.description.as_bytes());
-
-    // Events (length-prefixed)
-    hasher.update(&len_u64(bundle.events.len()).to_le_bytes());
-    for event in &bundle.events {
-        hasher.update(&event.sequence.to_le_bytes());
-        hasher.update(event.event_hash.as_bytes());
-        hasher.update(event.event_type.as_bytes());
-        hasher.update(event.actor.to_string().as_bytes());
-        hasher.update(&event.timestamp.physical_ms.to_le_bytes());
-        hasher.update(&event.timestamp.logical.to_le_bytes());
-        hasher.update(event.payload_summary.as_bytes());
-        hasher.update(&len_u64(event.parent_hashes.len()).to_le_bytes());
-        for ph in &event.parent_hashes {
-            hasher.update(ph.as_bytes());
+/// The payload excludes `bundle_hash`, bundle signer `signatures`, and derived
+/// verification steps. It includes checkpoint validator signatures because they
+/// are part of the DAG anchor content sealed by the bundle.
+///
+/// # Errors
+/// Returns `LegalError` if canonical payload serialization fails.
+pub fn bundle_hash_payload(bundle: &EvidenceBundle) -> Result<Vec<u8>> {
+    let payload = (
+        BUNDLE_HASH_DOMAIN,
+        BUNDLE_HASH_SCHEMA_VERSION,
+        &bundle.id,
+        bundle.version,
+        bundle.created_at,
+        &bundle.subject,
+        &bundle.events,
+        &bundle.evidence_items,
+        &bundle.consent_records,
+        &bundle.contract_summary,
+        &bundle.certification,
+        &bundle.dag_anchor,
+        bundle.verification.format_version,
+        &bundle.verification.hash_algorithm,
+    );
+    let mut encoded = Vec::new();
+    ciborium::into_writer(&payload, &mut encoded).map_err(|e| {
+        LegalError::InvalidStateTransition {
+            reason: format!("bundle hash payload CBOR serialization failed: {e}"),
         }
-        hasher.update(event.dag_node_hash.as_bytes());
-    }
-
-    // Evidence items
-    hasher.update(&len_u64(bundle.evidence_items.len()).to_le_bytes());
-    for ev in &bundle.evidence_items {
-        hasher.update(ev.id.as_bytes());
-        hasher.update(ev.type_tag.as_bytes());
-        hasher.update(ev.hash.as_bytes());
-        hasher.update(ev.creator.to_string().as_bytes());
-        hasher.update(&ev.timestamp.physical_ms.to_le_bytes());
-        hasher.update(&ev.timestamp.logical.to_le_bytes());
-    }
-
-    // Consent records
-    hasher.update(&len_u64(bundle.consent_records.len()).to_le_bytes());
-    for c in &bundle.consent_records {
-        hasher.update(c.bailment_id.as_bytes());
-        hasher.update(c.bailor.to_string().as_bytes());
-        hasher.update(c.bailee.to_string().as_bytes());
-        hasher.update(c.bailment_type.as_bytes());
-        hasher.update(c.terms_hash.as_bytes());
-        hasher.update(c.status.as_bytes());
-    }
-
-    // Contract summary (optional)
-    if let Some(cs) = &bundle.contract_summary {
-        hasher.update(&[0x01]);
-        hasher.update(cs.contract_id.as_bytes());
-        hasher.update(cs.contract_hash.as_bytes());
-        hasher.update(cs.template_name.as_bytes());
-        hasher.update(&len_u64(cs.parties.len()).to_le_bytes());
-        for p in &cs.parties {
-            hasher.update(p.to_string().as_bytes());
-        }
-        hasher.update(&len_u64(cs.key_terms.len()).to_le_bytes());
-        for t in &cs.key_terms {
-            hasher.update(t.as_bytes());
-        }
-    } else {
-        hasher.update(&[0x00]);
-    }
-
-    // Certification (optional)
-    if let Some(cert) = &bundle.certification {
-        hasher.update(&[0x01]);
-        hasher.update(cert.cert_hash.as_bytes());
-    } else {
-        hasher.update(&[0x00]);
-    }
-
-    // DAG anchor
-    hasher.update(&bundle.dag_anchor.checkpoint_height.to_le_bytes());
-    hasher.update(bundle.dag_anchor.event_root.as_bytes());
-    hasher.update(bundle.dag_anchor.state_root.as_bytes());
-    hasher.update(&bundle.dag_anchor.anchored_at.physical_ms.to_le_bytes());
-    hasher.update(&bundle.dag_anchor.anchored_at.logical.to_le_bytes());
-
-    // Verification manifest (hash algorithm + format version, not steps —
-    // steps are derived from the hash so including them would be circular)
-    hasher.update(&bundle.verification.format_version.to_le_bytes());
-    hasher.update(bundle.verification.hash_algorithm.as_bytes());
-
-    Hash256::from_bytes(*hasher.finalize().as_bytes())
+    })?;
+    Ok(encoded)
 }
 
-fn build_verification_steps(bundle: &EvidenceBundle) -> Vec<VerificationStep> {
-    let event_hashes: Vec<Hash256> = bundle.events.iter().map(|e| e.event_hash).collect();
-    let event_chain_hash = {
-        let mut h = blake3::Hasher::new();
-        for eh in &event_hashes {
-            h.update(eh.as_bytes());
+/// Compute the deterministic BLAKE3 root hash of a canonical CBOR bundle payload.
+///
+/// Covers all content fields except `bundle_hash`, signer `signatures`, and
+/// derived verification steps.
+///
+/// # Errors
+/// Returns `LegalError` if canonical payload serialization fails.
+pub fn compute_bundle_hash(bundle: &EvidenceBundle) -> Result<Hash256> {
+    let payload = bundle_hash_payload(bundle)?;
+    Ok(Hash256::digest(&payload))
+}
+
+fn canonical_input_hash(domain: &str, input_hashes: &[Hash256]) -> Result<Hash256> {
+    let payload = (domain, BUNDLE_HASH_SCHEMA_VERSION, input_hashes);
+    let mut encoded = Vec::new();
+    ciborium::into_writer(&payload, &mut encoded).map_err(|e| {
+        LegalError::InvalidStateTransition {
+            reason: format!("verification input hash CBOR serialization failed: {e}"),
         }
-        Hash256::from_bytes(*h.finalize().as_bytes())
-    };
+    })?;
+    Ok(Hash256::digest(&encoded))
+}
+
+fn build_verification_steps(bundle: &EvidenceBundle) -> Result<Vec<VerificationStep>> {
+    let event_hashes: Vec<Hash256> = bundle.events.iter().map(|e| e.event_hash).collect();
+    let event_chain_hash = canonical_input_hash(BUNDLE_EVENT_CHAIN_DOMAIN, &event_hashes)?;
 
     let evidence_hashes: Vec<Hash256> = bundle.evidence_items.iter().map(|e| e.hash).collect();
-    let evidence_hash = {
-        let mut h = blake3::Hasher::new();
-        for eh in &evidence_hashes {
-            h.update(eh.as_bytes());
-        }
-        Hash256::from_bytes(*h.finalize().as_bytes())
-    };
+    let evidence_hash = canonical_input_hash(BUNDLE_EVIDENCE_HASHES_DOMAIN, &evidence_hashes)?;
 
-    vec![
+    Ok(vec![
         VerificationStep {
             step_number: 1,
             description: "Verify event chain hash".into(),
@@ -489,7 +433,7 @@ fn build_verification_steps(bundle: &EvidenceBundle) -> Vec<VerificationStep> {
             input_hashes: vec![bundle.bundle_hash],
             expected_output: bundle.bundle_hash,
         },
-    ]
+    ])
 }
 
 // ---------------------------------------------------------------------------
@@ -529,7 +473,7 @@ fn verify_inner(
     bundle: &EvidenceBundle,
     resolver: Option<&dyn BundleSignerKeyResolver>,
 ) -> Result<VerificationResult> {
-    let recomputed = compute_bundle_hash(bundle);
+    let recomputed = compute_bundle_hash(bundle)?;
     let hash_valid = recomputed == bundle.bundle_hash;
 
     let event_chain_valid = validate_event_ordering(&bundle.events).is_ok();
@@ -705,7 +649,7 @@ pub fn sign(
             reason: "signer role must not be empty".into(),
         });
     }
-    if compute_bundle_hash(bundle) != bundle.bundle_hash {
+    if compute_bundle_hash(bundle)? != bundle.bundle_hash {
         return Err(LegalError::InvalidStateTransition {
             reason: "bundle hash must be current before signing".into(),
         });
@@ -873,6 +817,107 @@ mod tests {
         assemble(input).unwrap()
     }
 
+    fn legacy_len_u64(n: usize) -> u64 {
+        #[allow(clippy::as_conversions)]
+        {
+            n as u64
+        }
+    }
+
+    fn legacy_bundle_hash(bundle: &EvidenceBundle) -> Hash256 {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(BUNDLE_DOMAIN);
+
+        hasher.update(bundle.id.as_bytes());
+        hasher.update(&bundle.version.to_le_bytes());
+        hasher.update(&bundle.created_at.physical_ms.to_le_bytes());
+        hasher.update(&bundle.created_at.logical.to_le_bytes());
+
+        hasher.update(bundle.subject.subject_type.as_tag().as_bytes());
+        hasher.update(bundle.subject.subject_id.as_bytes());
+        hasher.update(bundle.subject.title.as_bytes());
+        hasher.update(bundle.subject.description.as_bytes());
+
+        hasher.update(&legacy_len_u64(bundle.events.len()).to_le_bytes());
+        for event in &bundle.events {
+            hasher.update(&event.sequence.to_le_bytes());
+            hasher.update(event.event_hash.as_bytes());
+            hasher.update(event.event_type.as_bytes());
+            hasher.update(event.actor.to_string().as_bytes());
+            hasher.update(&event.timestamp.physical_ms.to_le_bytes());
+            hasher.update(&event.timestamp.logical.to_le_bytes());
+            hasher.update(event.payload_summary.as_bytes());
+            hasher.update(&legacy_len_u64(event.parent_hashes.len()).to_le_bytes());
+            for ph in &event.parent_hashes {
+                hasher.update(ph.as_bytes());
+            }
+            hasher.update(event.dag_node_hash.as_bytes());
+        }
+
+        hasher.update(&legacy_len_u64(bundle.evidence_items.len()).to_le_bytes());
+        for ev in &bundle.evidence_items {
+            hasher.update(ev.id.as_bytes());
+            hasher.update(ev.type_tag.as_bytes());
+            hasher.update(ev.hash.as_bytes());
+            hasher.update(ev.creator.to_string().as_bytes());
+            hasher.update(&ev.timestamp.physical_ms.to_le_bytes());
+            hasher.update(&ev.timestamp.logical.to_le_bytes());
+        }
+
+        hasher.update(&legacy_len_u64(bundle.consent_records.len()).to_le_bytes());
+        for c in &bundle.consent_records {
+            hasher.update(c.bailment_id.as_bytes());
+            hasher.update(c.bailor.to_string().as_bytes());
+            hasher.update(c.bailee.to_string().as_bytes());
+            hasher.update(c.bailment_type.as_bytes());
+            hasher.update(c.terms_hash.as_bytes());
+            hasher.update(c.status.as_bytes());
+        }
+
+        if let Some(cs) = &bundle.contract_summary {
+            hasher.update(&[0x01]);
+            hasher.update(cs.contract_id.as_bytes());
+            hasher.update(cs.contract_hash.as_bytes());
+            hasher.update(cs.template_name.as_bytes());
+            hasher.update(&legacy_len_u64(cs.parties.len()).to_le_bytes());
+            for p in &cs.parties {
+                hasher.update(p.to_string().as_bytes());
+            }
+            hasher.update(&legacy_len_u64(cs.key_terms.len()).to_le_bytes());
+            for t in &cs.key_terms {
+                hasher.update(t.as_bytes());
+            }
+        } else {
+            hasher.update(&[0x00]);
+        }
+
+        if let Some(cert) = &bundle.certification {
+            hasher.update(&[0x01]);
+            hasher.update(cert.cert_hash.as_bytes());
+        } else {
+            hasher.update(&[0x00]);
+        }
+
+        hasher.update(&bundle.dag_anchor.checkpoint_height.to_le_bytes());
+        hasher.update(bundle.dag_anchor.event_root.as_bytes());
+        hasher.update(bundle.dag_anchor.state_root.as_bytes());
+        hasher.update(&bundle.dag_anchor.anchored_at.physical_ms.to_le_bytes());
+        hasher.update(&bundle.dag_anchor.anchored_at.logical.to_le_bytes());
+
+        hasher.update(&bundle.verification.format_version.to_le_bytes());
+        hasher.update(bundle.verification.hash_algorithm.as_bytes());
+
+        Hash256::from_bytes(*hasher.finalize().as_bytes())
+    }
+
+    fn canonical_verification_input_hash(domain: &str, input_hashes: &[Hash256]) -> Hash256 {
+        let payload = (domain, 1u32, input_hashes);
+        let mut encoded = Vec::new();
+        ciborium::into_writer(&payload, &mut encoded)
+            .expect("canonical verification step input payload");
+        Hash256::digest(&encoded)
+    }
+
     // -- Tests ------------------------------------------------------------
 
     #[test]
@@ -944,13 +989,97 @@ mod tests {
                 bundle_hash: Hash256::ZERO,
                 signatures: vec![],
             };
-            b.bundle_hash = compute_bundle_hash(&b);
+            b.bundle_hash = compute_bundle_hash(&b).unwrap();
             b
         };
 
         let b1 = mk("same-id");
         let b2 = mk("same-id");
         assert_eq!(b1.bundle_hash, b2.bundle_hash);
+    }
+
+    #[test]
+    fn bundle_hash_payload_is_domain_separated_cbor() {
+        type DecodedBundleHashPayload = (
+            String,
+            u32,
+            String,
+            u32,
+            Timestamp,
+            BundleSubject,
+            Vec<BundleEvent>,
+            Vec<Evidence>,
+            Vec<ConsentSummary>,
+            Option<ContractSummary>,
+            Option<CertSnapshot>,
+            DagAnchor,
+            u32,
+            String,
+        );
+
+        let bundle = assemble_full();
+        let payload = bundle_hash_payload(&bundle).unwrap();
+        let legacy_payload_hash = legacy_bundle_hash(&bundle);
+        let decoded: DecodedBundleHashPayload = ciborium::de::from_reader(payload.as_slice())
+            .expect("bundle hash payload decodes as canonical CBOR tuple");
+
+        assert_ne!(Hash256::digest(&payload), legacy_payload_hash);
+        assert_eq!(decoded.0, BUNDLE_HASH_DOMAIN);
+        assert_eq!(decoded.1, 1);
+        assert_eq!(decoded.2, bundle.id);
+        assert_eq!(
+            decoded.11.validator_signatures.len(),
+            bundle.dag_anchor.validator_signatures.len()
+        );
+        assert_eq!(
+            decoded.11.validator_signatures[0].validator_did,
+            bundle.dag_anchor.validator_signatures[0].validator_did
+        );
+        assert_eq!(
+            decoded.11.validator_signatures[0].signature,
+            bundle.dag_anchor.validator_signatures[0].signature
+        );
+    }
+
+    #[test]
+    fn verify_rejects_legacy_byte_concat_bundle_hash() {
+        let mut bundle = assemble_full();
+        bundle.bundle_hash = legacy_bundle_hash(&bundle);
+
+        let result = verify(&bundle).unwrap();
+
+        assert!(!result.hash_valid);
+        assert!(!result.overall);
+    }
+
+    #[test]
+    fn bundle_hash_changes_when_validator_signature_changes() {
+        let mut bundle = assemble_minimal();
+        let original = compute_bundle_hash(&bundle).unwrap();
+        bundle.dag_anchor.validator_signatures[0].signature = Signature::from_bytes([0xbb; 64]);
+
+        let changed = compute_bundle_hash(&bundle).unwrap();
+
+        assert_ne!(changed, original);
+    }
+
+    #[test]
+    fn verification_steps_use_domain_separated_cbor_hashes() {
+        let bundle = assemble_full();
+        let event_hashes: Vec<Hash256> = bundle.events.iter().map(|e| e.event_hash).collect();
+        let evidence_hashes: Vec<Hash256> = bundle.evidence_items.iter().map(|e| e.hash).collect();
+
+        assert_eq!(
+            bundle.verification.verification_steps[0].expected_output,
+            canonical_verification_input_hash("exo.legal.bundle.event_chain.v1", &event_hashes)
+        );
+        assert_eq!(
+            bundle.verification.verification_steps[1].expected_output,
+            canonical_verification_input_hash(
+                "exo.legal.bundle.evidence_hashes.v1",
+                &evidence_hashes
+            )
+        );
     }
 
     #[test]
@@ -981,7 +1110,7 @@ mod tests {
                 bundle_hash: Hash256::ZERO,
                 signatures: vec![],
             };
-            b.bundle_hash = compute_bundle_hash(&b);
+            b.bundle_hash = compute_bundle_hash(&b).unwrap();
             b
         };
 
@@ -1055,7 +1184,7 @@ mod tests {
         let bundle = assemble_minimal();
         let json = render_json(&bundle).unwrap();
         let parsed: EvidenceBundle = serde_json::from_str(&json).unwrap();
-        let recomputed = compute_bundle_hash(&parsed);
+        let recomputed = compute_bundle_hash(&parsed).unwrap();
         assert_eq!(recomputed, bundle.bundle_hash);
     }
 
@@ -1173,7 +1302,7 @@ mod tests {
                 bundle_hash: Hash256::ZERO,
                 signatures: vec![],
             };
-            b.bundle_hash = compute_bundle_hash(&b);
+            b.bundle_hash = compute_bundle_hash(&b).unwrap();
             b
         };
 
@@ -1220,7 +1349,7 @@ mod tests {
                 bundle_hash: Hash256::ZERO,
                 signatures: vec![],
             };
-            b.bundle_hash = compute_bundle_hash(&b);
+            b.bundle_hash = compute_bundle_hash(&b).unwrap();
             b.bundle_hash
         };
         let all = [
@@ -1495,7 +1624,7 @@ mod tests {
                 bundle_hash: Hash256::ZERO,
                 signatures: vec![],
             };
-            b.bundle_hash = compute_bundle_hash(&b);
+            b.bundle_hash = compute_bundle_hash(&b).unwrap();
             b.bundle_hash
         };
         assert_ne!(mk(Some(cert)), mk(None));

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 122001 lines of Rust under `crates/`, 2,951 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 122130 lines of Rust under `crates/`, 2,955 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,951 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,955 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,951 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,955 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-122001 lines of Rust under `crates/` · 20 workspace packages · 2,951 listed tests · 40 MCP tools · 8 constitutional invariants
+122130 lines of Rust under `crates/` · 20 workspace packages · 2,955 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 122001 lines of Rust under `crates/` | 266 Rust source files | 2,951 listed tests
+> **Codebase:** 20 workspace packages | 122130 lines of Rust under `crates/` | 266 Rust source files | 2,955 listed tests
 
 ---
 

--- a/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
+++ b/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
@@ -46,9 +46,9 @@ decision.forum is a constitutional trust fabric for AI-era governance. Not a fra
 
 The numbers, verified as of this writing:
 
-- **122001 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
+- **122130 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
 - **20 workspace packages** covering identity, consent, authority, governance, escalation, legal infrastructure, cryptographic proofs, and more
-- **2,951 listed tests** exercised by the workspace test gate.
+- **2,955 listed tests** exercised by the workspace test gate.
 - **10 formal proofs** demonstrating that constitutional properties hold under all reachable system states
 - Built and reviewed through a **5-panel council process** (Governance, Legal, Architecture, Security, Operations)
 
@@ -270,7 +270,7 @@ The question is whether we will build it before we need it.
 
 *Bob Stewart is the architect of EXOCHAIN and decision.forum, and the author of The ASI Report on LinkedIn, where he writes about the infrastructure required for safe superintelligence. His work focuses on the intersection of constitutional governance, cryptographic enforcement, and AI safety -- the premise that alignment is necessary but insufficient, and that enforceable structural constraints are the missing complement.*
 
-*The EXOCHAIN workspace -- 122001 lines of Rust under `crates/`, 20 packages, 2,951 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
+*The EXOCHAIN workspace -- 122130 lines of Rust under `crates/`, 20 packages, 2,955 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
 
 ---
 

--- a/docs/decision-forum/SYSTEM-DOCUMENTATION.md
+++ b/docs/decision-forum/SYSTEM-DOCUMENTATION.md
@@ -6,7 +6,7 @@ created: 2026-03-19
 publication: "The ASI Report — LinkedIn Newsletter"
 tags: [decision-forum, governance, constitutional, asi-safety, exochain]
 status: publication-ready
-codebase: "20 workspace packages | 122001 LOC Rust under crates/ | 266 source files | 2,951 listed tests"
+codebase: "20 workspace packages | 122130 LOC Rust under crates/ | 266 source files | 2,955 listed tests"
 ---
 
 # decision.forum — System Documentation
@@ -20,9 +20,9 @@ This document is the exhaustive technical reference for the decision.forum gover
 | Metric | Value |
 |--------|-------|
 | Workspace packages | 20 |
-| Rust LOC under `crates/` | 122001 |
+| Rust LOC under `crates/` | 122130 |
 | Rust source files | 273 |
-| Listed workspace tests | 2,951 |
+| Listed workspace tests | 2,955 |
 | Test gate | `cargo test --workspace` in CI Gate 2 |
 | decision-forum crate LOC | 3,800 |
 | decision-forum tests | 131 |

--- a/docs/guides/GETTING-STARTED.md
+++ b/docs/guides/GETTING-STARTED.md
@@ -124,7 +124,7 @@ open tarpaulin-report.html
 ```
 
 A clean build produces zero errors and zero warnings. The current workspace
-inventory lists 2,951 tests; the exact executed count can change as doctests and
+inventory lists 2,955 tests; the exact executed count can change as doctests and
 integration targets evolve. What matters is zero failures:
 
 ```

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,951 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,955 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 122001 lines of Rust under `crates/` · 2,951 listed tests
+20 workspace packages · 122130 lines of Rust under `crates/` · 2,955 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 

--- a/governance/EXOCHAIN-REFACTOR-PLAN.md
+++ b/governance/EXOCHAIN-REFACTOR-PLAN.md
@@ -68,7 +68,7 @@ All refactor work flows through the Syntaxis Builder system:
 - [ ] Complete Section 8 work orders from CR-001
 - [ ] Achieve release-blocking acceptance standard (CR-001 Section 9)
 
-> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 122001 Rust LOC under `crates/`, 2,951 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
+> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 122130 Rust LOC under `crates/`, 2,955 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
 
 ## Active Resolutions
 

--- a/governance/sub_agents.md
+++ b/governance/sub_agents.md
@@ -72,7 +72,7 @@ Historical 2026-03-19 sub-agent completion record. Numeric status claims are sup
 * **Inputs**: Spec Section 16 (Acceptance Criteria).
 * **Outputs**: Test harnesses, Integration tests, Fuzz targets.
 * **Definition of Done**: Section 16 Acceptance Criteria are automated and passing.
-* **Status**: **DONE** — Current workspace inventory lists 2,951 tests across 20 packages and 266 Rust files.
+* **Status**: **DONE** — Current workspace inventory lists 2,955 tests across 20 packages and 266 Rust files.
 
 ## J) DEVOPS_RELEASE_AGENT (Judicial) — DONE
 

--- a/governance/traceability_matrix.md
+++ b/governance/traceability_matrix.md
@@ -163,4 +163,4 @@ Updated 2026-03-20 after EXOCHAIN-REM-009 — continuous governance monitoring a
 | **TOTAL** | **86** | **83** | **1** | **2** |
 
 **Coverage: 83/86 requirements traced to code (97%). 2 planned (ExoForge scheduling + React dashboard). 1 partial (T-14 Rust attestation verification).**
-**Workspace inventory: 2,951 listed tests across 20 packages and 266 Rust files.**
+**Workspace inventory: 2,955 listed tests across 20 packages and 266 Rust files.**


### PR DESCRIPTION
## Summary
- replace legal evidence bundle root hashing with domain-separated canonical CBOR under exo.legal.bundle.hash.v1
- seal DagAnchor.validator_signatures in the bundle root
- replace verification-step event/evidence raw BLAKE3 reductions with domain-separated canonical CBOR hashes
- refresh repo-truth docs to 122130 Rust LOC and 2,955 listed workspace tests

## TDD red checks
- cargo test -p exo-legal bundle_hash_payload_is_domain_separated_cbor --lib -- --nocapture failed first because the canonical payload API/domain did not exist
- cargo test -p exo-legal verify_rejects_legacy_byte_concat_bundle_hash --lib -- --nocapture failed first because production accepted the legacy root
- cargo test -p exo-legal bundle_hash_changes_when_validator_signature_changes --lib -- --nocapture failed first because validator signatures were not sealed
- cargo test -p exo-legal verification_steps_use_domain_separated_cbor_hashes --lib -- --nocapture failed first because verification steps used raw BLAKE3 concatenation

## Verification
- cargo test -p exo-legal --lib
- cargo test -p exo-legal
- cargo build -p exo-legal
- cargo clippy -p exo-legal --lib --bins -- -D warnings
- cargo clippy -p exo-legal --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo fmt --all -- --check
- git diff --check
- bash tools/repo_truth.sh --json
- bash tools/test_repo_truth.sh
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo build --workspace --release
- cargo test --workspace --release
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
- cargo audit (existing allowed yanked core2 warning only)
- cargo deny check (existing duplicate/yanked/unused-allowance warnings only)
- cargo machete --with-metadata
- bash tools/test_cr001_status.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_no_orphan_rust_modules.sh
- bash tools/test_railway_entrypoint_args.sh