### PR TITLE
fix(exo-node): roundtrip mcp merkle proofs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 123869 | `wc -l` |
-| Workspace tests | 2,996 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 123923 | `wc -l` |
+| Workspace tests | 2,999 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,996 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **2,999 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 123869 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 123923 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,996 listed workspace tests
+         cryptographic proofs, 2,999 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/mcp/prompts/evidence_analysis.rs
+++ b/crates/exo-node/src/mcp/prompts/evidence_analysis.rs
@@ -75,7 +75,7 @@ Collection context:
 Required tool calls before answering:
 - `exochain_verify_chain_of_custody` with the bundle's evidence UUID, content
   hash, creator DID, creation HLC, transfer list, and verification HLC
-- `exochain_generate_merkle_proof` for the bundle's event hash
+- `exochain_generate_merkle_proof` with the bundle's 32-byte event hash set
 - `exochain_verify_inclusion` against the latest checkpoint
 - `exochain_get_event` for each referenced event in the bundle
 - `exochain_verify_signature` on every signer surfaced by the above

--- a/crates/exo-node/src/mcp/resources/readme.rs
+++ b/crates/exo-node/src/mcp/resources/readme.rs
@@ -43,8 +43,9 @@ MCP rules and 8 kernel invariants on every action. Read this document first.
 - **ledger (4)** — Submit events to the DAG, read events, verify inclusion,
   fetch checkpoints.
 - **proofs (4)** — Construct legal evidence envelopes, verify custody-chain
-  metadata and continuity, generate Merkle proofs, and refuse CGR proof
-  verification until a production verifier is wired.
+  metadata and continuity, generate verifier-compatible Merkle proofs from
+  32-byte event hashes, and refuse CGR proof verification until a production
+  verifier is wired.
 - **legal (4)** — eDiscovery search, privilege assertion, safe-harbor
   initiation, fiduciary-duty checks. These tools refuse by default unless
   `unaudited-mcp-simulation-tools` is enabled, because they are not wired to

--- a/crates/exo-node/src/mcp/tools/proofs.rs
+++ b/crates/exo-node/src/mcp/tools/proofs.rs
@@ -1,7 +1,10 @@
 //! Proofs MCP tools — evidence creation, chain of custody verification,
 //! Merkle proof generation, and CGR kernel proof verification.
 
-use exo_core::{Did, Hash256, Timestamp};
+use exo_core::{
+    Did, Hash256, Timestamp,
+    hash::{merkle_proof, merkle_root},
+};
 use exo_legal::evidence::{
     create_evidence_from_hash, custody_chain_digest, transfer_custody, verify_chain_of_custody,
 };
@@ -488,17 +491,17 @@ pub fn execute_verify_chain_of_custody(params: &Value, _context: &NodeContext) -
 pub fn generate_merkle_proof_definition() -> ToolDefinition {
     ToolDefinition {
         name: "exochain_generate_merkle_proof".to_owned(),
-        description: "Generate a Merkle inclusion proof for a target leaf given a set of leaves. Computes the actual Merkle root and proof path.".to_owned(),
+        description: "Generate a verifier-compatible Merkle inclusion proof for a target event hash given a set of event hashes. Computes the actual Merkle root and proof path.".to_owned(),
         input_schema: json!({
             "type": "object",
             "properties": {
                 "leaves": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Array of hex-encoded leaf values."
+                    "description": "Array of 64-character hex-encoded Hash256 event hashes."
                 },
                 "target_index": {
-                    "type": "number",
+                    "type": "integer",
                     "description": "Zero-based index of the target leaf."
                 }
             },
@@ -541,21 +544,21 @@ pub fn execute_generate_merkle_proof(params: &Value, _context: &NodeContext) -> 
         );
     }
 
-    // Hash each leaf.
-    let mut hashes: Vec<Hash256> = Vec::new();
+    // Parse each supplied leaf as the exact event hash consumed by
+    // exochain_verify_inclusion. Do not hash arbitrary caller bytes here.
+    let mut hashes: Vec<Hash256> = Vec::with_capacity(leaves_val.len());
     for (i, leaf) in leaves_val.iter().enumerate() {
         match leaf.as_str() {
-            Some(s) => {
-                let bytes = match hex::decode(s) {
-                    Ok(b) => b,
-                    Err(_) => {
-                        return ToolResult::error(
-                            json!({"error": format!("invalid hex at leaf index {i}")}).to_string(),
-                        );
-                    }
-                };
-                hashes.push(Hash256::digest(&bytes));
-            }
+            Some(s) => match parse_hash256_hex(s, &format!("leaf at index {i}")) {
+                Ok(hash) if hash != Hash256::ZERO => hashes.push(hash),
+                Ok(_) => {
+                    return ToolResult::error(
+                        json!({"error": format!("leaf at index {i} must not be Hash256::ZERO")})
+                            .to_string(),
+                    );
+                }
+                Err(result) => return result,
+            },
             None => {
                 return ToolResult::error(
                     json!({"error": format!("leaf at index {i} is not a string")}).to_string(),
@@ -564,53 +567,22 @@ pub fn execute_generate_merkle_proof(params: &Value, _context: &NodeContext) -> 
         }
     }
 
-    // Build the Merkle tree bottom-up and collect the proof path.
-    let mut proof: Vec<String> = Vec::new();
-    let mut current_level = hashes;
-    let mut idx = target_index;
-
-    while current_level.len() > 1 {
-        let mut next_level: Vec<Hash256> = Vec::new();
-        let mut i = 0;
-        while i < current_level.len() {
-            let left = &current_level[i];
-            let right = if i + 1 < current_level.len() {
-                &current_level[i + 1]
-            } else {
-                &current_level[i] // duplicate last if odd
-            };
-
-            // If this pair contains our target, record the sibling.
-            if i == (idx & !1) {
-                if idx % 2 == 0 {
-                    if i + 1 < current_level.len() {
-                        proof.push(right.to_string());
-                    } else {
-                        proof.push(left.to_string());
-                    }
-                } else {
-                    proof.push(left.to_string());
-                }
-            }
-
-            let mut combined = left.as_bytes().to_vec();
-            combined.extend_from_slice(right.as_bytes());
-            next_level.push(Hash256::digest(&combined));
-
-            i += 2;
-        }
-        idx /= 2;
-        current_level = next_level;
-    }
-
-    let root = current_level[0].to_string();
-    let target_leaf = leaves_val[target_index].as_str().unwrap_or("");
+    let root_hash = merkle_root(&hashes);
+    let proof_hashes = match merkle_proof(&hashes, target_index) {
+        Ok(proof) => proof.iter().map(ToString::to_string).collect::<Vec<_>>(),
+        Err(err) => return ToolResult::error(json!({"error": err.to_string()}).to_string()),
+    };
+    let target_hash = hashes[target_index].to_string();
 
     let response = json!({
-        "root": root,
-        "target_leaf": target_leaf,
+        "root": root_hash.to_string(),
+        "root_hash": root_hash.to_string(),
+        "target_leaf": target_hash,
+        "target_hash": target_hash,
+        "event_hash": target_hash,
         "target_index": target_index,
-        "proof": proof,
+        "proof": proof_hashes,
+        "proof_hashes": proof_hashes,
         "leaf_count": leaves_val.len(),
     });
     ToolResult::success(response.to_string())
@@ -709,6 +681,7 @@ pub fn execute_verify_cgr_proof(params: &Value, _context: &NodeContext) -> ToolR
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use crate::mcp::tools::ledger::execute_verify_inclusion;
 
     // -- create_evidence ------------------------------------------------------
 
@@ -953,17 +926,97 @@ mod tests {
 
     #[test]
     fn execute_generate_merkle_proof_success() {
+        let leaves = [
+            Hash256::digest(b"event-0").to_string(),
+            Hash256::digest(b"event-1").to_string(),
+            Hash256::digest(b"event-2").to_string(),
+            Hash256::digest(b"event-3").to_string(),
+        ];
         let params = json!({
-            "leaves": ["aabb", "ccdd", "eeff", "1122"],
+            "leaves": leaves,
             "target_index": 1,
         });
         let result = execute_generate_merkle_proof(&params, &NodeContext::empty());
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
-        assert!(v["root"].as_str().is_some());
+        assert!(v["root_hash"].as_str().is_some());
+        assert_eq!(v["root"], v["root_hash"]);
+        assert_eq!(v["event_hash"], leaves[1]);
+        assert_eq!(v["target_hash"], leaves[1]);
         assert_eq!(v["target_index"], 1);
         assert_eq!(v["leaf_count"], 4);
-        assert!(!v["proof"].as_array().expect("proof array").is_empty());
+        assert_eq!(v["proof"], v["proof_hashes"]);
+        assert!(
+            !v["proof_hashes"]
+                .as_array()
+                .expect("proof array")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn execute_generate_merkle_proof_output_verifies_with_verify_inclusion() {
+        let leaves = [
+            Hash256::digest(b"event-0").to_string(),
+            Hash256::digest(b"event-1").to_string(),
+            Hash256::digest(b"event-2").to_string(),
+        ];
+        let result = execute_generate_merkle_proof(
+            &json!({
+                "leaves": leaves,
+                "target_index": 2,
+            }),
+            &NodeContext::empty(),
+        );
+        assert!(!result.is_error, "{}", result.content[0].text());
+        let generated: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
+
+        let verify_result = execute_verify_inclusion(
+            &json!({
+                "event_hash": generated["event_hash"].clone(),
+                "proof_hashes": generated["proof_hashes"].clone(),
+                "root_hash": generated["root_hash"].clone(),
+                "target_index": generated["target_index"].clone(),
+            }),
+            &NodeContext::empty(),
+        );
+        assert!(
+            !verify_result.is_error,
+            "{}",
+            verify_result.content[0].text()
+        );
+        let verified: Value =
+            serde_json::from_str(verify_result.content[0].text()).expect("valid JSON");
+        assert_eq!(verified["verified"], true);
+        assert_eq!(verified["computed_root"], generated["root_hash"]);
+    }
+
+    #[test]
+    fn execute_generate_merkle_proof_rejects_short_raw_leaf_bytes() {
+        let params = json!({"leaves": ["aabb", "ccdd"], "target_index": 0});
+        let result = execute_generate_merkle_proof(&params, &NodeContext::empty());
+        assert!(result.is_error);
+        assert!(
+            result.content[0].text().contains("32 bytes"),
+            "Merkle generation must accept event hashes, not hash arbitrary short raw leaf bytes"
+        );
+    }
+
+    #[test]
+    fn execute_generate_merkle_proof_rejects_zero_leaf_hashes() {
+        let params = json!({
+            "leaves": [
+                "0000000000000000000000000000000000000000000000000000000000000000",
+                Hash256::digest(b"event-1").to_string()
+            ],
+            "target_index": 0,
+        });
+        let result = execute_generate_merkle_proof(&params, &NodeContext::empty());
+        assert!(result.is_error);
+        assert!(
+            result.content[0].text().contains("Hash256::ZERO"),
+            "zero leaf hashes are placeholders and must be refused"
+        );
     }
 
     #[test]

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 123869 lines of Rust under `crates/`, 2,996 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 123923 lines of Rust under `crates/`, 2,999 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,996 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,999 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,996 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,999 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-123869 lines of Rust under `crates/` · 20 workspace packages · 2,996 listed tests · 40 MCP tools · 8 constitutional invariants
+123923 lines of Rust under `crates/` · 20 workspace packages · 2,999 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 123869 lines of Rust under `crates/` | 266 Rust source files | 2,996 listed tests
+> **Codebase:** 20 workspace packages | 123923 lines of Rust under `crates/` | 266 Rust source files | 2,999 listed tests
 
 ---
 

--- a/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
+++ b/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
@@ -46,9 +46,9 @@ decision.forum is a constitutional trust fabric for AI-era governance. Not a fra
 
 The numbers, verified as of this writing:
 
-- **123869 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
+- **123923 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
 - **20 workspace packages** covering identity, consent, authority, governance, escalation, legal infrastructure, cryptographic proofs, and more
-- **2,996 listed tests** exercised by the workspace test gate.
+- **2,999 listed tests** exercised by the workspace test gate.
 - **10 formal proofs** demonstrating that constitutional properties hold under all reachable system states
 - Built and reviewed through a **5-panel council process** (Governance, Legal, Architecture, Security, Operations)
 
@@ -270,7 +270,7 @@ The question is whether we will build it before we need it.
 
 *Bob Stewart is the architect of EXOCHAIN and decision.forum, and the author of The ASI Report on LinkedIn, where he writes about the infrastructure required for safe superintelligence. His work focuses on the intersection of constitutional governance, cryptographic enforcement, and AI safety -- the premise that alignment is necessary but insufficient, and that enforceable structural constraints are the missing complement.*
 
-*The EXOCHAIN workspace -- 123869 lines of Rust under `crates/`, 20 packages, 2,996 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
+*The EXOCHAIN workspace -- 123923 lines of Rust under `crates/`, 20 packages, 2,999 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
 
 ---
 

--- a/docs/decision-forum/SYSTEM-DOCUMENTATION.md
+++ b/docs/decision-forum/SYSTEM-DOCUMENTATION.md
@@ -6,7 +6,7 @@ created: 2026-03-19
 publication: "The ASI Report — LinkedIn Newsletter"
 tags: [decision-forum, governance, constitutional, asi-safety, exochain]
 status: publication-ready
-codebase: "20 workspace packages | 123869 LOC Rust under crates/ | 266 source files | 2,996 listed tests"
+codebase: "20 workspace packages | 123923 LOC Rust under crates/ | 266 source files | 2,999 listed tests"
 ---
 
 # decision.forum — System Documentation
@@ -20,9 +20,9 @@ This document is the exhaustive technical reference for the decision.forum gover
 | Metric | Value |
 |--------|-------|
 | Workspace packages | 20 |
-| Rust LOC under `crates/` | 123869 |
+| Rust LOC under `crates/` | 123923 |
 | Rust source files | 266 |
-| Listed workspace tests | 2,996 |
+| Listed workspace tests | 2,999 |
 | Test gate | `cargo test --workspace` in CI Gate 2 |
 | decision-forum crate LOC | 3,800 |
 | decision-forum tests | 131 |

--- a/docs/guides/GETTING-STARTED.md
+++ b/docs/guides/GETTING-STARTED.md
@@ -124,7 +124,7 @@ open tarpaulin-report.html
 ```
 
 A clean build produces zero errors and zero warnings. The current workspace
-inventory lists 2,996 tests; the exact executed count can change as doctests and
+inventory lists 2,999 tests; the exact executed count can change as doctests and
 integration targets evolve. What matters is zero failures:
 
 ```

--- a/docs/guides/architecture-overview.md
+++ b/docs/guides/architecture-overview.md
@@ -399,7 +399,7 @@ dispatches `tools/call` requests to the appropriate handler.
 | Authority      | 3                    | Delegate, verify chain, check permission                         | `tools/authority.rs`                        |
 | Kernel         | 1                    | `exochain_adjudicate_action` — single-call kernel adjudication   | (dispatched to `governance.rs`)             |
 | Ledger         | 4                    | Submit event, get event, inclusion proof, get checkpoint         | `tools/ledger.rs`                           |
-| Proofs         | 4                    | Evidence envelopes, custody-chain verification, Merkle proof, fail-closed CGR proof verifier placeholder | `tools/proofs.rs`                           |
+| Proofs         | 4                    | Evidence envelopes, custody-chain verification, verifier-compatible Merkle proofs, fail-closed CGR proof verifier placeholder | `tools/proofs.rs`                           |
 | Legal          | 4                    | eDiscovery, privilege, DGCL §144 safe harbour, fiduciary duty    | `tools/legal.rs`                            |
 | Escalation     | 4                    | Evaluate threat, escalate case, triage, feedback                 | `tools/escalation.rs`                       |
 | Messaging      | 3                    | Send encrypted, receive encrypted, configure death trigger       | `tools/messaging.rs`                        |

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,996 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **2,999 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/guides/mcp-integration.md
+++ b/docs/guides/mcp-integration.md
@@ -297,7 +297,7 @@ Use these at session start to let the agent self-orient.
 |---|---|
 | `exochain_create_evidence` | Construct a verifier-compatible legal evidence envelope from UUID, content hash, creator DID, and creation HLC; this does not persist evidence. |
 | `exochain_verify_chain_of_custody` | Verify evidence UUID/DID/hash metadata, transfer continuity, transfer reasons, and monotonic HLC timestamps. |
-| `exochain_generate_merkle_proof` | Produce a Merkle inclusion proof for a leaf. |
+| `exochain_generate_merkle_proof` | Produce a verifier-compatible Merkle inclusion proof for a 32-byte event hash, returning `event_hash`, `root_hash`, and `proof_hashes`. |
 | `exochain_verify_cgr_proof` | Refuses CGR proof verification until proof bytes, public inputs, checkpoint roots, validator signatures, and a production verifier are wired. |
 
 ### Legal (4)

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 123869 lines of Rust under `crates/` · 2,996 listed tests
+20 workspace packages · 123923 lines of Rust under `crates/` · 2,999 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 

--- a/governance/EXOCHAIN-REFACTOR-PLAN.md
+++ b/governance/EXOCHAIN-REFACTOR-PLAN.md
@@ -68,7 +68,7 @@ All refactor work flows through the Syntaxis Builder system:
 - [ ] Complete Section 8 work orders from CR-001
 - [ ] Achieve release-blocking acceptance standard (CR-001 Section 9)
 
-> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 123869 Rust LOC under `crates/`, 2,996 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
+> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 123923 Rust LOC under `crates/`, 2,999 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
 
 ## Active Resolutions
 

--- a/governance/sub_agents.md
+++ b/governance/sub_agents.md
@@ -72,7 +72,7 @@ Historical 2026-03-19 sub-agent completion record. Numeric status claims are sup
 * **Inputs**: Spec Section 16 (Acceptance Criteria).
 * **Outputs**: Test harnesses, Integration tests, Fuzz targets.
 * **Definition of Done**: Section 16 Acceptance Criteria are automated and passing.
-* **Status**: **DONE** — Current workspace inventory lists 2,996 tests across 20 packages and 266 Rust files.
+* **Status**: **DONE** — Current workspace inventory lists 2,999 tests across 20 packages and 266 Rust files.
 
 ## J) DEVOPS_RELEASE_AGENT (Judicial) — DONE
 

--- a/governance/traceability_matrix.md
+++ b/governance/traceability_matrix.md
@@ -163,4 +163,4 @@ Updated 2026-03-20 after EXOCHAIN-REM-009 — continuous governance monitoring a
 | **TOTAL** | **86** | **83** | **1** | **2** |
 
 **Coverage: 83/86 requirements traced to code (97%). 2 planned (ExoForge scheduling + React dashboard). 1 partial (T-14 Rust attestation verification).**
-**Workspace inventory: 2,996 listed tests across 20 packages and 266 Rust files.**
+**Workspace inventory: 2,999 listed tests across 20 packages and 266 Rust files.**


### PR DESCRIPTION
## Summary
- make `exochain_generate_merkle_proof` accept explicit 32-byte event hashes instead of hashing arbitrary caller leaf bytes
- return verifier-compatible `event_hash`, `root_hash`, and `proof_hashes` fields while preserving legacy aliases as identical values
- add regression coverage proving generated proof output verifies through `exochain_verify_inclusion` and rejects short/zero placeholder leaves
- refresh MCP docs and repo-truth counts to 123923 Rust LOC / 2,999 listed tests

## Tests
- `cargo test -p exo-node execute_generate_merkle_proof_ -- --nocapture` (failed first, then passed)
- `cargo test -p exo-node mcp::tools::proofs -- --nocapture`
- `cargo test -p exo-node mcp::tools::ledger -- --nocapture`
- `cargo test -p exo-node mcp::tools -- --nocapture`
- `cargo test -p exo-node`
- `cargo build -p exo-node`
- `cargo clippy -p exo-node --bin exochain -- -D warnings`
- `cargo clippy -p exo-node --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash tools/repo_truth.sh --json`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit` (existing allowed yanked core2 warning)
- `cargo deny check` (existing duplicate/yanked/unused-allowance warnings)
- `cargo machete --with-metadata`
- `cargo build --workspace --release`
- `cargo test --workspace --release`