### PR TITLE
fix(gateway): scope decision reads by tenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 158871 | `wc -l` |
-| Workspace tests | 3,948 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 159078 | `wc -l` |
+| Workspace tests | 3,952 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,948 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,952 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -80,9 +80,9 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 158871 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 159078 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,948 listed workspace tests
+         cryptographic proofs, 3,952 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-gateway/migrations/20260504000002_add_gateway_tenant_scope_indexes.sql
+++ b/crates/exo-gateway/migrations/20260504000002_add_gateway_tenant_scope_indexes.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_users_tenant_created_at ON users(tenant_id, created_at);

--- a/crates/exo-gateway/src/db.rs
+++ b/crates/exo-gateway/src/db.rs
@@ -115,11 +115,14 @@ pub async fn find_user_by_did(pool: &PgPool, did: &str) -> Result<Option<UserRow
     ).bind(did).fetch_optional(pool).await
 }
 
-/// List all users ordered by creation time.
-pub async fn list_users_db(pool: &PgPool) -> Result<Vec<PublicUserRow>, sqlx::Error> {
+/// List users for a tenant ordered by creation time.
+pub async fn list_users_db(
+    pool: &PgPool,
+    tenant_id: &str,
+) -> Result<Vec<PublicUserRow>, sqlx::Error> {
     sqlx::query_as::<_, PublicUserRow>(
-        "SELECT did, display_name, email, roles, tenant_id, created_at, status, pace_status, mfa_enabled FROM users ORDER BY created_at LIMIT $1"
-    ).bind(MAX_DB_LIST_ROWS).fetch_all(pool).await
+        "SELECT did, display_name, email, roles, tenant_id, created_at, status, pace_status, mfa_enabled FROM users WHERE tenant_id = $1 ORDER BY created_at LIMIT $2"
+    ).bind(tenant_id).bind(MAX_DB_LIST_ROWS).fetch_all(pool).await
 }
 
 /// Update a user's PACE enrollment status.
@@ -352,17 +355,21 @@ pub async fn upsert_decision(
 pub async fn find_decision(
     pool: &PgPool,
     id_hash: &str,
+    tenant_id: &str,
 ) -> Result<Option<DecisionRow>, sqlx::Error> {
     sqlx::query_as::<_, DecisionRow>(
-        "SELECT id_hash, tenant_id, status, title, decision_class, author, created_at_ms, constitution_version, payload FROM decisions WHERE id_hash = $1"
-    ).bind(id_hash).fetch_optional(pool).await
+        "SELECT id_hash, tenant_id, status, title, decision_class, author, created_at_ms, constitution_version, payload FROM decisions WHERE id_hash = $1 AND tenant_id = $2"
+    ).bind(id_hash).bind(tenant_id).fetch_optional(pool).await
 }
 
-/// List all decisions ordered by creation timestamp.
-pub async fn list_decisions_db(pool: &PgPool) -> Result<Vec<DecisionRow>, sqlx::Error> {
+/// List decisions for a tenant ordered by creation timestamp.
+pub async fn list_decisions_db(
+    pool: &PgPool,
+    tenant_id: &str,
+) -> Result<Vec<DecisionRow>, sqlx::Error> {
     sqlx::query_as::<_, DecisionRow>(
-        "SELECT id_hash, tenant_id, status, title, decision_class, author, created_at_ms, constitution_version, payload FROM decisions ORDER BY created_at_ms LIMIT $1"
-    ).bind(MAX_DB_LIST_ROWS).fetch_all(pool).await
+        "SELECT id_hash, tenant_id, status, title, decision_class, author, created_at_ms, constitution_version, payload FROM decisions WHERE tenant_id = $1 ORDER BY created_at_ms LIMIT $2"
+    ).bind(tenant_id).bind(MAX_DB_LIST_ROWS).fetch_all(pool).await
 }
 
 /// Update a decision's status and JSONB payload by its content hash.
@@ -1161,6 +1168,7 @@ mod tests {
             include_str!("../migrations/20260426000001_livesafe_composite_basis_points.sql"),
             include_str!("../migrations/20260427000001_create_conflict_declarations.sql"),
             include_str!("../migrations/20260504000001_add_gateway_runtime_query_indexes.sql"),
+            include_str!("../migrations/20260504000002_add_gateway_tenant_scope_indexes.sql"),
         ]
         .join("\n")
     }
@@ -1177,6 +1185,16 @@ mod tests {
         let after_start = &source[start..];
         let end = after_start.find("\n/// ").unwrap_or(after_start.len());
         &after_start[..end]
+    }
+
+    fn contains_in_order(source: &str, first: &str, second: &str) -> bool {
+        let Some(first_index) = source.find(first) else {
+            return false;
+        };
+        let Some(second_index) = source.find(second) else {
+            return false;
+        };
+        first_index < second_index
     }
 
     #[test]
@@ -1268,6 +1286,7 @@ mod tests {
 
         for index_sql in [
             "CREATE INDEX IF NOT EXISTS idx_users_created_at ON users(created_at);",
+            "CREATE INDEX IF NOT EXISTS idx_users_tenant_created_at ON users(tenant_id, created_at);",
             "CREATE INDEX IF NOT EXISTS idx_agents_tenant_created_at ON agents(tenant_id, created_at);",
             "CREATE INDEX IF NOT EXISTS idx_agents_created_at ON agents(created_at);",
             "CREATE INDEX IF NOT EXISTS idx_decisions_tenant_created_at_ms ON decisions(tenant_id, created_at_ms);",
@@ -1282,6 +1301,60 @@ mod tests {
                 "gateway migration set must include runtime query index: {index_sql}"
             );
         }
+    }
+
+    #[test]
+    fn user_and_decision_list_queries_require_tenant_scope() {
+        let source = production_source();
+        let users = function_source(source, "list_users_db");
+        let decisions = function_source(source, "list_decisions_db");
+
+        assert!(
+            users.contains("tenant_id: &str"),
+            "list_users_db must require an explicit tenant scope"
+        );
+        assert!(
+            compact_sql(users)
+                .contains("FROM users WHERE tenant_id = $1 ORDER BY created_at LIMIT $2"),
+            "list_users_db must filter by tenant_id before ordering or limiting rows"
+        );
+        assert!(
+            contains_in_order(users, ".bind(tenant_id)", ".bind(MAX_DB_LIST_ROWS)"),
+            "list_users_db must bind tenant_id before the row limit"
+        );
+
+        assert!(
+            decisions.contains("tenant_id: &str"),
+            "list_decisions_db must require an explicit tenant scope"
+        );
+        assert!(
+            compact_sql(decisions)
+                .contains("FROM decisions WHERE tenant_id = $1 ORDER BY created_at_ms LIMIT $2"),
+            "list_decisions_db must filter by tenant_id before ordering or limiting rows"
+        );
+        assert!(
+            contains_in_order(decisions, ".bind(tenant_id)", ".bind(MAX_DB_LIST_ROWS)"),
+            "list_decisions_db must bind tenant_id before the row limit"
+        );
+    }
+
+    #[test]
+    fn decision_lookup_requires_tenant_scope() {
+        let source = production_source();
+        let lookup = function_source(source, "find_decision");
+
+        assert!(
+            lookup.contains("tenant_id: &str"),
+            "find_decision must require an explicit tenant scope"
+        );
+        assert!(
+            compact_sql(lookup).contains("FROM decisions WHERE id_hash = $1 AND tenant_id = $2"),
+            "find_decision must include tenant_id in the decision lookup predicate"
+        );
+        assert!(
+            contains_in_order(lookup, ".bind(id_hash)", ".bind(tenant_id)"),
+            "find_decision must bind id_hash and tenant_id together"
+        );
     }
 
     #[test]

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -30,7 +30,6 @@ use exo_identity::{
 };
 use percent_encoding::percent_decode_str;
 use serde::{Deserialize, Serialize};
-use sqlx::Row;
 use tokio::net::TcpListener;
 use tower::limit::GlobalConcurrencyLimitLayer;
 use tower_http::trace::TraceLayer;
@@ -1286,9 +1285,10 @@ async fn handle_decision_get(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    if let Err(e) = require_authenticated_session_actor_from_header(&state, &headers).await {
-        return auth_boundary_error_response(e);
-    }
+    let actor = match require_authenticated_session_user_from_header(&state, &headers).await {
+        Ok(actor) => actor,
+        Err(e) => return auth_boundary_error_response(e),
+    };
     let db = match state.require_db() {
         Ok(pool) => pool,
         Err(_) => {
@@ -1299,17 +1299,8 @@ async fn handle_decision_get(
                 .into_response();
         }
     };
-    match sqlx::query("SELECT payload FROM decisions WHERE id_hash = $1")
-        .bind(&id)
-        .fetch_optional(db)
-        .await
-    {
-        Ok(Some(row)) => match row.try_get::<serde_json::Value, _>("payload") {
-            Ok(payload) => Json::<serde_json::Value>(payload).into_response(),
-            Err(e) => {
-                internal_error_response(e, "decision payload decode", "decision lookup failed")
-            }
-        },
+    match db::find_decision(db, &id, &actor.tenant_id).await {
+        Ok(Some(row)) => Json::<serde_json::Value>(row.payload).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({ "error": "decision not found" })),
@@ -1807,6 +1798,20 @@ async fn require_authenticated_session_actor_from_header(
     let token = require_bearer_token(headers)?;
     let observed_at = required_observed_at_ms_header(headers)?;
     require_authenticated_session_actor_for_token(state, &token, observed_at).await
+}
+
+async fn require_authenticated_session_user_from_header(
+    state: &AppState,
+    headers: &HeaderMap,
+) -> Result<db::UserRow> {
+    let actor = require_authenticated_session_actor_from_header(state, headers).await?;
+    let db = state.require_db()?;
+    db::find_user_by_did(db, actor.as_str())
+        .await
+        .map_err(|e| GatewayError::Internal(format!("session user lookup failed: {e}")))?
+        .ok_or_else(|| GatewayError::AuthenticationFailed {
+            reason: "authenticated session actor has no tenant profile".to_owned(),
+        })
 }
 
 async fn require_authenticated_session_actor(
@@ -3188,6 +3193,32 @@ mod tests {
         .unwrap();
     }
 
+    async fn insert_test_user(pool: &sqlx::PgPool, did: &str, tenant_id: &str) {
+        let email = format!("{did}@example.invalid");
+        sqlx::query("DELETE FROM users WHERE did = $1 OR email = $2")
+            .bind(did)
+            .bind(&email)
+            .execute(pool)
+            .await
+            .unwrap();
+        db::insert_user(
+            pool,
+            did,
+            "Reader",
+            &email,
+            &serde_json::json!(["reader"]),
+            tenant_id,
+            10_000_i64,
+            "Active",
+            "Unenrolled",
+            "redacted-test-hash",
+            "redacted-test-salt",
+            false,
+        )
+        .await
+        .unwrap();
+    }
+
     // --- GatewayConfig / start() (existing tests preserved) ---
 
     #[test]
@@ -3643,6 +3674,7 @@ mod tests {
         ] {
             let auth = handler
                 .find("require_authenticated_session_actor_from_header")
+                .or_else(|| handler.find("require_authenticated_session_user_from_header"))
                 .unwrap_or_else(|| panic!("{name} must authenticate the bearer session"));
             let read = handler
                 .find(state_read)
@@ -3652,6 +3684,29 @@ mod tests {
                 "{name} must authenticate before reading protected gateway state"
             );
         }
+    }
+
+    #[test]
+    fn decision_get_uses_authenticated_actor_tenant_for_lookup() {
+        let source = include_str!("server.rs");
+        let handler = source_between(
+            source,
+            "async fn handle_decision_get",
+            "/// GET /api/v1/audit/:decision_id",
+        );
+
+        assert!(
+            handler.contains("require_authenticated_session_user_from_header"),
+            "decision get must load the authenticated session actor's tenant profile"
+        );
+        assert!(
+            handler.contains("db::find_decision(db, &id, &actor.tenant_id)"),
+            "decision get must query decisions using the authenticated actor tenant"
+        );
+        assert!(
+            !handler.contains("SELECT payload FROM decisions WHERE id_hash = $1"),
+            "decision get must not perform an unscoped id_hash lookup"
+        );
     }
 
     #[test]
@@ -4253,7 +4308,8 @@ mod tests {
             Some(pool) => pool,
             None => return,
         };
-        insert_test_session(&pool, "decision-get-token", "did:exo:reader").await;
+        insert_test_user(&pool, "did:exo:decision-reader", "tenant-read").await;
+        insert_test_session(&pool, "decision-get-token", "did:exo:decision-reader").await;
         sqlx::query("DELETE FROM decisions WHERE id_hash = $1")
             .bind("decision-get-authenticated")
             .execute(&pool)
@@ -4309,6 +4365,84 @@ mod tests {
             .unwrap();
         sqlx::query("DELETE FROM sessions WHERE token = $1")
             .bind("decision-get-token")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM users WHERE did = $1")
+            .bind("did:exo:decision-reader")
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn decision_get_rejects_cross_tenant_session_actor() {
+        let pool = match gateway_test_pool().await {
+            Some(pool) => pool,
+            None => return,
+        };
+        insert_test_user(&pool, "did:exo:tenant-b-reader", "tenant-b").await;
+        insert_test_session(
+            &pool,
+            "decision-get-cross-tenant-token",
+            "did:exo:tenant-b-reader",
+        )
+        .await;
+        sqlx::query("DELETE FROM decisions WHERE id_hash = $1")
+            .bind("decision-get-cross-tenant")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let payload = serde_json::json!({
+            "id": "decision-get-cross-tenant",
+            "tenant_id": "tenant-a",
+            "status": "Open",
+        });
+        db::insert_decision(
+            &pool,
+            "decision-get-cross-tenant",
+            "tenant-a",
+            "Open",
+            "Cross-tenant read",
+            "Routine",
+            "did:exo:author",
+            11_000,
+            "exochain-constitution-v1",
+            &payload,
+        )
+        .await
+        .unwrap();
+
+        let app = build_router(AppState::new(
+            Some(pool.clone()),
+            Arc::new(RwLock::new(LocalDidRegistry::new())),
+        ));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/decisions/decision-get-cross-tenant")
+                    .header("authorization", "Bearer decision-get-cross-tenant-token")
+                    .header(AUTH_OBSERVED_AT_MS_HEADER, "15000")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        sqlx::query("DELETE FROM decisions WHERE id_hash = $1")
+            .bind("decision-get-cross-tenant")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM sessions WHERE token = $1")
+            .bind("decision-get-cross-tenant-token")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM users WHERE did = $1")
+            .bind("did:exo:tenant-b-reader")
             .execute(&pool)
             .await
             .unwrap();


### PR DESCRIPTION
## Summary

Remediates Gauntlet F-051 for the owned EXOCHAIN gateway runtime adapter after validating the report against current `main`.

- requires explicit `tenant_id` scope for `list_users_db` and `list_decisions_db`
- requires explicit `tenant_id` scope for `find_decision`
- changes `GET /api/v1/decisions/:id` to derive tenant scope from the authenticated session actor's persisted user profile before returning a decision payload
- adds `users(tenant_id, created_at)` migration index for the new tenant-scoped list query
- updates README repo-truth counts from `tools/repo_truth.sh`

## Path Classification

- `crates/exo-gateway/src/db.rs`: core runtime adapter
- `crates/exo-gateway/src/server.rs`: core runtime adapter
- `crates/exo-gateway/migrations/20260504000002_add_gateway_tenant_scope_indexes.sql`: core runtime adapter
- `README.md`: documentation / repo-truth metadata

## Finding Validation

External finding F-051 claimed `list_decisions_db` and `list_users_db` returned all rows without tenant filters. Current code still had:

- `list_users_db(pool)` selecting from `users ORDER BY created_at LIMIT $1`
- `list_decisions_db(pool)` selecting from `decisions ORDER BY created_at_ms LIMIT $1`
- `handle_decision_get` selecting `payload` by `id_hash` only

Red tests were added first and failed on the current branch:

- `cargo test -p exo-gateway user_and_decision_list_queries_require_tenant_scope -- --nocapture`
- `cargo test -p exo-gateway decision_lookup_requires_tenant_scope -- --nocapture`
- `cargo test -p exo-gateway decision_get_uses_authenticated_actor_tenant_for_lookup -- --nocapture`
- `cargo test -p exo-gateway gateway_runtime_query_filters_have_migration_indexes -- --nocapture`

## Verification

Passed:

- `cargo test -p exo-gateway user_and_decision_list_queries_require_tenant_scope -- --nocapture`
- `cargo test -p exo-gateway decision_lookup_requires_tenant_scope -- --nocapture`
- `cargo test -p exo-gateway decision_get_uses_authenticated_actor_tenant_for_lookup -- --nocapture`
- `cargo test -p exo-gateway gateway_runtime_query_filters_have_migration_indexes -- --nocapture`
- `cargo test -p exo-gateway sensitive_read_handlers_require_session_before_state_reads -- --nocapture`
- `cargo test -p exo-gateway db::tests -- --nocapture`
- `cargo test -p exo-gateway server::tests -- --nocapture`
- `cargo test -p exo-gateway -- --nocapture`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `cargo fmt --all -- --check` (stable rustfmt emitted existing warnings for nightly-only rustfmt options)
- `cargo doc -p exo-gateway --no-deps`
- `bash tools/repo_truth.sh --json --list-tests`
- `bash tools/test_repo_truth.sh`
- `git diff --check`

Bypass search:

- `rg -n 'WHERE id_hash = \$1|FROM users ORDER BY created_at|FROM decisions ORDER BY created_at_ms' crates/exo-gateway/src crates/exo-gateway/tests -g '*.rs'`
- `rg -n 'list_users_db\(|list_decisions_db\(|find_decision\(' crates packages --glob '*.rs'`
- `rg -n 'SELECT .*payload FROM decisions WHERE id_hash|SELECT .* FROM decisions WHERE id_hash' crates/exo-gateway/src crates/exo-gateway/tests -g '*.rs'`

The remaining raw decision row-lock in `handlers.rs` is the vote transaction path, not the F-051 list/read exfiltration path; it should be triaged separately as a possible tenant-scoped write-path hardening item.
