### PR TITLE
fix(gateway): bound database pool acquisition

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 158026 | `wc -l` |
+| Rust LOC | 158046 | `wc -l` |
 | Workspace tests | 3,638 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |

--- a/crates/exo-gateway/src/db.rs
+++ b/crates/exo-gateway/src/db.rs
@@ -4,7 +4,7 @@
 //! Complex governance objects (DecisionObject, Delegation) are stored as
 //! JSONB payloads with indexed scalar columns for efficient queries.
 
-use std::fmt;
+use std::{fmt, time::Duration};
 
 use serde_json::Value as JsonValue;
 use sqlx::{
@@ -14,6 +14,7 @@ use sqlx::{
 use thiserror::Error;
 
 pub const MAX_DB_LIST_ROWS: i64 = 1_000;
+const DB_POOL_ACQUIRE_TIMEOUT_SECS: u64 = 5;
 
 #[derive(Debug, Error)]
 pub enum DbInitError {
@@ -37,6 +38,9 @@ pub enum DbInitError {
 pub async fn init_pool(database_url: &str) -> Result<PgPool, DbInitError> {
     let pool = PgPoolOptions::new()
         .max_connections(10)
+        // SQLx 0.8 bounds both waiting for a pooled connection and opening a
+        // new connection through acquire_timeout.
+        .acquire_timeout(Duration::from_secs(DB_POOL_ACQUIRE_TIMEOUT_SECS))
         .connect(database_url)
         .await
         .map_err(|source| DbInitError::Connect { source })?;
@@ -1238,6 +1242,22 @@ mod tests {
                 "{name} must bind the centralized row limit for every fetch_all query"
             );
         }
+    }
+
+    #[test]
+    fn pool_initialization_sets_explicit_connection_acquire_timeout() {
+        let source = production_source();
+        let init_pool = function_source(source, "init_pool");
+
+        assert!(
+            source.contains("const DB_POOL_ACQUIRE_TIMEOUT_SECS: u64"),
+            "gateway DB pool timeout must be explicit and centrally named"
+        );
+        assert!(
+            init_pool
+                .contains(".acquire_timeout(Duration::from_secs(DB_POOL_ACQUIRE_TIMEOUT_SECS))"),
+            "gateway DB pool initialization must bound waits for pooled or newly opened connections"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Bounds EXOCHAIN gateway PostgreSQL pool acquisition with an explicit 5s SQLx timeout; in SQLx 0.8 this caps waiting for pooled connections and opening new connections.
- Adds a regression guard proving gateway DB pool initialization keeps an explicit named timeout.
- Updates the README repo-truth Rust LOC row because the repo-truth gate derives it from current Rust sources.

## Classification
- crates/exo-gateway/src/db.rs: Core runtime adapter, persistence path for gateway state.
- README.md: Documentation/repo-truth metric only, required because tools/test_repo_truth.sh derives Rust LOC from this code change.

## Validation
- Confirmed current origin/main lacked explicit PgPoolOptions acquisition timeout before editing.
- RED: cargo test -p exo-gateway db::tests::pool_initialization_sets_explicit_connect_and_acquire_timeouts failed before production fix.
- GREEN/focused: cargo test -p exo-gateway db::tests::pool_initialization_sets_explicit_connection_acquire_timeout
- cargo test -p exo-gateway db::tests
- cargo test -p exo-gateway
- cargo fmt --all -- --check
- git diff --check
- cargo clippy -p exo-gateway --all-targets -- -D warnings
- cargo build --workspace --release
- cargo test --workspace
- cargo test --workspace --release
- cargo clippy --workspace --all-targets -- -D warnings
- RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps
- EXO_TS_ROOT=/Users/bobstewart/.config/superpowers/worktrees/exochain/core-sweep-20260504h/packages/exochain-sdk ./tools/cross-impl-test/compare.sh
- cargo audit --deny unsound --deny unmaintained
- cargo deny check
- bash tools/test_repo_truth.sh