### PR TITLE
fix(exo-node): refuse unavailable mcp consent reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 124090 | `wc -l` |
-| Workspace tests | 3,002 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 124165 | `wc -l` |
+| Workspace tests | 3,001 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,002 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,001 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 124090 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 124165 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,002 listed workspace tests
+         cryptographic proofs, 3,001 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/mcp/prompts/compliance_check.rs
+++ b/crates/exo-node/src/mcp/prompts/compliance_check.rs
@@ -77,7 +77,8 @@ Rationale:
 Gather context first:
 - `exochain_list_invariants` — the 8 constitutional invariants
 - `exochain_list_mcp_rules` — the 6 MCP enforcement rules
-- `exochain_check_consent` with actor={actor_did} and the resource
+- `exochain_check_consent` with actor={actor_did} and the resource; if it
+  returns `mcp_consent_registry_unavailable`, mark consent as not proven
 - `exochain_verify_authority_chain` with subject={actor_did}
 - `exochain_check_permission` for the specific permission the action needs
 

--- a/crates/exo-node/src/mcp/prompts/constitutional_audit.rs
+++ b/crates/exo-node/src/mcp/prompts/constitutional_audit.rs
@@ -77,7 +77,9 @@ Load the kernel context before auditing:
 - `exochain_node_status` — consensus round, height, validator set
 - `exochain_list_invariants` — canonical invariant list
 - `exochain_get_checkpoint` at the cited timestamp (or latest)
-- `exochain_list_bailments` for the scope
+- `exochain_list_bailments` for the scope; if it returns
+  `mcp_consent_registry_unavailable`, record that no live consent registry was
+  available for the audit
 - Read resource `exochain://constitution` and BLAKE3-hash it to confirm
   the kernel hash matches the current binary
 

--- a/crates/exo-node/src/mcp/resources/readme.rs
+++ b/crates/exo-node/src/mcp/resources/readme.rs
@@ -64,8 +64,9 @@ The kernel enforces 8 invariants on **every** action. Read
 
 1. **Separation of Powers** — You cannot hold legislative + executive +
    judicial roles at once. MCP agents are assigned the `Judicial` branch.
-2. **Consent Required** — No active bailment → denial. Always check
-   `exochain_check_consent` before acting on a resource.
+2. **Consent Required** — No active bailment → denial. Call
+   `exochain_check_consent` before acting on a resource, and treat
+   `mcp_consent_registry_unavailable` as no proof of consent.
 3. **No Self-Grant** — You cannot widen your own permissions. Delegation
    must come from an authority chain rooted in a human signer.
 4. **Human Override** — Your actions must remain reversible by a human
@@ -96,7 +97,8 @@ Read `exochain://mcp-rules` for the authoritative list. In short:
 - **Always call `exochain_node_status` first** — this tells you whether
   you're talking to a live consensus node or a standalone stdio session.
 - **Before any write-like action**, call `exochain_check_consent` and
-  `exochain_verify_authority_chain` on the actor. If either fails, stop.
+  `exochain_verify_authority_chain` on the actor. If either fails, or if the
+  consent registry is unavailable, stop.
 - **For reviews and audits**, use the prompts `governance_review`,
   `compliance_check`, `evidence_analysis`, `constitutional_audit` via
   `prompts/get`. They hand you a structured template filled with your

--- a/crates/exo-node/src/mcp/tools/consent.rs
+++ b/crates/exo-node/src/mcp/tools/consent.rs
@@ -11,6 +11,23 @@ use crate::mcp::{
     protocol::{ToolDefinition, ToolResult},
 };
 
+#[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+const MCP_CONSENT_READ_INITIATIVE: &str = "Initiatives/fix-mcp-consent-read-store-refusal.md";
+
+#[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+fn consent_registry_unavailable(tool_name: &str) -> ToolResult {
+    ToolResult::error(
+        json!({
+            "error": "mcp_consent_registry_unavailable",
+            "tool": tool_name,
+            "message": "This MCP consent read has no live consent registry attached, so it cannot prove active consent or enumerate bailments. Build with `unaudited-mcp-simulation-tools` only for explicit dev simulation.",
+            "feature_flag": "unaudited-mcp-simulation-tools",
+            "initiative": MCP_CONSENT_READ_INITIATIVE,
+        })
+        .to_string(),
+    )
+}
+
 // ---------------------------------------------------------------------------
 // exochain_propose_bailment
 // ---------------------------------------------------------------------------
@@ -151,7 +168,7 @@ pub fn execute_propose_bailment(params: &Value, _context: &NodeContext) -> ToolR
 pub fn check_consent_definition() -> ToolDefinition {
     ToolDefinition {
         name: "exochain_check_consent".to_owned(),
-        description: "Check whether active consent exists for a specific actor and scope. Returns consent status and details.".to_owned(),
+        description: "Check whether active consent can be proven for a specific actor and scope. The default MCP context has no consent registry and refuses rather than fabricating absence.".to_owned(),
         input_schema: json!({
             "type": "object",
             "properties": {
@@ -196,14 +213,23 @@ pub fn execute_check_consent(params: &Value, _context: &NodeContext) -> ToolResu
         );
     }
 
-    // No persistent consent registry yet — report no active consent.
-    let response = json!({
-        "actor": actor_str,
-        "scope": scope,
-        "consent_active": false,
-        "bailment_state": "none",
-    });
-    ToolResult::success(response.to_string())
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    {
+        let _ = scope;
+        consent_registry_unavailable("exochain_check_consent")
+    }
+
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
+    {
+        let response = json!({
+            "actor": actor_str,
+            "scope": scope,
+            "consent_active": false,
+            "bailment_state": "none",
+            "source": "simulation_no_consent_registry",
+        });
+        ToolResult::success(response.to_string())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -215,7 +241,7 @@ pub fn execute_check_consent(params: &Value, _context: &NodeContext) -> ToolResu
 pub fn list_bailments_definition() -> ToolDefinition {
     ToolDefinition {
         name: "exochain_list_bailments".to_owned(),
-        description: "List all bailments (active, proposed, terminated) for a given DID."
+        description: "List bailments for a given DID when a live consent registry is wired. The default MCP context refuses rather than returning a fabricated empty registry."
             .to_owned(),
         input_schema: json!({
             "type": "object",
@@ -266,13 +292,23 @@ pub fn execute_list_bailments(params: &Value, _context: &NodeContext) -> ToolRes
         );
     }
 
-    let response = json!({
-        "did": did_str,
-        "filter": filter,
-        "bailments": [],
-        "count": 0,
-    });
-    ToolResult::success(response.to_string())
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
+    {
+        let _ = filter;
+        consent_registry_unavailable("exochain_list_bailments")
+    }
+
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
+    {
+        let response = json!({
+            "did": did_str,
+            "filter": filter,
+            "bailments": [],
+            "count": 0,
+            "source": "simulation_no_consent_registry",
+        });
+        ToolResult::success(response.to_string())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -449,8 +485,26 @@ mod tests {
         assert!(!def.description.is_empty());
     }
 
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
     #[test]
-    fn execute_check_consent_success() {
+    fn execute_check_consent_refuses_without_live_registry() {
+        let result = execute_check_consent(
+            &json!({
+                "actor_did": "did:exo:alice",
+                "scope": "data:medical",
+            }),
+            &NodeContext::empty(),
+        );
+        assert!(result.is_error);
+        let text = result.content[0].text();
+        assert!(text.contains("mcp_consent_registry_unavailable"));
+        assert!(text.contains("fix-mcp-consent-read-store-refusal.md"));
+        assert!(text.contains("unaudited-mcp-simulation-tools"));
+    }
+
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
+    #[test]
+    fn execute_check_consent_simulation_success() {
         let result = execute_check_consent(
             &json!({
                 "actor_did": "did:exo:alice",
@@ -462,6 +516,7 @@ mod tests {
         let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
         assert_eq!(v["consent_active"], false);
         assert_eq!(v["bailment_state"], "none");
+        assert_eq!(v["source"], "simulation_no_consent_registry");
     }
 
     #[test]
@@ -496,8 +551,21 @@ mod tests {
         assert!(!def.description.is_empty());
     }
 
+    #[cfg(not(feature = "unaudited-mcp-simulation-tools"))]
     #[test]
-    fn execute_list_bailments_success() {
+    fn execute_list_bailments_refuses_without_live_registry() {
+        let result =
+            execute_list_bailments(&json!({"did": "did:exo:alice"}), &NodeContext::empty());
+        assert!(result.is_error);
+        let text = result.content[0].text();
+        assert!(text.contains("mcp_consent_registry_unavailable"));
+        assert!(text.contains("fix-mcp-consent-read-store-refusal.md"));
+        assert!(text.contains("unaudited-mcp-simulation-tools"));
+    }
+
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
+    #[test]
+    fn execute_list_bailments_simulation_success() {
         let result =
             execute_list_bailments(&json!({"did": "did:exo:alice"}), &NodeContext::empty());
         assert!(!result.is_error);
@@ -505,8 +573,10 @@ mod tests {
         assert_eq!(v["count"], 0);
         assert_eq!(v["filter"], "all");
         assert!(v["bailments"].as_array().expect("arr").is_empty());
+        assert_eq!(v["source"], "simulation_no_consent_registry");
     }
 
+    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_list_bailments_with_filter() {
         let result = execute_list_bailments(

--- a/docs/ASI-REPORT-FEATURE.md
+++ b/docs/ASI-REPORT-FEATURE.md
@@ -27,7 +27,7 @@ EXOCHAIN takes a different approach. Instead of aspirational guidelines, it prov
 
 ## What EXOCHAIN Is
 
-EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 124090 lines of Rust under `crates/`, 3,002 listed tests, and a formal proof chain demonstrating its intended governance properties.
+EXOCHAIN is a constitutional trust fabric: 20 Rust workspace packages, 124165 lines of Rust under `crates/`, 3,001 listed tests, and a formal proof chain demonstrating its intended governance properties.
 
 It implements a three-branch constitutional model — legislative, executive, and judicial — where:
 
@@ -187,7 +187,7 @@ The conventional approach to AI safety assumes we need to solve alignment — ma
 
 The analogy is constitutional democracy. We don't require every citizen to have perfect values. We require every action to comply with constitutional constraints — and we enforce those constraints through an independent judiciary that cannot be overruled by popular vote or executive fiat.
 
-EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 3,002 listed workspace tests, provide the structural guarantee that:
+EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, backed by formal proofs and 3,001 listed workspace tests, provide the structural guarantee that:
 
 1. No AI system can grant itself capabilities
 2. No AI system can forge consensus
@@ -195,7 +195,7 @@ EXOCHAIN is that judiciary for AI systems. Its five constitutional properties, b
 4. A human can always intervene
 5. The rules themselves cannot be changed
 
-These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 3,002 listed workspace tests, and a constitutional governance process that governs its own evolution.
+These aren't aspirational. They're enforced at the type level, the runtime level, and the cryptographic level. They are as immutable as the code that implements them — and that code is verified by formal proofs, 3,001 listed workspace tests, and a constitutional governance process that governs its own evolution.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,7 +10,7 @@ tags: [exochain, documentation, index]
 
 **Constitutional Trust Fabric for Safe Superintelligence Governance**
 
-124090 lines of Rust under `crates/` · 20 workspace packages · 3,002 listed tests · 40 MCP tools · 8 constitutional invariants
+124165 lines of Rust under `crates/` · 20 workspace packages · 3,001 listed tests · 40 MCP tools · 8 constitutional invariants
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EXOCHAIN Architecture
 
 > **Version:** 0.1.0 | **Status:** Living Document | **Last verified:** 2026-03-18
-> **Codebase:** 20 workspace packages | 124090 lines of Rust under `crates/` | 266 Rust source files | 3,002 listed tests
+> **Codebase:** 20 workspace packages | 124165 lines of Rust under `crates/` | 266 Rust source files | 3,001 listed tests
 
 ---
 

--- a/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
+++ b/docs/decision-forum/ASI-REPORT-DECISION-FORUM.md
@@ -46,9 +46,9 @@ decision.forum is a constitutional trust fabric for AI-era governance. Not a fra
 
 The numbers, verified as of this writing:
 
-- **124090 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
+- **124165 lines of Rust under `crates/`** -- not Python, not JavaScript. Rust. For determinism.
 - **20 workspace packages** covering identity, consent, authority, governance, escalation, legal infrastructure, cryptographic proofs, and more
-- **3,002 listed tests** exercised by the workspace test gate.
+- **3,001 listed tests** exercised by the workspace test gate.
 - **10 formal proofs** demonstrating that constitutional properties hold under all reachable system states
 - Built and reviewed through a **5-panel council process** (Governance, Legal, Architecture, Security, Operations)
 
@@ -270,7 +270,7 @@ The question is whether we will build it before we need it.
 
 *Bob Stewart is the architect of EXOCHAIN and decision.forum, and the author of The ASI Report on LinkedIn, where he writes about the infrastructure required for safe superintelligence. His work focuses on the intersection of constitutional governance, cryptographic enforcement, and AI safety -- the premise that alignment is necessary but insufficient, and that enforceable structural constraints are the missing complement.*
 
-*The EXOCHAIN workspace -- 124090 lines of Rust under `crates/`, 20 packages, 3,002 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
+*The EXOCHAIN workspace -- 124165 lines of Rust under `crates/`, 20 packages, 3,001 listed tests, and formal proof material -- is available for technical review. Participation in the council process is open to qualified reviewers across all five panels.*
 
 ---
 

--- a/docs/decision-forum/SYSTEM-DOCUMENTATION.md
+++ b/docs/decision-forum/SYSTEM-DOCUMENTATION.md
@@ -6,7 +6,7 @@ created: 2026-03-19
 publication: "The ASI Report — LinkedIn Newsletter"
 tags: [decision-forum, governance, constitutional, asi-safety, exochain]
 status: publication-ready
-codebase: "20 workspace packages | 124090 LOC Rust under crates/ | 266 source files | 3,002 listed tests"
+codebase: "20 workspace packages | 124165 LOC Rust under crates/ | 266 source files | 3,001 listed tests"
 ---
 
 # decision.forum — System Documentation
@@ -20,9 +20,9 @@ This document is the exhaustive technical reference for the decision.forum gover
 | Metric | Value |
 |--------|-------|
 | Workspace packages | 20 |
-| Rust LOC under `crates/` | 124090 |
+| Rust LOC under `crates/` | 124165 |
 | Rust source files | 266 |
-| Listed workspace tests | 3,002 |
+| Listed workspace tests | 3,001 |
 | Test gate | `cargo test --workspace` in CI Gate 2 |
 | decision-forum crate LOC | 3,800 |
 | decision-forum tests | 131 |

--- a/docs/guides/GETTING-STARTED.md
+++ b/docs/guides/GETTING-STARTED.md
@@ -124,7 +124,7 @@ open tarpaulin-report.html
 ```
 
 A clean build produces zero errors and zero warnings. The current workspace
-inventory lists 3,002 tests; the exact executed count can change as doctests and
+inventory lists 3,001 tests; the exact executed count can change as doctests and
 integration targets evolve. What matters is zero failures:
 
 ```

--- a/docs/guides/ai-agent-guide.md
+++ b/docs/guides/ai-agent-guide.md
@@ -221,8 +221,8 @@ scope boundary at the AI layer.
 **How to comply.** When your consent record is revoked or suspended,
 stop acting. Do not try to continue under the previous consent. Do
 not try to apply consent from a different BCTS scope. When in doubt,
-call `exochain_check_consent` (§4) to confirm active consent before
-proceeding.
+call `exochain_check_consent` (§4); a registry-unavailable error is
+not active consent, so stop until a live consent source is available.
 
 ---
 

--- a/docs/guides/developer-onboarding.md
+++ b/docs/guides/developer-onboarding.md
@@ -92,7 +92,7 @@ Expected output tail:
 test result: ok. ... passed; 0 failed; 0 ignored; ...
 ```
 
-The current workspace inventory lists **3,002 tests**. The number grows as new crates land; consult
+The current workspace inventory lists **3,001 tests**. The number grows as new crates land; consult
 `governance/traceability_matrix.md` and the `README.md` repo-truth
 table for the latest figure. What matters is `0 failed`.
 

--- a/docs/guides/mcp-integration.md
+++ b/docs/guides/mcp-integration.md
@@ -258,10 +258,10 @@ Use these at session start to let the agent self-orient.
 
 | Tool | Purpose |
 |---|---|
-| `exochain_propose_bailment` | Propose a scoped, time-bounded consent. Input: `{ bailor_did, bailee_did, scope, duration_hours? }`. |
-| `exochain_check_consent` | Is there active consent for actor+scope? Input: `{ actor_did, scope }`. |
-| `exochain_list_bailments` | List bailments the agent knows about. |
-| `exochain_terminate_bailment` | Revoke a bailment — effect is immediate (invariant `ConsentRequired`). |
+| `exochain_propose_bailment` | Simulation-gated proposal surface. Default build refuses instead of fabricating consent state. |
+| `exochain_check_consent` | Requires a live consent registry. Default build refuses with `mcp_consent_registry_unavailable`; that is no proof of active consent. |
+| `exochain_list_bailments` | Requires a live consent registry. Default build refuses rather than returning a fabricated empty registry. |
+| `exochain_terminate_bailment` | Simulation-gated revocation surface. Default build refuses instead of mutating imaginary consent state. |
 
 ### Governance (5)
 
@@ -391,8 +391,8 @@ A Claude agent performing a real governance operation end-to-end. In practice th
 
 ```
 1.  exochain_create_identity              -> actor DID + public key
-2.  exochain_propose_bailment              -> proposal_id (scope="governance:vote")
-3.  exochain_check_consent                 -> ensure active consent
+2.  REST consent flow / live registry      -> create or locate active bailment
+3.  exochain_check_consent                 -> prove active consent; stop on registry-unavailable errors
 4.  exochain_create_decision               -> decision_id
 5.  exochain_cast_vote    (x N validators) -> record approvals
 6.  exochain_check_quorum                  -> met=true at threshold
@@ -673,7 +673,7 @@ Every deny carries the invariant name. Common cases:
 | Message substring | Cause | Fix |
 |---|---|---|
 | `NoSelfGrant` | Actor tried to grant itself permissions | Route the grant through a distinct grantor DID. |
-| `ConsentRequired` | No active bailment for the scope | Call `exochain_propose_bailment` first. |
+| `ConsentRequired` | No active bailment for the scope | Use the real consent flow or a live consent registry; feature-gated MCP simulations are not consent proof. |
 | `AuthorityChainValid` | Chain broken or terminal mismatch | Inspect via `exochain_verify_authority_chain`. |
 | `KernelImmutability` | Tried to modify the constitution | Use the amendment proposal process instead. |
 | `ProvenanceVerifiable` | Missing signature or timestamp | Ensure the calling agent's identity is set (`--actor-did`). |

--- a/docs/reference/CRATE-REFERENCE.md
+++ b/docs/reference/CRATE-REFERENCE.md
@@ -9,7 +9,7 @@ tags: [exochain, reference, api, crates]
 
 **API reference for the workspace crates composing the EXOCHAIN constitutional trust fabric.**
 
-20 workspace packages · 124090 lines of Rust under `crates/` · 3,002 listed tests
+20 workspace packages · 124165 lines of Rust under `crates/` · 3,001 listed tests
 
 > Cross-references: [[ARCHITECTURE]], [[GETTING-STARTED]], [[THREAT-MODEL]], [[CONSTITUTIONAL-PROOFS]]
 

--- a/governance/EXOCHAIN-REFACTOR-PLAN.md
+++ b/governance/EXOCHAIN-REFACTOR-PLAN.md
@@ -68,7 +68,7 @@ All refactor work flows through the Syntaxis Builder system:
 - [ ] Complete Section 8 work orders from CR-001
 - [ ] Achieve release-blocking acceptance standard (CR-001 Section 9)
 
-> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 124090 Rust LOC under `crates/`, 3,002 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
+> **Completion notes**: Historical March 2026 completion claim; superseded numerically by Wave E Basalt. Current measured state is 20 workspace packages, 124165 Rust LOC under `crates/`, 3,001 listed workspace tests, 20 numbered CI gates plus aggregator, traceability rows at 83 implemented / 1 partial / 2 planned, and threat matrix rows at 14 implemented / 0 partial / 0 planned. Section 9 acceptance criteria remain open while any traceability row is partial or planned. Post-quantum signature support (Ed25519/PostQuantum/Hybrid) is implemented.
 
 ## Active Resolutions
 

--- a/governance/sub_agents.md
+++ b/governance/sub_agents.md
@@ -72,7 +72,7 @@ Historical 2026-03-19 sub-agent completion record. Numeric status claims are sup
 * **Inputs**: Spec Section 16 (Acceptance Criteria).
 * **Outputs**: Test harnesses, Integration tests, Fuzz targets.
 * **Definition of Done**: Section 16 Acceptance Criteria are automated and passing.
-* **Status**: **DONE** — Current workspace inventory lists 3,002 tests across 20 packages and 266 Rust files.
+* **Status**: **DONE** — Current workspace inventory lists 3,001 tests across 20 packages and 266 Rust files.
 
 ## J) DEVOPS_RELEASE_AGENT (Judicial) — DONE
 

--- a/governance/traceability_matrix.md
+++ b/governance/traceability_matrix.md
@@ -163,4 +163,4 @@ Updated 2026-03-20 after EXOCHAIN-REM-009 — continuous governance monitoring a
 | **TOTAL** | **86** | **83** | **1** | **2** |
 
 **Coverage: 83/86 requirements traced to code (97%). 2 planned (ExoForge scheduling + React dashboard). 1 partial (T-14 Rust attestation verification).**
-**Workspace inventory: 3,002 listed tests across 20 packages and 266 Rust files.**
+**Workspace inventory: 3,001 listed tests across 20 packages and 266 Rust files.**


### PR DESCRIPTION
## Summary

- make default-on MCP consent read tools refuse when no live consent registry is wired into `NodeContext`
- preserve the previous empty/false consent reads only behind `unaudited-mcp-simulation-tools`, labeled as simulation output
- update MCP docs/resources/prompts so agents treat registry-unavailable as no proof of consent or empty registry state
- refresh repo-truth documentation counts to `124165` Rust LOC and `3,001` listed workspace tests

## TDD

- `cargo test -p exo-node refuses_without_live_registry -- --nocapture` failed first because both consent read tools returned successful empty/false registry claims.
- After implementation, default tests prove `mcp_consent_registry_unavailable` refusals and feature-enabled tests prove explicit simulation behavior remains available.

## Verification

- `cargo test -p exo-node refuses_without_live_registry -- --nocapture`
- `cargo test -p exo-node mcp::tools::consent -- --nocapture`
- `cargo test -p exo-node mcp::tools::consent --features unaudited-mcp-simulation-tools -- --nocapture`
- `cargo test -p exo-node mcp::tools -- --nocapture`
- `cargo test -p exo-node mcp::resources -- --nocapture`
- `cargo test -p exo-node mcp::prompts -- --nocapture`
- `cargo test -p exo-node mcp::tools --features unaudited-mcp-simulation-tools -- --nocapture`
- `cargo test -p exo-node`
- `cargo build -p exo-node`
- `cargo clippy -p exo-node --bin exochain -- -D warnings`
- `cargo clippy -p exo-node --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo clippy -p exo-node --bin exochain --features unaudited-mcp-simulation-tools -- -D warnings`
- `cargo clippy -p exo-node --tests --features unaudited-mcp-simulation-tools -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo +nightly fmt --all -- --check`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash tools/repo_truth.sh --json`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit` (passed with the existing allowed yanked `core2` warning)
- `cargo deny check` (passed with existing duplicate/yanked/unused-allowance warnings)
- `cargo machete --with-metadata`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
