### PR TITLE
fix(gateway): persist DID documents for DB identity paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 159188 | `wc -l` |
-| Workspace tests | 3,954 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 159575 | `wc -l` |
+| Workspace tests | 3,956 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,954 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,956 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -80,9 +80,9 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 159188 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 159575 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,954 listed workspace tests
+         cryptographic proofs, 3,956 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-gateway/migrations/20260504000003_create_did_documents.sql
+++ b/crates/exo-gateway/migrations/20260504000003_create_did_documents.sql
@@ -1,0 +1,16 @@
+-- Durable DID registry backing for DB-configured gateway identity routes.
+--
+-- LocalDidRegistry remains a bounded development/cache implementation. When
+-- DATABASE_URL is configured, REST identity registration and resolution use
+-- this table so DID documents survive process restarts.
+CREATE TABLE IF NOT EXISTS did_documents (
+    did TEXT PRIMARY KEY,
+    document JSONB NOT NULL,
+    created_at_ms BIGINT NOT NULL,
+    updated_at_ms BIGINT NOT NULL,
+    revoked BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+CREATE INDEX IF NOT EXISTS idx_did_documents_active_did
+    ON did_documents(did)
+    WHERE revoked = false;

--- a/crates/exo-gateway/src/db.rs
+++ b/crates/exo-gateway/src/db.rs
@@ -6,6 +6,7 @@
 
 use std::{fmt, time::Duration};
 
+use exo_identity::did::DidDocument;
 use serde_json::Value as JsonValue;
 use sqlx::{
     Row,
@@ -35,6 +36,38 @@ pub enum DecisionUpdateError {
     #[error("decision update matched no rows for id_hash {id_hash}")]
     MissingDecision { id_hash: String },
     #[error("failed to update decision row")]
+    Query {
+        #[source]
+        source: sqlx::Error,
+    },
+}
+
+#[derive(Debug, Error)]
+pub enum DidDocumentPersistenceError {
+    #[error("DID document timestamp is out of database range for {did} field {field}: {value}")]
+    TimestampOutOfRange {
+        did: String,
+        field: &'static str,
+        value: u64,
+    },
+    #[error("failed to serialize DID document for {did}")]
+    Serialize {
+        did: String,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("failed to deserialize persisted DID document for {did}")]
+    Deserialize {
+        did: String,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("persisted DID document row key {row_did} does not match payload id {document_did}")]
+    DocumentDidMismatch {
+        row_did: String,
+        document_did: String,
+    },
+    #[error("DID document persistence query failed")]
     Query {
         #[source]
         source: sqlx::Error,
@@ -75,6 +108,102 @@ pub async fn next_hlc(pool: &PgPool) -> Result<i64, sqlx::Error> {
         .fetch_one(pool)
         .await?;
     Ok(row.get::<i64, _>("counter"))
+}
+
+// ---------------------------------------------------------------------------
+// DID documents
+// ---------------------------------------------------------------------------
+
+fn timestamp_ms_to_i64(
+    did: &str,
+    field: &'static str,
+    value: u64,
+) -> Result<i64, DidDocumentPersistenceError> {
+    i64::try_from(value).map_err(|_| DidDocumentPersistenceError::TimestampOutOfRange {
+        did: did.to_owned(),
+        field,
+        value,
+    })
+}
+
+pub async fn insert_did_document(
+    pool: &PgPool,
+    doc: &DidDocument,
+) -> Result<bool, DidDocumentPersistenceError> {
+    let did = doc.id.as_str();
+    let document =
+        serde_json::to_value(doc).map_err(|source| DidDocumentPersistenceError::Serialize {
+            did: did.to_owned(),
+            source,
+        })?;
+    let created_at_ms = timestamp_ms_to_i64(did, "created", doc.created.physical_ms)?;
+    let updated_at_ms = timestamp_ms_to_i64(did, "updated", doc.updated.physical_ms)?;
+
+    let result = sqlx::query(
+        "INSERT INTO did_documents (did, document, created_at_ms, updated_at_ms, revoked) \
+         VALUES ($1, $2, $3, $4, $5) \
+         ON CONFLICT (did) DO NOTHING",
+    )
+    .bind(did)
+    .bind(document)
+    .bind(created_at_ms)
+    .bind(updated_at_ms)
+    .bind(doc.revoked)
+    .execute(pool)
+    .await
+    .map_err(|source| DidDocumentPersistenceError::Query { source })?;
+
+    Ok(result.rows_affected() > 0)
+}
+
+pub async fn find_did_document(
+    pool: &PgPool,
+    did: &str,
+) -> Result<Option<DidDocument>, DidDocumentPersistenceError> {
+    let row = sqlx::query(
+        "SELECT document \
+         FROM did_documents \
+         WHERE did = $1 AND revoked = false",
+    )
+    .bind(did)
+    .fetch_optional(pool)
+    .await
+    .map_err(|source| DidDocumentPersistenceError::Query { source })?;
+
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let document = row.get::<JsonValue, _>("document");
+    let doc = serde_json::from_value::<DidDocument>(document).map_err(|source| {
+        DidDocumentPersistenceError::Deserialize {
+            did: did.to_owned(),
+            source,
+        }
+    })?;
+    if doc.id.as_str() != did {
+        return Err(DidDocumentPersistenceError::DocumentDidMismatch {
+            row_did: did.to_owned(),
+            document_did: doc.id.as_str().to_owned(),
+        });
+    }
+    Ok(Some(doc))
+}
+
+pub async fn list_did_document_ids(pool: &PgPool) -> Result<Vec<String>, sqlx::Error> {
+    let rows = sqlx::query(
+        "SELECT did \
+         FROM did_documents \
+         WHERE revoked = false \
+         ORDER BY did \
+         LIMIT $1",
+    )
+    .bind(MAX_DB_LIST_ROWS)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows
+        .into_iter()
+        .map(|row| row.get::<String, _>("did"))
+        .collect())
 }
 
 // ---------------------------------------------------------------------------
@@ -1190,6 +1319,20 @@ mod tests {
         .join("\n")
     }
 
+    fn migration_sources_from_disk() -> String {
+        let migration_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
+        let mut entries = std::fs::read_dir(&migration_dir)
+            .expect("read migrations directory")
+            .map(|entry| entry.expect("migration dir entry").path())
+            .collect::<Vec<_>>();
+        entries.sort();
+        entries
+            .into_iter()
+            .map(|path| std::fs::read_to_string(path).expect("read migration"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
     fn compact_sql(sql: &str) -> String {
         sql.split_whitespace().collect::<Vec<_>>().join(" ")
     }
@@ -1318,6 +1461,38 @@ mod tests {
                 "gateway migration set must include runtime query index: {index_sql}"
             );
         }
+    }
+
+    #[test]
+    fn did_documents_have_durable_schema_and_persistence_helpers() {
+        let migrations = compact_sql(&migration_sources_from_disk());
+        assert!(
+            migrations.contains("CREATE TABLE IF NOT EXISTS did_documents ("),
+            "DB-backed gateway identity must persist DID documents instead of relying on LocalDidRegistry memory"
+        );
+        assert!(
+            migrations.contains("did TEXT PRIMARY KEY"),
+            "persisted DID documents must be keyed by DID"
+        );
+        assert!(
+            migrations.contains("document JSONB NOT NULL"),
+            "persisted DID documents must retain the canonical serialized document payload"
+        );
+
+        let source = production_source();
+        let insert_source = function_source(source, "insert_did_document");
+        assert!(insert_source.contains("INSERT INTO did_documents"));
+        assert!(insert_source.contains("ON CONFLICT (did) DO NOTHING"));
+        assert!(insert_source.contains("rows_affected()"));
+
+        let lookup_source = function_source(source, "find_did_document");
+        assert!(lookup_source.contains("FROM did_documents"));
+        assert!(lookup_source.contains("serde_json::from_value"));
+
+        let list_source = function_source(source, "list_did_document_ids");
+        assert!(list_source.contains("FROM did_documents"));
+        assert!(list_source.contains("LIMIT $"));
+        assert!(list_source.contains(".bind(MAX_DB_LIST_ROWS)"));
     }
 
     #[test]

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -452,7 +452,8 @@ impl AppState {
 #[derive(Debug)]
 enum RegistryBlockingError {
     Registration(IdentityError),
-    Operation(String),
+    Authentication(String),
+    Persistence(String),
     Join(String),
 }
 
@@ -460,7 +461,8 @@ impl fmt::Display for RegistryBlockingError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Registration(error) => write!(f, "registry registration failed: {error}"),
-            Self::Operation(error) => write!(f, "registry operation failed: {error}"),
+            Self::Authentication(error) => write!(f, "registry authentication failed: {error}"),
+            Self::Persistence(error) => write!(f, "registry persistence failed: {error}"),
             Self::Join(error) => write!(f, "registry blocking task failed: {error}"),
         }
     }
@@ -508,6 +510,22 @@ async fn registry_register_document(
     .map_err(|e| RegistryBlockingError::Join(e.to_string()))?
 }
 
+async fn registry_cache_document(
+    registry: Arc<RwLock<LocalDidRegistry>>,
+    doc: DidDocument,
+) -> std::result::Result<(), RegistryBlockingError> {
+    tokio::task::spawn_blocking(move || {
+        let mut reg = registry.write().unwrap_or_else(|e| e.into_inner());
+        match reg.register(doc) {
+            Ok(()) | Err(IdentityError::DuplicateDid(_)) => Ok(()),
+            Err(IdentityError::RegistryCapacityExceeded { .. }) => Ok(()),
+            Err(error) => Err(RegistryBlockingError::Registration(error)),
+        }
+    })
+    .await
+    .map_err(|e| RegistryBlockingError::Join(e.to_string()))?
+}
+
 async fn registry_resolve_document(
     registry: Arc<RwLock<LocalDidRegistry>>,
     did: Did,
@@ -520,6 +538,53 @@ async fn registry_resolve_document(
     .map_err(|e| RegistryBlockingError::Join(e.to_string()))?
 }
 
+fn validate_did_document_for_registration(
+    doc: &DidDocument,
+) -> std::result::Result<(), IdentityError> {
+    let mut registry = LocalDidRegistry::with_max_documents(1);
+    registry.register(doc.clone())
+}
+
+async fn register_did_document(
+    state: &AppState,
+    doc: DidDocument,
+) -> std::result::Result<(), RegistryBlockingError> {
+    if let Some(pool) = state.pool.as_ref() {
+        validate_did_document_for_registration(&doc)
+            .map_err(RegistryBlockingError::Registration)?;
+        let inserted = db::insert_did_document(pool, &doc)
+            .await
+            .map_err(|e| RegistryBlockingError::Persistence(e.to_string()))?;
+        if !inserted {
+            return Err(RegistryBlockingError::Registration(
+                IdentityError::DuplicateDid(doc.id.clone()),
+            ));
+        }
+        registry_cache_document(Arc::clone(&state.registry), doc).await
+    } else {
+        registry_register_document(Arc::clone(&state.registry), doc).await
+    }
+}
+
+async fn resolve_did_document(
+    state: &AppState,
+    did: Did,
+) -> std::result::Result<Option<DidDocument>, RegistryBlockingError> {
+    if let Some(pool) = state.pool.as_ref() {
+        let did_str = did.as_str().to_owned();
+        let Some(doc) = db::find_did_document(pool, &did_str)
+            .await
+            .map_err(|e| RegistryBlockingError::Persistence(e.to_string()))?
+        else {
+            return Ok(None);
+        };
+        registry_cache_document(Arc::clone(&state.registry), doc.clone()).await?;
+        Ok(Some(doc))
+    } else {
+        registry_resolve_document(Arc::clone(&state.registry), did).await
+    }
+}
+
 async fn registry_list_dids(
     registry: Arc<RwLock<LocalDidRegistry>>,
 ) -> std::result::Result<Vec<String>, RegistryBlockingError> {
@@ -529,6 +594,16 @@ async fn registry_list_dids(
     })
     .await
     .map_err(|e| RegistryBlockingError::Join(e.to_string()))?
+}
+
+async fn list_dids(state: &AppState) -> std::result::Result<Vec<String>, RegistryBlockingError> {
+    if let Some(pool) = state.pool.as_ref() {
+        db::list_did_document_ids(pool)
+            .await
+            .map_err(|e| RegistryBlockingError::Persistence(e.to_string()))
+    } else {
+        registry_list_dids(Arc::clone(&state.registry)).await
+    }
 }
 
 async fn registry_len(
@@ -552,10 +627,42 @@ async fn registry_authenticate_session_login(
         let reg = registry.read().unwrap_or_else(|e| e.into_inner());
         authenticate_session_login(&did, &metadata, &proof, &*reg)
             .map(|_| ())
-            .map_err(|e| RegistryBlockingError::Operation(e.to_string()))
+            .map_err(|e| RegistryBlockingError::Authentication(e.to_string()))
     })
     .await
     .map_err(|e| RegistryBlockingError::Join(e.to_string()))?
+}
+
+async fn authenticate_session_login_with_state(
+    state: &AppState,
+    did: String,
+    metadata: SessionIssueMetadata,
+    proof: SessionLoginProof,
+) -> std::result::Result<(), RegistryBlockingError> {
+    if let Some(pool) = state.pool.as_ref() {
+        let Some(doc) = db::find_did_document(pool, &did)
+            .await
+            .map_err(|e| RegistryBlockingError::Persistence(e.to_string()))?
+        else {
+            return Err(RegistryBlockingError::Authentication(
+                "DID is not registered".to_owned(),
+            ));
+        };
+        registry_cache_document(Arc::clone(&state.registry), doc.clone()).await?;
+        tokio::task::spawn_blocking(move || {
+            let mut registry = LocalDidRegistry::with_max_documents(1);
+            registry
+                .register(doc)
+                .map_err(RegistryBlockingError::Registration)?;
+            authenticate_session_login(&did, &metadata, &proof, &registry)
+                .map(|_| ())
+                .map_err(|e| RegistryBlockingError::Authentication(e.to_string()))
+        })
+        .await
+        .map_err(|e| RegistryBlockingError::Join(e.to_string()))?
+    } else {
+        registry_authenticate_session_login(Arc::clone(&state.registry), did, metadata, proof).await
+    }
 }
 
 fn decode_conflict_declaration_payload(
@@ -1064,7 +1171,7 @@ async fn handle_auth_register(
     Json(doc): Json<DidDocument>,
 ) -> impl IntoResponse {
     let did_str = doc.id.as_str().to_owned();
-    match registry_register_document(Arc::clone(&state.registry), doc).await {
+    match register_did_document(&state, doc).await {
         Ok(()) => (
             StatusCode::CREATED,
             Json(serde_json::json!({ "did": did_str, "status": "registered" })),
@@ -1095,7 +1202,7 @@ async fn handle_auth_me(State(state): State<AppState>, headers: HeaderMap) -> im
         Ok(actor) => actor,
         Err(e) => return auth_boundary_error_response(e),
     };
-    match registry_resolve_document(Arc::clone(&state.registry), did).await {
+    match resolve_did_document(&state, did).await {
         Ok(Some(doc)) => Json(doc).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -1123,7 +1230,7 @@ async fn handle_agents_list(
     if let Err(e) = require_authenticated_session_actor_from_header(&state, &headers).await {
         return auth_boundary_error_response(e);
     }
-    match registry_list_dids(Arc::clone(&state.registry)).await {
+    match list_dids(&state).await {
         Ok(dids) => Json(serde_json::json!({ "agents": dids })).into_response(),
         Err(e) => {
             tracing::error!(error = %e, "DID registry listing failed");
@@ -1157,7 +1264,7 @@ async fn handle_agent_get(
                 .into_response();
         }
     };
-    match registry_resolve_document(Arc::clone(&state.registry), did).await {
+    match resolve_did_document(&state, did).await {
         Ok(Some(doc)) => Json(doc).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -1196,7 +1303,7 @@ async fn handle_identity_score(
                 .into_response();
         }
     };
-    match registry_resolve_document(Arc::clone(&state.registry), did).await {
+    match resolve_did_document(&state, did).await {
         Ok(None) => (
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({
@@ -1292,7 +1399,7 @@ async fn handle_users_list(State(state): State<AppState>, headers: HeaderMap) ->
     if let Err(e) = require_authenticated_session_actor_from_header(&state, &headers).await {
         return auth_boundary_error_response(e);
     }
-    match registry_list_dids(Arc::clone(&state.registry)).await {
+    match list_dids(&state).await {
         Ok(dids) => Json(serde_json::json!({ "users": dids })).into_response(),
         Err(e) => {
             tracing::error!(error = %e, "DID registry listing failed");
@@ -1400,7 +1507,7 @@ async fn handle_agents_enroll(
     Json(doc): Json<DidDocument>,
 ) -> impl IntoResponse {
     let did_str = doc.id.as_str().to_owned();
-    match registry_register_document(Arc::clone(&state.registry), doc).await {
+    match register_did_document(&state, doc).await {
         Ok(()) => (
             StatusCode::CREATED,
             Json(serde_json::json!({ "did": did_str, "status": "enrolled" })),
@@ -1482,16 +1589,9 @@ async fn handle_auth_login(
         Ok(proof) => proof,
         Err(e) => return metadata_error_response(e),
     };
-    match registry_authenticate_session_login(
-        Arc::clone(&state.registry),
-        did_str.clone(),
-        metadata,
-        proof,
-    )
-    .await
-    {
+    match authenticate_session_login_with_state(&state, did_str.clone(), metadata, proof).await {
         Ok(()) => {}
-        Err(RegistryBlockingError::Operation(e)) => {
+        Err(RegistryBlockingError::Authentication(e)) => {
             return (
                 StatusCode::UNAUTHORIZED,
                 Json(serde_json::json!({
@@ -3691,9 +3791,9 @@ mod tests {
         );
 
         for (name, handler, state_read) in [
-            ("agents list", agents_list, "registry_list_dids"),
-            ("agent get", agent_get, "registry_resolve_document"),
-            ("users list", users_list, "registry_list_dids"),
+            ("agents list", agents_list, "list_dids"),
+            ("agent get", agent_get, "resolve_did_document"),
+            ("users list", users_list, "list_dids"),
             ("decision get", decision_get, "state.require_db"),
             ("audit trail", audit_trail, "state.require_db"),
         ] {
@@ -3796,6 +3896,95 @@ mod tests {
                 "\"/api/v1/agents/enroll\",post(handle_agents_enroll).layer(DefaultBodyLimit::max(MAX_DID_DOCUMENT_BODY_BYTES))"
             ),
             "agents/enroll must apply the DID document body budget at the route"
+        );
+    }
+
+    #[test]
+    fn db_configured_identity_paths_do_not_depend_on_local_did_memory() {
+        let source = include_str!("server.rs");
+
+        let auth_register = source_between(
+            source,
+            "async fn handle_auth_register",
+            "/// GET /api/v1/auth/me",
+        );
+        assert!(
+            auth_register.contains("register_did_document(&state, doc).await"),
+            "auth/register must persist through the AppState DB-backed DID path when a pool is configured"
+        );
+        assert!(
+            !auth_register.contains("registry_register_document(Arc::clone(&state.registry), doc)"),
+            "auth/register must not write only to LocalDidRegistry"
+        );
+
+        let auth_me = source_between(
+            source,
+            "async fn handle_auth_me",
+            "/// GET /api/v1/auth/agents",
+        );
+        assert!(
+            auth_me.contains("resolve_did_document(&state, did).await"),
+            "auth/me must resolve persisted DID documents after a restart"
+        );
+
+        let agents_list = source_between(
+            source,
+            "async fn handle_agents_list",
+            "/// GET /api/v1/agents/:did",
+        );
+        assert!(
+            agents_list.contains("list_dids(&state).await"),
+            "agents list must read persisted DID ids when a DB pool is configured"
+        );
+
+        let agent_get = source_between(
+            source,
+            "async fn handle_agent_get",
+            "/// GET /api/v1/identity/:did/score",
+        );
+        assert!(
+            agent_get.contains("resolve_did_document(&state, did).await"),
+            "agent lookup must resolve persisted DID documents after a restart"
+        );
+
+        let agents_enroll = source_between(
+            source,
+            "async fn handle_agents_enroll",
+            "// ---------------------------------------------------------------------------\n// Session auth handlers",
+        );
+        assert!(
+            agents_enroll.contains("register_did_document(&state, doc).await"),
+            "agents/enroll must share the DB-backed DID persistence path"
+        );
+
+        let auth_login = source_between(
+            source,
+            "async fn handle_auth_login",
+            "/// POST /api/v1/auth/token",
+        );
+        assert!(
+            auth_login.contains("authenticate_session_login_with_state(&state,"),
+            "login proof verification must use the persisted DID document path when a DB pool is configured"
+        );
+
+        let identity_score = source_between(
+            source,
+            "async fn handle_identity_score",
+            "/// GET /api/v1/identity/status",
+        );
+        assert!(
+            identity_score.contains("resolve_did_document(&state, did).await"),
+            "identity score must resolve persisted DID documents after a restart"
+        );
+
+        let users_list = source_between(
+            source,
+            "async fn handle_users_list",
+            "/// GET /api/v1/decisions/:id",
+        );
+        assert!(
+            users_list.contains("list_dids(&state).await"),
+            "users list must read persisted DID ids when a DB pool is configured"
         );
     }
 
@@ -4591,8 +4780,23 @@ mod tests {
             .execute(&pool)
             .await
             .unwrap();
+        sqlx::query("DELETE FROM did_documents WHERE did = $1")
+            .bind(did)
+            .execute(&pool)
+            .await
+            .unwrap();
 
         let (registry, sk) = signing_registry();
+        let did_key = Did::new(did).unwrap();
+        let doc = registry
+            .read()
+            .unwrap()
+            .resolve(&did_key)
+            .expect("signing DID document")
+            .clone();
+        db::insert_did_document(&pool, &doc)
+            .await
+            .expect("persist signing DID document");
         let metadata = SessionIssueMetadata {
             created_at: 10_000,
             expires_at: 20_000,
@@ -4613,7 +4817,10 @@ mod tests {
         });
 
         let response = handle_auth_login(
-            State(AppState::new(Some(pool.clone()), registry)),
+            State(AppState::new(
+                Some(pool.clone()),
+                Arc::new(RwLock::new(LocalDidRegistry::new())),
+            )),
             Json(body),
         )
         .await
@@ -4635,6 +4842,11 @@ mod tests {
         assert!(!rows[0].get::<bool, _>("revoked"));
 
         sqlx::query("DELETE FROM sessions WHERE actor_did = $1")
+            .bind(did)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM did_documents WHERE did = $1")
             .bind(did)
             .execute(&pool)
             .await


### PR DESCRIPTION
## Summary
- Validated Gauntlet F-052 against current `origin/main`: stale at the `exo-consent` library boundary. `ConsentGateSnapshot` persists revocation/access logs and blocks revoked bailment replay after restore.
- Validated Gauntlet F-053 against current `origin/main`: unbounded `LocalDidRegistry` growth is already fixed, but the DB-configured gateway REST identity paths still depended on restart-lost local memory.
- Added durable `did_documents` PostgreSQL persistence and routed DB-configured register/resolve/list/login identity paths through it, leaving `LocalDidRegistry` as the bounded no-DB development store/cache.

## Path Classification
- `crates/exo-gateway/src/db.rs`: core runtime adapter
- `crates/exo-gateway/src/server.rs`: core runtime adapter
- `crates/exo-gateway/migrations/20260504000003_create_did_documents.sql`: core runtime adapter
- `README.md`: documentation/repo-truth metadata

## Security Notes
- External finding F-052 did not require code changes: focused gatekeeper tests already prove revocation snapshot restore blocks restart replay.
- F-053 survived only as a persistence/runtime-adapter issue. DB-configured deployments now persist DID documents and resolve login/auth/score/list paths from DB state after restart.
- Bypass search found remaining direct `LocalDidRegistry` use in no-DB fallbacks, tests, auth harnesses, and default-off unaudited GraphQL state.

## Verification
- RED before fix:
  - `cargo test -p exo-gateway did_documents_have_durable_schema_and_persistence_helpers -- --nocapture`
  - `cargo test -p exo-gateway db_configured_identity_paths_do_not_depend_on_local_did_memory -- --nocapture`
- Focused/current validation:
  - `cargo test -p exo-consent gatekeeper -- --nocapture`
  - `cargo test -p exo-identity register_rejects_documents_after_default_registry_capacity -- --nocapture`
  - `cargo test -p exo-gateway auth_register -- --nocapture`
  - `cargo test -p exo-gateway auth_login -- --nocapture`
  - `cargo test -p exo-gateway auth_me -- --nocapture`
  - `cargo test -p exo-gateway identity_score -- --nocapture`
  - `cargo test -p exo-gateway db::tests -- --nocapture`
  - `cargo test -p exo-gateway server::tests -- --nocapture`
  - `cargo test -p exo-gateway -- --nocapture`
  - `cargo test -p exo-gateway --features production-db -- --nocapture`
  - `cargo clippy -p exo-gateway --all-targets -- -D warnings`
  - `cargo clippy -p exo-gateway --features production-db --all-targets -- -D warnings`
  - `cargo fmt --all -- --check`
  - `cargo doc -p exo-gateway --no-deps`
  - `bash tools/repo_truth.sh --json --list-tests`
  - `bash tools/test_repo_truth.sh`
  - `git diff --check`
