### PR TITLE
fix(node): acknowledge p2p publish failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 158447 | `wc -l` |
-| Workspace tests | 3,938 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 158582 | `wc -l` |
+| Workspace tests | 3,940 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,938 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,940 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -80,9 +80,9 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 158447 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 158582 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,938 listed workspace tests
+         cryptographic proofs, 3,940 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/api.rs
+++ b/crates/exo-node/src/api.rs
@@ -626,7 +626,13 @@ mod tests {
         let store = Arc::new(Mutex::new(SqliteDagStore::open(dir.path()).unwrap()));
 
         let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::channel(32);
-        tokio::spawn(async move { while cmd_rx.recv().await.is_some() {} });
+        tokio::spawn(async move {
+            while let Some(command) = cmd_rx.recv().await {
+                if let crate::network::NetworkCommand::Publish { reply, .. } = command {
+                    let _ = reply.send(Ok(()));
+                }
+            }
+        });
         let net_handle = NetworkHandle::new(cmd_tx);
 
         Arc::new(NodeApiState {

--- a/crates/exo-node/src/holons.rs
+++ b/crates/exo-node/src/holons.rs
@@ -1395,6 +1395,9 @@ mod tests {
         tokio::spawn(async move {
             while let Some(cmd) = cmd_rx.recv().await {
                 match cmd {
+                    crate::network::NetworkCommand::Publish { reply, .. } => {
+                        let _ = reply.send(Ok(()));
+                    }
                     crate::network::NetworkCommand::PeerCount { reply } => {
                         let _ = reply.send(0);
                     }

--- a/crates/exo-node/src/network.rs
+++ b/crates/exo-node/src/network.rs
@@ -35,6 +35,9 @@ use crate::wire::{self, WireMessage, topics};
 
 const GOSSIPSUB_MESSAGE_ID_DOMAIN: &str = "exo.node.gossipsub.message-id.v1";
 const IDENTIFY_AGENT_VERSION: &str = "exochain/1.0";
+const NETWORK_PUBLISH_MAX_ATTEMPTS: usize = 3;
+const NETWORK_PUBLISH_RETRY_BACKOFF_MS: u64 = 50;
+const NETWORK_PUBLISH_ACK_TIMEOUT_MS: u64 = 5_000;
 
 #[derive(serde::Serialize)]
 struct GossipsubMessageIdPayload<'a> {
@@ -69,7 +72,11 @@ pub struct ExochainBehaviour {
 #[derive(Debug)]
 pub enum NetworkCommand {
     /// Publish a wire message to a gossipsub topic.
-    Publish { topic: String, message: WireMessage },
+    Publish {
+        topic: String,
+        message: WireMessage,
+        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+    },
     /// Dial a peer at a multiaddr.
     #[allow(dead_code)] // Used when governance API enables dynamic peer dialing
     Dial { addr: Multiaddr },
@@ -390,22 +397,30 @@ pub async fn run_network_loop(
             // Process application commands
             Some(cmd) = cmd_rx.recv() => {
                 match cmd {
-                    NetworkCommand::Publish { topic, message } => {
-                        match wire::encode(&message) {
+                    NetworkCommand::Publish { topic, message, reply } => {
+                        let result = match wire::encode(&message) {
                             Ok(bytes) => {
                                 let topic = gossipsub::IdentTopic::new(topic);
                                 match swarm.behaviour_mut().gossipsub.publish(topic, bytes) {
                                     Ok(msg_id) => {
                                         tracing::debug!(%msg_id, "Published message");
+                                        Ok(())
                                     }
                                     Err(e) => {
-                                        tracing::warn!(err = %e, "Failed to publish");
+                                        let reason = format!("gossipsub publish failed: {e}");
+                                        tracing::warn!(err = %reason, "Failed to publish");
+                                        Err(reason)
                                     }
                                 }
                             }
                             Err(e) => {
-                                tracing::warn!(err = %e, "Failed to encode message");
+                                let reason = format!("wire encode failed: {e}");
+                                tracing::warn!(err = %reason, "Failed to encode message");
+                                Err(reason)
                             }
+                        };
+                        if reply.send(result).is_err() {
+                            tracing::warn!("Network publish reply receiver dropped");
                         }
                     }
 
@@ -500,13 +515,43 @@ impl NetworkHandle {
 
     /// Publish a wire message to a gossipsub topic.
     pub async fn publish(&self, topic: &str, message: WireMessage) -> anyhow::Result<()> {
+        let mut last_error = None;
+        for attempt in 1..=NETWORK_PUBLISH_MAX_ATTEMPTS {
+            match self.publish_once(topic, message.clone()).await {
+                Ok(()) => return Ok(()),
+                Err(err) => {
+                    last_error = Some(err);
+                    if attempt < NETWORK_PUBLISH_MAX_ATTEMPTS {
+                        tokio::time::sleep(Duration::from_millis(NETWORK_PUBLISH_RETRY_BACKOFF_MS))
+                            .await;
+                    }
+                }
+            }
+        }
+
+        Err(last_error
+            .unwrap_or_else(|| anyhow::anyhow!("publish failed without a recorded error")))
+    }
+
+    async fn publish_once(&self, topic: &str, message: WireMessage) -> anyhow::Result<()> {
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
         self.cmd_tx
             .send(NetworkCommand::Publish {
                 topic: topic.to_string(),
                 message,
+                reply: reply_tx,
             })
             .await
-            .map_err(|_| anyhow::anyhow!("Network task has stopped"))
+            .map_err(|_| anyhow::anyhow!("Network task has stopped"))?;
+
+        tokio::time::timeout(
+            Duration::from_millis(NETWORK_PUBLISH_ACK_TIMEOUT_MS),
+            reply_rx,
+        )
+        .await
+        .map_err(|_| anyhow::anyhow!("Network publish acknowledgement timed out"))?
+        .map_err(|_| anyhow::anyhow!("Network task dropped publish acknowledgement"))?
+        .map_err(|err| anyhow::anyhow!(err))
     }
 
     /// Dial a peer at a multiaddr.
@@ -678,6 +723,70 @@ mod tests {
         // connect through loopback and make this assertion nondeterministic.
         let count = handle.peer_count().await.unwrap();
         assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn network_handle_publish_reports_gossipsub_failure() {
+        let swarm = build_swarm().unwrap();
+
+        let (cmd_tx, cmd_rx) = mpsc::channel(32);
+        let (event_tx, _event_rx) = mpsc::channel(32);
+
+        let handle = NetworkHandle::new(cmd_tx);
+        tokio::spawn(run_network_loop(swarm, cmd_rx, event_tx));
+
+        let oversized_msg = WireMessage::GovernanceEvent(wire::GovernanceEventMsg {
+            sender: Did::new("did:exo:network-publisher").unwrap(),
+            event_type: wire::GovernanceEventType::AuditEntry,
+            payload: vec![0; wire::MAX_WIRE_MESSAGE_BYTES + 1],
+            timestamp: Timestamp::ZERO,
+            signature: exo_core::types::Signature::empty(),
+        });
+
+        let result = handle.publish(topics::GOVERNANCE, oversized_msg).await;
+
+        assert!(
+            result.is_err(),
+            "publish must return the network-layer failure instead of only confirming queueing"
+        );
+    }
+
+    #[tokio::test]
+    async fn network_handle_publish_retries_until_acknowledged() {
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(32);
+        let handle = NetworkHandle::new(cmd_tx);
+        let publish_task = tokio::spawn(async move {
+            let message = WireMessage::PeerExchange(wire::PeerExchangeMsg {
+                sender: Did::new("did:exo:network-retry").unwrap(),
+                peers: Vec::new(),
+            });
+            handle.publish(topics::PEER_EXCHANGE, message).await
+        });
+
+        for attempt in 1..=2 {
+            let command = tokio::time::timeout(Duration::from_secs(1), cmd_rx.recv())
+                .await
+                .expect("publish command should arrive before timeout")
+                .expect("publish command should be sent");
+            let NetworkCommand::Publish { topic, reply, .. } = command else {
+                panic!("expected publish command");
+            };
+            assert_eq!(topic, topics::PEER_EXCHANGE);
+            if attempt == 1 {
+                reply
+                    .send(Err("transient publish failure".into()))
+                    .expect("first publish attempt should be waiting");
+            } else {
+                reply
+                    .send(Ok(()))
+                    .expect("second publish attempt should be waiting");
+            }
+        }
+
+        publish_task
+            .await
+            .expect("publish task joins")
+            .expect("publish succeeds after retry");
     }
 
     async fn wait_for_tcp_listen_addr(swarm: &mut Swarm<ExochainBehaviour>) -> Multiaddr {

--- a/crates/exo-node/src/reactor.rs
+++ b/crates/exo-node/src/reactor.rs
@@ -1466,7 +1466,8 @@ mod tests {
         let store = Arc::new(Mutex::new(SqliteDagStore::open(dir.path()).unwrap()));
 
         // Create a network handle (will fail on publish, but we test the local logic)
-        let (cmd_tx, _cmd_rx) = mpsc::channel(32);
+        let (cmd_tx, cmd_rx) = mpsc::channel(32);
+        drop(cmd_rx);
         let net_handle = NetworkHandle::new(cmd_tx);
 
         let _result = submit_proposal(&state, &store, &net_handle, b"test payload").await;
@@ -1565,19 +1566,35 @@ mod tests {
         let (cmd_tx, mut cmd_rx) = mpsc::channel(32);
         let net_handle = NetworkHandle::new(cmd_tx);
 
-        broadcast_governance_event(
-            &state,
-            &net_handle,
-            GovernanceEventType::AuditEntry,
-            b"audit".to_vec(),
-        )
-        .await
-        .expect("governance event broadcast");
+        let broadcast_task = {
+            let state = Arc::clone(&state);
+            let net_handle = net_handle.clone();
+            tokio::spawn(async move {
+                broadcast_governance_event(
+                    &state,
+                    &net_handle,
+                    GovernanceEventType::AuditEntry,
+                    b"audit".to_vec(),
+                )
+                .await
+            })
+        };
 
         let command = cmd_rx.recv().await.expect("published network command");
-        let crate::network::NetworkCommand::Publish { topic, message } = command else {
+        let crate::network::NetworkCommand::Publish {
+            topic,
+            message,
+            reply,
+        } = command
+        else {
             panic!("expected publish command");
         };
+        reply.send(Ok(())).expect("publish ack receiver active");
+        broadcast_task
+            .await
+            .expect("broadcast task joins")
+            .expect("governance event broadcast");
+
         assert_eq!(topic, topics::GOVERNANCE);
 
         let WireMessage::GovernanceEvent(event) = message else {

--- a/crates/exo-node/src/sync.rs
+++ b/crates/exo-node/src/sync.rs
@@ -722,6 +722,29 @@ mod tests {
         Did::new("did:exo:test-sync").unwrap()
     }
 
+    fn acking_network_handle() -> (NetworkHandle, Arc<Mutex<Vec<WireMessage>>>) {
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(256);
+        let published = Arc::new(Mutex::new(Vec::new()));
+        let published_for_task = Arc::clone(&published);
+
+        tokio::spawn(async move {
+            while let Some(cmd) = cmd_rx.recv().await {
+                match cmd {
+                    crate::network::NetworkCommand::Publish { message, reply, .. } => {
+                        published_for_task.lock().unwrap().push(message);
+                        let _ = reply.send(Ok(()));
+                    }
+                    crate::network::NetworkCommand::PeerCount { reply } => {
+                        let _ = reply.send(0);
+                    }
+                    _ => {}
+                }
+            }
+        });
+
+        (NetworkHandle::new(cmd_tx), published)
+    }
+
     #[test]
     fn sync_engine_store_access_uses_spawn_blocking() {
         let source = include_str!("sync.rs");
@@ -856,8 +879,7 @@ mod tests {
         let (store, _hashes) = build_store_with_committed_nodes(10);
         let store = Arc::new(Mutex::new(store));
 
-        let (cmd_tx, mut cmd_rx) = mpsc::channel(256);
-        let net_handle = NetworkHandle::new(cmd_tx);
+        let (net_handle, published) = acking_network_handle();
 
         let (event_tx, mut event_rx) = mpsc::channel(32);
         let engine = SyncEngine::new(sync_config(5, 200), store, net_handle, event_tx);
@@ -872,15 +894,7 @@ mod tests {
         engine.handle_snapshot_request(request).await;
 
         // Collect published messages.
-        let mut published = Vec::new();
-        while let Ok(cmd) = cmd_rx.try_recv() {
-            match cmd {
-                crate::network::NetworkCommand::Publish { message, .. } => {
-                    published.push(message);
-                }
-                _ => {}
-            }
-        }
+        let published = published.lock().unwrap().clone();
 
         // Should have 2 chunks (5 nodes each, total 10).
         assert_eq!(
@@ -1377,8 +1391,7 @@ mod tests {
         let db_path = dir.path().join("dag.db");
         let store = Arc::new(Mutex::new(store));
 
-        let (cmd_tx, mut cmd_rx) = mpsc::channel(256);
-        let net_handle = NetworkHandle::new(cmd_tx);
+        let (net_handle, published) = acking_network_handle();
         let (event_tx, _event_rx) = mpsc::channel(32);
         let mut engine = SyncEngine::new(
             sync_config(100, 200),
@@ -1421,7 +1434,7 @@ mod tests {
         engine.handle_dag_sync_response(response).await;
 
         assert!(
-            cmd_rx.try_recv().is_err(),
+            published.lock().unwrap().is_empty(),
             "DAG sync storage failure must not request the next batch"
         );
     }
@@ -1433,8 +1446,7 @@ mod tests {
         let db_path = dir.path().join("dag.db");
         let store = Arc::new(Mutex::new(store));
 
-        let (cmd_tx, mut cmd_rx) = mpsc::channel(256);
-        let net_handle = NetworkHandle::new(cmd_tx);
+        let (net_handle, published) = acking_network_handle();
         let (event_tx, _event_rx) = mpsc::channel(32);
         let mut engine = SyncEngine::new(
             sync_config(100, 200),
@@ -1499,7 +1511,7 @@ mod tests {
             );
         }
         assert!(
-            cmd_rx.try_recv().is_err(),
+            published.lock().unwrap().is_empty(),
             "rolled-back DAG sync failure must not request the next batch"
         );
     }
@@ -1510,8 +1522,7 @@ mod tests {
         let store = SqliteDagStore::open(dir.path()).unwrap();
         let store = Arc::new(Mutex::new(store));
 
-        let (cmd_tx, mut cmd_rx) = mpsc::channel(256);
-        let net_handle = NetworkHandle::new(cmd_tx);
+        let (net_handle, published) = acking_network_handle();
 
         let (event_tx, _event_rx) = mpsc::channel(32);
         let engine = SyncEngine::new(sync_config(100, 200), store, net_handle, event_tx);
@@ -1527,7 +1538,7 @@ mod tests {
 
         // Should not publish anything since we're behind.
         assert!(
-            cmd_rx.try_recv().is_err(),
+            published.lock().unwrap().is_empty(),
             "Should not serve snapshot when behind"
         );
     }
@@ -1538,8 +1549,7 @@ mod tests {
         let store = SqliteDagStore::open(dir.path()).unwrap();
         let store = Arc::new(Mutex::new(store));
 
-        let (cmd_tx, mut cmd_rx) = mpsc::channel(256);
-        let net_handle = NetworkHandle::new(cmd_tx);
+        let (net_handle, published) = acking_network_handle();
 
         let (event_tx, _event_rx) = mpsc::channel(32);
         let mut engine = SyncEngine::new(sync_config(50, 200), store, net_handle, event_tx);
@@ -1548,18 +1558,13 @@ mod tests {
         assert!(engine.needs_sync());
 
         // Check that a request was published.
-        let cmd = cmd_rx.try_recv().unwrap();
-        match cmd {
-            crate::network::NetworkCommand::Publish { message, .. } => {
-                match message {
-                    WireMessage::StateSnapshotRequest(req) => {
-                        assert_eq!(req.from_height, 1); // height 0 + 1
-                        assert_eq!(req.chunk_size, 50);
-                    }
-                    _ => panic!("Expected StateSnapshotRequest"),
-                }
+        let published = published.lock().unwrap();
+        match published.first().expect("snapshot request published") {
+            WireMessage::StateSnapshotRequest(req) => {
+                assert_eq!(req.from_height, 1); // height 0 + 1
+                assert_eq!(req.chunk_size, 50);
             }
-            _ => panic!("Expected Publish command"),
+            _ => panic!("Expected StateSnapshotRequest"),
         }
     }
 
@@ -1576,8 +1581,7 @@ mod tests {
         .unwrap();
         let store = Arc::new(Mutex::new(store));
 
-        let (cmd_tx, mut cmd_rx) = mpsc::channel(256);
-        let net_handle = NetworkHandle::new(cmd_tx);
+        let (net_handle, published) = acking_network_handle();
         let (event_tx, _event_rx) = mpsc::channel(32);
         let mut engine = SyncEngine::new(sync_config(50, 200), store, net_handle, event_tx);
 
@@ -1585,7 +1589,7 @@ mod tests {
 
         assert!(err.to_string().contains("committed.height"));
         assert!(!engine.needs_sync());
-        assert!(cmd_rx.try_recv().is_err());
+        assert!(published.lock().unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -1593,8 +1597,7 @@ mod tests {
         let (store, _hashes) = build_store_with_committed_nodes(5);
         let store = Arc::new(Mutex::new(store));
 
-        let (cmd_tx, mut cmd_rx) = mpsc::channel(256);
-        let net_handle = NetworkHandle::new(cmd_tx);
+        let (net_handle, published) = acking_network_handle();
 
         let (event_tx, _event_rx) = mpsc::channel(32);
         let engine = SyncEngine::new(sync_config(100, 200), store, net_handle, event_tx);
@@ -1609,16 +1612,13 @@ mod tests {
         engine.handle_dag_sync_request(request).await;
 
         // Should respond with some nodes.
-        let cmd = cmd_rx.try_recv().unwrap();
-        match cmd {
-            crate::network::NetworkCommand::Publish { message, .. } => match message {
-                WireMessage::DagSyncResponse(resp) => {
-                    assert!(!resp.nodes.is_empty(), "Should send some nodes");
-                    assert!(resp.nodes.len() <= 10);
-                }
-                _ => panic!("Expected DagSyncResponse"),
-            },
-            _ => panic!("Expected Publish command"),
+        let published = published.lock().unwrap();
+        match published.first().expect("DAG sync response published") {
+            WireMessage::DagSyncResponse(resp) => {
+                assert!(!resp.nodes.is_empty(), "Should send some nodes");
+                assert!(resp.nodes.len() <= 10);
+            }
+            _ => panic!("Expected DagSyncResponse"),
         }
     }
 }


### PR DESCRIPTION
## Summary
- classify Wally F-086 as a live EXOCHAIN core runtime adapter issue in `crates/exo-node/src/network.rs`: `NetworkHandle::publish()` reported success after queueing a command while the actual gossipsub publish failure was only logged in the network task
- add publish acknowledgements from the network loop to callers, bounded retry for transient publish failures, and an acknowledgement timeout when the network task stalls
- update affected tests/helpers to acknowledge publish commands and refresh README repo-truth counters

## Path Classification
- `crates/exo-node/src/network.rs` — Core runtime adapter
- `crates/exo-node/src/reactor.rs` — Core runtime adapter tests for consensus/governance publish callers
- `crates/exo-node/src/sync.rs` — Core runtime adapter tests for sync publish callers
- `crates/exo-node/src/api.rs` — Core runtime adapter test harness
- `crates/exo-node/src/holons.rs` — Core runtime adapter test harness
- `README.md` — Documentation / repo-truth gate metadata

## Validation
- RED: `cargo test -p exo-node network_handle_publish_reports_gossipsub_failure -- --nocapture` failed on current code because publish returned queue success instead of network-layer failure
- `cargo test -p exo-node network_handle_publish_ -- --nocapture`
- `cargo test -p exo-node network::tests:: -- --nocapture`
- `cargo test -p exo-node sync::tests:: -- --nocapture`
- `cargo test -p exo-node broadcast_governance_event_publishes_nonzero_timestamp -- --nocapture`
- `cargo test -p exo-node submit_proposal_creates_dag_node -- --nocapture`
- `cargo fmt --all -- --check`
- `bash tools/repo_truth.sh --json --list-tests`
- `bash tools/test_repo_truth.sh`
- `cargo test -p exo-node -- --nocapture`
- `cargo clippy -p exo-node --all-targets -- -D warnings`
- Bypass search: `rg -n "NetworkCommand::Publish|\.publish\(topics::|net_handle\.publish|let _ = .*publish|if let Err\(e\) = .*publish" crates/exo-node/src --glob '*.rs'`
