### PR TITLE
ci: pin GitHub Actions to immutable SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,11 @@ jobs:
     name: "Gate 1 — Build (release)"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Build workspace (release)
         run: cargo build --workspace --release
 
@@ -43,9 +43,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Run all workspace tests
         run: cargo test --workspace
       - name: Run tests in release mode (determinism check)
@@ -59,9 +59,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin
       - name: Run coverage
@@ -86,7 +86,7 @@ jobs:
             --timeout 300 \
             --fail-under 90
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: coverage-report
           path: coverage/cobertura.xml
@@ -98,11 +98,11 @@ jobs:
     name: "Gate 4 — Clippy Lint"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Clippy (all workspace targets, deny all warnings)
         run: cargo clippy --workspace --all-targets -- -D warnings
 
@@ -113,8 +113,8 @@ jobs:
     name: "Gate 5 — Format Check"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2
         with:
           components: rustfmt
       - name: Check formatting
@@ -127,7 +127,7 @@ jobs:
     name: "Gate 6 — Cargo Audit"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Install cargo-audit
         run: cargo install cargo-audit
       - name: Audit dependencies (strict — vulnerabilities, unsound, unmaintained)
@@ -148,9 +148,9 @@ jobs:
     name: "Gate 7 — Cargo Deny"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: EmbarkStudios/cargo-deny-action@5bb39ff5d5a0e94dc9e2dc94eced0c6129743a57
         with:
           command: check
 
@@ -163,9 +163,9 @@ jobs:
     env:
       RUSTDOCFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Build documentation
         run: cargo doc --workspace --no-deps
 
@@ -176,7 +176,7 @@ jobs:
     name: "Gate 9 — Repo Hygiene"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: No tracked node_modules
         run: |
           if git ls-files --error-unmatch node_modules/ 2>/dev/null; then
@@ -231,6 +231,8 @@ jobs:
             exit 1
           fi
           echo "✓ No GAP stubs remaining in code"
+      - name: GitHub Actions pinned to immutable SHAs
+        run: bash tools/test_github_actions_pinned.sh
       - name: Repo truth and public claims
         run: bash tools/test_repo_truth.sh
       - name: CR-001 status consistency
@@ -254,9 +256,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Install cargo-cyclonedx
         run: cargo install cargo-cyclonedx
       - name: Generate CycloneDX SBOM (validation only)
@@ -271,7 +273,7 @@ jobs:
           echo "✓ CycloneDX SBOM generated successfully ($SBOM_COUNT files):"
           find . -name '*.cdx.json' -o -name '*bom*.json' | head -20
       - name: Upload SBOM artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: sbom-ci-${{ github.sha }}
           path: |
@@ -287,9 +289,9 @@ jobs:
     name: "Gate 11 — Unused Dependencies (cargo-machete)"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Install cargo-machete
         run: cargo install cargo-machete
       - name: Check for unused dependencies
@@ -307,16 +309,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050
         id: filter
         with:
           filters: |
             gateway:
               - 'crates/exo-gateway/**'
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         if: steps.filter.outputs.gateway == 'true'
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
         if: steps.filter.outputs.gateway == 'true'
       - name: Run workspace integration tests
         if: steps.filter.outputs.gateway == 'true'
@@ -332,9 +334,9 @@ jobs:
     env:
       DATABASE_URL: postgres://exochain:test@localhost:5432/exochain_test
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Start Postgres via docker compose
         run: docker compose -f docker-compose.ci.yml up -d
       - name: Wait for Postgres to be healthy
@@ -366,17 +368,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050
         id: filter
         with:
           filters: |
             node:
               - 'crates/exo-node/**'
               - 'crates/exo-dag/**'
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         if: steps.filter.outputs.node == 'true'
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
         if: steps.filter.outputs.node == 'true'
       - name: Run exo-node unit and integration tests
         if: steps.filter.outputs.node == 'true'
@@ -396,16 +398,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050
         id: filter
         with:
           filters: |
             sync:
               - 'crates/exo-node/**'
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         if: steps.filter.outputs.sync == 'true'
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
         if: steps.filter.outputs.sync == 'true'
       - name: Run sync engine tests
         if: steps.filter.outputs.sync == 'true'
@@ -441,17 +443,17 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
         with:
           key: ${{ matrix.target }}
       - name: Build exochain binary
         run: cargo build --release --bin exochain --target ${{ matrix.target }}
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: exochain-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/exochain
@@ -469,9 +471,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin
       - name: Run 0dentity module coverage
@@ -486,7 +488,7 @@ jobs:
             --timeout 120 \
             --fail-under 80
       - name: Upload 0dentity coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: zerodentity-coverage-${{ github.sha }}
           path: coverage-zerodentity/cobertura.xml
@@ -499,11 +501,11 @@ jobs:
     name: "Gate 20 — WASM Build"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           targets: wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Build WASM
@@ -519,7 +521,7 @@ jobs:
           echo "Found $COUNT WASM exports"
           [ "$COUNT" -eq 149 ] || (echo "Expected 149 exports, got $COUNT" && exit 1)
       - name: Upload WASM artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: exochain-wasm
           path: packages/exochain-wasm/wasm/
@@ -532,11 +534,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-wasm
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 20
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: exochain-wasm
           path: packages/exochain-wasm/wasm/
@@ -550,7 +552,7 @@ jobs:
     name: "Gate 22 — WASM/JS Export Sync"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Verify Rust exports match JS expectations
         # Expected #[wasm_bindgen] count = 149. Baseline was 110 before the
         # Sprint-4 additions (decision-forum, messaging, death-trigger,

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Install flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1
 
       - name: Deploy to Fly.io
         env:

--- a/.github/workflows/exoforge-triage.yml
+++ b/.github/workflows/exoforge-triage.yml
@@ -58,7 +58,7 @@ jobs:
             }' || echo "ExoForge gateway not reachable — issue queued for manual triage"
 
       - name: Add triage acknowledgment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,11 +54,11 @@ jobs:
           - x86_64-unknown-linux-gnu
           - aarch64-unknown-linux-gnu
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
 
       - name: Install cross-compilation tools
         if: matrix.target == 'aarch64-unknown-linux-gnu'
@@ -79,7 +79,7 @@ jobs:
           tar czf exochain-${{ inputs.version }}-${{ matrix.target }}.tar.gz -C dist .
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: exochain-${{ inputs.version }}-${{ matrix.target }}
           path: exochain-${{ inputs.version }}-${{ matrix.target }}.tar.gz
@@ -106,12 +106,12 @@ jobs:
       id-token: write      # GitHub OIDC token for keyless Sigstore signing
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           path: artifacts
 
@@ -137,7 +137,7 @@ jobs:
           ls -lh exochain-${{ inputs.version }}-*.cdx.json
 
       - name: Upload SBOM artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: sbom-${{ inputs.version }}
           path: exochain-${{ inputs.version }}-*.cdx.json
@@ -145,7 +145,7 @@ jobs:
 
       # ── SLSA provenance attestation ──────────────────────────────────────
       - name: Attest build provenance (SLSA Level 2)
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45
         with:
           subject-path: release-archives/*.tar.gz
 
@@ -158,8 +158,8 @@ jobs:
     needs: [release-build, sbom-and-attest]
     if: ${{ !inputs.dry_run }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
 
       - name: Publish crates in dependency order
         env:
@@ -201,15 +201,15 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           path: artifacts
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
           tag_name: v${{ inputs.version }}
           name: "EXOCHAIN v${{ inputs.version }}"
@@ -261,10 +261,10 @@ jobs:
     if: ${{ !inputs.dry_run }}
     environment: release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Install flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1
 
       - name: Deploy seed node
         env:

--- a/tools/test_github_actions_pinned.sh
+++ b/tools/test_github_actions_pinned.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  printf 'github actions pinning test failed: %s\n' "$1" >&2
+  exit 1
+}
+
+shopt -s nullglob
+
+violations=()
+for workflow in .github/workflows/*.yml .github/workflows/*.yaml; do
+  while IFS= read -r match; do
+    line_no=${match%%:*}
+    uses_ref=${match#*:}
+    uses_ref=${uses_ref#*uses:}
+    uses_ref=${uses_ref%%#*}
+    uses_ref=$(printf '%s' "$uses_ref" | sed -E "s/^[[:space:]]+//;s/[[:space:]]+$//;s/^['\\\"]//;s/['\\\"]$//")
+
+    [[ -z "$uses_ref" ]] && continue
+    [[ "$uses_ref" == ./* ]] && continue
+
+    ref=${uses_ref##*@}
+    if [[ ! "$ref" =~ ^[0-9a-f]{40}$ ]]; then
+      violations+=("${workflow}:${line_no}: ${uses_ref}")
+    fi
+  done < <(grep -nE 'uses:[[:space:]]+[^[:space:]#]+@[^[:space:]#]+' "$workflow" || true)
+done
+
+if ((${#violations[@]} > 0)); then
+  printf '%s\n' "${violations[@]}" >&2
+  fail "external actions must be pinned to immutable commit SHAs"
+fi
+
+printf 'github actions pinning test passed\n'


### PR DESCRIPTION
## Summary
- Remediates the Wally supply-chain finding class by replacing movable external GitHub Action refs with immutable 40-character commit SHAs across CI, deploy, release, and ExoForge triage workflows.
- Adds `tools/test_github_actions_pinned.sh` and wires it into Gate 9 so future movable refs fail CI.
- Leaves local reusable workflows (`./.github/workflows/ci.yml`) allowed because they are repository-owned.

## Classification
- `.github/workflows/*.yml`: EXOCHAIN core CI/deployment contract.
- `tools/test_github_actions_pinned.sh`: EXOCHAIN core CI guard.
- Imported evidence: Wally F-123 / supply-chain workflow action pinning claim; read-only input, not committed.

## Verification
- RED first: `bash tools/test_github_actions_pinned.sh` failed on current main with movable refs including `actions/checkout@v4` and `superfly/flyctl-actions/setup-flyctl@master`.
- `bash tools/test_github_actions_pinned.sh`
- `rg -n "uses:\s*[^\s#]+@(v[0-9]+|master|main|stable|nightly|latest)" .github/workflows` returned no matches.
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].sort.each { |f| YAML.load_file(f); puts "parsed #{f}" }'`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `git diff --check HEAD~1..HEAD`

## Current-main confirmation
Current `origin/main` still used movable external action refs throughout workflows. This PR pins those refs and adds a repeatable guard to prevent regression.