### PR TITLE
fix(identity): require explicit vault nonces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1547,7 +1547,6 @@ dependencies = [
  "getrandom 0.2.16",
  "hkdf",
  "proptest",
- "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 163075 | `wc -l` |
+| Rust LOC | 163236 | `wc -l` |
 | Workspace tests | 3,998 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -80,7 +80,7 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 163075 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 163236 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 3,998 listed workspace tests
 

--- a/crates/exo-identity/Cargo.toml
+++ b/crates/exo-identity/Cargo.toml
@@ -20,7 +20,6 @@ bs58 = { workspace = true }
 sha2 = { workspace = true }
 chacha20poly1305 = { workspace = true }
 hkdf = { workspace = true }
-rand = { workspace = true }
 getrandom = { workspace = true }
 zeroize = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/exo-identity/src/error.rs
+++ b/crates/exo-identity/src/error.rs
@@ -152,6 +152,12 @@ pub enum IdentityError {
     #[error("vault key derivation failed: {0}")]
     VaultKeyDerivationFailed(String),
 
+    #[error("vault encryption requires a caller-supplied nonce")]
+    VaultNonceRequired,
+
+    #[error("invalid vault nonce: {reason}")]
+    InvalidVaultNonce { reason: String },
+
     #[error("vault encryption failed: {0}")]
     VaultEncryptionFailed(String),
 

--- a/crates/exo-identity/src/vault.rs
+++ b/crates/exo-identity/src/vault.rs
@@ -7,7 +7,7 @@
 //! Key derivation uses HKDF-SHA256 from an Ed25519 secret key with a
 //! protocol-domain salt.
 //!
-//! Ciphertext format: `[24-byte nonce][encrypted payload][16-byte Poly1305 tag]`
+//! Ciphertext format: `[24-byte nonce][encrypted payload][16-byte Poly1305 tag]`.
 
 use chacha20poly1305::{
     XChaCha20Poly1305,
@@ -21,7 +21,10 @@ use zeroize::{Zeroize, Zeroizing};
 use crate::error::IdentityError;
 
 /// Size of the XChaCha20-Poly1305 nonce in bytes.
-const NONCE_SIZE: usize = 24;
+pub const VAULT_NONCE_SIZE: usize = 24;
+
+/// Size of the XChaCha20-Poly1305 nonce in bytes.
+const NONCE_SIZE: usize = VAULT_NONCE_SIZE;
 
 /// Size of the Poly1305 authentication tag in bytes.
 const TAG_SIZE: usize = 16;
@@ -66,27 +69,25 @@ impl VaultEncryptor {
         Ok(Self { key: *okm })
     }
 
-    /// Encrypt `plaintext` with XChaCha20-Poly1305.
+    /// Legacy encryption entrypoint retained for API compatibility.
     ///
-    /// `associated_data` should be the DID bytes so the ciphertext is bound
-    /// to the identity.  A random 24-byte nonce is generated for each
+    /// Vault encryption must receive an explicit nonce from the caller so the
+    /// runtime path remains deterministic and the nonce provenance is auditable.
+    /// Use [`encrypt_with_nonce`](Self::encrypt_with_nonce) for supported
     /// encryption.
-    ///
-    /// Returns `[24-byte nonce][ciphertext][16-byte tag]`.
     ///
     /// # Errors
     ///
-    /// Returns `IdentityError::VaultEncryptionFailed` on cipher failure.
+    /// Always returns `IdentityError::VaultNonceRequired`.
     pub fn encrypt(
         &self,
-        plaintext: &[u8],
-        associated_data: &[u8],
+        _plaintext: &[u8],
+        _associated_data: &[u8],
     ) -> Result<Vec<u8>, IdentityError> {
-        let nonce = self.random_nonce();
-        self.encrypt_with_nonce(plaintext, associated_data, &nonce)
+        Err(IdentityError::VaultNonceRequired)
     }
 
-    /// Decrypt a ciphertext produced by [`encrypt`](Self::encrypt).
+    /// Decrypt a ciphertext produced by [`encrypt_with_nonce`](Self::encrypt_with_nonce).
     ///
     /// `associated_data` must match the value used during encryption.
     ///
@@ -128,22 +129,28 @@ impl VaultEncryptor {
         &self.key
     }
 
-    // ---- internal helpers ----
-
-    /// Generate a random 24-byte nonce using the OS CSPRNG.
-    fn random_nonce(&self) -> [u8; NONCE_SIZE] {
-        let mut nonce = [0u8; NONCE_SIZE];
-        rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut nonce);
-        nonce
-    }
-
-    /// Encrypt with an explicit nonce (used for deterministic tests).
-    fn encrypt_with_nonce(
+    /// Encrypt with an explicit caller-supplied nonce.
+    ///
+    /// `associated_data` should be the DID bytes so the ciphertext is bound
+    /// to the identity. The nonce must be unique for the derived key and must
+    /// be supplied by the caller from an auditable deterministic runtime input.
+    ///
+    /// Returns `[24-byte nonce][ciphertext][16-byte tag]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `IdentityError::InvalidVaultNonce` when the nonce fails local
+    /// validation.
+    ///
+    /// Returns `IdentityError::VaultEncryptionFailed` on cipher failure.
+    pub fn encrypt_with_nonce(
         &self,
         plaintext: &[u8],
         associated_data: &[u8],
-        nonce: &[u8; NONCE_SIZE],
+        nonce: &[u8; VAULT_NONCE_SIZE],
     ) -> Result<Vec<u8>, IdentityError> {
+        Self::validate_nonce(nonce)?;
+
         let cipher = XChaCha20Poly1305::new(self.cipher_key());
         let xcnonce = chacha20poly1305::XNonce::from_slice(nonce);
 
@@ -162,6 +169,18 @@ impl VaultEncryptor {
         out.extend_from_slice(nonce);
         out.extend_from_slice(&encrypted);
         Ok(out)
+    }
+
+    // ---- internal helpers ----
+
+    fn validate_nonce(nonce: &[u8; VAULT_NONCE_SIZE]) -> Result<(), IdentityError> {
+        if nonce.iter().all(|byte| *byte == 0) {
+            return Err(IdentityError::InvalidVaultNonce {
+                reason: "nonce must not be all zero".into(),
+            });
+        }
+
+        Ok(())
     }
 
     /// Build the `chacha20poly1305` key type from our raw bytes.
@@ -194,31 +213,87 @@ mod tests {
 
     use super::*;
 
-    /// Helper: create a VaultEncryptor from a fresh random key.
-    fn random_encryptor() -> VaultEncryptor {
-        let mut key = [0u8; 32];
-        rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut key);
-        VaultEncryptor::from_key(key)
+    /// Helper: create a VaultEncryptor from deterministic test key material.
+    fn test_encryptor() -> VaultEncryptor {
+        VaultEncryptor::from_key([0x42; 32])
+    }
+
+    fn test_nonce(tag: u8) -> [u8; NONCE_SIZE] {
+        [tag; NONCE_SIZE]
+    }
+
+    fn encrypt_for_test(
+        enc: &VaultEncryptor,
+        plaintext: &[u8],
+        associated_data: &[u8],
+        nonce_tag: u8,
+    ) -> Vec<u8> {
+        enc.encrypt_with_nonce(plaintext, associated_data, &test_nonce(nonce_tag))
+            .expect("encrypt_with_nonce")
     }
 
     #[test]
     fn encrypt_decrypt_round_trip() {
-        let enc = random_encryptor();
+        let enc = test_encryptor();
         let plaintext = b"secret identity data";
         let ad = b"did:exo:alice";
 
-        let ct = enc.encrypt(plaintext, ad).expect("encrypt");
+        let ct = encrypt_for_test(&enc, plaintext, ad, 1);
         let pt = enc.decrypt(&ct, ad).expect("decrypt");
         assert_eq!(pt, plaintext);
     }
 
     #[test]
+    fn encrypt_requires_caller_supplied_nonce() {
+        let enc = test_encryptor();
+        let result = enc.encrypt(b"secret identity data", b"did:exo:alice");
+
+        assert!(
+            matches!(result, Err(IdentityError::VaultNonceRequired)),
+            "implicit nonce generation must fail closed, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn encrypt_source_does_not_generate_internal_nonce() {
+        let source = include_str!("vault.rs");
+        let production = match source.split("#[cfg(test)]").next() {
+            Some(production) => production,
+            None => panic!("test boundary marker must be present"),
+        };
+
+        assert!(
+            !production.contains("random_nonce"),
+            "vault encryption must not hide nonce generation inside production logic"
+        );
+        assert!(
+            !production.contains("OsRng"),
+            "vault encryption must not use OS randomness in production logic"
+        );
+        assert!(
+            !production.contains("fill_bytes"),
+            "vault encryption must not fill nonce bytes from hidden randomness"
+        );
+    }
+
+    #[test]
+    fn encrypt_with_nonce_rejects_all_zero_nonce() {
+        let enc = test_encryptor();
+        let result = enc.encrypt_with_nonce(b"secret identity data", b"did:exo:alice", &[0u8; 24]);
+
+        assert!(
+            matches!(result, Err(IdentityError::InvalidVaultNonce { .. })),
+            "zero nonce must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
     fn tampered_ciphertext_fails() {
-        let enc = random_encryptor();
+        let enc = test_encryptor();
         let plaintext = b"do not tamper";
         let ad = b"did:exo:bob";
 
-        let mut ct = enc.encrypt(plaintext, ad).expect("encrypt");
+        let mut ct = encrypt_for_test(&enc, plaintext, ad, 2);
         // Flip a byte in the encrypted payload (after nonce)
         let idx = NONCE_SIZE + 1;
         ct[idx] ^= 0xff;
@@ -232,12 +307,12 @@ mod tests {
 
     #[test]
     fn wrong_key_fails() {
-        let enc1 = random_encryptor();
-        let enc2 = random_encryptor();
+        let enc1 = VaultEncryptor::from_key([0x11; 32]);
+        let enc2 = VaultEncryptor::from_key([0x22; 32]);
         let plaintext = b"key mismatch";
         let ad = b"did:exo:carol";
 
-        let ct = enc1.encrypt(plaintext, ad).expect("encrypt");
+        let ct = encrypt_for_test(&enc1, plaintext, ad, 3);
         let result = enc2.decrypt(&ct, ad);
         assert!(
             matches!(result, Err(IdentityError::VaultDecryptionFailed)),
@@ -247,12 +322,12 @@ mod tests {
 
     #[test]
     fn wrong_associated_data_fails() {
-        let enc = random_encryptor();
+        let enc = test_encryptor();
         let plaintext = b"bound to identity";
         let ad_a = b"did:exo:alice";
         let ad_b = b"did:exo:eve";
 
-        let ct = enc.encrypt(plaintext, ad_a).expect("encrypt");
+        let ct = encrypt_for_test(&enc, plaintext, ad_a, 4);
         let result = enc.decrypt(&ct, ad_b);
         assert!(
             matches!(result, Err(IdentityError::VaultDecryptionFailed)),
@@ -262,10 +337,10 @@ mod tests {
 
     #[test]
     fn empty_plaintext() {
-        let enc = random_encryptor();
+        let enc = test_encryptor();
         let ad = b"did:exo:empty";
 
-        let ct = enc.encrypt(b"", ad).expect("encrypt");
+        let ct = encrypt_for_test(&enc, b"", ad, 5);
         assert_eq!(
             ct.len(),
             NONCE_SIZE + TAG_SIZE,
@@ -278,11 +353,11 @@ mod tests {
 
     #[test]
     fn large_plaintext() {
-        let enc = random_encryptor();
+        let enc = test_encryptor();
         let plaintext = vec![0xab_u8; 1_000_000]; // 1 MB
         let ad = b"did:exo:large";
 
-        let ct = enc.encrypt(&plaintext, ad).expect("encrypt");
+        let ct = encrypt_for_test(&enc, &plaintext, ad, 6);
         let pt = enc.decrypt(&ct, ad).expect("decrypt");
         assert_eq!(pt, plaintext);
     }
@@ -369,7 +444,7 @@ mod tests {
         assert_zeroize_impl::<[u8; 32]>(); // underlying storage implements Zeroize
 
         // Functional check: create an encryptor, do work, drop it.
-        let enc = random_encryptor();
+        let enc = test_encryptor();
         let key_copy = *enc.key_bytes();
         // Key was non-zero before drop
         assert_ne!(key_copy, [0u8; 32]);

--- a/crates/exo-messaging/src/compose.rs
+++ b/crates/exo-messaging/src/compose.rs
@@ -5,7 +5,7 @@
 //! XChaCha20-Poly1305, and signs the envelope with the sender's Ed25519 key.
 
 use exo_core::{Did, Hash256, PublicKey, SecretKey, Signature, Timestamp};
-use exo_identity::vault::VaultEncryptor;
+use exo_identity::vault::{VAULT_NONCE_SIZE, VaultEncryptor};
 use uuid::Uuid;
 
 use crate::{
@@ -16,6 +16,7 @@ use crate::{
 
 /// The HKDF context string for message encryption key derivation.
 const MESSAGE_KEX_CONTEXT: &[u8] = b"vitallock-message-v1";
+const MESSAGE_VAULT_NONCE_DOMAIN: &[u8] = b"exo.messaging.vault-nonce.v1";
 
 /// Caller-supplied provenance metadata for an encrypted envelope.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -114,16 +115,26 @@ pub fn prepare_envelope_for_signing(
         MESSAGE_KEX_CONTEXT,
     )?;
 
+    let plaintext_hash = Hash256::digest(plaintext);
+    let nonce = derive_vault_nonce(
+        &metadata,
+        content_type,
+        sender_did,
+        recipient_did,
+        ephemeral.public.as_bytes(),
+        &plaintext_hash,
+        release_on_death,
+        release_delay_hours,
+    )?;
+
     // 3. Encrypt plaintext with XChaCha20-Poly1305
     //    Associated data = recipient DID (binds ciphertext to intended recipient)
     let encryptor = VaultEncryptor::from_key(shared_key);
     let ciphertext = encryptor
-        .encrypt(plaintext, recipient_did.as_str().as_bytes())
+        .encrypt_with_nonce(plaintext, recipient_did.as_str().as_bytes(), &nonce)
         .map_err(|e| MessagingError::EncryptionFailed(e.to_string()))?;
 
     // 4. Hash plaintext for post-decrypt integrity check
-    let plaintext_hash = Hash256::digest(plaintext);
-
     // 5. Build envelope (without signature first)
     let envelope = EncryptedEnvelope {
         id: metadata.id.to_string(),
@@ -140,6 +151,57 @@ pub fn prepare_envelope_for_signing(
     };
 
     Ok(envelope)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn derive_vault_nonce(
+    metadata: &ComposeMetadata,
+    content_type: ContentType,
+    sender_did: &Did,
+    recipient_did: &Did,
+    ephemeral_public_key: &[u8; 32],
+    plaintext_hash: &Hash256,
+    release_on_death: bool,
+    release_delay_hours: u32,
+) -> Result<[u8; VAULT_NONCE_SIZE], MessagingError> {
+    let mut transcript = Vec::new();
+    transcript.extend_from_slice(MESSAGE_VAULT_NONCE_DOMAIN);
+    append_len_prefixed(&mut transcript, "id", metadata.id.as_bytes())?;
+    transcript.extend_from_slice(&metadata.created.physical_ms.to_le_bytes());
+    transcript.extend_from_slice(&metadata.created.logical.to_le_bytes());
+    append_len_prefixed(
+        &mut transcript,
+        "sender_did",
+        sender_did.as_str().as_bytes(),
+    )?;
+    append_len_prefixed(
+        &mut transcript,
+        "recipient_did",
+        recipient_did.as_str().as_bytes(),
+    )?;
+    transcript.extend_from_slice(ephemeral_public_key);
+    transcript.extend_from_slice(plaintext_hash.as_bytes());
+    transcript.push(u8::from(content_type));
+    transcript.push(u8::from(release_on_death));
+    transcript.extend_from_slice(&release_delay_hours.to_le_bytes());
+
+    let digest = Hash256::digest(&transcript);
+    let mut nonce = [0u8; VAULT_NONCE_SIZE];
+    nonce.copy_from_slice(&digest.as_bytes()[..VAULT_NONCE_SIZE]);
+    Ok(nonce)
+}
+
+fn append_len_prefixed(
+    transcript: &mut Vec<u8>,
+    label: &'static str,
+    value: &[u8],
+) -> Result<(), MessagingError> {
+    transcript.extend_from_slice(label.as_bytes());
+    let len = u64::try_from(value.len())
+        .map_err(|_| MessagingError::InvalidEnvelope(format!("{label} length exceeds u64::MAX")))?;
+    transcript.extend_from_slice(&len.to_le_bytes());
+    transcript.extend_from_slice(value);
+    Ok(())
 }
 
 /// Sign a prepared envelope with an in-process Ed25519 secret key.
@@ -377,6 +439,24 @@ mod tests {
         assert!(
             !production.contains(&forbidden_clock),
             "compose production path must not fabricate HLC timestamps"
+        );
+    }
+
+    #[test]
+    fn compose_path_supplies_explicit_vault_nonce() {
+        let source = include_str!("compose.rs");
+        let production = source
+            .split("// ===========================================================================")
+            .next()
+            .expect("production section");
+
+        assert!(
+            production.contains("encrypt_with_nonce"),
+            "compose must pass an explicit deterministic nonce into vault encryption"
+        );
+        assert!(
+            !production.contains(".encrypt("),
+            "compose must not call the implicit vault encryption entrypoint"
         );
     }
 }


### PR DESCRIPTION
## Summary
- confirmed production `VaultEncryptor::encrypt` still generated XChaCha nonces internally with `OsRng` on current `origin/main`
- changed implicit vault encryption to fail closed with `VaultNonceRequired`
- exposed `encrypt_with_nonce` as the explicit deterministic nonce boundary and reject all-zero nonces
- updated `exo-messaging` compose path to derive a domain-separated vault nonce from caller-supplied envelope metadata and message context
- removed now-unused `rand` dependency from `exo-identity`
- updated README repo-truth Rust LOC

## Path classification
- EXOCHAIN core: `Cargo.lock`, `crates/exo-identity/Cargo.toml`, `crates/exo-identity/src/error.rs`, `crates/exo-identity/src/vault.rs`, `README.md`
- Core runtime adapter: `crates/exo-messaging/src/compose.rs`
- Imported evidence: none committed
- Adjacent surface / third-party/vendor: none touched

## TDD / live reproduction
- RED: `cargo test -p exo-identity vault::tests::encrypt -- --nocapture` failed because implicit nonce generation succeeded, production source contained `random_nonce`/`OsRng`/`fill_bytes`, and an all-zero nonce was accepted
- RED adapter bypass: `cargo test -p exo-messaging compose::tests::lock_and_send_produces_valid_envelope -- --nocapture` failed with `VaultNonceRequired`; `compose_path_supplies_explicit_vault_nonce` failed before the adapter fix

## Validation
- `cargo test -p exo-identity`
- `cargo test -p exo-messaging`
- `cargo clippy -p exo-identity -p exo-messaging --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `bash tools/test_repo_truth.sh`
- `git diff --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check` (existing duplicate dependency warnings; exit 0)
- `cargo machete --with-metadata`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `./tools/cross-impl-test/compare.sh` (Rust determinism passed; TypeScript skipped because `EXO_TS_ROOT` is not set)

## Bypass search
- Searched `VaultEncryptor`, `.encrypt(`, `encrypt_with_nonce`, `random_nonce`, `OsRng`, and `fill_bytes` across `crates`, `packages`, and `tools`
- Confirmed `exo-messaging` no longer calls the implicit vault encryption entrypoint
- Remaining RNG hits are separate candidates: core key generation, X25519 key exchange, and node OTP generation; not mixed into this commit