### PR TITLE
fix: domain separate merkle nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 146236 | `wc -l` |
-| Workspace tests | 3,610 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 146281 | `wc -l` |
+| Workspace tests | 3,611 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,610 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,611 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 146236 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 146281 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,610 listed workspace tests
+         cryptographic proofs, 3,611 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          145 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-core/src/hash.rs
+++ b/crates/exo-core/src/hash.rs
@@ -12,6 +12,9 @@ use crate::{
     types::Hash256,
 };
 
+const MERKLE_LEAF_DOMAIN: u8 = 0x00;
+const MERKLE_PARENT_DOMAIN: u8 = 0x01;
+
 /// Compute the blake3 hash of raw bytes.
 #[must_use]
 pub fn canonical_hash(data: &[u8]) -> Hash256 {
@@ -32,7 +35,7 @@ pub fn hash_structured<T: Serialize>(value: &T) -> Result<Hash256> {
 /// Compute a deterministic Merkle root from a slice of leaf hashes.
 ///
 /// - Empty input returns `Hash256::ZERO`.
-/// - Single leaf returns the leaf itself.
+/// - Single leaf returns `H(0x00 || leaf)`.
 /// - Otherwise, leaves are paired left-to-right; an odd leaf is promoted
 ///   (duplicated) to fill the pair.  This process repeats until one root
 ///   remains.
@@ -41,11 +44,8 @@ pub fn merkle_root(leaves: &[Hash256]) -> Hash256 {
     if leaves.is_empty() {
         return Hash256::ZERO;
     }
-    if leaves.len() == 1 {
-        return leaves[0];
-    }
 
-    let mut current: Vec<Hash256> = leaves.to_vec();
+    let mut current: Vec<Hash256> = leaves.iter().map(hash_leaf).collect();
     while current.len() > 1 {
         let mut next = Vec::with_capacity(current.len().div_ceil(2));
         let mut i = 0;
@@ -67,8 +67,8 @@ pub fn merkle_root(leaves: &[Hash256]) -> Hash256 {
 
 /// Generate a Merkle proof for the leaf at `index`.
 ///
-/// Returns the sibling hashes needed to reconstruct the root, along with
-/// the directions (false = left sibling, true = right sibling path element).
+/// Returns the sibling node hashes needed to reconstruct the root. Leaf
+/// siblings are returned in their domain-separated `H(0x00 || leaf)` form.
 ///
 /// # Errors
 ///
@@ -82,7 +82,7 @@ pub fn merkle_proof(leaves: &[Hash256], index: usize) -> Result<Vec<Hash256>> {
     }
 
     let mut proof = Vec::new();
-    let mut current: Vec<Hash256> = leaves.to_vec();
+    let mut current: Vec<Hash256> = leaves.iter().map(hash_leaf).collect();
     let mut idx = index;
 
     while current.len() > 1 {
@@ -110,9 +110,10 @@ pub fn merkle_proof(leaves: &[Hash256], index: usize) -> Result<Vec<Hash256>> {
 
 /// Verify a Merkle proof.
 ///
-/// Given the expected `root`, a `leaf` hash, the `proof` (sibling hashes),
-/// and the `index` of the leaf in the original tree, returns `true` if the
-/// proof is valid.
+/// Given the expected `root`, a raw `leaf` hash as supplied to
+/// [`merkle_root`], the `proof` (domain-separated sibling node hashes),
+/// and the `index` of the leaf in the original tree, returns `true` if
+/// the proof is valid.
 #[must_use]
 pub fn verify_merkle_proof(
     root: &Hash256,
@@ -127,7 +128,7 @@ pub fn verify_merkle_proof(
 /// Reconstruct the Merkle root implied by a leaf, proof path, and leaf index.
 #[must_use]
 pub fn merkle_root_from_proof(leaf: &Hash256, proof: &[Hash256], index: usize) -> Hash256 {
-    let mut current = *leaf;
+    let mut current = hash_leaf(leaf);
     let mut idx = index;
 
     for sibling in proof {
@@ -152,12 +153,22 @@ pub fn hash256_eq_constant_time(left: &Hash256, right: &Hash256) -> bool {
     diff == 0
 }
 
-/// Hash two nodes together: `H(left || right)`.
+/// Hash a leaf into the Merkle leaf domain: `H(0x00 || leaf)`.
+#[must_use]
+fn hash_leaf(leaf: &Hash256) -> Hash256 {
+    let mut combined = [0u8; 33];
+    combined[0] = MERKLE_LEAF_DOMAIN;
+    combined[1..].copy_from_slice(leaf.as_bytes());
+    canonical_hash(&combined)
+}
+
+/// Hash two nodes together in the Merkle parent domain: `H(0x01 || left || right)`.
 #[must_use]
 fn hash_pair(left: &Hash256, right: &Hash256) -> Hash256 {
-    let mut combined = [0u8; 64];
-    combined[..32].copy_from_slice(left.as_bytes());
-    combined[32..].copy_from_slice(right.as_bytes());
+    let mut combined = [0u8; 65];
+    combined[0] = MERKLE_PARENT_DOMAIN;
+    combined[1..33].copy_from_slice(left.as_bytes());
+    combined[33..].copy_from_slice(right.as_bytes());
     canonical_hash(&combined)
 }
 
@@ -214,7 +225,32 @@ mod tests {
     #[test]
     fn merkle_root_single() {
         let leaf = Hash256::digest(b"only");
-        assert_eq!(merkle_root(&[leaf]), leaf);
+        assert_eq!(merkle_root(&[leaf]), hash_leaf(&leaf));
+    }
+
+    fn raw_concat_pair_hash_for_test(left: &Hash256, right: &Hash256) -> Hash256 {
+        let mut combined = [0u8; 64];
+        combined[..32].copy_from_slice(left.as_bytes());
+        combined[32..].copy_from_slice(right.as_bytes());
+        canonical_hash(&combined)
+    }
+
+    #[test]
+    fn merkle_root_uses_distinct_leaf_and_parent_domains() {
+        let leaf = Hash256::digest(b"domain-separated-leaf");
+        assert_ne!(
+            merkle_root(&[leaf]),
+            leaf,
+            "single-leaf Merkle roots must not be interchangeable with raw leaf hashes"
+        );
+
+        let right = Hash256::digest(b"domain-separated-right");
+        let raw_parent_hash = raw_concat_pair_hash_for_test(&leaf, &right);
+        assert_ne!(
+            merkle_root(&[leaf, right]),
+            raw_parent_hash,
+            "interior Merkle nodes must not use the raw H(left || right) domain"
+        );
     }
 
     #[test]
@@ -222,8 +258,8 @@ mod tests {
         let a = Hash256::digest(b"a");
         let b = Hash256::digest(b"b");
         let root = merkle_root(&[a, b]);
-        // Should be hash_pair(a, b)
-        let expected = hash_pair(&a, &b);
+        // Should be hash_pair(hash_leaf(a), hash_leaf(b)).
+        let expected = hash_pair(&hash_leaf(&a), &hash_leaf(&b));
         assert_eq!(root, expected);
     }
 
@@ -233,10 +269,13 @@ mod tests {
         let b = Hash256::digest(b"b");
         let c = Hash256::digest(b"c");
         let root = merkle_root(&[a, b, c]);
-        // Level 1: hash_pair(a,b), hash_pair(c,c)
-        // Level 0: hash_pair(hash_pair(a,b), hash_pair(c,c))
-        let ab = hash_pair(&a, &b);
-        let cc = hash_pair(&c, &c);
+        // Level 1: hash_pair(hash_leaf(a), hash_leaf(b)), hash_pair(hash_leaf(c), hash_leaf(c))
+        // Level 0: hash_pair(level_1_left, level_1_right)
+        let a_leaf = hash_leaf(&a);
+        let b_leaf = hash_leaf(&b);
+        let c_leaf = hash_leaf(&c);
+        let ab = hash_pair(&a_leaf, &b_leaf);
+        let cc = hash_pair(&c_leaf, &c_leaf);
         let expected = hash_pair(&ab, &cc);
         assert_eq!(root, expected);
     }
@@ -245,8 +284,9 @@ mod tests {
     fn merkle_root_four_leaves() {
         let leaves: Vec<Hash256> = (0..4u8).map(|i| Hash256::digest(&[i])).collect();
         let root = merkle_root(&leaves);
-        let ab = hash_pair(&leaves[0], &leaves[1]);
-        let cd = hash_pair(&leaves[2], &leaves[3]);
+        let leaf_nodes: Vec<Hash256> = leaves.iter().map(hash_leaf).collect();
+        let ab = hash_pair(&leaf_nodes[0], &leaf_nodes[1]);
+        let cd = hash_pair(&leaf_nodes[2], &leaf_nodes[3]);
         let expected = hash_pair(&ab, &cd);
         assert_eq!(root, expected);
     }

--- a/crates/exo-core/tests/chain_of_custody.rs
+++ b/crates/exo-core/tests/chain_of_custody.rs
@@ -16,7 +16,10 @@ use exo_core::{
         verify, verify_hybrid, verify_pq,
     },
     events::{EventType, create_signed_event, verify_event},
-    hash::{canonical_hash, hash_structured, merkle_proof, merkle_root, verify_merkle_proof},
+    hash::{
+        canonical_hash, hash_structured, merkle_proof, merkle_root, merkle_root_from_proof,
+        verify_merkle_proof,
+    },
     hlc::HybridClock,
     types::{
         CorrelationId, DeterministicMap, Did, Hash256, Signature, SignerType, Timestamp, Version,
@@ -552,8 +555,10 @@ fn merkle_proof_single_leaf() {
     let hash = canonical_hash(b"single leaf");
     let leaves = vec![hash];
     let root = merkle_root(&leaves);
-    assert_eq!(root, hash);
+    assert_ne!(root, hash);
     let proof = merkle_proof(&leaves, 0).expect("ok");
+    assert!(proof.is_empty());
+    assert_eq!(merkle_root_from_proof(&hash, &proof, 0), root);
     assert!(verify_merkle_proof(&root, &hash, &proof, 0));
 }
 


### PR DESCRIPTION
## Summary
- remediates verified EXOCHAIN core Merkle-domain finding by tagging leaf nodes as H(0x00 || leaf) and parent nodes as H(0x01 || left || right)
- updates Merkle proof reconstruction so singleton roots and proof paths stay verifiable under the new domain-separated contract
- adds a regression test proving singleton roots are not raw leaf hashes and parent nodes are not raw H(left || right)
- updates README repo-truth counters after the new test increased the listed workspace test count

## Verification
- baseline: cargo test -p exo-core hash::tests
- red: cargo test -p exo-core hash::tests::merkle_root_uses_distinct_leaf_and_parent_domains -- --nocapture (failed before implementation)
- cargo test -p exo-core
- cargo test -p exo-proofs --features unaudited-pedagogical-proofs stark
- cargo +nightly fmt --all -- --check
- git diff --check
- bash tools/test_repo_truth.sh
- cargo clippy -p exo-core --all-targets -- -D warnings