### PR TITLE
fix(tools): require sybil cli neo4j secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,8 @@ jobs:
         run: bash tools/test_ci_supply_chain_hardening.sh
       - name: Repo truth and public claims
         run: bash tools/test_repo_truth.sh
+      - name: Sybil CLI secret boundary
+        run: bash tools/test_sybil_cli_secret_boundaries.sh
       - name: Audit policy documentation truth
         run: bash tools/test_audit_policy_docs.sh
       - name: Consensus liveness documentation truth

--- a/tools/sybil-cli/README.md
+++ b/tools/sybil-cli/README.md
@@ -20,6 +20,17 @@ Everything is **file-backed** (Git-friendly) so decisions are diffable, reviewab
 pip install -r requirements.txt
 ```
 
+## Neo4j configuration
+
+`graph_schema.py` fails closed unless Neo4j connection settings are supplied
+explicitly:
+
+```bash
+export NEO4J_URI="<neo4j-bolt-uri>"
+export NEO4J_USERNAME="<neo4j-username>"
+export NEO4J_PASSWORD="<secret-from-your-password-manager>"
+```
+
 ---
 
 ## Initialize store

--- a/tools/sybil-cli/graph_schema.py
+++ b/tools/sybil-cli/graph_schema.py
@@ -1,10 +1,24 @@
+import os
+
 from langchain.graphs.neo4j_graph import Neo4jGraph
 
-graph = Neo4jGraph(
-    url="bolt://localhost:7687",
-    username="neo4j",
-    password="password"  # secure via env var in prod
-)
+
+def required_neo4j_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"Missing required Neo4j configuration: {name}")
+    return value
+
+
+def build_graph() -> Neo4jGraph:
+    return Neo4jGraph(
+        url=required_neo4j_env("NEO4J_URI"),
+        username=required_neo4j_env("NEO4J_USERNAME"),
+        password=required_neo4j_env("NEO4J_PASSWORD"),
+    )
+
+
+graph = build_graph()
 
 # Example Cypher Model Definitions:
 # :Interaction - {id, text, timestamp, model}

--- a/tools/test_sybil_cli_secret_boundaries.sh
+++ b/tools/test_sybil_cli_secret_boundaries.sh
@@ -10,17 +10,17 @@ SOURCE="tools/sybil-cli/graph_schema.py"
 
 [[ -f "$SOURCE" ]] || fail "missing $SOURCE"
 
-if rg -n 'password\s*=\s*["'\'']password["'\'']|username\s*=\s*["'\'']neo4j["'\'']|bolt://localhost:7687' "$SOURCE" >/dev/null; then
+if grep -En 'password[[:space:]]*=[[:space:]]*["'\'']password["'\'']|username[[:space:]]*=[[:space:]]*["'\'']neo4j["'\'']|bolt://localhost:7687' "$SOURCE" >/dev/null; then
   fail "Neo4j connection settings must come from required environment variables, not literals"
 fi
 
 for required in NEO4J_URI NEO4J_USERNAME NEO4J_PASSWORD; do
-  if ! rg -n "$required" "$SOURCE" >/dev/null; then
+  if ! grep -Fn "$required" "$SOURCE" >/dev/null; then
     fail "$SOURCE must read required $required configuration"
   fi
 done
 
-if ! rg -n 'Missing required Neo4j configuration' "$SOURCE" >/dev/null; then
+if ! grep -Fn 'Missing required Neo4j configuration' "$SOURCE" >/dev/null; then
   fail "$SOURCE must fail closed with a clear missing-configuration error"
 fi
 

--- a/tools/test_sybil_cli_secret_boundaries.sh
+++ b/tools/test_sybil_cli_secret_boundaries.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  printf 'sybil-cli secret boundary test failed: %s\n' "$1" >&2
+  exit 1
+}
+
+SOURCE="tools/sybil-cli/graph_schema.py"
+
+[[ -f "$SOURCE" ]] || fail "missing $SOURCE"
+
+if rg -n 'password\s*=\s*["'\'']password["'\'']|username\s*=\s*["'\'']neo4j["'\'']|bolt://localhost:7687' "$SOURCE" >/dev/null; then
+  fail "Neo4j connection settings must come from required environment variables, not literals"
+fi
+
+for required in NEO4J_URI NEO4J_USERNAME NEO4J_PASSWORD; do
+  if ! rg -n "$required" "$SOURCE" >/dev/null; then
+    fail "$SOURCE must read required $required configuration"
+  fi
+done
+
+if ! rg -n 'Missing required Neo4j configuration' "$SOURCE" >/dev/null; then
+  fail "$SOURCE must fail closed with a clear missing-configuration error"
+fi
+
+env -u NEO4J_URI -u NEO4J_USERNAME -u NEO4J_PASSWORD python3 - <<'PY'
+import runpy
+import sys
+import types
+
+graph_module = types.ModuleType("langchain.graphs.neo4j_graph")
+
+class Neo4jGraph:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+graph_module.Neo4jGraph = Neo4jGraph
+sys.modules["langchain"] = types.ModuleType("langchain")
+sys.modules["langchain.graphs"] = types.ModuleType("langchain.graphs")
+sys.modules["langchain.graphs.neo4j_graph"] = graph_module
+
+try:
+    runpy.run_path("tools/sybil-cli/graph_schema.py")
+except RuntimeError as error:
+    if "Missing required Neo4j configuration: NEO4J_URI" not in str(error):
+        raise
+else:
+    raise SystemExit("graph_schema.py must fail closed when Neo4j env is missing")
+PY
+
+NEO4J_URI='bolt://neo4j.internal:7687' \
+NEO4J_USERNAME='sybil-operator' \
+NEO4J_PASSWORD='correct-horse-battery-staple' \
+python3 - <<'PY'
+import runpy
+import sys
+import types
+
+graph_module = types.ModuleType("langchain.graphs.neo4j_graph")
+
+class Neo4jGraph:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+graph_module.Neo4jGraph = Neo4jGraph
+sys.modules["langchain"] = types.ModuleType("langchain")
+sys.modules["langchain.graphs"] = types.ModuleType("langchain.graphs")
+sys.modules["langchain.graphs.neo4j_graph"] = graph_module
+
+namespace = runpy.run_path("tools/sybil-cli/graph_schema.py")
+graph = namespace["graph"]
+assert graph.kwargs == {
+    "url": "bolt://neo4j.internal:7687",
+    "username": "sybil-operator",
+    "password": "correct-horse-battery-staple",
+}
+PY
+
+printf 'sybil-cli secret boundary test passed\n'


### PR DESCRIPTION
## Classification
- EXOCHAIN core/tooling: `tools/sybil-cli/graph_schema.py`, `tools/sybil-cli/README.md`, `tools/test_sybil_cli_secret_boundaries.sh`.
- CI gate: `.github/workflows/ci.yml`.
- Imported evidence: Wally Fipps gauntlet finding F-015 was used read-only as a hypothesis; no external report artifacts are committed.
- No adjacent surfaces, third-party/vendor, deployment runtime, or Rust core crate code changed.

## Current-main confirmation
- Current base rechecked: `origin/main` at `4c0144ad861d541f978ce969a423524c75544f66`.
- The reported Sybil CLI Neo4j secret issue is still live on current main: `tools/sybil-cli/graph_schema.py` constructs `Neo4jGraph` with literal `bolt://localhost:7687`, `neo4j`, and `password` connection settings.
- Current main does not contain `tools/test_sybil_cli_secret_boundaries.sh`, so the regression guard is still absent there.

## RED / CI failure reproduced
- Original RED: `bash tools/test_sybil_cli_secret_boundaries.sh` failed before the secret-boundary fix with `Neo4j connection settings must come from required environment variables, not literals`.
- PR #374 Gate 9 failure was also reproduced locally with `PATH=/usr/bin:/bin bash tools/test_sybil_cli_secret_boundaries.sh`; it failed because the guard used `rg` and the GitHub Gate 9 runner did not have ripgrep installed.

## Remediation
- Require `NEO4J_URI`, `NEO4J_USERNAME`, and `NEO4J_PASSWORD` for Sybil CLI Neo4j connections.
- Fail closed with a specific missing-configuration error when any required setting is absent.
- Add a CI-enforced regression guard covering static literals, missing-env failure, and env propagation into the Neo4j adapter.
- Make the regression guard self-contained with `grep`/Python instead of relying on `rg` in CI.
- Update Sybil CLI documentation to use explicit placeholders instead of default credentials.

## Validation
- CI-like guard reproduction before fix: `PATH=/usr/bin:/bin bash tools/test_sybil_cli_secret_boundaries.sh` failed with `rg: command not found`.
- Fixed CI-like guard: `PATH=/usr/bin:/bin bash tools/test_sybil_cli_secret_boundaries.sh` passed.
- Focused guard: `bash tools/test_sybil_cli_secret_boundaries.sh` passed.
- Python syntax: `python3 -m py_compile tools/sybil-cli/graph_schema.py` exited 0.
- GitHub action pinning: `bash tools/test_github_actions_pinned.sh` passed.
- CI supply-chain hardening: `bash tools/test_ci_supply_chain_hardening.sh` passed.
- Repo truth: `bash tools/repo_truth.sh --json --skip-tests` reported Rust LOC `173537`.
- Repo truth: `bash tools/repo_truth.sh --json --list-tests` reported `4123` listed tests.
- Repo truth gate: `bash tools/test_repo_truth.sh` passed.
- Agent workflow bounds: `bash tools/test_agent_workflow_bounds.sh` passed.
- Agent prompt boundaries: `bash tools/test_agent_prompt_boundaries.sh` passed.
- Audit policy docs: `bash tools/test_audit_policy_docs.sh` passed.
- Format: `cargo +nightly fmt --all -- --check` exited 0.
- Diff hygiene: `git diff --check origin/main...HEAD` exited 0.
- Conflict search: exact marker scan with `rg -n '^(<<<<<<< |=======$|>>>>>>> )' --glob '!docs/superpowers/**' .` found no matches.
- Secret literal source search: `rg -n "password\\s*=\\s*['\\\"]password['\\\"]|username\\s*=\\s*['\\\"]neo4j['\\\"]|bolt://localhost:7687|NEO4J_USERNAME=\\\"neo4j\\\"|NEO4J_URI=\\\"bolt://127\\.0\\.0\\.1:7687\\\"" tools/sybil-cli/graph_schema.py tools/sybil-cli/README.md .github/workflows/ci.yml` found no matches.
- Guard dependency search: `rg -n "rg -n|ripgrep|command not found" tools/test_sybil_cli_secret_boundaries.sh .github/workflows/ci.yml` found no matches.
- Audit: `cargo audit --deny unsound --deny unmaintained` exited 0.
- Deny: `cargo deny check` exited 0 with existing duplicate dependency warnings only.
- Workspace tests: `env -u DATABASE_URL cargo test --workspace` exited 0.
- Workspace lint: `cargo clippy --workspace --all-targets -- -D warnings` exited 0.
- Workspace docs: `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` exited 0.

Refreshed head: `cb305a16d6ef39b17aac1607b567ed9dbca11c1b`.