### PR TITLE
fix(node): bound mcp prompt arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 158582 | `wc -l` |
-| Workspace tests | 3,940 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 158758 | `wc -l` |
+| Workspace tests | 3,945 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,940 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,945 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -80,9 +80,9 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 158582 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 158758 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,940 listed workspace tests
+         cryptographic proofs, 3,945 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/mcp/handler.rs
+++ b/crates/exo-node/src/mcp/handler.rs
@@ -29,6 +29,10 @@ use super::{
 /// The limit is intentionally well below Axum's default body limit so the
 /// protocol handler and HTTP transport enforce the same deterministic bound.
 pub const MAX_JSON_RPC_MESSAGE_BYTES: usize = 64 * 1024;
+const MAX_PROMPT_NAME_BYTES: usize = 128;
+const MAX_PROMPT_ARGUMENT_COUNT: usize = 16;
+const MAX_PROMPT_ARGUMENT_KEY_BYTES: usize = 64;
+const MAX_PROMPT_ARGUMENT_VALUE_BYTES: usize = 4 * 1024;
 
 fn serialize_json_rpc_response(response: &JsonRpcResponse) -> String {
     match serde_json::to_string(response) {
@@ -471,18 +475,55 @@ impl McpServer {
                 );
             }
         };
+        if name.len() > MAX_PROMPT_NAME_BYTES {
+            return JsonRpcResponse::error(
+                request.id.clone(),
+                INVALID_PARAMS,
+                format!("prompt name may contain at most {MAX_PROMPT_NAME_BYTES} bytes"),
+            );
+        }
 
         let mut args: BTreeMap<String, String> = BTreeMap::new();
         if let Some(arg_value) = params.get("arguments") {
-            if let Some(obj) = arg_value.as_object() {
-                for (k, v) in obj {
-                    let string_value = match v {
-                        Value::String(s) => s.clone(),
-                        Value::Null => String::new(),
-                        other => other.to_string(),
-                    };
-                    args.insert(k.clone(), string_value);
+            let Some(obj) = arg_value.as_object() else {
+                return JsonRpcResponse::error(
+                    request.id.clone(),
+                    INVALID_PARAMS,
+                    "prompt arguments must be an object".into(),
+                );
+            };
+            if obj.len() > MAX_PROMPT_ARGUMENT_COUNT {
+                return JsonRpcResponse::error(
+                    request.id.clone(),
+                    INVALID_PARAMS,
+                    format!("prompts/get accepts at most {MAX_PROMPT_ARGUMENT_COUNT} arguments"),
+                );
+            }
+            for (key, value) in obj {
+                if key.len() > MAX_PROMPT_ARGUMENT_KEY_BYTES {
+                    return JsonRpcResponse::error(
+                        request.id.clone(),
+                        INVALID_PARAMS,
+                        format!(
+                            "prompt argument names may contain at most {MAX_PROMPT_ARGUMENT_KEY_BYTES} bytes"
+                        ),
+                    );
                 }
+                let string_value = match value {
+                    Value::String(s) => s.clone(),
+                    Value::Null => String::new(),
+                    other => other.to_string(),
+                };
+                if string_value.len() > MAX_PROMPT_ARGUMENT_VALUE_BYTES {
+                    return JsonRpcResponse::error(
+                        request.id.clone(),
+                        INVALID_PARAMS,
+                        format!(
+                            "prompt argument '{key}' may contain at most {MAX_PROMPT_ARGUMENT_VALUE_BYTES} bytes"
+                        ),
+                    );
+                }
+                args.insert(key.clone(), string_value);
             }
         }
 
@@ -1009,6 +1050,141 @@ mod tests {
         let text = messages[0]["content"]["text"].as_str().unwrap();
         assert!(text.contains("dec-100"));
         assert!(text.contains("Sample decision"));
+    }
+
+    #[test]
+    fn handler_prompts_get_rejects_oversized_argument_value() {
+        let server = test_server();
+        let msg = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 84,
+            "method": "prompts/get",
+            "params": {
+                "name": "constitutional_audit",
+                "arguments": {
+                    "scope": "node",
+                    "focus": "x".repeat(MAX_PROMPT_ARGUMENT_VALUE_BYTES + 1)
+                }
+            }
+        })
+        .to_string();
+
+        let response = server.handle_message(&msg).unwrap();
+        let parsed: JsonRpcResponse = serde_json::from_str(&response).unwrap();
+        let error = parsed.error.expect("oversized prompt argument must fail");
+        assert_eq!(error.code, INVALID_PARAMS);
+        assert_eq!(
+            error.message,
+            format!(
+                "prompt argument 'focus' may contain at most {MAX_PROMPT_ARGUMENT_VALUE_BYTES} bytes"
+            )
+        );
+    }
+
+    #[test]
+    fn handler_prompts_get_rejects_oversized_name() {
+        let server = test_server();
+        let msg = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 85,
+            "method": "prompts/get",
+            "params": {
+                "name": "x".repeat(MAX_PROMPT_NAME_BYTES + 1),
+                "arguments": {}
+            }
+        })
+        .to_string();
+
+        let response = server.handle_message(&msg).unwrap();
+        let parsed: JsonRpcResponse = serde_json::from_str(&response).unwrap();
+        let error = parsed.error.expect("oversized prompt name must fail");
+        assert_eq!(error.code, INVALID_PARAMS);
+        assert_eq!(
+            error.message,
+            format!("prompt name may contain at most {MAX_PROMPT_NAME_BYTES} bytes")
+        );
+    }
+
+    #[test]
+    fn handler_prompts_get_rejects_non_object_arguments() {
+        let server = test_server();
+        let msg = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 86,
+            "method": "prompts/get",
+            "params": {
+                "name": "governance_review",
+                "arguments": ["decision_id", "dec-1"]
+            }
+        })
+        .to_string();
+
+        let response = server.handle_message(&msg).unwrap();
+        let parsed: JsonRpcResponse = serde_json::from_str(&response).unwrap();
+        let error = parsed.error.expect("non-object prompt arguments must fail");
+        assert_eq!(error.code, INVALID_PARAMS);
+        assert_eq!(error.message, "prompt arguments must be an object");
+    }
+
+    #[test]
+    fn handler_prompts_get_rejects_too_many_arguments() {
+        let server = test_server();
+        let mut arguments = serde_json::Map::new();
+        for idx in 0..=MAX_PROMPT_ARGUMENT_COUNT {
+            arguments.insert(format!("arg_{idx}"), serde_json::json!("value"));
+        }
+        let msg = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 87,
+            "method": "prompts/get",
+            "params": {
+                "name": "governance_review",
+                "arguments": serde_json::Value::Object(arguments)
+            }
+        })
+        .to_string();
+
+        let response = server.handle_message(&msg).unwrap();
+        let parsed: JsonRpcResponse = serde_json::from_str(&response).unwrap();
+        let error = parsed.error.expect("too many prompt arguments must fail");
+        assert_eq!(error.code, INVALID_PARAMS);
+        assert_eq!(
+            error.message,
+            format!("prompts/get accepts at most {MAX_PROMPT_ARGUMENT_COUNT} arguments")
+        );
+    }
+
+    #[test]
+    fn handler_prompts_get_rejects_oversized_argument_name() {
+        let server = test_server();
+        let mut arguments = serde_json::Map::new();
+        arguments.insert(
+            "x".repeat(MAX_PROMPT_ARGUMENT_KEY_BYTES + 1),
+            serde_json::json!("value"),
+        );
+        let msg = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 88,
+            "method": "prompts/get",
+            "params": {
+                "name": "governance_review",
+                "arguments": serde_json::Value::Object(arguments)
+            }
+        })
+        .to_string();
+
+        let response = server.handle_message(&msg).unwrap();
+        let parsed: JsonRpcResponse = serde_json::from_str(&response).unwrap();
+        let error = parsed
+            .error
+            .expect("oversized prompt argument name must fail");
+        assert_eq!(error.code, INVALID_PARAMS);
+        assert_eq!(
+            error.message,
+            format!(
+                "prompt argument names may contain at most {MAX_PROMPT_ARGUMENT_KEY_BYTES} bytes"
+            )
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- classify `crates/exo-node/src/mcp/handler.rs` as a core runtime adapter and bound MCP `prompts/get` names, argument counts, argument names, and argument values before prompt rendering
- reject non-object prompt arguments instead of silently ignoring malformed caller input
- update README repo-truth counters to 158,758 Rust LOC and 3,945 listed tests

## External finding disposition
- Wally F-158 raw prompt injection is stale on current main: prompt arguments are already JSON-escaped inside an explicitly untrusted block and covered by prompt quarantine tests.
- Wally F-165 unbounded `constitutional_audit.focus` survived validation as a bounded-resource hardening issue on the MCP prompt handler. This fix enforces deterministic fail-closed limits for all prompt templates, not only `focus`.

## Path classification
- `crates/exo-node/src/mcp/handler.rs`: core runtime adapter
- `README.md`: documentation / repo-truth gate metadata

## TDD / verification
- Red: `cargo test -p exo-node handler_prompts_get_rejects_oversized_argument_value -- --nocapture` failed before the handler bound existed.
- Green/focused: `cargo test -p exo-node handler_prompts_get -- --nocapture` -> 8 passed
- Prompt quarantine: `cargo test -p exo-node mcp::prompts -- --nocapture` -> 17 passed
- MCP sweep: `cargo test -p exo-node mcp:: -- --nocapture` -> 364 passed
- Touched crate: `cargo test -p exo-node -- --nocapture` -> 986 passed
- Lint: `cargo clippy -p exo-node --all-targets -- -D warnings` -> passed
- Format: `cargo fmt --all -- --check` -> passed
- Repo truth: `bash tools/test_repo_truth.sh` -> passed
- Bypass search: searched prompt rendering entrypoints; runtime `prompts/get` dispatches through `handle_prompts_get` before `self.prompts.get`
