### PR TITLE
Bound consensus commit certificates to quorum

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 173406 | `wc -l` |
-| Workspace tests | 4,120 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 173437 | `wc -l` |
+| Workspace tests | 4,125 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,034 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,125 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 173406 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 173437 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,036 listed workspace tests
+         cryptographic proofs, 4,125 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-dag/src/consensus.rs
+++ b/crates/exo-dag/src/consensus.rs
@@ -358,6 +358,7 @@ pub fn check_commit(state: &ConsensusState, node_hash: &Hash256) -> Option<Commi
                         && state.config.validators.contains(&vote.voter)
                         && seen_voters.insert(vote.voter.clone())
                 })
+                .take(quorum)
                 .cloned()
                 .collect();
 
@@ -1458,6 +1459,36 @@ mod tests {
         assert_eq!(cert.votes.len(), 3);
         let distinct: BTreeSet<_> = cert.votes.iter().map(|vote| vote.voter.clone()).collect();
         assert_eq!(distinct.len(), 3);
+    }
+
+    #[test]
+    fn check_commit_certificate_clones_only_quorum_votes() {
+        let validators = make_validators(7);
+        let config = ConsensusConfig::new(validators.clone(), 1000);
+        let quorum = config.quorum_size();
+        let mut state = ConsensusState::new(config);
+        let (_dag, node) = setup_dag_with_node();
+        let v: Vec<Did> = validators.iter().cloned().collect();
+
+        state
+            .pending
+            .entry(0)
+            .or_default()
+            .entry(node.hash)
+            .or_default()
+            .extend(
+                v.iter()
+                    .map(|validator| make_vote(validator, 0, &node.hash)),
+            );
+
+        let cert = check_commit(&state, &node.hash).expect("over-quorum votes commit");
+        assert_eq!(
+            cert.votes.len(),
+            quorum,
+            "commit certificates must carry only the quorum required for verification"
+        );
+        let distinct: BTreeSet<_> = cert.votes.iter().map(|vote| vote.voter.clone()).collect();
+        assert_eq!(distinct.len(), quorum);
     }
 
     // Covers propose_verified line 375: proposer not in validator set.


### PR DESCRIPTION
## Summary
- Confirms the consensus commit-certificate overcollection issue remains live on current `origin/main`: quorum for 7 validators is 5, but current `check_commit` collects every accumulated distinct valid vote into the certificate.
- Bounds commit certificates to the quorum-sized deterministic prefix once quorum is reached.
- Adds a regression proving certificates clone only quorum votes.
- Preserves the merged #332 consensus liveness documentation while applying this consensus enforcement fix.
- Updates README repo-truth counts after the Rust test addition.
- Rebased on current `origin/main` `4bba0f0e47f1921f310d10215169cc62433b549e`; head is `567d229835f3b6760289d070d599c67d04803458`.

## Path Classification
- `crates/exo-dag/src/consensus.rs`: EXOCHAIN core consensus enforcement and regression tests.
- `README.md`: EXOCHAIN core public repo truth values required by Gate 9 after Rust LOC/test-count changes.

## Current-Main Reproduction
- `git show origin/main:crates/exo-dag/src/consensus.rs` shows `check_commit` collecting all matching distinct validator votes without `.take(quorum)`.
- `git grep -n 'check_commit_certificate_clones_only_quorum_votes' origin/main -- crates/exo-dag/src/consensus.rs` finds no regression test on current `origin/main`.

## TDD / Verification
- RED: current `origin/main` still lacks the quorum cap and lacks the regression test.
- GREEN: `CARGO_TARGET_DIR=/Users/bobstewart/.config/superpowers/worktrees/exochain/workspace-dependency-exact-pins-20260506/target cargo test -p exo-dag check_commit_certificate_clones_only_quorum_votes -- --nocapture`
- `CARGO_TARGET_DIR=/Users/bobstewart/.config/superpowers/worktrees/exochain/workspace-dependency-exact-pins-20260506/target cargo test -p exo-dag -- --nocapture` (162 passed)
- `CARGO_TARGET_DIR=/Users/bobstewart/.config/superpowers/worktrees/exochain/workspace-dependency-exact-pins-20260506/target cargo clippy -p exo-dag --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/bobstewart/.config/superpowers/worktrees/exochain/workspace-dependency-exact-pins-20260506/target cargo doc -p exo-dag --no-deps`
- `CARGO_TARGET_DIR=/Users/bobstewart/.config/superpowers/worktrees/exochain/workspace-dependency-exact-pins-20260506/target bash tools/repo_truth.sh --json --list-tests` reported 4,125 listed workspace tests.
- `bash tools/test_repo_truth.sh`
- `git diff --check origin/main...HEAD`
- `rg -n '\.take\(quorum\)|check_commit_certificate_clones_only_quorum_votes|Liveness assumptions' crates/exo-dag/src/consensus.rs`