### PR TITLE
test: align ledger inclusion proofs with core merkle

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 146307 | `wc -l` |
+| Rust LOC | 146310 | `wc -l` |
 | Workspace tests | 3,612 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -57,7 +57,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 146307 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 146310 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 3,612 listed workspace tests
 

--- a/crates/exo-node/src/mcp/tools/ledger.rs
+++ b/crates/exo-node/src/mcp/tools/ledger.rs
@@ -553,13 +553,6 @@ mod tests {
         )
     }
 
-    fn test_hash_pair(left: &Hash256, right: &Hash256) -> Hash256 {
-        let mut combined = [0u8; 64];
-        combined[..32].copy_from_slice(left.as_bytes());
-        combined[32..].copy_from_slice(right.as_bytes());
-        Hash256::digest(&combined)
-    }
-
     fn assert_ledger_runtime_unavailable(result: &ToolResult, tool_name: &str) {
         assert!(result.is_error);
         let text = result.content[0].text();
@@ -811,15 +804,20 @@ mod tests {
 
     #[test]
     fn execute_verify_inclusion_valid_proof() {
-        let event_hash = Hash256::digest(b"event-left");
-        let sibling = Hash256::digest(b"event-right");
-        let expected_root = test_hash_pair(&event_hash, &sibling);
+        let leaves = [
+            Hash256::digest(b"event-left"),
+            Hash256::digest(b"event-right"),
+        ];
+        let target_index = 0;
+        let expected_root = merkle_root(&leaves);
+        let proof = merkle_proof(&leaves, target_index).expect("core proof");
+        let proof_hashes: Vec<String> = proof.iter().map(ToString::to_string).collect();
 
         let params = json!({
-            "event_hash": event_hash.to_string(),
-            "proof_hashes": [sibling.to_string()],
+            "event_hash": leaves[target_index].to_string(),
+            "proof_hashes": proof_hashes,
             "root_hash": expected_root.to_string(),
-            "target_index": 0,
+            "target_index": target_index,
         });
         let result = execute_verify_inclusion(&params, &NodeContext::empty());
         assert!(!result.is_error);
@@ -829,15 +827,20 @@ mod tests {
 
     #[test]
     fn execute_verify_inclusion_valid_right_hand_proof() {
-        let left_hash = Hash256::digest(b"event-left");
-        let right_hash = Hash256::digest(b"event-right");
-        let expected_root = test_hash_pair(&left_hash, &right_hash);
+        let leaves = [
+            Hash256::digest(b"event-left"),
+            Hash256::digest(b"event-right"),
+        ];
+        let target_index = 1;
+        let expected_root = merkle_root(&leaves);
+        let proof = merkle_proof(&leaves, target_index).expect("core proof");
+        let proof_hashes: Vec<String> = proof.iter().map(ToString::to_string).collect();
 
         let params = json!({
-            "event_hash": right_hash.to_string(),
-            "proof_hashes": [left_hash.to_string()],
+            "event_hash": leaves[target_index].to_string(),
+            "proof_hashes": proof_hashes,
             "root_hash": expected_root.to_string(),
-            "target_index": 1,
+            "target_index": target_index,
         });
         let result = execute_verify_inclusion(&params, &NodeContext::empty());
         assert!(!result.is_error);


### PR DESCRIPTION
## Summary
- Updates MCP ledger inclusion tests to generate proofs through `exo_core::hash::merkle_proof` instead of a stale raw pair hash helper.
- Preserves the production runtime path, which already delegates to `exo_core::hash::verify_merkle_proof`.
- Removes the local legacy `test_hash_pair` helper so this adapter test cannot drift from the canonical Merkle proof contract again.
- Updates README repo-truth LOC claims after the test-line delta.

## Classification
- `crates/exo-node/src/mcp/tools/ledger.rs`: core runtime adapter test surface for MCP ledger inclusion verification.
- `README.md`: public repo-truth documentation claim.

## Red Check
- `cargo test -p exo-node --bin exochain mcp::tools::ledger::tests::execute_verify_inclusion_valid_proof` failed on current `origin/main` because the stale hand-built proof verified false.

## Verification
- `cargo test -p exo-node --bin exochain mcp::tools::ledger::tests::execute_verify_inclusion`
- `cargo test -p exo-node --bin exochain`
- `cargo clippy -p exo-node --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `bash tools/test_repo_truth.sh`
- `git diff --check`
