### PR TITLE
fix(exo-consent): persist revocation tombstones and audit checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 > Run `bash tools/repo_truth.sh` to regenerate these numbers from source.
 >
-> The crate count includes `exo-catapult`, `exo-consensus`, `exo-messaging`, and `exochain-sdk` (four crates previously not listed in this README).
+> The crate count includes `exo-catapult`, `exo-consensus`, `exo-messaging`,
+> `exochain-sdk`, `exo-avc`, and `exo-economy` (six crates previously not
+> listed in this README).
 
 | Metric | Value | Source |
 |--------|-------|--------|
-| Rust crates | 20 | `ls -d crates/*/` |
-| Rust source files | 266 | `find crates -name '*.rs'` |
-| Rust LOC | 148414 | `wc -l` |
+| Rust crates | 22 | `ls -d crates/*/` |
+| Rust source files | 288 | `find crates -name '*.rs'` |
+| Rust LOC | 156564 | `wc -l` |
 | Workspace tests | 3,638 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -78,7 +80,7 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 20 crates, 148414 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 156564 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 3,638 listed workspace tests
 
@@ -110,7 +112,7 @@ Layer 5: ExoForge           (exoforge/)
 
 ## Repository Structure
 
-### Core Crates (20)
+### Core Crates (22)
 
 | Crate | Description |
 |-------|-------------|
@@ -134,6 +136,8 @@ Layer 5: ExoForge           (exoforge/)
 | `exo-messaging` | Encrypted messaging envelopes, death-trigger checks, and compose/open flows |
 | `exo-consensus` | Multi-model consensus session, scoring, commitment, and report primitives |
 | `exochain-sdk` | Rust SDK facade for identity, consent, authority, governance, and kernel calls |
+| `exo-avc` | Autonomous Volition Credentials: signed scope, delegation, revocation, and validation |
+| `exo-economy` | Custody-native zero-priced quote, settlement, receipt, revenue-share, and store primitives |
 
 ### Governance & Infrastructure
 

--- a/crates/exo-avc/src/credential.rs
+++ b/crates/exo-avc/src/credential.rs
@@ -638,8 +638,7 @@ pub(crate) mod test_support {
 
 #[cfg(test)]
 mod tests {
-    use super::test_support::*;
-    use super::*;
+    use super::{test_support::*, *};
 
     fn fixed_signature() -> Signature {
         Signature::from_bytes([7u8; 64])

--- a/crates/exo-avc/src/receipt.rs
+++ b/crates/exo-avc/src/receipt.rs
@@ -128,14 +128,17 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::credential::{
-        issue_avc,
-        test_support::{baseline_draft, did, ts},
-    };
-    use crate::registry::AvcRegistryWrite;
-    use crate::validation::{AvcDecision, AvcReasonCode, AvcValidationRequest, validate_avc};
     use exo_core::crypto::KeyPair;
+
+    use super::*;
+    use crate::{
+        credential::{
+            issue_avc,
+            test_support::{baseline_draft, did, ts},
+        },
+        registry::AvcRegistryWrite,
+        validation::{AvcDecision, AvcReasonCode, AvcValidationRequest, validate_avc},
+    };
 
     fn fixed_signature() -> Signature {
         Signature::from_bytes([7u8; 64])

--- a/crates/exo-avc/src/registry.rs
+++ b/crates/exo-avc/src/registry.rs
@@ -225,13 +225,16 @@ impl AvcRegistryWrite for InMemoryAvcRegistry {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::credential::{
-        issue_avc,
-        test_support::{baseline_draft, did, h256, ts},
-    };
-    use crate::revocation::{AvcRevocation, AvcRevocationReason};
     use exo_core::Signature;
+
+    use super::*;
+    use crate::{
+        credential::{
+            issue_avc,
+            test_support::{baseline_draft, did, h256, ts},
+        },
+        revocation::{AvcRevocation, AvcRevocationReason},
+    };
 
     fn fixed_signature() -> Signature {
         Signature::from_bytes([7u8; 64])

--- a/crates/exo-avc/src/validation.rs
+++ b/crates/exo-avc/src/validation.rs
@@ -16,9 +16,9 @@
 use std::collections::BTreeSet;
 
 use exo_authority::permission::Permission;
-use exo_core::{Did, Hash256, PublicKey, Timestamp, crypto};
 #[cfg(test)]
 use exo_core::Signature;
+use exo_core::{Did, Hash256, PublicKey, Timestamp, crypto};
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/crates/exo-avc/src/validation.rs
+++ b/crates/exo-avc/src/validation.rs
@@ -365,13 +365,16 @@ fn enforce_forbidden_action(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::credential::{
-        AVC_SCHEMA_VERSION, AuthorityChainRef, AvcConstraints, AvcDraft, AvcSubjectKind,
-        ConsentRef, PolicyRef, TimeWindow, issue_avc, test_support::*,
-    };
-    use crate::registry::{AvcRegistryWrite, InMemoryAvcRegistry};
     use exo_core::crypto::KeyPair;
+
+    use super::*;
+    use crate::{
+        credential::{
+            AVC_SCHEMA_VERSION, AuthorityChainRef, AvcConstraints, AvcDraft, AvcSubjectKind,
+            ConsentRef, PolicyRef, TimeWindow, issue_avc, test_support::*,
+        },
+        registry::{AvcRegistryWrite, InMemoryAvcRegistry},
+    };
 
     const ISSUER_SEED: [u8; 32] = [0x11; 32];
 

--- a/crates/exo-consent/src/error.rs
+++ b/crates/exo-consent/src/error.rs
@@ -23,6 +23,12 @@ pub enum ConsentError {
     #[error("consent denied: {0}")]
     Denied(String),
 
+    #[error("bailment has been revoked: {bailment_id}")]
+    Revoked { bailment_id: String },
+
+    #[error("consent audit sequence overflow for {counter}")]
+    SequenceOverflow { counter: String },
+
     #[error("serialization error: {0}")]
     Serialization(String),
 }

--- a/crates/exo-consent/src/gatekeeper.rs
+++ b/crates/exo-consent/src/gatekeeper.rs
@@ -4,22 +4,56 @@
 //! policy engine and active bailments, and returns a deterministic
 //! consent decision for every action request.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use exo_core::{Did, Timestamp};
+use serde::{Deserialize, Serialize};
 
 use crate::{
     bailment::{self, Bailment},
+    error::ConsentError,
     policy::{ActionRequest, ActiveConsent, ConsentDecision, ConsentPolicy, PolicyEngine},
 };
 
 /// Internal consent registration.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct ConsentReg {
     action_type: String,
     role: String,
     clearance_level: u32,
     bailment: Bailment,
+}
+
+/// Durable record of a consent check before a caller may release protected data.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConsentAccessLogEntry {
+    pub sequence: u64,
+    pub actor: Did,
+    pub action_type: String,
+    pub checked_at: Timestamp,
+    pub decision: ConsentDecision,
+}
+
+/// Durable revocation record used to prevent stale consent replay after restart.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConsentRevocationLogEntry {
+    pub sequence: u64,
+    pub bailment_id: String,
+    pub revoked_at: Timestamp,
+}
+
+/// Serializable consent gate state. Persist this snapshot atomically with the
+/// hosting runtime's durable state so revocations survive process restarts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConsentGateSnapshot {
+    pub policy: ConsentPolicy,
+    bailments: BTreeMap<String, Vec<Bailment>>,
+    consents: BTreeMap<String, Vec<ConsentReg>>,
+    pub revoked_bailment_ids: BTreeSet<String>,
+    pub revocation_log: Vec<ConsentRevocationLogEntry>,
+    pub access_log: Vec<ConsentAccessLogEntry>,
+    next_revocation_sequence: u64,
+    next_access_sequence: u64,
 }
 
 /// The consent gate — default-deny enforcement point.
@@ -29,6 +63,11 @@ pub struct ConsentGate {
     policy: ConsentPolicy,
     bailments: BTreeMap<String, Vec<Bailment>>,
     consents: BTreeMap<String, Vec<ConsentReg>>,
+    revoked_bailment_ids: BTreeSet<String>,
+    revocation_log: Vec<ConsentRevocationLogEntry>,
+    access_log: Vec<ConsentAccessLogEntry>,
+    next_revocation_sequence: u64,
+    next_access_sequence: u64,
 }
 
 impl ConsentGate {
@@ -39,14 +78,71 @@ impl ConsentGate {
             policy,
             bailments: BTreeMap::new(),
             consents: BTreeMap::new(),
+            revoked_bailment_ids: BTreeSet::new(),
+            revocation_log: Vec::new(),
+            access_log: Vec::new(),
+            next_revocation_sequence: 0,
+            next_access_sequence: 0,
         }
     }
 
-    pub fn register_bailment(&mut self, bailment: Bailment) {
+    #[must_use]
+    pub fn from_snapshot(snapshot: ConsentGateSnapshot) -> Self {
+        let ConsentGateSnapshot {
+            policy,
+            mut bailments,
+            mut consents,
+            revoked_bailment_ids,
+            revocation_log,
+            access_log,
+            next_revocation_sequence,
+            next_access_sequence,
+        } = snapshot;
+
+        for registered_bailments in bailments.values_mut() {
+            registered_bailments.retain(|bailment| !revoked_bailment_ids.contains(&bailment.id));
+        }
+        for registered_consents in consents.values_mut() {
+            registered_consents.retain(|reg| !revoked_bailment_ids.contains(&reg.bailment.id));
+        }
+        let next_revocation_sequence =
+            revocation_log_next_sequence(next_revocation_sequence, &revocation_log);
+        let next_access_sequence = access_log_next_sequence(next_access_sequence, &access_log);
+
+        Self {
+            engine: PolicyEngine::new(),
+            policy,
+            bailments,
+            consents,
+            revoked_bailment_ids,
+            revocation_log,
+            access_log,
+            next_revocation_sequence,
+            next_access_sequence,
+        }
+    }
+
+    #[must_use]
+    pub fn snapshot(&self) -> ConsentGateSnapshot {
+        ConsentGateSnapshot {
+            policy: self.policy.clone(),
+            bailments: self.bailments.clone(),
+            consents: self.consents.clone(),
+            revoked_bailment_ids: self.revoked_bailment_ids.clone(),
+            revocation_log: self.revocation_log.clone(),
+            access_log: self.access_log.clone(),
+            next_revocation_sequence: self.next_revocation_sequence,
+            next_access_sequence: self.next_access_sequence,
+        }
+    }
+
+    pub fn register_bailment(&mut self, bailment: Bailment) -> Result<(), ConsentError> {
+        self.ensure_not_revoked(&bailment.id)?;
         self.bailments
             .entry(bailment.bailee_did.as_str().to_owned())
             .or_default()
             .push(bailment);
+        Ok(())
     }
 
     pub fn register_consent(
@@ -56,7 +152,8 @@ impl ConsentGate {
         role: &str,
         clearance_level: u32,
         bailment: Bailment,
-    ) {
+    ) -> Result<(), ConsentError> {
+        self.ensure_not_revoked(&bailment.id)?;
         self.consents
             .entry(actor.as_str().to_owned())
             .or_default()
@@ -66,19 +163,43 @@ impl ConsentGate {
                 clearance_level,
                 bailment,
             });
+        Ok(())
     }
 
-    pub fn revoke_by_bailment_id(&mut self, bailment_id: &str) {
+    pub fn revoke_by_bailment_id(
+        &mut self,
+        bailment_id: &str,
+        revoked_at: Timestamp,
+    ) -> Result<(), ConsentError> {
+        if bailment_id.is_empty() {
+            return Err(ConsentError::Denied(
+                "bailment_id must not be empty for revocation".into(),
+            ));
+        }
         for regs in self.consents.values_mut() {
             regs.retain(|r| r.bailment.id != bailment_id);
         }
         for bs in self.bailments.values_mut() {
             bs.retain(|b| b.id != bailment_id);
         }
+        if self.revoked_bailment_ids.insert(bailment_id.to_owned()) {
+            let sequence = next_sequence(&mut self.next_revocation_sequence, "revocation_log")?;
+            self.revocation_log.push(ConsentRevocationLogEntry {
+                sequence,
+                bailment_id: bailment_id.to_owned(),
+                revoked_at,
+            });
+        }
+        Ok(())
     }
 
     /// Check consent. Default: DENY.
-    pub fn check(&self, actor: &Did, action: &str, now: &Timestamp) -> ConsentDecision {
+    pub fn check(
+        &mut self,
+        actor: &Did,
+        action: &str,
+        now: &Timestamp,
+    ) -> Result<ConsentDecision, ConsentError> {
         let req = ActionRequest {
             actor: actor.clone(),
             action_type: action.into(),
@@ -86,7 +207,7 @@ impl ConsentGate {
         let active: Vec<ActiveConsent> = match self.consents.get(actor.as_str()) {
             Some(regs) => regs
                 .iter()
-                .filter(|r| bailment::is_active(&r.bailment, now))
+                .filter(|r| self.is_registered_consent_active(r, now))
                 .map(|r| ActiveConsent {
                     grantor: r.bailment.bailor_did.clone(),
                     action_type: r.action_type.clone(),
@@ -98,7 +219,9 @@ impl ConsentGate {
             None => Vec::new(),
         };
 
-        self.engine.evaluate(&self.policy, &active, &req, now)
+        let decision = self.engine.evaluate(&self.policy, &active, &req, now);
+        self.append_access_log(actor, action, now, &decision)?;
+        Ok(decision)
     }
 
     #[must_use]
@@ -109,6 +232,77 @@ impl ConsentGate {
     pub fn set_policy(&mut self, policy: ConsentPolicy) {
         self.policy = policy;
     }
+
+    #[must_use]
+    pub fn access_log(&self) -> &[ConsentAccessLogEntry] {
+        &self.access_log
+    }
+
+    #[must_use]
+    pub fn revocation_log(&self) -> &[ConsentRevocationLogEntry] {
+        &self.revocation_log
+    }
+
+    fn ensure_not_revoked(&self, bailment_id: &str) -> Result<(), ConsentError> {
+        if self.revoked_bailment_ids.contains(bailment_id) {
+            return Err(ConsentError::Revoked {
+                bailment_id: bailment_id.to_owned(),
+            });
+        }
+        Ok(())
+    }
+
+    fn is_registered_consent_active(&self, reg: &ConsentReg, now: &Timestamp) -> bool {
+        !self.revoked_bailment_ids.contains(&reg.bailment.id)
+            && bailment::is_active(&reg.bailment, now)
+    }
+
+    fn append_access_log(
+        &mut self,
+        actor: &Did,
+        action: &str,
+        now: &Timestamp,
+        decision: &ConsentDecision,
+    ) -> Result<(), ConsentError> {
+        let sequence = next_sequence(&mut self.next_access_sequence, "access_log")?;
+        self.access_log.push(ConsentAccessLogEntry {
+            sequence,
+            actor: actor.clone(),
+            action_type: action.to_owned(),
+            checked_at: *now,
+            decision: decision.clone(),
+        });
+        Ok(())
+    }
+}
+
+fn next_sequence(counter: &mut u64, counter_name: &str) -> Result<u64, ConsentError> {
+    let sequence = *counter;
+    *counter = counter
+        .checked_add(1)
+        .ok_or_else(|| ConsentError::SequenceOverflow {
+            counter: counter_name.to_owned(),
+        })?;
+    Ok(sequence)
+}
+
+fn revocation_log_next_sequence(current: u64, log: &[ConsentRevocationLogEntry]) -> u64 {
+    log.iter().fold(current, |next, entry| {
+        next_after_seen_sequence(next, entry.sequence)
+    })
+}
+
+fn access_log_next_sequence(current: u64, log: &[ConsentAccessLogEntry]) -> u64 {
+    log.iter().fold(current, |next, entry| {
+        next_after_seen_sequence(next, entry.sequence)
+    })
+}
+
+fn next_after_seen_sequence(current: u64, seen: u64) -> u64 {
+    if seen < current {
+        return current;
+    }
+    seen.saturating_add(1)
 }
 
 #[cfg(test)]
@@ -168,10 +362,10 @@ mod tests {
 
     #[test]
     fn default_deny() {
-        let g = ConsentGate::new(strict_policy());
+        let mut g = ConsentGate::new(strict_policy());
         assert!(matches!(
             g.check(&bob(), "read", &now()),
-            ConsentDecision::Denied { .. }
+            Ok(ConsentDecision::Denied { .. })
         ));
     }
 
@@ -191,7 +385,7 @@ mod tests {
         assert!(
             matches!(
                 ConsentGate::new(strict_policy()).check(&charlie(), "read", &now()),
-                ConsentDecision::Denied { .. }
+                Ok(ConsentDecision::Denied { .. })
             ),
             "unregistered actors must remain denied"
         );
@@ -201,12 +395,34 @@ mod tests {
     fn grant_with_valid_consent() {
         let mut g = ConsentGate::new(strict_policy());
         let b = make_bailment(&alice(), &bob(), BailmentType::Custody, None);
-        g.register_bailment(b.clone());
-        g.register_consent(&bob(), "read", "data-owner", 1, b);
+        g.register_bailment(b.clone()).expect("register bailment");
+        g.register_consent(&bob(), "read", "data-owner", 1, b)
+            .expect("register consent");
         assert!(matches!(
             g.check(&bob(), "read", &now()),
-            ConsentDecision::Granted { .. }
+            Ok(ConsentDecision::Granted { .. })
         ));
+    }
+
+    #[test]
+    fn granted_check_appends_access_log_before_returning() {
+        let mut g = ConsentGate::new(strict_policy());
+        let b = make_bailment(&alice(), &bob(), BailmentType::Custody, None);
+        g.register_bailment(b.clone()).expect("register bailment");
+        g.register_consent(&bob(), "read", "data-owner", 1, b)
+            .expect("register consent");
+
+        assert!(g.access_log().is_empty());
+        let decision = g.check(&bob(), "read", &now()).expect("logged check");
+
+        assert!(matches!(decision, ConsentDecision::Granted { .. }));
+        let access_log = g.access_log();
+        assert_eq!(access_log.len(), 1);
+        assert_eq!(access_log[0].sequence, 0);
+        assert_eq!(access_log[0].actor, bob());
+        assert_eq!(access_log[0].action_type, "read");
+        assert_eq!(access_log[0].checked_at, now());
+        assert_eq!(access_log[0].decision, decision);
     }
 
     #[test]
@@ -214,28 +430,131 @@ mod tests {
         let mut g = ConsentGate::new(strict_policy());
         let b = make_bailment(&alice(), &bob(), BailmentType::Custody, None);
         let bid = b.id.clone();
-        g.register_bailment(b.clone());
-        g.register_consent(&bob(), "read", "data-owner", 1, b);
+        g.register_bailment(b.clone()).expect("register bailment");
+        g.register_consent(&bob(), "read", "data-owner", 1, b)
+            .expect("register consent");
         assert!(matches!(
             g.check(&bob(), "read", &now()),
+            Ok(ConsentDecision::Granted { .. })
+        ));
+        g.revoke_by_bailment_id(&bid, ts(6000))
+            .expect("revoke bailment");
+        assert!(matches!(
+            g.check(&bob(), "read", &now()),
+            Ok(ConsentDecision::Denied { .. })
+        ));
+    }
+
+    #[test]
+    fn revoked_bailment_snapshot_blocks_restart_replay() {
+        let mut g = ConsentGate::new(strict_policy());
+        let b = make_bailment(&alice(), &bob(), BailmentType::Custody, None);
+        let bid = b.id.clone();
+        g.register_bailment(b.clone()).expect("register bailment");
+        g.register_consent(&bob(), "read", "data-owner", 1, b.clone())
+            .expect("register consent");
+
+        assert!(matches!(
+            g.check(&bob(), "read", &now())
+                .expect("pre-revocation check"),
             ConsentDecision::Granted { .. }
         ));
-        g.revoke_by_bailment_id(&bid);
+
+        g.revoke_by_bailment_id(&bid, ts(6000))
+            .expect("revocation persists");
+        let snapshot = g.snapshot();
+        assert!(snapshot.revoked_bailment_ids.contains(&bid));
+        assert_eq!(snapshot.revocation_log.len(), 1);
+
+        let mut restored = ConsentGate::from_snapshot(snapshot);
         assert!(matches!(
-            g.check(&bob(), "read", &now()),
+            restored
+                .check(&bob(), "read", &ts(7000))
+                .expect("post-restore check"),
             ConsentDecision::Denied { .. }
         ));
+        assert!(
+            restored.register_bailment(b.clone()).is_err(),
+            "a revoked bailment id must not be replayable after restore"
+        );
+        assert!(
+            restored
+                .register_consent(&bob(), "read", "data-owner", 1, b)
+                .is_err(),
+            "a revoked consent id must not be replayable after restore"
+        );
+    }
+
+    #[test]
+    fn restored_snapshot_filters_revoked_stale_registrations() {
+        let mut g = ConsentGate::new(strict_policy());
+        let b = make_bailment(&alice(), &bob(), BailmentType::Custody, None);
+        let bid = b.id.clone();
+        g.register_bailment(b.clone()).expect("register bailment");
+        g.register_consent(&bob(), "read", "data-owner", 1, b)
+            .expect("register consent");
+
+        let mut snapshot = g.snapshot();
+        snapshot.revoked_bailment_ids.insert(bid.clone());
+        snapshot.revocation_log.push(ConsentRevocationLogEntry {
+            sequence: 0,
+            bailment_id: bid,
+            revoked_at: ts(6000),
+        });
+        snapshot.next_revocation_sequence = 1;
+
+        let restored = ConsentGate::from_snapshot(snapshot);
+        let restored_snapshot = restored.snapshot();
+
+        assert!(
+            restored_snapshot.bailments.values().all(Vec::is_empty),
+            "restored state must not retain stale bailment registrations for revoked ids"
+        );
+        assert!(
+            restored_snapshot.consents.values().all(Vec::is_empty),
+            "restored state must not retain stale consent registrations for revoked ids"
+        );
+    }
+
+    #[test]
+    fn snapshot_restore_advances_sequence_counters_past_persisted_logs() {
+        let mut g = ConsentGate::new(strict_policy());
+        let b = make_bailment(&alice(), &bob(), BailmentType::Custody, None);
+        let bid = b.id.clone();
+        g.register_bailment(b.clone()).expect("register bailment");
+        g.register_consent(&bob(), "read", "data-owner", 1, b)
+            .expect("register consent");
+        g.check(&bob(), "read", &now())
+            .expect("pre-revocation check");
+        g.revoke_by_bailment_id(&bid, ts(6000))
+            .expect("revoke bailment");
+
+        let mut snapshot = g.snapshot();
+        snapshot.next_access_sequence = 0;
+        snapshot.next_revocation_sequence = 0;
+
+        let mut restored = ConsentGate::from_snapshot(snapshot);
+        restored
+            .check(&bob(), "read", &ts(7000))
+            .expect("post-restore check");
+        restored
+            .revoke_by_bailment_id("another-bailment", ts(8000))
+            .expect("second revocation");
+
+        assert_eq!(restored.access_log()[1].sequence, 1);
+        assert_eq!(restored.revocation_log()[1].sequence, 1);
     }
 
     #[test]
     fn deny_after_expiry() {
         let mut g = ConsentGate::new(strict_policy());
         let b = make_bailment(&alice(), &bob(), BailmentType::Custody, Some(ts(3000)));
-        g.register_bailment(b.clone());
-        g.register_consent(&bob(), "read", "data-owner", 1, b);
+        g.register_bailment(b.clone()).expect("register bailment");
+        g.register_consent(&bob(), "read", "data-owner", 1, b)
+            .expect("register consent");
         assert!(matches!(
             g.check(&bob(), "read", &now()),
-            ConsentDecision::Denied { .. }
+            Ok(ConsentDecision::Denied { .. })
         ));
     }
 
@@ -244,11 +563,12 @@ mod tests {
         let mut g = ConsentGate::new(strict_policy());
         let exp = ts(10000);
         let b = make_bailment(&alice(), &bob(), BailmentType::Custody, Some(exp));
-        g.register_bailment(b.clone());
-        g.register_consent(&bob(), "read", "data-owner", 1, b);
+        g.register_bailment(b.clone()).expect("register bailment");
+        g.register_consent(&bob(), "read", "data-owner", 1, b)
+            .expect("register consent");
         assert_eq!(
             g.check(&bob(), "read", &now()),
-            ConsentDecision::Granted { expires: Some(exp) }
+            Ok(ConsentDecision::Granted { expires: Some(exp) })
         );
     }
 
@@ -256,11 +576,12 @@ mod tests {
     fn escalate_with_delegation() {
         let mut g = ConsentGate::new(strict_policy());
         let b = make_bailment(&alice(), &bob(), BailmentType::Delegation, None);
-        g.register_bailment(b.clone());
-        g.register_consent(&bob(), "read", "viewer", 0, b);
+        g.register_bailment(b.clone()).expect("register bailment");
+        g.register_consent(&bob(), "read", "viewer", 0, b)
+            .expect("register consent");
         let d = g.check(&bob(), "read", &now());
-        assert!(matches!(d, ConsentDecision::Escalated { .. }));
-        if let ConsentDecision::Escalated { to } = d {
+        assert!(matches!(d, Ok(ConsentDecision::Escalated { .. })));
+        if let Ok(ConsentDecision::Escalated { to }) = d {
             assert_eq!(to, alice());
         }
     }
@@ -269,19 +590,20 @@ mod tests {
     fn deny_unknown_action() {
         let mut g = ConsentGate::new(strict_policy());
         let b = make_bailment(&alice(), &bob(), BailmentType::Custody, None);
-        g.register_consent(&bob(), "read", "data-owner", 1, b);
+        g.register_consent(&bob(), "read", "data-owner", 1, b)
+            .expect("register consent");
         assert!(matches!(
             g.check(&bob(), "write", &now()),
-            ConsentDecision::Denied { .. }
+            Ok(ConsentDecision::Denied { .. })
         ));
     }
 
     #[test]
     fn deny_unknown_actor() {
-        let g = ConsentGate::new(strict_policy());
+        let mut g = ConsentGate::new(strict_policy());
         assert!(matches!(
             g.check(&charlie(), "read", &now()),
-            ConsentDecision::Denied { .. }
+            Ok(ConsentDecision::Denied { .. })
         ));
     }
 
@@ -299,12 +621,13 @@ mod tests {
         .expect("test bailment proposal");
         b.status = bailment::BailmentStatus::Active;
         b.signature = exo_core::Signature::from_bytes([0xAB; 64]);
-        g.register_consent(&bob(), "read", "data-owner", 1, b);
+        g.register_consent(&bob(), "read", "data-owner", 1, b)
+            .expect("register consent");
 
         assert!(
             matches!(
                 g.check(&bob(), "read", &now()),
-                ConsentDecision::Denied { .. }
+                Ok(ConsentDecision::Denied { .. })
             ),
             "ConsentGate must not grant on a status-forged active bailment"
         );
@@ -329,7 +652,7 @@ mod tests {
         assert_eq!(g.policy().id, "perm");
         assert!(matches!(
             g.check(&bob(), "anything", &now()),
-            ConsentDecision::Granted { .. }
+            Ok(ConsentDecision::Granted { .. })
         ));
     }
 
@@ -354,15 +677,17 @@ mod tests {
         });
         let b1 = make_bailment(&alice(), &bob(), BailmentType::Custody, None);
         let b2 = make_bailment(&alice(), &bob(), BailmentType::Processing, None);
-        g.register_consent(&bob(), "read", "data-owner", 1, b1);
-        g.register_consent(&bob(), "write", "admin", 3, b2);
+        g.register_consent(&bob(), "read", "data-owner", 1, b1)
+            .expect("register consent");
+        g.register_consent(&bob(), "write", "admin", 3, b2)
+            .expect("register consent");
         assert!(matches!(
             g.check(&bob(), "read", &now()),
-            ConsentDecision::Granted { .. }
+            Ok(ConsentDecision::Granted { .. })
         ));
         assert!(matches!(
             g.check(&bob(), "write", &now()),
-            ConsentDecision::Granted { .. }
+            Ok(ConsentDecision::Granted { .. })
         ));
     }
 
@@ -370,11 +695,13 @@ mod tests {
     fn revoke_nonexistent_is_noop() {
         let mut g = ConsentGate::new(strict_policy());
         let b = make_bailment(&alice(), &bob(), BailmentType::Custody, None);
-        g.register_consent(&bob(), "read", "data-owner", 1, b);
-        g.revoke_by_bailment_id("nonexistent");
+        g.register_consent(&bob(), "read", "data-owner", 1, b)
+            .expect("register consent");
+        g.revoke_by_bailment_id("nonexistent", ts(6000))
+            .expect("revoke nonexistent");
         assert!(matches!(
             g.check(&bob(), "read", &now()),
-            ConsentDecision::Granted { .. }
+            Ok(ConsentDecision::Granted { .. })
         ));
     }
 }

--- a/crates/exo-consent/src/policy.rs
+++ b/crates/exo-consent/src/policy.rs
@@ -40,7 +40,7 @@ pub struct ActionRequest {
 }
 
 /// The result of evaluating a consent policy.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ConsentDecision {
     Granted { expires: Option<Timestamp> },
     Denied { reason: String },

--- a/crates/exo-economy/src/policy.rs
+++ b/crates/exo-economy/src/policy.rs
@@ -8,11 +8,13 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::error::EconomyError;
-use crate::revenue_share::RevenueShareTemplate;
-use crate::types::{
-    ActorClass, AssuranceClass, BasisPoints, EventClass, MAX_BASIS_POINTS, MAX_MULTIPLIER_BP,
-    MicroExo, NEUTRAL_MULTIPLIER_BP,
+use crate::{
+    error::EconomyError,
+    revenue_share::RevenueShareTemplate,
+    types::{
+        ActorClass, AssuranceClass, BasisPoints, EventClass, MAX_BASIS_POINTS, MAX_MULTIPLIER_BP,
+        MicroExo, NEUTRAL_MULTIPLIER_BP,
+    },
 };
 
 /// Domain tag for canonical policy hashes.

--- a/crates/exo-economy/src/price.rs
+++ b/crates/exo-economy/src/price.rs
@@ -15,11 +15,13 @@
 use exo_core::{Did, Timestamp};
 use serde::{Deserialize, Serialize};
 
-use crate::error::EconomyError;
-use crate::policy::PricingPolicy;
-use crate::types::{
-    ActorClass, AssuranceClass, BasisPoints, EventClass, MAX_BASIS_POINTS, MicroExo,
-    NEUTRAL_MULTIPLIER_BP,
+use crate::{
+    error::EconomyError,
+    policy::PricingPolicy,
+    types::{
+        ActorClass, AssuranceClass, BasisPoints, EventClass, MAX_BASIS_POINTS, MicroExo,
+        NEUTRAL_MULTIPLIER_BP,
+    },
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/exo-economy/src/quote.rs
+++ b/crates/exo-economy/src/quote.rs
@@ -5,11 +5,13 @@
 use exo_core::{Did, Hash256, Timestamp};
 use serde::{Deserialize, Serialize};
 
-use crate::error::EconomyError;
-use crate::policy::PricingPolicy;
-use crate::price::{PriceBreakdown, PricingInputs, compute_breakdown};
-use crate::revenue_share::{RevenueShareLine, distribute_revenue};
-use crate::types::{ActorClass, AssuranceClass, EventClass, MicroExo, PricingMode, ZeroFeeReason};
+use crate::{
+    error::EconomyError,
+    policy::PricingPolicy,
+    price::{PriceBreakdown, PricingInputs, compute_breakdown},
+    revenue_share::{RevenueShareLine, distribute_revenue},
+    types::{ActorClass, AssuranceClass, EventClass, MicroExo, PricingMode, ZeroFeeReason},
+};
 
 /// Domain tag used when computing the canonical quote hash.
 pub const ECONOMY_QUOTE_HASH_DOMAIN: &str = "exo.economy.quote.v1";

--- a/crates/exo-economy/src/receipt.rs
+++ b/crates/exo-economy/src/receipt.rs
@@ -5,9 +5,11 @@
 use exo_core::{Did, Hash256, Signature, Timestamp, hash::hash_structured};
 use serde::{Deserialize, Serialize};
 
-use crate::error::EconomyError;
-use crate::revenue_share::RevenueShareLine;
-use crate::types::{EventClass, MicroExo, ZeroFeeReason};
+use crate::{
+    error::EconomyError,
+    revenue_share::RevenueShareLine,
+    types::{EventClass, MicroExo, ZeroFeeReason},
+};
 
 /// Domain tag used when computing the canonical settlement-receipt hash.
 pub const SETTLEMENT_RECEIPT_HASH_DOMAIN: &str = "exo.economy.settlement_receipt.v1";

--- a/crates/exo-economy/src/revenue_share.rs
+++ b/crates/exo-economy/src/revenue_share.rs
@@ -7,8 +7,10 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::error::EconomyError;
-use crate::types::{BasisPoints, EventClass, MAX_BASIS_POINTS, MicroExo, RevenueRecipient};
+use crate::{
+    error::EconomyError,
+    types::{BasisPoints, EventClass, MAX_BASIS_POINTS, MicroExo, RevenueRecipient},
+};
 
 /// A single recipient share within a revenue allocation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/exo-economy/src/settlement.rs
+++ b/crates/exo-economy/src/settlement.rs
@@ -8,9 +8,11 @@
 use exo_core::{Hash256, Signature, Timestamp};
 use serde::{Deserialize, Serialize};
 
-use crate::error::EconomyError;
-use crate::quote::SettlementQuote;
-use crate::receipt::{SettlementReceipt, canonical_content_hash};
+use crate::{
+    error::EconomyError,
+    quote::SettlementQuote,
+    receipt::{SettlementReceipt, canonical_content_hash},
+};
 
 /// Caller-supplied settlement context.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -80,12 +82,15 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::policy::PricingPolicy;
-    use crate::price::PricingInputs;
-    use crate::quote::quote;
-    use crate::types::{ActorClass, AssuranceClass, EventClass};
     use exo_core::{Did, Timestamp};
+
+    use super::*;
+    use crate::{
+        policy::PricingPolicy,
+        price::PricingInputs,
+        quote::quote,
+        types::{ActorClass, AssuranceClass, EventClass},
+    };
 
     fn fixed_signature() -> Signature {
         Signature::from_bytes([7u8; 64])

--- a/crates/exo-economy/src/store.rs
+++ b/crates/exo-economy/src/store.rs
@@ -8,10 +8,9 @@ use std::collections::BTreeMap;
 
 use exo_core::Hash256;
 
-use crate::error::EconomyError;
-use crate::policy::PricingPolicy;
-use crate::quote::SettlementQuote;
-use crate::receipt::SettlementReceipt;
+use crate::{
+    error::EconomyError, policy::PricingPolicy, quote::SettlementQuote, receipt::SettlementReceipt,
+};
 
 pub trait EconomyStore {
     fn put_quote(&mut self, quote: SettlementQuote) -> Result<(), EconomyError>;
@@ -115,13 +114,16 @@ impl EconomyStore for InMemoryEconomyStore {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::policy::PricingPolicy;
-    use crate::price::PricingInputs;
-    use crate::quote::quote;
-    use crate::settlement::{SettlementContext, settle};
-    use crate::types::{ActorClass, AssuranceClass, EventClass};
     use exo_core::{Did, Signature, Timestamp};
+
+    use super::*;
+    use crate::{
+        policy::PricingPolicy,
+        price::PricingInputs,
+        quote::quote,
+        settlement::{SettlementContext, settle},
+        types::{ActorClass, AssuranceClass, EventClass},
+    };
 
     fn fixed_signature() -> Signature {
         Signature::from_bytes([7u8; 64])

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -327,17 +327,19 @@ pub fn avc_router(state: Arc<AvcApiState>) -> Router {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use axum::body::{self, Body};
-    use axum::http::{Method, Request};
+    use axum::{
+        body::{self, Body},
+        http::{Method, Request},
+    };
     use exo_authority::permission::Permission;
     use exo_avc::{
         AVC_SCHEMA_VERSION, AuthorityScope, AutonomyLevel, AvcConstraints, AvcDecision, AvcDraft,
         AvcRevocationReason, AvcSubjectKind, DelegatedIntent, issue_avc, revoke_avc,
     };
-    use exo_core::crypto::KeyPair;
-    use exo_core::{Hash256, Timestamp};
+    use exo_core::{Hash256, Timestamp, crypto::KeyPair};
     use tower::ServiceExt;
+
+    use super::*;
 
     const ISSUER_SEED: [u8; 32] = [0x11; 32];
 

--- a/crates/exo-node/src/economy.rs
+++ b/crates/exo-node/src/economy.rs
@@ -244,12 +244,15 @@ pub fn economy_router(state: Arc<EconomyApiState>) -> Router {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use axum::body::{self, Body};
-    use axum::http::{Method, Request};
+    use axum::{
+        body::{self, Body},
+        http::{Method, Request},
+    };
     use exo_core::{Did, Timestamp};
     use exo_economy::{ActorClass, AssuranceClass, EventClass, ZeroFeeReason};
     use tower::ServiceExt;
+
+    use super::*;
 
     fn fresh_state() -> Arc<EconomyApiState> {
         Arc::new(EconomyApiState::new())


### PR DESCRIPTION
## Summary
- Classifies and remediates the consent persistence/audit finding cluster as EXOCHAIN core.
- Adds durable consent-gate snapshots, revocation tombstones, revocation/access audit logs, and fail-closed replay prevention for revoked bailment ids.
- Changes consent gate registration/check/revocation APIs to return typed `ConsentError` results and requires caller-supplied HLC timestamps for revocation logging.
- Adds CI hygiene follow-up for current `origin/main`: nightly rustfmt import grouping across newly added AVC/economy/node files and README repo-truth inventory updates for 22 crates / 288 Rust files / 156,564 Rust LOC.

## Path Classification
- EXOCHAIN core: `crates/exo-consent/src/error.rs`, `crates/exo-consent/src/gatekeeper.rs`, `crates/exo-consent/src/policy.rs`
- EXOCHAIN core CI/format hygiene: `crates/exo-avc/**`, `crates/exo-economy/**`, `crates/exo-node/src/avc.rs`, `crates/exo-node/src/economy.rs`, `README.md`
- Imported evidence: none committed
- Adjacent surface: none

## Verification
Red tests observed before implementation:
- `cargo test -p exo-consent gatekeeper::tests` initially failed on missing snapshot/access-log APIs and Result-returning checks.
- `cargo test -p exo-consent gatekeeper::tests::restored_snapshot_filters_revoked_stale_registrations` failed before restore scrubbing.
- `cargo test -p exo-consent gatekeeper::tests::snapshot_restore_advances_sequence_counters_past_persisted_logs` failed before counter normalization.

Green/final gates:
- `cargo test -p exo-consent`
- `cargo clippy -p exo-consent --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p exo-avc -p exo-economy -p exo-node`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
- `cargo +nightly fmt --all -- --check`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh && bash tools/test_cr001_status.sh && bash tools/test_gap_registry_truth.sh && bash tools/test_no_orphan_rust_modules.sh && bash tools/test_railway_entrypoint_args.sh`
- Nearby bypass search: `rg -n "ConsentGate::new\(|\.check\(&|register_consent\(|register_bailment\(|revoke_by_bailment_id\(|from_snapshot\(|snapshot\(" crates --glob "*.rs"` found no production `ConsentGate` callers outside the consent crate tests.

## Original Issue Disposition
The reported consent persistence/audit concern was live in current code: `ConsentGate` revocation state was memory-only, no durable revocation tombstone survived restore, and `check` returned a decision without appending an access audit record first. The new regressions exercise those exact paths and now pass against the fixed implementation.