### PR TITLE
fix(web): send canonical layout template payloads

### DIFF
--- a/web/src/stores/layoutTemplateStore.test.ts
+++ b/web/src/stores/layoutTemplateStore.test.ts
@@ -1295,7 +1295,7 @@ describe('useLayoutTemplateStore', () => {
       expect(result.current.templates.length).toBeGreaterThan(2)
     })
 
-    it('should serialize layout to JSON string for server', () => {
+    it('should send canonical layout arrays for server validation', () => {
       const { result } = renderHook(() => useLayoutTemplateStore())
 
       act(() => {
@@ -1306,8 +1306,9 @@ describe('useLayoutTemplateStore', () => {
 
       const callArgs = (global.fetch as any).mock.calls[0][1]
       const body = JSON.parse(callArgs.body)
-      expect(typeof body.layout).toBe('string')
-      expect(JSON.parse(body.layout)).toEqual(expect.any(Array))
+      expect(Array.isArray(body.layout)).toBe(true)
+      expect(body.layout).toEqual([{ i: 'panel-1', x: 0, y: 0, w: 6, h: 4 }])
+      expect(body.hiddenPanels).toEqual([])
     })
   })
 })

--- a/web/src/stores/layoutTemplateStore.ts
+++ b/web/src/stores/layoutTemplateStore.ts
@@ -59,7 +59,7 @@ async function saveToServer(template: LayoutTemplate) {
       body: JSON.stringify({
         id: template.id,
         name: template.name,
-        layout: JSON.stringify(template.layout),
+        layout: template.layout,
         hiddenPanels: template.hiddenPanels,
         isBuiltIn: template.isBuiltIn,
         createdAt: template.createdAt,


### PR DESCRIPTION
## Summary
- classify this as adjacent-surface remediation for `web/` Decision Forum UI caller behavior
- send layout template `layout` as a canonical JSON array instead of a nested JSON string
- update the regression test to match the hardened gateway validator contract

## Adjacent Surface Intake
- Owner/accountable maintainer: EXOCHAIN maintainers
- Deployment status: internal Decision Forum web UI; no evidence in this change that it is the production entrypoint for core trust decisions
- Constitutional trust claims: not allowed to claim EXOCHAIN constitutional enforcement by itself; it is an untrusted browser caller into the gateway
- Core read/write access: writes layout-template preferences only through `/api/v1/layout-templates`; no direct consent, authority, provenance, signature, governance-outcome, or tenant-state writes are added
- Trust boundary: browser state/localStorage and fetch payloads are adjacent and untrusted; the core gateway remains responsible for authentication, actor binding, and canonical schema validation
- Surface-specific tests/CI gate: `npm test -- layoutTemplateStore`, `npm test`, `npm run build`; `npm run lint` is currently blocked because the repo script references missing `eslint` tooling
- Secrets/runtime config: uses `df_token` from localStorage as an existing bearer token source; this change adds no hardcoded credentials or new runtime secrets
- Rollback/disablement: revert this client change or disable server sync; the merged gateway validator fails closed on malformed nested-string layout payloads

## Validation
- RED: `npm test -- layoutTemplateStore` failed at `Array.isArray(body.layout)` before the production change
- GREEN: `npm test -- layoutTemplateStore` passed: 67 tests
- `npm test` passed: 8 files, 372 tests
- `npm run build` passed: `tsc && vite build`
- `npm audit --omit=dev --audit-level=high` passed: 0 vulnerabilities
- `git diff --check` and `git diff --cached --check` passed
- Source scan confirms the remaining caller uses `layout: template.layout` and no `JSON.stringify(template.layout)` remains

## Known Existing Gates
- `npm run lint` fails before linting because `eslint` is not installed/configured in `web/`
- `npm audit --audit-level=moderate` reports inherited dev-tool moderate advisories in `vite`/`vitest`/`esbuild` and `postcss`; this PR keeps that separate from the payload-contract fix
