### PR TITLE
fix(node): redact 0dentity sentinel DIDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 163908 | `wc -l` |
+| Rust LOC | 163969 | `wc -l` |
 | Workspace tests | 4,014 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -80,7 +80,7 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 163908 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 163969 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,014 listed workspace tests
 

--- a/crates/exo-node/src/sentinels.rs
+++ b/crates/exo-node/src/sentinels.rs
@@ -21,7 +21,10 @@ use std::{
 };
 
 use axum::{Json, Router, extract::State, http::StatusCode, routing::get};
-use exo_core::hlc::HybridClock;
+use exo_core::{
+    hlc::HybridClock,
+    types::{Did, Hash256},
+};
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 
@@ -130,6 +133,13 @@ pub(crate) fn now_ms() -> u64 {
             0
         }
     }
+}
+
+fn redacted_did_ref(did: &Did) -> String {
+    let mut material = b"exo.sentinel.did_ref.v1:".to_vec();
+    material.extend_from_slice(did.as_str().as_bytes());
+    let digest = Hash256::digest(&material);
+    format!("did_ref={}", hex::encode(digest.as_bytes()))
 }
 
 // ---------------------------------------------------------------------------
@@ -349,8 +359,8 @@ fn check_score_integrity(zerodentity: &SharedZerodentityStore) -> SentinelStatus
                 check: SentinelCheck::ScoreIntegrity,
                 healthy: false,
                 message: format!(
-                    "Zerodentity claims unavailable for DID {}: {e}",
-                    did.as_str()
+                    "Zerodentity claims unavailable for {}: {e}",
+                    redacted_did_ref(&did)
                 ),
                 last_run_ms: now_ms(),
             };
@@ -365,8 +375,8 @@ fn check_score_integrity(zerodentity: &SharedZerodentityStore) -> SentinelStatus
                 check: SentinelCheck::ScoreIntegrity,
                 healthy: false,
                 message: format!(
-                    "Zerodentity fingerprints unavailable for DID {}: {e}",
-                    did.as_str()
+                    "Zerodentity fingerprints unavailable for {}: {e}",
+                    redacted_did_ref(&did)
                 ),
                 last_run_ms: now_ms(),
             };
@@ -379,8 +389,8 @@ fn check_score_integrity(zerodentity: &SharedZerodentityStore) -> SentinelStatus
                 check: SentinelCheck::ScoreIntegrity,
                 healthy: false,
                 message: format!(
-                    "Zerodentity behavioral samples unavailable for DID {}: {e}",
-                    did.as_str()
+                    "Zerodentity behavioral samples unavailable for {}: {e}",
+                    redacted_did_ref(&did)
                 ),
                 last_run_ms: now_ms(),
             };
@@ -406,8 +416,8 @@ fn check_score_integrity(zerodentity: &SharedZerodentityStore) -> SentinelStatus
             check: SentinelCheck::ScoreIntegrity,
             healthy: false,
             message: format!(
-                "Score drift {drift} bp detected for DID {} (stored={}, recomputed={})",
-                did.as_str(),
+                "Score drift {drift} bp detected for {} (stored={}, recomputed={})",
+                redacted_did_ref(&did),
                 stored.composite,
                 recomputed.composite
             ),
@@ -419,8 +429,8 @@ fn check_score_integrity(zerodentity: &SharedZerodentityStore) -> SentinelStatus
         check: SentinelCheck::ScoreIntegrity,
         healthy: true,
         message: format!(
-            "Score integrity verified — DID {} checked (drift {drift} bp)",
-            did.as_str()
+            "Score integrity verified for {} (drift {drift} bp)",
+            redacted_did_ref(&did)
         ),
         last_run_ms: now_ms(),
     }
@@ -955,6 +965,57 @@ mod tests {
                 .message
                 .contains("Zerodentity behavioral samples unavailable")
         );
+    }
+
+    #[test]
+    fn score_integrity_status_messages_redact_subject_dids() {
+        let raw_did = "did:exo:scored-sensitive";
+
+        let read_failures = [
+            crate::zerodentity::store::ZerodentityReadFailure::Claims,
+            crate::zerodentity::store::ZerodentityReadFailure::Fingerprints,
+            crate::zerodentity::store::ZerodentityReadFailure::Behavioral,
+        ];
+        for failure in read_failures {
+            let zerodentity = crate::zerodentity::store::new_shared_store();
+            {
+                let did = Did::new(raw_did).unwrap();
+                let mut store = zerodentity.lock().unwrap();
+                store.put_score(ZerodentityScore::compute(&did, &[], &[], &[], 1000));
+                store.inject_read_failure(failure);
+            }
+
+            let status = check_score_integrity(&zerodentity);
+
+            assert!(!status.message.contains(raw_did));
+            assert!(status.message.contains("did_ref="));
+        }
+
+        let zerodentity = crate::zerodentity::store::new_shared_store();
+        {
+            let did = Did::new(raw_did).unwrap();
+            let mut store = zerodentity.lock().unwrap();
+            store.put_score(ZerodentityScore::compute(&did, &[], &[], &[], 1000));
+        }
+
+        let status = check_score_integrity(&zerodentity);
+
+        assert!(!status.message.contains(raw_did));
+        assert!(status.message.contains("did_ref="));
+
+        let zerodentity = crate::zerodentity::store::new_shared_store();
+        {
+            let did = Did::new(raw_did).unwrap();
+            let mut score = ZerodentityScore::compute(&did, &[], &[], &[], 1000);
+            score.composite = score.composite.saturating_add(1000).min(10_000);
+            let mut store = zerodentity.lock().unwrap();
+            store.put_score(score);
+        }
+
+        let status = check_score_integrity(&zerodentity);
+
+        assert!(!status.message.contains(raw_did));
+        assert!(status.message.contains("did_ref="));
     }
 
     #[test]


### PR DESCRIPTION
Classification: core runtime adapter (`crates/exo-node/src/sentinels.rs`) plus repo-truth metadata (`README.md`).

External finding disposition: Wally F-055/F-079 observability/privacy class was re-checked against current `origin/main`. The exact F-079 zero-tracing wording is stale, but the live issue remained in score-integrity sentinel status messages: read-error, drift, and success paths embedded the sampled 0dentity DID.

Remediation: add a deterministic domain-tagged `did_ref=` hash for sentinel messages and replace raw sampled DID interpolation in score-integrity status text. Added a red-first regression covering claim, fingerprint, behavioral read errors, healthy verification, and drift detection.

Validation:
- RED: `cargo test -p exo-node score_integrity_status_messages_redact_subject_dids` failed before the fix because the message contained `did:exo:scored-sensitive`.
- GREEN: `cargo test -p exo-node score_integrity_status_messages_redact_subject_dids` passed.
- `cargo test -p exo-node sentinels::tests` passed.
- `cargo test -p exo-node` passed, 994 tests.
- `cargo clippy -p exo-node --all-targets -- -D warnings` passed.
- `cargo fmt --all -- --check` passed.
- `bash tools/test_repo_truth.sh` passed.
- `git diff --check` passed.
- Bypass search: `rg -n "Zerodentity .*DID \{}|Score .*DID \{}|DID \{}|did:exo:scored-sensitive" crates/exo-node/src/sentinels.rs` leaves only the regression-test fixture DID.