### PR TITLE
ci: harden wasm-pack installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,8 @@ jobs:
           echo "✓ No GAP stubs remaining in code"
       - name: GitHub Actions pinned to immutable SHAs
         run: bash tools/test_github_actions_pinned.sh
+      - name: CI tool installer supply-chain hardening
+        run: bash tools/test_ci_supply_chain_hardening.sh
       - name: Repo truth and public claims
         run: bash tools/test_repo_truth.sh
       - name: CR-001 status consistency
@@ -507,7 +509,7 @@ jobs:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        run: cargo install wasm-pack --version 0.14.0 --locked
       - name: Build WASM
         run: wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm
       - name: Verify WASM exports

--- a/tools/test_ci_supply_chain_hardening.sh
+++ b/tools/test_ci_supply_chain_hardening.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  printf 'ci supply-chain hardening test failed: %s\n' "$1" >&2
+  exit 1
+}
+
+workflow=".github/workflows/ci.yml"
+[[ -f "$workflow" ]] || fail "$workflow is missing"
+
+if grep -nE 'curl[^\n]*(\|[[:space:]]*(sh|bash)|>[[:space:]]*/tmp/)' "$workflow"; then
+  fail "GitHub Actions workflow must not install tools through curl-piped shell scripts"
+fi
+
+install_block=$(
+  awk '
+    /name: Install wasm-pack/ { capture = 1 }
+    capture { print }
+    capture && /name: Build WASM/ { exit }
+  ' "$workflow"
+)
+
+[[ -n "$install_block" ]] || fail "CI workflow must include an Install wasm-pack step"
+
+grep -F 'cargo install wasm-pack' <<<"$install_block" >/dev/null \
+  || fail "wasm-pack must be installed through Cargo, not a shell installer"
+
+grep -E -- '--version[[:space:]]+[0-9]+\.[0-9]+\.[0-9]+' <<<"$install_block" >/dev/null \
+  || fail "wasm-pack Cargo install must pin an explicit version"
+
+grep -F -- '--locked' <<<"$install_block" >/dev/null \
+  || fail "wasm-pack Cargo install must use --locked for dependency resolution"
+
+printf 'ci supply-chain hardening test passed\n'


### PR DESCRIPTION
## Classification

- `.github/workflows/ci.yml`: EXOCHAIN core CI gate / supply-chain hardening.
- `tools/test_ci_supply_chain_hardening.sh`: EXOCHAIN core CI validation guard.
- Imported Matthew/Wally evidence: read-only hypothesis input; no report, zip, screenshot, or extracted scanner artifact committed.

## Finding Validation

External finding Wally F-124 was re-checked against current `origin/main` before editing. The workflow still installed `wasm-pack` with `curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh`, so the concern was live and owned by EXOCHAIN CI.

## Remediation

- Added a CI guard that fails if GitHub Actions install tools through curl-piped shell scripts or `/tmp` redirects.
- Replaced the `wasm-pack` shell installer with `cargo install wasm-pack --version 0.14.0 --locked`.
- Added the guard to Gate 9 repo hygiene so the bypass cannot be reintroduced silently.

## TDD / Validation

Red before fix:
- `bash tools/test_ci_supply_chain_hardening.sh` failed with `wasm-pack must be installed through Cargo, not a shell installer`.

Green after fix:
- `bash tools/test_ci_supply_chain_hardening.sh`
- `bash -n tools/test_ci_supply_chain_hardening.sh`
- `bash tools/test_github_actions_pinned.sh`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `git diff --check`
- `rg -n "curl[^\n]*(\|[[:space:]]*(sh|bash)|>[[:space:]]*/tmp/)|rustwasm.github.io/wasm-pack|cargo install wasm-pack" .github/workflows/ci.yml tools/test_ci_supply_chain_hardening.sh` showed only the pinned Cargo install and guard rules.

## Boundary Notes

No Rust runtime behavior changed. This PR is intentionally isolated from adjacent-surface hardening and imported evidence triage.