### PR TITLE
Harden CommandBase provider key boundary

### DIFF
--- a/command-base/app/provider-key-boundary.test.js
+++ b/command-base/app/provider-key-boundary.test.js
@@ -1,0 +1,80 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const appSource = fs.readFileSync(path.join(__dirname, 'public', 'app.js'), 'utf8');
+const settingsRouteSource = fs.readFileSync(path.join(__dirname, 'routes', 'settings.js'), 'utf8');
+
+function sourceBetween(source, startMarker, endMarker) {
+  const start = source.indexOf(startMarker);
+  assert.notEqual(start, -1, `${startMarker} must exist`);
+  const end = source.indexOf(endMarker, start);
+  assert.notEqual(end, -1, `${endMarker} must exist after ${startMarker}`);
+  return source.slice(start, end);
+}
+
+test('provider cards do not store revealable API key material in DOM attributes', () => {
+  const card = sourceBetween(appSource, 'function renderProviderCard', 'function renderProviderForm');
+  const wiring = sourceBetween(appSource, 'function wireLLMProviderActions', 'function wireProviderFormActions');
+
+  assert.doesNotMatch(
+    card,
+    /data-full-key|provider-key-toggle/,
+    'provider cards must render only the masked key and must not add reveal controls'
+  );
+  assert.doesNotMatch(
+    wiring,
+    /dataset\.fullKey|provider-key-toggle/,
+    'provider action wiring must not reveal API key material from DOM data attributes'
+  );
+});
+
+test('provider edit form never pre-fills masked API keys as replacement secrets', () => {
+  const form = sourceBetween(appSource, 'function renderProviderForm', 'function renderMcpServerCard');
+
+  assert.doesNotMatch(
+    form,
+    /class="pf-api-key" value="' \+ escHtml\(p\.api_key \|\| ''\)/,
+    'edit form must not prefill API key input with the masked API key returned by the API'
+  );
+  assert.match(
+    form,
+    /isEdit \? '' :/,
+    'edit form must leave the API key field blank unless the user supplies a replacement'
+  );
+});
+
+test('provider save payload preserves existing key unless edit supplies replacement', () => {
+  const save = sourceBetween(appSource, 'function wireProviderFormActions', 'function wireLLMAssignmentActions');
+
+  assert.doesNotMatch(
+    save,
+    /api_key: api_key/,
+    'save payload must not always include api_key because edit pages only know a masked value'
+  );
+  assert.match(
+    save,
+    /if \(!existingProvider \|\| api_key\)/,
+    'save payload must include api_key only for create or explicit edit replacement'
+  );
+});
+
+test('provider update route rejects masked API key sentinels from stale clients', () => {
+  const putRoute = sourceBetween(
+    settingsRouteSource,
+    "app.put('/api/llm/providers/:id'",
+    '// DELETE /api/llm/providers/:id'
+  );
+
+  assert.match(
+    settingsRouteSource,
+    /function looksMaskedSecretValue/,
+    'settings route must define a masked-secret sentinel guard'
+  );
+  assert.match(
+    putRoute,
+    /looksMaskedSecretValue\(req\.body\[f\]\)/,
+    'provider update route must reject masked API key values before writing them'
+  );
+});

--- a/command-base/app/public/app.js
+++ b/command-base/app/public/app.js
@@ -10732,9 +10732,7 @@
   }
 
   function renderProviderCard(p) {
-    var maskedKey = p.api_key || '';
-    if (maskedKey.length > 8) maskedKey = maskedKey.slice(0, 4) + '****' + maskedKey.slice(-4);
-    else if (maskedKey.length > 0) maskedKey = '****' + maskedKey.slice(-4);
+    var maskedKey = p.api_key ? maskApiKey(p.api_key) : '';
     var html = '<div class="provider-card" data-provider-id="' + p.id + '">';
     html += '<div class="provider-card-header">';
     html += '<div class="provider-card-title">';
@@ -10756,10 +10754,7 @@
     html += '<div class="provider-detail-row">';
     html += '<span class="provider-detail-label">API Key</span>';
     html += '<span class="provider-detail-value provider-api-key-display">';
-    html += '<code class="provider-masked-key" data-full-key="' + escHtml(p.api_key || '') + '" data-masked="' + escHtml(maskedKey) + '">' + escHtml(maskedKey || 'None') + '</code>';
-    if (p.api_key) {
-      html += ' <button class="provider-key-toggle" title="Show/Hide">Show</button>';
-    }
+    html += '<code class="provider-masked-key" data-masked="' + escHtml(maskedKey) + '">' + escHtml(maskedKey || 'None') + '</code>';
     html += '</span>';
     html += '</div>';
     html += '<div class="provider-detail-row">';
@@ -10783,6 +10778,8 @@
   function renderProviderForm(existingProvider) {
     var p = existingProvider || {};
     var isEdit = !!p.id;
+    var apiKeyValue = isEdit ? '' : (p.api_key || '');
+    var apiKeyPlaceholder = isEdit ? 'Leave blank to keep existing key' : 'sk-...';
     var html = '<div class="provider-form">';
     html += '<div class="provider-form-title">' + (isEdit ? 'Edit Provider' : 'Add New Provider') + '</div>';
     html += '<div class="provider-form-grid">';
@@ -10808,7 +10805,7 @@
     html += '</div>';
     html += '<div class="config-field">';
     html += '<label>API Key</label>';
-    html += '<input type="password" class="pf-api-key" value="' + escHtml(p.api_key || '') + '" placeholder="sk-...">';
+    html += '<input type="password" class="pf-api-key" value="' + escHtml(apiKeyValue) + '" placeholder="' + escHtml(apiKeyPlaceholder) + '">';
     html += '</div>';
     html += '<div class="config-field">';
     html += '<label>Default Model</label>';
@@ -11109,22 +11106,6 @@
         });
       }
 
-      // Show/Hide API key
-      var keyToggle = card.querySelector('.provider-key-toggle');
-      if (keyToggle) {
-        keyToggle.addEventListener('click', function() {
-          var codeEl = card.querySelector('.provider-masked-key');
-          var fullKey = codeEl.dataset.fullKey;
-          var masked = codeEl.dataset.masked;
-          if (keyToggle.textContent === 'Show') {
-            codeEl.textContent = fullKey;
-            keyToggle.textContent = 'Hide';
-          } else {
-            codeEl.textContent = masked;
-            keyToggle.textContent = 'Show';
-          }
-        });
-      }
     });
   }
 
@@ -11174,7 +11155,10 @@
 
         if (!name) { showToast('Provider name is required', 'error'); return; }
 
-        var body = { name: name, type: type, base_url: base_url, api_key: api_key, default_model: default_model, enabled: 1 };
+        var body = { name: name, type: type, base_url: base_url, default_model: default_model, enabled: 1 };
+        if (!existingProvider || api_key) {
+          body.api_key = api_key;
+        }
 
         // Include session fields for perplexity/session_token types
         if (type === 'perplexity' || type === 'session_token') {

--- a/command-base/app/routes/settings.js
+++ b/command-base/app/routes/settings.js
@@ -3,6 +3,50 @@ module.exports = function(app, db, helpers) {
   const { broadcast, localNow, createNotification, authRateLimiter, apiRateLimiter, spawnMemberTerminal } = helpers;
   const stmt = helpers.stmt || ((sql) => db.prepare(sql));
 
+function maskCredential(value) {
+  if (!value) return '****';
+  const raw = String(value);
+  if (raw.length <= 4) return '****';
+  return '****' + raw.slice(-4);
+}
+
+function maskApiKey(key) {
+  if (!key) return null;
+  const raw = String(key);
+  if (raw.length <= 8) return '••••';
+  return '••••' + raw.slice(-8);
+}
+
+function isSensitiveSettingKey(key) {
+  const lower = String(key || '').toLowerCase();
+  return lower === 'webhook_secret'
+    || lower === 'anthropic_api_key'
+    || lower === 'oauth_token'
+    || lower.endsWith('_token')
+    || lower.endsWith('_key')
+    || lower.endsWith('_secret')
+    || lower.endsWith('_password')
+    || lower.endsWith('_passwd')
+    || lower.endsWith('_auth')
+    || lower.endsWith('_sid')
+    || lower.endsWith('_apikey')
+    || lower.startsWith('auth_')
+    || lower.startsWith('secret_')
+    || lower.startsWith('token_')
+    || lower.startsWith('api_key_')
+    || lower.includes('api_key')
+    || lower.includes('apikey')
+    || lower.includes('access_key')
+    || lower.includes('client_secret');
+}
+
+function looksMaskedSecretValue(value) {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  return /[•*]{2,}/.test(trimmed);
+}
+
 // GET /api/model-sources — list all configured model sources with live status
 app.get('/api/model-sources', async (req, res) => {
   try {
@@ -567,6 +611,9 @@ app.post('/api/llm/providers', (req, res) => {
     if (!type || !['claude', 'openai', 'ollama', 'perplexity', 'custom'].includes(type)) {
       return res.status(400).json({ error: 'type must be one of: claude, openai, ollama, perplexity, custom' });
     }
+    if (looksMaskedSecretValue(api_key)) {
+      return res.status(400).json({ error: 'api_key must be an unmasked secret value' });
+    }
     const now = localNow();
     const configStr = JSON.stringify(config || {});
     const result = db.prepare(`
@@ -607,7 +654,15 @@ app.put('/api/llm/providers/:id', (req, res) => {
         if (f === 'type' && !['claude', 'openai', 'ollama', 'perplexity', 'custom'].includes(req.body[f])) {
           return res.status(400).json({ error: 'type must be one of: claude, openai, ollama, perplexity, custom' });
         }
-        if (f === 'config') {
+        if (f === 'api_key') {
+          if (looksMaskedSecretValue(req.body[f])) {
+            return res.status(400).json({
+              error: 'api_key must be omitted to keep the existing key or supplied as a new unmasked secret'
+            });
+          }
+          updates.push('api_key = ?');
+          values.push(req.body[f]);
+        } else if (f === 'config') {
           updates.push('config = ?');
           values.push(JSON.stringify(req.body[f]));
         } else if (f === 'enabled') {


### PR DESCRIPTION
## Classification

- `command-base/app/public/app.js` — adjacent surface (CommandBase browser UI)
- `command-base/app/routes/settings.js` — adjacent surface runtime adapter for CommandBase settings, not EXOCHAIN core
- `command-base/app/provider-key-boundary.test.js` — adjacent surface regression test

## Live Verification Before Remediation

Verified on current `main` that the CommandBase provider UI received masked provider API keys from `/api/llm/providers`, then stored that value in `data-full-key`, pre-filled the edit form with it, and unconditionally submitted `api_key` on update. That could overwrite the stored provider credential with a masked sentinel. This is adjacent-surface credential-boundary hardening, not a core EXOCHAIN trust-fabric vulnerability.

## Remediation

- Provider cards now render only masked key text and no revealable `data-full-key` attribute or show/hide key button.
- Edit forms leave the API key field blank and tell users blank preserves the existing key.
- Save payloads include `api_key` only on create or when an edit supplies a replacement.
- Settings provider create/update routes reject masked key sentinel values from stale clients before database writes.
- Added local masking helpers in the extracted settings route so provider/settings responses fail closed without depending on outer `server.js` function scope.

## Verification

- `node --test command-base/app/provider-key-boundary.test.js`
- `node --test $(rg --files command-base/app | rg '\.test\.js$')`
- `node --check command-base/app/public/app.js`
- `node --check command-base/app/routes/settings.js`
- `rg -n "data-full-key|dataset\.fullKey|provider-key-toggle|api_key: api_key|class=\"pf-api-key\" value=\"' \+ escHtml\(p\.api_key" command-base/app/public/app.js command-base/app/routes/settings.js` (no matches)
- `bash tools/test_repo_truth.sh`
- `bash tools/test_audit_policy_docs.sh`
- `git diff --check`
- `git diff --cached --check`

## Adjacent Surface Intake

- Owner/accountable maintainer: CommandBase surface owner required before production use.
- Deployment status: adjacent operational surface in repo; not treated as canonical EXOCHAIN core.
- Constitutional trust claims: must not claim EXOCHAIN constitutional enforcement unless a tested runtime adapter invokes EXOCHAIN core.
- Core state access: this change does not add EXOCHAIN core state access. It handles CommandBase provider credentials only.
- Trust boundary: browser UI receives masked credentials only; server rejects masked sentinels as writes.
- Test command/CI gate: Node tests above plus repo truth guard.
- Secrets/config: provider API keys remain server-side; browser edit flow must submit a fresh replacement to change them.
- Rollback/disablement: revert this commit or disable CommandBase provider editing if provider credential writes misbehave.
