### PR TITLE
fix(dag): avoid full ancestor materialization in verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 158758 | `wc -l` |
-| Workspace tests | 3,945 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 158831 | `wc -l` |
+| Workspace tests | 3,947 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,945 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,947 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -80,9 +80,9 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 158758 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 158831 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,945 listed workspace tests
+         cryptographic proofs, 3,947 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-dag/src/dag.rs
+++ b/crates/exo-dag/src/dag.rs
@@ -280,6 +280,37 @@ pub fn ancestors(dag: &Dag, hash: &Hash256) -> Vec<Hash256> {
     topological_sort(dag, &hashes)
 }
 
+fn has_ancestor_path(dag: &Dag, start: &Hash256, target: &Hash256) -> bool {
+    let mut visited = BTreeSet::new();
+    let mut queue = VecDeque::new();
+
+    if let Some(node) = dag.nodes.get(start) {
+        for parent in &node.parents {
+            if parent == target {
+                return true;
+            }
+            if visited.insert(*parent) {
+                queue.push_back(*parent);
+            }
+        }
+    }
+
+    while let Some(current) = queue.pop_front() {
+        if let Some(node) = dag.nodes.get(&current) {
+            for parent in &node.parents {
+                if parent == target {
+                    return true;
+                }
+                if visited.insert(*parent) {
+                    queue.push_back(*parent);
+                }
+            }
+        }
+    }
+
+    false
+}
+
 /// Topological sort of a set of node hashes.
 fn topological_sort(dag: &Dag, hashes: &[Hash256]) -> Vec<Hash256> {
     let hash_set: BTreeSet<Hash256> = hashes.iter().copied().collect();
@@ -386,11 +417,8 @@ pub fn verify_node(
     }
 
     // Check for cycles: node's hash must not appear in its own ancestors
-    if !node.parents.is_empty() {
-        let ancs = ancestors(dag, &node.hash);
-        if ancs.contains(&node.hash) {
-            return Err(DagError::CycleDetected(node.hash));
-        }
+    if !node.parents.is_empty() && has_ancestor_path(dag, &node.hash, &node.hash) {
+        return Err(DagError::CycleDetected(node.hash));
     }
 
     Ok(())
@@ -408,13 +436,27 @@ mod tests {
     type SignFn = Box<dyn Fn(&[u8]) -> Signature>;
     type VerifyFn = Box<dyn Fn(&[u8], &Signature) -> bool>;
 
-    #[test]
-    fn dag_module_does_not_define_local_hybrid_clock() {
-        let source = include_str!("dag.rs");
-        let production = source
+    fn production_source() -> &'static str {
+        include_str!("dag.rs")
             .split("// ---------------------------------------------------------------------------\n// Tests")
             .next()
-            .expect("production section exists");
+            .expect("production section exists")
+    }
+
+    fn function_source<'a>(source: &'a str, name: &str) -> &'a str {
+        let marker = format!("pub fn {name}(");
+        let start = source.find(&marker).expect("function must be present");
+        let after_start = &source[start..];
+        let next_fn = after_start
+            .find("\n}\n\n")
+            .map(|idx| idx + "\n}\n".len())
+            .expect("function body must terminate");
+        &after_start[..next_fn]
+    }
+
+    #[test]
+    fn dag_module_does_not_define_local_hybrid_clock() {
+        let production = production_source();
 
         assert!(
             !production.contains("pub struct HybridClock")
@@ -424,6 +466,20 @@ mod tests {
         assert!(
             production.contains("pub struct DeterministicDagClock"),
             "exo-dag append tests/helpers should use an explicitly deterministic DAG clock type"
+        );
+    }
+
+    #[test]
+    fn verify_node_cycle_check_does_not_materialize_full_ancestor_list() {
+        let verify_node = function_source(production_source(), "verify_node");
+
+        assert!(
+            !verify_node.contains("ancestors(dag, &node.hash)"),
+            "verify_node must not allocate and topologically sort the full ancestor list on the verification path"
+        );
+        assert!(
+            !verify_node.contains(".contains(&node.hash)"),
+            "verify_node must use early-exit ancestor reachability instead of scanning a materialized list"
         );
     }
 
@@ -622,6 +678,23 @@ mod tests {
     fn ancestors_nonexistent_node() {
         let dag = Dag::new();
         assert!(ancestors(&dag, &Hash256::ZERO).is_empty());
+    }
+
+    #[test]
+    fn ancestor_path_detection_uses_parent_reachability() {
+        let mut dag = Dag::new();
+        let mut clock = DeterministicDagClock::new();
+        let creator = test_did("did:exo:alice");
+        let sign_fn = make_sign_fn();
+
+        let g = append(&mut dag, &[], b"g", &creator, &*sign_fn, &mut clock).unwrap();
+        let c1 = append(&mut dag, &[g.hash], b"c1", &creator, &*sign_fn, &mut clock).unwrap();
+        let c2 = append(&mut dag, &[c1.hash], b"c2", &creator, &*sign_fn, &mut clock).unwrap();
+
+        assert!(has_ancestor_path(&dag, &c2.hash, &g.hash));
+        assert!(has_ancestor_path(&dag, &c2.hash, &c1.hash));
+        assert!(!has_ancestor_path(&dag, &g.hash, &c2.hash));
+        assert!(!has_ancestor_path(&dag, &Hash256::ZERO, &g.hash));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- validates Wally F-095 against current `main` as a live EXOCHAIN-core verification-path performance concern
- replaces `verify_node`'s full `ancestors(...).contains(...)` cycle check with early-exit parent reachability
- adds regression/source guards proving the verification path does not materialize and topologically sort the full ancestor list
- updates README repo-truth counts after adding two tests

## Path Classification
- `crates/exo-dag/src/dag.rs`: EXOCHAIN core
- `README.md`: documentation / repo-truth metadata

## Validation
- RED: `cargo test -p exo-dag verify_node_cycle_check_does_not_materialize_full_ancestor_list -- --nocapture` failed before the production change
- `cargo test -p exo-dag verify_node_cycle_check_does_not_materialize_full_ancestor_list -- --nocapture`
- `cargo test -p exo-dag ancestor_path_detection_uses_parent_reachability -- --nocapture`
- `cargo test -p exo-dag verify_node -- --nocapture`
- `cargo test -p exo-dag -- --nocapture`
- `cargo clippy -p exo-dag --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `bash tools/repo_truth.sh --json --list-tests`
- `bash tools/test_repo_truth.sh`
- `git diff --check`

## Bypass Search
- searched `crates/exo-dag/src/dag.rs` for `ancestors(dag, &node.hash)`, `.contains(&node.hash)`, `has_ancestor_path`, and `topological_sort(dag`; production `verify_node` now uses only `has_ancestor_path`, while topological sorting remains isolated to the public `ancestors` API and regression guard text
