### PR TITLE
fix(runtime): emit structured filtered logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2937,6 +2937,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5106,17 +5115,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ anyhow = "1"
 
 # Logging / tracing
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # GraphQL (exo-gateway API layer)
 # Pinned to =7.0.17 — MSRV 1.86; 7.0.18+ bumped MSRV to 1.89; axum 0.7 compatible

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 163488 | `wc -l` |
+| Rust LOC | 163589 | `wc -l` |
 | Workspace tests | 4,014 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -80,7 +80,7 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 163488 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 163589 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,014 listed workspace tests
 

--- a/crates/exo-gateway/src/main.rs
+++ b/crates/exo-gateway/src/main.rs
@@ -13,11 +13,24 @@
 //! The `/ready` probe will return 503 until a pool is configured.
 
 use exo_gateway::server::{GatewayConfig, serve};
+use tracing_subscriber::EnvFilter;
+
+fn init_tracing() {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .json()
+        .flatten_event(true)
+        .with_current_span(true)
+        .with_span_list(true)
+        .init();
+}
 
 #[tokio::main]
 async fn main() {
     // Initialise structured logging.
-    tracing_subscriber::fmt::init();
+    init_tracing();
 
     // Build config from environment, falling back to defaults.
     let bind_address = std::env::var("BIND_ADDRESS").unwrap_or_else(|_| "127.0.0.1:8443".into());
@@ -56,5 +69,48 @@ async fn main() {
     if let Err(e) = serve(config, pool).await {
         tracing::error!("Gateway terminated with error: {e}");
         std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    const SOURCE: &str = include_str!("main.rs");
+
+    fn init_tracing_source() -> &'static str {
+        match SOURCE
+            .split("fn init_tracing()")
+            .nth(1)
+            .and_then(|section| section.split("#[tokio::main]").next())
+        {
+            Some(source) => source,
+            None => panic!("init_tracing must appear before main"),
+        }
+    }
+
+    #[test]
+    fn gateway_tracing_uses_env_filter_and_json_output() {
+        let production = match SOURCE.split("#[cfg(test)]").next() {
+            Some(source) => source,
+            None => panic!("production source precedes tests"),
+        };
+        let init_tracing = init_tracing_source();
+        let bare_fmt_init = concat!("tracing_subscriber::fmt", "::init()");
+
+        assert!(
+            !production.contains(bare_fmt_init),
+            "gateway runtime must not use bare tracing_subscriber::fmt::init()"
+        );
+        assert!(
+            init_tracing.contains("EnvFilter::try_from_default_env"),
+            "gateway runtime logging must honor RUST_LOG via EnvFilter"
+        );
+        assert!(
+            init_tracing.contains(".with_env_filter("),
+            "gateway runtime logging must attach the EnvFilter to the subscriber"
+        );
+        assert!(
+            init_tracing.contains(".json()"),
+            "gateway runtime logging must emit structured JSON"
+        );
     }
 }

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -62,10 +62,23 @@ use network::{NetworkConfig, NetworkEvent, NetworkHandle};
 use reactor::{ReactorConfig, ReactorEvent};
 use sync::{SyncConfig, SyncEngine, SyncEvent};
 use tokio::sync::mpsc;
+use tracing_subscriber::EnvFilter;
+
+fn init_tracing() {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .json()
+        .flatten_event(true)
+        .with_current_span(true)
+        .with_span_list(true)
+        .init();
+}
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::init();
+    init_tracing();
 
     let cli = Cli::parse();
 
@@ -1180,6 +1193,38 @@ mod tests {
         assert_eq!(addrs[0].to_string(), "/ip4/127.0.0.1/tcp/4001");
         assert_eq!(addrs[1].to_string(), "/ip4/192.0.2.10/tcp/4002");
         assert_eq!(addrs[2].to_string(), "/dns4/seed1.exochain.io/tcp/4003");
+    }
+
+    #[test]
+    fn node_tracing_uses_env_filter_and_json_output() {
+        let source = include_str!("main.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production source precedes tests");
+        let init_tracing = source
+            .split("fn init_tracing()")
+            .nth(1)
+            .and_then(|section| section.split("#[tokio::main]").next())
+            .expect("init_tracing must appear before main");
+        let bare_fmt_init = concat!("tracing_subscriber::fmt", "::init()");
+
+        assert!(
+            !production.contains(bare_fmt_init),
+            "node runtime must not use bare tracing_subscriber::fmt::init()"
+        );
+        assert!(
+            init_tracing.contains("EnvFilter::try_from_default_env"),
+            "node runtime logging must honor RUST_LOG via EnvFilter"
+        );
+        assert!(
+            init_tracing.contains(".with_env_filter("),
+            "node runtime logging must attach the EnvFilter to the subscriber"
+        );
+        assert!(
+            init_tracing.contains(".json()"),
+            "node runtime logging must emit structured JSON"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Remediates imported Gauntlet F-067 after confirming current `origin/main` still used bare `tracing_subscriber::fmt::init()` in the gateway and node runtime entrypoints.
- Replaces bare subscriber initialization with `EnvFilter`-backed structured JSON logging for `exo-gateway` and `exochain`.
- Adds source guards proving production entrypoints do not regress to bare `fmt::init()` and continue to honor `RUST_LOG` with JSON output.

## Classification
- `Cargo.toml`, `Cargo.lock`: EXOCHAIN core/runtime dependency contract.
- `crates/exo-gateway/src/main.rs`: core runtime adapter.
- `crates/exo-node/src/main.rs`: EXOCHAIN core node runtime.
- Gauntlet report: imported evidence only; not committed.

## Test Plan
- [x] Red: `cargo test -p exo-gateway --bin exo-gateway gateway_tracing_uses_env_filter_and_json_output` failed on bare `fmt::init()`.
- [x] Red: `cargo test -p exo-node --bin exochain node_tracing_uses_env_filter_and_json_output` failed on bare `fmt::init()`.
- [x] Green focused tests for both new guards.
- [x] `cargo test -p exo-gateway --bin exo-gateway`
- [x] `cargo test -p exo-node --bin exochain`
- [x] `cargo test -p exo-gateway`
- [x] `cargo test -p exo-node`
- [x] `cargo fmt --all -- --check` (stable rustfmt emitted existing nightly-option warnings only)
- [x] `git diff --check`
- [x] `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- [x] `cargo clippy -p exo-node --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace --release`
- [x] `cargo test --workspace --release`
- [x] `cargo doc --workspace --no-deps`
- [x] `cargo audit`
- [x] `cargo deny check` (passes with existing duplicate-version warnings)
- [x] `cargo machete --with-metadata`
- [x] `./tools/cross-impl-test/compare.sh` (Rust-only determinism; TypeScript comparison skipped because `EXO_TS_ROOT` is unset)
- [x] `cargo tarpaulin --workspace --fail-under 90 --timeout 120 --out Xml --output-dir target/tarpaulin` (91.30%)
