### PR TITLE
Require CommandBase dispatch identity

### DIFF
--- a/command-base/CLAUDE.md
+++ b/command-base/CLAUDE.md
@@ -656,4 +656,18 @@ Every function that assigns work to a team member automatically spawns a Claude 
 
 **Settings:** `auto_spawn_enabled` in system_settings (default: on). `claude_cli_path` for CLI binary location.
 
+**Per-dispatch identity assertion:** Every auto-spawned terminal MUST receive a per-dispatch identity assertion before it can start work. The assertion is an immutable envelope, persisted with the spawn record and repeated in the terminal's initial instructions, containing:
+
+- `dispatch_id` — unique spawn/terminal dispatch identifier for this single run.
+- `team_member_id` — the assigned CommandBase team member.
+- `task_assignment_id` — the task assignment row or equivalent assignment record.
+- `agent_passport_id` — the adjacent CommandBase agent passport governing allowed tools, limits, and review path.
+- `actor_did` — the EXOCHAIN DID only when a verified adapter has bound this adjacent agent to a real EXOCHAIN actor; otherwise `null`.
+- `authority_scope` — the CommandBase task/tool scope for this dispatch.
+- `issued_by` — the human, Board, or executive actor that approved the dispatch.
+
+The spawn must fail closed if the identity envelope is missing, malformed, references a disabled team member, references a revoked or absent `agent_passport_id`, or attempts to reuse another terminal's `dispatch_id`. A spawned agent must never inherit a shared Board, executive, or team identity, and it must not claim another member's tools, authority, memory, or output as its own.
+
+This adjacent identity envelope is attribution, not constitutional authority. It does not make the adjacent CommandBase agent an EXOCHAIN core actor, and it does not authorize constitutional trust claims unless the runtime path calls a verified EXOCHAIN adapter that adjudicates the action and binds the `actor_did`, provenance, consent, and authority chain.
+
 **Rule:** If a team member is assigned work, they get a terminal. No exceptions.

--- a/tools/test_commandbase_dispatch_identity.sh
+++ b/tools/test_commandbase_dispatch_identity.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Guard CommandBase's adjacent agent fleet against anonymous auto-spawned
+# terminals. Each dispatched terminal must carry a stable identity envelope so
+# agent actions remain attributable without expanding EXOCHAIN core trust.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+fail() {
+  echo "commandbase dispatch identity test failed: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+
+  grep -Fq -- "$expected" "$file" || fail "$file must contain: $expected"
+}
+
+assert_contains command-base/CLAUDE.md "per-dispatch identity assertion"
+assert_contains command-base/CLAUDE.md "dispatch_id"
+assert_contains command-base/CLAUDE.md "team_member_id"
+assert_contains command-base/CLAUDE.md "task_assignment_id"
+assert_contains command-base/CLAUDE.md "agent_passport_id"
+assert_contains command-base/CLAUDE.md "actor_did"
+assert_contains command-base/CLAUDE.md "spawn must fail closed"
+assert_contains command-base/CLAUDE.md "shared Board, executive, or team identity"
+assert_contains command-base/CLAUDE.md "does not make the adjacent CommandBase agent an EXOCHAIN core actor"
+
+echo "commandbase dispatch identity test passed"


### PR DESCRIPTION
## Summary
- remediate Wally F-161 for the adjacent CommandBase agent fleet by requiring every auto-spawned terminal to carry a per-dispatch identity assertion
- add a fail-closed guard for dispatch identity fields so future agent-rule edits cannot reintroduce anonymous shared identity spawning
- preserve the existing prompt-boundary and workflow-iteration guards

## Path classification
- Adjacent surface: command-base/CLAUDE.md
- Adjacent-surface guard: tools/test_commandbase_dispatch_identity.sh
- No EXOCHAIN core, runtime adapter, governance, cryptography, DAG, consent, authority, gatekeeper, gateway, SDK, WASM, CI, or deployment contract changed

## Adjacent Surface Intake
- owner/accountable maintainer: CommandBase/The Team owner (Bob/Max Stewart operational context); not EXOCHAIN core maintainership
- deployment status: adjacent customer-zero/internal operating guide
- constitutional trust claims: not allowed by this change; the new text explicitly says the identity envelope is attribution, not constitutional authority
- core state access: no direct read/write path added for EXOCHAIN core state, signatures, credentials, governance outcomes, consent records, or provenance records
- trust boundary: CommandBase identity envelopes remain adjacent until a verified EXOCHAIN adapter binds actor_did, provenance, consent, and authority chain
- test command/CI gate: tools/test_commandbase_dispatch_identity.sh plus existing agent prompt/workflow guards
- secrets/config: no secrets added; identity envelope must reference configured agent passport and dispatch records
- rollback/disable path: disable auto_spawn_enabled or reject dispatch when the identity envelope is missing, malformed, revoked, or reused

## Verification
- RED: bash tools/test_commandbase_dispatch_identity.sh failed before docs update on missing per-dispatch identity assertion
- bash tools/test_commandbase_dispatch_identity.sh
- tools/test_commandbase_dispatch_identity.sh
- bash tools/test_agent_prompt_boundaries.sh
- bash tools/test_agent_workflow_bounds.sh
- bash tools/test_repo_truth.sh
- git diff --check
- git diff --cached --check