### PR TITLE
fix: guard Version increment overflow

### DIFF
--- a/crates/exo-core/src/types.rs
+++ b/crates/exo-core/src/types.rs
@@ -874,10 +874,28 @@ impl Version {
     /// The initial version.
     pub const ZERO: Self = Self(0);
 
+    /// The maximum representable version.
+    pub const MAX: Self = Self(u64::MAX);
+
+    /// Return the next version, or `None` if this version is already at
+    /// [`Version::MAX`].
+    #[must_use]
+    pub const fn checked_next(self) -> Option<Self> {
+        match self.0.checked_add(1) {
+            Some(next) => Some(Self(next)),
+            None => None,
+        }
+    }
+
     /// Increment and return the next version.
+    ///
+    /// Saturates at [`Version::MAX`] instead of wrapping back to zero.
     #[must_use]
     pub const fn next(self) -> Self {
-        Self(self.0 + 1)
+        match self.checked_next() {
+            Some(next) => next,
+            None => Self::MAX,
+        }
     }
 
     /// Return the raw counter value.
@@ -1900,6 +1918,18 @@ mod tests {
     fn version_next() {
         let v = Version::ZERO.next().next().next();
         assert_eq!(v.value(), 3);
+    }
+
+    #[test]
+    fn version_next_saturates_at_u64_max_instead_of_wrapping() {
+        let v = Version(u64::MAX).next();
+        assert_eq!(v.value(), u64::MAX);
+    }
+
+    #[test]
+    fn version_checked_next_reports_overflow() {
+        assert_eq!(Version::ZERO.checked_next(), Some(Version(1)));
+        assert_eq!(Version::MAX.checked_next(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `Version::MAX` and `Version::checked_next()` for explicit overflow handling
- make `Version::next()` saturate at `u64::MAX` instead of wrapping or panicking on max-version input
- add regression coverage for max-version increments and checked overflow reporting

## Security Notes
- Remediates live core finding F-106 after confirming current `main` still performed `self.0 + 1`.
- Keeps the existing `next() -> Version` API stable for downstream crates while adding an explicit checked path for callers that need to reject max-version state.

## Test Plan
- RED before implementation: `cargo test -p exo-core types::tests::version_next_saturates_at_u64_max_instead_of_wrapping` failed with `attempt to add with overflow`.
- `cargo test -p exo-core types::tests::version_`
- `cargo test -p exo-core`
- `cargo clippy -p exo-core --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `rg -n "pub const fn next\(self\)|checked_next|self\.0 \+ 1|saturating" crates/exo-core/src/types.rs`
- `git diff --check`