### PR TITLE
Harden demo secret boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,8 @@ jobs:
         run: bash tools/test_repo_truth.sh
       - name: Audit policy documentation truth
         run: bash tools/test_audit_policy_docs.sh
+      - name: Demo secret boundary
+        run: bash tools/test_demo_secret_boundaries.sh
       - name: CR-001 status consistency
         run: bash tools/test_cr001_status.sh
       - name: GAP registry truth

--- a/demo/README.md
+++ b/demo/README.md
@@ -175,7 +175,7 @@ See [docs/guides/ARCHON-INTEGRATION.md](../docs/guides/ARCHON-INTEGRATION.md) fo
 
 | Variable | Description | Default |
 |---|---|---|
-| `DATABASE_URL` | PostgreSQL connection string | `postgres://exochain:exochain@localhost:5432/exochain` |
+| `DATABASE_URL` | PostgreSQL connection string | Required; no default |
 | `PORT` | Service listen port | Varies per service (see table above) |
 | `NODE_ENV` | Runtime environment | `development` |
 

--- a/demo/infra/docker-compose.yml
+++ b/demo/infra/docker-compose.yml
@@ -13,14 +13,14 @@ services:
     image: postgres:16-alpine
     ports: ["5432:5432"]
     environment:
-      POSTGRES_DB: exochain
-      POSTGRES_USER: exochain
-      POSTGRES_PASSWORD: exochain_dev
+      POSTGRES_DB: ${POSTGRES_DB:-exochain}
+      POSTGRES_USER: ${POSTGRES_USER:-exochain}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ./postgres/init:/docker-entrypoint-initdb.d
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U exochain"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-exochain}"]
       interval: 5s
       retries: 10
     networks: [exochain]
@@ -35,7 +35,7 @@ services:
     ports: ["3000:3000"]
     environment:
       PORT: 3000
-      DATABASE_URL: postgres://exochain:exochain_dev@postgres:5432/exochain
+      DATABASE_URL: "postgres://${POSTGRES_USER:-exochain}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-exochain}"
       SERVICE_NAME: gateway-api
     depends_on:
       postgres: { condition: service_healthy }
@@ -51,7 +51,7 @@ services:
     ports: ["3001:3001"]
     environment:
       PORT: 3001
-      DATABASE_URL: postgres://exochain:exochain_dev@postgres:5432/exochain
+      DATABASE_URL: "postgres://${POSTGRES_USER:-exochain}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-exochain}"
       SERVICE_NAME: identity-service
     depends_on:
       postgres: { condition: service_healthy }
@@ -67,7 +67,7 @@ services:
     ports: ["3002:3002"]
     environment:
       PORT: 3002
-      DATABASE_URL: postgres://exochain:exochain_dev@postgres:5432/exochain
+      DATABASE_URL: "postgres://${POSTGRES_USER:-exochain}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-exochain}"
       SERVICE_NAME: consent-service
     depends_on:
       postgres: { condition: service_healthy }
@@ -83,7 +83,7 @@ services:
     ports: ["3003:3003"]
     environment:
       PORT: 3003
-      DATABASE_URL: postgres://exochain:exochain_dev@postgres:5432/exochain
+      DATABASE_URL: "postgres://${POSTGRES_USER:-exochain}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-exochain}"
       SERVICE_NAME: governance-engine
     depends_on:
       postgres: { condition: service_healthy }
@@ -99,7 +99,7 @@ services:
     ports: ["3004:3004"]
     environment:
       PORT: 3004
-      DATABASE_URL: postgres://exochain:exochain_dev@postgres:5432/exochain
+      DATABASE_URL: "postgres://${POSTGRES_USER:-exochain}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-exochain}"
       SERVICE_NAME: decision-forge
     depends_on:
       postgres: { condition: service_healthy }
@@ -115,7 +115,7 @@ services:
     ports: ["3007:3007"]
     environment:
       PORT: 3007
-      DATABASE_URL: postgres://exochain:exochain_dev@postgres:5432/exochain
+      DATABASE_URL: "postgres://${POSTGRES_USER:-exochain}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-exochain}"
       SERVICE_NAME: audit-api
     depends_on:
       postgres: { condition: service_healthy }
@@ -131,7 +131,7 @@ services:
     ports: ["3006:3006"]
     environment:
       PORT: 3006
-      DATABASE_URL: postgres://exochain:exochain_dev@postgres:5432/exochain
+      DATABASE_URL: "postgres://${POSTGRES_USER:-exochain}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-exochain}"
       SERVICE_NAME: provenance-writer
     depends_on:
       postgres: { condition: service_healthy }

--- a/demo/packages/shared/src/index.js
+++ b/demo/packages/shared/src/index.js
@@ -1,13 +1,28 @@
 // @exochain/shared — Database pool + WASM initialization
-import pg from 'pg';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
 
 let pool = null;
 let wasmModule = null;
+let pgModule = null;
+
+function getPg() {
+  if (!pgModule) {
+    pgModule = require('pg');
+  }
+  return pgModule;
+}
 
 export function getPool() {
   if (!pool) {
+    const { DATABASE_URL } = process.env;
+    if (!DATABASE_URL || DATABASE_URL.trim() === '') {
+      throw new Error('DATABASE_URL is required for the ExoChain demo shared database pool');
+    }
+    const pg = getPg();
     pool = new pg.Pool({
-      connectionString: process.env.DATABASE_URL || 'postgres://exochain:exochain_dev@localhost:5432/exochain',
+      connectionString: DATABASE_URL,
     });
   }
   return pool;

--- a/demo/scripts/dev.sh
+++ b/demo/scripts/dev.sh
@@ -6,7 +6,8 @@ set -euo pipefail
 DEMO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$DEMO_DIR"
 
-export DATABASE_URL="${DATABASE_URL:-postgres://exochain:exochain_dev@localhost:5432/exochain}"
+: "${DATABASE_URL:?set DATABASE_URL to a PostgreSQL connection string before running demo/scripts/dev.sh}"
+export DATABASE_URL
 
 echo "═══════════════════════════════════════════════════════════"
 echo "  ExoChain Demo — Starting Services"

--- a/tools/test_demo_secret_boundaries.sh
+++ b/tools/test_demo_secret_boundaries.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+demo_file_list="$(mktemp)"
+trap 'rm -f "$demo_file_list"' EXIT
+
+git -C "$ROOT" ls-files demo \
+  | grep -Ev '^(demo/coverage/|demo/node_modules/)' \
+  | sed "s#^#$ROOT/#" > "$demo_file_list"
+
+if [ ! -s "$demo_file_list" ]; then
+  echo "no tracked demo files found" >&2
+  exit 1
+fi
+
+if xargs grep -En \
+  'exochain_dev|postgres://exochain:exochain|DATABASE_URL:-postgres://|POSTGRES_PASSWORD:[[:space:]]*exochain_dev' \
+  < "$demo_file_list"; then
+  echo "demo secret boundary failed: hardcoded database credentials or DATABASE_URL fallbacks remain" >&2
+  exit 1
+fi
+
+compose="$ROOT/demo/infra/docker-compose.yml"
+if ! grep -Fq 'POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?' "$compose"; then
+  echo "demo secret boundary failed: docker compose must require POSTGRES_PASSWORD from the environment" >&2
+  exit 1
+fi
+
+if grep -Eq 'DATABASE_URL:[[:space:]]+postgres://[^$]' "$compose"; then
+  echo "demo secret boundary failed: docker compose DATABASE_URL must interpolate environment secrets" >&2
+  exit 1
+fi
+
+shared="$ROOT/demo/packages/shared/src/index.js"
+if ! grep -Fq 'DATABASE_URL is required' "$shared"; then
+  echo "demo secret boundary failed: shared pool helper must fail closed when DATABASE_URL is missing" >&2
+  exit 1
+fi
+
+dev_script="$ROOT/demo/scripts/dev.sh"
+if ! grep -Fq '${DATABASE_URL:?set DATABASE_URL' "$dev_script"; then
+  echo "demo secret boundary failed: local dev script must require DATABASE_URL explicitly" >&2
+  exit 1
+fi
+
+echo "demo secret boundary test passed"


### PR DESCRIPTION
## Classification
- Adjacent surface: `demo/infra/docker-compose.yml`
- Adjacent surface: `demo/packages/shared/src/index.js`
- Adjacent surface: `demo/scripts/dev.sh`
- Adjacent surface documentation: `demo/README.md`
- CI guard: `.github/workflows/ci.yml`, `tools/test_demo_secret_boundaries.sh`

## Verified Current Issue
- Re-verified against current `origin/main` (`4ece768db6b049b92843658894699ada5368caac`) before rebasing.
- RED: `rg -n "postgres://|postgresql://|DATABASE_URL|POSTGRES_PASSWORD|POSTGRES_USER|POSTGRES_DB|localhost:5432|exochain" demo/infra/docker-compose.yml demo/packages/shared/src/index.js demo/scripts/dev.sh demo/README.md` found committed demo Postgres credentials and silent `DATABASE_URL` fallbacks on current main.
- RED: `test -x tools/test_demo_secret_boundaries.sh` exited nonzero on current main, so no repo guard existed for this class.
- Excluded demo coverage and node_modules as generated/vendor surfaces; they were not edited.

## Remediation
- Docker Compose now requires `POSTGRES_PASSWORD` from the environment and interpolates it into service `DATABASE_URL` values.
- Shared demo database pool now fails closed when `DATABASE_URL` is missing and loads `pg` only after configuration is validated.
- Local demo dev script now requires `DATABASE_URL` explicitly instead of fabricating a credentialed default.
- Demo README now documents `DATABASE_URL` as required with no default.
- Added CI source guard to prevent hardcoded demo DB credentials and `DATABASE_URL` fallbacks from returning.

## Intake Record
- Owner/accountable maintainer: demo/adjacent-surface owner.
- Deployment status: adjacent demo surface; exact deployment status not asserted by this PR.
- Constitutional trust claims: this PR does not add or expand EXOCHAIN constitutional trust claims.
- Core state access: demo services may connect to their demo Postgres only through caller-supplied `DATABASE_URL`; no EXOCHAIN core Rust runtime path changed.
- Trust boundary: demo remains outside the canonical Rust trust fabric and must not imply constitutional enforcement by proximity.
- Test command and CI gate: `bash tools/test_demo_secret_boundaries.sh`.
- Secrets inventory/config: `POSTGRES_PASSWORD` and `DATABASE_URL` must be supplied by environment/secrets; no committed default credentials.
- Rollback/disablement path: revert this adjacent-surface branch or do not run demo Compose/dev scripts; core EXOCHAIN runtime is unaffected.

## Verification
- `bash tools/test_demo_secret_boundaries.sh`
- `env -u DATABASE_URL node --input-type=module -e "const m = await import('./demo/packages/shared/src/index.js'); try { m.getPool(); throw new Error('getPool unexpectedly accepted missing DATABASE_URL'); } catch (error) { if (!String(error.message).includes('DATABASE_URL is required')) throw error; }"`
- `bash -n tools/test_demo_secret_boundaries.sh demo/scripts/dev.sh`
- `node --check demo/packages/shared/src/index.js`
- `bash tools/test_audit_policy_docs.sh`
- `bash tools/test_repo_truth.sh`
- `git diff --check origin/main...HEAD`
- `if rg -n "postgres://exochain:exochain|postgres://exochain:exochain_dev|DATABASE_URL:-|POSTGRES_PASSWORD:\\s*exochain|POSTGRES_PASSWORD:\\s*exochain_dev|localhost:5432/exochain" demo/infra/docker-compose.yml demo/packages/shared/src/index.js demo/scripts/dev.sh demo/README.md; then exit 1; else echo "no demo source credential fallback bypass matches"; fi`
