### PR TITLE
fix(exo-governance): canonicalize audit custody hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 122375 | `wc -l` |
-| Workspace tests | 2,966 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 122665 | `wc -l` |
+| Workspace tests | 2,972 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,966 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,972 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 122375 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 122665 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,966 listed workspace tests
+         cryptographic proofs, 2,972 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-governance/src/audit.rs
+++ b/crates/exo-governance/src/audit.rs
@@ -1,10 +1,26 @@
 //! Governance audit trail — append-only, hash-chained log.
 
-use exo_core::{Did, Hash256, Timestamp};
+use exo_core::{Did, Hash256, Timestamp, hash::hash_structured};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::errors::GovernanceError;
+
+const AUDIT_ENTRY_HASH_DOMAIN: &str = "exo.governance.audit_entry.v1";
+const AUDIT_ENTRY_HASH_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Debug, Clone, Serialize)]
+struct AuditEntryHashPayload {
+    domain: &'static str,
+    schema_version: u16,
+    entry_id: Uuid,
+    timestamp: Timestamp,
+    actor: Did,
+    action: String,
+    result: String,
+    evidence_hash: [u8; 32],
+    chain_hash: [u8; 32],
+}
 
 /// A single entry in the hash-chained audit log, linking to the previous entry via `chain_hash`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -34,9 +50,16 @@ impl AuditLog {
     }
 
     /// Return the hash of the most recent entry, or all-zeros if the log is empty.
-    #[must_use]
-    pub fn head_hash(&self) -> [u8; 32] {
-        self.entries.last().map(hash_entry).unwrap_or([0u8; 32])
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GovernanceError::Serialization`] if canonical CBOR hashing of
+    /// the latest entry fails.
+    pub fn head_hash(&self) -> Result<[u8; 32], GovernanceError> {
+        match self.entries.last() {
+            Some(entry) => hash_entry(entry),
+            None => Ok([0u8; 32]),
+        }
     }
 
     /// Return the number of entries in the audit log.
@@ -51,25 +74,37 @@ impl AuditLog {
     }
 }
 
-fn hash_entry(entry: &AuditEntry) -> [u8; 32] {
-    let mut h = blake3::Hasher::new();
-    h.update(entry.id.as_bytes());
-    h.update(&entry.timestamp.physical_ms.to_le_bytes());
-    h.update(&entry.timestamp.logical.to_le_bytes());
-    h.update(entry.actor.as_str().as_bytes());
-    h.update(entry.action.as_bytes());
-    h.update(entry.result.as_bytes());
-    h.update(&entry.evidence_hash);
-    h.update(&entry.chain_hash);
-    *h.finalize().as_bytes()
+fn audit_entry_hash_payload(entry: &AuditEntry) -> AuditEntryHashPayload {
+    AuditEntryHashPayload {
+        domain: AUDIT_ENTRY_HASH_DOMAIN,
+        schema_version: AUDIT_ENTRY_HASH_SCHEMA_VERSION,
+        entry_id: entry.id,
+        timestamp: entry.timestamp,
+        actor: entry.actor.clone(),
+        action: entry.action.clone(),
+        result: entry.result.clone(),
+        evidence_hash: entry.evidence_hash,
+        chain_hash: entry.chain_hash,
+    }
+}
+
+fn hash_entry(entry: &AuditEntry) -> Result<[u8; 32], GovernanceError> {
+    hash_structured(&audit_entry_hash_payload(entry))
+        .map(|hash| *hash.as_bytes())
+        .map_err(|e| {
+            GovernanceError::Serialization(format!("audit entry canonical CBOR hash failed: {e}"))
+        })
 }
 
 /// Append an entry to the audit log, verifying its chain hash matches the current head.
 pub fn append(log: &mut AuditLog, entry: AuditEntry) -> Result<(), GovernanceError> {
-    let head = log.head_hash();
+    let head = log.head_hash()?;
     if entry.chain_hash != head {
+        let sequence = u64::try_from(log.entries.len()).map_err(|_| {
+            GovernanceError::Serialization("audit log length does not fit u64 sequence".into())
+        })?;
         return Err(GovernanceError::AuditChainBroken {
-            sequence: u64::try_from(log.entries.len()).unwrap_or(u64::MAX),
+            sequence,
             expected: Hash256(head),
             actual: Hash256(entry.chain_hash),
         });
@@ -83,13 +118,16 @@ pub fn verify_chain(log: &AuditLog) -> Result<(), GovernanceError> {
     let mut prev = [0u8; 32];
     for (i, entry) in log.entries.iter().enumerate() {
         if entry.chain_hash != prev {
+            let sequence = u64::try_from(i).map_err(|_| {
+                GovernanceError::Serialization("audit log index does not fit u64 sequence".into())
+            })?;
             return Err(GovernanceError::AuditChainBroken {
-                sequence: u64::try_from(i).unwrap_or(u64::MAX),
+                sequence,
                 expected: Hash256(prev),
                 actual: Hash256(entry.chain_hash),
             });
         }
-        prev = hash_entry(entry);
+        prev = hash_entry(entry)?;
     }
     Ok(())
 }
@@ -124,7 +162,7 @@ pub fn create_entry(
         action,
         result,
         evidence_hash,
-        chain_hash: log.head_hash(),
+        chain_hash: log.head_hash()?,
     })
 }
 
@@ -152,6 +190,71 @@ mod tests {
             .find("#[cfg(test)]")
             .expect("tests marker must exist");
         &source[start..start + end]
+    }
+
+    fn production_source() -> &'static str {
+        let source = include_str!("audit.rs");
+        let end = source
+            .find("#[cfg(test)]")
+            .expect("tests marker must exist");
+        &source[..end]
+    }
+
+    fn sample_entry() -> AuditEntry {
+        AuditEntry {
+            id: entry_id(0xD001),
+            timestamp: Timestamp::new(1000, 7),
+            actor: did("test"),
+            action: "test".into(),
+            result: "ok".into(),
+            evidence_hash: [0x11u8; 32],
+            chain_hash: [0x22u8; 32],
+        }
+    }
+
+    #[test]
+    fn audit_entry_hash_payload_is_domain_separated_cbor() {
+        let entry = sample_entry();
+        let payload = audit_entry_hash_payload(&entry);
+        assert_eq!(payload.domain, AUDIT_ENTRY_HASH_DOMAIN);
+        assert_eq!(payload.schema_version, 1);
+        assert_eq!(payload.entry_id, entry.id);
+        assert_eq!(payload.timestamp, entry.timestamp);
+        assert_eq!(payload.actor, entry.actor);
+        assert_eq!(payload.action, entry.action);
+        assert_eq!(payload.result, entry.result);
+        assert_eq!(payload.evidence_hash, entry.evidence_hash);
+        assert_eq!(payload.chain_hash, entry.chain_hash);
+    }
+
+    #[test]
+    fn audit_entry_hash_rejects_legacy_raw_concat_hash() {
+        let entry = sample_entry();
+        let mut h = blake3::Hasher::new();
+        h.update(entry.id.as_bytes());
+        h.update(&entry.timestamp.physical_ms.to_le_bytes());
+        h.update(&entry.timestamp.logical.to_le_bytes());
+        h.update(entry.actor.as_str().as_bytes());
+        h.update(entry.action.as_bytes());
+        h.update(entry.result.as_bytes());
+        h.update(&entry.evidence_hash);
+        h.update(&entry.chain_hash);
+        let legacy = *h.finalize().as_bytes();
+
+        assert_ne!(hash_entry(&entry).expect("canonical audit hash"), legacy);
+    }
+
+    #[test]
+    fn audit_production_source_has_no_raw_hash_loop() {
+        let production = production_source();
+        assert!(
+            !production.contains("blake3::Hasher"),
+            "governance audit hashes must use domain-separated canonical CBOR"
+        );
+        assert!(
+            !production.contains("unwrap_or([0u8; 32])"),
+            "audit hashing must not hide serialization failures behind a zero hash"
+        );
     }
 
     #[test]
@@ -234,10 +337,10 @@ mod tests {
     #[test]
     fn head_hash_changes() {
         let mut log = AuditLog::new();
-        let h0 = log.head_hash();
+        let h0 = log.head_hash().expect("empty head hash");
         assert_eq!(h0, [0u8; 32]);
         make_and_append(&mut log, "a1");
-        assert_ne!(log.head_hash(), h0);
+        assert_ne!(log.head_hash().expect("head hash"), h0);
     }
     #[test]
     fn deterministic_hash() {
@@ -250,7 +353,10 @@ mod tests {
             evidence_hash: [0u8; 32],
             chain_hash: [0u8; 32],
         };
-        assert_eq!(hash_entry(&e), hash_entry(&e));
+        assert_eq!(
+            hash_entry(&e).expect("first hash"),
+            hash_entry(&e).expect("second hash")
+        );
     }
 
     #[test]

--- a/crates/exo-governance/src/custody.rs
+++ b/crates/exo-governance/src/custody.rs
@@ -6,10 +6,25 @@
 //!
 //! Satisfies: GOV-005 (authority chain), TNC-03 (audit continuity), LEG-001 (business records)
 
-use exo_core::{Did, Hash256, Timestamp};
+use exo_core::{Did, Hash256, Timestamp, hash::hash_structured};
 use serde::{Deserialize, Serialize};
 
 use crate::types::GovernanceSignature;
+
+const CUSTODY_EVENT_HASH_DOMAIN: &str = "exo.governance.custody_event.v1";
+const CUSTODY_EVENT_HASH_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Clone, Debug, Serialize)]
+struct CustodyEventHashPayload {
+    domain: &'static str,
+    schema_version: u16,
+    sequence: u64,
+    record_hash: Hash256,
+    prev_event_hash: Option<Hash256>,
+    actor_id: Did,
+    action: CustodyAction,
+    timestamp: Timestamp,
+}
 
 /// Actions that produce CustodyEvents.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -129,11 +144,11 @@ impl CustodyChain {
         record_hash: Hash256,
         timestamp: Timestamp,
         signature: Option<GovernanceSignature>,
-    ) -> &CustodyEvent {
+    ) -> Result<&CustodyEvent, CustodyChainError> {
         let prev_event_hash = self.events.last().map(|e| e.event_hash);
         let sequence = self.next_sequence;
 
-        // Compute event hash over canonical fields
+        // Compute event hash over canonical fields.
         let event_hash = Self::compute_event_hash(
             sequence,
             &record_hash,
@@ -141,7 +156,7 @@ impl CustodyChain {
             &actor_id,
             &action,
             &timestamp,
-        );
+        )?;
 
         let event = CustodyEvent {
             id: format!("ce-{}-{}", self.decision_id.as_bytes()[0], sequence),
@@ -160,7 +175,7 @@ impl CustodyChain {
         self.events.push(event);
         // SAFETY: we just pushed, so `last()` is guaranteed `Some`.
         // Using indexing instead of `expect` for constitutional lint compliance.
-        &self.events[self.events.len() - 1]
+        Ok(&self.events[self.events.len() - 1])
     }
 
     /// Verify the integrity of the custody chain.
@@ -216,7 +231,7 @@ impl CustodyChain {
                 &event.actor_id,
                 &event.action,
                 &event.timestamp,
-            );
+            )?;
             if recomputed != event.event_hash {
                 return Err(CustodyChainError::HashMismatch {
                     sequence: event.sequence,
@@ -274,10 +289,6 @@ impl CustodyChain {
     }
 
     /// Compute the hash of a custody event from its canonical fields.
-    ///
-    /// Uses blake3 for deterministic hashing. The action is serialized
-    /// via CBOR (through `exo_core::hash::hash_structured`) for canonical
-    /// byte representation.
     fn compute_event_hash(
         sequence: u64,
         record_hash: &Hash256,
@@ -285,22 +296,38 @@ impl CustodyChain {
         actor_id: &Did,
         action: &CustodyAction,
         timestamp: &Timestamp,
-    ) -> Hash256 {
-        let mut hasher = blake3::Hasher::new();
-        hasher.update(&sequence.to_le_bytes());
-        hasher.update(record_hash.as_bytes());
-        if let Some(prev) = prev_event_hash {
-            hasher.update(prev.as_bytes());
-        }
-        hasher.update(actor_id.as_str().as_bytes());
-        // Use CBOR canonical serialization for the action via exo_core
-        let action_hash = exo_core::hash::hash_structured(action).unwrap_or(Hash256::ZERO);
-        hasher.update(action_hash.as_bytes());
-        hasher.update(&timestamp.physical_ms.to_le_bytes());
-        hasher.update(&timestamp.logical.to_le_bytes());
+    ) -> Result<Hash256, CustodyChainError> {
+        hash_structured(&custody_event_hash_payload(
+            sequence,
+            record_hash,
+            prev_event_hash,
+            actor_id,
+            action,
+            timestamp,
+        ))
+        .map_err(|e| CustodyChainError::HashEncodingFailed {
+            reason: format!("custody event canonical CBOR hash failed: {e}"),
+        })
+    }
+}
 
-        let hash = hasher.finalize();
-        Hash256::from_bytes(*hash.as_bytes())
+fn custody_event_hash_payload(
+    sequence: u64,
+    record_hash: &Hash256,
+    prev_event_hash: Option<&Hash256>,
+    actor_id: &Did,
+    action: &CustodyAction,
+    timestamp: &Timestamp,
+) -> CustodyEventHashPayload {
+    CustodyEventHashPayload {
+        domain: CUSTODY_EVENT_HASH_DOMAIN,
+        schema_version: CUSTODY_EVENT_HASH_SCHEMA_VERSION,
+        sequence,
+        record_hash: *record_hash,
+        prev_event_hash: prev_event_hash.copied(),
+        actor_id: actor_id.clone(),
+        action: action.clone(),
+        timestamp: *timestamp,
     }
 }
 
@@ -325,6 +352,8 @@ pub enum CustodyChainError {
         expected: Hash256,
         actual: Hash256,
     },
+    /// Canonical CBOR event hash encoding failed.
+    HashEncodingFailed { reason: String },
 }
 
 impl std::fmt::Display for CustodyChainError {
@@ -342,6 +371,9 @@ impl std::fmt::Display for CustodyChainError {
             }
             Self::HashMismatch { sequence, .. } => {
                 write!(f, "Event hash mismatch at sequence {sequence}")
+            }
+            Self::HashEncodingFailed { reason } => {
+                write!(f, "Custody event hash encoding failed: {reason}")
             }
         }
     }
@@ -365,6 +397,89 @@ mod tests {
         Did::new(&format!("did:exo:{name}")).expect("valid")
     }
 
+    fn production_source() -> &'static str {
+        let source = include_str!("custody.rs");
+        let end = source
+            .find("#[cfg(test)]")
+            .expect("tests marker must exist");
+        &source[..end]
+    }
+
+    #[test]
+    fn custody_event_hash_payload_is_domain_separated_cbor() {
+        let record_hash = Hash256::digest(b"record-v1");
+        let prev_event_hash = Some(Hash256::digest(b"prev-event"));
+        let actor = test_did("alice");
+        let action = CustodyAction::AdvanceStatus {
+            from: "draft".into(),
+            to: "review".into(),
+        };
+        let timestamp = test_ts(1000);
+
+        let payload = custody_event_hash_payload(
+            7,
+            &record_hash,
+            prev_event_hash.as_ref(),
+            &actor,
+            &action,
+            &timestamp,
+        );
+
+        assert_eq!(payload.domain, CUSTODY_EVENT_HASH_DOMAIN);
+        assert_eq!(payload.schema_version, 1);
+        assert_eq!(payload.sequence, 7);
+        assert_eq!(payload.record_hash, record_hash);
+        assert_eq!(payload.prev_event_hash, prev_event_hash);
+        assert_eq!(payload.actor_id, actor);
+        assert_eq!(payload.action, action);
+        assert_eq!(payload.timestamp, timestamp);
+    }
+
+    #[test]
+    fn custody_event_hash_rejects_legacy_raw_concat_hash() {
+        let record_hash = Hash256::digest(b"record-v1");
+        let prev_event_hash = Some(Hash256::digest(b"prev-event"));
+        let actor = test_did("alice");
+        let action = CustodyAction::Approve;
+        let timestamp = test_ts(1000);
+
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(&7u64.to_le_bytes());
+        hasher.update(record_hash.as_bytes());
+        hasher.update(prev_event_hash.as_ref().expect("prev").as_bytes());
+        hasher.update(actor.as_str().as_bytes());
+        let action_hash = exo_core::hash::hash_structured(&action).expect("action hash");
+        hasher.update(action_hash.as_bytes());
+        hasher.update(&timestamp.physical_ms.to_le_bytes());
+        hasher.update(&timestamp.logical.to_le_bytes());
+        let legacy = Hash256::from_bytes(*hasher.finalize().as_bytes());
+
+        let canonical = CustodyChain::compute_event_hash(
+            7,
+            &record_hash,
+            prev_event_hash.as_ref(),
+            &actor,
+            &action,
+            &timestamp,
+        )
+        .expect("canonical custody hash");
+
+        assert_ne!(canonical, legacy);
+    }
+
+    #[test]
+    fn custody_production_source_has_no_raw_hash_loop_or_zero_fallback() {
+        let production = production_source();
+        assert!(
+            !production.contains("blake3::Hasher"),
+            "custody event hashes must use domain-separated canonical CBOR"
+        );
+        assert!(
+            !production.contains("unwrap_or(Hash256::ZERO)"),
+            "custody event hashing must fail closed instead of using a zero hash"
+        );
+    }
+
     #[test]
     fn test_custody_chain_creation() {
         let chain = CustodyChain::new(Hash256::digest(b"decision-1"));
@@ -378,27 +493,31 @@ mod tests {
         let mut chain = CustodyChain::new(Hash256::digest(b"decision-1"));
         let record_hash = Hash256::digest(b"record-v1");
 
-        chain.append(
-            test_did("alice"),
-            CustodyRole::Proposer,
-            CustodyAction::Create,
-            record_hash,
-            test_ts(1000),
-            None,
-        );
+        chain
+            .append(
+                test_did("alice"),
+                CustodyRole::Proposer,
+                CustodyAction::Create,
+                record_hash,
+                test_ts(1000),
+                None,
+            )
+            .expect("append custody event");
 
         assert_eq!(chain.len(), 1);
         assert_eq!(chain.events[0].sequence, 0);
         assert!(chain.events[0].prev_event_hash.is_none());
 
-        chain.append(
-            test_did("bob"),
-            CustodyRole::Reviewer,
-            CustodyAction::Approve,
-            record_hash,
-            test_ts(2000),
-            None,
-        );
+        chain
+            .append(
+                test_did("bob"),
+                CustodyRole::Reviewer,
+                CustodyAction::Approve,
+                record_hash,
+                test_ts(2000),
+                None,
+            )
+            .expect("append custody event");
 
         assert_eq!(chain.len(), 2);
         assert_eq!(chain.events[1].sequence, 1);
@@ -413,32 +532,38 @@ mod tests {
         let mut chain = CustodyChain::new(Hash256::digest(b"decision-1"));
         let record_hash = Hash256::digest(b"record-v1");
 
-        chain.append(
-            test_did("alice"),
-            CustodyRole::Proposer,
-            CustodyAction::Create,
-            record_hash,
-            test_ts(1000),
-            None,
-        );
-        chain.append(
-            test_did("bob"),
-            CustodyRole::Reviewer,
-            CustodyAction::Approve,
-            record_hash,
-            test_ts(2000),
-            None,
-        );
-        chain.append(
-            test_did("carol"),
-            CustodyRole::Steward,
-            CustodyAction::IssueClearance {
-                certificate_id: "cert-1".to_string(),
-            },
-            record_hash,
-            test_ts(3000),
-            None,
-        );
+        chain
+            .append(
+                test_did("alice"),
+                CustodyRole::Proposer,
+                CustodyAction::Create,
+                record_hash,
+                test_ts(1000),
+                None,
+            )
+            .expect("append custody event");
+        chain
+            .append(
+                test_did("bob"),
+                CustodyRole::Reviewer,
+                CustodyAction::Approve,
+                record_hash,
+                test_ts(2000),
+                None,
+            )
+            .expect("append custody event");
+        chain
+            .append(
+                test_did("carol"),
+                CustodyRole::Steward,
+                CustodyAction::IssueClearance {
+                    certificate_id: "cert-1".to_string(),
+                },
+                record_hash,
+                test_ts(3000),
+                None,
+            )
+            .expect("append custody event");
 
         assert!(chain.verify_integrity().is_ok());
     }
@@ -448,22 +573,26 @@ mod tests {
         let mut chain = CustodyChain::new(Hash256::digest(b"decision-1"));
         let record_hash = Hash256::digest(b"record-v1");
 
-        chain.append(
-            test_did("alice"),
-            CustodyRole::Proposer,
-            CustodyAction::Create,
-            record_hash,
-            test_ts(1000),
-            None,
-        );
-        chain.append(
-            test_did("bob"),
-            CustodyRole::Reviewer,
-            CustodyAction::Approve,
-            record_hash,
-            test_ts(2000),
-            None,
-        );
+        chain
+            .append(
+                test_did("alice"),
+                CustodyRole::Proposer,
+                CustodyAction::Create,
+                record_hash,
+                test_ts(1000),
+                None,
+            )
+            .expect("append custody event");
+        chain
+            .append(
+                test_did("bob"),
+                CustodyRole::Reviewer,
+                CustodyAction::Approve,
+                record_hash,
+                test_ts(2000),
+                None,
+            )
+            .expect("append custody event");
 
         // Tamper with the first event's hash
         chain.events[0].event_hash = Hash256::digest(b"tampered");
@@ -475,32 +604,38 @@ mod tests {
         let mut chain = CustodyChain::new(Hash256::digest(b"decision-1"));
         let record_hash = Hash256::digest(b"record-v1");
 
-        chain.append(
-            test_did("alice"),
-            CustodyRole::Proposer,
-            CustodyAction::Create,
-            record_hash,
-            test_ts(1000),
-            None,
-        );
-        chain.append(
-            test_did("bob"),
-            CustodyRole::Reviewer,
-            CustodyAction::Approve,
-            record_hash,
-            test_ts(2000),
-            None,
-        );
-        chain.append(
-            test_did("alice"),
-            CustodyRole::Proposer,
-            CustodyAction::Comment {
-                content: "Updated rationale".to_string(),
-            },
-            record_hash,
-            test_ts(3000),
-            None,
-        );
+        chain
+            .append(
+                test_did("alice"),
+                CustodyRole::Proposer,
+                CustodyAction::Create,
+                record_hash,
+                test_ts(1000),
+                None,
+            )
+            .expect("append custody event");
+        chain
+            .append(
+                test_did("bob"),
+                CustodyRole::Reviewer,
+                CustodyAction::Approve,
+                record_hash,
+                test_ts(2000),
+                None,
+            )
+            .expect("append custody event");
+        chain
+            .append(
+                test_did("alice"),
+                CustodyRole::Proposer,
+                CustodyAction::Comment {
+                    content: "Updated rationale".to_string(),
+                },
+                record_hash,
+                test_ts(3000),
+                None,
+            )
+            .expect("append custody event");
 
         let alice_events = chain.events_by_actor("did:exo:alice");
         assert_eq!(alice_events.len(), 2);
@@ -511,40 +646,48 @@ mod tests {
         let mut chain = CustodyChain::new(Hash256::digest(b"decision-1"));
         let record_hash = Hash256::digest(b"record-v1");
 
-        chain.append(
-            test_did("alice"),
-            CustodyRole::Proposer,
-            CustodyAction::Create,
-            record_hash,
-            test_ts(1000),
-            None,
-        );
-        chain.append(
-            test_did("bob"),
-            CustodyRole::Reviewer,
-            CustodyAction::Approve,
-            record_hash,
-            test_ts(2000),
-            None,
-        );
-        chain.append(
-            test_did("carol"),
-            CustodyRole::Reviewer,
-            CustodyAction::Reject,
-            record_hash,
-            test_ts(3000),
-            None,
-        );
-        chain.append(
-            test_did("dave"),
-            CustodyRole::Observer,
-            CustodyAction::Comment {
-                content: "I agree with Carol".to_string(),
-            },
-            record_hash,
-            test_ts(4000),
-            None,
-        );
+        chain
+            .append(
+                test_did("alice"),
+                CustodyRole::Proposer,
+                CustodyAction::Create,
+                record_hash,
+                test_ts(1000),
+                None,
+            )
+            .expect("append custody event");
+        chain
+            .append(
+                test_did("bob"),
+                CustodyRole::Reviewer,
+                CustodyAction::Approve,
+                record_hash,
+                test_ts(2000),
+                None,
+            )
+            .expect("append custody event");
+        chain
+            .append(
+                test_did("carol"),
+                CustodyRole::Reviewer,
+                CustodyAction::Reject,
+                record_hash,
+                test_ts(3000),
+                None,
+            )
+            .expect("append custody event");
+        chain
+            .append(
+                test_did("dave"),
+                CustodyRole::Observer,
+                CustodyAction::Comment {
+                    content: "I agree with Carol".to_string(),
+                },
+                record_hash,
+                test_ts(4000),
+                None,
+            )
+            .expect("append custody event");
 
         let attestations = chain.attestations();
         assert_eq!(attestations.len(), 2); // Approve + Reject
@@ -555,18 +698,20 @@ mod tests {
         let mut chain = CustodyChain::new(Hash256::digest(b"decision-1"));
         let record_hash = Hash256::digest(b"record-v1");
 
-        chain.append(
-            test_did("ai-assistant"),
-            CustodyRole::AiAgent {
-                delegation_id: Hash256::digest(b"delegation-001"),
-            },
-            CustodyAction::Comment {
-                content: "Automated analysis complete".to_string(),
-            },
-            record_hash,
-            test_ts(1000),
-            None,
-        );
+        chain
+            .append(
+                test_did("ai-assistant"),
+                CustodyRole::AiAgent {
+                    delegation_id: Hash256::digest(b"delegation-001"),
+                },
+                CustodyAction::Comment {
+                    content: "Automated analysis complete".to_string(),
+                },
+                record_hash,
+                test_ts(1000),
+                None,
+            )
+            .expect("append custody event");
 
         assert_eq!(chain.len(), 1);
         assert!(matches!(chain.events[0].role, CustodyRole::AiAgent { .. }));
@@ -577,16 +722,18 @@ mod tests {
         let mut chain = CustodyChain::new(Hash256::digest(b"decision-1"));
         let record_hash = Hash256::digest(b"record-v1");
 
-        chain.append(
-            test_did("steward"),
-            CustodyRole::Steward,
-            CustodyAction::EmergencyAction {
-                reason: "Security breach detected".to_string(),
-            },
-            record_hash,
-            test_ts(1000),
-            None,
-        );
+        chain
+            .append(
+                test_did("steward"),
+                CustodyRole::Steward,
+                CustodyAction::EmergencyAction {
+                    reason: "Security breach detected".to_string(),
+                },
+                record_hash,
+                test_ts(1000),
+                None,
+            )
+            .expect("append custody event");
 
         assert!(chain.verify_integrity().is_ok());
     }
@@ -609,14 +756,16 @@ mod tests {
     fn test_latest_and_is_empty_after_append() {
         let mut chain = CustodyChain::new(Hash256::digest(b"decision-latest"));
         let record_hash = Hash256::digest(b"record-v1");
-        chain.append(
-            test_did("alice"),
-            CustodyRole::Proposer,
-            CustodyAction::Create,
-            record_hash,
-            test_ts(1000),
-            None,
-        );
+        chain
+            .append(
+                test_did("alice"),
+                CustodyRole::Proposer,
+                CustodyAction::Create,
+                record_hash,
+                test_ts(1000),
+                None,
+            )
+            .expect("append custody event");
         assert!(!chain.is_empty());
         let latest = chain.latest().expect("non-empty");
         assert_eq!(latest.sequence, 0);
@@ -629,14 +778,16 @@ mod tests {
         let mut chain = CustodyChain::new(Hash256::digest(b"decision-sig"));
         let record_hash = Hash256::digest(b"record-v1");
         let sig = test_signature();
-        chain.append(
-            test_did("alice"),
-            CustodyRole::Proposer,
-            CustodyAction::Create,
-            record_hash,
-            test_ts(1000),
-            Some(sig.clone()),
-        );
+        chain
+            .append(
+                test_did("alice"),
+                CustodyRole::Proposer,
+                CustodyAction::Create,
+                record_hash,
+                test_ts(1000),
+                Some(sig.clone()),
+            )
+            .expect("append custody event");
         let stored = chain.events[0]
             .signature
             .as_ref()
@@ -650,14 +801,16 @@ mod tests {
     fn test_append_returns_last_event_reference() {
         let mut chain = CustodyChain::new(Hash256::digest(b"decision-ret"));
         let record_hash = Hash256::digest(b"record-v1");
-        let ev = chain.append(
-            test_did("alice"),
-            CustodyRole::Proposer,
-            CustodyAction::Create,
-            record_hash,
-            test_ts(1000),
-            None,
-        );
+        let ev = chain
+            .append(
+                test_did("alice"),
+                CustodyRole::Proposer,
+                CustodyAction::Create,
+                record_hash,
+                test_ts(1000),
+                None,
+            )
+            .expect("append custody event");
         assert_eq!(ev.sequence, 0);
         assert!(ev.prev_event_hash.is_none());
         let id = ev.id.clone();
@@ -668,14 +821,16 @@ mod tests {
     #[test]
     fn test_verify_integrity_invalid_genesis_link() {
         let mut chain = CustodyChain::new(Hash256::digest(b"decision-ig"));
-        chain.append(
-            test_did("alice"),
-            CustodyRole::Proposer,
-            CustodyAction::Create,
-            Hash256::digest(b"r"),
-            test_ts(1000),
-            None,
-        );
+        chain
+            .append(
+                test_did("alice"),
+                CustodyRole::Proposer,
+                CustodyAction::Create,
+                Hash256::digest(b"r"),
+                test_ts(1000),
+                None,
+            )
+            .expect("append custody event");
         chain.events[0].prev_event_hash = Some(Hash256::digest(b"unexpected"));
         let err = chain.verify_integrity().expect_err("must be error");
         assert!(matches!(err, CustodyChainError::InvalidGenesisLink));
@@ -686,22 +841,26 @@ mod tests {
     fn test_verify_integrity_broken_link() {
         let mut chain = CustodyChain::new(Hash256::digest(b"decision-bl"));
         let record_hash = Hash256::digest(b"r");
-        chain.append(
-            test_did("alice"),
-            CustodyRole::Proposer,
-            CustodyAction::Create,
-            record_hash,
-            test_ts(1000),
-            None,
-        );
-        chain.append(
-            test_did("bob"),
-            CustodyRole::Reviewer,
-            CustodyAction::Approve,
-            record_hash,
-            test_ts(2000),
-            None,
-        );
+        chain
+            .append(
+                test_did("alice"),
+                CustodyRole::Proposer,
+                CustodyAction::Create,
+                record_hash,
+                test_ts(1000),
+                None,
+            )
+            .expect("append custody event");
+        chain
+            .append(
+                test_did("bob"),
+                CustodyRole::Reviewer,
+                CustodyAction::Approve,
+                record_hash,
+                test_ts(2000),
+                None,
+            )
+            .expect("append custody event");
         let bogus = Hash256::digest(b"bogus-prev");
         chain.events[1].prev_event_hash = Some(bogus);
         let err = chain.verify_integrity().expect_err("must be error");
@@ -721,22 +880,26 @@ mod tests {
     fn test_verify_integrity_missing_link() {
         let mut chain = CustodyChain::new(Hash256::digest(b"decision-ml"));
         let record_hash = Hash256::digest(b"r");
-        chain.append(
-            test_did("alice"),
-            CustodyRole::Proposer,
-            CustodyAction::Create,
-            record_hash,
-            test_ts(1000),
-            None,
-        );
-        chain.append(
-            test_did("bob"),
-            CustodyRole::Reviewer,
-            CustodyAction::Approve,
-            record_hash,
-            test_ts(2000),
-            None,
-        );
+        chain
+            .append(
+                test_did("alice"),
+                CustodyRole::Proposer,
+                CustodyAction::Create,
+                record_hash,
+                test_ts(1000),
+                None,
+            )
+            .expect("append custody event");
+        chain
+            .append(
+                test_did("bob"),
+                CustodyRole::Reviewer,
+                CustodyAction::Approve,
+                record_hash,
+                test_ts(2000),
+                None,
+            )
+            .expect("append custody event");
         chain.events[1].prev_event_hash = None;
         let err = chain.verify_integrity().expect_err("must be error");
         assert!(matches!(
@@ -750,14 +913,16 @@ mod tests {
     fn test_verify_integrity_sequence_gap() {
         let mut chain = CustodyChain::new(Hash256::digest(b"decision-sg"));
         let record_hash = Hash256::digest(b"r");
-        chain.append(
-            test_did("alice"),
-            CustodyRole::Proposer,
-            CustodyAction::Create,
-            record_hash,
-            test_ts(1000),
-            None,
-        );
+        chain
+            .append(
+                test_did("alice"),
+                CustodyRole::Proposer,
+                CustodyAction::Create,
+                record_hash,
+                test_ts(1000),
+                None,
+            )
+            .expect("append custody event");
         chain.events[0].sequence = 99;
         let err = chain.verify_integrity().expect_err("must be error");
         match err {
@@ -774,14 +939,16 @@ mod tests {
     fn test_verify_integrity_hash_mismatch_variant() {
         let mut chain = CustodyChain::new(Hash256::digest(b"decision-hm"));
         let record_hash = Hash256::digest(b"r");
-        chain.append(
-            test_did("alice"),
-            CustodyRole::Proposer,
-            CustodyAction::Create,
-            record_hash,
-            test_ts(1000),
-            None,
-        );
+        chain
+            .append(
+                test_did("alice"),
+                CustodyRole::Proposer,
+                CustodyAction::Create,
+                record_hash,
+                test_ts(1000),
+                None,
+            )
+            .expect("append custody event");
         let tampered = Hash256::digest(b"tampered");
         chain.events[0].event_hash = tampered;
         let err = chain.verify_integrity().expect_err("must be error");
@@ -848,22 +1015,26 @@ mod tests {
         bytes[0] = 0x2a;
         let decision_id = Hash256::from_bytes(bytes);
         let mut chain = CustodyChain::new(decision_id);
-        chain.append(
-            test_did("alice"),
-            CustodyRole::Proposer,
-            CustodyAction::Create,
-            Hash256::digest(b"r"),
-            test_ts(1000),
-            None,
-        );
-        chain.append(
-            test_did("bob"),
-            CustodyRole::Reviewer,
-            CustodyAction::Approve,
-            Hash256::digest(b"r"),
-            test_ts(2000),
-            None,
-        );
+        chain
+            .append(
+                test_did("alice"),
+                CustodyRole::Proposer,
+                CustodyAction::Create,
+                Hash256::digest(b"r"),
+                test_ts(1000),
+                None,
+            )
+            .expect("append custody event");
+        chain
+            .append(
+                test_did("bob"),
+                CustodyRole::Reviewer,
+                CustodyAction::Approve,
+                Hash256::digest(b"r"),
+                test_ts(2000),
+                None,
+            )
+            .expect("append custody event");
         assert_eq!(chain.events[0].id, "ce-42-0");
         assert_eq!(chain.events[1].id, "ce-42-1");
     }
@@ -874,14 +1045,16 @@ mod tests {
         let mut chain = CustodyChain::new(Hash256::digest(b"decision-mono"));
         assert_eq!(chain.next_sequence, 0);
         for i in 0..3 {
-            chain.append(
-                test_did("alice"),
-                CustodyRole::Proposer,
-                CustodyAction::Create,
-                Hash256::digest(b"r"),
-                test_ts(1000 + i),
-                None,
-            );
+            chain
+                .append(
+                    test_did("alice"),
+                    CustodyRole::Proposer,
+                    CustodyAction::Create,
+                    Hash256::digest(b"r"),
+                    test_ts(1000 + i),
+                    None,
+                )
+                .expect("append custody event");
         }
         assert_eq!(chain.next_sequence, 3);
         assert_eq!(chain.len(), 3);
@@ -891,22 +1064,26 @@ mod tests {
     #[test]
     fn test_events_by_actor_nonmatching_filtered_out() {
         let mut chain = CustodyChain::new(Hash256::digest(b"decision-filter"));
-        chain.append(
-            test_did("alice"),
-            CustodyRole::Proposer,
-            CustodyAction::Create,
-            Hash256::digest(b"r"),
-            test_ts(1000),
-            None,
-        );
-        chain.append(
-            test_did("bob"),
-            CustodyRole::Reviewer,
-            CustodyAction::Approve,
-            Hash256::digest(b"r"),
-            test_ts(2000),
-            None,
-        );
+        chain
+            .append(
+                test_did("alice"),
+                CustodyRole::Proposer,
+                CustodyAction::Create,
+                Hash256::digest(b"r"),
+                test_ts(1000),
+                None,
+            )
+            .expect("append custody event");
+        chain
+            .append(
+                test_did("bob"),
+                CustodyRole::Reviewer,
+                CustodyAction::Approve,
+                Hash256::digest(b"r"),
+                test_ts(2000),
+                None,
+            )
+            .expect("append custody event");
         assert!(chain.events_by_actor("did:exo:charlie").is_empty());
         let bobs = chain.events_by_actor("did:exo:bob");
         assert_eq!(bobs.len(), 1);
@@ -930,14 +1107,16 @@ mod tests {
         .into_iter()
         .enumerate()
         {
-            chain.append(
-                test_did("alice"),
-                CustodyRole::Reviewer,
-                action,
-                r,
-                test_ts(1000 + u64::try_from(i).expect("small")),
-                None,
-            );
+            chain
+                .append(
+                    test_did("alice"),
+                    CustodyRole::Reviewer,
+                    action,
+                    r,
+                    test_ts(1000 + u64::try_from(i).expect("small")),
+                    None,
+                )
+                .expect("append custody event");
         }
         let atts = chain.attestations();
         assert_eq!(atts.len(), 4);
@@ -977,19 +1156,21 @@ mod tests {
     #[test]
     fn test_custody_chain_serde_roundtrip() {
         let mut chain = CustodyChain::new(Hash256::digest(b"decision-serde"));
-        chain.append(
-            test_did("alice"),
-            CustodyRole::AiAgent {
-                delegation_id: Hash256::digest(b"d"),
-            },
-            CustodyAction::Custom {
-                action: "sign-off".to_string(),
-                metadata: Some("ok".to_string()),
-            },
-            Hash256::digest(b"r"),
-            test_ts(1000),
-            None,
-        );
+        chain
+            .append(
+                test_did("alice"),
+                CustodyRole::AiAgent {
+                    delegation_id: Hash256::digest(b"d"),
+                },
+                CustodyAction::Custom {
+                    action: "sign-off".to_string(),
+                    metadata: Some("ok".to_string()),
+                },
+                Hash256::digest(b"r"),
+                test_ts(1000),
+                None,
+            )
+            .expect("append custody event");
         let json = serde_json::to_string(&chain).expect("serialize");
         let decoded: CustodyChain = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(decoded.events.len(), 1);

--- a/crates/exochain-wasm/src/governance_bindings.rs
+++ b/crates/exochain-wasm/src/governance_bindings.rs
@@ -141,10 +141,13 @@ pub fn wasm_audit_append(
     .map_err(|e| JsValue::from_str(&format!("Audit error: {e}")))?;
     exo_governance::audit::append(&mut log, entry)
         .map_err(|e| JsValue::from_str(&format!("Audit error: {e}")))?;
+    let head_hash = log
+        .head_hash()
+        .map_err(|e| JsValue::from_str(&format!("Audit error: {e}")))?;
     // AuditLog doesn't derive Serialize, return summary
     to_js_value(&serde_json::json!({
         "entries": log.len(),
-        "head_hash": hex::encode(log.head_hash()),
+        "head_hash": hex::encode(head_hash),
     }))
 }
 

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 122375 lines of Rust under `crates/`, 2,966 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 122665 lines of Rust under `crates/`, 2,972 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,966 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,972 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,966 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,972 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-122375 lines of Rust under `crates/` · 20 workspace packages · 2,966 listed tests · 40 MCP tools · 8 constitutional invariants
+122665 lines of Rust under `crates/` · 20 workspace packages · 2,972 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 122375 lines of Rust under `crates/` | 266 Rust source files | 2,966 listed tests
+> **Codebase:** 20 workspace packages | 122665 lines of Rust under `crates/` | 266 Rust source files | 2,972 listed tests
 
 ---
 

--- a/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
+++ b/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
@@ -46,9 +46,9 @@ decision.forum is a constitutional trust fabric for AI-era governance. Not a fra
 
 The numbers, verified as of this writing:
 
-- **122375 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
+- **122665 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
 - **20 workspace packages** covering identity, consent, authority, governance, escalation, legal infrastructure, cryptographic proofs, and more
-- **2,966 listed tests** exercised by the workspace test gate.
+- **2,972 listed tests** exercised by the workspace test gate.
 - **10 formal proofs** demonstrating that constitutional properties hold under all reachable system states
 - Built and reviewed through a **5-panel council process** (Governance, Legal, Architecture, Security, Operations)
 
@@ -270,7 +270,7 @@ The question is whether we will build it before we need it.
 
 *Bob Stewart is the architect of EXOCHAIN and decision.forum, and the author of The ASI Report on LinkedIn, where he writes about the infrastructure required for safe superintelligence. His work focuses on the intersection of constitutional governance, cryptographic enforcement, and AI safety -- the premise that alignment is necessary but insufficient, and that enforceable structural constraints are the missing complement.*
 
-*The EXOCHAIN workspace -- 122375 lines of Rust under `crates/`, 20 packages, 2,966 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
+*The EXOCHAIN workspace -- 122665 lines of Rust under `crates/`, 20 packages, 2,972 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
 
 ---
 

--- a/docs/decision-forum/SYSTEM-DOCUMENTATION.md
+++ b/docs/decision-forum/SYSTEM-DOCUMENTATION.md
@@ -6,7 +6,7 @@ created: 2026-03-19
 publication: "The ASI Report — LinkedIn Newsletter"
 tags: [decision-forum, governance, constitutional, asi-safety, exochain]
 status: publication-ready
-codebase: "20 workspace packages | 122375 LOC Rust under crates/ | 266 source files | 2,966 listed tests"
+codebase: "20 workspace packages | 122665 LOC Rust under crates/ | 266 source files | 2,972 listed tests"
 ---
 
 # decision.forum — System Documentation
@@ -20,9 +20,9 @@ This document is the exhaustive technical reference for the decision.forum gover
 | Metric | Value |
 |--------|-------|
 | Workspace packages | 20 |
-| Rust LOC under `crates/` | 122375 |
+| Rust LOC under `crates/` | 122665 |
 | Rust source files | 273 |
-| Listed workspace tests | 2,966 |
+| Listed workspace tests | 2,972 |
 | Test gate | `cargo test --workspace` in CI Gate 2 |
 | decision-forum crate LOC | 3,800 |
 | decision-forum tests | 131 |

--- a/docs/guides/GETTING-STARTED.md
+++ b/docs/guides/GETTING-STARTED.md
@@ -124,7 +124,7 @@ open tarpaulin-report.html
 ```
 
 A clean build produces zero errors and zero warnings. The current workspace
-inventory lists 2,966 tests; the exact executed count can change as doctests and
+inventory lists 2,972 tests; the exact executed count can change as doctests and
 integration targets evolve. What matters is zero failures:
 
 ```

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,966 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,972 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 122375 lines of Rust under `crates/` · 2,966 listed tests
+20 workspace packages · 122665 lines of Rust under `crates/` · 2,972 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 

--- a/governance/EXOCHAIN-REFACTOR-PLAN.md
+++ b/governance/EXOCHAIN-REFACTOR-PLAN.md
@@ -68,7 +68,7 @@ All refactor work flows through the Syntaxis Builder system:
 - [ ] Complete Section 8 work orders from CR-001
 - [ ] Achieve release-blocking acceptance standard (CR-001 Section 9)
 
-> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 122375 Rust LOC under `crates/`, 2,966 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
+> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 122665 Rust LOC under `crates/`, 2,972 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
 
 ## Active Resolutions
 

--- a/governance/sub_agents.md
+++ b/governance/sub_agents.md
@@ -72,7 +72,7 @@ Historical 2026-03-19 sub-agent completion record. Numeric status claims are sup
 * **Inputs**: Spec Section 16 (Acceptance Criteria).
 * **Outputs**: Test harnesses, Integration tests, Fuzz targets.
 * **Definition of Done**: Section 16 Acceptance Criteria are automated and passing.
-* **Status**: **DONE** — Current workspace inventory lists 2,966 tests across 20 packages and 266 Rust files.
+* **Status**: **DONE** — Current workspace inventory lists 2,972 tests across 20 packages and 266 Rust files.
 
 ## J) DEVOPS_RELEASE_AGENT (Judicial) — DONE
 

--- a/governance/traceability_matrix.md
+++ b/governance/traceability_matrix.md
@@ -163,4 +163,4 @@ Updated 2026-03-20 after EXOCHAIN-REM-009 — continuous governance monitoring a
 | **TOTAL** | **86** | **83** | **1** | **2** |
 
 **Coverage: 83/86 requirements traced to code (97%). 2 planned (ExoForge scheduling + React dashboard). 1 partial (T-14 Rust attestation verification).**
-**Workspace inventory: 2,966 listed tests across 20 packages and 266 Rust files.**
+**Workspace inventory: 2,972 listed tests across 20 packages and 266 Rust files.**


### PR DESCRIPTION
## Summary
- replace exo-governance audit entry and custody event raw BLAKE3 hash loops with domain-separated canonical CBOR payload hashing
- make audit/custody hash-chain operations fail closed on canonical encoding errors, including WASM audit binding fallout
- add TDD regressions for canonical payloads, legacy raw-concat rejection, raw hash-loop source guards, and zero-hash fallback removal
- refresh repo-truth counts to 122665 Rust LOC and 2,972 listed workspace tests

## Verification
- cargo test -p exo-governance audit_entry_hash_payload_is_domain_separated_cbor --lib -- --nocapture
- cargo test -p exo-governance custody_event_hash_payload_is_domain_separated_cbor --lib -- --nocapture
- cargo test -p exo-governance raw_concat_hash --lib -- --nocapture
- cargo test -p exo-governance raw_hash_loop --lib -- --nocapture
- cargo test -p exo-governance --lib
- cargo test -p exo-governance
- cargo build -p exo-governance
- cargo test -p exochain-wasm
- cargo clippy -p exo-governance --lib -- -D warnings
- cargo clippy -p exochain-wasm --lib -- -D warnings
- cargo clippy -p exo-governance --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo clippy -p exochain-wasm --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo fmt --all -- --check
- git diff --check
- bash tools/repo_truth.sh --json
- bash tools/test_repo_truth.sh
- bash tools/test_cr001_status.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_no_orphan_rust_modules.sh
- bash tools/test_railway_entrypoint_args.sh
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo build --workspace --release
- cargo test --workspace --release
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
- cargo audit
- cargo deny check
- cargo machete --with-metadata