### PR TITLE
Make CommandBase adjudicator selection deterministic

### DIFF
--- a/command-base/app/services/governance.js
+++ b/command-base/app/services/governance.js
@@ -763,26 +763,25 @@ module.exports = function(db, broadcast, helpers) {
     // Find an appropriate adjudicator — must not be the challenger
     let adjudicator = null;
     const challengerId = challenge.challenger_id;
+    function selectAdjudicatorForTier(tier) {
+      return db.prepare(`
+        SELECT id, name, tier FROM team_members
+        WHERE tier = ? AND status = 'active' AND id != ?
+        ORDER BY (
+          SELECT COUNT(*) FROM challenge_adjudication_stages
+          WHERE adjudicator_id = team_members.id AND verdict IS NULL
+        ) ASC, team_members.id ASC
+        LIMIT 1
+      `).get(tier, challengerId || 0);
+    }
 
     if (stageDef.tier === 'specialist') {
       // Pick a specialist from same department, ranked higher if possible, excluding challenger
-      adjudicator = db.prepare(`
-        SELECT id, name, tier FROM team_members
-        WHERE tier = 'IC' AND status = 'active' AND id != ?
-        ORDER BY RANDOM() LIMIT 1
-      `).get(challengerId || 0);
+      adjudicator = selectAdjudicatorForTier('IC');
     } else if (stageDef.tier === 'executive') {
-      adjudicator = db.prepare(`
-        SELECT id, name, tier FROM team_members
-        WHERE tier = 'C-Suite' AND status = 'active' AND id != ?
-        ORDER BY RANDOM() LIMIT 1
-      `).get(challengerId || 0);
+      adjudicator = selectAdjudicatorForTier('C-Suite');
     } else if (stageDef.tier === 'board') {
-      adjudicator = db.prepare(`
-        SELECT id, name, tier FROM team_members
-        WHERE tier = 'Board' AND status = 'active' AND id != ?
-        ORDER BY RANDOM() LIMIT 1
-      `).get(challengerId || 0);
+      adjudicator = selectAdjudicatorForTier('Board');
     }
 
     if (!adjudicator) {

--- a/command-base/app/services/governance.test.js
+++ b/command-base/app/services/governance.test.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
+const test = require('node:test');
+
+const source = readFileSync(join(__dirname, 'governance.js'), 'utf8');
+
+function functionSource(name) {
+  const start = source.indexOf(`function ${name}`);
+  assert.notEqual(start, -1, `${name} source must be present`);
+  const nextFunction = source.indexOf('\n  function ', start + 1);
+  return nextFunction === -1 ? source.slice(start) : source.slice(start, nextFunction);
+}
+
+test('assignAdjudicationStage uses deterministic adjudicator ordering', () => {
+  const body = functionSource('assignAdjudicationStage');
+
+  assert.equal(
+    /ORDER\s+BY\s+RANDOM\s*\(/i.test(body),
+    false,
+    'adjudicator selection must not use SQLite ORDER BY RANDOM()',
+  );
+  assert.match(
+    body,
+    /challenge_adjudication_stages[\s\S]+adjudicator_id\s*=\s*team_members\.id/i,
+    'adjudicator ordering must account for existing adjudication load',
+  );
+  assert.match(
+    body,
+    /ORDER\s+BY[\s\S]+ASC[\s\S]+id\s+ASC/i,
+    'adjudicator ordering must use a stable id tie-breaker',
+  );
+});


### PR DESCRIPTION
## Summary
- replace `ORDER BY RANDOM()` adjudicator selection in CommandBase governance challenges with deterministic least-active-stage ordering
- add a stable `team_members.id` tie-breaker and preserve challenger exclusion
- add a Node regression guard for the adjudicator SQL strategy

## Classification
- Adjacent surface: `command-base/app/services/governance.js`, `command-base/app/services/governance.test.js`
- Imported evidence: external F-166 report only; not committed
- EXOCHAIN core: unchanged

## Adjacent Surface Intake
- Owner/accountable maintainer: CommandBase surface owner; not EXOCHAIN core runtime ownership
- Deployment status: internal/customer-zero adjacent surface, not canonical EXOCHAIN trust fabric
- Constitutional trust claims: not allowed to claim EXOCHAIN constitutional enforcement from this change alone
- Core read/write access: this change does not read or write EXOCHAIN core state, signatures, credentials, governance outcomes, consent records, or provenance records
- Trust boundary: CommandBase challenge assignment remains an adjacent workflow; it must not be treated as EXOCHAIN adjudication unless routed through a verified EXOCHAIN adapter
- Surface-specific test/CI gate: `node --test command-base/app/services/*.test.js`
- Secrets/config: no new secrets or runtime configuration
- Rollback/disablement: revert this PR or disable CommandBase challenge auto-assignment; core remains unaffected

## TDD / Verification
- RED: `node --test command-base/app/services/governance.test.js` failed while `assignAdjudicationStage` used `ORDER BY RANDOM()`
- `node --test command-base/app/services/governance.test.js`
- `node --test command-base/app/services/*.test.js`
- `rg -n "ORDER\\s+BY\\s+RANDOM|RANDOM\\s*\\(" command-base/app/services/governance.js command-base/app/routes/governance.js` returned no matches
- `bash tools/test_repo_truth.sh`
- `git diff --check`
- `git diff --cached --check`
