### PR TITLE
Wire agent workflow guards into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,10 @@ jobs:
         run: bash tools/test_deployment_readiness_probes.sh
       - name: Docker production database feature contract
         run: bash tools/test_docker_production_db_feature.sh
+      - name: Agent prompt boundary contract
+        run: bash tools/test_agent_prompt_boundaries.sh
+      - name: Agent workflow loop-bound contract
+        run: bash tools/test_agent_workflow_bounds.sh
       - name: Core fuzz target compile contract
         run: bash tools/test_core_fuzz_targets.sh
 

--- a/tools/test_agent_workflow_bounds.sh
+++ b/tools/test_agent_workflow_bounds.sh
@@ -56,4 +56,8 @@ for workflow in .archon/workflows/*.yaml; do
   fi
 done
 
+require_file ".github/workflows/ci.yml"
+require_pattern ".github/workflows/ci.yml" 'bash tools/test_agent_prompt_boundaries\.sh' "agent prompt boundary CI gate"
+require_pattern ".github/workflows/ci.yml" 'bash tools/test_agent_workflow_bounds\.sh' "agent workflow bound CI gate"
+
 printf 'agent workflow bound test passed\n'


### PR DESCRIPTION
## Summary
- Wires the agent prompt-boundary and workflow-loop-bound guard scripts into the constitutional CI so remediation workflow rules are enforced on every PR.
- Extends `tools/test_agent_workflow_bounds.sh` so it proves CI continues invoking both agent-rule guards.
- No Rust runtime behavior changes.

## Classification
- `.github/workflows/ci.yml`: EXOCHAIN core CI/governance guard.
- `tools/test_agent_workflow_bounds.sh`: EXOCHAIN core workflow guard for bounded agent remediation loops.

## External Finding Validation
- Rechecked against current `origin/main` `5728fe7bb5d3d9e4a73f87aa43207d8624dd80e0` on May 9, 2026.
- RED evidence on current main: `git show origin/main:.github/workflows/ci.yml | rg -n 'test_agent_prompt_boundaries|test_agent_workflow_bounds'` returned no matches.
- RED evidence on current main: `git show origin/main:tools/test_agent_workflow_bounds.sh | rg -n 'test_agent_prompt_boundaries|test_agent_workflow_bounds|ci.yml'` returned no matches.
- The issue is CI enforcement coverage for trusted agent workflow rules, not a Rust runtime behavior change.

## TDD / Reproduction
- RED: current main lacks a CI call to `bash tools/test_agent_prompt_boundaries.sh`.
- RED: current main lacks a CI call to `bash tools/test_agent_workflow_bounds.sh` and the workflow-bound guard does not self-check those calls.
- GREEN: the branch adds both CI steps and extends the workflow-bound guard to fail closed if either CI invocation is removed.

## Validation
- `bash tools/test_agent_prompt_boundaries.sh`
- `bash tools/test_agent_workflow_bounds.sh`
- `bash tools/test_github_actions_pinned.sh`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_ci_supply_chain_hardening.sh`
- `bash tools/test_security_critical_dependencies_pinned.sh`
- `bash tools/test_audit_policy_docs.sh`
- `bash tools/test_deployment_readiness_probes.sh`
- `bash tools/test_docker_production_db_feature.sh`
- `bash tools/test_core_fuzz_targets.sh`
- `cargo +nightly fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `git grep -nE '^(<<<<<<<|=======|>>>>>>>)( |$)' -- ':!docs/superpowers/**'` returned no matches
- `env -u DATABASE_URL cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `env -u DATABASE_URL cargo build --workspace --release`
- `env -u DATABASE_URL cargo test --workspace --release`
- GitHub CI: all 46 checks green on #358 before merge
