### PR TITLE
ci: deny panic-prone clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,8 +111,8 @@ float_arithmetic = "deny"
 float_cmp = "deny"
 float_cmp_const = "deny"
 as_conversions = "warn"
-unwrap_used = "warn"
-expect_used = "warn"
+unwrap_used = "deny"
+expect_used = "deny"
 
 [profile.release]
 lto = true

--- a/tools/test_repo_truth.sh
+++ b/tools/test_repo_truth.sh
@@ -83,6 +83,11 @@ if grep -nE 'cargo clippy --workspace --(lib|bins|tests|benches)' .github/workfl
   fail "CI clippy gate must not split target classes; use --all-targets"
 fi
 
+grep -F 'unwrap_used = "deny"' Cargo.toml >/dev/null \
+  || fail "workspace must deny clippy::unwrap_used instead of warning"
+grep -F 'expect_used = "deny"' Cargo.toml >/dev/null \
+  || fail "workspace must deny clippy::expect_used instead of warning"
+
 test_mode=$(jq -r '.tests.mode' "$json_file")
 [ "$test_mode" = "skipped" ] || fail "--skip-tests should report tests.mode=skipped, got $test_mode"
 


### PR DESCRIPTION
## Classification
- EXOCHAIN core / CI policy: `Cargo.toml`, `tools/test_repo_truth.sh`.
- No adjacent surfaces, imported evidence files, third-party/vendor, deployment, or runtime adapter paths changed.

## Current-main validation
External lint-policy findings were treated as hypotheses and reproved against current `origin/main` (`fd4d137fc41637325bd9fe803fc8a42ba9052f86`) before keeping the branch fix.
- Current `origin/main` still has `unwrap_used = "warn"` and `expect_used = "warn"` in `[workspace.lints.clippy]`.
- The branch source guard proves the issue by failing when those lints are warning-only and passing only once they are deny-level.

## Remediation
- Tightens workspace `clippy::unwrap_used` and `clippy::expect_used` from `warn` to `deny`.
- Adds a fast repo-truth guard so this policy cannot silently regress back to warning-only.

## Verification
- `bash tools/test_repo_truth.sh`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `env -u DATABASE_URL cargo test --workspace`
- `cargo +nightly fmt --all -- --check`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `git diff --check origin/main...HEAD`