### PR TITLE
ci: lint all workspace targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,10 +103,8 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - name: Clippy (library and binary code, deny all warnings)
-        run: cargo clippy --workspace --lib --bins -- -D warnings
-      - name: Clippy (test code, allow expect/unwrap in tests)
-        run: cargo clippy --workspace --tests --benches -- -D warnings -A clippy::expect_used -A clippy::unwrap_used
+      - name: Clippy (all workspace targets, deny all warnings)
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
   # -----------------------------------------------------------------------
   # Gate 5: Format

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 125165 | `wc -l` |
+| Rust LOC | 145594 | `wc -l` |
 | Workspace tests | 3,029 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 - **3,029 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
-- **Clippy clean** under `-D warnings` for production code
+- **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
 - **20 numbered CI quality gates** plus the required "All Constitutional Gates" aggregator are defined and enforced
 - **Traceability matrix** maps 86 requirements — see `governance/traceability_matrix.md`
@@ -57,7 +57,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 125165 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 145594 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 3,029 listed workspace tests
 
@@ -196,7 +196,7 @@ cargo build --workspace --all-targets
 cargo test --workspace
 
 # Lint (strict — no warnings allowed)
-cargo clippy --workspace --lib --bins -- -D warnings
+cargo clippy --workspace --all-targets -- -D warnings
 
 # Format check
 cargo +nightly fmt --all -- --check

--- a/tools/test_repo_truth.sh
+++ b/tools/test_repo_truth.sh
@@ -77,6 +77,12 @@ expected_gates=$(grep -E 'name: "Gate [0-9]+' .github/workflows/ci.yml | sed -E 
 actual_gates=$(jq '.ci_gates.numbered' "$json_file")
 [ "$actual_gates" = "$expected_gates" ] || fail "CI gate count $actual_gates != $expected_gates"
 
+grep -F 'cargo clippy --workspace --all-targets -- -D warnings' .github/workflows/ci.yml >/dev/null \
+  || fail "CI clippy gate must cover all workspace targets"
+if grep -nE 'cargo clippy --workspace --(lib|bins|tests|benches)' .github/workflows/ci.yml; then
+  fail "CI clippy gate must not split target classes; use --all-targets"
+fi
+
 test_mode=$(jq -r '.tests.mode' "$json_file")
 [ "$test_mode" = "skipped" ] || fail "--skip-tests should report tests.mode=skipped, got $test_mode"
 


### PR DESCRIPTION
## Summary
- change Gate 4 to run `cargo clippy --workspace --all-targets -- -D warnings`
- add a repo-truth regression so CI cannot drift back to split `--lib/--bins/--tests/--benches` clippy coverage
- refresh README repo-truth LOC and clippy command wording surfaced by the repo-truth test

## Security Notes
- Remediates live core process finding F-133 after confirming current CI still split clippy target classes instead of using the all-targets gate we run locally.
- This closes future coverage gaps for examples and other workspace target classes and avoids special warning allowances that can mask target-specific lint bypasses.

## Test Plan
- RED before CI change: `bash tools/test_repo_truth.sh` failed with `CI clippy gate must cover all workspace targets`.
- `bash tools/test_repo_truth.sh`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`