### PR TITLE
fix: verify sentinel receipt integrity

### DIFF
--- a/crates/exo-node/src/sentinels.rs
+++ b/crates/exo-node/src/sentinels.rs
@@ -208,6 +208,8 @@ fn check_quorum_health(reactor: &SharedReactorState) -> SentinelStatus {
     }
 }
 
+const RECEIPT_INTEGRITY_SAMPLE_LIMIT: u32 = 10;
+
 /// Spot-check recent trust receipts for hash integrity.
 fn check_receipt_integrity(store: &Arc<Mutex<SqliteDagStore>>) -> SentinelStatus {
     let st = match store.lock() {
@@ -223,14 +225,10 @@ fn check_receipt_integrity(store: &Arc<Mutex<SqliteDagStore>>) -> SentinelStatus
         }
     };
 
-    // Load the 10 most recent receipts across all actors.
-    // We query via a raw SQL since load_receipts_by_actor requires an actor.
-    // For the sentinel, we'll check receipts from a known actor or skip if none.
-    // Simplified: check committed height is sane as a proxy.
-    let height = match st.committed_height_value() {
-        Ok(height) => height,
+    let receipts = match st.load_recent_receipts(RECEIPT_INTEGRITY_SAMPLE_LIMIT) {
+        Ok(receipts) => receipts,
         Err(e) => {
-            tracing::error!(err = %e, "Failed to read committed height in receipt sentinel");
+            tracing::error!(err = %e, "Failed to load receipts in receipt integrity sentinel");
             return SentinelStatus {
                 check: SentinelCheck::ReceiptIntegrity,
                 healthy: false,
@@ -240,10 +238,47 @@ fn check_receipt_integrity(store: &Arc<Mutex<SqliteDagStore>>) -> SentinelStatus
         }
     };
 
+    if receipts.is_empty() {
+        return SentinelStatus {
+            check: SentinelCheck::ReceiptIntegrity,
+            healthy: true,
+            message: "No trust receipts available for integrity check".into(),
+            last_run_ms: now_ms(),
+        };
+    }
+
+    for receipt in &receipts {
+        match receipt.verify_hash() {
+            Ok(true) => {}
+            Ok(false) => {
+                return SentinelStatus {
+                    check: SentinelCheck::ReceiptIntegrity,
+                    healthy: false,
+                    message: format!(
+                        "Receipt hash verification failed for {}",
+                        receipt.receipt_hash
+                    ),
+                    last_run_ms: now_ms(),
+                };
+            }
+            Err(e) => {
+                return SentinelStatus {
+                    check: SentinelCheck::ReceiptIntegrity,
+                    healthy: false,
+                    message: format!(
+                        "Receipt hash verification error for {}: {e}",
+                        receipt.receipt_hash
+                    ),
+                    last_run_ms: now_ms(),
+                };
+            }
+        }
+    }
+
     SentinelStatus {
         check: SentinelCheck::ReceiptIntegrity,
         healthy: true,
-        message: format!("Receipt store operational — committed height {height}"),
+        message: format!("Verified {} recent trust receipt hash(es)", receipts.len()),
         last_run_ms: now_ms(),
     }
 }
@@ -687,7 +722,7 @@ mod tests {
         body::Body,
         http::{Request, StatusCode},
     };
-    use exo_core::types::{Did, Signature};
+    use exo_core::types::{Did, Hash256, Signature};
     use tower::ServiceExt;
 
     use super::*;
@@ -734,6 +769,29 @@ mod tests {
         conn.execute(
             "INSERT INTO committed (hash, height) VALUES (?1, ?2)",
             rusqlite::params![hash.as_slice(), -1_i64],
+        )
+        .unwrap();
+        std::mem::forget(dir);
+        Arc::new(Mutex::new(store))
+    }
+
+    fn store_with_malformed_receipt() -> Arc<Mutex<SqliteDagStore>> {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SqliteDagStore::open(dir.path()).unwrap();
+        let conn = rusqlite::Connection::open(dir.path().join("dag.db")).unwrap();
+        let receipt_hash = Hash256::digest(b"malformed-receipt");
+        conn.execute(
+            "INSERT INTO trust_receipts
+             (receipt_hash, actor_did, action_type, outcome, timestamp_ms, cbor_data)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            rusqlite::params![
+                receipt_hash.0.as_slice(),
+                "did:exo:actor-a",
+                "dag.commit",
+                "Executed",
+                1_700_000_000_000_i64,
+                [0xff_u8].as_slice(),
+            ],
         )
         .unwrap();
         std::mem::forget(dir);
@@ -1074,6 +1132,21 @@ mod tests {
     }
 
     #[test]
+    fn receipt_integrity_source_verifies_receipt_hashes() {
+        let source = include_str!("sentinels.rs");
+        let receipt_integrity = source
+            .split("fn check_receipt_integrity")
+            .nth(1)
+            .and_then(|section| section.split("fn check_score_integrity").next())
+            .unwrap();
+
+        assert!(
+            receipt_integrity.contains(".verify_hash()"),
+            "ReceiptIntegrity sentinel must verify persisted trust receipt hashes"
+        );
+    }
+
+    #[test]
     fn receipt_integrity_empty_store() {
         let store = test_store();
         let status = check_receipt_integrity(&store);
@@ -1081,13 +1154,44 @@ mod tests {
     }
 
     #[test]
-    fn receipt_integrity_fails_closed_on_store_height_error() {
-        let store = store_with_negative_committed_height();
+    fn receipt_integrity_fails_closed_on_receipt_decode_error() {
+        let store = store_with_malformed_receipt();
         let status = check_receipt_integrity(&store);
 
         assert!(!status.healthy);
         assert_eq!(status.check, SentinelCheck::ReceiptIntegrity);
-        assert!(status.message.contains("committed.height"));
+        assert!(status.message.contains("CBOR decode receipt"));
+    }
+
+    #[test]
+    fn receipt_integrity_detects_tampered_receipt_hash() {
+        use exo_core::types::{ReceiptOutcome, Timestamp, TrustReceipt};
+
+        let store = test_store();
+        let sign_fn = make_sign_fn();
+        let mut receipt = TrustReceipt::new(
+            Did::new("did:exo:actor-a").unwrap(),
+            Hash256::digest(b"authority"),
+            None,
+            "dag.commit".to_string(),
+            Hash256::digest(b"action-payload"),
+            ReceiptOutcome::Executed,
+            Timestamp {
+                physical_ms: 1_700_000_000_000,
+                logical: 0,
+            },
+            &*sign_fn,
+        )
+        .expect("test trust receipt should encode");
+        receipt.action_type = "dag.commit.tampered".to_string();
+        assert!(!receipt.verify_hash().unwrap());
+        store.lock().unwrap().save_receipt(&receipt).unwrap();
+
+        let status = check_receipt_integrity(&store);
+
+        assert!(!status.healthy);
+        assert_eq!(status.check, SentinelCheck::ReceiptIntegrity);
+        assert!(status.message.contains("hash verification failed"));
     }
 
     #[test]

--- a/crates/exo-node/src/store.rs
+++ b/crates/exo-node/src/store.rs
@@ -493,6 +493,37 @@ impl SqliteDagStore {
         Ok(receipts)
     }
 
+    /// Load recent trust receipts across all actors, ordered deterministically.
+    pub fn load_recent_receipts(
+        &self,
+        limit: u32,
+    ) -> DagResult<Vec<exo_core::types::TrustReceipt>> {
+        let mut stmt = self
+            .conn
+            .prepare_cached(
+                "SELECT cbor_data FROM trust_receipts
+                 ORDER BY timestamp_ms DESC, receipt_hash ASC
+                 LIMIT ?1",
+            )
+            .map_err(store_err)?;
+
+        let rows = stmt
+            .query_map(params![limit], |row| {
+                let data: Vec<u8> = row.get(0)?;
+                Ok(data)
+            })
+            .map_err(store_err)?;
+
+        let mut receipts = Vec::new();
+        for row in rows {
+            let data = row.map_err(store_err)?;
+            let receipt: exo_core::types::TrustReceipt = ciborium::from_reader(&data[..])
+                .map_err(|e| store_err(format!("CBOR decode receipt: {e}")))?;
+            receipts.push(receipt);
+        }
+        Ok(receipts)
+    }
+
     /// Find all child nodes of a given parent hash.
     pub fn children(&self, parent_hash: &Hash256) -> DagResult<Vec<Hash256>> {
         let mut stmt = self
@@ -1381,6 +1412,46 @@ mod tests {
         // Query unknown actor — should get 0.
         let none = store.load_receipts_by_actor("did:exo:unknown", 10).unwrap();
         assert!(none.is_empty());
+    }
+
+    #[test]
+    fn receipt_load_recent_across_actors_orders_and_limits() {
+        use exo_core::types::{ReceiptOutcome, Timestamp, TrustReceipt};
+        let mut store = temp_store();
+        let sign_fn = make_sign_fn();
+
+        let actors = [
+            "did:exo:actor-a",
+            "did:exo:actor-b",
+            "did:exo:actor-c",
+            "did:exo:actor-d",
+        ];
+        for (idx, actor) in actors.iter().enumerate() {
+            let timestamp = Timestamp {
+                physical_ms: 1_000_000 + u64::try_from(idx).unwrap() * 1000,
+                logical: 0,
+            };
+            let receipt = TrustReceipt::new(
+                Did::new(actor).unwrap(),
+                Hash256::digest(format!("authority-{idx}").as_bytes()),
+                None,
+                format!("action.{idx}"),
+                Hash256::digest(format!("payload-{idx}").as_bytes()),
+                ReceiptOutcome::Executed,
+                timestamp,
+                &*sign_fn,
+            )
+            .expect("test trust receipt should encode");
+            store.save_receipt(&receipt).unwrap();
+        }
+
+        let recent = store.load_recent_receipts(3).unwrap();
+
+        assert_eq!(recent.len(), 3);
+        assert_eq!(recent[0].actor_did.to_string(), "did:exo:actor-d");
+        assert_eq!(recent[1].actor_did.to_string(), "did:exo:actor-c");
+        assert_eq!(recent[2].actor_did.to_string(), "did:exo:actor-b");
+        assert!(recent.iter().all(|receipt| receipt.verify_hash().unwrap()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace the ReceiptIntegrity committed-height proxy with a bounded recent trust receipt hash verification pass
- add deterministic cross-actor recent receipt loading from SQLite
- cover tampered receipt hashes, malformed receipt decode failures, and source-level drift back to non-verifying logic

## Test Plan
- [x] cargo test -p exo-node receipt_load_recent_across_actors_orders_and_limits (failed before implementation with missing API)
- [x] cargo test -p exo-node receipt_integrity_source_verifies_receipt_hashes (failed before sentinel fix)
- [x] cargo test -p exo-node receipt_integrity_detects_tampered_receipt_hash (failed before sentinel fix)
- [x] cargo test -p exo-node receipt_integrity
- [x] cargo test -p exo-node
- [x] cargo clippy -p exo-node --all-targets -- -D warnings
- [x] cargo fmt --all -- --check
- [x] cargo test --workspace
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo build --workspace --release
- [x] RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
- [x] cargo audit
- [x] cargo deny check
- [x] git diff --check
