### PR TITLE
fix(gateway): scope vote mutations by tenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 159078 | `wc -l` |
-| Workspace tests | 3,952 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 159144 | `wc -l` |
+| Workspace tests | 3,953 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,952 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,953 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -80,9 +80,9 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 159078 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 159144 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,952 listed workspace tests
+         cryptographic proofs, 3,953 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-gateway/src/handlers.rs
+++ b/crates/exo-gateway/src/handlers.rs
@@ -312,7 +312,7 @@ pub async fn vote_handler(
     Json(body): Json<VoteRequest>,
 ) -> impl IntoResponse {
     let actor = match state
-        .require_authenticated_session_actor_from_header(&headers)
+        .require_authenticated_session_user_from_header(&headers)
         .await
     {
         Ok(actor) => actor,
@@ -328,7 +328,7 @@ pub async fn vote_handler(
                 .into_response();
         }
     };
-    if actor != voter_did {
+    if actor.did != voter_did {
         return (
             StatusCode::FORBIDDEN,
             Json(serde_json::json!({
@@ -433,10 +433,13 @@ pub async fn vote_handler(
     };
 
     // Load and deserialize DecisionObject from DB.
-    let row = sqlx::query("SELECT tenant_id, payload FROM decisions WHERE id_hash = $1 FOR UPDATE")
-        .bind(&body.decision_id)
-        .fetch_optional(&mut *tx)
-        .await;
+    let row = sqlx::query(
+        "SELECT tenant_id, payload FROM decisions WHERE id_hash = $1 AND tenant_id = $2 FOR UPDATE",
+    )
+    .bind(&body.decision_id)
+    .bind(&actor.tenant_id)
+    .fetch_optional(&mut *tx)
+    .await;
     let (tenant_id, payload_val): (String, Value) = match row {
         Ok(Some(r)) => {
             let tenant_id = match r.try_get::<String, _>("tenant_id") {
@@ -609,11 +612,13 @@ pub async fn vote_handler(
     };
 
     // Persist updated decision.
-    if let Err(e) = sqlx::query("UPDATE decisions SET payload = $1 WHERE id_hash = $2")
-        .bind(&updated_payload)
-        .bind(&body.decision_id)
-        .execute(&mut *tx)
-        .await
+    if let Err(e) =
+        sqlx::query("UPDATE decisions SET payload = $1 WHERE id_hash = $2 AND tenant_id = $3")
+            .bind(&updated_payload)
+            .bind(&body.decision_id)
+            .bind(&actor.tenant_id)
+            .execute(&mut *tx)
+            .await
     {
         tracing::error!(error = %e, "failed to persist vote");
         return (
@@ -1095,7 +1100,7 @@ mod tests {
             .next()
             .expect("vote handler source end");
         let auth_index = vote_handler
-            .find("require_authenticated_session_actor_from_header")
+            .find("require_authenticated_session_user_from_header")
             .expect("vote handler must authenticate a bearer session");
         let conflict_index = vote_handler
             .find("load_conflict_declarations(&voter_did)")
@@ -1109,7 +1114,7 @@ mod tests {
             "vote handler must authenticate before conflict and kernel checks"
         );
         assert!(
-            vote_handler.contains("if actor != voter_did"),
+            vote_handler.contains("if actor.did != voter_did"),
             "vote handler must reject body voter_did spoofing"
         );
     }
@@ -1156,6 +1161,42 @@ mod tests {
         assert!(
             !vote_handler.contains(".execute(db)"),
             "vote handler must not update the mutable decision outside the transaction"
+        );
+    }
+
+    #[test]
+    fn vote_handler_scopes_decision_mutation_to_authenticated_actor_tenant() {
+        let source = include_str!("handlers.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("test module marker present");
+        let vote_handler = production
+            .split("pub async fn vote_handler")
+            .nth(1)
+            .expect("vote handler source present")
+            .split("// ── Health handler")
+            .next()
+            .expect("vote handler source end");
+
+        assert!(
+            vote_handler.contains("require_authenticated_session_user_from_header(&headers)"),
+            "vote handler must derive tenant scope from the authenticated session actor"
+        );
+        assert!(
+            vote_handler
+                .contains("FROM decisions WHERE id_hash = $1 AND tenant_id = $2 FOR UPDATE"),
+            "vote handler must lock only the decision row in the actor tenant"
+        );
+        assert!(
+            vote_handler.contains(".bind(&actor.tenant_id)"),
+            "vote handler must bind the authenticated actor tenant to decision queries"
+        );
+        assert!(
+            vote_handler.contains(
+                "UPDATE decisions SET payload = $1 WHERE id_hash = $2 AND tenant_id = $3"
+            ),
+            "vote handler must update only the decision row in the actor tenant"
         );
     }
 

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -269,6 +269,14 @@ pub struct AppState {
     rate_limiter: Arc<Mutex<GatewayRateLimiter>>,
 }
 
+/// Non-secret authenticated session profile used to carry tenant scope across
+/// gateway runtime adapter boundaries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthenticatedSessionUser {
+    pub did: Did,
+    pub tenant_id: String,
+}
+
 impl AppState {
     /// Create a new `AppState` with an optional database pool and a shared DID registry.
     pub fn new(pool: Option<sqlx::PgPool>, registry: Arc<RwLock<LocalDidRegistry>>) -> Self {
@@ -341,6 +349,28 @@ impl AppState {
         let token = require_bearer_token(headers)?;
         let observed_at = required_observed_at_ms_header(headers)?;
         require_authenticated_session_actor_for_token(self, &token, observed_at).await
+    }
+
+    /// Resolve the authenticated actor and its tenant scope from DB-backed
+    /// bearer session state.
+    pub async fn require_authenticated_session_user_from_header(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<AuthenticatedSessionUser> {
+        let did = self
+            .require_authenticated_session_actor_from_header(headers)
+            .await?;
+        let db = self.require_db()?;
+        let user = db::find_user_by_did(db, did.as_str())
+            .await
+            .map_err(|e| GatewayError::Internal(format!("session user lookup failed: {e}")))?
+            .ok_or_else(|| GatewayError::AuthenticationFailed {
+                reason: "authenticated session actor has no tenant profile".to_owned(),
+            })?;
+        Ok(AuthenticatedSessionUser {
+            did,
+            tenant_id: user.tenant_id,
+        })
     }
 
     /// Return the number of registered DIDs without blocking a Tokio worker
@@ -1803,15 +1833,10 @@ async fn require_authenticated_session_actor_from_header(
 async fn require_authenticated_session_user_from_header(
     state: &AppState,
     headers: &HeaderMap,
-) -> Result<db::UserRow> {
-    let actor = require_authenticated_session_actor_from_header(state, headers).await?;
-    let db = state.require_db()?;
-    db::find_user_by_did(db, actor.as_str())
+) -> Result<AuthenticatedSessionUser> {
+    state
+        .require_authenticated_session_user_from_header(headers)
         .await
-        .map_err(|e| GatewayError::Internal(format!("session user lookup failed: {e}")))?
-        .ok_or_else(|| GatewayError::AuthenticationFailed {
-            reason: "authenticated session actor has no tenant profile".to_owned(),
-        })
 }
 
 async fn require_authenticated_session_actor(


### PR DESCRIPTION
## Summary

Hardens a sibling gateway runtime-adapter path found during the F-051 bypass search. The vote transaction previously locked and updated decisions by `id_hash` only. This PR derives tenant scope from the authenticated session actor's persisted user profile and requires that tenant on the vote row lock and update.

- adds a non-secret `AuthenticatedSessionUser` projection on `AppState`
- changes `vote_handler` to authenticate and load tenant scope before conflict/kernel checks
- scopes `SELECT ... FOR UPDATE` with `id_hash` + `tenant_id`
- scopes the decision `UPDATE` with `id_hash` + `tenant_id`
- updates README repo-truth counts

## Path Classification

- `crates/exo-gateway/src/handlers.rs`: core runtime adapter
- `crates/exo-gateway/src/server.rs`: core runtime adapter
- `README.md`: documentation / repo-truth metadata

## Validation

Candidate source/control/sink tuple:

- attacker-controlled source: authenticated vote request with `decision_id`
- broken control: transaction read/update selected decision by `id_hash` only
- sink: mutation of serialized `DecisionObject` and audit path in gateway vote route
- required invariant: tenant-scoped gateway runtime adapter writes must derive scope from the authenticated session actor, not from caller-supplied IDs

Red test added first and failed on current main-derived branch:

- `cargo test -p exo-gateway vote_handler_scopes_decision_mutation_to_authenticated_actor_tenant -- --nocapture`

## Verification

Passed:

- `cargo test -p exo-gateway vote_handler_scopes_decision_mutation_to_authenticated_actor_tenant -- --nocapture`
- `cargo test -p exo-gateway vote_handler_authenticates_session_actor_before_conflict_and_kernel_checks -- --nocapture`
- `cargo test -p exo-gateway vote_handler_updates_decision_under_row_lock_transaction -- --nocapture`
- `cargo test -p exo-gateway handlers::tests -- --nocapture`
- `cargo test -p exo-gateway server::tests::decision_get_uses_authenticated_actor_tenant_for_lookup -- --nocapture`
- `cargo test -p exo-gateway sensitive_read_handlers_require_session_before_state_reads -- --nocapture`
- `cargo test -p exo-gateway -- --nocapture`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `cargo fmt --all -- --check` (stable rustfmt emitted existing warnings for nightly-only rustfmt options)
- `cargo doc -p exo-gateway --no-deps`
- `bash tools/repo_truth.sh --json --list-tests`
- `bash tools/test_repo_truth.sh`
- `git diff --check`

Bypass search:

- `rg -n 'SELECT tenant_id, payload FROM decisions WHERE id_hash = \$1 FOR UPDATE|UPDATE decisions SET payload = \$1 WHERE id_hash = \$2"|require_authenticated_session_actor_from_header\(&headers\)' crates/exo-gateway/src/handlers.rs`
- `rg -n 'WHERE id_hash = \$1|UPDATE decisions SET payload' crates/exo-gateway/src/handlers.rs crates/exo-gateway/src/server.rs`

The handlers path now contains only tenant-scoped decision row lock/update SQL.
