### PR TITLE
fix(demo): align wasm license boundary

### DIFF
--- a/demo/ADJACENT-SURFACE-INTAKE.md
+++ b/demo/ADJACENT-SURFACE-INTAKE.md
@@ -1,0 +1,42 @@
+# EXOCHAIN Demo Adjacent Surface Intake
+
+This directory is an adjacent prototype surface. It is not the canonical
+EXOCHAIN Rust trust fabric.
+
+## Accountability
+
+- Owner: EXOCHAIN maintainers
+- Accountable maintainer: repository maintainer on duty for demo changes
+- Deployment status: prototype
+
+## Trust Boundary
+
+- Constitutional trust claims allowed: no. Demo apps may describe themselves as
+  demonstrations of EXOCHAIN APIs, but they must not claim constitutional
+  enforcement unless the runtime path calls the canonical Rust API or generated
+  WASM binding and the behavior is covered by tests.
+- Core state access: demo services may call the generated
+  `@exochain/exochain-wasm` package for local demonstrations. They must not
+  write EXOCHAIN core state, signatures, credentials, governance outcomes,
+  consent records, or provenance records outside the canonical Rust runtime.
+- Exact boundary: `demo/packages/exochain-wasm` is a JavaScript wrapper around
+  generated WASM artifacts from `crates/exochain-wasm`. The generated Rust/WASM
+  output remains the enforcement boundary; demo services are callers, not
+  authorities.
+
+## Validation
+
+- Surface test commands: `npm --prefix demo run build:wasm`,
+  `npm --prefix demo run test:wasm`, `npm --prefix demo test`, and
+  `npm --prefix demo audit --audit-level=moderate`.
+- CI gate: WASM/JS bridge verification, demo workspace tests, dependency audit,
+  and repo hygiene gates must fail on license drift, bridge export drift, stale
+  workspace lock metadata, or known moderate-or-higher dependency advisories.
+- Runtime configuration source: environment variables and local demo service
+  package metadata only.
+- Secrets inventory: no production signing keys, bootstrap tokens, tenant
+  secrets, emergency override credentials, or production API keys are permitted
+  in this directory. Demo-only local variables must be supplied outside git.
+- Rollback or disablement path: remove the demo package from demo service
+  dependencies or stop the demo compose/service; canonical EXOCHAIN Rust crates
+  and runtime state remain unaffected.

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -257,21 +257,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -280,9 +280,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -714,6 +714,10 @@
       "resolved": "services/consent-service",
       "link": true
     },
+    "node_modules/@exochain/crosschecked-api": {
+      "resolved": "services/crosschecked-api",
+      "link": true
+    },
     "node_modules/@exochain/decision-forge": {
       "resolved": "services/decision-forge",
       "link": true
@@ -734,12 +738,20 @@
       "resolved": "services/identity-service",
       "link": true
     },
+    "node_modules/@exochain/livesafe-api": {
+      "resolved": "services/livesafe-api",
+      "link": true
+    },
     "node_modules/@exochain/provenance-writer": {
       "resolved": "services/provenance-writer",
       "link": true
     },
     "node_modules/@exochain/shared": {
       "resolved": "packages/shared",
+      "link": true
+    },
+    "node_modules/@exochain/vitallock-api": {
+      "resolved": "services/vitallock-api",
       "link": true
     },
     "node_modules/@isaacs/cliui": {
@@ -810,20 +822,22 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
-      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
         "@tybys/wasm-util": "^0.10.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@noble/hashes": {
@@ -840,9 +854,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.120.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.120.0.tgz",
-      "integrity": "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==",
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -871,9 +885,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.10.tgz",
-      "integrity": "sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
       "cpu": [
         "arm64"
       ],
@@ -888,9 +902,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.10.tgz",
-      "integrity": "sha512-gED05Teg/vtTZbIJBc4VNMAxAFDUPkuO/rAIyyxZjTj1a1/s6z5TII/5yMGZ0uLRCifEtwUQn8OlYzuYc0m70w==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
       "cpu": [
         "arm64"
       ],
@@ -905,9 +919,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.10.tgz",
-      "integrity": "sha512-rI15NcM1mA48lqrIxVkHfAqcyFLcQwyXWThy+BQ5+mkKKPvSO26ir+ZDp36AgYoYVkqvMcdS8zOE6SeBsR9e8A==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
       "cpu": [
         "x64"
       ],
@@ -922,9 +936,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.10.tgz",
-      "integrity": "sha512-XZRXHdTa+4ME1MuDVp021+doQ+z6Ei4CCFmNc5/sKbqb8YmkiJdj8QKlV3rCI0AJtAeSB5n0WGPuJWNL9p/L2w==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
       "cpu": [
         "x64"
       ],
@@ -939,9 +953,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.10.tgz",
-      "integrity": "sha512-R0SQMRluISSLzFE20sPWYHVmJdDQnRyc/FzSCN72BqQmh2SOZUFG+N3/vBZpR4C6WpEUVYJLrYUXaj43sJsNLA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
       "cpu": [
         "arm"
       ],
@@ -956,9 +970,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.10.tgz",
-      "integrity": "sha512-Y1reMrV/o+cwpduYhJuOE3OMKx32RMYCidf14y+HssARRmhDuWXJ4yVguDg2R/8SyyGNo+auzz64LnPK9Hq6jg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
       "cpu": [
         "arm64"
       ],
@@ -976,9 +990,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.10.tgz",
-      "integrity": "sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
       "cpu": [
         "arm64"
       ],
@@ -996,9 +1010,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.10.tgz",
-      "integrity": "sha512-ZqrufYTgzxbHwpqOjzSsb0UV/aV2TFIY5rP8HdsiPTv/CuAgCRjM6s9cYFwQ4CNH+hf9Y4erHW1GjZuZ7WoI7w==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
       "cpu": [
         "ppc64"
       ],
@@ -1016,9 +1030,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.10.tgz",
-      "integrity": "sha512-gSlmVS1FZJSRicA6IyjoRoKAFK7IIHBs7xJuHRSmjImqk3mPPWbR7RhbnfH2G6bcmMEllCt2vQ/7u9e6bBnByg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
       "cpu": [
         "s390x"
       ],
@@ -1036,9 +1050,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.10.tgz",
-      "integrity": "sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
       "cpu": [
         "x64"
       ],
@@ -1056,9 +1070,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.10.tgz",
-      "integrity": "sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
       "cpu": [
         "x64"
       ],
@@ -1076,9 +1090,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.10.tgz",
-      "integrity": "sha512-o1hYe8hLi1EY6jgPFyxQgQ1wcycX+qz8eEbVmot2hFkgUzPxy9+kF0u0NIQBeDq+Mko47AkaFFaChcvZa9UX9Q==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
       "cpu": [
         "arm64"
       ],
@@ -1093,9 +1107,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.10.tgz",
-      "integrity": "sha512-Ugv9o7qYJudqQO5Y5y2N2SOo6S4WiqiNOpuQyoPInnhVzCY+wi/GHltcLHypG9DEUYMB0iTB/huJrpadiAcNcA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
       "cpu": [
         "wasm32"
       ],
@@ -1103,16 +1117,18 @@
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.10.tgz",
-      "integrity": "sha512-7UODQb4fQUNT/vmgDZBl3XOBAIOutP5R3O/rkxg0aLfEGQ4opbCgU5vOw/scPe4xOqBwL9fw7/RP1vAMZ6QlAQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
       "cpu": [
         "arm64"
       ],
@@ -1127,9 +1143,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.10.tgz",
-      "integrity": "sha512-PYxKHMVHOb5NJuDL53vBUl1VwUjymDcYI6rzpIni0C9+9mTiJedvUxSk7/RPp7OOAm3v+EjgMu9bIy3N6b408w==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
       "cpu": [
         "x64"
       ],
@@ -1624,9 +1640,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -1904,9 +1920,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2499,9 +2515,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3431,9 +3447,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3443,9 +3459,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -3616,14 +3632,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.10.tgz",
-      "integrity": "sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@oxc-project/types": "=0.120.0",
-        "@rolldown/pluginutils": "1.0.0-rc.10"
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -3632,27 +3648,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.10",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.10",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.10",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.10",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.10",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.10",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.10",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.10",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.10",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.10",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.10",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.10",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.10",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.10",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.10"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.10.tgz",
-      "integrity": "sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "license": "MIT",
       "peer": true
     },
@@ -4117,13 +4133,13 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -4213,17 +4229,17 @@
       "peer": true
     },
     "node_modules/vite": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.1.tgz",
-      "integrity": "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==",
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.10",
-        "tinyglobby": "^0.2.15"
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -4240,7 +4256,7 @@
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
         "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",
@@ -4314,9 +4330,9 @@
       }
     },
     "node_modules/vite-node/node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4489,9 +4505,9 @@
       }
     },
     "node_modules/vitest/node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4805,7 +4821,7 @@
     "packages/exochain-wasm": {
       "name": "@exochain/exochain-wasm",
       "version": "0.1.0",
-      "license": "AGPL-3.0-or-later"
+      "license": "Apache-2.0"
     },
     "packages/shared": {
       "name": "@exochain/shared",
@@ -4826,6 +4842,19 @@
     },
     "services/consent-service": {
       "name": "@exochain/consent-service",
+      "version": "0.1.0",
+      "dependencies": {
+        "@exochain/exochain-wasm": "*",
+        "@exochain/shared": "*",
+        "pg": "^8.13.0"
+      },
+      "devDependencies": {
+        "supertest": "^7.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "services/crosschecked-api": {
+      "name": "@exochain/crosschecked-api",
       "version": "0.1.0",
       "dependencies": {
         "@exochain/exochain-wasm": "*",
@@ -4889,8 +4918,34 @@
         "vitest": "^3.0.0"
       }
     },
+    "services/livesafe-api": {
+      "name": "@exochain/livesafe-api",
+      "version": "0.1.0",
+      "dependencies": {
+        "@exochain/exochain-wasm": "*",
+        "@exochain/shared": "*",
+        "pg": "^8.13.0"
+      },
+      "devDependencies": {
+        "supertest": "^7.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
     "services/provenance-writer": {
       "name": "@exochain/provenance-writer",
+      "version": "0.1.0",
+      "dependencies": {
+        "@exochain/exochain-wasm": "*",
+        "@exochain/shared": "*",
+        "pg": "^8.13.0"
+      },
+      "devDependencies": {
+        "supertest": "^7.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "services/vitallock-api": {
+      "name": "@exochain/vitallock-api",
       "version": "0.1.0",
       "dependencies": {
         "@exochain/exochain-wasm": "*",

--- a/demo/package.json
+++ b/demo/package.json
@@ -14,7 +14,7 @@
     "test:wasm": "node packages/exochain-wasm/test.mjs",
     "test:services": "vitest run --workspace vitest.workspace.js --project services",
     "test:react": "vitest run --workspace vitest.workspace.js --project web",
-    "build:wasm": "cd .. && wasm-pack build crates/exochain-wasm --target nodejs --release --out-dir demo/packages/exochain-wasm/wasm",
+    "build:wasm": "bash scripts/build-wasm.sh",
     "dev": "docker compose -f infra/docker-compose.yml up --build"
   },
   "devDependencies": {

--- a/demo/packages/exochain-wasm/package.json
+++ b/demo/packages/exochain-wasm/package.json
@@ -4,7 +4,7 @@
   "description": "ExoChain governance engine — WebAssembly bindings for Node.js",
   "main": "index.js",
   "types": "wasm/exochain_wasm.d.ts",
-  "license": "AGPL-3.0-or-later",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/exochain/exochain"

--- a/demo/packages/exochain-wasm/test.mjs
+++ b/demo/packages/exochain-wasm/test.mjs
@@ -4,8 +4,9 @@
 // identity, authority, consent, legal, escalation
 
 import { createRequire } from 'module';
+import { readFileSync } from 'fs';
 const require = createRequire(import.meta.url);
-const wasm = require('./wasm/exochain_wasm.js');
+let wasm;
 
 let passed = 0;
 let failed = 0;
@@ -26,8 +27,45 @@ function assert(condition, msg) {
   if (!condition) throw new Error(msg || 'Assertion failed');
 }
 
+function assertThrowsContaining(fn, expected) {
+  try {
+    fn();
+  } catch (e) {
+    const message = e.message || String(e);
+    assert(message.includes(expected), `expected error containing "${expected}", got "${message}"`);
+    return;
+  }
+  throw new Error(`expected error containing "${expected}"`);
+}
+
+function hexToBytes(hex) {
+  assert(hex.length % 2 === 0, 'hex string must have an even number of characters');
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
 const TEST_DID = 'did:exo:test-actor';
 const DUMMY_SECRET_HEX = 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+
+// ═══════════════════════════════════════════════════════════════
+// PACKAGE METADATA
+// ═══════════════════════════════════════════════════════════════
+console.log('\n── Package Metadata ──');
+
+test('package license matches EXOCHAIN Apache-2.0 license position', () => {
+  const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
+  assert(pkg.license === 'Apache-2.0', `expected Apache-2.0 license, got ${pkg.license}`);
+});
+
+if (failed > 0) {
+  console.log('\nPackage metadata checks failed; skipping generated WASM runtime checks.');
+  process.exit(1);
+}
+
+wasm = require('./wasm/exochain_wasm.js');
 
 // ═══════════════════════════════════════════════════════════════
 // CORE BINDINGS
@@ -46,26 +84,48 @@ test('hash_structured produces deterministic hash', () => {
   assert(h1 === h2, 'same input should produce same hash');
 });
 
-test('generate_keypair returns pub+secret', () => {
+test('generate_keypair returns public key only', () => {
   const kp = wasm.wasm_generate_keypair();
   assert(kp.public_key, 'should have public_key');
   assert(kp.public_key.length === 64, `public key should be 64 hex chars, got ${kp.public_key.length}`);
+  assert(kp.secret_key === undefined, 'secret_key must not cross the WASM boundary');
 });
 
-test('sign + verify round-trip', () => {
-  const publicKey = wasm.wasm_ed25519_public_from_secret(DUMMY_SECRET_HEX);
+test('ephemeral sign + verify round-trip', () => {
   const msg = new Uint8Array([72, 101, 108, 108, 111]); // "Hello"
-  const sig = wasm.wasm_sign(msg, DUMMY_SECRET_HEX);
-  const valid = wasm.wasm_verify(msg, sig, publicKey);
+  const signed = wasm.wasm_sign_with_ephemeral_key(msg);
+  const valid = wasm.wasm_verify(msg, JSON.stringify(signed.signature), signed.public_key);
   assert(valid === true, 'signature should verify');
 });
 
-test('verify rejects bad signature', () => {
-  const publicKey = wasm.wasm_ed25519_public_from_secret(DUMMY_SECRET_HEX);
+test('verify rejects mismatched message', () => {
   const msg = new Uint8Array([1, 2, 3]);
-  const sig = wasm.wasm_sign(msg, DUMMY_SECRET_HEX);
-  const bad = wasm.wasm_verify(new Uint8Array([4, 5, 6]), sig, publicKey);
+  const signed = wasm.wasm_sign_with_ephemeral_key(msg);
+  const bad = wasm.wasm_verify(new Uint8Array([4, 5, 6]), JSON.stringify(signed.signature), signed.public_key);
   assert(bad === false, 'bad message should not verify');
+});
+
+test('raw secret-key crypto entrypoints fail closed', () => {
+  assertThrowsContaining(
+    () => wasm.wasm_sign(new Uint8Array([1, 2, 3]), DUMMY_SECRET_HEX),
+    'raw secret-key signing is disabled at the WASM boundary',
+  );
+  assertThrowsContaining(
+    () => wasm.wasm_ed25519_public_from_secret(DUMMY_SECRET_HEX),
+    'raw secret-key public derivation is disabled at the WASM boundary',
+  );
+  assertThrowsContaining(
+    () => wasm.wasm_create_signed_event(
+      '"GovernanceDecision"',
+      new Uint8Array([1, 2, 3]),
+      TEST_DID,
+      DUMMY_SECRET_HEX,
+      '018f7a96-8ad0-7c4f-8e0f-111111111101',
+      7100n,
+      0,
+    ),
+    'raw secret-key event signing is disabled at the WASM boundary',
+  );
 });
 
 test('bcts_valid_transitions returns array for Draft', () => {
@@ -82,14 +142,31 @@ test('bcts_is_terminal — Closed is terminal', () => {
   assert(wasm.wasm_bcts_is_terminal('"Closed"') === true);
 });
 
-test('create_signed_event', () => {
-  const evt = wasm.wasm_create_signed_event(
+test('create_event_with_signature accepts externally signed payload', () => {
+  const payload = new Uint8Array([1, 2, 3]);
+  const eventId = wasm.wasm_compute_event_id(new Uint8Array([101, 118, 101, 110, 116]));
+  const timestampPhysicalMs = 7100n;
+  const signingPayloadHex = wasm.wasm_event_signing_payload(
     '"GovernanceDecision"',
-    new Uint8Array([1, 2, 3]),
+    payload,
     TEST_DID,
-    DUMMY_SECRET_HEX,
+    eventId,
+    timestampPhysicalMs,
+    0,
+  );
+  const signed = wasm.wasm_sign_with_ephemeral_key(hexToBytes(signingPayloadHex));
+  const evt = wasm.wasm_create_event_with_signature(
+    '"GovernanceDecision"',
+    payload,
+    TEST_DID,
+    JSON.stringify(signed.signature),
+    signed.public_key,
+    eventId,
+    timestampPhysicalMs,
+    0,
   );
   assert(evt.source_did === TEST_DID, `source_did should be ${TEST_DID}, got ${evt.source_did}`);
+  assert(wasm.wasm_verify_event(JSON.stringify(evt), signed.public_key) === true, 'event signature should verify');
 });
 
 test('merkle_root computes root from 32-byte hex leaves', () => {
@@ -154,10 +231,14 @@ test('check_clearance for Governor', () => {
       "approve_decision": { required_level: "Governor" }
     }
   };
+  const registry = [
+    { did: 'did:exo:alice', level: 'Governor' }
+  ];
   const result = wasm.wasm_check_clearance(
     'did:exo:alice',
     'approve_decision',
-    JSON.stringify(policy)
+    JSON.stringify(policy),
+    JSON.stringify(registry)
   );
   assert(result.status === 'Granted', `expected Granted, got ${result.status}`);
 });
@@ -245,9 +326,15 @@ test('decision_content_hash produces hash', () => {
 // ═══════════════════════════════════════════════════════════════
 console.log('\n── Identity Bindings ──');
 
-test('shamir_split splits secret into shares', () => {
+test('shamir_split_with_entropy splits secret into shares', () => {
   const secret = new Uint8Array([42, 99, 17, 255, 0, 128]);
-  const result = wasm.wasm_shamir_split(secret, 2, 3);
+  const entropy = new Uint8Array([
+    11, 23, 37, 41, 53, 67, 79, 83,
+    97, 101, 113, 127, 131, 139, 149, 157,
+    163, 173, 181, 191, 197, 199, 211, 223,
+    227, 229, 233, 239, 241, 251, 7, 19,
+  ]);
+  const result = wasm.wasm_shamir_split_with_entropy(secret, 2, 3, entropy);
   assert(Array.isArray(result), 'should return array of shares');
   assert(result.length === 3, `should have 3 shares, got ${result.length}`);
 });


### PR DESCRIPTION
## Summary
- Classifies `demo/` as an adjacent prototype surface with an explicit intake/trust-boundary record.
- Aligns `demo/packages/exochain-wasm` license metadata with EXOCHAIN's Apache-2.0 position and guards it in the demo WASM test.
- Routes `npm --prefix demo run build:wasm` through the repo-aware build script so generated WASM lands where the package tests consume it.
- Updates the demo WASM test to assert current fail-closed raw-secret behavior, externally signed event creation, registry-backed clearance, and caller-supplied Shamir entropy.
- Repairs demo workspace lock metadata and applies non-force npm audit fixes for adjacent demo test/build dependencies.

## Classification
- Adjacent surface: `demo/ADJACENT-SURFACE-INTAKE.md`, `demo/package.json`, `demo/package-lock.json`, `demo/packages/exochain-wasm/package.json`, `demo/packages/exochain-wasm/test.mjs`.
- EXOCHAIN core/runtime adapter changes: none.
- Imported evidence changes: none.
- Third-party/vendor changes: lockfile version updates only, produced by npm with scripts disabled.

## Current-Issue Confirmation
- Re-verified against current `origin/main` (`4ece768db6b049b92843658894699ada5368caac`) before rebasing.
- RED: `jq -r '.name + "\\t" + .license' demo/packages/exochain-wasm/package.json packages/exochain-wasm/wasm/package.json` showed `@exochain/exochain-wasm` as `AGPL-3.0-or-later` while the owned WASM package is `Apache-2.0`.
- RED: `test "$(jq -r '.license' demo/packages/exochain-wasm/package.json)" = "Apache-2.0"` exited nonzero on current main.
- RED: `test -f demo/ADJACENT-SURFACE-INTAKE.md` exited nonzero on current main.
- Current main still routed `build:wasm` directly through `wasm-pack`; this branch keeps the repo-aware wrapper so generated output lands under `demo/packages/exochain-wasm/wasm`, where the demo package tests consume it.

## Test Plan
- `npm --prefix demo ci --ignore-scripts`
- `CARGO_TARGET_DIR=/Users/bobstewart/.config/superpowers/worktrees/exochain/workspace-dependency-exact-pins-20260506/target npm --prefix demo run build:wasm` (includes 27/27 demo WASM checks)
- `npm --prefix demo run test:wasm` (27/27)
- `npm --prefix demo test` (152/152)
- `npm --prefix demo audit --audit-level=moderate`
- `bash tools/test_repo_truth.sh`
- `git diff --check origin/main...HEAD`
- `cargo +nightly fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/bobstewart/.config/superpowers/worktrees/exochain/workspace-dependency-exact-pins-20260506/target cargo test -p exochain-wasm`
- `CARGO_TARGET_DIR=/Users/bobstewart/.config/superpowers/worktrees/exochain/workspace-dependency-exact-pins-20260506/target cargo clippy -p exochain-wasm --all-targets -- -D warnings`
- License bypass search: `if rg -n "AGPL-3.0-or-later" demo/ADJACENT-SURFACE-INTAKE.md demo/package.json demo/packages/exochain-wasm/package.json demo/packages/exochain-wasm/test.mjs; then exit 1; else echo "no touched demo metadata AGPL bypass matches"; fi`

## Core Behavior
- No EXOCHAIN core, runtime adapter, governance, CI, or deployment contract files changed.
- This is adjacent demo hardening plus behavioral guard coverage for the existing EXOCHAIN WASM demo package.
