### PR TITLE
fix(gateway): route decision create to create handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 160778 | `wc -l` |
-| Workspace tests | 3,971 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 161158 | `wc -l` |
+| Workspace tests | 3,974 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,960 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,974 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -80,9 +80,9 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 160778 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 161158 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,971 listed workspace tests
+         cryptographic proofs, 3,974 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-gateway/src/db.rs
+++ b/crates/exo-gateway/src/db.rs
@@ -44,6 +44,17 @@ pub enum DecisionUpdateError {
 }
 
 #[derive(Debug, Error)]
+pub enum DecisionCreateError {
+    #[error("decision already exists for id_hash {id_hash}")]
+    AlreadyExists { id_hash: String },
+    #[error("failed to create decision row")]
+    Query {
+        #[source]
+        source: sqlx::Error,
+    },
+}
+
+#[derive(Debug, Error)]
 pub enum DidDocumentPersistenceError {
     #[error("DID document timestamp is out of database range for field {field}: {value}")]
     TimestampOutOfRange {
@@ -651,6 +662,45 @@ pub async fn insert_decision(
     .bind(id_hash).bind(tenant_id).bind(status).bind(title).bind(decision_class)
     .bind(author).bind(created_at_ms).bind(constitution_version).bind(payload)
     .execute(pool).await?;
+    Ok(())
+}
+
+/// Create a new decision row without mutating an existing id.
+#[allow(clippy::too_many_arguments)]
+pub async fn create_decision(
+    pool: &PgPool,
+    id_hash: &str,
+    tenant_id: &str,
+    status: &str,
+    title: &str,
+    decision_class: &str,
+    author: &str,
+    created_at_ms: i64,
+    constitution_version: &str,
+    payload: &JsonValue,
+) -> Result<(), DecisionCreateError> {
+    let result = sqlx::query(
+        "INSERT INTO decisions (id_hash, tenant_id, status, title, decision_class, author, created_at_ms, constitution_version, payload)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+         ON CONFLICT (id_hash) DO NOTHING"
+    )
+    .bind(id_hash)
+    .bind(tenant_id)
+    .bind(status)
+    .bind(title)
+    .bind(decision_class)
+    .bind(author)
+    .bind(created_at_ms)
+    .bind(constitution_version)
+    .bind(payload)
+    .execute(pool)
+    .await
+    .map_err(|source| DecisionCreateError::Query { source })?;
+    if result.rows_affected() == 0 {
+        return Err(DecisionCreateError::AlreadyExists {
+            id_hash: id_hash.to_owned(),
+        });
+    }
     Ok(())
 }
 
@@ -2281,6 +2331,37 @@ mod tests {
         assert!(
             contains_in_order(lookup, ".bind(id_hash)", ".bind(tenant_id)"),
             "find_decision must bind id_hash and tenant_id together"
+        );
+    }
+
+    #[test]
+    fn create_decision_inserts_once_without_upsert_overwrite() {
+        let source = production_source();
+        let create = function_source(source, "create_decision");
+
+        assert!(
+            source.contains("pub enum DecisionCreateError"),
+            "create_decision must return typed duplicate-decision errors"
+        );
+        assert!(
+            create.contains("-> Result<(), DecisionCreateError>"),
+            "create_decision must distinguish duplicate ids from SQL failures"
+        );
+        assert!(
+            compact_sql(create).contains("ON CONFLICT (id_hash) DO NOTHING"),
+            "decision creation must not overwrite an existing decision row"
+        );
+        assert!(
+            create.contains("rows_affected()"),
+            "decision creation must inspect PgQueryResult row count"
+        );
+        assert!(
+            create.contains("DecisionCreateError::AlreadyExists"),
+            "decision creation must report a conflict when the id already exists"
+        );
+        assert!(
+            !create.contains("DO UPDATE"),
+            "decision creation must not silently mutate a pre-existing decision"
         );
     }
 

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -8,7 +8,7 @@ use std::{
 
 use axum::{
     Router,
-    body::Body,
+    body::{Body, Bytes},
     extract::{ConnectInfo, DefaultBodyLimit, Path, State},
     http::{HeaderMap, HeaderName, HeaderValue, Method, Request, StatusCode, header},
     middleware::{self, Next},
@@ -16,6 +16,7 @@ use axum::{
     routing::{get, post},
 };
 use axum_server::tls_rustls::RustlsConfig;
+use decision_forum::decision_object::{DecisionClass, DecisionObject, DecisionObjectInput};
 use exo_core::{Did, Hash256, Signature, Timestamp, hlc::HybridClock};
 use exo_gatekeeper::{
     invariants::InvariantSet,
@@ -48,7 +49,7 @@ use crate::{
     db,
     error::{GatewayError, Result},
     graphql,
-    handlers::{health_handler as db_health_handler, vote_handler},
+    handlers::health_handler as db_health_handler,
     rest::HealthResponse,
 };
 
@@ -275,6 +276,18 @@ pub struct AppState {
 pub struct AuthenticatedSessionUser {
     pub did: Did,
     pub tenant_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DecisionCreateRequest {
+    id: String,
+    title: String,
+    decision_class: String,
+    constitutional_hash: String,
+    created_at_physical_ms: u64,
+    created_at_logical: u32,
+    constitution_version: String,
 }
 
 impl AppState {
@@ -953,6 +966,47 @@ fn required_ed25519_signature_hex(body: &serde_json::Value, field: &str) -> Resu
     Ok(signature)
 }
 
+fn parse_decision_uuid(raw: &str, field: &str) -> Result<uuid::Uuid> {
+    let uuid = uuid::Uuid::parse_str(raw.trim())
+        .map_err(|e| metadata_error(format!("{field} must be a valid UUID: {e}")))?;
+    if uuid.is_nil() {
+        return Err(metadata_error(format!("{field} must not be the nil UUID")));
+    }
+    Ok(uuid)
+}
+
+fn parse_decision_class(raw: &str) -> Result<DecisionClass> {
+    match raw.trim() {
+        "Routine" => Ok(DecisionClass::Routine),
+        "Operational" => Ok(DecisionClass::Operational),
+        "Strategic" => Ok(DecisionClass::Strategic),
+        "Constitutional" => Ok(DecisionClass::Constitutional),
+        other => Err(metadata_error(format!(
+            "decision_class must be one of Routine, Operational, Strategic, Constitutional; got {other}"
+        ))),
+    }
+}
+
+fn parse_hash256_hex(raw: &str, field: &str) -> Result<Hash256> {
+    let encoded = raw.trim();
+    let mut bytes = [0u8; 32];
+    hex::decode_to_slice(encoded, &mut bytes)
+        .map_err(|e| metadata_error(format!("{field} must be 32 bytes of hex: {e}")))?;
+    let hash = Hash256::from_bytes(bytes);
+    if hash == Hash256::ZERO {
+        return Err(metadata_error(format!("{field} must not be all-zero")));
+    }
+    Ok(hash)
+}
+
+fn required_nonempty_trimmed(raw: &str, field: &str) -> Result<String> {
+    let value = raw.trim();
+    if value.is_empty() {
+        return Err(metadata_error(format!("{field} must not be empty")));
+    }
+    Ok(value.to_owned())
+}
+
 fn session_login_payload_hash(
     did: &str,
     metadata: &SessionIssueMetadata,
@@ -1538,6 +1592,142 @@ async fn handle_users_list(State(state): State<AppState>, headers: HeaderMap) ->
                 Json(serde_json::json!({ "error": "DID registry unavailable" })),
             )
                 .into_response()
+        }
+    }
+}
+
+/// POST /api/v1/decisions — create a new tenant-scoped decision record.
+///
+/// Requires a DB-backed bearer session. The tenant and author are derived from
+/// that session, while the decision id, constitutional hash, and HLC timestamp
+/// are caller-supplied to keep the runtime adapter deterministic.
+async fn handle_decision_create(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> impl IntoResponse {
+    let actor = match require_authenticated_session_user_from_header(&state, &headers).await {
+        Ok(actor) => actor,
+        Err(e) => return auth_boundary_error_response(e),
+    };
+    let request = match serde_json::from_slice::<DecisionCreateRequest>(&body) {
+        Ok(request) => request,
+        Err(e) => {
+            return metadata_error_response(metadata_error(format!(
+                "decision create request must be valid JSON: {e}"
+            )));
+        }
+    };
+    let id = match parse_decision_uuid(&request.id, "id") {
+        Ok(id) => id,
+        Err(e) => return metadata_error_response(e),
+    };
+    let title = match required_nonempty_trimmed(&request.title, "title") {
+        Ok(title) => title,
+        Err(e) => return metadata_error_response(e),
+    };
+    let class = match parse_decision_class(&request.decision_class) {
+        Ok(class) => class,
+        Err(e) => return metadata_error_response(e),
+    };
+    let constitutional_hash =
+        match parse_hash256_hex(&request.constitutional_hash, "constitutional_hash") {
+            Ok(hash) => hash,
+            Err(e) => return metadata_error_response(e),
+        };
+    let created_at = Timestamp::new(request.created_at_physical_ms, request.created_at_logical);
+    if request.created_at_physical_ms == 0 {
+        return metadata_error_response(metadata_error(
+            "created_at_physical_ms must be caller-supplied and non-zero",
+        ));
+    }
+    let created_at_ms = match i64::try_from(created_at.physical_ms) {
+        Ok(value) => value,
+        Err(_) => {
+            return metadata_error_response(metadata_error(
+                "created_at_physical_ms must fit in PostgreSQL BIGINT",
+            ));
+        }
+    };
+    let constitution_version =
+        match required_nonempty_trimmed(&request.constitution_version, "constitution_version") {
+            Ok(version) => version,
+            Err(e) => return metadata_error_response(e),
+        };
+
+    let decision = match DecisionObject::new(DecisionObjectInput {
+        id,
+        title,
+        class,
+        constitutional_hash,
+        created_at,
+    }) {
+        Ok(decision) => decision,
+        Err(e) => {
+            return metadata_error_response(metadata_error(format!(
+                "invalid decision object: {e}"
+            )));
+        }
+    };
+    let content_hash = match decision.content_hash() {
+        Ok(hash) => hash,
+        Err(e) => {
+            return internal_error_response(e, "decision content hash", "decision creation failed");
+        }
+    };
+    let id_hash = content_hash.to_string();
+    let decision_class = decision.class.quorum_policy_key();
+    let status = decision.state.as_str();
+    let author = actor.did.as_str();
+    let payload = serde_json::json!({
+        "schema": "exo.gateway.decision_create.v1",
+        "id_hash": id_hash.as_str(),
+        "id": decision.id.to_string(),
+        "tenant_id": actor.tenant_id.as_str(),
+        "status": status,
+        "title": decision.title.as_str(),
+        "decision_class": decision_class,
+        "author": author,
+        "created_at": {
+            "physical_ms": decision.created_at.physical_ms,
+            "logical": decision.created_at.logical
+        },
+        "constitutional_hash": constitutional_hash.to_string(),
+        "constitution_version": constitution_version.as_str(),
+        "content_hash": id_hash.as_str()
+    });
+    let db = match state.require_db() {
+        Ok(pool) => pool,
+        Err(_) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({"error": "database unavailable"})),
+            )
+                .into_response();
+        }
+    };
+    match db::create_decision(
+        db,
+        &id_hash,
+        &actor.tenant_id,
+        status,
+        &decision.title,
+        decision_class,
+        author,
+        created_at_ms,
+        &constitution_version,
+        &payload,
+    )
+    .await
+    {
+        Ok(()) => (StatusCode::CREATED, Json(payload)).into_response(),
+        Err(db::DecisionCreateError::AlreadyExists { .. }) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({ "error": "decision already exists" })),
+        )
+            .into_response(),
+        Err(db::DecisionCreateError::Query { source }) => {
+            internal_error_response(source, "decision create query", "decision creation failed")
         }
     }
 }
@@ -2653,9 +2843,9 @@ fn build_unlayered_router(state: AppState) -> Router {
         .route("/ready", get(handle_ready))
         // DB health deep probe (requires pool to be configured)
         .route("/health/db", get(db_health_handler))
-        // Decisions — vote handler enforces ConflictAdjudication + TNC-01
+        // Decisions — create and read tenant-scoped governance records.
         .route("/api/v1/decisions/:id", get(handle_decision_get))
-        .route("/api/v1/decisions", post(vote_handler))
+        .route("/api/v1/decisions", post(handle_decision_create))
         // Auth
         .route("/api/v1/auth/token", post(handle_auth_token))
         .route(
@@ -3927,6 +4117,11 @@ mod tests {
         let users_list = source_between(
             source,
             "async fn handle_users_list",
+            "/// POST /api/v1/decisions",
+        );
+        let decision_create = source_between(
+            source,
+            "async fn handle_decision_create",
             "/// GET /api/v1/decisions/:id",
         );
         let decision_get = source_between(
@@ -3944,6 +4139,7 @@ mod tests {
             ("agents list", agents_list, "list_dids"),
             ("agent get", agent_get, "resolve_did_document"),
             ("users list", users_list, "list_dids"),
+            ("decision create", decision_create, "state.require_db"),
             ("decision get", decision_get, "state.require_db"),
             ("audit trail", audit_trail, "state.require_db"),
         ] {
@@ -3981,6 +4177,26 @@ mod tests {
         assert!(
             !handler.contains("SELECT payload FROM decisions WHERE id_hash = $1"),
             "decision get must not perform an unscoped id_hash lookup"
+        );
+    }
+
+    #[test]
+    fn decision_post_route_dispatches_to_create_handler_not_vote_handler() {
+        let source = include_str!("server.rs");
+        let router = source_between(
+            source,
+            "fn build_unlayered_router",
+            "fn gateway_rate_limit_key",
+        );
+        let compact_router: String = router.chars().filter(|ch| !ch.is_whitespace()).collect();
+
+        assert!(
+            compact_router.contains(".route(\"/api/v1/decisions\",post(handle_decision_create))"),
+            "POST /api/v1/decisions must create a decision, matching RestRoute::CreateDecision"
+        );
+        assert!(
+            !compact_router.contains(".route(\"/api/v1/decisions\",post(vote_handler))"),
+            "POST /api/v1/decisions must not dispatch create requests to the vote handler"
         );
     }
 
@@ -4130,7 +4346,7 @@ mod tests {
         let users_list = source_between(
             source,
             "async fn handle_users_list",
-            "/// GET /api/v1/decisions/:id",
+            "/// POST /api/v1/decisions",
         );
         assert!(
             users_list.contains("list_dids(&state).await"),
@@ -4640,16 +4856,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn vote_route_missing_session_returns_401_before_conflict_register_lookup() {
+    async fn decision_create_shape_missing_session_returns_401_not_vote_schema_error() {
         let body = serde_json::to_string(&serde_json::json!({
-            "decision_id": "d1",
-            "voter_did": "did:exo:alice",
-            "affected_dids": ["did:exo:tenant-a"],
-            "choice": "Approve",
-            "actor_kind": "Human",
-            "rationale": null,
-            "timestamp_physical_ms": 7000,
-            "timestamp_logical": 0,
+            "id": "00000000-0000-0000-0000-000000000060",
+            "title": "F-060 route contract regression",
+            "decision_class": "Routine",
+            "constitutional_hash": "1111111111111111111111111111111111111111111111111111111111111111",
+            "created_at_physical_ms": 7000,
+            "created_at_logical": 0,
+            "constitution_version": "exochain-constitution-v1"
         }))
         .unwrap();
         let app = build_router(state());
@@ -4666,6 +4881,89 @@ mod tests {
             .unwrap();
 
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn decision_create_authenticated_session_persists_tenant_scoped_record() {
+        let pool = match gateway_test_pool().await {
+            Some(pool) => pool,
+            None => return,
+        };
+        let did = "did:exo:decision-creator";
+        let tenant_id = "tenant-create";
+        let title = "F-060 authenticated create";
+        insert_test_user(&pool, did, tenant_id).await;
+        insert_test_session(&pool, "decision-create-token", did).await;
+        sqlx::query("DELETE FROM decisions WHERE author = $1 AND title = $2")
+            .bind(did)
+            .bind(title)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let body = serde_json::to_string(&serde_json::json!({
+            "id": "00000000-0000-0000-0000-000000000601",
+            "title": title,
+            "decision_class": "Routine",
+            "constitutional_hash": "2222222222222222222222222222222222222222222222222222222222222222",
+            "created_at_physical_ms": 8000,
+            "created_at_logical": 1,
+            "constitution_version": "exochain-constitution-v1"
+        }))
+        .unwrap();
+        let app = build_router(AppState::new(
+            Some(pool.clone()),
+            Arc::new(RwLock::new(LocalDidRegistry::new())),
+        ));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/decisions")
+                    .header("content-type", "application/json")
+                    .header("authorization", "Bearer decision-create-token")
+                    .header(AUTH_OBSERVED_AT_MS_HEADER, "15000")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let val: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let id_hash = val["content_hash"].as_str().unwrap();
+        assert_eq!(val["tenant_id"], tenant_id);
+        assert_eq!(val["author"], did);
+        assert_eq!(val["status"], "Draft");
+        assert_eq!(val["title"], title);
+        assert_eq!(val["decision_class"], "Routine");
+
+        let row = db::find_decision(&pool, id_hash, tenant_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.tenant_id, tenant_id);
+        assert_eq!(row.author, did);
+        assert_eq!(row.status, "Draft");
+        assert_eq!(row.payload, val);
+
+        sqlx::query("DELETE FROM decisions WHERE id_hash = $1")
+            .bind(id_hash)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM sessions WHERE token = $1")
+            .bind("decision-create-token")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM users WHERE did = $1")
+            .bind(did)
+            .execute(&pool)
+            .await
+            .unwrap();
     }
 
     // --- Identity score endpoint tests ---

--- a/crates/exo-gateway/tests/decision_forum_integration.rs
+++ b/crates/exo-gateway/tests/decision_forum_integration.rs
@@ -1,8 +1,9 @@
 //! Integration tests for APE-58 — decision-forum gateway wiring.
 //!
 //! These tests exercise the `DecisionObject` + quorum domain logic that backs
-//! `POST /api/v1/decisions` without requiring a live database.  They verify the
-//! three acceptance criteria that must hold regardless of network/DB state:
+//! the gateway decision lifecycle without requiring a live database.
+//! They verify the three acceptance criteria that must hold regardless of
+//! network/DB state:
 //!
 //!   1. A valid vote is accepted and the quorum check result is included in the response.
 //!   2. A duplicate voter is rejected (TNC-07 voter independence).


### PR DESCRIPTION
## Summary

Remediates F-060 after validating it was still live on current `main`: `RestRoute::CreateDecision` declared `POST /api/v1/decisions`, but `build_unlayered_router` dispatched that route to `vote_handler`. A create-shaped request therefore hit vote schema parsing instead of decision creation.

Changes:
- Wire `POST /api/v1/decisions` to `handle_decision_create` instead of `vote_handler`.
- Add an authenticated, tenant-scoped decision create handler that derives `tenant_id` and `author` from the DB-backed bearer session.
- Require caller-supplied deterministic decision fields: UUID, decision class, non-zero constitutional hash, non-zero HLC physical timestamp, logical timestamp, and constitution version.
- Persist created decisions under a content hash using `DecisionObject::content_hash()`.
- Add `db::create_decision` with typed duplicate handling and `ON CONFLICT DO NOTHING`, so duplicate creates cannot silently upsert or overwrite an existing decision payload.
- Refresh README repo-truth counts and remove stale test wording that tied vote-domain tests to `POST /api/v1/decisions`.

## Path Classification

- `crates/exo-gateway/src/server.rs` — Core runtime adapter
- `crates/exo-gateway/src/db.rs` — Core runtime adapter
- `crates/exo-gateway/tests/decision_forum_integration.rs` — Core runtime adapter tests
- `README.md` — Documentation/repo-truth metadata required by repository truth gate

## Validation

Red tests observed before the fix:
- `cargo test -p exo-gateway decision_post_route_dispatches_to_create_handler_not_vote_handler -- --nocapture` failed because the route did not contain `post(handle_decision_create)`.
- `cargo test -p exo-gateway decision_create_shape_missing_session_returns_401_not_vote_schema_error -- --nocapture` failed with `422` instead of `401`, proving create-shaped input was being parsed as a vote request.
- `cargo test -p exo-gateway create_decision_inserts_once_without_upsert_overwrite -- --nocapture` failed because `db::create_decision` did not exist.

Passing verification:
- `cargo test -p exo-gateway decision -- --nocapture`
- `cargo test -p exo-gateway -- --nocapture`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `cargo test -p exo-gateway --features production-db -- --nocapture`
- `cargo clippy -p exo-gateway --features production-db --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `cargo doc -p exo-gateway --no-deps`
- `git diff --check`
- `bash tools/repo_truth.sh --json --list-tests`
- `bash tools/test_repo_truth.sh`
- Source/bypass scan: no live `POST /api/v1/decisions` route dispatch to `vote_handler`; only the regression assertion mentions that forbidden wiring.

## External Finding Disposition

F-060 survives validation and is remediated in this PR. No adjacent surface files, imported evidence, archives, or third-party/vendor code were modified.
