### PR TITLE
fix(exo-legal): canonicalize ediscovery hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 122970 | `wc -l` |
-| Workspace tests | 2,980 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 123208 | `wc -l` |
+| Workspace tests | 2,986 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,980 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,986 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 122970 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 123208 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,980 listed workspace tests
+         cryptographic proofs, 2,986 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-legal/src/ediscovery.rs
+++ b/crates/exo-legal/src/ediscovery.rs
@@ -1,9 +1,17 @@
 //! Electronic discovery — eDiscovery search and production.
 
-use exo_core::{Did, Hash256, Timestamp};
+use exo_core::{Did, Hash256, Timestamp, hash::hash_structured};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
-use crate::{evidence::Evidence, privilege::PrivilegeAssertion};
+use crate::{
+    error::{LegalError, Result},
+    evidence::{AdmissibilityStatus, CustodyTransfer, Evidence},
+    privilege::PrivilegeAssertion,
+};
+
+const EDISCOVERY_PRODUCTION_HASH_DOMAIN: &str = "exo.legal.ediscovery.production_hash.v1";
+const EDISCOVERY_PRODUCTION_HASH_SCHEMA_VERSION: u16 = 1;
 
 /// Parameters for an eDiscovery search: custodians, date range, and search terms.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -23,9 +31,37 @@ pub struct DiscoveryResponse {
     pub production_hash: Hash256,
 }
 
+#[derive(Debug, Clone, Serialize)]
+struct EdiscoveryProductionDocumentPayload {
+    id: Uuid,
+    type_tag: String,
+    hash: Hash256,
+    creator: Did,
+    timestamp: Timestamp,
+    chain_of_custody: Vec<CustodyTransfer>,
+    admissibility_status: AdmissibilityStatus,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct EdiscoveryProductionHashPayload {
+    domain: &'static str,
+    schema_version: u16,
+    requester: Did,
+    scope: String,
+    date_start: Timestamp,
+    date_end: Timestamp,
+    custodians: Vec<Did>,
+    search_terms: Vec<String>,
+    documents: Vec<EdiscoveryProductionDocumentPayload>,
+}
+
 /// Filters an evidence corpus by the discovery request criteria and returns a hashed production set.
-#[must_use]
-pub fn search(request: &DiscoveryRequest, corpus: &[Evidence]) -> DiscoveryResponse {
+///
+/// # Errors
+///
+/// Returns [`LegalError::DiscoveryHashEncodingFailed`] if canonical CBOR
+/// encoding of the production-set hash payload fails.
+pub fn search(request: &DiscoveryRequest, corpus: &[Evidence]) -> Result<DiscoveryResponse> {
     let documents: Vec<Evidence> = corpus
         .iter()
         .filter(|ev| {
@@ -40,23 +76,61 @@ pub fn search(request: &DiscoveryRequest, corpus: &[Evidence]) -> DiscoveryRespo
         })
         .cloned()
         .collect();
-    let mut hasher = blake3::Hasher::new();
-    for doc in &documents {
-        hasher.update(doc.hash.as_bytes());
-    }
-    DiscoveryResponse {
+
+    let production_hash = ediscovery_production_hash(request, &documents)?;
+
+    Ok(DiscoveryResponse {
         documents,
         privilege_log: Vec::new(),
-        production_hash: Hash256::from_bytes(*hasher.finalize().as_bytes()),
+        production_hash,
+    })
+}
+
+fn ediscovery_production_hash_payload(
+    request: &DiscoveryRequest,
+    documents: &[Evidence],
+) -> EdiscoveryProductionHashPayload {
+    EdiscoveryProductionHashPayload {
+        domain: EDISCOVERY_PRODUCTION_HASH_DOMAIN,
+        schema_version: EDISCOVERY_PRODUCTION_HASH_SCHEMA_VERSION,
+        requester: request.requester.clone(),
+        scope: request.scope.clone(),
+        date_start: request.date_range.0,
+        date_end: request.date_range.1,
+        custodians: request.custodians.clone(),
+        search_terms: request.search_terms.clone(),
+        documents: documents
+            .iter()
+            .map(|doc| EdiscoveryProductionDocumentPayload {
+                id: doc.id,
+                type_tag: doc.type_tag.clone(),
+                hash: doc.hash,
+                creator: doc.creator.clone(),
+                timestamp: doc.timestamp,
+                chain_of_custody: doc.chain_of_custody.clone(),
+                admissibility_status: doc.admissibility_status.clone(),
+            })
+            .collect(),
     }
+}
+
+fn ediscovery_production_hash(
+    request: &DiscoveryRequest,
+    documents: &[Evidence],
+) -> Result<Hash256> {
+    hash_structured(&ediscovery_production_hash_payload(request, documents)).map_err(|e| {
+        LegalError::DiscoveryHashEncodingFailed {
+            reason: format!("eDiscovery production hash canonical CBOR hash failed: {e}"),
+        }
+    })
 }
 
 #[cfg(test)]
 mod tests {
-    use uuid::Uuid;
+    use exo_core::hash::hash_structured;
 
     use super::*;
-    use crate::evidence::create_evidence;
+    use crate::evidence::{create_evidence, transfer_custody};
     fn did(n: &str) -> Did {
         Did::new(&format!("did:exo:{n}")).unwrap()
     }
@@ -99,27 +173,27 @@ mod tests {
     }
     #[test]
     fn by_custodian() {
-        let r = search(&req(vec![did("alice")], vec![], (0, 500)), &corpus());
+        let r = search(&req(vec![did("alice")], vec![], (0, 500)), &corpus()).unwrap();
         assert_eq!(r.documents.len(), 2);
     }
     #[test]
     fn by_date() {
-        let r = search(&req(vec![], vec![], (150, 250)), &corpus());
+        let r = search(&req(vec![], vec![], (150, 250)), &corpus()).unwrap();
         assert_eq!(r.documents.len(), 1);
     }
     #[test]
     fn by_terms() {
-        let r = search(&req(vec![], vec!["contract".into()], (0, 500)), &corpus());
+        let r = search(&req(vec![], vec!["contract".into()], (0, 500)), &corpus()).unwrap();
         assert_eq!(r.documents.len(), 1);
     }
     #[test]
     fn empty_corpus() {
-        let r = search(&req(vec![], vec![], (0, 500)), &[]);
+        let r = search(&req(vec![], vec![], (0, 500)), &[]).unwrap();
         assert!(r.documents.is_empty());
     }
     #[test]
     fn no_match() {
-        let r = search(&req(vec![did("nobody")], vec![], (0, 500)), &corpus());
+        let r = search(&req(vec![did("nobody")], vec![], (0, 500)), &corpus()).unwrap();
         assert!(r.documents.is_empty());
     }
     #[test]
@@ -127,8 +201,8 @@ mod tests {
         let rq = req(vec![], vec![], (0, 500));
         let c = corpus();
         assert_eq!(
-            search(&rq, &c).production_hash,
-            search(&rq, &c).production_hash
+            search(&rq, &c).unwrap().production_hash,
+            search(&rq, &c).unwrap().production_hash
         );
     }
     #[test]
@@ -136,7 +210,167 @@ mod tests {
         let r = search(
             &req(vec![did("alice")], vec!["contract".into()], (0, 150)),
             &corpus(),
-        );
+        )
+        .unwrap();
         assert_eq!(r.documents.len(), 1);
+    }
+
+    #[test]
+    fn production_hash_payload_is_domain_separated_cbor() {
+        let rq = req(vec![], vec![], (0, 500));
+        let docs = corpus();
+        let payload = ediscovery_production_hash_payload(&rq, &docs);
+
+        assert_eq!(payload.domain, EDISCOVERY_PRODUCTION_HASH_DOMAIN);
+        assert_eq!(
+            payload.schema_version,
+            EDISCOVERY_PRODUCTION_HASH_SCHEMA_VERSION
+        );
+        assert_eq!(payload.requester, rq.requester);
+        assert_eq!(payload.scope, rq.scope);
+        assert_eq!(payload.documents.len(), docs.len());
+        assert_eq!(payload.documents[0].id, docs[0].id);
+        assert_eq!(payload.documents[0].hash, docs[0].hash);
+
+        let expected = hash_structured(&payload).unwrap();
+        assert_eq!(ediscovery_production_hash(&rq, &docs).unwrap(), expected);
+    }
+
+    #[test]
+    fn production_hash_rejects_legacy_doc_hash_concat() {
+        let rq = req(vec![], vec![], (0, 500));
+        let response = search(&rq, &corpus()).unwrap();
+
+        let mut legacy_hasher = blake3::Hasher::new();
+        for doc in &response.documents {
+            legacy_hasher.update(doc.hash.as_bytes());
+        }
+        let legacy_hash = Hash256::from_bytes(*legacy_hasher.finalize().as_bytes());
+
+        assert_ne!(response.production_hash, legacy_hash);
+    }
+
+    #[test]
+    fn production_hash_binds_request_scope_and_terms() {
+        let mut all_docs = Vec::new();
+        for n in 0_u64..3 {
+            all_docs.push(
+                create_evidence(
+                    Uuid::from_u128(0x600 + u128::from(n)),
+                    format!("document {n}").as_bytes(),
+                    &did("alice"),
+                    "record",
+                    Timestamp::new(100 + n, 0),
+                )
+                .unwrap(),
+            );
+        }
+
+        let mut scoped_request = req(vec![did("alice")], vec![], (0, 500));
+        scoped_request.scope = "all".into();
+        let mut other_scope = scoped_request.clone();
+        other_scope.scope = "matter-42".into();
+        let mut explicit_term = scoped_request.clone();
+        explicit_term.search_terms = vec!["record".into()];
+
+        let scoped = search(&scoped_request, &all_docs).unwrap();
+        let scope_changed = search(&other_scope, &all_docs).unwrap();
+        let terms_changed = search(&explicit_term, &all_docs).unwrap();
+
+        assert_eq!(scoped.documents.len(), scope_changed.documents.len());
+        assert_eq!(scoped.documents.len(), terms_changed.documents.len());
+        assert_ne!(scoped.production_hash, scope_changed.production_hash);
+        assert_ne!(scoped.production_hash, terms_changed.production_hash);
+    }
+
+    #[test]
+    fn production_hash_binds_document_identity_and_timestamp() {
+        let rq = req(vec![did("alice")], vec!["contract".into()], (0, 500));
+        let first = vec![
+            create_evidence(
+                Uuid::from_u128(0x700),
+                b"same content",
+                &did("alice"),
+                "contract",
+                Timestamp::new(100, 0),
+            )
+            .unwrap(),
+        ];
+        let different_id = vec![
+            create_evidence(
+                Uuid::from_u128(0x701),
+                b"same content",
+                &did("alice"),
+                "contract",
+                Timestamp::new(100, 0),
+            )
+            .unwrap(),
+        ];
+        let different_timestamp = vec![
+            create_evidence(
+                Uuid::from_u128(0x700),
+                b"same content",
+                &did("alice"),
+                "contract",
+                Timestamp::new(101, 0),
+            )
+            .unwrap(),
+        ];
+
+        assert_eq!(first[0].hash, different_id[0].hash);
+        assert_eq!(first[0].hash, different_timestamp[0].hash);
+        assert_ne!(
+            search(&rq, &first).unwrap().production_hash,
+            search(&rq, &different_id).unwrap().production_hash
+        );
+        assert_ne!(
+            search(&rq, &first).unwrap().production_hash,
+            search(&rq, &different_timestamp).unwrap().production_hash
+        );
+    }
+
+    #[test]
+    fn production_hash_binds_custody_chain() {
+        let rq = req(vec![did("alice")], vec!["contract".into()], (0, 500));
+        let first = create_evidence(
+            Uuid::from_u128(0x800),
+            b"custody content",
+            &did("alice"),
+            "contract",
+            Timestamp::new(100, 0),
+        )
+        .unwrap();
+        let mut transferred = first.clone();
+        transfer_custody(
+            &mut transferred,
+            &did("alice"),
+            &did("counsel"),
+            Timestamp::new(200, 0),
+            "litigation hold",
+        )
+        .unwrap();
+
+        assert_eq!(first.hash, transferred.hash);
+        assert_ne!(
+            search(&rq, &[first]).unwrap().production_hash,
+            search(&rq, &[transferred]).unwrap().production_hash
+        );
+    }
+
+    fn production_source() -> &'static str {
+        let source = include_str!("ediscovery.rs");
+        let end = source
+            .find("#[cfg(test)]")
+            .expect("test module marker exists");
+        &source[..end]
+    }
+
+    #[test]
+    fn ediscovery_production_source_has_no_raw_hash_loop() {
+        let production = production_source();
+        assert!(
+            !production.contains("blake3::Hasher"),
+            "eDiscovery production hashes must use domain-separated canonical CBOR"
+        );
     }
 }

--- a/crates/exo-legal/src/error.rs
+++ b/crates/exo-legal/src/error.rs
@@ -22,6 +22,8 @@ pub enum LegalError {
     FiduciaryViolation { reason: String },
     #[error("discovery scope too broad: {reason}")]
     DiscoveryScopeTooBoard { reason: String },
+    #[error("eDiscovery production hash encoding failed: {reason}")]
+    DiscoveryHashEncodingFailed { reason: String },
     #[error("retention policy violation: {reason}")]
     RetentionViolation { reason: String },
     #[error("disclosure required for action: {action}")]
@@ -57,6 +59,7 @@ mod tests {
             Box::new(LegalError::PrivilegeAlreadyAsserted(id)),
             Box::new(LegalError::FiduciaryViolation { reason: "x".into() }),
             Box::new(LegalError::DiscoveryScopeTooBoard { reason: "x".into() }),
+            Box::new(LegalError::DiscoveryHashEncodingFailed { reason: "x".into() }),
             Box::new(LegalError::RetentionViolation { reason: "x".into() }),
             Box::new(LegalError::DisclosureRequired {
                 action: "vote".into(),

--- a/crates/exochain-wasm/src/legal_bindings.rs
+++ b/crates/exochain-wasm/src/legal_bindings.rs
@@ -48,7 +48,8 @@ pub fn wasm_check_fiduciary_duty(duty_json: &str, actions_json: &str) -> Result<
 pub fn wasm_ediscovery_search(request_json: &str, corpus_json: &str) -> Result<JsValue, JsValue> {
     let request: exo_legal::ediscovery::DiscoveryRequest = from_json_str(request_json)?;
     let corpus: Vec<exo_legal::evidence::Evidence> = from_json_str(corpus_json)?;
-    let response = exo_legal::ediscovery::search(&request, &corpus);
+    let response = exo_legal::ediscovery::search(&request, &corpus)
+        .map_err(|e| JsValue::from_str(&format!("eDiscovery error: {e}")))?;
     to_js_value(&response)
 }
 

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 122970 lines of Rust under `crates/`, 2,980 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 123208 lines of Rust under `crates/`, 2,986 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,980 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,986 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,980 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,986 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-122970 lines of Rust under `crates/` · 20 workspace packages · 2,980 listed tests · 40 MCP tools · 8 constitutional invariants
+123208 lines of Rust under `crates/` · 20 workspace packages · 2,986 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 122970 lines of Rust under `crates/` | 266 Rust source files | 2,980 listed tests
+> **Codebase:** 20 workspace packages | 123208 lines of Rust under `crates/` | 266 Rust source files | 2,986 listed tests
 
 ---
 

--- a/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
+++ b/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
@@ -46,9 +46,9 @@ decision.forum is a constitutional trust fabric for AI-era governance. Not a fra
 
 The numbers, verified as of this writing:
 
-- **122970 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
+- **123208 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
 - **20 workspace packages** covering identity, consent, authority, governance, escalation, legal infrastructure, cryptographic proofs, and more
-- **2,980 listed tests** exercised by the workspace test gate.
+- **2,986 listed tests** exercised by the workspace test gate.
 - **10 formal proofs** demonstrating that constitutional properties hold under all reachable system states
 - Built and reviewed through a **5-panel council process** (Governance, Legal, Architecture, Security, Operations)
 
@@ -270,7 +270,7 @@ The question is whether we will build it before we need it.
 
 *Bob Stewart is the architect of EXOCHAIN and decision.forum, and the author of The ASI Report on LinkedIn, where he writes about the infrastructure required for safe superintelligence. His work focuses on the intersection of constitutional governance, cryptographic enforcement, and AI safety -- the premise that alignment is necessary but insufficient, and that enforceable structural constraints are the missing complement.*
 
-*The EXOCHAIN workspace -- 122970 lines of Rust under `crates/`, 20 packages, 2,980 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
+*The EXOCHAIN workspace -- 123208 lines of Rust under `crates/`, 20 packages, 2,986 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
 
 ---
 

--- a/docs/decision-forum/SYSTEM-DOCUMENTATION.md
+++ b/docs/decision-forum/SYSTEM-DOCUMENTATION.md
@@ -6,7 +6,7 @@ created: 2026-03-19
 publication: "The ASI Report — LinkedIn Newsletter"
 tags: [decision-forum, governance, constitutional, asi-safety, exochain]
 status: publication-ready
-codebase: "20 workspace packages | 122970 LOC Rust under crates/ | 266 source files | 2,980 listed tests"
+codebase: "20 workspace packages | 123208 LOC Rust under crates/ | 266 source files | 2,986 listed tests"
 ---
 
 # decision.forum — System Documentation
@@ -20,9 +20,9 @@ This document is the exhaustive technical reference for the decision.forum gover
 | Metric | Value |
 |--------|-------|
 | Workspace packages | 20 |
-| Rust LOC under `crates/` | 122970 |
+| Rust LOC under `crates/` | 123208 |
 | Rust source files | 273 |
-| Listed workspace tests | 2,980 |
+| Listed workspace tests | 2,986 |
 | Test gate | `cargo test --workspace` in CI Gate 2 |
 | decision-forum crate LOC | 3,800 |
 | decision-forum tests | 131 |

--- a/docs/guides/GETTING-STARTED.md
+++ b/docs/guides/GETTING-STARTED.md
@@ -124,7 +124,7 @@ open tarpaulin-report.html
 ```
 
 A clean build produces zero errors and zero warnings. The current workspace
-inventory lists 2,980 tests; the exact executed count can change as doctests and
+inventory lists 2,986 tests; the exact executed count can change as doctests and
 integration targets evolve. What matters is zero failures:
 
 ```

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,980 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,986 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 122970 lines of Rust under `crates/` · 2,980 listed tests
+20 workspace packages · 123208 lines of Rust under `crates/` · 2,986 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 

--- a/governance/EXOCHAIN-REFACTOR-PLAN.md
+++ b/governance/EXOCHAIN-REFACTOR-PLAN.md
@@ -68,7 +68,7 @@ All refactor work flows through the Syntaxis Builder system:
 - [ ] Complete Section 8 work orders from CR-001
 - [ ] Achieve release-blocking acceptance standard (CR-001 Section 9)
 
-> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 122970 Rust LOC under `crates/`, 2,980 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
+> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 123208 Rust LOC under `crates/`, 2,986 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
 
 ## Active Resolutions
 

--- a/governance/sub_agents.md
+++ b/governance/sub_agents.md
@@ -72,7 +72,7 @@ Historical 2026-03-19 sub-agent completion record. Numeric status claims are sup
 * **Inputs**: Spec Section 16 (Acceptance Criteria).
 * **Outputs**: Test harnesses, Integration tests, Fuzz targets.
 * **Definition of Done**: Section 16 Acceptance Criteria are automated and passing.
-* **Status**: **DONE** — Current workspace inventory lists 2,980 tests across 20 packages and 266 Rust files.
+* **Status**: **DONE** — Current workspace inventory lists 2,986 tests across 20 packages and 266 Rust files.
 
 ## J) DEVOPS_RELEASE_AGENT (Judicial) — DONE
 

--- a/governance/traceability_matrix.md
+++ b/governance/traceability_matrix.md
@@ -163,4 +163,4 @@ Updated 2026-03-20 after EXOCHAIN-REM-009 — continuous governance monitoring a
 | **TOTAL** | **86** | **83** | **1** | **2** |
 
 **Coverage: 83/86 requirements traced to code (97%). 2 planned (ExoForge scheduling + React dashboard). 1 partial (T-14 Rust attestation verification).**
-**Workspace inventory: 2,980 listed tests across 20 packages and 266 Rust files.**
+**Workspace inventory: 2,986 listed tests across 20 packages and 266 Rust files.**


### PR DESCRIPTION
## Summary
- replace eDiscovery production-set raw BLAKE3 document-hash streaming with a domain-separated canonical CBOR payload
- bind requester, scope, date range, custodians, search terms, document identity, creator, timestamp, custody chain, and admissibility status into the production hash
- make `exo_legal::ediscovery::search` fail closed on canonical hash encoding errors and propagate that through the WASM legal binding
- refresh repo-truth public counts to `123208` Rust LOC and `2,986` listed workspace tests

## TDD
Red first:
- `cargo test -p exo-legal production_hash_payload_is_domain_separated_cbor --lib -- --nocapture` initially failed because `EDISCOVERY_PRODUCTION_HASH_DOMAIN`, `EDISCOVERY_PRODUCTION_HASH_SCHEMA_VERSION`, `ediscovery_production_hash_payload`, and `ediscovery_production_hash` did not exist.

Regression coverage added:
- `production_hash_payload_is_domain_separated_cbor`
- `production_hash_rejects_legacy_doc_hash_concat`
- `production_hash_binds_request_scope_and_terms`
- `production_hash_binds_document_identity_and_timestamp`
- `production_hash_binds_custody_chain`
- `ediscovery_production_source_has_no_raw_hash_loop`

## Local Verification
- `cargo test -p exo-legal production_hash_payload_is_domain_separated_cbor --lib -- --nocapture`
- `cargo test -p exo-legal ediscovery --lib -- --nocapture`
- `cargo test -p exo-legal error::tests::error_display_all_variants --lib -- --nocapture`
- `cargo test -p exo-legal`
- `cargo build -p exo-legal`
- `cargo test -p exochain-wasm`
- `cargo clippy -p exo-legal --lib --bins -- -D warnings`
- `cargo clippy -p exo-legal --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo clippy -p exochain-wasm --lib -- -D warnings`
- `cargo clippy -p exochain-wasm --tests -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `bash tools/repo_truth.sh --json --skip-tests`
- `cargo test -p exo-legal -- --list | rg -c ': test$'`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit` (passes with existing allowed yanked `core2` warning)
- `cargo deny check` (passes with existing duplicate/yanked/unused-allowance warnings)
- `cargo machete --with-metadata`

## Note
`bash tools/repo_truth.sh --json` without `--skip-tests` hung locally inside `cargo test --workspace -- --list` with no compiler activity. I stopped that local listing process and used the measured skip-tests LOC plus the six-test delta from `exo-legal`'s package-level test listing. The full debug and release workspace test gates passed.
