### PR TITLE
Make CommandBase CQI proposal IDs deterministic

### DIFF
--- a/command-base/app/services/cqi-orchestrator.js
+++ b/command-base/app/services/cqi-orchestrator.js
@@ -26,6 +26,7 @@ const crypto = require('crypto');
 
 module.exports = function(db, helpers) {
   const { localNow } = helpers;
+  let proposalSequence = 0;
 
   // ══════════════════════════════════════════════════════════════════════════════
   // SECTION 1: INTERNAL UTILITIES
@@ -40,14 +41,35 @@ module.exports = function(db, helpers) {
     return crypto.createHash('sha256').update(JSON.stringify(data)).digest('hex');
   }
 
+  function stableStringify(value) {
+    if (Array.isArray(value)) {
+      return `[${value.map(stableStringify).join(',')}]`;
+    }
+    if (value && typeof value === 'object') {
+      return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`;
+    }
+    return JSON.stringify(value);
+  }
+
+  function normalizeProposalTimestamp(value) {
+    const digits = String(value).replace(/\D/g, '');
+    if (digits.length >= 14) return digits.slice(0, 14);
+    return digits.padEnd(14, '0') || '00000000000000';
+  }
+
   /**
    * Generate a unique proposal ID.
-   * @returns {string} Proposal ID (proposal-TIMESTAMP-RANDOM)
+   * @returns {string} Proposal ID (proposal-YYYYMMDDHHMMSS-SEQUENCE-HASH)
    */
-  function generateProposalId() {
-    const ts = Date.now();
-    const rand = Math.random().toString(36).substring(2, 8);
-    return `proposal-${ts}-${rand}`;
+  function generateProposalId(finding, observedAt) {
+    proposalSequence += 1;
+    const sequence = String(proposalSequence).padStart(6, '0');
+    const findingHash = crypto
+      .createHash('sha256')
+      .update(stableStringify({ finding, observedAt }))
+      .digest('hex')
+      .slice(0, 12);
+    return `proposal-${normalizeProposalTimestamp(observedAt)}-${sequence}-${findingHash}`;
   }
 
   /**
@@ -383,8 +405,8 @@ module.exports = function(db, helpers) {
      * @returns {object} Proposal { proposal_id, finding_summary, patch_diff, affected_modules, test_criteria }
      */
     generateProposal(finding) {
-      const proposalId = generateProposalId();
       const now = localNow();
+      const proposalId = generateProposalId(finding, now);
 
       let patchDiff = '';
       const affectedModules = [];

--- a/command-base/app/services/cqi-orchestrator.test.js
+++ b/command-base/app/services/cqi-orchestrator.test.js
@@ -19,6 +19,8 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const crypto = require('crypto');
+const fs = require('node:fs');
+const path = require('node:path');
 
 // Mock database implementation
 class MockDatabase {
@@ -860,6 +862,38 @@ test('Proposal ID generation is unique', (t) => {
   const prop2 = orchestrator.generateProposal(finding2);
 
   assert.notStrictEqual(prop1.proposal_id, prop2.proposal_id);
+});
+
+test('Proposal ID generation uses deterministic local sequence and finding hash', (t) => {
+  const { orchestrator } = createTestOrchestrator();
+  const finding = {
+    type: 'high_error_rate',
+    severity: 'high',
+    message: 'Error rate high',
+    metric: 'error_rate',
+    value: 0.15,
+    timestamp: '2026-04-10 12:00:00'
+  };
+
+  const prop1 = orchestrator.generateProposal(finding);
+  const prop2 = orchestrator.generateProposal(finding);
+
+  assert.match(prop1.proposal_id, /^proposal-20260410120000-000001-[0-9a-f]{12}$/);
+  assert.match(prop2.proposal_id, /^proposal-20260410120000-000002-[0-9a-f]{12}$/);
+  assert.equal(prop1.proposal_id.slice(-12), prop2.proposal_id.slice(-12));
+});
+
+test('Proposal ID source does not use wall clock or randomness', (t) => {
+  const source = fs.readFileSync(path.join(__dirname, 'cqi-orchestrator.js'), 'utf8');
+  const start = source.indexOf('function generateProposalId');
+  assert.notEqual(start, -1, 'generateProposalId must exist');
+  const end = source.indexOf('/**\n   * Determine BCTS branch', start);
+  assert.notEqual(end, -1, 'generateProposalId section must have stable end marker');
+  const section = source.slice(start, end);
+
+  assert.doesNotMatch(section, /Date\.now\s*\(/, 'proposal IDs must use caller-supplied localNow');
+  assert.doesNotMatch(section, /Math\.random\s*\(/, 'proposal IDs must not use runtime randomness');
+  assert.match(section, /stableStringify/, 'proposal IDs must hash a stable finding representation');
 });
 
 test('Module factory pattern - createOrchestrator returns correct instance', (t) => {


### PR DESCRIPTION
## Classification
- Adjacent surface: `command-base/app/services/cqi-orchestrator.js`, `command-base/app/services/cqi-orchestrator.test.js`
- No EXOCHAIN core, runtime adapter, CI, governance, or deployment files changed.

## Adjacent Intake Record
- Owner / accountable maintainer: CommandBase surface owner.
- Deployment status: adjacent customer-zero/internal app surface; not the canonical EXOCHAIN Rust trust fabric.
- EXOCHAIN constitutional trust claims: this PR does not add or authorize constitutional trust claims.
- Core state access: no direct read/write to EXOCHAIN core state, signatures, credentials, governance outcomes, consent records, or provenance records.
- Trust boundary: local CommandBase CQI proposal and receipt metadata only; it does not adjudicate EXOCHAIN authority.
- Surface test command / CI gate: `node --test command-base/app/services/cqi-orchestrator.test.js`.
- Secrets inventory / runtime config: no new secrets or runtime config.
- Rollback / disablement: revert this PR to restore prior ID format; no core state migration involved.

## Verification against current main
Current `main` uses `Date.now()` and `Math.random()` to fabricate CommandBase CQI proposal IDs. That is live adjacent nondeterminism in a governance-like local workflow, separate from EXOCHAIN core.

## Remediation
- Replace wall-clock/random ID generation with caller-supplied `localNow()`, a deterministic local sequence, and a stable SHA-256 hash over the finding.
- Add stable stringify for the finding hash input.
- Preserve uniqueness across repeated calls via the deterministic sequence.

## TDD evidence
Red first:
- `node --test command-base/app/services/cqi-orchestrator.test.js` failed because proposal IDs used wall clock and `Math.random()`.

Green verification:
- `node --test command-base/app/services/cqi-orchestrator.test.js`
- source guard for `generateProposalId` confirmed no `Date.now()` or `Math.random()` and presence of `stableStringify`
- `git diff --check`

## Notes
This is intentionally an adjacent-surface hardening PR and does not claim to remediate any EXOCHAIN core vulnerability.