### PR TITLE
Harden CommandBase supply-chain guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,8 @@ jobs:
         run: bash tools/test_github_actions_pinned.sh
       - name: CI tool installer supply-chain hardening
         run: bash tools/test_ci_supply_chain_hardening.sh
+      - name: CommandBase adjacent supply-chain hardening
+        run: bash tools/test_commandbase_supply_chain.sh
       - name: Repo truth and public claims
         run: bash tools/test_repo_truth.sh
       - name: Audit policy documentation truth

--- a/command-base/app/package-lock.json
+++ b/command-base/app/package-lock.json
@@ -14,7 +14,7 @@
         "better-sqlite3": "^12.8.0",
         "compression": "^1.8.1",
         "express": "^4.21.0",
-        "multer": "^1.4.5-lts.1",
+        "multer": "2.1.1",
         "ws": "^8.20.0"
       }
     },
@@ -331,48 +331,18 @@
       }
     },
     "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
       "engines": [
-        "node >= 0.8"
+        "node >= 6.0"
       ],
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
+        "readable-stream": "^3.0.2",
         "typedarray": "^0.0.6"
-      }
-    },
-    "node_modules/concat-stream/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/concat-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/concat-stream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/content-disposition": {
@@ -409,12 +379,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
-      "license": "MIT"
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -917,12 +881,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1013,18 +971,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -1038,22 +984,22 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "1.4.5-lts.2",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.2.tgz",
-      "integrity": "sha512-VzGiVigcG9zUAoCNU+xShztrlr1auZOlurXynNvO9GiWD1/mTBbUljOKY+qMeazBqXgRnjzeEgJI/wyjJUHg9A==",
-      "deprecated": "Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
-        "busboy": "^1.0.0",
-        "concat-stream": "^1.5.2",
-        "mkdirp": "^0.5.4",
-        "object-assign": "^4.1.1",
-        "type-is": "^1.6.4",
-        "xtend": "^4.0.0"
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/napi-build-utils": {
@@ -1121,15 +1067,6 @@
         "encoding": {
           "optional": true
         }
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -1215,12 +1152,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -1717,15 +1648,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
       }
     }
   }

--- a/command-base/app/package.json
+++ b/command-base/app/package.json
@@ -9,7 +9,7 @@
     "audit:fix": "npm audit fix --force --audit-level=high",
     "audit:report": "npm audit --json > audit-report.json && echo 'Audit report written to audit-report.json'",
     "audit:moderate": "npm audit --audit-level=moderate",
-    "preinstall": "npm audit --audit-level=critical || true"
+    "preinstall": "npm audit --audit-level=critical"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
@@ -17,7 +17,7 @@
     "better-sqlite3": "^12.8.0",
     "compression": "^1.8.1",
     "express": "^4.21.0",
-    "multer": "^1.4.5-lts.1",
+    "multer": "2.1.1",
     "ws": "^8.20.0"
   }
 }

--- a/tools/test_commandbase_supply_chain.sh
+++ b/tools/test_commandbase_supply_chain.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+fail() {
+  printf 'commandbase supply-chain test failed: %s\n' "$1" >&2
+  exit 1
+}
+
+manifest="command-base/app/package.json"
+lockfile="command-base/app/package-lock.json"
+
+[[ -f "$manifest" ]] || fail "$manifest is missing"
+[[ -f "$lockfile" ]] || fail "$lockfile is missing"
+
+node <<'NODE'
+const fs = require('fs');
+
+const fail = (message) => {
+  console.error(`commandbase supply-chain test failed: ${message}`);
+  process.exit(1);
+};
+
+const pkg = JSON.parse(fs.readFileSync('command-base/app/package.json', 'utf8'));
+const lock = JSON.parse(fs.readFileSync('command-base/app/package-lock.json', 'utf8'));
+
+const scripts = pkg.scripts || {};
+const preinstall = scripts.preinstall || '';
+
+if (scripts['audit:check'] !== 'npm audit --audit-level=high') {
+  fail('command-base/app must keep a high-severity npm audit check');
+}
+
+if (preinstall && /(^|[;&|])\s*true\b|\|\|/.test(preinstall)) {
+  fail('preinstall must not suppress npm audit failures with || true or a true fallback');
+}
+
+if (preinstall && preinstall !== 'npm audit --audit-level=critical') {
+  fail('preinstall must fail closed with npm audit --audit-level=critical when present');
+}
+
+const dependencies = pkg.dependencies || {};
+if (dependencies.multer !== '2.1.1') {
+  fail(`multer must be exactly pinned to 2.1.1; found ${dependencies.multer || '<missing>'}`);
+}
+
+const rootPackage = lock.packages && lock.packages[''];
+if (!rootPackage || !rootPackage.dependencies || rootPackage.dependencies.multer !== '2.1.1') {
+  fail('package-lock root dependencies must pin multer to 2.1.1');
+}
+
+const lockedMulter = lock.packages && lock.packages['node_modules/multer'];
+if (!lockedMulter || lockedMulter.version !== '2.1.1') {
+  fail(`package-lock must resolve node_modules/multer to 2.1.1; found ${lockedMulter ? lockedMulter.version : '<missing>'}`);
+}
+NODE
+
+printf 'commandbase supply-chain test passed\n'


### PR DESCRIPTION
## Summary
- Classifies this as adjacent-surface hardening for `command-base/app`, not EXOCHAIN core.
- Removes the suppressed critical audit preinstall path and pins CommandBase `multer` to exact `2.1.1`.
- Adds a CI guard proving CommandBase keeps fail-closed audit behavior and an exact 2.x upload dependency lock.

## Classification
- Adjacent surface: `command-base/app/package.json`, `command-base/app/package-lock.json`
- CI/source guard: `.github/workflows/ci.yml`, `tools/test_commandbase_supply_chain.sh`
- EXOCHAIN core Rust crates: not changed
- Imported evidence: not changed

## Reproduction / RED
- `bash tools/test_commandbase_supply_chain.sh` failed before the package edit with: `preinstall must not suppress npm audit failures with || true or a true fallback`

## Test Plan
- `bash tools/test_commandbase_supply_chain.sh`
- `npm ci --ignore-scripts` from `command-base/app`
- `npm run preinstall` from `command-base/app`
- `npm audit --audit-level=high` from `command-base/app`
- `node command-base/app/services/governance.test.js`
- `node command-base/app/services/cqi-orchestrator.test.js`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_github_actions_pinned.sh`
- `bash tools/test_ci_supply_chain_hardening.sh`
- `bash tools/test_audit_policy_docs.sh`
- `git diff --check`

## Bypass Search
- `rg -n "npm audit[^\\n]*(\\|\\||true)|preinstall[^\\n]*true|1\\.4\\.5-lts|multer\\s*[\\\"']?\\s*[:=]\\s*[\\\"']\\^?1\\." --glob '!node_modules/**' --glob '!docs.zip' --glob '!docs/superpowers/**' command-base tools .github`
- Only the new guard's failure text matched.