### PR TITLE
fix(gateway): scope audit trail by tenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 163969 | `wc -l` |
+| Rust LOC | 164118 | `wc -l` |
 | Workspace tests | 4,014 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -80,7 +80,7 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 163969 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 164118 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,014 listed workspace tests
 

--- a/crates/exo-gateway/src/db.rs
+++ b/crates/exo-gateway/src/db.rs
@@ -925,12 +925,14 @@ pub async fn list_audit_entries(pool: &PgPool) -> Result<Vec<AuditRow>, sqlx::Er
 pub async fn list_audit_entries_for_decision(
     pool: &PgPool,
     decision_id: &str,
+    tenant_id: &str,
 ) -> Result<Vec<AuditRow>, sqlx::Error> {
     sqlx::query_as::<_, AuditRow>(
         "SELECT sequence, prev_hash, event_hash, event_type, actor, tenant_id, decision_id, timestamp_physical_ms, timestamp_logical, entry_hash
-         FROM audit_entries WHERE decision_id = $1 ORDER BY sequence LIMIT $2",
+         FROM audit_entries WHERE decision_id = $1 AND tenant_id = $2 ORDER BY sequence LIMIT $3",
     )
     .bind(decision_id)
+    .bind(tenant_id)
     .bind(MAX_DB_LIST_ROWS)
     .fetch_all(pool)
     .await
@@ -2356,6 +2358,28 @@ mod tests {
         assert!(
             contains_in_order(lookup, ".bind(id_hash)", ".bind(tenant_id)"),
             "find_decision must bind id_hash and tenant_id together"
+        );
+    }
+
+    #[test]
+    fn audit_entry_lookup_requires_decision_and_tenant_scope() {
+        let source = production_source();
+        let lookup = function_source(source, "list_audit_entries_for_decision");
+
+        assert!(
+            lookup.contains("tenant_id: &str"),
+            "list_audit_entries_for_decision must require an explicit tenant scope"
+        );
+        assert!(
+            compact_sql(lookup).contains(
+                "FROM audit_entries WHERE decision_id = $1 AND tenant_id = $2 ORDER BY sequence LIMIT $3"
+            ),
+            "list_audit_entries_for_decision must constrain audit rows by decision_id and tenant_id"
+        );
+        assert!(
+            contains_in_order(lookup, ".bind(decision_id)", ".bind(tenant_id)")
+                && contains_in_order(lookup, ".bind(tenant_id)", ".bind(MAX_DB_LIST_ROWS)"),
+            "list_audit_entries_for_decision must bind decision_id, tenant_id, then row limit"
         );
     }
 

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -2191,11 +2191,12 @@ async fn handle_audit_trail(
     headers: HeaderMap,
     Path(decision_id): Path<String>,
 ) -> impl IntoResponse {
-    if let Err(e) = require_authenticated_session_actor_from_header(&state, &headers).await {
-        return auth_boundary_error_response(e);
-    }
-    let pool = match state.require_db() {
-        Ok(pool) => pool,
+    let actor = match require_authenticated_session_user_from_header(&state, &headers).await {
+        Ok(actor) => actor,
+        Err(e) => return auth_boundary_error_response(e),
+    };
+    let db = match state.require_db() {
+        Ok(db) => db,
         Err(_) => {
             return (
                 StatusCode::SERVICE_UNAVAILABLE,
@@ -2204,7 +2205,7 @@ async fn handle_audit_trail(
                 .into_response();
         }
     };
-    match db::list_audit_entries_for_decision(pool, &decision_id).await {
+    match db::list_audit_entries_for_decision(db, &decision_id, &actor.tenant_id).await {
         Ok(rows) => {
             let entries: Vec<serde_json::Value> = rows
                 .into_iter()
@@ -4650,6 +4651,31 @@ mod tests {
     }
 
     #[test]
+    fn audit_trail_uses_authenticated_actor_tenant_for_lookup() {
+        let source = include_str!("server.rs");
+        let handler = source_between(
+            source,
+            "async fn handle_audit_trail",
+            "/// POST /api/v1/agents/enroll",
+        );
+
+        assert!(
+            handler.contains("require_authenticated_session_user_from_header"),
+            "audit trail must load the authenticated session actor's tenant profile"
+        );
+        assert!(
+            handler.contains(
+                "db::list_audit_entries_for_decision(db, &decision_id, &actor.tenant_id)"
+            ),
+            "audit trail must query audit entries using the authenticated actor tenant"
+        );
+        assert!(
+            !handler.contains("db::list_audit_entries_for_decision(pool, &decision_id)"),
+            "audit trail must not perform an unscoped decision_id lookup"
+        );
+    }
+
+    #[test]
     fn decision_post_route_dispatches_to_create_handler_not_vote_handler() {
         let source = include_str!("server.rs");
         let router = source_between(
@@ -5802,6 +5828,7 @@ mod tests {
             Some(pool) => pool,
             None => return,
         };
+        insert_test_user(&pool, "did:exo:reader", "tenant-read").await;
         insert_test_session(&pool, "audit-trail-token", "did:exo:reader").await;
         sqlx::query("DELETE FROM audit_entries WHERE sequence = $1 OR decision_id = $2")
             .bind(901_004_i64)
@@ -5858,6 +5885,104 @@ mod tests {
             .unwrap();
         sqlx::query("DELETE FROM sessions WHERE token = $1")
             .bind("audit-trail-token")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM users WHERE did = $1")
+            .bind("did:exo:reader")
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn audit_trail_filters_entries_to_authenticated_actor_tenant() {
+        let pool = match gateway_test_pool().await {
+            Some(pool) => pool,
+            None => return,
+        };
+        insert_test_user(&pool, "did:exo:audit-tenant-b-reader", "tenant-b").await;
+        insert_test_session(
+            &pool,
+            "audit-trail-cross-tenant-token",
+            "did:exo:audit-tenant-b-reader",
+        )
+        .await;
+        sqlx::query("DELETE FROM audit_entries WHERE decision_id = $1")
+            .bind("audit-cross-tenant-decision")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        db::insert_audit_entry(
+            &pool,
+            901_014,
+            "prev-a",
+            "event-a",
+            "VoteCast",
+            "did:exo:tenant-a-reader",
+            "tenant-a",
+            "audit-cross-tenant-decision",
+            10_001,
+            0,
+            "entry-a",
+        )
+        .await
+        .unwrap();
+        db::insert_audit_entry(
+            &pool,
+            901_015,
+            "prev-b",
+            "event-b",
+            "VoteCast",
+            "did:exo:audit-tenant-b-reader",
+            "tenant-b",
+            "audit-cross-tenant-decision",
+            10_002,
+            0,
+            "entry-b",
+        )
+        .await
+        .unwrap();
+
+        let app = build_router(AppState::new(
+            Some(pool.clone()),
+            Arc::new(RwLock::new(LocalDidRegistry::new())),
+        ));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/audit/audit-cross-tenant-decision")
+                    .header("authorization", "Bearer audit-trail-cross-tenant-token")
+                    .header(AUTH_OBSERVED_AT_MS_HEADER, "15000")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let val: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let entries = val["audit_entries"].as_array().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["tenant_id"], "tenant-b");
+        assert_eq!(entries[0]["actor"], "did:exo:audit-tenant-b-reader");
+
+        sqlx::query("DELETE FROM audit_entries WHERE decision_id = $1")
+            .bind("audit-cross-tenant-decision")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM sessions WHERE token = $1")
+            .bind("audit-trail-cross-tenant-token")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM users WHERE did = $1")
+            .bind("did:exo:audit-tenant-b-reader")
             .execute(&pool)
             .await
             .unwrap();


### PR DESCRIPTION
## Summary
- Classifies this as a core runtime adapter remediation: `GET /api/v1/audit/:decision_id` exposes tenant-scoped governance audit evidence through `crates/exo-gateway`.
- Reproduced the current gap against `origin/main`: the handler authenticated a session but called `db::list_audit_entries_for_decision(pool, &decision_id)` without the authenticated actor tenant.
- Requires the authenticated session user's tenant profile and binds `tenant_id` into the audit-entry lookup (`decision_id + tenant_id + LIMIT`).
- Adds source guards and a DB-backed route regression that proves same-decision audit rows are filtered to the caller tenant.
- Updates README repo-truth Rust LOC from tracked crate sources.

## Path Classification
- `crates/exo-gateway/src/server.rs` — core runtime adapter
- `crates/exo-gateway/src/db.rs` — core runtime adapter
- `README.md` — documentation/repo-truth metadata

## Red Evidence
- `cargo test -p exo-gateway audit_trail_uses_authenticated_actor_tenant_for_lookup` failed before production edits: handler did not load the authenticated session actor tenant profile.
- `cargo test -p exo-gateway audit_entry_lookup_requires_decision_and_tenant_scope` failed before production edits: DB helper did not require tenant scope.

## Test Plan
- [x] `cargo test -p exo-gateway audit_trail`
- [x] `cargo test -p exo-gateway audit_entry_lookup_requires_decision_and_tenant_scope`
- [x] `cargo test -p exo-gateway`
- [x] `cargo test -p exo-gateway --features production-db audit_trail`
- [x] `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- [x] `cargo clippy -p exo-gateway --features production-db --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `bash tools/test_repo_truth.sh`
- [x] `bash tools/test_cr001_status.sh`
- [x] `bash tools/test_gap_registry_truth.sh`
- [x] `git diff --check`
- [x] Bypass search: no production two-argument `list_audit_entries_for_decision` call remains; no unscoped `WHERE decision_id = $1 ORDER BY sequence` audit lookup remains.
