### PR TITLE
fix(governance): exclude observers from quorum

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 158046 | `wc -l` |
+| Rust LOC | 158200 | `wc -l` |
 | Workspace tests | 3,638 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -80,7 +80,7 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 158026 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 158200 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 3,638 listed workspace tests
 

--- a/crates/exo-governance/src/quorum.rs
+++ b/crates/exo-governance/src/quorum.rs
@@ -20,6 +20,7 @@ pub enum Role {
     Governor,
     Reviewer,
     Contributor,
+    /// Read-only participant; may observe governance but cannot satisfy quorum.
     Observer,
 }
 
@@ -200,6 +201,11 @@ fn invalid_quorum_policy(reason: impl Into<String>) -> QuorumResult {
     }
 }
 
+#[must_use]
+fn role_counts_toward_quorum(role: &Role) -> bool {
+    !matches!(role, Role::Observer)
+}
+
 fn validate_policy(policy: &QuorumPolicy) -> Option<QuorumResult> {
     if policy.min_approvals == 0 {
         return Some(invalid_quorum_policy(
@@ -209,6 +215,15 @@ fn validate_policy(policy: &QuorumPolicy) -> Option<QuorumResult> {
     if policy.min_independent > policy.min_approvals {
         return Some(invalid_quorum_policy(
             "min_independent must not exceed min_approvals",
+        ));
+    }
+    if policy
+        .required_roles
+        .iter()
+        .any(|role| !role_counts_toward_quorum(role))
+    {
+        return Some(invalid_quorum_policy(
+            "Observer cannot be a required quorum role",
         ));
     }
     None
@@ -233,19 +248,36 @@ pub fn compute_quorum(approvals: &[Approval], policy: &QuorumPolicy) -> QuorumRe
         };
     }
 
-    let total_count = approvals.len();
+    let quorum_eligible_approvals: Vec<&Approval> = approvals
+        .iter()
+        .filter(|approval| role_counts_toward_quorum(&approval.role))
+        .collect();
+
+    let total_count = quorum_eligible_approvals.len();
 
     if total_count < policy.min_approvals {
-        return QuorumResult::NotMet {
-            reason: format!(
+        let has_non_quorum_role = approvals
+            .iter()
+            .any(|approval| !role_counts_toward_quorum(&approval.role));
+        let reason = if has_non_quorum_role {
+            format!(
+                "insufficient approvals: {total_count} < {} quorum-eligible required (Observer cannot satisfy quorum)",
+                policy.min_approvals
+            )
+        } else {
+            format!(
                 "insufficient approvals: {total_count} < {}",
                 policy.min_approvals
-            ),
+            )
         };
+        return QuorumResult::NotMet { reason };
     }
 
     for required_role in &policy.required_roles {
-        if !approvals.iter().any(|a| &a.role == required_role) {
+        if !quorum_eligible_approvals
+            .iter()
+            .any(|a| &a.role == required_role)
+        {
             return QuorumResult::NotMet {
                 reason: format!("missing required role: {}", required_role.as_str()),
             };
@@ -256,7 +288,7 @@ pub fn compute_quorum(approvals: &[Approval], policy: &QuorumPolicy) -> QuorumRe
         return verified_quorum_required();
     }
 
-    let independent_count = approvals
+    let independent_count = quorum_eligible_approvals
         .iter()
         .filter(|a| {
             a.independence_attestation
@@ -379,26 +411,44 @@ pub fn compute_quorum_verified<R: PublicKeyResolver>(
         })
         .collect();
 
-    let total_count = verified_approvals.len();
+    let quorum_eligible_approvals: Vec<&Approval> = verified_approvals
+        .iter()
+        .copied()
+        .filter(|approval| role_counts_toward_quorum(&approval.role))
+        .collect();
+
+    let total_count = quorum_eligible_approvals.len();
 
     if total_count < policy.min_approvals {
-        return QuorumResult::NotMet {
-            reason: format!(
+        let has_verified_non_quorum_role = verified_approvals
+            .iter()
+            .any(|approval| !role_counts_toward_quorum(&approval.role));
+        let reason = if has_verified_non_quorum_role {
+            format!(
+                "insufficient verified approvals: {total_count} quorum-eligible verified of {} required (Observer cannot satisfy quorum)",
+                policy.min_approvals
+            )
+        } else {
+            format!(
                 "insufficient verified approvals: {total_count} verified of {} required",
                 policy.min_approvals
-            ),
+            )
         };
+        return QuorumResult::NotMet { reason };
     }
 
     for required_role in &policy.required_roles {
-        if !verified_approvals.iter().any(|a| &a.role == required_role) {
+        if !quorum_eligible_approvals
+            .iter()
+            .any(|a| &a.role == required_role)
+        {
             return QuorumResult::NotMet {
                 reason: format!("missing required role: {}", required_role.as_str()),
             };
         }
     }
 
-    let independent_count = verified_approvals
+    let independent_count = quorum_eligible_approvals
         .iter()
         .filter(|a| {
             a.independence_attestation.as_ref().is_some_and(|att| {
@@ -1134,6 +1184,30 @@ mod tests {
     }
 
     #[test]
+    fn quorum_policy_rejects_observer_as_required_role() {
+        let resolver = |_did: &Did| -> Option<PublicKey> { None };
+        let policy = QuorumPolicy {
+            min_approvals: 1,
+            min_independent: 0,
+            required_roles: vec![Role::Observer],
+            timeout: Timestamp::new(999_999, 0),
+        };
+
+        for result in [
+            compute_quorum(&[], &policy),
+            compute_quorum_verified(&[], &policy, &resolver),
+        ] {
+            match result {
+                QuorumResult::NotMet { reason } => {
+                    assert!(reason.contains("invalid quorum policy"));
+                    assert!(reason.contains("Observer cannot be a required quorum role"));
+                }
+                other => panic!("Observer must not be a required quorum role, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
     fn compute_quorum_verified_rejects_duplicate_approver_dids() {
         let (pk_alice, sk_alice) = crypto::generate_keypair();
         let alice = did("alice");
@@ -1156,6 +1230,86 @@ mod tests {
             }
             other => panic!("duplicate approver must not inflate verified quorum, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn compute_quorum_verified_rejects_observer_approvals() {
+        let (pk_observer, sk_observer) = crypto::generate_keypair();
+        let observer = did("observer");
+        let approval = signed_approval_with_attestation(
+            &observer,
+            Role::Observer,
+            Timestamp::new(1000, 0),
+            &sk_observer,
+            None,
+        );
+        let resolver = |d: &Did| -> Option<PublicKey> {
+            if *d == observer {
+                Some(pk_observer)
+            } else {
+                None
+            }
+        };
+        let policy = QuorumPolicy {
+            min_approvals: 1,
+            min_independent: 0,
+            required_roles: vec![],
+            timeout: Timestamp::new(999_999, 0),
+        };
+
+        match compute_quorum_verified(&[approval], &policy, &resolver) {
+            QuorumResult::NotMet { reason } => {
+                assert!(reason.contains("Observer") || reason.contains("observer"));
+            }
+            other => panic!("observer approval must not satisfy verified quorum, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn compute_quorum_verified_excludes_observers_from_total_count() {
+        let (pk_alice, sk_alice) = crypto::generate_keypair();
+        let (pk_observer, sk_observer) = crypto::generate_keypair();
+        let alice = did("alice");
+        let observer = did("observer");
+        let approvals = vec![
+            signed_approval_with_attestation(
+                &alice,
+                Role::Steward,
+                Timestamp::new(1000, 0),
+                &sk_alice,
+                None,
+            ),
+            signed_approval_with_attestation(
+                &observer,
+                Role::Observer,
+                Timestamp::new(1001, 0),
+                &sk_observer,
+                None,
+            ),
+        ];
+        let resolver = |d: &Did| -> Option<PublicKey> {
+            if *d == alice {
+                Some(pk_alice)
+            } else if *d == observer {
+                Some(pk_observer)
+            } else {
+                None
+            }
+        };
+        let policy = QuorumPolicy {
+            min_approvals: 1,
+            min_independent: 0,
+            required_roles: vec![Role::Steward],
+            timeout: Timestamp::new(999_999, 0),
+        };
+
+        assert_eq!(
+            compute_quorum_verified(&approvals, &policy, &resolver),
+            QuorumResult::Met {
+                independent_count: 0,
+                total_count: 1,
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Confirmed the external Observer-quorum finding still reproduced on current `main`: a valid signed `Role::Observer` approval could satisfy `compute_quorum_verified` when `min_approvals = 1`, `min_independent = 0`, and no required roles were configured.
- Added quorum-role eligibility enforcement so `Observer` remains read-only/observational and cannot count toward quorum totals or independence totals.
- Rejected quorum policies that attempt to require `Role::Observer`.
- Updated the README Rust LOC values derived by `tools/test_repo_truth.sh` after the core source-line change.

## Path Classification
- `crates/exo-governance/src/quorum.rs`: EXOCHAIN core.
- `README.md`: documentation / repo-truth derived metadata required by CI for this core source change.

## External Finding Disposition
- Imported evidence source: Matthew Butler / Wally Fipps audit corpus hypothesis about Observer approvals counting toward quorum.
- Current-code status: live and reproducible before this fix.
- Regression: `compute_quorum_verified_rejects_observer_approvals` was added first and failed red before the production change with `Met { independent_count: 0, total_count: 1 }`.

## Validation
- `cargo test -p exo-governance quorum::tests::compute_quorum_verified_rejects_observer_approvals -- --nocapture` red before fix, green after fix.
- `cargo test -p exo-governance quorum::tests::compute_quorum_verified_excludes_observers_from_total_count -- --nocapture`
- `cargo test -p exo-governance quorum::tests::quorum_policy_rejects_observer_as_required_role -- --nocapture`
- `cargo test -p exo-governance quorum -- --nocapture`
- `cargo test -p exo-governance`
- `cargo test -p exochain-wasm governance_bindings -- --nocapture`
- `cargo fmt --all -- --check` (passes; rustfmt emits existing stable-toolchain warnings for unstable rustfmt options)
- `cargo clippy -p exo-governance --all-targets -- -D warnings`
- `cargo build --workspace --release`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check` (passes with existing duplicate-version warnings; advisories/bans/licenses/sources OK)
- `bash tools/test_repo_truth.sh`
- `./tools/cross-impl-test/compare.sh` (passes Rust determinism; TypeScript comparison skipped because `EXO_TS_ROOT` is not set)

## Bypass Search
- `rg "compute_quorum\\(|compute_quorum_verified\\(|compute_quorum_with_challenges" crates packages --glob '*.rs'`
- Production quorum consumers route through `compute_quorum_verified`; the WASM governance binding delegates to the same core function.
