### PR TITLE
fix(authority): reject unknown delegatee grants

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 158200 | `wc -l` |
+| Rust LOC | 158269 | `wc -l` |
 | Workspace tests | 3,638 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -80,7 +80,7 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 158200 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 158269 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 3,638 listed workspace tests
 

--- a/crates/exo-authority/src/delegation.rs
+++ b/crates/exo-authority/src/delegation.rs
@@ -265,10 +265,18 @@ impl DelegationRegistry {
                 reason: "expiration must be later than created timestamp".into(),
             });
         }
-        if let DelegateeKind::AiAgent { model_id } = &delegatee_kind {
-            if model_id.trim().is_empty() {
+        match &delegatee_kind {
+            DelegateeKind::Human => {}
+            DelegateeKind::AiAgent { model_id } => {
+                if model_id.trim().is_empty() {
+                    return Err(AuthorityError::InvalidDelegation {
+                        reason: "AI-agent delegatee kind requires a non-empty model_id".into(),
+                    });
+                }
+            }
+            DelegateeKind::Unknown => {
                 return Err(AuthorityError::InvalidDelegation {
-                    reason: "AI-agent delegatee kind requires a non-empty model_id".into(),
+                    reason: "delegatee kind must be Human or AiAgent for new delegations".into(),
                 });
             }
         }
@@ -636,6 +644,67 @@ mod tests {
             result,
             Err(AuthorityError::InvalidSignature { index: 0 })
         ));
+    }
+
+    #[test]
+    fn delegate_rejects_unknown_delegatee_kind_for_new_grants() {
+        let mut reg = DelegationRegistry::new();
+        let keypair = KeyPair::generate();
+        let public_key = public_key(&keypair);
+        let from = did("alice");
+        let to = did("bob");
+
+        let result = reg.delegate(
+            DelegationGrant {
+                from: &from,
+                to: &to,
+                scope: &[Permission::Read],
+                expires: ts(10000),
+                now: &now(),
+                delegatee_kind: DelegateeKind::Unknown,
+                delegator_public_key: &public_key,
+            },
+            |payload| keypair.sign(payload),
+        );
+
+        assert!(matches!(
+            result,
+            Err(AuthorityError::InvalidDelegation { reason })
+                if reason.contains("delegatee kind")
+        ));
+    }
+
+    #[test]
+    fn delegate_accepts_ai_agent_delegatee_kind_with_model_id() {
+        let mut reg = DelegationRegistry::new();
+        let keypair = KeyPair::generate();
+        let public_key = public_key(&keypair);
+        let from = did("alice");
+        let to = did("agent");
+
+        let link = reg
+            .delegate(
+                DelegationGrant {
+                    from: &from,
+                    to: &to,
+                    scope: &[Permission::Read],
+                    expires: ts(10000),
+                    now: &now(),
+                    delegatee_kind: DelegateeKind::AiAgent {
+                        model_id: "exo-agent-v1".to_owned(),
+                    },
+                    delegator_public_key: &public_key,
+                },
+                |payload| keypair.sign(payload),
+            )
+            .expect("valid AI-agent delegation");
+
+        assert_eq!(
+            link.delegatee_kind,
+            DelegateeKind::AiAgent {
+                model_id: "exo-agent-v1".to_owned()
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Classifies this as EXOCHAIN core: `crates/exo-authority/src/delegation.rs` and generated README repo-truth counters.
- Rejects freshly signed authority delegations that set `DelegateeKind::Unknown`; that variant remains reserved for legacy deserialization.
- Adds regression coverage for the rejected Unknown grant and positive coverage for valid AI-agent delegatee metadata.

## External finding disposition
- Revalidated F-039 against current `origin/main` before production edits.
- Confirmed live with a failing regression: `delegate_rejects_unknown_delegatee_kind_for_new_grants` accepted the grant before the fix.
- Fixed at the authority grant boundary without altering legacy record deserialization.

## Validation
- RED before fix: `cargo test -p exo-authority delegation::tests::delegate_rejects_unknown_delegatee_kind_for_new_grants -- --nocapture` failed as expected.
- `cargo test -p exo-authority delegation::tests::delegate_rejects_unknown_delegatee_kind_for_new_grants -- --nocapture`
- `cargo test -p exo-authority delegation::tests::delegate_accepts_ai_agent_delegatee_kind_with_model_id -- --nocapture`
- `cargo test -p exo-authority`
- `cargo fmt --all -- --check`
- `cargo clippy -p exo-authority --all-targets -- -D warnings`
- `bash tools/test_repo_truth.sh`
- `cargo build --workspace --release`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check` (passes with existing duplicate-version warnings)
- `./tools/cross-impl-test/compare.sh` (Rust-only determinism; TypeScript comparison skipped because `EXO_TS_ROOT` is unset)

## Bypass search
- `rg -n "DelegateeKind::Unknown|delegatee_kind: DelegateeKind::Unknown|delegatee_kind" crates/exo-authority/src crates/exo-node/src crates/exo-governance/src crates/exo-gatekeeper/src --glob "*.rs"`
- Remaining `Unknown` references are the enum/default documentation and the new rejection test/path.
