### PR TITLE
fix(command-base): require webhook secret

### DIFF
--- a/command-base/app/lib/webhook-auth.js
+++ b/command-base/app/lib/webhook-auth.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const crypto = require('node:crypto');
+
+const WEBHOOK_SECRET_KEY = 'webhook_secret';
+
+function normalizeConfiguredSecret(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function loadWebhookSecret(db) {
+  const row = db
+    .prepare('SELECT value FROM system_settings WHERE key = ?')
+    .get(WEBHOOK_SECRET_KEY);
+  return normalizeConfiguredSecret(row && row.value);
+}
+
+function timingSafeSecretEqual(provided, expected) {
+  if (typeof provided !== 'string' || typeof expected !== 'string') return false;
+
+  const providedBuffer = Buffer.from(provided, 'utf8');
+  const expectedBuffer = Buffer.from(expected, 'utf8');
+  if (providedBuffer.length !== expectedBuffer.length) return false;
+
+  return crypto.timingSafeEqual(providedBuffer, expectedBuffer);
+}
+
+function readWebhookSecretHeader(req) {
+  if (req && typeof req.get === 'function') {
+    const header = req.get('x-webhook-secret');
+    return typeof header === 'string' ? header : undefined;
+  }
+
+  const headers = (req && req.headers) || {};
+  const header = headers['x-webhook-secret'] || headers['X-Webhook-Secret'];
+  return typeof header === 'string' ? header : undefined;
+}
+
+function configureWebhookSecretSetting(db, env = process.env) {
+  const configuredSecret = normalizeConfiguredSecret(env.COMMANDBASE_WEBHOOK_SECRET);
+
+  db.prepare('INSERT OR IGNORE INTO system_settings (key, value) VALUES (?, ?)')
+    .run(WEBHOOK_SECRET_KEY, configuredSecret);
+
+  if (!configuredSecret) return;
+
+  const storedSecret = loadWebhookSecret(db);
+  if (!storedSecret) {
+    db.prepare('UPDATE system_settings SET value = ? WHERE key = ?')
+      .run(configuredSecret, WEBHOOK_SECRET_KEY);
+  }
+}
+
+function requireWebhookSecret(req, db) {
+  const expectedSecret = loadWebhookSecret(db);
+  if (!expectedSecret) {
+    return {
+      ok: false,
+      status: 503,
+      body: { error: 'Webhook secret is not configured' },
+    };
+  }
+
+  const providedSecret = readWebhookSecretHeader(req);
+  if (!timingSafeSecretEqual(providedSecret, expectedSecret)) {
+    return {
+      ok: false,
+      status: 401,
+      body: { error: 'Unauthorized' },
+    };
+  }
+
+  return { ok: true };
+}
+
+module.exports = {
+  configureWebhookSecretSetting,
+  requireWebhookSecret,
+};

--- a/command-base/app/lib/webhook-auth.test.js
+++ b/command-base/app/lib/webhook-auth.test.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  configureWebhookSecretSetting,
+  requireWebhookSecret,
+} = require('./webhook-auth');
+
+class SettingsDb {
+  constructor(initialValue, hasRow = true) {
+    this.hasRow = hasRow;
+    this.value = initialValue;
+    this.operations = [];
+  }
+
+  prepare(sql) {
+    return {
+      get: (key) => {
+        this.operations.push(['get', sql, key]);
+        if (key !== 'webhook_secret' || !this.hasRow) return undefined;
+        return { value: this.value };
+      },
+      run: (...params) => {
+        this.operations.push(['run', sql, ...params]);
+        if (/INSERT OR IGNORE INTO system_settings/.test(sql)) {
+          const [key, value] = params;
+          if (key === 'webhook_secret' && !this.hasRow) {
+            this.hasRow = true;
+            this.value = value;
+          }
+          return { changes: this.hasRow ? 0 : 1 };
+        }
+        if (/UPDATE system_settings/.test(sql)) {
+          const [value, key] = params;
+          if (key === 'webhook_secret' && this.hasRow) {
+            this.value = value;
+            return { changes: 1 };
+          }
+        }
+        return { changes: 0 };
+      },
+    };
+  }
+}
+
+function requestWithSecret(secret) {
+  return { headers: { 'x-webhook-secret': secret } };
+}
+
+test('missing webhook secret setting fails closed before payload handling', () => {
+  const result = requireWebhookSecret({ headers: {} }, new SettingsDb(undefined, false));
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 503);
+  assert.deepEqual(result.body, { error: 'Webhook secret is not configured' });
+});
+
+test('empty webhook secret setting fails closed before payload handling', () => {
+  const result = requireWebhookSecret({ headers: {} }, new SettingsDb(''));
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 503);
+  assert.deepEqual(result.body, { error: 'Webhook secret is not configured' });
+});
+
+test('configured webhook secret rejects missing, query, and incorrect credentials', () => {
+  const db = new SettingsDb('shared-secret');
+
+  assert.deepEqual(
+    requireWebhookSecret({ headers: {} }, db),
+    { ok: false, status: 401, body: { error: 'Unauthorized' } }
+  );
+  assert.deepEqual(
+    requireWebhookSecret({ headers: {}, query: { secret: 'shared-secret' } }, db),
+    { ok: false, status: 401, body: { error: 'Unauthorized' } }
+  );
+  assert.deepEqual(
+    requireWebhookSecret(requestWithSecret('wrong-secret'), db),
+    { ok: false, status: 401, body: { error: 'Unauthorized' } }
+  );
+});
+
+test('configured webhook secret accepts only the matching header value', () => {
+  const result = requireWebhookSecret(requestWithSecret('shared-secret'), new SettingsDb('shared-secret'));
+
+  assert.deepEqual(result, { ok: true });
+});
+
+test('webhook secret bootstrap uses environment configuration without overwriting a configured secret', () => {
+  const emptyDb = new SettingsDb('', true);
+  configureWebhookSecretSetting(emptyDb, { COMMANDBASE_WEBHOOK_SECRET: 'configured-secret' });
+  assert.equal(emptyDb.value, 'configured-secret');
+
+  const missingDb = new SettingsDb(undefined, false);
+  configureWebhookSecretSetting(missingDb, { COMMANDBASE_WEBHOOK_SECRET: 'configured-secret' });
+  assert.equal(missingDb.value, 'configured-secret');
+
+  const existingDb = new SettingsDb('existing-secret', true);
+  configureWebhookSecretSetting(existingDb, { COMMANDBASE_WEBHOOK_SECRET: 'configured-secret' });
+  assert.equal(existingDb.value, 'existing-secret');
+});
+
+test('webhook secret bootstrap permits an unset secret only as a fail-closed placeholder', () => {
+  const db = new SettingsDb(undefined, false);
+
+  configureWebhookSecretSetting(db, {});
+
+  assert.equal(db.value, '');
+  assert.equal(requireWebhookSecret(requestWithSecret('anything'), db).status, 503);
+});

--- a/command-base/app/server-webhook-secret-boundary.test.js
+++ b/command-base/app/server-webhook-secret-boundary.test.js
@@ -1,0 +1,37 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const serverSource = fs.readFileSync(path.join(__dirname, 'server.js'), 'utf8');
+
+test('inbound webhooks do not seed or preserve an empty-open secret boundary', () => {
+  assert.equal(
+    /empty\s*=\s*open/.test(serverSource),
+    false,
+    'webhook configuration must not document an empty secret as an open boundary'
+  );
+  assert.equal(
+    /VALUES\s*\(\s*'webhook_secret'\s*,\s*''\s*\)/.test(serverSource),
+    false,
+    'webhook_secret must not be seeded as an empty string literal'
+  );
+  assert.equal(
+    /if\s*\(\s*webhookSecret\s*&&\s*webhookSecret\.value\s*\)/.test(serverSource),
+    false,
+    'webhook handlers must not skip authentication when the stored secret is absent or empty'
+  );
+});
+
+test('inbound webhook authentication uses a shared fail-closed header boundary', () => {
+  assert.equal(
+    /requireWebhookSecret/.test(serverSource),
+    true,
+    'both webhook handlers should use the shared fail-closed webhook authenticator'
+  );
+  assert.equal(
+    /req\.query\.secret/.test(serverSource),
+    false,
+    'webhook secrets must not be accepted through URL query parameters'
+  );
+});

--- a/command-base/app/server.js
+++ b/command-base/app/server.js
@@ -9,6 +9,10 @@ const fs = require('fs');
 // ── Structured logger — must come before any console.* calls ──
 const logger = require('./logger');
 logger.overrideConsole();
+const {
+  configureWebhookSecretSetting,
+  requireWebhookSecret,
+} = require('./lib/webhook-auth');
 
 const http = require('http');
 const https = require('https');
@@ -368,8 +372,8 @@ function scheduleWalCheckpoint() {
 
 scheduleWalCheckpoint();
 
-// Seed webhook_secret setting (empty = open for initial setup)
-db.exec(`INSERT OR IGNORE INTO system_settings (key, value) VALUES ('webhook_secret', '')`);
+// Seed webhook_secret setting; empty or missing values fail closed at webhook ingress.
+configureWebhookSecretSetting(db);
 
 // Seed backup_dir setting (empty = use DEFAULT_BACKUP_DIR / BACKUP_DIR env var)
 db.exec(`INSERT OR IGNORE INTO system_settings (key, value) VALUES ('backup_dir', '')`);
@@ -8706,13 +8710,9 @@ async function dispatchNotification(notification) {
 // POST /api/webhooks/sms — Twilio sends incoming SMS here
 app.post('/api/webhooks/sms', (req, res) => {
   try {
-    // Webhook authentication
-    const webhookSecret = db.prepare(`SELECT value FROM system_settings WHERE key = 'webhook_secret'`).get();
-    if (webhookSecret && webhookSecret.value) {
-      const provided = req.headers['x-webhook-secret'] || req.query.secret;
-      if (provided !== webhookSecret.value) {
-        return res.status(401).json({ error: 'Unauthorized' });
-      }
+    const webhookAuth = requireWebhookSecret(req, db);
+    if (!webhookAuth.ok) {
+      return res.status(webhookAuth.status).json(webhookAuth.body);
     }
 
     const from = req.body.From || 'unknown';
@@ -8779,13 +8779,9 @@ app.post('/api/webhooks/sms', (req, res) => {
 // POST /api/webhooks/slack — Slack sends events/commands here
 app.post('/api/webhooks/slack', (req, res) => {
   try {
-    // Webhook authentication
-    const webhookSecret = db.prepare(`SELECT value FROM system_settings WHERE key = 'webhook_secret'`).get();
-    if (webhookSecret && webhookSecret.value) {
-      const provided = req.headers['x-webhook-secret'] || req.query.secret;
-      if (provided !== webhookSecret.value) {
-        return res.status(401).json({ error: 'Unauthorized' });
-      }
+    const webhookAuth = requireWebhookSecret(req, db);
+    if (!webhookAuth.ok) {
+      return res.status(webhookAuth.status).json(webhookAuth.body);
     }
 
     // Handle Slack URL verification challenge


### PR DESCRIPTION
## Summary
- Classifies this as adjacent-surface remediation for CommandBase inbound SMS/Slack webhooks.
- Replaces the fail-open empty `webhook_secret` seed with a shared fail-closed authenticator.
- Requires `x-webhook-secret` for configured webhooks, ignores URL query secrets, and returns 503 when the secret is missing or empty.

## Current-main verification
- External finding: Wally gauntlet F-020, `webhook_secret` seeded as empty/open and handlers authenticate only when a value is present.
- Reproduced on `origin/main` at `4ece768d`: `server.js` documented `empty = open`, inserted `('webhook_secret', '')`, and both webhook handlers skipped authentication when the row was empty.
- Imported evidence was used only as input; no report, zip, screenshot, or generated scanner output is committed.

## Adjacent Surface Intake
- Owner/accountable maintainer: Bob Stewart / CommandBase maintainers.
- Deployment status: `internal` adjacent surface based on current repository evidence (`command-base/app` local dashboard); not treated as EXOCHAIN core.
- Constitutional trust claims: not allowed by this change.
- Core state access: this PR does not add or prove any EXOCHAIN core read/write path; inbound webhooks create CommandBase tasks only.
- Trust boundary: SMS/Slack webhook ingress terminates at CommandBase and must not mint, cache, or simulate EXOCHAIN consent, authority, provenance, governance outcomes, or constitutional adjudication.
- Surface-specific test command and CI gate: Node built-in tests listed below; no package-level test script exists on current main.
- Secrets inventory/config source: `COMMANDBASE_WEBHOOK_SECRET` can seed an empty DB row at startup; persisted secret is `system_settings.webhook_secret`; requests must present `x-webhook-secret`.
- Rollback/disablement: unset or clear the secret to fail closed with HTTP 503, rotate `COMMANDBASE_WEBHOOK_SECRET`/DB value, or disable `/api/webhooks/sms` and `/api/webhooks/slack` at the proxy.

## Test Plan
- [x] RED: `node --test command-base/app/server-webhook-secret-boundary.test.js` failed on current fail-open patterns before production code changed.
- [x] RED: `node --test command-base/app/lib/webhook-auth.test.js` failed because the shared authenticator did not exist before implementation.
- [x] `node --test command-base/app/server-webhook-secret-boundary.test.js command-base/app/lib/webhook-auth.test.js`
- [x] `node --test command-base/app/server-webhook-secret-boundary.test.js command-base/app/lib/webhook-auth.test.js command-base/app/services/governance.test.js command-base/app/services/cqi-orchestrator.test.js`
- [x] `node --check command-base/app/server.js && node --check command-base/app/lib/webhook-auth.js && node --check command-base/app/server-webhook-secret-boundary.test.js && node --check command-base/app/lib/webhook-auth.test.js`
- [x] `rg -n "empty = open|VALUES \\('webhook_secret', ''\\)|if \\(webhookSecret && webhookSecret\\.value\\)|req\\.query\\.secret" command-base/app/server.js command-base/app/lib command-base/app/*.test.js command-base/app/services` returned no matches.
- [x] `git diff --check`
- [x] `npm --prefix command-base/app audit --audit-level=moderate`