### PR TITLE
fix(exo-legal): canonicalize cert 902 hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 122789 | `wc -l` |
-| Workspace tests | 2,975 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 122970 | `wc -l` |
+| Workspace tests | 2,980 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,975 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,980 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 122789 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 122970 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,975 listed workspace tests
+         cryptographic proofs, 2,980 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-legal/src/cert_902_11.rs
+++ b/crates/exo-legal/src/cert_902_11.rs
@@ -17,8 +17,9 @@
 //!
 //! # Security note
 //!
-//! The `cert_hash` is a BLAKE3 digest of all structural fields.  Any
-//! modification after generation causes `verify_902_11_cert()` to fail.
+//! The `cert_hash` is a domain-separated canonical CBOR digest of all
+//! structural fields.  Any modification after generation causes
+//! `verify_902_11_cert()` to fail.
 //!
 //! # Legal disclaimer
 //!
@@ -26,13 +27,44 @@
 //! field must be completed by a qualified human declarant, and the certificate
 //! must be reviewed by qualified counsel before use in any legal proceeding.
 
-use exo_core::types::Hash256;
+use exo_core::{Did, Timestamp, hash::hash_structured, types::Hash256};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     error::{LegalError, Result},
     evidence::{Evidence, verify_chain_of_custody},
 };
+
+const CERT_902_11_CUSTODY_DIGEST_DOMAIN: &str = "exo.legal.cert_902_11.custody_digest.v1";
+const CERT_902_11_HASH_DOMAIN: &str = "exo.legal.cert_902_11.cert_hash.v1";
+const CERT_902_11_HASH_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Debug, Clone, Serialize)]
+struct Cert90211CustodyTransferPayload {
+    from: Did,
+    to: Did,
+    timestamp: Timestamp,
+    reason: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct Cert90211CustodyDigestPayload {
+    domain: &'static str,
+    schema_version: u16,
+    evidence_hash: Hash256,
+    evidence_timestamp: Timestamp,
+    transfers: Vec<Cert90211CustodyTransferPayload>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct Cert90211HashPayload<'a> {
+    domain: &'static str,
+    schema_version: u16,
+    record_hash: Hash256,
+    custody_chain_digest: Hash256,
+    system_description: &'a str,
+    generated_at_ms: u64,
+}
 
 // ---------------------------------------------------------------------------
 // Certificate
@@ -50,7 +82,7 @@ use crate::{
 pub struct Cert902_11 {
     /// BLAKE3 hash of the evidence record being certified.
     pub record_hash: Hash256,
-    /// BLAKE3 digest of the full custody chain at certification time.
+    /// Domain-separated canonical digest of the full custody chain at certification time.
     pub custody_chain_digest: Hash256,
     /// Description of the system that created the record (FRE 901(b)(9)).
     ///
@@ -61,9 +93,9 @@ pub struct Cert902_11 {
     /// **MUST be completed before filing.**  Replace with the declarant's
     /// full name, title, organization, and contact information.
     pub declarant_placeholder: String,
-    /// Physical millisecond timestamp when this certificate was generated.
+    /// Caller-supplied millisecond timestamp when this certificate was generated.
     pub generated_at_ms: u64,
-    /// BLAKE3 hash sealing all above fields — tamper-evident.
+    /// Domain-separated canonical hash sealing all above fields — tamper-evident.
     pub cert_hash: Hash256,
     /// Mandatory legal disclaimer reminding the user this is not ready to file.
     pub filing_disclaimer: &'static str,
@@ -86,7 +118,7 @@ impl Cert902_11 {
 /// * `evidence` — the evidence record to certify.
 /// * `system_description` — human-readable description of the record system
 ///   (satisfies FRE 901(b)(9) system description requirement).
-/// * `generated_at_ms` — wall-clock time in milliseconds (must be > 0).
+/// * `generated_at_ms` — caller-supplied time in milliseconds (must be > 0).
 ///
 /// # Errors
 /// - `InvalidStateTransition` if `evidence.timestamp == Timestamp::ZERO` (evidence
@@ -116,13 +148,13 @@ pub fn generate_902_11_cert(
     verify_chain_of_custody(evidence)?;
 
     let record_hash = evidence.hash;
-    let custody_chain_digest = compute_custody_digest(evidence);
+    let custody_chain_digest = compute_custody_digest(evidence)?;
     let cert_hash = compute_cert_hash(
         &record_hash,
         &custody_chain_digest,
         system_description,
         generated_at_ms,
-    );
+    )?;
 
     Ok(Cert902_11 {
         record_hash,
@@ -138,34 +170,68 @@ pub fn generate_902_11_cert(
 
 /// Verify a `Cert902_11` has not been modified since generation.
 ///
-/// Recomputes `cert_hash` from the structural fields and compares to the
-/// stored value.  Returns `true` if the certificate is intact.
-#[must_use]
-pub fn verify_902_11_cert(cert: &Cert902_11) -> bool {
+/// Recomputes `cert_hash` from the structural fields and compares to the stored
+/// value.
+///
+/// # Errors
+///
+/// Returns [`LegalError::CertificationHashEncodingFailed`] if canonical CBOR
+/// hashing fails.
+pub fn verify_902_11_cert(cert: &Cert902_11) -> Result<bool> {
     let expected = compute_cert_hash(
         &cert.record_hash,
         &cert.custody_chain_digest,
         &cert.system_description,
         cert.generated_at_ms,
-    );
-    expected == cert.cert_hash
+    )?;
+    Ok(expected == cert.cert_hash)
 }
 
 // ---------------------------------------------------------------------------
 // Internal
 // ---------------------------------------------------------------------------
 
-fn compute_custody_digest(evidence: &Evidence) -> Hash256 {
-    let mut hasher = blake3::Hasher::new();
-    hasher.update(b"fre902:custody:");
-    hasher.update(evidence.hash.as_bytes());
-    hasher.update(&evidence.timestamp.physical_ms.to_le_bytes());
-    for transfer in &evidence.chain_of_custody {
-        hasher.update(transfer.from.to_string().as_bytes());
-        hasher.update(transfer.to.to_string().as_bytes());
-        hasher.update(&transfer.timestamp.physical_ms.to_le_bytes());
+fn cert_902_11_custody_digest_payload(evidence: &Evidence) -> Cert90211CustodyDigestPayload {
+    Cert90211CustodyDigestPayload {
+        domain: CERT_902_11_CUSTODY_DIGEST_DOMAIN,
+        schema_version: CERT_902_11_HASH_SCHEMA_VERSION,
+        evidence_hash: evidence.hash,
+        evidence_timestamp: evidence.timestamp,
+        transfers: evidence
+            .chain_of_custody
+            .iter()
+            .map(|transfer| Cert90211CustodyTransferPayload {
+                from: transfer.from.clone(),
+                to: transfer.to.clone(),
+                timestamp: transfer.timestamp,
+                reason: transfer.reason.clone(),
+            })
+            .collect(),
     }
-    Hash256::from_bytes(*hasher.finalize().as_bytes())
+}
+
+fn cert_902_11_hash_payload<'a>(
+    record_hash: &Hash256,
+    custody_chain_digest: &Hash256,
+    system_description: &'a str,
+    generated_at_ms: u64,
+) -> Cert90211HashPayload<'a> {
+    Cert90211HashPayload {
+        domain: CERT_902_11_HASH_DOMAIN,
+        schema_version: CERT_902_11_HASH_SCHEMA_VERSION,
+        record_hash: *record_hash,
+        custody_chain_digest: *custody_chain_digest,
+        system_description,
+        generated_at_ms,
+    }
+}
+
+fn compute_custody_digest(evidence: &Evidence) -> Result<Hash256> {
+    hash_structured(&cert_902_11_custody_digest_payload(evidence)).map_err(|e| {
+        LegalError::CertificationHashEncodingFailed {
+            reason: format!("FRE 902(11) custody digest canonical CBOR hash failed: {e}"),
+        }
+    })
 }
 
 fn compute_cert_hash(
@@ -173,14 +239,16 @@ fn compute_cert_hash(
     custody_chain_digest: &Hash256,
     system_description: &str,
     generated_at_ms: u64,
-) -> Hash256 {
-    let mut hasher = blake3::Hasher::new();
-    hasher.update(b"fre902:cert:v1:");
-    hasher.update(record_hash.as_bytes());
-    hasher.update(custody_chain_digest.as_bytes());
-    hasher.update(system_description.as_bytes());
-    hasher.update(&generated_at_ms.to_le_bytes());
-    Hash256::from_bytes(*hasher.finalize().as_bytes())
+) -> Result<Hash256> {
+    hash_structured(&cert_902_11_hash_payload(
+        record_hash,
+        custody_chain_digest,
+        system_description,
+        generated_at_ms,
+    ))
+    .map_err(|e| LegalError::CertificationHashEncodingFailed {
+        reason: format!("FRE 902(11) certificate hash canonical CBOR hash failed: {e}"),
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -193,7 +261,7 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
-    use crate::evidence::create_evidence;
+    use crate::evidence::{create_evidence, transfer_custody};
 
     fn did(n: &str) -> Did {
         Did::new(&format!("did:exo:{n}")).unwrap()
@@ -216,6 +284,116 @@ mod tests {
 
     const SYSTEM_DESC: &str = "EXOCHAIN decision.forum v1.0 — records created at vote-close via BCTS lifecycle \
          as a regular practice of board governance operations.";
+
+    fn production_source() -> &'static str {
+        let source = include_str!("cert_902_11.rs");
+        let end = source
+            .find("// ---------------------------------------------------------------------------\n// Tests")
+            .unwrap();
+        &source[..end]
+    }
+
+    fn evidence_with_transfer(reason: &str) -> Evidence {
+        let mut ev = make_evidence();
+        transfer_custody(
+            &mut ev,
+            &did("secretary"),
+            &did("counsel"),
+            real_ts(1_700_000_000_100),
+            reason,
+        )
+        .unwrap();
+        ev
+    }
+
+    #[test]
+    fn custody_digest_payload_is_domain_separated_cbor() {
+        let ev = evidence_with_transfer("certification transfer");
+        let payload = cert_902_11_custody_digest_payload(&ev);
+        assert_eq!(payload.domain, CERT_902_11_CUSTODY_DIGEST_DOMAIN);
+        assert_eq!(payload.schema_version, 1);
+        assert_eq!(payload.evidence_hash, ev.hash);
+        assert_eq!(payload.evidence_timestamp, ev.timestamp);
+        assert_eq!(payload.transfers.len(), 1);
+        assert_eq!(payload.transfers[0].from, ev.chain_of_custody[0].from);
+        assert_eq!(payload.transfers[0].to, ev.chain_of_custody[0].to);
+        assert_eq!(
+            payload.transfers[0].timestamp,
+            ev.chain_of_custody[0].timestamp
+        );
+        assert_eq!(payload.transfers[0].reason, ev.chain_of_custody[0].reason);
+    }
+
+    #[test]
+    fn cert_hash_payload_is_domain_separated_cbor() {
+        let ev = make_evidence();
+        let custody_digest = compute_custody_digest(&ev).expect("canonical 902(11) custody digest");
+        let payload =
+            cert_902_11_hash_payload(&ev.hash, &custody_digest, SYSTEM_DESC, 1_700_000_001_000);
+        assert_eq!(payload.domain, CERT_902_11_HASH_DOMAIN);
+        assert_eq!(payload.schema_version, 1);
+        assert_eq!(payload.record_hash, ev.hash);
+        assert_eq!(payload.custody_chain_digest, custody_digest);
+        assert_eq!(payload.system_description, SYSTEM_DESC);
+        assert_eq!(payload.generated_at_ms, 1_700_000_001_000);
+    }
+
+    #[test]
+    fn cert_hashes_reject_legacy_raw_concat_hashes() {
+        let ev = evidence_with_transfer("certification transfer");
+
+        let mut custody_hasher = blake3::Hasher::new();
+        custody_hasher.update(b"fre902:custody:");
+        custody_hasher.update(ev.hash.as_bytes());
+        custody_hasher.update(&ev.timestamp.physical_ms.to_le_bytes());
+        for transfer in &ev.chain_of_custody {
+            custody_hasher.update(transfer.from.to_string().as_bytes());
+            custody_hasher.update(transfer.to.to_string().as_bytes());
+            custody_hasher.update(&transfer.timestamp.physical_ms.to_le_bytes());
+        }
+        let legacy_custody_digest = Hash256::from_bytes(*custody_hasher.finalize().as_bytes());
+
+        let mut cert_hasher = blake3::Hasher::new();
+        cert_hasher.update(b"fre902:cert:v1:");
+        cert_hasher.update(ev.hash.as_bytes());
+        cert_hasher.update(legacy_custody_digest.as_bytes());
+        cert_hasher.update(SYSTEM_DESC.as_bytes());
+        cert_hasher.update(&1_700_000_001_000u64.to_le_bytes());
+        let legacy_cert_hash = Hash256::from_bytes(*cert_hasher.finalize().as_bytes());
+
+        let cert = generate_902_11_cert(&ev, SYSTEM_DESC, 1_700_000_001_000).unwrap();
+
+        assert_ne!(cert.custody_chain_digest, legacy_custody_digest);
+        assert_ne!(cert.cert_hash, legacy_cert_hash);
+    }
+
+    #[test]
+    fn custody_digest_binds_transfer_reason_and_logical_time() {
+        let ev_a = evidence_with_transfer("certification transfer");
+        let mut ev_b = evidence_with_transfer("litigation hold transfer");
+        ev_b.chain_of_custody[0].timestamp = Timestamp::new(
+            ev_a.chain_of_custody[0].timestamp.physical_ms,
+            ev_a.chain_of_custody[0].timestamp.logical + 1,
+        );
+
+        assert_ne!(
+            compute_custody_digest(&ev_a).expect("first custody digest"),
+            compute_custody_digest(&ev_b).expect("second custody digest")
+        );
+    }
+
+    #[test]
+    fn cert_production_source_has_no_raw_hash_loops() {
+        let production = production_source();
+        assert!(
+            !production.contains("blake3::Hasher"),
+            "902(11) certificate hashes must use domain-separated canonical CBOR"
+        );
+        assert!(
+            !production.contains("fre902:"),
+            "902(11) certificate hashes must not use raw byte domain prefixes"
+        );
+    }
 
     #[test]
     fn cert_contains_required_elements() {
@@ -250,7 +428,7 @@ mod tests {
         let ev = make_evidence();
         let cert = generate_902_11_cert(&ev, SYSTEM_DESC, 1_700_000_001_000).unwrap();
         assert!(
-            verify_902_11_cert(&cert),
+            verify_902_11_cert(&cert).unwrap(),
             "cert must verify immediately after generation"
         );
     }
@@ -261,7 +439,7 @@ mod tests {
         let mut cert = generate_902_11_cert(&ev, SYSTEM_DESC, 1_700_000_001_000).unwrap();
         cert.record_hash = Hash256::digest(b"tampered");
         assert!(
-            !verify_902_11_cert(&cert),
+            !verify_902_11_cert(&cert).unwrap(),
             "tampered record_hash must fail verification"
         );
     }
@@ -272,7 +450,7 @@ mod tests {
         let mut cert = generate_902_11_cert(&ev, SYSTEM_DESC, 1_700_000_001_000).unwrap();
         cert.system_description = "evil system".to_string();
         assert!(
-            !verify_902_11_cert(&cert),
+            !verify_902_11_cert(&cert).unwrap(),
             "tampered system_description must fail verification"
         );
     }
@@ -283,7 +461,7 @@ mod tests {
         let mut cert = generate_902_11_cert(&ev, SYSTEM_DESC, 1_700_000_001_000).unwrap();
         cert.generated_at_ms = 9_999_999_999_999;
         assert!(
-            !verify_902_11_cert(&cert),
+            !verify_902_11_cert(&cert).unwrap(),
             "tampered timestamp must fail verification"
         );
     }

--- a/crates/exo-legal/src/error.rs
+++ b/crates/exo-legal/src/error.rs
@@ -34,6 +34,8 @@ pub enum LegalError {
     RecordNotFound(Uuid),
     #[error("invalid state transition: {reason}")]
     InvalidStateTransition { reason: String },
+    #[error("FRE 902(11) certificate hash encoding failed: {reason}")]
+    CertificationHashEncodingFailed { reason: String },
 }
 
 /// Convenience alias for results that carry a [`LegalError`].
@@ -63,6 +65,7 @@ mod tests {
             Box::new(LegalError::ConflictOfInterest { reason: "x".into() }),
             Box::new(LegalError::RecordNotFound(id)),
             Box::new(LegalError::InvalidStateTransition { reason: "x".into() }),
+            Box::new(LegalError::CertificationHashEncodingFailed { reason: "x".into() }),
         ];
         for c in &cases {
             assert!(!c.to_string().is_empty());

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 122789 lines of Rust under `crates/`, 2,975 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 122970 lines of Rust under `crates/`, 2,980 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,975 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,980 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,975 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,980 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-122789 lines of Rust under `crates/` · 20 workspace packages · 2,975 listed tests · 40 MCP tools · 8 constitutional invariants
+122970 lines of Rust under `crates/` · 20 workspace packages · 2,980 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 122789 lines of Rust under `crates/` | 266 Rust source files | 2,975 listed tests
+> **Codebase:** 20 workspace packages | 122970 lines of Rust under `crates/` | 266 Rust source files | 2,980 listed tests
 
 ---
 

--- a/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
+++ b/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
@@ -46,9 +46,9 @@ decision.forum is a constitutional trust fabric for AI-era governance. Not a fra
 
 The numbers, verified as of this writing:
 
-- **122789 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
+- **122970 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
 - **20 workspace packages** covering identity, consent, authority, governance, escalation, legal infrastructure, cryptographic proofs, and more
-- **2,975 listed tests** exercised by the workspace test gate.
+- **2,980 listed tests** exercised by the workspace test gate.
 - **10 formal proofs** demonstrating that constitutional properties hold under all reachable system states
 - Built and reviewed through a **5-panel council process** (Governance, Legal, Architecture, Security, Operations)
 
@@ -270,7 +270,7 @@ The question is whether we will build it before we need it.
 
 *Bob Stewart is the architect of EXOCHAIN and decision.forum, and the author of The ASI Report on LinkedIn, where he writes about the infrastructure required for safe superintelligence. His work focuses on the intersection of constitutional governance, cryptographic enforcement, and AI safety -- the premise that alignment is necessary but insufficient, and that enforceable structural constraints are the missing complement.*
 
-*The EXOCHAIN workspace -- 122789 lines of Rust under `crates/`, 20 packages, 2,975 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
+*The EXOCHAIN workspace -- 122970 lines of Rust under `crates/`, 20 packages, 2,980 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
 
 ---
 

--- a/docs/decision-forum/SYSTEM-DOCUMENTATION.md
+++ b/docs/decision-forum/SYSTEM-DOCUMENTATION.md
@@ -6,7 +6,7 @@ created: 2026-03-19
 publication: "The ASI Report — LinkedIn Newsletter"
 tags: [decision-forum, governance, constitutional, asi-safety, exochain]
 status: publication-ready
-codebase: "20 workspace packages | 122789 LOC Rust under crates/ | 266 source files | 2,975 listed tests"
+codebase: "20 workspace packages | 122970 LOC Rust under crates/ | 266 source files | 2,980 listed tests"
 ---
 
 # decision.forum — System Documentation
@@ -20,9 +20,9 @@ This document is the exhaustive technical reference for the decision.forum gover
 | Metric | Value |
 |--------|-------|
 | Workspace packages | 20 |
-| Rust LOC under `crates/` | 122789 |
+| Rust LOC under `crates/` | 122970 |
 | Rust source files | 273 |
-| Listed workspace tests | 2,975 |
+| Listed workspace tests | 2,980 |
 | Test gate | `cargo test --workspace` in CI Gate 2 |
 | decision-forum crate LOC | 3,800 |
 | decision-forum tests | 131 |

--- a/docs/guides/GETTING-STARTED.md
+++ b/docs/guides/GETTING-STARTED.md
@@ -124,7 +124,7 @@ open tarpaulin-report.html
 ```
 
 A clean build produces zero errors and zero warnings. The current workspace
-inventory lists 2,975 tests; the exact executed count can change as doctests and
+inventory lists 2,980 tests; the exact executed count can change as doctests and
 integration targets evolve. What matters is zero failures:
 
 ```

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,975 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,980 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 122789 lines of Rust under `crates/` · 2,975 listed tests
+20 workspace packages · 122970 lines of Rust under `crates/` · 2,980 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 

--- a/governance/EXOCHAIN-REFACTOR-PLAN.md
+++ b/governance/EXOCHAIN-REFACTOR-PLAN.md
@@ -68,7 +68,7 @@ All refactor work flows through the Syntaxis Builder system:
 - [ ] Complete Section 8 work orders from CR-001
 - [ ] Achieve release-blocking acceptance standard (CR-001 Section 9)
 
-> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 122789 Rust LOC under `crates/`, 2,975 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
+> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 122970 Rust LOC under `crates/`, 2,980 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
 
 ## Active Resolutions
 

--- a/governance/sub_agents.md
+++ b/governance/sub_agents.md
@@ -72,7 +72,7 @@ Historical 2026-03-19 sub-agent completion record. Numeric status claims are sup
 * **Inputs**: Spec Section 16 (Acceptance Criteria).
 * **Outputs**: Test harnesses, Integration tests, Fuzz targets.
 * **Definition of Done**: Section 16 Acceptance Criteria are automated and passing.
-* **Status**: **DONE** — Current workspace inventory lists 2,975 tests across 20 packages and 266 Rust files.
+* **Status**: **DONE** — Current workspace inventory lists 2,980 tests across 20 packages and 266 Rust files.
 
 ## J) DEVOPS_RELEASE_AGENT (Judicial) — DONE
 

--- a/governance/traceability_matrix.md
+++ b/governance/traceability_matrix.md
@@ -163,4 +163,4 @@ Updated 2026-03-20 after EXOCHAIN-REM-009 — continuous governance monitoring a
 | **TOTAL** | **86** | **83** | **1** | **2** |
 
 **Coverage: 83/86 requirements traced to code (97%). 2 planned (ExoForge scheduling + React dashboard). 1 partial (T-14 Rust attestation verification).**
-**Workspace inventory: 2,975 listed tests across 20 packages and 266 Rust files.**
+**Workspace inventory: 2,980 listed tests across 20 packages and 266 Rust files.**


### PR DESCRIPTION
## Summary
- replaces FRE 902(11) custody and certificate raw BLAKE3 field streaming with domain-separated canonical CBOR payload hashes
- binds custody digest to evidence HLC timestamp, transfer reason, and transfer HLC logical time
- makes certificate generation/verification fail closed on canonical encoding errors via `LegalError::CertificationHashEncodingFailed`
- refreshes repo-truth public counts to `122970` Rust LOC and `2,980` listed workspace tests

## TDD
- added red-first tests for canonical custody payloads, canonical cert payloads, legacy raw-concat rejection, custody reason/logical-time binding, and a source guard against raw hash loops

## Verification
- `cargo test -p exo-legal custody_digest_payload_is_domain_separated_cbor --lib -- --nocapture`
- `cargo test -p exo-legal cert_902_11 --lib -- --nocapture`
- `cargo test -p exo-legal error::tests::error_display_all_variants --lib -- --nocapture`
- `cargo test -p exo-legal`
- `cargo build -p exo-legal`
- `cargo clippy -p exo-legal --lib --bins -- -D warnings`
- `cargo clippy -p exo-legal --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash tools/repo_truth.sh --json`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check`
- `cargo machete --with-metadata`
