### PR TITLE
fix(exo-node): verify mcp custody chains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1582,6 +1582,7 @@ dependencies = [
  "exo-gateway",
  "exo-governance",
  "exo-identity",
+ "exo-legal",
  "futures",
  "getrandom 0.2.16",
  "hex",

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 123371 | `wc -l` |
-| Workspace tests | 2,989 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 123803 | `wc -l` |
+| Workspace tests | 2,994 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,989 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,994 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 123371 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 123803 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,989 listed workspace tests
+         cryptographic proofs, 2,994 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-legal/src/error.rs
+++ b/crates/exo-legal/src/error.rs
@@ -24,6 +24,8 @@ pub enum LegalError {
     DiscoveryScopeTooBoard { reason: String },
     #[error("eDiscovery production hash encoding failed: {reason}")]
     DiscoveryHashEncodingFailed { reason: String },
+    #[error("evidence hash encoding failed: {reason}")]
+    EvidenceHashEncodingFailed { reason: String },
     #[error("retention policy violation: {reason}")]
     RetentionViolation { reason: String },
     #[error("disclosure required for action: {action}")]
@@ -60,6 +62,7 @@ mod tests {
             Box::new(LegalError::FiduciaryViolation { reason: "x".into() }),
             Box::new(LegalError::DiscoveryScopeTooBoard { reason: "x".into() }),
             Box::new(LegalError::DiscoveryHashEncodingFailed { reason: "x".into() }),
+            Box::new(LegalError::EvidenceHashEncodingFailed { reason: "x".into() }),
             Box::new(LegalError::RetentionViolation { reason: "x".into() }),
             Box::new(LegalError::DisclosureRequired {
                 action: "vote".into(),

--- a/crates/exo-legal/src/evidence.rs
+++ b/crates/exo-legal/src/evidence.rs
@@ -1,10 +1,13 @@
 //! Evidence chain management — litigation-grade evidence tracking.
 
-use exo_core::{Did, Hash256, Timestamp};
+use exo_core::{Did, Hash256, Timestamp, hash::hash_structured};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::error::{LegalError, Result};
+
+const EVIDENCE_CUSTODY_CHAIN_DIGEST_DOMAIN: &str = "exo.legal.evidence.custody_chain.v1";
+const EVIDENCE_CUSTODY_CHAIN_DIGEST_SCHEMA_VERSION: u16 = 1;
 
 /// Whether a piece of evidence has been admitted, challenged, excluded, or is still pending review.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -36,18 +39,28 @@ pub struct Evidence {
     pub admissibility_status: AdmissibilityStatus,
 }
 
-/// Create evidence with a real HLC timestamp.
-///
-/// # Errors
-/// Returns `LegalError` if the timestamp is `Timestamp::ZERO` (placeholder).
-/// Evidence must carry a real timestamp for litigation-grade provenance.
-pub fn create_evidence(
-    id: Uuid,
-    data: &[u8],
-    creator: &Did,
-    type_tag: &str,
+#[derive(Debug, Clone, Serialize)]
+struct EvidenceCustodyTransferDigestPayload {
+    from: Did,
+    to: Did,
     timestamp: Timestamp,
-) -> Result<Evidence> {
+    reason: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct EvidenceCustodyChainDigestPayload {
+    domain: &'static str,
+    schema_version: u16,
+    evidence_id: Uuid,
+    type_tag: String,
+    content_hash: Hash256,
+    creator: Did,
+    created_at: Timestamp,
+    admissibility_status: AdmissibilityStatus,
+    transfers: Vec<EvidenceCustodyTransferDigestPayload>,
+}
+
+fn validate_evidence_metadata(id: Uuid, type_tag: &str, timestamp: Timestamp) -> Result<()> {
     if id.is_nil() {
         return Err(LegalError::InvalidStateTransition {
             reason: "evidence ID must be caller-supplied and non-nil".into(),
@@ -64,10 +77,54 @@ pub fn create_evidence(
                 .into(),
         });
     }
+    Ok(())
+}
+
+/// Create evidence with a real HLC timestamp.
+///
+/// # Errors
+/// Returns `LegalError` if the timestamp is `Timestamp::ZERO` (placeholder).
+/// Evidence must carry a real timestamp for litigation-grade provenance.
+pub fn create_evidence(
+    id: Uuid,
+    data: &[u8],
+    creator: &Did,
+    type_tag: &str,
+    timestamp: Timestamp,
+) -> Result<Evidence> {
+    validate_evidence_metadata(id, type_tag, timestamp)?;
     Ok(Evidence {
         id,
         type_tag: type_tag.to_string(),
         hash: Hash256::digest(data),
+        creator: creator.clone(),
+        timestamp,
+        chain_of_custody: Vec::new(),
+        admissibility_status: AdmissibilityStatus::Pending,
+    })
+}
+
+/// Create evidence when the caller already has the canonical content hash.
+///
+/// # Errors
+/// Returns `LegalError` if the ID, type tag, timestamp, or hash is a placeholder.
+pub fn create_evidence_from_hash(
+    id: Uuid,
+    content_hash: Hash256,
+    creator: &Did,
+    type_tag: &str,
+    timestamp: Timestamp,
+) -> Result<Evidence> {
+    validate_evidence_metadata(id, type_tag, timestamp)?;
+    if content_hash == Hash256::ZERO {
+        return Err(LegalError::InvalidStateTransition {
+            reason: "evidence content hash must not be Hash256::ZERO".into(),
+        });
+    }
+    Ok(Evidence {
+        id,
+        type_tag: type_tag.to_string(),
+        hash: content_hash,
         creator: creator.clone(),
         timestamp,
         chain_of_custody: Vec::new(),
@@ -136,6 +193,42 @@ pub fn verify_chain_of_custody(evidence: &Evidence) -> Result<()> {
     Ok(())
 }
 
+fn evidence_custody_chain_digest_payload(evidence: &Evidence) -> EvidenceCustodyChainDigestPayload {
+    EvidenceCustodyChainDigestPayload {
+        domain: EVIDENCE_CUSTODY_CHAIN_DIGEST_DOMAIN,
+        schema_version: EVIDENCE_CUSTODY_CHAIN_DIGEST_SCHEMA_VERSION,
+        evidence_id: evidence.id,
+        type_tag: evidence.type_tag.clone(),
+        content_hash: evidence.hash,
+        creator: evidence.creator.clone(),
+        created_at: evidence.timestamp,
+        admissibility_status: evidence.admissibility_status.clone(),
+        transfers: evidence
+            .chain_of_custody
+            .iter()
+            .map(|transfer| EvidenceCustodyTransferDigestPayload {
+                from: transfer.from.clone(),
+                to: transfer.to.clone(),
+                timestamp: transfer.timestamp,
+                reason: transfer.reason.clone(),
+            })
+            .collect(),
+    }
+}
+
+/// Computes a domain-separated canonical CBOR digest for the evidence custody chain.
+///
+/// # Errors
+/// Returns `LegalError` if the custody chain is broken or canonical CBOR hashing fails.
+pub fn custody_chain_digest(evidence: &Evidence) -> Result<Hash256> {
+    verify_chain_of_custody(evidence)?;
+    hash_structured(&evidence_custody_chain_digest_payload(evidence)).map_err(|e| {
+        LegalError::EvidenceHashEncodingFailed {
+            reason: format!("evidence custody-chain canonical CBOR hash failed: {e}"),
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -189,6 +282,21 @@ mod tests {
     fn create_hashes_data() {
         let ev = create_evidence(id(0x104), b"x", &did("a"), "d", ts(1000)).unwrap();
         assert_eq!(ev.hash, Hash256::digest(b"x"));
+    }
+    #[test]
+    fn create_evidence_from_hash_uses_caller_supplied_hash() {
+        let evidence_hash = Hash256::digest(b"already-hashed-evidence");
+        let ev =
+            create_evidence_from_hash(id(0x120), evidence_hash, &did("a"), "d", ts(1000)).unwrap();
+        assert_eq!(ev.hash, evidence_hash);
+        assert_eq!(ev.id, id(0x120));
+        assert_eq!(ev.creator, did("a"));
+        assert_eq!(ev.timestamp, ts(1000));
+    }
+    #[test]
+    fn create_evidence_from_hash_rejects_zero_hash() {
+        let result = create_evidence_from_hash(id(0x121), Hash256::ZERO, &did("a"), "d", ts(1000));
+        assert!(result.is_err());
     }
     #[test]
     fn create_rejects_zero_timestamp() {
@@ -277,5 +385,29 @@ mod tests {
         transfer_custody(&mut ev, &a, &b, ts(2000), "first transfer").unwrap();
         transfer_custody(&mut ev, &b, &c, ts(3000), "second transfer").unwrap();
         assert!(ev.chain_of_custody[1].timestamp > ev.chain_of_custody[0].timestamp);
+    }
+    #[test]
+    fn custody_chain_digest_binds_transfer_reason_and_logical_time() {
+        let evidence_hash = Hash256::digest(b"evidence-hash");
+        let (a, b) = (did("a"), did("b"));
+        let mut ev_a =
+            create_evidence_from_hash(id(0x122), evidence_hash, &a, "d", ts(1000)).unwrap();
+        let mut ev_b =
+            create_evidence_from_hash(id(0x122), evidence_hash, &a, "d", ts(1000)).unwrap();
+
+        transfer_custody(&mut ev_a, &a, &b, Timestamp::new(2000, 0), "first transfer").unwrap();
+        transfer_custody(
+            &mut ev_b,
+            &a,
+            &b,
+            Timestamp::new(2000, 1),
+            "alternate transfer",
+        )
+        .unwrap();
+
+        assert_ne!(
+            custody_chain_digest(&ev_a).unwrap(),
+            custody_chain_digest(&ev_b).unwrap()
+        );
     }
 }

--- a/crates/exo-node/Cargo.toml
+++ b/crates/exo-node/Cargo.toml
@@ -26,6 +26,7 @@ exo-governance = { path = "../exo-governance" }
 exo-identity = { path = "../exo-identity" }
 exo-consent = { path = "../exo-consent" }
 exo-escalation = { path = "../exo-escalation" }
+exo-legal = { path = "../exo-legal" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/exo-node/src/mcp/tools/proofs.rs
+++ b/crates/exo-node/src/mcp/tools/proofs.rs
@@ -1,8 +1,12 @@
 //! Proofs MCP tools — evidence creation, chain of custody verification,
 //! Merkle proof generation, and CGR kernel proof verification.
 
-use exo_core::{Did, Hash256};
+use exo_core::{Did, Hash256, Timestamp};
+use exo_legal::evidence::{
+    create_evidence_from_hash, custody_chain_digest, transfer_custody, verify_chain_of_custody,
+};
 use serde_json::{Value, json};
+use uuid::Uuid;
 
 use crate::mcp::{
     context::NodeContext,
@@ -11,16 +15,114 @@ use crate::mcp::{
 
 const MCP_CGR_PROOF_INITIATIVE: &str = "Initiatives/fix-mcp-cgr-proof-verification-stub.md";
 
+fn tool_error(message: impl Into<String>) -> ToolResult {
+    let message = message.into();
+    ToolResult::error(json!({"error": message}).to_string())
+}
+
 fn required_nonzero_u64(params: &Value, name: &str) -> std::result::Result<u64, ToolResult> {
     match params.get(name).and_then(Value::as_u64) {
         Some(value) if value > 0 => Ok(value),
-        Some(_) => Err(ToolResult::error(
-            json!({"error": format!("{name} must be a nonzero integer")}).to_string(),
-        )),
-        None => Err(ToolResult::error(
-            json!({"error": format!("missing required parameter: {name}")}).to_string(),
-        )),
+        Some(_) => Err(tool_error(format!("{name} must be a nonzero integer"))),
+        None => Err(tool_error(format!("missing required parameter: {name}"))),
     }
+}
+
+fn required_u32(params: &Value, name: &str) -> std::result::Result<u32, ToolResult> {
+    match params.get(name).and_then(Value::as_u64) {
+        Some(value) if value <= u64::from(u32::MAX) => Ok(value as u32),
+        Some(_) => Err(tool_error(format!("{name} must fit in u32"))),
+        None => Err(tool_error(format!("missing required parameter: {name}"))),
+    }
+}
+
+fn required_nonempty_str<'a>(
+    params: &'a Value,
+    name: &str,
+) -> std::result::Result<&'a str, ToolResult> {
+    match params.get(name).and_then(Value::as_str) {
+        Some(value) if !value.trim().is_empty() => Ok(value),
+        Some(_) => Err(tool_error(format!("{name} must not be empty"))),
+        None => Err(tool_error(format!("missing required parameter: {name}"))),
+    }
+}
+
+fn required_transfer_nonempty_str<'a>(
+    transfer: &'a Value,
+    index: usize,
+    name: &str,
+) -> std::result::Result<&'a str, ToolResult> {
+    match transfer.get(name).and_then(Value::as_str) {
+        Some(value) if !value.trim().is_empty() => Ok(value),
+        Some(_) => Err(tool_error(format!(
+            "chain entry {index}: {name} must not be empty"
+        ))),
+        None => Err(tool_error(format!(
+            "chain entry {index}: missing required field: {name}"
+        ))),
+    }
+}
+
+fn required_transfer_nonzero_u64(
+    transfer: &Value,
+    index: usize,
+    name: &str,
+) -> std::result::Result<u64, ToolResult> {
+    match transfer.get(name).and_then(Value::as_u64) {
+        Some(value) if value > 0 => Ok(value),
+        Some(_) => Err(tool_error(format!(
+            "chain entry {index}: {name} must be a nonzero integer"
+        ))),
+        None => Err(tool_error(format!(
+            "chain entry {index}: missing required field: {name}"
+        ))),
+    }
+}
+
+fn required_transfer_u32(
+    transfer: &Value,
+    index: usize,
+    name: &str,
+) -> std::result::Result<u32, ToolResult> {
+    match transfer.get(name).and_then(Value::as_u64) {
+        Some(value) if value <= u64::from(u32::MAX) => Ok(value as u32),
+        Some(_) => Err(tool_error(format!(
+            "chain entry {index}: {name} must fit in u32"
+        ))),
+        None => Err(tool_error(format!(
+            "chain entry {index}: missing required field: {name}"
+        ))),
+    }
+}
+
+fn parse_uuid(value: &str, name: &str) -> std::result::Result<Uuid, ToolResult> {
+    Uuid::parse_str(value).map_err(|err| tool_error(format!("{name} must be a valid UUID: {err}")))
+}
+
+fn parse_did(value: &str, name: &str) -> std::result::Result<Did, ToolResult> {
+    Did::new(value).map_err(|err| tool_error(format!("{name} must be a valid DID: {err}")))
+}
+
+fn parse_hash256_hex(value: &str, name: &str) -> std::result::Result<Hash256, ToolResult> {
+    let decoded =
+        hex::decode(value).map_err(|err| tool_error(format!("{name} must be hex: {err}")))?;
+    if decoded.len() != 32 {
+        return Err(tool_error(format!(
+            "{name} must decode to exactly 32 bytes, got {}",
+            decoded.len()
+        )));
+    }
+    let mut bytes = [0u8; 32];
+    bytes.copy_from_slice(&decoded);
+    Ok(Hash256::from_bytes(bytes))
+}
+
+fn final_custodian(evidence: &exo_legal::evidence::Evidence) -> &Did {
+    evidence
+        .chain_of_custody
+        .last()
+        .map(|transfer| &transfer.to)
+        .unwrap_or(&evidence.creator)
 }
 
 // ---------------------------------------------------------------------------
@@ -140,31 +242,76 @@ pub fn execute_create_evidence(params: &Value, _context: &NodeContext) -> ToolRe
 pub fn verify_chain_of_custody_definition() -> ToolDefinition {
     ToolDefinition {
         name: "exochain_verify_chain_of_custody".to_owned(),
-        description: "Verify the integrity of an evidence chain of custody, checking for gaps and unauthorized transfers.".to_owned(),
+        description: "Verify the integrity of an evidence chain of custody using EXOCHAIN legal evidence rules, checking UUID/DID/hash metadata, transfer continuity, reasons, and monotonic HLC timestamps.".to_owned(),
         input_schema: json!({
             "type": "object",
             "properties": {
                 "evidence_id": {
                     "type": "string",
-                    "description": "The evidence ID to verify."
+                    "description": "UUID of the evidence record to verify."
+                },
+                "evidence_type": {
+                    "type": "string",
+                    "description": "Evidence type tag recorded at creation."
+                },
+                "content_hash": {
+                    "type": "string",
+                    "description": "64-character hex-encoded Hash256 of the evidence content."
+                },
+                "creator_did": {
+                    "type": "string",
+                    "description": "DID of the original evidence creator."
+                },
+                "created_at_ms": {
+                    "type": "integer",
+                    "description": "Caller-supplied nonzero HLC physical milliseconds for evidence creation."
+                },
+                "created_at_logical": {
+                    "type": "integer",
+                    "description": "Caller-supplied HLC logical counter for evidence creation."
                 },
                 "chain": {
                     "type": "array",
                     "items": {
                         "type": "object",
                         "properties": {
-                            "custodian": { "type": "string" },
-                            "action": { "type": "string" }
-                        }
+                            "from_did": { "type": "string" },
+                            "to_did": { "type": "string" },
+                            "transferred_at_ms": { "type": "integer" },
+                            "transferred_at_logical": { "type": "integer" },
+                            "reason": { "type": "string" }
+                        },
+                        "required": [
+                            "from_did",
+                            "to_did",
+                            "transferred_at_ms",
+                            "transferred_at_logical",
+                            "reason"
+                        ],
+                        "additionalProperties": false
                     },
-                    "description": "Array of custody entries with custodian and action fields."
+                    "description": "Array of custody transfer records. The original creator is supplied separately; an empty transfer chain means the creator still has custody."
                 },
                 "verified_at_ms": {
                     "type": "integer",
                     "description": "Caller-supplied nonzero HLC physical milliseconds for verification."
+                },
+                "verified_at_logical": {
+                    "type": "integer",
+                    "description": "Caller-supplied HLC logical counter for verification."
                 }
             },
-            "required": ["evidence_id", "chain", "verified_at_ms"],
+            "required": [
+                "evidence_id",
+                "evidence_type",
+                "content_hash",
+                "creator_did",
+                "created_at_ms",
+                "created_at_logical",
+                "chain",
+                "verified_at_ms",
+                "verified_at_logical"
+            ],
             "additionalProperties": false,
         }),
     }
@@ -173,62 +320,145 @@ pub fn verify_chain_of_custody_definition() -> ToolDefinition {
 /// Execute the `exochain_verify_chain_of_custody` tool.
 #[must_use]
 pub fn execute_verify_chain_of_custody(params: &Value, _context: &NodeContext) -> ToolResult {
-    let evidence_id = match params.get("evidence_id").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: evidence_id"}).to_string(),
-            );
-        }
+    let evidence_id_str = match required_nonempty_str(params, "evidence_id") {
+        Ok(value) => value,
+        Err(result) => return result,
+    };
+    let evidence_id = match parse_uuid(evidence_id_str, "evidence_id") {
+        Ok(value) => value,
+        Err(result) => return result,
+    };
+    let evidence_type = match required_nonempty_str(params, "evidence_type") {
+        Ok(value) => value,
+        Err(result) => return result,
+    };
+    let content_hash_str = match required_nonempty_str(params, "content_hash") {
+        Ok(value) => value,
+        Err(result) => return result,
+    };
+    let content_hash = match parse_hash256_hex(content_hash_str, "content_hash") {
+        Ok(value) => value,
+        Err(result) => return result,
+    };
+    let creator_did_str = match required_nonempty_str(params, "creator_did") {
+        Ok(value) => value,
+        Err(result) => return result,
+    };
+    let creator_did = match parse_did(creator_did_str, "creator_did") {
+        Ok(value) => value,
+        Err(result) => return result,
+    };
+    let created_at_ms = match required_nonzero_u64(params, "created_at_ms") {
+        Ok(value) => value,
+        Err(result) => return result,
+    };
+    let created_at_logical = match required_u32(params, "created_at_logical") {
+        Ok(value) => value,
+        Err(result) => return result,
     };
     let chain = match params.get("chain").and_then(Value::as_array) {
         Some(arr) => arr,
         None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: chain (must be an array)"})
-                    .to_string(),
-            );
+            return tool_error("missing required parameter: chain (must be an array)");
         }
     };
     let verified_at_ms = match required_nonzero_u64(params, "verified_at_ms") {
         Ok(value) => value,
         Err(result) => return result,
     };
+    let verified_at_logical = match required_u32(params, "verified_at_logical") {
+        Ok(value) => value,
+        Err(result) => return result,
+    };
 
-    if chain.is_empty() {
-        return ToolResult::error(
-            json!({"error": "chain must contain at least one entry"}).to_string(),
+    let mut evidence = match create_evidence_from_hash(
+        evidence_id,
+        content_hash,
+        &creator_did,
+        evidence_type,
+        Timestamp::new(created_at_ms, created_at_logical),
+    ) {
+        Ok(value) => value,
+        Err(err) => return tool_error(err.to_string()),
+    };
+
+    for (i, entry) in chain.iter().enumerate() {
+        let from_did_str = match required_transfer_nonempty_str(entry, i, "from_did") {
+            Ok(value) => value,
+            Err(result) => return result,
+        };
+        let to_did_str = match required_transfer_nonempty_str(entry, i, "to_did") {
+            Ok(value) => value,
+            Err(result) => return result,
+        };
+        let transferred_at_ms = match required_transfer_nonzero_u64(entry, i, "transferred_at_ms") {
+            Ok(value) => value,
+            Err(result) => return result,
+        };
+        let transferred_at_logical = match required_transfer_u32(entry, i, "transferred_at_logical")
+        {
+            Ok(value) => value,
+            Err(result) => return result,
+        };
+        let reason = match required_transfer_nonempty_str(entry, i, "reason") {
+            Ok(value) => value,
+            Err(result) => return result,
+        };
+        let from_did = match parse_did(from_did_str, &format!("chain entry {i} from_did")) {
+            Ok(value) => value,
+            Err(result) => return result,
+        };
+        let to_did = match parse_did(to_did_str, &format!("chain entry {i} to_did")) {
+            Ok(value) => value,
+            Err(result) => return result,
+        };
+
+        if let Err(err) = transfer_custody(
+            &mut evidence,
+            &from_did,
+            &to_did,
+            Timestamp::new(transferred_at_ms, transferred_at_logical),
+            reason,
+        ) {
+            return ToolResult::success(
+                json!({
+                    "evidence_id": evidence_id_str,
+                    "chain_length": chain.len(),
+                    "valid": false,
+                    "issues": [err.to_string()],
+                    "verified_at": Timestamp::new(verified_at_ms, verified_at_logical).to_string(),
+                })
+                .to_string(),
+            );
+        }
+    }
+
+    if let Err(err) = verify_chain_of_custody(&evidence) {
+        return ToolResult::success(
+            json!({
+                "evidence_id": evidence_id_str,
+                "chain_length": chain.len(),
+                "valid": false,
+                "issues": [err.to_string()],
+                "verified_at": Timestamp::new(verified_at_ms, verified_at_logical).to_string(),
+            })
+            .to_string(),
         );
     }
 
-    // Validate chain continuity: each entry must have custodian and action.
-    let mut issues: Vec<String> = Vec::new();
-    for (i, entry) in chain.iter().enumerate() {
-        if entry.get("custodian").and_then(Value::as_str).is_none() {
-            issues.push(format!("entry {i}: missing custodian"));
-        }
-        if entry.get("action").and_then(Value::as_str).is_none() {
-            issues.push(format!("entry {i}: missing action"));
-        }
-    }
-
-    // Check that the first entry is a creation action.
-    if let Some(first) = chain.first() {
-        if let Some(action) = first.get("action").and_then(Value::as_str) {
-            if action != "created" {
-                issues.push("first entry action should be 'created'".to_owned());
-            }
-        }
-    }
-
-    let valid = issues.is_empty();
+    let custody_digest = match custody_chain_digest(&evidence) {
+        Ok(value) => value,
+        Err(err) => return tool_error(err.to_string()),
+    };
 
     let response = json!({
-        "evidence_id": evidence_id,
+        "evidence_id": evidence_id_str,
         "chain_length": chain.len(),
-        "valid": valid,
-        "issues": issues,
-        "verified_at": format!("{}:0", verified_at_ms),
+        "valid": true,
+        "issues": [],
+        "final_custodian": final_custodian(&evidence).to_string(),
+        "custody_digest": custody_digest.to_string(),
+        "verified_at": Timestamp::new(verified_at_ms, verified_at_logical).to_string(),
     });
     ToolResult::success(response.to_string())
 }
@@ -541,44 +771,111 @@ mod tests {
         assert!(!def.description.is_empty());
     }
 
+    fn valid_custody_verification_params() -> Value {
+        json!({
+            "evidence_id": "00000000-0000-0000-0000-000000000111",
+            "evidence_type": "document",
+            "content_hash": "0101010101010101010101010101010101010101010101010101010101010101",
+            "creator_did": "did:exo:alice",
+            "created_at_ms": 1_700_000_000_000_u64,
+            "created_at_logical": 0_u64,
+            "chain": [
+                {
+                    "from_did": "did:exo:alice",
+                    "to_did": "did:exo:bob",
+                    "transferred_at_ms": 1_700_000_000_100_u64,
+                    "transferred_at_logical": 0_u64,
+                    "reason": "signed release to records custodian"
+                },
+                {
+                    "from_did": "did:exo:bob",
+                    "to_did": "did:exo:carol",
+                    "transferred_at_ms": 1_700_000_000_200_u64,
+                    "transferred_at_logical": 0_u64,
+                    "reason": "litigation hold transfer"
+                }
+            ],
+            "verified_at_ms": 1_700_000_000_300_u64,
+            "verified_at_logical": 0_u64,
+        })
+    }
+
     #[test]
-    fn execute_verify_chain_of_custody_valid() {
-        let params = json!({
-            "evidence_id": "abc123",
+    fn execute_verify_chain_of_custody_rejects_shape_only_chain() {
+        let legacy_shape_only_params = json!({
+            "evidence_id": "00000000-0000-0000-0000-000000000222",
             "chain": [
                 {"custodian": "did:exo:alice", "action": "created"},
                 {"custodian": "did:exo:bob", "action": "transferred"},
             ],
             "verified_at_ms": 1700000000001_u64,
         });
+        let result =
+            execute_verify_chain_of_custody(&legacy_shape_only_params, &NodeContext::empty());
+        assert!(result.is_error);
+        assert!(
+            result.content[0].text().contains("evidence_type"),
+            "shape-only verification must be refused with required evidence metadata"
+        );
+    }
+
+    #[test]
+    fn execute_verify_chain_of_custody_accepts_legal_evidence_chain() {
+        let params = valid_custody_verification_params();
         let result = execute_verify_chain_of_custody(&params, &NodeContext::empty());
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
         assert_eq!(v["valid"], true);
         assert_eq!(v["chain_length"], 2);
+        assert_eq!(v["final_custodian"], "did:exo:carol");
+        assert_eq!(
+            v["custody_digest"].as_str().expect("custody digest").len(),
+            64
+        );
     }
 
     #[test]
-    fn execute_verify_chain_of_custody_invalid() {
-        let params = json!({
-            "evidence_id": "abc123",
-            "chain": [
-                {"custodian": "did:exo:alice", "action": "transferred"},
-            ],
-            "verified_at_ms": 1700000000001_u64,
-        });
+    fn execute_verify_chain_of_custody_rejects_broken_transfer_continuity() {
+        let mut params = valid_custody_verification_params();
+        params["chain"][1]["from_did"] = json!("did:exo:alice");
         let result = execute_verify_chain_of_custody(&params, &NodeContext::empty());
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
         assert_eq!(v["valid"], false);
+        assert!(
+            v["issues"][0]
+                .as_str()
+                .expect("issue")
+                .contains("current custodian")
+        );
     }
 
     #[test]
-    fn execute_verify_chain_of_custody_empty() {
-        let params =
-            json!({"evidence_id": "abc", "chain": [], "verified_at_ms": 1700000000001_u64});
+    fn execute_verify_chain_of_custody_rejects_non_monotonic_transfer_timestamps() {
+        let mut params = valid_custody_verification_params();
+        params["chain"][1]["transferred_at_ms"] = json!(1_700_000_000_050_u64);
         let result = execute_verify_chain_of_custody(&params, &NodeContext::empty());
-        assert!(result.is_error);
+        assert!(!result.is_error);
+        let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
+        assert_eq!(v["valid"], false);
+        assert!(
+            v["issues"][0]
+                .as_str()
+                .expect("issue")
+                .contains("must be after previous timestamp")
+        );
+    }
+
+    #[test]
+    fn execute_verify_chain_of_custody_allows_creator_only_chain() {
+        let mut params = valid_custody_verification_params();
+        params["chain"] = json!([]);
+        let result = execute_verify_chain_of_custody(&params, &NodeContext::empty());
+        assert!(!result.is_error);
+        let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
+        assert_eq!(v["valid"], true);
+        assert_eq!(v["chain_length"], 0);
+        assert_eq!(v["final_custodian"], "did:exo:alice");
     }
 
     // -- generate_merkle_proof ------------------------------------------------

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 123371 lines of Rust under `crates/`, 2,989 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 123803 lines of Rust under `crates/`, 2,994 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,989 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,994 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,989 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,994 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-123371 lines of Rust under `crates/` · 20 workspace packages · 2,989 listed tests · 40 MCP tools · 8 constitutional invariants
+123803 lines of Rust under `crates/` · 20 workspace packages · 2,994 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 123371 lines of Rust under `crates/` | 266 Rust source files | 2,989 listed tests
+> **Codebase:** 20 workspace packages | 123803 lines of Rust under `crates/` | 266 Rust source files | 2,994 listed tests
 
 ---
 

--- a/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
+++ b/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
@@ -46,9 +46,9 @@ decision.forum is a constitutional trust fabric for AI-era governance. Not a fra
 
 The numbers, verified as of this writing:
 
-- **123371 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
+- **123803 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
 - **20 workspace packages** covering identity, consent, authority, governance, escalation, legal infrastructure, cryptographic proofs, and more
-- **2,989 listed tests** exercised by the workspace test gate.
+- **2,994 listed tests** exercised by the workspace test gate.
 - **10 formal proofs** demonstrating that constitutional properties hold under all reachable system states
 - Built and reviewed through a **5-panel council process** (Governance, Legal, Architecture, Security, Operations)
 
@@ -270,7 +270,7 @@ The question is whether we will build it before we need it.
 
 *Bob Stewart is the architect of EXOCHAIN and decision.forum, and the author of The ASI Report on LinkedIn, where he writes about the infrastructure required for safe superintelligence. His work focuses on the intersection of constitutional governance, cryptographic enforcement, and AI safety -- the premise that alignment is necessary but insufficient, and that enforceable structural constraints are the missing complement.*
 
-*The EXOCHAIN workspace -- 123371 lines of Rust under `crates/`, 20 packages, 2,989 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
+*The EXOCHAIN workspace -- 123803 lines of Rust under `crates/`, 20 packages, 2,994 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
 
 ---
 

--- a/docs/decision-forum/SYSTEM-DOCUMENTATION.md
+++ b/docs/decision-forum/SYSTEM-DOCUMENTATION.md
@@ -6,7 +6,7 @@ created: 2026-03-19
 publication: "The ASI Report — LinkedIn Newsletter"
 tags: [decision-forum, governance, constitutional, asi-safety, exochain]
 status: publication-ready
-codebase: "20 workspace packages | 123371 LOC Rust under crates/ | 266 source files | 2,989 listed tests"
+codebase: "20 workspace packages | 123803 LOC Rust under crates/ | 266 source files | 2,994 listed tests"
 ---
 
 # decision.forum — System Documentation
@@ -20,9 +20,9 @@ This document is the exhaustive technical reference for the decision.forum gover
 | Metric | Value |
 |--------|-------|
 | Workspace packages | 20 |
-| Rust LOC under `crates/` | 123371 |
+| Rust LOC under `crates/` | 123803 |
 | Rust source files | 266 |
-| Listed workspace tests | 2,989 |
+| Listed workspace tests | 2,994 |
 | Test gate | `cargo test --workspace` in CI Gate 2 |
 | decision-forum crate LOC | 3,800 |
 | decision-forum tests | 131 |

--- a/docs/guides/GETTING-STARTED.md
+++ b/docs/guides/GETTING-STARTED.md
@@ -124,7 +124,7 @@ open tarpaulin-report.html
 ```
 
 A clean build produces zero errors and zero warnings. The current workspace
-inventory lists 2,989 tests; the exact executed count can change as doctests and
+inventory lists 2,994 tests; the exact executed count can change as doctests and
 integration targets evolve. What matters is zero failures:
 
 ```

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,989 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,994 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 123371 lines of Rust under `crates/` · 2,989 listed tests
+20 workspace packages · 123803 lines of Rust under `crates/` · 2,994 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 

--- a/governance/EXOCHAIN-REFACTOR-PLAN.md
+++ b/governance/EXOCHAIN-REFACTOR-PLAN.md
@@ -68,7 +68,7 @@ All refactor work flows through the Syntaxis Builder system:
 - [ ] Complete Section 8 work orders from CR-001
 - [ ] Achieve release-blocking acceptance standard (CR-001 Section 9)
 
-> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 123371 Rust LOC under `crates/`, 2,989 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
+> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 123803 Rust LOC under `crates/`, 2,994 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
 
 ## Active Resolutions
 

--- a/governance/sub_agents.md
+++ b/governance/sub_agents.md
@@ -72,7 +72,7 @@ Historical 2026-03-19 sub-agent completion record. Numeric status claims are sup
 * **Inputs**: Spec Section 16 (Acceptance Criteria).
 * **Outputs**: Test harnesses, Integration tests, Fuzz targets.
 * **Definition of Done**: Section 16 Acceptance Criteria are automated and passing.
-* **Status**: **DONE** — Current workspace inventory lists 2,989 tests across 20 packages and 266 Rust files.
+* **Status**: **DONE** — Current workspace inventory lists 2,994 tests across 20 packages and 266 Rust files.
 
 ## J) DEVOPS_RELEASE_AGENT (Judicial) — DONE
 

--- a/governance/traceability_matrix.md
+++ b/governance/traceability_matrix.md
@@ -163,4 +163,4 @@ Updated 2026-03-20 after EXOCHAIN-REM-009 — continuous governance monitoring a
 | **TOTAL** | **86** | **83** | **1** | **2** |
 
 **Coverage: 83/86 requirements traced to code (97%). 2 planned (ExoForge scheduling + React dashboard). 1 partial (T-14 Rust attestation verification).**
-**Workspace inventory: 2,989 listed tests across 20 packages and 266 Rust files.**
+**Workspace inventory: 2,994 listed tests across 20 packages and 266 Rust files.**


### PR DESCRIPTION
## Summary

- Replace the default-on MCP chain-of-custody JSON-shape checker with real `exo_legal::evidence` reconstruction and validation.
- Add `create_evidence_from_hash` and a domain-separated canonical CBOR `custody_chain_digest` to `exo-legal`.
- Require UUID, content hash, creator DID, full HLC timestamps, transfer actors, and transfer reasons for `exochain_verify_chain_of_custody`.
- Refresh repo-truth docs to `123803` Rust LOC and `2,994` listed tests.

## Root Cause

`exochain_verify_chain_of_custody` claimed evidence custody verification but only checked that legacy JSON entries had `custodian` and `action` fields. Shape-only fabricated chains could receive `valid: true` without UUID, DID, content hash, HLC, transfer continuity, or legal evidence validation.

## Validation

- `cargo test -p exo-legal create_evidence_from_hash --lib -- --nocapture`
- `cargo test -p exo-legal custody_chain_digest_binds_transfer_reason_and_logical_time --lib -- --nocapture`
- `cargo test -p exo-node execute_verify_chain_of_custody_ -- --nocapture`
- `cargo test -p exo-legal`
- `cargo test -p exo-node`
- `cargo build -p exo-legal && cargo build -p exo-node`
- `cargo clippy -p exo-legal --lib --bins -- -D warnings`
- `cargo clippy -p exo-node --bin exochain -- -D warnings`
- `cargo clippy -p exo-legal --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo clippy -p exo-node --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check`
- `cargo machete --with-metadata`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `bash tools/repo_truth.sh --json`
