### PR TITLE
docs: prove consensus quorum formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 289 | `find crates -name '*.rs'` |
-| Rust LOC | 164923 | `wc -l` |
+| Rust LOC | 164955 | `wc -l` |
 | Workspace tests | 4,036 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -80,7 +80,7 @@ pricing on by policy without modifying AVC validation.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 164923 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 164955 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,036 listed workspace tests
 

--- a/crates/exo-dag/src/consensus.rs
+++ b/crates/exo-dag/src/consensus.rs
@@ -47,6 +47,17 @@ impl ConsensusConfig {
     }
 
     /// The quorum size required for a commit: > 2/3 of validators.
+    ///
+    /// For nonzero `n`, `n - ((n - 1) / 3) equals floor(2n / 3) + 1`, the
+    /// smallest integer strictly greater than two thirds of the validator set.
+    /// Writing `n = 3f + r`:
+    ///
+    /// - n = 3f + 0 -> quorum = 2f + 1
+    /// - n = 3f + 1 -> quorum = 2f + 1
+    /// - n = 3f + 2 -> quorum = 2f + 2
+    ///
+    /// This form avoids multiplying the validator count by two, so it remains
+    /// overflow-safe for large validator sets.
     #[must_use]
     pub fn quorum_size(&self) -> usize {
         let n = self.validators.len();
@@ -652,6 +663,27 @@ mod tests {
             !production.contains("2 * n"),
             "quorum_size must not compute 2 * n before division"
         );
+    }
+
+    #[test]
+    fn quorum_size_docs_prove_strict_two_thirds_equivalence() {
+        let source = include_str!("consensus.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production section");
+
+        for required in [
+            "n - ((n - 1) / 3) equals floor(2n / 3) + 1",
+            "n = 3f + 0 -> quorum = 2f + 1",
+            "n = 3f + 1 -> quorum = 2f + 1",
+            "n = 3f + 2 -> quorum = 2f + 2",
+        ] {
+            assert!(
+                production.contains(required),
+                "quorum_size docs must prove strict >2/3 equivalence: {required}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Remediates Wally Gauntlet F-156 after confirming the issue is still live on current `origin/main`: `ConsensusConfig::quorum_size()` had sample tests and an overflow guard, but no inline proof that `n - ((n - 1) / 3)` is equivalent to the smallest integer strictly greater than two thirds, including the `n = 3f + r` cases.

## Path Classification

- `crates/exo-dag/src/consensus.rs` - EXOCHAIN core consensus documentation and regression/source guard
- `README.md` - EXOCHAIN core repo-truth counter
- `Exochain Gauntlet Findings.zip` - imported evidence, read-only, not committed

## Current-Issue Confirmation

- Re-verified against current `origin/main` (`4ece768db6b049b92843658894699ada5368caac`) before rebasing.
- RED: `rg -n "quorum_size_docs_prove_strict_two_thirds_equivalence|strictly greater than two thirds|n = 3f|3f \\+" crates/exo-dag/src/consensus.rs README.md` found no proof/source-guard marker on current main.
- RED: `cargo test -p exo-dag quorum_size_docs_prove_strict_two_thirds_equivalence -- --nocapture` ran zero tests on current main, confirming the guard was absent.

## Red / Green Evidence

- RED from original branch work: added `quorum_size_docs_prove_strict_two_thirds_equivalence`; `cargo test -p exo-dag quorum_size_docs_prove_strict_two_thirds_equivalence -- --nocapture` failed because the production quorum docs lacked the proof.
- GREEN: documented the nonzero `n` equivalence and the `n = 3f + 0/1/2` cases, preserving the existing overflow-safe formula.

## Verification After Rebase

- `CARGO_TARGET_DIR=/Users/bobstewart/.config/superpowers/worktrees/exochain/workspace-dependency-exact-pins-20260506/target cargo test -p exo-dag quorum_size_docs_prove_strict_two_thirds_equivalence -- --nocapture`
- `CARGO_TARGET_DIR=/Users/bobstewart/.config/superpowers/worktrees/exochain/workspace-dependency-exact-pins-20260506/target cargo test -p exo-dag quorum_size -- --nocapture` (3 passed)
- `CARGO_TARGET_DIR=/Users/bobstewart/.config/superpowers/worktrees/exochain/workspace-dependency-exact-pins-20260506/target cargo clippy -p exo-dag --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `bash tools/test_repo_truth.sh`
- `CARGO_TARGET_DIR=/Users/bobstewart/.config/superpowers/worktrees/exochain/workspace-dependency-exact-pins-20260506/target cargo doc -p exo-dag --no-deps`
- `git diff --check origin/main...HEAD`
