### PR TITLE
fix(gatekeeper): validate governed role names

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 162619 | `wc -l` |
-| Workspace tests | 3,993 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 162862 | `wc -l` |
+| Workspace tests | 3,998 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,993 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **3,998 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -80,9 +80,9 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 162619 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 162862 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,993 listed workspace tests
+         cryptographic proofs, 3,998 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/decision-forum/tests/governance_kernel_integration.rs
+++ b/crates/decision-forum/tests/governance_kernel_integration.rs
@@ -179,7 +179,7 @@ fn make_approved_decision(class: DecisionClass, clock: &mut HybridClock) -> Deci
 fn valid_adj_context(actor: &Did) -> AdjudicationContext {
     AdjudicationContext {
         actor_roles: vec![Role {
-            name: "governance-judge".into(),
+            name: "judge".into(),
             branch: GovernmentBranch::Judicial,
         }],
         authority_chain: AuthorityChain {
@@ -705,15 +705,15 @@ fn all_eight_invariants_exercised() {
             mutate: |_, ctx| {
                 ctx.actor_roles = vec![
                     Role {
-                        name: "l".into(),
+                        name: "legislator".into(),
                         branch: GovernmentBranch::Legislative,
                     },
                     Role {
-                        name: "e".into(),
+                        name: "worker".into(),
                         branch: GovernmentBranch::Executive,
                     },
                     Role {
-                        name: "j".into(),
+                        name: "judge".into(),
                         branch: GovernmentBranch::Judicial,
                     },
                 ];

--- a/crates/exo-escalation/tests/sybil_adjudication.rs
+++ b/crates/exo-escalation/tests/sybil_adjudication.rs
@@ -139,7 +139,7 @@ fn signed_provenance(actor: &Did) -> Provenance {
 fn valid_kernel_context(actor: &Did, challenge_reason: Option<String>) -> AdjudicationContext {
     AdjudicationContext {
         actor_roles: vec![Role {
-            name: "reviewer".into(),
+            name: "judge".into(),
             branch: GovernmentBranch::Judicial,
         }],
         authority_chain: AuthorityChain {

--- a/crates/exo-gatekeeper/src/holon.rs
+++ b/crates/exo-gatekeeper/src/holon.rs
@@ -306,11 +306,11 @@ mod tests {
         let mut ctx = valid_adj(&h.id);
         ctx.actor_roles = vec![
             Role {
-                name: "j".into(),
+                name: "judge".into(),
                 branch: GovernmentBranch::Judicial,
             },
             Role {
-                name: "s".into(),
+                name: "senator".into(),
                 branch: GovernmentBranch::Legislative,
             },
         ];

--- a/crates/exo-gatekeeper/src/invariants.rs
+++ b/crates/exo-gatekeeper/src/invariants.rs
@@ -193,11 +193,7 @@ fn check_invariant(
 }
 
 fn government_branch_label(branch: GovernmentBranch) -> &'static str {
-    match branch {
-        GovernmentBranch::Legislative => "legislative",
-        GovernmentBranch::Executive => "executive",
-        GovernmentBranch::Judicial => "judicial",
-    }
+    branch.as_str()
 }
 
 fn role_evidence_label(roles: &[Role]) -> String {
@@ -241,7 +237,18 @@ fn bailment_state_evidence(state: &BailmentState) -> Vec<String> {
 
 fn check_separation_of_powers(ctx: &InvariantContext) -> Result<(), InvariantViolation> {
     let mut branches = std::collections::BTreeSet::new();
-    for role in &ctx.actor_roles {
+    for (index, role) in ctx.actor_roles.iter().enumerate() {
+        if let Err(err) = role.validate_governed() {
+            return Err(InvariantViolation {
+                invariant: ConstitutionalInvariant::SeparationOfPowers,
+                description: err.to_string(),
+                evidence: vec![
+                    format!("actor: {}", ctx.actor),
+                    format!("role_index: {index}"),
+                    format!("actual_branch: {}", government_branch_label(role.branch)),
+                ],
+            });
+        }
         branches.insert(role.branch);
     }
     if branches.contains(&GovernmentBranch::Legislative)
@@ -726,15 +733,15 @@ mod tests {
         let mut ctx = passing_context();
         ctx.actor_roles = vec![
             Role {
-                name: "s".into(),
+                name: "senator".into(),
                 branch: GovernmentBranch::Legislative,
             },
             Role {
-                name: "g".into(),
+                name: "worker".into(),
                 branch: GovernmentBranch::Executive,
             },
             Role {
-                name: "j".into(),
+                name: "judge".into(),
                 branch: GovernmentBranch::Judicial,
             },
         ];
@@ -747,6 +754,56 @@ mod tests {
             ConstitutionalInvariant::SeparationOfPowers,
         ]));
         assert!(enforce_all(&engine, &passing_context()).is_ok());
+    }
+
+    #[test]
+    fn separation_rejects_unknown_role_name() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::SeparationOfPowers,
+        ]));
+        let mut ctx = passing_context();
+        ctx.actor_roles = vec![Role {
+            name: "root".into(),
+            branch: GovernmentBranch::Judicial,
+        }];
+
+        let err = enforce_all(&engine, &ctx).expect_err("unknown role name must fail closed");
+
+        assert_eq!(
+            err[0].invariant,
+            ConstitutionalInvariant::SeparationOfPowers
+        );
+        assert!(
+            err[0].description.contains("unknown governed role name"),
+            "unexpected description: {}",
+            err[0].description
+        );
+    }
+
+    #[test]
+    fn separation_rejects_role_name_branch_mismatch() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::SeparationOfPowers,
+        ]));
+        let mut ctx = passing_context();
+        ctx.actor_roles = vec![Role {
+            name: "judge".into(),
+            branch: GovernmentBranch::Executive,
+        }];
+
+        let err = enforce_all(&engine, &ctx).expect_err("role name branch mismatch must fail");
+
+        assert_eq!(
+            err[0].invariant,
+            ConstitutionalInvariant::SeparationOfPowers
+        );
+        assert!(
+            err[0]
+                .description
+                .contains("does not match governed branch"),
+            "unexpected description: {}",
+            err[0].description
+        );
     }
 
     #[test]

--- a/crates/exo-gatekeeper/src/kernel.rs
+++ b/crates/exo-gatekeeper/src/kernel.rs
@@ -333,11 +333,11 @@ mod tests {
         let mut ctx = valid_context(&actor);
         ctx.actor_roles = vec![
             Role {
-                name: "s".into(),
+                name: "senator".into(),
                 branch: GovernmentBranch::Legislative,
             },
             Role {
-                name: "j".into(),
+                name: "judge".into(),
                 branch: GovernmentBranch::Judicial,
             },
         ];

--- a/crates/exo-gatekeeper/src/types.rs
+++ b/crates/exo-gatekeeper/src/types.rs
@@ -48,11 +48,100 @@ impl PermissionSet {
 // ---------------------------------------------------------------------------
 
 /// Branch of government.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum GovernmentBranch {
     Legislative,
     Executive,
     Judicial,
+}
+
+impl GovernmentBranch {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Legislative => "legislative",
+            Self::Executive => "executive",
+            Self::Judicial => "judicial",
+        }
+    }
+}
+
+/// Governed role names recognized by the constitutional fabric.
+///
+/// The names are intentionally finite.  Adjudication may carry zero roles, but
+/// any supplied role must be one of these governed names and must match the
+/// branch assigned below.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum GovernedRoleName {
+    Senator,
+    Legislator,
+    Voter,
+    Executive,
+    ExecutiveAdmin,
+    Operator,
+    Worker,
+    Judge,
+    TransitionJudge,
+}
+
+impl GovernedRoleName {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Senator => "senator",
+            Self::Legislator => "legislator",
+            Self::Voter => "voter",
+            Self::Executive => "executive",
+            Self::ExecutiveAdmin => "executive-admin",
+            Self::Operator => "operator",
+            Self::Worker => "worker",
+            Self::Judge => "judge",
+            Self::TransitionJudge => "transition-judge",
+        }
+    }
+
+    #[must_use]
+    pub const fn branch(self) -> GovernmentBranch {
+        match self {
+            Self::Senator | Self::Legislator | Self::Voter => GovernmentBranch::Legislative,
+            Self::Executive | Self::ExecutiveAdmin | Self::Operator | Self::Worker => {
+                GovernmentBranch::Executive
+            }
+            Self::Judge | Self::TransitionJudge => GovernmentBranch::Judicial,
+        }
+    }
+
+    #[must_use]
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "senator" => Some(Self::Senator),
+            "legislator" => Some(Self::Legislator),
+            "voter" => Some(Self::Voter),
+            "executive" => Some(Self::Executive),
+            "executive-admin" => Some(Self::ExecutiveAdmin),
+            "operator" => Some(Self::Operator),
+            "worker" => Some(Self::Worker),
+            "judge" => Some(Self::Judge),
+            "transition-judge" => Some(Self::TransitionJudge),
+            _ => None,
+        }
+    }
+}
+
+/// Role validation failure with enough structured context for diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum RoleValidationError {
+    #[error("unknown governed role name")]
+    UnknownName { name: String },
+    #[error(
+        "role name does not match governed branch: expected {expected_branch}, actual {actual_branch}"
+    )]
+    BranchMismatch {
+        name: String,
+        expected_branch: &'static str,
+        actual_branch: &'static str,
+    },
 }
 
 /// Role held by an actor in the constitutional fabric.
@@ -60,6 +149,58 @@ pub enum GovernmentBranch {
 pub struct Role {
     pub name: String,
     pub branch: GovernmentBranch,
+}
+
+impl Role {
+    #[must_use]
+    pub fn governed(name: GovernedRoleName) -> Self {
+        Self {
+            name: name.as_str().to_owned(),
+            branch: name.branch(),
+        }
+    }
+
+    /// Validate a role supplied from storage, API, MCP, or WASM context.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RoleValidationError::UnknownName`] when `self.name` is not a
+    /// governed role name, or [`RoleValidationError::BranchMismatch`] when the
+    /// governed role belongs to a different branch than `self.branch`.
+    pub fn validate_governed(&self) -> Result<GovernedRoleName, RoleValidationError> {
+        let Some(governed_name) = GovernedRoleName::parse(&self.name) else {
+            return Err(RoleValidationError::UnknownName {
+                name: self.name.clone(),
+            });
+        };
+        let expected_branch = governed_name.branch();
+        if expected_branch != self.branch {
+            return Err(RoleValidationError::BranchMismatch {
+                name: self.name.clone(),
+                expected_branch: expected_branch.as_str(),
+                actual_branch: self.branch.as_str(),
+            });
+        }
+        Ok(governed_name)
+    }
+
+    /// Construct and validate a governed role from external string input.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RoleValidationError`] if `name` is not governed or if it is
+    /// paired with the wrong branch.
+    pub fn try_new(
+        name: impl Into<String>,
+        branch: GovernmentBranch,
+    ) -> Result<Self, RoleValidationError> {
+        let role = Self {
+            name: name.into(),
+            branch,
+        };
+        role.validate_governed()?;
+        Ok(role)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -1505,10 +1505,8 @@ fn build_adjudication_context_from_rows(
                     )));
                 }
             };
-            Ok(Role {
-                name: r.role.clone(),
-                branch,
-            })
+            Role::try_new(r.role.clone(), branch)
+                .map_err(|e| GatewayError::Internal(format!("adjudication role row invalid: {e}")))
         })
         .collect::<Result<Vec<_>>>()?;
 
@@ -7283,7 +7281,7 @@ mod tests {
         AdjudicationContext {
             actor_roles: vec![Role {
                 name: "voter".to_string(),
-                branch: GovernmentBranch::Executive,
+                branch: GovernmentBranch::Legislative,
             }],
             authority_chain: AuthorityChain {
                 links: vec![signed_authority_link(&root, actor)],
@@ -7327,10 +7325,10 @@ mod tests {
         }
     }
 
-    fn db_role_row(actor: &Did, branch: &str) -> crate::db::AgentRoleRow {
+    fn db_role_row(actor: &Did, role: &str, branch: &str) -> crate::db::AgentRoleRow {
         crate::db::AgentRoleRow {
             agent_did: actor.as_str().to_string(),
-            role: "voter".to_string(),
+            role: role.to_string(),
             branch: branch.to_string(),
             granted_by: "did:exo:root-grantor".to_string(),
             valid_from: 1,
@@ -7378,11 +7376,31 @@ mod tests {
     #[test]
     fn adjudication_context_rows_reject_unknown_role_branch() {
         let actor = Did::new("did:exo:alice").unwrap();
-        let role_rows = vec![db_role_row(&actor, "tribunal")];
+        let role_rows = vec![db_role_row(&actor, "voter", "tribunal")];
 
         let result = build_adjudication_context_from_rows(&actor, &role_rows, &[], None);
 
         assert_internal_error_contains(result, "unknown role branch");
+    }
+
+    #[test]
+    fn adjudication_context_rows_reject_unknown_role_name() {
+        let actor = Did::new("did:exo:alice").unwrap();
+        let role_rows = vec![db_role_row(&actor, "root", "judicial")];
+
+        let result = build_adjudication_context_from_rows(&actor, &role_rows, &[], None);
+
+        assert_internal_error_contains(result, "unknown governed role name");
+    }
+
+    #[test]
+    fn adjudication_context_rows_reject_role_name_branch_mismatch() {
+        let actor = Did::new("did:exo:alice").unwrap();
+        let role_rows = vec![db_role_row(&actor, "judge", "executive")];
+
+        let result = build_adjudication_context_from_rows(&actor, &role_rows, &[], None);
+
+        assert_internal_error_contains(result, "does not match governed branch");
     }
 
     #[test]
@@ -7415,7 +7433,7 @@ mod tests {
         let kernel = adjudication_kernel();
         let actor = Did::new("did:exo:alice").unwrap();
         let valid_context = valid_db_context(&actor);
-        let role_rows = vec![db_role_row(&actor, "executive")];
+        let role_rows = vec![db_role_row(&actor, "voter", "legislative")];
         let consent_rows = vec![db_consent_row(&actor, "did:exo:root-grantor")];
         let chain_row = db_authority_chain_row(
             &actor,
@@ -7449,7 +7467,7 @@ mod tests {
                 PermissionSet::new(vec![Permission::new("advance_pace")]),
             )],
         };
-        let role_rows = vec![db_role_row(&actor, "executive")];
+        let role_rows = vec![db_role_row(&actor, "worker", "executive")];
         let consent_rows = vec![db_consent_row(&actor, root.as_str())];
         let chain_row =
             db_authority_chain_row(&actor, serde_json::to_value(&authority_chain).unwrap());
@@ -7586,7 +7604,7 @@ mod tests {
         let mut ctx = valid_db_context(&actor);
         ctx.actor_roles = vec![
             Role {
-                name: "voter".to_string(),
+                name: "worker".to_string(),
                 branch: GovernmentBranch::Executive,
             },
             Role {

--- a/crates/exo-gateway/tests/adjudication_db_integration.rs
+++ b/crates/exo-gateway/tests/adjudication_db_integration.rs
@@ -97,7 +97,7 @@ fn full_db_context(actor: &Did) -> AdjudicationContext {
     AdjudicationContext {
         actor_roles: vec![Role {
             name: "voter".into(),
-            branch: GovernmentBranch::Executive,
+            branch: GovernmentBranch::Legislative,
         }],
         authority_chain: AuthorityChain {
             links: vec![signed_authority_link(&grantor, actor)],
@@ -249,7 +249,7 @@ fn revoked_consent_denies() {
     let ctx = AdjudicationContext {
         actor_roles: vec![Role {
             name: "voter".into(),
-            branch: GovernmentBranch::Executive,
+            branch: GovernmentBranch::Legislative,
         }],
         authority_chain: AuthorityChain {
             links: vec![signed_authority_link(&grantor, &actor)],
@@ -287,7 +287,7 @@ fn cross_branch_roles_denies() {
     let mut ctx = full_db_context(&actor);
     ctx.actor_roles = vec![
         Role {
-            name: "voter".into(),
+            name: "worker".into(),
             branch: GovernmentBranch::Executive,
         },
         Role {

--- a/crates/exo-gateway/tests/decision_forum_integration.rs
+++ b/crates/exo-gateway/tests/decision_forum_integration.rs
@@ -118,7 +118,7 @@ fn transition_context(actor: &Did, from: BctsState, to: BctsState) -> Adjudicati
     let permission = bcts_transition_permission(from, to);
     AdjudicationContext {
         actor_roles: vec![Role {
-            name: "gateway-transition-judge".into(),
+            name: "transition-judge".into(),
             branch: GovernmentBranch::Judicial,
         }],
         authority_chain: AuthorityChain {

--- a/crates/exo-node/src/holons.rs
+++ b/crates/exo-node/src/holons.rs
@@ -404,7 +404,7 @@ pub fn build_holon_adjudication_context(
     let provenance_timestamp = next_provenance_timestamp(config)?;
     Ok(AdjudicationContext {
         actor_roles: vec![Role {
-            name: "infrastructure-agent".into(),
+            name: "worker".into(),
             branch: GovernmentBranch::Executive,
         }],
         authority_chain: AuthorityChain {

--- a/crates/exo-node/src/mcp/handler.rs
+++ b/crates/exo-node/src/mcp/handler.rs
@@ -627,7 +627,7 @@ mod tests {
             "self_escalation": false,
             "adjudication_context": {
                 "actor_roles": [
-                    { "name": "mcp-agent", "branch": "Judicial" }
+                    { "name": "operator", "branch": "Executive" }
                 ],
                 "authority_chain": [
                     {

--- a/crates/exo-node/src/mcp/middleware.rs
+++ b/crates/exo-node/src/mcp/middleware.rs
@@ -414,7 +414,7 @@ mod tests {
                 "self_escalation": false,
                 "adjudication_context": {
                     "actor_roles": [
-                        { "name": "mcp-agent", "branch": "Judicial" }
+                        { "name": "operator", "branch": "Executive" }
                     ],
                     "authority_chain": [
                         {

--- a/crates/exo-node/src/mcp/tools/authority.rs
+++ b/crates/exo-node/src/mcp/tools/authority.rs
@@ -271,7 +271,9 @@ fn parse_roles(value: &Value) -> Result<Vec<Role>, String> {
             .map_err(|err| format!("actor_roles[{idx}]: {err}"))?;
         let branch =
             parse_branch(branch_raw).map_err(|err| format!("actor_roles[{idx}]: {err}"))?;
-        roles.push(Role { name, branch });
+        let role =
+            Role::try_new(name, branch).map_err(|err| format!("actor_roles[{idx}]: {err}"))?;
+        roles.push(role);
     }
     Ok(roles)
 }
@@ -1457,6 +1459,31 @@ mod tests {
         let text = result.content[0].text();
         assert_text_omits_raw_input(text, attacker_marker);
         assert!(text.contains("actor_roles[0]"));
+    }
+
+    #[test]
+    fn execute_adjudicate_action_context_role_name_error_omits_raw_input() {
+        let action = "read medical record";
+        let attacker_marker = "<script>alert(1)</script>";
+        let attacker_input = format!("operator-{attacker_marker}");
+        let mut context = adjudication_context_json("did:exo:alice", action);
+        context["actor_roles"][0]["name"] = json!(attacker_input);
+
+        let result = execute_adjudicate_action(
+            &json!({
+                "actor_did": "did:exo:alice",
+                "action": action,
+                "required_permissions": ["execute"],
+                "context": context,
+            }),
+            &NodeContext::empty(),
+        );
+
+        assert!(result.is_error);
+        let text = result.content[0].text();
+        assert_text_omits_raw_input(text, attacker_marker);
+        assert!(text.contains("actor_roles[0]"));
+        assert!(text.contains("unknown governed role name"));
     }
 
     #[test]

--- a/crates/exochain-sdk/src/kernel.rs
+++ b/crates/exochain-sdk/src/kernel.rs
@@ -507,7 +507,7 @@ impl ConstitutionalKernel {
 
         let context = AdjudicationContext {
             actor_roles: vec![Role {
-                name: "sdk-default".into(),
+                name: "judge".into(),
                 branch: GovernmentBranch::Judicial,
             }],
             authority_chain: AuthorityChain {


### PR DESCRIPTION
## Summary

Remediates the live portion of the external F-035 role-fidelity finding. The outside report claimed SeparationOfPowers could be bypassed through `Role.name`; current `main` already aggregated by `GovernmentBranch`, so the exact branch-bypass claim was stale/overbroad. The live issue was that `Role.name` was unconstrained string evidence accepted from core runtime adapters, allowing arbitrary or mismatched role labels to enter adjudication context.

This PR:
- adds a finite `GovernedRoleName` enum and branch mapping in `exo-gatekeeper`
- validates every supplied role during `SeparationOfPowers` enforcement
- fails closed on unknown governed role names and name/branch mismatches
- validates DB-loaded gateway roles and MCP-supplied adjudication roles at adapter boundaries
- normalizes internal test/fixture roles to governed names
- refreshes README repo-truth counts after adding regression tests

## Classification

- EXOCHAIN core: `crates/exo-gatekeeper/src/types.rs`, `crates/exo-gatekeeper/src/invariants.rs`, `crates/exo-gatekeeper/src/kernel.rs`, `crates/exo-gatekeeper/src/holon.rs`
- Core runtime adapters: `crates/exo-gateway/src/server.rs`, gateway adjudication integration tests, `crates/exo-node/src/mcp/*`, `crates/exochain-sdk/src/kernel.rs`
- EXOCHAIN core tests/fixtures: `crates/decision-forum/tests/governance_kernel_integration.rs`, `crates/exo-escalation/tests/sybil_adjudication.rs`
- Documentation truth only: `README.md`
- Imported evidence: none committed
- Adjacent surface: none

## TDD / Verification

Red tests observed before fixes:
- `cargo test -p exo-gatekeeper separation_rejects_unknown_role_name`
- `cargo test -p exo-gatekeeper separation_rejects_role_name_branch_mismatch`
- `cargo test -p exo-gateway adjudication_context_rows_reject_unknown_role_name`
- `cargo test -p exo-gateway adjudication_context_rows_reject_role_name_branch_mismatch`
- `cargo test -p exo-node execute_adjudicate_action_context_role_name_error_omits_raw_input`

Passing validation:
- `cargo test -p exo-gatekeeper`
- `cargo test -p exo-gateway`
- `cargo test -p exo-node`
- `cargo test -p exo-escalation`
- `cargo test -p exochain-sdk`
- `cargo test -p decision-forum`
- `cargo test -p exo-legal`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --release`
- `cargo fmt --all -- --check`
- `cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check` (passes; existing duplicate dependency warnings remain)
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `git diff --check`
- `./tools/cross-impl-test/compare.sh` (Rust-only; TypeScript comparison skipped because `EXO_TS_ROOT` is not configured)

After a final non-behavioral derive cleanup, reran:
- `cargo test -p exo-gatekeeper separation_rejects_`
- `cargo clippy -p exo-gatekeeper --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `bash tools/test_repo_truth.sh`
- `git diff --check`
