### PR TITLE
fix(deploy): probe readiness for rollout health checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,8 @@ jobs:
         run: bash tools/test_no_orphan_rust_modules.sh
       - name: Railway entrypoint ingress contract
         run: bash tools/test_railway_entrypoint_args.sh
+      - name: Deployment readiness probes
+        run: bash tools/test_deployment_readiness_probes.sh
 
   # -----------------------------------------------------------------------
   # Gate 10: SBOM (dry-run generation — no upload, validates toolchain)

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,9 +53,10 @@ EXPOSE 4001 4002 8080
 # repaired at startup; deploy/entrypoint.sh drops to the exochain user before
 # launching the node process.
 
-# Probe the effective API port (Railway sets $PORT; otherwise $API_PORT or 8080).
+# Probe the dependency-validating readiness endpoint on the effective API port
+# (Railway sets $PORT; otherwise $API_PORT or 8080).
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
-    CMD curl -sf "http://localhost:${PORT:-${API_PORT:-8080}}/health" || exit 1
+    CMD curl -sf "http://localhost:${PORT:-${API_PORT:-8080}}/ready" || exit 1
 
 # ENTRYPOINT (exec form) ensures the script is always invoked and signals
 # reach the child binary via entrypoint.sh's `exec exochain ...`.

--- a/deploy/Dockerfile.node
+++ b/deploy/Dockerfile.node
@@ -34,6 +34,6 @@ EXPOSE 4001 4002 8080
 VOLUME ["/data"]
 
 HEALTHCHECK --interval=10s --timeout=3s --retries=3 \
-    CMD curl -sf http://localhost:8080/health || exit 1
+    CMD curl -sf http://localhost:8080/ready || exit 1
 
 ENTRYPOINT ["entrypoint.sh"]

--- a/deploy/fly.toml
+++ b/deploy/fly.toml
@@ -73,12 +73,12 @@ primary_region = "iad"
     hard_limit = 500
     soft_limit = 250
 
-# Health check — gateway /health route.
+# Health check — dependency-validating gateway /ready route.
 [[services.http_checks]]
   interval = 10000
   grace_period = "10s"
   method = "GET"
-  path = "/health"
+  path = "/ready"
   protocol = "http"
   timeout = 5000
 

--- a/railway.json
+++ b/railway.json
@@ -6,8 +6,8 @@
   },
   "deploy": {
     "_comment_startCommand": "Empty — Dockerfile CMD invokes /app/entrypoint.sh which reads env vars (IS_VALIDATOR, SEED_ADDR, EXOCHAIN_DATA_DIR, PORT, P2P_PORT, VALIDATORS).",
-    "healthcheckPath": "/health",
-    "_comment_healthcheckTimeout": "Per-probe timeout in seconds. Lowered from 300 → 15 so a hung /health fails fast instead of delaying failed deploys by 5 minutes. (A-042)",
+    "healthcheckPath": "/ready",
+    "_comment_healthcheckTimeout": "Per-probe timeout in seconds. Lowered from 300 → 15 so a hung /ready fails fast instead of delaying failed deploys by 5 minutes. (A-042)",
     "healthcheckTimeout": 15,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 3

--- a/tools/test_deployment_readiness_probes.sh
+++ b/tools/test_deployment_readiness_probes.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Guard deployment contracts against probing the liveness-only /health route.
+# Production rollout checks must use /ready so dependency failures stop deploys.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+fail() {
+  echo "deployment readiness probe test failed: $*" >&2
+  exit 1
+}
+
+assert_file_contains() {
+  local file="$1"
+  local expected="$2"
+
+  grep -Fq -- "$expected" "$file" || fail "$file must contain: $expected"
+}
+
+assert_healthcheck_uses_ready() {
+  local file="$1"
+
+  assert_file_contains "$file" "HEALTHCHECK"
+  assert_file_contains "$file" "/ready"
+
+  if awk '
+    /HEALTHCHECK/ { in_healthcheck = 1 }
+    in_healthcheck && /\/health/ { found = 1 }
+    in_healthcheck && !/\\$/ && /exit 1/ { in_healthcheck = 0 }
+    END { exit found ? 0 : 1 }
+  ' "$file"; then
+    fail "$file HEALTHCHECK must not probe /health"
+  fi
+}
+
+assert_healthcheck_uses_ready Dockerfile
+assert_healthcheck_uses_ready deploy/Dockerfile.node
+assert_file_contains railway.json '"healthcheckPath": "/ready"'
+assert_file_contains deploy/fly.toml 'path = "/ready"'
+
+echo "deployment readiness probe test passed"


### PR DESCRIPTION
## Summary
- Remediates imported-evidence finding F-075 after confirming current deployment contracts still probed `/health` while the gateway already exposes dependency-validating `/ready`.
- Moves Docker, Railway, and Fly rollout health checks to `/ready` so missing gateway dependencies fail deploy readiness instead of passing liveness only.
- Adds `tools/test_deployment_readiness_probes.sh` and wires it into CI to keep deployment health probes from regressing to `/health`.

## Path Classification
- Core runtime adapter/deployment contract: `Dockerfile`, `deploy/Dockerfile.node`, `deploy/fly.toml`, `railway.json`
- CI/source guard for core runtime adapter: `.github/workflows/ci.yml`, `tools/test_deployment_readiness_probes.sh`
- Imported evidence only: Gauntlet F-075 report; not committed or modified

## Verification
- Red first: `bash tools/test_deployment_readiness_probes.sh` failed before the deployment contracts were changed
- `bash tools/test_deployment_readiness_probes.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `cargo test -p exo-gateway ready_without_db_returns_503 -- --nocapture`
- `cargo test -p exo-gateway health_returns_200 -- --nocapture`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `cargo fmt --all -- --check`
- `cargo test -p exo-gateway`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check` (passed with existing duplicate-version warnings only)
- `cargo machete --with-metadata`
- `./tools/cross-impl-test/compare.sh` (passed Rust determinism; TypeScript comparison skipped because `EXO_TS_ROOT` is unset)
- `cargo tarpaulin --workspace --fail-under 90 --timeout 120 --out Xml --output-dir target/tarpaulin` (91.30% line coverage)
- `git diff --check`

## Bypass Search
- Checked Docker, node Dockerfile, Railway, Fly, CI, and the new guard for deployment healthcheck references. Remaining `/health` references in this change are limited to the guard text that forbids probing it.
