### PR TITLE
fix(gateway): authenticate REST actors before state changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 157451 | `wc -l` |
+| Rust LOC | 157616 | `wc -l` |
 | Workspace tests | 3,638 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -80,7 +80,7 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 157451 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 157616 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 3,638 listed workspace tests
 

--- a/crates/exo-gateway/src/handlers.rs
+++ b/crates/exo-gateway/src/handlers.rs
@@ -7,7 +7,12 @@
 
 use std::io::{self, Write};
 
-use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
+use axum::{
+    Json,
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+};
 use decision_forum::{
     decision_object::{ActorKind, DecisionObject, Vote, VoteChoice},
     quorum::{QuorumCheckResult, QuorumRegistry, check_quorum, verify_quorum_precondition},
@@ -24,7 +29,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sqlx::Row;
 
-use crate::server::AppState;
+use crate::server::{AppState, auth_boundary_error_response};
 
 // ── Violation 3 fix: CBOR canonical hashing ──────────────────────────────
 
@@ -303,8 +308,16 @@ impl VoteRequest {
 /// Handle a vote submission with conflict-of-interest and authority chain checks.
 pub async fn vote_handler(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(body): Json<VoteRequest>,
 ) -> impl IntoResponse {
+    let actor = match state
+        .require_authenticated_session_actor_from_header(&headers)
+        .await
+    {
+        Ok(actor) => actor,
+        Err(e) => return auth_boundary_error_response(e),
+    };
     let voter_did = match exo_core::Did::new(&body.voter_did) {
         Ok(d) => d,
         Err(_) => {
@@ -315,6 +328,16 @@ pub async fn vote_handler(
                 .into_response();
         }
     };
+    if actor != voter_did {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "forbidden",
+                "message": "authenticated session actor does not match voter_did"
+            })),
+        )
+            .into_response();
+    }
     let affected_dids = match body.caller_supplied_affected_dids() {
         Ok(dids) => dids,
         Err(e) => {
@@ -1054,6 +1077,40 @@ mod tests {
         assert!(
             production.contains("check_and_block(&voter_did, &conflicts)"),
             "vote handler must use the enforcing conflict gate, not advisory-only recusal checks"
+        );
+    }
+
+    #[test]
+    fn vote_handler_authenticates_session_actor_before_conflict_and_kernel_checks() {
+        let source = include_str!("handlers.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("test module marker present");
+        let vote_handler = production
+            .split("pub async fn vote_handler")
+            .nth(1)
+            .expect("vote handler source present")
+            .split("// Verify quorum precondition")
+            .next()
+            .expect("vote handler source end");
+        let auth_index = vote_handler
+            .find("require_authenticated_session_actor_from_header")
+            .expect("vote handler must authenticate a bearer session");
+        let conflict_index = vote_handler
+            .find("load_conflict_declarations(&voter_did)")
+            .expect("vote handler must retain conflict lookup");
+        let kernel_index = vote_handler
+            .find("state.kernel.adjudicate")
+            .expect("vote handler must retain kernel adjudication");
+
+        assert!(
+            auth_index < conflict_index && conflict_index < kernel_index,
+            "vote handler must authenticate before conflict and kernel checks"
+        );
+        assert!(
+            vote_handler.contains("if actor != voter_did"),
+            "vote handler must reject body voter_did spoofing"
         );
     }
 

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -334,6 +334,16 @@ impl AppState {
             .ok_or_else(|| GatewayError::Internal("database unavailable".into()))
     }
 
+    /// Resolve the authenticated actor from the DB-backed bearer session.
+    pub async fn require_authenticated_session_actor_from_header(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<Did> {
+        let token = require_bearer_token(headers)?;
+        let observed_at = required_observed_at_ms_header(headers)?;
+        require_authenticated_session_actor_for_token(self, &token, observed_at).await
+    }
+
     /// Return the number of registered DIDs without blocking a Tokio worker
     /// on the synchronous registry lock.
     pub async fn registry_len(&self) -> Result<usize> {
@@ -1617,6 +1627,7 @@ async fn handle_auth_saml_callback() -> (StatusCode, Json<serde_json::Value>) {
 async fn handle_advance_pace(
     State(state): State<AppState>,
     Path(did_str): Path<String>,
+    headers: HeaderMap,
     body: Option<Json<serde_json::Value>>,
 ) -> impl IntoResponse {
     let did = match Did::new(&did_str) {
@@ -1629,10 +1640,27 @@ async fn handle_advance_pace(
                 .into_response();
         }
     };
+    let actor = match state
+        .require_authenticated_session_actor_from_header(&headers)
+        .await
+    {
+        Ok(actor) => actor,
+        Err(e) => return auth_boundary_error_response(e),
+    };
+    if actor != did {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "forbidden",
+                "message": "authenticated session actor does not match advance-pace target"
+            })),
+        )
+            .into_response();
+    }
     // Build an adjudication context for this actor.
-    let ctx = state.build_adjudication_context(&did).await;
+    let ctx = state.build_adjudication_context(&actor).await;
     let action = GkActionRequest {
-        actor: did.clone(),
+        actor: actor.clone(),
         action: "advance_pace".into(),
         required_permissions: PermissionSet::new(vec![Permission::new("advance_pace")]),
         is_self_grant: false,
@@ -1817,7 +1845,7 @@ fn reject_caller_supplied_builtin_layout(body: &serde_json::Value) -> Result<()>
     }
 }
 
-fn auth_boundary_error_response(err: GatewayError) -> Response {
+pub(crate) fn auth_boundary_error_response(err: GatewayError) -> Response {
     match err {
         GatewayError::AuthenticationFailed { reason } => (
             StatusCode::UNAUTHORIZED,
@@ -3850,7 +3878,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn vote_route_without_conflict_register_returns_503() {
+    async fn vote_route_missing_session_returns_401_before_conflict_register_lookup() {
         let body = serde_json::to_string(&serde_json::json!({
             "decision_id": "d1",
             "voter_did": "did:exo:alice",
@@ -3874,10 +3902,8 @@ mod tests {
             )
             .await
             .unwrap();
-        // Conflict adjudication is a required vote precondition. Without a
-        // DB-backed standing conflict register, the route fails closed before
-        // reaching kernel adjudication.
-        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 
     // --- Identity score endpoint tests ---
@@ -4556,6 +4582,38 @@ mod tests {
         }
     }
 
+    #[test]
+    fn advance_pace_handler_authenticates_session_actor_before_adjudication() {
+        let source = include_str!("server.rs");
+        let handler = source_between(
+            source,
+            "async fn handle_advance_pace",
+            "// ---------------------------------------------------------------------------\n// Legal / eDiscovery handlers",
+        );
+        let auth_index = handler
+            .find("require_authenticated_session_actor_from_header")
+            .expect("advance_pace must authenticate a bearer session");
+        let context_index = handler
+            .find("build_adjudication_context(&actor)")
+            .expect("advance_pace must adjudicate the authenticated session actor");
+        let kernel_index = handler
+            .find("state.kernel.adjudicate")
+            .expect("advance_pace must retain kernel adjudication");
+
+        assert!(
+            auth_index < context_index && context_index < kernel_index,
+            "advance_pace must authenticate before building the adjudication context"
+        );
+        assert!(
+            handler.contains("if actor != did"),
+            "advance_pace must reject path-DID spoofing"
+        );
+        assert!(
+            !handler.contains("actor: did.clone()"),
+            "advance_pace must not use the caller-controlled path DID as the action actor"
+        );
+    }
+
     fn source_between<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
         let start_index = source.find(start).expect("source start marker");
         let after_start = &source[start_index..];
@@ -4565,12 +4623,38 @@ mod tests {
 
     #[tokio::test]
     async fn advance_pace_without_authority_returns_403() {
-        let app = build_router(state());
+        let pool = match gateway_test_pool().await {
+            Some(pool) => pool,
+            None => return,
+        };
+        sqlx::query("DELETE FROM sessions WHERE token = $1")
+            .bind("advance-no-authority-token")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO sessions (token, actor_did, created_at, expires_at, revoked) \
+             VALUES ($1, $2, $3, $4, false)",
+        )
+        .bind("advance-no-authority-token")
+        .bind("did:exo:alice")
+        .bind(1_000_i64)
+        .bind(20_000_i64)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let app = build_router(AppState::new(
+            Some(pool.clone()),
+            Arc::new(RwLock::new(LocalDidRegistry::new())),
+        ));
         let resp = app
             .oneshot(
                 Request::builder()
                     .method("POST")
                     .uri("/api/v1/agents/did:exo:alice/advance-pace")
+                    .header("authorization", "Bearer advance-no-authority-token")
+                    .header(AUTH_OBSERVED_AT_MS_HEADER, "10000")
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -4578,10 +4662,34 @@ mod tests {
             .unwrap();
         // Kernel rejects before DB check: no consent + no authority chain.
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+        sqlx::query("DELETE FROM sessions WHERE token = $1")
+            .bind("advance-no-authority-token")
+            .execute(&pool)
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
-    async fn user_advance_pace_without_authority_returns_403() {
+    async fn advance_pace_missing_session_returns_401_before_trusting_path_did() {
+        let app = build_router(state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/agents/did:exo:pace-target/advance-pace")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"queuedAt":9000}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn user_advance_pace_missing_session_returns_401() {
         let app = build_router(state());
         let resp = app
             .oneshot(
@@ -4593,7 +4701,7 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Classifies this remediation as **core runtime adapter** hardening for `exo-gateway` REST state-changing routes.
- Requires DB-backed bearer session authentication before `POST /api/v1/decisions` vote handling can trust `voter_did` or reach conflict/kernel checks.
- Requires bearer session authentication before agent/user `advance-pace` routes can use the path DID for adjudication, and rejects session/path actor mismatch fail-closed.
- Updates README repo-truth LOC counts after the Rust source change.

## External finding disposition
- This addresses a live subset of the external REST role/auth concern after repro against current code, not the imported HTML/zip artifacts themselves.
- Imported evidence remains read-only and is not committed.
- Changed paths:
  - `crates/exo-gateway/src/handlers.rs` — core runtime adapter
  - `crates/exo-gateway/src/server.rs` — core runtime adapter
  - `README.md` — repo-truth metadata

## TDD / regression proof
- Red test before fix: unauthenticated vote route returned `503` after reaching conflict setup instead of `401` at auth boundary.
- Red test before fix: unauthenticated `advance-pace` route returned `403` after kernel adjudication instead of `401` at auth boundary.
- Added source guards proving authentication occurs before conflict/kernel/adjudication work and that caller-controlled body/path DID spoofing is rejected.

## Test plan
- [x] `cargo test -p exo-gateway vote_route_missing_session_returns_401_before_conflict_register_lookup -- --nocapture`
- [x] `cargo test -p exo-gateway advance_pace_missing_session_returns_401_before_trusting_path_did -- --nocapture`
- [x] `cargo test -p exo-gateway user_advance_pace_missing_session_returns_401 -- --nocapture`
- [x] `cargo test -p exo-gateway advance_pace_without_authority_returns_403 -- --nocapture`
- [x] `cargo test -p exo-gateway authenticates_session_actor -- --nocapture`
- [x] `cargo test -p exo-gateway -- --nocapture`
- [x] `cargo test -p exo-gateway --features production-db -- --nocapture`
- [x] `cargo test -p exo-gateway --features unaudited-gateway-graphql-api -- --nocapture`
- [x] `cargo fmt --all -- --check`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo doc --workspace --no-deps`
- [x] `cargo build --workspace --release`
- [x] `cargo test --workspace`
- [x] `cargo test --workspace --release`
- [x] `cargo audit`
- [x] `cargo deny check`
- [x] `cargo machete`
- [x] `./tools/cross-impl-test/compare.sh` (Rust determinism passed; TypeScript comparison skipped because `EXO_TS_ROOT` is unset)
- [x] `bash tools/test_no_orphan_rust_modules.sh`
- [x] `bash tools/test_cr001_status.sh`
- [x] `bash tools/test_gap_registry_truth.sh`
- [x] `bash tools/test_railway_entrypoint_args.sh`
- [x] `bash tools/test_repo_truth.sh`
- [x] `git diff --check`
