### PR TITLE
fix(gateway): bound graphql decision offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 173602 | `wc -l` |
+| Rust LOC | 173651 | `wc -l` |
 | Workspace tests | 4,125 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -96,7 +96,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 173602 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 173651 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,125 listed workspace tests
 

--- a/crates/exo-gateway/src/graphql.rs
+++ b/crates/exo-gateway/src/graphql.rs
@@ -491,6 +491,8 @@ pub const UNAUDITED_GRAPHQL_API_MEMO: &str =
     "exochain/council-intake/exo-spline-gateway-api-messaging.md";
 pub const GRAPHQL_MAX_QUERY_DEPTH: usize = 12;
 pub const GRAPHQL_MAX_QUERY_COMPLEXITY: usize = 256;
+pub const GRAPHQL_MAX_DECISIONS_LIMIT: i32 = 200;
+pub const GRAPHQL_MAX_DECISIONS_OFFSET: i32 = 10_000;
 pub const GRAPHQL_CONSENT_FABRICATION_INITIATIVE: &str =
     "Initiatives/fix-spline-r2-graphql-consent-fabrication.md";
 pub const GRAPHQL_PROOF_STUB_INITIATIVE: &str = "Initiatives/fix-spline-r3-graphql-proof-stub.md";
@@ -524,10 +526,14 @@ impl QueryRoot {
         guard_graphql_execution()?;
         let state = app_state_from_context(ctx)?;
         let guard = state.lock().await;
-        let offset =
-            graphql_nonnegative_i32_to_usize(offset.unwrap_or(0).max(0), "decisions.offset")?;
-        let limit =
-            graphql_nonnegative_i32_to_usize(limit.unwrap_or(50).clamp(1, 200), "decisions.limit")?;
+        let offset = graphql_nonnegative_i32_to_usize(
+            offset.unwrap_or(0).clamp(0, GRAPHQL_MAX_DECISIONS_OFFSET),
+            "decisions.offset",
+        )?;
+        let limit = graphql_nonnegative_i32_to_usize(
+            limit.unwrap_or(50).clamp(1, GRAPHQL_MAX_DECISIONS_LIMIT),
+            "decisions.limit",
+        )?;
         let results: Vec<GqlDecision> = guard
             .decisions
             .values()
@@ -1688,6 +1694,49 @@ mod tests {
         assert!(res.errors.is_empty(), "errors: {:?}", res.errors);
         let data = res.data.into_json().expect("data");
         assert_eq!(data["decisions"], serde_json::json!([]));
+    }
+
+    #[cfg(feature = "unaudited-gateway-graphql-api")]
+    #[tokio::test]
+    async fn query_decisions_clamps_oversized_offset() {
+        let mut state = AppState::new();
+        for index in 0..10_002 {
+            let id = format!("decision-{index:05}");
+            state.decisions.insert(
+                id.clone(),
+                DecisionRecord {
+                    decision: GqlDecision {
+                        id: ID::from(id),
+                        tenant_id: "tenant-a".to_owned(),
+                        status: "CREATED".to_owned(),
+                        title: format!("Decision {index:05}"),
+                        decision_class: "Routine".to_owned(),
+                        author: "did:exo:author".to_owned(),
+                        created_at: "1:0".to_owned(),
+                        votes: Vec::new(),
+                        challenges: Vec::new(),
+                        content_hash: Hash256::digest(format!("decision-{index:05}").as_bytes())
+                            .to_string(),
+                    },
+                    audit_trail: Vec::new(),
+                },
+            );
+        }
+        let schema = build_schema(Arc::new(Mutex::new(state)));
+
+        let res = schema
+            .execute(r#"{ decisions(tenantId: "tenant-a", limit: 1, offset: 10001) { id title } }"#)
+            .await;
+
+        assert!(res.errors.is_empty(), "errors: {:?}", res.errors);
+        let data = res.data.into_json().expect("data");
+        assert_eq!(
+            data["decisions"],
+            serde_json::json!([
+                {"id": "decision-10000", "title": "Decision 10000"}
+            ]),
+            "oversized offsets must clamp to the gateway GraphQL offset ceiling"
+        );
     }
 
     #[cfg(feature = "unaudited-gateway-graphql-api")]


### PR DESCRIPTION
## Classification

- Core runtime adapter: `crates/exo-gateway/src/graphql.rs` GraphQL decision-list pagination.
- Documentation/repo-truth metadata: `README.md`.
- No adjacent surface, imported evidence, or third-party source was modified.

## Current-base verification

Revalidated May 9, 2026 after rebasing onto current `origin/main` (`35f800e34d643effdcf40d6450b7b471e2840210`). Current main clamps negative offsets to zero but still allows oversized `i32` offsets into `.skip(offset)`, and the oversized-offset regression is absent.

Verification command used against current main:
`git show origin/main:crates/exo-gateway/src/graphql.rs | rg -n 'GRAPHQL_MAX_DECISIONS_OFFSET|query_decisions_clamps_oversized_offset|skip\\(offset\\)|offset.*as usize|graphql_nonnegative_i32_to_usize'`

## Remediation

- Adds `GRAPHQL_MAX_DECISIONS_OFFSET` and clamps decision-list offsets before conversion to `usize`.
- Preserves existing nonnegative conversion and limit bounds.
- Adds feature-enabled regression coverage for oversized offset behavior.

## Validation

- `cargo test -p exo-gateway --features unaudited-gateway-graphql-api query_decisions_clamps_oversized_offset -- --nocapture` — 1 passed.
- `cargo test -p exo-gateway --features unaudited-gateway-graphql-api graphql -- --nocapture` — 28 passed.
- `bash tools/repo_truth.sh` — Rust LOC `173586`, tests listed `4123`, format clean true.
- `bash tools/test_repo_truth.sh` — passed.
- `git diff --check origin/main...HEAD` — passed.
- `rg -n '^<<<<<<<|^=======|^>>>>>>>' README.md crates/exo-gateway/src/graphql.rs` — no conflict markers.
- `rg -n 'GRAPHQL_MAX_DECISIONS_OFFSET|graphql_nonnegative_i32_to_usize|clamp\\(0, GRAPHQL_MAX_DECISIONS_OFFSET\\)|query_decisions_clamps_oversized_offset|as usize' crates/exo-gateway/src/graphql.rs` — verified bounded conversion path and no unchecked `as usize` match.
- `cargo test -p exo-gateway -- --nocapture` — 256 lib tests, 1 binary test, 13 integration tests, and doctests passed.
- `cargo +nightly fmt --all -- --check` — passed.
- `cargo clippy -p exo-gateway --all-targets -- -D warnings` — passed.
- `cargo clippy -p exo-gateway --features unaudited-gateway-graphql-api --all-targets -- -D warnings` — passed.
- `RUSTDOCFLAGS='-D warnings' cargo doc -p exo-gateway --features unaudited-gateway-graphql-api --no-deps` — passed.

Rebased head: `c496d6b893962a2bead98cbf405f326bed48a2ad`.
