### PR TITLE
fix(identity): bound local DID registry intake

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 156751 | `wc -l` |
+| Rust LOC | 157092 | `wc -l` |
 | Workspace tests | 3,638 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -80,7 +80,7 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 156751 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 157092 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 3,638 listed workspace tests
 

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -25,6 +25,7 @@ use exo_gatekeeper::{
 use exo_governance::conflict::ConflictDeclaration;
 use exo_identity::{
     did::DidDocument,
+    error::IdentityError,
     registry::{DidRegistry, LocalDidRegistry},
 };
 use percent_encoding::percent_decode_str;
@@ -411,6 +412,7 @@ impl AppState {
 
 #[derive(Debug)]
 enum RegistryBlockingError {
+    Registration(IdentityError),
     Operation(String),
     Join(String),
 }
@@ -418,9 +420,39 @@ enum RegistryBlockingError {
 impl fmt::Display for RegistryBlockingError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Registration(error) => write!(f, "registry registration failed: {error}"),
             Self::Operation(error) => write!(f, "registry operation failed: {error}"),
             Self::Join(error) => write!(f, "registry blocking task failed: {error}"),
         }
+    }
+}
+
+fn did_registration_rejection_response(
+    error: IdentityError,
+    duplicate_message: &'static str,
+) -> Response {
+    match error {
+        IdentityError::DuplicateDid(_) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({ "error": duplicate_message })),
+        )
+            .into_response(),
+        IdentityError::RegistryCapacityExceeded { .. } => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({ "error": "DID registry capacity exhausted" })),
+        )
+            .into_response(),
+        IdentityError::InvalidDidDocumentField { .. }
+        | IdentityError::DidDocumentFieldTooLarge { .. } => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "invalid DID document" })),
+        )
+            .into_response(),
+        _ => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "DID registration rejected" })),
+        )
+            .into_response(),
     }
 }
 
@@ -431,7 +463,7 @@ async fn registry_register_document(
     tokio::task::spawn_blocking(move || {
         let mut reg = registry.write().unwrap_or_else(|e| e.into_inner());
         reg.register(doc)
-            .map_err(|e| RegistryBlockingError::Operation(e.to_string()))
+            .map_err(RegistryBlockingError::Registration)
     })
     .await
     .map_err(|e| RegistryBlockingError::Join(e.to_string()))?
@@ -999,13 +1031,9 @@ async fn handle_auth_register(
             Json(serde_json::json!({ "did": did_str, "status": "registered" })),
         )
             .into_response(),
-        Err(RegistryBlockingError::Operation(e)) => {
+        Err(RegistryBlockingError::Registration(e)) => {
             tracing::warn!(error = %e, did = %did_str, "DID registration rejected");
-            (
-                StatusCode::CONFLICT,
-                Json(serde_json::json!({ "error": "DID already registered" })),
-            )
-                .into_response()
+            did_registration_rejection_response(e, "DID already registered")
         }
         Err(e) => {
             tracing::error!(error = %e, "DID registry registration task failed");
@@ -1319,13 +1347,9 @@ async fn handle_agents_enroll(
             Json(serde_json::json!({ "did": did_str, "status": "enrolled" })),
         )
             .into_response(),
-        Err(RegistryBlockingError::Operation(e)) => {
+        Err(RegistryBlockingError::Registration(e)) => {
             tracing::warn!(error = %e, did = %did_str, "agent enrollment rejected");
-            (
-                StatusCode::CONFLICT,
-                Json(serde_json::json!({ "error": "DID already enrolled" })),
-            )
-                .into_response()
+            did_registration_rejection_response(e, "DID already enrolled")
         }
         Err(e) => {
             tracing::error!(error = %e, "DID registry enrollment task failed");
@@ -3346,6 +3370,37 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn auth_register_returns_503_when_local_did_registry_capacity_is_exhausted() {
+        let (pk, _) = generate_keypair();
+        let registry = Arc::new(RwLock::new(LocalDidRegistry::new()));
+        {
+            let mut guard = registry.write().unwrap();
+            for i in 0..exo_identity::registry::MAX_LOCAL_DID_REGISTRY_DOCUMENTS {
+                let mut doc = minimal_doc(&format!("did:exo:capacity-{i:05}"));
+                doc.public_keys.push(pk);
+                guard.register(doc).unwrap();
+            }
+        }
+
+        let st = AppState::new(None, registry);
+        let body = serde_json::to_string(&minimal_doc("did:exo:capacity-overflow")).unwrap();
+        let app = build_router(st);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/auth/register")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[tokio::test]

--- a/crates/exo-identity/src/error.rs
+++ b/crates/exo-identity/src/error.rs
@@ -8,6 +8,29 @@ pub enum IdentityError {
     #[error("DID already registered: {0}")]
     DuplicateDid(Did),
 
+    #[error(
+        "DID registry capacity exceeded: max_documents={max_documents}, attempted_documents={attempted_documents}"
+    )]
+    RegistryCapacityExceeded {
+        max_documents: usize,
+        attempted_documents: usize,
+    },
+
+    #[error("DID document for {did} has invalid field {field}: {reason}")]
+    InvalidDidDocumentField {
+        did: String,
+        field: String,
+        reason: String,
+    },
+
+    #[error("DID document for {did} exceeds {field} bound: max={max}, actual={actual}")]
+    DidDocumentFieldTooLarge {
+        did: String,
+        field: String,
+        max: usize,
+        actual: usize,
+    },
+
     #[error("DID not found: {0}")]
     DidNotFound(Did),
 

--- a/crates/exo-identity/src/registry.rs
+++ b/crates/exo-identity/src/registry.rs
@@ -10,6 +10,16 @@ use crate::{
 
 const DID_REVOCATION_PROOF_DOMAIN: &str = "exo.identity.did_registry.revocation.v1";
 const DID_KEY_ROTATION_PROOF_DOMAIN: &str = "exo.identity.did_registry.key_rotation.v1";
+pub const MAX_LOCAL_DID_REGISTRY_DOCUMENTS: usize = 16_384;
+const MAX_DID_DOCUMENT_ID_BYTES: usize = 512;
+const MAX_DID_DOCUMENT_PUBLIC_KEYS: usize = 16;
+const MAX_DID_DOCUMENT_AUTHENTICATION_METHODS: usize = 32;
+const MAX_DID_DOCUMENT_VERIFICATION_METHODS: usize = 32;
+const MAX_DID_DOCUMENT_HYBRID_VERIFICATION_METHODS: usize = 16;
+const MAX_DID_DOCUMENT_SERVICE_ENDPOINTS: usize = 32;
+const MAX_DID_DOCUMENT_FIELD_BYTES: usize = 1024;
+const MAX_DID_DOCUMENT_PQ_MULTIBASE_BYTES: usize = 4096;
+const MAX_DID_DOCUMENT_ENDPOINT_BYTES: usize = 2048;
 
 #[derive(Serialize)]
 struct RevocationProofPayload<'a> {
@@ -97,15 +107,33 @@ pub trait DidRegistry {
 }
 
 /// A local, in-memory implementation of the `DidRegistry` trait.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct LocalDidRegistry {
     documents: BTreeMap<String, DidDocument>,
+    max_documents: usize,
+}
+
+impl Default for LocalDidRegistry {
+    fn default() -> Self {
+        Self {
+            documents: BTreeMap::new(),
+            max_documents: MAX_LOCAL_DID_REGISTRY_DOCUMENTS,
+        }
+    }
 }
 
 impl LocalDidRegistry {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    #[must_use]
+    pub fn with_max_documents(max_documents: usize) -> Self {
+        Self {
+            documents: BTreeMap::new(),
+            max_documents,
+        }
     }
 
     #[must_use]
@@ -124,10 +152,182 @@ impl LocalDidRegistry {
     }
 }
 
+fn ensure_byte_bound(did: &str, field: &str, value: &str, max: usize) -> Result<(), IdentityError> {
+    let actual = value.len();
+    if actual > max {
+        return Err(IdentityError::DidDocumentFieldTooLarge {
+            did: did.to_owned(),
+            field: field.to_owned(),
+            max,
+            actual,
+        });
+    }
+    Ok(())
+}
+
+fn ensure_len_bound(
+    did: &str,
+    field: &str,
+    actual: usize,
+    max: usize,
+) -> Result<(), IdentityError> {
+    if actual > max {
+        return Err(IdentityError::DidDocumentFieldTooLarge {
+            did: did.to_owned(),
+            field: field.to_owned(),
+            max,
+            actual,
+        });
+    }
+    Ok(())
+}
+
+fn validate_registered_did_document(doc: &DidDocument) -> Result<(), IdentityError> {
+    let did = doc.id.as_str();
+    Did::new(did).map_err(|e| IdentityError::InvalidDidDocumentField {
+        did: did.to_owned(),
+        field: "id".to_owned(),
+        reason: e.to_string(),
+    })?;
+    ensure_byte_bound(did, "id", did, MAX_DID_DOCUMENT_ID_BYTES)?;
+    ensure_len_bound(
+        did,
+        "public_keys",
+        doc.public_keys.len(),
+        MAX_DID_DOCUMENT_PUBLIC_KEYS,
+    )?;
+    ensure_len_bound(
+        did,
+        "authentication",
+        doc.authentication.len(),
+        MAX_DID_DOCUMENT_AUTHENTICATION_METHODS,
+    )?;
+    ensure_len_bound(
+        did,
+        "verification_methods",
+        doc.verification_methods.len(),
+        MAX_DID_DOCUMENT_VERIFICATION_METHODS,
+    )?;
+    ensure_len_bound(
+        did,
+        "hybrid_verification_methods",
+        doc.hybrid_verification_methods.len(),
+        MAX_DID_DOCUMENT_HYBRID_VERIFICATION_METHODS,
+    )?;
+    ensure_len_bound(
+        did,
+        "service_endpoints",
+        doc.service_endpoints.len(),
+        MAX_DID_DOCUMENT_SERVICE_ENDPOINTS,
+    )?;
+
+    for method in &doc.authentication {
+        ensure_byte_bound(
+            did,
+            "authentication.id",
+            &method.id,
+            MAX_DID_DOCUMENT_FIELD_BYTES,
+        )?;
+        ensure_byte_bound(
+            did,
+            "authentication.method_type",
+            &method.method_type,
+            MAX_DID_DOCUMENT_FIELD_BYTES,
+        )?;
+    }
+    for method in &doc.verification_methods {
+        ensure_byte_bound(
+            did,
+            "verification_methods.id",
+            &method.id,
+            MAX_DID_DOCUMENT_FIELD_BYTES,
+        )?;
+        ensure_byte_bound(
+            did,
+            "verification_methods.key_type",
+            &method.key_type,
+            MAX_DID_DOCUMENT_FIELD_BYTES,
+        )?;
+        ensure_byte_bound(
+            did,
+            "verification_methods.controller",
+            method.controller.as_str(),
+            MAX_DID_DOCUMENT_ID_BYTES,
+        )?;
+        ensure_byte_bound(
+            did,
+            "verification_methods.public_key_multibase",
+            &method.public_key_multibase,
+            MAX_DID_DOCUMENT_FIELD_BYTES,
+        )?;
+    }
+    for method in &doc.hybrid_verification_methods {
+        ensure_byte_bound(
+            did,
+            "hybrid_verification_methods.id",
+            &method.id,
+            MAX_DID_DOCUMENT_FIELD_BYTES,
+        )?;
+        ensure_byte_bound(
+            did,
+            "hybrid_verification_methods.key_type",
+            &method.key_type,
+            MAX_DID_DOCUMENT_FIELD_BYTES,
+        )?;
+        ensure_byte_bound(
+            did,
+            "hybrid_verification_methods.controller",
+            method.controller.as_str(),
+            MAX_DID_DOCUMENT_ID_BYTES,
+        )?;
+        ensure_byte_bound(
+            did,
+            "hybrid_verification_methods.classical_public_key_multibase",
+            &method.classical_public_key_multibase,
+            MAX_DID_DOCUMENT_FIELD_BYTES,
+        )?;
+        ensure_byte_bound(
+            did,
+            "hybrid_verification_methods.pq_public_key_multibase",
+            &method.pq_public_key_multibase,
+            MAX_DID_DOCUMENT_PQ_MULTIBASE_BYTES,
+        )?;
+    }
+    for endpoint in &doc.service_endpoints {
+        ensure_byte_bound(
+            did,
+            "service_endpoints.id",
+            &endpoint.id,
+            MAX_DID_DOCUMENT_FIELD_BYTES,
+        )?;
+        ensure_byte_bound(
+            did,
+            "service_endpoints.service_type",
+            &endpoint.service_type,
+            MAX_DID_DOCUMENT_FIELD_BYTES,
+        )?;
+        ensure_byte_bound(
+            did,
+            "service_endpoints.endpoint",
+            &endpoint.endpoint,
+            MAX_DID_DOCUMENT_ENDPOINT_BYTES,
+        )?;
+    }
+
+    Ok(())
+}
+
 impl DidRegistry for LocalDidRegistry {
     fn register(&mut self, doc: DidDocument) -> Result<(), IdentityError> {
         if self.documents.contains_key(doc.id.as_str()) {
             return Err(IdentityError::DuplicateDid(doc.id));
+        }
+        validate_registered_did_document(&doc)?;
+        if self.documents.len() >= self.max_documents {
+            return Err(IdentityError::RegistryCapacityExceeded {
+                max_documents: self.max_documents,
+                attempted_documents: self.documents.len().saturating_add(1),
+            });
         }
         self.documents.insert(doc.id.as_str().to_owned(), doc);
         Ok(())
@@ -226,6 +426,10 @@ mod tests {
         }
     }
 
+    fn make_doc_with_label(label: &str, pk: PublicKey) -> DidDocument {
+        make_doc(make_did(label), pk)
+    }
+
     fn rotation_signature(
         did: &Did,
         new_key: &PublicKey,
@@ -248,6 +452,65 @@ mod tests {
 
         let resolved = reg.resolve(&did).unwrap();
         assert_eq!(resolved.id, did);
+    }
+
+    #[test]
+    fn register_rejects_documents_after_default_registry_capacity() {
+        let (pk, _) = generate_keypair();
+        let mut reg = LocalDidRegistry::new();
+
+        for i in 0..MAX_LOCAL_DID_REGISTRY_DOCUMENTS {
+            reg.register(make_doc_with_label(&format!("capacity-{i:05}"), pk))
+                .unwrap();
+        }
+
+        let err = reg
+            .register(make_doc_with_label("capacity-overflow", pk))
+            .expect_err("registry must reject documents after the fixed capacity");
+
+        assert!(
+            err.to_string().contains("capacity"),
+            "capacity error should carry diagnostic context: {err}"
+        );
+        assert_eq!(reg.len(), MAX_LOCAL_DID_REGISTRY_DOCUMENTS);
+    }
+
+    #[test]
+    fn register_rejects_did_document_with_unbounded_public_keys() {
+        let (pk, _) = generate_keypair();
+        let mut doc = make_doc_with_label("too-many-keys", pk);
+        doc.public_keys = vec![pk; 17];
+
+        let mut reg = LocalDidRegistry::new();
+        let err = reg
+            .register(doc)
+            .expect_err("oversized DID document vectors must be rejected");
+
+        assert!(
+            err.to_string().contains("public_keys"),
+            "field-specific bound error should identify public_keys: {err}"
+        );
+        assert_eq!(reg.len(), 0);
+    }
+
+    #[test]
+    fn register_revalidates_deserialized_did_document_id() {
+        let (pk, _) = generate_keypair();
+        let mut value =
+            serde_json::to_value(make_doc_with_label("deserialized-invalid-did", pk)).unwrap();
+        value["id"] = serde_json::json!("not-a-did");
+        let doc: DidDocument = serde_json::from_value(value).unwrap();
+
+        let mut reg = LocalDidRegistry::new();
+        let err = reg
+            .register(doc)
+            .expect_err("registry must reject deserialized DIDs that bypass Did::new");
+
+        assert!(
+            err.to_string().contains("id"),
+            "invalid DID error should identify the id field: {err}"
+        );
+        assert_eq!(reg.len(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Bounds `exo_identity::LocalDidRegistry` to a deterministic maximum document count and rejects oversized DID document vectors before insertion.
- Revalidates deserialized DID IDs at registry intake so JSON/storage paths cannot bypass `Did::new()`.
- Maps gateway DID registration/enrollment capacity and validation failures to fail-closed, non-leaking HTTP responses.
- Updates README repo-truth Rust LOC after the core change.

## Path Classification
- `crates/exo-identity/src/registry.rs` — EXOCHAIN core.
- `crates/exo-identity/src/error.rs` — EXOCHAIN core.
- `crates/exo-gateway/src/server.rs` — core runtime adapter.
- `README.md` — documentation/repo-truth metadata only.

## Reproduction / TDD
- Before production changes, `cargo test -p exo-identity register_rejects_ -- --nocapture` failed because the registry accepted the 16,385th document and a DID document with 17 public keys.
- Before production changes, `cargo test -p exo-gateway auth_register_returns_503_when_local_did_registry_capacity_is_exhausted -- --nocapture` failed because `/api/v1/auth/register` returned `201` instead of failing closed at registry capacity.

## Verification
- `cargo test -p exo-identity register_rejects_ -- --nocapture`
- `cargo test -p exo-gateway auth_register_returns_503_when_local_did_registry_capacity_is_exhausted -- --nocapture`
- `cargo test -p exo-identity registry::tests::register_ -- --nocapture`
- `cargo test -p exo-gateway auth_register -- --nocapture`
- `cargo test -p exo-identity`
- `cargo test -p exo-gateway`
- `cargo clippy -p exo-identity -p exo-gateway --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `cargo audit`
- `cargo deny check` (duplicate-version warnings only; advisories/bans/licenses/sources OK)
- `cargo machete`
- `./tools/cross-impl-test/compare.sh` (TypeScript skipped because `EXO_TS_ROOT` is not set; Rust vectors and determinism passed)

## Notes
- Imported audit evidence was not modified or committed.
- This PR is limited to EXOCHAIN core/core-runtime-adapter hardening; adjacent surfaces are not included.
