### PR TITLE
fix(exo-node): read mcp events from live store

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 123923 | `wc -l` |
-| Workspace tests | 2,999 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 124090 | `wc -l` |
+| Workspace tests | 3,002 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **2,999 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,002 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 123923 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 124090 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 2,999 listed workspace tests
+         cryptographic proofs, 3,002 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/mcp/tools/ledger.rs
+++ b/crates/exo-node/src/mcp/tools/ledger.rs
@@ -152,7 +152,7 @@ pub fn get_event_definition() -> ToolDefinition {
 /// Execute the `exochain_get_event` tool.
 #[must_use]
 pub fn execute_get_event(params: &Value, context: &NodeContext) -> ToolResult {
-    let event_hash = match params.get("event_hash").and_then(Value::as_str) {
+    let event_hash_raw = match params.get("event_hash").and_then(Value::as_str) {
         Some(s) => s,
         None => {
             return ToolResult::error(
@@ -161,27 +161,85 @@ pub fn execute_get_event(params: &Value, context: &NodeContext) -> ToolResult {
         }
     };
 
-    // Validate hex format.
-    if hex::decode(event_hash).is_err() {
-        return ToolResult::error(
-            json!({"error": "invalid event_hash: not valid hexadecimal"}).to_string(),
-        );
-    }
+    let event_hash = match decode_hash256_hex("event_hash", event_hash_raw) {
+        Ok(hash) => hash,
+        Err(error) => return ToolResult::error(json!({"error": error}).to_string()),
+    };
 
-    // When a DAG store is attached, we differentiate the response so
-    // callers know the lookup was attempted against real state.
-    if context.has_store() {
+    if let Some(store) = context.store.as_ref() {
+        let guard = match store.lock() {
+            Ok(guard) => guard,
+            Err(_) => {
+                tracing::error!("MCP ledger get_event store mutex poisoned");
+                return ToolResult::error(
+                    json!({"error": "ledger store is temporarily unavailable"}).to_string(),
+                );
+            }
+        };
+
+        let node = match guard.get_sync(&event_hash) {
+            Ok(node) => node,
+            Err(e) => {
+                return ToolResult::error(
+                    json!({"error": format!("store event lookup failed: {e}")}).to_string(),
+                );
+            }
+        };
+
+        let Some(node) = node else {
+            let response = json!({
+                "event_hash": event_hash.to_string(),
+                "found": false,
+                "status": "not_found",
+                "source": "attached_store",
+            });
+            return ToolResult::success(response.to_string());
+        };
+
+        let children = match guard.children(&event_hash) {
+            Ok(children) => children,
+            Err(e) => {
+                return ToolResult::error(
+                    json!({"error": format!("store child lookup failed: {e}")}).to_string(),
+                );
+            }
+        };
+        let committed_height = match guard.committed_height_for(&event_hash) {
+            Ok(height) => height,
+            Err(e) => {
+                return ToolResult::error(
+                    json!({"error": format!("store commit lookup failed: {e}")}).to_string(),
+                );
+            }
+        };
+
+        let parents: Vec<String> = node.parents.iter().map(ToString::to_string).collect();
+        let children_hex: Vec<String> = children.iter().map(ToString::to_string).collect();
         let response = json!({
-            "event_hash": event_hash,
-            "found": false,
-            "status": "known_store_but_lookup_not_yet_implemented",
-            "suggestion": "Store is attached; this MCP tool cannot retrieve event bodies.",
+            "event_hash": node.hash.to_string(),
+            "found": true,
+            "status": "found",
+            "source": "attached_store",
+            "payload_hash": node.payload_hash.to_string(),
+            "payload_hash_size": node.payload_hash.as_bytes().len(),
+            "creator_did": node.creator_did.to_string(),
+            "parents": parents,
+            "parent_count": node.parents.len(),
+            "children": children_hex,
+            "child_count": children.len(),
+            "committed": committed_height.is_some(),
+            "committed_height": committed_height,
+            "timestamp": node.timestamp.to_string(),
+            "timestamp_physical_ms": node.timestamp.physical_ms,
+            "timestamp_logical": node.timestamp.logical,
+            "signature_algorithm": node.signature.algorithm(),
+            "signature_hex": node.signature.to_string(),
         });
         return ToolResult::success(response.to_string());
     }
 
     let response = json!({
-        "event_hash": event_hash,
+        "event_hash": event_hash.to_string(),
         "found": false,
         "status": "not_found_no_store",
         "suggestion": "No DAG store is attached to this MCP server; run within a live node to query events.",
@@ -444,9 +502,62 @@ pub fn execute_get_checkpoint(params: &Value, context: &NodeContext) -> ToolResu
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
-    use exo_core::hash::{merkle_proof, merkle_root};
+    use std::sync::{Arc, Mutex};
+
+    use exo_core::{
+        hash::{merkle_proof, merkle_root},
+        types::{Did, Signature},
+    };
+    use exo_dag::dag::{Dag, DeterministicDagClock, append};
 
     use super::*;
+
+    fn make_sign_fn() -> Box<dyn Fn(&[u8]) -> Signature> {
+        Box::new(|data: &[u8]| {
+            let digest = blake3::hash(data);
+            let mut signature = [0u8; 64];
+            signature[..32].copy_from_slice(digest.as_bytes());
+            Signature::from_bytes(signature)
+        })
+    }
+
+    fn context_with_store_node() -> (NodeContext, tempfile::TempDir, Hash256, Hash256) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut store = crate::store::SqliteDagStore::open(dir.path()).expect("store");
+
+        let mut dag = Dag::new();
+        let mut clock = DeterministicDagClock::new();
+        let creator = Did::new("did:exo:mcp-ledger-test").expect("valid DID");
+        let sign_fn = make_sign_fn();
+
+        let genesis =
+            append(&mut dag, &[], b"genesis", &creator, &*sign_fn, &mut clock).expect("genesis");
+        let child = append(
+            &mut dag,
+            &[genesis.hash],
+            b"child",
+            &creator,
+            &*sign_fn,
+            &mut clock,
+        )
+        .expect("child");
+
+        store.put_sync(genesis.clone()).expect("put genesis");
+        store.put_sync(child.clone()).expect("put child");
+        store
+            .mark_committed_sync(&genesis.hash, 1)
+            .expect("commit genesis");
+
+        (
+            NodeContext {
+                store: Some(Arc::new(Mutex::new(store))),
+                ..NodeContext::empty()
+            },
+            dir,
+            genesis.hash,
+            child.hash,
+        )
+    }
 
     fn test_hash_pair(left: &Hash256, right: &Hash256) -> Hash256 {
         let mut combined = [0u8; 64];
@@ -539,7 +650,7 @@ mod tests {
 
     #[test]
     fn execute_get_event_not_found() {
-        let params = json!({"event_hash": "abcdef0123456789"});
+        let params = json!({"event_hash": Hash256::digest(b"missing-event").to_string()});
         let result = execute_get_event(&params, &NodeContext::empty());
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
@@ -554,9 +665,65 @@ mod tests {
     }
 
     #[test]
+    fn execute_get_event_rejects_short_event_hash() {
+        let result = execute_get_event(
+            &json!({"event_hash": "abcdef0123456789"}),
+            &NodeContext::empty(),
+        );
+
+        assert!(result.is_error);
+        assert!(result.content[0].text().contains("32-byte"));
+        assert!(result.content[0].text().contains("event_hash"));
+    }
+
+    #[test]
     fn execute_get_event_missing_hash() {
         let result = execute_get_event(&json!({}), &NodeContext::empty());
         assert!(result.is_error);
+    }
+
+    #[test]
+    fn execute_get_event_reads_attached_store_node() {
+        let (context, _dir, genesis_hash, child_hash) = context_with_store_node();
+
+        let result = execute_get_event(&json!({"event_hash": child_hash.to_string()}), &context);
+
+        assert!(!result.is_error);
+        let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
+        assert_eq!(v["found"], true);
+        assert_eq!(v["status"], "found");
+        assert_eq!(v["event_hash"], child_hash.to_string());
+        assert_eq!(v["creator_did"], "did:exo:mcp-ledger-test");
+        assert_eq!(v["parent_count"], 1);
+        assert_eq!(v["parents"][0], genesis_hash.to_string());
+        assert_eq!(v["child_count"], 0);
+        assert_eq!(v["committed"], false);
+        assert!(v["committed_height"].is_null());
+        assert_eq!(v["payload_hash_size"], 32);
+        assert_eq!(v["timestamp"], "0:2");
+        assert_eq!(v["timestamp_physical_ms"], 0);
+        assert_eq!(v["timestamp_logical"], 2);
+        assert_eq!(v["signature_algorithm"], "Ed25519");
+        assert_eq!(
+            v["signature_hex"].as_str().expect("signature hex").len(),
+            128
+        );
+    }
+
+    #[test]
+    fn execute_get_event_reports_committed_height_from_attached_store() {
+        let (context, _dir, genesis_hash, _child_hash) = context_with_store_node();
+
+        let result = execute_get_event(&json!({"event_hash": genesis_hash.to_string()}), &context);
+
+        assert!(!result.is_error);
+        let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
+        assert_eq!(v["found"], true);
+        assert_eq!(v["status"], "found");
+        assert_eq!(v["committed"], true);
+        assert_eq!(v["committed_height"], 1);
+        assert_eq!(v["parent_count"], 0);
+        assert_eq!(v["child_count"], 1);
     }
 
     // -- verify_inclusion -----------------------------------------------------

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 123923 lines of Rust under `crates/`, 2,999 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 124090 lines of Rust under `crates/`, 3,002 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 2,999 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 3,002 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 2,999 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 3,002 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-123923 lines of Rust under `crates/` · 20 workspace packages · 2,999 listed tests · 40 MCP tools · 8 constitutional invariants
+124090 lines of Rust under `crates/` · 20 workspace packages · 3,002 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 123923 lines of Rust under `crates/` | 266 Rust source files | 2,999 listed tests
+> **Codebase:** 20 workspace packages | 124090 lines of Rust under `crates/` | 266 Rust source files | 3,002 listed tests
 
 ---
 

--- a/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
+++ b/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
@@ -46,9 +46,9 @@ decision.forum is a constitutional trust fabric for AI-era governance. Not a fra
 
 The numbers, verified as of this writing:
 
-- **123923 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
+- **124090 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
 - **20 workspace packages** covering identity, consent, authority, governance, escalation, legal infrastructure, cryptographic proofs, and more
-- **2,999 listed tests** exercised by the workspace test gate.
+- **3,002 listed tests** exercised by the workspace test gate.
 - **10 formal proofs** demonstrating that constitutional properties hold under all reachable system states
 - Built and reviewed through a **5-panel council process** (Governance, Legal, Architecture, Security, Operations)
 
@@ -270,7 +270,7 @@ The question is whether we will build it before we need it.
 
 *Bob Stewart is the architect of EXOCHAIN and decision.forum, and the author of The ASI Report on LinkedIn, where he writes about the infrastructure required for safe superintelligence. His work focuses on the intersection of constitutional governance, cryptographic enforcement, and AI safety -- the premise that alignment is necessary but insufficient, and that enforceable structural constraints are the missing complement.*
 
-*The EXOCHAIN workspace -- 123923 lines of Rust under `crates/`, 20 packages, 2,999 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
+*The EXOCHAIN workspace -- 124090 lines of Rust under `crates/`, 20 packages, 3,002 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
 
 ---
 

--- a/docs/decision-forum/SYSTEM-DOCUMENTATION.md
+++ b/docs/decision-forum/SYSTEM-DOCUMENTATION.md
@@ -6,7 +6,7 @@ created: 2026-03-19
 publication: "The ASI Report — LinkedIn Newsletter"
 tags: [decision-forum, governance, constitutional, asi-safety, exochain]
 status: publication-ready
-codebase: "20 workspace packages | 123923 LOC Rust under crates/ | 266 source files | 2,999 listed tests"
+codebase: "20 workspace packages | 124090 LOC Rust under crates/ | 266 source files | 3,002 listed tests"
 ---
 
 # decision.forum — System Documentation
@@ -20,9 +20,9 @@ This document is the exhaustive technical reference for the decision.forum gover
 | Metric | Value |
 |--------|-------|
 | Workspace packages | 20 |
-| Rust LOC under `crates/` | 123923 |
+| Rust LOC under `crates/` | 124090 |
 | Rust source files | 266 |
-| Listed workspace tests | 2,999 |
+| Listed workspace tests | 3,002 |
 | Test gate | `cargo test --workspace` in CI Gate 2 |
 | decision-forum crate LOC | 3,800 |
 | decision-forum tests | 131 |

--- a/docs/guides/GETTING-STARTED.md
+++ b/docs/guides/GETTING-STARTED.md
@@ -124,7 +124,7 @@ open tarpaulin-report.html
 ```
 
 A clean build produces zero errors and zero warnings. The current workspace
-inventory lists 2,999 tests; the exact executed count can change as doctests and
+inventory lists 3,002 tests; the exact executed count can change as doctests and
 integration targets evolve. What matters is zero failures:
 
 ```

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **2,999 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **3,002 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/guides/mcp-integration.md
+++ b/docs/guides/mcp-integration.md
@@ -287,7 +287,7 @@ Use these at session start to let the agent self-orient.
 | Tool | Purpose |
 |---|---|
 | `exochain_submit_event` | Append a signed event to the ledger. |
-| `exochain_get_event` | Fetch an event by hash. |
+| `exochain_get_event` | Fetch a DAG node by 32-byte event hash when a live store is attached; returns payload hash, creator DID, parents, children, timestamp, signature metadata, and committed height if available. |
 | `exochain_verify_inclusion` | Prove a given event is in a given checkpoint. |
 | `exochain_get_checkpoint` | Fetch the latest signed checkpoint. |
 

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 123923 lines of Rust under `crates/` · 2,999 listed tests
+20 workspace packages · 124090 lines of Rust under `crates/` · 3,002 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 

--- a/governance/EXOCHAIN-REFACTOR-PLAN.md
+++ b/governance/EXOCHAIN-REFACTOR-PLAN.md
@@ -68,7 +68,7 @@ All refactor work flows through the Syntaxis Builder system:
 - [ ] Complete Section 8 work orders from CR-001
 - [ ] Achieve release-blocking acceptance standard (CR-001 Section 9)
 
-> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 123923 Rust LOC under `crates/`, 2,999 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
+> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 124090 Rust LOC under `crates/`, 3,002 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
 
 ## Active Resolutions
 

--- a/governance/sub_agents.md
+++ b/governance/sub_agents.md
@@ -72,7 +72,7 @@ Historical 2026-03-19 sub-agent completion record. Numeric status claims are sup
 * **Inputs**: Spec Section 16 (Acceptance Criteria).
 * **Outputs**: Test harnesses, Integration tests, Fuzz targets.
 * **Definition of Done**: Section 16 Acceptance Criteria are automated and passing.
-* **Status**: **DONE** — Current workspace inventory lists 2,999 tests across 20 packages and 266 Rust files.
+* **Status**: **DONE** — Current workspace inventory lists 3,002 tests across 20 packages and 266 Rust files.
 
 ## J) DEVOPS_RELEASE_AGENT (Judicial) — DONE
 

--- a/governance/traceability_matrix.md
+++ b/governance/traceability_matrix.md
@@ -163,4 +163,4 @@ Updated 2026-03-20 after EXOCHAIN-REM-009 — continuous governance monitoring a
 | **TOTAL** | **86** | **83** | **1** | **2** |
 
 **Coverage: 83/86 requirements traced to code (97%). 2 planned (ExoForge scheduling + React dashboard). 1 partial (T-14 Rust attestation verification).**
-**Workspace inventory: 2,999 listed tests across 20 packages and 266 Rust files.**
+**Workspace inventory: 3,002 listed tests across 20 packages and 266 Rust files.**


### PR DESCRIPTION
## Summary
- make `exochain_get_event` parse strict 32-byte Hash256 event hashes
- read attached `SqliteDagStore` events through `get_sync`, `children`, and `committed_height_for`
- return factual DAG node metadata instead of the placeholder `known_store_but_lookup_not_yet_implemented` status
- refresh repo-truth counts to 124090 Rust LOC / 3002 listed tests

## TDD
- `cargo test -p exo-node execute_get_event_ -- --nocapture` failed first on short-hash acceptance and attached-store placeholder behavior, then passed

## Verification
- `cargo test -p exo-node execute_get_event_ -- --nocapture`
- `cargo test -p exo-node mcp::tools::ledger -- --nocapture`
- `cargo test -p exo-node mcp::tools -- --nocapture`
- `cargo test -p exo-node`
- `cargo build -p exo-node`
- `cargo clippy -p exo-node --bin exochain -- -D warnings`
- `cargo clippy -p exo-node --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo fmt --all -- --check`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/repo_truth.sh --json`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check`
- `cargo machete --with-metadata`
- `cargo build --workspace --release`
- `cargo test --workspace --release`