### PR TITLE
fix(exo-gatekeeper): canonicalize MCP audit hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 122665 | `wc -l` |
-| Workspace tests | 2,972 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 122789 | `wc -l` |
+| Workspace tests | 2,975 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,972 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,975 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 122665 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 122789 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,972 listed workspace tests
+         cryptographic proofs, 2,975 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-gatekeeper/src/error.rs
+++ b/crates/exo-gatekeeper/src/error.rs
@@ -40,6 +40,9 @@ pub enum GatekeeperError {
 
     #[error("MCP audit record invalid: {reason}")]
     McpAuditInvalidRecord { reason: String },
+
+    #[error("MCP audit hash encoding failed: {reason}")]
+    McpAuditHashEncodingFailed { reason: String },
 }
 
 impl From<exo_core::ExoError> for GatekeeperError {
@@ -76,6 +79,12 @@ mod tests {
                     reason: "missing deterministic metadata".into(),
                 },
                 "missing deterministic metadata",
+            ),
+            (
+                GatekeeperError::McpAuditHashEncodingFailed {
+                    reason: "canonical CBOR failed".into(),
+                },
+                "canonical CBOR failed",
             ),
         ];
         for (err, fragment) in cases {

--- a/crates/exo-gatekeeper/src/mcp_audit.rs
+++ b/crates/exo-gatekeeper/src/mcp_audit.rs
@@ -9,11 +9,27 @@
 //! typed enum rather than a plain `String` prevents injection of fabricated
 //! rule identifiers into the tamper-evident chain.
 
-use exo_core::{Did, Timestamp};
+use exo_core::{Did, Timestamp, hash::hash_structured};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{error::GatekeeperError, mcp::McpRule};
+
+const MCP_AUDIT_RECORD_HASH_DOMAIN: &str = "exo.gatekeeper.mcp_audit_record.v1";
+const MCP_AUDIT_RECORD_HASH_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Debug, Clone, Serialize)]
+struct McpAuditRecordHashPayload {
+    domain: &'static str,
+    schema_version: u16,
+    record_id: Uuid,
+    timestamp: Timestamp,
+    rule: McpRule,
+    actor: Did,
+    outcome: McpEnforcementOutcome,
+    data_residency_region: Option<String>,
+    chain_hash: [u8; 32],
+}
 
 // ---------------------------------------------------------------------------
 // Enforcement outcome
@@ -60,20 +76,26 @@ pub struct McpAuditRecord {
 // Hash function
 // ---------------------------------------------------------------------------
 
-fn hash_record(r: &McpAuditRecord) -> [u8; 32] {
-    let mut h = blake3::Hasher::new();
-    h.update(r.id.as_bytes());
-    h.update(&r.timestamp.physical_ms.to_le_bytes());
-    h.update(&r.timestamp.logical.to_le_bytes());
-    // Rule is hashed via its debug representation for determinism.
-    h.update(format!("{:?}", r.rule).as_bytes());
-    h.update(r.actor.as_str().as_bytes());
-    h.update(format!("{:?}", r.outcome).as_bytes());
-    if let Some(region) = &r.data_residency_region {
-        h.update(region.as_bytes());
+fn mcp_audit_record_hash_payload(r: &McpAuditRecord) -> McpAuditRecordHashPayload {
+    McpAuditRecordHashPayload {
+        domain: MCP_AUDIT_RECORD_HASH_DOMAIN,
+        schema_version: MCP_AUDIT_RECORD_HASH_SCHEMA_VERSION,
+        record_id: r.id,
+        timestamp: r.timestamp,
+        rule: r.rule,
+        actor: r.actor.clone(),
+        outcome: r.outcome,
+        data_residency_region: r.data_residency_region.clone(),
+        chain_hash: r.chain_hash,
     }
-    h.update(&r.chain_hash);
-    *h.finalize().as_bytes()
+}
+
+fn hash_record(r: &McpAuditRecord) -> Result<[u8; 32], GatekeeperError> {
+    hash_structured(&mcp_audit_record_hash_payload(r))
+        .map(|hash| *hash.as_bytes())
+        .map_err(|e| GatekeeperError::McpAuditHashEncodingFailed {
+            reason: format!("MCP audit record canonical CBOR hash failed: {e}"),
+        })
 }
 
 // ---------------------------------------------------------------------------
@@ -96,9 +118,16 @@ impl McpAuditLog {
     }
 
     /// Hash of the last record; `[0u8; 32]` for an empty log.
-    #[must_use]
-    pub fn head_hash(&self) -> [u8; 32] {
-        self.records.last().map(hash_record).unwrap_or([0u8; 32])
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GatekeeperError::McpAuditHashEncodingFailed`] if canonical
+    /// CBOR hashing of the latest record fails.
+    pub fn head_hash(&self) -> Result<[u8; 32], GatekeeperError> {
+        match self.records.last() {
+            Some(record) => hash_record(record),
+            None => Ok([0u8; 32]),
+        }
     }
 
     #[must_use]
@@ -119,7 +148,7 @@ impl McpAuditLog {
 /// does not match the current log head — indicating either an ordering error
 /// or tampering.
 pub fn append(log: &mut McpAuditLog, record: McpAuditRecord) -> Result<(), GatekeeperError> {
-    if record.chain_hash != log.head_hash() {
+    if record.chain_hash != log.head_hash()? {
         return Err(GatekeeperError::McpAuditChainBroken {
             index: log.records.len(),
         });
@@ -138,7 +167,7 @@ pub fn verify_chain(log: &McpAuditLog) -> Result<(), GatekeeperError> {
         if record.chain_hash != prev {
             return Err(GatekeeperError::McpAuditChainBroken { index: i });
         }
-        prev = hash_record(record);
+        prev = hash_record(record)?;
     }
     Ok(())
 }
@@ -171,7 +200,7 @@ pub fn create_record(
         actor,
         outcome,
         data_residency_region,
-        chain_hash: log.head_hash(),
+        chain_hash: log.head_hash()?,
     })
 }
 
@@ -207,6 +236,80 @@ mod tests {
             .find("// ===========================================================================")
             .expect("tests section marker must exist");
         &source[start..start + end]
+    }
+
+    fn production_source() -> &'static str {
+        let source = include_str!("mcp_audit.rs");
+        let end = source
+            .find("// ===========================================================================")
+            .expect("tests section marker must exist");
+        &source[..end]
+    }
+
+    fn sample_record() -> McpAuditRecord {
+        McpAuditRecord {
+            id: record_id(0xD001),
+            timestamp: Timestamp::new(1000, 4),
+            rule: McpRule::Mcp003ProvenanceRequired,
+            actor: did("agent"),
+            outcome: McpEnforcementOutcome::Blocked,
+            data_residency_region: Some("EU-WEST-1".into()),
+            chain_hash: [0x22u8; 32],
+        }
+    }
+
+    #[test]
+    fn mcp_audit_record_hash_payload_is_domain_separated_cbor() {
+        let record = sample_record();
+        let payload = mcp_audit_record_hash_payload(&record);
+        assert_eq!(payload.domain, MCP_AUDIT_RECORD_HASH_DOMAIN);
+        assert_eq!(payload.schema_version, 1);
+        assert_eq!(payload.record_id, record.id);
+        assert_eq!(payload.timestamp, record.timestamp);
+        assert_eq!(payload.rule, record.rule);
+        assert_eq!(payload.actor, record.actor);
+        assert_eq!(payload.outcome, record.outcome);
+        assert_eq!(payload.data_residency_region, record.data_residency_region);
+        assert_eq!(payload.chain_hash, record.chain_hash);
+    }
+
+    #[test]
+    fn mcp_audit_record_hash_rejects_legacy_debug_concat_hash() {
+        let record = sample_record();
+        let mut h = blake3::Hasher::new();
+        h.update(record.id.as_bytes());
+        h.update(&record.timestamp.physical_ms.to_le_bytes());
+        h.update(&record.timestamp.logical.to_le_bytes());
+        h.update(format!("{:?}", record.rule).as_bytes());
+        h.update(record.actor.as_str().as_bytes());
+        h.update(format!("{:?}", record.outcome).as_bytes());
+        if let Some(region) = &record.data_residency_region {
+            h.update(region.as_bytes());
+        }
+        h.update(&record.chain_hash);
+        let legacy = *h.finalize().as_bytes();
+
+        assert_ne!(
+            hash_record(&record).expect("canonical MCP audit hash"),
+            legacy
+        );
+    }
+
+    #[test]
+    fn mcp_audit_production_source_has_no_raw_hash_loop_or_debug_string_hashing() {
+        let production = production_source();
+        assert!(
+            !production.contains("blake3::Hasher"),
+            "MCP audit hashes must use domain-separated canonical CBOR"
+        );
+        assert!(
+            !production.contains("format!(\"{:?}\""),
+            "MCP audit hashes must not bind rule/outcome through debug strings"
+        );
+        assert!(
+            !production.contains("unwrap_or([0u8; 32])"),
+            "MCP audit hashing must not hide hash failures behind a zero hash"
+        );
     }
 
     #[test]
@@ -300,14 +403,14 @@ mod tests {
     #[test]
     fn head_hash_changes_on_append() {
         let mut log = McpAuditLog::new();
-        let h0 = log.head_hash();
+        let h0 = log.head_hash().expect("empty MCP audit head hash");
         assert_eq!(h0, [0u8; 32]);
         append_ok(
             &mut log,
             McpRule::Mcp003ProvenanceRequired,
             McpEnforcementOutcome::Allowed,
         );
-        assert_ne!(log.head_hash(), h0);
+        assert_ne!(log.head_hash().expect("MCP audit head hash"), h0);
     }
 
     #[test]
@@ -321,7 +424,10 @@ mod tests {
             data_residency_region: None,
             chain_hash: [0u8; 32],
         };
-        assert_eq!(hash_record(&r), hash_record(&r));
+        assert_eq!(
+            hash_record(&r).expect("first MCP audit record hash"),
+            hash_record(&r).expect("second MCP audit record hash")
+        );
     }
 
     #[test]

--- a/crates/exo-legal/src/ai_transparency.rs
+++ b/crates/exo-legal/src/ai_transparency.rs
@@ -222,6 +222,12 @@ pub fn generate_report(params: ReportParams<'_>) -> Result<AiTransparencyReport>
 
     // Aggregate MCP rule outcomes.
     let mcp_rule_outcomes = aggregate_mcp_outcomes(mcp_log, period_start, period_end);
+    let mcp_audit_head_hash =
+        mcp_log
+            .head_hash()
+            .map_err(|e| LegalError::InvalidStateTransition {
+                reason: format!("MCP audit head hash failed before transparency report: {e}"),
+            })?;
 
     Ok(AiTransparencyReport {
         tenant_id: tenant_id.clone(),
@@ -238,7 +244,7 @@ pub fn generate_report(params: ReportParams<'_>) -> Result<AiTransparencyReport>
             .map(|revocation| revocation.event().clone())
             .collect(),
         mcp_rule_outcomes,
-        mcp_audit_head_hash: mcp_log.head_hash(),
+        mcp_audit_head_hash,
         authority_clearance: authority_clearance.evidence().clone(),
     })
 }
@@ -909,7 +915,10 @@ mod tests {
         assert_eq!(report.ai_agent_action_count, 2);
         assert_eq!(report.legal_jurisdiction, "EU-AI-ACT");
         assert_eq!(report.authority_clearance.requester, tenant);
-        assert_eq!(report.mcp_audit_head_hash, log.head_hash());
+        assert_eq!(
+            report.mcp_audit_head_hash,
+            log.head_hash().expect("MCP audit head hash")
+        );
     }
 
     #[test]

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 122665 lines of Rust under `crates/`, 2,972 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 122789 lines of Rust under `crates/`, 2,975 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,972 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,975 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,972 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,975 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-122665 lines of Rust under `crates/` · 20 workspace packages · 2,972 listed tests · 40 MCP tools · 8 constitutional invariants
+122789 lines of Rust under `crates/` · 20 workspace packages · 2,975 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 122665 lines of Rust under `crates/` | 266 Rust source files | 2,972 listed tests
+> **Codebase:** 20 workspace packages | 122789 lines of Rust under `crates/` | 266 Rust source files | 2,975 listed tests
 
 ---
 

--- a/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
+++ b/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
@@ -46,9 +46,9 @@ decision.forum is a constitutional trust fabric for AI-era governance. Not a fra
 
 The numbers, verified as of this writing:
 
-- **122665 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
+- **122789 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
 - **20 workspace packages** covering identity, consent, authority, governance, escalation, legal infrastructure, cryptographic proofs, and more
-- **2,972 listed tests** exercised by the workspace test gate.
+- **2,975 listed tests** exercised by the workspace test gate.
 - **10 formal proofs** demonstrating that constitutional properties hold under all reachable system states
 - Built and reviewed through a **5-panel council process** (Governance, Legal, Architecture, Security, Operations)
 
@@ -270,7 +270,7 @@ The question is whether we will build it before we need it.
 
 *Bob Stewart is the architect of EXOCHAIN and decision.forum, and the author of The ASI Report on LinkedIn, where he writes about the infrastructure required for safe superintelligence. His work focuses on the intersection of constitutional governance, cryptographic enforcement, and AI safety -- the premise that alignment is necessary but insufficient, and that enforceable structural constraints are the missing complement.*
 
-*The EXOCHAIN workspace -- 122665 lines of Rust under `crates/`, 20 packages, 2,972 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
+*The EXOCHAIN workspace -- 122789 lines of Rust under `crates/`, 20 packages, 2,975 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
 
 ---
 

--- a/docs/decision-forum/SYSTEM-DOCUMENTATION.md
+++ b/docs/decision-forum/SYSTEM-DOCUMENTATION.md
@@ -6,7 +6,7 @@ created: 2026-03-19
 publication: "The ASI Report — LinkedIn Newsletter"
 tags: [decision-forum, governance, constitutional, asi-safety, exochain]
 status: publication-ready
-codebase: "20 workspace packages | 122665 LOC Rust under crates/ | 266 source files | 2,972 listed tests"
+codebase: "20 workspace packages | 122789 LOC Rust under crates/ | 266 source files | 2,975 listed tests"
 ---
 
 # decision.forum — System Documentation
@@ -20,9 +20,9 @@ This document is the exhaustive technical reference for the decision.forum gover
 | Metric | Value |
 |--------|-------|
 | Workspace packages | 20 |
-| Rust LOC under `crates/` | 122665 |
+| Rust LOC under `crates/` | 122789 |
 | Rust source files | 273 |
-| Listed workspace tests | 2,972 |
+| Listed workspace tests | 2,975 |
 | Test gate | `cargo test --workspace` in CI Gate 2 |
 | decision-forum crate LOC | 3,800 |
 | decision-forum tests | 131 |

--- a/docs/guides/GETTING-STARTED.md
+++ b/docs/guides/GETTING-STARTED.md
@@ -124,7 +124,7 @@ open tarpaulin-report.html
 ```
 
 A clean build produces zero errors and zero warnings. The current workspace
-inventory lists 2,972 tests; the exact executed count can change as doctests and
+inventory lists 2,975 tests; the exact executed count can change as doctests and
 integration targets evolve. What matters is zero failures:
 
 ```

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,972 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,975 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 122665 lines of Rust under `crates/` · 2,972 listed tests
+20 workspace packages · 122789 lines of Rust under `crates/` · 2,975 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 

--- a/governance/EXOCHAIN-REFACTOR-PLAN.md
+++ b/governance/EXOCHAIN-REFACTOR-PLAN.md
@@ -68,7 +68,7 @@ All refactor work flows through the Syntaxis Builder system:
 - [ ] Complete Section 8 work orders from CR-001
 - [ ] Achieve release-blocking acceptance standard (CR-001 Section 9)
 
-> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 122665 Rust LOC under `crates/`, 2,972 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
+> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 122789 Rust LOC under `crates/`, 2,975 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
 
 ## Active Resolutions
 

--- a/governance/sub_agents.md
+++ b/governance/sub_agents.md
@@ -72,7 +72,7 @@ Historical 2026-03-19 sub-agent completion record. Numeric status claims are sup
 * **Inputs**: Spec Section 16 (Acceptance Criteria).
 * **Outputs**: Test harnesses, Integration tests, Fuzz targets.
 * **Definition of Done**: Section 16 Acceptance Criteria are automated and passing.
-* **Status**: **DONE** — Current workspace inventory lists 2,972 tests across 20 packages and 266 Rust files.
+* **Status**: **DONE** — Current workspace inventory lists 2,975 tests across 20 packages and 266 Rust files.
 
 ## J) DEVOPS_RELEASE_AGENT (Judicial) — DONE
 

--- a/governance/traceability_matrix.md
+++ b/governance/traceability_matrix.md
@@ -163,4 +163,4 @@ Updated 2026-03-20 after EXOCHAIN-REM-009 — continuous governance monitoring a
 | **TOTAL** | **86** | **83** | **1** | **2** |
 
 **Coverage: 83/86 requirements traced to code (97%). 2 planned (ExoForge scheduling + React dashboard). 1 partial (T-14 Rust attestation verification).**
-**Workspace inventory: 2,972 listed tests across 20 packages and 266 Rust files.**
+**Workspace inventory: 2,975 listed tests across 20 packages and 266 Rust files.**


### PR DESCRIPTION
## Summary
- replace MCP audit record raw BLAKE3/debug-string hashing with domain-separated canonical CBOR hashing
- make MCP audit head hashing, append, record creation, and chain verification fail closed on canonical encoding errors
- update AI transparency reporting to propagate MCP audit head-hash failures
- refresh repo-truth docs to 122789 Rust LOC and 2,975 listed tests

## TDD
- red first: `cargo test -p exo-gatekeeper mcp_audit_record_hash_payload_is_domain_separated_cbor --lib -- --nocapture` failed before the canonical payload/domain API existed
- green: canonical payload, legacy debug-concat rejection, and production source-guard tests now pass

## Verification
- `cargo test -p exo-gatekeeper mcp_audit --lib -- --nocapture`
- `cargo test -p exo-legal ai_transparency --lib -- --nocapture`
- `cargo test -p exo-gatekeeper`
- `cargo test -p exo-legal`
- `cargo build -p exo-gatekeeper -p exo-legal`
- `cargo clippy -p exo-gatekeeper -p exo-legal --lib -- -D warnings`
- `cargo clippy -p exo-gatekeeper -p exo-legal --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `bash tools/test_repo_truth.sh`
- `bash tools/repo_truth.sh --json`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check`
- `cargo machete --with-metadata`