### PR TITLE
fix(node): persist commit receipts atomically

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 173651 | `wc -l` |
-| Workspace tests | 4,125 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 174181 | `wc -l` |
+| Workspace tests | 4,131 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,125 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,131 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 173651 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 174181 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,125 listed workspace tests
+         cryptographic proofs, 4,131 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          147 verified bridge exports — Rust → WebAssembly → JavaScript

--- a/crates/exo-node/src/reactor.rs
+++ b/crates/exo-node/src/reactor.rs
@@ -1016,14 +1016,16 @@ async fn handle_commit(
                 return Ok(None);
             }
 
-            // Apply the commit certificate after verifying every certificate vote.
+            // Verify on a clone first; durable receipt persistence must succeed
+            // before the live consensus state is advanced.
             let round = cert.round;
             let hash = cert.node_hash;
             let resolver = s.validator_public_keys.clone();
-            consensus::commit_verified(&mut s.consensus, cert.clone(), &resolver)
+            let mut preview = s.consensus.clone();
+            consensus::commit_verified(&mut preview, cert.clone(), &resolver)
                 .map_err(|e| format!("invalid commit certificate: {e}"))?;
 
-            let height = checked_committed_height(s.consensus.committed.len())?;
+            let height = checked_committed_height(preview.committed.len())?;
             Ok(Some((cert, (hash, height, round))))
         })
         .await
@@ -1040,19 +1042,7 @@ async fn handle_commit(
 
     let (hash, height, round) = commit_info;
 
-    // Mark committed in the persistent store.
-    if let Err(e) = with_store_blocking(Arc::clone(store), "handle_commit_mark", move |store| {
-        store
-            .mark_committed_sync(&hash, height)
-            .map_err(|e| format!("mark committed {hash} at height {height}: {e}"))
-    })
-    .await
-    {
-        tracing::warn!(err = %e, "Failed to mark committed in store");
-        return;
-    }
-
-    // Emit a trust receipt for the network-received commit.
+    // Build and persist the trust receipt before advancing live consensus state.
     let receipt = match commit_receipt_from_certificate(state, store, &cert).await {
         Ok(receipt) => receipt,
         Err(e) => {
@@ -1060,17 +1050,46 @@ async fn handle_commit(
             return;
         }
     };
-    if let Err(e) = with_store_blocking(Arc::clone(store), "handle_commit_save_receipt", {
+    if let Err(e) = with_store_blocking(Arc::clone(store), "handle_commit_persist", {
         let receipt = receipt.clone();
         move |store| {
             store
-                .save_receipt(&receipt)
-                .map_err(|e| format!("save network commit receipt: {e}"))
+                .mark_committed_with_receipt_sync(&hash, height, &receipt)
+                .map_err(|e| {
+                    format!(
+                        "persist network commit marker and receipt for {hash} at height {height}: {e}"
+                    )
+                })
         }
     })
     .await
     {
-        tracing::warn!(err = %e, "Failed to persist trust receipt for network commit");
+        tracing::warn!(err = %e, "Failed to persist network commit state");
+        return;
+    }
+
+    let cert_for_commit = cert.clone();
+    if let Err(e) =
+        with_reactor_state_blocking(Arc::clone(state), "handle_commit_apply", move |s| {
+            if !consensus::is_finalized(&s.consensus, &hash) {
+                let resolver = s.validator_public_keys.clone();
+                consensus::commit_verified(&mut s.consensus, cert_for_commit, &resolver)
+                    .map_err(|e| format!("apply persisted network commit certificate: {e}"))?;
+            }
+            checked_committed_height(s.consensus.committed.len()).and_then(|actual_height| {
+                if actual_height == height {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "persisted network commit height {height} does not match consensus height {actual_height}"
+                    ))
+                }
+            })
+        })
+        .await
+    {
+        tracing::warn!(err = %e, "Failed to apply persisted network commit certificate");
+        return;
     }
 
     tracing::info!(
@@ -1122,14 +1141,15 @@ async fn check_and_commit(
         let cert_for_commit = cert.clone();
         let height = match with_reactor_state_blocking(
             Arc::clone(state),
-            "check_and_commit_commit",
+            "check_and_commit_preview",
             move |s| {
-                if !consensus::is_finalized(&s.consensus, &hash) {
+                let mut preview = s.consensus.clone();
+                if !consensus::is_finalized(&preview, &hash) {
                     let resolver = s.validator_public_keys.clone();
-                    consensus::commit_verified(&mut s.consensus, cert_for_commit, &resolver)
+                    consensus::commit_verified(&mut preview, cert_for_commit, &resolver)
                         .map_err(|e| format!("verify local commit certificate: {e}"))?;
                 }
-                checked_committed_height(s.consensus.committed.len())
+                checked_committed_height(preview.committed.len())
             },
         )
         .await
@@ -1141,16 +1161,25 @@ async fn check_and_commit(
             }
         };
 
-        // Persist to store.
+        // Build and persist the trust receipt before advancing live consensus state.
+        let receipt = match commit_receipt_from_certificate(state, store, &cert).await {
+            Ok(receipt) => receipt,
+            Err(e) => {
+                tracing::warn!(err = %e, "Failed to build trust receipt for commit");
+                return;
+            }
+        };
         if let Err(e) = with_store_blocking(Arc::clone(store), "check_and_commit_persist", {
+            let receipt = receipt.clone();
             let cert = cert.clone();
             move |store| {
                 store
-                    .mark_committed_sync(&hash, height)
-                    .map_err(|e| format!("mark committed {hash} at height {height}: {e}"))?;
-                store
-                    .save_certificate(&cert)
-                    .map_err(|e| format!("persist certificate for {hash}: {e}"))
+                    .persist_commit_certificate_with_receipt_sync(&hash, height, &cert, &receipt)
+                    .map_err(|e| {
+                        format!(
+                            "persist local commit certificate and receipt for {hash} at height {height}: {e}"
+                        )
+                    })
             }
         })
         .await
@@ -1159,25 +1188,28 @@ async fn check_and_commit(
             return;
         }
 
-        // Emit a trust receipt recording the commit action.
-        let receipt = match commit_receipt_from_certificate(state, store, &cert).await {
-            Ok(receipt) => receipt,
-            Err(e) => {
-                tracing::warn!(err = %e, "Failed to build trust receipt for commit");
-                return;
-            }
-        };
-        if let Err(e) = with_store_blocking(Arc::clone(store), "check_and_commit_save_receipt", {
-            let receipt = receipt.clone();
-            move |store| {
-                store
-                    .save_receipt(&receipt)
-                    .map_err(|e| format!("save local commit receipt: {e}"))
-            }
-        })
-        .await
+        let cert_for_commit = cert.clone();
+        if let Err(e) =
+            with_reactor_state_blocking(Arc::clone(state), "check_and_commit_apply", move |s| {
+                if !consensus::is_finalized(&s.consensus, &hash) {
+                    let resolver = s.validator_public_keys.clone();
+                    consensus::commit_verified(&mut s.consensus, cert_for_commit, &resolver)
+                        .map_err(|e| format!("apply persisted local commit certificate: {e}"))?;
+                }
+                checked_committed_height(s.consensus.committed.len()).and_then(|actual_height| {
+                    if actual_height == height {
+                        Ok(())
+                    } else {
+                        Err(format!(
+                            "persisted local commit height {height} does not match consensus height {actual_height}"
+                        ))
+                    }
+                })
+            })
+            .await
         {
-            tracing::warn!(err = %e, "Failed to persist trust receipt for commit");
+            tracing::warn!(err = %e, "Failed to apply persisted local commit certificate");
+            return;
         }
 
         tracing::info!(%hash, height, round, "Node committed — quorum reached");
@@ -1460,6 +1492,14 @@ mod tests {
         )
     }
 
+    fn single_validator_certificate(node_hash: Hash256, voter: &Did) -> CommitCertificate {
+        CommitCertificate {
+            node_hash,
+            round: 0,
+            votes: vec![vote_for(voter, 0, 0, node_hash)],
+        }
+    }
+
     fn proposal_msg_for(
         proposer: Did,
         proposer_index: usize,
@@ -1635,6 +1675,55 @@ mod tests {
             production.contains("checked_committed_height"),
             "reactor commit paths must route height conversion through the checked helper"
         );
+    }
+
+    #[test]
+    fn reactor_commit_paths_persist_receipts_atomically_with_commit_state() {
+        let source = include_str!("reactor.rs");
+        let production = source
+            .split("// ---------------------------------------------------------------------------\n// Tests")
+            .next()
+            .expect("tests marker present");
+        let handle_commit_body = production
+            .split("async fn handle_commit")
+            .nth(1)
+            .expect("handle_commit present")
+            .split("/// Check if a node has reached quorum")
+            .next()
+            .expect("handle_commit body present");
+        let check_and_commit_body = production
+            .split("async fn check_and_commit")
+            .nth(1)
+            .expect("check_and_commit present")
+            .split("// ---------------------------------------------------------------------------\n// Proposal submission")
+            .next()
+            .expect("check_and_commit body present");
+
+        for (name, body, atomic_call) in [
+            (
+                "handle_commit",
+                handle_commit_body,
+                "mark_committed_with_receipt_sync",
+            ),
+            (
+                "check_and_commit",
+                check_and_commit_body,
+                "persist_commit_certificate_with_receipt_sync",
+            ),
+        ] {
+            assert!(
+                body.contains(atomic_call),
+                "{name} must use the atomic commit/receipt persistence helper"
+            );
+            assert!(
+                !body.contains(".mark_committed_sync("),
+                "{name} must not persist a commit marker separately from its receipt"
+            );
+            assert!(
+                !body.contains(".save_receipt(&receipt)"),
+                "{name} must not persist commit receipts separately from commit state"
+            );
+        }
     }
 
     #[test]
@@ -2012,6 +2101,248 @@ mod tests {
             .unwrap_err();
 
         assert!(err.contains("not found for trust receipt"));
+    }
+
+    #[tokio::test]
+    async fn local_commit_does_not_advance_without_persisted_trust_receipt() {
+        let validators = make_single_validator();
+        let node_did = Did::new("did:exo:v0").unwrap();
+        let config = config_for(node_did.clone(), true, validators);
+        let state = create_reactor_state(&config, Arc::new(|_| Signature::empty()), None);
+        let (_dir, store) = temp_store();
+        let (cmd_tx, _cmd_rx) = mpsc::channel(32);
+        let net_handle = NetworkHandle::new(cmd_tx);
+        let (reactor_tx, mut reactor_rx) = mpsc::channel(8);
+        let valid_sign_fn = make_sign_fn();
+        let mut dag = Dag::new();
+        let mut clock = DeterministicDagClock::new();
+        let node = append(
+            &mut dag,
+            &[],
+            b"must-not-commit-without-receipt",
+            &node_did,
+            &*valid_sign_fn,
+            &mut clock,
+        )
+        .unwrap();
+        let node_hash = node.hash;
+
+        store.lock().unwrap().put_sync(node.clone()).unwrap();
+        {
+            let mut s = state.lock().unwrap();
+            let resolver = s.validator_public_keys.clone();
+            let proposal = Proposal {
+                proposer: node_did.clone(),
+                round: s.consensus.current_round,
+                node_hash: node.hash,
+            };
+            let proposal_sig = sign_proposal_for_index(&proposal, 0);
+            consensus::propose_verified(
+                &mut s.consensus,
+                &node,
+                &node_did,
+                &proposal_sig,
+                &resolver,
+            )
+            .unwrap();
+            consensus::vote_verified(
+                &mut s.consensus,
+                vote_for(&node_did, 0, 0, node.hash),
+                &resolver,
+            )
+            .unwrap();
+            assert!(
+                consensus::check_commit(&s.consensus, &node.hash).is_some(),
+                "test setup must form a valid quorum certificate before exercising the receipt boundary"
+            );
+        }
+
+        check_and_commit(&state, &store, &net_handle, &reactor_tx, &node_hash).await;
+
+        assert!(
+            reactor_rx.try_recv().is_err(),
+            "commit event must not be emitted when the trust receipt cannot be persisted"
+        );
+        {
+            let s = state.lock().unwrap();
+            assert!(
+                !consensus::is_finalized(&s.consensus, &node.hash),
+                "consensus state must not finalize a node without a durable trust receipt"
+            );
+            assert!(
+                s.consensus.committed.is_empty(),
+                "commit order must not advance without a durable trust receipt"
+            );
+        }
+        {
+            let st = store.lock().unwrap();
+            assert!(
+                !st.is_committed(&node.hash).unwrap(),
+                "store commit marker must roll back when receipt persistence rejects the signature"
+            );
+            assert!(
+                st.load_receipts_by_actor("did:exo:v0", 10)
+                    .unwrap()
+                    .is_empty(),
+                "failed receipt persistence must not leave a partial receipt row"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn network_commit_does_not_advance_without_persisted_trust_receipt() {
+        let validators = make_single_validator();
+        let node_did = Did::new("did:exo:v0").unwrap();
+        let config = config_for(node_did.clone(), true, validators);
+        let state = create_reactor_state(&config, Arc::new(|_| Signature::empty()), None);
+        let (_dir, store) = temp_store();
+        let (reactor_tx, mut reactor_rx) = mpsc::channel(8);
+        let valid_sign_fn = make_sign_fn();
+        let mut dag = Dag::new();
+        let mut clock = DeterministicDagClock::new();
+        let node = append(
+            &mut dag,
+            &[],
+            b"network-commit-must-not-outpace-receipt",
+            &node_did,
+            &*valid_sign_fn,
+            &mut clock,
+        )
+        .unwrap();
+        store.lock().unwrap().put_sync(node.clone()).unwrap();
+        let msg = ConsensusCommitMsg {
+            certificate: single_validator_certificate(node.hash, &node_did),
+        };
+
+        handle_commit(&state, &store, &reactor_tx, msg).await;
+
+        assert!(
+            reactor_rx.try_recv().is_err(),
+            "network commit event must not be emitted when the trust receipt cannot be persisted"
+        );
+        {
+            let s = state.lock().unwrap();
+            assert!(
+                !consensus::is_finalized(&s.consensus, &node.hash),
+                "network certificate must not finalize consensus without a durable trust receipt"
+            );
+            assert!(
+                s.consensus.committed.is_empty(),
+                "network certificate must not advance commit order without a durable trust receipt"
+            );
+        }
+        {
+            let st = store.lock().unwrap();
+            assert!(
+                !st.is_committed(&node.hash).unwrap(),
+                "network certificate must not persist a commit marker without its receipt"
+            );
+            assert!(
+                st.load_receipts_by_actor("did:exo:v0", 10)
+                    .unwrap()
+                    .is_empty(),
+                "failed network receipt persistence must not leave a partial receipt row"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn local_commit_persists_certificate_receipt_and_emits_event() {
+        let validators = make_single_validator();
+        let node_did = Did::new("did:exo:v0").unwrap();
+        let config = config_for(node_did.clone(), true, validators);
+        let sign_fn = make_sign_fn();
+        let state = create_reactor_state(&config, Arc::clone(&sign_fn), None);
+        let (_dir, store) = temp_store();
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(32);
+        let net_handle = NetworkHandle::new(cmd_tx);
+        let (reactor_tx, mut reactor_rx) = mpsc::channel(8);
+        let mut dag = Dag::new();
+        let mut clock = DeterministicDagClock::new();
+        let node = append(
+            &mut dag,
+            &[],
+            b"valid-local-commit-with-receipt",
+            &node_did,
+            &*sign_fn,
+            &mut clock,
+        )
+        .unwrap();
+        let node_hash = node.hash;
+
+        store.lock().unwrap().put_sync(node.clone()).unwrap();
+        {
+            let mut s = state.lock().unwrap();
+            let resolver = s.validator_public_keys.clone();
+            let proposal = Proposal {
+                proposer: node_did.clone(),
+                round: s.consensus.current_round,
+                node_hash: node.hash,
+            };
+            let proposal_sig = sign_proposal_for_index(&proposal, 0);
+            consensus::propose_verified(
+                &mut s.consensus,
+                &node,
+                &node_did,
+                &proposal_sig,
+                &resolver,
+            )
+            .unwrap();
+            consensus::vote_verified(
+                &mut s.consensus,
+                vote_for(&node_did, 0, 0, node.hash),
+                &resolver,
+            )
+            .unwrap();
+        }
+
+        let commit_task = {
+            let state = Arc::clone(&state);
+            let store = Arc::clone(&store);
+            let net_handle = net_handle.clone();
+            let reactor_tx = reactor_tx.clone();
+            tokio::spawn(async move {
+                check_and_commit(&state, &store, &net_handle, &reactor_tx, &node_hash).await;
+            })
+        };
+        let command = cmd_rx.recv().await.expect("commit certificate publish");
+        let crate::network::NetworkCommand::Publish {
+            topic,
+            message,
+            reply,
+        } = command
+        else {
+            panic!("expected publish command");
+        };
+        assert_eq!(topic, topics::CONSENSUS);
+        assert!(matches!(message, WireMessage::ConsensusCommit(_)));
+        reply.send(Ok(())).expect("publish ack receiver active");
+        commit_task.await.expect("commit task joins");
+
+        let ReactorEvent::NodeCommitted {
+            hash,
+            height,
+            round,
+        } = reactor_rx.recv().await.expect("commit event emitted")
+        else {
+            panic!("expected commit event");
+        };
+        assert_eq!(hash, node.hash);
+        assert_eq!(height, 1);
+        assert_eq!(round, 0);
+        {
+            let s = state.lock().unwrap();
+            assert!(consensus::is_finalized(&s.consensus, &node.hash));
+        }
+        {
+            let st = store.lock().unwrap();
+            assert!(st.is_committed(&node.hash).unwrap());
+            assert_eq!(st.load_certificates().unwrap().len(), 1);
+            let receipts = st.load_receipts_by_actor("did:exo:v0", 10).unwrap();
+            assert_eq!(receipts.len(), 1);
+            assert_eq!(receipts[0].action_hash, node.hash);
+            assert!(!receipts[0].signature.is_empty());
+        }
     }
 
     #[test]

--- a/crates/exo-node/src/store.rs
+++ b/crates/exo-node/src/store.rs
@@ -6,7 +6,7 @@
 
 use std::{collections::BTreeSet, path::Path};
 
-use exo_core::types::{Did, Hash256, Signature, Timestamp};
+use exo_core::types::{Did, Hash256, Signature, Timestamp, TrustReceipt};
 use exo_dag::{
     consensus::{CommitCertificate, Vote},
     dag::DagNode,
@@ -357,6 +357,7 @@ impl SqliteDagStore {
     }
 
     /// Persist a commit certificate.
+    #[allow(dead_code)]
     pub fn save_certificate(&mut self, cert: &CommitCertificate) -> DagResult<()> {
         let round = sqlite_u64_to_i64(cert.round, "commit_certificates.round")?;
         validate_commit_certificate(cert)?;
@@ -375,6 +376,67 @@ impl SqliteDagStore {
                 ],
             )
             .map_err(store_err)?;
+        Ok(())
+    }
+
+    fn ensure_node_exists_tx(tx: &rusqlite::Transaction<'_>, hash: &Hash256) -> DagResult<()> {
+        match tx.query_row(
+            "SELECT 1 FROM dag_nodes WHERE hash = ?1",
+            params![hash.0.as_slice()],
+            |_| Ok(()),
+        ) {
+            Ok(()) => Ok(()),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Err(DagError::NodeNotFound(*hash)),
+            Err(e) => Err(store_err(format!("dag_nodes.hash presence query: {e}"))),
+        }
+    }
+
+    fn insert_committed_tx(
+        tx: &rusqlite::Transaction<'_>,
+        hash: &Hash256,
+        height: u64,
+    ) -> DagResult<()> {
+        let height = sqlite_u64_to_i64(height, "committed.height")?;
+        tx.execute(
+            "INSERT OR REPLACE INTO committed (hash, height) VALUES (?1, ?2)",
+            params![hash.0.as_slice(), height],
+        )
+        .map_err(store_err)?;
+        Ok(())
+    }
+
+    fn insert_certificate_tx(
+        tx: &rusqlite::Transaction<'_>,
+        cert: &CommitCertificate,
+    ) -> DagResult<()> {
+        let round = sqlite_u64_to_i64(cert.round, "commit_certificates.round")?;
+        validate_commit_certificate(cert)?;
+        let cbor_buf = encode_cbor(cert, "commit_certificates.cbor_data")?;
+        tx.execute(
+            "INSERT OR IGNORE INTO commit_certificates (node_hash, round, cbor_data) VALUES (?1, ?2, ?3)",
+            params![cert.node_hash.0.as_slice(), round, cbor_buf],
+        )
+        .map_err(store_err)?;
+        Ok(())
+    }
+
+    fn insert_receipt_tx(tx: &rusqlite::Transaction<'_>, receipt: &TrustReceipt) -> DagResult<()> {
+        validate_signature(&receipt.signature, "trust_receipts.signature")?;
+        let timestamp_ms =
+            sqlite_u64_to_i64(receipt.timestamp.physical_ms, "trust_receipts.timestamp_ms")?;
+        let buf = encode_cbor(receipt, "trust_receipts.cbor_data")?;
+        tx.execute(
+            "INSERT OR IGNORE INTO trust_receipts (receipt_hash, actor_did, action_type, outcome, timestamp_ms, cbor_data) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                receipt.receipt_hash.0.as_slice(),
+                receipt.actor_did.to_string(),
+                receipt.action_type.as_str(),
+                receipt.outcome.to_string(),
+                timestamp_ms,
+                buf,
+            ],
+        )
+        .map_err(store_err)?;
         Ok(())
     }
 
@@ -452,7 +514,7 @@ impl SqliteDagStore {
     }
 
     /// Save a trust receipt to the database.
-    pub fn save_receipt(&mut self, receipt: &exo_core::types::TrustReceipt) -> DagResult<()> {
+    pub fn save_receipt(&mut self, receipt: &TrustReceipt) -> DagResult<()> {
         validate_signature(&receipt.signature, "trust_receipts.signature")?;
         let timestamp_ms =
             sqlite_u64_to_i64(receipt.timestamp.physical_ms, "trust_receipts.timestamp_ms")?;
@@ -474,6 +536,55 @@ impl SqliteDagStore {
                 ],
             )
             .map_err(store_err)?;
+        Ok(())
+    }
+
+    /// Atomically persist a committed marker with the trust receipt that proves it.
+    pub fn mark_committed_with_receipt_sync(
+        &mut self,
+        hash: &Hash256,
+        height: u64,
+        receipt: &TrustReceipt,
+    ) -> DagResult<()> {
+        if receipt.action_hash != *hash {
+            return Err(store_err(
+                "trust_receipts.action_hash must match committed node hash",
+            ));
+        }
+
+        let tx = self.conn.transaction().map_err(store_err)?;
+        Self::ensure_node_exists_tx(&tx, hash)?;
+        Self::insert_committed_tx(&tx, hash, height)?;
+        Self::insert_receipt_tx(&tx, receipt)?;
+        tx.commit().map_err(store_err)?;
+        Ok(())
+    }
+
+    /// Atomically persist a committed marker, its certificate, and its trust receipt.
+    pub fn persist_commit_certificate_with_receipt_sync(
+        &mut self,
+        hash: &Hash256,
+        height: u64,
+        cert: &CommitCertificate,
+        receipt: &TrustReceipt,
+    ) -> DagResult<()> {
+        if cert.node_hash != *hash {
+            return Err(store_err(
+                "commit_certificates.node_hash must match committed node hash",
+            ));
+        }
+        if receipt.action_hash != *hash {
+            return Err(store_err(
+                "trust_receipts.action_hash must match committed node hash",
+            ));
+        }
+
+        let tx = self.conn.transaction().map_err(store_err)?;
+        Self::ensure_node_exists_tx(&tx, hash)?;
+        Self::insert_committed_tx(&tx, hash, height)?;
+        Self::insert_certificate_tx(&tx, cert)?;
+        Self::insert_receipt_tx(&tx, receipt)?;
+        tx.commit().map_err(store_err)?;
         Ok(())
     }
 
@@ -713,6 +824,7 @@ impl SqliteDagStore {
     }
 
     /// Sync version of `DagStore::contains`.
+    #[allow(dead_code)]
     pub fn contains_sync(&self, hash: &Hash256) -> DagResult<bool> {
         let mut stmt = self
             .conn
@@ -765,6 +877,7 @@ impl SqliteDagStore {
     }
 
     /// Sync version of `DagStore::mark_committed`.
+    #[allow(dead_code)]
     pub fn mark_committed_sync(&mut self, hash: &Hash256, height: u64) -> DagResult<()> {
         if !self.contains_sync(hash)? {
             return Err(DagError::NodeNotFound(*hash));
@@ -1878,6 +1991,92 @@ mod tests {
         let err = store.mark_committed_sync(&node.hash, u64::MAX).unwrap_err();
 
         assert!(err.to_string().contains("committed.height"));
+    }
+
+    #[test]
+    fn mark_committed_with_receipt_rolls_back_when_receipt_is_rejected() {
+        use exo_core::types::{ReceiptOutcome, Timestamp, TrustReceipt};
+        let mut store = temp_store();
+        let node = make_test_node();
+        store.put_sync(node.clone()).unwrap();
+        let receipt = TrustReceipt::new(
+            Did::new("did:exo:test").unwrap(),
+            Hash256::digest(b"authority"),
+            None,
+            "dag.commit".to_string(),
+            node.hash,
+            ReceiptOutcome::Executed,
+            Timestamp {
+                physical_ms: 1_700_000_000_000,
+                logical: 0,
+            },
+            &|_| Signature::empty(),
+        )
+        .expect("test receipt should encode");
+
+        let err = store
+            .mark_committed_with_receipt_sync(&node.hash, 1, &receipt)
+            .unwrap_err();
+
+        assert!(err.to_string().contains("trust_receipts.signature"));
+        assert!(
+            !store.is_committed(&node.hash).unwrap(),
+            "commit marker must not persist when receipt insert fails"
+        );
+        assert!(
+            store.load_receipt(&receipt.receipt_hash).unwrap().is_none(),
+            "rejected receipt must not persist partial receipt data"
+        );
+    }
+
+    #[test]
+    fn certificate_commit_with_receipt_rolls_back_every_row_when_receipt_is_rejected() {
+        use exo_core::types::{ReceiptOutcome, Timestamp, TrustReceipt};
+        let mut store = temp_store();
+        let node = make_test_node();
+        store.put_sync(node.clone()).unwrap();
+        let cert = CommitCertificate {
+            node_hash: node.hash,
+            round: 0,
+            votes: vec![Vote {
+                voter: Did::new("did:exo:v0").unwrap(),
+                round: 0,
+                node_hash: node.hash,
+                signature: Signature::from_bytes([7u8; 64]),
+            }],
+        };
+        let receipt = TrustReceipt::new(
+            Did::new("did:exo:test").unwrap(),
+            Hash256::digest(b"authority"),
+            None,
+            "dag.commit".to_string(),
+            node.hash,
+            ReceiptOutcome::Executed,
+            Timestamp {
+                physical_ms: 1_700_000_000_000,
+                logical: 0,
+            },
+            &|_| Signature::empty(),
+        )
+        .expect("test receipt should encode");
+
+        let err = store
+            .persist_commit_certificate_with_receipt_sync(&node.hash, 1, &cert, &receipt)
+            .unwrap_err();
+
+        assert!(err.to_string().contains("trust_receipts.signature"));
+        assert!(
+            !store.is_committed(&node.hash).unwrap(),
+            "commit marker must not persist when receipt insert fails"
+        );
+        assert!(
+            store.load_certificates().unwrap().is_empty(),
+            "certificate must not persist without its matching receipt"
+        );
+        assert!(
+            store.load_receipt(&receipt.receipt_hash).unwrap().is_none(),
+            "rejected receipt must not persist partial receipt data"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Classification

- `crates/exo-node/src/reactor.rs`: EXOCHAIN core/runtime node consensus reactor.
- `crates/exo-node/src/store.rs`: EXOCHAIN core/runtime node SQLite persistence boundary.

## Confirmed Current-Main Issue

Verified against current `origin/main`: local quorum commits and inbound network commit certificates could advance in-memory consensus and/or durable commit markers before the matching trust receipt was durably persisted. If the node receipt signer produced an empty/all-zero signature, `SqliteDagStore::save_receipt` rejected the receipt, but the reactor still emitted `NodeCommitted` on the old path.

## Remediation

- Added SQLite transaction helpers that persist commit markers, commit certificates, and trust receipts atomically.
- Moved reactor commit paths to preview certificate validity on a cloned consensus state, build the receipt, persist the commit state plus receipt atomically, then advance live consensus state and emit/broadcast only after persistence succeeds.
- Added a source guard preventing `handle_commit` and `check_and_commit` from returning to separate commit-marker and receipt writes.

## Tests / Validation

RED before implementation:

- `cargo test -p exo-node local_commit_does_not_advance_without_persisted_trust_receipt -- --nocapture` failed because `NodeCommitted` was emitted after receipt persistence rejection.
- `cargo test -p exo-node with_receipt_rolls_back -- --nocapture` failed to compile until the atomic store helpers existed.

GREEN after implementation:

- `cargo test -p exo-node receipt -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo test -p exo-node`
- `cargo clippy -p exo-node --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --release`
- `cargo doc --workspace --no-deps`
- `cargo audit && cargo deny check` (passed; existing duplicate dependency warnings reported by cargo-deny)
- `git diff --check`

Bypass search:

- Searched for old commit-path persistence calls and stale helper labels in `crates/exo-node/src/reactor.rs` and `crates/exo-node/src/store.rs`.
- Remaining standalone `save_receipt(&receipt)` in `reactor.rs` is the governance audit receipt path, not the commit-certificate path.
