### PR TITLE
Fail closed on OTP cleanup clock errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 161907 | `wc -l` |
-| Workspace tests | 3,981 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 161967 | `wc -l` |
+| Workspace tests | 3,983 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,981 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,983 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -80,9 +80,9 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 161793 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 161967 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,980 listed workspace tests
+         cryptographic proofs, 3,983 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/sentinels.rs
+++ b/crates/exo-node/src/sentinels.rs
@@ -110,19 +110,23 @@ pub type AlertReceiver = mpsc::Receiver<SentinelAlert>;
 
 type PreviousRound = Option<u64>;
 
-pub(crate) fn now_ms() -> u64 {
+fn sentinel_now_ms() -> Result<u64, String> {
     static SENTINEL_CLOCK: OnceLock<Mutex<HybridClock>> = OnceLock::new();
     let clock = SENTINEL_CLOCK.get_or_init(|| Mutex::new(HybridClock::new()));
-    match clock.lock() {
-        Ok(mut clock) => match clock.now() {
-            Ok(timestamp) => timestamp.physical_ms,
-            Err(err) => {
-                tracing::error!(error = %err, "Sentinel HLC exhausted while reading timestamp");
-                0
-            }
-        },
-        Err(_) => {
-            tracing::error!("Sentinel HLC mutex poisoned while reading timestamp");
+    let mut clock = clock
+        .lock()
+        .map_err(|_| "Sentinel HLC mutex poisoned while reading timestamp".to_owned())?;
+    clock
+        .now()
+        .map(|timestamp| timestamp.physical_ms)
+        .map_err(|err| format!("Sentinel HLC exhausted while reading timestamp: {err}"))
+}
+
+pub(crate) fn now_ms() -> u64 {
+    match sentinel_now_ms() {
+        Ok(now) => now,
+        Err(message) => {
+            tracing::error!(%message, "Sentinel timestamp unavailable");
             0
         }
     }
@@ -426,6 +430,25 @@ fn check_score_integrity(zerodentity: &SharedZerodentityStore) -> SentinelStatus
 ///
 /// Spec §10.4 — ensures no stale challenges linger in memory.
 fn check_otp_cleanup(zerodentity: &SharedZerodentityStore) -> SentinelStatus {
+    check_otp_cleanup_with_time(zerodentity, sentinel_now_ms())
+}
+
+fn check_otp_cleanup_with_time(
+    zerodentity: &SharedZerodentityStore,
+    now_result: Result<u64, String>,
+) -> SentinelStatus {
+    let now = match now_result {
+        Ok(now) => now,
+        Err(message) => {
+            return SentinelStatus {
+                check: SentinelCheck::OtpCleanup,
+                healthy: false,
+                message,
+                last_run_ms: 0,
+            };
+        }
+    };
+
     let mut zstore = match zerodentity.lock() {
         Ok(s) => s,
         Err(_) => {
@@ -438,7 +461,6 @@ fn check_otp_cleanup(zerodentity: &SharedZerodentityStore) -> SentinelStatus {
             };
         }
     };
-    let now = now_ms();
 
     // Count expired-but-pending challenges before cleanup
     let expired_pending = zstore
@@ -978,6 +1000,44 @@ mod tests {
         assert!(status.healthy);
         assert_eq!(status.check, SentinelCheck::OtpCleanup);
         assert_eq!(status.message, "No expired pending OTP challenges");
+    }
+
+    #[test]
+    fn otp_cleanup_does_not_use_zero_timestamp_fallback() {
+        let source = include_str!("sentinels.rs");
+        let production = source
+            .split("// ---------------------------------------------------------------------------\n// Tests")
+            .next()
+            .expect("tests marker present");
+        let otp_cleanup = production
+            .split("fn check_otp_cleanup")
+            .nth(1)
+            .and_then(|section| section.split("fn check_store_consistency").next())
+            .expect("OTP cleanup sentinel present");
+
+        assert!(
+            otp_cleanup.contains("sentinel_now_ms()"),
+            "OTP cleanup must use the fallible sentinel clock before evaluating expiry"
+        );
+        assert!(
+            !otp_cleanup.contains("let now = now_ms()"),
+            "OTP cleanup must not evaluate expiry with the zero timestamp fallback"
+        );
+    }
+
+    #[test]
+    fn otp_cleanup_fails_closed_when_timestamp_unavailable() {
+        let zerodentity = crate::zerodentity::store::new_shared_store();
+
+        let status = check_otp_cleanup_with_time(
+            &zerodentity,
+            Err("injected sentinel clock failure".to_owned()),
+        );
+
+        assert!(!status.healthy);
+        assert_eq!(status.check, SentinelCheck::OtpCleanup);
+        assert!(status.message.contains("clock failure"));
+        assert_eq!(status.last_run_ms, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Classifies `crates/exo-node/src/sentinels.rs` as EXOCHAIN core/node runtime and `README.md` as derived documentation.
- Confirms the current OTP cleanup sentinel could evaluate challenge expiry using the legacy zero timestamp fallback when the sentinel HLC was unavailable.
- Routes OTP cleanup through a fallible sentinel clock and returns an unhealthy sentinel status before evaluating expiry on clock errors.
- Refreshes README repo-truth counts derived from the added Rust tests.

## TDD / Reproduction
- Added `otp_cleanup_does_not_use_zero_timestamp_fallback` first; it failed against the pre-fix code because OTP cleanup still used `now_ms()` with the zero fallback.
- Added `otp_cleanup_fails_closed_when_timestamp_unavailable` to prove injected clock failure returns an unhealthy OTP cleanup status with no expiry evaluation.

## Validation
- `cargo test -p exo-node otp_cleanup_does_not_use_zero_timestamp_fallback`
- `cargo test -p exo-node otp_cleanup_fails_closed_when_timestamp_unavailable`
- `cargo test -p exo-node sentinels`
- `cargo test -p exo-node otp_cleanup`
- `cargo clippy -p exo-node --all-targets -- -D warnings`
- `cargo test -p exo-node`
- `cargo fmt --all -- --check`
- `bash tools/test_repo_truth.sh`
- `bash tools/repo_truth.sh --json --list-tests | jq '{rust_loc, tests_listed}'`\n- `git diff --check`\n\n## External Finding Disposition\nThis is a newly confirmed core hardening issue discovered during the residual sweep. It was not accepted from the outside report at face value; the current branch was inspected, the stale/remediated sibling claims were separated, and this surviving fail-open clock path was reproduced with a failing regression guard before the production change.