### PR TITLE
Harden event signing payload domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 164667 | `wc -l` |
-| Workspace tests | 4,032 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 164704 | `wc -l` |
+| Workspace tests | 4,033 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,032 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,033 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -80,9 +80,9 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 164667 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 164704 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,032 listed workspace tests
+         cryptographic proofs, 4,033 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-core/src/events.rs
+++ b/crates/exo-core/src/events.rs
@@ -13,6 +13,10 @@ use crate::{
     types::{CorrelationId, Did, PqPublicKey, PublicKey, Signature, Timestamp},
 };
 
+/// Domain separation tag for EXOCHAIN event signatures.
+pub const EVENT_SIGNING_DOMAIN: &str = "exo.core.event.signable.v1";
+const EVENT_SIGNING_SCHEMA_VERSION: u16 = 1;
+
 // ---------------------------------------------------------------------------
 // EventType
 // ---------------------------------------------------------------------------
@@ -86,8 +90,9 @@ impl fmt::Debug for Event {
 impl Event {
     /// Construct the canonical bytes that are signed.
     ///
-    /// The signed content is: `id || timestamp || event_type || payload || source_did`
-    /// serialized as CBOR.
+    /// The signed content is a domain-separated, schema-versioned CBOR
+    /// envelope over `id`, `timestamp`, `event_type`, `payload`, and
+    /// `source_did`.
     ///
     /// # Errors
     ///
@@ -95,6 +100,8 @@ impl Event {
     pub fn write_signable_bytes<W: Write>(&self, writer: W) -> crate::Result<()> {
         #[derive(Serialize)]
         struct Signable<'a> {
+            domain: &'static str,
+            schema_version: u16,
             id: &'a CorrelationId,
             timestamp: &'a Timestamp,
             event_type: &'a EventType,
@@ -102,6 +109,8 @@ impl Event {
             source_did: &'a Did,
         }
         let s = Signable {
+            domain: EVENT_SIGNING_DOMAIN,
+            schema_version: EVENT_SIGNING_SCHEMA_VERSION,
             id: &self.id,
             timestamp: &self.timestamp,
             event_type: &self.event_type,
@@ -545,6 +554,34 @@ mod tests {
         let b1 = event.signable_bytes().expect("serialize signable bytes");
         let b2 = event.signable_bytes().expect("serialize signable bytes");
         assert_eq!(b1, b2);
+    }
+
+    #[test]
+    fn signable_bytes_are_domain_separated_and_versioned_cbor() {
+        #[derive(Deserialize)]
+        struct EventSignableEnvelope {
+            domain: String,
+            schema_version: u16,
+            id: CorrelationId,
+            timestamp: Timestamp,
+            event_type: EventType,
+            payload: Vec<u8>,
+            source_did: Did,
+        }
+
+        let kp = KeyPair::generate();
+        let event = make_event(&kp);
+        let bytes = event.signable_bytes().expect("serialize signable bytes");
+        let envelope: EventSignableEnvelope =
+            ciborium::from_reader(&bytes[..]).expect("domain-separated event signing payload");
+
+        assert_eq!(envelope.domain, "exo.core.event.signable.v1");
+        assert_eq!(envelope.schema_version, 1);
+        assert_eq!(envelope.id, event.id);
+        assert_eq!(envelope.timestamp, event.timestamp);
+        assert_eq!(envelope.event_type, event.event_type);
+        assert_eq!(envelope.payload, event.payload);
+        assert_eq!(envelope.source_did, event.source_did);
     }
 
     #[test]


### PR DESCRIPTION
## Classification

- EXOCHAIN core: `crates/exo-core/src/events.rs`
- Documentation/repo truth: `README.md`

## Current-code confirmation

Task 6 canonical signing sweep found a live core issue on current `main`: `Event::write_signable_bytes` serialized event fields as canonical CBOR but did not bind an explicit signing domain or schema version into the signed envelope.

## Red test evidence

Before production edits, this regression failed as expected:

- `cargo test -p exo-core signable_bytes_are_domain_separated_and_versioned_cbor`
  - Failure: `missing field 'domain'`

## Remediation

- Added `EVENT_SIGNING_DOMAIN = "exo.core.event.signable.v1"` and schema version `1` to the event signing envelope.
- Kept event creation and verification flow deterministic and self-contained.
- Added a CBOR decode regression proving the envelope carries domain, schema version, and the original signed event fields.
- Refreshed README repo-truth counts.

## Validation

- `cargo test -p exo-core signable_bytes_are_domain_separated_and_versioned_cbor`
- `cargo test -p exo-core`
- `cargo clippy -p exo-core --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `cargo test --workspace`
- `git diff --check`

## Bypass search

- `rg -n "EVENT_SIGNING_DOMAIN|EVENT_SIGNING_SCHEMA_VERSION|domain: EVENT_SIGNING_DOMAIN|schema_version: EVENT_SIGNING_SCHEMA_VERSION|signable_bytes_are_domain_separated" crates/exo-core/src/events.rs`
