### PR TITLE
fix: domain separate sparse merkle parents

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 146281 | `wc -l` |
-| Workspace tests | 3,611 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 146307 | `wc -l` |
+| Workspace tests | 3,612 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,611 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,612 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 146281 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 146307 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,611 listed workspace tests
+         cryptographic proofs, 3,612 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          145 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-dag/src/smt.rs
+++ b/crates/exo-dag/src/smt.rs
@@ -14,20 +14,21 @@ use crate::error::{DagError, Result};
 // ---------------------------------------------------------------------------
 
 const TREE_DEPTH: usize = 256;
+const SMT_EMPTY_LEAF_DOMAIN: &[u8] = b"smt:empty:leaf";
+const SMT_LEAF_DOMAIN: &[u8] = b"smt:leaf:";
+const SMT_PARENT_DOMAIN: &[u8] = b"smt:node:";
 
 fn default_hash(level: usize) -> Hash256 {
-    let mut h = Hash256::digest(b"smt:empty:leaf");
+    let mut h = Hash256::digest(SMT_EMPTY_LEAF_DOMAIN);
     for _ in 0..level {
-        let mut hasher = blake3::Hasher::new();
-        hasher.update(h.as_bytes());
-        hasher.update(h.as_bytes());
-        h = Hash256::from_bytes(*hasher.finalize().as_bytes());
+        h = hash_pair(&h, &h);
     }
     h
 }
 
 fn hash_pair(left: &Hash256, right: &Hash256) -> Hash256 {
     let mut hasher = blake3::Hasher::new();
+    hasher.update(SMT_PARENT_DOMAIN);
     hasher.update(left.as_bytes());
     hasher.update(right.as_bytes());
     Hash256::from_bytes(*hasher.finalize().as_bytes())
@@ -35,7 +36,7 @@ fn hash_pair(left: &Hash256, right: &Hash256) -> Hash256 {
 
 fn hash_leaf(value: &[u8]) -> Hash256 {
     let mut hasher = blake3::Hasher::new();
-    hasher.update(b"smt:leaf:");
+    hasher.update(SMT_LEAF_DOMAIN);
     hasher.update(value);
     Hash256::from_bytes(*hasher.finalize().as_bytes())
 }
@@ -274,6 +275,13 @@ pub fn verify_proof(
 mod tests {
     use super::*;
 
+    fn raw_concat_pair_hash_for_test(left: &Hash256, right: &Hash256) -> Hash256 {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(left.as_bytes());
+        hasher.update(right.as_bytes());
+        Hash256::from_bytes(*hasher.finalize().as_bytes())
+    }
+
     #[test]
     fn empty_tree_root() {
         let tree = SparseMerkleTree::new();
@@ -281,6 +289,24 @@ mod tests {
         assert_eq!(root, default_hash(TREE_DEPTH));
         assert!(tree.is_empty());
         assert_eq!(tree.len(), 0);
+    }
+
+    #[test]
+    fn smt_parent_hashes_use_distinct_node_domain() {
+        let left = Hash256::digest(b"smt-left");
+        let right = Hash256::digest(b"smt-right");
+        assert_ne!(
+            hash_pair(&left, &right),
+            raw_concat_pair_hash_for_test(&left, &right),
+            "SMT parent nodes must not use raw H(left || right)"
+        );
+
+        let empty_leaf = default_hash(0);
+        assert_ne!(
+            default_hash(1),
+            raw_concat_pair_hash_for_test(&empty_leaf, &empty_leaf),
+            "SMT empty parent defaults must use the same domain-separated parent hash"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- remediates verified EXOCHAIN sparse Merkle parent-domain issue by tagging SMT parent hashes with smt:node:
- routes empty-default parent hashes through the same domain-separated parent helper
- adds a regression test proving SMT parent/default nodes do not equal raw H(left || right)
- updates README repo-truth counters after the new test increased the listed workspace test count

## Verification
- baseline: cargo test -p exo-dag smt::tests
- red: cargo test -p exo-dag smt::tests::smt_parent_hashes_use_distinct_node_domain -- --nocapture (failed before implementation)
- cargo test -p exo-dag smt::tests
- cargo test -p exo-dag
- cargo +nightly fmt --all -- --check
- git diff --check
- bash tools/test_repo_truth.sh
- cargo clippy -p exo-dag --all-targets -- -D warnings