### PR TITLE
fix(decision-forum): canonicalize governance hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 122130 | `wc -l` |
-| Workspace tests | 2,955 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 122375 | `wc -l` |
+| Workspace tests | 2,966 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,955 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,966 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 122130 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 122375 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,955 listed workspace tests
+         cryptographic proofs, 2,966 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/decision-forum/src/constitution.rs
+++ b/crates/decision-forum/src/constitution.rs
@@ -5,10 +5,16 @@
 //! conflict resolution hierarchy:
 //! Articles > Bylaws > Resolutions > Charters > Policies (GOV-006).
 
-use exo_core::types::{Did, Hash256, Signature, Timestamp, Version};
+use exo_core::{
+    hash::hash_structured,
+    types::{Did, Hash256, Signature, Timestamp, Version},
+};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{ForumError, Result};
+
+const CONSTITUTION_CORPUS_HASH_DOMAIN: &str = "decision.forum.constitution_corpus.v1";
+const CONSTITUTION_CORPUS_HASH_SCHEMA_VERSION: u16 = 1;
 
 /// Document tier in the conflict resolution hierarchy (GOV-006).
 /// Articles override Bylaws, Bylaws override Resolutions, etc.
@@ -59,16 +65,15 @@ pub struct ConstitutionCorpus {
 impl ConstitutionCorpus {
     /// Create a new constitution from a set of articles. Computes the
     /// corpus hash deterministically.
-    #[must_use]
-    pub fn new(articles: Vec<Article>) -> Self {
-        let hash = compute_corpus_hash(&articles);
-        ConstitutionCorpus {
+    pub fn new(articles: Vec<Article>) -> Result<Self> {
+        let hash = compute_corpus_hash(&articles)?;
+        Ok(ConstitutionCorpus {
             version: Version::ZERO.next(),
             hash,
             articles,
             ratified_at: None,
             amendment_count: 0,
-        }
+        })
     }
 
     /// Returns true if the constitution has been ratified.
@@ -143,7 +148,7 @@ pub fn amend(
     }
     corpus.articles.push(amendment);
     corpus.version = corpus.version.next();
-    corpus.hash = compute_corpus_hash(&corpus.articles);
+    corpus.hash = compute_corpus_hash(&corpus.articles)?;
     corpus.amendment_count += 1;
     Ok(())
 }
@@ -167,14 +172,24 @@ pub fn dry_run_amendment(corpus: &ConstitutionCorpus, proposed: &Article) -> Res
     Ok(conflicts)
 }
 
-/// Compute a deterministic hash over all articles in the corpus.
-fn compute_corpus_hash(articles: &[Article]) -> Hash256 {
-    let mut hasher = blake3::Hasher::new();
-    for a in articles {
-        hasher.update(a.text_hash.as_bytes());
-        hasher.update(a.id.as_bytes());
+#[derive(Debug, Clone, Serialize)]
+struct CorpusHashPayload<'a> {
+    domain: &'static str,
+    schema_version: u16,
+    articles: &'a [Article],
+}
+
+fn corpus_hash_payload(articles: &[Article]) -> CorpusHashPayload<'_> {
+    CorpusHashPayload {
+        domain: CONSTITUTION_CORPUS_HASH_DOMAIN,
+        schema_version: CONSTITUTION_CORPUS_HASH_SCHEMA_VERSION,
+        articles,
     }
-    Hash256::from_bytes(*hasher.finalize().as_bytes())
+}
+
+/// Compute a deterministic hash over all articles in the corpus.
+fn compute_corpus_hash(articles: &[Article]) -> Result<Hash256> {
+    hash_structured(&corpus_hash_payload(articles)).map_err(ForumError::from)
 }
 
 #[cfg(test)]
@@ -214,14 +229,16 @@ mod tests {
 
     #[test]
     fn new_not_ratified() {
-        let c = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)]);
+        let c = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)])
+            .expect("valid corpus");
         assert!(!c.is_ratified());
         assert_eq!(c.version, Version::ZERO.next());
     }
 
     #[test]
     fn ratify_ok() {
-        let mut c = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)]);
+        let mut c = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)])
+            .expect("valid corpus");
         ratify(
             &mut c,
             &[(did("a"), sig()), (did("b"), sig())],
@@ -234,14 +251,16 @@ mod tests {
 
     #[test]
     fn ratify_quorum_not_met() {
-        let mut c = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)]);
+        let mut c = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)])
+            .expect("valid corpus");
         let err = ratify(&mut c, &[(did("a"), sig())], &quorum(), Timestamp::ZERO).unwrap_err();
         assert!(matches!(err, ForumError::QuorumNotMet { .. }));
     }
 
     #[test]
     fn ratify_already() {
-        let mut c = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)]);
+        let mut c = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)])
+            .expect("valid corpus");
         ratify(
             &mut c,
             &[(did("a"), sig()), (did("b"), sig())],
@@ -262,7 +281,8 @@ mod tests {
 
     #[test]
     fn empty_sig_not_counted() {
-        let mut c = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)]);
+        let mut c = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)])
+            .expect("valid corpus");
         assert!(
             ratify(
                 &mut c,
@@ -276,7 +296,8 @@ mod tests {
 
     #[test]
     fn amend_ok() {
-        let mut c = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)]);
+        let mut c = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)])
+            .expect("valid corpus");
         ratify(
             &mut c,
             &[(did("a"), sig()), (did("b"), sig())],
@@ -299,7 +320,8 @@ mod tests {
 
     #[test]
     fn amend_not_ratified() {
-        let mut c = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)]);
+        let mut c = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)])
+            .expect("valid corpus");
         assert!(
             amend(
                 &mut c,
@@ -312,7 +334,8 @@ mod tests {
 
     #[test]
     fn amend_no_valid_sigs() {
-        let mut c = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)]);
+        let mut c = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)])
+            .expect("valid corpus");
         ratify(
             &mut c,
             &[(did("a"), sig()), (did("b"), sig())],
@@ -332,7 +355,7 @@ mod tests {
 
     #[test]
     fn conflict_resolution_hierarchy() {
-        let c = ConstitutionCorpus::new(vec![]);
+        let c = ConstitutionCorpus::new(vec![]).expect("valid corpus");
         let art = article("a1", DocumentTier::Articles);
         let bylaw = article("b1", DocumentTier::Bylaws);
         assert_eq!(c.resolve_conflict(&art, &bylaw).id, "a1");
@@ -341,21 +364,67 @@ mod tests {
 
     #[test]
     fn dry_run_detects_conflict() {
-        let c = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)]);
+        let c = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)])
+            .expect("valid corpus");
         let conflicts = dry_run_amendment(&c, &article("a1", DocumentTier::Articles)).expect("ok");
         assert_eq!(conflicts.len(), 1);
     }
 
     #[test]
     fn dry_run_no_conflict() {
-        let c = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)]);
+        let c = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)])
+            .expect("valid corpus");
         let conflicts = dry_run_amendment(&c, &article("a2", DocumentTier::Bylaws)).expect("ok");
         assert!(conflicts.is_empty());
     }
 
     #[test]
+    fn corpus_hash_payload_is_domain_separated_cbor() {
+        let articles = vec![article("a1", DocumentTier::Articles)];
+        let payload = corpus_hash_payload(&articles);
+        assert_eq!(payload.domain, CONSTITUTION_CORPUS_HASH_DOMAIN);
+        assert_eq!(
+            payload.schema_version,
+            CONSTITUTION_CORPUS_HASH_SCHEMA_VERSION
+        );
+        assert_eq!(payload.articles.len(), 1);
+        assert_eq!(payload.articles[0].id, "a1");
+    }
+
+    #[test]
+    fn corpus_hash_changes_when_article_title_changes() {
+        let base = article("a1", DocumentTier::Articles);
+        let mut renamed = base.clone();
+        renamed.title = "renamed article".into();
+        let c1 = ConstitutionCorpus::new(vec![base]).expect("valid corpus");
+        let c2 = ConstitutionCorpus::new(vec![renamed]).expect("valid corpus");
+        assert_ne!(c1.hash, c2.hash);
+    }
+
+    #[test]
+    fn corpus_hash_changes_when_article_status_changes() {
+        let base = article("a1", DocumentTier::Articles);
+        let mut repealed = base.clone();
+        repealed.status = ArticleStatus::Repealed;
+        let c1 = ConstitutionCorpus::new(vec![base]).expect("valid corpus");
+        let c2 = ConstitutionCorpus::new(vec![repealed]).expect("valid corpus");
+        assert_ne!(c1.hash, c2.hash);
+    }
+
+    #[test]
+    fn constitution_production_source_has_no_raw_corpus_hashing() {
+        let production = include_str!("constitution.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production section");
+        assert!(!production.contains("blake3::Hasher"));
+        assert!(!production.contains("hasher.update"));
+    }
+
+    #[test]
     fn find_article() {
-        let c = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)]);
+        let c = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)])
+            .expect("valid corpus");
         assert!(c.find_article("a1").is_some());
         assert!(c.find_article("nope").is_none());
     }
@@ -365,15 +434,18 @@ mod tests {
         let mut c = ConstitutionCorpus::new(vec![
             article("a1", DocumentTier::Articles),
             article("a2", DocumentTier::Articles),
-        ]);
+        ])
+        .expect("valid corpus");
         c.articles[1].status = ArticleStatus::Repealed;
         assert_eq!(c.active_article_count(), 1);
     }
 
     #[test]
     fn hash_deterministic() {
-        let c1 = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)]);
-        let c2 = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)]);
+        let c1 = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)])
+            .expect("valid corpus");
+        let c2 = ConstitutionCorpus::new(vec![article("a1", DocumentTier::Articles)])
+            .expect("valid corpus");
         assert_eq!(c1.hash, c2.hash);
     }
 

--- a/crates/decision-forum/src/fiduciary_package.rs
+++ b/crates/decision-forum/src/fiduciary_package.rs
@@ -24,8 +24,13 @@
 //! All scoring uses integer arithmetic only — no floating-point — per
 //! constitutional determinism requirement (`float_arithmetic = "deny"`).
 
-use exo_core::types::Hash256;
+use exo_core::{hash::hash_structured, types::Hash256};
 use serde::{Deserialize, Serialize};
+
+use crate::error::{ForumError, Result};
+
+const FIDUCIARY_PACKAGE_HASH_DOMAIN: &str = "decision.forum.fiduciary_package.v1";
+const FIDUCIARY_PACKAGE_HASH_SCHEMA_VERSION: u16 = 1;
 
 // ---------------------------------------------------------------------------
 // Prong evidence containers
@@ -206,22 +211,22 @@ impl FiduciaryDefensePackage {
     ///
     /// Computes `package_hash` over all prong data so any field mutation is
     /// detectable.
-    #[must_use]
     pub fn generate(
         decision_hash: Hash256,
         prong_disinterestedness: ProngDisinterestedness,
         prong_informed_basis: ProngInformedBasis,
         prong_good_faith: ProngGoodFaith,
         prong_rational_basis: ProngRationalBasis,
-    ) -> Self {
+    ) -> Result<Self> {
         let package_hash = compute_package_hash(
             &decision_hash,
             &prong_disinterestedness,
             &prong_informed_basis,
             &prong_good_faith,
             &prong_rational_basis,
-        );
-        Self {
+            Self::DISCLAIMER,
+        )?;
+        Ok(Self {
             decision_hash,
             prong_disinterestedness,
             prong_informed_basis,
@@ -229,7 +234,7 @@ impl FiduciaryDefensePackage {
             prong_rational_basis,
             package_hash,
             disclaimer: Self::DISCLAIMER,
-        }
+        })
     }
 
     /// Overall BJR defensibility score in basis points (0–10_000 ≡ 0.00%–100.00%).
@@ -250,16 +255,16 @@ impl FiduciaryDefensePackage {
     }
 
     /// Verify the package has not been tampered with since generation.
-    #[must_use]
-    pub fn verify(&self) -> bool {
+    pub fn verify(&self) -> Result<bool> {
         let expected = compute_package_hash(
             &self.decision_hash,
             &self.prong_disinterestedness,
             &self.prong_informed_basis,
             &self.prong_good_faith,
             &self.prong_rational_basis,
-        );
-        expected == self.package_hash
+            self.disclaimer,
+        )?;
+        Ok(expected == self.package_hash)
     }
 }
 
@@ -267,49 +272,48 @@ impl FiduciaryDefensePackage {
 // Internal
 // ---------------------------------------------------------------------------
 
+#[derive(Debug, Clone, Serialize)]
+struct FiduciaryPackageHashPayload<'a> {
+    domain: &'static str,
+    schema_version: u16,
+    decision_hash: &'a Hash256,
+    prong_disinterestedness: &'a ProngDisinterestedness,
+    prong_informed_basis: &'a ProngInformedBasis,
+    prong_good_faith: &'a ProngGoodFaith,
+    prong_rational_basis: &'a ProngRationalBasis,
+    disclaimer: &'a str,
+}
+
+fn fiduciary_package_hash_payload<'a>(
+    decision_hash: &'a Hash256,
+    p1: &'a ProngDisinterestedness,
+    p2: &'a ProngInformedBasis,
+    p3: &'a ProngGoodFaith,
+    p4: &'a ProngRationalBasis,
+) -> FiduciaryPackageHashPayload<'a> {
+    FiduciaryPackageHashPayload {
+        domain: FIDUCIARY_PACKAGE_HASH_DOMAIN,
+        schema_version: FIDUCIARY_PACKAGE_HASH_SCHEMA_VERSION,
+        decision_hash,
+        prong_disinterestedness: p1,
+        prong_informed_basis: p2,
+        prong_good_faith: p3,
+        prong_rational_basis: p4,
+        disclaimer: FiduciaryDefensePackage::DISCLAIMER,
+    }
+}
+
 fn compute_package_hash(
     decision_hash: &Hash256,
     p1: &ProngDisinterestedness,
     p2: &ProngInformedBasis,
     p3: &ProngGoodFaith,
     p4: &ProngRationalBasis,
-) -> Hash256 {
-    let mut hasher = blake3::Hasher::new();
-    hasher.update(b"fjp:v1:");
-    hasher.update(decision_hash.as_bytes());
-    // Prong 1
-    hasher.update(&p1.total_members.to_le_bytes());
-    hasher.update(&p1.recused_count.to_le_bytes());
-    hasher.update(&p1.disinterested_voters.to_le_bytes());
-    hasher.update(&[u8::from(p1.majority_disinterested)]);
-    for h in &p1.disclosure_record_hashes {
-        hasher.update(h.as_bytes());
-    }
-    // Prong 2
-    hasher.update(&p2.voters_who_reviewed.to_le_bytes());
-    hasher.update(&p2.total_voters.to_le_bytes());
-    hasher.update(&[u8::from(p2.materials_complete_before_vote)]);
-    for h in &p2.evidence_manifest_hashes {
-        hasher.update(h.as_bytes());
-    }
-    // Prong 3
-    hasher.update(&p3.alternatives_count.to_le_bytes());
-    hasher.update(&p3.dissent_records.to_le_bytes());
-    hasher.update(&[u8::from(p3.process_compliant)]);
-    for h in &p3.deliberation_hashes {
-        hasher.update(h.as_bytes());
-    }
-    // Prong 4
-    if let Some(h) = &p4.selected_rationale_hash {
-        hasher.update(h.as_bytes());
-    }
-    if let Some(h) = &p4.risk_assessment_hash {
-        hasher.update(h.as_bytes());
-    }
-    for h in &p4.supporting_evidence_hashes {
-        hasher.update(h.as_bytes());
-    }
-    Hash256::from_bytes(*hasher.finalize().as_bytes())
+    disclaimer: &str,
+) -> Result<Hash256> {
+    let mut payload = fiduciary_package_hash_payload(decision_hash, p1, p2, p3, p4);
+    payload.disclaimer = disclaimer;
+    hash_structured(&payload).map_err(ForumError::from)
 }
 
 // ---------------------------------------------------------------------------
@@ -361,6 +365,65 @@ mod tests {
     }
 
     #[test]
+    fn fiduciary_package_hash_payload_is_domain_separated_cbor() {
+        let decision_hash = decision_hash();
+        let p1 = full_prong1();
+        let p2 = full_prong2();
+        let p3 = full_prong3();
+        let p4 = full_prong4();
+        let payload = fiduciary_package_hash_payload(&decision_hash, &p1, &p2, &p3, &p4);
+        assert_eq!(payload.domain, FIDUCIARY_PACKAGE_HASH_DOMAIN);
+        assert_eq!(
+            payload.schema_version,
+            FIDUCIARY_PACKAGE_HASH_SCHEMA_VERSION
+        );
+        assert_eq!(*payload.decision_hash, decision_hash);
+    }
+
+    #[test]
+    fn package_hash_distinguishes_optional_rationale_and_risk_slots() {
+        let shared = Hash256::digest(b"shared-optional-hash");
+        let p4_rationale = ProngRationalBasis {
+            selected_rationale_hash: Some(shared),
+            risk_assessment_hash: None,
+            supporting_evidence_hashes: vec![],
+        };
+        let p4_risk = ProngRationalBasis {
+            selected_rationale_hash: None,
+            risk_assessment_hash: Some(shared),
+            supporting_evidence_hashes: vec![],
+        };
+        let pkg_rationale = FiduciaryDefensePackage::generate(
+            decision_hash(),
+            full_prong1(),
+            full_prong2(),
+            full_prong3(),
+            p4_rationale,
+        )
+        .expect("package");
+        let pkg_risk = FiduciaryDefensePackage::generate(
+            decision_hash(),
+            full_prong1(),
+            full_prong2(),
+            full_prong3(),
+            p4_risk,
+        )
+        .expect("package");
+        assert_ne!(pkg_rationale.package_hash, pkg_risk.package_hash);
+    }
+
+    #[test]
+    fn fiduciary_production_source_has_no_raw_package_hashing() {
+        let production = include_str!("fiduciary_package.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production section");
+        assert!(!production.contains("blake3::Hasher"));
+        assert!(!production.contains("hasher.update"));
+        assert!(!production.contains("to_le_bytes"));
+    }
+
+    #[test]
     fn defense_package_four_prong_completeness() {
         let pkg = FiduciaryDefensePackage::generate(
             decision_hash(),
@@ -368,7 +431,8 @@ mod tests {
             full_prong2(),
             full_prong3(),
             full_prong4(),
-        );
+        )
+        .expect("package");
         // All four prongs have content.
         assert!(pkg.prong_disinterestedness.total_members > 0);
         assert!(pkg.prong_informed_basis.total_voters > 0);
@@ -384,7 +448,8 @@ mod tests {
             full_prong2(),
             full_prong3(),
             full_prong4(),
-        );
+        )
+        .expect("package");
         let score = pkg.bjr_defensibility_score_bps();
         assert!(score <= 10_000, "score must be in [0, 10_000] bps");
         assert!(
@@ -401,9 +466,10 @@ mod tests {
             full_prong2(),
             full_prong3(),
             full_prong4(),
-        );
+        )
+        .expect("package");
         assert!(
-            pkg.verify(),
+            pkg.verify().expect("verify"),
             "package must verify immediately after generation"
         );
     }
@@ -416,10 +482,14 @@ mod tests {
             full_prong2(),
             full_prong3(),
             full_prong4(),
-        );
+        )
+        .expect("package");
         // Mutate a field after sealing.
         pkg.prong_disinterestedness.recused_count = 99;
-        assert!(!pkg.verify(), "tampered package must fail verification");
+        assert!(
+            !pkg.verify().expect("verify"),
+            "tampered package must fail verification"
+        );
     }
 
     #[test]
@@ -430,7 +500,8 @@ mod tests {
             full_prong2(),
             full_prong3(),
             full_prong4(),
-        );
+        )
+        .expect("package");
         assert!(
             pkg.disclaimer.contains("not a legal opinion"),
             "package must include legal disclaimer"

--- a/crates/decision-forum/src/workflow.rs
+++ b/crates/decision-forum/src/workflow.rs
@@ -5,12 +5,16 @@
 
 use exo_core::{
     bcts::BctsState,
+    hash::hash_structured,
     types::{Hash256, Timestamp},
 };
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::error::{ForumError, Result};
+
+const WORKFLOW_RECEIPT_HASH_DOMAIN: &str = "decision.forum.workflow_receipt.v1";
+const WORKFLOW_RECEIPT_HASH_SCHEMA_VERSION: u16 = 1;
 
 /// A workflow stage corresponding to a BCTS state.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -148,27 +152,63 @@ pub struct WorkflowReceipt {
     pub receipt_hash: Hash256,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct WorkflowReceiptHashPayload {
+    domain: &'static str,
+    schema_version: u16,
+    workflow_id: Uuid,
+    stage: BctsState,
+    decision_id: Uuid,
+    timestamp: Timestamp,
+}
+
+fn workflow_receipt_hash_payload(
+    workflow_id: Uuid,
+    stage: BctsState,
+    decision_id: Uuid,
+    timestamp: Timestamp,
+) -> WorkflowReceiptHashPayload {
+    WorkflowReceiptHashPayload {
+        domain: WORKFLOW_RECEIPT_HASH_DOMAIN,
+        schema_version: WORKFLOW_RECEIPT_HASH_SCHEMA_VERSION,
+        workflow_id,
+        stage,
+        decision_id,
+        timestamp,
+    }
+}
+
 /// Generate a receipt for a workflow stage.
-#[must_use]
 pub fn generate_receipt(
     workflow_id: Uuid,
     stage: BctsState,
     decision_id: Uuid,
     timestamp: Timestamp,
-) -> WorkflowReceipt {
-    let mut hasher = blake3::Hasher::new();
-    hasher.update(workflow_id.as_bytes());
-    hasher.update(decision_id.as_bytes());
-    hasher.update(&timestamp.physical_ms.to_le_bytes());
-    hasher.update(&u64::from(timestamp.logical).to_le_bytes());
-    hasher.update(format!("{stage:?}").as_bytes());
-    WorkflowReceipt {
+) -> Result<WorkflowReceipt> {
+    if workflow_id.is_nil() {
+        return Err(ForumError::InvalidProvenance {
+            reason: "workflow receipt workflow_id must not be nil".into(),
+        });
+    }
+    if decision_id.is_nil() {
+        return Err(ForumError::InvalidProvenance {
+            reason: "workflow receipt decision_id must not be nil".into(),
+        });
+    }
+    if timestamp == Timestamp::ZERO {
+        return Err(ForumError::InvalidProvenance {
+            reason: "workflow receipt timestamp must be non-zero HLC".into(),
+        });
+    }
+    let payload = workflow_receipt_hash_payload(workflow_id, stage, decision_id, timestamp);
+    let receipt_hash = hash_structured(&payload).map_err(ForumError::from)?;
+    Ok(WorkflowReceipt {
         workflow_id,
         stage,
         decision_id,
         timestamp,
-        receipt_hash: Hash256::from_bytes(*hasher.finalize().as_bytes()),
-    }
+        receipt_hash,
+    })
 }
 
 #[cfg(test)]
@@ -215,22 +255,84 @@ mod tests {
     }
 
     #[test]
+    fn workflow_receipt_hash_payload_is_domain_separated_cbor() {
+        let wf_id = Uuid::from_u128(90);
+        let dec_id = Uuid::from_u128(91);
+        let ts = Timestamp::new(1000, 1);
+        let payload = workflow_receipt_hash_payload(wf_id, BctsState::Submitted, dec_id, ts);
+        assert_eq!(payload.domain, WORKFLOW_RECEIPT_HASH_DOMAIN);
+        assert_eq!(payload.schema_version, WORKFLOW_RECEIPT_HASH_SCHEMA_VERSION);
+        assert_eq!(payload.workflow_id, wf_id);
+        assert_eq!(payload.decision_id, dec_id);
+        assert_eq!(payload.stage, BctsState::Submitted);
+        assert_eq!(payload.timestamp, ts);
+    }
+
+    #[test]
+    fn workflow_receipt_rejects_legacy_raw_concat_hash() {
+        let wf_id = Uuid::from_u128(92);
+        let dec_id = Uuid::from_u128(93);
+        let ts = Timestamp::new(1000, 1);
+        let receipt = generate_receipt(wf_id, BctsState::Submitted, dec_id, ts).expect("receipt");
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(wf_id.as_bytes());
+        hasher.update(dec_id.as_bytes());
+        hasher.update(&ts.physical_ms.to_le_bytes());
+        hasher.update(&u64::from(ts.logical).to_le_bytes());
+        hasher.update(format!("{:?}", BctsState::Submitted).as_bytes());
+        let legacy = Hash256::from_bytes(*hasher.finalize().as_bytes());
+        assert_ne!(receipt.receipt_hash, legacy);
+    }
+
+    #[test]
+    fn generate_receipt_rejects_placeholder_inputs() {
+        let ts = Timestamp::new(1000, 1);
+        let err = generate_receipt(Uuid::nil(), BctsState::Submitted, Uuid::from_u128(94), ts)
+            .unwrap_err();
+        assert!(matches!(err, ForumError::InvalidProvenance { .. }));
+
+        let err = generate_receipt(Uuid::from_u128(95), BctsState::Submitted, Uuid::nil(), ts)
+            .unwrap_err();
+        assert!(matches!(err, ForumError::InvalidProvenance { .. }));
+
+        let err = generate_receipt(
+            Uuid::from_u128(96),
+            BctsState::Submitted,
+            Uuid::from_u128(97),
+            Timestamp::ZERO,
+        )
+        .unwrap_err();
+        assert!(matches!(err, ForumError::InvalidProvenance { .. }));
+    }
+
+    #[test]
+    fn workflow_production_source_has_no_raw_receipt_hashing() {
+        let production = include_str!("workflow.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production section");
+        assert!(!production.contains("blake3::Hasher"));
+        assert!(!production.contains("hasher.update"));
+        assert!(!production.contains("format!(\"{stage:?}\""));
+    }
+
+    #[test]
     fn generate_receipt_deterministic() {
-        let wf_id = Uuid::nil();
-        let dec_id = Uuid::nil();
-        let ts = Timestamp::new(1000, 0);
-        let r1 = generate_receipt(wf_id, BctsState::Submitted, dec_id, ts);
-        let r2 = generate_receipt(wf_id, BctsState::Submitted, dec_id, ts);
+        let wf_id = Uuid::from_u128(98);
+        let dec_id = Uuid::from_u128(99);
+        let ts = Timestamp::new(1000, 1);
+        let r1 = generate_receipt(wf_id, BctsState::Submitted, dec_id, ts).expect("receipt");
+        let r2 = generate_receipt(wf_id, BctsState::Submitted, dec_id, ts).expect("receipt");
         assert_eq!(r1.receipt_hash, r2.receipt_hash);
     }
 
     #[test]
     fn receipt_differs_per_stage() {
-        let wf_id = Uuid::nil();
-        let dec_id = Uuid::nil();
-        let ts = Timestamp::new(1000, 0);
-        let r1 = generate_receipt(wf_id, BctsState::Submitted, dec_id, ts);
-        let r2 = generate_receipt(wf_id, BctsState::Approved, dec_id, ts);
+        let wf_id = Uuid::from_u128(100);
+        let dec_id = Uuid::from_u128(101);
+        let ts = Timestamp::new(1000, 1);
+        let r1 = generate_receipt(wf_id, BctsState::Submitted, dec_id, ts).expect("receipt");
+        let r2 = generate_receipt(wf_id, BctsState::Approved, dec_id, ts).expect("receipt");
         assert_ne!(r1.receipt_hash, r2.receipt_hash);
     }
 

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 122130 lines of Rust under `crates/`, 2,955 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 122375 lines of Rust under `crates/`, 2,966 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,955 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,966 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,955 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,966 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-122130 lines of Rust under `crates/` · 20 workspace packages · 2,955 listed tests · 40 MCP tools · 8 constitutional invariants
+122375 lines of Rust under `crates/` · 20 workspace packages · 2,966 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 122130 lines of Rust under `crates/` | 266 Rust source files | 2,955 listed tests
+> **Codebase:** 20 workspace packages | 122375 lines of Rust under `crates/` | 266 Rust source files | 2,966 listed tests
 
 ---
 

--- a/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
+++ b/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
@@ -46,9 +46,9 @@ decision.forum is a constitutional trust fabric for AI-era governance. Not a fra
 
 The numbers, verified as of this writing:
 
-- **122130 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
+- **122375 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
 - **20 workspace packages** covering identity, consent, authority, governance, escalation, legal infrastructure, cryptographic proofs, and more
-- **2,955 listed tests** exercised by the workspace test gate.
+- **2,966 listed tests** exercised by the workspace test gate.
 - **10 formal proofs** demonstrating that constitutional properties hold under all reachable system states
 - Built and reviewed through a **5-panel council process** (Governance, Legal, Architecture, Security, Operations)
 
@@ -270,7 +270,7 @@ The question is whether we will build it before we need it.
 
 *Bob Stewart is the architect of EXOCHAIN and decision.forum, and the author of The ASI Report on LinkedIn, where he writes about the infrastructure required for safe superintelligence. His work focuses on the intersection of constitutional governance, cryptographic enforcement, and AI safety -- the premise that alignment is necessary but insufficient, and that enforceable structural constraints are the missing complement.*
 
-*The EXOCHAIN workspace -- 122130 lines of Rust under `crates/`, 20 packages, 2,955 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
+*The EXOCHAIN workspace -- 122375 lines of Rust under `crates/`, 20 packages, 2,966 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
 
 ---
 

--- a/docs/decision-forum/SYSTEM-DOCUMENTATION.md
+++ b/docs/decision-forum/SYSTEM-DOCUMENTATION.md
@@ -6,7 +6,7 @@ created: 2026-03-19
 publication: "The ASI Report — LinkedIn Newsletter"
 tags: [decision-forum, governance, constitutional, asi-safety, exochain]
 status: publication-ready
-codebase: "20 workspace packages | 122130 LOC Rust under crates/ | 266 source files | 2,955 listed tests"
+codebase: "20 workspace packages | 122375 LOC Rust under crates/ | 266 source files | 2,966 listed tests"
 ---
 
 # decision.forum — System Documentation
@@ -20,9 +20,9 @@ This document is the exhaustive technical reference for the decision.forum gover
 | Metric | Value |
 |--------|-------|
 | Workspace packages | 20 |
-| Rust LOC under `crates/` | 122130 |
+| Rust LOC under `crates/` | 122375 |
 | Rust source files | 273 |
-| Listed workspace tests | 2,955 |
+| Listed workspace tests | 2,966 |
 | Test gate | `cargo test --workspace` in CI Gate 2 |
 | decision-forum crate LOC | 3,800 |
 | decision-forum tests | 131 |

--- a/docs/guides/GETTING-STARTED.md
+++ b/docs/guides/GETTING-STARTED.md
@@ -124,7 +124,7 @@ open tarpaulin-report.html
 ```
 
 A clean build produces zero errors and zero warnings. The current workspace
-inventory lists 2,955 tests; the exact executed count can change as doctests and
+inventory lists 2,966 tests; the exact executed count can change as doctests and
 integration targets evolve. What matters is zero failures:
 
 ```

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,955 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,966 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 122130 lines of Rust under `crates/` · 2,955 listed tests
+20 workspace packages · 122375 lines of Rust under `crates/` · 2,966 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 

--- a/governance/EXOCHAIN-REFACTOR-PLAN.md
+++ b/governance/EXOCHAIN-REFACTOR-PLAN.md
@@ -68,7 +68,7 @@ All refactor work flows through the Syntaxis Builder system:
 - [ ] Complete Section 8 work orders from CR-001
 - [ ] Achieve release-blocking acceptance standard (CR-001 Section 9)
 
-> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 122130 Rust LOC under `crates/`, 2,955 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
+> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 122375 Rust LOC under `crates/`, 2,966 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
 
 ## Active Resolutions
 

--- a/governance/sub_agents.md
+++ b/governance/sub_agents.md
@@ -72,7 +72,7 @@ Historical 2026-03-19 sub-agent completion record. Numeric status claims are sup
 * **Inputs**: Spec Section 16 (Acceptance Criteria).
 * **Outputs**: Test harnesses, Integration tests, Fuzz targets.
 * **Definition of Done**: Section 16 Acceptance Criteria are automated and passing.
-* **Status**: **DONE** — Current workspace inventory lists 2,955 tests across 20 packages and 266 Rust files.
+* **Status**: **DONE** — Current workspace inventory lists 2,966 tests across 20 packages and 266 Rust files.
 
 ## J) DEVOPS_RELEASE_AGENT (Judicial) — DONE
 

--- a/governance/traceability_matrix.md
+++ b/governance/traceability_matrix.md
@@ -163,4 +163,4 @@ Updated 2026-03-20 after EXOCHAIN-REM-009 — continuous governance monitoring a
 | **TOTAL** | **86** | **83** | **1** | **2** |
 
 **Coverage: 83/86 requirements traced to code (97%). 2 planned (ExoForge scheduling + React dashboard). 1 partial (T-14 Rust attestation verification).**
-**Workspace inventory: 2,955 listed tests across 20 packages and 266 Rust files.**
+**Workspace inventory: 2,966 listed tests across 20 packages and 266 Rust files.**


### PR DESCRIPTION
## Summary
- replace decision-forum workflow receipt, constitution corpus, and fiduciary package raw BLAKE3 concatenation with domain-separated canonical CBOR hashing
- make workflow receipts, constitution corpus construction, and fiduciary package generation/verification fail closed on canonical hash errors
- reject placeholder workflow receipt IDs/timestamps and add regression/source-guard tests
- refresh repo-truth docs to 122375 Rust LOC and 2,966 listed workspace tests

## TDD / Verification
- Red: `cargo test -p decision-forum workflow_receipt_hash_payload_is_domain_separated_cbor --lib -- --nocapture` failed first before canonical payload/domain APIs existed
- Red: `cargo test -p decision-forum corpus_hash_payload_is_domain_separated_cbor --lib -- --nocapture` failed first before corpus payload/domain APIs existed
- Red: `cargo test -p decision-forum fiduciary_package_hash_payload_is_domain_separated_cbor --lib -- --nocapture` failed first before fiduciary payload/domain APIs existed
- Green: focused decision-forum payload, legacy hash, placeholder, article sensitivity, optional-slot, and source-guard tests
- Green: `cargo test -p decision-forum --lib`; `cargo test -p decision-forum`; `cargo build -p decision-forum`; both decision-forum clippy modes
- Green: `bash tools/repo_truth.sh --json`; `bash tools/test_repo_truth.sh`
- Green: `cargo build --workspace`; `cargo test --workspace`; both workspace clippy modes
- Green: `cargo build --workspace --release`; `cargo test --workspace --release`; docs; audit; deny; machete; CR-001/GAP/orphan/Railway guards; fmt; diff check

## Notes
- `docs.zip` remains untracked locally and is not part of this PR.