### PR TITLE
Harden MCP typed signature payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,6 +1474,7 @@ name = "exo-gatekeeper"
 version = "0.1.0-beta"
 dependencies = [
  "blake3",
+ "ciborium",
  "ed25519-dalek",
  "exo-core",
  "serde",

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 173437 | `wc -l` |
-| Workspace tests | 4,125 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 173537 | `wc -l` |
+| Workspace tests | 4,123 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,125 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,123 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 173437 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 173537 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,125 listed workspace tests
+         cryptographic proofs, 4,123 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-gatekeeper/Cargo.toml
+++ b/crates/exo-gatekeeper/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 exo-core = { path = "../exo-core" }
 serde = { workspace = true }
 blake3 = { workspace = true }
+ciborium = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }
 tracing = { workspace = true }

--- a/crates/exo-gatekeeper/src/error.rs
+++ b/crates/exo-gatekeeper/src/error.rs
@@ -20,6 +20,9 @@ pub enum GatekeeperError {
     #[error("MCP violation: {0}")]
     McpViolation(String),
 
+    #[error("MCP typed signature payload encoding failed: {reason}")]
+    McpTypedSignatureEncodingFailed { reason: String },
+
     #[error("TEE attestation failed: {0}")]
     TeeError(String),
 
@@ -69,6 +72,12 @@ mod tests {
             (GatekeeperError::CombinatorError("fail".into()), "fail"),
             (GatekeeperError::HolonError("holon".into()), "holon"),
             (GatekeeperError::McpViolation("mcp".into()), "mcp"),
+            (
+                GatekeeperError::McpTypedSignatureEncodingFailed {
+                    reason: "canonical CBOR failed".into(),
+                },
+                "canonical CBOR failed",
+            ),
             (GatekeeperError::TeeError("tee".into()), "tee"),
             (GatekeeperError::CapabilityDenied("cap".into()), "cap"),
             (GatekeeperError::Timeout(500), "500"),

--- a/crates/exo-gatekeeper/src/mcp.rs
+++ b/crates/exo-gatekeeper/src/mcp.rs
@@ -3,15 +3,26 @@
 //! Ensures AI systems operating within the EXOCHAIN fabric respect
 //! constitutional boundaries on autonomy, identity, and consent.
 //!
-//! **Key design**: The `SignerType` enum is part of the signed payload,
-//! not a caller-set flag. An AI key uses prefix `0x02` in all signed
-//! payloads, so even if an AI has valid key material, it cannot produce
-//! a signature that could be mistaken for a human (`0x01`) signature.
+//! **Key design**: The `SignerType` enum is part of a domain-separated
+//! canonical CBOR signed payload, not a caller-set flag. Even if an AI has
+//! valid key material, it cannot produce a signature that could be mistaken
+//! for a human signature.
 
 use exo_core::{Did, SignerType};
 use serde::{Deserialize, Serialize};
 
-use crate::types::PermissionSet;
+use crate::{error::GatekeeperError, types::PermissionSet};
+
+const MCP_TYPED_SIGNATURE_DOMAIN: &str = "exo.gatekeeper.mcp.typed-signature.v1";
+const MCP_TYPED_SIGNATURE_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Serialize)]
+struct McpTypedSignaturePayload<'a> {
+    domain: &'static str,
+    schema_version: u16,
+    signer_type: &'a SignerType,
+    message: &'a [u8],
+}
 
 // ---------------------------------------------------------------------------
 // MCP rules
@@ -199,16 +210,30 @@ fn check_rule(rule: McpRule, ctx: &McpContext) -> Result<(), McpViolation> {
 }
 
 /// Build a signable message that embeds the signer type.
-/// This ensures the signer type is cryptographically bound to the signature.
-#[must_use]
-pub fn build_signed_payload(signer_type: &SignerType, message: &[u8]) -> Vec<u8> {
-    let mut payload = signer_type.to_payload_prefix();
-    payload.extend_from_slice(message);
-    payload
+///
+/// The payload is a versioned, domain-separated canonical CBOR envelope so
+/// signer identity is cryptographically bound without raw byte concatenation.
+pub fn build_signed_payload(
+    signer_type: &SignerType,
+    message: &[u8],
+) -> Result<Vec<u8>, GatekeeperError> {
+    let payload = McpTypedSignaturePayload {
+        domain: MCP_TYPED_SIGNATURE_DOMAIN,
+        schema_version: MCP_TYPED_SIGNATURE_SCHEMA_VERSION,
+        signer_type,
+        message,
+    };
+    let mut encoded = Vec::new();
+    ciborium::ser::into_writer(&payload, &mut encoded).map_err(|error| {
+        GatekeeperError::McpTypedSignatureEncodingFailed {
+            reason: error.to_string(),
+        }
+    })?;
+    Ok(encoded)
 }
 
 /// Verify that a signature was produced with the claimed signer type.
-/// The signer type prefix is prepended to the message before verification.
+/// The signer type is embedded in the canonical signed payload before verification.
 #[must_use]
 pub fn verify_typed_signature(
     signer_type: &SignerType,
@@ -216,8 +241,10 @@ pub fn verify_typed_signature(
     signature: &exo_core::Signature,
     public_key: &exo_core::PublicKey,
 ) -> bool {
-    let payload = build_signed_payload(signer_type, message);
-    exo_core::crypto::verify(&payload, signature, public_key)
+    match build_signed_payload(signer_type, message) {
+        Ok(payload) => exo_core::crypto::verify(&payload, signature, public_key),
+        Err(_) => false,
+    }
 }
 
 // ===========================================================================
@@ -227,9 +254,18 @@ pub fn verify_typed_signature(
 #[cfg(test)]
 mod tests {
     use exo_core::{Hash256, crypto::KeyPair};
+    use serde::Deserialize;
 
     use super::*;
     use crate::types::Permission;
+
+    fn production_source() -> &'static str {
+        let source = include_str!("mcp.rs");
+        let end = source
+            .find("// ===========================================================================")
+            .expect("tests section marker must exist");
+        &source[..end]
+    }
 
     fn did(s: &str) -> Did {
         Did::new(s).expect("valid DID")
@@ -417,7 +453,7 @@ mod tests {
         let ai_type = SignerType::Ai {
             delegation_id: Hash256::digest(b"session-1"),
         };
-        let ai_payload = build_signed_payload(&ai_type, message);
+        let ai_payload = build_signed_payload(&ai_type, message).expect("AI payload encodes");
         let ai_sig = kp.sign(&ai_payload);
 
         // Verify as AI — should succeed
@@ -443,7 +479,8 @@ mod tests {
         let message = b"budget approval";
 
         // Human signs
-        let human_payload = build_signed_payload(&SignerType::Human, message);
+        let human_payload =
+            build_signed_payload(&SignerType::Human, message).expect("human payload encodes");
         let human_sig = kp.sign(&human_payload);
 
         // Verify as human — should succeed
@@ -478,8 +515,8 @@ mod tests {
             delegation_id: Hash256::digest(b"delegation-B"),
         };
 
-        let payload1 = build_signed_payload(&ai1, message);
-        let payload2 = build_signed_payload(&ai2, message);
+        let payload1 = build_signed_payload(&ai1, message).expect("AI payload encodes");
+        let payload2 = build_signed_payload(&ai2, message).expect("AI payload encodes");
         assert_ne!(payload1, payload2);
 
         let sig1 = kp.sign(&payload1);
@@ -496,6 +533,60 @@ mod tests {
             &sig1,
             kp.public_key()
         ));
+    }
+
+    #[test]
+    fn typed_signature_payload_is_domain_separated_versioned_cbor() {
+        #[derive(Debug, Deserialize, PartialEq, Eq)]
+        struct TypedSignaturePayload {
+            domain: String,
+            schema_version: u16,
+            signer_type: SignerType,
+            message: Vec<u8>,
+        }
+
+        let signer_type = SignerType::Ai {
+            delegation_id: Hash256::digest(b"typed-signature-session"),
+        };
+        let message = b"constitutional MCP action";
+
+        let payload = build_signed_payload(&signer_type, message).expect("payload encodes");
+        let decoded: TypedSignaturePayload =
+            ciborium::from_reader(payload.as_slice()).expect("typed signature payload is CBOR");
+
+        assert_eq!(decoded.domain, "exo.gatekeeper.mcp.typed-signature.v1");
+        assert_eq!(decoded.schema_version, 1);
+        assert_eq!(decoded.signer_type, signer_type);
+        assert_eq!(decoded.message, message);
+    }
+
+    #[test]
+    fn typed_signature_payload_source_uses_cbor_not_raw_concatenation() {
+        let production = production_source();
+        let start = production
+            .find("pub fn build_signed_payload")
+            .expect("build_signed_payload exists");
+        let end = production
+            .find("/// Verify that a signature was produced with the claimed signer type.")
+            .expect("verify_typed_signature marker exists");
+        let body = &production[start..end];
+
+        assert!(
+            body.contains("ciborium::"),
+            "typed signature payloads must use canonical CBOR"
+        );
+        assert!(
+            !body.contains("extend_from_slice"),
+            "typed signature payloads must not be raw byte concatenations"
+        );
+        assert!(
+            !body.contains("to_payload_prefix"),
+            "typed signature payloads must bind the structured signer type, not an ad hoc prefix"
+        );
+        assert!(
+            !body.contains("return Vec::new()"),
+            "typed signature serialization must not silently fall back to an empty payload"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Classification

- EXOCHAIN core: `crates/exo-gatekeeper/src/mcp.rs`, `crates/exo-gatekeeper/src/error.rs`.
- Core dependency metadata: `crates/exo-gatekeeper/Cargo.toml`, `Cargo.lock` for canonical CBOR payload encoding.
- Documentation truth counters only: `README.md` repo-truth values updated after rebase.
- No adjacent surface, imported evidence, or third-party source was modified.

## Current-base verification

Revalidated after rebasing onto current `origin/main` (`fd4d137fc41637325bd9fe803fc8a42ba9052f86`). The concern remains live on current main: `build_signed_payload` still concatenates `SignerType::to_payload_prefix()` with raw message bytes, which is not a canonical domain-separated structured signing payload.

## Remediation

- Replace raw prefix/message concatenation with a domain-separated, versioned CBOR signing payload for MCP typed signatures.
- Return typed serialization errors instead of silently manufacturing unverifiable payloads.
- Preserve replay rejection across signer type and delegation identity boundaries.

## Validation

- `cargo test -p exo-gatekeeper typed_signature_payload -- --nocapture`
- `cargo test -p exo-gatekeeper mcp -- --nocapture`
- `bash tools/test_repo_truth.sh`
- `git diff --check origin/main...HEAD`
- `rg -n 'build_signed_payload|verify_typed_signature|to_payload_prefix|extend_from_slice|MCP_TYPED_SIGNATURE|ciborium::ser::into_writer' crates/exo-gatekeeper/src/mcp.rs crates/exo-core/src/types.rs`
- `cargo test -p exo-gatekeeper -- --nocapture`
- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p exo-gatekeeper --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p exo-gatekeeper --no-deps`
- `cargo deny check` (passed advisories/bans/licenses/sources, with existing duplicate-version warnings only)