### PR TITLE
fix(node): back off telegram poll failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 158418 | `wc -l` |
-| Workspace tests | 3,638 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 158447 | `wc -l` |
+| Workspace tests | 3,938 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,638 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,938 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -80,9 +80,9 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 158418 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 158447 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,638 listed workspace tests
+         cryptographic proofs, 3,938 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/telegram.rs
+++ b/crates/exo-node/src/telegram.rs
@@ -42,6 +42,7 @@ use crate::{
 // ---------------------------------------------------------------------------
 
 const TELEGRAM_HTTP_TIMEOUT_SECS: u64 = 30;
+const TELEGRAM_POLL_FAILURE_BACKOFF_MS: u64 = 1_000;
 const MAX_TELEGRAM_UPDATE_RESPONSE_BYTES: usize = 1024 * 1024;
 
 #[derive(Debug, Serialize)]
@@ -343,15 +344,13 @@ impl Adjutant {
         }
     }
 
-    /// Poll for new updates (long-poll, 10s timeout).
-    pub async fn poll_updates(&mut self) -> Vec<Update> {
+    async fn poll_updates_result(&mut self) -> Result<Vec<Update>, String> {
         let base_url = self.api_url("getUpdates");
         let Some(offset) = next_update_offset(self.last_update_id) else {
-            tracing::warn!(
-                last_update_id = self.last_update_id,
-                "Telegram update offset cannot advance without overflow"
-            );
-            return Vec::new();
+            return Err(format!(
+                "telegram update offset overflow after update id {}",
+                self.last_update_id
+            ));
         };
         let url = Zeroizing::new(format!(
             "{}?offset={}&timeout=10",
@@ -361,33 +360,24 @@ impl Adjutant {
 
         let resp = match self.client.get(url.as_str()).send().await {
             Ok(r) => r,
-            Err(e) => {
-                tracing::debug!(err = %e, "Telegram poll failed");
-                return Vec::new();
-            }
+            Err(e) => return Err(format!("telegram poll failed: {e}")),
         };
 
         let bytes = match read_telegram_update_body(resp).await {
             Ok(bytes) => bytes,
-            Err(e) => {
-                tracing::debug!(err = %e, "Telegram update body read failed");
-                return Vec::new();
-            }
+            Err(e) => return Err(format!("telegram update body read failed: {e}")),
         };
 
         let updates = match parse_updates_response(bytes.as_ref()) {
             Ok(updates) => updates,
-            Err(e) => {
-                tracing::debug!(err = %e, "Telegram update response rejected");
-                return Vec::new();
-            }
+            Err(e) => return Err(format!("telegram update response rejected: {e}")),
         };
 
         if let Some(last) = updates.last() {
             self.last_update_id = last.update_id;
         }
 
-        updates
+        Ok(updates)
     }
 
     /// Acknowledge a callback query (removes the "loading" indicator).
@@ -929,7 +919,19 @@ pub async fn run_adjutant(
             }
 
             // Poll for Telegram updates.
-            updates = adjutant.poll_updates() => {
+            poll_result = adjutant.poll_updates_result() => {
+                let updates = match poll_result {
+                    Ok(updates) => updates,
+                    Err(e) => {
+                        tracing::debug!(err = %e, "Telegram poll failed; backing off before retry");
+                        tokio::time::sleep(std::time::Duration::from_millis(
+                            TELEGRAM_POLL_FAILURE_BACKOFF_MS,
+                        ))
+                        .await;
+                        Vec::new()
+                    }
+                };
+
                 // Parse the configured authorized chat id once per batch.
                 // If it fails to parse (misconfigured env), we fail-closed:
                 // no commands are dispatched.
@@ -1491,7 +1493,7 @@ mod tests {
             .next()
             .unwrap();
         let poll_updates = production
-            .split("pub async fn poll_updates")
+            .split("async fn poll_updates_result")
             .nth(1)
             .and_then(|section| section.split("/// Acknowledge a callback query").next())
             .unwrap();
@@ -1500,6 +1502,33 @@ mod tests {
         assert!(!poll_updates.contains(".bytes().await"));
         assert!(poll_updates.contains("read_telegram_update_body"));
         assert!(poll_updates.contains("parse_updates_response"));
+    }
+
+    #[test]
+    fn run_adjutant_backs_off_after_telegram_poll_failures() {
+        let source = include_str!("telegram.rs");
+        let production = source
+            .split("// ---------------------------------------------------------------------------\n// Tests")
+            .next()
+            .unwrap();
+        let run_adjutant = production
+            .split("pub async fn run_adjutant")
+            .nth(1)
+            .and_then(|section| section.split("async fn handle_command").next())
+            .unwrap();
+
+        assert!(
+            run_adjutant.contains("poll_updates_result"),
+            "run_adjutant must distinguish failed polls from successful empty long-poll responses"
+        );
+        assert!(
+            run_adjutant.contains("TELEGRAM_POLL_FAILURE_BACKOFF_MS"),
+            "failed Telegram polls must use a bounded backoff instead of immediate repolling"
+        );
+        assert!(
+            run_adjutant.contains("tokio::time::sleep"),
+            "Telegram poll failure backoff must sleep before the next poll attempt"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- distinguish failed Telegram update polls from successful empty long-poll responses
- add a bounded poll-failure backoff before retrying, preventing tight retry loops on immediate transport/API/body failures
- keep the existing successful long-poll path and bounded response parsing intact
- refresh README repo-truth LOC/test count after the Rust test/source change

## Path Classification
- crates/exo-node/src/telegram.rs: Core runtime adapter / node operator command surface
- README.md: Documentation / repo-truth gate metadata

## Freshness / Reproduction
- Validated against current origin/main after PR #279 merge.
- Confirmed live: poll_updates returned Vec::new() for request/body/API parse failures, and run_adjutant immediately re-entered polling with no failure backoff.
- Red test before fix: cargo test -p exo-node run_adjutant_backs_off_after_telegram_poll_failures -- --nocapture failed because run_adjutant could not distinguish failures from successful empty long polls.

## Validation
- cargo test -p exo-node run_adjutant_backs_off_after_telegram_poll_failures -- --nocapture
- cargo test -p exo-node telegram::tests:: -- --nocapture
- cargo fmt --all -- --check
- cargo clippy -p exo-node --all-targets -- -D warnings
- cargo test -p exo-node -- --nocapture
- bash tools/repo_truth.sh --json --list-tests
- bash tools/test_repo_truth.sh

## Adjacent Surface Impact
- No adjacent product code changed. The runtime code change is limited to the EXOCHAIN node Telegram operator surface; README.md changed only to keep source-derived repo truth current.