### PR TITLE
fix(gateway): redact DID diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 160388 | `wc -l` |
-| Workspace tests | 3,960 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 160631 | `wc -l` |
+| Workspace tests | 3,968 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -80,7 +80,7 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 160388 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 160631 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 3,960 listed workspace tests
 

--- a/crates/exo-gateway/src/auth.rs
+++ b/crates/exo-gateway/src/auth.rs
@@ -292,7 +292,7 @@ pub fn authenticate(
 ) -> Result<AuthenticatedActor> {
     // 1. Validate DID format.
     let did = Did::new(&request.actor_did).map_err(|_| GatewayError::AuthenticationFailed {
-        reason: format!("invalid DID: {}", request.actor_did),
+        reason: "invalid DID".into(),
     })?;
 
     // 2. Reject empty / all-zero signatures (covers Signature::Empty and
@@ -310,7 +310,7 @@ pub fn authenticate(
     let doc = registry
         .resolve(&did)
         .ok_or_else(|| GatewayError::AuthenticationFailed {
-            reason: format!("DID not registered: {}", request.actor_did),
+            reason: "DID not registered".into(),
         })?;
 
     // 5. Find the first active verification method.
@@ -319,10 +319,7 @@ pub fn authenticate(
         .iter()
         .find(|m| m.active)
         .ok_or_else(|| GatewayError::AuthenticationFailed {
-            reason: format!(
-                "no active verification method for DID: {}",
-                request.actor_did
-            ),
+            reason: "no active verification method for DID".into(),
         })?;
 
     // 6. Cryptographically verify the Ed25519 signature over body_hash.
@@ -548,6 +545,47 @@ mod tests {
     }
 
     #[test]
+    fn authentication_failure_messages_do_not_echo_request_dids() {
+        let (reg, _) = registry_with_alice();
+        let signature = Signature::from_bytes({
+            let mut s = [0u8; 64];
+            s[0] = 1;
+            s
+        });
+        let invalid_raw_did = "not-a-did-private-identifier";
+        let invalid_request = Request {
+            actor_did: invalid_raw_did.into(),
+            action: "read".into(),
+            body_hash: Hash256::ZERO,
+            signature: signature.clone(),
+            timestamp: req_ts(),
+        };
+        let invalid_error = authenticate(&invalid_request, &reg, auth_metadata())
+            .expect_err("invalid DID must be rejected")
+            .to_string();
+        assert!(
+            !invalid_error.contains(invalid_raw_did),
+            "authentication errors must not echo malformed DID input: {invalid_error}"
+        );
+
+        let unregistered_did = "did:exo:privacy-sensitive-subject";
+        let unregistered_request = Request {
+            actor_did: unregistered_did.into(),
+            action: "read".into(),
+            body_hash: Hash256::ZERO,
+            signature,
+            timestamp: req_ts(),
+        };
+        let unregistered_error = authenticate(&unregistered_request, &reg, auth_metadata())
+            .expect_err("unknown DID must be rejected")
+            .to_string();
+        assert!(
+            !unregistered_error.contains(unregistered_did),
+            "authentication errors must not echo unknown DIDs: {unregistered_error}"
+        );
+    }
+
+    #[test]
     fn auth_empty_sig() {
         let (reg, _) = registry_with_alice();
         let r = Request {
@@ -687,6 +725,26 @@ mod tests {
             !production.contains(&forbidden_system_time),
             "gateway auth must not read wall-clock time"
         );
+    }
+
+    #[test]
+    fn auth_production_does_not_format_request_dids_into_errors() {
+        let source = include_str!("auth.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production section");
+
+        for pattern in [
+            r#"format!("invalid DID: {}", request.actor_did)"#,
+            r#"format!("DID not registered: {}", request.actor_did)"#,
+            r#"format!("no active verification method for DID: {}", request.actor_did)"#,
+        ] {
+            assert!(
+                !production.contains(pattern),
+                "authentication diagnostics must not format raw request DIDs: {pattern}"
+            );
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/crates/exo-gateway/src/db.rs
+++ b/crates/exo-gateway/src/db.rs
@@ -44,25 +44,25 @@ pub enum DecisionUpdateError {
 
 #[derive(Debug, Error)]
 pub enum DidDocumentPersistenceError {
-    #[error("DID document timestamp is out of database range for {did} field {field}: {value}")]
+    #[error("DID document timestamp is out of database range for field {field}: {value}")]
     TimestampOutOfRange {
         did: String,
         field: &'static str,
         value: u64,
     },
-    #[error("failed to serialize DID document for {did}")]
+    #[error("failed to serialize DID document")]
     Serialize {
         did: String,
         #[source]
         source: serde_json::Error,
     },
-    #[error("failed to deserialize persisted DID document for {did}")]
+    #[error("failed to deserialize persisted DID document")]
     Deserialize {
         did: String,
         #[source]
         source: serde_json::Error,
     },
-    #[error("persisted DID document row key {row_did} does not match payload id {document_did}")]
+    #[error("persisted DID document row key does not match payload id")]
     DocumentDidMismatch {
         row_did: String,
         document_did: String,
@@ -1768,6 +1768,46 @@ mod tests {
         assert!(list_source.contains("FROM did_documents"));
         assert!(list_source.contains("LIMIT $"));
         assert!(list_source.contains(".bind(MAX_DB_LIST_ROWS)"));
+    }
+
+    #[test]
+    fn did_document_persistence_errors_do_not_display_raw_dids() {
+        let sensitive_did = "did:exo:persistence-sensitive-subject";
+        let payload_did = "did:exo:persistence-payload-subject";
+        let serde_source =
+            serde_json::from_str::<serde_json::Value>("{").expect_err("invalid JSON source");
+
+        let errors = [
+            DidDocumentPersistenceError::TimestampOutOfRange {
+                did: sensitive_did.to_owned(),
+                field: "created",
+                value: 42,
+            }
+            .to_string(),
+            DidDocumentPersistenceError::Serialize {
+                did: sensitive_did.to_owned(),
+                source: serde_source,
+            }
+            .to_string(),
+            DidDocumentPersistenceError::Deserialize {
+                did: sensitive_did.to_owned(),
+                source: serde_json::from_str::<serde_json::Value>("{")
+                    .expect_err("invalid JSON source"),
+            }
+            .to_string(),
+            DidDocumentPersistenceError::DocumentDidMismatch {
+                row_did: sensitive_did.to_owned(),
+                document_did: payload_did.to_owned(),
+            }
+            .to_string(),
+        ];
+
+        for error in errors {
+            assert!(
+                !error.contains(sensitive_did) && !error.contains(payload_did),
+                "persistence error display must not expose raw DID identifiers: {error}"
+            );
+        }
     }
 
     #[test]

--- a/crates/exo-gateway/src/handlers.rs
+++ b/crates/exo-gateway/src/handlers.rs
@@ -657,7 +657,7 @@ pub async fn vote_handler(
     )
     .await
     {
-        tracing::error!(error = %e, voter_did = %body.voter_did, "audit write failed");
+        tracing::error!(error = %e, "audit write failed");
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({"error": "audit write failed"})),
@@ -828,6 +828,26 @@ mod tests {
             assert!(
                 !production.contains(pattern),
                 "HTTP response bodies must not expose raw internal error details: {pattern}"
+            );
+        }
+    }
+
+    #[test]
+    fn handlers_do_not_emit_raw_did_fields_to_error_logs() {
+        let source = include_str!("handlers.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("test module marker present");
+
+        for pattern in [
+            "voter_did = %body.voter_did",
+            "actor_did = %",
+            "subject_did = %",
+        ] {
+            assert!(
+                !production.contains(pattern),
+                "handler logs must not emit raw DID identifiers: {pattern}"
             );
         }
     }

--- a/crates/exo-gateway/src/middleware.rs
+++ b/crates/exo-gateway/src/middleware.rs
@@ -51,12 +51,12 @@ impl AuditLog {
 }
 
 /// Consent check — default-deny. Returns Ok if consent is explicitly granted.
-pub fn consent_middleware(actor: &Did, _action: &str, consent_granted: bool) -> Result<()> {
+pub fn consent_middleware(_actor: &Did, _action: &str, consent_granted: bool) -> Result<()> {
     if consent_granted {
         Ok(())
     } else {
         Err(GatewayError::ConsentDenied {
-            reason: format!("no consent for {actor}"),
+            reason: "no active consent for actor".into(),
         })
     }
 }
@@ -117,6 +117,20 @@ mod tests {
     fn consent_denied() {
         assert!(consent_middleware(&did("a"), "read", false).is_err());
     }
+
+    #[test]
+    fn consent_denial_does_not_display_raw_did() {
+        let sensitive_did = did("privacy-sensitive-consent-subject");
+        let error = consent_middleware(&sensitive_did, "read", false)
+            .expect_err("missing consent must be rejected")
+            .to_string();
+
+        assert!(
+            !error.contains(sensitive_did.as_str()),
+            "consent denial display must not expose raw DID identifiers: {error}"
+        );
+    }
+
     #[test]
     fn governance_allow() {
         assert!(governance_middleware(&did("a"), "r", &Verdict::Allow).is_ok());

--- a/crates/exo-gateway/src/routes.rs
+++ b/crates/exo-gateway/src/routes.rs
@@ -94,9 +94,9 @@ pub fn process_request(
 }
 
 /// Default-deny: a request with no consent is always rejected.
-pub fn default_deny_check(actor: &Did, action: &str) -> Result<()> {
+pub fn default_deny_check(_actor: &Did, action: &str) -> Result<()> {
     Err(GatewayError::ConsentDenied {
-        reason: format!("default-deny: {actor} cannot {action} without explicit consent"),
+        reason: format!("default-deny: {action} requires explicit consent"),
     })
 }
 
@@ -291,6 +291,20 @@ mod tests {
         let did = Did::new("did:exo:alice").unwrap();
         assert!(default_deny_check(&did, "write").is_err());
     }
+
+    #[test]
+    fn default_deny_does_not_display_raw_did() {
+        let sensitive_did = Did::new("did:exo:privacy-sensitive-route-subject").unwrap();
+        let error = default_deny_check(&sensitive_did, "write")
+            .expect_err("default deny must reject missing consent")
+            .to_string();
+
+        assert!(
+            !error.contains(sensitive_did.as_str()),
+            "default-deny display must not expose raw DID identifiers: {error}"
+        );
+    }
+
     #[test]
     fn route_serde() {
         for r in [

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -426,7 +426,6 @@ impl AppState {
                 Ok(ctx) => return ctx,
                 Err(e) => {
                     tracing::warn!(
-                        actor = %actor,
                         error = %e,
                         "DB adjudication context query failed; falling back to WO-009 scaffold"
                     );
@@ -457,10 +456,27 @@ enum RegistryBlockingError {
     Join(String),
 }
 
+fn identity_registration_log_reason(error: &IdentityError) -> &'static str {
+    match error {
+        IdentityError::DuplicateDid(_) => "duplicate_did",
+        IdentityError::RegistryCapacityExceeded { .. } => "registry_capacity_exceeded",
+        IdentityError::InvalidDidDocumentField { .. } => "invalid_did_document_field",
+        IdentityError::DidDocumentFieldTooLarge { .. } => "did_document_field_too_large",
+        IdentityError::DidRevoked(_) => "did_revoked",
+        IdentityError::NonMonotonicTimestamp { .. } => "non_monotonic_timestamp",
+        IdentityError::DuplicatePaceDid(_) => "duplicate_pace_did",
+        _ => "identity_registration_failed",
+    }
+}
+
 impl fmt::Display for RegistryBlockingError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Registration(error) => write!(f, "registry registration failed: {error}"),
+            Self::Registration(error) => write!(
+                f,
+                "registry registration failed: {}",
+                identity_registration_log_reason(error)
+            ),
             Self::Authentication(error) => write!(f, "registry authentication failed: {error}"),
             Self::Persistence(error) => write!(f, "registry persistence failed: {error}"),
             Self::Join(error) => write!(f, "registry blocking task failed: {error}"),
@@ -680,10 +696,9 @@ fn validate_conflict_declaration(
     declaration: ConflictDeclaration,
 ) -> std::result::Result<ConflictDeclaration, GatewayError> {
     if &declaration.declarant_did != actor {
-        return Err(GatewayError::Internal(format!(
-            "stored conflict declaration for {} was returned while loading {}",
-            declaration.declarant_did, actor
-        )));
+        return Err(GatewayError::Internal(
+            "stored conflict declaration was returned for a different declarant".into(),
+        ));
     }
     if declaration.nature.trim().is_empty() {
         return Err(GatewayError::Internal(
@@ -1040,8 +1055,8 @@ fn build_adjudication_context_from_rows(
                 "judicial" => GovernmentBranch::Judicial,
                 other => {
                     return Err(GatewayError::Internal(format!(
-                        "adjudication role row unknown role branch for actor '{}' role '{}': '{}'",
-                        r.agent_did, r.role, other
+                        "adjudication role row unknown role branch for role '{}': '{}'",
+                        r.role, other
                     )));
                 }
             };
@@ -1055,10 +1070,10 @@ fn build_adjudication_context_from_rows(
     let consent_records: Vec<ConsentRecord> = consent_rows
         .iter()
         .map(|r| {
-            let subject = Did::new(&r.subject_did).map_err(|e| {
+            let subject = Did::new(&r.subject_did).map_err(|_| {
                 GatewayError::Internal(format!(
-                    "adjudication consent subject DID invalid for actor '{}' scope '{}': '{}' ({e})",
-                    r.actor_did, r.scope, r.subject_did
+                    "adjudication consent subject DID invalid for scope '{}'",
+                    r.scope
                 ))
             })?;
             Ok(ConsentRecord {
@@ -1072,10 +1087,10 @@ fn build_adjudication_context_from_rows(
 
     let bailment_state = match consent_rows.iter().find(|r| r.status == "active") {
         Some(r) => {
-            let bailor = Did::new(&r.subject_did).map_err(|e| {
+            let bailor = Did::new(&r.subject_did).map_err(|_| {
                 GatewayError::Internal(format!(
-                    "adjudication consent subject DID invalid for active bailment actor '{}' scope '{}': '{}' ({e})",
-                    r.actor_did, r.scope, r.subject_did
+                    "adjudication consent subject DID invalid for active bailment scope '{}'",
+                    r.scope
                 ))
             })?;
             GkBailment::Active {
@@ -1089,10 +1104,7 @@ fn build_adjudication_context_from_rows(
 
     let authority_chain = match chain_row {
         Some(row) => serde_json::from_value::<GkChain>(row.chain_json.clone()).map_err(|e| {
-            GatewayError::Internal(format!(
-                "adjudication authority chain JSON invalid for actor '{}': {e}",
-                row.actor_did
-            ))
+            GatewayError::Internal(format!("adjudication authority chain JSON invalid: {e}"))
         })?,
         None => GkChain::default(),
     };
@@ -1194,7 +1206,10 @@ async fn handle_auth_register(
         )
             .into_response(),
         Err(RegistryBlockingError::Registration(e)) => {
-            tracing::warn!(error = %e, did = %did_str, "DID registration rejected");
+            tracing::warn!(
+                reason = identity_registration_log_reason(&e),
+                "DID registration rejected"
+            );
             did_registration_rejection_response(e, "DID already registered")
         }
         Err(e) => {
@@ -1629,7 +1644,10 @@ async fn handle_agents_enroll(
         )
             .into_response(),
         Err(RegistryBlockingError::Registration(e)) => {
-            tracing::warn!(error = %e, did = %did_str, "agent enrollment rejected");
+            tracing::warn!(
+                reason = identity_registration_log_reason(&e),
+                "agent enrollment rejected"
+            );
             did_registration_rejection_response(e, "DID already enrolled")
         }
         Err(e) => {
@@ -2087,10 +2105,8 @@ async fn require_authenticated_session_actor_for_token(
     let actor_did = actor_did.ok_or_else(|| GatewayError::AuthenticationFailed {
         reason: "session token expired, revoked, or not found".to_owned(),
     })?;
-    Did::new(&actor_did).map_err(|e| {
-        GatewayError::Internal(format!(
-            "session actor DID stored in database is invalid: {actor_did}: {e}"
-        ))
+    Did::new(&actor_did).map_err(|_| {
+        GatewayError::Internal("session actor DID stored in database is invalid".into())
     })
 }
 
@@ -4159,6 +4175,87 @@ mod tests {
                 "\"/api/v1/identity/:did\",axum::routing::delete(handle_identity_erasure)"
             ),
             "gateway must expose a DELETE identity erasure route, not only an in-memory 0dentity route"
+        );
+    }
+
+    #[test]
+    fn gateway_production_logs_do_not_emit_raw_did_identifiers() {
+        let source = include_str!("server.rs");
+        let production = source
+            .split("// ---------------------------------------------------------------------------\n// Tests")
+            .next()
+            .expect("tests marker present");
+
+        for pattern in [
+            "actor = %actor",
+            "did = %did_str",
+            "actor_did = %",
+            "subject_did = %",
+            "declarant_did = %",
+        ] {
+            assert!(
+                !production.contains(pattern),
+                "gateway logs must not emit raw DID identifiers: {pattern}"
+            );
+        }
+    }
+
+    #[test]
+    fn gateway_internal_errors_do_not_display_raw_did_identifiers() {
+        let actor = Did::new("did:exo:privacy-sensitive-actor").unwrap();
+        let related = Did::new("did:exo:privacy-sensitive-related").unwrap();
+        let declaration = ConflictDeclaration {
+            declarant_did: related.clone(),
+            nature: "financial conflict".into(),
+            related_dids: vec![actor.clone()],
+            timestamp: Timestamp::new(1, 0),
+        };
+        let conflict_error = validate_conflict_declaration(&actor, declaration)
+            .expect_err("mismatched stored declaration must be rejected")
+            .to_string();
+        assert!(
+            !conflict_error.contains(actor.as_str()) && !conflict_error.contains(related.as_str()),
+            "stored conflict declaration errors must not expose raw DID identifiers: {conflict_error}"
+        );
+
+        let role_rows = vec![crate::db::AgentRoleRow {
+            agent_did: actor.as_str().to_owned(),
+            role: "voter".to_owned(),
+            branch: "tribunal".to_owned(),
+            granted_by: related.as_str().to_owned(),
+            valid_from: 1,
+            expires_at: None,
+        }];
+        let role_error = build_adjudication_context_from_rows(&actor, &role_rows, &[], None)
+            .expect_err("unknown role branch must be rejected")
+            .to_string();
+        assert!(
+            !role_error.contains(actor.as_str()) && !role_error.contains(related.as_str()),
+            "adjudication role errors must not expose raw DID identifiers: {role_error}"
+        );
+
+        let consent_rows = vec![crate::db::ConsentRecordRow {
+            subject_did: related.as_str().to_owned(),
+            actor_did: actor.as_str().to_owned(),
+            scope: "data:vote".to_owned(),
+            bailment_type: "standard".to_owned(),
+            status: "active".to_owned(),
+            created_at: 1,
+            expires_at: None,
+        }];
+        let chain_row = crate::db::AuthorityChainRow {
+            actor_did: actor.as_str().to_owned(),
+            chain_json: serde_json::json!({ "links": "not-an-array" }),
+            valid_from: 1,
+            expires_at: None,
+        };
+        let chain_error =
+            build_adjudication_context_from_rows(&actor, &[], &consent_rows, Some(&chain_row))
+                .expect_err("malformed authority chain JSON must be rejected")
+                .to_string();
+        assert!(
+            !chain_error.contains(actor.as_str()) && !chain_error.contains(related.as_str()),
+            "adjudication chain errors must not expose raw DID identifiers: {chain_error}"
         );
     }
 


### PR DESCRIPTION
## Summary
- Remediates F-055 after validating the original zerodentity API redaction was already present on current main.
- Redacts raw DID values from gateway authentication failure messages, consent/default-deny diagnostics, DID document persistence error displays, adjudication/internal errors, and structured error-log fields.
- Adds regression/source-guard coverage for raw DID exposure in gateway logs and diagnostics; updates README repo-truth counts from the verified repo-truth command.

## Path classification
- `crates/exo-gateway/src/auth.rs` - Core runtime adapter
- `crates/exo-gateway/src/db.rs` - Core runtime adapter
- `crates/exo-gateway/src/handlers.rs` - Core runtime adapter
- `crates/exo-gateway/src/middleware.rs` - Core runtime adapter
- `crates/exo-gateway/src/routes.rs` - Core runtime adapter
- `crates/exo-gateway/src/server.rs` - Core runtime adapter
- `README.md` - Repo-truth metadata

## Validation
- RED observed: `cargo test -p exo-gateway raw_did -- --nocapture` failed on raw gateway DID log/error exposures.
- RED observed: `cargo test -p exo-gateway request_dids -- --nocapture` failed on auth error DID echo.
- GREEN: `cargo test -p exo-gateway raw_did -- --nocapture`
- GREEN: `cargo test -p exo-gateway request_dids -- --nocapture`
- PASS: `cargo test -p exo-gateway -- --nocapture`
- PASS: `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- PASS: `cargo test -p exo-gateway --features production-db -- --nocapture`
- PASS: `cargo clippy -p exo-gateway --features production-db --all-targets -- -D warnings`
- PASS: `cargo fmt --all -- --check` (stable rustfmt prints existing unstable-option warnings)
- PASS: `cargo doc -p exo-gateway --no-deps`
- PASS: `cargo test -p exo-node zerodentity -- --nocapture`
- PASS: production-source raw-DID logging/error bypass scan for changed gateway files
- PASS: production-source determinism scan for changed gateway files; matches were comments only for HashMap references
- PASS: `git diff --check`
- PASS: `bash tools/repo_truth.sh --json --list-tests` (`rust_loc=160631`, `tests_listed=3968`, `fmt_clean=false` due existing stable-rustfmt warning behavior)
- PASS: `bash tools/test_repo_truth.sh`
