### PR TITLE
Harden CommandBase auth boundary

### DIFF
--- a/command-base/app/lib/api-key-auth.js
+++ b/command-base/app/lib/api-key-auth.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const crypto = require('crypto');
+
+function headerValue(req, name) {
+  const headers = (req && req.headers) || {};
+  const value = headers[name];
+  return typeof value === 'string' ? value : null;
+}
+
+function cookieValue(req, name) {
+  const cookieHeader = headerValue(req, 'cookie');
+  if (!cookieHeader) return null;
+
+  for (const part of cookieHeader.split(';')) {
+    const separator = part.indexOf('=');
+    if (separator === -1) continue;
+    const key = part.slice(0, separator).trim();
+    if (key !== name) continue;
+    const value = part.slice(separator + 1).trim();
+    try {
+      return decodeURIComponent(value);
+    } catch (_err) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function constantTimeEquals(expected, candidate) {
+  if (!expected || !candidate) return false;
+  if (typeof expected !== 'string' || typeof candidate !== 'string') return false;
+
+  const expectedBytes = Buffer.from(expected, 'utf8');
+  const candidateBytes = Buffer.from(candidate, 'utf8');
+  if (expectedBytes.length !== candidateBytes.length) return false;
+
+  return crypto.timingSafeEqual(expectedBytes, candidateBytes);
+}
+
+function isApiAuthenticated(req, apiKey) {
+  return (
+    constantTimeEquals(apiKey, headerValue(req, 'x-api-key')) ||
+    constantTimeEquals(apiKey, cookieValue(req, 'cb_auth'))
+  );
+}
+
+function buildAuthStatus(req, apiKey) {
+  return {
+    authenticated: isApiAuthenticated(req, apiKey),
+    auth_required: true,
+  };
+}
+
+module.exports = {
+  buildAuthStatus,
+  isApiAuthenticated,
+};

--- a/command-base/app/lib/api-key-auth.test.js
+++ b/command-base/app/lib/api-key-auth.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildAuthStatus,
+  isApiAuthenticated,
+} = require('./api-key-auth');
+
+test('auth status reports authentication without exposing the API key', () => {
+  const apiKey = '0123456789abcdef0123456789abcdef';
+  const req = {
+    headers: {
+      'x-api-key': apiKey,
+      cookie: `cb_auth=${apiKey}`,
+    },
+  };
+
+  const status = buildAuthStatus(req, apiKey);
+
+  assert.deepEqual(status, {
+    authenticated: true,
+    auth_required: true,
+  });
+  assert.equal(Object.hasOwn(status, 'key'), false);
+  assert.equal(JSON.stringify(status).includes(apiKey), false);
+});
+
+test('auth status stays unauthenticated without a matching header or cookie', () => {
+  const apiKey = '0123456789abcdef0123456789abcdef';
+
+  assert.equal(isApiAuthenticated({ headers: {} }, apiKey), false);
+  assert.equal(isApiAuthenticated({ headers: { 'x-api-key': 'wrong' } }, apiKey), false);
+  assert.equal(
+    isApiAuthenticated({ headers: { cookie: 'cb_auth=wrong' } }, apiKey),
+    false,
+  );
+});
+
+test('auth accepts the configured key from header or cookie only', () => {
+  const apiKey = '0123456789abcdef0123456789abcdef';
+
+  assert.equal(isApiAuthenticated({ headers: { 'x-api-key': apiKey } }, apiKey), true);
+  assert.equal(isApiAuthenticated({ headers: { cookie: `cb_auth=${apiKey}` } }, apiKey), true);
+  assert.equal(isApiAuthenticated({ headers: { authorization: `Bearer ${apiKey}` } }, apiKey), false);
+});

--- a/command-base/app/lib/auth.js
+++ b/command-base/app/lib/auth.js
@@ -24,8 +24,19 @@ const crypto = require('crypto');
 /** Default token TTL in seconds (1 hour). */
 const DEFAULT_TTL_SECONDS = 3600;
 
-/** HMAC fallback secret — override via EXOCHAIN_AUTH_SECRET env var. */
-const HMAC_SECRET = process.env.EXOCHAIN_AUTH_SECRET || 'exochain-dev-secret-change-in-production';
+/** Minimum HMAC fallback secret length in bytes. */
+const MIN_HMAC_SECRET_BYTES = 32;
+
+function getHmacSecret() {
+  const secret = process.env.EXOCHAIN_AUTH_SECRET;
+  if (!secret || typeof secret !== 'string' || secret.trim() === '') {
+    throw new Error('EXOCHAIN_AUTH_SECRET must be set when WASM Ed25519 signing is unavailable');
+  }
+  if (Buffer.byteLength(secret, 'utf8') < MIN_HMAC_SECRET_BYTES) {
+    throw new Error('EXOCHAIN_AUTH_SECRET must be at least 32 bytes when HMAC signing is used');
+  }
+  return secret;
+}
 
 // ---------------------------------------------------------------------------
 // WASM loader — lazy, non-fatal
@@ -87,7 +98,7 @@ function sign(message) {
     return base64urlEncode(sigBytes);
   }
   // HMAC-SHA256 fallback
-  const hmac = crypto.createHmac('sha256', HMAC_SECRET);
+  const hmac = crypto.createHmac('sha256', getHmacSecret());
   hmac.update(message);
   return base64urlEncode(hmac.digest());
 }
@@ -107,6 +118,7 @@ function verify(message, signature) {
   }
   // HMAC-SHA256 fallback: recompute and compare
   const expected = sign(message);
+  if (expected.length !== signature.length) return false;
   return crypto.timingSafeEqual(
     Buffer.from(expected, 'utf8'),
     Buffer.from(signature, 'utf8')
@@ -172,8 +184,14 @@ function verifyToken(token) {
   const [headerB64, payloadB64, signature] = parts;
   const signingInput = `${headerB64}.${payloadB64}`;
 
-  // Verify signature
-  if (!verify(signingInput, signature)) {
+  let signatureValid;
+  try {
+    signatureValid = verify(signingInput, signature);
+  } catch (err) {
+    return { valid: false, error: err.message };
+  }
+
+  if (!signatureValid) {
     return { valid: false, error: 'Invalid signature' };
   }
 
@@ -256,6 +274,7 @@ module.exports = {
   // Exposed for testing
   _sign: sign,
   _verify: verify,
+  _getHmacSecret: getHmacSecret,
   _base64urlEncode: base64urlEncode,
   _base64urlDecode: base64urlDecode,
 };

--- a/command-base/app/lib/auth.test.js
+++ b/command-base/app/lib/auth.test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const AUTH_PATH = path.join(__dirname, 'auth.js');
+
+function reloadAuthWithSecret(secret) {
+  delete require.cache[require.resolve(AUTH_PATH)];
+  if (secret === undefined) {
+    delete process.env.EXOCHAIN_AUTH_SECRET;
+  } else {
+    process.env.EXOCHAIN_AUTH_SECRET = secret;
+  }
+  return require(AUTH_PATH);
+}
+
+test('HMAC signing has no hardcoded development secret fallback', () => {
+  const source = fs.readFileSync(AUTH_PATH, 'utf8');
+
+  assert.doesNotMatch(source, /exochain-dev-secret-change-in-production/);
+  assert.doesNotMatch(source, /EXOCHAIN_AUTH_SECRET\s*\|\|/);
+});
+
+test('HMAC fallback fails closed when EXOCHAIN_AUTH_SECRET is absent', () => {
+  const auth = reloadAuthWithSecret(undefined);
+
+  assert.throws(
+    () => auth._sign('header.payload'),
+    /EXOCHAIN_AUTH_SECRET/,
+  );
+});
+
+test('HMAC fallback accepts an explicit high-entropy secret', () => {
+  const auth = reloadAuthWithSecret('0123456789abcdef0123456789abcdef');
+  const token = auth.createToken('did:exo:alice', 'governance:full', 'delegation-1', {
+    ttl: 60,
+  });
+
+  const result = auth.verifyToken(token);
+
+  assert.equal(result.valid, true);
+  assert.equal(result.payload.did, 'did:exo:alice');
+});

--- a/command-base/app/public/app.js
+++ b/command-base/app/public/app.js
@@ -96,10 +96,11 @@
     if (cached && Date.now() - cached.ts < ttl) {
       return cached.data;
     }
-    var opts = {};
+    var opts = { headers: {} };
     if (cached && cached.etag) {
-      opts.headers = { 'If-None-Match': cached.etag };
+      opts.headers['If-None-Match'] = cached.etag;
     }
+    if (_cbApiKey) opts.headers['X-API-Key'] = _cbApiKey;
     const res = await fetch(`/api/${endpoint}`, opts);
     if (res.status === 304) {
       // Server confirmed cache is still valid — refresh TTL
@@ -127,13 +128,17 @@
     }
   }
 
-  // ── API Auth: fetch key from server, include in all requests ──
+  // API Auth: use caller-provided key when present; status never discloses it.
   var _cbApiKey = null;
+  try {
+    _cbApiKey = localStorage.getItem('cb_api_key') || null;
+  } catch (_) {}
   (async function() {
     try {
-      var r = await fetch('/api/auth/status');
+      var authOpts = _cbApiKey ? { headers: { 'X-API-Key': _cbApiKey } } : {};
+      var r = await fetch('/api/auth/status', authOpts);
       var d = await r.json();
-      if (d.key) { _cbApiKey = d.key; document.cookie = 'cb_auth=' + d.key + ';path=/;SameSite=Strict'; }
+      if (!d.authenticated && _cbApiKey) _cbApiKey = null;
     } catch (_) {}
   })();
 

--- a/command-base/app/public/whitepaper.html
+++ b/command-base/app/public/whitepaper.html
@@ -777,8 +777,11 @@
     }
 
     // ── Main Render ─────────────────────────────────────
-    // Auth: get API key for authenticated requests
+    // Auth: use caller-provided key when present; status never discloses it.
     var _wpApiKey = null;
+    try {
+      _wpApiKey = localStorage.getItem('cb_api_key') || null;
+    } catch (_) {}
     async function wpFetch(url, extraOpts) {
       var opts = Object.assign({}, extraOpts || {});
       opts.headers = Object.assign({}, opts.headers || {});
@@ -791,12 +794,12 @@
       var refreshTime = document.getElementById('wp-refresh-time');
 
       try {
-        // Bootstrap auth key
+        // Confirm auth state without bootstrapping secrets.
         if (!_wpApiKey) {
           try {
             var authRes = await fetch('/api/auth/status');
             var authData = await authRes.json();
-            if (authData.key) { _wpApiKey = authData.key; document.cookie = 'cb_auth=' + authData.key + ';path=/;SameSite=Strict'; }
+            if (!authData.authenticated) _wpApiKey = null;
           } catch(e) {}
         }
 
@@ -959,7 +962,7 @@
             '<li style="margin-bottom:8px"><strong style="color:var(--accent)">Modularized Routes</strong> &mdash; 16 domain-specific route files (governance, companies, projects, etc.) extracted from the monolith. Core server handles DB setup, middleware, engines, and spawning.</li>' +
             '<li style="margin-bottom:8px"><strong style="color:var(--accent)">Dual Inference</strong> &mdash; Claude (Sonnet/Opus) for code tasks requiring tool use. Nemotron/qwen3-coder on DGX Spark (GB10, 128GB RAM) for free analysis, reviews, digestion. SSH tunnel at localhost:11435.</li>' +
             '<li style="margin-bottom:8px"><strong style="color:var(--accent)">Task Forces</strong> &mdash; External execution teams with their own DB, process management, and auto-guardian. Survive server crashes. Anti-bias enforcement prevents builders from reviewing their own work.</li>' +
-            '<li style="margin-bottom:8px"><strong style="color:var(--accent)">API Key Auth</strong> &mdash; Auto-generated 256-bit key on first boot. All /api/* routes protected. Frontend auto-authenticates via /api/auth/status bootstrap.</li>' +
+            '<li style="margin-bottom:8px"><strong style="color:var(--accent)">API Key Auth</strong> &mdash; Auto-generated 256-bit key on first boot. All /api/* routes protected. Auth status reports boolean state and never discloses the key.</li>' +
             '<li style="margin-bottom:8px"><strong style="color:var(--accent)">Prepared Statement Cache</strong> &mdash; All SQL queries go through a stmt() cache to avoid re-parsing.</li>' +
             '<li style="margin-bottom:8px"><strong style="color:var(--accent)">In-Memory TTL Cache</strong> &mdash; team_members (30s TTL) and system_settings (10s TTL) cached in-process to eliminate hot-path DB round-trips.</li>' +
             '<li style="margin-bottom:8px"><strong style="color:var(--accent)">Resource Management</strong> &mdash; Per-device resource profiles (Mac: 60% RAM cap for protection, Spark: 98% for full utilization). Process breakdown shows grouped app-level resource usage. Emergency kill buttons for instant model termination.</li>' +

--- a/command-base/app/server-auth-boundary.test.js
+++ b/command-base/app/server-auth-boundary.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const APP_ROOT = __dirname;
+
+function readAppFile(relativePath) {
+  return fs.readFileSync(path.join(APP_ROOT, relativePath), 'utf8');
+}
+
+test('server auth status route never returns the raw API key', () => {
+  const source = readAppFile('server.js');
+  const statusRouteStart = source.indexOf("app.get('/api/auth/status'");
+  assert.notEqual(statusRouteStart, -1, 'auth status route must exist');
+
+  const statusRouteEnd = source.indexOf("app.use('/api'", statusRouteStart);
+  assert.notEqual(statusRouteEnd, -1, 'auth middleware must follow status route');
+  const statusRoute = source.slice(statusRouteStart, statusRouteEnd);
+
+  assert.match(statusRoute, /buildAuthStatus/);
+  assert.doesNotMatch(statusRoute, /key\s*:\s*getApiAuthKey\(\)/);
+  assert.doesNotMatch(statusRoute, /res\.json\(\s*\{\s*authenticated\s*:\s*true\s*,\s*key\s*:/);
+});
+
+test('API middleware does not exempt auth status from authorization checks', () => {
+  const source = readAppFile('server.js');
+  const middlewareStart = source.indexOf("app.use('/api'");
+  assert.notEqual(middlewareStart, -1, 'API middleware must exist');
+
+  const rateLimiterStart = source.indexOf('// -- In-memory rate limiter', middlewareStart);
+  const middleware = source.slice(middlewareStart, rateLimiterStart);
+
+  assert.doesNotMatch(middleware, /req\.path\s*===\s*['"]\/auth\/status['"]/);
+  assert.match(middleware, /isApiAuthenticated/);
+});
+
+test('browser surfaces do not bootstrap by reading a raw auth status key', () => {
+  for (const relativePath of ['public/app.js', 'public/whitepaper.html']) {
+    const source = readAppFile(relativePath);
+    assert.doesNotMatch(source, /\bd\.key\b|\bauthData\.key\b/);
+    assert.doesNotMatch(source, /document\.cookie\s*=\s*['"]cb_auth=.*(?:d\.key|authData\.key)/);
+    assert.doesNotMatch(source, /auto-authenticates via \/api\/auth\/status bootstrap/i);
+  }
+});
+
+test('browser GET helper sends caller-provided API key without requiring a cookie', () => {
+  const source = readAppFile('public/app.js');
+  const helperStart = source.indexOf('async function api(endpoint)');
+  assert.notEqual(helperStart, -1, 'GET helper must exist');
+
+  const helperEnd = source.indexOf('function invalidateCache', helperStart);
+  const helper = source.slice(helperStart, helperEnd);
+
+  assert.match(helper, /opts\.headers/);
+  assert.match(helper, /_cbApiKey/);
+  assert.match(helper, /X-API-Key/);
+});

--- a/command-base/app/server.js
+++ b/command-base/app/server.js
@@ -15,6 +15,10 @@ const https = require('https');
 const { URL } = require('url');
 const crypto = require('crypto');
 const zlib = require('zlib');
+const {
+  buildAuthStatus,
+  isApiAuthenticated,
+} = require('./lib/api-key-auth');
 const app = express();
 
 // Trust the first proxy hop (Cloudflare, nginx, Railway, etc.) so that
@@ -3413,16 +3417,12 @@ function getApiAuthKey() {
   return _apiAuthKey;
 }
 app.get('/api/auth/status', (req, res) => {
-  res.json({ authenticated: true, key: getApiAuthKey() });
+  res.json(buildAuthStatus(req, getApiAuthKey()));
 });
 app.use('/api', (req, res, next) => {
-  // Exempt auth status and whitepaper data (non-sensitive, needed before auth bootstrap)
-  if (req.path === '/auth/status' || req.path.startsWith('/whitepaper/')) return next();
-  const key = getApiAuthKey();
-  const headerKey = req.headers['x-api-key'];
-  const cookieMatch = (req.headers.cookie || '').match(/cb_auth=([^;]+)/);
-  const cookieKey = cookieMatch ? cookieMatch[1] : null;
-  if (headerKey === key || cookieKey === key) return next();
+  // Exempt whitepaper data only; auth status is a route, not a key bootstrap.
+  if (req.path.startsWith('/whitepaper/')) return next();
+  if (isApiAuthenticated(req, getApiAuthKey())) return next();
   res.status(401).json({ error: 'Unauthorized — missing or invalid API key' });
 });
 


### PR DESCRIPTION
## Classification
- Adjacent surface: command-base/app/lib/api-key-auth.js
- Adjacent surface: command-base/app/lib/auth.js
- Adjacent surface: command-base/app/server.js
- Adjacent surface: command-base/app/public/app.js
- Adjacent surface: command-base/app/public/whitepaper.html
- Adjacent surface tests: command-base/app/lib/api-key-auth.test.js, command-base/app/lib/auth.test.js, command-base/app/server-auth-boundary.test.js

## Verified Current Issue
- Confirmed current main exposed the raw API key from unauthenticated /api/auth/status.
- Confirmed current main allowed HMAC token signing with a hardcoded development fallback secret.

## Remediation
- Auth status now reports boolean auth state only and never returns the API key.
- API middleware no longer treats /auth/status as an authorization exemption.
- Header/cookie API-key matching is centralized in a testable helper using constant-time comparison.
- Browser surfaces no longer bootstrap secrets from auth status; they can use caller-provided localStorage key material without requiring a leaked cookie.
- HMAC signing now fails closed unless EXOCHAIN_AUTH_SECRET is explicitly configured and at least 32 bytes.

## Intake Record
- Owner/accountable maintainer: CommandBase adjacent-surface owner.
- Deployment status: adjacent surface; exact deployment status not asserted by this PR.
- Constitutional trust claims: this PR does not add or expand EXOCHAIN constitutional trust claims.
- Core state access: no EXOCHAIN core state, signatures, credentials, governance outcomes, consent records, or provenance records are newly read or written.
- Trust boundary: CommandBase auth remains outside the canonical Rust trust fabric; no core runtime adapter changed.
- Test command and CI gate: node --test 
- Secrets inventory/config: EXOCHAIN_AUTH_SECRET is required for HMAC fallback signing; API auth key remains stored in CommandBase system_settings.
- Rollback/disablement path: revert this adjacent-surface branch or disable CommandBase exposure; core EXOCHAIN runtime is unaffected.

## Verification
- node --test command-base/app/lib/api-key-auth.test.js command-base/app/lib/auth.test.js command-base/app/server-auth-boundary.test.js
- node --test 
- rg exploit-signature search over production command-base JS/HTML returned no matches
- node --check command-base/app/server.js && node --check command-base/app/lib/auth.js && node --check command-base/app/lib/api-key-auth.js && git diff --check