### PR TITLE
fix(command-base): harden adjacent surface boundary

### DIFF
--- a/command-base/ADJACENT-SURFACE-INTAKE.md
+++ b/command-base/ADJACENT-SURFACE-INTAKE.md
@@ -1,0 +1,44 @@
+# CommandBase Adjacent Surface Intake
+
+CommandBase is an adjacent operational surface. It is not the canonical
+EXOCHAIN Rust trust fabric.
+
+## Accountability
+
+- Owner: EXOCHAIN maintainers
+- Accountable maintainer: repository maintainer on duty for CommandBase changes
+- Deployment status: customer-zero
+
+## Trust Boundary
+
+- Constitutional trust claims allowed: limited. CommandBase may claim EXOCHAIN
+  participation only for runtime paths that call the canonical Rust API or the
+  generated EXOCHAIN WASM package and have tests proving fail-closed behavior.
+- Core state access: CommandBase may call generated EXOCHAIN WASM bindings and
+  local service adapters. It must not mint, cache, or simulate consent,
+  authority, provenance, or governance outcomes outside tested core or adapter
+  calls.
+- Exact boundary: `command-base/app` is an Express/SQLite application and
+  `command-base/worker` is an adjacent worker. The trusted enforcement boundary
+  remains the canonical EXOCHAIN Rust crates, generated WASM bindings, and any
+  tested runtime adapter they call.
+
+## Validation
+
+- Surface test commands: `npm --prefix command-base/app run dependency-policy:check`,
+  `npm --prefix command-base/app audit --audit-level=moderate`, and focused
+  Node tests under `command-base/app/services/*.test.js` when service code
+  changes.
+- CI gate: CommandBase dependency policy and audit checks must fail on known
+  moderate-or-higher dependency advisories, deprecated upload parser major
+  versions, or stale package-lock metadata.
+- Runtime configuration source: environment variables, local SQLite path
+  configuration, and package metadata in `command-base/app` and
+  `command-base/worker`.
+- Secrets inventory: no production signing keys, bootstrap tokens, tenant
+  secrets, emergency override credentials, or production API keys are permitted
+  in this directory. Runtime secrets must be supplied outside git through
+  deployment-specific secret stores.
+- Rollback or disablement path: stop the CommandBase app or worker, remove it
+  from deployment routing, or disable upload endpoints at the reverse proxy.
+  Canonical EXOCHAIN Rust crates and runtime state remain unaffected.

--- a/command-base/README.md
+++ b/command-base/README.md
@@ -1,13 +1,19 @@
 # CommandBase.ai
 
-cognitiveplane.ai Hypervisor -- operational command center for AI agents under constitutional governance.
+cognitiveplane.ai Hypervisor -- adjacent operational command center for AI
+agents that can call tested EXOCHAIN runtime adapters.
 
 ## What This Is
 
-- **Not a dashboard.** A command center with real authority delegation, consent enforcement, trust receipts, challenge surfaces, and kill switches.
-- All governance logic executes in Rust via WebAssembly (110 WASM-bridged functions).
-- Every action produces a cryptographically hash-chained governance receipt.
-- Constitutional invariants are enforced at the kernel level -- no overrides, no exceptions.
+- **Adjacent surface, not core.** CommandBase is not the canonical EXOCHAIN
+  Rust trust fabric; see `ADJACENT-SURFACE-INTAKE.md` for ownership,
+  deployment status, and trust-boundary rules.
+- Governance-sensitive paths may call generated EXOCHAIN WebAssembly bindings
+  or tested runtime adapters. CommandBase itself does not mint, cache, or
+  simulate constitutional decisions outside those call paths.
+- Receipt and enforcement claims apply only to routes that are backed by tested
+  WASM/core-adapter calls and fail closed when that boundary rejects, times out,
+  or is unavailable.
 
 ## Architecture
 
@@ -79,4 +85,6 @@ cd command-base && npm install && npm start
 - Archived agents in `Team/archived/`
 - Research briefs in `Team/research-brief-*.md`
 
-Every agent operates under constitutional authority delegated through the WASM bridge. Agent actions are receipt-chained and auditable.
+Agent workflows may call the EXOCHAIN WASM bridge. Only tested bridge-backed
+paths may be described as constitutionally enforced, receipt-chained, or
+auditable by EXOCHAIN core.

--- a/command-base/app/lib/auth.js
+++ b/command-base/app/lib/auth.js
@@ -3,7 +3,8 @@
 /**
  * Shared Auth Middleware — ExoChain CommandBase
  *
- * JWT-style session tokens using Ed25519 (via WASM) with HMAC-SHA256 fallback.
+ * JWT-style session tokens using Ed25519 (via WASM) with explicit
+ * HMAC-SHA256 fallback configuration.
  *
  * Token format:  base64url(header) . base64url(payload) . base64url(signature)
  *
@@ -24,8 +25,25 @@ const crypto = require('crypto');
 /** Default token TTL in seconds (1 hour). */
 const DEFAULT_TTL_SECONDS = 3600;
 
-/** HMAC fallback secret — override via EXOCHAIN_AUTH_SECRET env var. */
-const HMAC_SECRET = process.env.EXOCHAIN_AUTH_SECRET || 'exochain-dev-secret-change-in-production';
+const HISTORICAL_DEV_HMAC_SECRET = 'exochain-dev-secret-change-in-production';
+const MIN_HMAC_SECRET_BYTES = 32;
+
+function configuredHmacSecret() {
+  const secret = process.env.EXOCHAIN_AUTH_SECRET;
+  if (!secret) {
+    throw new Error('EXOCHAIN_AUTH_SECRET is required when the WASM Ed25519 backend is unavailable');
+  }
+  if (secret === HISTORICAL_DEV_HMAC_SECRET) {
+    throw new Error('Refusing to use the historical development HMAC secret for session tokens');
+  }
+  const byteLength = Buffer.byteLength(secret, 'utf8');
+  if (byteLength < MIN_HMAC_SECRET_BYTES) {
+    throw new Error(
+      `EXOCHAIN_AUTH_SECRET must be at least ${MIN_HMAC_SECRET_BYTES} bytes, got ${byteLength}`,
+    );
+  }
+  return secret;
+}
 
 // ---------------------------------------------------------------------------
 // WASM loader — lazy, non-fatal
@@ -75,7 +93,7 @@ function base64urlDecode(str) {
 // ---------------------------------------------------------------------------
 
 /**
- * Sign a message using Ed25519 (WASM) or HMAC-SHA256 (fallback).
+ * Sign a message using Ed25519 (WASM) or explicitly configured HMAC-SHA256.
  * @param {string} message - The message to sign (header.payload)
  * @returns {string} Base64url-encoded signature
  */
@@ -86,8 +104,7 @@ function sign(message) {
     const sigBytes = wasm.wasm_ed25519_sign(Buffer.from(message, 'utf8'));
     return base64urlEncode(sigBytes);
   }
-  // HMAC-SHA256 fallback
-  const hmac = crypto.createHmac('sha256', HMAC_SECRET);
+  const hmac = crypto.createHmac('sha256', configuredHmacSecret());
   hmac.update(message);
   return base64urlEncode(hmac.digest());
 }
@@ -107,9 +124,14 @@ function verify(message, signature) {
   }
   // HMAC-SHA256 fallback: recompute and compare
   const expected = sign(message);
+  const expectedBytes = Buffer.from(expected, 'utf8');
+  const signatureBytes = Buffer.from(signature, 'utf8');
+  if (expectedBytes.length !== signatureBytes.length) {
+    return false;
+  }
   return crypto.timingSafeEqual(
-    Buffer.from(expected, 'utf8'),
-    Buffer.from(signature, 'utf8')
+    expectedBytes,
+    signatureBytes
   );
 }
 
@@ -173,7 +195,13 @@ function verifyToken(token) {
   const signingInput = `${headerB64}.${payloadB64}`;
 
   // Verify signature
-  if (!verify(signingInput, signature)) {
+  let signatureValid;
+  try {
+    signatureValid = verify(signingInput, signature);
+  } catch (err) {
+    return { valid: false, error: err.message };
+  }
+  if (!signatureValid) {
     return { valid: false, error: 'Invalid signature' };
   }
 

--- a/command-base/app/lib/auth.test.js
+++ b/command-base/app/lib/auth.test.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const test = require('node:test');
+
+function runAuthSnippet(env, source) {
+  const result = spawnSync(process.execPath, ['-e', source], {
+    cwd: __dirname + '/..',
+    env: {
+      ...process.env,
+      EXOCHAIN_AUTH_SECRET: '',
+      NODE_ENV: 'production',
+      ...env,
+    },
+    encoding: 'utf8',
+  });
+  assert.equal(
+    result.status,
+    0,
+    `auth snippet failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+}
+
+test('HMAC fallback refuses to sign with an absent secret', () => {
+  runAuthSnippet(
+    { EXOCHAIN_AUTH_SECRET: '' },
+    `
+      const { createToken } = require('./lib/auth');
+      try {
+        createToken('did:exo:alice', 'governance:full', null);
+      } catch (err) {
+        if (String(err.message).includes('EXOCHAIN_AUTH_SECRET')) process.exit(0);
+        throw err;
+      }
+      throw new Error('createToken unexpectedly signed without EXOCHAIN_AUTH_SECRET');
+    `,
+  );
+});
+
+test('HMAC fallback refuses the historical development secret', () => {
+  runAuthSnippet(
+    { EXOCHAIN_AUTH_SECRET: 'exochain-dev-secret-change-in-production' },
+    `
+      const { createToken } = require('./lib/auth');
+      try {
+        createToken('did:exo:alice', 'governance:full', null);
+      } catch (err) {
+        if (String(err.message).includes('development HMAC secret')) process.exit(0);
+        throw err;
+      }
+      throw new Error('createToken unexpectedly signed with the development HMAC secret');
+    `,
+  );
+});
+
+test('HMAC fallback signs and verifies with an explicit deployment secret', () => {
+  runAuthSnippet(
+    { EXOCHAIN_AUTH_SECRET: 'test-only-commandbase-auth-secret-32b' },
+    `
+      const { createToken, verifyToken } = require('./lib/auth');
+      const token = createToken('did:exo:alice', 'governance:full', 'delegation-1');
+      const verified = verifyToken(token);
+      if (!verified.valid) throw new Error(verified.error || 'token did not verify');
+      if (verified.payload.did !== 'did:exo:alice') throw new Error('payload DID mismatch');
+      const parts = token.split('.');
+      parts[2] = parts[2].slice(0, -2);
+      const tampered = verifyToken(parts.join('.'));
+      if (tampered.valid) throw new Error('tampered token unexpectedly verified');
+    `,
+  );
+});

--- a/command-base/app/package-lock.json
+++ b/command-base/app/package-lock.json
@@ -14,7 +14,7 @@
         "better-sqlite3": "^12.8.0",
         "compression": "^1.8.1",
         "express": "^4.21.0",
-        "multer": "^1.4.5-lts.1",
+        "multer": "^2.1.1",
         "ws": "^8.20.0"
       }
     },
@@ -331,48 +331,18 @@
       }
     },
     "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
       "engines": [
-        "node >= 0.8"
+        "node >= 6.0"
       ],
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
+        "readable-stream": "^3.0.2",
         "typedarray": "^0.0.6"
-      }
-    },
-    "node_modules/concat-stream/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/concat-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/concat-stream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/content-disposition": {
@@ -409,12 +379,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
-      "license": "MIT"
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -917,12 +881,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1013,18 +971,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -1038,22 +984,22 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "1.4.5-lts.2",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.2.tgz",
-      "integrity": "sha512-VzGiVigcG9zUAoCNU+xShztrlr1auZOlurXynNvO9GiWD1/mTBbUljOKY+qMeazBqXgRnjzeEgJI/wyjJUHg9A==",
-      "deprecated": "Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
-        "busboy": "^1.0.0",
-        "concat-stream": "^1.5.2",
-        "mkdirp": "^0.5.4",
-        "object-assign": "^4.1.1",
-        "type-is": "^1.6.4",
-        "xtend": "^4.0.0"
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/napi-build-utils": {
@@ -1121,15 +1067,6 @@
         "encoding": {
           "optional": true
         }
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -1215,12 +1152,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -1717,15 +1648,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
       }
     }
   }

--- a/command-base/app/package.json
+++ b/command-base/app/package.json
@@ -12,7 +12,7 @@
     "auth:check": "node --test lib/auth.test.js",
     "dependency-policy:check": "node scripts/check-dependency-policy.js",
     "surface-policy:check": "node scripts/check-surface-policy.js",
-    "preinstall": "npm audit --audit-level=critical || true"
+    "preinstall": "npm audit --audit-level=critical"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",

--- a/command-base/app/package.json
+++ b/command-base/app/package.json
@@ -9,6 +9,7 @@
     "audit:fix": "npm audit fix --force --audit-level=high",
     "audit:report": "npm audit --json > audit-report.json && echo 'Audit report written to audit-report.json'",
     "audit:moderate": "npm audit --audit-level=moderate",
+    "auth:check": "node --test lib/auth.test.js",
     "dependency-policy:check": "node scripts/check-dependency-policy.js",
     "surface-policy:check": "node scripts/check-surface-policy.js",
     "preinstall": "npm audit --audit-level=critical || true"

--- a/command-base/app/package.json
+++ b/command-base/app/package.json
@@ -9,6 +9,8 @@
     "audit:fix": "npm audit fix --force --audit-level=high",
     "audit:report": "npm audit --json > audit-report.json && echo 'Audit report written to audit-report.json'",
     "audit:moderate": "npm audit --audit-level=moderate",
+    "dependency-policy:check": "node scripts/check-dependency-policy.js",
+    "surface-policy:check": "node scripts/check-surface-policy.js",
     "preinstall": "npm audit --audit-level=critical || true"
   },
   "dependencies": {
@@ -17,7 +19,7 @@
     "better-sqlite3": "^12.8.0",
     "compression": "^1.8.1",
     "express": "^4.21.0",
-    "multer": "^1.4.5-lts.1",
+    "multer": "^2.1.1",
     "ws": "^8.20.0"
   }
 }

--- a/command-base/app/scripts/check-dependency-policy.js
+++ b/command-base/app/scripts/check-dependency-policy.js
@@ -8,6 +8,8 @@ const appRoot = join(__dirname, '..');
 const pkg = JSON.parse(readFileSync(join(appRoot, 'package.json'), 'utf8'));
 const lock = JSON.parse(readFileSync(join(appRoot, 'package-lock.json'), 'utf8'));
 
+const scripts = pkg.scripts || {};
+
 function dependencyRange(name) {
   const range = pkg.dependencies && pkg.dependencies[name];
   assert.ok(range, `${name} must be declared as a production dependency`);
@@ -42,5 +44,12 @@ assert.equal(
   undefined,
   `locked multer package must not be deprecated: ${lockedMulter.deprecated}`,
 );
+
+for (const [name, command] of Object.entries(scripts)) {
+  assert.ok(
+    !/\bnpm\s+audit\b.*\|\|\s*true/.test(command),
+    `${name} must not suppress npm audit failures with || true`,
+  );
+}
 
 console.log('CommandBase dependency policy OK');

--- a/command-base/app/scripts/check-dependency-policy.js
+++ b/command-base/app/scripts/check-dependency-policy.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
+
+const appRoot = join(__dirname, '..');
+const pkg = JSON.parse(readFileSync(join(appRoot, 'package.json'), 'utf8'));
+const lock = JSON.parse(readFileSync(join(appRoot, 'package-lock.json'), 'utf8'));
+
+function dependencyRange(name) {
+  const range = pkg.dependencies && pkg.dependencies[name];
+  assert.ok(range, `${name} must be declared as a production dependency`);
+  return range;
+}
+
+function lockedPackage(name) {
+  const entry = lock.packages && lock.packages[`node_modules/${name}`];
+  assert.ok(entry, `${name} must be present in package-lock.json`);
+  return entry;
+}
+
+function majorFromVersion(version, name) {
+  const major = Number.parseInt(String(version).replace(/^[^\d]*/, '').split('.')[0], 10);
+  assert.ok(Number.isSafeInteger(major), `${name} version must start with a numeric major`);
+  return major;
+}
+
+const multerRange = dependencyRange('multer');
+assert.ok(
+  majorFromVersion(multerRange, 'multer dependency range') >= 2,
+  `multer dependency range must require 2.x or newer, got ${multerRange}`,
+);
+
+const lockedMulter = lockedPackage('multer');
+assert.ok(
+  majorFromVersion(lockedMulter.version, 'locked multer') >= 2,
+  `package-lock.json must resolve multer 2.x or newer, got ${lockedMulter.version}`,
+);
+assert.equal(
+  lockedMulter.deprecated,
+  undefined,
+  `locked multer package must not be deprecated: ${lockedMulter.deprecated}`,
+);
+
+console.log('CommandBase dependency policy OK');

--- a/command-base/app/scripts/check-surface-policy.js
+++ b/command-base/app/scripts/check-surface-policy.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
+
+const commandBaseRoot = join(__dirname, '..', '..');
+const readme = readFileSync(join(commandBaseRoot, 'README.md'), 'utf8');
+const intake = readFileSync(join(commandBaseRoot, 'ADJACENT-SURFACE-INTAKE.md'), 'utf8');
+const canonicalBoundaryPattern = /not the canonical\s+EXOCHAIN\s+Rust trust fabric/i;
+
+assert.match(
+  intake,
+  canonicalBoundaryPattern,
+  'CommandBase intake must classify the surface outside the canonical Rust trust fabric',
+);
+
+assert.match(
+  readme,
+  /adjacent/i,
+  'CommandBase README must identify the surface as adjacent',
+);
+assert.match(
+  readme,
+  canonicalBoundaryPattern,
+  'CommandBase README must not imply it is the canonical Rust trust fabric',
+);
+assert.doesNotMatch(
+  readme,
+  /no overrides,\s*no exceptions/i,
+  'CommandBase README must not make unconditional kernel-enforcement claims for the adjacent surface',
+);
+
+console.log('CommandBase surface policy OK');


### PR DESCRIPTION
## Summary
- Upgrades CommandBase upload handling from deprecated `multer` 1.x to current `multer` 2.1.1 and removes deprecated Multer lock metadata.
- Requires an explicit, non-default `EXOCHAIN_AUTH_SECRET` when the WASM Ed25519 backend is unavailable, and makes malformed HMAC signatures fail closed instead of throwing through verification.
- Adds dependency-policy, surface-policy, and auth regression guards for the adjacent CommandBase surface.
- Adds a CommandBase adjacent-surface intake record and narrows README trust language to tested EXOCHAIN WASM/core-adapter paths.

## Classification
- Adjacent surface: `command-base/ADJACENT-SURFACE-INTAKE.md`, `command-base/README.md`, `command-base/app/package.json`, `command-base/app/package-lock.json`, `command-base/app/lib/auth.js`, `command-base/app/lib/auth.test.js`, `command-base/app/scripts/check-dependency-policy.js`, `command-base/app/scripts/check-surface-policy.js`.
- EXOCHAIN core/runtime adapter changes: none.
- Imported evidence changes: none.
- Third-party/vendor changes: npm lockfile dependency resolution for `multer` 2.1.1 and its dependency tree.

## Finding Disposition
- External CommandBase Multer concern was sanity-checked against current `origin/main`.
- `npm --prefix command-base/app audit --json` reported 0 known vulnerabilities before remediation, so this was not an active audited high/critical vulnerability.
- Current `origin/main` still declared `multer` `^1.4.5-lts.1` and locked deprecated `multer` `1.4.5-lts.2`, whose package metadata says 1.x is impacted by vulnerabilities patched in 2.x.
- Adjacent trust-claim hygiene was live: the README did not classify CommandBase as adjacent and made unconditional enforcement claims.
- CommandBase auth fallback was live: current `origin/main` signed HMAC fallback tokens with a hardcoded development secret when WASM signing was unavailable; truncated HMAC signatures also threw from `timingSafeEqual` instead of returning invalid.

## Test Plan
- RED: `node command-base/app/scripts/check-dependency-policy.js` failed before the dependency update with `multer dependency range must require 2.x or newer, got ^1.4.5-lts.1`.
- RED: `node command-base/app/scripts/check-surface-policy.js` failed before README clarification with `CommandBase README must identify the surface as adjacent`.
- RED: `node --test command-base/app/lib/auth.test.js` failed before the auth fix because missing/default `EXOCHAIN_AUTH_SECRET` still signed tokens and truncated signatures threw through verification.
- `npm --prefix command-base/app ci --ignore-scripts` passed.
- `npm --prefix command-base/app run auth:check` passed, 3/3.
- `npm --prefix command-base/app run dependency-policy:check` passed.
- `npm --prefix command-base/app run surface-policy:check` passed.
- `npm --prefix command-base/app audit --audit-level=moderate` passed with 0 vulnerabilities.
- `node --test command-base/app/services/*.test.js` passed, 32/32.
- Multer 2 middleware smoke check passed.
- `npm --prefix command-base/app ls multer --depth=0` resolved `multer@2.1.1`.
- `git diff --check` passed.
