### PR TITLE
fix(messaging): require explicit x25519 ephemeral keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,7 +1581,6 @@ dependencies = [
  "exo-identity",
  "hex",
  "hkdf",
- "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 163236 | `wc -l` |
+| Rust LOC | 163455 | `wc -l` |
 | Workspace tests | 3,998 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -80,7 +80,7 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 163236 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 163455 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 3,998 listed workspace tests
 

--- a/crates/exo-messaging/Cargo.toml
+++ b/crates/exo-messaging/Cargo.toml
@@ -20,7 +20,6 @@ serde_json = { workspace = true }
 x25519-dalek = { workspace = true }
 hkdf = { workspace = true }
 sha2 = { workspace = true }
-rand = { workspace = true }
 zeroize = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }

--- a/crates/exo-messaging/src/compose.rs
+++ b/crates/exo-messaging/src/compose.rs
@@ -1,8 +1,9 @@
 //! Compose & Lock — sender-side message encryption.
 //!
-//! Generates an ephemeral X25519 keypair, performs ECDH with the recipient's
-//! public key, derives a symmetric key via HKDF, encrypts the plaintext with
-//! XChaCha20-Poly1305, and signs the envelope with the sender's Ed25519 key.
+//! Requires caller-supplied ephemeral X25519 key material, performs ECDH with
+//! the recipient's public key, derives a symmetric key via HKDF, encrypts the
+//! plaintext with XChaCha20-Poly1305, and signs the envelope with the sender's
+//! Ed25519 key.
 
 use exo_core::{Did, Hash256, PublicKey, SecretKey, Signature, Timestamp};
 use exo_identity::vault::{VAULT_NONCE_SIZE, VaultEncryptor};
@@ -11,7 +12,7 @@ use uuid::Uuid;
 use crate::{
     envelope::{ContentType, EncryptedEnvelope},
     error::MessagingError,
-    kex::{self, X25519PublicKey},
+    kex::{self, X25519KeyPair, X25519PublicKey},
 };
 
 /// The HKDF context string for message encryption key derivation.
@@ -44,7 +45,11 @@ impl ComposeMetadata {
     }
 }
 
-/// Lock & Send: encrypt a message for a specific recipient.
+/// Legacy Lock & Send entrypoint.
+///
+/// This fails closed because EXOCHAIN message composition must not fabricate
+/// X25519 key material internally. Use [`lock_and_send_with_ephemeral`] with a
+/// caller-supplied one-time X25519 keypair.
 ///
 /// # Arguments
 ///
@@ -60,7 +65,7 @@ impl ComposeMetadata {
 ///
 /// # Returns
 ///
-/// An `EncryptedEnvelope` ready for transmission/storage.
+/// A fail-closed error directing callers to the explicit ephemeral-key API.
 #[allow(clippy::too_many_arguments)]
 // 8 args is the minimum for a sender→recipient envelope with
 // death-trigger semantics: plaintext + content_type + sender DID +
@@ -79,12 +84,41 @@ pub fn lock_and_send(
     release_on_death: bool,
     release_delay_hours: u32,
 ) -> Result<EncryptedEnvelope, MessagingError> {
-    let envelope = prepare_envelope_for_signing(
+    let _ = (
+        plaintext,
+        content_type,
+        sender_did,
+        recipient_did,
+        sender_signing_key,
+        recipient_x25519_public,
+        metadata,
+        release_on_death,
+        release_delay_hours,
+    );
+    Err(caller_supplied_ephemeral_required())
+}
+
+/// Lock & Send with caller-supplied X25519 ephemeral key material.
+#[allow(clippy::too_many_arguments)]
+pub fn lock_and_send_with_ephemeral(
+    plaintext: &[u8],
+    content_type: ContentType,
+    sender_did: &Did,
+    recipient_did: &Did,
+    sender_signing_key: &SecretKey,
+    recipient_x25519_public: &X25519PublicKey,
+    ephemeral_x25519_keypair: &X25519KeyPair,
+    metadata: ComposeMetadata,
+    release_on_death: bool,
+    release_delay_hours: u32,
+) -> Result<EncryptedEnvelope, MessagingError> {
+    let envelope = prepare_envelope_for_signing_with_ephemeral(
         plaintext,
         content_type,
         sender_did,
         recipient_did,
         recipient_x25519_public,
+        ephemeral_x25519_keypair,
         metadata,
         release_on_death,
         release_delay_hours,
@@ -92,8 +126,12 @@ pub fn lock_and_send(
     sign_prepared_envelope(envelope, sender_signing_key)
 }
 
-/// Encrypt a message and return the unsigned envelope whose signing payload
-/// can be signed outside this crate.
+/// Legacy unsigned-envelope entrypoint.
+///
+/// This fails closed because EXOCHAIN message composition must not fabricate
+/// X25519 key material internally. Use
+/// [`prepare_envelope_for_signing_with_ephemeral`] with a caller-supplied
+/// one-time X25519 keypair.
 #[allow(clippy::too_many_arguments)]
 pub fn prepare_envelope_for_signing(
     plaintext: &[u8],
@@ -105,12 +143,36 @@ pub fn prepare_envelope_for_signing(
     release_on_death: bool,
     release_delay_hours: u32,
 ) -> Result<EncryptedEnvelope, MessagingError> {
-    // 1. Generate ephemeral X25519 keypair
-    let ephemeral = kex::generate_ephemeral();
+    let _ = (
+        plaintext,
+        content_type,
+        sender_did,
+        recipient_did,
+        recipient_x25519_public,
+        metadata,
+        release_on_death,
+        release_delay_hours,
+    );
+    Err(caller_supplied_ephemeral_required())
+}
 
-    // 2. ECDH: derive shared symmetric key
+/// Encrypt a message with caller-supplied X25519 ephemeral key material and
+/// return the unsigned envelope whose signing payload can be signed externally.
+#[allow(clippy::too_many_arguments)]
+pub fn prepare_envelope_for_signing_with_ephemeral(
+    plaintext: &[u8],
+    content_type: ContentType,
+    sender_did: &Did,
+    recipient_did: &Did,
+    recipient_x25519_public: &X25519PublicKey,
+    ephemeral_x25519_keypair: &X25519KeyPair,
+    metadata: ComposeMetadata,
+    release_on_death: bool,
+    release_delay_hours: u32,
+) -> Result<EncryptedEnvelope, MessagingError> {
+    // 1. ECDH: derive shared symmetric key using caller-supplied ephemeral key.
     let shared_key = kex::derive_shared_key(
-        &ephemeral.secret,
+        &ephemeral_x25519_keypair.secret,
         recipient_x25519_public,
         MESSAGE_KEX_CONTEXT,
     )?;
@@ -121,7 +183,7 @@ pub fn prepare_envelope_for_signing(
         content_type,
         sender_did,
         recipient_did,
-        ephemeral.public.as_bytes(),
+        ephemeral_x25519_keypair.public.as_bytes(),
         &plaintext_hash,
         release_on_death,
         release_delay_hours,
@@ -140,7 +202,7 @@ pub fn prepare_envelope_for_signing(
         id: metadata.id.to_string(),
         sender_did: sender_did.clone(),
         recipient_did: recipient_did.clone(),
-        ephemeral_public_key: *ephemeral.public.as_bytes(),
+        ephemeral_public_key: *ephemeral_x25519_keypair.public.as_bytes(),
         ciphertext,
         content_type,
         signature: exo_core::Signature::empty(),
@@ -151,6 +213,12 @@ pub fn prepare_envelope_for_signing(
     };
 
     Ok(envelope)
+}
+
+fn caller_supplied_ephemeral_required() -> MessagingError {
+    MessagingError::KeyExchangeFailed(
+        "message composition requires caller-supplied ephemeral X25519 keypair".to_owned(),
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -253,21 +321,28 @@ mod tests {
         .expect("valid compose metadata")
     }
 
+    fn x25519_keypair(seed: u8) -> kex::X25519KeyPair {
+        kex::X25519KeyPair::from_secret_bytes([seed; 32])
+            .expect("valid deterministic X25519 keypair")
+    }
+
     #[test]
     fn lock_and_send_produces_valid_envelope() {
         let sender_did = Did::new("did:exo:alice").unwrap();
         let recipient_did = Did::new("did:exo:bob").unwrap();
         let (_, sender_sk) = generate_keypair();
-        let recipient_kp = kex::X25519KeyPair::generate();
+        let recipient_kp = x25519_keypair(0x21);
+        let ephemeral_kp = x25519_keypair(0x31);
         let metadata = metadata();
 
-        let envelope = lock_and_send(
+        let envelope = lock_and_send_with_ephemeral(
             b"my secret password: hunter2",
             ContentType::Password,
             &sender_did,
             &recipient_did,
             &sender_sk,
             &recipient_kp.public,
+            &ephemeral_kp,
             metadata,
             false,
             0,
@@ -291,14 +366,16 @@ mod tests {
     fn prepare_envelope_for_signing_returns_canonical_payload_without_signature() {
         let sender_did = Did::new("did:exo:alice").unwrap();
         let recipient_did = Did::new("did:exo:bob").unwrap();
-        let recipient_kp = kex::X25519KeyPair::generate();
+        let recipient_kp = x25519_keypair(0x22);
+        let ephemeral_kp = x25519_keypair(0x32);
 
-        let envelope = prepare_envelope_for_signing(
+        let envelope = prepare_envelope_for_signing_with_ephemeral(
             b"external signer",
             ContentType::Secret,
             &sender_did,
             &recipient_did,
             &recipient_kp.public,
+            &ephemeral_kp,
             metadata(),
             false,
             0,
@@ -320,14 +397,16 @@ mod tests {
         let sender_did = Did::new("did:exo:alice").unwrap();
         let recipient_did = Did::new("did:exo:bob").unwrap();
         let (sender_pk, sender_sk) = generate_keypair();
-        let recipient_kp = kex::X25519KeyPair::generate();
+        let recipient_kp = x25519_keypair(0x23);
+        let ephemeral_kp = x25519_keypair(0x33);
 
-        let envelope = prepare_envelope_for_signing(
+        let envelope = prepare_envelope_for_signing_with_ephemeral(
             b"external signer",
             ContentType::Secret,
             &sender_did,
             &recipient_did,
             &recipient_kp.public,
+            &ephemeral_kp,
             metadata(),
             false,
             0,
@@ -350,14 +429,16 @@ mod tests {
         let recipient_did = Did::new("did:exo:bob").unwrap();
         let (_, sender_sk) = generate_keypair();
         let (wrong_pk, _) = generate_keypair();
-        let recipient_kp = kex::X25519KeyPair::generate();
+        let recipient_kp = x25519_keypair(0x24);
+        let ephemeral_kp = x25519_keypair(0x34);
 
-        let envelope = prepare_envelope_for_signing(
+        let envelope = prepare_envelope_for_signing_with_ephemeral(
             b"external signer",
             ContentType::Secret,
             &sender_did,
             &recipient_did,
             &recipient_kp.public,
+            &ephemeral_kp,
             metadata(),
             false,
             0,
@@ -381,16 +462,18 @@ mod tests {
         let sender_did = Did::new("did:exo:alice").unwrap();
         let recipient_did = Did::new("did:exo:bob").unwrap();
         let (_, sender_sk) = generate_keypair();
-        let recipient_kp = kex::X25519KeyPair::generate();
+        let recipient_kp = x25519_keypair(0x25);
+        let ephemeral_kp = x25519_keypair(0x35);
         let metadata = metadata();
 
-        let envelope = lock_and_send(
+        let envelope = lock_and_send_with_ephemeral(
             b"Read this after I'm gone",
             ContentType::AfterlifeMessage,
             &sender_did,
             &recipient_did,
             &sender_sk,
             &recipient_kp.public,
+            &ephemeral_kp,
             metadata,
             true,
             72,
@@ -458,5 +541,48 @@ mod tests {
             !production.contains(".encrypt("),
             "compose must not call the implicit vault encryption entrypoint"
         );
+    }
+
+    #[test]
+    fn prepare_envelope_for_signing_requires_caller_supplied_ephemeral_key() {
+        let sender_did = Did::new("did:exo:alice").unwrap();
+        let recipient_did = Did::new("did:exo:bob").unwrap();
+        let recipient_kp = x25519_keypair(0x26);
+
+        let result = prepare_envelope_for_signing(
+            b"external signer",
+            ContentType::Secret,
+            &sender_did,
+            &recipient_did,
+            &recipient_kp.public,
+            metadata(),
+            false,
+            0,
+        );
+
+        assert!(
+            matches!(result, Err(MessagingError::KeyExchangeFailed(reason)) if reason.contains("caller-supplied ephemeral")),
+            "message composition must fail closed unless the caller supplies the ephemeral X25519 keypair"
+        );
+    }
+
+    #[test]
+    fn compose_path_requires_caller_supplied_ephemeral_key() {
+        let source = include_str!("compose.rs");
+        let production = source
+            .split("// ===========================================================================")
+            .next()
+            .expect("production section");
+
+        assert!(
+            production.contains("prepare_envelope_for_signing_with_ephemeral"),
+            "compose must expose an explicit ephemeral-key entrypoint"
+        );
+        for pattern in ["generate_ephemeral", "X25519KeyPair::generate"] {
+            assert!(
+                !production.contains(pattern),
+                "compose production path must not fabricate X25519 ephemeral key material via {pattern}"
+            );
+        }
     }
 }

--- a/crates/exo-messaging/src/kex.rs
+++ b/crates/exo-messaging/src/kex.rs
@@ -1,7 +1,7 @@
 //! X25519 Diffie-Hellman key exchange for E2E encrypted messaging.
 //!
-//! Generates ephemeral X25519 keypairs and derives shared secrets via ECDH.
-//! The shared secret is then expanded via HKDF-SHA256 into a 256-bit
+//! Requires caller-supplied X25519 key material and derives shared secrets via
+//! ECDH. The shared secret is then expanded via HKDF-SHA256 into a 256-bit
 //! symmetric key suitable for XChaCha20-Poly1305.
 
 use hkdf::Hkdf;
@@ -87,9 +87,9 @@ impl core::fmt::Debug for X25519PublicKey {
 pub struct X25519SecretKey([u8; 32]);
 
 impl X25519SecretKey {
-    #[must_use]
-    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
-        Self(bytes)
+    pub fn from_bytes(bytes: [u8; 32]) -> Result<Self, MessagingError> {
+        validate_x25519_secret_key(&bytes)?;
+        Ok(Self(bytes))
     }
 
     /// Create from hex string.
@@ -106,7 +106,7 @@ impl X25519SecretKey {
         }
         let mut arr = [0u8; 32];
         arr.copy_from_slice(&bytes);
-        Ok(Self(arr))
+        Self::from_bytes(arr)
     }
 
     /// Derive the public key corresponding to this secret key.
@@ -138,26 +138,22 @@ pub struct X25519KeyPair {
 }
 
 impl X25519KeyPair {
-    /// Generate a fresh random X25519 keypair.
-    #[must_use]
-    pub fn generate() -> Self {
-        let secret = StaticSecret::random_from_rng(rand::rngs::OsRng);
-        let public = PublicKey::from(&secret);
-        Self {
-            public: X25519PublicKey::from_trusted_bytes(public.to_bytes()),
-            secret: X25519SecretKey(secret.to_bytes()),
-        }
+    /// Fail closed for legacy callers that previously relied on internal RNG.
+    ///
+    /// EXOCHAIN runtime adapters must receive X25519 key material from an
+    /// explicit caller-controlled key-management boundary.
+    pub fn generate() -> Result<Self, MessagingError> {
+        Err(MessagingError::KeyExchangeFailed(
+            "X25519 keypair generation requires caller-supplied key material".to_owned(),
+        ))
     }
 
     /// Reconstruct from raw secret bytes.
-    #[must_use]
-    pub fn from_secret_bytes(bytes: [u8; 32]) -> Self {
-        let secret = StaticSecret::from(bytes);
-        let public = PublicKey::from(&secret);
-        Self {
-            public: X25519PublicKey::from_trusted_bytes(public.to_bytes()),
-            secret: X25519SecretKey(secret.to_bytes()),
-        }
+    pub fn from_secret_bytes(bytes: [u8; 32]) -> Result<Self, MessagingError> {
+        let secret = X25519SecretKey::from_bytes(bytes)?;
+        let public = secret.public_key();
+        validate_x25519_public_key(public.as_bytes())?;
+        Ok(Self { public, secret })
     }
 }
 
@@ -223,14 +219,22 @@ fn validate_x25519_public_key(bytes: &[u8; 32]) -> Result<(), MessagingError> {
     Ok(())
 }
 
-/// Generate an ephemeral X25519 keypair for one-time use in message encryption.
-///
-/// This uses `EphemeralSecret` which is consumed after a single DH operation,
-/// but we return the raw bytes so the ephemeral public key can be included
-/// in the message envelope.
-#[must_use]
-pub fn generate_ephemeral() -> X25519KeyPair {
-    X25519KeyPair::generate()
+fn validate_x25519_secret_key(bytes: &[u8; 32]) -> Result<(), MessagingError> {
+    if bytes.iter().all(|byte| *byte == 0) {
+        return Err(MessagingError::KeyExchangeFailed(
+            "invalid X25519 secret key: all-zero value".to_owned(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Fail closed for legacy callers that previously generated an ephemeral
+/// X25519 keypair inside the messaging crate.
+pub fn generate_ephemeral() -> Result<X25519KeyPair, MessagingError> {
+    Err(MessagingError::KeyExchangeFailed(
+        "ephemeral X25519 key generation requires caller-supplied key material".to_owned(),
+    ))
 }
 
 // ===========================================================================
@@ -241,20 +245,40 @@ pub fn generate_ephemeral() -> X25519KeyPair {
 mod tests {
     use super::*;
 
+    fn keypair(seed: u8) -> X25519KeyPair {
+        X25519KeyPair::from_secret_bytes([seed; 32]).expect("valid deterministic X25519 keypair")
+    }
+
     #[test]
-    fn keypair_generation() {
-        let kp = X25519KeyPair::generate();
-        assert_ne!(
-            *kp.public.as_bytes(),
-            [0u8; 32],
-            "public key should not be all zeros"
+    fn keypair_generation_fails_closed_without_caller_material() {
+        let result = X25519KeyPair::generate();
+
+        assert!(
+            matches!(result, Err(MessagingError::KeyExchangeFailed(reason)) if reason.contains("caller-supplied key material")),
+            "legacy X25519 key generation must fail closed"
         );
     }
 
     #[test]
+    fn x25519_keypair_source_does_not_generate_internal_entropy() {
+        let source = include_str!("kex.rs");
+        let production = source
+            .split("// ===========================================================================")
+            .next()
+            .expect("production section");
+
+        for pattern in ["random_from_rng", "OsRng", "fill_bytes", "rand::"] {
+            assert!(
+                !production.contains(pattern),
+                "X25519 key exchange must require caller-supplied key material instead of internal entropy via {pattern}"
+            );
+        }
+    }
+
+    #[test]
     fn ecdh_shared_secret_agreement() {
-        let alice = X25519KeyPair::generate();
-        let bob = X25519KeyPair::generate();
+        let alice = keypair(0xA1);
+        let bob = keypair(0xB2);
         let context = b"test-context";
 
         let alice_key =
@@ -266,8 +290,8 @@ mod tests {
 
     #[test]
     fn different_contexts_produce_different_keys() {
-        let alice = X25519KeyPair::generate();
-        let bob = X25519KeyPair::generate();
+        let alice = keypair(0xA3);
+        let bob = keypair(0xB4);
 
         let key1 = derive_shared_key(&alice.secret, &bob.public, b"context-a").expect("derive");
         let key2 = derive_shared_key(&alice.secret, &bob.public, b"context-b").expect("derive");
@@ -277,8 +301,8 @@ mod tests {
 
     #[test]
     fn from_secret_bytes_deterministic() {
-        let secret = X25519SecretKey::from_bytes([7u8; 32]);
-        let kp1 = X25519KeyPair::from_secret_bytes([7u8; 32]);
+        let secret = X25519SecretKey::from_bytes([7u8; 32]).expect("valid secret");
+        let kp1 = X25519KeyPair::from_secret_bytes([7u8; 32]).expect("valid keypair");
         let kp2 = X25519KeyPair {
             public: secret.public_key(),
             secret,
@@ -293,10 +317,22 @@ mod tests {
 
     #[test]
     fn hex_round_trip() {
-        let kp = X25519KeyPair::generate();
+        let kp = keypair(0xC5);
         let hex = kp.public.to_hex();
         let recovered = X25519PublicKey::from_hex(&hex).expect("from_hex");
         assert_eq!(kp.public, recovered);
+    }
+
+    #[test]
+    fn x25519_secret_key_rejects_all_zero_hex() {
+        let zero_hex = "00".repeat(32);
+
+        let result = X25519SecretKey::from_hex(&zero_hex);
+
+        assert!(
+            matches!(result, Err(MessagingError::KeyExchangeFailed(reason)) if reason.contains("all-zero")),
+            "all-zero X25519 secret keys must be rejected"
+        );
     }
 
     #[test]

--- a/crates/exo-messaging/src/lib.rs
+++ b/crates/exo-messaging/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate provides:
 //!
-//! - **Key exchange** (`kex`) — X25519 Diffie-Hellman ephemeral key exchange
+//! - **Key exchange** (`kex`) — X25519 Diffie-Hellman with caller-supplied key material
 //! - **Message envelopes** (`envelope`) — Encrypted message container types
 //! - **Compose & lock** (`compose`) — Sender-side: encrypt + sign → Lock & Send
 //! - **Open & verify** (`open`) — Recipient-side: decrypt + verify signature
@@ -18,7 +18,8 @@ pub mod kex;
 pub mod open;
 
 pub use compose::{
-    ComposeMetadata, attach_verified_signature, lock_and_send, prepare_envelope_for_signing,
+    ComposeMetadata, attach_verified_signature, lock_and_send, lock_and_send_with_ephemeral,
+    prepare_envelope_for_signing, prepare_envelope_for_signing_with_ephemeral,
     sign_prepared_envelope,
 };
 pub use envelope::{ContentType, EncryptedEnvelope};

--- a/crates/exo-messaging/src/open.rs
+++ b/crates/exo-messaging/src/open.rs
@@ -75,7 +75,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        compose::{ComposeMetadata, lock_and_send},
+        compose::{ComposeMetadata, lock_and_send_with_ephemeral},
         envelope::{ContentType, EncryptedEnvelope},
         kex::X25519KeyPair,
     };
@@ -83,6 +83,10 @@ mod tests {
     fn metadata(suffix: u128) -> ComposeMetadata {
         ComposeMetadata::new(Uuid::from_u128(suffix), Timestamp::new(8_000, 0))
             .expect("valid compose metadata")
+    }
+
+    fn x25519_keypair(seed: u8) -> X25519KeyPair {
+        X25519KeyPair::from_secret_bytes([seed; 32]).expect("valid deterministic X25519 keypair")
     }
 
     fn legacy_signable_bytes(envelope: &EncryptedEnvelope) -> Vec<u8> {
@@ -106,17 +110,19 @@ mod tests {
         let sender_did = Did::new("did:exo:alice").unwrap();
         let recipient_did = Did::new("did:exo:bob").unwrap();
         let (sender_pk, sender_sk) = generate_keypair();
-        let recipient_kp = X25519KeyPair::generate();
+        let recipient_kp = x25519_keypair(0x41);
+        let ephemeral_kp = x25519_keypair(0x51);
 
         let plaintext = b"super secret password: correcthorsebatterystaple";
 
-        let envelope = lock_and_send(
+        let envelope = lock_and_send_with_ephemeral(
             plaintext,
             ContentType::Password,
             &sender_did,
             &recipient_did,
             &sender_sk,
             &recipient_kp.public,
+            &ephemeral_kp,
             metadata(0x018f_7a96_8ad0_7c4f_8e0f_1111_1111_1101),
             false,
             0,
@@ -133,16 +139,18 @@ mod tests {
         let sender_did = Did::new("did:exo:alice").unwrap();
         let recipient_did = Did::new("did:exo:bob").unwrap();
         let (sender_pk, sender_sk) = generate_keypair();
-        let recipient_kp = X25519KeyPair::generate();
-        let wrong_kp = X25519KeyPair::generate();
+        let recipient_kp = x25519_keypair(0x42);
+        let wrong_kp = x25519_keypair(0x52);
+        let ephemeral_kp = x25519_keypair(0x62);
 
-        let envelope = lock_and_send(
+        let envelope = lock_and_send_with_ephemeral(
             b"secret",
             ContentType::Secret,
             &sender_did,
             &recipient_did,
             &sender_sk,
             &recipient_kp.public,
+            &ephemeral_kp,
             metadata(0x018f_7a96_8ad0_7c4f_8e0f_1111_1111_1102),
             false,
             0,
@@ -159,15 +167,17 @@ mod tests {
         let recipient_did = Did::new("did:exo:bob").unwrap();
         let (_, sender_sk) = generate_keypair();
         let (wrong_pk, _) = generate_keypair(); // different sender's public key
-        let recipient_kp = X25519KeyPair::generate();
+        let recipient_kp = x25519_keypair(0x43);
+        let ephemeral_kp = x25519_keypair(0x53);
 
-        let envelope = lock_and_send(
+        let envelope = lock_and_send_with_ephemeral(
             b"secret",
             ContentType::Secret,
             &sender_did,
             &recipient_did,
             &sender_sk,
             &recipient_kp.public,
+            &ephemeral_kp,
             metadata(0x018f_7a96_8ad0_7c4f_8e0f_1111_1111_1103),
             false,
             0,
@@ -186,15 +196,17 @@ mod tests {
         let sender_did = Did::new("did:exo:alice").unwrap();
         let recipient_did = Did::new("did:exo:bob").unwrap();
         let (sender_pk, sender_sk) = generate_keypair();
-        let recipient_kp = X25519KeyPair::generate();
+        let recipient_kp = x25519_keypair(0x44);
+        let ephemeral_kp = x25519_keypair(0x54);
 
-        let mut envelope = lock_and_send(
+        let mut envelope = lock_and_send_with_ephemeral(
             b"secret",
             ContentType::Secret,
             &sender_did,
             &recipient_did,
             &sender_sk,
             &recipient_kp.public,
+            &ephemeral_kp,
             metadata(0x018f_7a96_8ad0_7c4f_8e0f_1111_1111_1121),
             false,
             0,
@@ -215,17 +227,19 @@ mod tests {
         let sender_did = Did::new("did:exo:alice").unwrap();
         let recipient_did = Did::new("did:exo:family").unwrap();
         let (sender_pk, sender_sk) = generate_keypair();
-        let recipient_kp = X25519KeyPair::generate();
+        let recipient_kp = x25519_keypair(0x45);
+        let ephemeral_kp = x25519_keypair(0x55);
 
         let plaintext = b"I love you all. The safe combination is 42-17-93.";
 
-        let envelope = lock_and_send(
+        let envelope = lock_and_send_with_ephemeral(
             plaintext,
             ContentType::AfterlifeMessage,
             &sender_did,
             &recipient_did,
             &sender_sk,
             &recipient_kp.public,
+            &ephemeral_kp,
             metadata(0x018f_7a96_8ad0_7c4f_8e0f_1111_1111_1104),
             true,
             72,
@@ -244,15 +258,17 @@ mod tests {
         let sender_did = Did::new("did:exo:alice").unwrap();
         let recipient_did = Did::new("did:exo:bob").unwrap();
         let (sender_pk, sender_sk) = generate_keypair();
-        let recipient_kp = X25519KeyPair::generate();
+        let recipient_kp = x25519_keypair(0x46);
+        let ephemeral_kp = x25519_keypair(0x56);
 
-        let envelope = lock_and_send(
+        let envelope = lock_and_send_with_ephemeral(
             b"",
             ContentType::Text,
             &sender_did,
             &recipient_did,
             &sender_sk,
             &recipient_kp.public,
+            &ephemeral_kp,
             metadata(0x018f_7a96_8ad0_7c4f_8e0f_1111_1111_1105),
             false,
             0,
@@ -268,17 +284,19 @@ mod tests {
         let sender_did = Did::new("did:exo:alice").unwrap();
         let recipient_did = Did::new("did:exo:bob").unwrap();
         let (sender_pk, sender_sk) = generate_keypair();
-        let recipient_kp = X25519KeyPair::generate();
+        let recipient_kp = x25519_keypair(0x47);
+        let ephemeral_kp = x25519_keypair(0x57);
 
         let plaintext = vec![0xab_u8; 100_000]; // 100 KB
 
-        let envelope = lock_and_send(
+        let envelope = lock_and_send_with_ephemeral(
             &plaintext,
             ContentType::Attachment,
             &sender_did,
             &recipient_did,
             &sender_sk,
             &recipient_kp.public,
+            &ephemeral_kp,
             metadata(0x018f_7a96_8ad0_7c4f_8e0f_1111_1111_1106),
             false,
             0,

--- a/crates/exochain-wasm/src/lib.rs
+++ b/crates/exochain-wasm/src/lib.rs
@@ -445,6 +445,24 @@ mod source_guard_tests {
     }
 
     #[test]
+    fn wasm_messaging_bridge_does_not_generate_x25519_keypairs() {
+        let source = include_str!("messaging_bindings.rs");
+        let production = source
+            .split("// ===========================================================================")
+            .next()
+            .unwrap_or(source);
+
+        assert!(
+            !production.contains("X25519KeyPair::generate"),
+            "messaging WASM must not generate X25519 key material inside the bridge"
+        );
+        assert!(
+            production.contains("ephemeral_x25519_secret_hex"),
+            "messaging WASM encryption must receive caller-supplied ephemeral X25519 material"
+        );
+    }
+
+    #[test]
     fn wasm_messaging_bridge_does_not_decode_ed25519_signing_secrets() {
         let source = include_str!("messaging_bindings.rs");
         let production = source

--- a/crates/exochain-wasm/src/messaging_bindings.rs
+++ b/crates/exochain-wasm/src/messaging_bindings.rs
@@ -15,14 +15,15 @@ struct WasmAuthorizedTrustee {
     public_key_hex: String,
 }
 
-/// Generate a new X25519 public key for Diffie-Hellman key exchange.
-/// Returns `{ public_key_hex }`.
+/// Legacy X25519 key generation entrypoint.
+///
+/// This fails closed because the WASM bridge must not fabricate X25519 key
+/// material internally.
 #[wasm_bindgen]
 pub fn wasm_generate_x25519_keypair() -> Result<JsValue, JsValue> {
-    let kp = exo_messaging::kex::X25519KeyPair::generate();
-    to_js_value(&serde_json::json!({
-        "public_key_hex": kp.public.to_hex(),
-    }))
+    Err(JsValue::from_str(
+        "X25519 key generation is disabled at the WASM boundary; use external key management and pass caller-supplied ephemeral material to wasm_prepare_encrypted_message",
+    ))
 }
 
 /// Derive an X25519 public key from a secret key hex string.
@@ -82,7 +83,7 @@ pub fn wasm_encrypt_message(
         release_delay_hours,
     );
     Err(JsValue::from_str(
-        "raw Ed25519 sender signing is disabled at the WASM boundary; call wasm_prepare_encrypted_message, sign externally, then call wasm_attach_message_signature",
+        "raw Ed25519 sender signing is disabled at the WASM boundary; call wasm_prepare_encrypted_message with caller-supplied ephemeral X25519 material, sign externally, then call wasm_attach_message_signature",
     ))
 }
 
@@ -95,6 +96,7 @@ pub fn wasm_prepare_encrypted_message(
     sender_did: &str,
     recipient_did: &str,
     recipient_x25519_public_hex: &str,
+    ephemeral_x25519_secret_hex: &str,
     message_id: &str,
     created_physical_ms: u64,
     created_logical: u32,
@@ -110,6 +112,8 @@ pub fn wasm_prepare_encrypted_message(
 
     let recipient_pub = exo_messaging::X25519PublicKey::from_hex(recipient_x25519_public_hex)
         .map_err(|e| JsValue::from_str(&format!("invalid recipient X25519 key: {e}")))?;
+    let ephemeral_keypair =
+        parse_x25519_keypair_hex("ephemeral X25519 secret", ephemeral_x25519_secret_hex)?;
     let message_uuid = uuid::Uuid::parse_str(message_id)
         .map_err(|e| JsValue::from_str(&format!("invalid message id: {e}")))?;
     let metadata = exo_messaging::ComposeMetadata::new(
@@ -118,12 +122,13 @@ pub fn wasm_prepare_encrypted_message(
     )
     .map_err(|e| JsValue::from_str(&format!("invalid envelope metadata: {e}")))?;
 
-    let envelope = exo_messaging::prepare_envelope_for_signing(
+    let envelope = exo_messaging::prepare_envelope_for_signing_with_ephemeral(
         plaintext.as_bytes(),
         content_type,
         &sender,
         &recipient,
         &recipient_pub,
+        &ephemeral_keypair,
         metadata,
         release_on_death,
         release_delay_hours,
@@ -137,6 +142,21 @@ pub fn wasm_prepare_encrypted_message(
         "envelope": envelope,
         "signing_payload_hex": hex::encode(signing_payload),
     }))
+}
+
+fn parse_x25519_keypair_hex(
+    label: &str,
+    secret_hex: &str,
+) -> Result<exo_messaging::X25519KeyPair, JsValue> {
+    let bytes = hex::decode(secret_hex)
+        .map_err(|e| JsValue::from_str(&format!("{label} must be hex: {e}")))?;
+    if bytes.len() != 32 {
+        return Err(JsValue::from_str(&format!("{label} must be 32 bytes")));
+    }
+    let mut secret = [0u8; 32];
+    secret.copy_from_slice(&bytes);
+    exo_messaging::X25519KeyPair::from_secret_bytes(secret)
+        .map_err(|e| JsValue::from_str(&format!("invalid {label}: {e}")))
 }
 
 /// Attach a caller-produced Ed25519 signature to a prepared encrypted envelope.

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -290,15 +290,14 @@ test('wasm_verify_event', () => {
 
 console.log('\n--- Messaging / Death Verification ---');
 
-test('wasm_generate_x25519_keypair', () => {
-  const keypair = wasm.wasm_generate_x25519_keypair();
-  if (keypair.public_key_hex.length !== 64 || keypair.secret_key_hex !== undefined) {
-    throw new Error('X25519 keypair must return only the 32-byte public key');
-  }
-  return keypair;
-});
+test('wasm_generate_x25519_keypair rejects internal X25519 key generation', () =>
+  expectErrorContains(
+    'wasm_generate_x25519_keypair',
+    () => wasm.wasm_generate_x25519_keypair(),
+    'external key management'
+  ));
 
-const recipientKex = setup(() => wasm.wasm_generate_x25519_keypair());
+const recipientKex = { public_key_hex: NONZERO_32_HEX };
 
 test('wasm_x25519_public_from_secret rejects raw X25519 secret derivation', () =>
   expectErrorContains(
@@ -335,6 +334,7 @@ const preparedEnvelope = setup(() =>
     TEST_DID,
     TEST_DID_2,
     recipientKex.public_key_hex,
+    DUMMY_SECRET_HEX_2,
     '018f7a96-8ad0-7c4f-8e0f-111111111202',
     7001n,
     0,


### PR DESCRIPTION
## Summary
- Confirmed the external-report concern was still live on current `main`: `exo-messaging` generated X25519 ephemeral key material internally via `StaticSecret::random_from_rng(rand::rngs::OsRng)`, and the WASM messaging bridge called that implicit path.
- Added regression/source-guard tests proving internal X25519 generation is rejected and message encryption requires caller-supplied ephemeral X25519 material.
- Replaced implicit generation with fail-closed legacy APIs plus explicit `*_with_ephemeral` composition APIs, and updated WASM preparation to accept an external ephemeral secret.

## Path Classification
- Core runtime adapter: `crates/exo-messaging/Cargo.toml`, `crates/exo-messaging/src/compose.rs`, `crates/exo-messaging/src/kex.rs`, `crates/exo-messaging/src/lib.rs`, `crates/exo-messaging/src/open.rs`, `crates/exochain-wasm/src/lib.rs`, `crates/exochain-wasm/src/messaging_bindings.rs`, `packages/exochain-wasm/test/bridge_verification.mjs`
- EXOCHAIN core/workspace metadata: `Cargo.lock`
- Documentation/repo truth: `README.md`
- Adjacent surfaces: none
- Imported evidence: none
- Third-party/vendor: none

## TDD / Regression Evidence
- RED confirmed before production changes:
  - `cargo test -p exo-messaging kex::tests::x25519_keypair_source_does_not_generate_internal_entropy -- --nocapture`
  - `cargo test -p exo-messaging compose::tests::prepare_envelope_for_signing_requires_caller_supplied_ephemeral_key -- --nocapture`
  - `cargo test -p exochain-wasm wasm_messaging_bridge_does_not_generate_x25519_keypairs -- --nocapture`
- GREEN after remediation:
  - same focused tests now pass

## Validation
- `cargo test -p exo-messaging`
- `cargo test -p exochain-wasm`
- `cargo clippy -p exo-messaging -p exochain-wasm --all-targets -- -D warnings`
- `cargo doc -p exo-messaging -p exochain-wasm --no-deps`
- `cargo fmt --all -- --check`
- `wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm`
- `node packages/exochain-wasm/test/bridge_verification.mjs` (148/148)
- JS/Rust WASM export count parity: 149/149
- `cargo machete --with-metadata`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check` (existing duplicate-dependency warnings only; advisories/bans/licenses/sources ok)
- `./tools/cross-impl-test/compare.sh` (Rust 6/6; TypeScript comparison skipped because `EXO_TS_ROOT` is not configured)

## Bypass Search
- `rg -n "X25519KeyPair::generate\(|generate_ephemeral\(|random_from_rng|OsRng|fill_bytes|rand::" crates packages tools --glob '!target/**' --glob '!docs/**'`
- `rg -n "lock_and_send\(|prepare_envelope_for_signing\(" crates packages tools --glob '!target/**' --glob '!docs/**'`

Remaining X25519 generation hits are fail-closed APIs, tests, or source guards. No production caller remains in owned core/runtime paths.
