### PR TITLE
Make CommandBase task assignment deterministic

### DIFF
--- a/command-base/app/server-assignment-determinism.test.js
+++ b/command-base/app/server-assignment-determinism.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function serverSection(startMarker, endMarker) {
+  const source = fs.readFileSync(path.join(__dirname, 'server.js'), 'utf8');
+  const start = source.indexOf(startMarker);
+  assert.notEqual(start, -1, `${startMarker} must exist`);
+  const end = source.indexOf(endMarker, start);
+  assert.notEqual(end, -1, `${endMarker} must follow ${startMarker}`);
+  return source.slice(start, end);
+}
+
+test('assignMember routes deterministically without SQL or runtime randomness', () => {
+  const section = serverSection('function assignMember', 'function findImprovementAssignee');
+
+  assert.doesNotMatch(section, /ORDER\s+BY\s+RANDOM\s*\(\)/i);
+  assert.doesNotMatch(section, /,\s*RANDOM\s*\(\)/i);
+  assert.doesNotMatch(section, /Math\.random\s*\(/);
+  assert.match(
+    section,
+    /ORDER\s+BY\s+[\s\S]*running_tasks\s+ASC,[\s\S]*completed_tasks\s+ASC,[\s\S]*tm\.id\s+ASC/i,
+    'primary assignee query must use load ordering and stable member-id tie-break'
+  );
+  assert.match(
+    section,
+    /ORDER\s+BY\s+[\s\S]*running_tasks\s+ASC,[\s\S]*completed_tasks\s+ASC,[\s\S]*id\s+ASC/i,
+    'fallback assignee query must use load ordering and stable member-id tie-break'
+  );
+});
+
+test('assignMember deterministically prefers first load-sorted affinity member', () => {
+  const section = serverSection('function assignMember', 'function findImprovementAssignee');
+
+  assert.match(section, /if\s*\(\s*affinityMember\s*\)\s*\{\s*return affinityMember;\s*\}/);
+  assert.doesNotMatch(section, /70\/30|growth opportunity|chance/i);
+});

--- a/command-base/app/server.js
+++ b/command-base/app/server.js
@@ -9096,29 +9096,32 @@ function assignMember(taskCategory, projectId) {
     ORDER BY
       running_tasks ASC,
       completed_tasks ASC,
-      RANDOM()
+      tm.id ASC
     LIMIT 5
   `).all();
 
   if (candidates.length === 0) {
     // Fallback: any active specialist, least loaded
     const fallback = db.prepare(`
-      SELECT id, name, role FROM team_members
-      WHERE status = 'active' AND tier = 'specialist'
-      ORDER BY (SELECT COUNT(*) FROM active_processes WHERE member_id = team_members.id AND status = 'completed') ASC, RANDOM()
+      SELECT id, name, role,
+        (SELECT COUNT(*) FROM active_processes WHERE member_id = team_members.id AND status = 'running') as running_tasks,
+        (SELECT COUNT(*) FROM active_processes WHERE member_id = team_members.id AND status = 'completed') as completed_tasks
+      FROM team_members
+      WHERE status = 'active'
+        AND tier = 'specialist'
+      ORDER BY running_tasks ASC, completed_tasks ASC, id ASC
       LIMIT 1
     `).get();
     return fallback || null;
   }
 
-  // If project specified, prefer members with affinity (but not always — 70/30 split for growth)
+  // If project specified, prefer the first affinity member in load-sorted order.
   if (projectId) {
     const affinityMember = candidates.find(c => {
       const affinity = db.prepare('SELECT id FROM project_affinity WHERE project_id = ? AND member_id = ?').get(projectId, c.id);
       return affinity !== undefined;
     });
-    // 70% chance affinity member, 30% chance someone new (growth opportunity)
-    if (affinityMember && Math.random() < 0.7) {
+    if (affinityMember) {
       return affinityMember;
     }
   }


### PR DESCRIPTION
## Classification
- Adjacent surface: `command-base/app/server.js`, `command-base/app/server-assignment-determinism.test.js`
- No EXOCHAIN core, runtime adapter, CI, governance, or deployment files changed.

## Adjacent Intake Record
- Owner / accountable maintainer: CommandBase surface owner.
- Deployment status: adjacent customer-zero/internal app surface; not the canonical EXOCHAIN Rust trust fabric.
- EXOCHAIN constitutional trust claims: this PR does not add or authorize constitutional trust claims.
- Core state access: no direct read/write to EXOCHAIN core state, signatures, credentials, governance outcomes, consent records, or provenance records.
- Trust boundary: local CommandBase task assignment only; it does not adjudicate EXOCHAIN authority.
- Surface test command / CI gate: `node --test command-base/app/server-assignment-determinism.test.js command-base/app/services/cqi-orchestrator.test.js`.
- Secrets inventory / runtime config: no new secrets or runtime config.
- Rollback / disablement: revert this PR to restore prior routing behavior; no core state migration involved.

## Verification against current main
Current `main` uses SQL `RANDOM()` and a `Math.random()` affinity split in `assignMember()`. That is live adjacent nondeterminism in local task routing, separate from EXOCHAIN core.

## Remediation
- Replace random tie-breaks with `running_tasks ASC`, `completed_tasks ASC`, and stable member ID ordering.
- Make project affinity preference deterministic by returning the first affinity member from the existing load-sorted candidate list.
- Add source guards for the `assignMember()` section.

## TDD evidence
Red first:
- `node --test command-base/app/server-assignment-determinism.test.js` failed on SQL `RANDOM()` and `Math.random()`.

Green verification:
- `node --test command-base/app/server-assignment-determinism.test.js`
- `node --test command-base/app/server-assignment-determinism.test.js command-base/app/services/cqi-orchestrator.test.js`
- `git diff --check`

## Notes
This is intentionally an adjacent-surface hardening PR and does not claim to remediate any EXOCHAIN core vulnerability.