### PR TITLE
fix(gateway): route db startup logs through tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 163589 | `wc -l` |
+| Rust LOC | 163608 | `wc -l` |
 | Workspace tests | 4,014 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -80,7 +80,7 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 163589 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 163608 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,014 listed workspace tests
 

--- a/crates/exo-gateway/src/db.rs
+++ b/crates/exo-gateway/src/db.rs
@@ -149,7 +149,7 @@ pub async fn init_pool(database_url: &str) -> Result<PgPool, DbInitError> {
         .await
         .map_err(|source| DbInitError::Migrate { source })?;
 
-    println!("[DB] Connected to PostgreSQL, migrations applied");
+    tracing::info!("PostgreSQL connection pool ready and migrations applied");
     Ok(pool)
 }
 
@@ -1726,6 +1726,25 @@ mod tests {
         assert!(
             !init_pool_source.contains("#[allow(clippy::expect_used)]"),
             "init_pool must not suppress panic linting"
+        );
+    }
+
+    #[test]
+    fn init_pool_uses_structured_tracing_not_stdout() {
+        let source = production_source();
+        let init_pool_source = function_source(source, "init_pool");
+
+        assert!(
+            init_pool_source.contains("tracing::info!"),
+            "database initialization events must flow through structured tracing"
+        );
+        assert!(
+            !init_pool_source.contains("println!("),
+            "database initialization must not bypass structured tracing with stdout logging"
+        );
+        assert!(
+            !init_pool_source.contains("eprintln!("),
+            "database initialization must not bypass structured tracing with stderr logging"
         );
     }
 


### PR DESCRIPTION
## Summary
- Remediates Wally Gauntlet F-080: `println!` used for DB startup events.
- Confirmed live before fixing on this branch: `crates/exo-gateway/src/db.rs::init_pool` emitted `[DB] Connected to PostgreSQL, migrations applied` through `println!`.
- Replaced the stdout bypass with structured `tracing::info!` so DB initialization events use the gateway tracing pipeline.
- Added a source guard regression test that fails if `init_pool` reintroduces `println!` or `eprintln!`.
- Refreshed README repo-truth LOC after rebasing onto current `origin/main`.

## Classification
- `crates/exo-gateway/src/db.rs`: EXOCHAIN core runtime adapter.
- `README.md`: repository truth/public claim sync required by repo-truth checks.
- `/Users/bobstewart/Downloads/Exochain Gauntlet Findings.zip`: imported evidence, read-only, not committed.

## TDD / validation
- RED before production change: `cargo test -p exo-gateway db::tests::init_pool_uses_structured_tracing_not_stdout` failed with `database initialization events must flow through structured tracing`.
- GREEN after fix: `cargo test -p exo-gateway db::tests::init_pool_uses_structured_tracing_not_stdout` passed.
- `cargo test -p exo-gateway` passed.
- `bash tools/test_repo_truth.sh` passed.
- `cargo fmt --all -- --check` passed with existing stable-rustfmt warnings for nightly-only config keys.
- `cargo clippy -p exo-gateway --all-targets -- -D warnings` passed.
- `git diff --check` passed.
- Bypass search: `rg -n "println!|eprintln!" crates/exo-gateway/src/db.rs crates/exo-gateway/src/main.rs` now only finds the regression guard assertions.