### PR TITLE
fix(command-base): surface task-force log failures

### DIFF
--- a/command-base/app/lib/task-force-engine.js
+++ b/command-base/app/lib/task-force-engine.js
@@ -23,12 +23,22 @@ function now() {
   return new Date().toISOString().replace('T', ' ').slice(0, 19);
 }
 
-function log(forceId, level, source, message, metadata) {
+function recordTaskForceLog(getDbFn, forceId, level, source, message, metadata, clock = now) {
   try {
-    const db = getDb();
-    db.prepare(`INSERT INTO task_force_logs (force_id, level, source, message, metadata, created_at) VALUES (?,?,?,?,?,?)`)
-      .run(forceId, level, source, message, metadata ? JSON.stringify(metadata) : null, now());
-  } catch (_) {}
+    const db = getDbFn();
+    return db.prepare(`INSERT INTO task_force_logs (force_id, level, source, message, metadata, created_at) VALUES (?,?,?,?,?,?)`)
+      .run(forceId, level, source, message, metadata ? JSON.stringify(metadata) : null, clock());
+  } catch (err) {
+    const wrapped = new Error(
+      `task force log insert failed for force_id=${forceId} source=${source} level=${level}: ${err.message}`,
+    );
+    wrapped.cause = err;
+    throw wrapped;
+  }
+}
+
+function log(forceId, level, source, message, metadata) {
+  return recordTaskForceLog(getDb, forceId, level, source, message, metadata);
 }
 
 // ── Resource Monitoring ──
@@ -754,5 +764,6 @@ module.exports = {
   killProcess, killForce, emergencyKillDevice,
   getResourceUsage, getAllResourceUsage, getProcessBreakdown, checkCanSpawnOnDevice, updateResourceProfile,
   recordBiasAction, checkBias, getUnbiasedReviewer,
-  reconnectOrphans, startGuardian, stopGuardian, closeDb
+  reconnectOrphans, startGuardian, stopGuardian, closeDb,
+  __test: { recordTaskForceLog }
 };

--- a/command-base/app/lib/task-force-engine.test.js
+++ b/command-base/app/lib/task-force-engine.test.js
@@ -1,0 +1,93 @@
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const test = require('node:test');
+
+function loadEngineWithDb(getDb = () => {
+  throw new Error('unexpected DB access');
+}) {
+  const enginePath = require.resolve('./task-force-engine');
+  const dbPath = require.resolve('./task-force-db');
+  const originalLoad = Module._load;
+  delete require.cache[enginePath];
+
+  Module._load = function patchedLoad(request, parent, isMain) {
+    const resolved = Module._resolveFilename(request, parent, isMain);
+    if (resolved === dbPath) {
+      return { getDb, close: () => {} };
+    }
+    return originalLoad.apply(this, arguments);
+  };
+
+  try {
+    return require('./task-force-engine');
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+test('task-force log insert failures are surfaced with context', () => {
+  const engine = loadEngineWithDb();
+  assert.equal(typeof engine.__test.recordTaskForceLog, 'function');
+
+  const failingDb = {
+    prepare(sql) {
+      assert.match(sql, /INSERT INTO task_force_logs/);
+      return {
+        run() {
+          throw new Error('readonly database');
+        },
+      };
+    },
+  };
+
+  assert.throws(
+    () =>
+      engine.__test.recordTaskForceLog(
+        () => failingDb,
+        42,
+        'error',
+        'guardian',
+        'zombie process detected',
+        { pid: 1234 },
+      ),
+    /task force log insert failed for force_id=42 source=guardian level=error: readonly database/,
+  );
+});
+
+test('task-force log helper writes deterministic metadata JSON', () => {
+  const engine = loadEngineWithDb();
+  const calls = [];
+  const db = {
+    prepare(sql) {
+      assert.match(sql, /INSERT INTO task_force_logs/);
+      return {
+        run(...args) {
+          calls.push(args);
+          return { changes: 1 };
+        },
+      };
+    },
+  };
+
+  const result = engine.__test.recordTaskForceLog(
+    () => db,
+    7,
+    'info',
+    'engine',
+    'force deployed',
+    { adapter: 'claude_cli', device: 'mac' },
+    () => '2026-05-06 01:02:03',
+  );
+
+  assert.deepEqual(result, { changes: 1 });
+  assert.deepEqual(calls, [
+    [
+      7,
+      'info',
+      'engine',
+      'force deployed',
+      '{"adapter":"claude_cli","device":"mac"}',
+      '2026-05-06 01:02:03',
+    ],
+  ]);
+});


### PR DESCRIPTION
## Summary
- Classification: adjacent surface (`command-base/app/lib/*` only); no EXOCHAIN core, runtime adapter, governance, CI, or deployment contract files changed.
- Confirms current-main F-090-style behavior was live in `command-base/app/lib/task-force-engine.js`: task-force log DB insert errors were caught and discarded.
- Replaces the swallowed insert with a small helper that throws contextual errors for force/source/level and keeps deterministic metadata serialization covered by tests.

## Test Plan
- RED: `node --test command-base/app/lib/task-force-engine.test.js` failed on current code because the task-force log helper was not exposed and the swallowed failure boundary was still present.
- GREEN: `node --test command-base/app/lib/task-force-engine.test.js`
- `node --test command-base/app/lib/task-force-engine.test.js command-base/app/services/governance.test.js command-base/app/services/cqi-orchestrator.test.js`
- `node --test command-base/app/services/governance.test.js`
- `node --check command-base/app/lib/task-force-engine.js && node --check command-base/app/lib/task-force-engine.test.js`
- `git diff --check`

## Adjacent Surface Intake
- Owner/accountable maintainer: CommandBase adjacent surface owner.
- Deployment status: adjacent internal/customer-zero operational surface, not canonical EXOCHAIN core.
- EXOCHAIN trust claims: this change does not add or expand constitutional trust claims.
- Core state access: no EXOCHAIN core state, signatures, credentials, governance outcomes, consent records, or provenance records are read or written by this patch.
- Trust boundary: CommandBase task-force logs remain local adjacent operational audit evidence; failures now surface instead of silently disappearing.
- Surface test/CI gate: `node --test command-base/app/lib/task-force-engine.test.js` plus nearby CommandBase service tests above.
- Secrets/runtime config: unchanged.
- Rollback/disablement: revert this PR to restore previous best-effort logging behavior if task-force execution must temporarily ignore local log persistence failures.
