### PR TITLE
fix(deploy): build containers with production db adjudication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,8 @@ jobs:
         run: bash tools/test_railway_entrypoint_args.sh
       - name: Deployment readiness probes
         run: bash tools/test_deployment_readiness_probes.sh
+      - name: Docker production database feature contract
+        run: bash tools/test_docker_production_db_feature.sh
 
   # -----------------------------------------------------------------------
   # Gate 10: SBOM (dry-run generation — no upload, validates toolchain)

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,9 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y pkg-config libssl-dev clang && rm -rf /var/lib/apt/lists/*
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/
-# Build the distributed node binary and the legacy HTTP gateway.
-RUN cargo build --release --bin exochain --bin exo-gateway
+# Build the distributed node binary and standalone gateway with DB-backed
+# adjudication enabled for production container deployments.
+RUN cargo build --release --bin exochain --bin exo-gateway --features exo-gateway/production-db
 
 # Stage 2: Runtime
 FROM debian:bookworm-slim

--- a/deploy/Dockerfile.node
+++ b/deploy/Dockerfile.node
@@ -15,7 +15,7 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/
-RUN cargo build --release --bin exochain
+RUN cargo build --release --bin exochain --features exo-gateway/production-db
 
 FROM debian:bookworm-slim
 RUN apt-get update && \

--- a/tools/test_docker_production_db_feature.sh
+++ b/tools/test_docker_production_db_feature.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Guard production container builds so deployed gateway paths compile with
+# DB-backed adjudication instead of the default WO-009 deny-all scaffold.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+fail() {
+  echo "docker production-db feature test failed: $*" >&2
+  exit 1
+}
+
+assert_file_contains() {
+  local file="$1"
+  local expected="$2"
+
+  grep -Fq -- "$expected" "$file" || fail "$file must contain: $expected"
+}
+
+assert_exochain_build_enables_production_db() {
+  local file="$1"
+
+  if ! awk '
+    /^RUN[[:space:]]+cargo build/ {
+      command = $0
+      while (command ~ /\\$/ && getline continuation) {
+        sub(/\\$/, "", command)
+        command = command " " continuation
+      }
+      if (command ~ /--bin[[:space:]]+exochain/) {
+        found = 1
+        if (command !~ /--features[[:space:]][^\\n]*exo-gateway\/production-db/) {
+          bad = 1
+        }
+      }
+    }
+    END {
+      if (!found || bad) {
+        exit 1
+      }
+    }
+  ' "$file"; then
+    fail "$file must build exochain with --features exo-gateway/production-db"
+  fi
+}
+
+assert_exochain_build_enables_production_db Dockerfile
+assert_exochain_build_enables_production_db deploy/Dockerfile.node
+assert_file_contains Dockerfile "--bin exo-gateway"
+
+echo "docker production-db feature test passed"


### PR DESCRIPTION
## Summary
- Remediates imported Gauntlet finding F-168 after confirming it is still live on current `origin/main`: production Docker builds compiled `exochain`/`exo-gateway` without `exo-gateway/production-db`, leaving deployed adjudication on the WO-009 deny-all scaffold path.
- Enables `--features exo-gateway/production-db` in both production container build contracts.
- Adds a CI source guard so future Docker build commands for `--bin exochain` must include the production DB adjudication feature.

## Classification
- `Dockerfile`: core runtime adapter / deployment contract.
- `deploy/Dockerfile.node`: core runtime adapter / deployment contract.
- `.github/workflows/ci.yml`: CI guard for core runtime adapter.
- `tools/test_docker_production_db_feature.sh`: deterministic source guard for deployment contract.
- Gauntlet markdown/zip inputs: imported evidence only, read-only and not committed.

## Red / Green
- Red first: `bash tools/test_docker_production_db_feature.sh` failed on current `origin/main` with `Dockerfile must build exochain with --features exo-gateway/production-db`.
- Green after patch: same guard passed and is now wired into CI.

## Validation
- `bash tools/test_docker_production_db_feature.sh`
- `git diff --check`
- `bash tools/test_deployment_readiness_probes.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `bash tools/test_repo_truth.sh && bash tools/test_cr001_status.sh && bash tools/test_gap_registry_truth.sh && bash tools/test_no_orphan_rust_modules.sh`
- `cargo build --release --bin exochain --bin exo-gateway --features exo-gateway/production-db`
- `cargo test -p exo-gateway --features production-db`
- `cargo clippy -p exo-gateway --all-targets --features production-db -- -D warnings`
- `cargo test --workspace --features exo-gateway/production-db`
- `cargo clippy --workspace --all-targets --features exo-gateway/production-db -- -D warnings`
- `cargo build --workspace --release --features exo-gateway/production-db`
- `cargo test --workspace --release --features exo-gateway/production-db`
- `cargo fmt --all -- --check` (passes with existing stable-rustfmt warnings about ignored nightly-only options)
- `cargo doc --workspace --no-deps --features exo-gateway/production-db`
- `cargo audit`
- `cargo deny check` (passes with existing duplicate-version warnings)
- `cargo machete --with-metadata`
- `./tools/cross-impl-test/compare.sh` (Rust-only determinism; TypeScript skipped because `EXO_TS_ROOT` is not set)
- `cargo tarpaulin --workspace --features exo-gateway/production-db --fail-under 90 --timeout 120 --out Xml --output-dir target/tarpaulin` (91.30%)