### PR TITLE
fix(node): bound 0dentity page offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 174917 | `wc -l` |
-| Workspace tests | 4,140 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 174965 | `wc -l` |
+| Workspace tests | 4,142 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,140 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,142 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 174917 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 174965 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,140 listed workspace tests
+         cryptographic proofs, 4,142 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/zerodentity/api.rs
+++ b/crates/exo-node/src/zerodentity/api.rs
@@ -82,6 +82,7 @@ pub struct HistoryQuery {
 
 const DEFAULT_PAGE_LIMIT: u64 = 50;
 const MAX_PAGE_LIMIT: u64 = 100;
+const MAX_PAGE_OFFSET: u64 = 10_000;
 
 #[derive(Debug, Clone, Copy)]
 struct PageBounds {
@@ -357,6 +358,12 @@ fn parse_page_bounds(limit: Option<u64>, offset: Option<u64>) -> ApiResult<PageB
     }
 
     let offset_u64 = offset.unwrap_or(0);
+    if offset_u64 > MAX_PAGE_OFFSET {
+        return Err(bad_request(&format!(
+            "offset must be between 0 and {MAX_PAGE_OFFSET}"
+        )));
+    }
+
     let limit = usize::try_from(limit_u64)
         .map_err(|_| bad_request("limit exceeds this platform's addressable range"))?;
     let offset = usize::try_from(offset_u64)
@@ -1544,6 +1551,26 @@ mod tests {
         assert!(result["error"].as_str().unwrap().contains("limit"));
     }
 
+    #[tokio::test]
+    async fn score_history_rejects_offset_above_maximum() {
+        let state = make_state_with_score_history("did:exo:history", &[1000]);
+        let app = zerodentity_api_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/0dentity/did%3Aexo%3Ahistory/score/history?offset=10001")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(result["error"].as_str().unwrap().contains("offset"));
+    }
+
     // --- create_peer_attestation ---
 
     #[tokio::test]
@@ -1740,6 +1767,27 @@ mod tests {
         let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
         let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert!(result["error"].as_str().unwrap().contains("limit"));
+    }
+
+    #[tokio::test]
+    async fn list_claims_rejects_offset_above_maximum() {
+        let state = make_state_with_session_and_claims("tok-alice", "did:exo:alice", 2);
+        let app = zerodentity_api_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/0dentity/did%3Aexo%3Aalice/claims?offset=10001")
+                    .header("authorization", "Bearer tok-alice")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(result["error"].as_str().unwrap().contains("offset"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Classifies this as EXOCHAIN core runtime/API remediation in `crates/exo-node/src/zerodentity/api.rs`, with README repository-truth counter refresh only.
- Adds a deterministic `MAX_PAGE_OFFSET` enforcement boundary for 0dentity pagination before converting request offsets to `usize`.
- Adds regression coverage proving both score history and claim listing reject offsets above the bounded maximum instead of accepting unbounded pagination input.

## Current-main verification
- Report date context: external findings are treated as stale hypotheses until reproduced.
- Verified against current `origin/main` 64fd2ff4a2b9f67eb5dbe2f6f564b2281f618e14: 0dentity API has checked `usize::try_from(offset_u64)`, but no explicit `MAX_PAGE_OFFSET` cap and no `score_history_rejects_offset_above_maximum` / `list_claims_rejects_offset_above_maximum` regression coverage.
- Imported evidence remains read-only; this branch only changes owned EXOCHAIN runtime/API code and README truth counters.

## Path classification
- `crates/exo-node/src/zerodentity/api.rs` - EXOCHAIN core runtime/API adapter
- `README.md` - EXOCHAIN governance/project metadata, refreshed by `tools/repo_truth.sh`

## Validation
- `bash tools/repo_truth.sh`
- `bash tools/test_repo_truth.sh`
- `cargo test -p exo-node score_history_rejects_offset_above_maximum -- --nocapture`
- `cargo test -p exo-node list_claims_rejects_offset_above_maximum -- --nocapture`
- `cargo test -p exo-node zerodentity::api -- --nocapture`
- `cargo test -p exo-node -- --nocapture`
- `cargo +nightly fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- conflict marker scan over tracked files
- source guard for `MAX_PAGE_OFFSET`, `parse_page_bounds`, rejection tests, and lossy offset casts
- `RUSTDOCFLAGS='-D warnings' cargo doc -p exo-node --no-deps`
- `cargo clippy -p exo-node --all-targets -- -D warnings`
- `env -u DATABASE_URL cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`

Head after validation: 29448c3063c224a9562fe8d6cb42cd8186893d88
