### PR TITLE
Harden CommandBase upload allowlist

### DIFF
--- a/command-base/app/lib/upload-policy.js
+++ b/command-base/app/lib/upload-policy.js
@@ -1,0 +1,272 @@
+'use strict';
+
+const path = require('path');
+
+const UPLOAD_ALLOWED_EXTENSIONS = new Set([
+  '.c',
+  '.cpp',
+  '.cs',
+  '.css',
+  '.csv',
+  '.gif',
+  '.go',
+  '.h',
+  '.hpp',
+  '.java',
+  '.jpeg',
+  '.jpg',
+  '.js',
+  '.json',
+  '.jsx',
+  '.kt',
+  '.log',
+  '.md',
+  '.markdown',
+  '.mjs',
+  '.pdf',
+  '.png',
+  '.py',
+  '.rb',
+  '.rs',
+  '.sql',
+  '.toml',
+  '.ts',
+  '.tsx',
+  '.tsv',
+  '.txt',
+  '.webp',
+  '.yaml',
+  '.yml',
+  '.zip',
+]);
+
+const UPLOAD_BLOCKED_EXTENSIONS = new Set([
+  '.app',
+  '.apk',
+  '.bash',
+  '.bat',
+  '.cgi',
+  '.cmd',
+  '.com',
+  '.dll',
+  '.dylib',
+  '.exe',
+  '.htm',
+  '.html',
+  '.jar',
+  '.msi',
+  '.php',
+  '.phtml',
+  '.pl',
+  '.ps1',
+  '.scr',
+  '.sh',
+  '.so',
+  '.svg',
+  '.war',
+  '.zsh',
+]);
+
+const UPLOAD_ALLOWED_MIME_TYPES = new Set([
+  'application/json',
+  'application/pdf',
+  'application/zip',
+  'application/x-zip-compressed',
+  'image/gif',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'text/css',
+  'text/csv',
+  'text/markdown',
+  'text/plain',
+  'text/tab-separated-values',
+  'text/x-c',
+  'text/x-c++',
+  'text/x-go',
+  'text/x-java-source',
+  'text/x-markdown',
+  'text/x-python',
+  'text/x-ruby',
+  'text/x-rust',
+]);
+
+const UPLOAD_TEXT_MIME_TYPES = new Set([
+  'application/json',
+  'text/css',
+  'text/csv',
+  'text/markdown',
+  'text/plain',
+  'text/tab-separated-values',
+  'text/x-c',
+  'text/x-c++',
+  'text/x-go',
+  'text/x-java-source',
+  'text/x-markdown',
+  'text/x-python',
+  'text/x-ruby',
+  'text/x-rust',
+]);
+
+const UPLOAD_TEXT_EXTENSIONS = new Set([
+  '.c',
+  '.cpp',
+  '.cs',
+  '.css',
+  '.csv',
+  '.go',
+  '.h',
+  '.hpp',
+  '.java',
+  '.js',
+  '.json',
+  '.jsx',
+  '.kt',
+  '.log',
+  '.md',
+  '.markdown',
+  '.mjs',
+  '.py',
+  '.rb',
+  '.rs',
+  '.sql',
+  '.toml',
+  '.ts',
+  '.tsx',
+  '.tsv',
+  '.txt',
+  '.yaml',
+  '.yml',
+]);
+
+const UPLOAD_IMAGE_EXTENSIONS = new Set(['.gif', '.jpeg', '.jpg', '.png', '.webp']);
+const UPLOAD_IMAGE_MIME_TYPES = new Set(['image/gif', 'image/jpeg', 'image/png', 'image/webp']);
+const UPLOAD_ARCHIVE_MIME_TYPES = new Set(['application/zip', 'application/x-zip-compressed']);
+
+const UPLOAD_BLOCKED_MIME_TYPES = new Set([
+  'application/java-archive',
+  'application/javascript',
+  'application/octet-stream-executable',
+  'application/vnd.microsoft.portable-executable',
+  'application/x-dosexec',
+  'application/x-executable',
+  'application/x-msdownload',
+  'application/x-msdos-program',
+  'application/x-php',
+  'application/x-sh',
+  'application/x-shellscript',
+  'application/xhtml+xml',
+  'image/svg+xml',
+  'text/html',
+  'text/javascript',
+  'text/x-php',
+  'text/x-shellscript',
+]);
+
+function normalizeMimeType(mimetype) {
+  return String(mimetype || '')
+    .split(';', 1)[0]
+    .trim()
+    .toLowerCase();
+}
+
+function sanitizeCommandBaseUploadFilename(originalname) {
+  const basename = path.basename(String(originalname || '')).trim();
+  const sanitized = basename.replace(/[^a-zA-Z0-9._-]/g, '_').replace(/_+/g, '_');
+  return sanitized.replace(/^[._-]+/, '') || 'upload';
+}
+
+function createUnsupportedUploadError(reason) {
+  const err = new Error(`Unsupported upload file type: ${reason}`);
+  err.status = 415;
+  err.code = 'UNSUPPORTED_UPLOAD_TYPE';
+  return err;
+}
+
+function isTextLikeMime(mimetype) {
+  return mimetype.startsWith('text/');
+}
+
+function isMimeAllowedForExtension(extension, mimetype) {
+  if (!mimetype) {
+    return true;
+  }
+
+  if (UPLOAD_TEXT_EXTENSIONS.has(extension)) {
+    return UPLOAD_TEXT_MIME_TYPES.has(mimetype) || isTextLikeMime(mimetype);
+  }
+
+  if (UPLOAD_IMAGE_EXTENSIONS.has(extension)) {
+    return UPLOAD_IMAGE_MIME_TYPES.has(mimetype);
+  }
+
+  if (extension === '.pdf') {
+    return mimetype === 'application/pdf';
+  }
+
+  if (extension === '.zip') {
+    return UPLOAD_ARCHIVE_MIME_TYPES.has(mimetype) || mimetype === 'application/octet-stream';
+  }
+
+  return false;
+}
+
+function isCommandBaseUploadAllowed(file) {
+  const sanitizedName = sanitizeCommandBaseUploadFilename(file && file.originalname);
+  const extension = path.extname(sanitizedName).toLowerCase();
+  const mimetype = normalizeMimeType(file && file.mimetype);
+
+  if (!extension) {
+    return { allowed: false, sanitizedName, reason: 'missing file extension' };
+  }
+
+  if (UPLOAD_BLOCKED_EXTENSIONS.has(extension)) {
+    return { allowed: false, sanitizedName, reason: `blocked extension ${extension}` };
+  }
+
+  if (!UPLOAD_ALLOWED_EXTENSIONS.has(extension)) {
+    return { allowed: false, sanitizedName, reason: `unsupported extension ${extension}` };
+  }
+
+  if (UPLOAD_BLOCKED_MIME_TYPES.has(mimetype)) {
+    return { allowed: false, sanitizedName, reason: `blocked MIME type ${mimetype || 'unknown'}` };
+  }
+
+  if (!mimetype) {
+    return { allowed: true, sanitizedName, reason: 'allowed extension with absent MIME type' };
+  }
+
+  if (isMimeAllowedForExtension(extension, mimetype)) {
+    return { allowed: true, sanitizedName, reason: 'allowed extension and MIME type' };
+  }
+
+  return { allowed: false, sanitizedName, reason: `unsupported MIME type ${mimetype}` };
+}
+
+function commandBaseUploadFileFilter(req, file, cb) {
+  const result = isCommandBaseUploadAllowed(file);
+  if (!result.allowed) {
+    cb(createUnsupportedUploadError(result.reason), false);
+    return;
+  }
+
+  file.originalname = result.sanitizedName;
+  cb(null, true);
+}
+
+module.exports = {
+  UPLOAD_ALLOWED_EXTENSIONS,
+  UPLOAD_ALLOWED_MIME_TYPES,
+  UPLOAD_ARCHIVE_MIME_TYPES,
+  UPLOAD_BLOCKED_EXTENSIONS,
+  UPLOAD_BLOCKED_MIME_TYPES,
+  UPLOAD_IMAGE_EXTENSIONS,
+  UPLOAD_IMAGE_MIME_TYPES,
+  UPLOAD_TEXT_EXTENSIONS,
+  UPLOAD_TEXT_MIME_TYPES,
+  commandBaseUploadFileFilter,
+  createUnsupportedUploadError,
+  isCommandBaseUploadAllowed,
+  isMimeAllowedForExtension,
+  sanitizeCommandBaseUploadFilename,
+};

--- a/command-base/app/lib/upload-policy.test.js
+++ b/command-base/app/lib/upload-policy.test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const {
+  commandBaseUploadFileFilter,
+  isCommandBaseUploadAllowed,
+  sanitizeCommandBaseUploadFilename,
+} = require('./upload-policy');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`ok - ${name}`);
+  } catch (err) {
+    console.error(`not ok - ${name}`);
+    console.error(err.stack || err.message);
+    process.exitCode = 1;
+  }
+}
+
+function file(originalname, mimetype) {
+  return { fieldname: 'files', originalname, mimetype };
+}
+
+test('sanitizes uploaded names to a basename with stable filesystem-safe characters', () => {
+  assert.strictEqual(
+    sanitizeCommandBaseUploadFilename('../../<script>quarterly plan.pdf'),
+    'script_quarterly_plan.pdf'
+  );
+  assert.strictEqual(sanitizeCommandBaseUploadFilename('   '), 'upload');
+  assert.strictEqual(sanitizeCommandBaseUploadFilename('résumé final.md'), 'r_sum_final.md');
+});
+
+test('allows only explicit document, data, source-text, image, and archive upload types', () => {
+  assert.strictEqual(isCommandBaseUploadAllowed(file('notes.md', 'text/markdown')).allowed, true);
+  assert.strictEqual(isCommandBaseUploadAllowed(file('plan.pdf', 'application/pdf')).allowed, true);
+  assert.strictEqual(isCommandBaseUploadAllowed(file('data.json', 'application/json')).allowed, true);
+  assert.strictEqual(isCommandBaseUploadAllowed(file('review.ts', 'text/plain')).allowed, true);
+  assert.strictEqual(isCommandBaseUploadAllowed(file('bundle.zip', 'application/zip')).allowed, true);
+  assert.strictEqual(isCommandBaseUploadAllowed(file('diagram.png', 'image/png')).allowed, true);
+});
+
+test('rejects executable and active browser-rendered upload types', () => {
+  assert.strictEqual(isCommandBaseUploadAllowed(file('installer.exe', 'application/x-msdownload')).allowed, false);
+  assert.strictEqual(isCommandBaseUploadAllowed(file('deploy.sh', 'text/x-shellscript')).allowed, false);
+  assert.strictEqual(isCommandBaseUploadAllowed(file('payload.html', 'text/html')).allowed, false);
+  assert.strictEqual(isCommandBaseUploadAllowed(file('icon.svg', 'image/svg+xml')).allowed, false);
+  assert.strictEqual(isCommandBaseUploadAllowed(file('unknown.bin', 'application/octet-stream')).allowed, false);
+});
+
+test('rejects MIME types that do not match the allowed extension category', () => {
+  assert.strictEqual(isCommandBaseUploadAllowed(file('diagram.png', 'text/plain')).allowed, false);
+  assert.strictEqual(isCommandBaseUploadAllowed(file('bundle.zip', 'text/plain')).allowed, false);
+  assert.strictEqual(isCommandBaseUploadAllowed(file('notes.md', 'image/png')).allowed, false);
+});
+
+test('multer filter normalizes accepted original names and returns 415 for blocked files', () => {
+  const accepted = file('../../review notes.md', 'text/markdown');
+  let acceptedCallback;
+  commandBaseUploadFileFilter({}, accepted, (err, ok) => {
+    acceptedCallback = { err, ok };
+  });
+  assert.deepStrictEqual(acceptedCallback, { err: null, ok: true });
+  assert.strictEqual(accepted.originalname, 'review_notes.md');
+
+  const rejected = file('payload.html', 'text/html');
+  let rejectedCallback;
+  commandBaseUploadFileFilter({}, rejected, (err, ok) => {
+    rejectedCallback = { err, ok };
+  });
+  assert.strictEqual(rejectedCallback.ok, false);
+  assert.strictEqual(rejectedCallback.err.status, 415);
+  assert.match(rejectedCallback.err.message, /Unsupported upload file type/);
+});
+
+test('server wires the upload policy into every multer upload surface', () => {
+  const serverPath = path.join(__dirname, '..', 'server.js');
+  const source = fs.readFileSync(serverPath, 'utf8');
+
+  assert.match(source, /require\('\.\/lib\/upload-policy'\)/);
+  assert.strictEqual((source.match(/fileFilter:\s*commandBaseUploadFileFilter/g) || []).length, 3);
+  assert.strictEqual((source.match(/sanitizeCommandBaseUploadFilename\(file\.originalname\)/g) || []).length, 3);
+  assert.doesNotMatch(source, /`\$\{timestamp\}_\$\{file\.originalname\}`/);
+});
+
+test('browser intake allowlists match the server active-content boundary', () => {
+  const publicPath = path.join(__dirname, '..', 'public', 'app.js');
+  const source = fs.readFileSync(publicPath, 'utf8');
+
+  assert.doesNotMatch(source, /accept="[^"]*\.html/);
+  assert.doesNotMatch(source, /acceptedExts\s*=\s*\[[^\]]*'\.html'/);
+});

--- a/command-base/app/package.json
+++ b/command-base/app/package.json
@@ -5,6 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
+    "test:upload-policy": "node lib/upload-policy.test.js",
     "audit:check": "npm audit --audit-level=high",
     "audit:fix": "npm audit fix --force --audit-level=high",
     "audit:report": "npm audit --json > audit-report.json && echo 'Audit report written to audit-report.json'",

--- a/command-base/app/public/app.js
+++ b/command-base/app/public/app.js
@@ -32459,8 +32459,8 @@
       +     '<div class="intake-drop-icon"><svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V9z"/><polyline points="13 2 13 9 20 9"/></svg></div>'
       +     '<div class="intake-drop-text">Drop files or folders here</div>'
       +     '<div class="intake-drop-subtext">or click to browse</div>'
-      +     '<div class="intake-drop-types">Accepted: .md, .txt, .js, .py, .json, .ts, .css, .html, .yaml, .yml, .toml, .pdf, .zip</div>'
-      +     '<input type="file" id="intake-file-input" multiple style="display:none" accept=".md,.txt,.js,.py,.json,.ts,.css,.html,.yaml,.yml,.toml,.pdf,.zip" />'
+      +     '<div class="intake-drop-types">Accepted: .md, .txt, .js, .jsx, .ts, .tsx, .py, .rs, .go, .json, .csv, .css, .yaml, .yml, .toml, .pdf, .zip, images</div>'
+      +     '<input type="file" id="intake-file-input" multiple style="display:none" accept=".md,.txt,.js,.jsx,.ts,.tsx,.py,.rs,.go,.json,.csv,.css,.yaml,.yml,.toml,.pdf,.zip,.png,.jpg,.jpeg,.gif,.webp" />'
       +   '</div>'
       // Attached files list
       +   '<div class="intake-section" id="intake-attached-section" style="display:none">'
@@ -32482,7 +32482,7 @@
       +       '<button class="intake-btn intake-btn-secondary" id="intake-browse-folder-btn">Browse Folder</button>'
       +       '<button class="intake-btn intake-btn-secondary" id="intake-browse-file-btn">Browse File</button>'
       +       '<input type="file" id="intake-folder-input" webkitdirectory multiple style="display:none" />'
-      +       '<input type="file" id="intake-single-file-input" multiple style="display:none" accept=".md,.txt,.js,.py,.json,.ts,.css,.html,.yaml,.yml,.toml,.pdf,.zip" />'
+      +       '<input type="file" id="intake-single-file-input" multiple style="display:none" accept=".md,.txt,.js,.jsx,.ts,.tsx,.py,.rs,.go,.json,.csv,.css,.yaml,.yml,.toml,.pdf,.zip,.png,.jpg,.jpeg,.gif,.webp" />'
       +     '</div>'
       +   '</div>'
       // Additional context
@@ -32531,7 +32531,7 @@
     });
 
     function processFiles(fileList) {
-      var acceptedExts = ['.md','.txt','.js','.py','.json','.ts','.css','.html','.yaml','.yml','.toml','.pdf','.zip'];
+      var acceptedExts = ['.md','.txt','.js','.jsx','.ts','.tsx','.py','.rs','.go','.json','.csv','.css','.yaml','.yml','.toml','.pdf','.zip','.png','.jpg','.jpeg','.gif','.webp'];
       for (var i = 0; i < fileList.length; i++) {
         var file = fileList[i];
         var ext = '.' + file.name.split('.').pop().toLowerCase();
@@ -32542,7 +32542,7 @@
             intakeFiles.push({ name: f.name, content: ev.target.result, size: f.size });
             renderAttached();
           };
-          if (fext === '.pdf' || fext === '.zip') {
+          if (fext === '.pdf' || fext === '.zip' || ['.png','.jpg','.jpeg','.gif','.webp'].indexOf(fext) !== -1) {
             reader.readAsDataURL(f);
           } else {
             reader.readAsText(f);
@@ -32622,7 +32622,7 @@
       var folderName = files[0].webkitRelativePath ? files[0].webkitRelativePath.split('/')[0] : 'folder';
       var folderEntry = { name: folderName, path: folderName, fileCount: 0, fileContents: [] };
 
-      var acceptedExts = ['.md','.txt','.js','.py','.json','.ts','.css','.html','.yaml','.yml','.toml'];
+      var acceptedExts = ['.md','.txt','.js','.jsx','.ts','.tsx','.py','.rs','.go','.json','.csv','.css','.yaml','.yml','.toml'];
       var pending = 0;
       for (var i = 0; i < files.length && i < 30; i++) {
         var ext = '.' + files[i].name.split('.').pop().toLowerCase();

--- a/command-base/app/server.js
+++ b/command-base/app/server.js
@@ -5,6 +5,10 @@ const Database = require('better-sqlite3');
 const multer = require('multer');
 const path = require('path');
 const fs = require('fs');
+const {
+  commandBaseUploadFileFilter,
+  sanitizeCommandBaseUploadFilename,
+} = require('./lib/upload-policy');
 
 // ── Structured logger — must come before any console.* calls ──
 const logger = require('./logger');
@@ -3631,12 +3635,15 @@ const storage = multer.diskStorage({
     cb(null, INBOX_PATH);
   },
   filename: (req, file, cb) => {
-    // Preserve original filename, prefix with timestamp to avoid collisions
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    cb(null, `${timestamp}_${file.originalname}`);
+    cb(null, `${timestamp}_${sanitizeCommandBaseUploadFilename(file.originalname)}`);
   }
 });
-const upload = multer({ storage, limits: { fileSize: 200 * 1024 * 1024 } }); // 200MB limit for project imports
+const upload = multer({
+  storage,
+  fileFilter: commandBaseUploadFileFilter,
+  limits: { fileSize: 200 * 1024 * 1024 }
+}); // 200MB limit for project imports
 
 // ── Context Management System Functions ──────────────────────
 
@@ -5467,11 +5474,12 @@ const taskAttachmentStorage = multer.diskStorage({
   },
   filename: (req, file, cb) => {
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    cb(null, `${timestamp}_${file.originalname}`);
+    cb(null, `${timestamp}_${sanitizeCommandBaseUploadFilename(file.originalname)}`);
   }
 });
 const uploadTaskAttachment = multer({
   storage: taskAttachmentStorage,
+  fileFilter: commandBaseUploadFileFilter,
   limits: { fileSize: 50 * 1024 * 1024 }
 });
 
@@ -5998,12 +6006,12 @@ const commandUploadStorage = multer.diskStorage({
   },
   filename: (req, file, cb) => {
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    const safeName = file.originalname.replace(/[^a-zA-Z0-9._-]/g, '_');
-    cb(null, `${timestamp}_${safeName}`);
+    cb(null, `${timestamp}_${sanitizeCommandBaseUploadFilename(file.originalname)}`);
   }
 });
 const uploadCommandFiles = multer({
   storage: commandUploadStorage,
+  fileFilter: commandBaseUploadFileFilter,
   limits: { fileSize: 50 * 1024 * 1024, files: 10 }
 });
 


### PR DESCRIPTION
Classification: Adjacent surface. Touched paths are CommandBase app code and tests only; no EXOCHAIN core, runtime adapter, governance, CI, or deployment contracts changed.

External finding verified: F-115 on current main still had three multer upload surfaces without a shared fileFilter and two storage handlers persisted unsanitized original filenames. This PR adds one shared CommandBase upload policy, wires it into inbox/mission/board-room uploads, task attachments, and command uploads, sanitizes stored filenames consistently, and aligns the browser intake allowlist with the server boundary.

Policy boundary:
- allows explicit document, data, source-text, image, and zip archive types only
- rejects executable, shell, active HTML/SVG/browser-rendered, unknown binary, and mismatched extension/MIME pairs
- returns 415 Unsupported Media Type through existing Express error handling

Validation:
- npm run test:upload-policy
- node --check command-base/app/server.js
- node --check command-base/app/lib/upload-policy.js
- node --check command-base/app/public/app.js
- npm run audit:check
- bash tools/test_repo_truth.sh
- git diff --check