### PR TITLE
fix(gateway): fail closed on adjudication clock errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 161793 | `wc -l` |
-| Workspace tests | 3,980 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 161907 | `wc -l` |
+| Workspace tests | 3,981 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,980 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,981 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -441,7 +441,24 @@ impl AppState {
         // Production path — compiled only when the feature flag is set.
         #[cfg(feature = "production-db")]
         if let Some(pool) = &self.pool {
-            let now = i64::try_from(self.now_ms()).unwrap_or(i64::MAX);
+            let now = match self.try_now_ms() {
+                Ok(now_ms) => match i64::try_from(now_ms) {
+                    Ok(now) => now,
+                    Err(_) => {
+                        tracing::warn!(
+                            "Gateway adjudication timestamp exceeds database range; falling back to WO-009 scaffold"
+                        );
+                        return deny_all_adjudication_context();
+                    }
+                },
+                Err(message) => {
+                    tracing::warn!(
+                        message,
+                        "Gateway adjudication timestamp unavailable; falling back to WO-009 scaffold"
+                    );
+                    return deny_all_adjudication_context();
+                }
+            };
             match build_adjudication_context_from_db(pool, actor, now).await {
                 Ok(ctx) => return ctx,
                 Err(e) => {
@@ -454,17 +471,21 @@ impl AppState {
         }
 
         // WO-009 deny-all scaffold (dev/test default and production fallback).
-        AdjudicationContext {
-            actor_roles: vec![],
-            authority_chain: AuthorityChain::default(),
-            consent_records: vec![],
-            bailment_state: BailmentState::None,
-            human_override_preserved: true,
-            actor_permissions: PermissionSet::new(vec![Permission::new("vote")]),
-            provenance: None,
-            quorum_evidence: None,
-            active_challenge_reason: None,
-        }
+        deny_all_adjudication_context()
+    }
+}
+
+fn deny_all_adjudication_context() -> AdjudicationContext {
+    AdjudicationContext {
+        actor_roles: vec![],
+        authority_chain: AuthorityChain::default(),
+        consent_records: vec![],
+        bailment_state: BailmentState::None,
+        human_override_preserved: true,
+        actor_permissions: PermissionSet::new(vec![Permission::new("vote")]),
+        provenance: None,
+        quorum_evidence: None,
+        active_challenge_reason: None,
     }
 }
 
@@ -3545,6 +3566,25 @@ mod tests {
         assert!(!production.contains(&timestamp_now));
         assert!(!production.contains(&system_time_now));
         assert!(!production.contains(&instant_now));
+    }
+
+    #[test]
+    fn adjudication_db_context_does_not_use_zero_timestamp_fallback() {
+        let source = include_str!("server.rs");
+        let adjudication_block = source
+            .split("pub async fn build_adjudication_context")
+            .nth(1)
+            .and_then(|section| section.split("// WO-009 deny-all scaffold").next())
+            .expect("adjudication context builder present");
+
+        assert!(
+            adjudication_block.contains("self.try_now_ms()"),
+            "DB adjudication must use the fallible HLC path before querying state"
+        );
+        assert!(
+            !adjudication_block.contains("self.now_ms()"),
+            "DB adjudication must not query consent/authority state with the zero timestamp fallback"
+        );
     }
 
     #[test]

--- a/crates/exo-gateway/tests/adjudication_db_integration.rs
+++ b/crates/exo-gateway/tests/adjudication_db_integration.rs
@@ -314,11 +314,11 @@ fn cross_branch_roles_denies() {
 mod db_roundtrip {
     use std::sync::{Arc, RwLock};
 
-    use exo_core::Did;
+    use exo_core::{Did, ExoError, hlc::HybridClock};
     use exo_gatekeeper::{
         ActionRequest, Kernel, authority_link_signature_message,
         invariants::{ConstitutionalInvariant, InvariantSet},
-        types::{AuthorityChain, AuthorityLink, Permission, PermissionSet},
+        types::{AuthorityChain, AuthorityLink, BailmentState, Permission, PermissionSet},
     };
     use exo_gateway::server::AppState;
     use exo_identity::registry::LocalDidRegistry;
@@ -454,8 +454,82 @@ mod db_roundtrip {
         );
     }
 
+    /// If the HLC is unavailable, the gateway must not query adjudication rows
+    /// at a fabricated fallback timestamp. Even with DB rows that would permit
+    /// at epoch zero, the context must be the WO-009 deny-all scaffold.
+    #[tokio::test]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    async fn db_roundtrip_hlc_failure_uses_scaffold_even_when_rows_would_permit() {
+        let pool = match connect_and_migrate().await {
+            Some(p) => p,
+            None => return, // DATABASE_URL not set — skip
+        };
+
+        let actor_did = "did:exo:db-roundtrip-clock-failure-010";
+        let grantor_did = "did:exo:db-roundtrip-clock-grantor-010";
+
+        let _ = sqlx::query("DELETE FROM consent_records WHERE actor_did = $1")
+            .bind(actor_did)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM authority_chains WHERE actor_did = $1")
+            .bind(actor_did)
+            .execute(&pool)
+            .await;
+
+        sqlx::query(
+            "INSERT INTO consent_records \
+             (subject_did, actor_did, scope, bailment_type, status, created_at) \
+             VALUES ($1, $2, $3, 'standard', 'active', 0)",
+        )
+        .bind(grantor_did)
+        .bind(actor_did)
+        .bind("data:vote")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let actor = did(actor_did);
+        let grantor = did(grantor_did);
+        let chain = AuthorityChain {
+            links: vec![signed_authority_link(&grantor, &actor)],
+        };
+        let chain_json = serde_json::to_value(&chain).unwrap();
+        sqlx::query(
+            "INSERT INTO authority_chains (actor_did, chain_json, valid_from) \
+             VALUES ($1, $2, 0)",
+        )
+        .bind(actor_did)
+        .bind(&chain_json)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let failing_clock = HybridClock::with_fallible_wall_clock(|| {
+            Err(ExoError::ClockUnavailable {
+                reason: "injected adjudication clock failure".to_owned(),
+            })
+        });
+        let state = AppState::new_with_clock(
+            Some(pool),
+            Arc::new(RwLock::new(LocalDidRegistry::new())),
+            failing_clock,
+        );
+        let ctx = state.build_adjudication_context(&actor).await;
+
+        assert_eq!(ctx.bailment_state, BailmentState::None);
+        assert!(ctx.actor_roles.is_empty());
+        assert!(ctx.authority_chain.is_empty());
+        assert!(
+            adjudication_kernel()
+                .adjudicate(&vote_action(&actor), &ctx)
+                .is_denied(),
+            "HLC failure must deny even when DB rows would permit at a fabricated fallback timestamp"
+        );
+    }
+
     // -----------------------------------------------------------------------
-    // Test 9: DB round-trip — no rows for actor → Denied (ConsentRequired)
+    // Test 10: DB round-trip — no rows for actor → Denied (ConsentRequired)
     // -----------------------------------------------------------------------
 
     /// Ensures that an actor with no rows in any adjudication table results in


### PR DESCRIPTION
## Classification
- `crates/exo-gateway/src/server.rs`: core runtime adapter
- `crates/exo-gateway/tests/adjudication_db_integration.rs`: core runtime adapter tests
- `README.md`: documentation/public repo-truth count refresh required by CI after Rust LOC/test-count changes

## Confirmed Current Issue
- Validated against current `origin/main` after PR #295 merged.
- The production DB adjudication path used `self.now_ms()`, whose HLC failure fallback is `0`, before querying consent and authority state. That could query DB rows at a fabricated epoch-zero timestamp instead of immediately taking the WO-009 deny-all scaffold.

## Remediation
- Route DB adjudication through `try_now_ms()` and checked `i64` conversion.
- On HLC failure or timestamp range failure, return the existing WO-009 deny-all context before any DB resolver call.
- Extract the deny-all context into one helper so fallback behavior stays identical across dev/test and production failure paths.
- Refresh README repo-truth counts as a separate docs commit because the hygiene gate derives public counts from current source.

## Regression Coverage
- Added a source guard proving the DB adjudication block no longer uses the zero-fallback timestamp helper.
- Added a `production-db` integration regression where active consent/authority rows at epoch zero would permit, but an injected HLC failure still yields the deny-all scaffold and kernel denial.

## Local Validation
- `cargo test -p exo-gateway adjudication_db_context_does_not_use_zero_timestamp_fallback`
- `cargo test -p exo-gateway --features production-db db_roundtrip_hlc_failure_uses_scaffold_even_when_rows_would_permit`
- `cargo test -p exo-gateway`
- `cargo test -p exo-gateway --features production-db`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `cargo clippy -p exo-gateway --all-targets --features production-db -- -D warnings`
- `cargo fmt --all -- --check`
- `bash tools/test_repo_truth.sh`
- `git diff --check`