### PR TITLE
fix(gateway): report missing decision updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 159144 | `wc -l` |
-| Workspace tests | 3,953 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 159188 | `wc -l` |
+| Workspace tests | 3,954 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,953 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,954 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -80,9 +80,9 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 159144 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 159188 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,953 listed workspace tests
+         cryptographic proofs, 3,954 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-gateway/src/db.rs
+++ b/crates/exo-gateway/src/db.rs
@@ -30,6 +30,17 @@ pub enum DbInitError {
     },
 }
 
+#[derive(Debug, Error)]
+pub enum DecisionUpdateError {
+    #[error("decision update matched no rows for id_hash {id_hash}")]
+    MissingDecision { id_hash: String },
+    #[error("failed to update decision row")]
+    Query {
+        #[source]
+        source: sqlx::Error,
+    },
+}
+
 // ---------------------------------------------------------------------------
 // Pool initialization
 // ---------------------------------------------------------------------------
@@ -378,13 +389,19 @@ pub async fn update_decision(
     id_hash: &str,
     status: &str,
     payload: &JsonValue,
-) -> Result<(), sqlx::Error> {
-    sqlx::query("UPDATE decisions SET status = $1, payload = $2 WHERE id_hash = $3")
+) -> Result<(), DecisionUpdateError> {
+    let result = sqlx::query("UPDATE decisions SET status = $1, payload = $2 WHERE id_hash = $3")
         .bind(status)
         .bind(payload)
         .bind(id_hash)
         .execute(pool)
-        .await?;
+        .await
+        .map_err(|source| DecisionUpdateError::Query { source })?;
+    if result.rows_affected() == 0 {
+        return Err(DecisionUpdateError::MissingDecision {
+            id_hash: id_hash.to_owned(),
+        });
+    }
     Ok(())
 }
 
@@ -1354,6 +1371,33 @@ mod tests {
         assert!(
             contains_in_order(lookup, ".bind(id_hash)", ".bind(tenant_id)"),
             "find_decision must bind id_hash and tenant_id together"
+        );
+    }
+
+    #[test]
+    fn update_decision_reports_missing_rows() {
+        let source = production_source();
+        let update = function_source(source, "update_decision");
+
+        assert!(
+            source.contains("pub enum DecisionUpdateError"),
+            "update_decision must use a typed error for missing-row decisions"
+        );
+        assert!(
+            update.contains("-> Result<(), DecisionUpdateError>"),
+            "update_decision must distinguish SQL failures from missing decision rows"
+        );
+        assert!(
+            update.contains("rows_affected()"),
+            "update_decision must inspect PgQueryResult row count"
+        );
+        assert!(
+            update.contains("DecisionUpdateError::MissingDecision"),
+            "update_decision must return a missing-row error when no decision is updated"
+        );
+        assert!(
+            !update.contains(".execute(pool).await?;\n    Ok(())"),
+            "update_decision must not discard PgQueryResult and report success"
         );
     }
 


### PR DESCRIPTION
## Summary

Remediates Gauntlet F-050 after validating it against current `main`. `update_decision` previously discarded `PgQueryResult` and returned `Ok(())` even when no decision row matched.

- adds typed `DecisionUpdateError`
- preserves SQL failures as `source` errors
- checks `rows_affected()` and returns `MissingDecision` when the update matches no row
- updates README repo-truth counts

## Path Classification

- `crates/exo-gateway/src/db.rs`: core runtime adapter
- `README.md`: documentation / repo-truth metadata

## Validation

Candidate source/control/sink tuple:

- source: callers of exported DB helper `update_decision`
- broken control: `UPDATE` result was not inspected
- sink: caller could treat a missing decision update as successful
- invariant: DB write helpers must fail closed when a requested owned row does not exist

Red test added first and failed on current main-derived branch:

- `cargo test -p exo-gateway update_decision_reports_missing_rows -- --nocapture`

## Verification

Passed:

- `cargo test -p exo-gateway update_decision_reports_missing_rows -- --nocapture`
- `cargo test -p exo-gateway db::tests -- --nocapture`
- `cargo test -p exo-gateway -- --nocapture`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `cargo fmt --all -- --check` (stable rustfmt emitted existing warnings for nightly-only rustfmt options)
- `cargo doc -p exo-gateway --no-deps`
- `bash tools/repo_truth.sh --json --list-tests`
- `bash tools/test_repo_truth.sh`
- `git diff --check`

Bypass search:

- `rg -n 'update_decision\(|UPDATE decisions SET status = \$1, payload = \$2 WHERE id_hash = \$3|rows_affected\(\)|DecisionUpdateError' crates/exo-gateway/src crates/exo-gateway/tests -g '*.rs'`

There are currently no production call sites of `update_decision`, so the API change is contained to the exported runtime adapter helper and its regression guard.
