### PR TITLE
fix(node): make consensus round timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 164118 | `wc -l` |
-| Workspace tests | 4,014 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 164210 | `wc -l` |
+| Workspace tests | 4,026 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,014 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,026 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -80,9 +80,9 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 164118 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 164210 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,014 listed workspace tests
+         cryptographic proofs, 4,026 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/cli.rs
+++ b/crates/exo-node/src/cli.rs
@@ -4,6 +4,22 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 
+pub const DEFAULT_ROUND_TIMEOUT_MS: u64 = 5_000;
+pub const MIN_ROUND_TIMEOUT_MS: u64 = 250;
+pub const MAX_ROUND_TIMEOUT_MS: u64 = 300_000;
+
+fn parse_round_timeout_ms(value: &str) -> Result<u64, String> {
+    let timeout_ms = value
+        .parse::<u64>()
+        .map_err(|error| format!("round timeout must be a millisecond integer: {error}"))?;
+    if !(MIN_ROUND_TIMEOUT_MS..=MAX_ROUND_TIMEOUT_MS).contains(&timeout_ms) {
+        return Err(format!(
+            "round timeout must be between {MIN_ROUND_TIMEOUT_MS} and {MAX_ROUND_TIMEOUT_MS} milliseconds"
+        ));
+    }
+    Ok(timeout_ms)
+}
+
 #[derive(Parser)]
 #[command(
     name = "exochain",
@@ -39,6 +55,14 @@ pub enum Command {
         /// P2P listen port.
         #[arg(long, default_value = None)]
         p2p_port: Option<u16>,
+
+        /// Consensus round timeout in milliseconds.
+        #[arg(
+            long,
+            default_value_t = DEFAULT_ROUND_TIMEOUT_MS,
+            value_parser = parse_round_timeout_ms
+        )]
+        round_timeout_ms: u64,
 
         /// Data directory (default: ~/.exochain).
         #[arg(long)]
@@ -78,6 +102,14 @@ pub enum Command {
         /// P2P listen port.
         #[arg(long, default_value = None)]
         p2p_port: Option<u16>,
+
+        /// Consensus round timeout in milliseconds.
+        #[arg(
+            long,
+            default_value_t = DEFAULT_ROUND_TIMEOUT_MS,
+            value_parser = parse_round_timeout_ms
+        )]
+        round_timeout_ms: u64,
 
         /// Data directory (default: ~/.exochain).
         #[arg(long)]

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -324,17 +324,18 @@ fn spawn_event_fanout(
 
 /// Start all subsystems for a running node.
 #[allow(clippy::too_many_arguments)]
-// 8 args is the minimum for a node bootstrap entry point:
-// data_dir, api_host, api_port, p2p_port, validator, validators,
-// validator_public_keys, seed_addrs, is_join. Each is a distinct bootstrap parameter
-// that came in through CLI parsing; bundling them behind a
-// struct would add a layer of boilerplate with no safety benefit
-// since this is the single call site from `main()`.
+// 10 args is the minimum for a node bootstrap entry point:
+// data_dir, api_host, api_port, p2p_port, round_timeout_ms, validator, validators,
+// validator_public_keys, seed_addrs, is_join. Each is a distinct bootstrap
+// parameter that came in through CLI parsing; bundling them behind a struct would
+// add a layer of boilerplate with no safety benefit since this is the single call
+// site from `main()`.
 async fn start_node(
     data_dir: &std::path::Path,
     api_host: &str,
     api_port: u16,
     p2p_port: u16,
+    round_timeout_ms: u64,
     validator: bool,
     validators: &Option<Vec<String>>,
     validator_public_key_entries: &Option<Vec<String>>,
@@ -377,6 +378,7 @@ async fn start_node(
     tracing::info!(
         api_port,
         p2p_port,
+        round_timeout_ms,
         validator,
         did = %node_identity.did,
         "Starting exochain node"
@@ -429,7 +431,7 @@ async fn start_node(
         is_validator: validator,
         validators: validator_set.clone(),
         validator_public_keys,
-        round_timeout_ms: 5000,
+        round_timeout_ms,
     };
 
     let sign_fn: Arc<dyn Fn(&[u8]) -> exo_core::types::Signature + Send + Sync> = {
@@ -986,6 +988,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             api_port,
             api_host,
             p2p_port,
+            round_timeout_ms,
             data_dir,
             validator,
             validators,
@@ -1005,6 +1008,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                 &api_host,
                 api_port,
                 p2p_port,
+                round_timeout_ms,
                 validator,
                 &validators,
                 &validator_public_keys,
@@ -1019,6 +1023,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             api_port,
             api_host,
             p2p_port,
+            round_timeout_ms,
             data_dir,
             validator,
             validators,
@@ -1040,6 +1045,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                 &api_host,
                 api_port,
                 p2p_port,
+                round_timeout_ms,
                 validator,
                 &validators,
                 &validator_public_keys,
@@ -1225,6 +1231,60 @@ mod tests {
             init_tracing.contains(".json()"),
             "node runtime logging must emit structured JSON"
         );
+    }
+
+    #[test]
+    fn cli_accepts_consensus_round_timeout_for_start_and_join() {
+        let start = Cli::try_parse_from([
+            "exochain",
+            "start",
+            "--round-timeout-ms",
+            "7500",
+            "--validator",
+        ]);
+        assert!(
+            start.is_ok(),
+            "start command must accept a bounded consensus round timeout"
+        );
+
+        let join = Cli::try_parse_from([
+            "exochain",
+            "join",
+            "--seed",
+            "seed1.exochain.io:4001",
+            "--round-timeout-ms",
+            "7500",
+        ]);
+        assert!(
+            join.is_ok(),
+            "join command must accept a bounded consensus round timeout"
+        );
+
+        assert!(
+            Cli::try_parse_from(["exochain", "start", "--round-timeout-ms", "0"]).is_err(),
+            "round timeout must reject zero-millisecond busy-loop values"
+        );
+        assert!(
+            Cli::try_parse_from(["exochain", "start", "--round-timeout-ms", "300001"]).is_err(),
+            "round timeout must reject deployment-stalling values above five minutes"
+        );
+    }
+
+    #[test]
+    fn node_bootstrap_uses_configured_round_timeout_not_fixed_literal() {
+        let source = include_str!("main.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production source precedes tests");
+        let reactor_config = production
+            .split("let reactor_config = ReactorConfig")
+            .nth(1)
+            .and_then(|section| section.split("};").next())
+            .expect("reactor config is constructed during node startup");
+
+        assert!(!reactor_config.contains("round_timeout_ms: 5000"));
+        assert!(reactor_config.contains("round_timeout_ms,"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Verified Wally F-084 still reproduced on current `origin/main`: node startup hardcoded `round_timeout_ms: 5000`, while `start`/`join` exposed no bounded operator override.
- Added bounded `--round-timeout-ms` support to `exochain start` and `exochain join` with deterministic integer bounds of 250..=300000 ms and the existing 5000 ms default.
- Threaded the CLI value into `ReactorConfig` and added regression guards that reject the fixed production literal.

## Path classification
- EXOCHAIN core runtime adapter: `crates/exo-node/src/cli.rs`, `crates/exo-node/src/main.rs`
- Documentation / repo-truth metadata: `README.md`

## Validation
- RED before fix: `cargo test -p exo-node round_timeout` failed because the CLI rejected `--round-timeout-ms` and startup still contained `round_timeout_ms: 5000`.
- PASS: `cargo test -p exo-node round_timeout`
- PASS: `cargo test -p exo-node`
- PASS: `cargo clippy -p exo-node --all-targets -- -D warnings`
- PASS: `cargo fmt --all -- --check`
- PASS: `bash tools/test_repo_truth.sh`
- PASS: `bash tools/test_cr001_status.sh`
- PASS: `bash tools/test_gap_registry_truth.sh`
- PASS: `git diff --check`
- BYPASS SEARCH: `rg -n "round_timeout_ms: 5000|round_timeout_ms: 5_000|from_millis\\(5000\\)|from_millis\\(5_000\\)" crates/exo-node/src/main.rs crates/exo-node/src/cli.rs crates/exo-node/src/reactor.rs` now returns only test fixtures.
