### PR TITLE
Make CommandBase refinement assignment deterministic

### DIFF
--- a/command-base/app/routes/refinement.js
+++ b/command-base/app/routes/refinement.js
@@ -130,7 +130,21 @@ app.post('/api/refinement/candidates/:id/refine', (req, res) => {
     let memberId = candidate.assigned_member_id;
 
     if (!memberId) {
-      const assignment = db.prepare(`SELECT tm.id FROM refinement_team_assignments rta JOIN team_members tm ON rta.member_id = tm.id WHERE rta.target_id = ? AND rta.enabled = 1 AND tm.status = 'active' ORDER BY RANDOM() LIMIT 1`).get(candidate.target_id);
+      const assignment = db.prepare(`
+        SELECT tm.id
+        FROM refinement_team_assignments rta
+        JOIN team_members tm ON rta.member_id = tm.id
+        LEFT JOIN refinement_candidates active
+          ON active.assigned_member_id = tm.id
+         AND active.target_id = rta.target_id
+         AND active.status = 'in_progress'
+        WHERE rta.target_id = ?
+          AND rta.enabled = 1
+          AND tm.status = 'active'
+        GROUP BY tm.id
+        ORDER BY COUNT(active.id) ASC, tm.id ASC
+        LIMIT 1
+      `).get(candidate.target_id);
       if (!assignment) return res.status(400).json({ error: 'No enabled team members for this target' });
       memberId = assignment.id;
     }

--- a/command-base/app/routes/refinement.test.js
+++ b/command-base/app/routes/refinement.test.js
@@ -1,0 +1,148 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const registerRefinementRoutes = require('./refinement');
+
+function createFakeApp() {
+  const routes = new Map();
+  const register = (method) => (route, handler) => {
+    routes.set(`${method} ${route}`, handler);
+  };
+  return {
+    routes,
+    get: register('GET'),
+    post: register('POST'),
+    put: register('PUT'),
+    delete: register('DELETE')
+  };
+}
+
+function createResponse() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+function createDb(sqlAssertions) {
+  return {
+    prepare(sql) {
+      return {
+        get(...params) {
+          if (sql.includes('FROM refinement_candidates rc JOIN refinement_targets rt')) {
+            return {
+              id: 7,
+              target_id: 3,
+              title: 'Reduce query latency',
+              description: 'Tune the slow path',
+              file_path: 'app/services/search.js',
+              metric_name: 'latency_ms',
+              metric_command: 'npm test',
+              priority: 'high',
+              target_path: '/tmp/commandbase',
+              assigned_member_id: null
+            };
+          }
+          if (sql.includes('FROM refinement_team_assignments rta')) {
+            sqlAssertions.push(sql);
+            assert.doesNotMatch(
+              sql,
+              /ORDER\s+BY\s+RANDOM\s*\(\)/i,
+              'refinement assignment must not select team members randomly'
+            );
+            assert.match(
+              sql,
+              /ORDER\s+BY\s+COUNT\s*\(\s*active\.id\s*\)\s+ASC,\s*tm\.id\s+ASC/i,
+              'refinement assignment must use least-active load and stable id tie-break'
+            );
+            assert.deepStrictEqual(params, [3]);
+            return { id: 11, name: 'Ada' };
+          }
+          return null;
+        },
+        run() {
+          if (sql.includes('INSERT INTO research_programs')) {
+            return { lastInsertRowid: 101 };
+          }
+          if (sql.includes('INSERT INTO tasks')) {
+            return { lastInsertRowid: 202 };
+          }
+          return { changes: 1, lastInsertRowid: 0 };
+        },
+        all() {
+          return [];
+        }
+      };
+    }
+  };
+}
+
+test('POST /api/refinement/candidates/:id/refine assigns least-active enabled member deterministically', async () => {
+  const app = createFakeApp();
+  const sqlAssertions = [];
+  const db = createDb(sqlAssertions);
+  const broadcasts = [];
+
+  registerRefinementRoutes(app, db, {
+    localNow: () => '2026-05-05 12:00:00',
+    broadcast: (event, payload) => broadcasts.push({ event, payload }),
+    spawnMemberTerminal: async () => {}
+  });
+
+  const handler = app.routes.get('POST /api/refinement/candidates/:id/refine');
+  assert.equal(typeof handler, 'function');
+
+  const req = { params: { id: '7' } };
+  const res = createResponse();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepStrictEqual(res.body, { success: true, task_id: 202, program_id: 101 });
+  assert.equal(sqlAssertions.length, 1);
+  assert.deepStrictEqual(broadcasts, [
+    {
+      event: 'refinement.started',
+      payload: { target_id: 3, candidate_id: 7, task_id: 202 }
+    }
+  ]);
+});
+
+test('refinement assignment source has no random selector in route or legacy server loop', () => {
+  const appDir = path.resolve(__dirname, '..');
+  const routeSource = fs.readFileSync(path.join(appDir, 'routes', 'refinement.js'), 'utf8');
+  const serverSource = fs.readFileSync(path.join(appDir, 'server.js'), 'utf8');
+  const loopStart = serverSource.indexOf('function runRefinementCycle');
+  assert.notEqual(loopStart, -1, 'server refinement loop must exist');
+  const loopEnd = serverSource.indexOf('const refinementTimers', loopStart);
+  assert.notEqual(loopEnd, -1, 'server refinement loop section must have a stable end marker');
+  const loopSource = serverSource.slice(loopStart, loopEnd);
+
+  for (const [label, source] of [
+    ['routes/refinement.js', routeSource],
+    ['server.js runRefinementCycle', loopSource]
+  ]) {
+    assert.doesNotMatch(
+      source,
+      /ORDER\s+BY\s+RANDOM\s*\(\)/i,
+      `${label} must not use random team-member assignment`
+    );
+    assert.match(
+      source,
+      /ORDER\s+BY\s+COUNT\s*\(\s*active\.id\s*\)\s+ASC,\s*tm\.id\s+ASC/i,
+      `${label} must use least-active load and stable id tie-break`
+    );
+  }
+});

--- a/command-base/app/server.js
+++ b/command-base/app/server.js
@@ -21902,8 +21902,14 @@ function runRefinementCycle(targetId) {
   const assignment = db.prepare(`
     SELECT tm.id, tm.name FROM refinement_team_assignments rta
     JOIN team_members tm ON rta.member_id = tm.id
+    LEFT JOIN refinement_candidates active
+      ON active.assigned_member_id = tm.id
+     AND active.target_id = rta.target_id
+     AND active.status = 'in_progress'
     WHERE rta.target_id = ? AND rta.enabled = 1 AND tm.status = 'active'
-    ORDER BY RANDOM() LIMIT 1
+    GROUP BY tm.id
+    ORDER BY COUNT(active.id) ASC, tm.id ASC
+    LIMIT 1
   `).get(targetId);
 
   if (!assignment) {


### PR DESCRIPTION
## Classification
- Adjacent surface: `command-base/app/routes/refinement.js`, `command-base/app/server.js`, `command-base/app/routes/refinement.test.js`
- No EXOCHAIN core, runtime adapter, CI, governance, or deployment files changed.

## Adjacent Intake Record
- Owner / accountable maintainer: CommandBase surface owner.
- Deployment status: adjacent customer-zero/internal app surface; not the canonical EXOCHAIN Rust trust fabric.
- EXOCHAIN constitutional trust claims: this PR does not add or authorize constitutional trust claims.
- Core state access: no direct read/write to EXOCHAIN core state, signatures, credentials, governance outcomes, consent records, or provenance records.
- Trust boundary: deterministic local CommandBase SQLite assignment only; it does not adjudicate EXOCHAIN authority.
- Surface test command / CI gate: `node --test command-base/app/routes/refinement.test.js command-base/app/services/cqi-orchestrator.test.js`.
- Secrets inventory / runtime config: no new secrets or runtime config.
- Rollback / disablement: revert this PR to restore prior assignment behavior; no core state migration involved.

## Verification Against Current Main
- Re-verified against current `origin/main` (`4ece768db6b049b92843658894699ada5368caac`) before rebasing.
- RED: `rg -n "ORDER\\s+BY\\s+RANDOM\\s*\\(\\)|Math\\.random\\s*\\(" command-base/app/routes/refinement.js command-base/app/server.js command-base/app/routes/refinement.test.js 2>/dev/null || true` found the targeted random refinement assignment in both the route module and legacy server loop on current main.
- RED: `node --test command-base/app/routes/refinement.test.js` failed on current main because the regression test file was absent.
- Other CommandBase random-selection sites are covered by separate already-open branches; this PR remains scoped to refinement assignment.

## Remediation
- Replace random assignment with least-active enabled member selection.
- Use `COUNT(active.id) ASC, tm.id ASC` for deterministic load-based order and stable tie-break.
- Cover both the modular route and legacy server loop.

## TDD Evidence
Red first:
- `node --test command-base/app/routes/refinement.test.js` failed on the existing `ORDER BY RANDOM()` selector.

Green verification after rebase:
- `node --test command-base/app/routes/refinement.test.js`
- `node --test command-base/app/routes/refinement.test.js command-base/app/services/cqi-orchestrator.test.js`
- `if rg -n "ORDER\\s+BY\\s+RANDOM\\s*\\(\\)|Math\\.random\\s*\\(" command-base/app/routes/refinement.js command-base/app/routes/refinement.test.js; then exit 1; else echo "no refinement route random assignment matches"; fi`
- `git diff --check origin/main...HEAD`
- `bash tools/test_repo_truth.sh`

## Notes
This is intentionally an adjacent-surface hardening PR and does not claim to remediate any EXOCHAIN core vulnerability.
