### PR TITLE
fix: require trusted consent termination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,14 +505,14 @@ jobs:
       - name: Build WASM
         run: wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm
       - name: Verify WASM exports
-        # Expected export count = 145. Baseline was 110 before
+        # Expected export count = 147. Baseline was 110 before
         # decision-forum, messaging, death-trigger, and franchise/NewCo
         # scaffold were added. Remaining bridge coverage debt is tracked in
         # Initiative `wasm-bridge-test-coverage`.
         run: |
           COUNT=$(grep -c "module.exports.wasm_" packages/exochain-wasm/wasm/exochain_wasm.js)
           echo "Found $COUNT WASM exports"
-          [ "$COUNT" -eq 145 ] || (echo "Expected 145 exports, got $COUNT" && exit 1)
+          [ "$COUNT" -eq 147 ] || (echo "Expected 147 exports, got $COUNT" && exit 1)
       - name: Upload WASM artifact
         uses: actions/upload-artifact@v4
         with:
@@ -547,14 +547,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Verify Rust exports match JS expectations
-        # Expected #[wasm_bindgen] count = 145. Baseline was 110 before the
+        # Expected #[wasm_bindgen] count = 147. Baseline was 110 before the
         # Sprint-4 additions (decision-forum, messaging, death-trigger,
         # franchise/NewCo scaffold). Remaining bridge coverage debt is tracked
         # in initiative `wasm-bridge-test-coverage`.
         run: |
           RUST_COUNT=$(grep -r '#\[wasm_bindgen\]' crates/exochain-wasm/src/ | wc -l | tr -d ' ')
           echo "Rust #[wasm_bindgen] exports: $RUST_COUNT"
-          [ "$RUST_COUNT" -eq 145 ] || (echo "WASM export count changed from 145 to $RUST_COUNT — update bridge tests" && exit 1)
+          [ "$RUST_COUNT" -eq 147 ] || (echo "WASM export count changed from 147 to $RUST_COUNT — update bridge tests" && exit 1)
 
   # -----------------------------------------------------------------------
   # Constitutional gate: all must pass

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 146637 | `wc -l` |
-| Workspace tests | 3,617 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 146997 | `wc -l` |
+| Workspace tests | 3,626 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -57,12 +57,12 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 146637 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 146997 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,617 listed workspace tests
+         cryptographic proofs, 3,626 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
-         145 verified bridge exports — Rust → WebAssembly → JavaScript
+         147 verified bridge exports — Rust → WebAssembly → JavaScript
 
 Layer 3: CommandBase.ai     (command-base/)
          Operational hypervisor for cognitiveplane.ai

--- a/crates/exo-consent/src/bailment.rs
+++ b/crates/exo-consent/src/bailment.rs
@@ -185,6 +185,40 @@ pub fn signing_payload(bailment: &Bailment) -> Result<Vec<u8>, ConsentError> {
     Ok(buf)
 }
 
+/// Canonical CBOR signing payload for bailment termination.
+///
+/// The payload binds an actor's termination authorization to the bailment
+/// identity fields, current lifecycle state, optional expiration, and the
+/// actor DID. Including the current state prevents a signature gathered for
+/// one lifecycle state from being replayed after the bailment changes state.
+///
+/// # Errors
+/// Returns `Serialization` on CBOR encoding failure.
+pub fn termination_signing_payload(
+    bailment: &Bailment,
+    actor: &Did,
+) -> Result<Vec<u8>, ConsentError> {
+    let tuple = (
+        "exo.bailment.terminate.v1",
+        &bailment.id,
+        &bailment.bailor_did,
+        &bailment.bailee_did,
+        &bailment.bailment_type,
+        &bailment.terms_hash,
+        &bailment.created,
+        &bailment.expires,
+        &bailment.status,
+        actor,
+    );
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&tuple, &mut buf).map_err(|e| {
+        ConsentError::Serialization(format!(
+            "bailment termination signing payload encoding failed: {e}"
+        ))
+    })?;
+    Ok(buf)
+}
+
 /// Accept a proposed bailment. Transitions `Proposed` -> `Active`.
 ///
 /// **Closes GAP-012.** The previous implementation checked only that the
@@ -348,6 +382,46 @@ pub fn terminate(bailment: &mut Bailment, actor: &Did) -> Result<(), ConsentErro
         });
     }
     require_bailment_party(bailment, actor)?;
+    bailment.status = BailmentStatus::Terminated;
+    Ok(())
+}
+
+/// Terminate a bailment only after verifying actor proof-of-control.
+///
+/// `resolve_actor_public_key` must resolve the actor DID from a trusted DID
+/// registry or equivalent authenticated key source. The signature must verify
+/// over [`termination_signing_payload`]. This prevents external adapters from
+/// treating a caller-supplied DID string as authorization.
+///
+/// # Errors
+/// - `InvalidState` if already terminated or expired.
+/// - `Unauthorized` if actor is neither bailor nor bailee.
+/// - `InvalidSignature` if the actor key is unresolved, the signature is a
+///   placeholder/sentinel, or verification fails.
+/// - `Serialization` on canonical encoding failure.
+pub fn terminate_verified(
+    bailment: &mut Bailment,
+    actor: &Did,
+    resolve_actor_public_key: impl FnOnce(&Did) -> Option<PublicKey>,
+    actor_signature: &Signature,
+) -> Result<(), ConsentError> {
+    if bailment.status == BailmentStatus::Terminated || bailment.status == BailmentStatus::Expired {
+        return Err(ConsentError::InvalidState {
+            expected: "Active, Proposed, or Suspended".into(),
+            actual: bailment.status.to_string(),
+        });
+    }
+    require_bailment_party(bailment, actor)?;
+    if actor_signature.is_empty() || actor_signature.ed25519_component_is_zero() {
+        return Err(ConsentError::InvalidSignature);
+    }
+
+    let actor_public_key = resolve_actor_public_key(actor).ok_or(ConsentError::InvalidSignature)?;
+    let payload = termination_signing_payload(bailment, actor)?;
+    if !crypto::verify(&payload, actor_signature, &actor_public_key) {
+        return Err(ConsentError::InvalidSignature);
+    }
+
     bailment.status = BailmentStatus::Terminated;
     Ok(())
 }
@@ -892,6 +966,84 @@ mod tests {
         accept_test_bailment(&mut b);
         suspend(&mut b, &alice()).expect("suspend active bailment");
         assert!(terminate(&mut b, &alice()).is_ok());
+    }
+
+    #[test]
+    fn termination_signing_payload_binds_actor_and_state() {
+        let mut active = propose_test(b"t", BailmentType::Custody);
+        accept_test_bailment(&mut active);
+
+        let actor = alice();
+        let payload = termination_signing_payload(&active, &actor).expect("termination payload");
+        let same_payload =
+            termination_signing_payload(&active, &actor).expect("same termination payload");
+        assert_eq!(payload, same_payload);
+
+        let different_actor =
+            termination_signing_payload(&active, &bob()).expect("different actor payload");
+        assert_ne!(payload, different_actor);
+
+        let mut suspended = active.clone();
+        suspend(&mut suspended, &actor).expect("suspend");
+        let different_state =
+            termination_signing_payload(&suspended, &actor).expect("suspended payload");
+        assert_ne!(payload, different_state);
+    }
+
+    #[test]
+    fn terminate_verified_rejects_unresolved_actor_key() {
+        let mut b = propose_test(b"t", BailmentType::Custody);
+        accept_test_bailment(&mut b);
+        let actor = alice();
+        let signature = Signature::Empty;
+
+        let err = terminate_verified(&mut b, &actor, |_| None, &signature)
+            .expect_err("missing DID key must fail closed");
+
+        assert_eq!(err, ConsentError::InvalidSignature);
+        assert_eq!(b.status, BailmentStatus::Active);
+    }
+
+    #[test]
+    fn terminate_verified_rejects_wrong_signature_and_preserves_state() {
+        let mut b = propose_test(b"t", BailmentType::Custody);
+        accept_test_bailment(&mut b);
+        let actor = alice();
+        let (actor_pk, _actor_sk) = crypto::generate_keypair();
+        let (_wrong_pk, wrong_sk) = crypto::generate_keypair();
+        let payload = termination_signing_payload(&b, &actor).expect("termination payload");
+        let wrong_signature = crypto::sign(&payload, &wrong_sk);
+
+        let err = terminate_verified(
+            &mut b,
+            &actor,
+            |did| (did == &actor).then_some(actor_pk),
+            &wrong_signature,
+        )
+        .expect_err("wrong signature must fail");
+
+        assert_eq!(err, ConsentError::InvalidSignature);
+        assert_eq!(b.status, BailmentStatus::Active);
+    }
+
+    #[test]
+    fn terminate_verified_allows_party_with_resolved_signature() {
+        let mut b = propose_test(b"t", BailmentType::Custody);
+        accept_test_bailment(&mut b);
+        let actor = alice();
+        let (actor_pk, actor_sk) = crypto::generate_keypair();
+        let payload = termination_signing_payload(&b, &actor).expect("termination payload");
+        let signature = crypto::sign(&payload, &actor_sk);
+
+        terminate_verified(
+            &mut b,
+            &actor,
+            |did| (did == &actor).then_some(actor_pk),
+            &signature,
+        )
+        .expect("party signature should authorize termination");
+
+        assert_eq!(b.status, BailmentStatus::Terminated);
     }
 
     #[test]

--- a/crates/exochain-wasm/src/consent_bindings.rs
+++ b/crates/exochain-wasm/src/consent_bindings.rs
@@ -4,6 +4,22 @@ use wasm_bindgen::prelude::*;
 
 use crate::serde_bridge::*;
 
+#[cfg(all(test, not(target_arch = "wasm32")))]
+fn consent_bridge_error(_message: impl AsRef<str>) -> JsValue {
+    JsValue::NULL
+}
+
+#[cfg(not(all(test, not(target_arch = "wasm32"))))]
+fn consent_bridge_error(message: impl AsRef<str>) -> JsValue {
+    JsValue::from_str(message.as_ref())
+}
+
+fn untrusted_wasm_bailment_termination_error() -> JsValue {
+    consent_bridge_error(
+        "WASM bailment termination cannot trust caller-supplied DID key material; use wasm_bailment_termination_payload and submit the signed request to a core runtime adapter with a trusted DID registry",
+    )
+}
+
 /// Propose a new bailment (consent-conditioned data sharing)
 #[wasm_bindgen]
 pub fn wasm_propose_bailment(
@@ -79,15 +95,164 @@ pub fn wasm_bailment_signing_payload(bailment_json: &str) -> Result<Vec<u8>, JsV
         .map_err(|e| JsValue::from_str(&format!("Signing payload error: {e}")))
 }
 
-/// Terminate an active bailment.
-///
-/// The `actor_did` must be either the bailor or bailee.
+/// Compute the canonical termination payload for external signing.
 #[wasm_bindgen]
-pub fn wasm_terminate_bailment(bailment_json: &str, actor_did: &str) -> Result<JsValue, JsValue> {
-    let mut bailment: exo_consent::Bailment = from_json_str(bailment_json)?;
+pub fn wasm_bailment_termination_payload(
+    bailment_json: &str,
+    actor_did: &str,
+) -> Result<Vec<u8>, JsValue> {
+    let bailment: exo_consent::Bailment = from_json_str(bailment_json)?;
     let actor =
         exo_core::Did::new(actor_did).map_err(|e| JsValue::from_str(&format!("DID error: {e}")))?;
-    exo_consent::bailment::terminate(&mut bailment, &actor)
-        .map_err(|e| JsValue::from_str(&format!("Terminate error: {e}")))?;
-    to_js_value(&bailment)
+    exo_consent::bailment::termination_signing_payload(&bailment, &actor)
+        .map_err(|e| JsValue::from_str(&format!("Termination payload error: {e}")))
+}
+
+/// Unsigned bailment termination is disabled.
+///
+/// Use [`wasm_bailment_termination_payload`] to construct the signable bytes,
+/// sign them outside WASM, then submit the signed request to a core runtime
+/// adapter that owns trusted DID resolution.
+#[wasm_bindgen]
+pub fn wasm_terminate_bailment(_bailment_json: &str, _actor_did: &str) -> Result<JsValue, JsValue> {
+    Err(consent_bridge_error(
+        "unsigned bailment termination is disabled; use wasm_bailment_termination_payload and submit the signed request to a core runtime adapter with a trusted DID registry",
+    ))
+}
+
+/// Refuse WASM-local bailment termination from caller-supplied identity data.
+///
+/// WASM can construct the canonical payload for external signing, but it cannot
+/// prove that a caller-supplied DID-to-key binding came from the trusted
+/// EXOCHAIN identity registry. Submit the signed payload to a core runtime
+/// adapter that owns trusted DID resolution instead.
+#[wasm_bindgen]
+pub fn wasm_terminate_bailment_signed(
+    _bailment_json: &str,
+    _actor_did: &str,
+    _public_keys_json: &str,
+    _signature_json: &str,
+) -> Result<JsValue, JsValue> {
+    Err(untrusted_wasm_bailment_termination_error())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use exo_core::{Timestamp, crypto};
+
+    use super::*;
+
+    fn did(value: &str) -> exo_core::Did {
+        exo_core::Did::new(value).expect("valid did")
+    }
+
+    fn active_bailment() -> exo_consent::Bailment {
+        let bailor = did("did:exo:alice");
+        let bailee = did("did:exo:bob");
+        let mut bailment = exo_consent::bailment::propose(
+            &bailor,
+            &bailee,
+            b"wasm consent terms",
+            exo_consent::BailmentType::Custody,
+            "wasm-consent-test",
+            Timestamp::new(1_000, 0),
+        )
+        .expect("proposal");
+        let (bailee_pk, bailee_sk) = crypto::generate_keypair();
+        let acceptance_payload =
+            exo_consent::bailment::signing_payload(&bailment).expect("acceptance payload");
+        let acceptance_signature = crypto::sign(&acceptance_payload, &bailee_sk);
+        exo_consent::bailment::accept(&mut bailment, &bailee_pk, &acceptance_signature)
+            .expect("accept");
+        bailment
+    }
+
+    fn public_keys_json(did: &exo_core::Did, public_key: &exo_core::PublicKey) -> String {
+        serde_json::to_string(&vec![(did.as_str(), hex::encode(public_key.as_bytes()))])
+            .expect("public keys json")
+    }
+
+    fn signature_json(signature: &exo_core::Signature) -> String {
+        serde_json::to_string(signature).expect("signature json")
+    }
+
+    #[test]
+    fn bailment_termination_payload_bridge_matches_core_payload() {
+        let bailment = active_bailment();
+        let bailment_json = serde_json::to_string(&bailment).expect("bailment json");
+        let actor = did("did:exo:alice");
+        let core_payload =
+            exo_consent::bailment::termination_signing_payload(&bailment, &actor).expect("payload");
+
+        let bridge_payload =
+            wasm_bailment_termination_payload(&bailment_json, actor.as_str()).expect("payload");
+
+        assert_eq!(bridge_payload, core_payload);
+    }
+
+    #[test]
+    fn wasm_terminate_bailment_signed_rejects_missing_actor_key() {
+        let bailment = active_bailment();
+        let bailment_json = serde_json::to_string(&bailment).expect("bailment json");
+        let actor = did("did:exo:alice");
+        let other = did("did:exo:charlie");
+        let (actor_pk, actor_sk) = crypto::generate_keypair();
+        let payload =
+            exo_consent::bailment::termination_signing_payload(&bailment, &actor).expect("payload");
+        let signature = crypto::sign(&payload, &actor_sk);
+
+        let result = wasm_terminate_bailment_signed(
+            &bailment_json,
+            actor.as_str(),
+            &public_keys_json(&other, &actor_pk),
+            &signature_json(&signature),
+        );
+
+        assert!(result.is_err(), "missing actor key must fail");
+    }
+
+    #[test]
+    fn wasm_terminate_bailment_signed_rejects_caller_substituted_actor_key() {
+        let bailment = active_bailment();
+        let bailment_json = serde_json::to_string(&bailment).expect("bailment json");
+        let actor = did("did:exo:alice");
+        let (attacker_pk, attacker_sk) = crypto::generate_keypair();
+        let payload =
+            exo_consent::bailment::termination_signing_payload(&bailment, &actor).expect("payload");
+        let attacker_signature = crypto::sign(&payload, &attacker_sk);
+
+        let result = wasm_terminate_bailment_signed(
+            &bailment_json,
+            actor.as_str(),
+            &public_keys_json(&actor, &attacker_pk),
+            &signature_json(&attacker_signature),
+        );
+
+        assert!(
+            result.is_err(),
+            "WASM consent termination must not trust a caller-supplied DID-to-key binding"
+        );
+    }
+
+    #[test]
+    fn wasm_terminate_bailment_signed_rejects_wrong_signature() {
+        let bailment = active_bailment();
+        let bailment_json = serde_json::to_string(&bailment).expect("bailment json");
+        let actor = did("did:exo:alice");
+        let (actor_pk, _actor_sk) = crypto::generate_keypair();
+        let (_wrong_pk, wrong_sk) = crypto::generate_keypair();
+        let payload =
+            exo_consent::bailment::termination_signing_payload(&bailment, &actor).expect("payload");
+        let wrong_signature = crypto::sign(&payload, &wrong_sk);
+
+        let result = wasm_terminate_bailment_signed(
+            &bailment_json,
+            actor.as_str(),
+            &public_keys_json(&actor, &actor_pk),
+            &signature_json(&wrong_signature),
+        );
+
+        assert!(result.is_err(), "wrong signature must fail");
+    }
 }

--- a/crates/exochain-wasm/src/lib.rs
+++ b/crates/exochain-wasm/src/lib.rs
@@ -78,6 +78,49 @@ mod source_guard_tests {
     }
 
     #[test]
+    fn wasm_consent_termination_refuses_unsigned_actor_did_bridge() {
+        let source = include_str!("consent_bindings.rs");
+        let termination = source
+            .split("pub fn wasm_terminate_bailment(")
+            .nth(1)
+            .and_then(|section| {
+                section
+                    .split("pub fn wasm_terminate_bailment_signed(")
+                    .next()
+            })
+            .expect("wasm_terminate_bailment source");
+        let signed_termination = source
+            .split("pub fn wasm_terminate_bailment_signed(")
+            .nth(1)
+            .expect("wasm_terminate_bailment_signed source");
+
+        assert!(
+            termination.contains("unsigned bailment termination is disabled"),
+            "legacy WASM bailment termination must fail closed instead of trusting actor_did"
+        );
+        assert!(
+            !termination.contains("exo_consent::bailment::terminate(&mut bailment, &actor)"),
+            "legacy WASM bailment termination must not reach the core state transition"
+        );
+        assert!(
+            source.contains("pub fn wasm_bailment_termination_payload("),
+            "WASM consent bridge must expose the canonical termination payload for external signing"
+        );
+        assert!(
+            source.contains("pub fn wasm_terminate_bailment_signed("),
+            "WASM consent bridge must keep the signed termination entrypoint fail-closed"
+        );
+        assert!(
+            signed_termination.contains("untrusted_wasm_bailment_termination_error"),
+            "WASM signed termination must fail closed instead of trusting caller-supplied key material"
+        );
+        assert!(
+            !signed_termination.contains("terminate_verified"),
+            "WASM signed termination must not call core termination without trusted DID resolution"
+        );
+    }
+
+    #[test]
     fn wasm_governance_bridge_requires_caller_supplied_metadata() {
         let source = include_str!("governance_bindings.rs");
         let forbidden = [

--- a/governance/traceability_matrix.md
+++ b/governance/traceability_matrix.md
@@ -163,4 +163,4 @@ Updated 2026-03-20 after EXOCHAIN-REM-009 — continuous governance monitoring a
 | **TOTAL** | **86** | **83** | **1** | **2** |
 
 **Coverage: 83/86 requirements traced to code (97%). 2 planned (ExoForge scheduling + React dashboard). 1 partial (T-14 Rust attestation verification).**
-**Workspace inventory: 3,617 listed tests across 20 packages and 266 Rust files.**
+**Workspace inventory: 3,626 listed tests across 20 packages and 266 Rust files.**

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -734,11 +734,41 @@ const activeBailment = setup(() =>
     JSON.stringify(bailSig.signature)
   ));
 
-test('wasm_terminate_bailment', () => {
+test('wasm_bailment_termination_payload', () => {
   if (!activeBailment) throw new Error('skipped -- no active bailment from setup');
-  return wasm.wasm_terminate_bailment(
+  const payload = wasm.wasm_bailment_termination_payload(
     JSON.stringify(activeBailment),
     TEST_DID
+  );
+  if (!payload || payload.length === 0) {
+    throw new Error('termination payload must be non-empty');
+  }
+  return payload;
+});
+
+test('wasm_terminate_bailment rejects unsigned termination', () => {
+  if (!activeBailment) throw new Error('skipped -- no active bailment from setup');
+  return expectErrorContains(
+    'wasm_terminate_bailment',
+    () => wasm.wasm_terminate_bailment(
+      JSON.stringify(activeBailment),
+      TEST_DID
+    ),
+    'unsigned bailment termination is disabled'
+  );
+});
+
+test('wasm_terminate_bailment_signed rejects caller-supplied DID key material', () => {
+  if (!activeBailment) throw new Error('skipped -- no active bailment from setup');
+  return expectErrorContains(
+    'wasm_terminate_bailment_signed',
+    () => wasm.wasm_terminate_bailment_signed(
+      JSON.stringify(activeBailment),
+      TEST_DID,
+      JSON.stringify([[TEST_DID, signer1.publicKeyHex]]),
+      JSON.stringify(signatureJsonFromHex(signer1.signHex(TEXT_BYTES)))
+    ),
+    'cannot trust caller-supplied DID key material'
   );
 });
 


### PR DESCRIPTION

## Summary
- Adds a canonical CBOR bailment termination signing payload in `exo-consent` that binds bailment identity, terms hash, lifecycle state, optional expiry, and actor DID.
- Adds `terminate_verified` for trusted core/runtime callers with actor DID resolution and signature verification before state mutation.
- Changes WASM consent termination to fail closed for both legacy unsigned termination and caller-supplied DID key material; WASM now only exposes canonical termination bytes for external signing.
- Updates WASM export-count gates, JS bridge coverage, and repo-truth documentation for the two new WASM exports and added tests.

## Path Classification
- EXOCHAIN core: `crates/exo-consent/src/bailment.rs`
- Core runtime adapter: `crates/exochain-wasm/src/consent_bindings.rs`, `crates/exochain-wasm/src/lib.rs`, `packages/exochain-wasm/test/bridge_verification.mjs`
- CI/runtime contract: `.github/workflows/ci.yml`
- Constitutional governance artifact: `governance/traceability_matrix.md`
- Documentation: `README.md`
- Imported evidence: external Matt/Wally audit hypotheses only; no report, zip, screenshot, or generated scanner output committed.
- Adjacent surface: none
- Third-party/vendor: none

## TDD / Current-Code Validation
- Confirmed the stale report hypothesis against current code before remediation: `wasm_terminate_bailment(bailment_json, actor_did)` trusted a caller-supplied DID string.
- Wrote red tests for `terminate_verified` and WASM unsigned termination refusal before implementation.
- Added an additional red regression proving caller-substituted DID key material would be accepted by the first signed WASM bridge shape; then changed WASM termination to fail closed because WASM does not own a trusted DID resolver.

## Verification
- `cargo test -p exo-consent terminate_verified`
- `cargo test -p exo-consent termination_signing_payload`
- `cargo test -p exochain-wasm wasm_terminate_bailment_signed`
- `cargo test -p exochain-wasm wasm_consent_termination_refuses_unsigned_actor_did_bridge`
- `cargo test -p exochain-wasm bailment_termination_payload_bridge_matches_core_payload`
- `cargo test -p exo-consent`
- `cargo test -p exochain-wasm`
- `cargo test -p exo-node mcp::tools::consent`
- `cargo clippy -p exo-consent -p exochain-wasm --all-targets -- -D warnings`
- `cargo fmt --all -- --check` on stable, with existing unstable rustfmt option warnings only
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- Bypass search: `rg -n "wasm_terminate_bailment|terminate_bailment|bailment::terminate\(|terminate_verified|termination_signing_payload|consent_store_unavailable|exochain_terminate_bailment|caller-supplied DID key" crates/exo-consent/src crates/exochain-wasm/src crates/exo-node/src/mcp/tools/consent.rs -g "*.rs"`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check` passed with existing duplicate-dependency warnings only
- `bash tools/test_repo_truth.sh`
- `grep -r "#\[wasm_bindgen\]" crates/exochain-wasm/src/ | wc -l | tr -d " "` -> 147
- `wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm`
- `grep -c "module.exports.wasm_" packages/exochain-wasm/wasm/exochain_wasm.js` -> 147
- `node packages/exochain-wasm/test/bridge_verification.mjs` -> 146/146 passed
