### PR TITLE
fix: deny empty authority chain permissions

### DIFF
--- a/crates/exo-authority/src/chain.rs
+++ b/crates/exo-authority/src/chain.rs
@@ -283,6 +283,10 @@ where
 /// and scope must have narrowed properly through the chain.
 #[must_use]
 pub fn has_permission(chain: &AuthorityChain, permission: &Permission) -> bool {
+    if chain.links.is_empty() {
+        return false;
+    }
+
     // All links must contain the permission (scope narrows but must include it)
     chain
         .links
@@ -707,7 +711,7 @@ mod tests {
             links: vec![],
             max_depth: 5,
         };
-        assert!(has_permission(&chain, &Permission::Read));
+        assert!(!has_permission(&chain, &Permission::Read));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- deny permissions for empty `AuthorityChain` values instead of relying on vacuous `Iterator::all()` behavior
- update the empty-chain unit test to assert default-deny authorization semantics

## Security Notes
- Remediates live core finding F-103 after confirming current `main` still granted permission for a directly constructed empty authority chain.
- `build_chain()` and `verify_chain()` already reject empty chains; this closes the remaining helper-level bypass for callers that receive or construct an empty `AuthorityChain` value.

## Test Plan
- RED before implementation: `cargo test -p exo-authority chain::tests::has_permission_empty_chain` failed with `assertion failed: !has_permission(...)`.
- `cargo test -p exo-authority chain::tests::has_permission_empty_chain`
- `cargo test -p exo-authority`
- `cargo clippy -p exo-authority --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`