### PR TITLE
fix(gatekeeper): enforce requested authority scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 162469 | `wc -l` |
-| Workspace tests | 3,989 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 162619 | `wc -l` |
+| Workspace tests | 3,993 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,985 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,993 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -80,9 +80,9 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 162175 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 162619 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,985 listed workspace tests
+         cryptographic proofs, 3,993 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-gatekeeper/src/invariants.rs
+++ b/crates/exo-gatekeeper/src/invariants.rs
@@ -427,6 +427,34 @@ fn check_authority_chain_valid(ctx: &InvariantContext) -> Result<(), InvariantVi
         }
     }
 
+    for permission in &ctx.requested_permissions.permissions {
+        if !ctx.actor_permissions.contains(permission) {
+            return Err(InvariantViolation {
+                invariant: ConstitutionalInvariant::AuthorityChainValid,
+                description: "Requested permission is absent from actor authority context".into(),
+                evidence: vec![
+                    format!("actor: {}", ctx.actor),
+                    format!("requested_permission: {}", permission.0),
+                ],
+            });
+        }
+
+        for (idx, link) in links.iter().enumerate() {
+            if !link.permissions.contains(permission) {
+                return Err(InvariantViolation {
+                    invariant: ConstitutionalInvariant::AuthorityChainValid,
+                    description: "Requested permission is absent from authority chain scope".into(),
+                    evidence: vec![
+                        format!("link_index: {idx}"),
+                        format!("grantor: {}", link.grantor),
+                        format!("grantee: {}", link.grantee),
+                        format!("requested_permission: {}", permission.0),
+                    ],
+                });
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -1478,6 +1506,37 @@ mod tests {
         let (link, _pk) = signed_link("did:exo:root", "did:exo:actor1");
         ctx.authority_chain = AuthorityChain { links: vec![link] };
         assert!(enforce_all(&engine, &ctx).is_ok());
+    }
+
+    #[test]
+    fn authority_chain_fails_when_requested_permission_absent_from_actor_permissions() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::AuthorityChainValid,
+        ]));
+        let mut ctx = passing_context();
+        ctx.requested_permissions = PermissionSet::new(vec![Permission::new("advance_pace")]);
+
+        let err = enforce_all(&engine, &ctx).unwrap_err();
+        assert!(
+            err[0].description.contains("Requested permission"),
+            "requested permission missing from actor permissions must fail AuthorityChainValid"
+        );
+    }
+
+    #[test]
+    fn authority_chain_fails_when_requested_permission_absent_from_chain_scope() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::AuthorityChainValid,
+        ]));
+        let mut ctx = passing_context();
+        ctx.actor_permissions = PermissionSet::new(vec![Permission::new("advance_pace")]);
+        ctx.requested_permissions = PermissionSet::new(vec![Permission::new("advance_pace")]);
+
+        let err = enforce_all(&engine, &ctx).unwrap_err();
+        assert!(
+            err[0].description.contains("authority chain scope"),
+            "requested permission missing from signed chain scope must fail AuthorityChainValid"
+        );
     }
 
     #[test]

--- a/crates/exo-gatekeeper/src/kernel.rs
+++ b/crates/exo-gatekeeper/src/kernel.rs
@@ -583,6 +583,21 @@ mod tests {
             );
         }
 
+        /// F-010: required permissions must be backed by the actor context and
+        /// by the signed authority chain, not merely supplied on the action.
+        #[test]
+        fn missing_required_permission_not_permitted() {
+            let kernel = test_kernel();
+            let actor = did("did:exo:scope-mismatch");
+            let mut action = valid_action(&actor);
+            action.required_permissions = PermissionSet::new(vec![Permission::new("advance_pace")]);
+            let verdict = kernel.adjudicate(&action, &valid_context(&actor));
+            assert!(
+                !verdict.is_permitted(),
+                "F-010: requested permission absent from authority evidence must not be permitted"
+            );
+        }
+
         /// WO-009 §4: An empty authority chain is never permitted, even when all
         /// other context fields are valid.  Per kernel escalation rules, an
         /// isolated AuthorityChainValid violation escalates (not denies) — the

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -483,7 +483,7 @@ fn deny_all_adjudication_context() -> AdjudicationContext {
         consent_records: vec![],
         bailment_state: BailmentState::None,
         human_override_preserved: true,
-        actor_permissions: PermissionSet::new(vec![Permission::new("vote")]),
+        actor_permissions: PermissionSet::default(),
         provenance: None,
         quorum_evidence: None,
         active_challenge_reason: None,
@@ -1553,6 +1553,7 @@ fn build_adjudication_context_from_rows(
         })?,
         None => GkChain::default(),
     };
+    let actor_permissions = effective_authority_permissions(&authority_chain);
 
     Ok(AdjudicationContext {
         actor_roles,
@@ -1560,13 +1561,38 @@ fn build_adjudication_context_from_rows(
         consent_records,
         bailment_state,
         human_override_preserved: true,
-        actor_permissions: PermissionSet::new(vec![Permission::new("vote")]),
+        actor_permissions,
         // Provenance is per-action, not per-actor; callers that need full
         // ProvenanceVerifiable enforcement must attach it before adjudication.
         provenance: None,
         quorum_evidence: None,
         active_challenge_reason: None,
     })
+}
+
+#[cfg(any(test, feature = "production-db"))]
+fn effective_authority_permissions(
+    authority_chain: &exo_gatekeeper::types::AuthorityChain,
+) -> PermissionSet {
+    let Some(first_link) = authority_chain.links.first() else {
+        return PermissionSet::default();
+    };
+
+    let mut effective_permissions = Vec::new();
+    for permission in &first_link.permissions.permissions {
+        if effective_permissions.contains(permission) {
+            continue;
+        }
+        if authority_chain
+            .links
+            .iter()
+            .all(|link| link.permissions.contains(permission))
+        {
+            effective_permissions.push(permission.clone());
+        }
+    }
+
+    PermissionSet::new(effective_permissions)
 }
 
 /// Build an `AdjudicationContext` by loading the actor's roles, consent
@@ -7291,6 +7317,16 @@ mod tests {
         }
     }
 
+    fn action_for_permission(actor: &Did, permission: &str) -> GkActionRequest {
+        GkActionRequest {
+            actor: actor.clone(),
+            action: permission.to_string(),
+            required_permissions: PermissionSet::new(vec![Permission::new(permission)]),
+            is_self_grant: false,
+            modifies_kernel: false,
+        }
+    }
+
     fn db_role_row(actor: &Did, branch: &str) -> crate::db::AgentRoleRow {
         crate::db::AgentRoleRow {
             agent_did: actor.as_str().to_string(),
@@ -7399,6 +7435,46 @@ mod tests {
         assert_eq!(ctx.consent_records.len(), 1);
         assert!(matches!(ctx.bailment_state, BailmentState::Active { .. }));
         assert!(verdict.is_permitted(), "valid DB rows must be permitted");
+    }
+
+    #[test]
+    fn adjudication_context_rows_derive_actor_permissions_from_authority_chain_scope() {
+        let kernel = adjudication_kernel();
+        let actor = Did::new("did:exo:pace-agent").unwrap();
+        let root = Did::new("did:exo:root-grantor").unwrap();
+        let authority_chain = AuthorityChain {
+            links: vec![signed_authority_link_for_permissions(
+                &root,
+                &actor,
+                PermissionSet::new(vec![Permission::new("advance_pace")]),
+            )],
+        };
+        let role_rows = vec![db_role_row(&actor, "executive")];
+        let consent_rows = vec![db_consent_row(&actor, root.as_str())];
+        let chain_row =
+            db_authority_chain_row(&actor, serde_json::to_value(&authority_chain).unwrap());
+
+        let ctx = build_adjudication_context_from_rows(
+            &actor,
+            &role_rows,
+            &consent_rows,
+            Some(&chain_row),
+        )
+        .unwrap();
+        let verdict = kernel.adjudicate(&action_for_permission(&actor, "advance_pace"), &ctx);
+
+        assert!(
+            ctx.actor_permissions
+                .contains(&Permission::new("advance_pace"))
+        );
+        assert!(
+            !ctx.actor_permissions.contains(&Permission::new("vote")),
+            "F-010: DB adjudication context must not synthesize vote permission"
+        );
+        assert!(
+            verdict.is_permitted(),
+            "F-010: action permission backed by DB authority-chain scope must be permitted"
+        );
     }
 
     /// [APE-53 test 1] Scaffold remains deny-all regardless of feature flag.

--- a/docs/guides/constitutional-model.md
+++ b/docs/guides/constitutional-model.md
@@ -341,9 +341,11 @@ violation never escalates, always denies.
 
 **Rule.** The `AuthorityChain` must (a) be non-empty, (b) be
 topologically valid — each link's `grantee` is the next link's
-`grantor` — (c) terminate at the actor, and (d) every link that
-carries a `grantor_public_key` must have an Ed25519 signature that
-verifies against the canonical payload.
+`grantor` — (c) terminate at the actor, (d) every link that carries a
+`grantor_public_key` must have an Ed25519 signature that verifies
+against the canonical payload, and (e) every requested permission must
+appear in the actor authority context and in every signed chain link's
+permission scope.
 
 **Why.** Delegation is how authority flows through a multi-actor
 system. If the chain is broken or unsigned, there is no chain — just a
@@ -370,6 +372,8 @@ with a valid Ed25519 signature verifying under the supplied public key.
 - Broken topology — `link[0].grantee != link[1].grantor`.
 - Wrong terminal — last link's grantee is not the actor.
 - Tampered signature, wrong public key, malformed key.
+- Requested permission absent from actor permissions or from any link's
+  signed permission scope.
 
 **Escalation special case.** When the *only* invariant that fails is
 `AuthorityChainValid`, the kernel returns `Verdict::Escalated` rather
@@ -379,10 +383,11 @@ temporary problem with a legitimate fix path (contest, re-issue), not
 a malicious attack.
 
 **Violation evidence.** Includes the broken link indices and, for
-signature failures, the grantor/grantee DIDs.
+signature or permission-scope failures, the grantor/grantee DIDs and
+requested permission.
 
 **Code reference.**
-[`crates/exo-gatekeeper/src/invariants.rs:246–357`][invariants-rs]
+[`crates/exo-gatekeeper/src/invariants.rs:331–458`][invariants-rs]
 
 ---
 


### PR DESCRIPTION
## Summary
- Confirms Wally gauntlet F-010 is still live on current `origin/main`: `build_adjudication_context_from_rows` fabricated `vote` and `AuthorityChainValid` ignored `requested_permissions`.
- Enforces requested permissions in `exo-gatekeeper` by requiring each requested permission to be present in actor authority context and every signed authority-chain link scope.
- Changes gateway DB adjudication context construction to derive actor permissions from the signed chain scope intersection, and keeps the no-DB scaffold permissionless/deny-all.
- Updates core constitutional model docs and README repo-truth counts.

## Path Classification
- `crates/exo-gatekeeper/src/invariants.rs` — EXOCHAIN core, constitutional invariant enforcement.
- `crates/exo-gatekeeper/src/kernel.rs` — EXOCHAIN core, kernel regression coverage.
- `crates/exo-gateway/src/server.rs` — core runtime adapter, DB-loaded adjudication context boundary.
- `docs/guides/constitutional-model.md` — constitutional governance documentation aligned with core behavior.
- `README.md` — repo-truth documentation count refresh.
- `/Users/bobstewart/Downloads/Exochain Gauntlet Findings.zip` — imported evidence only, read-only, not committed.

## Stale-Report Check
- External F-010 was re-read from the imported gauntlet artifact and re-confirmed against fresh `origin/main` after PR #299 merged.
- Current code still had the reported adapter behavior and a deeper kernel enforcement gap: requested action permissions were passed into `InvariantContext` but not checked by `AuthorityChainValid`.

## Red Tests Added First
- `cargo test -p exo-gatekeeper authority_chain_fails_when_requested_permission_absent_from_actor_permissions` failed before patch: requested permissions were ignored.
- `cargo test -p exo-gatekeeper missing_required_permission_not_permitted` failed before patch: kernel permitted a scope mismatch.
- `cargo test -p exo-gateway adjudication_context_rows_derive_actor_permissions_from_authority_chain_scope` failed before patch: gateway DB context returned `vote` instead of `advance_pace`.

## Validation
- `cargo test -p exo-gatekeeper`
- `cargo test -p exo-gateway`
- `cargo test -p exo-gateway --features production-db`
- `cargo clippy -p exo-gatekeeper -p exo-gateway --all-targets --features production-db -- -D warnings`
- `cargo fmt --all -- --check`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --release`
- `cargo doc --workspace --no-deps`
- `cargo build --workspace --release`
- `cargo audit`
- `cargo deny check` (passes with existing duplicate dependency warnings)
- `./tools/cross-impl-test/compare.sh` (Rust determinism and vectors passed; TypeScript comparison skipped because `EXO_TS_ROOT` is not configured locally)
- `git diff --check`

## Bypass Search
- Searched for production gateway `actor_permissions` hardcoded to `vote`; no production path remains. Remaining `vote` matches are test/integration fixtures.
- Searched requested permission ingress paths in gatekeeper, MCP, WASM, and gateway; enforcement now occurs centrally in `AuthorityChainValid` through `Kernel::adjudicate`.
