### PR TITLE
Add tenant-scoped audit lookup index

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 164663 | `wc -l` |
+| Rust LOC | 164667 | `wc -l` |
 | Workspace tests | 4,032 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -80,7 +80,7 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 164663 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 164667 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,032 listed workspace tests
 

--- a/crates/exo-gateway/migrations/20260505000001_add_audit_decision_tenant_sequence_index.sql
+++ b/crates/exo-gateway/migrations/20260505000001_add_audit_decision_tenant_sequence_index.sql
@@ -1,0 +1,3 @@
+-- Match the tenant-scoped audit decision lookup used by /api/v1/audit/:decision_id.
+CREATE INDEX IF NOT EXISTS idx_audit_entries_decision_tenant_sequence
+    ON audit_entries(decision_id, tenant_id, sequence);

--- a/crates/exo-gateway/src/db.rs
+++ b/crates/exo-gateway/src/db.rs
@@ -1600,6 +1600,9 @@ mod tests {
             include_str!("../migrations/20260504000002_add_gateway_tenant_scope_indexes.sql"),
             include_str!("../migrations/20260504000003_create_did_documents.sql"),
             include_str!("../migrations/20260504000004_add_gateway_identity_erasure.sql"),
+            include_str!(
+                "../migrations/20260505000001_add_audit_decision_tenant_sequence_index.sql"
+            ),
         ]
         .join("\n")
     }
@@ -1820,6 +1823,7 @@ mod tests {
             "CREATE INDEX IF NOT EXISTS idx_delegations_active_delegatee ON delegations(delegatee) WHERE revoked_at IS NULL;",
             "CREATE INDEX IF NOT EXISTS idx_delegations_active_delegator ON delegations(delegator) WHERE revoked_at IS NULL;",
             "CREATE INDEX IF NOT EXISTS idx_audit_entries_actor_event_type ON audit_entries(actor, event_type);",
+            "CREATE INDEX IF NOT EXISTS idx_audit_entries_decision_tenant_sequence ON audit_entries(decision_id, tenant_id, sequence);",
         ] {
             assert!(
                 migrations.contains(index_sql),


### PR DESCRIPTION
## Summary
- classify this as a core runtime adapter hardening change for the gateway PostgreSQL audit persistence boundary
- add a forward SQLx migration for `audit_entries(decision_id, tenant_id, sequence)` to match the authenticated `/api/v1/audit/:decision_id` lookup predicate and order
- extend the migration source guard so future query/index drift fails in tests
- refresh README repo-truth metadata derived from this branch

## Report sanity check
The external finding was treated as a hypothesis and checked against current `origin/main` after PR #320. The current runtime query filters by `decision_id` and authenticated actor `tenant_id`, but the migration set only had `idx_audit_entries_decision_id`, so the composite tenant-scoped lookup index was still missing.

## Path classification
- `crates/exo-gateway/src/db.rs`: core runtime adapter; gateway persistence guard for runtime query/index coverage
- `crates/exo-gateway/migrations/20260505000001_add_audit_decision_tenant_sequence_index.sql`: core runtime adapter; PostgreSQL migration for audit lookup performance/isolation boundary
- `README.md`: documentation/repo-truth metadata only

## Red test observed
`cargo test -p exo-gateway gateway_runtime_query_filters_have_migration_indexes` failed before the migration with: gateway migration set must include runtime query index: `CREATE INDEX IF NOT EXISTS idx_audit_entries_decision_tenant_sequence ON audit_entries(decision_id, tenant_id, sequence);`

## Validation
- `cargo test -p exo-gateway gateway_runtime_query_filters_have_migration_indexes`
- `cargo test -p exo-gateway`
- `cargo test -p exo-gateway --features production-db`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `cargo clippy -p exo-gateway --features production-db --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `git diff --check`
- bypass search: `rg -n "list_audit_entries_for_decision|FROM audit_entries WHERE decision_id|idx_audit_entries_decision_tenant_sequence|idx_audit_entries_decision_id" crates/exo-gateway/src crates/exo-gateway/migrations`
