### PR TITLE
fix(wasm): align package license metadata

### DIFF
--- a/demo/packages/exochain-wasm/package.json
+++ b/demo/packages/exochain-wasm/package.json
@@ -4,7 +4,7 @@
   "description": "ExoChain governance engine — WebAssembly bindings for Node.js",
   "main": "index.js",
   "types": "wasm/exochain_wasm.d.ts",
-  "license": "AGPL-3.0-or-later",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/exochain/exochain"

--- a/tools/test_repo_truth.sh
+++ b/tools/test_repo_truth.sh
@@ -77,6 +77,21 @@ expected_gates=$(grep -E 'name: "Gate [0-9]+' .github/workflows/ci.yml | sed -E 
 actual_gates=$(jq '.ci_gates.numbered' "$json_file")
 [ "$actual_gates" = "$expected_gates" ] || fail "CI gate count $actual_gates != $expected_gates"
 
+workspace_license=$(awk -F '"' '/^license =/ { print $2; exit }' Cargo.toml)
+[ "$workspace_license" = "Apache-2.0" ] || fail "workspace license must remain Apache-2.0, got ${workspace_license:-<missing>}"
+
+check_package_license() {
+  local package_file="$1"
+  local package_license
+  package_license=$(jq -r '.license // "<missing>"' "$package_file")
+  [ "$package_license" = "$workspace_license" ] \
+    || fail "$package_file license must match workspace license $workspace_license, got $package_license"
+}
+
+check_package_license packages/exochain-sdk/package.json
+check_package_license packages/exochain-wasm/wasm/package.json
+check_package_license demo/packages/exochain-wasm/package.json
+
 grep -F 'cargo clippy --workspace --all-targets -- -D warnings' .github/workflows/ci.yml >/dev/null \
   || fail "CI clippy gate must cover all workspace targets"
 if grep -nE 'cargo clippy --workspace --(lib|bins|tests|benches)' .github/workflows/ci.yml; then


### PR DESCRIPTION
## Summary
- Remediates F-120 as a core runtime adapter metadata mismatch: `demo/packages/exochain-wasm/package.json` now matches the workspace Apache-2.0 license.
- Adds a repo-truth guard proving EXOCHAIN-owned SDK/WASM package manifests continue to match the workspace license.

## Classification
- `demo/packages/exochain-wasm/package.json`: Core runtime adapter metadata for the EXOCHAIN WASM package shim.
- `tools/test_repo_truth.sh`: EXOCHAIN core CI/repo-hygiene guard.

## External Finding Validation
- Re-verified against current `origin/main` (`4ece768db6b049b92843658894699ada5368caac`) before rebasing: `demo/packages/exochain-wasm/package.json` declared `AGPL-3.0-or-later`, while `packages/exochain-wasm/wasm/package.json` and `packages/exochain-sdk/package.json` declared `Apache-2.0`.
- RED on current main: `test "$(jq -r '.license' demo/packages/exochain-wasm/package.json)" = "$(jq -r '.license' packages/exochain-wasm/wasm/package.json)"` exited nonzero.
- Current main also lacked this repo-truth guard; `bash tools/test_repo_truth.sh` still passed while the mismatch existed.
- Treated the external report as a hypothesis and changed only the owned package metadata boundary that still reproduced.

## TDD Evidence
- RED from original branch work: after adding the guard and before changing the manifest, `bash tools/test_repo_truth.sh` failed with `demo/packages/exochain-wasm/package.json license must match workspace license Apache-2.0, got AGPL-3.0-or-later`.
- GREEN after rebasing onto current main: the same guard passed after the manifest correction.

## Verification
- `bash tools/test_repo_truth.sh`
- `jq -r '.name + "\\t" + .license' demo/packages/exochain-wasm/package.json packages/exochain-wasm/wasm/package.json packages/exochain-sdk/package.json`
- `git diff --check origin/main...HEAD`
- `cargo +nightly fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/bobstewart/.config/superpowers/worktrees/exochain/workspace-dependency-exact-pins-20260506/target cargo test -p exochain-wasm`
- `CARGO_TARGET_DIR=/Users/bobstewart/.config/superpowers/worktrees/exochain/workspace-dependency-exact-pins-20260506/target cargo clippy -p exochain-wasm --all-targets -- -D warnings`

## Core Behavior
- No Rust source behavior changed.
- This PR hardens metadata consistency for downstream EXOCHAIN WASM/SDK distributions.
