### PR TITLE
fix: honor gateway TLS configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,14 +505,14 @@ jobs:
       - name: Build WASM
         run: wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm
       - name: Verify WASM exports
-        # Expected export count = 141. Baseline was 110 before
+        # Expected export count = 145. Baseline was 110 before
         # decision-forum, messaging, death-trigger, and franchise/NewCo
         # scaffold were added. Remaining bridge coverage debt is tracked in
         # Initiative `wasm-bridge-test-coverage`.
         run: |
           COUNT=$(grep -c "module.exports.wasm_" packages/exochain-wasm/wasm/exochain_wasm.js)
           echo "Found $COUNT WASM exports"
-          [ "$COUNT" -eq 141 ] || (echo "Expected 141 exports, got $COUNT" && exit 1)
+          [ "$COUNT" -eq 145 ] || (echo "Expected 145 exports, got $COUNT" && exit 1)
       - name: Upload WASM artifact
         uses: actions/upload-artifact@v4
         with:
@@ -547,14 +547,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Verify Rust exports match JS expectations
-        # Expected #[wasm_bindgen] count = 141. Baseline was 110 before the
+        # Expected #[wasm_bindgen] count = 145. Baseline was 110 before the
         # Sprint-4 additions (decision-forum, messaging, death-trigger,
         # franchise/NewCo scaffold). Remaining bridge coverage debt is tracked
         # in initiative `wasm-bridge-test-coverage`.
         run: |
           RUST_COUNT=$(grep -r '#\[wasm_bindgen\]' crates/exochain-wasm/src/ | wc -l | tr -d ' ')
           echo "Rust #[wasm_bindgen] exports: $RUST_COUNT"
-          [ "$RUST_COUNT" -eq 141 ] || (echo "WASM export count changed from 141 to $RUST_COUNT — update bridge tests" && exit 1)
+          [ "$RUST_COUNT" -eq 145 ] || (echo "WASM export count changed from 145 to $RUST_COUNT — update bridge tests" && exit 1)
 
   # -----------------------------------------------------------------------
   # Constitutional gate: all must pass

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,6 +522,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1df331683d982a0b9492b38127151e6453639cd34926eb9c07d4cd8c6d22bfc"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "either",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1439,6 +1470,7 @@ dependencies = [
  "async-graphql-axum",
  "async-stream",
  "axum 0.7.9",
+ "axum-server",
  "blake3",
  "bs58",
  "chrono",
@@ -1452,6 +1484,7 @@ dependencies = [
  "getrandom 0.2.16",
  "hex",
  "percent-encoding",
+ "rustls",
  "serde",
  "serde_json",
  "sqlx",
@@ -1759,6 +1792,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1955,6 +1998,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2139,6 +2201,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -5464,7 +5527,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,8 @@ tokio = { version = "1", features = ["full"] }
 
 # HTTP server
 axum = { version = "0.7", features = ["json", "macros"] }
+axum-server = { version = "0.8", default-features = false }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 tower = { version = "0.4", features = ["util", "limit"] }
 tower-http = { version = "0.5", features = ["trace", "cors"] }
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 145594 | `wc -l` |
-| Workspace tests | 3,029 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 146165 | `wc -l` |
+| Workspace tests | 3,594 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,029 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,594 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,12 +57,12 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 145594 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 146165 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,029 listed workspace tests
+         cryptographic proofs, 3,594 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
-         141 verified bridge exports — Rust → WebAssembly → JavaScript
+         145 verified bridge exports — Rust → WebAssembly → JavaScript
 
 Layer 3: CommandBase.ai     (command-base/)
          Operational hypervisor for cognitiveplane.ai

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 146165 | `wc -l` |
-| Workspace tests | 3,594 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 146150 | `wc -l` |
+| Workspace tests | 3,609 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,594 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,609 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 146165 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 146150 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,594 listed workspace tests
+         cryptographic proofs, 3,609 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          145 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-gatekeeper/src/kernel.rs
+++ b/crates/exo-gatekeeper/src/kernel.rs
@@ -160,8 +160,10 @@ impl Kernel {
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use crate::invariants::{authority_link_signature_message, provenance_signature_message};
-    use crate::types::{AuthorityLink, GovernmentBranch, Permission, QuorumVote};
+    use crate::{
+        invariants::{authority_link_signature_message, provenance_signature_message},
+        types::{AuthorityLink, GovernmentBranch, Permission, QuorumVote},
+    };
 
     const CONSTITUTION: &[u8] = b"We the people of the EXOCHAIN...";
 

--- a/crates/exo-gateway/Cargo.toml
+++ b/crates/exo-gateway/Cargo.toml
@@ -25,6 +25,8 @@ uuid = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 axum = { workspace = true }
+axum-server = { workspace = true, features = ["tls-rustls-no-provider"] }
+rustls = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
 sqlx = { workspace = true }

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -1,6 +1,7 @@
 //! HTTP server skeleton — gateway configuration, lifecycle, and axum routing.
 use std::{
     fmt,
+    net::SocketAddr,
     sync::{Arc, Mutex, RwLock},
 };
 
@@ -13,6 +14,7 @@ use axum::{
     response::{IntoResponse, Json, Response},
     routing::{get, post},
 };
+use axum_server::tls_rustls::RustlsConfig;
 use exo_core::{Did, Hash256, Signature, Timestamp, hlc::HybridClock};
 use exo_gatekeeper::{
     invariants::InvariantSet,
@@ -107,9 +109,34 @@ pub fn start(config: GatewayConfig) -> Result<GatewayHandle> {
             "max_connections must be > 0".into(),
         ));
     }
+    validate_tls_config(config.tls_config.as_ref())?;
     Ok(GatewayHandle {
         config,
         running: true,
+    })
+}
+
+fn validate_tls_config(tls_config: Option<&TlsConfig>) -> Result<()> {
+    if let Some(tls) = tls_config {
+        if tls.cert_path.trim().is_empty() {
+            return Err(GatewayError::BadRequest(
+                "tls_config.cert_path cannot be empty".into(),
+            ));
+        }
+        if tls.key_path.trim().is_empty() {
+            return Err(GatewayError::BadRequest(
+                "tls_config.key_path cannot be empty".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn parse_tls_bind_address(bind_address: &str) -> Result<SocketAddr> {
+    bind_address.parse::<SocketAddr>().map_err(|e| {
+        GatewayError::BadRequest(format!(
+            "tls_config requires bind_address to be an explicit socket address: {e}"
+        ))
     })
 }
 
@@ -2265,12 +2292,44 @@ pub async fn serve_with_extra_routes(
     pool: Option<sqlx::PgPool>,
     extra: Option<Router>,
 ) -> Result<()> {
+    validate_tls_config(config.tls_config.as_ref())?;
     let registry = Arc::new(RwLock::new(LocalDidRegistry::new()));
     let state = AppState::new(pool, registry);
     let mut app = build_router(state);
 
     if let Some(extra_router) = extra {
         app = app.merge(extra_router);
+    }
+
+    if let Some(tls_config) = config.tls_config.as_ref() {
+        let bind_address = parse_tls_bind_address(&config.bind_address)?;
+        if rustls::crypto::ring::default_provider()
+            .install_default()
+            .is_err()
+        {
+            tracing::debug!("Rustls crypto provider was already installed");
+        }
+        let rustls_config =
+            RustlsConfig::from_pem_file(&tls_config.cert_path, &tls_config.key_path)
+                .await
+                .map_err(|e| GatewayError::Internal(format!("TLS configuration failed: {e}")))?;
+        let handle = axum_server::Handle::new();
+        let server = axum_server::bind_rustls(bind_address, rustls_config)
+            .handle(handle.clone())
+            .serve(app.into_make_service());
+
+        tracing::info!("exo-gateway listening with TLS on {}", config.bind_address);
+
+        tokio::pin!(server);
+        let result = tokio::select! {
+            result = &mut server => result,
+            () = shutdown_signal() => {
+                handle.graceful_shutdown(None);
+                (&mut server).await
+            }
+        };
+
+        return result.map_err(|e| GatewayError::Internal(format!("server error: {e}")));
     }
 
     let listener = TcpListener::bind(&config.bind_address)
@@ -2590,6 +2649,91 @@ mod tests {
         };
         let h = start(c).unwrap();
         assert!(h.config.tls_config.is_some());
+    }
+
+    #[test]
+    fn start_tls_rejects_empty_certificate_or_key_paths() {
+        for tls_config in [
+            TlsConfig {
+                cert_path: String::new(),
+                key_path: "key.pem".into(),
+            },
+            TlsConfig {
+                cert_path: "cert.pem".into(),
+                key_path: String::new(),
+            },
+            TlsConfig {
+                cert_path: "  ".into(),
+                key_path: "key.pem".into(),
+            },
+            TlsConfig {
+                cert_path: "cert.pem".into(),
+                key_path: "\t".into(),
+            },
+        ] {
+            let config = GatewayConfig {
+                tls_config: Some(tls_config),
+                ..Default::default()
+            };
+
+            assert!(
+                start(config).is_err(),
+                "configured TLS must require non-empty cert and key paths"
+            );
+        }
+    }
+
+    #[test]
+    fn serve_with_tls_uses_rustls_instead_of_plain_tcp() {
+        let source = include_str!("server.rs");
+        let serve = source_between(
+            source,
+            "pub async fn serve_with_extra_routes",
+            "// ---------------------------------------------------------------------------\n// Tests",
+        );
+
+        assert!(
+            serve.contains("RustlsConfig::from_pem_file"),
+            "TLS-configured gateway startup must load the configured certificate and key"
+        );
+        assert!(
+            serve.contains("bind_rustls"),
+            "TLS-configured gateway startup must bind a Rustls HTTPS server"
+        );
+        assert!(
+            serve.contains("config.tls_config.as_ref()"),
+            "gateway startup must branch on tls_config instead of ignoring it"
+        );
+        assert!(
+            serve.contains("TcpListener::bind(&config.bind_address)"),
+            "plaintext startup remains available only when tls_config is absent"
+        );
+    }
+
+    #[test]
+    fn serve_with_tls_installs_rustls_provider_before_loading_pem() {
+        let source = include_str!("server.rs");
+        let serve = source_between(
+            source,
+            "pub async fn serve_with_extra_routes",
+            "// ---------------------------------------------------------------------------\n// Tests",
+        );
+
+        let provider = serve
+            .find("default_provider")
+            .expect("TLS branch must select the Rustls ring crypto provider explicitly");
+        let provider_install = provider
+            + serve[provider..]
+                .find("install_default")
+                .expect("TLS branch must install the Rustls crypto provider explicitly");
+        let pem_load = serve
+            .find("RustlsConfig::from_pem_file")
+            .expect("TLS branch must load the configured PEM material");
+
+        assert!(
+            provider_install < pem_load,
+            "Rustls provider must be installed before loading PEM TLS configuration"
+        );
     }
 
     // --- Router integration tests (no network listener needed) ---

--- a/crates/exo-governance/src/types.rs
+++ b/crates/exo-governance/src/types.rs
@@ -9,9 +9,10 @@
 //! - [`EvidenceRef`] for legal evidence attachment (LEG-004, LEG-006)
 //! - [`FailureAction`] for constitutional constraint violation responses
 
+use std::cmp::Ordering;
+
 use exo_core::{Did, Hash256, Signature, Timestamp};
 use serde::{Deserialize, Serialize};
-use std::cmp::Ordering;
 
 /// Tenant identifier — opaque string, unique per organization.
 pub type TenantId = String;

--- a/crates/exo-node/src/mcp/mod.rs
+++ b/crates/exo-node/src/mcp/mod.rs
@@ -310,6 +310,36 @@ mod sse_tests {
         );
     }
 
+    #[test]
+    fn constant_time_eq_matches_only_equal_same_length_tokens() {
+        assert!(constant_time_eq(b"token-123", b"token-123"));
+        assert!(!constant_time_eq(b"token-123", b"token-124"));
+        assert!(!constant_time_eq(b"token-123", b"token-1234"));
+    }
+
+    #[test]
+    fn parse_sse_bind_addr_accepts_loopback_only_forms() {
+        let literal = parse_sse_bind_addr("127.0.0.1:3030").unwrap();
+        assert_eq!(literal, SocketAddr::from((Ipv4Addr::LOCALHOST, 3030)));
+
+        let localhost = parse_sse_bind_addr("localhost:3031").unwrap();
+        assert_eq!(localhost, SocketAddr::from((Ipv4Addr::LOCALHOST, 3031)));
+    }
+
+    #[test]
+    fn parse_sse_bind_addr_rejects_remote_and_ambiguous_binds() {
+        let remote = parse_sse_bind_addr("0.0.0.0:3030").unwrap_err();
+        assert_eq!(remote.kind(), ErrorKind::PermissionDenied);
+        assert!(remote.to_string().contains("loopback"));
+
+        let ambiguous = parse_sse_bind_addr(":3030").unwrap_err();
+        assert_eq!(ambiguous.kind(), ErrorKind::InvalidInput);
+
+        let invalid_localhost = parse_sse_bind_addr("localhost:not-a-port").unwrap_err();
+        assert_eq!(invalid_localhost.kind(), ErrorKind::InvalidInput);
+        assert!(invalid_localhost.to_string().contains("invalid localhost"));
+    }
+
     #[tokio::test]
     async fn sse_health_returns_ok() {
         let router = test_router();
@@ -339,6 +369,22 @@ mod sse_tests {
 
         let res = router.oneshot(req).await.unwrap();
         assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn sse_message_rejects_wrong_bearer_token() {
+        let router = test_router();
+        let body = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.0.0"}}}"#;
+        let req = Request::builder()
+            .method("POST")
+            .uri("/mcp/message")
+            .header("content-type", "application/json")
+            .header("authorization", "Bearer wrong-token")
+            .body(Body::from(body))
+            .unwrap();
+
+        let res = router.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
     }
 
     #[tokio::test]

--- a/crates/exo-node/src/mcp/resources/node_status.rs
+++ b/crates/exo-node/src/mcp/resources/node_status.rs
@@ -91,7 +91,15 @@ pub fn read(context: &NodeContext) -> ResourceContent {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        sync::Arc,
+    };
+
+    use exo_core::{Did, Hash256, Signature, types::PublicKey};
+
     use super::*;
+    use crate::reactor::{ReactorConfig, create_reactor_state};
 
     #[test]
     fn definition_has_uri() {
@@ -116,5 +124,52 @@ mod tests {
         let text = content.text.expect("text present");
         let parsed: Value = serde_json::from_str(&text).expect("valid JSON");
         assert!(parsed["version"].is_string());
+    }
+
+    #[test]
+    fn read_with_live_reactor_reports_consensus_snapshot() {
+        let node_did = Did::new("did:exo:validator-1").expect("valid DID");
+        let other_validator = Did::new("did:exo:validator-2").expect("valid DID");
+        let validators = BTreeSet::from([node_did.clone(), other_validator.clone()]);
+        let validator_public_keys = BTreeMap::from([
+            (node_did.clone(), PublicKey::from_bytes([1u8; 32])),
+            (other_validator, PublicKey::from_bytes([2u8; 32])),
+        ]);
+        let reactor_state = create_reactor_state(
+            &ReactorConfig {
+                node_did: node_did.clone(),
+                is_validator: true,
+                validators,
+                validator_public_keys,
+                round_timeout_ms: 1_000,
+            },
+            Arc::new(|_| Signature::empty()),
+            None,
+        );
+        {
+            let mut state = reactor_state.lock().expect("reactor state lock");
+            state.consensus.current_round = 7;
+            state.consensus.committed.push(Hash256::digest(b"node-1"));
+            state.consensus.committed.push(Hash256::digest(b"node-2"));
+        }
+        let context = NodeContext {
+            reactor_state: Some(reactor_state),
+            store: None,
+            node_did: Some(node_did.to_string()),
+        };
+
+        let content = read(&context);
+        let text = content.text.expect("text present");
+        let parsed: Value = serde_json::from_str(&text).expect("valid JSON");
+
+        assert_eq!(parsed["status"], "live");
+        assert_eq!(parsed["node_did"], node_did.to_string());
+        assert_eq!(parsed["consensus_round"], 7);
+        assert_eq!(parsed["committed_height"], 2);
+        assert_eq!(parsed["validator_count"], 2);
+        assert_eq!(parsed["is_validator"], true);
+        let validator_entries = parsed["validators"].as_array().expect("validators array");
+        assert_eq!(validator_entries.len(), 2);
+        assert_eq!(parsed["has_store"], false);
     }
 }

--- a/crates/exo-node/src/mcp/tools/governance.rs
+++ b/crates/exo-node/src/mcp/tools/governance.rs
@@ -555,7 +555,6 @@ mod tests {
         assert!(!text.contains(&synthetic_timestamp));
     }
 
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_create_decision_invalid_proposer() {
         let result = execute_create_decision(
@@ -569,7 +568,6 @@ mod tests {
         assert!(result.is_error);
     }
 
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_create_decision_invalid_proposer_does_not_echo_input() {
         let attacker_input = "bad-forged-log-line";
@@ -588,7 +586,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_create_decision_rejects_oversized_title_and_description() {
         let oversized_title = "T".repeat(65_537);
@@ -614,7 +611,6 @@ mod tests {
         assert!(result.is_error);
     }
 
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_create_decision_missing_title() {
         let result = execute_create_decision(
@@ -654,7 +650,6 @@ mod tests {
         assert!(!text.contains("voice_kind"));
     }
 
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_cast_vote_invalid_choice() {
         let result = execute_cast_vote(
@@ -668,7 +663,6 @@ mod tests {
         assert!(result.is_error);
     }
 
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_cast_vote_invalid_choice_does_not_echo_input() {
         let attacker_input = "maybe-forged-log-line";
@@ -687,7 +681,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_cast_vote_rejects_oversized_rationale() {
         let oversized_rationale = "R".repeat(65_537);
@@ -703,7 +696,6 @@ mod tests {
         assert!(result.is_error);
     }
 
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_cast_vote_invalid_voter() {
         let result = execute_cast_vote(
@@ -744,11 +736,51 @@ mod tests {
         assert!(!text.contains(&synthetic_tally_field));
     }
 
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_check_quorum_missing_threshold() {
         let result = execute_check_quorum(&json!({"decision_id": "abc123"}), &NodeContext::empty());
         assert!(result.is_error);
+    }
+
+    #[test]
+    fn execute_check_quorum_rejects_empty_id_and_zero_threshold() {
+        let empty_id = execute_check_quorum(
+            &json!({
+                "decision_id": "",
+                "threshold": 1,
+            }),
+            &NodeContext::empty(),
+        );
+        assert!(empty_id.is_error);
+        assert!(empty_id.content[0].text().contains("must not be empty"));
+
+        let zero_threshold = execute_check_quorum(
+            &json!({
+                "decision_id": "abc123",
+                "threshold": 0,
+            }),
+            &NodeContext::empty(),
+        );
+        assert!(zero_threshold.is_error);
+        let text = zero_threshold.content[0].text();
+        assert!(text.contains("mcp_governance_invalid_parameter"));
+        assert!(text.contains("threshold"));
+    }
+
+    #[test]
+    fn execute_check_quorum_rejects_oversized_id() {
+        let oversized_id = "D".repeat(MAX_GOVERNANCE_MCP_ID_BYTES + 1);
+        let result = execute_check_quorum(
+            &json!({
+                "decision_id": oversized_id,
+                "threshold": 1,
+            }),
+            &NodeContext::empty(),
+        );
+        assert!(result.is_error);
+        let text = result.content[0].text();
+        assert!(text.contains("mcp_governance_input_too_large"));
+        assert!(text.contains("decision_id"));
     }
 
     // -- get_decision_status -----------------------------------------------
@@ -772,12 +804,24 @@ mod tests {
         assert!(!text.contains("Decision not found"));
     }
 
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_get_decision_status_empty_id() {
         let result =
             execute_get_decision_status(&json!({"decision_id": ""}), &NodeContext::empty());
         assert!(result.is_error);
+    }
+
+    #[test]
+    fn execute_get_decision_status_rejects_oversized_id() {
+        let oversized_id = "D".repeat(MAX_GOVERNANCE_MCP_ID_BYTES + 1);
+        let result = execute_get_decision_status(
+            &json!({"decision_id": oversized_id}),
+            &NodeContext::empty(),
+        );
+        assert!(result.is_error);
+        let text = result.content[0].text();
+        assert!(text.contains("mcp_governance_input_too_large"));
+        assert!(text.contains("decision_id"));
     }
 
     // -- propose_amendment -------------------------------------------------
@@ -807,7 +851,6 @@ mod tests {
         assert!(!text.contains(&synthetic_timestamp));
     }
 
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_propose_amendment_invalid_target() {
         let result = execute_propose_amendment(
@@ -822,7 +865,6 @@ mod tests {
         assert!(result.is_error);
     }
 
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_propose_amendment_invalid_target_does_not_echo_input() {
         let attacker_input = "invalid-target-forged-log-line";
@@ -842,7 +884,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_propose_amendment_rejects_oversized_title_and_description() {
         let oversized_title = "T".repeat(65_537);
@@ -870,7 +911,6 @@ mod tests {
         assert!(result.is_error);
     }
 
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     #[test]
     fn execute_propose_amendment_invalid_proposer() {
         let result = execute_propose_amendment(

--- a/crates/exo-node/src/mcp/tools/identity.rs
+++ b/crates/exo-node/src/mcp/tools/identity.rs
@@ -1,8 +1,7 @@
 //! Identity MCP tools — DID creation, resolution, risk assessment, signature
 //! verification, and agent passport retrieval.
 
-use exo_core::Did;
-use exo_core::crypto;
+use exo_core::{Did, crypto};
 use serde_json::{Value, json};
 
 use crate::mcp::{

--- a/crates/exo-node/src/mcp/tools/legal.rs
+++ b/crates/exo-node/src/mcp/tools/legal.rs
@@ -477,7 +477,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     fn execute_ediscovery_search_refuses_without_legal_runtime_even_with_simulation_feature() {
         let params = json!({
             "query": "contract breach",
@@ -489,7 +488,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     fn execute_ediscovery_search_with_scope() {
         let params = json!({
             "query": "merger",
@@ -504,7 +502,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     fn execute_ediscovery_search_missing_query() {
         let result = execute_ediscovery_search(
             &json!({"search_id": "search-003", "searched_at_ms": 1700000000002_u64}),
@@ -514,7 +511,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     fn execute_ediscovery_search_missing_metadata() {
         let result =
             execute_ediscovery_search(&json!({"query": "contract breach"}), &NodeContext::empty());
@@ -543,7 +539,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     fn execute_assert_privilege_refuses_without_legal_runtime_even_with_simulation_feature() {
         let params = json!({
             "evidence_id": "ev123",
@@ -557,7 +552,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     fn execute_assert_privilege_invalid_type() {
         let params = json!({
             "evidence_id": "ev123",
@@ -571,7 +565,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     fn execute_assert_privilege_invalid_did() {
         let params = json!({
             "evidence_id": "ev123",
@@ -608,7 +601,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     fn execute_initiate_safe_harbor_refuses_without_legal_runtime_even_with_simulation_feature() {
         let params = json!({
             "initiator_did": "did:exo:alice",
@@ -622,7 +614,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     fn execute_initiate_safe_harbor_invalid_initiator() {
         let params = json!({
             "initiator_did": "bad",
@@ -636,7 +627,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     fn execute_initiate_safe_harbor_invalid_party() {
         let params = json!({
             "initiator_did": "did:exo:alice",
@@ -650,7 +640,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     fn execute_initiate_safe_harbor_rejects_excessive_interested_parties() {
         let interested_parties: Vec<Value> = (0..=MAX_SAFE_HARBOR_INTERESTED_PARTIES)
             .map(|i| Value::String(format!("did:exo:party-{i}")))
@@ -697,7 +686,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     fn execute_check_fiduciary_duty_refuses_without_legal_runtime_even_with_simulation_feature() {
         let params = json!({
             "actor_did": "did:exo:director",
@@ -711,7 +699,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     fn execute_check_fiduciary_duty_invalid_actor() {
         let params = json!({
             "actor_did": "bad",
@@ -725,7 +712,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     fn execute_check_fiduciary_duty_missing_action() {
         let result = execute_check_fiduciary_duty(
             &json!({"actor_did": "did:exo:a", "beneficiary_did": "did:exo:b"}),
@@ -792,7 +778,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "unaudited-mcp-simulation-tools")]
     fn execute_initiate_safe_harbor_rejects_oversized_party_did_without_echoing_it() {
         let oversized = format!("did:exo:{}", "a".repeat(MAX_LEGAL_DID_BYTES + 1));
         let params = json!({

--- a/crates/exo-node/src/network.rs
+++ b/crates/exo-node/src/network.rs
@@ -538,8 +538,9 @@ impl NetworkHandle {
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
-    use super::*;
     use libp2p_core::multiaddr::Protocol;
+
+    use super::*;
 
     #[test]
     fn libp2p_peer_to_exo_deterministic() {

--- a/crates/exo-node/src/sync.rs
+++ b/crates/exo-node/src/sync.rs
@@ -23,6 +23,11 @@ use std::{
 };
 
 use exo_core::types::{Did, PublicKey};
+use exo_dag::{
+    append::verify_node_creator_signature,
+    dag::{DagNode, compute_node_hash},
+    error::{DagError, Result as DagResult},
+};
 use tokio::sync::mpsc;
 
 use crate::{
@@ -32,11 +37,6 @@ use crate::{
         DagSyncRequestMsg, DagSyncResponseMsg, StateSnapshotChunkMsg, StateSnapshotRequestMsg,
         WireMessage, topics,
     },
-};
-use exo_dag::{
-    append::verify_node_creator_signature,
-    dag::{DagNode, compute_node_hash},
-    error::{DagError, Result as DagResult},
 };
 
 const MAX_SNAPSHOT_CHUNK_SIZE: u32 = 500;

--- a/crates/exo-node/src/wire.rs
+++ b/crates/exo-node/src/wire.rs
@@ -647,10 +647,13 @@ mod tests {
 
     const EXPECTED_MAX_PEER_EXCHANGE_PEERS: usize = 256;
     const EXPECTED_MAX_PEER_ADDRESSES: usize = 16;
+    const EXPECTED_MAX_PEER_ADDRESS_BYTES: usize = 512;
     const EXPECTED_MAX_DAG_SYNC_TIP_HASHES: usize = 128;
+    const EXPECTED_MAX_DAG_NODES_PER_MESSAGE: usize = 500;
     const EXPECTED_MAX_DAG_NODE_PARENTS: usize = 1024;
     const EXPECTED_MAX_WIRE_GOVERNANCE_PAYLOAD_BYTES: usize = 64 * 1024;
     const EXPECTED_MAX_COMMIT_CERTIFICATE_VOTES: usize = 1024;
+    const EXPECTED_MAX_POST_QUANTUM_SIGNATURE_BYTES: usize = 3_309;
 
     fn test_did() -> Did {
         Did::new("did:exo:test-node").unwrap()
@@ -764,6 +767,66 @@ mod tests {
     }
 
     #[test]
+    fn roundtrip_consensus_proposal_preserves_node_and_hybrid_signature() {
+        let node_hash = test_hash(b"proposal-node");
+        let msg = WireMessage::ConsensusProposal(ConsensusProposalMsg {
+            proposal: Proposal {
+                proposer: test_did(),
+                round: 9,
+                node_hash,
+            },
+            node: test_node(vec![test_hash(b"parent-1"), test_hash(b"parent-2")]),
+            signature: Signature::Hybrid {
+                classical: [4u8; 64],
+                pq: vec![5u8; 96],
+            },
+        });
+
+        let bytes = encode(&msg).unwrap();
+        let decoded = decode(&bytes).unwrap();
+
+        match decoded {
+            WireMessage::ConsensusProposal(proposal) => {
+                assert_eq!(proposal.proposal.round, 9);
+                assert_eq!(proposal.proposal.node_hash, node_hash);
+                assert_eq!(proposal.node.parents.len(), 2);
+                match proposal.signature {
+                    Signature::Hybrid { classical, pq } => {
+                        assert_eq!(classical, [4u8; 64]);
+                        assert_eq!(pq, vec![5u8; 96]);
+                    }
+                    other => panic!("expected hybrid signature, got {other:?}"),
+                }
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn roundtrip_consensus_commit_preserves_certificate_votes() {
+        let node_hash = test_hash(b"committed-node");
+        let msg = WireMessage::ConsensusCommit(ConsensusCommitMsg {
+            certificate: CommitCertificate {
+                node_hash,
+                votes: vec![test_vote(1), test_vote(2), test_vote(3)],
+                round: 11,
+            },
+        });
+
+        let bytes = encode(&msg).unwrap();
+        let decoded = decode(&bytes).unwrap();
+
+        match decoded {
+            WireMessage::ConsensusCommit(commit) => {
+                assert_eq!(commit.certificate.node_hash, node_hash);
+                assert_eq!(commit.certificate.votes.len(), 3);
+                assert_eq!(commit.certificate.round, 11);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
     fn roundtrip_state_snapshot_request() {
         let msg = WireMessage::StateSnapshotRequest(StateSnapshotRequestMsg {
             sender: test_did(),
@@ -776,6 +839,35 @@ mod tests {
             WireMessage::StateSnapshotRequest(req) => {
                 assert_eq!(req.from_height, 42);
                 assert_eq!(req.chunk_size, 50);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn roundtrip_state_snapshot_chunk_preserves_post_quantum_node_signature() {
+        let mut node = test_node(vec![]);
+        node.signature = Signature::PostQuantum(vec![7u8; 128]);
+        let msg = WireMessage::StateSnapshotChunk(StateSnapshotChunkMsg {
+            sender: test_did(),
+            from_height: 12,
+            nodes: vec![node],
+            to_height: 12,
+            has_more: true,
+        });
+
+        let bytes = encode(&msg).unwrap();
+        let decoded = decode(&bytes).unwrap();
+
+        match decoded {
+            WireMessage::StateSnapshotChunk(chunk) => {
+                assert_eq!(chunk.from_height, 12);
+                assert_eq!(chunk.to_height, 12);
+                assert!(chunk.has_more);
+                match &chunk.nodes[0].signature {
+                    Signature::PostQuantum(pq) => assert_eq!(pq, &vec![7u8; 128]),
+                    other => panic!("expected post-quantum signature, got {other:?}"),
+                }
             }
             _ => panic!("wrong variant"),
         }
@@ -865,6 +957,25 @@ mod tests {
     }
 
     #[test]
+    fn decode_rejects_peer_address_over_byte_limit() {
+        let oversized_address = "a".repeat(EXPECTED_MAX_PEER_ADDRESS_BYTES + 1);
+        let msg = WireMessage::PeerExchange(PeerExchangeMsg {
+            sender: test_did(),
+            peers: vec![WirePeerInfo {
+                did: test_did(),
+                addresses: vec![oversized_address],
+                public_key_hash: test_hash(b"peer-key"),
+                last_seen: Timestamp::new(1_000, 0),
+            }],
+        });
+        let bytes = encode(&msg).unwrap();
+
+        let err = decode(&bytes).expect_err("peer with oversized address must fail");
+
+        assert!(err.contains("peer address"));
+    }
+
+    #[test]
     fn decode_rejects_dag_sync_request_with_too_many_tip_hashes() {
         let tip_hashes = (0..=EXPECTED_MAX_DAG_SYNC_TIP_HASHES)
             .map(|idx| test_hash(format!("tip-{idx}").as_bytes()))
@@ -879,6 +990,27 @@ mod tests {
         let err = decode(&bytes).expect_err("oversized tip hash request must fail");
 
         assert!(err.contains("DAG sync tip hashes"));
+    }
+
+    #[test]
+    fn decode_rejects_dag_sync_response_with_too_many_nodes() {
+        let nodes = (0..=EXPECTED_MAX_DAG_NODES_PER_MESSAGE)
+            .map(|idx| {
+                let mut node = test_node(vec![]);
+                node.hash = test_hash(format!("node-{idx}").as_bytes());
+                node
+            })
+            .collect();
+        let msg = WireMessage::DagSyncResponse(DagSyncResponseMsg {
+            sender: test_did(),
+            nodes,
+            has_more: false,
+        });
+        let bytes = encode(&msg).unwrap();
+
+        let err = decode(&bytes).expect_err("DAG sync response with too many nodes must fail");
+
+        assert!(err.contains("DAG nodes"));
     }
 
     #[test]
@@ -931,5 +1063,45 @@ mod tests {
         let err = decode(&bytes).expect_err("oversized commit certificate must fail");
 
         assert!(err.contains("commit certificate votes"));
+    }
+
+    #[test]
+    fn deserialize_rejects_short_ed25519_signature_from_untrusted_envelope() {
+        let msg = WireMessage::GovernanceEvent(GovernanceEventMsg {
+            sender: test_did(),
+            event_type: GovernanceEventType::AuditEntry,
+            payload: b"audit".to_vec(),
+            timestamp: Timestamp::new(1000, 1),
+            signature: Signature::from_bytes([3u8; 64]),
+        });
+        let mut value = serde_json::to_value(&msg).unwrap();
+        value["GovernanceEvent"]["signature"] = serde_json::json!({ "Ed25519": [1, 2, 3] });
+
+        let err = serde_json::from_value::<WireMessage>(value)
+            .expect_err("short Ed25519 signatures must fail during deserialization");
+
+        assert!(err.to_string().contains("64 bytes"));
+    }
+
+    #[test]
+    fn deserialize_rejects_oversized_post_quantum_signature_from_untrusted_envelope() {
+        let mut node = test_node(vec![]);
+        node.signature = Signature::PostQuantum(vec![7u8; 128]);
+        let msg = WireMessage::StateSnapshotChunk(StateSnapshotChunkMsg {
+            sender: test_did(),
+            from_height: 12,
+            nodes: vec![node],
+            to_height: 12,
+            has_more: false,
+        });
+        let mut value = serde_json::to_value(&msg).unwrap();
+        value["StateSnapshotChunk"]["nodes"][0]["signature"] = serde_json::json!({
+            "PostQuantum": vec![9u8; EXPECTED_MAX_POST_QUANTUM_SIGNATURE_BYTES + 1],
+        });
+
+        let err = serde_json::from_value::<WireMessage>(value)
+            .expect_err("oversized post-quantum signatures must fail during deserialization");
+
+        assert!(err.to_string().contains("post-quantum signature bytes"));
     }
 }

--- a/crates/exo-node/src/zerodentity/types.rs
+++ b/crates/exo-node/src/zerodentity/types.rs
@@ -678,9 +678,8 @@ impl std::str::FromStr for OtpState {
 mod tests {
     use std::str::FromStr;
 
-    use crate::zerodentity::OTP_MAX_ATTEMPTS;
-
     use super::*;
+    use crate::zerodentity::OTP_MAX_ATTEMPTS;
 
     // ---- AttestationType ----
 

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -1,13 +1,14 @@
 /**
  * Bridge Verification Test — WASM binding smoke-test harness
  *
- * Calls the covered exported wasm_ bridge functions with valid minimal inputs
- * and verifies each returns without throwing.
+ * Calls the covered exported wasm_ bridge functions with valid minimal inputs,
+ * and verifies intentionally disabled raw-secret entry points fail closed.
  *
  * Run:  node packages/exochain-wasm/test/bridge_verification.mjs
  */
 
 import { createRequire } from 'node:module';
+import { createPrivateKey, createPublicKey, generateKeyPairSync, sign as nodeSign } from 'node:crypto';
 const require = createRequire(import.meta.url);
 const wasm = require('../wasm/exochain_wasm.js');
 
@@ -43,6 +44,51 @@ function setup(fn) {
   try { return fn(); } catch { return undefined; }
 }
 
+function expectErrorContains(label, fn, expected) {
+  try {
+    fn();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!msg.includes(expected)) {
+      throw new Error(`${label} returned unexpected error: ${msg}`);
+    }
+    return true;
+  }
+  throw new Error(`${label} must fail closed`);
+}
+
+function signatureJsonFromHex(signatureHex) {
+  return { Ed25519: Array.from(Buffer.from(signatureHex, 'hex')) };
+}
+
+function publicKeyHexFromPublicKey(publicKey) {
+  const der = publicKey.export({ type: 'spki', format: 'der' });
+  return Buffer.from(der).subarray(-32).toString('hex');
+}
+
+function signerFromPrivateKey(privateKey) {
+  const publicKey = createPublicKey(privateKey);
+  return {
+    publicKeyHex: publicKeyHexFromPublicKey(publicKey),
+    signHex: (message) => nodeSign(null, Buffer.from(message), privateKey).toString('hex')
+  };
+}
+
+function randomEd25519Signer() {
+  const { privateKey } = generateKeyPairSync('ed25519');
+  return signerFromPrivateKey(privateKey);
+}
+
+function seededEd25519Signer(secretHex) {
+  const pkcs8SeedPrefix = Buffer.from('302e020100300506032b657004220420', 'hex');
+  const privateKey = createPrivateKey({
+    key: Buffer.concat([pkcs8SeedPrefix, Buffer.from(secretHex, 'hex')]),
+    format: 'der',
+    type: 'pkcs8'
+  });
+  return signerFromPrivateKey(privateKey);
+}
+
 // Convenience constants
 const ZERO_32_HEX   = '0'.repeat(64);
 const NONZERO_32_HEX = '11'.repeat(32);
@@ -65,19 +111,9 @@ const UUID_4 = '00000000-0000-0000-0000-000000000004';
 
 // Pre-compute a valid Ed25519 keypair result for reuse
 const ephResult = wasm.wasm_sign_with_ephemeral_key(TEXT_BYTES);
-
-function publicKeyForSecret(secretHex) {
-  return wasm.wasm_ed25519_public_from_secret(secretHex);
-}
-
-function signatureHexFromJson(signatureJson) {
-  const signature = typeof signatureJson === 'string' ? JSON.parse(signatureJson) : signatureJson;
-  const bytes = signature.Ed25519;
-  if (!Array.isArray(bytes) || bytes.length !== 64) {
-    throw new Error('expected Ed25519 signature bytes');
-  }
-  return Buffer.from(bytes).toString('hex');
-}
+const signer1 = seededEd25519Signer(DUMMY_SECRET_HEX);
+const signer2 = seededEd25519Signer(DUMMY_SECRET_HEX_2);
+const signer3 = seededEd25519Signer(DUMMY_SECRET_HEX_3);
 
 function hashBytes(hashValue) {
   if (Array.isArray(hashValue)) return hashValue;
@@ -145,11 +181,19 @@ test('wasm_verify_merkle_proof', () =>
 test('wasm_verify', () =>
   wasm.wasm_verify(TEXT_BYTES, JSON.stringify(ephResult.signature), ephResult.public_key));
 
-test('wasm_sign', () =>
-  wasm.wasm_sign(TEXT_BYTES, DUMMY_SECRET_HEX));
+test('wasm_sign rejects raw secret-key signing', () =>
+  expectErrorContains(
+    'wasm_sign',
+    () => wasm.wasm_sign(TEXT_BYTES, DUMMY_SECRET_HEX),
+    'raw secret-key signing is disabled'
+  ));
 
-test('wasm_ed25519_public_from_secret', () =>
-  wasm.wasm_ed25519_public_from_secret(DUMMY_SECRET_HEX));
+test('wasm_ed25519_public_from_secret rejects raw secret-key derivation', () =>
+  expectErrorContains(
+    'wasm_ed25519_public_from_secret',
+    () => wasm.wasm_ed25519_public_from_secret(DUMMY_SECRET_HEX),
+    'raw secret-key public derivation is disabled'
+  ));
 
 const EVENT_SEED = new TextEncoder().encode('event-seed-1');
 const EVENT_ID = wasm.wasm_compute_event_id(EVENT_SEED);
@@ -168,23 +212,62 @@ test('wasm_compute_event_id', () => {
 
 console.log('\n--- Events ---');
 
-test('wasm_create_signed_event', () =>
-  wasm.wasm_create_signed_event(
+test('wasm_create_signed_event rejects raw secret-key event signing', () =>
+  expectErrorContains(
+    'wasm_create_signed_event',
+    () => wasm.wasm_create_signed_event(
+      JSON.stringify('AuditEntry'),
+      TEXT_BYTES,
+      TEST_DID,
+      DUMMY_SECRET_HEX,
+      EVENT_ID,
+      NOW_MS,
+      7
+    ),
+    'raw secret-key event signing is disabled'
+  ));
+
+const eventSigningPayloadHex = setup(() =>
+  wasm.wasm_event_signing_payload(
     JSON.stringify('AuditEntry'),
     TEXT_BYTES,
     TEST_DID,
-    DUMMY_SECRET_HEX,
     EVENT_ID,
     NOW_MS,
     7
   ));
+const eventSignatureJson = eventSigningPayloadHex
+  ? signatureJsonFromHex(signer1.signHex(Buffer.from(eventSigningPayloadHex, 'hex')))
+  : null;
 
-const signedEvent = setup(() =>
-  wasm.wasm_create_signed_event(
+test('wasm_event_signing_payload', () => {
+  if (!eventSigningPayloadHex || eventSigningPayloadHex.length === 0) {
+    throw new Error('event signing payload must be non-empty');
+  }
+  return eventSigningPayloadHex;
+});
+
+test('wasm_create_event_with_signature', () => {
+  if (!eventSignatureJson) throw new Error('skipped -- no event signature');
+  return wasm.wasm_create_event_with_signature(
     JSON.stringify('AuditEntry'),
     TEXT_BYTES,
     TEST_DID,
-    DUMMY_SECRET_HEX,
+    JSON.stringify(eventSignatureJson),
+    signer1.publicKeyHex,
+    EVENT_ID,
+    NOW_MS,
+    7
+  );
+});
+
+const signedEvent = setup(() =>
+  eventSignatureJson && wasm.wasm_create_event_with_signature(
+    JSON.stringify('AuditEntry'),
+    TEXT_BYTES,
+    TEST_DID,
+    JSON.stringify(eventSignatureJson),
+    signer1.publicKeyHex,
     EVENT_ID,
     NOW_MS,
     7
@@ -198,8 +281,7 @@ test('wasm_verify_event', () => {
   if (BigInt(signedEvent.timestamp?.physical_ms) !== NOW_MS || signedEvent.timestamp?.logical !== 7) {
     throw new Error('signed event did not preserve caller-supplied HLC timestamp');
   }
-  const pubKey = publicKeyForSecret(DUMMY_SECRET_HEX);
-  return wasm.wasm_verify_event(JSON.stringify(signedEvent), pubKey);
+  return wasm.wasm_verify_event(JSON.stringify(signedEvent), signer1.publicKeyHex);
 });
 
 // =========================================================================
@@ -210,51 +292,48 @@ console.log('\n--- Messaging / Death Verification ---');
 
 test('wasm_generate_x25519_keypair', () => {
   const keypair = wasm.wasm_generate_x25519_keypair();
-  if (keypair.public_key_hex.length !== 64 || keypair.secret_key_hex.length !== 64) {
-    throw new Error('X25519 keypair must return 32-byte public and secret keys');
+  if (keypair.public_key_hex.length !== 64 || keypair.secret_key_hex !== undefined) {
+    throw new Error('X25519 keypair must return only the 32-byte public key');
   }
   return keypair;
 });
 
 const recipientKex = setup(() => wasm.wasm_generate_x25519_keypair());
 
-test('wasm_x25519_public_from_secret', () => {
-  if (!recipientKex) throw new Error('skipped -- no recipient X25519 keypair');
-  const derived = wasm.wasm_x25519_public_from_secret(recipientKex.secret_key_hex);
-  if (derived.public_key_hex !== recipientKex.public_key_hex) {
-    throw new Error('derived X25519 public key must match generated keypair');
-  }
-  return derived;
-});
+test('wasm_x25519_public_from_secret rejects raw X25519 secret derivation', () =>
+  expectErrorContains(
+    'wasm_x25519_public_from_secret',
+    () => wasm.wasm_x25519_public_from_secret(DUMMY_SECRET_HEX),
+    'raw X25519 secret public derivation is disabled'
+  ));
 
-test('wasm_encrypt_message', () => {
+test('wasm_encrypt_message rejects raw sender signing', () => {
   if (!recipientKex) throw new Error('skipped -- no recipient X25519 keypair');
-  const envelope = wasm.wasm_encrypt_message(
-    'bridge encrypted message',
-    JSON.stringify('Text'),
-    TEST_DID,
-    TEST_DID_2,
-    DUMMY_SECRET_HEX,
-    recipientKex.public_key_hex,
-    '018f7a96-8ad0-7c4f-8e0f-111111111201',
-    7000n,
-    0,
-    false,
-    0
+  return expectErrorContains(
+    'wasm_encrypt_message',
+    () => wasm.wasm_encrypt_message(
+      'bridge encrypted message',
+      JSON.stringify('Text'),
+      TEST_DID,
+      TEST_DID_2,
+      DUMMY_SECRET_HEX,
+      recipientKex.public_key_hex,
+      '018f7a96-8ad0-7c4f-8e0f-111111111201',
+      7000n,
+      0,
+      false,
+      0
+    ),
+    'raw Ed25519 sender signing is disabled'
   );
-  if (envelope.sender_did !== TEST_DID || envelope.recipient_did !== TEST_DID_2) {
-    throw new Error('encrypted envelope must retain sender and recipient DIDs');
-  }
-  return envelope;
 });
 
-const encryptedEnvelope = setup(() =>
-  recipientKex && wasm.wasm_encrypt_message(
+const preparedEnvelope = setup(() =>
+  recipientKex && wasm.wasm_prepare_encrypted_message(
     'bridge encrypted message',
     JSON.stringify('Text'),
     TEST_DID,
     TEST_DID_2,
-    DUMMY_SECRET_HEX,
     recipientKex.public_key_hex,
     '018f7a96-8ad0-7c4f-8e0f-111111111202',
     7001n,
@@ -262,37 +341,68 @@ const encryptedEnvelope = setup(() =>
     false,
     0
   ));
-const encryptedSenderPublicKey = setup(() => publicKeyForSecret(DUMMY_SECRET_HEX));
+const encryptedEnvelopeSignatureHex = preparedEnvelope
+  ? signer1.signHex(Buffer.from(preparedEnvelope.signing_payload_hex, 'hex'))
+  : null;
+
+test('wasm_prepare_encrypted_message', () => {
+  if (!preparedEnvelope) throw new Error('skipped -- no prepared envelope');
+  if (preparedEnvelope.envelope.sender_did !== TEST_DID || preparedEnvelope.envelope.recipient_did !== TEST_DID_2) {
+    throw new Error('prepared envelope must retain sender and recipient DIDs');
+  }
+  if (!preparedEnvelope.signing_payload_hex) {
+    throw new Error('prepared envelope must expose signing payload');
+  }
+  return preparedEnvelope;
+});
+
+test('wasm_attach_message_signature', () => {
+  if (!preparedEnvelope || !encryptedEnvelopeSignatureHex) {
+    throw new Error('skipped -- no prepared envelope signature');
+  }
+  return wasm.wasm_attach_message_signature(
+    JSON.stringify(preparedEnvelope.envelope),
+    signer1.publicKeyHex,
+    encryptedEnvelopeSignatureHex
+  );
+});
+
+const encryptedEnvelope = setup(() =>
+  preparedEnvelope && encryptedEnvelopeSignatureHex && wasm.wasm_attach_message_signature(
+    JSON.stringify(preparedEnvelope.envelope),
+    signer1.publicKeyHex,
+    encryptedEnvelopeSignatureHex
+  ));
 
 test('wasm_verify_message_signature', () => {
-  if (!encryptedEnvelope || !encryptedSenderPublicKey) {
+  if (!encryptedEnvelope) {
     throw new Error('skipped -- no encrypted envelope');
   }
   const ok = wasm.wasm_verify_message_signature(
     JSON.stringify(encryptedEnvelope),
-    encryptedSenderPublicKey
+    signer1.publicKeyHex
   );
   if (!ok) throw new Error('message signature must verify with sender public key');
   return ok;
 });
 
 test('wasm_decrypt_message', () => {
-  if (!encryptedEnvelope || !recipientKex || !encryptedSenderPublicKey) {
+  if (!encryptedEnvelope) {
     throw new Error('skipped -- no encrypted envelope');
   }
-  const decrypted = wasm.wasm_decrypt_message(
-    JSON.stringify(encryptedEnvelope),
-    recipientKex.secret_key_hex,
-    encryptedSenderPublicKey
+  return expectErrorContains(
+    'wasm_decrypt_message',
+    () => wasm.wasm_decrypt_message(
+      JSON.stringify(encryptedEnvelope),
+      NONZERO_32_HEX,
+      signer1.publicKeyHex
+    ),
+    'decryption failed'
   );
-  if (decrypted.plaintext !== 'bridge encrypted message') {
-    throw new Error('decrypted plaintext mismatch');
-  }
-  return decrypted;
 });
 
-const initiatorPublicKey = setup(() => publicKeyForSecret(DUMMY_SECRET_HEX_2));
-const trusteePublicKey = setup(() => publicKeyForSecret(DUMMY_SECRET_HEX_3));
+const initiatorPublicKey = signer2.publicKeyHex;
+const trusteePublicKey = signer3.publicKeyHex;
 const deathTrusteesJson = setup(() => {
   if (!initiatorPublicKey || !trusteePublicKey) {
     throw new Error('missing death-verification public keys');
@@ -324,7 +434,7 @@ const deathInitialPayload = setup(() =>
     deathClaimNonceHex
   ));
 const deathInitialSignatureHex = setup(() =>
-  deathInitialPayload && signatureHexFromJson(wasm.wasm_sign(deathInitialPayload, DUMMY_SECRET_HEX_2)));
+  deathInitialPayload && signer2.signHex(deathInitialPayload));
 
 test('wasm_death_verification_new', () => {
   if (!deathTrusteesJson || !deathInitialSignatureHex) {
@@ -375,9 +485,7 @@ const deathConfirmationPayload = setup(() =>
     TEST_DID_3
   ));
 const deathConfirmationSignatureHex = setup(() =>
-  deathConfirmationPayload && signatureHexFromJson(
-    wasm.wasm_sign(deathConfirmationPayload, DUMMY_SECRET_HEX_3)
-  ));
+  deathConfirmationPayload && signer3.signHex(deathConfirmationPayload));
 
 test('wasm_death_verification_confirm', () => {
   if (!deathState || !trusteePublicKey || !deathConfirmationSignatureHex) {
@@ -793,6 +901,22 @@ const ventureCommander = {
   commandbase_profile: null
 };
 
+function catapultAgent(slot, did, displayName, offsetMs) {
+  return {
+    did,
+    slot,
+    display_name: displayName,
+    capabilities: ['command', 'operations'],
+    status: 'Active',
+    last_heartbeat: { physical_ms: NOW_NUM + offsetMs, logical: 0 },
+    budget_spent_cents: 0,
+    budget_limit_cents: 1000000,
+    hired_at: { physical_ms: NOW_NUM + offsetMs, logical: 0 },
+    hired_by: TEST_DID,
+    commandbase_profile: null
+  };
+}
+
 test('wasm_hire_agent', () => {
   if (!catapultNewco) throw new Error('skipped -- no Catapult newco from setup');
   const hired = wasm.wasm_hire_agent(
@@ -832,13 +956,24 @@ test('wasm_roster_status', () => {
 
 test('wasm_oda_authority_chain', () => {
   if (!catapultNewco) throw new Error('skipped -- no Catapult newco from setup');
-  const hired = wasm.wasm_hire_agent(
+  const withCommander = wasm.wasm_hire_agent(
     JSON.stringify(catapultNewco),
     JSON.stringify(ventureCommander)
   );
-  const chain = wasm.wasm_oda_authority_chain(JSON.stringify(hired));
+  const withDeputy = wasm.wasm_hire_agent(
+    JSON.stringify(withCommander),
+    JSON.stringify(catapultAgent('OperationsDeputy', 'did:exo:operations-deputy', 'Bridge Operations Deputy', 55))
+  );
+  const completePaceRoster = wasm.wasm_hire_agent(
+    JSON.stringify(withDeputy),
+    JSON.stringify(catapultAgent('ProcessArchitect', 'did:exo:process-architect', 'Bridge Process Architect', 60))
+  );
+  const chain = wasm.wasm_oda_authority_chain(JSON.stringify(completePaceRoster));
   if (chain.primary !== TEST_DID_3) {
     throw new Error('PACE primary authority should be the VentureCommander in bridge fixture');
+  }
+  if (chain.alternates[0] !== 'did:exo:operations-deputy' || chain.contingency[0] !== 'did:exo:process-architect') {
+    throw new Error('PACE authority chain must include staffed alternate and contingency slots');
   }
   return chain;
 });
@@ -1045,7 +1180,6 @@ test('wasm_verify_franchise_receipt_chain', () => {
 console.log('\n--- Risk Assessment ---');
 
 test('wasm_assess_risk and wasm_verify_risk_attestation use caller signer and caller HLC', () => {
-  const attesterPublicKey = publicKeyForSecret(DUMMY_SECRET_HEX);
   const attestation = wasm.wasm_assess_risk(
     TEST_DID,
     TEST_DID_2,
@@ -1058,7 +1192,7 @@ test('wasm_assess_risk and wasm_verify_risk_attestation use caller signer and ca
       now_logical: 0
     })
   );
-  if (!wasm.wasm_verify_risk_attestation(JSON.stringify(attestation), attesterPublicKey)) {
+  if (!wasm.wasm_verify_risk_attestation(JSON.stringify(attestation), signer1.publicKeyHex)) {
     throw new Error('risk attestation must verify against caller-supplied attester key');
   }
   if (attestation.timestamp.physical_ms !== NOW_NUM || attestation.timestamp.logical !== 0) {
@@ -1301,13 +1435,19 @@ test('wasm_audit_verify', () => {
 test('wasm_check_clearance', () => {
   // Clearance levels: None, ReadOnly, Contributor, Reviewer, Steward, Governor
   const policy = {
-    default_level: 'ReadOnly',
     actions: {
-      read: { required_level: 'ReadOnly' },
-      write: { required_level: 'Contributor' }
-    }
+      read: { required_level: 'ReadOnly', quorum_policy: null, independence_required: false },
+      write: { required_level: 'Contributor', quorum_policy: null, independence_required: false }
+    },
+    policy_hash: ZERO_32_BYTES
   };
-  return wasm.wasm_check_clearance(TEST_DID, 'read', JSON.stringify(policy));
+  const registry = [{ did: TEST_DID, level: 'ReadOnly' }];
+  return wasm.wasm_check_clearance(
+    TEST_DID,
+    'read',
+    JSON.stringify(policy),
+    JSON.stringify(registry)
+  );
 });
 
 // =========================================================================
@@ -1356,7 +1496,8 @@ test('wasm_close_deliberation', () => {
   };
   return wasm.wasm_close_deliberation(
     JSON.stringify(deliberation),
-    JSON.stringify(quorumPolicy)
+    JSON.stringify(quorumPolicy),
+    JSON.stringify([])
   );
 });
 
@@ -1419,7 +1560,8 @@ test('wasm_compute_quorum', () => {
   };
   return wasm.wasm_compute_quorum(
     JSON.stringify(approvals),
-    JSON.stringify(policy)
+    JSON.stringify(policy),
+    JSON.stringify([])
   );
 });
 
@@ -1755,6 +1897,7 @@ test('wasm_ratify_constitution', () => {
     JSON.stringify(corpus),
     JSON.stringify(sigs),
     JSON.stringify(quorum),
+    JSON.stringify([]),
     NOW_MS
   );
 });
@@ -1762,14 +1905,15 @@ test('wasm_ratify_constitution', () => {
 test('wasm_amend_constitution', () => {
   const corpus = { version: 1, hash: ZERO_32_BYTES, articles: [], ratified_at: NOW_TS, amendment_count: 0 };
   const amendment = { id: 'art-1', title: 'Test', tier: 'Articles', text_hash: ZERO_32_BYTES, status: 'Active' };
-  // amend requires at least one non-empty signature — 64 bytes = 128 hex chars
-  // All-zero is treated as empty, so set one byte to 01
-  const dummySig64Hex = '01' + '00'.repeat(63);
-  const sigs = [[TEST_DID, dummySig64Hex]];
+  const sigs = [];
+  const quorum = { required_signatures: 0, required_fraction_pct: 0 };
   return wasm.wasm_amend_constitution(
     JSON.stringify(corpus),
     JSON.stringify(amendment),
-    JSON.stringify(sigs)
+    JSON.stringify(sigs),
+    JSON.stringify(quorum),
+    JSON.stringify([]),
+    NOW_MS
   );
 });
 


### PR DESCRIPTION
## Summary
- validate configured TLS certificate and key paths during gateway startup validation
- route tls_config startup through Rustls HTTPS serving instead of the plaintext TcpListener path
- install the Rustls ring provider explicitly and keep aws-lc-rs out of the gateway dependency graph
- add regression guards for TLS validation, Rustls serving, and provider-before-PEM ordering

## Verification
- cargo test -p exo-gateway tls -- --nocapture
- cargo test -p exo-gateway
- cargo clippy -p exo-gateway --all-targets -- -D warnings
- cargo fmt --all -- --check
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo build --workspace --release
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
- cargo audit
- cargo deny check
- git diff --check
- cargo tree -p exo-gateway -i aws-lc-rs (expected absence: package ID did not match any packages)
