### PR TITLE
fix(exo-node): fail closed on MCP JSON emitters

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 124165 | `wc -l` |
-| Workspace tests | 3,001 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 124219 | `wc -l` |
+| Workspace tests | 3,004 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,001 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,004 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 124165 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 124219 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,001 listed workspace tests
+         cryptographic proofs, 3,004 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/mcp/protocol.rs
+++ b/crates/exo-node/src/mcp/protocol.rs
@@ -162,6 +162,24 @@ impl ToolResult {
             is_error: true,
         }
     }
+
+    /// Create a JSON success result, failing closed if serialization fails.
+    #[must_use]
+    pub fn json_success<T>(payload: &T) -> Self
+    where
+        T: Serialize + ?Sized,
+    {
+        match serde_json::to_string_pretty(payload) {
+            Ok(text) => Self::success(text),
+            Err(err) => Self::error(
+                serde_json::json!({
+                    "error": "mcp_tool_result_serialization_failed",
+                    "message": err.to_string(),
+                })
+                .to_string(),
+            ),
+        }
+    }
 }
 
 /// MCP Resource definition.
@@ -187,6 +205,32 @@ pub struct ResourceContent {
     pub mime_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
+}
+
+impl ResourceContent {
+    /// Create JSON resource content, failing closed if serialization fails.
+    #[must_use]
+    pub fn json<T>(uri: impl Into<String>, payload: &T) -> Self
+    where
+        T: Serialize + ?Sized,
+    {
+        let uri = uri.into();
+        let text = match serde_json::to_string_pretty(payload) {
+            Ok(text) => text,
+            Err(err) => serde_json::json!({
+                "error": "mcp_resource_serialization_failed",
+                "uri": uri.clone(),
+                "message": err.to_string(),
+            })
+            .to_string(),
+        };
+
+        Self {
+            uri,
+            mime_type: Some("application/json".into()),
+            text: Some(text),
+        }
+    }
 }
 
 /// MCP Prompt definition.
@@ -427,6 +471,57 @@ mod tests {
         };
         let json = serde_json::to_value(&result).unwrap();
         assert_eq!(json["is_error"], true);
+    }
+
+    struct FailingSerialize;
+
+    impl serde::Serialize for FailingSerialize {
+        fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            Err(serde::ser::Error::custom(
+                "intentional serialization failure",
+            ))
+        }
+    }
+
+    #[test]
+    fn tool_result_json_success_fails_closed_on_serialization_error() {
+        let result = ToolResult::json_success(&FailingSerialize);
+        assert!(result.is_error);
+        let text = result.content[0].text();
+        assert!(text.contains("mcp_tool_result_serialization_failed"));
+        assert!(text.contains("intentional serialization failure"));
+        assert_ne!(text, "{}");
+    }
+
+    #[test]
+    fn resource_content_json_fails_closed_on_serialization_error() {
+        let content = ResourceContent::json("exochain://test", &FailingSerialize);
+        let text = content.text.expect("error JSON present");
+        assert!(text.contains("mcp_resource_serialization_failed"));
+        assert!(text.contains("exochain://test"));
+        assert!(text.contains("intentional serialization failure"));
+        assert_ne!(text, "{}");
+    }
+
+    #[test]
+    fn mcp_json_emitters_do_not_fallback_to_empty_objects() {
+        let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        for path in [
+            "src/mcp/tools/node.rs",
+            "src/mcp/resources/node_status.rs",
+            "src/mcp/resources/invariants.rs",
+            "src/mcp/resources/mcp_rules.rs",
+            "src/mcp/resources/tools_summary.rs",
+        ] {
+            let source = std::fs::read_to_string(manifest_dir.join(path)).unwrap();
+            assert!(
+                !source.contains("unwrap_or_else(|_| \"{}\".to_string())"),
+                "{path} must fail closed instead of suppressing serialization errors as {{}}"
+            );
+        }
     }
 
     #[test]

--- a/crates/exo-node/src/mcp/resources/invariants.rs
+++ b/crates/exo-node/src/mcp/resources/invariants.rs
@@ -117,13 +117,7 @@ pub(crate) fn build_payload() -> Value {
 #[must_use]
 pub fn read(_context: &NodeContext) -> ResourceContent {
     let payload = build_payload();
-    let text = serde_json::to_string_pretty(&payload).unwrap_or_else(|_| "{}".to_string());
-
-    ResourceContent {
-        uri: "exochain://invariants".into(),
-        mime_type: Some("application/json".into()),
-        text: Some(text),
-    }
+    ResourceContent::json("exochain://invariants", &payload)
 }
 
 #[cfg(test)]

--- a/crates/exo-node/src/mcp/resources/mcp_rules.rs
+++ b/crates/exo-node/src/mcp/resources/mcp_rules.rs
@@ -98,13 +98,7 @@ pub(crate) fn build_payload() -> Value {
 #[must_use]
 pub fn read(_context: &NodeContext) -> ResourceContent {
     let payload = build_payload();
-    let text = serde_json::to_string_pretty(&payload).unwrap_or_else(|_| "{}".to_string());
-
-    ResourceContent {
-        uri: "exochain://mcp-rules".into(),
-        mime_type: Some("application/json".into()),
-        text: Some(text),
-    }
+    ResourceContent::json("exochain://mcp-rules", &payload)
 }
 
 #[cfg(test)]

--- a/crates/exo-node/src/mcp/resources/node_status.rs
+++ b/crates/exo-node/src/mcp/resources/node_status.rs
@@ -82,13 +82,7 @@ fn build_payload(context: &NodeContext) -> Value {
 #[must_use]
 pub fn read(context: &NodeContext) -> ResourceContent {
     let payload = build_payload(context);
-    let text = serde_json::to_string_pretty(&payload).unwrap_or_else(|_| "{}".to_string());
-
-    ResourceContent {
-        uri: "exochain://node/status".into(),
-        mime_type: Some("application/json".into()),
-        text: Some(text),
-    }
+    ResourceContent::json("exochain://node/status", &payload)
 }
 
 #[cfg(test)]

--- a/crates/exo-node/src/mcp/resources/tools_summary.rs
+++ b/crates/exo-node/src/mcp/resources/tools_summary.rs
@@ -152,13 +152,7 @@ pub(crate) fn build_payload() -> Value {
 #[must_use]
 pub fn read(_context: &NodeContext) -> ResourceContent {
     let payload = build_payload();
-    let text = serde_json::to_string_pretty(&payload).unwrap_or_else(|_| "{}".to_string());
-
-    ResourceContent {
-        uri: "exochain://tools".into(),
-        mime_type: Some("application/json".into()),
-        text: Some(text),
-    }
+    ResourceContent::json("exochain://tools", &payload)
 }
 
 #[cfg(test)]

--- a/crates/exo-node/src/mcp/tools/node.rs
+++ b/crates/exo-node/src/mcp/tools/node.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 
 use crate::mcp::{
     context::NodeContext,
-    protocol::{ToolContent, ToolDefinition, ToolResult},
+    protocol::{ToolDefinition, ToolResult},
 };
 
 // ---------------------------------------------------------------------------
@@ -75,15 +75,12 @@ pub fn execute_node_status(_params: &Value, context: &NodeContext) -> ToolResult
                 // message to the client so internal architecture details
                 // (mutex poisoning) don't leak. (A-023)
                 tracing::error!(?err, "reactor state lock poisoned");
-                return ToolResult {
-                    content: vec![ToolContent::Text {
-                        text: serde_json::json!({
-                            "error": "internal error: node state is temporarily unavailable",
-                        })
-                        .to_string(),
-                    }],
-                    is_error: true,
-                };
+                return ToolResult::error(
+                    serde_json::json!({
+                        "error": "internal error: node state is temporarily unavailable",
+                    })
+                    .to_string(),
+                );
             }
         }
     } else {
@@ -98,12 +95,7 @@ pub fn execute_node_status(_params: &Value, context: &NodeContext) -> ToolResult
         })
     };
 
-    ToolResult {
-        content: vec![ToolContent::Text {
-            text: serde_json::to_string_pretty(&status).unwrap_or_else(|_| "{}".to_string()),
-        }],
-        is_error: false,
-    }
+    ToolResult::json_success(&status)
 }
 
 // ---------------------------------------------------------------------------
@@ -196,12 +188,7 @@ pub fn execute_list_invariants(_params: &Value, _context: &NodeContext) -> ToolR
         "invariants": invariants,
     });
 
-    ToolResult {
-        content: vec![ToolContent::Text {
-            text: serde_json::to_string_pretty(&output).unwrap_or_else(|_| "{}".to_string()),
-        }],
-        is_error: false,
-    }
+    ToolResult::json_success(&output)
 }
 
 // ---------------------------------------------------------------------------
@@ -257,12 +244,7 @@ pub fn execute_list_mcp_rules(_params: &Value, _context: &NodeContext) -> ToolRe
         "rules": rules,
     });
 
-    ToolResult {
-        content: vec![ToolContent::Text {
-            text: serde_json::to_string_pretty(&output).unwrap_or_else(|_| "{}".to_string()),
-        }],
-        is_error: false,
-    }
+    ToolResult::json_success(&output)
 }
 
 // ===========================================================================
@@ -272,6 +254,7 @@ pub fn execute_list_mcp_rules(_params: &Value, _context: &NodeContext) -> ToolRe
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mcp::protocol::ToolContent;
 
     #[test]
     fn tool_node_status_definition() {


### PR DESCRIPTION
## Summary
- add shared MCP JSON emission helpers for tool results and resources
- replace default-on MCP node/resource serialization fallbacks that returned successful `{}` on serializer failure
- add regression tests and a source guard preventing the empty-object fallback from returning
- refresh README repo-truth counts to 124219 Rust LOC and 3,004 listed tests

## Tests
- cargo test -p exo-node mcp::protocol::tests -- --nocapture (failed first, then passed)
- cargo test -p exo-node mcp::resources -- --nocapture
- cargo test -p exo-node mcp::tools::node -- --nocapture
- cargo test -p exo-node
- cargo build -p exo-node
- cargo clippy -p exo-node --bin exochain -- -D warnings
- cargo clippy -p exo-node --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo +nightly fmt --all -- --check
- cargo fmt --all -- --check
- git diff --check
- bash tools/repo_truth.sh --json
- bash tools/test_repo_truth.sh
- bash tools/test_cr001_status.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_no_orphan_rust_modules.sh
- bash tools/test_railway_entrypoint_args.sh
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --lib --bins -- -D warnings
- cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
- cargo audit
- cargo deny check
- cargo machete --with-metadata
- cargo build --workspace --release
- cargo test --workspace --release