### PR TITLE
fix(exo-node): fail closed on zerodentity consumer reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 124245 | `wc -l` |
-| Workspace tests | 3,005 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 124634 | `wc -l` |
+| Workspace tests | 3,018 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,005 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,018 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 124245 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 124634 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,005 listed workspace tests
+         cryptographic proofs, 3,018 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/passport.rs
+++ b/crates/exo-node/src/passport.rs
@@ -234,7 +234,8 @@ async fn handle_passport(
             computed_ms: s.computed_ms,
         });
 
-        let standing = build_standing_profile(known, &did_obj, &zd);
+        let standing = build_standing_profile(known, &did_obj, &zd)
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
 
         (score_profile, standing)
     };
@@ -315,7 +316,8 @@ async fn handle_standing(
             "Zerodentity store unavailable".to_string(),
         )
     })?;
-    let standing = build_standing_profile(known, &did_obj, &zd);
+    let standing = build_standing_profile(known, &did_obj, &zd)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
 
     Ok(Json(StandingResponse {
         did,
@@ -372,10 +374,15 @@ fn build_standing_profile(
     known: bool,
     did: &exo_core::types::Did,
     zd_store: &crate::zerodentity::store::ZerodentityStore,
-) -> StandingProfile {
+) -> Result<StandingProfile, String> {
     use crate::zerodentity::types::{ClaimStatus, ClaimType};
 
-    let claims = zd_store.get_claims(did).unwrap_or_default();
+    let claims = zd_store.get_claims(did).map_err(|e| {
+        format!(
+            "Zerodentity claims unavailable for DID {}: {e}",
+            did.as_str()
+        )
+    })?;
 
     // Check if all claims are revoked (identity erased).
     let all_revoked =
@@ -410,13 +417,13 @@ fn build_standing_profile(
         "unknown"
     };
 
-    StandingProfile {
+    Ok(StandingProfile {
         status: status.into(),
         revoked: all_revoked,
         sanctioned: false,
         sybil_challenge_hold: sybil_hold,
         risk_level: risk_level.into(),
-    }
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -465,6 +472,22 @@ mod tests {
         })
     }
 
+    #[test]
+    fn passport_standing_does_not_discard_zerodentity_read_errors() {
+        let source = include_str!("passport.rs");
+        let production = source
+            .split("// ---------------------------------------------------------------------------\n// Tests")
+            .next()
+            .unwrap();
+        let standing_profile = production
+            .split("fn build_standing_profile")
+            .nth(1)
+            .and_then(|section| section.split("// ---------------------------------------------------------------------------\n// Router construction").next())
+            .unwrap();
+
+        assert!(!standing_profile.contains(".unwrap_or_default()"));
+    }
+
     fn test_passport_state() -> Arc<PassportApiState> {
         let validators: BTreeSet<Did> = (0..4)
             .map(|i| Did::new(&format!("did:exo:v{i}")).unwrap())
@@ -487,6 +510,32 @@ mod tests {
             store,
             zerodentity_store: new_shared_store(),
         })
+    }
+
+    #[tokio::test]
+    async fn standing_fails_closed_when_claim_read_fails() {
+        let state = test_passport_state();
+        {
+            let mut zd = state.zerodentity_store.lock().unwrap();
+            zd.inject_read_failure(crate::zerodentity::store::ZerodentityReadFailure::Claims);
+        }
+
+        let app = passport_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/agents/did:exo:v0/standing")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = axum::body::to_bytes(resp.into_body(), 8192).await.unwrap();
+        let message = String::from_utf8(body.to_vec()).unwrap();
+        assert!(message.contains("Zerodentity claims unavailable"));
+        assert!(message.contains("did:exo:v0"));
     }
 
     #[tokio::test]

--- a/crates/exo-node/src/sentinels.rs
+++ b/crates/exo-node/src/sentinels.rs
@@ -278,11 +278,50 @@ fn check_score_integrity(zerodentity: &SharedZerodentityStore) -> SentinelStatus
     };
 
     // Extract plain IdentityClaims from (claim_id, claim) tuples.
-    let raw_claims = zstore.get_claims(&did).unwrap_or_default();
+    let raw_claims = match zstore.get_claims(&did) {
+        Ok(claims) => claims,
+        Err(e) => {
+            return SentinelStatus {
+                check: SentinelCheck::ScoreIntegrity,
+                healthy: false,
+                message: format!(
+                    "Zerodentity claims unavailable for DID {}: {e}",
+                    did.as_str()
+                ),
+                last_run_ms: now_ms(),
+            };
+        }
+    };
     let claims_plain: Vec<crate::zerodentity::types::IdentityClaim> =
         raw_claims.into_iter().map(|(_, c)| c).collect();
-    let fingerprints = zstore.get_fingerprints(&did).unwrap_or_default();
-    let behavioral = zstore.get_behavioral_samples(&did).unwrap_or_default();
+    let fingerprints = match zstore.get_fingerprints(&did) {
+        Ok(fingerprints) => fingerprints,
+        Err(e) => {
+            return SentinelStatus {
+                check: SentinelCheck::ScoreIntegrity,
+                healthy: false,
+                message: format!(
+                    "Zerodentity fingerprints unavailable for DID {}: {e}",
+                    did.as_str()
+                ),
+                last_run_ms: now_ms(),
+            };
+        }
+    };
+    let behavioral = match zstore.get_behavioral_samples(&did) {
+        Ok(behavioral) => behavioral,
+        Err(e) => {
+            return SentinelStatus {
+                check: SentinelCheck::ScoreIntegrity,
+                healthy: false,
+                message: format!(
+                    "Zerodentity behavioral samples unavailable for DID {}: {e}",
+                    did.as_str()
+                ),
+                last_run_ms: now_ms(),
+            };
+        }
+    };
 
     // Release the lock before running compute (can be non-trivial).
     drop(zstore);
@@ -587,6 +626,164 @@ mod tests {
     }
 
     #[test]
+    fn score_integrity_sentinel_does_not_discard_zerodentity_read_errors() {
+        let source = include_str!("sentinels.rs");
+        let production = source
+            .split("// ---------------------------------------------------------------------------\n// Tests")
+            .next()
+            .unwrap();
+        let score_integrity = production
+            .split("fn check_score_integrity")
+            .nth(1)
+            .and_then(|section| section.split("fn check_otp_cleanup").next())
+            .unwrap();
+
+        assert!(!score_integrity.contains(".unwrap_or_default()"));
+    }
+
+    #[test]
+    fn score_integrity_fails_closed_on_claim_read_error() {
+        let zerodentity = crate::zerodentity::store::new_shared_store();
+        {
+            let did = Did::new("did:exo:scored").unwrap();
+            let mut store = zerodentity.lock().unwrap();
+            store.put_score(ZerodentityScore::compute(&did, &[], &[], &[], 1000));
+            store.inject_read_failure(crate::zerodentity::store::ZerodentityReadFailure::Claims);
+        }
+
+        let status = check_score_integrity(&zerodentity);
+
+        assert!(!status.healthy);
+        assert_eq!(status.check, SentinelCheck::ScoreIntegrity);
+        assert!(status.message.contains("Zerodentity claims unavailable"));
+    }
+
+    #[test]
+    fn score_integrity_fails_closed_on_fingerprint_read_error() {
+        let zerodentity = crate::zerodentity::store::new_shared_store();
+        {
+            let did = Did::new("did:exo:scored").unwrap();
+            let mut store = zerodentity.lock().unwrap();
+            store.put_score(ZerodentityScore::compute(&did, &[], &[], &[], 1000));
+            store.inject_read_failure(
+                crate::zerodentity::store::ZerodentityReadFailure::Fingerprints,
+            );
+        }
+
+        let status = check_score_integrity(&zerodentity);
+
+        assert!(!status.healthy);
+        assert_eq!(status.check, SentinelCheck::ScoreIntegrity);
+        assert!(
+            status
+                .message
+                .contains("Zerodentity fingerprints unavailable")
+        );
+    }
+
+    #[test]
+    fn score_integrity_fails_closed_on_behavioral_read_error() {
+        let zerodentity = crate::zerodentity::store::new_shared_store();
+        {
+            let did = Did::new("did:exo:scored").unwrap();
+            let mut store = zerodentity.lock().unwrap();
+            store.put_score(ZerodentityScore::compute(&did, &[], &[], &[], 1000));
+            store
+                .inject_read_failure(crate::zerodentity::store::ZerodentityReadFailure::Behavioral);
+        }
+
+        let status = check_score_integrity(&zerodentity);
+
+        assert!(!status.healthy);
+        assert_eq!(status.check, SentinelCheck::ScoreIntegrity);
+        assert!(
+            status
+                .message
+                .contains("Zerodentity behavioral samples unavailable")
+        );
+    }
+
+    #[test]
+    fn score_integrity_verifies_matching_score() {
+        let zerodentity = crate::zerodentity::store::new_shared_store();
+        {
+            let did = Did::new("did:exo:scored").unwrap();
+            let mut store = zerodentity.lock().unwrap();
+            store.put_score(ZerodentityScore::compute(&did, &[], &[], &[], 1000));
+        }
+
+        let status = check_score_integrity(&zerodentity);
+
+        assert!(status.healthy);
+        assert_eq!(status.check, SentinelCheck::ScoreIntegrity);
+        assert!(status.message.contains("Score integrity verified"));
+    }
+
+    #[test]
+    fn score_integrity_detects_score_drift() {
+        let zerodentity = crate::zerodentity::store::new_shared_store();
+        {
+            let did = Did::new("did:exo:scored").unwrap();
+            let mut score = ZerodentityScore::compute(&did, &[], &[], &[], 1000);
+            score.composite = score.composite.saturating_add(1000).min(10_000);
+            let mut store = zerodentity.lock().unwrap();
+            store.put_score(score);
+        }
+
+        let status = check_score_integrity(&zerodentity);
+
+        assert!(!status.healthy);
+        assert_eq!(status.check, SentinelCheck::ScoreIntegrity);
+        assert!(status.message.contains("Score drift"));
+    }
+
+    #[test]
+    fn otp_cleanup_reports_clean_when_no_expired_pending_challenges() {
+        let zerodentity = crate::zerodentity::store::new_shared_store();
+
+        let status = check_otp_cleanup(&zerodentity);
+
+        assert!(status.healthy);
+        assert_eq!(status.check, SentinelCheck::OtpCleanup);
+        assert_eq!(status.message, "No expired pending OTP challenges");
+    }
+
+    #[test]
+    fn otp_cleanup_removes_expired_pending_challenges() {
+        let zerodentity = crate::zerodentity::store::new_shared_store();
+        {
+            let now = now_ms();
+            let challenge = crate::zerodentity::types::OtpChallenge {
+                challenge_id: "expired-otp".into(),
+                subject_did: Did::new("did:exo:otp").unwrap(),
+                channel: crate::zerodentity::types::OtpChannel::Email,
+                hmac_secret: [7u8; 32],
+                dispatched_ms: now.saturating_sub(10_000),
+                ttl_ms: 1,
+                attempts: 0,
+                max_attempts: 3,
+                state: crate::zerodentity::types::OtpState::Pending,
+            };
+            zerodentity
+                .lock()
+                .unwrap()
+                .insert_otp_challenge(&challenge)
+                .unwrap();
+        }
+
+        let status = check_otp_cleanup(&zerodentity);
+
+        assert!(status.healthy);
+        assert_eq!(status.check, SentinelCheck::OtpCleanup);
+        assert!(
+            status
+                .message
+                .contains("Cleaned up 1 expired OTP challenge")
+        );
+        assert!(zerodentity.lock().unwrap().all_otp_challenges().is_empty());
+    }
+
+    #[test]
     fn liveness_check_healthy() {
         let reactor = test_reactor();
         let mut prev = 0;
@@ -688,5 +885,54 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert!(results[0].healthy);
         assert!(!results[1].healthy);
+    }
+
+    #[tokio::test]
+    async fn sentinel_loop_updates_state_and_emits_unhealthy_alert() {
+        let validators: BTreeSet<Did> = (0..3)
+            .map(|i| Did::new(&format!("did:exo:v{i}")).unwrap())
+            .collect();
+        let config = ReactorConfig {
+            node_did: Did::new("did:exo:v0").unwrap(),
+            is_validator: true,
+            validators,
+            validator_public_keys: std::collections::BTreeMap::new(),
+            round_timeout_ms: 5000,
+        };
+        let reactor = create_reactor_state(&config, make_sign_fn(), None);
+        let store = test_store();
+        let zerodentity = crate::zerodentity::store::new_shared_store();
+        let sentinel_state: SharedSentinelState = Arc::new(Mutex::new(Vec::new()));
+        let (alert_tx, mut alert_rx) = tokio::sync::mpsc::channel(4);
+
+        let task = tokio::spawn(run_sentinel_loop(
+            reactor,
+            store,
+            zerodentity,
+            Arc::clone(&sentinel_state),
+            alert_tx,
+            Duration::from_millis(50),
+        ));
+
+        let alert = tokio::time::timeout(Duration::from_secs(1), alert_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        task.abort();
+        let aborted = task.await.unwrap_err();
+        assert!(aborted.is_cancelled());
+
+        assert_eq!(alert.check, SentinelCheck::QuorumHealth);
+        assert_eq!(alert.severity, Severity::Critical);
+        assert!(alert.message.contains("BELOW BFT MINIMUM"));
+
+        let statuses = sentinel_state.lock().unwrap().clone();
+        assert_eq!(statuses.len(), 6);
+        assert!(statuses.iter().any(|status| {
+            status.check == SentinelCheck::QuorumHealth
+                && !status.healthy
+                && status.message.contains("BELOW BFT MINIMUM")
+        }));
     }
 }

--- a/crates/exo-node/src/telegram.rs
+++ b/crates/exo-node/src/telegram.rs
@@ -418,7 +418,19 @@ pub fn build_zerodentity_alerts_message(
         }
 
         // 2. Fingerprint consistency.
-        let fps = zstore.get_fingerprints(did).unwrap_or_default();
+        let fps = match zstore.get_fingerprints(did) {
+            Ok(fps) => fps,
+            Err(e) => {
+                return (
+                    format!(
+                        "\u{274c} <b>0dentity Alerts</b>\n\
+                         0dentity alert scan unavailable while reading fingerprints for <code>{}</code>: {e}",
+                        did.as_str()
+                    ),
+                    vec![],
+                );
+            }
+        };
         if let Some(latest) = fps.last() {
             if let Some(consistency) = latest.consistency_score_bp {
                 if consistency < ALERT_FINGERPRINT_LOW_BP {
@@ -862,6 +874,47 @@ mod tests {
             round_timeout_ms: 5000,
         };
         create_reactor_state(&config, make_sign_fn(), None)
+    }
+
+    #[test]
+    fn zerodentity_alerts_do_not_discard_store_read_errors() {
+        let source = include_str!("telegram.rs");
+        let production = source
+            .split("// ---------------------------------------------------------------------------\n// Tests")
+            .next()
+            .unwrap();
+        let alerts = production
+            .split("pub fn build_zerodentity_alerts_message")
+            .nth(1)
+            .and_then(|section| section.split("/// Build the /sentinels response.").next())
+            .unwrap();
+
+        assert!(!alerts.contains(".unwrap_or_default()"));
+    }
+
+    #[test]
+    fn zerodentity_alerts_fail_closed_on_fingerprint_read_error() {
+        let zerodentity = crate::zerodentity::store::new_shared_store();
+        {
+            let did = Did::new("did:exo:alerted").unwrap();
+            let mut store = zerodentity.lock().unwrap();
+            store.put_score(crate::zerodentity::types::ZerodentityScore::compute(
+                &did,
+                &[],
+                &[],
+                &[],
+                1000,
+            ));
+            store.inject_read_failure(
+                crate::zerodentity::store::ZerodentityReadFailure::Fingerprints,
+            );
+        }
+
+        let (text, keyboard) = build_zerodentity_alerts_message(&zerodentity);
+
+        assert!(text.contains("0dentity alert scan unavailable"));
+        assert!(text.contains("did:exo:alerted"));
+        assert!(keyboard.is_empty());
     }
 
     #[test]

--- a/crates/exo-node/src/zerodentity/store.rs
+++ b/crates/exo-node/src/zerodentity/store.rs
@@ -72,6 +72,14 @@ pub struct ErasureEvidence {
     pub receipt_hash: Hash256,
 }
 
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ZerodentityReadFailure {
+    Claims,
+    Fingerprints,
+    Behavioral,
+}
+
 fn canonicalize_claim_entries(claims: &mut [(String, IdentityClaim)]) {
     claims.sort_by(|(left_id, left), (right_id, right)| {
         left.created_ms
@@ -158,6 +166,12 @@ pub struct ZerodentityStore {
     trust_receipts: Vec<TrustReceipt>,
     /// Node identity signer used to emit verifiable trust receipts.
     receipt_signing: Option<ReceiptSigningContext>,
+    #[cfg(test)]
+    fail_claim_reads: bool,
+    #[cfg(test)]
+    fail_fingerprint_reads: bool,
+    #[cfg(test)]
+    fail_behavioral_reads: bool,
 }
 
 impl ZerodentityStore {
@@ -182,6 +196,21 @@ impl ZerodentityStore {
     /// Configure the node identity used to sign store-emitted trust receipts.
     pub fn set_receipt_signer(&mut self, actor_did: Did, signer: ReceiptSigner) {
         self.receipt_signing = Some(ReceiptSigningContext::new(actor_did, signer));
+    }
+
+    #[cfg(test)]
+    pub(crate) fn inject_read_failure(&mut self, failure: ZerodentityReadFailure) {
+        match failure {
+            ZerodentityReadFailure::Claims => {
+                self.fail_claim_reads = true;
+            }
+            ZerodentityReadFailure::Fingerprints => {
+                self.fail_fingerprint_reads = true;
+            }
+            ZerodentityReadFailure::Behavioral => {
+                self.fail_behavioral_reads = true;
+            }
+        }
     }
 
     /// Open the 0dentity store.
@@ -409,6 +438,10 @@ impl ZerodentityStore {
     ///
     /// Returns an empty `Vec` (not an error) when the DID has no claims.
     pub fn get_claims(&self, did: &Did) -> anyhow::Result<Vec<(String, IdentityClaim)>> {
+        #[cfg(test)]
+        if self.fail_claim_reads {
+            anyhow::bail!("injected 0dentity claims read failure");
+        }
         let mut claims = self.claims.get(did.as_str()).cloned().unwrap_or_default();
         canonicalize_claim_entries(&mut claims);
         Ok(claims)
@@ -432,6 +465,10 @@ impl ZerodentityStore {
 
     /// Return all device fingerprints for a DID.
     pub fn get_fingerprints(&self, did: &Did) -> anyhow::Result<Vec<DeviceFingerprint>> {
+        #[cfg(test)]
+        if self.fail_fingerprint_reads {
+            anyhow::bail!("injected 0dentity fingerprint read failure");
+        }
         let mut fingerprints = self
             .fingerprints
             .get(did.as_str())
@@ -443,6 +480,10 @@ impl ZerodentityStore {
 
     /// Return all behavioral samples for a DID.
     pub fn get_behavioral_samples(&self, did: &Did) -> anyhow::Result<Vec<BehavioralSample>> {
+        #[cfg(test)]
+        if self.fail_behavioral_reads {
+            anyhow::bail!("injected 0dentity behavioral read failure");
+        }
         let mut samples = self
             .behavioral
             .get(did.as_str())


### PR DESCRIPTION
## Summary
- fail closed when score-integrity sentinels cannot read 0dentity evidence
- fail closed when Telegram 0dentity alerts cannot read fingerprint evidence
- propagate passport standing claim-read failures as HTTP 500 instead of building empty standing
- refresh README repo-truth counts to 124351 Rust LOC and 3,008 listed tests

## Tests
- cargo test -p exo-node zerodentity_read_errors -- --nocapture
- cargo test -p exo-node zerodentity_alerts_do_not_discard_store_read_errors -- --nocapture
- cargo test -p exo-node sentinels:: -- --nocapture
- cargo test -p exo-node telegram:: -- --nocapture
- cargo test -p exo-node passport:: -- --nocapture
- cargo test -p exo-node
- cargo build -p exo-node
- cargo clippy -p exo-node --bin exochain -- -D warnings
- cargo clippy -p exo-node --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
- cargo +nightly fmt --all -- --check
- cargo fmt --all -- --check
- bash tools/repo_truth.sh --json
- bash tools/repo_truth.sh --json --skip-tests
- bash tools/test_repo_truth.sh
- bash tools/test_cr001_status.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_no_orphan_rust_modules.sh
- bash tools/test_railway_entrypoint_args.sh
- git diff --check

Initiative: /Users/bobstewart/obsidian/aeon/Initiatives/fix-zerodentity-consumer-read-errors-failclosed.md