### PR TITLE
fix: require kernel-adjudicated BCTS transitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,14 +505,15 @@ jobs:
       - name: Build WASM
         run: wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm
       - name: Verify WASM exports
-        # Expected export count = 147. Baseline was 110 before
+        # Expected export count = 148. Baseline was 110 before
         # decision-forum, messaging, death-trigger, and franchise/NewCo
-        # scaffold were added. Remaining bridge coverage debt is tracked in
+        # scaffold were added; the adjudicated decision transition bridge
+        # adds the current security boundary. Remaining bridge coverage debt is tracked in
         # Initiative `wasm-bridge-test-coverage`.
         run: |
           COUNT=$(grep -c "module.exports.wasm_" packages/exochain-wasm/wasm/exochain_wasm.js)
           echo "Found $COUNT WASM exports"
-          [ "$COUNT" -eq 147 ] || (echo "Expected 147 exports, got $COUNT" && exit 1)
+          [ "$COUNT" -eq 148 ] || (echo "Expected 148 exports, got $COUNT" && exit 1)
       - name: Upload WASM artifact
         uses: actions/upload-artifact@v4
         with:
@@ -547,14 +548,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Verify Rust exports match JS expectations
-        # Expected #[wasm_bindgen] count = 147. Baseline was 110 before the
+        # Expected #[wasm_bindgen] count = 148. Baseline was 110 before the
         # Sprint-4 additions (decision-forum, messaging, death-trigger,
-        # franchise/NewCo scaffold). Remaining bridge coverage debt is tracked
-        # in initiative `wasm-bridge-test-coverage`.
+        # franchise/NewCo scaffold); the adjudicated decision transition bridge
+        # adds the current security boundary. Remaining bridge coverage debt is
+        # tracked in initiative `wasm-bridge-test-coverage`.
         run: |
           RUST_COUNT=$(grep -r '#\[wasm_bindgen\]' crates/exochain-wasm/src/ | wc -l | tr -d ' ')
           echo "Rust #[wasm_bindgen] exports: $RUST_COUNT"
-          [ "$RUST_COUNT" -eq 147 ] || (echo "WASM export count changed from 147 to $RUST_COUNT — update bridge tests" && exit 1)
+          [ "$RUST_COUNT" -eq 148 ] || (echo "WASM export count changed from 148 to $RUST_COUNT — update bridge tests" && exit 1)
 
   # -----------------------------------------------------------------------
   # Constitutional gate: all must pass

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 20 | `ls -d crates/*/` |
 | Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 147403 | `wc -l` |
-| Workspace tests | 3,631 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 148414 | `wc -l` |
+| Workspace tests | 3,638 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -25,7 +25,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,631 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,638 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -57,9 +57,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 147403 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 20 crates, 148414 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,631 listed workspace tests
+         cryptographic proofs, 3,638 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/decision-forum/src/decision_object.rs
+++ b/crates/decision-forum/src/decision_object.rs
@@ -11,6 +11,10 @@ use exo_core::{
     hash::hash_structured,
     types::{DeterministicMap, Did, Hash256, Timestamp},
 };
+use exo_gatekeeper::{
+    kernel::{ActionRequest, AdjudicationContext, Kernel, Verdict},
+    types::Permission,
+};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -101,6 +105,21 @@ pub struct LifecycleReceipt {
     pub receipt_hash: Hash256,
 }
 
+const BCTS_TRANSITION_ACTION_PREFIX: &str = "bcts:transition";
+
+/// Stable action name used when submitting a BCTS state transition to the
+/// constitutional kernel.
+#[must_use]
+pub fn bcts_transition_action_name(from: BctsState, to: BctsState) -> String {
+    format!("{BCTS_TRANSITION_ACTION_PREFIX}:{from}->{to}")
+}
+
+/// Stable permission required for a BCTS state transition.
+#[must_use]
+pub fn bcts_transition_permission(from: BctsState, to: BctsState) -> Permission {
+    Permission::new(bcts_transition_action_name(from, to))
+}
+
 /// The core Decision Object.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DecisionObject {
@@ -166,13 +185,53 @@ impl DecisionObject {
         self.state == BctsState::Closed
     }
 
-    /// Transition the decision to a new BCTS state, recording a receipt.
+    /// Raw BCTS transitions are disabled in production. Use
+    /// [`Self::transition_adjudicated_at`] so the constitutional kernel
+    /// adjudicates the transition before state is mutated.
     pub fn transition_at(
+        &mut self,
+        _to: BctsState,
+        _actor: &Did,
+        _timestamp: Timestamp,
+    ) -> Result<()> {
+        Err(ForumError::ConstitutionalConflict {
+            reason: "raw BCTS decision transition requires Kernel::adjudicate via transition_adjudicated_at".into(),
+        })
+    }
+
+    /// Transition the decision to a new BCTS state after a permitted kernel
+    /// adjudication, recording a receipt.
+    pub fn transition_adjudicated_at(
         &mut self,
         to: BctsState,
         actor: &Did,
         timestamp: Timestamp,
+        kernel: &Kernel,
+        action: &ActionRequest,
+        context: &AdjudicationContext,
     ) -> Result<()> {
+        self.validate_transition_preconditions(to, timestamp)?;
+        validate_transition_action_binding(self.state, to, actor, action)?;
+
+        match kernel.adjudicate(action, context) {
+            Verdict::Permitted => self.apply_transition_at(to, actor, timestamp),
+            Verdict::Denied { violations } => {
+                let reason = violations
+                    .iter()
+                    .map(|v| format!("{}: {}", v.invariant.id(), v.description))
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                Err(ForumError::ConstitutionalConflict {
+                    reason: format!("BCTS transition denied by kernel: {reason}"),
+                })
+            }
+            Verdict::Escalated { reason } => Err(ForumError::ConstitutionalConflict {
+                reason: format!("BCTS transition escalated by kernel: {reason}"),
+            }),
+        }
+    }
+
+    fn validate_transition_preconditions(&self, to: BctsState, timestamp: Timestamp) -> Result<()> {
         if self.is_terminal() {
             return Err(ForumError::DecisionImmutable);
         }
@@ -183,7 +242,15 @@ impl DecisionObject {
             });
         }
         self.validate_transition_timestamp(timestamp)?;
+        Ok(())
+    }
 
+    fn apply_transition_at(
+        &mut self,
+        to: BctsState,
+        actor: &Did,
+        timestamp: Timestamp,
+    ) -> Result<()> {
         let receipt_hash = self.compute_receipt_hash(self.state, to, &timestamp, actor)?;
 
         self.receipt_chain.push(LifecycleReceipt {
@@ -306,6 +373,44 @@ impl DecisionObject {
     }
 }
 
+fn validate_transition_action_binding(
+    from: BctsState,
+    to: BctsState,
+    actor: &Did,
+    action: &ActionRequest,
+) -> Result<()> {
+    if &action.actor != actor {
+        return Err(ForumError::ConstitutionalConflict {
+            reason: format!(
+                "BCTS transition actor {actor} does not match adjudicated action actor {}",
+                action.actor
+            ),
+        });
+    }
+
+    let expected_action = bcts_transition_action_name(from, to);
+    if action.action != expected_action {
+        return Err(ForumError::ConstitutionalConflict {
+            reason: format!(
+                "BCTS transition requires action {expected_action}, got {}",
+                action.action
+            ),
+        });
+    }
+
+    let required = bcts_transition_permission(from, to);
+    if !action.required_permissions.contains(&required) {
+        return Err(ForumError::ConstitutionalConflict {
+            reason: format!(
+                "BCTS transition action must require permission {}",
+                required.0
+            ),
+        });
+    }
+
+    Ok(())
+}
+
 fn validate_uuid(id: Uuid, label: &str) -> Result<()> {
     if id.is_nil() {
         return Err(ForumError::InvalidProvenance {
@@ -329,8 +434,19 @@ mod tests {
     use std::sync::atomic::{AtomicU64, Ordering};
 
     use exo_core::hlc::HybridClock;
+    use exo_gatekeeper::{
+        authority_link_signature_message,
+        invariants::InvariantSet,
+        provenance_signature_message,
+        types::{
+            AuthorityChain, AuthorityLink as GatekeeperAuthorityLink, BailmentState, ConsentRecord,
+            GovernmentBranch, PermissionSet, Provenance, Role,
+        },
+    };
 
     use super::*;
+
+    const CONSTITUTION: &[u8] = b"EXOCHAIN decision object test constitution";
 
     fn test_clock() -> HybridClock {
         let counter = AtomicU64::new(1000);
@@ -339,6 +455,103 @@ mod tests {
 
     fn test_did() -> Did {
         Did::new("did:exo:test-actor").expect("valid")
+    }
+
+    fn signed_authority_link(actor: &Did, permission: Permission) -> GatekeeperAuthorityLink {
+        let (pk, sk) = exo_core::crypto::generate_keypair();
+        let grantor = Did::new("did:exo:governance-root").expect("valid DID");
+        let mut link = GatekeeperAuthorityLink {
+            grantor,
+            grantee: actor.clone(),
+            permissions: PermissionSet::new(vec![permission]),
+            signature: Vec::new(),
+            grantor_public_key: Some(pk.as_bytes().to_vec()),
+        };
+        let message = authority_link_signature_message(&link).expect("canonical link payload");
+        let signature = exo_core::crypto::sign(message.as_bytes(), &sk);
+        link.signature = signature.to_bytes().to_vec();
+        link
+    }
+
+    fn signed_provenance(actor: &Did) -> Provenance {
+        let (pk, sk) = exo_core::crypto::generate_keypair();
+        let mut provenance = Provenance {
+            actor: actor.clone(),
+            timestamp: "2026-04-30T00:00:00Z".to_owned(),
+            action_hash: vec![0xB7, 0xC5],
+            signature: Vec::new(),
+            public_key: Some(pk.as_bytes().to_vec()),
+            voice_kind: None,
+            independence: None,
+            review_order: None,
+        };
+        let message =
+            provenance_signature_message(&provenance).expect("canonical provenance payload");
+        let signature = exo_core::crypto::sign(message.as_bytes(), &sk);
+        provenance.signature = signature.to_bytes().to_vec();
+        provenance
+    }
+
+    fn transition_action(actor: &Did, from: BctsState, to: BctsState) -> ActionRequest {
+        let required = bcts_transition_permission(from, to);
+        ActionRequest {
+            actor: actor.clone(),
+            action: bcts_transition_action_name(from, to),
+            required_permissions: PermissionSet::new(vec![required]),
+            is_self_grant: false,
+            modifies_kernel: false,
+        }
+    }
+
+    fn transition_context(actor: &Did, from: BctsState, to: BctsState) -> AdjudicationContext {
+        let permission = bcts_transition_permission(from, to);
+        AdjudicationContext {
+            actor_roles: vec![Role {
+                name: "transition-judge".into(),
+                branch: GovernmentBranch::Judicial,
+            }],
+            authority_chain: AuthorityChain {
+                links: vec![signed_authority_link(actor, permission.clone())],
+            },
+            consent_records: vec![ConsentRecord {
+                subject: Did::new("did:exo:bailor").expect("valid DID"),
+                granted_to: actor.clone(),
+                scope: "bcts:transition".into(),
+                active: true,
+            }],
+            bailment_state: BailmentState::Active {
+                bailor: Did::new("did:exo:bailor").expect("valid DID"),
+                bailee: actor.clone(),
+                scope: "bcts:transition".into(),
+            },
+            human_override_preserved: true,
+            actor_permissions: PermissionSet::new(vec![permission]),
+            provenance: Some(signed_provenance(actor)),
+            quorum_evidence: None,
+            active_challenge_reason: None,
+        }
+    }
+
+    fn adjudicated_transition_result(
+        decision: &mut DecisionObject,
+        to: BctsState,
+        actor: &Did,
+        timestamp: Timestamp,
+    ) -> Result<()> {
+        let from = decision.state;
+        let kernel = Kernel::new(CONSTITUTION, InvariantSet::all());
+        let action = transition_action(actor, from, to);
+        let context = transition_context(actor, from, to);
+        decision.transition_adjudicated_at(to, actor, timestamp, &kernel, &action, &context)
+    }
+
+    fn transition_ok(
+        decision: &mut DecisionObject,
+        to: BctsState,
+        actor: &Did,
+        timestamp: Timestamp,
+    ) {
+        adjudicated_transition_result(decision, to, actor, timestamp).expect("transition ok");
     }
 
     fn make_decision(clock: &mut HybridClock) -> DecisionObject {
@@ -398,33 +611,41 @@ mod tests {
         let actor = test_did();
         let mut d = make_decision(&mut clock);
 
-        d.transition_at(BctsState::Submitted, &actor, Timestamp::new(10_001, 0))
-            .expect("submitted");
+        transition_ok(
+            &mut d,
+            BctsState::Submitted,
+            &actor,
+            Timestamp::new(10_001, 0),
+        );
 
-        let zero = d
-            .transition_at(BctsState::IdentityResolved, &actor, Timestamp::ZERO)
-            .unwrap_err();
+        let zero = adjudicated_transition_result(
+            &mut d,
+            BctsState::IdentityResolved,
+            &actor,
+            Timestamp::ZERO,
+        )
+        .unwrap_err();
         assert!(matches!(zero, ForumError::InvalidProvenance { .. }));
 
-        let regressive = d
-            .transition_at(
-                BctsState::IdentityResolved,
-                &actor,
-                Timestamp::new(10_000, 0),
-            )
-            .unwrap_err();
+        let regressive = adjudicated_transition_result(
+            &mut d,
+            BctsState::IdentityResolved,
+            &actor,
+            Timestamp::new(10_000, 0),
+        )
+        .unwrap_err();
         assert!(matches!(regressive, ForumError::InvalidProvenance { .. }));
         assert_eq!(
             regressive.to_string(),
             "invalid provenance metadata: transition timestamp 10000:0 must be greater than prior timestamp 10001:0"
         );
 
-        d.transition_at(
+        transition_ok(
+            &mut d,
             BctsState::IdentityResolved,
             &actor,
             Timestamp::new(10_002, 0),
-        )
-        .expect("monotonic transition");
+        );
     }
 
     #[test]
@@ -444,10 +665,68 @@ mod tests {
         let mut clock = test_clock();
         let mut d = make_decision(&mut clock);
         let ts = clock.now().expect("HLC timestamp");
-        d.transition_at(BctsState::Submitted, &test_did(), ts)
-            .expect("ok");
+        transition_ok(&mut d, BctsState::Submitted, &test_did(), ts);
         assert_eq!(d.state, BctsState::Submitted);
         assert_eq!(d.receipt_chain.len(), 1);
+    }
+
+    #[test]
+    fn raw_transition_without_kernel_adjudication_fails_closed() {
+        let mut clock = test_clock();
+        let actor = test_did();
+        let mut d = make_decision(&mut clock);
+        let ts = clock.now().expect("HLC timestamp");
+
+        let err = d
+            .transition_at(BctsState::Submitted, &actor, ts)
+            .expect_err("raw BCTS decision transition must require kernel adjudication");
+
+        assert!(matches!(err, ForumError::ConstitutionalConflict { .. }));
+        assert_eq!(d.state, BctsState::Draft);
+        assert!(d.receipt_chain.is_empty());
+    }
+
+    #[test]
+    fn adjudicated_transition_denies_kernel_denial_without_mutating() {
+        let mut clock = test_clock();
+        let actor = test_did();
+        let mut d = make_decision(&mut clock);
+        let to = BctsState::Submitted;
+        let ts = clock.now().expect("HLC timestamp");
+        let kernel = Kernel::new(CONSTITUTION, InvariantSet::all());
+        let action = transition_action(&actor, d.state, to);
+        let mut context = transition_context(&actor, d.state, to);
+        context.provenance = None;
+
+        let err = d
+            .transition_adjudicated_at(to, &actor, ts, &kernel, &action, &context)
+            .expect_err("kernel denial must fail the transition");
+
+        assert!(matches!(err, ForumError::ConstitutionalConflict { .. }));
+        assert!(err.to_string().contains("provenance-verifiable"));
+        assert_eq!(d.state, BctsState::Draft);
+        assert!(d.receipt_chain.is_empty());
+    }
+
+    #[test]
+    fn adjudicated_transition_rejects_unbound_action_without_mutating() {
+        let mut clock = test_clock();
+        let actor = test_did();
+        let mut d = make_decision(&mut clock);
+        let to = BctsState::Submitted;
+        let ts = clock.now().expect("HLC timestamp");
+        let kernel = Kernel::new(CONSTITUTION, InvariantSet::all());
+        let action = transition_action(&actor, BctsState::Submitted, BctsState::Denied);
+        let context = transition_context(&actor, BctsState::Submitted, BctsState::Denied);
+
+        let err = d
+            .transition_adjudicated_at(to, &actor, ts, &kernel, &action, &context)
+            .expect_err("mismatched kernel action must fail the transition");
+
+        assert!(matches!(err, ForumError::ConstitutionalConflict { .. }));
+        assert!(err.to_string().contains("requires action"));
+        assert_eq!(d.state, BctsState::Draft);
+        assert!(d.receipt_chain.is_empty());
     }
 
     #[test]
@@ -455,9 +734,8 @@ mod tests {
         let mut clock = test_clock();
         let mut d = make_decision(&mut clock);
         let ts = clock.now().expect("HLC timestamp");
-        let err = d
-            .transition_at(BctsState::Closed, &test_did(), ts)
-            .unwrap_err();
+        let err =
+            adjudicated_transition_result(&mut d, BctsState::Closed, &test_did(), ts).unwrap_err();
         assert!(matches!(err, ForumError::InvalidTransition { .. }));
     }
 
@@ -480,7 +758,7 @@ mod tests {
         ];
         for s in steps {
             let ts = clock.now().expect("HLC timestamp");
-            d.transition_at(s, &actor, ts).expect("ok");
+            transition_ok(&mut d, s, &actor, ts);
         }
         assert!(d.is_terminal());
         assert_eq!(d.receipt_chain.len(), 10);
@@ -504,10 +782,10 @@ mod tests {
             BctsState::Closed,
         ] {
             let ts = clock.now().expect("HLC timestamp");
-            d.transition_at(s, &actor, ts).expect("ok");
+            transition_ok(&mut d, s, &actor, ts);
         }
         let ts = clock.now().expect("HLC timestamp");
-        assert!(d.transition_at(BctsState::Draft, &actor, ts).is_err());
+        assert!(adjudicated_transition_result(&mut d, BctsState::Draft, &actor, ts).is_err());
         assert!(
             d.add_vote(Vote {
                 voter_did: actor.clone(),
@@ -592,8 +870,7 @@ mod tests {
         let mut d = make_decision(&mut clock);
         let h1 = d.content_hash().expect("ok");
         let ts = clock.now().expect("HLC timestamp");
-        d.transition_at(BctsState::Submitted, &actor, ts)
-            .expect("ok");
+        transition_ok(&mut d, BctsState::Submitted, &actor, ts);
         let h2 = d.content_hash().expect("ok");
         assert_ne!(h1, h2);
     }
@@ -604,11 +881,9 @@ mod tests {
         let actor = test_did();
         let mut d = make_decision(&mut clock);
         let ts = clock.now().expect("HLC timestamp");
-        d.transition_at(BctsState::Submitted, &actor, ts)
-            .expect("ok");
+        transition_ok(&mut d, BctsState::Submitted, &actor, ts);
         let ts = clock.now().expect("HLC timestamp");
-        d.transition_at(BctsState::IdentityResolved, &actor, ts)
-            .expect("ok");
+        transition_ok(&mut d, BctsState::IdentityResolved, &actor, ts);
         assert_ne!(
             d.receipt_chain[0].receipt_hash,
             d.receipt_chain[1].receipt_hash

--- a/crates/decision-forum/src/tnc_enforcer.rs
+++ b/crates/decision-forum/src/tnc_enforcer.rs
@@ -225,10 +225,22 @@ mod tests {
         hlc::HybridClock,
         types::{Did, Hash256},
     };
+    use exo_gatekeeper::{
+        authority_link_signature_message,
+        invariants::InvariantSet,
+        kernel::{ActionRequest, AdjudicationContext, Kernel},
+        provenance_signature_message,
+        types::{
+            AuthorityChain, AuthorityLink as GatekeeperAuthorityLink, BailmentState, ConsentRecord,
+            GovernmentBranch, PermissionSet, Provenance, Role,
+        },
+    };
     use uuid::Uuid;
 
     use super::*;
     use crate::decision_object::*;
+
+    const CONSTITUTION: &[u8] = b"EXOCHAIN TNC test constitution";
 
     fn test_clock() -> HybridClock {
         let counter = AtomicU64::new(1000);
@@ -271,6 +283,99 @@ mod tests {
         })
         .expect("ok");
         d
+    }
+
+    fn signed_authority_link(
+        actor: &Did,
+        permission: exo_gatekeeper::types::Permission,
+    ) -> GatekeeperAuthorityLink {
+        let (pk, sk) = exo_core::crypto::generate_keypair();
+        let grantor = Did::new("did:exo:governance-root").expect("valid DID");
+        let mut link = GatekeeperAuthorityLink {
+            grantor,
+            grantee: actor.clone(),
+            permissions: PermissionSet::new(vec![permission]),
+            signature: Vec::new(),
+            grantor_public_key: Some(pk.as_bytes().to_vec()),
+        };
+        let message = authority_link_signature_message(&link).expect("canonical link payload");
+        let signature = exo_core::crypto::sign(message.as_bytes(), &sk);
+        link.signature = signature.to_bytes().to_vec();
+        link
+    }
+
+    fn signed_provenance(actor: &Did) -> Provenance {
+        let (pk, sk) = exo_core::crypto::generate_keypair();
+        let mut provenance = Provenance {
+            actor: actor.clone(),
+            timestamp: "2026-04-30T00:00:00Z".to_owned(),
+            action_hash: vec![0x54, 0x4E, 0x43],
+            signature: Vec::new(),
+            public_key: Some(pk.as_bytes().to_vec()),
+            voice_kind: None,
+            independence: None,
+            review_order: None,
+        };
+        let message =
+            provenance_signature_message(&provenance).expect("canonical provenance payload");
+        let signature = exo_core::crypto::sign(message.as_bytes(), &sk);
+        provenance.signature = signature.to_bytes().to_vec();
+        provenance
+    }
+
+    fn transition_action(actor: &Did, from: BctsState, to: BctsState) -> ActionRequest {
+        let required = bcts_transition_permission(from, to);
+        ActionRequest {
+            actor: actor.clone(),
+            action: bcts_transition_action_name(from, to),
+            required_permissions: PermissionSet::new(vec![required]),
+            is_self_grant: false,
+            modifies_kernel: false,
+        }
+    }
+
+    fn transition_context(actor: &Did, from: BctsState, to: BctsState) -> AdjudicationContext {
+        let permission = bcts_transition_permission(from, to);
+        AdjudicationContext {
+            actor_roles: vec![Role {
+                name: "transition-judge".into(),
+                branch: GovernmentBranch::Judicial,
+            }],
+            authority_chain: AuthorityChain {
+                links: vec![signed_authority_link(actor, permission.clone())],
+            },
+            consent_records: vec![ConsentRecord {
+                subject: Did::new("did:exo:bailor").expect("valid DID"),
+                granted_to: actor.clone(),
+                scope: "bcts:transition".into(),
+                active: true,
+            }],
+            bailment_state: BailmentState::Active {
+                bailor: Did::new("did:exo:bailor").expect("valid DID"),
+                bailee: actor.clone(),
+                scope: "bcts:transition".into(),
+            },
+            human_override_preserved: true,
+            actor_permissions: PermissionSet::new(vec![permission]),
+            provenance: Some(signed_provenance(actor)),
+            quorum_evidence: None,
+            active_challenge_reason: None,
+        }
+    }
+
+    fn transition_ok(
+        decision: &mut DecisionObject,
+        to: BctsState,
+        actor: &Did,
+        timestamp: exo_core::Timestamp,
+    ) {
+        let from = decision.state;
+        let kernel = Kernel::new(CONSTITUTION, InvariantSet::all());
+        let action = transition_action(actor, from, to);
+        let context = transition_context(actor, from, to);
+        decision
+            .transition_adjudicated_at(to, actor, timestamp, &kernel, &action, &context)
+            .expect("transition ok");
     }
 
     #[test]
@@ -363,7 +468,7 @@ mod tests {
             BctsState::Closed,
         ] {
             let ts = clock.now().expect("HLC timestamp");
-            d.transition_at(s, &actor, ts).expect("ok");
+            transition_ok(&mut d, s, &actor, ts);
         }
         let ctx = passing_ctx(&d);
         let err = enforce_tnc_08(&ctx).unwrap_err();

--- a/crates/decision-forum/tests/governance_kernel_integration.rs
+++ b/crates/decision-forum/tests/governance_kernel_integration.rs
@@ -27,7 +27,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use decision_forum::{
     decision_object::{
         ActorKind, AuthorityLink as ForumAuthorityLink, DecisionClass, DecisionObject,
-        DecisionObjectInput, EvidenceItem,
+        DecisionObjectInput, EvidenceItem, bcts_transition_action_name, bcts_transition_permission,
     },
     tnc_enforcer::{TncContext, enforce_all as enforce_tnc_all},
 };
@@ -64,10 +64,10 @@ fn did(s: &str) -> Did {
     Did::new(s).expect("valid DID")
 }
 
-fn signed_authority_link(grantee: &Did) -> GkAuthorityLink {
+fn signed_authority_link_for_permission(grantee: &Did, permission: Permission) -> GkAuthorityLink {
     let (pk, sk) = exo_core::crypto::generate_keypair();
     let grantor = did("did:exo:governance-root");
-    let permissions = PermissionSet::new(vec![Permission::new("enact:decision")]);
+    let permissions = PermissionSet::new(vec![permission]);
 
     let mut link = GkAuthorityLink {
         grantor,
@@ -80,6 +80,10 @@ fn signed_authority_link(grantee: &Did) -> GkAuthorityLink {
     let signature = exo_core::crypto::sign(message.as_bytes(), &sk);
     link.signature = signature.to_bytes().to_vec();
     link
+}
+
+fn signed_authority_link(grantee: &Did) -> GkAuthorityLink {
+    signed_authority_link_for_permission(grantee, Permission::new("enact:decision"))
 }
 
 fn signed_provenance(actor: &Did) -> Provenance {
@@ -141,6 +145,7 @@ fn make_approved_decision(class: DecisionClass, clock: &mut HybridClock) -> Deci
     .expect("add evidence");
 
     // Advance through the full BCTS happy-path lifecycle.
+    let kernel = test_kernel();
     for state in [
         BctsState::Submitted,
         BctsState::IdentityResolved,
@@ -151,7 +156,9 @@ fn make_approved_decision(class: DecisionClass, clock: &mut HybridClock) -> Deci
         BctsState::Approved,
     ] {
         let ts = clock.now().expect("HLC timestamp");
-        d.transition_at(state, &actor, ts)
+        let action = transition_action(&actor, d.state, state);
+        let context = transition_context(&actor, d.state, state);
+        d.transition_adjudicated_at(state, &actor, ts, &kernel, &action, &context)
             .expect("lifecycle transition");
     }
 
@@ -206,6 +213,30 @@ fn enact_action(actor: &Did) -> ActionRequest {
         is_self_grant: false,
         modifies_kernel: false,
     }
+}
+
+fn transition_action(actor: &Did, from: BctsState, to: BctsState) -> ActionRequest {
+    let permission = bcts_transition_permission(from, to);
+    ActionRequest {
+        actor: actor.clone(),
+        action: bcts_transition_action_name(from, to),
+        required_permissions: PermissionSet::new(vec![permission]),
+        is_self_grant: false,
+        modifies_kernel: false,
+    }
+}
+
+fn transition_context(actor: &Did, from: BctsState, to: BctsState) -> AdjudicationContext {
+    let permission = bcts_transition_permission(from, to);
+    let mut context = valid_adj_context(actor);
+    context.authority_chain = AuthorityChain {
+        links: vec![signed_authority_link_for_permission(
+            actor,
+            permission.clone(),
+        )],
+    };
+    context.actor_permissions = PermissionSet::new(vec![permission]);
+    context
 }
 
 // ---------------------------------------------------------------------------
@@ -399,8 +430,17 @@ fn full_lifecycle_adjudicated_at_each_transition() {
 
     for state in transitions {
         let ts = clock.now().expect("HLC timestamp");
-        d.transition_at(state, &actor, ts)
-            .expect("lifecycle transition");
+        let transition_action = transition_action(&actor, d.state, state);
+        let transition_context = transition_context(&actor, d.state, state);
+        d.transition_adjudicated_at(
+            state,
+            &actor,
+            ts,
+            &kernel,
+            &transition_action,
+            &transition_context,
+        )
+        .expect("lifecycle transition");
         let verdict = kernel.adjudicate(&action, &context);
         assert!(
             verdict.is_permitted(),
@@ -617,10 +657,14 @@ fn denied_forum_decision_correlates_with_kernel_denial() {
     })
     .expect("add link");
     let ts = clock.now().expect("HLC timestamp");
-    d.transition_at(BctsState::Submitted, &actor, ts)
+    let action = transition_action(&actor, d.state, BctsState::Submitted);
+    let context = transition_context(&actor, d.state, BctsState::Submitted);
+    d.transition_adjudicated_at(BctsState::Submitted, &actor, ts, &kernel, &action, &context)
         .expect("submit");
     let ts = clock.now().expect("HLC timestamp");
-    d.transition_at(BctsState::Denied, &actor, ts)
+    let action = transition_action(&actor, d.state, BctsState::Denied);
+    let context = transition_context(&actor, d.state, BctsState::Denied);
+    d.transition_adjudicated_at(BctsState::Denied, &actor, ts, &kernel, &action, &context)
         .expect("deny");
     assert_eq!(d.state, BctsState::Denied);
 

--- a/crates/exo-core/src/bcts.rs
+++ b/crates/exo-core/src/bcts.rs
@@ -108,6 +108,37 @@ pub struct BctsTransition {
     pub actor_did: Did,
 }
 
+/// Deterministic intent supplied to constitutional adjudicators before a BCTS
+/// state mutation is applied.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BctsTransitionRequest {
+    pub correlation_id: CorrelationId,
+    pub from_state: BctsState,
+    pub to_state: BctsState,
+    pub actor_did: Did,
+    pub prior_receipt_hash: Hash256,
+}
+
+/// Constitutional gate invoked by BCTS before applying a valid state transition.
+pub trait BctsTransitionAdjudicator {
+    /// Adjudicate the transition intent.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when constitutional invariants deny or escalate the
+    /// transition request.
+    fn adjudicate_transition(&self, request: &BctsTransitionRequest) -> Result<()>;
+}
+
+impl<F> BctsTransitionAdjudicator for F
+where
+    F: Fn(&BctsTransitionRequest) -> Result<()>,
+{
+    fn adjudicate_transition(&self, request: &BctsTransitionRequest) -> Result<()> {
+        self(request)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // BailmentTransaction trait
 // ---------------------------------------------------------------------------
@@ -128,6 +159,7 @@ pub trait BailmentTransaction {
         to: BctsState,
         actor: &Did,
         clock: &mut HybridClock,
+        adjudicator: &dyn BctsTransitionAdjudicator,
     ) -> Result<BctsTransition>;
 
     /// The chain of receipt hashes for every transition so far.
@@ -241,6 +273,7 @@ impl BailmentTransaction for Transaction {
         to: BctsState,
         actor: &Did,
         clock: &mut HybridClock,
+        adjudicator: &dyn BctsTransitionAdjudicator,
     ) -> Result<BctsTransition> {
         let from = self.current_state;
         if !from.can_transition_to(to) {
@@ -249,6 +282,15 @@ impl BailmentTransaction for Transaction {
                 to: to.to_string(),
             });
         }
+
+        let prior_receipt_hash = self.receipt_chain.last().copied().unwrap_or(Hash256::ZERO);
+        adjudicator.adjudicate_transition(&BctsTransitionRequest {
+            correlation_id: self.correlation_id,
+            from_state: from,
+            to_state: to,
+            actor_did: actor.clone(),
+            prior_receipt_hash,
+        })?;
 
         let timestamp = clock.now()?;
         let receipt_hash = self.compute_receipt(from, to, &timestamp, actor)?;
@@ -300,6 +342,14 @@ mod tests {
 
     fn test_did() -> Did {
         Did::new("did:exo:test-actor").expect("valid")
+    }
+
+    struct AllowAllAdjudicator;
+
+    impl BctsTransitionAdjudicator for AllowAllAdjudicator {
+        fn adjudicate_transition(&self, _request: &BctsTransitionRequest) -> Result<()> {
+            Ok(())
+        }
     }
 
     // -- BctsState ---------------------------------------------------------
@@ -438,6 +488,99 @@ mod tests {
     }
 
     #[test]
+    fn transition_invokes_adjudicator_before_state_mutation() {
+        struct DenyingAdjudicator;
+
+        impl BctsTransitionAdjudicator for DenyingAdjudicator {
+            fn adjudicate_transition(&self, _request: &BctsTransitionRequest) -> Result<()> {
+                Err(ExoError::InvariantViolation {
+                    description: "test denial".into(),
+                })
+            }
+        }
+
+        let mut clock = test_clock();
+        let actor = test_did();
+        let mut tx = Transaction::new(correlation_id!());
+
+        let err = tx
+            .transition(
+                BctsState::Submitted,
+                &actor,
+                &mut clock,
+                &DenyingAdjudicator,
+            )
+            .expect_err("transition must fail before mutation when adjudication denies");
+
+        assert!(matches!(err, ExoError::InvariantViolation { .. }));
+        assert_eq!(tx.state(), BctsState::Draft);
+        assert!(tx.receipt_chain().is_empty());
+        assert!(tx.transitions().is_empty());
+    }
+
+    #[test]
+    fn transition_supplies_canonical_request_to_adjudicator() {
+        use std::cell::RefCell;
+
+        struct RecordingAdjudicator {
+            request: RefCell<Option<BctsTransitionRequest>>,
+        }
+
+        impl BctsTransitionAdjudicator for RecordingAdjudicator {
+            fn adjudicate_transition(&self, request: &BctsTransitionRequest) -> Result<()> {
+                self.request.replace(Some(request.clone()));
+                Ok(())
+            }
+        }
+
+        let mut clock = test_clock();
+        let actor = test_did();
+        let correlation_id = correlation_id!();
+        let mut tx = Transaction::new(correlation_id);
+        let adjudicator = RecordingAdjudicator {
+            request: RefCell::new(None),
+        };
+
+        tx.transition(BctsState::Submitted, &actor, &mut clock, &adjudicator)
+            .expect("transition ok");
+
+        let request = adjudicator
+            .request
+            .take()
+            .expect("adjudicator received request");
+        assert_eq!(request.correlation_id, correlation_id);
+        assert_eq!(request.from_state, BctsState::Draft);
+        assert_eq!(request.to_state, BctsState::Submitted);
+        assert_eq!(request.actor_did, actor);
+        assert_eq!(request.prior_receipt_hash, Hash256::ZERO);
+    }
+
+    #[test]
+    fn transition_source_invokes_adjudicator_before_hlc_and_mutation() {
+        let source = include_str!("bcts.rs");
+        let implementation = source
+            .split("impl BailmentTransaction for Transaction")
+            .nth(1)
+            .expect("transaction impl");
+        let adjudicator_call = implementation
+            .find("adjudicator.adjudicate_transition")
+            .expect("adjudicator call");
+        let hlc_tick = implementation.find("clock.now()").expect("HLC tick");
+        let mutation = implementation
+            .find("self.current_state = to")
+            .expect("state mutation");
+
+        assert!(
+            adjudicator_call < hlc_tick,
+            "BCTS must adjudicate before consuming an HLC tick"
+        );
+        assert!(
+            adjudicator_call < mutation,
+            "BCTS must adjudicate before mutating state"
+        );
+    }
+
+    #[test]
     fn happy_path_full_lifecycle() {
         let mut clock = test_clock();
         let actor = test_did();
@@ -458,7 +601,7 @@ mod tests {
 
         for (i, &target) in steps.iter().enumerate() {
             let t = tx
-                .transition(target, &actor, &mut clock)
+                .transition(target, &actor, &mut clock, &AllowAllAdjudicator)
                 .expect("transition ok");
             assert_eq!(t.to_state, target);
             assert_eq!(tx.state(), target);
@@ -476,7 +619,7 @@ mod tests {
         let mut tx = Transaction::new(correlation_id!());
 
         let err = tx
-            .transition(BctsState::Closed, &actor, &mut clock)
+            .transition(BctsState::Closed, &actor, &mut clock, &AllowAllAdjudicator)
             .unwrap_err();
         assert!(matches!(err, ExoError::InvalidTransition { .. }));
         // State should not have changed
@@ -502,12 +645,13 @@ mod tests {
             BctsState::Recorded,
             BctsState::Closed,
         ] {
-            tx.transition(s, &actor, &mut clock).expect("ok");
+            tx.transition(s, &actor, &mut clock, &AllowAllAdjudicator)
+                .expect("ok");
         }
 
         // Closed is terminal
         let err = tx
-            .transition(BctsState::Draft, &actor, &mut clock)
+            .transition(BctsState::Draft, &actor, &mut clock, &AllowAllAdjudicator)
             .unwrap_err();
         assert!(matches!(err, ExoError::InvalidTransition { .. }));
     }
@@ -518,9 +662,14 @@ mod tests {
         let actor = test_did();
         let mut tx = Transaction::new(correlation_id!());
 
-        tx.transition(BctsState::Submitted, &actor, &mut clock)
-            .expect("ok");
-        tx.transition(BctsState::Denied, &actor, &mut clock)
+        tx.transition(
+            BctsState::Submitted,
+            &actor,
+            &mut clock,
+            &AllowAllAdjudicator,
+        )
+        .expect("ok");
+        tx.transition(BctsState::Denied, &actor, &mut clock, &AllowAllAdjudicator)
             .expect("ok");
         assert_eq!(tx.state(), BctsState::Denied);
         tx.verify_receipt_chain().expect("chain valid");
@@ -541,7 +690,8 @@ mod tests {
             BctsState::Deliberated,
             BctsState::Verified,
         ] {
-            tx.transition(s, &actor, &mut clock).expect("ok");
+            tx.transition(s, &actor, &mut clock, &AllowAllAdjudicator)
+                .expect("ok");
         }
         assert_eq!(tx.state(), BctsState::Verified);
         tx.verify_receipt_chain().expect("chain valid");
@@ -553,14 +703,29 @@ mod tests {
         let actor = test_did();
         let mut tx = Transaction::new(correlation_id!());
 
-        tx.transition(BctsState::Submitted, &actor, &mut clock)
+        tx.transition(
+            BctsState::Submitted,
+            &actor,
+            &mut clock,
+            &AllowAllAdjudicator,
+        )
+        .expect("ok");
+        tx.transition(BctsState::Denied, &actor, &mut clock, &AllowAllAdjudicator)
             .expect("ok");
-        tx.transition(BctsState::Denied, &actor, &mut clock)
-            .expect("ok");
-        tx.transition(BctsState::Remediated, &actor, &mut clock)
-            .expect("ok");
-        tx.transition(BctsState::Submitted, &actor, &mut clock)
-            .expect("ok");
+        tx.transition(
+            BctsState::Remediated,
+            &actor,
+            &mut clock,
+            &AllowAllAdjudicator,
+        )
+        .expect("ok");
+        tx.transition(
+            BctsState::Submitted,
+            &actor,
+            &mut clock,
+            &AllowAllAdjudicator,
+        )
+        .expect("ok");
         assert_eq!(tx.state(), BctsState::Submitted);
         tx.verify_receipt_chain().expect("chain valid");
     }
@@ -571,12 +736,22 @@ mod tests {
         let actor = test_did();
         let mut tx = Transaction::new(correlation_id!());
 
-        tx.transition(BctsState::Submitted, &actor, &mut clock)
-            .expect("ok");
+        tx.transition(
+            BctsState::Submitted,
+            &actor,
+            &mut clock,
+            &AllowAllAdjudicator,
+        )
+        .expect("ok");
         assert_eq!(tx.receipt_chain().len(), 1);
 
-        tx.transition(BctsState::IdentityResolved, &actor, &mut clock)
-            .expect("ok");
+        tx.transition(
+            BctsState::IdentityResolved,
+            &actor,
+            &mut clock,
+            &AllowAllAdjudicator,
+        )
+        .expect("ok");
         assert_eq!(tx.receipt_chain().len(), 2);
 
         // Each receipt should be unique
@@ -590,7 +765,12 @@ mod tests {
         let mut tx = Transaction::new(correlation_id!());
 
         let t = tx
-            .transition(BctsState::Submitted, &actor, &mut clock)
+            .transition(
+                BctsState::Submitted,
+                &actor,
+                &mut clock,
+                &AllowAllAdjudicator,
+            )
             .expect("ok");
         assert_eq!(t.actor_did, actor);
     }
@@ -601,10 +781,20 @@ mod tests {
         let actor = test_did();
         let mut tx = Transaction::new(correlation_id!());
 
-        tx.transition(BctsState::Submitted, &actor, &mut clock)
-            .expect("ok");
-        tx.transition(BctsState::IdentityResolved, &actor, &mut clock)
-            .expect("ok");
+        tx.transition(
+            BctsState::Submitted,
+            &actor,
+            &mut clock,
+            &AllowAllAdjudicator,
+        )
+        .expect("ok");
+        tx.transition(
+            BctsState::IdentityResolved,
+            &actor,
+            &mut clock,
+            &AllowAllAdjudicator,
+        )
+        .expect("ok");
 
         let ts = &tx.transitions();
         assert!(ts[0].timestamp < ts[1].timestamp);
@@ -616,10 +806,20 @@ mod tests {
         let actor = test_did();
         let mut tx = Transaction::new(correlation_id!());
 
-        tx.transition(BctsState::Submitted, &actor, &mut clock)
-            .expect("ok");
-        tx.transition(BctsState::IdentityResolved, &actor, &mut clock)
-            .expect("ok");
+        tx.transition(
+            BctsState::Submitted,
+            &actor,
+            &mut clock,
+            &AllowAllAdjudicator,
+        )
+        .expect("ok");
+        tx.transition(
+            BctsState::IdentityResolved,
+            &actor,
+            &mut clock,
+            &AllowAllAdjudicator,
+        )
+        .expect("ok");
 
         // Tamper with a receipt
         tx.receipt_chain[0] = Hash256::ZERO;
@@ -632,8 +832,13 @@ mod tests {
         let mut clock = test_clock();
         let actor = test_did();
         let mut tx = Transaction::new(correlation_id!());
-        tx.transition(BctsState::Submitted, &actor, &mut clock)
-            .expect("ok");
+        tx.transition(
+            BctsState::Submitted,
+            &actor,
+            &mut clock,
+            &AllowAllAdjudicator,
+        )
+        .expect("ok");
 
         let json = serde_json::to_string(&tx).expect("ser");
         let tx2: Transaction = serde_json::from_str(&json).expect("de");
@@ -696,7 +901,8 @@ mod tests {
             BctsState::Remediated,
             BctsState::Submitted,
         ] {
-            tx.transition(s, &actor, &mut clock).expect("ok");
+            tx.transition(s, &actor, &mut clock, &AllowAllAdjudicator)
+                .expect("ok");
         }
         assert_eq!(tx.state(), BctsState::Submitted);
         tx.verify_receipt_chain().expect("chain valid");
@@ -717,7 +923,8 @@ mod tests {
             BctsState::Remediated,
             BctsState::Submitted,
         ] {
-            tx.transition(s, &actor, &mut clock).expect("ok");
+            tx.transition(s, &actor, &mut clock, &AllowAllAdjudicator)
+                .expect("ok");
         }
         tx.verify_receipt_chain().expect("chain valid");
     }

--- a/crates/exo-core/tests/chain_of_custody.rs
+++ b/crates/exo-core/tests/chain_of_custody.rs
@@ -10,7 +10,10 @@
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use exo_core::{
-    bcts::{BailmentTransaction, BctsState, Transaction},
+    bcts::{
+        BailmentTransaction, BctsState, BctsTransitionAdjudicator, BctsTransitionRequest,
+        Transaction,
+    },
     crypto::{
         KeyPair, PqKeyPair, generate_keypair, generate_pq_keypair, sign, sign_hybrid, sign_pq,
         verify, verify_hybrid, verify_pq,
@@ -25,6 +28,14 @@ use exo_core::{
         CorrelationId, DeterministicMap, Did, Hash256, Signature, SignerType, Timestamp, Version,
     },
 };
+
+struct AllowAllAdjudicator;
+
+impl BctsTransitionAdjudicator for AllowAllAdjudicator {
+    fn adjudicate_transition(&self, _request: &BctsTransitionRequest) -> exo_core::Result<()> {
+        Ok(())
+    }
+}
 
 macro_rules! correlation_id {
     () => {
@@ -86,7 +97,12 @@ fn multi_actor_signed_event_chain_with_merkle_proof() {
 
     // Phase 1: Proposer submits
     let t1 = tx
-        .transition(BctsState::Submitted, &actors.proposer.0, &mut clock)
+        .transition(
+            BctsState::Submitted,
+            &actors.proposer.0,
+            &mut clock,
+            &AllowAllAdjudicator,
+        )
         .expect("submit ok");
     let event1 = create_signed_event(
         correlation_id!(),
@@ -101,7 +117,12 @@ fn multi_actor_signed_event_chain_with_merkle_proof() {
 
     // Phase 2: Identity resolution by reviewer1
     let t2 = tx
-        .transition(BctsState::IdentityResolved, &actors.reviewer1.0, &mut clock)
+        .transition(
+            BctsState::IdentityResolved,
+            &actors.reviewer1.0,
+            &mut clock,
+            &AllowAllAdjudicator,
+        )
         .expect("identity ok");
     let event2 = create_signed_event(
         correlation_id!(),
@@ -116,7 +137,12 @@ fn multi_actor_signed_event_chain_with_merkle_proof() {
 
     // Phase 3: Consent validation by reviewer2
     let t3 = tx
-        .transition(BctsState::ConsentValidated, &actors.reviewer2.0, &mut clock)
+        .transition(
+            BctsState::ConsentValidated,
+            &actors.reviewer2.0,
+            &mut clock,
+            &AllowAllAdjudicator,
+        )
         .expect("consent ok");
     let event3 = create_signed_event(
         correlation_id!(),
@@ -131,7 +157,12 @@ fn multi_actor_signed_event_chain_with_merkle_proof() {
 
     // Phase 4: Deliberation by steward
     let t4 = tx
-        .transition(BctsState::Deliberated, &actors.steward.0, &mut clock)
+        .transition(
+            BctsState::Deliberated,
+            &actors.steward.0,
+            &mut clock,
+            &AllowAllAdjudicator,
+        )
         .expect("deliberation ok");
     let event4 = create_signed_event(
         correlation_id!(),
@@ -204,7 +235,7 @@ fn denial_remediation_resubmission_with_full_proof_chain() {
     let mut events = Vec::new();
     for (index, &target) in transitions.iter().enumerate() {
         let t = tx
-            .transition(target, &actor, &mut clock)
+            .transition(target, &actor, &mut clock, &AllowAllAdjudicator)
             .expect("transition ok");
         let event = create_signed_event(
             indexed_correlation_id(2_000, index),
@@ -274,7 +305,9 @@ fn hybrid_crypto_custody_chain() {
 
     let mut hybrid_sigs = Vec::new();
     for &s in &states {
-        let t = tx.transition(s, &actor, &mut clock).expect("ok");
+        let t = tx
+            .transition(s, &actor, &mut clock, &AllowAllAdjudicator)
+            .expect("ok");
         let sig =
             sign_hybrid(t.receipt_hash.as_bytes(), &classical_sk, &pq_sk).expect("hybrid sign");
         assert!(
@@ -326,7 +359,9 @@ fn pq_only_custody_chain() {
         BctsState::ConsentValidated,
         BctsState::Deliberated,
     ] {
-        let t = tx.transition(s, &actor, &mut clock).expect("ok");
+        let t = tx
+            .transition(s, &actor, &mut clock, &AllowAllAdjudicator)
+            .expect("ok");
         let sig = pq_kp.sign(t.receipt_hash.as_bytes()).expect("pq sign");
         assert!(
             pq_kp.verify(t.receipt_hash.as_bytes(), &sig),
@@ -348,16 +383,41 @@ fn escalation_path_proof() {
     let mut tx = Transaction::new(correlation_id!());
 
     // Submit → IdentityResolved → ConsentValidated → Deliberated → Escalated
-    tx.transition(BctsState::Submitted, &actor, &mut clock)
-        .expect("ok");
-    tx.transition(BctsState::IdentityResolved, &actor, &mut clock)
-        .expect("ok");
-    tx.transition(BctsState::ConsentValidated, &actor, &mut clock)
-        .expect("ok");
-    tx.transition(BctsState::Deliberated, &actor, &mut clock)
-        .expect("ok");
+    tx.transition(
+        BctsState::Submitted,
+        &actor,
+        &mut clock,
+        &AllowAllAdjudicator,
+    )
+    .expect("ok");
+    tx.transition(
+        BctsState::IdentityResolved,
+        &actor,
+        &mut clock,
+        &AllowAllAdjudicator,
+    )
+    .expect("ok");
+    tx.transition(
+        BctsState::ConsentValidated,
+        &actor,
+        &mut clock,
+        &AllowAllAdjudicator,
+    )
+    .expect("ok");
+    tx.transition(
+        BctsState::Deliberated,
+        &actor,
+        &mut clock,
+        &AllowAllAdjudicator,
+    )
+    .expect("ok");
     let t_esc = tx
-        .transition(BctsState::Escalated, &actor, &mut clock)
+        .transition(
+            BctsState::Escalated,
+            &actor,
+            &mut clock,
+            &AllowAllAdjudicator,
+        )
         .expect("escalation ok");
 
     let event = create_signed_event(
@@ -389,7 +449,8 @@ fn receipt_chain_tamper_detection() {
         BctsState::IdentityResolved,
         BctsState::ConsentValidated,
     ] {
-        tx.transition(s, &actor, &mut clock).expect("ok");
+        tx.transition(s, &actor, &mut clock, &AllowAllAdjudicator)
+            .expect("ok");
     }
 
     // Chain should be valid before tampering
@@ -422,13 +483,28 @@ fn concurrent_transactions_hlc_ordering() {
     let mut tx_b = Transaction::new(correlation_id!());
 
     let t_a1 = tx_a
-        .transition(BctsState::Submitted, &actors.proposer.0, &mut clock)
+        .transition(
+            BctsState::Submitted,
+            &actors.proposer.0,
+            &mut clock,
+            &AllowAllAdjudicator,
+        )
         .expect("ok");
     let t_b1 = tx_b
-        .transition(BctsState::Submitted, &actors.reviewer1.0, &mut clock)
+        .transition(
+            BctsState::Submitted,
+            &actors.reviewer1.0,
+            &mut clock,
+            &AllowAllAdjudicator,
+        )
         .expect("ok");
     let t_a2 = tx_a
-        .transition(BctsState::IdentityResolved, &actors.reviewer2.0, &mut clock)
+        .transition(
+            BctsState::IdentityResolved,
+            &actors.reviewer2.0,
+            &mut clock,
+            &AllowAllAdjudicator,
+        )
         .expect("ok");
 
     // Strict HLC ordering: t_a1 < t_b1 < t_a2
@@ -528,18 +604,28 @@ fn invalid_transition_rejected() {
     let mut tx = Transaction::new(correlation_id!());
 
     // Draft → Approved (skipping required states) should fail
-    let result = tx.transition(BctsState::Approved, &actor, &mut clock);
+    let result = tx.transition(
+        BctsState::Approved,
+        &actor,
+        &mut clock,
+        &AllowAllAdjudicator,
+    );
     assert!(
         result.is_err(),
         "skipping from Draft to Approved must be rejected"
     );
 
     // Draft → Submitted is valid
-    tx.transition(BctsState::Submitted, &actor, &mut clock)
-        .expect("ok");
+    tx.transition(
+        BctsState::Submitted,
+        &actor,
+        &mut clock,
+        &AllowAllAdjudicator,
+    )
+    .expect("ok");
 
     // Submitted → Closed (skipping) should fail
-    let result2 = tx.transition(BctsState::Closed, &actor, &mut clock);
+    let result2 = tx.transition(BctsState::Closed, &actor, &mut clock, &AllowAllAdjudicator);
     assert!(
         result2.is_err(),
         "skipping from Submitted to Closed must be rejected"
@@ -723,8 +809,13 @@ fn bailment_transaction_lifecycle() {
     assert_eq!(tx.state(), BctsState::Draft);
     assert!(tx.receipt_chain().is_empty());
 
-    tx.transition(BctsState::Submitted, &actor, &mut clock)
-        .expect("ok");
+    tx.transition(
+        BctsState::Submitted,
+        &actor,
+        &mut clock,
+        &AllowAllAdjudicator,
+    )
+    .expect("ok");
     assert_eq!(tx.state(), BctsState::Submitted);
     assert_eq!(tx.receipt_chain().len(), 1);
 

--- a/crates/exo-core/tests/integration.rs
+++ b/crates/exo-core/tests/integration.rs
@@ -6,7 +6,10 @@
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use exo_core::{
-    bcts::{BailmentTransaction, BctsState, Transaction},
+    bcts::{
+        BailmentTransaction, BctsState, BctsTransitionAdjudicator, BctsTransitionRequest,
+        Transaction,
+    },
     crypto::KeyPair,
     events::{EventType, create_signed_event, verify_event},
     hash::{canonical_hash, hash_structured, merkle_proof, merkle_root, verify_merkle_proof},
@@ -16,6 +19,14 @@ use exo_core::{
     },
     types::{CorrelationId, DeterministicMap, Did, Hash256, Timestamp, Version},
 };
+
+struct AllowAllAdjudicator;
+
+impl BctsTransitionAdjudicator for AllowAllAdjudicator {
+    fn adjudicate_transition(&self, _request: &BctsTransitionRequest) -> exo_core::Result<()> {
+        Ok(())
+    }
+}
 
 macro_rules! correlation_id {
     () => {
@@ -56,7 +67,9 @@ fn full_bcts_lifecycle_with_signed_events() {
     ];
 
     for (index, &target) in steps.iter().enumerate() {
-        let transition = tx.transition(target, &actor, &mut clock).expect("ok");
+        let transition = tx
+            .transition(target, &actor, &mut clock, &AllowAllAdjudicator)
+            .expect("ok");
 
         // Create a signed event for each transition
         let event = create_signed_event(
@@ -91,7 +104,8 @@ fn receipt_chain_merkle_tree() {
         BctsState::ConsentValidated,
         BctsState::Deliberated,
     ] {
-        tx.transition(s, &actor, &mut clock).expect("ok");
+        tx.transition(s, &actor, &mut clock, &AllowAllAdjudicator)
+            .expect("ok");
     }
 
     let receipts = tx.receipt_chain();
@@ -207,12 +221,22 @@ fn hlc_ordering_across_transactions() {
 
     let mut tx1 = Transaction::new(correlation_id!());
     let t1 = tx1
-        .transition(BctsState::Submitted, &actor, &mut clock)
+        .transition(
+            BctsState::Submitted,
+            &actor,
+            &mut clock,
+            &AllowAllAdjudicator,
+        )
         .expect("ok");
 
     let mut tx2 = Transaction::new(correlation_id!());
     let t2 = tx2
-        .transition(BctsState::Submitted, &actor, &mut clock)
+        .transition(
+            BctsState::Submitted,
+            &actor,
+            &mut clock,
+            &AllowAllAdjudicator,
+        )
         .expect("ok");
 
     // t2 must be after t1
@@ -246,16 +270,36 @@ fn denial_remediation_resubmission() {
     let mut tx = Transaction::new(correlation_id!());
 
     // Submit -> Deny -> Remediate -> Resubmit -> succeed
-    tx.transition(BctsState::Submitted, &actor, &mut clock)
+    tx.transition(
+        BctsState::Submitted,
+        &actor,
+        &mut clock,
+        &AllowAllAdjudicator,
+    )
+    .expect("ok");
+    tx.transition(BctsState::Denied, &actor, &mut clock, &AllowAllAdjudicator)
         .expect("ok");
-    tx.transition(BctsState::Denied, &actor, &mut clock)
-        .expect("ok");
-    tx.transition(BctsState::Remediated, &actor, &mut clock)
-        .expect("ok");
-    tx.transition(BctsState::Submitted, &actor, &mut clock)
-        .expect("ok");
-    tx.transition(BctsState::IdentityResolved, &actor, &mut clock)
-        .expect("ok");
+    tx.transition(
+        BctsState::Remediated,
+        &actor,
+        &mut clock,
+        &AllowAllAdjudicator,
+    )
+    .expect("ok");
+    tx.transition(
+        BctsState::Submitted,
+        &actor,
+        &mut clock,
+        &AllowAllAdjudicator,
+    )
+    .expect("ok");
+    tx.transition(
+        BctsState::IdentityResolved,
+        &actor,
+        &mut clock,
+        &AllowAllAdjudicator,
+    )
+    .expect("ok");
 
     assert_eq!(tx.state(), BctsState::IdentityResolved);
     assert_eq!(tx.receipt_chain().len(), 5);

--- a/crates/exo-gatekeeper/src/kernel.rs
+++ b/crates/exo-gatekeeper/src/kernel.rs
@@ -3,7 +3,10 @@
 //! The kernel is immutable after initialization. It holds the invariant set
 //! and constitution hash, and adjudicates every action request.
 
-use exo_core::Did;
+use exo_core::{
+    Did, ExoError,
+    bcts::{BctsTransitionAdjudicator, BctsTransitionRequest},
+};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -43,7 +46,7 @@ impl Verdict {
 // ---------------------------------------------------------------------------
 
 /// A request submitted to the kernel for adjudication against constitutional invariants.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ActionRequest {
     pub actor: Did,
     pub action: String,
@@ -57,7 +60,7 @@ pub struct ActionRequest {
 // ---------------------------------------------------------------------------
 
 /// Contextual evidence (roles, authority chain, consent, etc.) supplied alongside an action request.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AdjudicationContext {
     pub actor_roles: Vec<Role>,
     pub authority_chain: AuthorityChain,
@@ -149,6 +152,59 @@ impl Kernel {
     #[must_use]
     pub fn invariant_engine(&self) -> &InvariantEngine {
         &self.invariant_engine
+    }
+}
+
+/// Adapter that binds a BCTS transition boundary to a concrete kernel
+/// adjudication request and context.
+pub struct KernelBctsAdjudicator<'a> {
+    kernel: &'a Kernel,
+    action: &'a ActionRequest,
+    context: &'a AdjudicationContext,
+}
+
+impl<'a> KernelBctsAdjudicator<'a> {
+    #[must_use]
+    pub fn new(
+        kernel: &'a Kernel,
+        action: &'a ActionRequest,
+        context: &'a AdjudicationContext,
+    ) -> Self {
+        Self {
+            kernel,
+            action,
+            context,
+        }
+    }
+}
+
+impl BctsTransitionAdjudicator for KernelBctsAdjudicator<'_> {
+    fn adjudicate_transition(&self, request: &BctsTransitionRequest) -> exo_core::Result<()> {
+        if self.action.actor != request.actor_did {
+            return Err(ExoError::InvariantViolation {
+                description: format!(
+                    "BCTS transition actor {} does not match adjudicated action actor {}",
+                    request.actor_did, self.action.actor
+                ),
+            });
+        }
+
+        match self.kernel.adjudicate(self.action, self.context) {
+            Verdict::Permitted => Ok(()),
+            Verdict::Denied { violations } => {
+                let reason = violations
+                    .iter()
+                    .map(|v| format!("{}: {}", v.invariant.id(), v.description))
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                Err(ExoError::InvariantViolation {
+                    description: format!("BCTS transition denied by kernel: {reason}"),
+                })
+            }
+            Verdict::Escalated { reason } => Err(ExoError::InvariantViolation {
+                description: format!("BCTS transition escalated by kernel: {reason}"),
+            }),
+        }
     }
 }
 

--- a/crates/exo-gateway/tests/decision_forum_integration.rs
+++ b/crates/exo-gateway/tests/decision_forum_integration.rs
@@ -14,6 +14,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use decision_forum::{
     decision_object::{
         ActorKind, DecisionClass, DecisionObject, DecisionObjectInput, Vote, VoteChoice,
+        bcts_transition_action_name, bcts_transition_permission,
     },
     quorum::{QuorumCheckResult, QuorumRegistry, check_quorum, verify_quorum_precondition},
 };
@@ -21,6 +22,16 @@ use exo_core::{
     bcts::BctsState,
     hlc::HybridClock,
     types::{Did, Hash256},
+};
+use exo_gatekeeper::{
+    authority_link_signature_message,
+    invariants::InvariantSet,
+    kernel::{ActionRequest, AdjudicationContext, Kernel},
+    provenance_signature_message,
+    types::{
+        AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch, Permission,
+        PermissionSet, Provenance, Role,
+    },
 };
 
 // ---------------------------------------------------------------------------
@@ -55,6 +66,98 @@ fn human_approve(name: &str, clock: &mut HybridClock) -> Vote {
         timestamp: clock.now().expect("HLC timestamp"),
         signature_hash: Hash256::digest(name.as_bytes()),
     }
+}
+
+fn signed_authority_link(actor: &Did, permission: Permission) -> AuthorityLink {
+    let (pk, sk) = exo_core::crypto::generate_keypair();
+    let grantor = did("did:exo:governance-root");
+    let mut link = AuthorityLink {
+        grantor,
+        grantee: actor.clone(),
+        permissions: PermissionSet::new(vec![permission]),
+        signature: Vec::new(),
+        grantor_public_key: Some(pk.as_bytes().to_vec()),
+    };
+    let message = authority_link_signature_message(&link).expect("canonical link payload");
+    let signature = exo_core::crypto::sign(message.as_bytes(), &sk);
+    link.signature = signature.to_bytes().to_vec();
+    link
+}
+
+fn signed_provenance(actor: &Did) -> Provenance {
+    let (pk, sk) = exo_core::crypto::generate_keypair();
+    let mut provenance = Provenance {
+        actor: actor.clone(),
+        timestamp: "2026-04-30T00:00:00Z".to_owned(),
+        action_hash: vec![0x47, 0x57],
+        signature: Vec::new(),
+        public_key: Some(pk.as_bytes().to_vec()),
+        voice_kind: None,
+        independence: None,
+        review_order: None,
+    };
+    let message = provenance_signature_message(&provenance).expect("canonical provenance payload");
+    let signature = exo_core::crypto::sign(message.as_bytes(), &sk);
+    provenance.signature = signature.to_bytes().to_vec();
+    provenance
+}
+
+fn transition_action(actor: &Did, from: BctsState, to: BctsState) -> ActionRequest {
+    let permission = bcts_transition_permission(from, to);
+    ActionRequest {
+        actor: actor.clone(),
+        action: bcts_transition_action_name(from, to),
+        required_permissions: PermissionSet::new(vec![permission]),
+        is_self_grant: false,
+        modifies_kernel: false,
+    }
+}
+
+fn transition_context(actor: &Did, from: BctsState, to: BctsState) -> AdjudicationContext {
+    let permission = bcts_transition_permission(from, to);
+    AdjudicationContext {
+        actor_roles: vec![Role {
+            name: "gateway-transition-judge".into(),
+            branch: GovernmentBranch::Judicial,
+        }],
+        authority_chain: AuthorityChain {
+            links: vec![signed_authority_link(actor, permission.clone())],
+        },
+        consent_records: vec![ConsentRecord {
+            subject: did("did:exo:bailor"),
+            granted_to: actor.clone(),
+            scope: "bcts:transition".into(),
+            active: true,
+        }],
+        bailment_state: BailmentState::Active {
+            bailor: did("did:exo:bailor"),
+            bailee: actor.clone(),
+            scope: "bcts:transition".into(),
+        },
+        human_override_preserved: true,
+        actor_permissions: PermissionSet::new(vec![permission]),
+        provenance: Some(signed_provenance(actor)),
+        quorum_evidence: None,
+        active_challenge_reason: None,
+    }
+}
+
+fn transition_ok(
+    decision: &mut DecisionObject,
+    to: BctsState,
+    actor: &Did,
+    timestamp: exo_core::Timestamp,
+) {
+    let from = decision.state;
+    let kernel = Kernel::new(
+        b"EXOCHAIN gateway decision test constitution",
+        InvariantSet::all(),
+    );
+    let action = transition_action(actor, from, to);
+    let context = transition_context(actor, from, to);
+    decision
+        .transition_adjudicated_at(to, actor, timestamp, &kernel, &action, &context)
+        .expect("transition ok");
 }
 
 // ---------------------------------------------------------------------------
@@ -157,9 +260,7 @@ fn terminal_decision_rejects_votes() {
     ];
     for state in lifecycle {
         let ts = clock.now().expect("HLC timestamp");
-        decision
-            .transition_at(state, &actor, ts)
-            .expect("transition ok");
+        transition_ok(&mut decision, state, &actor, ts);
     }
 
     assert!(decision.is_terminal(), "decision must be in terminal state");

--- a/crates/exochain-wasm/src/decision_forum_bindings.rs
+++ b/crates/exochain-wasm/src/decision_forum_bindings.rs
@@ -1,6 +1,7 @@
 //! Decision Forum bindings: DecisionObject lifecycle, constitution, TNC enforcement,
 //! contestation, accountability, workflow, emergency
 
+use serde::Deserialize;
 use wasm_bindgen::prelude::*;
 
 use crate::serde_bridge::*;
@@ -9,6 +10,19 @@ const MAX_WASM_FORUM_EMERGENCY_ACTIONS: usize = 4_096;
 const MAX_WASM_FORUM_CHALLENGES: usize = 4_096;
 const MAX_WASM_FORUM_SIGNATURES: usize = 1_024;
 const MAX_WASM_FORUM_PUBLIC_KEYS: usize = 1_024;
+const MAX_WASM_FORUM_CONSTITUTION_BYTES: usize = 1_048_576;
+
+#[derive(Deserialize)]
+struct WasmDecisionTransitionAdjudicatedRequest {
+    decision: decision_forum::decision_object::DecisionObject,
+    to_state: exo_core::bcts::BctsState,
+    actor_did: String,
+    timestamp_ms: u64,
+    timestamp_logical: u32,
+    invariant_set: exo_gatekeeper::invariants::InvariantSet,
+    action: exo_gatekeeper::kernel::ActionRequest,
+    context: exo_gatekeeper::kernel::AdjudicationContext,
+}
 
 /// Create a new DecisionObject with full BCTS lifecycle
 #[wasm_bindgen]
@@ -47,15 +61,42 @@ pub fn wasm_transition_decision(
     timestamp_ms: u64,
     timestamp_logical: u32,
 ) -> Result<JsValue, JsValue> {
-    let mut decision: decision_forum::decision_object::DecisionObject =
-        from_json_str(decision_json)?;
-    let to_state: exo_core::bcts::BctsState = from_json_str(to_state_json)?;
-    let actor =
-        exo_core::Did::new(actor_did).map_err(|e| JsValue::from_str(&format!("DID error: {e}")))?;
+    let _ = (
+        decision_json,
+        to_state_json,
+        actor_did,
+        timestamp_ms,
+        timestamp_logical,
+    );
+    Err(JsValue::from_str(
+        "unadjudicated decision transitions are disabled; use wasm_transition_decision_adjudicated",
+    ))
+}
+
+/// Transition a DecisionObject to a new BCTS state after kernel adjudication.
+#[wasm_bindgen]
+pub fn wasm_transition_decision_adjudicated(
+    request_json: &str,
+    constitution: &[u8],
+) -> Result<JsValue, JsValue> {
+    ensure_constitution_bytes(constitution.len())?;
+    let WasmDecisionTransitionAdjudicatedRequest {
+        mut decision,
+        to_state,
+        actor_did,
+        timestamp_ms,
+        timestamp_logical,
+        invariant_set,
+        action,
+        context,
+    } = from_json_str(request_json)?;
+    let actor = exo_core::Did::new(&actor_did)
+        .map_err(|e| JsValue::from_str(&format!("DID error: {e}")))?;
     let ts = exo_core::types::Timestamp::new(timestamp_ms, timestamp_logical);
+    let kernel = exo_gatekeeper::kernel::Kernel::new(constitution, invariant_set);
 
     decision
-        .transition_at(to_state, &actor, ts)
+        .transition_adjudicated_at(to_state, &actor, ts, &kernel, &action, &context)
         .map_err(|e| JsValue::from_str(&format!("Transition error: {e}")))?;
     to_js_value(&decision)
 }
@@ -820,6 +861,15 @@ fn parse_public_key_pairs(
         public_keys.insert(did, exo_core::PublicKey::from_bytes(arr));
     }
     Ok(public_keys)
+}
+
+fn ensure_constitution_bytes(len: usize) -> Result<(), JsValue> {
+    if len > MAX_WASM_FORUM_CONSTITUTION_BYTES {
+        return Err(JsValue::from_str(
+            "constitution exceeds maximum WASM decision-forum size",
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/exochain-wasm/src/lib.rs
+++ b/crates/exochain-wasm/src/lib.rs
@@ -360,6 +360,44 @@ mod source_guard_tests {
     }
 
     #[test]
+    fn wasm_decision_transition_requires_kernel_adjudication() {
+        let source = include_str!("decision_forum_bindings.rs");
+        let legacy_transition = source
+            .split("pub fn wasm_transition_decision(")
+            .nth(1)
+            .and_then(|section| {
+                section
+                    .split("pub fn wasm_transition_decision_adjudicated(")
+                    .next()
+            })
+            .expect("legacy decision transition export source");
+
+        assert!(
+            legacy_transition.contains("unadjudicated decision transitions are disabled"),
+            "legacy WASM decision transition must fail closed without a kernel verdict"
+        );
+        assert!(
+            !legacy_transition.contains(".transition_at("),
+            "legacy WASM decision transition must not reach the raw BCTS transition"
+        );
+        assert!(
+            source.contains("Kernel::new") && source.contains(".transition_adjudicated_at("),
+            "WASM decision bridge must expose a kernel-adjudicated transition entrypoint"
+        );
+        assert!(
+            source.contains("WasmDecisionTransitionAdjudicatedRequest")
+                && source.contains("request_json"),
+            "WASM adjudicated decision transition must use a typed bounded request JSON instead of a wide argument list"
+        );
+        assert!(
+            !source.contains(
+                "timestamp_logical: u32,\n    constitution: &[u8],\n    invariant_set_json: &str,"
+            ),
+            "WASM adjudicated decision transition must not expose a clippy-wide argument list"
+        );
+    }
+
+    #[test]
     fn wasm_messaging_bridge_requires_caller_supplied_envelope_metadata() {
         let source = include_str!("messaging_bindings.rs");
         assert!(

--- a/governance/traceability_matrix.md
+++ b/governance/traceability_matrix.md
@@ -163,4 +163,4 @@ Updated 2026-03-20 after EXOCHAIN-REM-009 — continuous governance monitoring a
 | **TOTAL** | **86** | **83** | **1** | **2** |
 
 **Coverage: 83/86 requirements traced to code (97%). 2 planned (ExoForge scheduling + React dashboard). 1 partial (T-14 Rust attestation verification).**
-**Workspace inventory: 3,631 listed tests across 20 packages and 266 Rust files.**
+**Workspace inventory: 3,638 listed tests across 20 packages and 266 Rust files.**

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -1808,14 +1808,53 @@ test('wasm_add_vote', () => {
   return wasm.wasm_add_vote(decJson, JSON.stringify(vote));
 });
 
-test('wasm_transition_decision', () =>
-  wasm.wasm_transition_decision(
-    decJson,
-    JSON.stringify('Submitted'),
-    TEST_DID,
-    BigInt(NOW_NUM + 1),
-    0
+test('wasm_transition_decision rejects unadjudicated transition', () =>
+  expectErrorContains(
+    'wasm_transition_decision',
+    () => wasm.wasm_transition_decision(
+      decJson,
+      JSON.stringify('Submitted'),
+      TEST_DID,
+      BigInt(NOW_NUM + 1),
+      0
+    ),
+    'unadjudicated decision transitions are disabled'
   ));
+
+test('wasm_transition_decision_adjudicated', () => {
+  if (!decision) throw new Error('skipped -- no decision from setup');
+  const transitionPermission = 'bcts:transition:Draft->Submitted';
+  const request = {
+    decision,
+    to_state: 'Submitted',
+    actor_did: TEST_DID,
+    timestamp_ms: NOW_NUM + 1,
+    timestamp_logical: 0,
+    invariant_set: { invariants: [] },
+    action: {
+      actor: TEST_DID,
+      action: transitionPermission,
+      required_permissions: { permissions: [transitionPermission] },
+      is_self_grant: false,
+      modifies_kernel: false
+    },
+    context: {
+      actor_roles: [],
+      authority_chain: { links: [] },
+      consent_records: [],
+      bailment_state: 'None',
+      human_override_preserved: true,
+      actor_permissions: { permissions: [transitionPermission] },
+      provenance: null,
+      quorum_evidence: null,
+      active_challenge_reason: null
+    }
+  };
+  return wasm.wasm_transition_decision_adjudicated(
+    JSON.stringify(request),
+    new TextEncoder().encode('bridge constitution')
+  );
+});
 
 test('wasm_check_quorum', () => {
   const registry = {


### PR DESCRIPTION
## Summary

Remediates Wally F-034: BCTS/Decision Forum lifecycle transitions could mutate state without an enforced kernel adjudication boundary.

The external finding was treated as a hypothesis and revalidated against current main before implementation. Current code still exposed raw DecisionObject and core BCTS transition paths, so this PR closes the live core issue.

## Path classification

- EXOCHAIN core: `crates/exo-core/src/bcts.rs`, `crates/exo-gatekeeper/src/kernel.rs`, `crates/decision-forum/src/decision_object.rs`, `crates/decision-forum/src/tnc_enforcer.rs`, `crates/decision-forum/tests/governance_kernel_integration.rs`
- Core runtime adapter: `crates/exochain-wasm/src/decision_forum_bindings.rs`, `crates/exochain-wasm/src/lib.rs`, `crates/exo-gateway/tests/decision_forum_integration.rs`
- Repo-truth docs/governance artifact: `README.md`, `governance/traceability_matrix.md`
- Imported evidence: Wally zip / Matt report remain read-only and are not committed

## Security behavior

- Core `BailmentTransaction::transition` now requires a `BctsTransitionAdjudicator` and calls it before HLC advancement or state mutation.
- `DecisionObject::transition_at` is fail-closed; callers must use `transition_adjudicated_at`.
- Decision transitions bind action name and permission to the exact `from->to` BCTS transition before kernel adjudication.
- WASM legacy transition export is fail-closed; the adjudicated export accepts a typed bounded request JSON and constitution bytes.
- Integration fixtures now perform real adjudicated lifecycle transitions instead of sidecar adjudication.

## TDD / reproduction evidence

Red tests observed before implementation:

- `cargo test -p decision-forum raw_transition_without_kernel_adjudication_fails_closed` failed because raw transition mutated successfully.
- `cargo test -p exochain-wasm wasm_decision_transition_requires_kernel_adjudication` failed because legacy WASM transition did not fail closed.
- `cargo test -p exo-core transition_invokes_adjudicator_before_state_mutation` failed to compile because no adjudicator boundary existed.
- During clippy remediation, the new source guard first failed against the wide-argument WASM bridge before converting it to a typed request JSON.

## Local validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo +nightly fmt --all -- --check`
- `bash tools/test_repo_truth.sh`
- `cargo audit`
- `cargo deny check` (exit 0; existing duplicate-version warnings only)
- `./tools/cross-impl-test/compare.sh` (exit 0; Rust vectors and Rust x2 determinism pass; TypeScript comparison skipped because `EXO_TS_ROOT` is not configured)
- `git diff --check`
- Bypass searches for raw transition paths and determinism-rule violations across touched files
