### PR TITLE
fix(exo-gateway): fail closed on adjudication row decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 124634 | `wc -l` |
-| Workspace tests | 3,018 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 124769 | `wc -l` |
+| Workspace tests | 3,022 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,018 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,022 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 124634 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 124769 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,018 listed workspace tests
+         cryptographic proofs, 3,022 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -567,6 +567,99 @@ fn generate_session_token() -> Result<String> {
 // Production DB adjudication context resolver (APE-53)
 // ---------------------------------------------------------------------------
 
+#[cfg(any(test, feature = "production-db"))]
+fn build_adjudication_context_from_rows(
+    actor: &Did,
+    role_rows: &[crate::db::AgentRoleRow],
+    consent_rows: &[crate::db::ConsentRecordRow],
+    chain_row: Option<&crate::db::AuthorityChainRow>,
+) -> Result<AdjudicationContext> {
+    use exo_gatekeeper::types::{
+        AuthorityChain as GkChain, BailmentState as GkBailment, ConsentRecord, GovernmentBranch,
+        Role,
+    };
+
+    let actor_roles: Vec<Role> = role_rows
+        .iter()
+        .map(|r| {
+            let branch = match r.branch.as_str() {
+                "executive" => GovernmentBranch::Executive,
+                "legislative" => GovernmentBranch::Legislative,
+                "judicial" => GovernmentBranch::Judicial,
+                other => {
+                    return Err(GatewayError::Internal(format!(
+                        "adjudication role row unknown role branch for actor '{}' role '{}': '{}'",
+                        r.agent_did, r.role, other
+                    )));
+                }
+            };
+            Ok(Role {
+                name: r.role.clone(),
+                branch,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let consent_records: Vec<ConsentRecord> = consent_rows
+        .iter()
+        .map(|r| {
+            let subject = Did::new(&r.subject_did).map_err(|e| {
+                GatewayError::Internal(format!(
+                    "adjudication consent subject DID invalid for actor '{}' scope '{}': '{}' ({e})",
+                    r.actor_did, r.scope, r.subject_did
+                ))
+            })?;
+            Ok(ConsentRecord {
+                subject,
+                granted_to: actor.clone(),
+                scope: r.scope.clone(),
+                active: r.status == "active",
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let bailment_state = match consent_rows.iter().find(|r| r.status == "active") {
+        Some(r) => {
+            let bailor = Did::new(&r.subject_did).map_err(|e| {
+                GatewayError::Internal(format!(
+                    "adjudication consent subject DID invalid for active bailment actor '{}' scope '{}': '{}' ({e})",
+                    r.actor_did, r.scope, r.subject_did
+                ))
+            })?;
+            GkBailment::Active {
+                bailor,
+                bailee: actor.clone(),
+                scope: r.scope.clone(),
+            }
+        }
+        None => GkBailment::None,
+    };
+
+    let authority_chain = match chain_row {
+        Some(row) => serde_json::from_value::<GkChain>(row.chain_json.clone()).map_err(|e| {
+            GatewayError::Internal(format!(
+                "adjudication authority chain JSON invalid for actor '{}': {e}",
+                row.actor_did
+            ))
+        })?,
+        None => GkChain::default(),
+    };
+
+    Ok(AdjudicationContext {
+        actor_roles,
+        authority_chain,
+        consent_records,
+        bailment_state,
+        human_override_preserved: true,
+        actor_permissions: PermissionSet::new(vec![Permission::new("vote")]),
+        // Provenance is per-action, not per-actor; callers that need full
+        // ProvenanceVerifiable enforcement must attach it before adjudication.
+        provenance: None,
+        quorum_evidence: None,
+        active_challenge_reason: None,
+    })
+}
+
 /// Build an `AdjudicationContext` by loading the actor's roles, consent
 /// records, and authority chain from the live database.
 ///
@@ -582,11 +675,6 @@ async fn build_adjudication_context_from_db(
     actor: &Did,
     now: i64,
 ) -> Result<AdjudicationContext> {
-    use exo_gatekeeper::types::{
-        AuthorityChain as GkChain, BailmentState as GkBailment, ConsentRecord, GovernmentBranch,
-        Role,
-    };
-
     let actor_str = actor.as_str();
 
     let role_rows = crate::db::load_agent_roles(pool, actor_str, now)
@@ -601,70 +689,7 @@ async fn build_adjudication_context_from_db(
         .await
         .map_err(|e| GatewayError::Internal(format!("adjudication chain query: {e}")))?;
 
-    // Convert role rows → `Role` values.
-    let actor_roles: Vec<Role> = role_rows
-        .iter()
-        .map(|r| {
-            let branch = match r.branch.as_str() {
-                "legislative" => GovernmentBranch::Legislative,
-                "judicial" => GovernmentBranch::Judicial,
-                _ => GovernmentBranch::Executive,
-            };
-            Role {
-                name: r.role.clone(),
-                branch,
-            }
-        })
-        .collect();
-
-    // Convert consent rows → `ConsentRecord` values.
-    let consent_records: Vec<ConsentRecord> = consent_rows
-        .iter()
-        .filter_map(|r| {
-            let subject = Did::new(&r.subject_did).ok()?;
-            Some(ConsentRecord {
-                subject,
-                granted_to: actor.clone(),
-                scope: r.scope.clone(),
-                active: r.status == "active",
-            })
-        })
-        .collect();
-
-    // Derive `BailmentState` from the first active consent record.
-    // `BailmentState::None` is the safe default when no active consent exists.
-    let bailment_state = consent_rows
-        .iter()
-        .find(|r| r.status == "active")
-        .and_then(|r| {
-            let bailor = Did::new(&r.subject_did).ok()?;
-            Some(GkBailment::Active {
-                bailor,
-                bailee: actor.clone(),
-                scope: r.scope.clone(),
-            })
-        })
-        .unwrap_or(GkBailment::None);
-
-    // Deserialise the stored `AuthorityChain` blob; fall back to empty chain.
-    let authority_chain = chain_row
-        .as_ref()
-        .and_then(|row| serde_json::from_value::<GkChain>(row.chain_json.clone()).ok())
-        .unwrap_or_default();
-
-    Ok(AdjudicationContext {
-        actor_roles,
-        authority_chain,
-        consent_records,
-        bailment_state,
-        human_override_preserved: true,
-        actor_permissions: PermissionSet::new(vec![Permission::new("vote")]),
-        // Provenance is per-action, not per-actor; callers that need full
-        // ProvenanceVerifiable enforcement must attach it before adjudication.
-        provenance: None,
-        quorum_evidence: None,
-        active_challenge_reason: None,
-    })
+    build_adjudication_context_from_rows(actor, &role_rows, &consent_rows, chain_row.as_ref())
 }
 
 // ---------------------------------------------------------------------------
@@ -3526,6 +3551,116 @@ mod tests {
             is_self_grant: false,
             modifies_kernel: false,
         }
+    }
+
+    fn db_role_row(actor: &Did, branch: &str) -> crate::db::AgentRoleRow {
+        crate::db::AgentRoleRow {
+            agent_did: actor.as_str().to_string(),
+            role: "voter".to_string(),
+            branch: branch.to_string(),
+            granted_by: "did:exo:root-grantor".to_string(),
+            valid_from: 1,
+            expires_at: None,
+        }
+    }
+
+    fn db_consent_row(actor: &Did, subject_did: &str) -> crate::db::ConsentRecordRow {
+        crate::db::ConsentRecordRow {
+            subject_did: subject_did.to_string(),
+            actor_did: actor.as_str().to_string(),
+            scope: "data:vote".to_string(),
+            bailment_type: "standard".to_string(),
+            status: "active".to_string(),
+            created_at: 1,
+            expires_at: None,
+        }
+    }
+
+    fn db_authority_chain_row(
+        actor: &Did,
+        chain_json: serde_json::Value,
+    ) -> crate::db::AuthorityChainRow {
+        crate::db::AuthorityChainRow {
+            actor_did: actor.as_str().to_string(),
+            chain_json,
+            valid_from: 1,
+            expires_at: None,
+        }
+    }
+
+    fn assert_internal_error_contains(result: Result<AdjudicationContext>, expected: &str) {
+        match result {
+            Err(GatewayError::Internal(reason)) => {
+                assert!(
+                    reason.contains(expected),
+                    "error reason {reason:?} did not contain {expected:?}"
+                );
+            }
+            Err(other) => panic!("expected internal error, got {other}"),
+            Ok(_) => panic!("expected internal error, got adjudication context"),
+        }
+    }
+
+    #[test]
+    fn adjudication_context_rows_reject_unknown_role_branch() {
+        let actor = Did::new("did:exo:alice").unwrap();
+        let role_rows = vec![db_role_row(&actor, "tribunal")];
+
+        let result = build_adjudication_context_from_rows(&actor, &role_rows, &[], None);
+
+        assert_internal_error_contains(result, "unknown role branch");
+    }
+
+    #[test]
+    fn adjudication_context_rows_reject_malformed_consent_subject_did() {
+        let actor = Did::new("did:exo:alice").unwrap();
+        let consent_rows = vec![db_consent_row(&actor, "not-a-did")];
+
+        let result = build_adjudication_context_from_rows(&actor, &[], &consent_rows, None);
+
+        assert_internal_error_contains(result, "consent subject DID");
+    }
+
+    #[test]
+    fn adjudication_context_rows_reject_malformed_authority_chain_json() {
+        let actor = Did::new("did:exo:alice").unwrap();
+        let chain_row = db_authority_chain_row(
+            &actor,
+            serde_json::json!({
+                "links": "not-an-array"
+            }),
+        );
+
+        let result = build_adjudication_context_from_rows(&actor, &[], &[], Some(&chain_row));
+
+        assert_internal_error_contains(result, "authority chain JSON");
+    }
+
+    #[test]
+    fn adjudication_context_rows_build_valid_db_context() {
+        let kernel = adjudication_kernel();
+        let actor = Did::new("did:exo:alice").unwrap();
+        let valid_context = valid_db_context(&actor);
+        let role_rows = vec![db_role_row(&actor, "executive")];
+        let consent_rows = vec![db_consent_row(&actor, "did:exo:root-grantor")];
+        let chain_row = db_authority_chain_row(
+            &actor,
+            serde_json::to_value(&valid_context.authority_chain).unwrap(),
+        );
+
+        let ctx = build_adjudication_context_from_rows(
+            &actor,
+            &role_rows,
+            &consent_rows,
+            Some(&chain_row),
+        )
+        .unwrap();
+        let verdict = kernel.adjudicate(&vote_action(&actor), &ctx);
+
+        assert_eq!(ctx.actor_roles.len(), 1);
+        assert_eq!(ctx.consent_records.len(), 1);
+        assert!(matches!(ctx.bailment_state, BailmentState::Active { .. }));
+        assert!(verdict.is_permitted(), "valid DB rows must be permitted");
     }
 
     /// [APE-53 test 1] Scaffold remains deny-all regardless of feature flag.


### PR DESCRIPTION
## Summary

- Extracts production DB adjudication row conversion into a strict, testable helper.
- Rejects unknown role branches, malformed consent subject DIDs, malformed active bailment DIDs, and malformed authority-chain JSON as explicit internal resolver errors.
- Preserves deny-all defaults for absent rows and keeps the WO-009 scaffold fallback path intact.
- Refreshes README repo-truth counts to 124,769 Rust LOC and 3,022 listed tests.

## TDD

- Added RED tests first; `cargo test -p exo-gateway adjudication_context_rows_reject -- --nocapture` failed because `build_adjudication_context_from_rows` did not exist.
- Implemented strict row decoding and a positive valid-row regression.

## Verification

- `cargo test -p exo-gateway adjudication_context_rows -- --nocapture`
- `cargo test -p exo-gateway --features production-db adjudication_context_rows -- --nocapture`
- `cargo test -p exo-gateway --lib`
- `cargo test -p exo-gateway --features production-db`
- `cargo test -p exo-gateway`
- `cargo build -p exo-gateway`
- `cargo build -p exo-gateway --features production-db`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `cargo clippy -p exo-gateway --all-targets --features production-db -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `cargo fmt --all -- --check`
- `bash tools/repo_truth.sh --json --list-tests`
- `bash tools/repo_truth.sh --json --skip-tests`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `cargo test --workspace`
- `cargo build --workspace`
- `cargo build --workspace --release`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check`
- `git diff --check`

Notes: `cargo fmt` emitted the existing stable-rustfmt warnings for nightly-only config keys; `cargo audit` reported the existing allowed yanked `core2` warning; `cargo deny check` passed with existing warnings.
