### PR TITLE
ci: exact-pin workspace dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
       - uses: EmbarkStudios/cargo-deny-action@5bb39ff5d5a0e94dc9e2dc94eced0c6129743a57
         with:
           command: check
-      - name: Security-critical dependency pin guard
+      - name: Workspace dependency exact pin guard
         run: bash tools/test_security_critical_dependencies_pinned.sh
 
   # -----------------------------------------------------------------------

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ ciborium = "=0.2.2"          # CBOR — canonical, deterministic
 
 # Cryptography
 blake3 = "=1.8.2"
-bs58 = "0.5"
+bs58 = "=0.5.1"
 ed25519-dalek = { version = "=2.2.0", features = ["serde", "rand_core"] }
 x25519-dalek = { version = "=2.0.1", features = ["serde", "static_secrets"] }
 sha2 = "=0.10.9"
@@ -53,53 +53,53 @@ zeroize = { version = "=1.8.2", features = ["derive"] }
 ml-dsa = { version = "=0.1.0-rc.7", features = ["zeroize"] }
 
 # Deterministic data structures
-indexmap = { version = "2", features = ["serde"] }
+indexmap = { version = "=2.12.1", features = ["serde"] }
 
 # Async runtime (deterministic task ordering where possible)
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "=1.50.0", features = ["full"] }
 
 # HTTP server
-axum = { version = "0.7", features = ["json", "macros"] }
-axum-server = { version = "0.8", default-features = false }
-rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
-tower = { version = "0.4", features = ["util", "limit"] }
-tower-http = { version = "0.5", features = ["trace", "cors"] }
+axum = { version = "=0.7.9", features = ["json", "macros"] }
+axum-server = { version = "=0.8.0", default-features = false }
+rustls = { version = "=0.23.37", default-features = false, features = ["ring", "std", "tls12"] }
+tower = { version = "=0.4.13", features = ["util", "limit"] }
+tower-http = { version = "=0.5.2", features = ["trace", "cors"] }
 
 # Database
-sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "uuid", "json", "macros", "migrate"] }
+sqlx = { version = "=0.8.6", features = ["runtime-tokio-rustls", "postgres", "uuid", "json", "macros", "migrate"] }
 
 # Encoding
-hex = "0.4"
-percent-encoding = "2"
+hex = "=0.4.3"
+percent-encoding = "=2.3.2"
 
 # Async trait (used by DagStore)
-async-trait = "0.1"
+async-trait = "=0.1.89"
 
 # Error handling
-thiserror = "2"
-anyhow = "1"
+thiserror = "=2.0.17"
+anyhow = "=1.0.100"
 
 # Logging / tracing
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+tracing = "=0.1.43"
+tracing-subscriber = { version = "=0.3.23", features = ["env-filter", "json"] }
 
 # GraphQL (exo-gateway API layer)
 # Pinned to =7.0.17 — MSRV 1.86; 7.0.18+ bumped MSRV to 1.89; axum 0.7 compatible
 async-graphql = { version = "=7.0.17", features = ["tokio"] }
 async-graphql-axum = "=7.0.17"
-async-stream = "0.3"
+async-stream = "=0.3.6"
 
 # Time (no std::time — use HLC only)
-chrono = { version = "0.4", default-features = false, features = ["serde", "wasmbind", "clock"] }
-getrandom = { version = "0.2", features = ["js"] }
+chrono = { version = "=0.4.44", default-features = false, features = ["serde", "wasmbind", "clock"] }
+getrandom = { version = "=0.2.16", features = ["js"] }
 
 # UUID for correlation IDs
-uuid = { version = "1", features = ["v4", "serde", "js"] }
+uuid = { version = "=1.22.0", features = ["v4", "serde", "js"] }
 
 # Testing
-proptest = "1"
-criterion = { version = "0.5", features = ["html_reports"] }
-tokio-test = "0.4"
+proptest = "=1.9.0"
+criterion = { version = "=0.5.1", features = ["html_reports"] }
+tokio-test = "=0.4.5"
 
 [workspace.lints.rust]
 # DETERMINISM ENFORCEMENT — Constitutional requirement

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -111,9 +111,9 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -404,7 +404,7 @@ dependencies = [
  "chrono",
  "ciborium",
  "ed25519-dalek",
- "getrandom 0.2.17",
+ "getrandom 0.2.16",
  "indexmap",
  "js-sys",
  "ml-dsa",
@@ -456,7 +456,7 @@ dependencies = [
  "chacha20poly1305",
  "ciborium",
  "exo-core",
- "getrandom 0.2.17",
+ "getrandom 0.2.16",
  "hkdf",
  "serde",
  "sha2",
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -577,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -647,12 +647,12 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -684,9 +684,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -899,7 +899,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.17",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -1069,18 +1069,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1132,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -1174,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1187,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1197,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1210,9 +1210,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]

--- a/tools/test_security_critical_dependencies_pinned.sh
+++ b/tools/test_security_critical_dependencies_pinned.sh
@@ -5,6 +5,26 @@ cd "$(dirname "$0")/.."
 
 manifest="Cargo.toml"
 
+python3 - <<'PY'
+import sys
+import tomllib
+
+with open("Cargo.toml", "rb") as manifest:
+    dependencies = tomllib.load(manifest)["workspace"]["dependencies"]
+
+unpinned = []
+for name, spec in sorted(dependencies.items()):
+    version = spec if isinstance(spec, str) else spec.get("version")
+    if version and not version.startswith("="):
+        unpinned.append(f"{name} ({version})")
+
+if unpinned:
+    print("workspace dependencies must be exactly pinned:", file=sys.stderr)
+    for dependency in unpinned:
+        print(f"  - {dependency}", file=sys.stderr)
+    sys.exit(1)
+PY
+
 require_exact_pin() {
   local crate="$1"
   local version="$2"
@@ -33,4 +53,4 @@ require_exact_pin "rand" "0.8.6"
 require_exact_pin "zeroize" "1.8.2"
 require_exact_pin "ml-dsa" "0.1.0-rc.7"
 
-echo "security-critical dependency pin test passed"
+echo "workspace dependency exact pin test passed"


### PR DESCRIPTION
## Classification
- EXOCHAIN core / CI supply-chain hardening: `Cargo.toml`, `fuzz/Cargo.lock`, `.github/workflows/ci.yml`, `tools/test_security_critical_dependencies_pinned.sh`.
- No adjacent surface, imported evidence, or third-party source was modified.

## Current-main verification
- Revalidated against current `origin/main` `4c0144ad861d541f978ce969a423524c75544f66` on May 9, 2026.
- The reported concern remains live on current main: workspace dependency declarations still use broad ranges such as `tokio = "1"`, `axum = "0.7"`, `tower = "0.4"`, `sqlx = "0.8"`, `anyhow = "1"`, and related runtime crates.
- Current main's guard still checks only a narrow critical set, so it does not fail closed on broad workspace dependency ranges.

## Remediation
- Exact-pin all workspace dependency declarations so core/runtime dependency resolution is reviewable and deterministic under lockfiles.
- Pin the CI dependency guard name to its expanded workspace exact-pin scope.
- Expand `tools/test_security_critical_dependencies_pinned.sh` so it rejects any workspace dependency version that is not exact-pinned.
- Synchronize `fuzz/Cargo.lock` so fuzz-target validation remains compatible with `--locked` after exact pinning.

## Validation
- `bash tools/test_security_critical_dependencies_pinned.sh`
- `bash tools/test_github_actions_pinned.sh`
- `bash tools/test_ci_supply_chain_hardening.sh`
- `bash tools/test_core_fuzz_targets.sh`
- `bash tools/test_audit_policy_docs.sh`
- `bash tools/test_agent_workflow_bounds.sh`
- `bash tools/test_agent_prompt_boundaries.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_repo_truth.sh`
- `cargo metadata --locked --format-version 1`
- `cargo +nightly fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- conflict marker scan over tracked files, excluding `docs/superpowers/**` evidence/plans, returned no matches
- `cargo audit --deny unsound --deny unmaintained`
- `cargo deny check` (passed with existing duplicate-version warnings only)
- `env -u DATABASE_URL cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`

Head after validation: `a70c143de67c0d2e6626c458db3e838f71731213`
