### PR TITLE
fix(gatekeeper): reject simulated tee in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 162862 | `wc -l` |
+| Rust LOC | 162844 | `wc -l` |
 | Workspace tests | 3,998 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -80,7 +80,7 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 162862 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 162844 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 3,998 listed workspace tests
 

--- a/crates/exo-gatekeeper/src/tee.rs
+++ b/crates/exo-gatekeeper/src/tee.rs
@@ -31,8 +31,7 @@ pub enum TeePlatform {
 /// The deployment environment for TEE policy enforcement.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TeeEnvironment {
-    /// Production — simulated TEE is rejected unless the
-    /// `allow-simulated-tee` feature flag is enabled.
+    /// Production — simulated TEE fixtures are rejected.
     Production,
     /// Testing — all platforms including Simulated are permitted.
     Testing,
@@ -130,13 +129,8 @@ impl TeePolicy {
 /// Check whether a platform is allowed by policy, enforcing the production
 /// gate against simulated TEEs.
 fn is_platform_allowed(platform: &TeePlatform, policy: &TeePolicy) -> bool {
-    if *platform == TeePlatform::Simulated {
-        #[cfg(not(feature = "allow-simulated-tee"))]
-        {
-            if policy.environment == TeeEnvironment::Production {
-                return false;
-            }
-        }
+    if *platform == TeePlatform::Simulated && policy.environment != TeeEnvironment::Testing {
+        return false;
     }
     policy.accepted_platforms.contains(platform)
 }
@@ -193,19 +187,7 @@ fn synthetic_signature_allowed(attestation: &TeeAttestation, policy: &TeePolicy)
         return false;
     }
 
-    if policy.environment == TeeEnvironment::Testing {
-        return true;
-    }
-
-    #[cfg(feature = "allow-simulated-tee")]
-    {
-        policy.environment == TeeEnvironment::Production
-    }
-
-    #[cfg(not(feature = "allow-simulated-tee"))]
-    {
-        false
-    }
+    policy.environment == TeeEnvironment::Testing
 }
 
 fn measurement_hash_eq_ct(left: &[u8; 32], right: &[u8; 32]) -> bool {


### PR DESCRIPTION
## Summary
- keep `TeePlatform::Simulated` limited to explicit `TeeEnvironment::Testing` policies, even when the legacy `allow-simulated-tee` feature is compiled
- update README repo-truth Rust LOC values after the code delta

## Classification
- `crates/exo-gatekeeper/src/tee.rs`: EXOCHAIN core
- `README.md`: documentation/repo-truth hygiene

## Finding Validation
- Old Task 4 report was re-checked against current main before editing. Default TEE and proof boundaries were already remediated.
- Live issue reproduced with `cargo test -p exo-gatekeeper --features allow-simulated-tee tee`, which failed `tee::tests::simulated_rejected_in_production` before the fix because a production policy manually containing `Simulated` accepted synthetic fixture attestation.

## Validation
- `cargo test -p exo-gatekeeper --features allow-simulated-tee tee::tests::simulated_rejected_in_production`
- `cargo test -p exo-gatekeeper tee`
- `cargo test -p exo-gatekeeper --features allow-simulated-tee tee`
- `cargo test -p exo-gatekeeper`
- `cargo test -p exo-gatekeeper --features allow-simulated-tee`
- `cargo test -p exo-proofs`
- `cargo test -p exo-proofs --features unaudited-pedagogical-proofs stark`
- `cargo fmt --all -- --check`
- `cargo clippy -p exo-gatekeeper --all-targets --features allow-simulated-tee -- -D warnings`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --release`
- `cargo doc --workspace --no-deps`
- `cargo test --workspace --release`
- `cargo audit`
- `cargo deny check`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `git diff --check`

## Notes
- `cargo fmt --all -- --check` emits existing stable-toolchain warnings for nightly-only rustfmt settings, but exits 0.
- `cargo deny check` exits 0 with existing duplicate dependency warnings.
