### PR TITLE
fix(wasm): require signed catapult receipt chains

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -528,15 +528,16 @@ jobs:
       - name: Build WASM
         run: wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm
       - name: Verify WASM exports
-        # Expected export count = 154. Baseline was 110 before
+        # Expected export count = 155. Baseline was 110 before
         # decision-forum, messaging, death-trigger, and franchise/NewCo
         # scaffold were added; the adjudicated decision transition bridge
         # adds the current security boundary, and the HonorGood economy bridge
-        # adds the current settlement/provenance anchor helpers.
+        # adds the current settlement/provenance anchor helpers. The Catapult
+        # receipt-chain bridge adds explicit actor-key signature verification.
         run: |
           COUNT=$(grep -c "module.exports.wasm_" packages/exochain-wasm/wasm/exochain_wasm.js)
           echo "Found $COUNT WASM exports"
-          [ "$COUNT" -eq 154 ] || (echo "Expected 154 exports, got $COUNT" && exit 1)
+          [ "$COUNT" -eq 155 ] || (echo "Expected 155 exports, got $COUNT" && exit 1)
       - name: Upload WASM artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
@@ -571,15 +572,16 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Verify Rust exports match JS expectations
-        # Expected #[wasm_bindgen] count = 154. Baseline was 110 before the
+        # Expected #[wasm_bindgen] count = 155. Baseline was 110 before the
         # Sprint-4 additions (decision-forum, messaging, death-trigger,
         # franchise/NewCo scaffold); the adjudicated decision transition bridge
-        # adds the current security boundary, and the HonorGood economy bridge
-        # adds the current settlement/provenance anchor helpers.
+        # adds the current security boundary, the HonorGood economy bridge
+        # adds the current settlement/provenance anchor helpers, and Catapult
+        # signed receipt-chain verification adds an explicit key-registry path.
         run: |
           RUST_COUNT=$(grep -r '#\[wasm_bindgen\]' crates/exochain-wasm/src/ | wc -l | tr -d ' ')
           echo "Rust #[wasm_bindgen] exports: $RUST_COUNT"
-          [ "$RUST_COUNT" -eq 154 ] || (echo "WASM export count changed from 154 to $RUST_COUNT — update bridge tests" && exit 1)
+          [ "$RUST_COUNT" -eq 155 ] || (echo "WASM export count changed from 155 to $RUST_COUNT — update bridge tests" && exit 1)
 
   # -----------------------------------------------------------------------
   # Constitutional gate: all must pass

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 174181 | `wc -l` |
-| Workspace tests | 4,131 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 174371 | `wc -l` |
+| Workspace tests | 4,134 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,131 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,134 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 174181 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 174371 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,131 listed workspace tests
+         cryptographic proofs, 4,134 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-catapult/src/receipt.rs
+++ b/crates/exo-catapult/src/receipt.rs
@@ -219,7 +219,11 @@ impl ReceiptChain {
         self.receipts.is_empty()
     }
 
-    /// Verify the hash chain integrity.
+    /// Verify hash-linkage integrity only.
+    ///
+    /// This does not authenticate receipt signatures. Use
+    /// [`Self::verify_signed_chain`] when the chain comes from storage,
+    /// transport, WASM, or any other untrusted boundary.
     ///
     /// # Errors
     /// Returns [`CatapultError`] if canonical CBOR hashing fails.
@@ -227,6 +231,41 @@ impl ReceiptChain {
         let mut expected_prev = Hash256::ZERO;
         for receipt in &self.receipts {
             if receipt.prev_receipt != expected_prev {
+                return Ok(false);
+            }
+            expected_prev = receipt.content_hash()?;
+        }
+        Ok(true)
+    }
+
+    /// Verify hash-linkage integrity and every receipt actor signature.
+    ///
+    /// The resolver must return the trusted Ed25519 public key for each
+    /// `actor_did` appearing in the chain. A missing key is an error because
+    /// unauthenticated provenance must fail closed at trust boundaries.
+    ///
+    /// # Errors
+    /// Returns [`CatapultError`] if a receipt cannot be serialized for hashing
+    /// or signing, or if an actor key cannot be resolved.
+    pub fn verify_signed_chain<F>(&self, mut resolve_actor_public_key: F) -> Result<bool>
+    where
+        F: FnMut(&Did) -> Option<PublicKey>,
+    {
+        let mut expected_prev = Hash256::ZERO;
+        for (index, receipt) in self.receipts.iter().enumerate() {
+            if receipt.prev_receipt != expected_prev {
+                return Ok(false);
+            }
+            let actor_public_key =
+                resolve_actor_public_key(&receipt.actor_did).ok_or_else(|| {
+                    CatapultError::InvalidReceipt {
+                        reason: format!(
+                            "receipt {} at index {index} actor {} missing public key",
+                            receipt.id, receipt.actor_did
+                        ),
+                    }
+                })?;
+            if !receipt.verify_signature(&actor_public_key)? {
                 return Ok(false);
             }
             expected_prev = receipt.content_hash()?;
@@ -632,6 +671,81 @@ mod tests {
 
         assert!(!receipt.is_signed());
         assert!(!receipt.verify_signature(signer.public_key()).unwrap());
+    }
+
+    #[test]
+    fn signed_chain_verification_rejects_signature_tamper_after_deserialize() {
+        let signer = keypair(11);
+        let newco_id = uuid(10);
+        let mut chain = ReceiptChain::new();
+        let r1 = FranchiseReceipt::signed(
+            receipt_input(
+                uuid(91),
+                newco_id,
+                FranchiseOperation::NewcoCreated {
+                    franchise_id: uuid(20),
+                },
+                Hash256::ZERO,
+            ),
+            signer.secret_key(),
+        )
+        .unwrap();
+        let r1_hash = r1.content_hash().unwrap();
+        let mut r2 = FranchiseReceipt::signed(
+            receipt_input(
+                uuid(92),
+                newco_id,
+                FranchiseOperation::GoalCreated { goal_id: uuid(30) },
+                r1_hash,
+            ),
+            signer.secret_key(),
+        )
+        .unwrap();
+        r2.signature = Signature::Empty;
+        chain.receipts.push(r1);
+        chain.receipts.push(r2);
+
+        assert!(
+            chain.verify_chain().unwrap(),
+            "hash-only verification must not be treated as signature authentication"
+        );
+        assert!(
+            !chain
+                .verify_signed_chain(|did| {
+                    if did == &test_did() {
+                        Some(*signer.public_key())
+                    } else {
+                        None
+                    }
+                })
+                .unwrap(),
+            "signed chain verification must reject tampered signatures"
+        );
+    }
+
+    #[test]
+    fn signed_chain_verification_rejects_missing_actor_key() {
+        let signer = keypair(12);
+        let receipt = FranchiseReceipt::signed(
+            receipt_input(
+                uuid(93),
+                uuid(10),
+                FranchiseOperation::HeartbeatRecorded {
+                    agent_did: test_did(),
+                },
+                Hash256::ZERO,
+            ),
+            signer.secret_key(),
+        )
+        .unwrap();
+        let mut chain = ReceiptChain::new();
+        chain.receipts.push(receipt);
+
+        let err = chain.verify_signed_chain(|_| None).unwrap_err();
+        assert!(matches!(
+            err,
+            CatapultError::InvalidReceipt { reason } if reason.contains("missing public key")
+        ));
     }
 
     #[test]

--- a/crates/exochain-wasm/src/catapult_bindings.rs
+++ b/crates/exochain-wasm/src/catapult_bindings.rs
@@ -1,5 +1,7 @@
 //! Catapult bindings: franchise incubator, ODA team management, lifecycle
 
+use std::collections::BTreeMap;
+
 use wasm_bindgen::prelude::*;
 
 use crate::serde_bridge::*;
@@ -29,6 +31,45 @@ fn parse_hash_hex(value: &str, label: &str) -> Result<exo_core::Hash256, JsValue
         )));
     }
     Ok(hash)
+}
+
+fn parse_public_key_hex(value: &str, label: &str) -> Result<exo_core::PublicKey, JsValue> {
+    let public_key_bytes =
+        hex::decode(value).map_err(|e| JsValue::from_str(&format!("{label} hex: {e}")))?;
+    let public_key_arr: [u8; 32] = public_key_bytes
+        .try_into()
+        .map_err(|_| JsValue::from_str(&format!("{label} public key must be 32 bytes")))?;
+    let public_key = exo_core::PublicKey::from_bytes(public_key_arr);
+    if public_key.as_bytes().iter().all(|byte| *byte == 0) {
+        return Err(JsValue::from_str(&format!(
+            "{label} public key must be caller-supplied and nonzero"
+        )));
+    }
+    Ok(public_key)
+}
+
+#[derive(serde::Deserialize)]
+struct WasmActorPublicKey {
+    actor_did: String,
+    public_key_hex: String,
+}
+
+fn parse_actor_public_key_registry(
+    actor_public_keys_json: &str,
+) -> Result<BTreeMap<exo_core::Did, exo_core::PublicKey>, JsValue> {
+    let entries: Vec<WasmActorPublicKey> = from_json_str(actor_public_keys_json)?;
+    let mut registry = BTreeMap::new();
+    for entry in entries {
+        let actor_did = exo_core::Did::new(&entry.actor_did)
+            .map_err(|e| JsValue::from_str(&format!("actor DID error: {e}")))?;
+        let public_key = parse_public_key_hex(&entry.public_key_hex, "actor")?;
+        if registry.insert(actor_did.clone(), public_key).is_some() {
+            return Err(JsValue::from_str(&format!(
+                "duplicate actor public key for {actor_did}"
+            )));
+        }
+    }
+    Ok(registry)
 }
 
 fn parse_timestamp(
@@ -442,10 +483,23 @@ pub fn wasm_generate_franchise_receipt(
 
 /// Verify a franchise receipt chain's integrity.
 #[wasm_bindgen]
-pub fn wasm_verify_franchise_receipt_chain(chain_json: &str) -> Result<bool, JsValue> {
+pub fn wasm_verify_franchise_receipt_chain(_chain_json: &str) -> Result<bool, JsValue> {
+    Err(JsValue::from_str(
+        "wasm_verify_franchise_receipt_chain requires actor public keys; \
+         use wasm_verify_franchise_receipt_chain_with_keys",
+    ))
+}
+
+/// Verify a franchise receipt chain's hash linkage and actor signatures.
+#[wasm_bindgen]
+pub fn wasm_verify_franchise_receipt_chain_with_keys(
+    chain_json: &str,
+    actor_public_keys_json: &str,
+) -> Result<bool, JsValue> {
     let chain: exo_catapult::receipt::ReceiptChain = from_json_str(chain_json)?;
+    let actor_public_keys = parse_actor_public_key_registry(actor_public_keys_json)?;
     chain
-        .verify_chain()
+        .verify_signed_chain(|did| actor_public_keys.get(did).copied())
         .map_err(|e| JsValue::from_str(&format!("Receipt chain verification error: {e}")))
 }
 
@@ -500,6 +554,28 @@ mod tests {
         assert!(
             !production.contains("build_pace_config(&newco)"),
             "WASM authority-chain export must not return summary PACE defaults as operational config"
+        );
+    }
+
+    #[test]
+    fn receipt_chain_export_requires_actor_key_verification() {
+        let source = include_str!("catapult_bindings.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production section");
+
+        assert!(
+            production.contains("requires actor public keys"),
+            "legacy WASM receipt-chain verification must fail closed without actor keys"
+        );
+        assert!(
+            production.contains(".verify_signed_chain("),
+            "WASM receipt-chain verification must use signed-chain verification"
+        );
+        assert!(
+            !production.contains(".verify_chain()"),
+            "WASM receipt-chain verification must not rely on hash-only verification"
         );
     }
 

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -1211,8 +1211,19 @@ test('wasm_generate_franchise_receipt', () => {
 });
 
 test('wasm_verify_franchise_receipt_chain', () => {
-  const ok = wasm.wasm_verify_franchise_receipt_chain(JSON.stringify({ receipts: [] }));
-  if (!ok) throw new Error('empty franchise receipt chain should verify');
+  return expectErrorContains(
+    'wasm_verify_franchise_receipt_chain',
+    () => wasm.wasm_verify_franchise_receipt_chain(JSON.stringify({ receipts: [] })),
+    'requires actor public keys'
+  );
+});
+
+test('wasm_verify_franchise_receipt_chain_with_keys', () => {
+  const ok = wasm.wasm_verify_franchise_receipt_chain_with_keys(
+    JSON.stringify({ receipts: [] }),
+    JSON.stringify([])
+  );
+  if (!ok) throw new Error('empty franchise receipt chain should verify with explicit key registry');
   return ok;
 });
 


### PR DESCRIPTION
## Summary
- Adds `ReceiptChain::verify_signed_chain` to verify hash linkage and each receipt actor signature with a trusted DID public-key resolver.
- Changes the legacy WASM `wasm_verify_franchise_receipt_chain` export to fail closed because it has no actor key material.
- Adds `wasm_verify_franchise_receipt_chain_with_keys` plus bridge/source-guard coverage and updates the WASM export-count gate to 155.

## Path Classification
- `crates/exo-catapult/src/receipt.rs`: EXOCHAIN core/workspace provenance-adjacent receipt logic.
- `crates/exochain-wasm/src/catapult_bindings.rs`: Core runtime adapter.
- `packages/exochain-wasm/test/bridge_verification.mjs`: Core runtime adapter bridge validation.
- `.github/workflows/ci.yml`: CI gate for runtime-adapter export synchronization.

## Current Finding Validation
The stale/external concern was rechecked against current `origin/main` before editing. The issue still reproduced conceptually: WASM accepted `ReceiptChain::verify_chain()`, which only validates hash linkage and cannot authenticate signatures because no actor public keys are provided. A regression now proves an otherwise intact hash chain with a blanked signature still passes hash-only verification but fails signed-chain verification.

## Tests
- `cargo test -p exo-catapult signed_chain_verification -- --nocapture`
- `cargo test -p exo-catapult`
- `cargo test -p exochain-wasm catapult -- --nocapture`
- `cargo test -p exochain-wasm`
- `wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm`
- `node packages/exochain-wasm/test/bridge_verification.mjs`
- `COUNT=$(grep -c "module.exports.wasm_" packages/exochain-wasm/wasm/exochain_wasm.js); test "$COUNT" -eq 155`
- `RUST_COUNT=$(grep -r '#\[wasm_bindgen\]' crates/exochain-wasm/src/ | wc -l | tr -d ' '); test "$RUST_COUNT" -eq 155`
- `cargo fmt --all -- --check`
- `cargo clippy -p exo-catapult -p exochain-wasm --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- bypass search: `rg -n "verify_franchise_receipt_chain|verify_signed_chain|\.verify_chain\(\)" crates/exo-catapult crates/exochain-wasm packages/exochain-wasm/test .github/workflows/ci.yml`
- deterministic guard search: `rg -n "HashMap|HashSet|SystemTime|Instant::now|std::time|Math\.random|unwrap_or_default|let _ =" crates/exo-catapult/src/receipt.rs crates/exochain-wasm/src/catapult_bindings.rs packages/exochain-wasm/test/bridge_verification.mjs .github/workflows/ci.yml`

## Notes
- Imported reports/artifacts were treated as hypotheses only; no imported evidence was modified or committed.
- The old hash-linkage helper remains documented as hash-only for internal callers; trust-boundary verification must use `verify_signed_chain`.
