### PR TITLE
Add cross-implementation hash vector guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 | Metric | Value | Source |
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
-| Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 164825 | `wc -l` |
-| Workspace tests | 4,033 listed | `cargo test --workspace -- --list` |
+| Rust source files | 289 | `find crates -name '*.rs'` |
+| Rust LOC | 164923 | `wc -l` |
+| Workspace tests | 4,036 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,033 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,034 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -80,9 +80,9 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 164825 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 164923 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,033 listed workspace tests
+         cryptographic proofs, 4,036 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-core/tests/cross_impl_hash_vectors.rs
+++ b/crates/exo-core/tests/cross_impl_hash_vectors.rs
@@ -1,0 +1,98 @@
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+use exo_core::hash::canonical_hash;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct HashVector {
+    input: HashVectorInput,
+    expected: HashVectorExpected,
+}
+
+#[derive(Debug, Deserialize)]
+struct HashVectorInput {
+    canonical_cbor_hex: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct HashVectorExpected {
+    blake3_hex: String,
+}
+
+#[test]
+fn cross_impl_hash_vectors_match_golden() -> Result<(), Box<dyn std::error::Error>> {
+    let Some(vectors_dir) = env::var_os("EXOCHAIN_CROSS_IMPL_HASH_VECTORS") else {
+        return Ok(());
+    };
+
+    let mut vector_files = Vec::new();
+    for entry in fs::read_dir(PathBuf::from(vectors_dir))? {
+        let path = entry?.path();
+        if path
+            .extension()
+            .is_some_and(|extension| extension == "json")
+        {
+            vector_files.push(path);
+        }
+    }
+    vector_files.sort();
+
+    let mut checked = 0usize;
+    for vector_file in vector_files {
+        let contents = fs::read_to_string(&vector_file)?;
+        let Ok(vector) = serde_json::from_str::<HashVector>(&contents) else {
+            continue;
+        };
+
+        let canonical_cbor = decode_hex(&vector.input.canonical_cbor_hex, &vector_file)?;
+        let actual = canonical_hash(&canonical_cbor).to_string();
+        assert_eq!(
+            actual,
+            vector.expected.blake3_hex.to_ascii_lowercase(),
+            "{} canonical hash diverged",
+            vector_file.display()
+        );
+        checked += 1;
+    }
+
+    assert!(
+        checked > 0,
+        "at least one canonical hash vector must be checked"
+    );
+    Ok(())
+}
+
+fn decode_hex(hex: &str, vector_file: &Path) -> Result<Vec<u8>, String> {
+    if hex.len() % 2 != 0 {
+        return Err(format!(
+            "{} canonical_cbor_hex must be even-length",
+            vector_file.display()
+        ));
+    }
+
+    let decoded = hex
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            let high = decode_hex_digit(pair[0], vector_file)?;
+            let low = decode_hex_digit(pair[1], vector_file)?;
+            Ok((high << 4) | low)
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    Ok(decoded)
+}
+
+fn decode_hex_digit(byte: u8, vector_file: &Path) -> Result<u8, String> {
+    match byte {
+        b'0'..=b'9' => Ok(byte - b'0'),
+        b'a'..=b'f' => Ok(byte - b'a' + 10),
+        b'A'..=b'F' => Ok(byte - b'A' + 10),
+        _ => Err(format!(
+            "{} canonical_cbor_hex must be hex",
+            vector_file.display()
+        )),
+    }
+}

--- a/tools/cross-impl-test/compare.sh
+++ b/tools/cross-impl-test/compare.sh
@@ -137,6 +137,82 @@ capture_rust_test_summary() {
     return "$cargo_status"
 }
 
+count_hash_vectors() {
+    local vectors_dir="$1"
+    local count=0
+
+    for vector_file in "$vectors_dir"/*.json; do
+        [ -e "$vector_file" ] || continue
+        if jq -e '(.input.canonical_cbor_hex? | type == "string") and (.expected.blake3_hex? | type == "string")' "$vector_file" >/dev/null; then
+            count=$((count + 1))
+        fi
+    done
+
+    echo "$count"
+}
+
+ensure_local_node_deps() {
+    local output_dir="$1"
+
+    if [ -d "$SCRIPT_DIR/node_modules" ]; then
+        return 0
+    fi
+
+    log_info "Installing local cross-implementation Node dependencies..."
+    if (cd "$SCRIPT_DIR" && npm ci > "$output_dir/npm_ci.txt" 2>&1); then
+        return 0
+    fi
+
+    log_fail "npm ci failed for tools/cross-impl-test"
+    if $VERBOSE; then
+        tail -20 "$output_dir/npm_ci.txt"
+    fi
+    return 1
+}
+
+run_hash_vectors() {
+    local vectors_dir="$1"
+    local output_dir="$2"
+    mkdir -p "$output_dir"
+
+    local hash_vector_count
+    hash_vector_count="$(count_hash_vectors "$vectors_dir")"
+    if [ "$hash_vector_count" -eq 0 ]; then
+        log_fail "No canonical hash vectors found in $vectors_dir"
+        return 1
+    fi
+
+    log_info "Verifying $hash_vector_count canonical hash vector(s)..."
+
+    if EXOCHAIN_CROSS_IMPL_HASH_VECTORS="$vectors_dir" \
+        cargo test -p exo-core cross_impl_hash_vectors_match_golden -- --exact --nocapture \
+        > "$output_dir/rust_hash_vectors.txt" 2>&1; then
+        log_pass "Rust canonical hash vectors passed"
+    else
+        log_fail "Rust canonical hash vectors failed"
+        if $VERBOSE; then
+            tail -40 "$output_dir/rust_hash_vectors.txt"
+        fi
+        return 1
+    fi
+
+    ensure_local_node_deps "$output_dir" || return 1
+
+    if EXOCHAIN_CROSS_IMPL_HASH_VECTORS="$vectors_dir" \
+        node "$SCRIPT_DIR/index.js" > "$output_dir/node_hash_vectors.txt" 2>&1; then
+        log_pass "Node canonical hash vectors passed"
+    else
+        log_fail "Node canonical hash vectors failed"
+        if $VERBOSE; then
+            tail -40 "$output_dir/node_hash_vectors.txt"
+        fi
+        return 1
+    fi
+
+    echo "$hash_vector_count" > "$output_dir/pass_count"
+    echo "$hash_vector_count" > "$output_dir/total_count"
+}
+
 # ---------------------------------------------------------------------------
 # Setup
 # ---------------------------------------------------------------------------
@@ -187,17 +263,17 @@ setup() {
 create_default_vectors() {
     mkdir -p "$VECTORS_DIR"
 
-    # Vector 1: BLAKE3 hash consistency
+    # Vector 1: BLAKE3 hash consistency over canonical CBOR bytes.
     cat > "$VECTORS_DIR/hash_blake3.json" <<'VECTOR_EOF'
 {
     "name": "BLAKE3 hash of canonical CBOR",
-    "category": "crypto",
+    "category": "crypto_hash",
     "input": {
-        "data": {"action": "create", "actor": "did:exo:alice", "target": "resource-001"},
-        "encoding": "cbor_canonical"
+        "canonical_cbor_hex": "a1616101"
     },
     "expected": {
-        "description": "BLAKE3 hash of the CBOR-encoded input object with sorted keys"
+        "blake3_hex": "74a1c68dabb660207c842b9b7dd0953a6a8e8158bb397c5bd4ea9fceda0c4c96",
+        "description": "BLAKE3 hash of the canonical CBOR map {\"a\": 1}"
     }
 }
 VECTOR_EOF
@@ -341,31 +417,14 @@ run_rust_tests() {
         return 1
     fi
 
-    # Run each vector through the Rust implementation
-    local vector_count=0
-    local pass_count=0
+    run_hash_vectors "$VECTORS_DIR" "$rust_results/hash_vectors" || return 1
 
-    for vector_file in "$VECTORS_DIR"/*.json; do
-        local vector_name
-        vector_name=$(jq -r '.name' "$vector_file")
-        local category
-        category=$(jq -r '.category' "$vector_file")
-        vector_count=$((vector_count + 1))
+    local pass_count
+    local vector_count
+    pass_count="$(cat "$rust_results/hash_vectors/pass_count")"
+    vector_count="$(cat "$rust_results/hash_vectors/total_count")"
 
-        log_verbose "Vector: $vector_name ($category)"
-
-        # Extract the input and write to a temp file for the Rust runner
-        local input_file="$rust_results/input_${vector_count}.json"
-        local output_file="$rust_results/output_${vector_count}.json"
-        jq '.input' "$vector_file" > "$input_file"
-
-        # For now, mark as passed if the relevant crate tests pass
-        # A full runner would invoke a dedicated binary
-        pass_count=$((pass_count + 1))
-        log_verbose "  Rust: category=$category [delegated to cargo test]"
-    done
-
-    log_pass "Rust: $pass_count/$vector_count vectors processed"
+    log_pass "Rust/Node canonical hash vectors: $pass_count/$vector_count verified"
     echo "$pass_count" > "$rust_results/pass_count"
     echo "$vector_count" > "$rust_results/total_count"
 }

--- a/tools/cross-impl-test/compare_unit_test.sh
+++ b/tools/cross-impl-test/compare_unit_test.sh
@@ -42,3 +42,56 @@ printf '6\n' > "$RESULTS_DIR/rust/total_count"
 generate_report
 grep -F "Determinism: Failed (normalized Rust test summaries differ)" \
     "$RESULTS_DIR/report.txt" > /dev/null
+
+declare -F run_hash_vectors > /dev/null || {
+    echo "run_hash_vectors function missing" >&2
+    exit 1
+}
+
+HASH_RESULTS="$TMP_DIR/hash-results"
+GOOD_VECTORS="$TMP_DIR/good-hash-vectors"
+BAD_VECTORS="$TMP_DIR/bad-hash-vectors"
+mkdir -p "$HASH_RESULTS" "$GOOD_VECTORS" "$BAD_VECTORS"
+
+cat > "$GOOD_VECTORS/hash_blake3.json" <<'EOF'
+{
+  "name": "BLAKE3 hash of canonical CBOR",
+  "category": "crypto_hash",
+  "input": {
+    "canonical_cbor_hex": "a1616101"
+  },
+  "expected": {
+    "blake3_hex": "74a1c68dabb660207c842b9b7dd0953a6a8e8158bb397c5bd4ea9fceda0c4c96"
+  }
+}
+EOF
+
+run_hash_vectors "$GOOD_VECTORS" "$HASH_RESULTS/good"
+
+cat > "$BAD_VECTORS/hash_blake3.json" <<'EOF'
+{
+  "name": "BLAKE3 hash rejects incorrect expected output",
+  "category": "crypto_hash",
+  "input": {
+    "canonical_cbor_hex": "a1616101"
+  },
+  "expected": {
+    "blake3_hex": "0000000000000000000000000000000000000000000000000000000000000000"
+  }
+}
+EOF
+
+set +e
+run_hash_vectors "$BAD_VECTORS" "$HASH_RESULTS/bad"
+bad_status=$?
+set -e
+
+if [ "$bad_status" -eq 0 ]; then
+    echo "bad canonical hash vector unexpectedly passed" >&2
+    exit 1
+fi
+
+if grep -nE 'for now|would invoke|placeholder' "$SCRIPT_DIR/compare.sh"; then
+    echo "cross-implementation harness must not describe unimplemented vector runners as passing" >&2
+    exit 1
+fi

--- a/tools/cross-impl-test/index.js
+++ b/tools/cross-impl-test/index.js
@@ -1,30 +1,85 @@
+const fs = require('fs');
+const path = require('path');
 const blake3 = require('blake3');
-const cbor = require('cbor');
 
-// Normative Event Structure mirroring Rust
-// Note: CBOR map keys must be sorted for canonical encoding.
-// Rust's serde_cbor does this by default or configuration.
-// We will simply confirm that specific inputs produce specific BLAKE3 hashes.
-
-function computeHash(obj) {
-    const encoded = cbor.encode(obj);
-    const hash = blake3.hash(encoded);
-    return hash.toString('hex');
-}
-
-// Test Vector 1: Simple Opaque Event
-// Corresponds to Rust test case
-const testVector1 = {
-    parents: [],
-    logical_time: { physical_ms: 1000, logical: 0 },
-    author: "did:exo:test",
-    key_version: 1,
-    payload: { Opaque: [1, 2, 3] } // Note: Rust Enum serialization variant
+const DEFAULT_HASH_VECTOR = {
+  name: 'BLAKE3 hash of canonical CBOR',
+  input: {
+    canonical_cbor_hex: 'a1616101',
+  },
+  expected: {
+    blake3_hex: '74a1c68dabb660207c842b9b7dd0953a6a8e8158bb397c5bd4ea9fceda0c4c96',
+  },
 };
 
-// Rust serde_cbor default enum serialization might vary (tagged vs object).
-// We need to aliign exactly.
-// For now, we output what we expect and will tweak Rust/JS to match during detailed verification.
+function isHashVector(vector) {
+  return (
+    vector &&
+    vector.input &&
+    typeof vector.input.canonical_cbor_hex === 'string' &&
+    vector.expected &&
+    typeof vector.expected.blake3_hex === 'string'
+  );
+}
 
-const hash1 = computeHash(testVector1);
-console.log(`TestVector1 Hash: ${hash1}`);
+function decodeHex(hex, filePath) {
+  if (hex.length % 2 !== 0 || /[^0-9a-f]/i.test(hex)) {
+    throw new Error(`${filePath}: canonical_cbor_hex must be even-length hex`);
+  }
+  return Buffer.from(hex, 'hex');
+}
+
+function verifyHashVector(vector, label) {
+  if (!isHashVector(vector)) {
+    return false;
+  }
+
+  const input = decodeHex(vector.input.canonical_cbor_hex, label);
+  const actual = blake3.hash(input).toString('hex');
+  const expected = vector.expected.blake3_hex.toLowerCase();
+
+  if (actual !== expected) {
+    throw new Error(`${label}: expected ${expected}, got ${actual}`);
+  }
+
+  console.log(`PASS ${path.basename(label)} ${actual}`);
+  return true;
+}
+
+function readVectorFile(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function main() {
+  const vectorsDir =
+    process.env.EXOCHAIN_CROSS_IMPL_HASH_VECTORS || path.join(__dirname, 'vectors');
+
+  let verified = 0;
+  if (fs.existsSync(vectorsDir)) {
+    const files = fs
+      .readdirSync(vectorsDir)
+      .filter((file) => file.endsWith('.json'))
+      .sort()
+      .map((file) => path.join(vectorsDir, file));
+
+    for (const filePath of files) {
+      if (verifyHashVector(readVectorFile(filePath), filePath)) {
+        verified += 1;
+      }
+    }
+  } else if (!process.env.EXOCHAIN_CROSS_IMPL_HASH_VECTORS) {
+    if (verifyHashVector(DEFAULT_HASH_VECTOR, 'builtin:hash_blake3.json')) {
+      verified += 1;
+    }
+  }
+
+  if (verified === 0) {
+    throw new Error(`no canonical hash vectors found in ${vectorsDir}`);
+  }
+
+  console.log(`Verified ${verified} canonical hash vector(s)`);
+}
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## Summary
- Confirms Wally F-143 was live: the cross-implementation harness had canonical hash vectors but only incremented pass counters instead of executing or comparing hash outputs.
- Adds a Rust `exo-core` vector test that validates golden canonical-CBOR BLAKE3 vectors through `canonical_hash` when the harness sets `EXOCHAIN_CROSS_IMPL_HASH_VECTORS`.
- Replaces the Node placeholder runner with a real verifier for the same vectors and wires `compare.sh` to fail if Rust or Node diverge.
- Extends `compare_unit_test.sh` to prove a good vector passes and an incorrect expected hash fails.
- Updates the generated README Rust file/LOC claims required by the repo-truth hygiene gate.

## Path Classification
- `crates/exo-core/tests/cross_impl_hash_vectors.rs`: EXOCHAIN core regression guard.
- `tools/cross-impl-test/*`: EXOCHAIN core tooling / determinism guard.
- `README.md`: documentation/public claim hygiene required by CI repo-truth gate.

## Validation
- RED: `bash tools/cross-impl-test/compare_unit_test.sh` failed before implementation with `run_hash_vectors function missing`.
- GREEN: `bash tools/cross-impl-test/compare_unit_test.sh`
- `npm test` in `tools/cross-impl-test`
- `cargo test -p exo-core cross_impl_hash_vectors_match_golden -- --exact --nocapture`
- `cargo test -p exo-core -- --nocapture`
- `cargo clippy -p exo-core --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `bash tools/test_repo_truth.sh`
- `git diff --cached --check`
