### PR TITLE
fix(node): fail closed on sync persistence errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 157159 | `wc -l` |
+| Rust LOC | 157451 | `wc -l` |
 | Workspace tests | 3,638 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -80,7 +80,7 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 157159 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 157451 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 3,638 listed workspace tests
 

--- a/crates/exo-node/src/store.rs
+++ b/crates/exo-node/src/store.rs
@@ -602,6 +602,26 @@ impl SqliteDagStore {
 // ---------------------------------------------------------------------------
 
 impl SqliteDagStore {
+    fn insert_node_tx(tx: &rusqlite::Transaction<'_>, node: &DagNode) -> DagResult<()> {
+        let cbor = Self::encode_node(node)?;
+
+        tx.execute(
+            "INSERT OR IGNORE INTO dag_nodes (hash, cbor_payload) VALUES (?1, ?2)",
+            params![node.hash.0.as_slice(), cbor],
+        )
+        .map_err(store_err)?;
+
+        for parent in &node.parents {
+            tx.execute(
+                "INSERT OR IGNORE INTO dag_parents (child_hash, parent_hash) VALUES (?1, ?2)",
+                params![node.hash.0.as_slice(), parent.0.as_slice()],
+            )
+            .map_err(store_err)?;
+        }
+
+        Ok(())
+    }
+
     /// Sync version of `DagStore::get`.
     pub fn get_sync(&self, hash: &Hash256) -> DagResult<Option<DagNode>> {
         let mut stmt = self
@@ -621,24 +641,32 @@ impl SqliteDagStore {
 
     /// Sync version of `DagStore::put`.
     pub fn put_sync(&mut self, node: DagNode) -> DagResult<()> {
-        let cbor = Self::encode_node(&node)?;
+        self.put_many_sync(&[node])
+    }
 
-        self.conn
-            .execute(
-                "INSERT OR IGNORE INTO dag_nodes (hash, cbor_payload) VALUES (?1, ?2)",
-                params![node.hash.0.as_slice(), cbor],
+    /// Persist a batch of DAG nodes atomically.
+    pub fn put_many_sync(&mut self, nodes: &[DagNode]) -> DagResult<()> {
+        let tx = self.conn.transaction().map_err(store_err)?;
+        for node in nodes {
+            Self::insert_node_tx(&tx, node)?;
+        }
+        tx.commit().map_err(store_err)?;
+        Ok(())
+    }
+
+    /// Persist and mark a batch of DAG nodes as committed atomically.
+    pub fn put_committed_many_sync(&mut self, nodes: &[(DagNode, u64)]) -> DagResult<()> {
+        let tx = self.conn.transaction().map_err(store_err)?;
+        for (node, height) in nodes {
+            Self::insert_node_tx(&tx, node)?;
+            let height = sqlite_u64_to_i64(*height, "committed.height")?;
+            tx.execute(
+                "INSERT OR REPLACE INTO committed (hash, height) VALUES (?1, ?2)",
+                params![node.hash.0.as_slice(), height],
             )
             .map_err(store_err)?;
-
-        for parent in &node.parents {
-            self.conn
-                .execute(
-                    "INSERT OR IGNORE INTO dag_parents (child_hash, parent_hash) VALUES (?1, ?2)",
-                    params![node.hash.0.as_slice(), parent.0.as_slice()],
-                )
-                .map_err(store_err)?;
         }
-
+        tx.commit().map_err(store_err)?;
         Ok(())
     }
 

--- a/crates/exo-node/src/sync.rs
+++ b/crates/exo-node/src/sync.rs
@@ -433,18 +433,7 @@ impl SyncEngine {
                     accepted_nodes.insert(node.hash, node.clone());
                 }
 
-                for (node, height) in nodes_with_heights {
-                    let hash = node.hash;
-
-                    if let Err(e) = store.put_sync(node) {
-                        tracing::warn!(err = %e, %hash, "Failed to store synced node");
-                        continue;
-                    }
-
-                    if let Err(e) = store.mark_committed_sync(&hash, height) {
-                        tracing::warn!(err = %e, %hash, height, "Failed to mark committed");
-                    }
-                }
+                store.put_committed_many_sync(&nodes_with_heights)?;
                 Ok(())
             },
         )
@@ -616,12 +605,7 @@ impl SyncEngine {
                     accepted_nodes.insert(node.hash, node.clone());
                 }
 
-                for node in nodes {
-                    let hash = node.hash;
-                    if let Err(e) = store.put_sync(node) {
-                        tracing::warn!(err = %e, %hash, "Failed to store synced node");
-                    }
-                }
+                store.put_many_sync(&nodes)?;
                 Ok(())
             },
         )
@@ -1237,6 +1221,286 @@ mod tests {
         assert!(
             event_rx.try_recv().is_err(),
             "rejected chunks must not emit progress or completion events"
+        );
+    }
+
+    #[tokio::test]
+    async fn snapshot_chunk_storage_failure_does_not_emit_progress_or_complete() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SqliteDagStore::open(dir.path()).unwrap();
+        let db_path = dir.path().join("dag.db");
+        let store = Arc::new(Mutex::new(store));
+
+        let (cmd_tx, _cmd_rx) = mpsc::channel(256);
+        let net_handle = NetworkHandle::new(cmd_tx);
+        let (event_tx, mut event_rx) = mpsc::channel(32);
+        let mut engine = SyncEngine::new(
+            sync_config(100, 200),
+            Arc::clone(&store),
+            net_handle,
+            event_tx,
+        );
+
+        let sign_fn = make_sign_fn();
+        let did = test_did();
+        let mut dag = Dag::new();
+        let mut clock = DeterministicDagClock::new();
+        let node = append(
+            &mut dag,
+            &[],
+            b"storage-failure-snapshot-node",
+            &did,
+            &*sign_fn,
+            &mut clock,
+        )
+        .unwrap();
+
+        rusqlite::Connection::open(&db_path)
+            .unwrap()
+            .execute_batch(
+                "CREATE TRIGGER reject_synced_snapshot_node
+                 BEFORE INSERT ON dag_nodes
+                 BEGIN
+                   SELECT RAISE(FAIL, 'reject synced snapshot node');
+                 END;",
+            )
+            .unwrap();
+
+        engine.syncing = true;
+        let chunk = StateSnapshotChunkMsg {
+            sender: Did::new("did:exo:sender").unwrap(),
+            from_height: 1,
+            nodes: vec![node],
+            to_height: 1,
+            has_more: false,
+        };
+
+        engine.handle_snapshot_chunk(chunk).await;
+
+        assert!(
+            engine.needs_sync(),
+            "snapshot storage failure must keep sync incomplete"
+        );
+        assert!(
+            event_rx.try_recv().is_err(),
+            "snapshot storage failure must not emit progress or completion events"
+        );
+    }
+
+    #[tokio::test]
+    async fn snapshot_chunk_storage_failure_rolls_back_partial_batch() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SqliteDagStore::open(dir.path()).unwrap();
+        let db_path = dir.path().join("dag.db");
+        let store = Arc::new(Mutex::new(store));
+
+        let (cmd_tx, _cmd_rx) = mpsc::channel(256);
+        let net_handle = NetworkHandle::new(cmd_tx);
+        let (event_tx, mut event_rx) = mpsc::channel(32);
+        let mut engine = SyncEngine::new(
+            sync_config(100, 200),
+            Arc::clone(&store),
+            net_handle,
+            event_tx,
+        );
+
+        let sign_fn = make_sign_fn();
+        let did = test_did();
+        let mut dag = Dag::new();
+        let mut clock = DeterministicDagClock::new();
+        let node1 = append(
+            &mut dag,
+            &[],
+            b"partial-storage-snapshot-node-1",
+            &did,
+            &*sign_fn,
+            &mut clock,
+        )
+        .unwrap();
+        let node2 = append(
+            &mut dag,
+            &[node1.hash],
+            b"partial-storage-snapshot-node-2",
+            &did,
+            &*sign_fn,
+            &mut clock,
+        )
+        .unwrap();
+
+        let rejected_hash = hex::encode(node2.hash.0);
+        rusqlite::Connection::open(&db_path)
+            .unwrap()
+            .execute_batch(&format!(
+                "CREATE TRIGGER reject_second_snapshot_node
+                 BEFORE INSERT ON dag_nodes
+                 WHEN NEW.hash = X'{rejected_hash}'
+                 BEGIN
+                   SELECT RAISE(FAIL, 'reject second snapshot node');
+                 END;"
+            ))
+            .unwrap();
+
+        engine.syncing = true;
+        let chunk = StateSnapshotChunkMsg {
+            sender: Did::new("did:exo:sender").unwrap(),
+            from_height: 1,
+            nodes: vec![node1.clone(), node2.clone()],
+            to_height: 2,
+            has_more: false,
+        };
+
+        engine.handle_snapshot_chunk(chunk).await;
+
+        {
+            let st = store.lock().unwrap();
+            assert!(
+                !st.contains_sync(&node1.hash).unwrap(),
+                "snapshot batch failure must roll back node 1"
+            );
+            assert!(
+                !st.contains_sync(&node2.hash).unwrap(),
+                "snapshot batch failure must not persist node 2"
+            );
+            assert_eq!(st.committed_height_value().unwrap(), 0);
+        }
+        assert!(engine.needs_sync());
+        assert!(
+            event_rx.try_recv().is_err(),
+            "rolled-back snapshot chunks must not emit progress or completion events"
+        );
+    }
+
+    #[tokio::test]
+    async fn dag_sync_response_storage_failure_does_not_request_next_batch() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SqliteDagStore::open(dir.path()).unwrap();
+        let db_path = dir.path().join("dag.db");
+        let store = Arc::new(Mutex::new(store));
+
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(256);
+        let net_handle = NetworkHandle::new(cmd_tx);
+        let (event_tx, _event_rx) = mpsc::channel(32);
+        let mut engine = SyncEngine::new(
+            sync_config(100, 200),
+            Arc::clone(&store),
+            net_handle,
+            event_tx,
+        );
+
+        let sign_fn = make_sign_fn();
+        let did = test_did();
+        let mut dag = Dag::new();
+        let mut clock = DeterministicDagClock::new();
+        let node = append(
+            &mut dag,
+            &[],
+            b"storage-failure-dag-response-node",
+            &did,
+            &*sign_fn,
+            &mut clock,
+        )
+        .unwrap();
+
+        rusqlite::Connection::open(&db_path)
+            .unwrap()
+            .execute_batch(
+                "CREATE TRIGGER reject_synced_dag_response_node
+                 BEFORE INSERT ON dag_nodes
+                 BEGIN
+                   SELECT RAISE(FAIL, 'reject synced dag response node');
+                 END;",
+            )
+            .unwrap();
+
+        let response = DagSyncResponseMsg {
+            sender: Did::new("did:exo:sender").unwrap(),
+            nodes: vec![node],
+            has_more: true,
+        };
+
+        engine.handle_dag_sync_response(response).await;
+
+        assert!(
+            cmd_rx.try_recv().is_err(),
+            "DAG sync storage failure must not request the next batch"
+        );
+    }
+
+    #[tokio::test]
+    async fn dag_sync_response_storage_failure_rolls_back_partial_batch() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SqliteDagStore::open(dir.path()).unwrap();
+        let db_path = dir.path().join("dag.db");
+        let store = Arc::new(Mutex::new(store));
+
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(256);
+        let net_handle = NetworkHandle::new(cmd_tx);
+        let (event_tx, _event_rx) = mpsc::channel(32);
+        let mut engine = SyncEngine::new(
+            sync_config(100, 200),
+            Arc::clone(&store),
+            net_handle,
+            event_tx,
+        );
+
+        let sign_fn = make_sign_fn();
+        let did = test_did();
+        let mut dag = Dag::new();
+        let mut clock = DeterministicDagClock::new();
+        let node1 = append(
+            &mut dag,
+            &[],
+            b"partial-storage-dag-response-node-1",
+            &did,
+            &*sign_fn,
+            &mut clock,
+        )
+        .unwrap();
+        let node2 = append(
+            &mut dag,
+            &[node1.hash],
+            b"partial-storage-dag-response-node-2",
+            &did,
+            &*sign_fn,
+            &mut clock,
+        )
+        .unwrap();
+
+        let rejected_hash = hex::encode(node2.hash.0);
+        rusqlite::Connection::open(&db_path)
+            .unwrap()
+            .execute_batch(&format!(
+                "CREATE TRIGGER reject_second_dag_response_node
+                 BEFORE INSERT ON dag_nodes
+                 WHEN NEW.hash = X'{rejected_hash}'
+                 BEGIN
+                   SELECT RAISE(FAIL, 'reject second dag response node');
+                 END;"
+            ))
+            .unwrap();
+
+        let response = DagSyncResponseMsg {
+            sender: Did::new("did:exo:sender").unwrap(),
+            nodes: vec![node1.clone(), node2.clone()],
+            has_more: true,
+        };
+
+        engine.handle_dag_sync_response(response).await;
+
+        {
+            let st = store.lock().unwrap();
+            assert!(
+                !st.contains_sync(&node1.hash).unwrap(),
+                "DAG sync batch failure must roll back node 1"
+            );
+            assert!(
+                !st.contains_sync(&node2.hash).unwrap(),
+                "DAG sync batch failure must not persist node 2"
+            );
+        }
+        assert!(
+            cmd_rx.try_recv().is_err(),
+            "rolled-back DAG sync failure must not request the next batch"
         );
     }
 


### PR DESCRIPTION
## Classification

- `crates/exo-node/src/sync.rs`: core runtime adapter, state sync/DAG sync ingress and progress boundary.
- `crates/exo-node/src/store.rs`: core runtime adapter, SQLite DAG persistence boundary.
- `README.md`: repo-truth metadata only, updated to the derived Rust LOC after source changes.

## Reproduced current issue

On current `main`, state snapshot and DAG sync response handling validated incoming nodes but treated SQLite persistence failures as warnings. Snapshot chunks could still emit `SyncEvent::Progress` / `SyncEvent::Complete`, clear `syncing`, and leave partial persistence; DAG sync responses could still request the next batch after accepted nodes failed to persist.

Red regression evidence before the fix:

- `cargo test -p exo-node storage_failure -- --nocapture`
  - `snapshot_chunk_storage_failure_does_not_emit_progress_or_complete` failed because storage failure completed sync.
  - `dag_sync_response_storage_failure_does_not_request_next_batch` failed because storage failure requested the next batch.

## Remediation

- Validate the full incoming batch first, then persist accepted snapshot nodes and committed heights atomically.
- Validate the full DAG sync response first, then persist accepted DAG nodes atomically.
- Propagate persistence errors so failed storage aborts progress/completion and next-batch requests.
- Add regression coverage for fail-closed behavior and rollback of partially persisted batches.

## Validation

- `cargo test -p exo-node storage_failure -- --nocapture`
- `cargo test -p exo-node sync::tests -- --nocapture`
- `cargo test -p exo-node store::tests -- --nocapture`
- `cargo test -p exo-node`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
- `cargo +nightly fmt --all -- --check`
- `cargo build --workspace --release`
- `cargo test --workspace`
- `cargo test --workspace --release`
- `cargo audit`
- `cargo deny check` (passed with existing duplicate-version warnings)
- `cargo machete`
- `./tools/cross-impl-test/compare.sh` (Rust-only; TS comparison skipped because `EXO_TS_ROOT` is unset)
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `bash tools/test_repo_truth.sh`

Bypass search verified the previous warning-only store/commit paths were removed from `crates/exo-node/src/sync.rs`.
