### PR TITLE
ci: make coverage scope explicit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@
 # Constitutional requirements enforced:
 #   - Determinism: no floats, no HashMap, canonical serialization
 #   - Clippy float_arithmetic = deny (workspace lint)
-#   - 90%+ line coverage
+#   - Scoped 90%+ line coverage with explicit runtime-adapter exclusions
 #   - Dependency audit gates with documented advisory exceptions
 #   - License compliance (Apache-2.0; no copyleft contamination)
 
@@ -52,14 +52,16 @@ jobs:
         run: cargo test --workspace --release
 
   # -----------------------------------------------------------------------
-  # Gate 3: Coverage (90%+ line coverage required)
+  # Gate 3: Coverage (scoped 90%+ line coverage required)
   # -----------------------------------------------------------------------
   coverage:
-    name: "Gate 3 — Coverage (>= 90%)"
+    name: "Gate 3 — Coverage (scoped >= 90%)"
     runs-on: ubuntu-latest
     needs: build
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Coverage policy guard
+        run: bash tools/test_coverage_policy.sh
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Install cargo-tarpaulin

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is supported by design but not yet production-hardened
 
-- **90% coverage threshold** — configured in CI via cargo-tarpaulin; not independently verified outside CI
+- **Scoped 90% coverage threshold** — configured in CI via cargo-tarpaulin and `tarpaulin.toml`; not independently verified outside CI
 - **exo-gateway binary** — operational HTTP server with 28 endpoints (REST, GraphQL, health probes); production hardening ongoing
 - **GraphQL API** — types and schema stubs exist in `exo-api`; async runtime integration pending
 - **exo-dag benchmark** — disabled; needs rewrite against current API

--- a/docs/guides/GETTING-STARTED.md
+++ b/docs/guides/GETTING-STARTED.md
@@ -78,7 +78,7 @@ That's it — you have a constitutional node running with 40 MCP tools, 6 resour
 | Tool | Minimum | Purpose |
 |---|---|---|
 | **Rust** | 1.85+ (edition 2024) | Core workspace |
-| **cargo-tarpaulin** | latest | Coverage (CI requires >=90%) |
+| **cargo-tarpaulin** | latest | Coverage (CI requires scoped >=90%) |
 | **cargo-deny** | latest | License + advisory + source governance |
 | **cargo-audit** | latest | Known-vulnerability scanning |
 | **Node 20+** *(optional)* | | TypeScript SDK |
@@ -118,7 +118,7 @@ cargo test -p exo-gatekeeper
 # Lint (zero warnings — CI denies)
 cargo clippy --workspace --all-targets -- -D warnings
 
-# Coverage (HTML report)
+# Coverage (HTML report; local default uses tarpaulin.toml exclusions)
 cargo tarpaulin --workspace --out html
 open tarpaulin-report.html
 ```

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -1,11 +1,15 @@
 # Tarpaulin coverage configuration
 #
-# Excludes files that are structurally untestable by cargo-tarpaulin:
+# This is a scoped coverage gate, not a whole-workspace coverage claim.
+#
+# Excludes files that are structurally untestable by the default cargo-tarpaulin
+# unit-test gate without credentials, filesystem fixtures, a live database,
+# a live P2P network, or feature-gated bridge/runtime coverage:
 #   - Binary entry points (main.rs) — bootstrapping code with no logic to unit-test
 #   - External-service integrations requiring credentials at runtime (Telegram)
-#   - PostgreSQL/DB layers requiring a running database (exo-gateway db.rs)
-#   - HTTP server initialisation code requiring a running server to reach
-#     (server.rs, handlers.rs, graphql.rs in exo-gateway)
+#   - Gateway runtime adapters whose DB-backed branches require DATABASE_URL
+#     and production runtime fixtures (exo-gateway db.rs, server.rs, handlers.rs,
+#     graphql.rs)
 #   - Configuration loading from disk/env (structurally requires the filesystem)
 #   - Node identity key loading from disk (requires filesystem)
 #   - Consensus reactor and event-loop orchestration surfaces (requires live P2P
@@ -15,9 +19,8 @@
 #   - Pedagogical proof modules (default-off feature; covered by dedicated
 #     `unaudited-pedagogical-proofs` test passes)
 #
-# All of these are exercised by the dedicated integration-test gates (Gate 12,
-# Gate 14, Gate 15) which run against a live environment; they are not meant
-# to be instrumented by tarpaulin's unit-test harness.
+# These runtime-adapter exclusions are intentionally explicit so the CI and
+# README cannot present the scoped 90% gate as whole-workspace line coverage.
 #
 # Note: the correct TOML key is "exclude-files" (with hyphens), not
 # "exclude_files" (with underscores) — tarpaulin follows CLI flag naming.

--- a/tools/test_coverage_policy.sh
+++ b/tools/test_coverage_policy.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+fail() {
+  printf 'coverage policy test failed: %s\n' "$1" >&2
+  exit 1
+}
+
+[[ -f tarpaulin.toml ]] || fail "tarpaulin.toml is missing"
+[[ -f .github/workflows/ci.yml ]] || fail ".github/workflows/ci.yml is missing"
+
+python3 - <<'PY'
+import sys
+import tomllib
+from pathlib import Path
+
+runtime_adapter_paths = {
+    "crates/exo-gateway/src/db.rs": "gateway database persistence is a core runtime adapter",
+    "crates/exo-gateway/src/server.rs": "gateway HTTP authentication and routing is a core runtime adapter",
+    "crates/exo-gateway/src/handlers.rs": "gateway API handlers expose core runtime decisions",
+    "crates/exo-gateway/src/graphql.rs": "gateway GraphQL exposes core runtime decisions",
+}
+
+tarpaulin_text = Path("tarpaulin.toml").read_text()
+config = tomllib.loads(tarpaulin_text)
+exclude_files = config.get("default", {}).get("exclude-files", [])
+excluded = set(exclude_files)
+
+runtime_adapter_exclusions = [
+    f"{path} ({reason})"
+    for path, reason in runtime_adapter_paths.items()
+    if path in excluded
+]
+
+if runtime_adapter_exclusions and "not a whole-workspace coverage claim" not in tarpaulin_text:
+    print(
+        "coverage policy test failed: runtime adapter exclusions require an "
+        "explicit scoped-coverage disclosure:",
+        file=sys.stderr,
+    )
+    for exclusion in runtime_adapter_exclusions:
+        print(f"  - {exclusion}", file=sys.stderr)
+    sys.exit(1)
+
+if runtime_adapter_exclusions and "Gateway runtime adapters" not in tarpaulin_text:
+    print(
+        "coverage policy test failed: runtime adapter exclusions must be "
+        "classified in tarpaulin.toml comments",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+PY
+
+grep -F 'bash tools/test_coverage_policy.sh' .github/workflows/ci.yml >/dev/null \
+  || fail "CI must run tools/test_coverage_policy.sh before the coverage gate"
+
+if grep -nE '90%[+[:space:]-]*line coverage|Coverage.*>=90|Coverage.*>= 90' README.md .github/workflows/ci.yml docs/guides/GETTING-STARTED.md \
+  | grep -viE 'scoped|tarpaulin.toml|not independently verified outside CI' >/tmp/coverage-policy-claims.txt; then
+  if grep -nE 'exclude-files|--exclude' tarpaulin.toml .github/workflows/ci.yml >/dev/null; then
+    cat /tmp/coverage-policy-claims.txt >&2
+    rm -f /tmp/coverage-policy-claims.txt
+    fail "coverage claims must disclose that the 90% gate is scoped by explicit exclusions"
+  fi
+fi
+rm -f /tmp/coverage-policy-claims.txt
+
+printf 'coverage policy test passed\n'


### PR DESCRIPTION
## Summary
- Confirms F-139 is still live on current `origin/main`: `tarpaulin.toml` excludes runtime-adapter paths while CI/docs presented the gate as an unqualified 90% line-coverage claim.
- Makes the coverage claim explicitly scoped in CI, README, and getting-started docs.
- Adds `tools/test_coverage_policy.sh` and runs it before the tarpaulin CI gate so future runtime-adapter exclusions cannot be paired with unqualified coverage claims.

## Classification
- `.github/workflows/ci.yml`: EXOCHAIN core CI guard.
- `tarpaulin.toml`: EXOCHAIN core CI coverage policy.
- `tools/test_coverage_policy.sh`: EXOCHAIN core CI guard.
- `README.md`, `docs/guides/GETTING-STARTED.md`: EXOCHAIN public documentation/coverage claims.

## External Finding Validation
- Rechecked against current `origin/main` `4c0144ad861d541f978ce969a423524c75544f66` on May 9, 2026.
- RED evidence on current main: `.github/workflows/ci.yml` still contained an unqualified `90%+ line coverage` claim while scoped tarpaulin exclusions remained active.
- RED evidence on current main: `README.md` and `docs/guides/GETTING-STARTED.md` still described the threshold without the same scope disclosure enforced by CI.
- RED evidence on current main: `tools/test_coverage_policy.sh` was absent, so there was no source guard keeping coverage claims synchronized with exclusions.
- The issue is documentation/CI claim accuracy, not a Rust runtime behavior change.

## TDD / Reproduction
- RED: `bash tools/test_coverage_policy.sh` failed before remediation because gateway runtime-adapter exclusions were present without explicit scoped-coverage disclosure and without a CI guard.
- Hard-remediation sanity check from the original branch work: removing the gateway exclusions made the same CI-shaped tarpaulin command fail at `83.92% < 90.00`, confirming the old claim was not whole-workspace coverage.
- GREEN: after the policy wording and guard changes, `bash tools/test_coverage_policy.sh` passes and the CI-shaped tarpaulin pass reports scoped coverage above threshold.

## Validation
- `bash tools/test_coverage_policy.sh`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_agent_workflow_bounds.sh`
- `bash tools/test_agent_prompt_boundaries.sh`
- `cargo +nightly fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- exact conflict marker scan over tracked files, excluding `docs/superpowers/**`, returned no matches
- `rg -n '90%[+[:space:]-]*line coverage|Coverage.*>=90|Coverage.*>= 90|scoped|tarpaulin.toml|test_coverage_policy|exclude-files|--exclude|not a whole-workspace coverage claim' .github/workflows/ci.yml README.md docs/guides/GETTING-STARTED.md tarpaulin.toml tools/test_coverage_policy.sh`
- `env -u DATABASE_URL cargo test -p exo-gateway`
- `rm -rf coverage && env -u DATABASE_URL cargo tarpaulin --workspace --exclude exochain-wasm --exclude exo-proofs --out xml --output-dir coverage --skip-clean --engine llvm --timeout 300 --fail-under 90` (`91.18%` scoped coverage)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`

## Notes
- No Rust source behavior changed.
- DB-backed hardening probe from the original branch found currently skipped DB-backed gateway tests that fail when globally enabled; that is a separate runtime-adapter test determinism/provenance remediation candidate.

Head after validation: `1075d28a7b9400258b468be2120d51dbb8c2017e`
