### PR TITLE
ci: pin security-critical dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,8 @@ jobs:
       - uses: EmbarkStudios/cargo-deny-action@5bb39ff5d5a0e94dc9e2dc94eced0c6129743a57
         with:
           command: check
+      - name: Security-critical dependency pin guard
+        run: bash tools/test_security_critical_dependencies_pinned.sh
 
   # -----------------------------------------------------------------------
   # Gate 8: Documentation (must build without warnings)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,24 +33,24 @@ repository = "https://github.com/exochain/exochain"
 
 [workspace.dependencies]
 # Deterministic serialization
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-ciborium = "0.2"          # CBOR — canonical, deterministic
+serde = { version = "=1.0.228", features = ["derive"] }
+serde_json = "=1.0.145"
+ciborium = "=0.2.2"          # CBOR — canonical, deterministic
 
 # Cryptography
-blake3 = "1"
+blake3 = "=1.8.2"
 bs58 = "0.5"
-ed25519-dalek = { version = "2", features = ["serde", "rand_core"] }
-x25519-dalek = { version = "2", features = ["serde", "static_secrets"] }
-sha2 = "0.10"
-hmac = "0.12"
-chacha20poly1305 = "0.10"
-hkdf = "0.12"
-rand = "0.8"
-zeroize = { version = "1", features = ["derive"] }
+ed25519-dalek = { version = "=2.2.0", features = ["serde", "rand_core"] }
+x25519-dalek = { version = "=2.0.1", features = ["serde", "static_secrets"] }
+sha2 = "=0.10.9"
+hmac = "=0.12.1"
+chacha20poly1305 = "=0.10.1"
+hkdf = "=0.12.4"
+rand = "=0.8.6"
+zeroize = { version = "=1.8.2", features = ["derive"] }
 # Post-quantum cryptography — NIST FIPS 204 (ML-DSA / CRYSTALS-Dilithium)
 # v0.1.0-rc.7 patches RUSTSEC-2025-0144 timing side-channel (fixed in rc.3+)
-ml-dsa = { version = "0.1.0-rc.7", features = ["zeroize"] }
+ml-dsa = { version = "=0.1.0-rc.7", features = ["zeroize"] }
 
 # Deterministic data structures
 indexmap = { version = "2", features = ["serde"] }

--- a/tools/test_security_critical_dependencies_pinned.sh
+++ b/tools/test_security_critical_dependencies_pinned.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+manifest="Cargo.toml"
+
+require_exact_pin() {
+  local crate="$1"
+  local version="$2"
+  if grep -Eq "^${crate}[[:space:]]*=[[:space:]]*\"=${version}\"([[:space:]]*(#.*)?)?$" "$manifest"; then
+    return 0
+  fi
+  if grep -Eq "^${crate}[[:space:]]*=[[:space:]]*\\{[^}]*version[[:space:]]*=[[:space:]]*\"=${version}\"" "$manifest"; then
+    return 0
+  fi
+
+  echo "security-critical dependency is not exactly pinned: ${crate} must use =${version}" >&2
+  return 1
+}
+
+require_exact_pin "serde" "1.0.228"
+require_exact_pin "serde_json" "1.0.145"
+require_exact_pin "ciborium" "0.2.2"
+require_exact_pin "blake3" "1.8.2"
+require_exact_pin "ed25519-dalek" "2.2.0"
+require_exact_pin "x25519-dalek" "2.0.1"
+require_exact_pin "sha2" "0.10.9"
+require_exact_pin "hmac" "0.12.1"
+require_exact_pin "chacha20poly1305" "0.10.1"
+require_exact_pin "hkdf" "0.12.4"
+require_exact_pin "rand" "0.8.6"
+require_exact_pin "zeroize" "1.8.2"
+require_exact_pin "ml-dsa" "0.1.0-rc.7"
+
+echo "security-critical dependency pin test passed"


### PR DESCRIPTION
## Summary
- Classifies Wally F-125 as EXOCHAIN core dependency-governance remediation.
- Pins direct canonical serialization and cryptographic workspace dependencies to the versions already committed in Cargo.lock.
- Adds a CI guard so future PRs cannot widen these security-critical requirements back to semver ranges.

## Path Classification
- `.github/workflows/ci.yml` — EXOCHAIN core CI gate
- `Cargo.toml` — EXOCHAIN core workspace dependency contract
- `tools/test_security_critical_dependencies_pinned.sh` — EXOCHAIN core CI/source guard

## TDD / Verification
- Red first: `bash tools/test_security_critical_dependencies_pinned.sh` failed on current main with `serde must use =1.0.228`.
- `bash tools/test_security_critical_dependencies_pinned.sh`
- `cargo metadata --locked --format-version 1`
- `cargo check --workspace --locked`
- `cargo test -p exo-core --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `bash tools/test_github_actions_pinned.sh`
- `bash tools/test_repo_truth.sh`
- `git diff --check`
- `git diff --cached --check`

Imported reports remain read-only; no adjacent surfaces are touched.