### PR TITLE
fix(economy): require signed settlement receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 158357 | `wc -l` |
+| Rust LOC | 158418 | `wc -l` |
 | Workspace tests | 3,638 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -80,7 +80,7 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 158357 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 158418 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 3,638 listed workspace tests
 

--- a/crates/exo-economy/src/error.rs
+++ b/crates/exo-economy/src/error.rs
@@ -52,6 +52,10 @@ pub enum EconomyError {
     #[error("economy settlement amount {amount} exceeds charged amount {charged}")]
     SettlementOverAllocated { amount: u128, charged: u128 },
 
+    /// Settlement signer returned an empty placeholder signature.
+    #[error("economy settlement receipt `{receipt_id}` signer returned an empty signature")]
+    EmptySettlementSignature { receipt_id: String },
+
     /// Constant-evaluation invariant in the zero-launch policy was violated.
     #[error("zero-launch invariant violated: {reason}")]
     ZeroLaunchInvariantViolated { reason: String },
@@ -119,6 +123,9 @@ mod tests {
             EconomyError::SettlementOverAllocated {
                 amount: 10,
                 charged: 5,
+            },
+            EconomyError::EmptySettlementSignature {
+                receipt_id: "rec".into(),
             },
             EconomyError::ZeroLaunchInvariantViolated { reason: "x".into() },
             EconomyError::InvalidInput { reason: "x".into() },

--- a/crates/exo-economy/src/settlement.rs
+++ b/crates/exo-economy/src/settlement.rs
@@ -76,7 +76,13 @@ where
         signature: Signature::empty(),
     };
     receipt.content_hash = canonical_content_hash(&receipt)?;
-    receipt.signature = sign(receipt.content_hash.as_bytes());
+    let signature = sign(receipt.content_hash.as_bytes());
+    if signature.is_empty() {
+        return Err(EconomyError::EmptySettlementSignature {
+            receipt_id: context.receipt_id.clone(),
+        });
+    }
+    receipt.signature = signature;
     Ok(receipt)
 }
 
@@ -176,6 +182,17 @@ mod tests {
         ctx.now = Timestamp::new(q.expires_at.physical_ms + 1, q.expires_at.logical);
         let err = settle(&q, &ctx, |_| fixed_signature()).unwrap_err();
         assert!(matches!(err, EconomyError::QuoteExpired));
+    }
+
+    #[test]
+    fn settle_rejects_empty_signer_output() {
+        let policy = PricingPolicy::zero_launch_default();
+        let q = quote(&policy, &baseline_inputs(), "q-1".into()).unwrap();
+        let err = settle(&q, &baseline_context(), |_| Signature::empty()).unwrap_err();
+        assert!(matches!(
+            err,
+            EconomyError::EmptySettlementSignature { receipt_id } if receipt_id == "rec-1"
+        ));
     }
 
     #[test]

--- a/crates/exo-node/src/economy.rs
+++ b/crates/exo-node/src/economy.rs
@@ -37,25 +37,23 @@ use tower::limit::ConcurrencyLimitLayer;
 const MAX_ECONOMY_API_BODY_BYTES: usize = 64 * 1024;
 const MAX_ECONOMY_API_CONCURRENT_REQUESTS: usize = 64;
 
+pub type SettlementSigner = Arc<dyn Fn(&[u8]) -> Signature + Send + Sync>;
+
 /// Shared state for economy route handlers.
 #[derive(Clone)]
 pub struct EconomyApiState {
     pub store: Arc<Mutex<InMemoryEconomyStore>>,
+    settlement_signer: SettlementSigner,
 }
 
 impl EconomyApiState {
     /// Construct a fresh state seeded with the zero-launch policy.
     #[must_use]
-    pub fn new() -> Self {
+    pub fn new(settlement_signer: SettlementSigner) -> Self {
         Self {
             store: Arc::new(Mutex::new(InMemoryEconomyStore::new())),
+            settlement_signer,
         }
-    }
-}
-
-impl Default for EconomyApiState {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -146,7 +144,9 @@ fn map_economy_error(err: EconomyError) -> ApiError {
         | EconomyError::SettlementOverAllocated { .. } => {
             (StatusCode::UNPROCESSABLE_ENTITY, err.to_string())
         }
-        EconomyError::Serialization { .. } | EconomyError::ZeroLaunchInvariantViolated { .. } => {
+        EconomyError::Serialization { .. }
+        | EconomyError::EmptySettlementSignature { .. }
+        | EconomyError::ZeroLaunchInvariantViolated { .. } => {
             (StatusCode::INTERNAL_SERVER_ERROR, "economy error".into())
         }
     }
@@ -181,13 +181,14 @@ async fn handle_settle(
 ) -> ApiResult<Json<SettlementReceipt>> {
     let quote_hash = parse_hash(&payload.quote_hash_hex)?;
     let context = payload.context;
+    let settlement_signer = Arc::clone(&state.settlement_signer);
     let receipt = with_store_blocking(state, move |store| {
         let stored = store
             .get_quote(&quote_hash)
             .map_err(map_economy_error)?
             .ok_or_else(|| map_economy_error(EconomyError::QuoteNotFound))?;
-        let receipt =
-            settle(&stored, &context, |_| Signature::empty()).map_err(map_economy_error)?;
+        let receipt = settle(&stored, &context, |payload| (settlement_signer)(payload))
+            .map_err(map_economy_error)?;
         store
             .put_receipt(receipt.clone())
             .map_err(map_economy_error)?;
@@ -248,14 +249,29 @@ mod tests {
         body::{self, Body},
         http::{Method, Request},
     };
-    use exo_core::{Did, Timestamp};
+    use exo_core::{
+        Did, Timestamp,
+        crypto::{self, KeyPair},
+        types::PublicKey,
+    };
     use exo_economy::{ActorClass, AssuranceClass, EventClass, ZeroFeeReason};
     use tower::ServiceExt;
 
     use super::*;
 
+    fn test_keypair() -> KeyPair {
+        KeyPair::from_secret_bytes([0xEC; 32]).unwrap()
+    }
+
+    fn fresh_signed_state() -> (Arc<EconomyApiState>, PublicKey) {
+        let keypair = test_keypair();
+        let public_key = *keypair.public_key();
+        let signer: SettlementSigner = Arc::new(move |payload: &[u8]| keypair.sign(payload));
+        (Arc::new(EconomyApiState::new(signer)), public_key)
+    }
+
     fn fresh_state() -> Arc<EconomyApiState> {
-        Arc::new(EconomyApiState::new())
+        fresh_signed_state().0
     }
 
     fn baseline_inputs() -> PricingInputs {
@@ -311,7 +327,7 @@ mod tests {
 
     #[tokio::test]
     async fn settle_creates_zero_priced_receipt() {
-        let state = fresh_state();
+        let (state, public_key) = fresh_signed_state();
         let app = economy_router(Arc::clone(&state));
 
         // Step 1: quote.
@@ -361,6 +377,18 @@ mod tests {
             serde_json::from_slice(&read_body(response).await).unwrap();
         assert_eq!(receipt.charged_amount_micro_exo, 0);
         assert!(receipt.zero_fee_reason.is_some());
+        assert!(
+            !receipt.signature.is_empty(),
+            "economy settlement receipts must be signed by the node identity"
+        );
+        assert!(
+            crypto::verify(
+                receipt.content_hash.as_bytes(),
+                &receipt.signature,
+                &public_key
+            ),
+            "economy settlement receipt signature must verify against the node identity"
+        );
     }
 
     #[tokio::test]
@@ -521,6 +549,14 @@ mod tests {
         assert!(
             production.contains("ConcurrencyLimitLayer::new("),
             "economy router must apply local admission control"
+        );
+        assert!(
+            production.contains("settlement_signer"),
+            "economy settlement must use the configured node identity signer"
+        );
+        assert!(
+            !production.contains("Signature::empty()"),
+            "production economy settlement must not fabricate empty receipt signatures"
         );
     }
 }

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -863,7 +863,11 @@ async fn start_node(
     );
 
     // Build the economy API router (zero-priced launch settlement).
-    let economy_state = Arc::new(economy::EconomyApiState::new());
+    let economy_settlement_signer: economy::SettlementSigner = {
+        let identity = identity::load_or_create(data_dir)?;
+        Arc::new(move |payload: &[u8]| identity.sign(payload))
+    };
+    let economy_state = Arc::new(economy::EconomyApiState::new(economy_settlement_signer));
     let economy_router = economy::economy_router(Arc::clone(&economy_state));
     tracing::info!(
         "Economy router ready — /api/v1/economy/{{quote,settle,receipts/:id,policy/active}} (zero-priced launch policy active)"


### PR DESCRIPTION
## Summary
- reject empty settlement signer output in exo-economy instead of emitting placeholder receipt signatures
- require exo-node economy API state to be constructed with a node identity settlement signer
- verify API settlement receipts are non-empty and Ed25519-verifiable against the configured node identity public key
- refresh README repo-truth LOC after the Rust source change so Gate 9 remains source-derived

## Path Classification
- crates/exo-economy/src/error.rs: EXOCHAIN core
- crates/exo-economy/src/settlement.rs: EXOCHAIN core
- crates/exo-node/src/economy.rs: Core runtime adapter
- crates/exo-node/src/main.rs: Core runtime adapter
- README.md: Documentation / repo-truth gate metadata

## Freshness / Reproduction
- Validated against current origin/main after PR #278 merge.
- Reproduced live: /api/v1/economy/settle returned SettlementReceipt values signed with Signature::empty().
- Red test before fix: cargo test -p exo-node settle_creates_zero_priced_receipt -- --nocapture failed because the API receipt signature was empty.

## Validation
- cargo test -p exo-node settle_creates_zero_priced_receipt -- --nocapture
- cargo test -p exo-economy settle_rejects_empty_signer_output -- --nocapture
- cargo test -p exo-node economy -- --nocapture
- cargo test -p exo-economy -- --nocapture
- cargo fmt --all -- --check
- cargo test -p exo-node -- --nocapture
- cargo clippy -p exo-economy -p exo-node --all-targets -- -D warnings
- bash tools/test_repo_truth.sh
- bash tools/test_cr001_status.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_railway_entrypoint_args.sh

## Adjacent Surface Impact
- None. The code change only touches EXOCHAIN Rust workspace core and node runtime adapter paths; README.md changed only to keep repo-truth CI current.