### PR TITLE
fix(gateway): add runtime query indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 158831 | `wc -l` |
-| Workspace tests | 3,947 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 158871 | `wc -l` |
+| Workspace tests | 3,948 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,947 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,948 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -80,9 +80,9 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 158831 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 158871 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,947 listed workspace tests
+         cryptographic proofs, 3,948 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-gateway/migrations/20260504000001_add_gateway_runtime_query_indexes.sql
+++ b/crates/exo-gateway/migrations/20260504000001_add_gateway_runtime_query_indexes.sql
@@ -1,0 +1,29 @@
+-- Indexes for gateway runtime list, tenant-filter, and audit activity queries.
+CREATE INDEX IF NOT EXISTS idx_users_created_at
+    ON users(created_at);
+
+CREATE INDEX IF NOT EXISTS idx_agents_tenant_created_at
+    ON agents(tenant_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_agents_created_at
+    ON agents(created_at);
+
+CREATE INDEX IF NOT EXISTS idx_decisions_tenant_created_at_ms
+    ON decisions(tenant_id, created_at_ms);
+
+CREATE INDEX IF NOT EXISTS idx_decisions_created_at_ms
+    ON decisions(created_at_ms);
+
+CREATE INDEX IF NOT EXISTS idx_delegations_created_at_ms
+    ON delegations(created_at_ms);
+
+CREATE INDEX IF NOT EXISTS idx_delegations_active_delegatee
+    ON delegations(delegatee)
+    WHERE revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_delegations_active_delegator
+    ON delegations(delegator)
+    WHERE revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_audit_entries_actor_event_type
+    ON audit_entries(actor, event_type);

--- a/crates/exo-gateway/src/db.rs
+++ b/crates/exo-gateway/src/db.rs
@@ -1151,6 +1151,24 @@ mod tests {
         source.split("#[cfg(test)]").next().unwrap_or(source)
     }
 
+    fn migration_sources() -> String {
+        [
+            include_str!("../migrations/20260316000001_initial_schema.sql"),
+            include_str!("../migrations/20260330000001_create_sessions.sql"),
+            include_str!("../migrations/20260330000002_create_adjudication_tables.sql"),
+            include_str!("../migrations/20260407000001_create_dashboard_tables.sql"),
+            include_str!("../migrations/20260425000001_add_decision_id_to_audit_entries.sql"),
+            include_str!("../migrations/20260426000001_livesafe_composite_basis_points.sql"),
+            include_str!("../migrations/20260427000001_create_conflict_declarations.sql"),
+            include_str!("../migrations/20260504000001_add_gateway_runtime_query_indexes.sql"),
+        ]
+        .join("\n")
+    }
+
+    fn compact_sql(sql: &str) -> String {
+        sql.split_whitespace().collect::<Vec<_>>().join(" ")
+    }
+
     fn function_source<'a>(source: &'a str, name: &str) -> &'a str {
         let signature = format!("pub async fn {name}");
         let start = source
@@ -1240,6 +1258,28 @@ mod tests {
                 body.matches(".bind(MAX_DB_LIST_ROWS)").count(),
                 expected_limit_clauses,
                 "{name} must bind the centralized row limit for every fetch_all query"
+            );
+        }
+    }
+
+    #[test]
+    fn gateway_runtime_query_filters_have_migration_indexes() {
+        let migrations = compact_sql(&migration_sources());
+
+        for index_sql in [
+            "CREATE INDEX IF NOT EXISTS idx_users_created_at ON users(created_at);",
+            "CREATE INDEX IF NOT EXISTS idx_agents_tenant_created_at ON agents(tenant_id, created_at);",
+            "CREATE INDEX IF NOT EXISTS idx_agents_created_at ON agents(created_at);",
+            "CREATE INDEX IF NOT EXISTS idx_decisions_tenant_created_at_ms ON decisions(tenant_id, created_at_ms);",
+            "CREATE INDEX IF NOT EXISTS idx_decisions_created_at_ms ON decisions(created_at_ms);",
+            "CREATE INDEX IF NOT EXISTS idx_delegations_created_at_ms ON delegations(created_at_ms);",
+            "CREATE INDEX IF NOT EXISTS idx_delegations_active_delegatee ON delegations(delegatee) WHERE revoked_at IS NULL;",
+            "CREATE INDEX IF NOT EXISTS idx_delegations_active_delegator ON delegations(delegator) WHERE revoked_at IS NULL;",
+            "CREATE INDEX IF NOT EXISTS idx_audit_entries_actor_event_type ON audit_entries(actor, event_type);",
+        ] {
+            assert!(
+                migrations.contains(index_sql),
+                "gateway migration set must include runtime query index: {index_sql}"
             );
         }
     }


### PR DESCRIPTION
## Summary
- validates Wally F-098 against current `main` as a live core-runtime-adapter performance/availability concern in gateway PostgreSQL migrations
- adds a migration for indexes used by owned gateway runtime queries over `users`, `agents`, `decisions`, `delegations`, and `audit_entries`
- adds a migration-source regression guard so these runtime query indexes cannot disappear silently
- updates README repo-truth counters after adding one test

## Path Classification
- `crates/exo-gateway/src/db.rs`: core runtime adapter
- `crates/exo-gateway/migrations/20260504000001_add_gateway_runtime_query_indexes.sql`: core runtime adapter
- `README.md`: documentation / repo-truth metadata

## External Finding Disposition
- Imported evidence claim: missing DB indexes. Confirmed live only for owned gateway runtime query paths after checking current `main`; existing migrations already covered sessions, consent/authority adjudication tables, audit decision lookup, and several dashboard indexes.
- Sibling search also found dashboard layout/feedback list queries. Those are adjacent dashboard-surface paths, so they are not mixed into this core/runtime-adapter commit.

## Validation
- RED: `cargo test -p exo-gateway gateway_runtime_query_filters_have_migration_indexes -- --nocapture` failed before the migration for missing runtime indexes
- RED expansion after sibling search: same test failed for `idx_users_created_at` before adding users/delegations coverage
- `cargo test -p exo-gateway gateway_runtime_query_filters_have_migration_indexes -- --nocapture`
- `cargo test -p exo-gateway db::tests -- --nocapture`
- `cargo test -p exo-gateway -- --nocapture`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `bash tools/repo_truth.sh --json --list-tests`
- `bash tools/test_repo_truth.sh`
- `git diff --check origin/main...HEAD`

## Bypass Search
- searched `crates/exo-gateway/src/db.rs` and `crates/exo-gateway/migrations` for `FROM users|agents|decisions|delegations|audit_entries`, `WHERE tenant_id`, `WHERE actor`, `ORDER BY created_at|created_at_ms|sequence`, and the new `CREATE INDEX` names
- confirmed primary-key paths already cover `did`, `id_hash`, and audit `sequence`; existing migrations already cover `users.email`, `decisions.status`, `delegations.delegator`, `delegations.delegatee`, and `audit_entries.decision_id`
