### PR TITLE
fix(syntaxis): bind proof verification to generated statements

### DIFF
--- a/tools/syntaxis/README.md
+++ b/tools/syntaxis/README.md
@@ -29,8 +29,8 @@ The Syntaxis Protocol Engine is an intermediary protocol that translates council
   - `invariant-check`: Validates system invariants
 
 #### Proof & Ledger Nodes (3 nodes)
-- `proof-generate`: Generates cryptographic proofs
-- `proof-verify`: Verifies cryptographic proofs
+- `proof-generate`: Generates deterministic Syntaxis proof records
+- `proof-verify`: Verifies deterministic proof records against generated statements
 - `dag-append`: Appends execution record to governance DAG
 
 #### Escalation & Enforcement (2 nodes)
@@ -86,7 +86,7 @@ Implements new features with tenant isolation
 - **Default Duration**: 1 hour
 
 ### 3. Bug Fix Deployment
-Deploys bug fixes with proof verification
+Deploys bug fixes with deterministic proof-record verification
 - **Nodes**: 7
 - **Required Panels**: Governance, Kernel
 - **Consent Required**: No
@@ -141,7 +141,7 @@ A directed acyclic graph of nodes compiled from a council verdict and proposal. 
 - Map to BCTS state transitions
 - Validate constitutional invariants
 - Execute with fault tolerance policies
-- Generate cryptographic proofs
+- Generate deterministic proof records
 - Record execution in the governance DAG
 
 ### Council Verdict

--- a/tools/syntaxis/compiler.js
+++ b/tools/syntaxis/compiler.js
@@ -495,20 +495,10 @@ class SyntaxisCompiler {
         };
 
       case 'proof-generate':
-        return {
-          ...baseInputs,
-          dataHash: this._hashObject(proposal),
-          prover: proposal.proposer,
-          proofType: 'PROPOSAL_VALIDITY'
-        };
+        return this._buildProofGenerateInputs(baseInputs, proposal);
 
       case 'proof-verify':
-        return {
-          ...baseInputs,
-          proofId: `proof_${proposal.id}`,
-          proofHash: this._hashObject(proposal),
-          verifier: 'KERNEL_PANEL'
-        };
+        return this._buildProofVerifyInputs(baseInputs, proposal);
 
       case 'dag-append':
         return {
@@ -592,6 +582,33 @@ class SyntaxisCompiler {
       default:
         return baseInputs;
     }
+  }
+
+  _buildProofGenerateInputs(baseInputs, proposal) {
+    return {
+      ...baseInputs,
+      dataHash: this._hashObject(proposal),
+      prover: proposal.proposer,
+      proofType: 'PROPOSAL_VALIDITY',
+      proofData: proposal.proofData || {}
+    };
+  }
+
+  _buildProofVerifyInputs(baseInputs, proposal) {
+    const proofInputs = this._buildProofGenerateInputs(baseInputs, proposal);
+    const generated = NODE_IMPLEMENTATIONS['proof-generate'].execute({ inputs: proofInputs });
+
+    return {
+      ...baseInputs,
+      proofId: generated.outputs.proofId,
+      proofHash: generated.outputs.proofHash,
+      dataHash: generated.outputs.dataHash,
+      proofType: generated.outputs.proofType,
+      prover: generated.outputs.prover,
+      proofData: proofInputs.proofData,
+      generatedAtHlc: generated.outputs.generatedAtHlc,
+      verifier: 'KERNEL_PANEL'
+    };
   }
 
   _getConsentRequirementBasisPoints(nodeType) {

--- a/tools/syntaxis/determinism.test.js
+++ b/tools/syntaxis/determinism.test.js
@@ -5,6 +5,7 @@ const path = require('path');
 const { SyntaxisCompiler } = require('./compiler');
 const { NODE_IMPLEMENTATIONS } = require('./nodes');
 const { SolutionsBuilder } = require('./solutions-builder');
+const { deterministicId, hashCanonical } = require('./determinism');
 
 const HLC = { physicalMs: 1700000000000, logical: 7 };
 const DEPLOY_HLC = { physicalMs: 1700000000001, logical: 0 };
@@ -110,6 +111,108 @@ function run() {
   });
   assert.strictEqual(adjudication.outputs.confidenceBasisPoints, 6666);
   assert.ok(!Object.prototype.hasOwnProperty.call(adjudication.outputs, 'confidence'));
+
+  const proofInputs = {
+    dataHash: `0x${'11'.repeat(32)}`,
+    prover: 'GOVERNANCE_PANEL',
+    proofType: 'PROPOSAL_VALIDITY',
+    proofData: { claim: 'proposal-hash' },
+    timestampHlc: HLC
+  };
+  const generatedProof = NODE_IMPLEMENTATIONS['proof-generate'].execute({ inputs: proofInputs });
+  const proofVerificationInputs = {
+    proofId: generatedProof.outputs.proofId,
+    proofHash: generatedProof.outputs.proofHash,
+    dataHash: generatedProof.outputs.dataHash,
+    proofType: generatedProof.outputs.proofType,
+    prover: generatedProof.outputs.prover,
+    proofData: proofInputs.proofData,
+    generatedAtHlc: generatedProof.outputs.generatedAtHlc,
+    verifier: 'KERNEL_PANEL',
+    timestampHlc: HLC
+  };
+  const proofVerification = NODE_IMPLEMENTATIONS['proof-verify'].execute({
+    inputs: proofVerificationInputs
+  });
+  assert.strictEqual(proofVerification.outputs.verified, true);
+  assert.strictEqual(proofVerification.nextState, 'PROOF_VERIFIED');
+
+  const forgedShapeOnlyProof = NODE_IMPLEMENTATIONS['proof-verify'].execute({
+    inputs: {
+      proofId: 'proof_untrusted',
+      proofHash: 'proof_hash_attacker_controlled',
+      verifier: 'KERNEL_PANEL',
+      timestampHlc: HLC
+    }
+  });
+  assert.strictEqual(
+    forgedShapeOnlyProof.outputs.verified,
+    false,
+    'proof-verify must reject caller-controlled proofId/proofHash strings without a generated proof statement'
+  );
+  assert.strictEqual(forgedShapeOnlyProof.nextState, 'PROOF_INVALID');
+
+  const omittedStatementFieldsProof = NODE_IMPLEMENTATIONS['proof-verify'].execute({
+    inputs: {
+      proofId: deterministicId('proof', { proofData: {}, timestampHlc: HLC }),
+      proofHash: `proof_hash_${hashCanonical({ proofData: {} }).slice(0, 32)}`,
+      generatedAtHlc: HLC,
+      verifier: 'KERNEL_PANEL',
+      timestampHlc: HLC
+    }
+  });
+  assert.strictEqual(
+    omittedStatementFieldsProof.outputs.verified,
+    false,
+    'proof-verify execute must fail closed when dataHash, proofType, or prover are omitted'
+  );
+  assert.strictEqual(omittedStatementFieldsProof.nextState, 'PROOF_INVALID');
+
+  const tamperedProof = NODE_IMPLEMENTATIONS['proof-verify'].execute({
+    inputs: {
+      ...proofVerificationInputs,
+      proofHash: `proof_hash_${'00'.repeat(16)}`
+    }
+  });
+  assert.strictEqual(tamperedProof.outputs.verified, false);
+  assert.strictEqual(tamperedProof.nextState, 'PROOF_INVALID');
+
+  const missingStatementValidation = NODE_IMPLEMENTATIONS['proof-verify'].validate({
+    proofId: generatedProof.outputs.proofId,
+    proofHash: generatedProof.outputs.proofHash,
+    verifier: 'KERNEL_PANEL'
+  });
+  assert.strictEqual(missingStatementValidation.valid, false);
+  assert.ok(
+    missingStatementValidation.errors.some(error => error.includes('dataHash is required')),
+    'proof-verify validation must require the proof statement, not just proofId/proofHash'
+  );
+
+  const bugFixWorkflow = compiler.compileSyntaxis(verdict(), {
+    ...proposal(),
+    id: 'proposal-bugfix-001',
+    type: 'bug-fix',
+    proposer: 'ENGINEERING_PANEL'
+  });
+  assert.deepStrictEqual(
+    compiler.validateSyntaxisWorkflow(bugFixWorkflow),
+    { valid: true, errors: [], nodeCount: 5, dependencyCount: 4 },
+    'compiled bug-fix workflows must satisfy proof node validation'
+  );
+  const proofGenerateNode = bugFixWorkflow.nodes.find(node => node.type === 'proof-generate');
+  const proofVerifyNode = bugFixWorkflow.nodes.find(node => node.type === 'proof-verify');
+  const generatedWorkflowProof = NODE_IMPLEMENTATIONS['proof-generate'].execute({
+    inputs: proofGenerateNode.inputs
+  });
+  assert.strictEqual(
+    proofVerifyNode.inputs.proofId,
+    generatedWorkflowProof.outputs.proofId,
+    'compiled proof-verify node must bind to the proof generated for the same workflow statement'
+  );
+  const compiledProofVerification = NODE_IMPLEMENTATIONS['proof-verify'].execute({
+    inputs: proofVerifyNode.inputs
+  });
+  assert.strictEqual(compiledProofVerification.outputs.verified, true);
 
   const builder = new SolutionsBuilder();
   const solutionA = builder.createSolution('security-patch', {

--- a/tools/syntaxis/index.js
+++ b/tools/syntaxis/index.js
@@ -203,9 +203,9 @@ const NODE_REGISTRY = {
 
   'proof-generate': {
     category: 'Proof & Ledger',
-    description: 'Generates cryptographic proofs of execution',
+    description: 'Generates deterministic Syntaxis proof records of execution',
     requiredInputs: ['dataHash', 'prover', 'proofType'],
-    outputs: ['proofId', 'proofHash', 'proofType', 'prover'],
+    outputs: ['proofId', 'proofHash', 'proofType', 'prover', 'dataHash', 'generatedAtHlc'],
     bctsTransition: 'EXECUTING -> EXECUTING',
     requiredPanels: ['Kernel Panel'],
     timeoutMs: 20000,
@@ -214,9 +214,9 @@ const NODE_REGISTRY = {
 
   'proof-verify': {
     category: 'Proof & Ledger',
-    description: 'Verifies cryptographic proofs',
-    requiredInputs: ['proofId', 'proofHash', 'verifier'],
-    outputs: ['proofId', 'verified', 'verifier', 'integrity'],
+    description: 'Verifies deterministic Syntaxis proof records against their generated statement',
+    requiredInputs: ['proofId', 'proofHash', 'dataHash', 'proofType', 'prover', 'generatedAtHlc', 'verifier'],
+    outputs: ['proofId', 'proofHash', 'dataHash', 'proofType', 'prover', 'verified', 'verifier', 'integrity'],
     bctsTransition: 'EXECUTING -> COMPLETED',
     requiredPanels: ['Kernel Panel'],
     timeoutMs: 20000,

--- a/tools/syntaxis/node_registry.json
+++ b/tools/syntaxis/node_registry.json
@@ -214,25 +214,25 @@
     },
     "proof-generate": {
       "label": "Proof Generate",
-      "description": "Generate a cryptographic proof for a constitutional claim.",
+      "description": "Generate a deterministic Syntaxis proof record for a constitutional claim.",
       "crate": "exo-proofs",
       "rust_trait": "ProofEngine::generate",
       "rust_module": "exo_proofs::engine",
       "combinator": "Transform(Identity, { output_key: 'proof' })",
       "invariants": ["ProvenanceVerifiable"],
-      "inputs": ["claim", "evidence"],
-      "outputs": ["proof"]
+      "inputs": ["claim", "evidence", "generated_at_hlc"],
+      "outputs": ["proof_id", "proof_hash", "proof_statement"]
     },
     "proof-verify": {
       "label": "Proof Verify",
-      "description": "Verify a cryptographic proof against its claim.",
+      "description": "Verify a deterministic Syntaxis proof record against its generated proof statement.",
       "crate": "exo-proofs",
       "rust_trait": "ProofEngine::verify",
       "rust_module": "exo_proofs::engine",
       "combinator": "Guard(Identity, Predicate { required_key: 'proof_valid' })",
       "invariants": ["ProvenanceVerifiable"],
-      "inputs": ["proof", "claim"],
-      "outputs": ["verification_result"]
+      "inputs": ["proof_id", "proof_hash", "proof_statement", "generated_at_hlc"],
+      "outputs": ["verification_result", "integrity"]
     },
     "tenant-isolate": {
       "label": "Tenant Isolate",

--- a/tools/syntaxis/nodes.js
+++ b/tools/syntaxis/nodes.js
@@ -8,10 +8,15 @@ const {
   deterministicId,
   hashCanonical,
   hlcToString,
+  normalizeHlc,
   normalizeBasisPoints,
   ratioBasisPoints,
   timestampFromContext
 } = require('./determinism');
+
+function isObjectRecord(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
 
 /**
  * Base Node class - all node types extend this
@@ -721,25 +726,71 @@ class ProofVerifyNode extends SyntaxisNode {
 
   validate(inputs) {
     const errors = [];
-    if (!inputs.proofId) {
+    if (typeof inputs.proofId !== 'string' || inputs.proofId.length === 0) {
       errors.push('proofId is required');
+    } else if (!/^proof_[0-9a-f]{16}$/.test(inputs.proofId)) {
+      errors.push('proofId must be a deterministic proof identifier');
     }
-    if (!inputs.proofHash) {
+    if (typeof inputs.proofHash !== 'string' || inputs.proofHash.length === 0) {
       errors.push('proofHash is required');
+    } else if (!/^proof_hash_[0-9a-f]{32}$/.test(inputs.proofHash)) {
+      errors.push('proofHash must be a deterministic proof hash');
     }
-    if (!inputs.verifier) {
+    if (typeof inputs.dataHash !== 'string' || inputs.dataHash.length === 0) {
+      errors.push('dataHash is required');
+    }
+    if (typeof inputs.proofType !== 'string' || inputs.proofType.length === 0) {
+      errors.push('proofType is required');
+    }
+    if (typeof inputs.prover !== 'string' || inputs.prover.length === 0) {
+      errors.push('prover is required');
+    }
+    if (!inputs.generatedAtHlc) {
+      errors.push('generatedAtHlc is required');
+    } else {
+      try {
+        normalizeHlc(inputs.generatedAtHlc, 'generatedAtHlc');
+      } catch (error) {
+        errors.push(error.message);
+      }
+    }
+    if (inputs.proofData !== undefined && !isObjectRecord(inputs.proofData)) {
+      errors.push('proofData must be an object when provided');
+    }
+    if (typeof inputs.verifier !== 'string' || inputs.verifier.length === 0) {
       errors.push('verifier is required');
     }
     return { valid: errors.length === 0, errors };
   }
 
   execute(context) {
-    const { proofId, proofHash, verifier } = context.inputs;
+    const {
+      proofId,
+      proofHash,
+      dataHash,
+      proofType,
+      prover,
+      proofData,
+      generatedAtHlc,
+      verifier
+    } = context.inputs;
     const timestampHlc = timestampFromContext(context);
-    const verified = this._verifyProof(proofId, proofHash);
+    const verified = this._verifyProof({
+      proofId,
+      proofHash,
+      dataHash,
+      proofType,
+      prover,
+      proofData,
+      generatedAtHlc
+    });
     return {
       outputs: {
         proofId,
+        proofHash,
+        dataHash,
+        proofType,
+        prover,
         verified,
         verifier,
         verifiedAt: hlcToString(timestampHlc),
@@ -755,9 +806,49 @@ class ProofVerifyNode extends SyntaxisNode {
     return ['Kernel Panel'];
   }
 
-  _verifyProof(proofId, proofHash) {
-    // In production, would verify cryptographic proof integrity
-    return !!(proofId && proofHash && proofHash.length > 0);
+  _verifyProof(proof) {
+    if (
+      typeof proof.proofId !== 'string'
+      || !/^proof_[0-9a-f]{16}$/.test(proof.proofId)
+      || typeof proof.proofHash !== 'string'
+      || !/^proof_hash_[0-9a-f]{32}$/.test(proof.proofHash)
+      || typeof proof.dataHash !== 'string'
+      || proof.dataHash.length === 0
+      || typeof proof.proofType !== 'string'
+      || proof.proofType.length === 0
+      || typeof proof.prover !== 'string'
+      || proof.prover.length === 0
+    ) {
+      return false;
+    }
+
+    const proofData = proof.proofData || {};
+    if (!isObjectRecord(proofData)) {
+      return false;
+    }
+
+    let generatedAtHlc;
+    try {
+      generatedAtHlc = normalizeHlc(proof.generatedAtHlc, 'generatedAtHlc');
+    } catch (_error) {
+      return false;
+    }
+
+    const expectedProofId = deterministicId('proof', {
+      dataHash: proof.dataHash,
+      proofData,
+      proofType: proof.proofType,
+      prover: proof.prover,
+      timestampHlc: generatedAtHlc
+    });
+    const expectedProofHash = `proof_hash_${hashCanonical({
+      dataHash: proof.dataHash,
+      proofData,
+      proofType: proof.proofType,
+      prover: proof.prover
+    }).slice(0, 32)}`;
+
+    return proof.proofId === expectedProofId && proof.proofHash === expectedProofHash;
   }
 }
 

--- a/tools/syntaxis/package.json
+++ b/tools/syntaxis/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "node determinism.test.js && node test.js",
-    "validate": "node validate.js"
+    "validate": "node determinism.test.js && node test.js"
   },
   "keywords": [
     "exochain",


### PR DESCRIPTION
## Summary
- classify Wally proof-stub cluster as imported evidence and confirmed current live runtime/tooling-adapter issue in tools/syntaxis: proof-verify accepted caller-controlled proofId/proofHash strings by shape only
- bind proof-verify to deterministic Syntaxis proof records by recomputing the expected proof ID and proof hash from dataHash, proofType, prover, proofData, and generatedAtHlc
- compile bug-fix workflows so proof-verify consumes the exact statement generated by proof-generate
- remove Syntaxis cryptographic-proof overclaims and fix the package validate script to run the real suite

## Path Classification
- tools/syntaxis/*: core runtime/tooling adapter for governance workflow generation and proof-node execution
- Wally zip: imported evidence, read-only, not committed
- no Rust crates, WASM bindings, governance runtime artifacts, CI workflows, deployment contracts, or adjacent product surfaces changed

## Confirmation Before Remediation
- Wally F-025/F-030/F-032 were treated as hypotheses; current Rust exo-proofs/DAG/MCP proof paths were sanity-checked first and are either fail-closed/gated or already backed by core verifier tests
- live issue reproduced in current main at tools/syntaxis/nodes.js: proof-verify returned verified=true for forged non-empty proof strings
- red tests failed before production changes with: proof-verify must reject caller-controlled proofId/proofHash strings without a generated proof statement
- a second red bypass test proved execute() had to fail closed even if validate() is skipped

## Tests
- node tools/syntaxis/determinism.test.js
- npm test (tools/syntaxis)
- npm run validate (tools/syntaxis)
- node -e JSON.parse checks for tools/syntaxis/node_registry.json and package.json
- rg bypass search for proof-verifier stub/overclaim patterns in tools/syntaxis
- git diff --check
- bash tools/test_repo_truth.sh