### PR TITLE
Make CommandBase autofill deterministic

### DIFF
--- a/command-base/app/server-autofill-determinism.test.js
+++ b/command-base/app/server-autofill-determinism.test.js
@@ -1,0 +1,52 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const serverSource = fs.readFileSync(path.join(__dirname, 'server.js'), 'utf8');
+
+function sourceBetween(startMarker, endMarker) {
+  const start = serverSource.indexOf(startMarker);
+  assert.notEqual(start, -1, `${startMarker} must exist`);
+  const end = serverSource.indexOf(endMarker, start);
+  assert.notEqual(end, -1, `${endMarker} must exist after ${startMarker}`);
+  return serverSource.slice(start, end);
+}
+
+test('project chamber autofill ranks available seeds deterministically', () => {
+  const section = sourceBetween('function autoFillProjectChamber', 'function superviseProjectImprovement');
+
+  assert.doesNotMatch(
+    section,
+    /Math\.random|sort\(\(\)\s*=>\s*Math\.random\(\)\s*-\s*0\.5\)/,
+    'project chamber autofill must not randomly shuffle candidate seeds'
+  );
+  assert.match(
+    section,
+    /rankTemplatesDeterministically/,
+    'project chamber autofill must use the shared deterministic template ordering helper'
+  );
+});
+
+test('brainstorm autofill ranks available templates deterministically', () => {
+  const section = sourceBetween('function autoFillBrainstorm', '// Fill brainstorm on startup');
+
+  assert.doesNotMatch(
+    section,
+    /Math\.random|sort\(\(\)\s*=>\s*Math\.random\(\)\s*-\s*0\.5\)/,
+    'brainstorm autofill must not randomly shuffle candidate templates'
+  );
+  assert.match(
+    section,
+    /rankTemplatesDeterministically/,
+    'brainstorm autofill must use the shared deterministic template ordering helper'
+  );
+});
+
+test('server source has no random-sort autofill shuffles', () => {
+  assert.doesNotMatch(
+    serverSource,
+    /sort\(\(\)\s*=>\s*Math\.random\(\)\s*-\s*0\.5\)/,
+    'CommandBase server must not use random comparator shuffles for deterministic work selection'
+  );
+});

--- a/command-base/app/server.js
+++ b/command-base/app/server.js
@@ -9357,6 +9357,34 @@ const PROJECT_IMPROVEMENT_SEEDS = {
   ]
 };
 
+function compareTemplateText(left, right) {
+  const l = String(left || '').trim().toLowerCase();
+  const r = String(right || '').trim().toLowerCase();
+  if (l < r) return -1;
+  if (l > r) return 1;
+  return 0;
+}
+
+function deterministicTemplateOrder(left, right) {
+  const sourceOrder = left.sourceIndex - right.sourceIndex;
+  if (sourceOrder !== 0) return sourceOrder;
+
+  for (const field of ['category', 'impact', 'effort', 'title', 'tagline', 'description']) {
+    const leftValue = left.template && left.template[field];
+    const rightValue = right.template && right.template[field];
+    const byField = compareTemplateText(leftValue, rightValue);
+    if (byField !== 0) return byField;
+  }
+  return 0;
+}
+
+function rankTemplatesDeterministically(templates) {
+  return templates
+    .map((template, sourceIndex) => ({ template, sourceIndex }))
+    .sort(deterministicTemplateOrder)
+    .map(entry => entry.template);
+}
+
 /**
  * Auto-fill a project-specific improvement chamber.
  */
@@ -9376,8 +9404,7 @@ function autoFillProjectChamber(projectId) {
   // Get seeds for this project
   const seeds = PROJECT_IMPROVEMENT_SEEDS[project.name] || PROJECT_IMPROVEMENT_SEEDS['default'];
   const availableSeeds = seeds.filter(s => !existingTitles.includes(s.title.toLowerCase()));
-  const shuffled = availableSeeds.sort(() => Math.random() - 0.5);
-  const batch = shuffled.slice(0, needed);
+  const batch = rankTemplatesDeterministically(availableSeeds).slice(0, needed);
 
   let inserted = 0;
   for (const s of batch) {
@@ -10556,9 +10583,7 @@ function autoFillBrainstorm() {
   // Find templates not already used
   const available = BRAINSTORM_TEMPLATES.filter(t => !existingTitles.includes(t.title.toLowerCase()));
 
-  // Shuffle and pick what we need
-  const shuffled = available.sort(() => Math.random() - 0.5);
-  const toInsert = shuffled.slice(0, needed);
+  const toInsert = rankTemplatesDeterministically(available).slice(0, needed);
 
   for (const t of toInsert) {
     db.prepare(`INSERT INTO idea_board (title, tagline, description, category, status, generated_by, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?)`)


### PR DESCRIPTION
## Classification

- `command-base/app/server.js` — adjacent surface (CommandBase operational surface, not EXOCHAIN core trust fabric)
- `command-base/app/server-autofill-determinism.test.js` — adjacent surface regression test

## Live Verification Before Remediation

Verified on current `main` that `autoFillProjectChamber` and `autoFillBrainstorm` used `available.sort(() => Math.random() - 0.5)` style random comparator shuffles for work/template selection. This is adjacent-surface nondeterminism, not a core EXOCHAIN vulnerability.

## Remediation

- Added a deterministic ranking helper that preserves curated source order and uses stable text-field tie-breakers.
- Replaced random comparator shuffles in project improvement chamber and brainstorm autofill.
- Added a source regression test proving both autofill paths use deterministic ranking and no random-sort autofill shuffle remains.

## Verification

- `node --test command-base/app/server-autofill-determinism.test.js`
- `node --test $(rg --files command-base/app | rg '\\.test\\.js$')`\n- `node --check command-base/app/server.js`\n- `rg -n "sort\\(\\(\\) => Math\\.random\\(\\) - 0\\.5\\)" command-base/app/server.js command-base/app/server-autofill-determinism.test.js` (no matches)\n- `bash tools/test_repo_truth.sh`\n- `bash tools/test_audit_policy_docs.sh`\n- `git diff --check`\n\n## Adjacent Surface Intake\n\n- Owner/accountable maintainer: CommandBase surface owner required before production use.\n- Deployment status: adjacent operational surface in repo; not treated as canonical EXOCHAIN core.\n- Constitutional trust claims: must not claim EXOCHAIN constitutional enforcement unless a tested runtime adapter invokes EXOCHAIN core.\n- Core state access: this change does not add access to EXOCHAIN core state, signatures, credentials, governance outcomes, consent records, or provenance records.\n- Trust boundary: deterministic UI/workflow autofill only; no core invariant enforcement is delegated to CommandBase.\n- Test command/CI gate: Node test command above plus repo truth guard.\n- Secrets/config: no secret handling changed.\n- Rollback/disablement: revert this commit or disable CommandBase autofill callers if deterministic fill behavior misroutes adjacent workflow items.