### PR TITLE
fix(legal): avoid compliance over-attestation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 161967 | `wc -l` |
-| Workspace tests | 3,983 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 162175 | `wc -l` |
+| Workspace tests | 3,985 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,983 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,985 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -80,9 +80,9 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 161967 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 162175 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,983 listed workspace tests
+         cryptographic proofs, 3,985 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-legal/src/compliance_report.rs
+++ b/crates/exo-legal/src/compliance_report.rs
@@ -229,11 +229,7 @@ fn derive_status_and_evidence(
         }
 
         ConstitutionalInvariant::ProvenanceVerifiable => {
-            let mcp_count = report.mcp_rule_outcomes.iter().fold(0u64, |acc, outcome| {
-                acc.saturating_add(outcome.allowed)
-                    .saturating_add(outcome.blocked)
-                    .saturating_add(outcome.escalated)
-            });
+            let (_, _, _, mcp_count) = mcp_enforcement_totals(report);
             if mcp_count == 0 {
                 (
                     AttestationStatus::NotApplicable,
@@ -280,17 +276,99 @@ fn derive_status_and_evidence(
 
         ConstitutionalInvariant::SeparationOfPowers
         | ConstitutionalInvariant::ConsentRequired
-        | ConstitutionalInvariant::NoSelfGrant
-        | ConstitutionalInvariant::KernelImmutability
-        | ConstitutionalInvariant::QuorumLegitimate => (
+        | ConstitutionalInvariant::NoSelfGrant => {
+            derive_action_dependent_kernel_attestation(invariant, report)
+        }
+
+        ConstitutionalInvariant::KernelImmutability => (
             AttestationStatus::Compliant,
             format!(
-                "{} enforced synchronously by InvariantEngine::enforce_all(). \
-                 No violations recorded this period.",
+                "{} enforced by immutable Kernel construction and invariant-set binding. \
+                 This is a static kernel configuration attestation, not an action-count claim.",
                 invariant.id()
             ),
         ),
+
+        ConstitutionalInvariant::QuorumLegitimate => derive_quorum_attestation(report),
     }
+}
+
+fn derive_action_dependent_kernel_attestation(
+    invariant: ConstitutionalInvariant,
+    report: &AiTransparencyReport,
+) -> (AttestationStatus, String) {
+    let (allowed, blocked, escalated, mcp_count) = mcp_enforcement_totals(report);
+    if report.ai_agent_action_count == 0 {
+        return (
+            AttestationStatus::NotApplicable,
+            format!(
+                "No AI actions recorded this period; {} is not attested for action \
+                 execution. Kernel enforcement remains configured, but this report \
+                 does not claim period compliance without action evidence.",
+                invariant.id()
+            ),
+        );
+    }
+    if mcp_count == 0 {
+        return (
+            AttestationStatus::Gap,
+            format!(
+                "{} cannot be attested: {} AI actions were recorded, but no MCP \
+                 enforcement outcome summary is present.",
+                invariant.id(),
+                report.ai_agent_action_count
+            ),
+        );
+    }
+
+    (
+        AttestationStatus::Compliant,
+        format!(
+            "{} enforced by InvariantEngine::enforce_all() across {} AI actions \
+             captured in the verified MCP audit log (allowed: {allowed}, blocked: \
+             {blocked}, escalated: {escalated}). Blocked and escalated outcomes \
+             are enforcement evidence, not a silent all-clear claim.",
+            invariant.id(),
+            report.ai_agent_action_count
+        ),
+    )
+}
+
+fn derive_quorum_attestation(report: &AiTransparencyReport) -> (AttestationStatus, String) {
+    if report.ai_agent_action_count == 0 {
+        (
+            AttestationStatus::NotApplicable,
+            "No AI actions recorded this period; quorum legitimacy is not attested \
+             without quorum-bearing decision evidence."
+                .into(),
+        )
+    } else {
+        (
+            AttestationStatus::NotApplicable,
+            format!(
+                "This AI transparency report covers {} MCP actions but does not \
+                 include quorum-bearing governance decision evidence; \
+                 QuorumLegitimate is therefore not attested by this report.",
+                report.ai_agent_action_count
+            ),
+        )
+    }
+}
+
+fn mcp_enforcement_totals(report: &AiTransparencyReport) -> (u64, u64, u64, u64) {
+    report.mcp_rule_outcomes.iter().fold(
+        (0u64, 0u64, 0u64, 0u64),
+        |(allowed_acc, blocked_acc, escalated_acc, total_acc), outcome| {
+            let allowed = allowed_acc.saturating_add(outcome.allowed);
+            let blocked = blocked_acc.saturating_add(outcome.blocked);
+            let escalated = escalated_acc.saturating_add(outcome.escalated);
+            let total = total_acc
+                .saturating_add(outcome.allowed)
+                .saturating_add(outcome.blocked)
+                .saturating_add(outcome.escalated);
+            (allowed, blocked, escalated, total)
+        },
+    )
 }
 
 fn redact_delegation_count(report: &AiTransparencyReport, mode: &ComplianceReportMode) -> usize {
@@ -395,7 +473,10 @@ fn hash_report_payload(payload: &ComplianceReportHashPayload<'_>) -> Result<[u8;
 mod tests {
     use exo_authority::{AuthorityChain, AuthorityLink, DelegateeKind, Permission};
     use exo_core::{Did, Signature, Timestamp, crypto::KeyPair};
-    use exo_gatekeeper::mcp_audit::McpAuditLog;
+    use exo_gatekeeper::{
+        mcp::McpRule,
+        mcp_audit::{McpAuditLog, McpEnforcementOutcome, append, create_record},
+    };
 
     use super::*;
     use crate::ai_transparency::{
@@ -451,6 +532,33 @@ mod tests {
             period_end: ts(9999),
             legal_jurisdiction: "EU-AI-ACT",
             mcp_log: &McpAuditLog::new(),
+            ai_delegation_grants: vec![],
+            ai_delegation_revocations: vec![],
+            authority_clearance: &clearance,
+        })
+        .expect("ok")
+    }
+
+    fn report_with_mcp_action(tenant: &Did) -> AiTransparencyReport {
+        let clearance = verified_clearance(tenant);
+        let mut mcp_log = McpAuditLog::new();
+        let record = create_record(
+            &mcp_log,
+            uuid::Uuid::from_u128(0xA11CE),
+            ts(2_000),
+            McpRule::Mcp001BctsScope,
+            did("mcp-actor"),
+            McpEnforcementOutcome::Allowed,
+            Some("EU-WEST-1".into()),
+        )
+        .expect("deterministic MCP audit record");
+        append(&mut mcp_log, record).expect("MCP audit append");
+        generate_report(ReportParams {
+            tenant_id: tenant,
+            period_start: ts(0),
+            period_end: ts(9999),
+            legal_jurisdiction: "EU-AI-ACT",
+            mcp_log: &mcp_log,
             ai_delegation_grants: vec![],
             ai_delegation_revocations: vec![],
             authority_clearance: &clearance,
@@ -610,17 +718,41 @@ mod tests {
         let tenant = did("tenant");
         let tr = empty_report(&tenant);
         let report = build_report(&tr, &ComplianceReportMode::Full, ts(10000)).expect("ok");
-        for att in &report.attestations {
-            if att.invariant == ConstitutionalInvariant::ProvenanceVerifiable.id() {
-                assert_eq!(att.status, AttestationStatus::NotApplicable);
-            } else {
-                assert_eq!(
-                    att.status,
-                    AttestationStatus::Compliant,
-                    "invariant {} should be Compliant",
-                    att.invariant
-                );
-            }
+        for invariant in [
+            ConstitutionalInvariant::HumanOverride,
+            ConstitutionalInvariant::KernelImmutability,
+            ConstitutionalInvariant::AuthorityChainValid,
+        ] {
+            let att = report
+                .attestations
+                .iter()
+                .find(|a| a.invariant == invariant.id())
+                .expect("invariant must appear in compliance report");
+            assert_eq!(
+                att.status,
+                AttestationStatus::Compliant,
+                "{} has static or report-generation evidence in an empty period",
+                invariant.id()
+            );
+        }
+        for invariant in [
+            ConstitutionalInvariant::SeparationOfPowers,
+            ConstitutionalInvariant::ConsentRequired,
+            ConstitutionalInvariant::NoSelfGrant,
+            ConstitutionalInvariant::QuorumLegitimate,
+            ConstitutionalInvariant::ProvenanceVerifiable,
+        ] {
+            let att = report
+                .attestations
+                .iter()
+                .find(|a| a.invariant == invariant.id())
+                .expect("invariant must appear in compliance report");
+            assert_eq!(
+                att.status,
+                AttestationStatus::NotApplicable,
+                "{} should not be marked Compliant without period evidence",
+                invariant.id()
+            );
         }
     }
 
@@ -657,6 +789,82 @@ mod tests {
                 .evidence_summary
                 .contains("Authority chain verified for all actions"),
             "authority attestations must name concrete verified evidence, not all-action prose"
+        );
+    }
+
+    #[test]
+    fn empty_period_does_not_attest_action_dependent_invariant_compliance() {
+        let tenant = did("tenant");
+        let tr = empty_report(&tenant);
+        assert_eq!(tr.ai_agent_action_count, 0);
+        let report = build_report(&tr, &ComplianceReportMode::Full, ts(10000)).expect("ok");
+
+        for invariant in [
+            ConstitutionalInvariant::SeparationOfPowers,
+            ConstitutionalInvariant::ConsentRequired,
+            ConstitutionalInvariant::NoSelfGrant,
+            ConstitutionalInvariant::QuorumLegitimate,
+        ] {
+            let attestation = report
+                .attestations
+                .iter()
+                .find(|a| a.invariant == invariant.id())
+                .expect("invariant must appear in compliance report");
+            assert_eq!(
+                attestation.status,
+                AttestationStatus::NotApplicable,
+                "{} must not be marked Compliant without period action evidence",
+                invariant.id()
+            );
+            assert!(
+                attestation
+                    .evidence_summary
+                    .contains("No AI actions recorded"),
+                "{} summary must explain the absent evidence",
+                invariant.id()
+            );
+        }
+    }
+
+    #[test]
+    fn mcp_action_period_attests_action_dependent_kernel_invariant_compliance() {
+        let tenant = did("tenant");
+        let tr = report_with_mcp_action(&tenant);
+        assert_eq!(tr.ai_agent_action_count, 1);
+        let report = build_report(&tr, &ComplianceReportMode::Full, ts(10000)).expect("ok");
+
+        for invariant in [
+            ConstitutionalInvariant::SeparationOfPowers,
+            ConstitutionalInvariant::ConsentRequired,
+            ConstitutionalInvariant::NoSelfGrant,
+        ] {
+            let attestation = report
+                .attestations
+                .iter()
+                .find(|a| a.invariant == invariant.id())
+                .expect("invariant must appear in compliance report");
+            assert_eq!(
+                attestation.status,
+                AttestationStatus::Compliant,
+                "{} should be attested from verified MCP action evidence",
+                invariant.id()
+            );
+            assert!(
+                attestation.evidence_summary.contains("allowed: 1"),
+                "{} summary must name the enforcement evidence count",
+                invariant.id()
+            );
+        }
+
+        let quorum = report
+            .attestations
+            .iter()
+            .find(|a| a.invariant == ConstitutionalInvariant::QuorumLegitimate.id())
+            .expect("QuorumLegitimate must appear in compliance report");
+        assert_eq!(
+            quorum.status,
+            AttestationStatus::NotApplicable,
+            "MCP action counts alone must not attest quorum legitimacy"
         );
     }
 


### PR DESCRIPTION
## Classification
- EXOCHAIN core: `crates/exo-legal/src/compliance_report.rs`
- Documentation/repo truth: `README.md` count refresh only
- Imported evidence: Wally gauntlet F-041 treated as a hypothesis and reproduced against current `origin/main` before the fix

## Problem Reconfirmed
Current `origin/main` still marked action-dependent invariants such as `separation-of-powers`, `consent-required`, `no-self-grant`, and `quorum-legitimate` as `Compliant` for an empty report period. The new regression was written first and failed with `left: Compliant` for `separation-of-powers`.

## Remediation
- Makes action-dependent compliance attestations evidence-driven. Empty periods now return `NotApplicable` instead of blanket `Compliant`.
- Keeps static/report-generation evidence separate: `HumanOverride`, `KernelImmutability`, and verified report-generation `AuthorityChainValid` may still be compliant in an empty period.
- Keeps `QuorumLegitimate` un-attested by MCP action counts unless quorum-bearing evidence exists in the report type.
- Adds positive coverage proving verified MCP action evidence still attests the action-dependent kernel invariants.

## Validation
- `cargo test -p exo-legal empty_period_does_not_attest_action_dependent_invariant_compliance` (failed before fix, passed after)
- `cargo test -p exo-legal mcp_action_period_attests_action_dependent_kernel_invariant_compliance`
- `cargo test -p exo-legal compliance_report::tests`
- `cargo test -p exo-legal nist_compliance_tests`
- `cargo test -p exo-legal`
- `cargo clippy -p exo-legal --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `bash tools/test_repo_truth.sh`
- `git diff --check`