### PR TITLE
fix(exo-identity): canonicalize verification evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 123208 | `wc -l` |
-| Workspace tests | 2,986 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 123371 | `wc -l` |
+| Workspace tests | 2,989 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,986 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,989 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 123208 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 123371 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,986 listed workspace tests
+         cryptographic proofs, 2,989 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-identity/src/verification.rs
+++ b/crates/exo-identity/src/verification.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
-use exo_core::{Did, SecretKey, Signature, Timestamp};
+use exo_core::{Did, Hash256, PublicKey, SecretKey, Signature, Timestamp, hash::hash_structured};
+use serde::Serialize;
 use thiserror::Error;
 
 use crate::risk::{RiskAttestation, RiskContext, RiskLevel, assess_risk};
@@ -17,13 +18,24 @@ pub enum VerificationCeremonyError {
     InsufficientScore { score: u32 },
     #[error("Invalid attester DID: {0}")]
     InvalidAttesterDid(String),
+    #[error("verification ceremony evidence encoding failed: {reason}")]
+    EvidenceEncoding { reason: String },
     #[error("risk attestation failed: {0}")]
     RiskAttestation(#[from] crate::error::IdentityError),
 }
 
+/// Domain tag for canonical verification ceremony evidence.
+pub const VERIFICATION_CEREMONY_EVIDENCE_DOMAIN: &str =
+    "exo.identity.verification_ceremony.evidence.v1";
+
+const VERIFICATION_CEREMONY_EVIDENCE_SCHEMA_VERSION: u16 = 1;
+const VERIFICATION_CEREMONY_PROOF_MATERIAL_HASH_DOMAIN: &str =
+    "exo.identity.verification_ceremony.proof_material.v1";
+const VERIFICATION_CEREMONY_PROOF_MATERIAL_HASH_SCHEMA_VERSION: u16 = 1;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IdentityProof {
-    Signature(Signature, exo_core::PublicKey, Vec<u8>), // sig, pubkey, message
+    Signature(Signature, PublicKey, Vec<u8>), // sig, pubkey, message
     Otp(String),
     WebAuthnAssertion(Vec<u8>),
     KycToken(String),
@@ -36,6 +48,57 @@ pub struct VerificationCeremony {
     pub initiated_at: Timestamp,
     pub proofs: Vec<IdentityProof>,
     pub finalized: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct VerificationCeremonyEvidencePayload {
+    domain: &'static str,
+    schema_version: u16,
+    target_did: Did,
+    session_id: String,
+    initiated_at: Timestamp,
+    proofs: Vec<VerificationProofEvidencePayload>,
+}
+
+#[derive(Debug, Serialize)]
+struct VerificationProofEvidencePayload {
+    index: u64,
+    kind: &'static str,
+    material_hash: Hash256,
+}
+
+#[derive(Serialize)]
+struct SignatureProofMaterialPayload<'a> {
+    domain: &'static str,
+    schema_version: u16,
+    kind: &'static str,
+    signature: &'a Signature,
+    public_key: &'a PublicKey,
+    message: &'a [u8],
+}
+
+#[derive(Serialize)]
+struct OtpProofMaterialPayload<'a> {
+    domain: &'static str,
+    schema_version: u16,
+    kind: &'static str,
+    token: &'a str,
+}
+
+#[derive(Serialize)]
+struct WebAuthnProofMaterialPayload<'a> {
+    domain: &'static str,
+    schema_version: u16,
+    kind: &'static str,
+    assertion: &'a [u8],
+}
+
+#[derive(Serialize)]
+struct KycProofMaterialPayload<'a> {
+    domain: &'static str,
+    schema_version: u16,
+    kind: &'static str,
+    token: &'a str,
 }
 
 impl VerificationCeremony {
@@ -112,10 +175,9 @@ impl VerificationCeremony {
     ///   verifiable with `risk::verify_attestation` against that pubkey.
     ///
     /// The evidence bytes over which the attestation's `evidence_hash`
-    /// is computed are a canonical summary of the submitted proofs
-    /// (one domain-separated line per proof, in submission order).
-    /// This binds the attestation to the exact proof set that produced
-    /// the risk score.
+    /// is computed are a domain-separated canonical CBOR summary of the
+    /// submitted proofs in submission order. This binds the attestation to the
+    /// exact proof set that produced the risk score.
     pub fn finalize(
         &mut self,
         now: Timestamp,
@@ -153,10 +215,10 @@ impl VerificationCeremony {
             RiskLevel::Minimal
         };
 
-        // Build canonical evidence bytes summarizing the proof set.
+        // Build canonical CBOR evidence bytes summarizing the proof set.
         // The attestation's evidence_hash will be blake3 over these bytes
         // (computed inside risk::assess_risk).
-        let evidence = self.canonical_evidence();
+        let evidence = self.canonical_evidence()?;
 
         // Validity: 1 year from `now`, matching the previous behavior.
         const ONE_YEAR_MS: u64 = 31_536_000_000;
@@ -191,72 +253,96 @@ impl VerificationCeremony {
         Ok(attestation)
     }
 
-    /// Canonical byte serialization of this ceremony's proof set, used
-    /// as input to the attestation's `evidence_hash`. Format is:
+    /// Canonical CBOR serialization of this ceremony's proof set, used
+    /// as input to the attestation's `evidence_hash`.
     ///
-    /// ```text
-    /// "exo.verification.ceremony.v1\n"
-    /// "<target_did>\n"
-    /// "<session_id>\n"
-    /// "<initiated_at_ms>\n"
-    /// "proof\t<index>\t<kind>\t<hash_hex>\n" ... (one per proof)
-    /// ```
-    ///
-    /// Where `<hash_hex>` is the blake3 hash (32 bytes, hex-encoded) of
-    /// a kind-tagged canonical encoding of the proof's contents. This
-    /// binds the attestation to an exact proof set and ordering while
-    /// keeping raw proof material (e.g. OTPs, KYC tokens) out of the
-    /// evidence payload.
-    fn canonical_evidence(&self) -> Vec<u8> {
+    /// The evidence payload binds the exact target DID, session ID, full
+    /// initiation HLC timestamp, proof ordering, proof kind, and per-proof
+    /// canonical material hash. Raw OTP, KYC, and WebAuthn material does not
+    /// appear directly in the evidence bytes.
+    fn canonical_evidence(&self) -> Result<Vec<u8>, VerificationCeremonyError> {
+        let payload = self.evidence_payload()?;
         let mut out = Vec::new();
-        out.extend_from_slice(b"exo.verification.ceremony.v1\n");
-        out.extend_from_slice(self.target_did.as_str().as_bytes());
-        out.push(b'\n');
-        out.extend_from_slice(self.session_id.as_bytes());
-        out.push(b'\n');
-        out.extend_from_slice(self.initiated_at.physical_ms.to_string().as_bytes());
-        out.push(b'\n');
-
-        for (idx, proof) in self.proofs.iter().enumerate() {
-            let (kind, material_hash) = match proof {
-                IdentityProof::Signature(sig, pk, msg) => {
-                    let mut h = blake3::Hasher::new();
-                    h.update(b"proof.signature.v1");
-                    h.update(&sig.to_bytes());
-                    h.update(pk.as_bytes());
-                    h.update(msg);
-                    ("Signature", *h.finalize().as_bytes())
-                }
-                IdentityProof::Otp(token) => {
-                    let mut h = blake3::Hasher::new();
-                    h.update(b"proof.otp.v1");
-                    h.update(token.as_bytes());
-                    ("Otp", *h.finalize().as_bytes())
-                }
-                IdentityProof::WebAuthnAssertion(bytes) => {
-                    let mut h = blake3::Hasher::new();
-                    h.update(b"proof.webauthn.v1");
-                    h.update(bytes);
-                    ("WebAuthnAssertion", *h.finalize().as_bytes())
-                }
-                IdentityProof::KycToken(token) => {
-                    let mut h = blake3::Hasher::new();
-                    h.update(b"proof.kyc.v1");
-                    h.update(token.as_bytes());
-                    ("KycToken", *h.finalize().as_bytes())
-                }
-            };
-            out.extend_from_slice(b"proof\t");
-            out.extend_from_slice(idx.to_string().as_bytes());
-            out.push(b'\t');
-            out.extend_from_slice(kind.as_bytes());
-            out.push(b'\t');
-            for byte in material_hash {
-                out.extend_from_slice(format!("{byte:02x}").as_bytes());
+        ciborium::ser::into_writer(&payload, &mut out).map_err(|e| {
+            VerificationCeremonyError::EvidenceEncoding {
+                reason: e.to_string(),
             }
-            out.push(b'\n');
+        })?;
+        Ok(out)
+    }
+
+    fn evidence_payload(
+        &self,
+    ) -> Result<VerificationCeremonyEvidencePayload, VerificationCeremonyError> {
+        let mut proofs = Vec::with_capacity(self.proofs.len());
+        for (idx, proof) in self.proofs.iter().enumerate() {
+            let index =
+                u64::try_from(idx).map_err(|e| VerificationCeremonyError::EvidenceEncoding {
+                    reason: format!("proof index does not fit u64: {e}"),
+                })?;
+            proofs.push(VerificationProofEvidencePayload {
+                index,
+                kind: proof.kind(),
+                material_hash: proof.material_hash()?,
+            });
         }
-        out
+
+        Ok(VerificationCeremonyEvidencePayload {
+            domain: VERIFICATION_CEREMONY_EVIDENCE_DOMAIN,
+            schema_version: VERIFICATION_CEREMONY_EVIDENCE_SCHEMA_VERSION,
+            target_did: self.target_did.clone(),
+            session_id: self.session_id.clone(),
+            initiated_at: self.initiated_at,
+            proofs,
+        })
+    }
+}
+
+impl IdentityProof {
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::Signature(..) => "Signature",
+            Self::Otp(_) => "Otp",
+            Self::WebAuthnAssertion(_) => "WebAuthnAssertion",
+            Self::KycToken(_) => "KycToken",
+        }
+    }
+
+    fn material_hash(&self) -> Result<Hash256, VerificationCeremonyError> {
+        let hash_result = match self {
+            Self::Signature(signature, public_key, message) => {
+                hash_structured(&SignatureProofMaterialPayload {
+                    domain: VERIFICATION_CEREMONY_PROOF_MATERIAL_HASH_DOMAIN,
+                    schema_version: VERIFICATION_CEREMONY_PROOF_MATERIAL_HASH_SCHEMA_VERSION,
+                    kind: self.kind(),
+                    signature,
+                    public_key,
+                    message,
+                })
+            }
+            Self::Otp(token) => hash_structured(&OtpProofMaterialPayload {
+                domain: VERIFICATION_CEREMONY_PROOF_MATERIAL_HASH_DOMAIN,
+                schema_version: VERIFICATION_CEREMONY_PROOF_MATERIAL_HASH_SCHEMA_VERSION,
+                kind: self.kind(),
+                token,
+            }),
+            Self::WebAuthnAssertion(assertion) => hash_structured(&WebAuthnProofMaterialPayload {
+                domain: VERIFICATION_CEREMONY_PROOF_MATERIAL_HASH_DOMAIN,
+                schema_version: VERIFICATION_CEREMONY_PROOF_MATERIAL_HASH_SCHEMA_VERSION,
+                kind: self.kind(),
+                assertion,
+            }),
+            Self::KycToken(token) => hash_structured(&KycProofMaterialPayload {
+                domain: VERIFICATION_CEREMONY_PROOF_MATERIAL_HASH_DOMAIN,
+                schema_version: VERIFICATION_CEREMONY_PROOF_MATERIAL_HASH_SCHEMA_VERSION,
+                kind: self.kind(),
+                token,
+            }),
+        };
+
+        hash_result.map_err(|e| VerificationCeremonyError::EvidenceEncoding {
+            reason: e.to_string(),
+        })
     }
 }
 
@@ -761,5 +847,82 @@ mod tests {
         assert_ne!(a, d_diff_kyc);
         // Non-zero sanity (also asserted by debug_assert in finalize).
         assert_ne!(a, [0u8; 32]);
+    }
+
+    #[test]
+    fn canonical_evidence_binds_initiated_at_hlc_logical_counter() {
+        fn evidence_hash_for(initiated_at: Timestamp) -> [u8; 32] {
+            let did = Did::new("did:exo:canon-hlc-logical").unwrap();
+            let mut ceremony =
+                VerificationCeremony::new(did, "sess-canon-hlc".to_string(), initiated_at);
+            ceremony
+                .submit_proof(
+                    IdentityProof::KycToken("kyc-logical".to_string()),
+                    Timestamp::new(2000, 0),
+                )
+                .unwrap();
+
+            let (_pk, sk) = generate_keypair();
+            let attester = Did::new("did:exo:att-canon-hlc").unwrap();
+            ceremony
+                .finalize(Timestamp::new(2010, 0), &attester, &sk)
+                .unwrap()
+                .evidence_hash
+        }
+
+        let logical_zero = evidence_hash_for(Timestamp::new(1000, 0));
+        let logical_one = evidence_hash_for(Timestamp::new(1000, 1));
+
+        assert_ne!(
+            logical_zero, logical_one,
+            "verification ceremony evidence must bind the full HLC, not only physical_ms"
+        );
+    }
+
+    #[test]
+    fn canonical_evidence_payload_is_domain_separated_cbor() {
+        let did = Did::new("did:exo:canon-cbor").unwrap();
+        let mut ceremony =
+            VerificationCeremony::new(did, "sess-cbor".to_string(), Timestamp::new(1000, 2));
+        ceremony
+            .submit_proof(
+                IdentityProof::Otp("otp-cbor".to_string()),
+                Timestamp::new(1001, 0),
+            )
+            .unwrap();
+
+        let evidence = ceremony.canonical_evidence().unwrap();
+
+        assert!(
+            !evidence.starts_with(b"exo.verification.ceremony.v1\n"),
+            "verification ceremony evidence must not use the legacy line format"
+        );
+        assert!(
+            evidence
+                .windows(b"exo.identity.verification_ceremony.evidence.v1".len())
+                .any(|window| window == b"exo.identity.verification_ceremony.evidence.v1"),
+            "canonical evidence must include a domain tag in the CBOR payload"
+        );
+
+        let decoded: ciborium::value::Value =
+            ciborium::de::from_reader(evidence.as_slice()).expect("canonical evidence CBOR");
+        assert!(
+            matches!(decoded, ciborium::value::Value::Map(_)),
+            "canonical evidence should decode as a structured CBOR map"
+        );
+    }
+
+    #[test]
+    fn verification_evidence_source_has_no_raw_proof_hash_streaming() {
+        let source = include_str!("verification.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production section");
+
+        assert!(
+            !production.contains("blake3::Hasher"),
+            "verification ceremony evidence must use domain-separated canonical CBOR, not raw BLAKE3 streaming"
+        );
     }
 }

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 123208 lines of Rust under `crates/`, 2,986 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 123371 lines of Rust under `crates/`, 2,989 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,986 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,989 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,986 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,989 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-123208 lines of Rust under `crates/` · 20 workspace packages · 2,986 listed tests · 40 MCP tools · 8 constitutional invariants
+123371 lines of Rust under `crates/` · 20 workspace packages · 2,989 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 123208 lines of Rust under `crates/` | 266 Rust source files | 2,986 listed tests
+> **Codebase:** 20 workspace packages | 123371 lines of Rust under `crates/` | 266 Rust source files | 2,989 listed tests
 
 ---
 

--- a/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
+++ b/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
@@ -46,9 +46,9 @@ decision.forum is a constitutional trust fabric for AI-era governance. Not a fra
 
 The numbers, verified as of this writing:
 
-- **123208 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
+- **123371 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
 - **20 workspace packages** covering identity, consent, authority, governance, escalation, legal infrastructure, cryptographic proofs, and more
-- **2,986 listed tests** exercised by the workspace test gate.
+- **2,989 listed tests** exercised by the workspace test gate.
 - **10 formal proofs** demonstrating that constitutional properties hold under all reachable system states
 - Built and reviewed through a **5-panel council process** (Governance, Legal, Architecture, Security, Operations)
 
@@ -270,7 +270,7 @@ The question is whether we will build it before we need it.
 
 *Bob Stewart is the architect of EXOCHAIN and decision.forum, and the author of The ASI Report on LinkedIn, where he writes about the infrastructure required for safe superintelligence. His work focuses on the intersection of constitutional governance, cryptographic enforcement, and AI safety -- the premise that alignment is necessary but insufficient, and that enforceable structural constraints are the missing complement.*
 
-*The EXOCHAIN workspace -- 123208 lines of Rust under `crates/`, 20 packages, 2,986 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
+*The EXOCHAIN workspace -- 123371 lines of Rust under `crates/`, 20 packages, 2,989 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
 
 ---
 

--- a/docs/decision-forum/SYSTEM-DOCUMENTATION.md
+++ b/docs/decision-forum/SYSTEM-DOCUMENTATION.md
@@ -6,7 +6,7 @@ created: 2026-03-19
 publication: "The ASI Report — LinkedIn Newsletter"
 tags: [decision-forum, governance, constitutional, asi-safety, exochain]
 status: publication-ready
-codebase: "20 workspace packages | 123208 LOC Rust under crates/ | 266 source files | 2,986 listed tests"
+codebase: "20 workspace packages | 123371 LOC Rust under crates/ | 266 source files | 2,989 listed tests"
 ---
 
 # decision.forum — System Documentation
@@ -20,9 +20,9 @@ This document is the exhaustive technical reference for the decision.forum gover
 | Metric | Value |
 |--------|-------|
 | Workspace packages | 20 |
-| Rust LOC under `crates/` | 123208 |
-| Rust source files | 273 |
-| Listed workspace tests | 2,986 |
+| Rust LOC under `crates/` | 123371 |
+| Rust source files | 266 |
+| Listed workspace tests | 2,989 |
 | Test gate | `cargo test --workspace` in CI Gate 2 |
 | decision-forum crate LOC | 3,800 |
 | decision-forum tests | 131 |

--- a/docs/guides/GETTING-STARTED.md
+++ b/docs/guides/GETTING-STARTED.md
@@ -124,7 +124,7 @@ open tarpaulin-report.html
 ```
 
 A clean build produces zero errors and zero warnings. The current workspace
-inventory lists 2,986 tests; the exact executed count can change as doctests and
+inventory lists 2,989 tests; the exact executed count can change as doctests and
 integration targets evolve. What matters is zero failures:
 
 ```

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,986 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,989 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 123208 lines of Rust under `crates/` · 2,986 listed tests
+20 workspace packages · 123371 lines of Rust under `crates/` · 2,989 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 

--- a/governance/EXOCHAIN-REFACTOR-PLAN.md
+++ b/governance/EXOCHAIN-REFACTOR-PLAN.md
@@ -68,7 +68,7 @@ All refactor work flows through the Syntaxis Builder system:
 - [ ] Complete Section 8 work orders from CR-001
 - [ ] Achieve release-blocking acceptance standard (CR-001 Section 9)
 
-> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 123208 Rust LOC under `crates/`, 2,986 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
+> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 123371 Rust LOC under `crates/`, 2,989 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
 
 ## Active Resolutions
 

--- a/governance/sub_agents.md
+++ b/governance/sub_agents.md
@@ -72,7 +72,7 @@ Historical 2026-03-19 sub-agent completion record. Numeric status claims are sup
 * **Inputs**: Spec Section 16 (Acceptance Criteria).
 * **Outputs**: Test harnesses, Integration tests, Fuzz targets.
 * **Definition of Done**: Section 16 Acceptance Criteria are automated and passing.
-* **Status**: **DONE** — Current workspace inventory lists 2,986 tests across 20 packages and 266 Rust files.
+* **Status**: **DONE** — Current workspace inventory lists 2,989 tests across 20 packages and 266 Rust files.
 
 ## J) DEVOPS_RELEASE_AGENT (Judicial) — DONE
 

--- a/governance/traceability_matrix.md
+++ b/governance/traceability_matrix.md
@@ -163,4 +163,4 @@ Updated 2026-03-20 after EXOCHAIN-REM-009 — continuous governance monitoring a
 | **TOTAL** | **86** | **83** | **1** | **2** |
 
 **Coverage: 83/86 requirements traced to code (97%). 2 planned (ExoForge scheduling + React dashboard). 1 partial (T-14 Rust attestation verification).**
-**Workspace inventory: 2,986 listed tests across 20 packages and 266 Rust files.**
+**Workspace inventory: 2,989 listed tests across 20 packages and 266 Rust files.**


### PR DESCRIPTION
## Summary
- replace verification ceremony evidence line encoding with domain-separated canonical CBOR
- include the full HLC timestamp, including logical counter, in the evidence payload
- hash proof material through domain-separated structured payloads instead of raw BLAKE3 streaming
- update repo-truth LOC/test-count documentation to 123371 Rust LOC and 2,989 listed tests

## TDD red checks observed before implementation
- `cargo test -p exo-identity canonical_evidence_binds_initiated_at_hlc_logical_counter --lib -- --nocapture` failed because logical-zero and logical-one HLC ceremonies produced the same evidence hash
- `cargo test -p exo-identity canonical_evidence_payload_is_domain_separated_cbor --lib -- --nocapture` failed because evidence used the legacy line format
- `cargo test -p exo-identity verification_evidence_source_has_no_raw_proof_hash_streaming --lib -- --nocapture` failed because production code used `blake3::Hasher` directly for proof material

## Verification
- `cargo test -p exo-identity canonical_evidence --lib -- --nocapture`
- `cargo test -p exo-identity verification_evidence_source_has_no_raw_proof_hash_streaming --lib -- --nocapture`
- `cargo test -p exo-identity`
- `cargo build -p exo-identity`
- `cargo clippy -p exo-identity --lib --bins -- -D warnings`
- `cargo clippy -p exo-identity --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo test --workspace -- --list | rg -c '\\: test$'`\n- `bash tools/repo_truth.sh --json --skip-tests`\n- `cargo fmt --all -- --check`\n- `git diff --check`\n- `bash tools/test_repo_truth.sh`\n- `bash tools/test_cr001_status.sh`\n- `bash tools/test_gap_registry_truth.sh`\n- `bash tools/test_no_orphan_rust_modules.sh`\n- `bash tools/test_railway_entrypoint_args.sh`\n- `cargo build --workspace`\n- `cargo test --workspace`\n- `cargo clippy --workspace --lib --bins -- -D warnings`\n- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`\n- `cargo build --workspace --release`\n- `cargo test --workspace --release`\n- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`\n- `cargo audit`\n- `cargo deny check`\n- `cargo machete --with-metadata`\n- `bash tools/repo_truth.sh --json`\n- `git diff --cached --check`