### PR TITLE
fix(consensus): move rounds on session finalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 163455 | `wc -l` |
-| Workspace tests | 3,998 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 163488 | `wc -l` |
+| Workspace tests | 4,014 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **3,998 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,014 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -80,9 +80,9 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 163455 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 163488 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 3,998 listed workspace tests
+         cryptographic proofs, 4,014 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-consensus/src/session.rs
+++ b/crates/exo-consensus/src/session.rs
@@ -208,16 +208,26 @@ impl DeliberationSession {
         false
     }
 
-    pub fn finalize(&self, timing: FinalizationTiming) -> Result<DeliberationResult> {
+    /// Finalize the session, consuming it so the full round history moves into
+    /// the result without duplicating consensus evidence in memory.
+    pub fn finalize(self, timing: FinalizationTiming) -> Result<DeliberationResult> {
         timing.validate()?;
 
-        if self.rounds.is_empty() {
+        let DeliberationSession {
+            session_id,
+            panel,
+            question,
+            rounds,
+            ..
+        } = self;
+
+        if rounds.is_empty() {
             return Err(ConsensusError::StateError(
                 "Cannot finalize without any rounds".into(),
             ));
         }
 
-        let Some(last_round) = self.rounds.last() else {
+        let Some(last_round) = rounds.last() else {
             return Err(ConsensusError::StateError(
                 "Rounds exist but last() failed".into(),
             ));
@@ -237,10 +247,10 @@ impl DeliberationSession {
 
         let claim_sets = position_claim_sets(&last_round.positions);
         let consensus_claims =
-            consensus_claims_at_threshold(&claim_sets, self.panel.convergence_threshold_bps);
+            consensus_claims_at_threshold(&claim_sets, panel.convergence_threshold_bps);
 
         for pos in last_round.positions.values() {
-            if is_minority_report(pos, &consensus_claims, self.panel.convergence_threshold_bps) {
+            if is_minority_report(pos, &consensus_claims, panel.convergence_threshold_bps) {
                 let missing_claims = missing_consensus_claims(pos, &consensus_claims);
                 minority_reports.push(MinorityReport {
                     model_id: pos.model_id.clone(),
@@ -265,7 +275,7 @@ impl DeliberationSession {
 
         let panelists_count = usize_to_u32(
             "panelists_count",
-            self.panel
+            panel
                 .models
                 .iter()
                 .filter(|m| m.role == ModelRole::Panelist)
@@ -273,13 +283,13 @@ impl DeliberationSession {
         )?;
         let minority_reports_count =
             usize_to_u32("minority_reports_count", minority_reports.len())?;
-        let rounds_to_convergence = usize_to_u32("rounds_to_convergence", self.rounds.len())?;
+        let rounds_to_convergence = usize_to_u32("rounds_to_convergence", rounds.len())?;
 
         let inputs = PanelConfidenceInputs {
             models_agreeing: panelists_count.saturating_sub(minority_reports_count),
             total_models: panelists_count,
             rounds_to_convergence,
-            max_rounds: self.panel.max_rounds,
+            max_rounds: panel.max_rounds,
             devil_found_serious_objection: serious_objection,
             minority_reports_count,
         };
@@ -287,9 +297,9 @@ impl DeliberationSession {
         let pci = calculate_panel_confidence(&inputs);
 
         let mut result = DeliberationResult {
-            session_id: self.session_id.clone(),
-            question: self.question.clone(),
-            rounds: self.rounds.clone(),
+            session_id,
+            question,
+            rounds,
             final_consensus,
             minority_reports,
             panel_confidence_index_bps: pci,
@@ -761,6 +771,29 @@ mod tests {
         assert!(
             production.contains("usize_to_u32(\"minority_reports_count\""),
             "minority report count conversion must use the typed finalization count helper"
+        );
+    }
+
+    #[test]
+    fn production_finalization_moves_rounds_without_cloning_full_history() {
+        let source = include_str!("session.rs");
+        let production = source
+            .split("\n#[cfg(test)]")
+            .next()
+            .expect("production section");
+        let finalize = production
+            .split("pub fn finalize(")
+            .nth(1)
+            .and_then(|section| section.split("\nfn validate_model_response").next())
+            .expect("finalize implementation");
+
+        assert!(
+            !finalize.contains("self.rounds.clone()"),
+            "DeliberationSession::finalize must not clone the full round history"
+        );
+        assert!(
+            production.contains("pub fn finalize(self,"),
+            "DeliberationSession::finalize must consume the session so rounds can move into the result"
         );
     }
 


### PR DESCRIPTION
## Summary
- Confirms Gauntlet F-097 is still live on current `origin/main`: `DeliberationSession::finalize` borrowed `self` and cloned the full `rounds` history into `DeliberationResult`.
- Changes finalization to consume the session, moving `session_id`, `question`, and `rounds` into the result without duplicating consensus evidence.
- Refreshes README repo-truth counters required by `tools/test_repo_truth.sh` after the Rust source/test inventory changed.

## Path Classification
- `crates/exo-consensus/src/session.rs`: EXOCHAIN core.
- `README.md`: documentation/repo-truth metadata required by the core validation gate.
- External Gauntlet finding markdown: imported evidence only; not modified or committed.

## TDD / Original Finding Reproduction
- RED: `cargo test -p exo-consensus session::tests::production_finalization_moves_rounds_without_cloning_full_history -- --nocapture` failed before the fix with `DeliberationSession::finalize must not clone the full round history`.
- GREEN: same focused guard passes after `finalize(self, ...)` moves `rounds` into `DeliberationResult`.
- Bypass search: `rg -n "self\\.rounds\\.clone\\(\\)|rounds: self\\.rounds|pub fn finalize\\(&self" crates/exo-consensus/src` now finds only the regression guard string.

## Validation
- `cargo test -p exo-consensus session::tests::production_finalization_moves_rounds_without_cloning_full_history -- --nocapture`
- `cargo test -p exo-consensus session::tests::finalize_errors_with_state_error_when_rounds_empty -- --nocapture`
- `cargo test -p exo-consensus`
- `cargo clippy -p exo-consensus --all-targets -- -D warnings`
- `cargo fmt --all -- --check` (passes with existing stable-rustfmt warnings about ignored nightly-only options)
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check` (passes; existing duplicate-version warnings remain warnings)
- `cargo machete --with-metadata`
- `bash tools/test_repo_truth.sh`
- `bash tools/repo_truth.sh --json --list-tests | jq -r '"loc=\\(.rust_loc) tests=\\(.tests_listed)"'` -> `loc=163488 tests=4014`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `git diff --check`
- `./tools/cross-impl-test/compare.sh` (passes Rust vectors and Rust x2 determinism; TypeScript comparison skipped because `EXO_TS_ROOT` is not configured locally)