### PR TITLE
fix(gatekeeper): enforce combinator timeout budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 175810 | `wc -l` |
+| Rust LOC | 175916 | `wc -l` |
 | Workspace tests | 4,152 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -96,7 +96,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 175810 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 175916 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,152 listed workspace tests
 

--- a/crates/exo-gatekeeper/src/combinator.rs
+++ b/crates/exo-gatekeeper/src/combinator.rs
@@ -25,6 +25,39 @@ pub const MAX_COMBINATOR_NODE_COUNT: usize = 10_000;
 /// Maximum retry budget accepted for a retry combinator.
 pub const MAX_RETRY_ATTEMPTS: u32 = 100;
 
+#[derive(Debug, Clone, Copy)]
+struct ReductionBudget {
+    original_units: u64,
+    remaining_units: u64,
+}
+
+impl ReductionBudget {
+    const fn new(duration: Duration) -> Self {
+        Self {
+            original_units: duration.0,
+            remaining_units: duration.0,
+        }
+    }
+
+    fn consume(&mut self) -> Result<(), GatekeeperError> {
+        if self.remaining_units == 0 {
+            return Err(GatekeeperError::CombinatorError(format!(
+                "timeout budget exhausted: deterministic reduction exceeded {} units",
+                self.original_units
+            )));
+        }
+        self.remaining_units -= 1;
+        Ok(())
+    }
+}
+
+fn consume_active_budgets(budgets: &mut [ReductionBudget]) -> Result<(), GatekeeperError> {
+    for budget in budgets {
+        budget.consume()?;
+    }
+    Ok(())
+}
+
 /// A predicate that guards combinator execution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Predicate {
@@ -111,7 +144,12 @@ impl<'de> Deserialize<'de> for RetryPolicy {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct CheckpointId(pub String);
 
-/// Duration in milliseconds (deterministic, no floating-point).
+/// Deterministic timeout budget expressed in reduction units.
+///
+/// Each unit permits one combinator node reduction while this timeout is active.
+/// The unit name remains `Duration` for compatibility with existing workflow
+/// terminology, but enforcement is deliberately deterministic and does not read
+/// wall-clock time.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct Duration(pub u64);
 
@@ -132,7 +170,7 @@ pub enum Combinator {
     Transform(Box<Combinator>, TransformFn),
     /// Retry with policy.
     Retry(Box<Combinator>, RetryPolicy),
-    /// Time-bounded (simulated in deterministic mode).
+    /// Deterministically budget-bounded reduction.
     Timeout(Box<Combinator>, Duration),
     /// Resumable checkpoint.
     Checkpoint(Box<Combinator>, CheckpointId),
@@ -352,7 +390,8 @@ pub fn reduce(
     input: &CombinatorInput,
 ) -> Result<CombinatorOutput, GatekeeperError> {
     validate_combinator_structure(combinator)?;
-    reduce_inner(combinator, input, 0)
+    let mut budgets = Vec::new();
+    reduce_inner(combinator, input, 0, &mut budgets)
 }
 
 fn validate_combinator_structure(combinator: &Combinator) -> Result<(), GatekeeperError> {
@@ -415,6 +454,7 @@ fn reduce_inner(
     combinator: &Combinator,
     input: &CombinatorInput,
     depth: usize,
+    budgets: &mut Vec<ReductionBudget>,
 ) -> Result<CombinatorOutput, GatekeeperError> {
     if depth > MAX_COMBINATOR_DEPTH {
         return Err(GatekeeperError::CombinatorError(format!(
@@ -422,6 +462,7 @@ fn reduce_inner(
             depth, MAX_COMBINATOR_DEPTH
         )));
     }
+    consume_active_budgets(budgets)?;
 
     match combinator {
         Combinator::Identity => Ok(CombinatorOutput::from_input(input)),
@@ -432,7 +473,7 @@ fn reduce_inner(
             let mut last_output = CombinatorOutput::from_input(input);
 
             for (i, c) in combinators.iter().enumerate() {
-                match reduce_inner(c, &current_input, depth + 1) {
+                match reduce_inner(c, &current_input, depth + 1, budgets) {
                     Ok(output) => {
                         // Feed output as next input.
                         current_input = CombinatorInput {
@@ -456,7 +497,7 @@ fn reduce_inner(
             let mut merged = CombinatorOutput::from_input(input);
 
             for (i, c) in combinators.iter().enumerate() {
-                match reduce_inner(c, input, depth + 1) {
+                match reduce_inner(c, input, depth + 1, budgets) {
                     Ok(output) => {
                         merged.merge(&output);
                     }
@@ -474,7 +515,7 @@ fn reduce_inner(
         Combinator::Choice(combinators) => {
             enforce_branch_width("Choice", combinators.len())?;
             for c in combinators {
-                match reduce_inner(c, input, depth + 1) {
+                match reduce_inner(c, input, depth + 1, budgets) {
                     Ok(output) => return Ok(output),
                     Err(_) => continue,
                 }
@@ -491,11 +532,11 @@ fn reduce_inner(
                     predicate.name
                 )));
             }
-            reduce_inner(inner, input, depth + 1)
+            reduce_inner(inner, input, depth + 1, budgets)
         }
 
         Combinator::Transform(inner, transform) => {
-            let mut output = reduce_inner(inner, input, depth + 1)?;
+            let mut output = reduce_inner(inner, input, depth + 1, budgets)?;
             output.set(transform.output_key.clone(), transform.output_value.clone());
             Ok(output)
         }
@@ -504,7 +545,7 @@ fn reduce_inner(
             policy.validate()?;
             let mut last_err = None;
             for attempt in 0..=policy.max_retries {
-                match reduce_inner(inner, input, depth + 1) {
+                match reduce_inner(inner, input, depth + 1, budgets) {
                     Ok(mut output) => {
                         output.set("retry_attempts", attempt.to_string());
                         return Ok(output);
@@ -519,15 +560,20 @@ fn reduce_inner(
         }
 
         Combinator::Timeout(inner, duration) => {
-            // In deterministic mode, we simulate timeout by simply running.
-            // Real timeout enforcement is at the Holon runtime level.
-            let mut output = reduce_inner(inner, input, depth + 1)?;
+            budgets.push(ReductionBudget::new(*duration));
+            let result = reduce_inner(inner, input, depth + 1, budgets);
+            if budgets.pop().is_none() {
+                return Err(GatekeeperError::CombinatorError(
+                    "timeout budget stack underflow".into(),
+                ));
+            }
+            let mut output = result?;
             output.set("timeout_budget_ms", duration.0.to_string());
             Ok(output)
         }
 
         Combinator::Checkpoint(inner, checkpoint_id) => {
-            let mut output = reduce_inner(inner, input, depth + 1)?;
+            let mut output = reduce_inner(inner, input, depth + 1, budgets)?;
             output.checkpoint = Some(checkpoint_id.clone());
             Ok(output)
         }
@@ -991,6 +1037,42 @@ mod tests {
         assert_eq!(
             output.fields.get("timeout_budget_ms"),
             Some(&"5000".to_string())
+        );
+    }
+
+    #[test]
+    fn timeout_rejects_inner_reduction_over_deterministic_budget() {
+        let input = sample_input();
+        let timed = Combinator::Timeout(
+            Box::new(Combinator::Sequence(vec![
+                Combinator::Identity,
+                Combinator::Identity,
+            ])),
+            Duration(2),
+        );
+
+        let err = reduce(&timed, &input).expect_err("over-budget timeout must fail closed");
+        assert!(
+            err.to_string().contains("timeout budget exhausted"),
+            "unexpected timeout error: {err}"
+        );
+    }
+
+    #[test]
+    fn timeout_allows_inner_reduction_within_deterministic_budget() {
+        let input = sample_input();
+        let timed = Combinator::Timeout(
+            Box::new(Combinator::Sequence(vec![
+                Combinator::Identity,
+                Combinator::Identity,
+            ])),
+            Duration(3),
+        );
+
+        let output = reduce(&timed, &input).expect("three-node inner reduction should fit budget");
+        assert_eq!(
+            output.fields.get("timeout_budget_ms"),
+            Some(&"3".to_owned())
         );
     }
 

--- a/crates/exo-gatekeeper/src/holon.rs
+++ b/crates/exo-gatekeeper/src/holon.rs
@@ -444,6 +444,30 @@ mod tests {
         assert!(step(&mut h, &CombinatorInput::new(), &kernel, &ctx).is_err());
     }
 
+    #[test]
+    fn step_enforces_combinator_timeout_budget() {
+        let kernel = test_kernel();
+        let mut h = spawn(
+            did("did:exo:timeout-holon"),
+            PermissionSet::new(vec![Permission::new("read")]),
+            Combinator::Timeout(
+                Box::new(Combinator::Sequence(vec![
+                    Combinator::Identity,
+                    Combinator::Identity,
+                ])),
+                crate::combinator::Duration(2),
+            ),
+        );
+        let ctx = valid_adj(&h.id);
+
+        let err = step(&mut h, &CombinatorInput::new(), &kernel, &ctx)
+            .expect_err("over-budget holon combinator must fail closed");
+        assert!(
+            err.to_string().contains("timeout budget exhausted"),
+            "unexpected holon timeout error: {err}"
+        );
+    }
+
     // ── SPR2-04: Holon isolation + lifecycle ──────────────────────────────────
 
     /// Terminating Holon A must not change the state of Holon B.  Each Holon


### PR DESCRIPTION
## Summary
- enforce `Combinator::Timeout` as a deterministic reduction-unit budget instead of metadata-only decoration
- route Holon execution through the same budgeted reducer path
- add regressions proving over-budget reductions fail closed and in-budget reductions still succeed

## Path Classification
- `crates/exo-gatekeeper/src/combinator.rs` - EXOCHAIN core
- `crates/exo-gatekeeper/src/holon.rs` - EXOCHAIN core

## Current-Main Verification
F-087 was rechecked against `origin/main` at `c7cc84bc82f3bfb44f966d8dba8ea78cc46dc0e6`. `Combinator::Timeout` still reduced the inner combinator unconditionally and only wrote `timeout_budget_ms`; `Holon::step` called `reduce()` with no separate runtime timeout enforcement. The finding was live.

## Test-Driven Evidence
Red first:
- `cargo test -p exo-gatekeeper timeout -- --nocapture` failed before the fix because an over-budget timeout returned success.
- `cargo test -p exo-gatekeeper step_enforces_combinator_timeout_budget -- --nocapture` failed before the fix through the Holon path.

Validation after fix:
- `cargo test -p exo-gatekeeper timeout -- --nocapture` - passed, 4 tests
- `cargo test -p exo-gatekeeper holon -- --nocapture` - passed, 18 tests
- `cargo test -p exo-gatekeeper combinator -- --nocapture` - passed, 36 tests
- `cargo test -p exo-gatekeeper -- --nocapture` - passed, 264 tests plus doctests
- `cargo +nightly fmt --all -- --check` - passed
- `git diff --check` - passed
- `git diff --check origin/main...HEAD` - passed
- `cargo clippy -p exo-gatekeeper --all-targets -- -D warnings` - passed
- `RUSTDOCFLAGS="-D warnings" cargo doc -p exo-gatekeeper --no-deps` - passed
- `env -u DATABASE_URL cargo test --workspace` - passed, workspace unit/integration/doc tests

## Bypass Search
The reducer now carries active timeout budgets through sequence, parallel, choice, guard, transform, retry, timeout, checkpoint, and Holon `step()` execution. The previous comment claiming runtime-level Holon enforcement was removed because no such enforcement existed.