### PR TITLE
fix(gateway): erase persisted identity records

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 159575 | `wc -l` |
-| Workspace tests | 3,956 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 160388 | `wc -l` |
+| Workspace tests | 3,960 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,956 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,960 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -80,9 +80,9 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 159575 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 160388 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,956 listed workspace tests
+         cryptographic proofs, 3,960 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-gateway/migrations/20260504000004_add_gateway_identity_erasure.sql
+++ b/crates/exo-gateway/migrations/20260504000004_add_gateway_identity_erasure.sql
@@ -1,0 +1,6 @@
+ALTER TABLE did_documents
+    ADD COLUMN IF NOT EXISTS erased_at_ms BIGINT;
+
+CREATE INDEX IF NOT EXISTS idx_did_documents_erased_at_ms
+    ON did_documents(erased_at_ms)
+    WHERE erased_at_ms IS NOT NULL;

--- a/crates/exo-gateway/src/db.rs
+++ b/crates/exo-gateway/src/db.rs
@@ -74,6 +74,38 @@ pub enum DidDocumentPersistenceError {
     },
 }
 
+#[derive(Debug, Error)]
+pub enum GatewayIdentityErasureError {
+    #[error("identity erasure timestamp must be positive: {erased_at_ms}")]
+    InvalidTimestamp { erased_at_ms: i64 },
+    #[error("gateway identity erasure query failed")]
+    Query {
+        #[source]
+        source: sqlx::Error,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct GatewayIdentityErasureSummary {
+    pub did_documents_tombstoned: u64,
+    pub users_deleted: u64,
+    pub agents_deleted: u64,
+    pub sessions_deleted: u64,
+    pub identity_scores_deleted: u64,
+    pub enrollment_log_deleted: u64,
+    pub livesafe_identities_deleted: u64,
+    pub scan_receipts_deleted: u64,
+    pub consent_anchors_deleted: u64,
+    pub trustee_shards_deleted: u64,
+    pub agent_roles_deleted: u64,
+    pub consent_records_deleted: u64,
+    pub authority_chains_deleted: u64,
+    pub delegations_deleted: u64,
+    pub layout_templates_deleted: u64,
+    pub feedback_issues_deleted: u64,
+    pub conflict_declarations_deleted: u64,
+}
+
 // ---------------------------------------------------------------------------
 // Pool initialization
 // ---------------------------------------------------------------------------
@@ -204,6 +236,185 @@ pub async fn list_did_document_ids(pool: &PgPool) -> Result<Vec<String>, sqlx::E
         .into_iter()
         .map(|row| row.get::<String, _>("did"))
         .collect())
+}
+
+pub async fn erase_gateway_identity_records(
+    pool: &PgPool,
+    did: &str,
+    erased_at_ms: i64,
+) -> Result<GatewayIdentityErasureSummary, GatewayIdentityErasureError> {
+    if erased_at_ms <= 0 {
+        return Err(GatewayIdentityErasureError::InvalidTimestamp { erased_at_ms });
+    }
+
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|source| GatewayIdentityErasureError::Query { source })?;
+    let tombstone = serde_json::json!({
+        "schema": "exo.gateway.did_document_tombstone.v1",
+        "erased": true
+    });
+
+    let did_documents_tombstoned = sqlx::query(
+        "UPDATE did_documents \
+         SET document = $2, updated_at_ms = $3, revoked = true, erased_at_ms = $3 \
+         WHERE did = $1",
+    )
+    .bind(did)
+    .bind(tombstone)
+    .bind(erased_at_ms)
+    .execute(&mut *tx)
+    .await
+    .map_err(|source| GatewayIdentityErasureError::Query { source })?
+    .rows_affected();
+
+    let sessions_deleted = sqlx::query("DELETE FROM sessions WHERE actor_did = $1")
+        .bind(did)
+        .execute(&mut *tx)
+        .await
+        .map_err(|source| GatewayIdentityErasureError::Query { source })?
+        .rows_affected();
+
+    let users_deleted = sqlx::query("DELETE FROM users WHERE did = $1")
+        .bind(did)
+        .execute(&mut *tx)
+        .await
+        .map_err(|source| GatewayIdentityErasureError::Query { source })?
+        .rows_affected();
+
+    let agents_deleted = sqlx::query("DELETE FROM agents WHERE did = $1 OR owner_did = $1")
+        .bind(did)
+        .execute(&mut *tx)
+        .await
+        .map_err(|source| GatewayIdentityErasureError::Query { source })?
+        .rows_affected();
+
+    let identity_scores_deleted = sqlx::query("DELETE FROM identity_scores WHERE did = $1")
+        .bind(did)
+        .execute(&mut *tx)
+        .await
+        .map_err(|source| GatewayIdentityErasureError::Query { source })?
+        .rows_affected();
+
+    let enrollment_log_deleted = sqlx::query("DELETE FROM enrollment_log WHERE did = $1")
+        .bind(did)
+        .execute(&mut *tx)
+        .await
+        .map_err(|source| GatewayIdentityErasureError::Query { source })?
+        .rows_affected();
+
+    let livesafe_identities_deleted = sqlx::query("DELETE FROM livesafe_identities WHERE did = $1")
+        .bind(did)
+        .execute(&mut *tx)
+        .await
+        .map_err(|source| GatewayIdentityErasureError::Query { source })?
+        .rows_affected();
+
+    let scan_receipts_deleted =
+        sqlx::query("DELETE FROM scan_receipts WHERE subscriber_did = $1 OR responder_did = $1")
+            .bind(did)
+            .execute(&mut *tx)
+            .await
+            .map_err(|source| GatewayIdentityErasureError::Query { source })?
+            .rows_affected();
+
+    let consent_anchors_deleted =
+        sqlx::query("DELETE FROM consent_anchors WHERE subscriber_did = $1 OR provider_did = $1")
+            .bind(did)
+            .execute(&mut *tx)
+            .await
+            .map_err(|source| GatewayIdentityErasureError::Query { source })?
+            .rows_affected();
+
+    let trustee_shards_deleted = sqlx::query(
+        "DELETE FROM trustee_shard_status WHERE subscriber_did = $1 OR trustee_did = $1",
+    )
+    .bind(did)
+    .execute(&mut *tx)
+    .await
+    .map_err(|source| GatewayIdentityErasureError::Query { source })?
+    .rows_affected();
+
+    let agent_roles_deleted =
+        sqlx::query("DELETE FROM agent_roles WHERE agent_did = $1 OR granted_by = $1")
+            .bind(did)
+            .execute(&mut *tx)
+            .await
+            .map_err(|source| GatewayIdentityErasureError::Query { source })?
+            .rows_affected();
+
+    let consent_records_deleted =
+        sqlx::query("DELETE FROM consent_records WHERE subject_did = $1 OR actor_did = $1")
+            .bind(did)
+            .execute(&mut *tx)
+            .await
+            .map_err(|source| GatewayIdentityErasureError::Query { source })?
+            .rows_affected();
+
+    let authority_chains_deleted = sqlx::query("DELETE FROM authority_chains WHERE actor_did = $1")
+        .bind(did)
+        .execute(&mut *tx)
+        .await
+        .map_err(|source| GatewayIdentityErasureError::Query { source })?
+        .rows_affected();
+
+    let delegations_deleted =
+        sqlx::query("DELETE FROM delegations WHERE delegator = $1 OR delegatee = $1")
+            .bind(did)
+            .execute(&mut *tx)
+            .await
+            .map_err(|source| GatewayIdentityErasureError::Query { source })?
+            .rows_affected();
+
+    let layout_templates_deleted = sqlx::query("DELETE FROM layout_templates WHERE user_did = $1")
+        .bind(did)
+        .execute(&mut *tx)
+        .await
+        .map_err(|source| GatewayIdentityErasureError::Query { source })?
+        .rows_affected();
+
+    let feedback_issues_deleted =
+        sqlx::query("DELETE FROM feedback_issues WHERE reporter_did = $1")
+            .bind(did)
+            .execute(&mut *tx)
+            .await
+            .map_err(|source| GatewayIdentityErasureError::Query { source })?
+            .rows_affected();
+
+    let conflict_declarations_deleted = sqlx::query(
+        "DELETE FROM conflict_declarations \
+         WHERE declarant_did = $1 OR related_dids @> jsonb_build_array($1::text)",
+    )
+    .bind(did)
+    .execute(&mut *tx)
+    .await
+    .map_err(|source| GatewayIdentityErasureError::Query { source })?
+    .rows_affected();
+
+    tx.commit()
+        .await
+        .map_err(|source| GatewayIdentityErasureError::Query { source })?;
+
+    Ok(GatewayIdentityErasureSummary {
+        did_documents_tombstoned,
+        users_deleted,
+        agents_deleted,
+        sessions_deleted,
+        identity_scores_deleted,
+        enrollment_log_deleted,
+        livesafe_identities_deleted,
+        scan_receipts_deleted,
+        consent_anchors_deleted,
+        trustee_shards_deleted,
+        agent_roles_deleted,
+        consent_records_deleted,
+        authority_chains_deleted,
+        delegations_deleted,
+        layout_templates_deleted,
+        feedback_issues_deleted,
+        conflict_declarations_deleted,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -1298,6 +1509,7 @@ pub async fn update_feedback_issue_status(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use exo_core::{Did, Timestamp};
 
     fn production_source() -> &'static str {
         let source = include_str!("db.rs");
@@ -1315,6 +1527,8 @@ mod tests {
             include_str!("../migrations/20260427000001_create_conflict_declarations.sql"),
             include_str!("../migrations/20260504000001_add_gateway_runtime_query_indexes.sql"),
             include_str!("../migrations/20260504000002_add_gateway_tenant_scope_indexes.sql"),
+            include_str!("../migrations/20260504000003_create_did_documents.sql"),
+            include_str!("../migrations/20260504000004_add_gateway_identity_erasure.sql"),
         ]
         .join("\n")
     }
@@ -1355,6 +1569,67 @@ mod tests {
             return false;
         };
         first_index < second_index
+    }
+
+    async fn gateway_test_pool() -> Option<PgPool> {
+        let url = std::env::var("DATABASE_URL").ok()?;
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&url)
+            .await
+            .ok()?;
+        sqlx::migrate!("./migrations").run(&pool).await.ok()?;
+        Some(pool)
+    }
+
+    async fn cleanup_identity_erasure_fixture(pool: &PgPool, did: &str) -> Result<(), sqlx::Error> {
+        for statement in [
+            "DELETE FROM did_documents WHERE did = $1",
+            "DELETE FROM sessions WHERE actor_did = $1",
+            "DELETE FROM users WHERE did = $1",
+            "DELETE FROM agents WHERE did = $1 OR owner_did = $1",
+            "DELETE FROM identity_scores WHERE did = $1",
+            "DELETE FROM enrollment_log WHERE did = $1",
+            "DELETE FROM livesafe_identities WHERE did = $1",
+            "DELETE FROM scan_receipts WHERE subscriber_did = $1 OR responder_did = $1",
+            "DELETE FROM consent_anchors WHERE subscriber_did = $1 OR provider_did = $1",
+            "DELETE FROM trustee_shard_status WHERE subscriber_did = $1 OR trustee_did = $1",
+            "DELETE FROM agent_roles WHERE agent_did = $1 OR granted_by = $1",
+            "DELETE FROM consent_records WHERE subject_did = $1 OR actor_did = $1",
+            "DELETE FROM authority_chains WHERE actor_did = $1",
+            "DELETE FROM delegations WHERE delegator = $1 OR delegatee = $1",
+            "DELETE FROM layout_templates WHERE user_did = $1",
+            "DELETE FROM feedback_issues WHERE reporter_did = $1",
+            "DELETE FROM conflict_declarations WHERE declarant_did = $1 OR related_dids @> jsonb_build_array($1::text)",
+        ] {
+            sqlx::query(statement).bind(did).execute(pool).await?;
+        }
+        Ok(())
+    }
+
+    async fn count_rows_by_did(
+        pool: &PgPool,
+        statement: &str,
+        did: &str,
+    ) -> Result<i64, sqlx::Error> {
+        sqlx::query_scalar(statement)
+            .bind(did)
+            .fetch_one(pool)
+            .await
+    }
+
+    fn minimal_doc(did_str: &str) -> DidDocument {
+        DidDocument {
+            id: Did::new(did_str).expect("valid DID"),
+            public_keys: vec![],
+            authentication: vec![],
+            verification_methods: vec![],
+            hybrid_verification_methods: vec![],
+            service_endpoints: vec![],
+            created: Timestamp::ZERO,
+            updated: Timestamp::ZERO,
+            revoked: false,
+        }
     }
 
     #[test]
@@ -1493,6 +1768,291 @@ mod tests {
         assert!(list_source.contains("FROM did_documents"));
         assert!(list_source.contains("LIMIT $"));
         assert!(list_source.contains(".bind(MAX_DB_LIST_ROWS)"));
+    }
+
+    #[test]
+    fn gateway_identity_erasure_has_durable_tombstone_schema_and_helper() {
+        let migrations = compact_sql(&migration_sources_from_disk());
+        assert!(
+            migrations
+                .contains("ALTER TABLE did_documents ADD COLUMN IF NOT EXISTS erased_at_ms BIGINT"),
+            "gateway DID erasure must persist a tombstone timestamp so erased DIDs cannot be re-registered after process restart"
+        );
+
+        let source = production_source();
+        let helper = function_source(source, "erase_gateway_identity_records");
+        for table in [
+            "did_documents",
+            "users",
+            "agents",
+            "sessions",
+            "identity_scores",
+            "enrollment_log",
+            "livesafe_identities",
+            "scan_receipts",
+            "consent_anchors",
+            "trustee_shard_status",
+            "agent_roles",
+            "consent_records",
+            "authority_chains",
+            "delegations",
+            "layout_templates",
+            "feedback_issues",
+            "conflict_declarations",
+        ] {
+            assert!(
+                helper.contains(table),
+                "gateway identity erasure helper must cover durable DID-linked table {table}"
+            );
+        }
+        assert!(
+            helper.contains("revoked = true") && helper.contains("erased_at_ms"),
+            "DID document erasure must tombstone the DID instead of deleting the reuse guard"
+        );
+    }
+
+    #[tokio::test]
+    async fn erase_gateway_identity_records_tombstones_did_and_removes_durable_identity_rows()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let Some(pool) = gateway_test_pool().await else {
+            return Ok(());
+        };
+        let did = "did:exo:erasure-db-subject";
+        cleanup_identity_erasure_fixture(&pool, did).await?;
+
+        let doc = minimal_doc(did);
+        insert_did_document(&pool, &doc).await?;
+        sqlx::query(
+            "INSERT INTO sessions (token, actor_did, created_at, expires_at, revoked) \
+             VALUES ($1, $2, $3, $4, false)",
+        )
+        .bind("erasure-db-session")
+        .bind(did)
+        .bind(1_000_i64)
+        .bind(2_000_i64)
+        .execute(&pool)
+        .await?;
+        insert_user(
+            &pool,
+            did,
+            "Erasure Subject",
+            "erasure-db-subject@example.invalid",
+            &serde_json::json!(["subject"]),
+            "tenant-erasure",
+            1_000,
+            "Active",
+            "Complete",
+            "hash-to-delete",
+            "salt-to-delete",
+            false,
+        )
+        .await?;
+        insert_agent(
+            &pool,
+            did,
+            "Erasure Agent",
+            "agent",
+            did,
+            "tenant-erasure",
+            &serde_json::json!(["read"]),
+            "Trusted",
+            7_500,
+            None,
+            "Complete",
+            1_000,
+            "Active",
+            "Routine",
+        )
+        .await?;
+        upsert_identity_score(
+            &pool,
+            did,
+            7_500,
+            "Trusted",
+            &serde_json::json!({"registered": true}),
+            1_000,
+        )
+        .await?;
+        insert_enrollment(&pool, did, "user", "pace", 1_000, did, "audit").await?;
+        insert_livesafe_identity(
+            &pool,
+            did,
+            7_500,
+            "Complete",
+            "Issued",
+            1_000,
+            Some("anchor"),
+        )
+        .await?;
+        insert_scan_receipt(
+            &pool,
+            "erasure-db-scan",
+            did,
+            "did:exo:responder",
+            Some("40.0,-70.0"),
+            1_000,
+            2_000,
+            "scan-audit",
+            Some("scan-anchor"),
+        )
+        .await?;
+        insert_consent_anchor(
+            &pool,
+            "erasure-db-consent",
+            did,
+            "did:exo:provider",
+            &serde_json::json!(["location"]),
+            1_000,
+            Some(2_000),
+            "consent-audit",
+        )
+        .await?;
+        insert_trustee_shard(&pool, did, "did:exo:trustee", "guardian", true, Some(1_000)).await?;
+        sqlx::query(
+            "INSERT INTO agent_roles (agent_did, role, branch, granted_by, valid_from, expires_at) \
+             VALUES ($1, $2, $3, $4, $5, NULL)",
+        )
+        .bind(did)
+        .bind("operator")
+        .bind("executive")
+        .bind(did)
+        .bind(1_000_i64)
+        .execute(&pool)
+        .await?;
+        sqlx::query(
+            "INSERT INTO consent_records (subject_did, actor_did, scope, bailment_type, status, created_at, expires_at) \
+             VALUES ($1, $2, $3, $4, $5, $6, NULL)",
+        )
+        .bind(did)
+        .bind("did:exo:actor")
+        .bind("read")
+        .bind("standard")
+        .bind("active")
+        .bind(1_000_i64)
+        .execute(&pool)
+        .await?;
+        sqlx::query(
+            "INSERT INTO authority_chains (actor_did, chain_json, valid_from, expires_at) \
+             VALUES ($1, $2, $3, NULL)",
+        )
+        .bind(did)
+        .bind(serde_json::json!({"chain": []}))
+        .bind(1_000_i64)
+        .execute(&pool)
+        .await?;
+        insert_delegation(
+            &pool,
+            "erasure-db-delegation",
+            "tenant-erasure",
+            did,
+            "did:exo:delegatee",
+            1_000,
+            2_000,
+            "exochain-constitution-v1",
+            &serde_json::json!({"delegator": did}),
+        )
+        .await?;
+        upsert_layout_template(
+            &pool,
+            "erasure-db-layout",
+            Some(did),
+            "Subject layout",
+            &serde_json::json!([{"id": "panel", "x": 0, "y": 0}]),
+            &serde_json::json!(["hidden"]),
+            false,
+            1_000,
+            1_000,
+        )
+        .await?;
+        insert_feedback_issue(
+            &pool,
+            "erasure-db-feedback",
+            "Subject feedback",
+            "remove reporter DID",
+            "medium",
+            "privacy",
+            "identity-panel",
+            "dashboard",
+            Some(did),
+            Some(&serde_json::json!({"did": did})),
+            Some(&serde_json::json!({"userAgent": "test"})),
+            1_000,
+        )
+        .await?;
+        sqlx::query(
+            "INSERT INTO conflict_declarations (id_hash, declarant_did, nature, related_dids, timestamp_physical_ms, timestamp_logical, payload) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7)",
+        )
+        .bind("erasure-db-conflict")
+        .bind(did)
+        .bind("test conflict")
+        .bind(serde_json::json!(["did:exo:related"]))
+        .bind(1_000_i64)
+        .bind(0_i32)
+        .bind(serde_json::json!({"declarant_did": did}))
+        .execute(&pool)
+        .await?;
+
+        let summary = erase_gateway_identity_records(&pool, did, 9_000).await?;
+
+        assert_eq!(summary.did_documents_tombstoned, 1);
+        assert_eq!(summary.sessions_deleted, 1);
+        assert_eq!(summary.users_deleted, 1);
+        assert_eq!(summary.agents_deleted, 1);
+        assert_eq!(summary.identity_scores_deleted, 1);
+        assert_eq!(summary.enrollment_log_deleted, 1);
+        assert_eq!(summary.livesafe_identities_deleted, 1);
+        assert_eq!(summary.scan_receipts_deleted, 1);
+        assert_eq!(summary.consent_anchors_deleted, 1);
+        assert_eq!(summary.trustee_shards_deleted, 1);
+        assert_eq!(summary.agent_roles_deleted, 1);
+        assert_eq!(summary.consent_records_deleted, 1);
+        assert_eq!(summary.authority_chains_deleted, 1);
+        assert_eq!(summary.delegations_deleted, 1);
+        assert_eq!(summary.layout_templates_deleted, 1);
+        assert_eq!(summary.feedback_issues_deleted, 1);
+        assert_eq!(summary.conflict_declarations_deleted, 1);
+
+        assert!(find_did_document(&pool, did).await?.is_none());
+        let tombstone =
+            sqlx::query("SELECT revoked, erased_at_ms, document FROM did_documents WHERE did = $1")
+                .bind(did)
+                .fetch_one(&pool)
+                .await?;
+        assert!(tombstone.get::<bool, _>("revoked"));
+        assert_eq!(tombstone.get::<Option<i64>, _>("erased_at_ms"), Some(9_000));
+        assert_eq!(
+            tombstone.get::<JsonValue, _>("document")["schema"],
+            "exo.gateway.did_document_tombstone.v1"
+        );
+        assert!(
+            !insert_did_document(&pool, &doc).await?,
+            "erased DID tombstone must block DID document re-registration"
+        );
+
+        for statement in [
+            "SELECT COUNT(*) FROM sessions WHERE actor_did = $1",
+            "SELECT COUNT(*) FROM users WHERE did = $1",
+            "SELECT COUNT(*) FROM agents WHERE did = $1 OR owner_did = $1",
+            "SELECT COUNT(*) FROM identity_scores WHERE did = $1",
+            "SELECT COUNT(*) FROM enrollment_log WHERE did = $1",
+            "SELECT COUNT(*) FROM livesafe_identities WHERE did = $1",
+            "SELECT COUNT(*) FROM scan_receipts WHERE subscriber_did = $1 OR responder_did = $1",
+            "SELECT COUNT(*) FROM consent_anchors WHERE subscriber_did = $1 OR provider_did = $1",
+            "SELECT COUNT(*) FROM trustee_shard_status WHERE subscriber_did = $1 OR trustee_did = $1",
+            "SELECT COUNT(*) FROM agent_roles WHERE agent_did = $1 OR granted_by = $1",
+            "SELECT COUNT(*) FROM consent_records WHERE subject_did = $1 OR actor_did = $1",
+            "SELECT COUNT(*) FROM authority_chains WHERE actor_did = $1",
+            "SELECT COUNT(*) FROM delegations WHERE delegator = $1 OR delegatee = $1",
+            "SELECT COUNT(*) FROM layout_templates WHERE user_did = $1",
+            "SELECT COUNT(*) FROM feedback_issues WHERE reporter_did = $1",
+            "SELECT COUNT(*) FROM conflict_declarations WHERE declarant_did = $1 OR related_dids @> jsonb_build_array($1::text)",
+        ] {
+            assert_eq!(count_rows_by_did(&pool, statement, did).await?, 0);
+        }
+
+        cleanup_identity_erasure_fixture(&pool, did).await?;
+        Ok(())
     }
 
     #[test]

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -861,6 +861,22 @@ impl AdvancePaceMetadata {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct IdentityErasureMetadata {
+    erased_at: i64,
+}
+
+impl IdentityErasureMetadata {
+    fn from_optional_body(body: Option<&serde_json::Value>) -> Result<Self> {
+        let body = body.ok_or_else(|| {
+            metadata_error("identity erasure requires caller-supplied erasedAt metadata")
+        })?;
+        Ok(Self {
+            erased_at: required_nonzero_i64(body, "erasedAt")?,
+        })
+    }
+}
+
 fn required_nonempty_string(body: &serde_json::Value, field: &str) -> Result<String> {
     let value = body
         .get(field)
@@ -1342,6 +1358,105 @@ async fn handle_identity_score(
                 .into_response()
         }
     }
+}
+
+/// DELETE /api/v1/identity/:did — erase DB-backed gateway identity records.
+///
+/// Requires a DB-backed bearer session whose actor DID exactly matches the path
+/// DID, plus caller-supplied `erasedAt` metadata. The DID document is
+/// tombstoned so the erased DID remains permanently unusable after restart.
+async fn handle_identity_erasure(
+    State(state): State<AppState>,
+    Path(did_str): Path<String>,
+    headers: HeaderMap,
+    body: Option<Json<serde_json::Value>>,
+) -> impl IntoResponse {
+    let did = match Did::new(&did_str) {
+        Ok(d) => d,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": "invalid DID format" })),
+            )
+                .into_response();
+        }
+    };
+    let actor = match state
+        .require_authenticated_session_actor_from_header(&headers)
+        .await
+    {
+        Ok(actor) => actor,
+        Err(e) => return auth_boundary_error_response(e),
+    };
+    if actor != did {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "forbidden",
+                "message": "authenticated session actor does not match identity erasure target"
+            })),
+        )
+            .into_response();
+    }
+    let body_ref = body.as_ref().map(|Json(value)| value);
+    let metadata = match IdentityErasureMetadata::from_optional_body(body_ref) {
+        Ok(metadata) => metadata,
+        Err(e) => return metadata_error_response(e),
+    };
+    let db = match state.require_db() {
+        Ok(pool) => pool,
+        Err(_) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({"error": "database unavailable"})),
+            )
+                .into_response();
+        }
+    };
+    let summary = match db::erase_gateway_identity_records(db, did.as_str(), metadata.erased_at)
+        .await
+    {
+        Ok(summary) => summary,
+        Err(db::GatewayIdentityErasureError::InvalidTimestamp { .. }) => {
+            return metadata_error_response(metadata_error(
+                "identity erasure erasedAt must be a positive non-zero epoch millisecond",
+            ));
+        }
+        Err(e) => return internal_error_response(e, "identity erasure", "identity erasure failed"),
+    };
+
+    let mut erased_records = BTreeMap::new();
+    erased_records.insert("did_documents_tombstoned", summary.did_documents_tombstoned);
+    erased_records.insert("users_deleted", summary.users_deleted);
+    erased_records.insert("agents_deleted", summary.agents_deleted);
+    erased_records.insert("sessions_deleted", summary.sessions_deleted);
+    erased_records.insert("identity_scores_deleted", summary.identity_scores_deleted);
+    erased_records.insert("enrollment_log_deleted", summary.enrollment_log_deleted);
+    erased_records.insert(
+        "livesafe_identities_deleted",
+        summary.livesafe_identities_deleted,
+    );
+    erased_records.insert("scan_receipts_deleted", summary.scan_receipts_deleted);
+    erased_records.insert("consent_anchors_deleted", summary.consent_anchors_deleted);
+    erased_records.insert("trustee_shards_deleted", summary.trustee_shards_deleted);
+    erased_records.insert("agent_roles_deleted", summary.agent_roles_deleted);
+    erased_records.insert("consent_records_deleted", summary.consent_records_deleted);
+    erased_records.insert("authority_chains_deleted", summary.authority_chains_deleted);
+    erased_records.insert("delegations_deleted", summary.delegations_deleted);
+    erased_records.insert("layout_templates_deleted", summary.layout_templates_deleted);
+    erased_records.insert("feedback_issues_deleted", summary.feedback_issues_deleted);
+    erased_records.insert(
+        "conflict_declarations_deleted",
+        summary.conflict_declarations_deleted,
+    );
+
+    Json(serde_json::json!({
+        "status": "identity_erased",
+        "subject_did": did_str,
+        "erased_at": metadata.erased_at,
+        "records": erased_records,
+    }))
+    .into_response()
 }
 
 /// GET /api/v1/tenants/:id/constitution — return the ExoChain constitutional invariants.
@@ -2552,6 +2667,10 @@ fn build_unlayered_router(state: AppState) -> Router {
         )
         // Identity
         .route("/api/v1/identity/:did/score", get(handle_identity_score))
+        .route(
+            "/api/v1/identity/:did",
+            axum::routing::delete(handle_identity_erasure),
+        )
         // Tenant
         .route(
             "/api/v1/tenants/:id/constitution",
@@ -3344,6 +3463,21 @@ mod tests {
         .unwrap();
     }
 
+    async fn cleanup_identity_erasure_route_fixture(pool: &sqlx::PgPool, did: &str) {
+        for statement in [
+            "DELETE FROM did_documents WHERE did = $1",
+            "DELETE FROM sessions WHERE actor_did = $1",
+            "DELETE FROM users WHERE did = $1",
+            "DELETE FROM identity_scores WHERE did = $1",
+        ] {
+            sqlx::query(statement)
+                .bind(did)
+                .execute(pool)
+                .await
+                .unwrap();
+        }
+    }
+
     // --- GatewayConfig / start() (existing tests preserved) ---
 
     #[test]
@@ -3970,7 +4104,7 @@ mod tests {
         let identity_score = source_between(
             source,
             "async fn handle_identity_score",
-            "/// GET /api/v1/identity/status",
+            "/// DELETE /api/v1/identity/:did",
         );
         assert!(
             identity_score.contains("resolve_did_document(&state, did).await"),
@@ -3985,6 +4119,46 @@ mod tests {
         assert!(
             users_list.contains("list_dids(&state).await"),
             "users list must read persisted DID ids when a DB pool is configured"
+        );
+    }
+
+    #[test]
+    fn identity_erasure_route_requires_authenticated_self_session_before_db_write() {
+        let source = include_str!("server.rs");
+        let handler = source_between(
+            source,
+            "async fn handle_identity_erasure",
+            "/// GET /api/v1/tenants/:id/constitution",
+        );
+        let router = source_between(
+            source,
+            "fn build_unlayered_router",
+            "fn gateway_rate_limit_key",
+        );
+        let compact_router: String = router.chars().filter(|ch| !ch.is_whitespace()).collect();
+
+        let auth = handler
+            .find("require_authenticated_session_actor_from_header")
+            .expect("identity erasure must authenticate a bearer session");
+        let self_check = handler
+            .find("if actor != did")
+            .expect("identity erasure must reject path-DID spoofing");
+        let metadata = handler
+            .find("IdentityErasureMetadata::from_optional_body")
+            .expect("identity erasure must require caller-supplied erasure metadata");
+        let db_write = handler
+            .find("db::erase_gateway_identity_records")
+            .expect("identity erasure must call the durable DB erasure helper");
+
+        assert!(
+            auth < self_check && self_check < metadata && metadata < db_write,
+            "identity erasure must authenticate, enforce owner-only path DID, require deterministic metadata, then erase durable records"
+        );
+        assert!(
+            compact_router.contains(
+                "\"/api/v1/identity/:did\",axum::routing::delete(handle_identity_erasure)"
+            ),
+            "gateway must expose a DELETE identity erasure route, not only an in-memory 0dentity route"
         );
     }
 
@@ -4437,6 +4611,85 @@ mod tests {
         let val: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(val["registered"], true);
         assert!(val["score_bps"].as_u64().unwrap() > 0);
+    }
+
+    #[tokio::test]
+    async fn identity_erasure_route_tombstones_did_and_invalidates_session() {
+        use sqlx::Row;
+
+        let pool = match gateway_test_pool().await {
+            Some(pool) => pool,
+            None => return,
+        };
+        let did = "did:exo:erasure-route-subject";
+        cleanup_identity_erasure_route_fixture(&pool, did).await;
+        db::insert_did_document(&pool, &minimal_doc(did))
+            .await
+            .unwrap();
+        insert_test_user(&pool, did, "tenant-erasure-route").await;
+        db::upsert_identity_score(
+            &pool,
+            did,
+            7_500,
+            "Trusted",
+            &serde_json::json!({"registered": true}),
+            10_000,
+        )
+        .await
+        .unwrap();
+        insert_test_session(&pool, "identity-erasure-route-token", did).await;
+
+        let app = build_router(AppState::new(
+            Some(pool.clone()),
+            Arc::new(RwLock::new(LocalDidRegistry::new())),
+        ));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/v1/identity/{did}"))
+                    .header("authorization", "Bearer identity-erasure-route-token")
+                    .header(AUTH_OBSERVED_AT_MS_HEADER, "15000")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"erasedAt":16000}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let val: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(val["status"], "identity_erased");
+        assert_eq!(val["subject_did"], did);
+        assert_eq!(val["records"]["did_documents_tombstoned"], 1);
+        assert_eq!(val["records"]["sessions_deleted"], 1);
+        assert_eq!(val["records"]["users_deleted"], 1);
+        assert_eq!(val["records"]["identity_scores_deleted"], 1);
+
+        assert!(db::find_did_document(&pool, did).await.unwrap().is_none());
+        let tombstone =
+            sqlx::query("SELECT revoked, erased_at_ms FROM did_documents WHERE did = $1")
+                .bind(did)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(tombstone.get::<bool, _>("revoked"));
+        assert_eq!(
+            tombstone.get::<Option<i64>, _>("erased_at_ms"),
+            Some(16_000)
+        );
+        let session_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM sessions WHERE actor_did = $1")
+                .bind(did)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(session_count, 0);
+
+        cleanup_identity_erasure_route_fixture(&pool, did).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Remediates Gauntlet F-054 for the DB-backed gateway runtime adapter. The external claim was stale for the in-memory `0dentity` store itself, which already revokes sessions/claims and emits signed erasure evidence, but it remained live for persisted gateway identity records: the gateway had no DB erasure boundary for DID documents, users, sessions, identity scores, LiveSafe records, adjudication resolver rows, dashboard identity rows, or conflict declarations.

This PR adds an authenticated owner-only `DELETE /api/v1/identity/:did` gateway route and a transactional `erase_gateway_identity_records` DB helper. The DID document is tombstoned with `revoked = true` and `erased_at_ms` so erased DIDs cannot be re-registered after restart; mutable DID-linked gateway rows are deleted in the same transaction.

## Path classification

- `crates/exo-gateway/src/db.rs`: core runtime adapter
- `crates/exo-gateway/src/server.rs`: core runtime adapter
- `crates/exo-gateway/migrations/20260504000004_add_gateway_identity_erasure.sql`: core runtime adapter
- `README.md`: repo-truth metadata

Imported evidence remains read-only. No adjacent surfaces were modified.

## Validation

Red tests were added first and observed failing:

- `cargo test -p exo-gateway gateway_identity_erasure_has_durable_tombstone_schema_and_helper -- --nocapture`
- `cargo test -p exo-gateway identity_erasure_route_requires_authenticated_self_session_before_db_write -- --nocapture`
- Expanded bypass test then failed at compile time until layout templates, feedback issues, and conflict declarations were included.

Passing verification after the fix:

- `cargo test -p exo-gateway erase_gateway_identity -- --nocapture`
- `cargo test -p exo-gateway identity_erasure -- --nocapture`
- `cargo test -p exo-gateway db::tests -- --nocapture`
- `cargo test -p exo-gateway server::tests -- --nocapture`
- `cargo test -p exo-gateway -- --nocapture`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `cargo fmt --all -- --check` (exit 0; existing stable-rustfmt warnings)
- `git diff --check`
- `cargo doc -p exo-gateway --no-deps`
- `cargo test -p exo-gateway --features production-db -- --nocapture`
- `cargo clippy -p exo-gateway --features production-db --all-targets -- -D warnings`
- `bash tools/repo_truth.sh --json --list-tests`
- `bash tools/test_repo_truth.sh`

## Boundary notes

The helper covers mutable DB-backed identity/runtime-adapter tables. Immutable governance/audit ledger redaction is not bundled here because mutating `decisions` or `audit_entries` would affect provenance hash semantics and needs a separate redaction-proof design rather than an identity-table deletion.
