### PR TITLE
fix(exo-gateway): bind dashboard persistence to sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 124871 | `wc -l` |
-| Workspace tests | 3,027 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 125165 | `wc -l` |
+| Workspace tests | 3,029 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,027 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,029 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for production code
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 124871 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 125165 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,027 listed workspace tests
+         cryptographic proofs, 3,029 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          141 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-gateway/src/db.rs
+++ b/crates/exo-gateway/src/db.rs
@@ -924,16 +924,17 @@ pub async fn upsert_layout_template(
     is_built_in: bool,
     created_at: i64,
     updated_at: i64,
-) -> Result<(), sqlx::Error> {
-    sqlx::query(
+) -> Result<bool, sqlx::Error> {
+    let result = sqlx::query(
         "INSERT INTO layout_templates (id, user_did, name, layout_json, hidden_panels, is_built_in, created_at, updated_at)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-         ON CONFLICT (id) DO UPDATE SET name = $3, layout_json = $4, hidden_panels = $5, updated_at = $8"
+         ON CONFLICT (id) DO UPDATE SET name = $3, layout_json = $4, hidden_panels = $5, updated_at = $8
+         WHERE layout_templates.user_did = $2 AND layout_templates.is_built_in = false"
     )
     .bind(id).bind(user_did).bind(name).bind(layout_json).bind(hidden_panels)
     .bind(is_built_in).bind(created_at).bind(updated_at)
     .execute(pool).await?;
-    Ok(())
+    Ok(result.rows_affected() > 0)
 }
 
 /// List all layout templates for a user (or all templates if `user_did` is None).
@@ -954,12 +955,20 @@ pub async fn list_layout_templates(
     }
 }
 
-/// Delete a layout template by ID (refuses to delete built-in templates).
-pub async fn delete_layout_template(pool: &PgPool, id: &str) -> Result<bool, sqlx::Error> {
-    let result = sqlx::query("DELETE FROM layout_templates WHERE id = $1 AND is_built_in = false")
-        .bind(id)
-        .execute(pool)
-        .await?;
+/// Delete an actor-owned layout template by ID (refuses built-in templates).
+pub async fn delete_layout_template(
+    pool: &PgPool,
+    id: &str,
+    user_did: &str,
+) -> Result<bool, sqlx::Error> {
+    let result = sqlx::query(
+        "DELETE FROM layout_templates \
+         WHERE id = $1 AND user_did = $2 AND is_built_in = false",
+    )
+    .bind(id)
+    .bind(user_did)
+    .execute(pool)
+    .await?;
     Ok(result.rows_affected() > 0)
 }
 
@@ -1017,20 +1026,38 @@ pub async fn insert_feedback_issue(
 /// List feedback issues, optionally filtered by status.
 pub async fn list_feedback_issues(
     pool: &PgPool,
+    reporter_did: Option<&str>,
     status_filter: Option<&str>,
 ) -> Result<Vec<FeedbackIssueRow>, sqlx::Error> {
-    if let Some(status) = status_filter {
-        sqlx::query_as::<_, FeedbackIssueRow>(
-            "SELECT id, title, description, severity, category, status, source_widget_id, source_module_type, \
-             reporter_did, assigned_agent_team, widget_state, browser_info, resolution_notes, created_at, updated_at \
-             FROM feedback_issues WHERE status = $1 ORDER BY created_at DESC"
-        ).bind(status).fetch_all(pool).await
-    } else {
-        sqlx::query_as::<_, FeedbackIssueRow>(
-            "SELECT id, title, description, severity, category, status, source_widget_id, source_module_type, \
-             reporter_did, assigned_agent_team, widget_state, browser_info, resolution_notes, created_at, updated_at \
-             FROM feedback_issues ORDER BY created_at DESC"
-        ).fetch_all(pool).await
+    match (reporter_did, status_filter) {
+        (Some(reporter), Some(status)) => {
+            sqlx::query_as::<_, FeedbackIssueRow>(
+                "SELECT id, title, description, severity, category, status, source_widget_id, source_module_type, \
+                 reporter_did, assigned_agent_team, widget_state, browser_info, resolution_notes, created_at, updated_at \
+                 FROM feedback_issues WHERE reporter_did = $1 AND status = $2 ORDER BY created_at DESC"
+            ).bind(reporter).bind(status).fetch_all(pool).await
+        }
+        (Some(reporter), None) => {
+            sqlx::query_as::<_, FeedbackIssueRow>(
+                "SELECT id, title, description, severity, category, status, source_widget_id, source_module_type, \
+                 reporter_did, assigned_agent_team, widget_state, browser_info, resolution_notes, created_at, updated_at \
+                 FROM feedback_issues WHERE reporter_did = $1 ORDER BY created_at DESC"
+            ).bind(reporter).fetch_all(pool).await
+        }
+        (None, Some(status)) => {
+            sqlx::query_as::<_, FeedbackIssueRow>(
+                "SELECT id, title, description, severity, category, status, source_widget_id, source_module_type, \
+                 reporter_did, assigned_agent_team, widget_state, browser_info, resolution_notes, created_at, updated_at \
+                 FROM feedback_issues WHERE status = $1 ORDER BY created_at DESC"
+            ).bind(status).fetch_all(pool).await
+        }
+        (None, None) => {
+            sqlx::query_as::<_, FeedbackIssueRow>(
+                "SELECT id, title, description, severity, category, status, source_widget_id, source_module_type, \
+                 reporter_did, assigned_agent_team, widget_state, browser_info, resolution_notes, created_at, updated_at \
+                 FROM feedback_issues ORDER BY created_at DESC"
+            ).fetch_all(pool).await
+        }
     }
 }
 
@@ -1038,6 +1065,7 @@ pub async fn list_feedback_issues(
 pub async fn update_feedback_issue_status(
     pool: &PgPool,
     id: &str,
+    reporter_did: &str,
     status: &str,
     assigned_agent_team: Option<&str>,
     resolution_notes: Option<&str>,
@@ -1045,10 +1073,10 @@ pub async fn update_feedback_issue_status(
 ) -> Result<bool, sqlx::Error> {
     let result = sqlx::query(
         "UPDATE feedback_issues SET status = $1, assigned_agent_team = COALESCE($2, assigned_agent_team), \
-         resolution_notes = COALESCE($3, resolution_notes), updated_at = $4 WHERE id = $5"
+         resolution_notes = COALESCE($3, resolution_notes), updated_at = $4 WHERE id = $5 AND reporter_did = $6"
     )
     .bind(status).bind(assigned_agent_team).bind(resolution_notes)
-    .bind(updated_at).bind(id)
+    .bind(updated_at).bind(id).bind(reporter_did)
     .execute(pool).await?;
     Ok(result.rows_affected() > 0)
 }

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -47,6 +47,7 @@ use crate::{
 
 const XSRF_COOKIE_PREFIX: &str = "XSRF-TOKEN=";
 const CSRF_HEADER_NAME: &str = "x-csrf-token";
+const AUTH_OBSERVED_AT_MS_HEADER: &str = "x-exo-auth-observed-at-ms";
 const GLOBAL_CONCURRENCY_LIMIT: usize = 1024;
 
 // ---------------------------------------------------------------------------
@@ -1417,6 +1418,143 @@ fn extract_bearer_token(headers: &HeaderMap) -> Option<String> {
         .map(|s| s.trim().to_owned())
 }
 
+fn require_bearer_token(headers: &HeaderMap) -> Result<String> {
+    extract_bearer_token(headers).ok_or_else(|| GatewayError::AuthenticationFailed {
+        reason: "missing or malformed Authorization header".to_owned(),
+    })
+}
+
+fn required_observed_at_ms_header(headers: &HeaderMap) -> Result<i64> {
+    let raw = headers
+        .get(AUTH_OBSERVED_AT_MS_HEADER)
+        .ok_or_else(|| {
+            GatewayError::BadRequest(format!(
+                "missing required '{AUTH_OBSERVED_AT_MS_HEADER}' header"
+            ))
+        })?
+        .to_str()
+        .map_err(|_| {
+            GatewayError::BadRequest(format!(
+                "'{AUTH_OBSERVED_AT_MS_HEADER}' header must be valid UTF-8"
+            ))
+        })?;
+    let observed_at = raw.parse::<i64>().map_err(|e| {
+        GatewayError::BadRequest(format!(
+            "'{AUTH_OBSERVED_AT_MS_HEADER}' header must be an integer millisecond timestamp: {e}"
+        ))
+    })?;
+    if observed_at <= 0 {
+        return Err(GatewayError::BadRequest(format!(
+            "'{AUTH_OBSERVED_AT_MS_HEADER}' header must be non-zero"
+        )));
+    }
+    Ok(observed_at)
+}
+
+async fn require_authenticated_session_actor_from_header(
+    state: &AppState,
+    headers: &HeaderMap,
+) -> Result<Did> {
+    let token = require_bearer_token(headers)?;
+    let observed_at = required_observed_at_ms_header(headers)?;
+    require_authenticated_session_actor_for_token(state, &token, observed_at).await
+}
+
+async fn require_authenticated_session_actor(
+    state: &AppState,
+    headers: &HeaderMap,
+    observed_at_ms: i64,
+) -> Result<Did> {
+    let token = require_bearer_token(headers)?;
+    require_authenticated_session_actor_for_token(state, &token, observed_at_ms).await
+}
+
+async fn require_authenticated_session_actor_for_token(
+    state: &AppState,
+    token: &str,
+    observed_at_ms: i64,
+) -> Result<Did> {
+    if observed_at_ms <= 0 {
+        return Err(GatewayError::BadRequest(
+            "session authentication observed_at must be caller-supplied and non-zero".into(),
+        ));
+    }
+    let db = state.require_db()?;
+    let actor_did: Option<String> = sqlx::query_scalar(
+        "SELECT actor_did FROM sessions \
+         WHERE token = $1 AND revoked = false AND expires_at > $2",
+    )
+    .bind(token)
+    .bind(observed_at_ms)
+    .fetch_optional(db)
+    .await
+    .map_err(|e| GatewayError::Internal(format!("session actor lookup failed: {e}")))?;
+
+    let actor_did = actor_did.ok_or_else(|| GatewayError::AuthenticationFailed {
+        reason: "session token expired, revoked, or not found".to_owned(),
+    })?;
+    Did::new(&actor_did).map_err(|e| {
+        GatewayError::Internal(format!(
+            "session actor DID stored in database is invalid: {actor_did}: {e}"
+        ))
+    })
+}
+
+fn reject_caller_supplied_identity_field(body: &serde_json::Value, field: &str) -> Result<()> {
+    if body
+        .as_object()
+        .is_some_and(|object| object.contains_key(field))
+    {
+        return Err(GatewayError::BadRequest(format!(
+            "{field} is derived from the authenticated session actor and must not be supplied"
+        )));
+    }
+    Ok(())
+}
+
+fn reject_caller_supplied_builtin_layout(body: &serde_json::Value) -> Result<()> {
+    let Some(value) = body.as_object().and_then(|object| object.get("isBuiltIn")) else {
+        return Ok(());
+    };
+    match value.as_bool() {
+        Some(false) | None => Ok(()),
+        Some(true) => Err(GatewayError::BadRequest(
+            "built-in layout templates are code-owned and cannot be persisted by callers".into(),
+        )),
+    }
+}
+
+fn auth_boundary_error_response(err: GatewayError) -> Response {
+    match err {
+        GatewayError::AuthenticationFailed { reason } => (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({
+                "error": "authentication failed",
+                "message": reason,
+            })),
+        )
+            .into_response(),
+        GatewayError::BadRequest(reason) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": reason })),
+        )
+            .into_response(),
+        GatewayError::Internal(reason) if reason.contains("no database configured") => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "error": "database not configured",
+                "message": reason,
+            })),
+        )
+            .into_response(),
+        other => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": other.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
 fn is_csrf_protected_method(method: &Method) -> bool {
     matches!(
         *method,
@@ -1489,8 +1627,24 @@ async fn require_csrf_double_submit(
 /// PUT /api/v1/layout-templates — upsert a layout template.
 async fn handle_layout_template_put(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
+    let metadata = match LayoutTemplateMetadata::from_body(&body) {
+        Ok(metadata) => metadata,
+        Err(e) => return metadata_error_response(e),
+    };
+    let actor =
+        match require_authenticated_session_actor(&state, &headers, metadata.updated_at).await {
+            Ok(actor) => actor,
+            Err(e) => return auth_boundary_error_response(e),
+        };
+    if let Err(e) = reject_caller_supplied_identity_field(&body, "userDid") {
+        return metadata_error_response(e);
+    }
+    if let Err(e) = reject_caller_supplied_builtin_layout(&body) {
+        return metadata_error_response(e);
+    }
     let db = match state.require_db() {
         Ok(pool) => pool,
         Err(_) => {
@@ -1520,39 +1674,30 @@ async fn handle_layout_template_put(
         .get("hiddenPanels")
         .cloned()
         .unwrap_or(serde_json::json!([]));
-    let is_built_in = body
-        .get("isBuiltIn")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-    let metadata = match LayoutTemplateMetadata::from_body(&body) {
-        Ok(metadata) => metadata,
-        Err(e) => return metadata_error_response(e),
-    };
-
-    // Extract user DID from bearer token session if available.
-    // For now, accept an optional `userDid` field in the body.
-    let user_did_owned = body
-        .get("userDid")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_owned());
-    let user_did = user_did_owned.as_deref();
 
     match crate::db::upsert_layout_template(
         db,
         &id,
-        user_did,
+        Some(actor.as_str()),
         name,
         &layout_json,
         &hidden_panels,
-        is_built_in,
+        false,
         metadata.created_at,
         metadata.updated_at,
     )
     .await
     {
-        Ok(()) => (
+        Ok(true) => (
             StatusCode::OK,
             Json(serde_json::json!({ "id": id, "status": "saved" })),
+        )
+            .into_response(),
+        Ok(false) => (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "layout template belongs to another actor or is code-owned"
+            })),
         )
             .into_response(),
         Err(e) => (
@@ -1566,8 +1711,13 @@ async fn handle_layout_template_put(
 /// DELETE /api/v1/layout-templates/:id — delete a user layout template.
 async fn handle_layout_template_delete(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
+    let actor = match require_authenticated_session_actor_from_header(&state, &headers).await {
+        Ok(actor) => actor,
+        Err(e) => return auth_boundary_error_response(e),
+    };
     let db = match state.require_db() {
         Ok(pool) => pool,
         Err(_) => {
@@ -1578,7 +1728,7 @@ async fn handle_layout_template_delete(
                 .into_response();
         }
     };
-    match crate::db::delete_layout_template(db, &id).await {
+    match crate::db::delete_layout_template(db, &id, actor.as_str()).await {
         Ok(true) => (
             StatusCode::OK,
             Json(serde_json::json!({ "id": id, "status": "deleted" })),
@@ -1598,7 +1748,14 @@ async fn handle_layout_template_delete(
 }
 
 /// GET /api/v1/layout-templates — list all layout templates.
-async fn handle_layout_templates_list(State(state): State<AppState>) -> impl IntoResponse {
+async fn handle_layout_templates_list(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    let actor = match require_authenticated_session_actor_from_header(&state, &headers).await {
+        Ok(actor) => actor,
+        Err(e) => return auth_boundary_error_response(e),
+    };
     let db = match state.require_db() {
         Ok(pool) => pool,
         Err(_) => {
@@ -1609,7 +1766,7 @@ async fn handle_layout_templates_list(State(state): State<AppState>) -> impl Int
                 .into_response();
         }
     };
-    match crate::db::list_layout_templates(db, None).await {
+    match crate::db::list_layout_templates(db, Some(actor.as_str())).await {
         Ok(rows) => {
             let templates: Vec<serde_json::Value> = rows
                 .into_iter()
@@ -1638,8 +1795,21 @@ async fn handle_layout_templates_list(State(state): State<AppState>) -> impl Int
 /// POST /api/v1/feedback-issues — file a new feedback issue.
 async fn handle_feedback_issue_create(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
+    let metadata = match FeedbackIssueCreateMetadata::from_body(&body) {
+        Ok(metadata) => metadata,
+        Err(e) => return metadata_error_response(e),
+    };
+    let actor =
+        match require_authenticated_session_actor(&state, &headers, metadata.created_at).await {
+            Ok(actor) => actor,
+            Err(e) => return auth_boundary_error_response(e),
+        };
+    if let Err(e) = reject_caller_supplied_identity_field(&body, "reporterDid") {
+        return metadata_error_response(e);
+    }
     let db = match state.require_db() {
         Ok(pool) => pool,
         Err(_) => {
@@ -1670,10 +1840,6 @@ async fn handle_feedback_issue_create(
                 .into_response();
         }
     };
-    let metadata = match FeedbackIssueCreateMetadata::from_body(&body) {
-        Ok(metadata) => metadata,
-        Err(e) => return metadata_error_response(e),
-    };
     let description = body
         .get("description")
         .and_then(|v| v.as_str())
@@ -1690,11 +1856,6 @@ async fn handle_feedback_issue_create(
         .get("sourceModuleType")
         .and_then(|v| v.as_str())
         .unwrap_or("");
-    let reporter_did_owned = body
-        .get("reporterDid")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_owned());
-    let reporter_did = reporter_did_owned.as_deref();
     let widget_state = body.get("widgetState");
     let browser_info = body.get("browserInfo");
 
@@ -1707,7 +1868,7 @@ async fn handle_feedback_issue_create(
         category,
         &source_widget_id,
         source_module_type,
-        reporter_did,
+        Some(actor.as_str()),
         widget_state,
         browser_info,
         metadata.created_at,
@@ -1728,7 +1889,14 @@ async fn handle_feedback_issue_create(
 }
 
 /// GET /api/v1/feedback-issues — list feedback issues.
-async fn handle_feedback_issues_list(State(state): State<AppState>) -> impl IntoResponse {
+async fn handle_feedback_issues_list(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    let actor = match require_authenticated_session_actor_from_header(&state, &headers).await {
+        Ok(actor) => actor,
+        Err(e) => return auth_boundary_error_response(e),
+    };
     let db = match state.require_db() {
         Ok(pool) => pool,
         Err(_) => {
@@ -1739,7 +1907,7 @@ async fn handle_feedback_issues_list(State(state): State<AppState>) -> impl Into
                 .into_response();
         }
     };
-    match crate::db::list_feedback_issues(db, None).await {
+    match crate::db::list_feedback_issues(db, Some(actor.as_str()), None).await {
         Ok(rows) => {
             let issues: Vec<serde_json::Value> = rows
                 .into_iter()
@@ -1773,9 +1941,19 @@ async fn handle_feedback_issues_list(State(state): State<AppState>) -> impl Into
 /// PATCH /api/v1/feedback-issues/:id — update issue status/assignment.
 async fn handle_feedback_issue_update(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Path(id): Path<String>,
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
+    let metadata = match FeedbackIssueUpdateMetadata::from_body(&body) {
+        Ok(metadata) => metadata,
+        Err(e) => return metadata_error_response(e),
+    };
+    let actor =
+        match require_authenticated_session_actor(&state, &headers, metadata.updated_at).await {
+            Ok(actor) => actor,
+            Err(e) => return auth_boundary_error_response(e),
+        };
     let db = match state.require_db() {
         Ok(pool) => pool,
         Err(_) => {
@@ -1800,14 +1978,11 @@ async fn handle_feedback_issue_update(
         .and_then(|v| v.as_str())
         .map(|s| s.to_owned());
     let notes = notes_owned.as_deref();
-    let metadata = match FeedbackIssueUpdateMetadata::from_body(&body) {
-        Ok(metadata) => metadata,
-        Err(e) => return metadata_error_response(e),
-    };
 
     match crate::db::update_feedback_issue_status(
         db,
         &id,
+        actor.as_str(),
         status,
         agent_team,
         notes,
@@ -3204,6 +3379,97 @@ mod tests {
         assert!(
             matches!(&err, GatewayError::BadRequest(reason) if reason.contains("updatedAt")),
             "expected updatedAt refusal, got {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dashboard_persistence_routes_reject_missing_bearer_before_db() {
+        let requests = [
+            (
+                Method::PUT,
+                "/api/v1/layout-templates",
+                Some(serde_json::json!({
+                    "id": "layout-1",
+                    "name": "Layout",
+                    "layout": [],
+                    "hiddenPanels": [],
+                    "createdAt": 10_000,
+                    "updatedAt": 10_001
+                })),
+            ),
+            (Method::GET, "/api/v1/layout-templates", None),
+            (Method::DELETE, "/api/v1/layout-templates/layout-1", None),
+            (
+                Method::POST,
+                "/api/v1/feedback-issues",
+                Some(serde_json::json!({
+                    "id": "issue-1",
+                    "title": "Bad panel state",
+                    "sourceWidgetId": "panel-1",
+                    "createdAt": 10_000
+                })),
+            ),
+            (Method::GET, "/api/v1/feedback-issues", None),
+            (
+                Method::PATCH,
+                "/api/v1/feedback-issues/issue-1",
+                Some(serde_json::json!({
+                    "status": "triaged",
+                    "updatedAt": 10_001
+                })),
+            ),
+        ];
+
+        for (method, uri, body) in requests {
+            let app = build_router(state());
+            let request_body = body
+                .map(|value| Body::from(value.to_string()))
+                .unwrap_or_else(Body::empty);
+            let response = app
+                .oneshot(
+                    Request::builder()
+                        .method(method.clone())
+                        .uri(uri)
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .body(request_body)
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(
+                response.status(),
+                StatusCode::UNAUTHORIZED,
+                "{method} {uri} must reject missing bearer before DB access"
+            );
+        }
+    }
+
+    #[test]
+    fn dashboard_persistence_handlers_do_not_trust_body_identity_scope() {
+        let source = include_str!("server.rs");
+        let layout_put = source_between(
+            source,
+            "async fn handle_layout_template_put",
+            "/// DELETE /api/v1/layout-templates/:id",
+        );
+        let feedback_create = source_between(
+            source,
+            "async fn handle_feedback_issue_create",
+            "/// GET /api/v1/feedback-issues",
+        );
+
+        assert!(
+            !layout_put.contains(".get(\"userDid\")"),
+            "layout user_did must come from the authenticated session actor"
+        );
+        assert!(
+            !layout_put.contains(".get(\"isBuiltIn\")"),
+            "callers must not be able to persist code-owned built-in templates"
+        );
+        assert!(
+            !feedback_create.contains(".get(\"reporterDid\")"),
+            "feedback reporter_did must come from the authenticated session actor"
         );
     }
 

--- a/web/src/stores/feedbackStore.test.ts
+++ b/web/src/stores/feedbackStore.test.ts
@@ -334,6 +334,29 @@ describe('feedbackStore.ts — Feedback store', () => {
         })
       )
     })
+
+    it('sends gateway-required actor binding metadata', () => {
+      localStorage.setItem('df_token', 'test-token')
+
+      const { result } = renderHook(() => useFeedbackStore())
+
+      act(() => {
+        result.current.openReporter('widget-1', 'decisions')
+        result.current.fileIssue({
+          title: 'Gateway Metadata',
+          description: 'Test',
+          severity: 'high',
+          category: 'security',
+        })
+      })
+
+      const [, init] = vi.mocked(global.fetch).mock.calls[0]
+      const headers = init?.headers as Record<string, string>
+      const body = JSON.parse(init?.body as string)
+
+      expect(body.createdAt).toBeGreaterThan(0)
+      expect(headers['x-exo-auth-observed-at-ms']).toBe(String(body.updatedAt))
+    })
   })
 
   // ─────────────────────────────────────────────────────────────

--- a/web/src/stores/feedbackStore.ts
+++ b/web/src/stores/feedbackStore.ts
@@ -75,6 +75,7 @@ async function submitToServer(issue: FeedbackIssue) {
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${localStorage.getItem('df_token')}`,
+        'x-exo-auth-observed-at-ms': String(issue.updatedAt),
       },
       body: JSON.stringify(issue),
     })

--- a/web/src/stores/layoutTemplateStore.test.ts
+++ b/web/src/stores/layoutTemplateStore.test.ts
@@ -1259,6 +1259,26 @@ describe('useLayoutTemplateStore', () => {
       )
     })
 
+    it('should send gateway-required actor binding metadata', () => {
+      localStorage.setItem('df_token', 'test-token-123')
+
+      const { result } = renderHook(() => useLayoutTemplateStore())
+
+      act(() => {
+        result.current.setEditMode(true)
+        result.current.updateDraftLayout([{ i: 'panel-1', x: 0, y: 0, w: 6, h: 4 }])
+        result.current.saveAsTemplate('Gateway Metadata')
+      })
+
+      const [, init] = vi.mocked(global.fetch).mock.calls[0]
+      const headers = init?.headers as Record<string, string>
+      const body = JSON.parse(init?.body as string)
+
+      expect(body.createdAt).toBeGreaterThan(0)
+      expect(body.updatedAt).toBeGreaterThan(0)
+      expect(headers['x-exo-auth-observed-at-ms']).toBe(String(body.updatedAt))
+    })
+
     it('should continue on server sync failure (fire-and-forget)', () => {
       ;(global.fetch as any).mockRejectedValueOnce(new Error('Network error'))
 

--- a/web/src/stores/layoutTemplateStore.ts
+++ b/web/src/stores/layoutTemplateStore.ts
@@ -51,13 +51,18 @@ async function saveToServer(template: LayoutTemplate) {
   try {
     await fetch('/api/v1/layout-templates', {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${localStorage.getItem('df_token')}` },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${localStorage.getItem('df_token')}`,
+        'x-exo-auth-observed-at-ms': String(template.updatedAt),
+      },
       body: JSON.stringify({
         id: template.id,
         name: template.name,
         layout: JSON.stringify(template.layout),
         hiddenPanels: template.hiddenPanels,
         isBuiltIn: template.isBuiltIn,
+        createdAt: template.createdAt,
         updatedAt: template.updatedAt,
       }),
     })
@@ -66,9 +71,13 @@ async function saveToServer(template: LayoutTemplate) {
 
 async function deleteFromServer(id: string) {
   try {
+    const observedAt = Date.now()
     await fetch(`/api/v1/layout-templates/${id}`, {
       method: 'DELETE',
-      headers: { Authorization: `Bearer ${localStorage.getItem('df_token')}` },
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem('df_token')}`,
+        'x-exo-auth-observed-at-ms': String(observedAt),
+      },
     })
   } catch { /* best-effort */ }
 }


### PR DESCRIPTION
## Summary
- bind dashboard layout-template and feedback persistence routes to the authenticated gateway session actor
- reject caller-supplied `userDid` / `reporterDid` and caller-persisted built-in layouts
- scope layout deletion/upsert and feedback list/update operations by actor DID
- add web request metadata so the gateway can evaluate sessions against caller-supplied operation time

## Root Cause
The dashboard persistence APIs accepted identity fields from request JSON and some read/write paths were not actor-scoped. A bearer token was available in the client, but the server-side persistence boundary did not derive the actor from the session table before applying layout and feedback changes.

## TDD Evidence
Red tests first:
- `cargo test -p exo-gateway dashboard_persistence -- --nocapture` failed with missing-bearer requests returning DB errors and handler source still reading body identity.
- `npm test -- --run src/stores/layoutTemplateStore.test.ts src/stores/feedbackStore.test.ts` failed because gateway-required actor-binding metadata was absent.

Green checks:
- `cargo test -p exo-gateway dashboard_persistence -- --nocapture`
- `cargo test -p exo-gateway --lib`
- `cargo test -p exo-gateway`
- `cargo test -p exo-gateway --features production-db`
- `cargo build -p exo-gateway`
- `cargo build -p exo-gateway --features production-db`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `cargo clippy -p exo-gateway --all-targets --features production-db -- -D warnings`
- `npm test -- --run src/stores/layoutTemplateStore.test.ts src/stores/feedbackStore.test.ts`
- `npm test`
- `npm run build`
- `cargo +nightly fmt --all -- --check`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash tools/repo_truth.sh --json --skip-tests`
- `bash tools/repo_truth.sh --json --list-tests`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `cargo test --workspace`
- `cargo build --workspace`
- `cargo build --workspace --release`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used`
- `cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check`

## Known Tooling Gap
`npm run lint` is currently blocked because `eslint` is not installed or declared in `web/package.json`; `npm ls eslint` returns empty.
