### PR TITLE
fix: verify external DAG node signatures

### DIFF
--- a/crates/exo-dag/src/append.rs
+++ b/crates/exo-dag/src/append.rs
@@ -8,9 +8,13 @@
 //! These checks implement the normative HLC check (EXOCHAIN Specification v2.2): event > parent,
 //! preventing Byzantine clock manipulation in the trust fabric.
 
-use exo_core::types::{Hash256, Timestamp};
+use exo_core::{
+    crypto,
+    types::{Hash256, Timestamp},
+};
 
 use crate::{
+    consensus::PublicKeyResolver,
     dag::compute_node_hash,
     error::{DagError, Result},
     store::DagStore,
@@ -36,6 +40,7 @@ pub async fn validated_append(
     store: &mut impl DagStore,
     node: crate::dag::DagNode,
     validation_time: Timestamp,
+    public_keys: &impl PublicKeyResolver,
 ) -> Result<()> {
     // 1. Validation-time skew check: reject future-dated nodes
     if node.timestamp.physical_ms > 0 {
@@ -64,8 +69,48 @@ pub async fn validated_append(
         }
     }
 
-    // 3. Persist
+    // 3. Creator signature verification. External append must prove that
+    // creator_did controls the key configured for this DAG node signer.
+    verify_node_creator_signature(&node, public_keys)?;
+
+    // 4. Persist
     store.put(node).await
+}
+
+/// Verify a DAG node's canonical identity and creator signature.
+///
+/// This is intentionally resolver-based: a DID alone does not contain enough
+/// public-key material to prove authorship. Callers handling external DAG
+/// input must supply a governance/identity backed key resolver and fail closed
+/// when a creator key is unknown.
+pub fn verify_node_creator_signature(
+    node: &crate::dag::DagNode,
+    public_keys: &impl PublicKeyResolver,
+) -> Result<()> {
+    let mut sorted_parents = node.parents.clone();
+    sorted_parents.sort();
+    sorted_parents.dedup();
+    if sorted_parents != node.parents {
+        return Err(DagError::InvalidSignature(node.hash));
+    }
+
+    let expected_hash = compute_node_hash(
+        &node.parents,
+        &node.payload_hash,
+        &node.creator_did,
+        &node.timestamp,
+    )?;
+    if expected_hash != node.hash {
+        return Err(DagError::InvalidSignature(node.hash));
+    }
+
+    let Some(public_key) = public_keys.resolve(&node.creator_did) else {
+        return Err(DagError::InvalidSignature(node.hash));
+    };
+    if !crypto::verify(node.hash.as_bytes(), &node.signature, &public_key) {
+        return Err(DagError::InvalidSignature(node.hash));
+    }
+    Ok(())
 }
 
 /// Verify integrity of a stored node: check that its hash is correctly
@@ -105,7 +150,10 @@ pub async fn verify_stored_integrity(store: &impl DagStore, hash: &Hash256) -> R
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
-    use exo_core::types::{Did, Signature, Timestamp};
+    use exo_core::{
+        crypto::KeyPair,
+        types::{Did, PublicKey, Signature, Timestamp},
+    };
 
     use super::*;
     use crate::{
@@ -119,13 +167,29 @@ mod tests {
 
     type SignFn = Box<dyn Fn(&[u8]) -> Signature>;
 
+    fn test_keypair() -> KeyPair {
+        KeyPair::from_secret_bytes([0xD5; 32]).expect("valid test secret key")
+    }
+
+    fn test_public_key() -> PublicKey {
+        *test_keypair().public_key()
+    }
+
+    fn test_resolver() -> impl PublicKeyResolver {
+        let did = test_did();
+        let public_key = test_public_key();
+        move |candidate: &Did| {
+            if candidate == &did {
+                Some(public_key)
+            } else {
+                None
+            }
+        }
+    }
+
     fn make_sign_fn() -> SignFn {
-        Box::new(|data: &[u8]| {
-            let h = blake3::hash(data);
-            let mut sig = [0u8; 64];
-            sig[..32].copy_from_slice(h.as_bytes());
-            Signature::from_bytes(sig)
-        })
+        let keypair = test_keypair();
+        Box::new(move |data: &[u8]| keypair.sign(data))
     }
 
     fn make_test_node() -> DagNode {
@@ -212,9 +276,15 @@ mod tests {
         store.put(genesis.clone()).await.expect("put genesis");
 
         let child = make_child_node(&genesis);
-        validated_append(&mut store, child.clone(), validation_time_for(&child))
-            .await
-            .expect("validated append");
+        let resolver = test_resolver();
+        validated_append(
+            &mut store,
+            child.clone(),
+            validation_time_for(&child),
+            &resolver,
+        )
+        .await
+        .expect("validated append");
 
         assert!(store.contains(&child.hash).await.expect("contains"));
     }
@@ -226,10 +296,95 @@ mod tests {
         let genesis = make_test_node();
         let child = make_child_node(&genesis);
 
-        let err = validated_append(&mut store, child.clone(), validation_time_for(&child))
-            .await
-            .unwrap_err();
+        let resolver = test_resolver();
+        let err = validated_append(
+            &mut store,
+            child.clone(),
+            validation_time_for(&child),
+            &resolver,
+        )
+        .await
+        .unwrap_err();
         assert!(matches!(err, DagError::ParentNotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn validated_append_rejects_forged_external_signature() {
+        let mut store = MemoryStore::new();
+        let genesis = make_test_node();
+        store.put(genesis.clone()).await.expect("put genesis");
+
+        let mut child = make_child_node(&genesis);
+        child.signature = Signature::from_bytes([0u8; 64]);
+
+        let resolver = test_resolver();
+        let err = validated_append(
+            &mut store,
+            child.clone(),
+            validation_time_for(&child),
+            &resolver,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, DagError::InvalidSignature(hash) if hash == child.hash),
+            "external DAG append must reject forged node signatures, got: {err:?}"
+        );
+        assert!(
+            !store.contains(&child.hash).await.expect("contains"),
+            "forged external node must not be persisted"
+        );
+    }
+
+    #[tokio::test]
+    async fn validated_append_rejects_mismatched_canonical_hash() {
+        let mut store = MemoryStore::new();
+        let genesis = make_test_node();
+        store.put(genesis.clone()).await.expect("put genesis");
+
+        let mut child = make_child_node(&genesis);
+        child.payload_hash = Hash256::digest(b"tampered");
+
+        let resolver = test_resolver();
+        let err = validated_append(
+            &mut store,
+            child.clone(),
+            validation_time_for(&child),
+            &resolver,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, DagError::InvalidSignature(hash) if hash == child.hash),
+            "external DAG append must reject nodes whose hash does not match canonical fields, got: {err:?}"
+        );
+        assert!(!store.contains(&child.hash).await.expect("contains"));
+    }
+
+    #[tokio::test]
+    async fn validated_append_rejects_unknown_creator_key() {
+        let mut store = MemoryStore::new();
+        let genesis = make_test_node();
+        store.put(genesis.clone()).await.expect("put genesis");
+
+        let child = make_child_node(&genesis);
+        let unknown_key_resolver = |_did: &Did| -> Option<PublicKey> { None };
+        let err = validated_append(
+            &mut store,
+            child.clone(),
+            validation_time_for(&child),
+            &unknown_key_resolver,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, DagError::InvalidSignature(hash) if hash == child.hash),
+            "external DAG append must fail closed without a creator public key, got: {err:?}"
+        );
+        assert!(!store.contains(&child.hash).await.expect("contains"));
     }
 
     #[tokio::test]
@@ -255,10 +410,12 @@ mod tests {
             signature,
         };
 
+        let resolver = test_resolver();
         let err = validated_append(
             &mut store,
             bad_child.clone(),
             validation_time_for(&bad_child),
+            &resolver,
         )
         .await
         .unwrap_err();
@@ -273,7 +430,8 @@ mod tests {
         let mut store = MemoryStore::new();
         let node = make_node_at(Timestamp::new(2_001, 0));
 
-        let err = validated_append(&mut store, node, Timestamp::new(1_500, 0))
+        let resolver = test_resolver();
+        let err = validated_append(&mut store, node, Timestamp::new(1_500, 0), &resolver)
             .await
             .unwrap_err();
 
@@ -292,9 +450,15 @@ mod tests {
         let mut store = MemoryStore::new();
         let node = make_node_at(Timestamp::new(2_000, 0));
 
-        validated_append(&mut store, node.clone(), Timestamp::new(1_500, 0))
-            .await
-            .expect("node inside validation-time tolerance");
+        let resolver = test_resolver();
+        validated_append(
+            &mut store,
+            node.clone(),
+            Timestamp::new(1_500, 0),
+            &resolver,
+        )
+        .await
+        .expect("node inside validation-time tolerance");
 
         assert!(store.contains(&node.hash).await.expect("contains"));
     }
@@ -345,9 +509,15 @@ mod tests {
         let mut store = MemoryStore::new();
         let genesis = make_test_node();
         // Genesis has no parents — should pass validation
-        validated_append(&mut store, genesis.clone(), validation_time_for(&genesis))
-            .await
-            .expect("genesis append");
+        let resolver = test_resolver();
+        validated_append(
+            &mut store,
+            genesis.clone(),
+            validation_time_for(&genesis),
+            &resolver,
+        )
+        .await
+        .expect("genesis append");
         assert!(store.contains(&genesis.hash).await.expect("contains"));
     }
 }

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -408,6 +408,7 @@ async fn start_node(
         &node_identity,
         &validator_set,
     )?;
+    let sync_validator_public_keys = validator_public_keys.clone();
     let reactor_config = ReactorConfig {
         node_did: node_identity.did.clone(),
         is_validator: validator,
@@ -458,6 +459,7 @@ async fn start_node(
     // --- Sync engine ---
     let sync_config = SyncConfig {
         node_did: node_identity.did.clone(),
+        validator_public_keys: sync_validator_public_keys.clone(),
         chunk_size: 100,
         max_sync_nodes: 200,
     };
@@ -477,6 +479,7 @@ async fn start_node(
         let mut sync_for_join = SyncEngine::new(
             SyncConfig {
                 node_did: node_identity.did.clone(),
+                validator_public_keys: sync_validator_public_keys.clone(),
                 chunk_size: 100,
                 max_sync_nodes: 200,
             },

--- a/crates/exo-node/src/reactor.rs
+++ b/crates/exo-node/src/reactor.rs
@@ -31,6 +31,7 @@ use exo_core::{
     types::{Did, Hash256, PublicKey, ReceiptOutcome, Signature, Timestamp, TrustReceipt},
 };
 use exo_dag::{
+    append::verify_node_creator_signature,
     consensus::{self, CommitCertificate, ConsensusConfig, ConsensusState, Proposal, Vote},
     dag::{Dag, DagNode, DeterministicDagClock, append},
 };
@@ -543,6 +544,8 @@ fn validate_proposal<R: consensus::PublicKeyResolver>(
             msg.proposal.node_hash, msg.node.hash
         ));
     }
+    verify_node_creator_signature(&msg.node, resolver)
+        .map_err(|e| format!("proposal DAG node creator signature invalid: {e}"))?;
     Ok(())
 }
 
@@ -1761,6 +1764,23 @@ mod tests {
         let msg = proposal_msg_for(proposer, 0, 0, node);
 
         validate_proposal(&msg, &validators, &resolver).unwrap();
+    }
+
+    #[test]
+    fn validate_proposal_rejects_forged_node_signature() {
+        let validators = make_validators(1);
+        let proposer = Did::new("did:exo:v0").unwrap();
+        let resolver = validator_keys_for_single(&proposer, key_for_validator_index(0));
+        let mut node = make_node_for_test();
+        node.signature = Signature::from_bytes([0u8; 64]);
+        let msg = proposal_msg_for(proposer, 0, 0, node);
+
+        let err = validate_proposal(&msg, &validators, &resolver).unwrap_err();
+
+        assert!(
+            err.contains("proposal DAG node creator signature invalid"),
+            "network proposals must reject forged attached DAG nodes, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/exo-node/src/sync.rs
+++ b/crates/exo-node/src/sync.rs
@@ -17,9 +17,12 @@
 //! `DagSyncResponse`) and operates over the gossipsub + direct messaging
 //! layer.
 
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+};
 
-use exo_core::types::Did;
+use exo_core::types::{Did, PublicKey};
 use tokio::sync::mpsc;
 
 use crate::{
@@ -29,6 +32,11 @@ use crate::{
         DagSyncRequestMsg, DagSyncResponseMsg, StateSnapshotChunkMsg, StateSnapshotRequestMsg,
         WireMessage, topics,
     },
+};
+use exo_dag::{
+    append::verify_node_creator_signature,
+    dag::{DagNode, compute_node_hash},
+    error::{DagError, Result as DagResult},
 };
 
 const MAX_SNAPSHOT_CHUNK_SIZE: u32 = 500;
@@ -80,6 +88,8 @@ fn snapshot_node_height(from_height: u64, index: usize) -> anyhow::Result<u64> {
 pub struct SyncConfig {
     /// This node's DID.
     pub node_did: Did,
+    /// Public keys authorized to sign externally synced DAG nodes.
+    pub validator_public_keys: BTreeMap<Did, PublicKey>,
     /// Maximum number of nodes per snapshot chunk.
     pub chunk_size: u32,
     /// Maximum number of nodes per DAG sync response.
@@ -90,10 +100,53 @@ impl Default for SyncConfig {
     fn default() -> Self {
         Self {
             node_did: static_did("did:exo:default"),
+            validator_public_keys: BTreeMap::new(),
             chunk_size: 100,
             max_sync_nodes: 200,
         }
     }
+}
+
+fn validate_incoming_sync_node(
+    store: &SqliteDagStore,
+    accepted_nodes: &BTreeMap<exo_core::types::Hash256, DagNode>,
+    node: &DagNode,
+    public_keys: &BTreeMap<Did, PublicKey>,
+) -> DagResult<()> {
+    let mut sorted_parents = node.parents.clone();
+    sorted_parents.sort();
+    sorted_parents.dedup();
+    if sorted_parents != node.parents {
+        return Err(DagError::InvalidSignature(node.hash));
+    }
+
+    let expected_hash = compute_node_hash(
+        &node.parents,
+        &node.payload_hash,
+        &node.creator_did,
+        &node.timestamp,
+    )?;
+    if expected_hash != node.hash {
+        return Err(DagError::InvalidSignature(node.hash));
+    }
+
+    for parent_hash in &node.parents {
+        let stored_parent = if let Some(parent) = accepted_nodes.get(parent_hash) {
+            Some(parent.clone())
+        } else {
+            store.get_sync(parent_hash)?
+        };
+        let parent = stored_parent.ok_or(DagError::ParentNotFound(*parent_hash))?;
+        if node.timestamp <= parent.timestamp {
+            return Err(DagError::StoreError(format!(
+                "causality violation: synced node timestamp {:?} <= parent timestamp {:?}",
+                node.timestamp, parent.timestamp
+            )));
+        }
+    }
+
+    let resolver = |did: &Did| public_keys.get(did).copied();
+    verify_node_creator_signature(node, &resolver)
 }
 
 // ---------------------------------------------------------------------------
@@ -363,6 +416,7 @@ impl SyncEngine {
         // Store the nodes and mark them as committed.
         let from_height = msg.from_height;
         let nodes = msg.nodes;
+        let public_keys = self.config.validator_public_keys.clone();
         if let Err(e) = with_store_blocking(
             Arc::clone(&self.store),
             "handle_snapshot_chunk",
@@ -371,6 +425,12 @@ impl SyncEngine {
                 for (i, node) in nodes.into_iter().enumerate() {
                     let height = snapshot_node_height(from_height, i)?;
                     nodes_with_heights.push((node, height));
+                }
+
+                let mut accepted_nodes = BTreeMap::new();
+                for (node, _) in &nodes_with_heights {
+                    validate_incoming_sync_node(store, &accepted_nodes, node, &public_keys)?;
+                    accepted_nodes.insert(node.hash, node.clone());
                 }
 
                 for (node, height) in nodes_with_heights {
@@ -545,10 +605,17 @@ impl SyncEngine {
 
         let has_more = msg.has_more;
         let nodes = msg.nodes;
+        let public_keys = self.config.validator_public_keys.clone();
         if let Err(e) = with_store_blocking(
             Arc::clone(&self.store),
             "handle_dag_sync_response",
             move |store| {
+                let mut accepted_nodes = BTreeMap::new();
+                for node in &nodes {
+                    validate_incoming_sync_node(store, &accepted_nodes, node, &public_keys)?;
+                    accepted_nodes.insert(node.hash, node.clone());
+                }
+
                 for node in nodes {
                     let hash = node.hash;
                     if let Err(e) = store.put_sync(node) {
@@ -632,19 +699,39 @@ pub async fn run_sync_engine(mut engine: SyncEngine, mut net_events: mpsc::Recei
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
-    use exo_core::types::{Did, Signature};
+    use exo_core::{
+        crypto::KeyPair,
+        types::{Did, PublicKey, Signature},
+    };
     use exo_dag::dag::{Dag, DeterministicDagClock, append};
     use tokio::sync::mpsc;
 
     use super::*;
 
+    fn test_keypair() -> KeyPair {
+        KeyPair::from_secret_bytes([0x5C; 32]).expect("valid test secret key")
+    }
+
+    fn test_public_key() -> PublicKey {
+        *test_keypair().public_key()
+    }
+
+    fn test_validator_public_keys() -> BTreeMap<Did, PublicKey> {
+        BTreeMap::from([(test_did(), test_public_key())])
+    }
+
+    fn sync_config(chunk_size: u32, max_sync_nodes: u32) -> SyncConfig {
+        SyncConfig {
+            node_did: test_did(),
+            validator_public_keys: test_validator_public_keys(),
+            chunk_size,
+            max_sync_nodes,
+        }
+    }
+
     fn make_sign_fn() -> Box<dyn Fn(&[u8]) -> Signature> {
-        Box::new(|data: &[u8]| {
-            let h = blake3::hash(data);
-            let mut sig = [0u8; 64];
-            sig[..32].copy_from_slice(h.as_bytes());
-            Signature::from_bytes(sig)
-        })
+        let keypair = test_keypair();
+        Box::new(move |data: &[u8]| keypair.sign(data))
     }
 
     fn test_did() -> Did {
@@ -789,16 +876,7 @@ mod tests {
         let net_handle = NetworkHandle::new(cmd_tx);
 
         let (event_tx, mut event_rx) = mpsc::channel(32);
-        let engine = SyncEngine::new(
-            SyncConfig {
-                node_did: test_did(),
-                chunk_size: 5,
-                max_sync_nodes: 200,
-            },
-            store,
-            net_handle,
-            event_tx,
-        );
+        let engine = SyncEngine::new(sync_config(5, 200), store, net_handle, event_tx);
 
         // Simulate a snapshot request from a peer.
         let request = StateSnapshotRequestMsg {
@@ -868,11 +946,7 @@ mod tests {
 
         let (event_tx, mut event_rx) = mpsc::channel(32);
         let mut engine = SyncEngine::new(
-            SyncConfig {
-                node_did: test_did(),
-                chunk_size: 100,
-                max_sync_nodes: 200,
-            },
+            sync_config(100, 200),
             Arc::clone(&store),
             net_handle,
             event_tx,
@@ -933,6 +1007,108 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn snapshot_chunk_rejects_forged_node_signature() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SqliteDagStore::open(dir.path()).unwrap();
+        let store = Arc::new(Mutex::new(store));
+
+        let (cmd_tx, _cmd_rx) = mpsc::channel(256);
+        let net_handle = NetworkHandle::new(cmd_tx);
+
+        let (event_tx, mut event_rx) = mpsc::channel(32);
+        let mut engine = SyncEngine::new(
+            sync_config(100, 200),
+            Arc::clone(&store),
+            net_handle,
+            event_tx,
+        );
+
+        let sign_fn = make_sign_fn();
+        let did = test_did();
+        let mut dag = Dag::new();
+        let mut clock = DeterministicDagClock::new();
+        let mut node = append(
+            &mut dag,
+            &[],
+            b"forged-snapshot-node",
+            &did,
+            &*sign_fn,
+            &mut clock,
+        )
+        .unwrap();
+        node.signature = Signature::from_bytes([0u8; 64]);
+
+        engine.syncing = true;
+        let chunk = StateSnapshotChunkMsg {
+            sender: Did::new("did:exo:sender").unwrap(),
+            from_height: 1,
+            nodes: vec![node.clone()],
+            to_height: 1,
+            has_more: false,
+        };
+
+        engine.handle_snapshot_chunk(chunk).await;
+
+        let st = store.lock().unwrap();
+        assert!(
+            !st.contains_sync(&node.hash).unwrap(),
+            "sync must reject forged DAG nodes before persistence"
+        );
+        assert_eq!(st.committed_height_value().unwrap(), 0);
+        assert!(
+            event_rx.try_recv().is_err(),
+            "rejected forged chunks must not emit progress or completion"
+        );
+    }
+
+    #[tokio::test]
+    async fn dag_sync_response_rejects_forged_node_signature() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SqliteDagStore::open(dir.path()).unwrap();
+        let store = Arc::new(Mutex::new(store));
+
+        let (cmd_tx, _cmd_rx) = mpsc::channel(256);
+        let net_handle = NetworkHandle::new(cmd_tx);
+
+        let (event_tx, _event_rx) = mpsc::channel(32);
+        let mut engine = SyncEngine::new(
+            sync_config(100, 200),
+            Arc::clone(&store),
+            net_handle,
+            event_tx,
+        );
+
+        let sign_fn = make_sign_fn();
+        let did = test_did();
+        let mut dag = Dag::new();
+        let mut clock = DeterministicDagClock::new();
+        let mut node = append(
+            &mut dag,
+            &[],
+            b"forged-dag-sync-node",
+            &did,
+            &*sign_fn,
+            &mut clock,
+        )
+        .unwrap();
+        node.signature = Signature::from_bytes([0u8; 64]);
+
+        let response = DagSyncResponseMsg {
+            sender: Did::new("did:exo:sender").unwrap(),
+            nodes: vec![node.clone()],
+            has_more: false,
+        };
+
+        engine.handle_dag_sync_response(response).await;
+
+        let st = store.lock().unwrap();
+        assert!(
+            !st.contains_sync(&node.hash).unwrap(),
+            "DAG sync responses must reject forged nodes before persistence"
+        );
+    }
+
+    #[tokio::test]
     async fn unsolicited_snapshot_chunk_is_rejected_without_mutating_store() {
         let dir = tempfile::tempdir().unwrap();
         let store = SqliteDagStore::open(dir.path()).unwrap();
@@ -943,11 +1119,7 @@ mod tests {
 
         let (event_tx, mut event_rx) = mpsc::channel(32);
         let mut engine = SyncEngine::new(
-            SyncConfig {
-                node_did: test_did(),
-                chunk_size: 100,
-                max_sync_nodes: 200,
-            },
+            sync_config(100, 200),
             Arc::clone(&store),
             net_handle,
             event_tx,
@@ -1006,11 +1178,7 @@ mod tests {
 
         let (event_tx, mut event_rx) = mpsc::channel(32);
         let mut engine = SyncEngine::new(
-            SyncConfig {
-                node_did: test_did(),
-                chunk_size: 100,
-                max_sync_nodes: 200,
-            },
+            sync_config(100, 200),
             Arc::clone(&store),
             net_handle,
             event_tx,
@@ -1082,16 +1250,7 @@ mod tests {
         let net_handle = NetworkHandle::new(cmd_tx);
 
         let (event_tx, _event_rx) = mpsc::channel(32);
-        let engine = SyncEngine::new(
-            SyncConfig {
-                node_did: test_did(),
-                chunk_size: 100,
-                max_sync_nodes: 200,
-            },
-            store,
-            net_handle,
-            event_tx,
-        );
+        let engine = SyncEngine::new(sync_config(100, 200), store, net_handle, event_tx);
 
         // Request snapshot from height 5, but our store is empty (height 0).
         let request = StateSnapshotRequestMsg {
@@ -1119,16 +1278,7 @@ mod tests {
         let net_handle = NetworkHandle::new(cmd_tx);
 
         let (event_tx, _event_rx) = mpsc::channel(32);
-        let mut engine = SyncEngine::new(
-            SyncConfig {
-                node_did: test_did(),
-                chunk_size: 50,
-                max_sync_nodes: 200,
-            },
-            store,
-            net_handle,
-            event_tx,
-        );
+        let mut engine = SyncEngine::new(sync_config(50, 200), store, net_handle, event_tx);
 
         engine.request_sync().await.unwrap();
         assert!(engine.needs_sync());
@@ -1165,16 +1315,7 @@ mod tests {
         let (cmd_tx, mut cmd_rx) = mpsc::channel(256);
         let net_handle = NetworkHandle::new(cmd_tx);
         let (event_tx, _event_rx) = mpsc::channel(32);
-        let mut engine = SyncEngine::new(
-            SyncConfig {
-                node_did: test_did(),
-                chunk_size: 50,
-                max_sync_nodes: 200,
-            },
-            store,
-            net_handle,
-            event_tx,
-        );
+        let mut engine = SyncEngine::new(sync_config(50, 200), store, net_handle, event_tx);
 
         let err = engine.request_sync().await.unwrap_err();
 
@@ -1192,16 +1333,7 @@ mod tests {
         let net_handle = NetworkHandle::new(cmd_tx);
 
         let (event_tx, _event_rx) = mpsc::channel(32);
-        let engine = SyncEngine::new(
-            SyncConfig {
-                node_did: test_did(),
-                chunk_size: 100,
-                max_sync_nodes: 200,
-            },
-            store,
-            net_handle,
-            event_tx,
-        );
+        let engine = SyncEngine::new(sync_config(100, 200), store, net_handle, event_tx);
 
         // Request DAG sync with different tips (triggers response).
         let request = DagSyncRequestMsg {


### PR DESCRIPTION
## Summary
- verifies canonical DAG node hash, parent ordering, and creator signatures before external validated append
- rejects forged DAG nodes received through sync snapshot, DAG sync response, and network proposal paths before persistence
- wires sync engines to the configured validator public-key resolver

## Test Plan
- cargo test -p exo-dag append::tests::validated_append_rejects_mismatched_canonical_hash (red before fix, green after)
- cargo test -p exo-node reactor::tests::validate_proposal_rejects_forged_node_signature (red before fix, green after)
- cargo test -p exo-dag append::tests
- cargo test -p exo-node sync::tests
- cargo test -p exo-node reactor::tests::validate_proposal
- cargo test -p exo-dag
- cargo test -p exo-node
- cargo fmt --all -- --check
- cargo clippy -p exo-dag --all-targets -- -D warnings
- cargo clippy -p exo-node --all-targets -- -D warnings
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- rg bypass searches for validated_append, put_sync(node), mark_committed_sync, and verify_node_creator_signature