### PR TITLE
fix: audit clearance assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 146310 | `wc -l` |
-| Workspace tests | 3,612 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 146637 | `wc -l` |
+| Workspace tests | 3,617 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,612 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,617 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 146310 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 146637 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,612 listed workspace tests
+         cryptographic proofs, 3,617 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          145 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-escalation/tests/sybil_adjudication.rs
+++ b/crates/exo-escalation/tests/sybil_adjudication.rs
@@ -33,7 +33,10 @@ use exo_gatekeeper::{
         PermissionSet, Provenance, Role,
     },
 };
-use exo_governance::clearance::{ClearanceLevel, ClearanceRegistry};
+use exo_governance::{
+    audit::AuditLog,
+    clearance::{ClearanceAssignment, ClearanceLevel, ClearanceRegistry},
+};
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -223,10 +226,25 @@ fn full_detection_to_reinstatement_flow() {
     advance_sybil_stage(&mut case, SybilStage::EvidentaryReview).unwrap();
 
     // ── Stage 5: Clearance downgrade via exo-governance registry ─────────────
-    let mut registry = ClearanceRegistry::default();
-    registry.set_level(actor.clone(), ClearanceLevel::Governor);
+    let clearance_admin = did("did:exo:clearance-admin");
+    let mut clearance_entries = std::collections::BTreeMap::new();
+    clearance_entries.insert(clearance_admin.clone(), ClearanceLevel::Governor);
+    clearance_entries.insert(actor.clone(), ClearanceLevel::Governor);
+    let mut registry = ClearanceRegistry::from_verified_snapshot(clearance_entries);
     // Sybil evidence causes downgrade to ReadOnly
-    registry.set_level(actor.clone(), ClearanceLevel::ReadOnly);
+    let mut clearance_audit_log = AuditLog::new();
+    registry
+        .assign_level(
+            &mut clearance_audit_log,
+            ClearanceAssignment {
+                entry_id: uuid(0xCE),
+                timestamp: ts(1_300),
+                assigner: clearance_admin,
+                subject: actor.clone(),
+                level: ClearanceLevel::ReadOnly,
+            },
+        )
+        .unwrap();
     assert_eq!(registry.get_level(&actor), ClearanceLevel::ReadOnly);
     advance_sybil_stage(&mut case, SybilStage::ClearanceDowngrade).unwrap();
 

--- a/crates/exo-governance/src/clearance.rs
+++ b/crates/exo-governance/src/clearance.rs
@@ -2,10 +2,18 @@
 
 use std::collections::BTreeMap;
 
-use exo_core::Did;
+use exo_core::{Did, Timestamp, hash::hash_structured};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
-use crate::quorum::QuorumPolicy;
+use crate::{
+    audit::{self, AuditLog},
+    errors::GovernanceError,
+    quorum::QuorumPolicy,
+};
+
+const CLEARANCE_ASSIGNMENT_EVIDENCE_DOMAIN: &str = "exo.governance.clearance_assignment.v1";
+const CLEARANCE_ASSIGNMENT_EVIDENCE_SCHEMA_VERSION: u16 = 1;
 
 /// Hierarchical clearance level from None (lowest) to Governor (highest).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -57,13 +65,60 @@ pub struct ClearancePolicy {
     pub policy_hash: [u8; 32],
 }
 
+/// Caller-supplied metadata for a clearance assignment.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClearanceAssignment {
+    pub entry_id: Uuid,
+    pub timestamp: Timestamp,
+    pub assigner: Did,
+    pub subject: Did,
+    pub level: ClearanceLevel,
+}
+
+/// Deterministic receipt proving the registry mutation and its audit evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClearanceAssignmentReceipt {
+    pub audit_entry_id: Uuid,
+    pub timestamp: Timestamp,
+    pub assigner: Did,
+    pub subject: Did,
+    pub previous_level: ClearanceLevel,
+    pub assigned_level: ClearanceLevel,
+    pub evidence_hash: [u8; 32],
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ClearanceAssignmentEvidencePayload {
+    domain: &'static str,
+    schema_version: u16,
+    audit_entry_id: Uuid,
+    timestamp: Timestamp,
+    assigner: Did,
+    assigner_level: ClearanceLevel,
+    subject: Did,
+    previous_level: ClearanceLevel,
+    assigned_level: ClearanceLevel,
+}
+
 /// Maps DIDs to their assigned clearance levels.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ClearanceRegistry {
-    pub entries: BTreeMap<Did, ClearanceLevel>,
+    entries: BTreeMap<Did, ClearanceLevel>,
 }
 
 impl ClearanceRegistry {
+    /// Build a registry from a previously verified state snapshot.
+    #[must_use]
+    pub fn from_verified_snapshot(entries: BTreeMap<Did, ClearanceLevel>) -> Self {
+        Self { entries }
+    }
+
+    /// Return the immutable clearance state snapshot.
+    #[must_use]
+    pub fn entries(&self) -> &BTreeMap<Did, ClearanceLevel> {
+        &self.entries
+    }
+
     /// Return the clearance level for the given actor, defaulting to `None`.
     #[must_use]
     pub fn get_level(&self, actor: &Did) -> ClearanceLevel {
@@ -72,10 +127,104 @@ impl ClearanceRegistry {
             .copied()
             .unwrap_or(ClearanceLevel::None)
     }
-    /// Assign or update the clearance level for the given actor.
-    pub fn set_level(&mut self, actor: Did, level: ClearanceLevel) {
-        self.entries.insert(actor, level);
+
+    /// Assign or update clearance through an audited authorization boundary.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GovernanceError::ConstitutionalViolation`] when the assignment
+    /// is self-directed, the assigner is not a Governor, or the assignment would
+    /// set a level equal to or above the assigner's own clearance. Returns audit
+    /// and serialization errors from the underlying append-only audit log.
+    pub fn assign_level(
+        &mut self,
+        audit_log: &mut AuditLog,
+        assignment: ClearanceAssignment,
+    ) -> Result<ClearanceAssignmentReceipt, GovernanceError> {
+        if assignment.assigner == assignment.subject {
+            return Err(GovernanceError::ConstitutionalViolation {
+                constraint_id: "NoSelfGrant".into(),
+                reason: format!(
+                    "actor {} cannot assign its own clearance",
+                    assignment.assigner
+                ),
+            });
+        }
+
+        let assigner_level = self.get_level(&assignment.assigner);
+        if assigner_level != ClearanceLevel::Governor {
+            return Err(GovernanceError::ConstitutionalViolation {
+                constraint_id: "ClearanceAuthority".into(),
+                reason: format!(
+                    "assigner {} has clearance {assigner_level}; Governor required",
+                    assignment.assigner
+                ),
+            });
+        }
+        if assignment.level >= assigner_level {
+            return Err(GovernanceError::ConstitutionalViolation {
+                constraint_id: "ClearanceCeiling".into(),
+                reason: format!(
+                    "assigner {} with clearance {assigner_level} cannot assign {}",
+                    assignment.assigner, assignment.level
+                ),
+            });
+        }
+
+        let previous_level = self.get_level(&assignment.subject);
+        let evidence_hash =
+            clearance_assignment_evidence_hash(&assignment, assigner_level, previous_level)?;
+        let audit_entry = audit::create_entry(
+            audit_log,
+            assignment.entry_id,
+            assignment.timestamp,
+            assignment.assigner.clone(),
+            "clearance.assign".into(),
+            format!(
+                "subject={} previous={previous_level} assigned={}",
+                assignment.subject, assignment.level
+            ),
+            evidence_hash,
+        )?;
+        audit::append(audit_log, audit_entry)?;
+
+        self.entries
+            .insert(assignment.subject.clone(), assignment.level);
+        Ok(ClearanceAssignmentReceipt {
+            audit_entry_id: assignment.entry_id,
+            timestamp: assignment.timestamp,
+            assigner: assignment.assigner,
+            subject: assignment.subject,
+            previous_level,
+            assigned_level: assignment.level,
+            evidence_hash,
+        })
     }
+}
+
+fn clearance_assignment_evidence_hash(
+    assignment: &ClearanceAssignment,
+    assigner_level: ClearanceLevel,
+    previous_level: ClearanceLevel,
+) -> Result<[u8; 32], GovernanceError> {
+    let payload = ClearanceAssignmentEvidencePayload {
+        domain: CLEARANCE_ASSIGNMENT_EVIDENCE_DOMAIN,
+        schema_version: CLEARANCE_ASSIGNMENT_EVIDENCE_SCHEMA_VERSION,
+        audit_entry_id: assignment.entry_id,
+        timestamp: assignment.timestamp,
+        assigner: assignment.assigner.clone(),
+        assigner_level,
+        subject: assignment.subject.clone(),
+        previous_level,
+        assigned_level: assignment.level,
+    };
+    hash_structured(&payload)
+        .map(|hash| *hash.as_bytes())
+        .map_err(|e| {
+            GovernanceError::Serialization(format!(
+                "clearance assignment canonical CBOR hash failed: {e}"
+            ))
+        })
 }
 
 /// Result of a clearance check: granted (with policy hash), denied, or insufficient independence.
@@ -156,6 +305,47 @@ mod tests {
         }
     }
 
+    fn timestamp(ms: u64) -> exo_core::Timestamp {
+        exo_core::Timestamp::new(ms, 0)
+    }
+
+    fn audit_id(value: u128) -> uuid::Uuid {
+        uuid::Uuid::from_u128(value)
+    }
+
+    fn assignment(
+        assigner: Did,
+        subject: Did,
+        level: ClearanceLevel,
+        entry_id: uuid::Uuid,
+    ) -> ClearanceAssignment {
+        ClearanceAssignment {
+            entry_id,
+            timestamp: timestamp(10_000),
+            assigner,
+            subject,
+            level,
+        }
+    }
+
+    fn snapshot_registry(entries: Vec<(Did, ClearanceLevel)>) -> ClearanceRegistry {
+        let mut levels = BTreeMap::new();
+        for (did, level) in entries {
+            assert!(
+                levels.insert(did, level).is_none(),
+                "test registry snapshots must not contain duplicates"
+            );
+        }
+        ClearanceRegistry::from_verified_snapshot(levels)
+    }
+
+    fn production_source() -> &'static str {
+        include_str!("clearance.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production source")
+    }
+
     fn setup() -> (ClearancePolicy, ClearanceRegistry) {
         let mut p = ClearancePolicy::default();
         p.actions
@@ -172,10 +362,11 @@ mod tests {
             "govern".into(),
             make_action_policy(ClearanceLevel::Governor),
         );
-        let mut r = ClearanceRegistry::default();
-        r.set_level(did("alice"), ClearanceLevel::Governor);
-        r.set_level(did("bob"), ClearanceLevel::Contributor);
-        r.set_level(did("carol"), ClearanceLevel::ReadOnly);
+        let r = snapshot_registry(vec![
+            (did("alice"), ClearanceLevel::Governor),
+            (did("bob"), ClearanceLevel::Contributor),
+            (did("carol"), ClearanceLevel::ReadOnly),
+        ]);
         (p, r)
     }
 
@@ -267,10 +458,132 @@ mod tests {
     }
     #[test]
     fn registry_set_get() {
-        let mut r = ClearanceRegistry::default();
         let d = did("test");
-        r.set_level(d.clone(), ClearanceLevel::Steward);
+        let r = snapshot_registry(vec![(d.clone(), ClearanceLevel::Steward)]);
         assert_eq!(r.get_level(&d), ClearanceLevel::Steward);
+    }
+
+    #[test]
+    fn registry_has_no_public_unchecked_mutation_surface() {
+        let source = production_source();
+        assert!(
+            !source.contains("pub entries:"),
+            "clearance entries must not be publicly mutable"
+        );
+        assert!(
+            !source.contains("pub fn set_level("),
+            "clearance assignment must pass through the audited authorization boundary"
+        );
+    }
+
+    #[test]
+    fn governor_assignment_updates_registry_and_appends_audit_entry() {
+        let governor = did("governor");
+        let subject = did("delegate");
+        let mut registry = snapshot_registry(vec![(governor.clone(), ClearanceLevel::Governor)]);
+        let mut audit_log = crate::audit::AuditLog::new();
+
+        let receipt = registry
+            .assign_level(
+                &mut audit_log,
+                assignment(
+                    governor.clone(),
+                    subject.clone(),
+                    ClearanceLevel::Steward,
+                    audit_id(0xC1EA),
+                ),
+            )
+            .expect("governor may assign lower clearance");
+
+        assert_eq!(registry.get_level(&subject), ClearanceLevel::Steward);
+        assert_eq!(receipt.subject, subject);
+        assert_eq!(receipt.previous_level, ClearanceLevel::None);
+        assert_eq!(receipt.assigned_level, ClearanceLevel::Steward);
+        assert_eq!(audit_log.len(), 1);
+        assert_eq!(audit_log.entries[0].actor, governor);
+        assert_eq!(audit_log.entries[0].action, "clearance.assign");
+        assert_eq!(audit_log.entries[0].evidence_hash, receipt.evidence_hash);
+        crate::audit::verify_chain(&audit_log).expect("assignment audit entry must chain");
+    }
+
+    #[test]
+    fn clearance_assignment_rejects_self_grant_without_mutation_or_audit() {
+        let actor = did("actor");
+        let mut registry = snapshot_registry(vec![(actor.clone(), ClearanceLevel::Governor)]);
+        let mut audit_log = crate::audit::AuditLog::new();
+
+        let err = registry
+            .assign_level(
+                &mut audit_log,
+                assignment(
+                    actor.clone(),
+                    actor.clone(),
+                    ClearanceLevel::Steward,
+                    audit_id(0xC1EB),
+                ),
+            )
+            .expect_err("actors must not assign their own clearance");
+
+        assert!(matches!(
+            err,
+            crate::GovernanceError::ConstitutionalViolation { .. }
+        ));
+        assert_eq!(registry.get_level(&actor), ClearanceLevel::Governor);
+        assert!(audit_log.is_empty());
+    }
+
+    #[test]
+    fn clearance_assignment_enforces_superior_clearance_ceiling() {
+        let steward = did("steward");
+        let subject = did("subject");
+        let mut registry = snapshot_registry(vec![(steward.clone(), ClearanceLevel::Steward)]);
+        let mut audit_log = crate::audit::AuditLog::new();
+
+        let err = registry
+            .assign_level(
+                &mut audit_log,
+                assignment(
+                    steward,
+                    subject.clone(),
+                    ClearanceLevel::Steward,
+                    audit_id(0xC1EC),
+                ),
+            )
+            .expect_err("assigner must not assign its own level or higher");
+
+        assert!(matches!(
+            err,
+            crate::GovernanceError::ConstitutionalViolation { .. }
+        ));
+        assert_eq!(registry.get_level(&subject), ClearanceLevel::None);
+        assert!(audit_log.is_empty());
+    }
+
+    #[test]
+    fn clearance_assignment_rejects_invalid_audit_metadata_before_mutation() {
+        let governor = did("governor");
+        let subject = did("subject");
+        let mut registry = snapshot_registry(vec![(governor.clone(), ClearanceLevel::Governor)]);
+        let mut audit_log = crate::audit::AuditLog::new();
+
+        let err = registry
+            .assign_level(
+                &mut audit_log,
+                assignment(
+                    governor,
+                    subject.clone(),
+                    ClearanceLevel::Reviewer,
+                    uuid::Uuid::nil(),
+                ),
+            )
+            .expect_err("assignment requires caller-supplied audit metadata");
+
+        assert!(matches!(
+            err,
+            crate::GovernanceError::InvalidGovernanceMetadata { .. }
+        ));
+        assert_eq!(registry.get_level(&subject), ClearanceLevel::None);
+        assert!(audit_log.is_empty());
     }
     #[test]
     fn insufficient_independence_variant() {
@@ -296,8 +609,7 @@ mod tests {
                 independence_required: true,
             },
         );
-        let mut r = ClearanceRegistry::default();
-        r.set_level(did("alice"), ClearanceLevel::Governor);
+        let r = snapshot_registry(vec![(did("alice"), ClearanceLevel::Governor)]);
         assert!(matches!(
             check_clearance(&did("alice"), "critical", &p, &r),
             ClearanceDecision::InsufficientIndependence { .. }
@@ -323,8 +635,7 @@ mod tests {
                 independence_required: true,
             },
         );
-        let mut r = ClearanceRegistry::default();
-        r.set_level(did("alice"), ClearanceLevel::Governor);
+        let r = snapshot_registry(vec![(did("alice"), ClearanceLevel::Governor)]);
         assert!(matches!(
             check_clearance(&did("alice"), "critical", &p, &r),
             ClearanceDecision::InsufficientIndependence { .. }
@@ -354,8 +665,7 @@ mod tests {
                 independence_required: true,
             },
         );
-        let mut r = ClearanceRegistry::default();
-        r.set_level(did("alice"), ClearanceLevel::Governor);
+        let r = snapshot_registry(vec![(did("alice"), ClearanceLevel::Governor)]);
         assert_eq!(
             check_clearance(&did("alice"), "critical", &p, &r),
             ClearanceDecision::Granted { policy_hash: hash }
@@ -371,8 +681,7 @@ mod tests {
         };
         p.actions
             .insert("read".into(), make_action_policy(ClearanceLevel::ReadOnly));
-        let mut r = ClearanceRegistry::default();
-        r.set_level(did("alice"), ClearanceLevel::Governor);
+        let r = snapshot_registry(vec![(did("alice"), ClearanceLevel::Governor)]);
         assert_eq!(
             check_clearance(&did("alice"), "read", &p, &r),
             ClearanceDecision::Granted { policy_hash: hash }

--- a/crates/exochain-wasm/src/governance_bindings.rs
+++ b/crates/exochain-wasm/src/governance_bindings.rs
@@ -126,17 +126,17 @@ fn parse_clearance_registry(
         "clearance registry",
         MAX_WASM_CLEARANCE_REGISTRY_ENTRIES,
     )?;
-    let mut registry = exo_governance::clearance::ClearanceRegistry::default();
+    let mut registry_entries = std::collections::BTreeMap::new();
     for entry in entries {
         let did = exo_core::Did::new(&entry.did)
             .map_err(|e| JsValue::from_str(&format!("DID error: {e}")))?;
-        if registry.entries.insert(did.clone(), entry.level).is_some() {
+        if registry_entries.insert(did.clone(), entry.level).is_some() {
             return Err(JsValue::from_str(&format!(
                 "duplicate clearance registry entry for {did}"
             )));
         }
     }
-    Ok(registry)
+    Ok(exo_governance::clearance::ClearanceRegistry::from_verified_snapshot(registry_entries))
 }
 
 /// Compute cryptographically verified quorum result from approvals, policy, and signer keys.

--- a/governance/traceability_matrix.md
+++ b/governance/traceability_matrix.md
@@ -60,7 +60,7 @@ Updated 2026-03-20 after EXOCHAIN-REM-009 — continuous governance monitoring a
 | **13.1** | **Independence-aware quorum** | `exo-governance::quorum` | `exo-governance/src/quorum.rs` (mod tests) | 10 | 🟢 |
 | 13.2 | Challenge / contestation | `exo-governance::challenge` | `exo-governance/src/challenge.rs` (mod tests) | 12 | 🟢 |
 | 13.3 | Crosscheck + coordination detection | `exo-governance::crosscheck` | `exo-governance/src/crosscheck.rs` (mod tests) | 11 | 🟢 |
-| 13.4 | Independence-aware clearance | `exo-governance::clearance` | `exo-governance/src/clearance.rs` (mod tests) | 10 | 🟢 |
+| 13.4 | Independence-aware clearance | `exo-governance::clearance` | `exo-governance/src/clearance.rs` (mod tests) | 19 | 🟢 |
 | 13.5 | Deliberation + voting | `exo-governance::deliberation` | `exo-governance/src/deliberation.rs` (mod tests) | 9 | 🟢 |
 | 13.6 | Conflict disclosure + recusal | `exo-governance::conflict` | `exo-governance/src/conflict.rs` (mod tests) | 9 | 🟢 |
 | 13.7 | Hash-chained audit log | `exo-governance::audit` | `exo-governance/src/audit.rs` (mod tests) | 7 | 🟢 |
@@ -163,4 +163,4 @@ Updated 2026-03-20 after EXOCHAIN-REM-009 — continuous governance monitoring a
 | **TOTAL** | **86** | **83** | **1** | **2** |
 
 **Coverage: 83/86 requirements traced to code (97%). 2 planned (ExoForge scheduling + React dashboard). 1 partial (T-14 Rust attestation verification).**
-**Workspace inventory: 3,001 listed tests across 20 packages and 266 Rust files.**
+**Workspace inventory: 3,617 listed tests across 20 packages and 266 Rust files.**


### PR DESCRIPTION
## Summary
- remove the public unchecked clearance mutation surface by making registry entries private and deleting `set_level`
- add `ClearanceRegistry::assign_level` with Governor-only authority, no self-grants, strict clearance ceiling, caller-supplied HLC/UUID audit metadata, and domain-separated CBOR evidence hashes
- update WASM registry parsing and Sybil adjudication downgrade tests to use verified snapshots plus audited assignment
- refresh README and traceability inventory counts from source

## Classification
- EXOCHAIN core: `crates/exo-governance/src/clearance.rs`
- Core runtime adapter: `crates/exochain-wasm/src/governance_bindings.rs`
- EXOCHAIN core test: `crates/exo-escalation/tests/sybil_adjudication.rs`
- Constitutional governance/docs inventory: `README.md`, `governance/traceability_matrix.md`

## TDD evidence
- RED: `cargo test -p exo-governance clearance::tests` failed before implementation because `ClearanceAssignment`, `from_verified_snapshot`, and `assign_level` did not exist and the public unchecked setter was still present.

## Verification
- PASS: `cargo test -p exo-governance clearance::tests` (19 passed)
- PASS: `cargo test -p exochain-wasm governance_bindings` (6 passed)
- PASS: `cargo test -p exo-escalation --test sybil_adjudication` (3 passed)
- PASS: `cargo clippy -p exo-governance --all-targets -- -D warnings`
- PASS: `cargo clippy -p exochain-wasm --all-targets -- -D warnings`
- PASS: `cargo clippy -p exo-escalation --all-targets -- -D warnings`
- PASS: `cargo fmt --all -- --check`
- PASS: `git diff --check`
- PASS: `cargo test --workspace -- --list 2>/dev/null | rg -c ': test$'` => `3617`
- PASS: bypass search for `set_level(`, `registry.entries`, and `pub entries:` in the touched clearance paths only finds source-test guard strings.
