### PR TITLE
docs: define reactor locking contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 288 | `find crates -name '*.rs'` |
-| Rust LOC | 164792 | `wc -l` |
+| Rust LOC | 164825 | `wc -l` |
 | Workspace tests | 4,033 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -80,11 +80,7 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-<<<<<<< HEAD
-Layer 1: CGR Kernel         (Rust, 22 crates, 164704 tracked LOC under crates/)
-=======
-Layer 1: CGR Kernel         (Rust, 22 crates, 164755 tracked LOC under crates/)
->>>>>>> da492c56 (Harden checkpoint signing preimage)
+Layer 1: CGR Kernel         (Rust, 22 crates, 164825 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,033 listed workspace tests
 

--- a/crates/exo-node/src/reactor.rs
+++ b/crates/exo-node/src/reactor.rs
@@ -17,6 +17,17 @@
 //! rejects proposals, votes, and commit certificates that cannot be verified
 //! against that resolver. Local proposal and self-vote signatures are produced
 //! over the canonical CBOR payloads defined by `exo-dag::consensus`.
+//!
+//! ## Locking model
+//!
+//! The reactor has two shared synchronous mutexes: `SharedReactorState` for
+//! consensus state and `Arc<Mutex<SqliteDagStore>>` for local DAG persistence.
+//! Async paths must enter these mutexes only through `with_reactor_state_blocking`
+//! or `with_store_blocking`, which move the synchronous critical section onto
+//! `tokio::task::spawn_blocking`. Never hold both mutexes at the same time.
+//! Workflows that need data from both sides must snapshot, release, then acquire
+//! the other mutex in a separate blocking section before performing any async
+//! send, broadcast, or timer operation.
 
 #![allow(clippy::type_complexity, clippy::single_match)]
 
@@ -1385,6 +1396,28 @@ mod tests {
                 "async reactor path still directly locks reactor state: {forbidden}"
             );
         }
+    }
+
+    #[test]
+    fn reactor_documents_locking_model_and_single_mutex_sections() {
+        let source = include_str!("reactor.rs");
+        let production = source
+            .split("// ---------------------------------------------------------------------------\n// Tests")
+            .next()
+            .expect("tests marker present");
+
+        assert!(
+            production.contains("## Locking model"),
+            "reactor docs must spell out the store/state locking model"
+        );
+        assert!(
+            production.contains("Never hold both mutexes at the same time"),
+            "reactor docs must require single-mutex critical sections"
+        );
+        assert!(
+            production.contains("snapshot, release, then acquire"),
+            "reactor docs must define the safe order for workflows needing store and state"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Remediates the still-live portion of the reported reactor/store locking concern: the async direct-lock issue already has blocking adapters and regression guards on current `main`, but the store/state locking model was not documented as an enforceable reactor contract.
- Documents the single-mutex critical-section rule for `SharedReactorState` and `Arc<Mutex<SqliteDagStore>>`.
- Adds a reactor unit guard so the locking contract cannot disappear silently.

## Path Classification
- `crates/exo-node/src/reactor.rs` - Core runtime adapter / EXOCHAIN node reactor

## TDD / Verification
- RED: `cargo test -p exo-node reactor::tests::reactor_documents_locking_model_and_single_mutex_sections -- --nocapture` failed with `reactor docs must spell out the store/state locking model`.
- GREEN: `cargo test -p exo-node reactor::tests::reactor_documents_locking_model_and_single_mutex_sections -- --nocapture`
- `cargo test -p exo-node reactor::tests -- --nocapture`
- `cargo clippy -p exo-node --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `git diff --cached --check`