### PR TITLE
fix(exo-node): create real MCP evidence envelopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 123803 | `wc -l` |
-| Workspace tests | 2,994 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 123869 | `wc -l` |
+| Workspace tests | 2,996 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,994 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,996 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 123803 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 123869 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,994 listed workspace tests
+         cryptographic proofs, 2,996 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/mcp/prompts/evidence_analysis.rs
+++ b/crates/exo-node/src/mcp/prompts/evidence_analysis.rs
@@ -73,7 +73,8 @@ Collection context:
 {context}
 
 Required tool calls before answering:
-- `exochain_verify_chain_of_custody` with bundle={bundle_id}
+- `exochain_verify_chain_of_custody` with the bundle's evidence UUID, content
+  hash, creator DID, creation HLC, transfer list, and verification HLC
 - `exochain_generate_merkle_proof` for the bundle's event hash
 - `exochain_verify_inclusion` against the latest checkpoint
 - `exochain_get_event` for each referenced event in the bundle

--- a/crates/exo-node/src/mcp/resources/readme.rs
+++ b/crates/exo-node/src/mcp/resources/readme.rs
@@ -42,8 +42,9 @@ MCP rules and 8 kernel invariants on every action. Read this document first.
   here.
 - **ledger (4)** — Submit events to the DAG, read events, verify inclusion,
   fetch checkpoints.
-- **proofs (4)** — Create/verify evidence bundles, chain-of-custody checks,
-  Merkle proofs, CGR proofs.
+- **proofs (4)** — Construct legal evidence envelopes, verify custody-chain
+  metadata and continuity, generate Merkle proofs, and refuse CGR proof
+  verification until a production verifier is wired.
 - **legal (4)** — eDiscovery search, privilege assertion, safe-harbor
   initiation, fiduciary-duty checks. These tools refuse by default unless
   `unaudited-mcp-simulation-tools` is enabled, because they are not wired to

--- a/crates/exo-node/src/mcp/tools/proofs.rs
+++ b/crates/exo-node/src/mcp/tools/proofs.rs
@@ -134,32 +134,43 @@ fn final_custodian(evidence: &exo_legal::evidence::Evidence) -> &Did {
 pub fn create_evidence_definition() -> ToolDefinition {
     ToolDefinition {
         name: "exochain_create_evidence".to_owned(),
-        description: "Create evidence with an initial chain of custody entry. Returns the evidence ID and custody record.".to_owned(),
+        description: "Construct a legal evidence envelope from caller-supplied UUID, content hash, creator DID, and creation HLC. Returns a verifier-compatible creator-only custody payload; it does not persist evidence to a store.".to_owned(),
         input_schema: json!({
             "type": "object",
             "properties": {
-                "description": {
-                    "type": "string",
-                    "description": "Human-readable description of the evidence."
-                },
                 "evidence_type": {
                     "type": "string",
-                    "description": "Type of evidence (e.g. \"document\", \"digital_artifact\", \"testimony\")."
+                    "description": "Evidence type tag recorded at creation."
                 },
-                "source_did": {
+                "content_hash": {
                     "type": "string",
-                    "description": "DID of the evidence source/creator."
+                    "description": "64-character hex-encoded Hash256 of the evidence content."
+                },
+                "creator_did": {
+                    "type": "string",
+                    "description": "DID of the evidence creator and initial custodian."
                 },
                 "evidence_id": {
                     "type": "string",
-                    "description": "Caller-supplied non-placeholder evidence ID."
+                    "description": "Caller-supplied non-nil evidence UUID."
                 },
                 "created_at_ms": {
                     "type": "integer",
                     "description": "Caller-supplied nonzero HLC physical milliseconds for creation."
+                },
+                "created_at_logical": {
+                    "type": "integer",
+                    "description": "Caller-supplied HLC logical counter for creation."
                 }
             },
-            "required": ["description", "evidence_type", "source_did", "evidence_id", "created_at_ms"],
+            "required": [
+                "evidence_id",
+                "evidence_type",
+                "content_hash",
+                "creator_did",
+                "created_at_ms",
+                "created_at_logical"
+            ],
             "additionalProperties": false,
         }),
     }
@@ -168,67 +179,72 @@ pub fn create_evidence_definition() -> ToolDefinition {
 /// Execute the `exochain_create_evidence` tool.
 #[must_use]
 pub fn execute_create_evidence(params: &Value, _context: &NodeContext) -> ToolResult {
-    let description = match params.get("description").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: description"}).to_string(),
-            );
-        }
+    let evidence_id_str = match required_nonempty_str(params, "evidence_id") {
+        Ok(value) => value,
+        Err(result) => return result,
     };
-    let evidence_type = match params.get("evidence_type").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: evidence_type"}).to_string(),
-            );
-        }
+    let evidence_id = match parse_uuid(evidence_id_str, "evidence_id") {
+        Ok(value) => value,
+        Err(result) => return result,
     };
-    let source_did_str = match params.get("source_did").and_then(Value::as_str) {
-        Some(s) => s,
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: source_did"}).to_string(),
-            );
-        }
+    let evidence_type = match required_nonempty_str(params, "evidence_type") {
+        Ok(value) => value,
+        Err(result) => return result,
     };
-    let evidence_id = match params.get("evidence_id").and_then(Value::as_str) {
-        Some(s) if !s.trim().is_empty() => s,
-        Some(_) => {
-            return ToolResult::error(
-                json!({"error": "evidence_id must not be empty"}).to_string(),
-            );
-        }
-        None => {
-            return ToolResult::error(
-                json!({"error": "missing required parameter: evidence_id"}).to_string(),
-            );
-        }
+    let content_hash_str = match required_nonempty_str(params, "content_hash") {
+        Ok(value) => value,
+        Err(result) => return result,
+    };
+    let content_hash = match parse_hash256_hex(content_hash_str, "content_hash") {
+        Ok(value) => value,
+        Err(result) => return result,
+    };
+    let creator_did_str = match required_nonempty_str(params, "creator_did") {
+        Ok(value) => value,
+        Err(result) => return result,
+    };
+    let creator_did = match parse_did(creator_did_str, "creator_did") {
+        Ok(value) => value,
+        Err(result) => return result,
     };
     let created_at_ms = match required_nonzero_u64(params, "created_at_ms") {
         Ok(value) => value,
         Err(result) => return result,
     };
-
-    if Did::new(source_did_str).is_err() {
-        return ToolResult::error(
-            json!({"error": format!("invalid DID format: {source_did_str}")}).to_string(),
-        );
-    }
+    let created_at_logical = match required_u32(params, "created_at_logical") {
+        Ok(value) => value,
+        Err(result) => return result,
+    };
+    let created_at = Timestamp::new(created_at_ms, created_at_logical);
+    let evidence = match create_evidence_from_hash(
+        evidence_id,
+        content_hash,
+        &creator_did,
+        evidence_type,
+        created_at,
+    ) {
+        Ok(value) => value,
+        Err(err) => return tool_error(err.to_string()),
+    };
+    let custody_digest = match custody_chain_digest(&evidence) {
+        Ok(value) => value,
+        Err(err) => return tool_error(err.to_string()),
+    };
 
     let response = json!({
-        "evidence_id": evidence_id,
-        "description": description,
-        "evidence_type": evidence_type,
-        "source_did": source_did_str,
-        "chain_of_custody": [
-            {
-                "custodian": source_did_str,
-                "action": "created",
-                "timestamp": format!("{}:0", created_at_ms),
-            }
-        ],
+        "evidence_id": evidence_id_str,
+        "evidence_type": evidence.type_tag.as_str(),
+        "content_hash": evidence.hash.to_string(),
+        "creator_did": evidence.creator.to_string(),
+        "created_at": evidence.timestamp.to_string(),
+        "created_at_ms": created_at_ms,
+        "created_at_logical": created_at_logical,
+        "chain": [],
+        "final_custodian": final_custodian(&evidence).to_string(),
+        "admissibility_status": &evidence.admissibility_status,
+        "custody_digest": custody_digest.to_string(),
         "status": "created",
+        "persistence": "not_persisted",
     });
     ToolResult::success(response.to_string())
 }
@@ -703,8 +719,44 @@ mod tests {
         assert!(!def.description.is_empty());
     }
 
+    fn valid_create_evidence_params() -> Value {
+        json!({
+            "evidence_type": "document",
+            "content_hash": "0202020202020202020202020202020202020202020202020202020202020202",
+            "creator_did": "did:exo:alice",
+            "evidence_id": "00000000-0000-0000-0000-000000000001",
+            "created_at_ms": 1700000000000_u64,
+            "created_at_logical": 7_u64,
+        })
+    }
+
     #[test]
-    fn execute_create_evidence_success() {
+    fn execute_create_evidence_success_returns_verifier_compatible_envelope() {
+        let params = valid_create_evidence_params();
+        let result = execute_create_evidence(&params, &NodeContext::empty());
+        assert!(!result.is_error, "{}", result.content[0].text());
+        let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
+        assert_eq!(v["evidence_id"], "00000000-0000-0000-0000-000000000001");
+        assert_eq!(v["evidence_type"], "document");
+        assert_eq!(
+            v["content_hash"],
+            "0202020202020202020202020202020202020202020202020202020202020202"
+        );
+        assert_eq!(v["creator_did"], "did:exo:alice");
+        assert_eq!(v["created_at_ms"], 1700000000000_u64);
+        assert_eq!(v["created_at_logical"], 7_u64);
+        assert_eq!(v["chain"], json!([]));
+        assert_eq!(v["final_custodian"], "did:exo:alice");
+        assert_eq!(v["admissibility_status"], "Pending");
+        assert_eq!(v["status"], "created");
+        assert_eq!(
+            v["custody_digest"].as_str().expect("custody digest").len(),
+            64
+        );
+    }
+
+    #[test]
+    fn execute_create_evidence_rejects_legacy_shape_without_content_hash() {
         let params = json!({
             "description": "Contract PDF",
             "evidence_type": "document",
@@ -713,53 +765,65 @@ mod tests {
             "created_at_ms": 1700000000000_u64,
         });
         let result = execute_create_evidence(&params, &NodeContext::empty());
-        assert!(!result.is_error);
-        let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
-        assert_eq!(v["evidence_id"], "00000000-0000-0000-0000-000000000001");
-        assert_eq!(v["evidence_type"], "document");
-        assert_eq!(v["source_did"], "did:exo:alice");
-        assert_eq!(v["status"], "created");
-        let chain = v["chain_of_custody"].as_array().expect("chain array");
-        assert_eq!(chain.len(), 1);
-        assert_eq!(chain[0]["action"], "created");
+        assert!(result.is_error);
+        assert!(
+            result.content[0].text().contains("content_hash"),
+            "legacy shape-only evidence creation must be refused with required content hash metadata"
+        );
     }
 
     #[test]
     fn execute_create_evidence_invalid_did() {
-        let params = json!({
-            "description": "test",
-            "evidence_type": "document",
-            "source_did": "bad",
-            "evidence_id": "00000000-0000-0000-0000-000000000001",
-            "created_at_ms": 1700000000000_u64,
-        });
+        let mut params = valid_create_evidence_params();
+        params["creator_did"] = json!("bad");
         let result = execute_create_evidence(&params, &NodeContext::empty());
         assert!(result.is_error);
     }
 
     #[test]
-    fn execute_create_evidence_missing_description() {
+    fn execute_create_evidence_rejects_missing_hlc_logical_time() {
         let result = execute_create_evidence(
             &json!({
                 "evidence_type": "doc",
-                "source_did": "did:exo:a",
+                "content_hash": "0202020202020202020202020202020202020202020202020202020202020202",
+                "creator_did": "did:exo:a",
                 "evidence_id": "00000000-0000-0000-0000-000000000001",
                 "created_at_ms": 1700000000000_u64
             }),
             &NodeContext::empty(),
         );
         assert!(result.is_error);
+        assert!(
+            result.content[0].text().contains("created_at_logical"),
+            "full HLC logical counter must be required"
+        );
     }
 
     #[test]
-    fn execute_create_evidence_rejects_missing_metadata() {
-        let params = json!({
-            "description": "Contract PDF",
-            "evidence_type": "document",
-            "source_did": "did:exo:alice",
-        });
+    fn execute_create_evidence_rejects_zero_content_hash() {
+        let mut params = valid_create_evidence_params();
+        params["content_hash"] =
+            json!("0000000000000000000000000000000000000000000000000000000000000000");
         let result = execute_create_evidence(&params, &NodeContext::empty());
         assert!(result.is_error);
+        assert!(
+            result.content[0]
+                .text()
+                .contains("content hash must not be Hash256::ZERO"),
+            "zero hashes are placeholders and must be refused"
+        );
+    }
+
+    #[test]
+    fn execute_create_evidence_rejects_nil_uuid() {
+        let mut params = valid_create_evidence_params();
+        params["evidence_id"] = json!("00000000-0000-0000-0000-000000000000");
+        let result = execute_create_evidence(&params, &NodeContext::empty());
+        assert!(result.is_error);
+        assert!(
+            result.content[0].text().contains("evidence ID must"),
+            "nil UUID placeholders must be refused"
+        );
     }
 
     // -- verify_chain_of_custody ----------------------------------------------

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 123803 lines of Rust under `crates/`, 2,994 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 123869 lines of Rust under `crates/`, 2,996 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,994 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,996 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,994 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,996 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-123803 lines of Rust under `crates/` · 20 workspace packages · 2,994 listed tests · 40 MCP tools · 8 constitutional invariants
+123869 lines of Rust under `crates/` · 20 workspace packages · 2,996 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 123803 lines of Rust under `crates/` | 266 Rust source files | 2,994 listed tests
+> **Codebase:** 20 workspace packages | 123869 lines of Rust under `crates/` | 266 Rust source files | 2,996 listed tests
 
 ---
 

--- a/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
+++ b/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
@@ -46,9 +46,9 @@ decision.forum is a constitutional trust fabric for AI-era governance. Not a fra
 
 The numbers, verified as of this writing:
 
-- **123803 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
+- **123869 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
 - **20 workspace packages** covering identity, consent, authority, governance, escalation, legal infrastructure, cryptographic proofs, and more
-- **2,994 listed tests** exercised by the workspace test gate.
+- **2,996 listed tests** exercised by the workspace test gate.
 - **10 formal proofs** demonstrating that constitutional properties hold under all reachable system states
 - Built and reviewed through a **5-panel council process** (Governance, Legal, Architecture, Security, Operations)
 
@@ -270,7 +270,7 @@ The question is whether we will build it before we need it.
 
 *Bob Stewart is the architect of EXOCHAIN and decision.forum, and the author of The ASI Report on LinkedIn, where he writes about the infrastructure required for safe superintelligence. His work focuses on the intersection of constitutional governance, cryptographic enforcement, and AI safety -- the premise that alignment is necessary but insufficient, and that enforceable structural constraints are the missing complement.*
 
-*The EXOCHAIN workspace -- 123803 lines of Rust under `crates/`, 20 packages, 2,994 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
+*The EXOCHAIN workspace -- 123869 lines of Rust under `crates/`, 20 packages, 2,996 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
 
 ---
 

--- a/docs/decision-forum/SYSTEM-DOCUMENTATION.md
+++ b/docs/decision-forum/SYSTEM-DOCUMENTATION.md
@@ -6,7 +6,7 @@ created: 2026-03-19
 publication: "The ASI Report — LinkedIn Newsletter"
 tags: [decision-forum, governance, constitutional, asi-safety, exochain]
 status: publication-ready
-codebase: "20 workspace packages | 123803 LOC Rust under crates/ | 266 source files | 2,994 listed tests"
+codebase: "20 workspace packages | 123869 LOC Rust under crates/ | 266 source files | 2,996 listed tests"
 ---
 
 # decision.forum — System Documentation
@@ -20,9 +20,9 @@ This document is the exhaustive technical reference for the decision.forum gover
 | Metric | Value |
 |--------|-------|
 | Workspace packages | 20 |
-| Rust LOC under `crates/` | 123803 |
+| Rust LOC under `crates/` | 123869 |
 | Rust source files | 266 |
-| Listed workspace tests | 2,994 |
+| Listed workspace tests | 2,996 |
 | Test gate | `cargo test --workspace` in CI Gate 2 |
 | decision-forum crate LOC | 3,800 |
 | decision-forum tests | 131 |

--- a/docs/guides/GETTING-STARTED.md
+++ b/docs/guides/GETTING-STARTED.md
@@ -124,7 +124,7 @@ open tarpaulin-report.html
 ```
 
 A clean build produces zero errors and zero warnings. The current workspace
-inventory lists 2,994 tests; the exact executed count can change as doctests and
+inventory lists 2,996 tests; the exact executed count can change as doctests and
 integration targets evolve. What matters is zero failures:
 
 ```

--- a/docs/guides/ai-agent-guide.md
+++ b/docs/guides/ai-agent-guide.md
@@ -327,8 +327,9 @@ inclusion proofs — for admissibility review.
 2. `tools/call` → `exochain_verify_inclusion` for each event in the
    bundle against the bundle's checkpoint.
 3. `tools/call` → `exochain_verify_chain_of_custody` for the
-   bundle's custody chain. Every transfer must be signed and
-   time-ordered.
+   bundle's custody chain. The tool checks UUID/DID/hash metadata,
+   transfer continuity, non-empty reasons, and HLC ordering; it does
+   not accept signatures as proof of transfer authority.
 4. Do not treat `exochain_verify_cgr_proof` as a verifier in default
    builds. It refuses hash-only CGR proof claims until proof bytes,
    public inputs, checkpoint roots, validator signatures, and a

--- a/docs/guides/architecture-overview.md
+++ b/docs/guides/architecture-overview.md
@@ -399,7 +399,7 @@ dispatches `tools/call` requests to the appropriate handler.
 | Authority      | 3                    | Delegate, verify chain, check permission                         | `tools/authority.rs`                        |
 | Kernel         | 1                    | `exochain_adjudicate_action` — single-call kernel adjudication   | (dispatched to `governance.rs`)             |
 | Ledger         | 4                    | Submit event, get event, inclusion proof, get checkpoint         | `tools/ledger.rs`                           |
-| Proofs         | 4                    | Evidence, chain of custody, Merkle proof, fail-closed CGR proof verifier placeholder | `tools/proofs.rs`                           |
+| Proofs         | 4                    | Evidence envelopes, custody-chain verification, Merkle proof, fail-closed CGR proof verifier placeholder | `tools/proofs.rs`                           |
 | Legal          | 4                    | eDiscovery, privilege, DGCL §144 safe harbour, fiduciary duty    | `tools/legal.rs`                            |
 | Escalation     | 4                    | Evaluate threat, escalate case, triage, feedback                 | `tools/escalation.rs`                       |
 | Messaging      | 3                    | Send encrypted, receive encrypted, configure death trigger       | `tools/messaging.rs`                        |

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,994 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,996 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/guides/mcp-integration.md
+++ b/docs/guides/mcp-integration.md
@@ -295,8 +295,8 @@ Use these at session start to let the agent self-orient.
 
 | Tool | Purpose |
 |---|---|
-| `exochain_create_evidence` | Bundle evidence with a chain-of-custody record. |
-| `exochain_verify_chain_of_custody` | Verify an evidence bundle end-to-end. |
+| `exochain_create_evidence` | Construct a verifier-compatible legal evidence envelope from UUID, content hash, creator DID, and creation HLC; this does not persist evidence. |
+| `exochain_verify_chain_of_custody` | Verify evidence UUID/DID/hash metadata, transfer continuity, transfer reasons, and monotonic HLC timestamps. |
 | `exochain_generate_merkle_proof` | Produce a Merkle inclusion proof for a leaf. |
 | `exochain_verify_cgr_proof` | Refuses CGR proof verification until proof bytes, public inputs, checkpoint roots, validator signatures, and a production verifier are wired. |
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 123803 lines of Rust under `crates/` · 2,994 listed tests
+20 workspace packages · 123869 lines of Rust under `crates/` · 2,996 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 

--- a/governance/EXOCHAIN-REFACTOR-PLAN.md
+++ b/governance/EXOCHAIN-REFACTOR-PLAN.md
@@ -68,7 +68,7 @@ All refactor work flows through the Syntaxis Builder system:
 - [ ] Complete Section 8 work orders from CR-001
 - [ ] Achieve release-blocking acceptance standard (CR-001 Section 9)
 
-> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 123803 Rust LOC under `crates/`, 2,994 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
+> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 123869 Rust LOC under `crates/`, 2,996 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
 
 ## Active Resolutions
 

--- a/governance/sub_agents.md
+++ b/governance/sub_agents.md
@@ -72,7 +72,7 @@ Historical 2026-03-19 sub-agent completion record. Numeric status claims are sup
 * **Inputs**: Spec Section 16 (Acceptance Criteria).
 * **Outputs**: Test harnesses, Integration tests, Fuzz targets.
 * **Definition of Done**: Section 16 Acceptance Criteria are automated and passing.
-* **Status**: **DONE** — Current workspace inventory lists 2,994 tests across 20 packages and 266 Rust files.
+* **Status**: **DONE** — Current workspace inventory lists 2,996 tests across 20 packages and 266 Rust files.
 
 ## J) DEVOPS_RELEASE_AGENT (Judicial) — DONE
 

--- a/governance/traceability_matrix.md
+++ b/governance/traceability_matrix.md
@@ -163,4 +163,4 @@ Updated 2026-03-20 after EXOCHAIN-REM-009 — continuous governance monitoring a
 | **TOTAL** | **86** | **83** | **1** | **2** |
 
 **Coverage: 83/86 requirements traced to code (97%). 2 planned (ExoForge scheduling + React dashboard). 1 partial (T-14 Rust attestation verification).**
-**Workspace inventory: 2,994 listed tests across 20 packages and 266 Rust files.**
+**Workspace inventory: 2,996 listed tests across 20 packages and 266 Rust files.**


### PR DESCRIPTION
## Summary
- changes `exochain_create_evidence` from a legacy echo response into a legal evidence envelope built through `exo_legal::evidence::create_evidence_from_hash`
- requires evidence UUID, content hash, creator DID, and full creation HLC, rejecting legacy shape-only requests, nil UUIDs, zero hashes, and missing HLC logical counters
- returns verifier-compatible creator-only custody payloads with `chain: []`, `final_custodian`, `admissibility_status`, and canonical `custody_digest`
- updates MCP docs/prompts and repo-truth counts to 123869 Rust LOC / 2996 listed tests

## TDD
- `cargo test -p exo-node execute_create_evidence_ -- --nocapture` failed first against the legacy implementation, then passed after the fix

## Verification
- `cargo test -p exo-node execute_create_evidence_ -- --nocapture`
- `cargo test -p exo-node mcp::tools::proofs -- --nocapture`
- `cargo test -p exo-node mcp::tools -- --nocapture`
- `cargo test -p exo-node`
- `cargo build -p exo-node`
- `cargo clippy -p exo-node --bin exochain -- -D warnings`
- `cargo clippy -p exo-node --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit` (passes with existing allowed yanked `core2` warning)
- `cargo deny check` (passes with existing duplicate/yanked/unused-allowance warnings)
- `cargo machete --with-metadata`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `bash tools/repo_truth.sh --json`