### PR TITLE
fix(gatekeeper): require trusted authority grantor keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 175916 | `wc -l` |
+| Rust LOC | 176362 | `wc -l` |
 | Workspace tests | 4,152 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -96,7 +96,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 175916 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 176362 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,152 listed workspace tests
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 176400 | `wc -l` |
+| Rust LOC | 176440 | `wc -l` |
 | Workspace tests | 4,152 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -96,7 +96,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 176400 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 176440 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,152 listed workspace tests
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 176479 | `wc -l` |
+| Rust LOC | 176523 | `wc -l` |
 | Workspace tests | 4,152 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -96,7 +96,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 176479 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 176523 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,152 listed workspace tests
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 176440 | `wc -l` |
+| Rust LOC | 176479 | `wc -l` |
 | Workspace tests | 4,152 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -96,7 +96,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 176440 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 176479 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,152 listed workspace tests
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 176362 | `wc -l` |
+| Rust LOC | 176372 | `wc -l` |
 | Workspace tests | 4,152 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -96,7 +96,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 176362 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 176372 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,152 listed workspace tests
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 176372 | `wc -l` |
+| Rust LOC | 176400 | `wc -l` |
 | Workspace tests | 4,152 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -96,7 +96,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 176372 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 176400 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,152 listed workspace tests
 

--- a/crates/decision-forum/src/decision_object.rs
+++ b/crates/decision-forum/src/decision_object.rs
@@ -440,7 +440,7 @@ mod tests {
         provenance_signature_message,
         types::{
             AuthorityChain, AuthorityLink as GatekeeperAuthorityLink, BailmentState, ConsentRecord,
-            GovernmentBranch, PermissionSet, Provenance, Role,
+            GovernmentBranch, PermissionSet, Provenance, Role, TrustedAuthorityKeys,
         },
     };
 
@@ -505,14 +505,21 @@ mod tests {
 
     fn transition_context(actor: &Did, from: BctsState, to: BctsState) -> AdjudicationContext {
         let permission = bcts_transition_permission(from, to);
+        let authority_chain = AuthorityChain {
+            links: vec![signed_authority_link(actor, permission.clone())],
+        };
+        let mut trusted_authority_keys = TrustedAuthorityKeys::default();
+        for link in &authority_chain.links {
+            if let Some(public_key) = &link.grantor_public_key {
+                trusted_authority_keys.insert(link.grantor.clone(), vec![public_key.clone()]);
+            }
+        }
         AdjudicationContext {
             actor_roles: vec![Role {
                 name: "transition-judge".into(),
                 branch: GovernmentBranch::Judicial,
             }],
-            authority_chain: AuthorityChain {
-                links: vec![signed_authority_link(actor, permission.clone())],
-            },
+            authority_chain,
             consent_records: vec![ConsentRecord {
                 subject: Did::new("did:exo:bailor").expect("valid DID"),
                 granted_to: actor.clone(),
@@ -526,6 +533,7 @@ mod tests {
             },
             human_override_preserved: true,
             actor_permissions: PermissionSet::new(vec![permission]),
+            trusted_authority_keys,
             provenance: Some(signed_provenance(actor)),
             quorum_evidence: None,
             active_challenge_reason: None,

--- a/crates/decision-forum/src/tnc_enforcer.rs
+++ b/crates/decision-forum/src/tnc_enforcer.rs
@@ -232,7 +232,7 @@ mod tests {
         provenance_signature_message,
         types::{
             AuthorityChain, AuthorityLink as GatekeeperAuthorityLink, BailmentState, ConsentRecord,
-            GovernmentBranch, PermissionSet, Provenance, Role,
+            GovernmentBranch, PermissionSet, Provenance, Role, TrustedAuthorityKeys,
         },
     };
     use uuid::Uuid;
@@ -336,14 +336,21 @@ mod tests {
 
     fn transition_context(actor: &Did, from: BctsState, to: BctsState) -> AdjudicationContext {
         let permission = bcts_transition_permission(from, to);
+        let authority_chain = AuthorityChain {
+            links: vec![signed_authority_link(actor, permission.clone())],
+        };
+        let mut trusted_authority_keys = TrustedAuthorityKeys::default();
+        for link in &authority_chain.links {
+            if let Some(public_key) = &link.grantor_public_key {
+                trusted_authority_keys.insert(link.grantor.clone(), vec![public_key.clone()]);
+            }
+        }
         AdjudicationContext {
             actor_roles: vec![Role {
                 name: "transition-judge".into(),
                 branch: GovernmentBranch::Judicial,
             }],
-            authority_chain: AuthorityChain {
-                links: vec![signed_authority_link(actor, permission.clone())],
-            },
+            authority_chain,
             consent_records: vec![ConsentRecord {
                 subject: Did::new("did:exo:bailor").expect("valid DID"),
                 granted_to: actor.clone(),
@@ -357,6 +364,7 @@ mod tests {
             },
             human_override_preserved: true,
             actor_permissions: PermissionSet::new(vec![permission]),
+            trusted_authority_keys,
             provenance: Some(signed_provenance(actor)),
             quorum_evidence: None,
             active_challenge_reason: None,

--- a/crates/decision-forum/tests/governance_kernel_integration.rs
+++ b/crates/decision-forum/tests/governance_kernel_integration.rs
@@ -44,6 +44,7 @@ use exo_gatekeeper::{
     types::{
         AuthorityChain, AuthorityLink as GkAuthorityLink, BailmentState, ConsentRecord,
         GovernmentBranch, Permission, PermissionSet, Provenance, QuorumEvidence, QuorumVote, Role,
+        TrustedAuthorityKeys,
     },
 };
 use uuid::Uuid;
@@ -177,14 +178,21 @@ fn make_approved_decision(class: DecisionClass, clock: &mut HybridClock) -> Deci
 /// - CP-7: `quorum_evidence` = None (invariant skips when None)
 /// - CP-8: provenance present, actor matches, Ed25519 signature verifies
 fn valid_adj_context(actor: &Did) -> AdjudicationContext {
+    let authority_chain = AuthorityChain {
+        links: vec![signed_authority_link(actor)],
+    };
+    let mut trusted_authority_keys = TrustedAuthorityKeys::default();
+    for link in &authority_chain.links {
+        if let Some(public_key) = &link.grantor_public_key {
+            trusted_authority_keys.insert(link.grantor.clone(), vec![public_key.clone()]);
+        }
+    }
     AdjudicationContext {
         actor_roles: vec![Role {
             name: "judge".into(),
             branch: GovernmentBranch::Judicial,
         }],
-        authority_chain: AuthorityChain {
-            links: vec![signed_authority_link(actor)],
-        },
+        authority_chain,
         consent_records: vec![ConsentRecord {
             subject: did("did:exo:bailor"),
             granted_to: actor.clone(),
@@ -198,6 +206,7 @@ fn valid_adj_context(actor: &Did) -> AdjudicationContext {
         },
         human_override_preserved: true,
         actor_permissions: PermissionSet::new(vec![Permission::new("enact:decision")]),
+        trusted_authority_keys,
         provenance: Some(signed_provenance(actor)),
         quorum_evidence: None,
         active_challenge_reason: None,
@@ -235,6 +244,14 @@ fn transition_context(actor: &Did, from: BctsState, to: BctsState) -> Adjudicati
             permission.clone(),
         )],
     };
+    context.trusted_authority_keys = TrustedAuthorityKeys::default();
+    for link in &context.authority_chain.links {
+        if let Some(public_key) = &link.grantor_public_key {
+            context
+                .trusted_authority_keys
+                .insert(link.grantor.clone(), vec![public_key.clone()]);
+        }
+    }
     context.actor_permissions = PermissionSet::new(vec![permission]);
     context
 }

--- a/crates/exo-escalation/tests/sybil_adjudication.rs
+++ b/crates/exo-escalation/tests/sybil_adjudication.rs
@@ -30,7 +30,7 @@ use exo_gatekeeper::{
     provenance_signature_message,
     types::{
         AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch, Permission,
-        PermissionSet, Provenance, Role,
+        PermissionSet, Provenance, Role, TrustedAuthorityKeys,
     },
 };
 use exo_governance::{
@@ -137,14 +137,21 @@ fn signed_provenance(actor: &Did) -> Provenance {
 /// Build a fully valid `AdjudicationContext`.  Pass `Some(reason)` to inject
 /// an active Sybil challenge hold so the kernel returns `Verdict::Escalated`.
 fn valid_kernel_context(actor: &Did, challenge_reason: Option<String>) -> AdjudicationContext {
+    let authority_chain = AuthorityChain {
+        links: vec![signed_authority_link(actor)],
+    };
+    let mut trusted_authority_keys = TrustedAuthorityKeys::default();
+    for link in &authority_chain.links {
+        if let Some(public_key) = &link.grantor_public_key {
+            trusted_authority_keys.insert(link.grantor.clone(), vec![public_key.clone()]);
+        }
+    }
     AdjudicationContext {
         actor_roles: vec![Role {
             name: "judge".into(),
             branch: GovernmentBranch::Judicial,
         }],
-        authority_chain: AuthorityChain {
-            links: vec![signed_authority_link(actor)],
-        },
+        authority_chain,
         consent_records: vec![ConsentRecord {
             subject: did("did:exo:bailor"),
             granted_to: actor.clone(),
@@ -158,6 +165,7 @@ fn valid_kernel_context(actor: &Did, challenge_reason: Option<String>) -> Adjudi
         },
         human_override_preserved: true,
         actor_permissions: PermissionSet::new(vec![Permission::new("read")]),
+        trusted_authority_keys,
         provenance: Some(signed_provenance(actor)),
         quorum_evidence: None,
         active_challenge_reason: challenge_reason,

--- a/crates/exo-gatekeeper/src/holon.rs
+++ b/crates/exo-gatekeeper/src/holon.rs
@@ -221,14 +221,21 @@ mod tests {
     }
 
     fn valid_adj(actor: &Did) -> AdjudicationContext {
+        let authority_chain = AuthorityChain {
+            links: vec![signed_link("did:exo:root", actor)],
+        };
+        let mut trusted_authority_keys = TrustedAuthorityKeys::default();
+        for link in &authority_chain.links {
+            if let Some(public_key) = &link.grantor_public_key {
+                trusted_authority_keys.insert(link.grantor.clone(), vec![public_key.clone()]);
+            }
+        }
         AdjudicationContext {
             actor_roles: vec![Role {
                 name: "worker".into(),
                 branch: GovernmentBranch::Executive,
             }],
-            authority_chain: AuthorityChain {
-                links: vec![signed_link("did:exo:root", actor)],
-            },
+            authority_chain,
             consent_records: vec![ConsentRecord {
                 subject: did("did:exo:owner"),
                 granted_to: actor.clone(),
@@ -242,6 +249,7 @@ mod tests {
             },
             human_override_preserved: true,
             actor_permissions: PermissionSet::new(vec![Permission::new("read")]),
+            trusted_authority_keys,
             provenance: Some(signed_provenance(actor)),
             quorum_evidence: None,
             active_challenge_reason: None,

--- a/crates/exo-gatekeeper/src/invariants.rs
+++ b/crates/exo-gatekeeper/src/invariants.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::{
     AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch, PermissionSet,
-    Provenance, QuorumEvidence, Role,
+    Provenance, QuorumEvidence, Role, TrustedAuthorityKeys,
 };
 
 // ---------------------------------------------------------------------------
@@ -100,6 +100,7 @@ pub struct InvariantContext {
     pub provenance: Option<Provenance>,
     pub actor_permissions: PermissionSet,
     pub requested_permissions: PermissionSet,
+    pub trusted_authority_keys: TrustedAuthorityKeys,
 }
 
 // ---------------------------------------------------------------------------
@@ -396,6 +397,28 @@ fn check_authority_chain_valid(ctx: &InvariantContext) -> Result<(), InvariantVi
                 evidence: vec![format!("key_len: {}", pk_bytes.len())],
             })?;
 
+        let trusted_keys = ctx
+            .trusted_authority_keys
+            .get(&link.grantor)
+            .ok_or_else(|| InvariantViolation {
+                invariant: ConstitutionalInvariant::AuthorityChainValid,
+                description: format!(
+                    "link[{idx}] grantor_public_key is unresolved for grantor DID"
+                ),
+                evidence: vec![format!("grantor: {}", link.grantor)],
+            })?;
+
+        if !trusted_keys
+            .iter()
+            .any(|trusted_key| trusted_key.as_slice() == pk_bytes.as_slice())
+        {
+            return Err(InvariantViolation {
+                invariant: ConstitutionalInvariant::AuthorityChainValid,
+                description: format!("link[{idx}] grantor_public_key is not bound to grantor DID"),
+                evidence: vec![format!("grantor: {}", link.grantor)],
+            });
+        }
+
         // Validate signature length.
         let sig_arr: [u8; 64] =
             link.signature
@@ -634,8 +657,13 @@ mod tests {
 
     fn passing_context() -> InvariantContext {
         let actor = did("did:exo:actor1");
-        let (authority_link, _) = signed_link("did:exo:root", actor.as_str());
+        let (authority_link, authority_public_key) = signed_link("did:exo:root", actor.as_str());
         let (provenance, _, _) = signed_provenance(actor.as_str());
+        let mut trusted_authority_keys = TrustedAuthorityKeys::default();
+        trusted_authority_keys.insert(
+            authority_link.grantor.clone(),
+            vec![authority_public_key.as_bytes().to_vec()],
+        );
         InvariantContext {
             actor: actor.clone(),
             actor_roles: vec![Role {
@@ -663,6 +691,7 @@ mod tests {
             provenance: Some(provenance),
             actor_permissions: PermissionSet::new(vec![Permission::new("read")]),
             requested_permissions: PermissionSet::default(),
+            trusted_authority_keys,
         }
     }
 
@@ -1019,8 +1048,12 @@ mod tests {
             ConstitutionalInvariant::AuthorityChainValid,
         ]));
         let mut ctx = passing_context();
-        let (link1, _) = signed_link("did:exo:root", "did:exo:mid");
-        let (link2, _) = signed_link("did:exo:mid", "did:exo:actor1");
+        let (link1, pk1) = signed_link("did:exo:root", "did:exo:mid");
+        let (link2, pk2) = signed_link("did:exo:mid", "did:exo:actor1");
+        ctx.trusted_authority_keys
+            .insert(link1.grantor.clone(), vec![pk1.as_bytes().to_vec()]);
+        ctx.trusted_authority_keys
+            .insert(link2.grantor.clone(), vec![pk2.as_bytes().to_vec()]);
         ctx.authority_chain = AuthorityChain {
             links: vec![link1, link2],
         };
@@ -1396,6 +1429,38 @@ mod tests {
         );
     }
 
+    #[test]
+    fn authority_chain_validation_requires_trusted_grantor_key_resolution() {
+        let source = production_source();
+        let checker = source
+            .split("fn check_authority_chain_valid")
+            .nth(1)
+            .and_then(|rest| rest.split("fn check_quorum_legitimate").next())
+            .expect("AuthorityChainValid checker source must be present");
+        let compact_checker = checker
+            .chars()
+            .filter(|ch| !ch.is_whitespace())
+            .collect::<String>();
+
+        assert!(
+            compact_checker.contains("ctx.trusted_authority_keys"),
+            "AuthorityChainValid must consult runtime-resolved trusted grantor keys"
+        );
+        assert!(
+            checker.contains("grantor_public_key is unresolved for grantor DID"),
+            "AuthorityChainValid must fail closed when the grantor DID has no resolved key"
+        );
+        assert!(
+            checker.contains("grantor_public_key is not bound to grantor DID"),
+            "AuthorityChainValid must reject self-attested keys not bound to the grantor DID"
+        );
+        assert!(
+            compact_checker.find("ctx.trusted_authority_keys").unwrap()
+                < compact_checker.find("exo_core::crypto::verify").unwrap(),
+            "grantor key binding must be checked before accepting the Ed25519 signature"
+        );
+    }
+
     fn signed_provenance(
         actor_str: &str,
     ) -> (Provenance, exo_core::PublicKey, exo_core::SecretKey) {
@@ -1560,9 +1625,28 @@ mod tests {
             ConstitutionalInvariant::AuthorityChainValid,
         ]));
         let mut ctx = passing_context();
-        let (link, _pk) = signed_link("did:exo:root", "did:exo:actor1");
+        let (link, pk) = signed_link("did:exo:root", "did:exo:actor1");
+        ctx.trusted_authority_keys
+            .insert(link.grantor.clone(), vec![pk.as_bytes().to_vec()]);
         ctx.authority_chain = AuthorityChain { links: vec![link] };
         assert!(enforce_all(&engine, &ctx).is_ok());
+    }
+
+    #[test]
+    fn authority_chain_rejects_unresolved_grantor_public_key() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::AuthorityChainValid,
+        ]));
+        let mut ctx = passing_context();
+        let (link, _pk) = signed_link("did:exo:unresolved-root", "did:exo:actor1");
+        ctx.authority_chain = AuthorityChain { links: vec![link] };
+
+        let err = enforce_all(&engine, &ctx).unwrap_err();
+        assert!(
+            err[0].description.contains("grantor_public_key")
+                && err[0].description.contains("unresolved"),
+            "self-attested grantor public keys must not satisfy AuthorityChainValid: {err:?}"
+        );
     }
 
     #[test]
@@ -1602,7 +1686,9 @@ mod tests {
             ConstitutionalInvariant::AuthorityChainValid,
         ]));
         let mut ctx = passing_context();
-        let (mut link, _pk) = signed_link("did:exo:root", "did:exo:actor1");
+        let (mut link, pk) = signed_link("did:exo:root", "did:exo:actor1");
+        ctx.trusted_authority_keys
+            .insert(link.grantor.clone(), vec![pk.as_bytes().to_vec()]);
         // Flip a byte in the signature to corrupt it.
         link.signature[0] ^= 0xFF;
         ctx.authority_chain = AuthorityChain { links: vec![link] };
@@ -1616,13 +1702,15 @@ mod tests {
             ConstitutionalInvariant::AuthorityChainValid,
         ]));
         let mut ctx = passing_context();
-        let (mut link, _pk) = signed_link("did:exo:root", "did:exo:actor1");
+        let (mut link, pk) = signed_link("did:exo:root", "did:exo:actor1");
+        ctx.trusted_authority_keys
+            .insert(link.grantor.clone(), vec![pk.as_bytes().to_vec()]);
         // Replace public key with a different one.
         let (other_pk, _other_sk) = exo_core::crypto::generate_keypair();
         link.grantor_public_key = Some(other_pk.as_bytes().to_vec());
         ctx.authority_chain = AuthorityChain { links: vec![link] };
         let err = enforce_all(&engine, &ctx).unwrap_err();
-        assert!(err[0].description.contains("cryptographically invalid"));
+        assert!(err[0].description.contains("not bound"));
     }
 
     #[test]
@@ -1649,7 +1737,9 @@ mod tests {
             ConstitutionalInvariant::AuthorityChainValid,
         ]));
         let mut ctx = passing_context();
-        let (mut link, _) = signed_link("did:exo:root", "did:exo:actor1");
+        let (mut link, pk) = signed_link("did:exo:root", "did:exo:actor1");
+        ctx.trusted_authority_keys
+            .insert(link.grantor.clone(), vec![pk.as_bytes().to_vec()]);
         link.signature.clear();
         ctx.authority_chain = AuthorityChain { links: vec![link] };
         let err = enforce_all(&engine, &ctx).unwrap_err();
@@ -1697,6 +1787,8 @@ mod tests {
         }
         let message = Hash256::digest(&payload);
         let sig = exo_core::crypto::sign(message.as_bytes(), &sk);
+        ctx.trusted_authority_keys
+            .insert(grantor.clone(), vec![pk.as_bytes().to_vec()]);
 
         ctx.authority_chain = AuthorityChain {
             links: vec![AuthorityLink {
@@ -1718,8 +1810,12 @@ mod tests {
             ConstitutionalInvariant::AuthorityChainValid,
         ]));
         let mut ctx = passing_context();
-        let (link1, _) = signed_link("did:exo:root", "did:exo:mid");
-        let (link2, _) = signed_link("did:exo:mid", "did:exo:actor1");
+        let (link1, pk1) = signed_link("did:exo:root", "did:exo:mid");
+        let (link2, pk2) = signed_link("did:exo:mid", "did:exo:actor1");
+        ctx.trusted_authority_keys
+            .insert(link1.grantor.clone(), vec![pk1.as_bytes().to_vec()]);
+        ctx.trusted_authority_keys
+            .insert(link2.grantor.clone(), vec![pk2.as_bytes().to_vec()]);
         ctx.authority_chain = AuthorityChain {
             links: vec![link1, link2],
         };

--- a/crates/exo-gatekeeper/src/kernel.rs
+++ b/crates/exo-gatekeeper/src/kernel.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     types::{
         AuthorityChain, BailmentState, ConsentRecord, PermissionSet, Provenance, QuorumEvidence,
-        Role,
+        Role, TrustedAuthorityKeys,
     },
 };
 
@@ -68,6 +68,7 @@ pub struct AdjudicationContext {
     pub bailment_state: BailmentState,
     pub human_override_preserved: bool,
     pub actor_permissions: PermissionSet,
+    pub trusted_authority_keys: TrustedAuthorityKeys,
     pub provenance: Option<Provenance>,
     pub quorum_evidence: Option<QuorumEvidence>,
     /// When set, the action is under an active Sybil challenge hold.
@@ -120,6 +121,7 @@ impl Kernel {
             provenance: context.provenance.clone(),
             actor_permissions: context.actor_permissions.clone(),
             requested_permissions: action.required_permissions.clone(),
+            trusted_authority_keys: context.trusted_authority_keys.clone(),
         };
 
         match enforce_all(&self.invariant_engine, &inv_ctx) {
@@ -218,7 +220,7 @@ mod tests {
     use super::*;
     use crate::{
         invariants::{authority_link_signature_message, provenance_signature_message},
-        types::{AuthorityLink, GovernmentBranch, Permission, QuorumVote},
+        types::{AuthorityLink, GovernmentBranch, Permission, QuorumVote, TrustedAuthorityKeys},
     };
 
     const CONSTITUTION: &[u8] = b"We the people of the EXOCHAIN...";
@@ -280,14 +282,21 @@ mod tests {
     }
 
     fn valid_context(actor: &Did) -> AdjudicationContext {
+        let authority_chain = AuthorityChain {
+            links: vec![signed_link("did:exo:root", actor)],
+        };
+        let mut trusted_authority_keys = TrustedAuthorityKeys::default();
+        for link in &authority_chain.links {
+            if let Some(public_key) = &link.grantor_public_key {
+                trusted_authority_keys.insert(link.grantor.clone(), vec![public_key.clone()]);
+            }
+        }
         AdjudicationContext {
             actor_roles: vec![Role {
                 name: "judge".into(),
                 branch: GovernmentBranch::Judicial,
             }],
-            authority_chain: AuthorityChain {
-                links: vec![signed_link("did:exo:root", actor)],
-            },
+            authority_chain,
             consent_records: vec![ConsentRecord {
                 subject: did("did:exo:bailor"),
                 granted_to: actor.clone(),
@@ -301,6 +310,7 @@ mod tests {
             },
             human_override_preserved: true,
             actor_permissions: PermissionSet::new(vec![Permission::new("read")]),
+            trusted_authority_keys,
             provenance: Some(signed_provenance(actor)),
             quorum_evidence: None,
             active_challenge_reason: None,
@@ -521,6 +531,7 @@ mod tests {
                 bailment_state: BailmentState::None,
                 human_override_preserved: true,
                 actor_permissions: PermissionSet::new(vec![Permission::new("vote")]),
+                trusted_authority_keys: TrustedAuthorityKeys::default(),
                 provenance: None,
                 quorum_evidence: None,
                 active_challenge_reason: None,

--- a/crates/exo-gatekeeper/src/types.rs
+++ b/crates/exo-gatekeeper/src/types.rs
@@ -2,7 +2,7 @@
 //!
 //! Types specific to the judicial branch that are not part of exo-core.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use exo_core::Did;
 use serde::{Deserialize, Serialize};
@@ -278,6 +278,13 @@ pub struct AuthorityLink {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub grantor_public_key: Option<Vec<u8>>,
 }
+
+/// DID-resolved Ed25519 public keys trusted by the runtime context.
+///
+/// Authority links still carry the key used for signature verification, but
+/// the invariant engine only accepts that key when it matches independently
+/// resolved key material for the claimed grantor DID.
+pub type TrustedAuthorityKeys = BTreeMap<Did, Vec<Vec<u8>>>;
 
 // ---------------------------------------------------------------------------
 // Quorum evidence

--- a/crates/exo-gateway/Cargo.toml
+++ b/crates/exo-gateway/Cargo.toml
@@ -18,6 +18,7 @@ exo-identity = { path = "../exo-identity" }
 exo-consent = { path = "../exo-consent" }
 exo-gatekeeper = { path = "../exo-gatekeeper" }
 exo-governance = { path = "../exo-governance" }
+bs58 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -61,4 +62,3 @@ unaudited-gateway-graphql-api = []
 [dev-dependencies]
 serde_json = { workspace = true }
 tower = { workspace = true }
-bs58 = { workspace = true }

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -4344,18 +4344,16 @@ mod tests {
         }
     }
 
-    fn signing_registry() -> (Arc<RwLock<LocalDidRegistry>>, exo_core::SecretKey) {
-        let did = Did::new("did:exo:login-alice").unwrap();
-        let (pk, sk) = generate_keypair();
-        let multibase = format!("z{}", bs58::encode(pk.as_bytes()).into_string());
-        let doc = DidDocument {
+    fn did_document_with_ed25519_key(did: &Did, public_key: &exo_core::PublicKey) -> DidDocument {
+        let multibase = format!("z{}", bs58::encode(public_key.as_bytes()).into_string());
+        DidDocument {
             id: did.clone(),
-            public_keys: vec![pk],
+            public_keys: vec![*public_key],
             authentication: vec![],
             verification_methods: vec![VerificationMethod {
-                id: "did:exo:login-alice#key-1".into(),
+                id: format!("{}#key-1", did.as_str()),
                 key_type: "Ed25519VerificationKey2020".into(),
-                controller: did,
+                controller: did.clone(),
                 public_key_multibase: multibase,
                 version: 1,
                 active: true,
@@ -4367,7 +4365,13 @@ mod tests {
             created: Timestamp::ZERO,
             updated: Timestamp::ZERO,
             revoked: false,
-        };
+        }
+    }
+
+    fn signing_registry() -> (Arc<RwLock<LocalDidRegistry>>, exo_core::SecretKey) {
+        let did = Did::new("did:exo:login-alice").unwrap();
+        let (pk, sk) = generate_keypair();
+        let doc = did_document_with_ed25519_key(&did, &pk);
         let registry = Arc::new(RwLock::new(LocalDidRegistry::new()));
         registry.write().unwrap().register(doc).unwrap();
         (registry, sk)
@@ -7663,6 +7667,24 @@ mod tests {
         );
     }
 
+    #[test]
+    fn advance_pace_authorization_fixture_registers_trusted_grantor_document() {
+        let source = include_str!("server.rs");
+        let start_index = source
+            .rfind("async fn insert_advance_pace_authorization")
+            .expect("fixture function marker present");
+        let after_start = &source[start_index..];
+        let end_index = after_start
+            .find("    async fn insert_test_agent")
+            .expect("fixture end marker present");
+        let fixture = &after_start[..end_index];
+
+        assert!(
+            fixture.contains("db::insert_did_document(pool, &grantor_doc)"),
+            "DB-backed advance-pace fixture must register the authority grantor DID document so trusted grantor keys are resolved from durable state"
+        );
+    }
+
     fn source_between<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
         let start_index = source.find(start).expect("source start marker");
         let after_start = &source[start_index..];
@@ -7683,6 +7705,7 @@ mod tests {
             "DELETE FROM agent_roles WHERE agent_did = $1 OR granted_by = $1",
             "DELETE FROM consent_records WHERE subject_did = $1 OR actor_did = $1",
             "DELETE FROM authority_chains WHERE actor_did = $1",
+            "DELETE FROM did_documents WHERE did = $1",
         ] {
             sqlx::query(statement)
                 .bind(did)
@@ -7690,6 +7713,11 @@ mod tests {
                 .await
                 .unwrap();
         }
+        sqlx::query("DELETE FROM did_documents WHERE did = $1")
+            .bind("did:exo:advance-pace-root")
+            .execute(pool)
+            .await
+            .unwrap();
     }
 
     async fn insert_advance_pace_authorization(pool: &sqlx::PgPool, did: &str, token: &str) {
@@ -7732,6 +7760,17 @@ mod tests {
                 PermissionSet::new(vec![Permission::new("advance_pace")]),
             )],
         };
+        let grantor_public_key = chain.links[0]
+            .grantor_public_key
+            .as_ref()
+            .and_then(|key| <[u8; 32]>::try_from(key.as_slice()).ok())
+            .map(exo_core::PublicKey::from_bytes)
+            .expect("test authority link includes a 32-byte Ed25519 grantor key");
+        let grantor_doc = did_document_with_ed25519_key(&root, &grantor_public_key);
+        assert!(
+            db::insert_did_document(pool, &grantor_doc).await.unwrap(),
+            "advance-pace root DID document should insert into the live DB fixture"
+        );
         sqlx::query(
             "INSERT INTO authority_chains (actor_did, chain_json, valid_from, expires_at) \
              VALUES ($1, $2, $3, NULL)",

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -21,7 +21,9 @@ use exo_core::{Did, Hash256, Signature, Timestamp, hash::hash_structured, hlc::H
 use exo_gatekeeper::{
     invariants::InvariantSet,
     kernel::{ActionRequest as GkActionRequest, AdjudicationContext, Kernel, Verdict},
-    types::{AuthorityChain, BailmentState, Permission, PermissionSet, Provenance},
+    types::{
+        AuthorityChain, BailmentState, Permission, PermissionSet, Provenance, TrustedAuthorityKeys,
+    },
 };
 use exo_governance::conflict::ConflictDeclaration;
 use exo_identity::{
@@ -485,6 +487,7 @@ fn deny_all_adjudication_context() -> AdjudicationContext {
         bailment_state: BailmentState::None,
         human_override_preserved: true,
         actor_permissions: PermissionSet::default(),
+        trusted_authority_keys: TrustedAuthorityKeys::default(),
         provenance: None,
         quorum_evidence: None,
         active_challenge_reason: None,
@@ -1506,6 +1509,7 @@ fn build_adjudication_context_from_rows(
     role_rows: &[crate::db::AgentRoleRow],
     consent_rows: &[crate::db::ConsentRecordRow],
     chain_row: Option<&crate::db::AuthorityChainRow>,
+    trusted_authority_keys: TrustedAuthorityKeys,
 ) -> Result<AdjudicationContext> {
     use exo_gatekeeper::types::{
         AuthorityChain as GkChain, BailmentState as GkBailment, ConsentRecord, GovernmentBranch,
@@ -1581,6 +1585,7 @@ fn build_adjudication_context_from_rows(
         bailment_state,
         human_override_preserved: true,
         actor_permissions,
+        trusted_authority_keys,
         // Provenance is per-action, not per-actor; callers that need full
         // ProvenanceVerifiable enforcement must attach it before adjudication.
         provenance: None,
@@ -1614,6 +1619,74 @@ fn effective_authority_permissions(
     PermissionSet::new(effective_permissions)
 }
 
+#[cfg(feature = "production-db")]
+fn active_did_document_ed25519_keys(doc: &DidDocument) -> Result<Vec<Vec<u8>>> {
+    let mut keys = Vec::new();
+    for method in &doc.verification_methods {
+        if !method.active
+            || method.controller != doc.id
+            || method.key_type != "Ed25519VerificationKey2020"
+        {
+            continue;
+        }
+        let encoded = method
+            .public_key_multibase
+            .strip_prefix('z')
+            .ok_or_else(|| {
+                GatewayError::Internal(format!(
+                    "authority grantor DID document key '{}' uses unsupported multibase prefix",
+                    method.id
+                ))
+            })?;
+        let key = bs58::decode(encoded).into_vec().map_err(|e| {
+            GatewayError::Internal(format!(
+                "authority grantor DID document key '{}' is not valid base58btc: {e}",
+                method.id
+            ))
+        })?;
+        if key.len() != 32 {
+            return Err(GatewayError::Internal(format!(
+                "authority grantor DID document key '{}' is {} bytes, expected 32",
+                method.id,
+                key.len()
+            )));
+        }
+        if !keys.contains(&key) {
+            keys.push(key);
+        }
+    }
+    Ok(keys)
+}
+
+#[cfg(feature = "production-db")]
+async fn load_trusted_authority_keys(
+    pool: &sqlx::PgPool,
+    authority_chain: &AuthorityChain,
+) -> Result<TrustedAuthorityKeys> {
+    let mut trusted_keys = TrustedAuthorityKeys::default();
+    for link in &authority_chain.links {
+        if trusted_keys.contains_key(&link.grantor) {
+            continue;
+        }
+        let Some(doc) = db::find_did_document(pool, link.grantor.as_str())
+            .await
+            .map_err(|e| {
+                GatewayError::Internal(format!(
+                    "authority grantor DID document lookup failed for '{}': {e}",
+                    link.grantor
+                ))
+            })?
+        else {
+            continue;
+        };
+        let keys = active_did_document_ed25519_keys(&doc)?;
+        if !keys.is_empty() {
+            trusted_keys.insert(link.grantor.clone(), keys);
+        }
+    }
+    Ok(trusted_keys)
+}
+
 /// Build an `AdjudicationContext` by loading the actor's roles, consent
 /// records, and authority chain from the live database.
 ///
@@ -1643,7 +1716,26 @@ async fn build_adjudication_context_from_db(
         .await
         .map_err(|e| GatewayError::Internal(format!("adjudication chain query: {e}")))?;
 
-    build_adjudication_context_from_rows(actor, &role_rows, &consent_rows, chain_row.as_ref())
+    let trusted_authority_keys = match &chain_row {
+        Some(row) => {
+            let authority_chain = serde_json::from_value::<AuthorityChain>(row.chain_json.clone())
+                .map_err(|e| {
+                    GatewayError::Internal(format!(
+                        "adjudication authority chain JSON invalid: {e}"
+                    ))
+                })?;
+            load_trusted_authority_keys(pool, &authority_chain).await?
+        }
+        None => TrustedAuthorityKeys::default(),
+    };
+
+    build_adjudication_context_from_rows(
+        actor,
+        &role_rows,
+        &consent_rows,
+        chain_row.as_ref(),
+        trusted_authority_keys,
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -3830,6 +3922,37 @@ mod tests {
     }
 
     #[test]
+    fn adjudication_db_context_resolves_authority_grantor_keys() {
+        let source = include_str!("server.rs");
+        let db_resolver = source
+            .split("async fn build_adjudication_context_from_db")
+            .nth(1)
+            .and_then(|section| section.split("// ---------------------------------------------------------------------------").next())
+            .expect("DB adjudication resolver source present");
+        let row_builder = source
+            .split("fn build_adjudication_context_from_rows")
+            .nth(1)
+            .and_then(|section| section.split("fn effective_authority_permissions").next())
+            .expect("DB row builder source present");
+
+        assert!(
+            db_resolver.contains("load_trusted_authority_keys(pool, &authority_chain).await"),
+            "production DB adjudication must resolve trusted grantor keys from DID documents"
+        );
+        assert!(
+            row_builder.contains("trusted_authority_keys"),
+            "DB row builder must carry resolved grantor keys into AdjudicationContext"
+        );
+        assert!(
+            db_resolver.find("load_trusted_authority_keys").unwrap()
+                < db_resolver
+                    .find("build_adjudication_context_from_rows")
+                    .unwrap(),
+            "trusted grantor keys must be resolved before returning the adjudication context"
+        );
+    }
+
+    #[test]
     fn shutdown_signal_setup_failures_are_not_silent_or_panicking() {
         let source = include_str!("server.rs");
         let shutdown_signal = source_between(
@@ -5311,9 +5434,15 @@ mod tests {
             valid_from: 1,
             expires_at: None,
         }];
-        let role_error = build_adjudication_context_from_rows(&actor, &role_rows, &[], None)
-            .expect_err("unknown role branch must be rejected")
-            .to_string();
+        let role_error = build_adjudication_context_from_rows(
+            &actor,
+            &role_rows,
+            &[],
+            None,
+            TrustedAuthorityKeys::default(),
+        )
+        .expect_err("unknown role branch must be rejected")
+        .to_string();
         assert!(
             !role_error.contains(actor.as_str()) && !role_error.contains(related.as_str()),
             "adjudication role errors must not expose raw DID identifiers: {role_error}"
@@ -5334,10 +5463,15 @@ mod tests {
             valid_from: 1,
             expires_at: None,
         };
-        let chain_error =
-            build_adjudication_context_from_rows(&actor, &[], &consent_rows, Some(&chain_row))
-                .expect_err("malformed authority chain JSON must be rejected")
-                .to_string();
+        let chain_error = build_adjudication_context_from_rows(
+            &actor,
+            &[],
+            &consent_rows,
+            Some(&chain_row),
+            TrustedAuthorityKeys::default(),
+        )
+        .expect_err("malformed authority chain JSON must be rejected")
+        .to_string();
         assert!(
             !chain_error.contains(actor.as_str()) && !chain_error.contains(related.as_str()),
             "adjudication chain errors must not expose raw DID identifiers: {chain_error}"
@@ -8098,16 +8232,34 @@ mod tests {
         )
     }
 
+    fn trusted_authority_keys_for_test_chain(
+        authority_chain: &AuthorityChain,
+    ) -> TrustedAuthorityKeys {
+        let mut trusted_keys = TrustedAuthorityKeys::default();
+        for link in &authority_chain.links {
+            let Some(public_key) = link.grantor_public_key.clone() else {
+                continue;
+            };
+            trusted_keys
+                .entry(link.grantor.clone())
+                .or_default()
+                .push(public_key);
+        }
+        trusted_keys
+    }
+
     fn valid_db_context(actor: &Did) -> AdjudicationContext {
         let root = Did::new("did:exo:root-grantor").unwrap();
+        let authority_chain = AuthorityChain {
+            links: vec![signed_authority_link(&root, actor)],
+        };
+        let trusted_authority_keys = trusted_authority_keys_for_test_chain(&authority_chain);
         AdjudicationContext {
             actor_roles: vec![Role {
                 name: "voter".to_string(),
                 branch: GovernmentBranch::Legislative,
             }],
-            authority_chain: AuthorityChain {
-                links: vec![signed_authority_link(&root, actor)],
-            },
+            authority_chain,
             consent_records: vec![ConsentRecord {
                 subject: root.clone(),
                 granted_to: actor.clone(),
@@ -8121,6 +8273,7 @@ mod tests {
             },
             human_override_preserved: true,
             actor_permissions: PermissionSet::new(vec![Permission::new("vote")]),
+            trusted_authority_keys,
             provenance: None,
             quorum_evidence: None,
             active_challenge_reason: None,
@@ -8200,7 +8353,13 @@ mod tests {
         let actor = Did::new("did:exo:alice").unwrap();
         let role_rows = vec![db_role_row(&actor, "voter", "tribunal")];
 
-        let result = build_adjudication_context_from_rows(&actor, &role_rows, &[], None);
+        let result = build_adjudication_context_from_rows(
+            &actor,
+            &role_rows,
+            &[],
+            None,
+            TrustedAuthorityKeys::default(),
+        );
 
         assert_internal_error_contains(result, "unknown role branch");
     }
@@ -8210,7 +8369,13 @@ mod tests {
         let actor = Did::new("did:exo:alice").unwrap();
         let role_rows = vec![db_role_row(&actor, "root", "judicial")];
 
-        let result = build_adjudication_context_from_rows(&actor, &role_rows, &[], None);
+        let result = build_adjudication_context_from_rows(
+            &actor,
+            &role_rows,
+            &[],
+            None,
+            TrustedAuthorityKeys::default(),
+        );
 
         assert_internal_error_contains(result, "unknown governed role name");
     }
@@ -8220,7 +8385,13 @@ mod tests {
         let actor = Did::new("did:exo:alice").unwrap();
         let role_rows = vec![db_role_row(&actor, "judge", "executive")];
 
-        let result = build_adjudication_context_from_rows(&actor, &role_rows, &[], None);
+        let result = build_adjudication_context_from_rows(
+            &actor,
+            &role_rows,
+            &[],
+            None,
+            TrustedAuthorityKeys::default(),
+        );
 
         assert_internal_error_contains(result, "does not match governed branch");
     }
@@ -8230,7 +8401,13 @@ mod tests {
         let actor = Did::new("did:exo:alice").unwrap();
         let consent_rows = vec![db_consent_row(&actor, "not-a-did")];
 
-        let result = build_adjudication_context_from_rows(&actor, &[], &consent_rows, None);
+        let result = build_adjudication_context_from_rows(
+            &actor,
+            &[],
+            &consent_rows,
+            None,
+            TrustedAuthorityKeys::default(),
+        );
 
         assert_internal_error_contains(result, "consent subject DID");
     }
@@ -8245,7 +8422,13 @@ mod tests {
             }),
         );
 
-        let result = build_adjudication_context_from_rows(&actor, &[], &[], Some(&chain_row));
+        let result = build_adjudication_context_from_rows(
+            &actor,
+            &[],
+            &[],
+            Some(&chain_row),
+            TrustedAuthorityKeys::default(),
+        );
 
         assert_internal_error_contains(result, "authority chain JSON");
     }
@@ -8267,6 +8450,7 @@ mod tests {
             &role_rows,
             &consent_rows,
             Some(&chain_row),
+            valid_context.trusted_authority_keys.clone(),
         )
         .unwrap();
         let verdict = kernel.adjudicate(&vote_action(&actor), &ctx);
@@ -8293,12 +8477,14 @@ mod tests {
         let consent_rows = vec![db_consent_row(&actor, root.as_str())];
         let chain_row =
             db_authority_chain_row(&actor, serde_json::to_value(&authority_chain).unwrap());
+        let trusted_authority_keys = trusted_authority_keys_for_test_chain(&authority_chain);
 
         let ctx = build_adjudication_context_from_rows(
             &actor,
             &role_rows,
             &consent_rows,
             Some(&chain_row),
+            trusted_authority_keys,
         )
         .unwrap();
         let verdict = kernel.adjudicate(&action_for_permission(&actor, "advance_pace"), &ctx);
@@ -8314,6 +8500,39 @@ mod tests {
         assert!(
             verdict.is_permitted(),
             "F-010: action permission backed by DB authority-chain scope must be permitted"
+        );
+    }
+
+    #[test]
+    fn adjudication_context_rows_reject_unresolved_authority_grantor_public_key() {
+        let kernel = adjudication_kernel();
+        let actor = Did::new("did:exo:pace-agent").unwrap();
+        let unresolved_root = Did::new("did:exo:unresolved-root-grantor").unwrap();
+        let authority_chain = AuthorityChain {
+            links: vec![signed_authority_link_for_permissions(
+                &unresolved_root,
+                &actor,
+                PermissionSet::new(vec![Permission::new("advance_pace")]),
+            )],
+        };
+        let role_rows = vec![db_role_row(&actor, "worker", "executive")];
+        let consent_rows = vec![db_consent_row(&actor, unresolved_root.as_str())];
+        let chain_row =
+            db_authority_chain_row(&actor, serde_json::to_value(&authority_chain).unwrap());
+
+        let ctx = build_adjudication_context_from_rows(
+            &actor,
+            &role_rows,
+            &consent_rows,
+            Some(&chain_row),
+            TrustedAuthorityKeys::default(),
+        )
+        .unwrap();
+        let verdict = kernel.adjudicate(&action_for_permission(&actor, "advance_pace"), &ctx);
+
+        assert!(
+            !verdict.is_permitted(),
+            "DB-loaded authority chains must not trust self-attested unresolved grantor keys"
         );
     }
 

--- a/crates/exo-gateway/tests/adjudication_db_integration.rs
+++ b/crates/exo-gateway/tests/adjudication_db_integration.rs
@@ -333,14 +333,17 @@ fn cross_branch_roles_denies() {
 mod db_roundtrip {
     use std::sync::{Arc, RwLock};
 
-    use exo_core::{Did, ExoError, hlc::HybridClock};
+    use exo_core::{Did, ExoError, PublicKey, Timestamp, hlc::HybridClock};
     use exo_gatekeeper::{
         ActionRequest, Kernel, authority_link_signature_message,
         invariants::{ConstitutionalInvariant, InvariantSet},
         types::{AuthorityChain, AuthorityLink, BailmentState, Permission, PermissionSet},
     };
-    use exo_gateway::server::AppState;
-    use exo_identity::registry::LocalDidRegistry;
+    use exo_gateway::{db, server::AppState};
+    use exo_identity::{
+        did::{DidDocument, VerificationMethod},
+        registry::LocalDidRegistry,
+    };
     use sqlx::postgres::PgPoolOptions;
 
     fn did(s: &str) -> Did {
@@ -389,6 +392,34 @@ mod db_roundtrip {
         link
     }
 
+    fn did_document_with_ed25519_key(did: &Did, public_key: &[u8]) -> DidDocument {
+        let key_bytes: [u8; 32] = public_key
+            .try_into()
+            .expect("test authority link includes a 32-byte Ed25519 grantor key");
+        let public_key = PublicKey::from_bytes(key_bytes);
+        let multibase = format!("z{}", bs58::encode(public_key.as_bytes()).into_string());
+        DidDocument {
+            id: did.clone(),
+            public_keys: vec![public_key],
+            authentication: vec![],
+            verification_methods: vec![VerificationMethod {
+                id: format!("{}#key-1", did.as_str()),
+                key_type: "Ed25519VerificationKey2020".into(),
+                controller: did.clone(),
+                public_key_multibase: multibase,
+                version: 1,
+                active: true,
+                valid_from: 0,
+                revoked_at: None,
+            }],
+            hybrid_verification_methods: vec![],
+            service_endpoints: vec![],
+            created: Timestamp::ZERO,
+            updated: Timestamp::ZERO,
+            revoked: false,
+        }
+    }
+
     /// Connect to the real Postgres instance and run migrations.
     /// Returns `None` (causing the calling test to skip) when `DATABASE_URL`
     /// is unset or the connection fails.
@@ -430,6 +461,10 @@ mod db_roundtrip {
             .bind(actor_did)
             .execute(&pool)
             .await;
+        let _ = sqlx::query("DELETE FROM did_documents WHERE did = $1")
+            .bind(grantor_did)
+            .execute(&pool)
+            .await;
 
         // Insert an active consent record (bailor = grantor, bailee = actor).
         sqlx::query(
@@ -450,6 +485,15 @@ mod db_roundtrip {
         let chain = AuthorityChain {
             links: vec![signed_authority_link(&grantor, &actor)],
         };
+        let grantor_public_key = chain.links[0]
+            .grantor_public_key
+            .as_ref()
+            .expect("test authority link includes grantor key");
+        let grantor_doc = did_document_with_ed25519_key(&grantor, grantor_public_key);
+        assert!(
+            db::insert_did_document(&pool, &grantor_doc).await.unwrap(),
+            "DB round-trip fixture must register the trusted authority grantor key"
+        );
         let chain_json = serde_json::to_value(&chain).unwrap();
         sqlx::query(
             "INSERT INTO authority_chains (actor_did, chain_json, valid_from) \

--- a/crates/exo-gateway/tests/adjudication_db_integration.rs
+++ b/crates/exo-gateway/tests/adjudication_db_integration.rs
@@ -26,7 +26,7 @@ use exo_gatekeeper::{
     invariants::{ConstitutionalInvariant, InvariantSet},
     types::{
         AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch, Permission,
-        PermissionSet, Role,
+        PermissionSet, Role, TrustedAuthorityKeys,
     },
 };
 use exo_gateway::server::AppState;
@@ -89,19 +89,34 @@ fn signed_authority_link(grantor: &Did, grantee: &Did) -> AuthorityLink {
     link
 }
 
+fn trusted_authority_keys_for_chain(authority_chain: &AuthorityChain) -> TrustedAuthorityKeys {
+    let mut trusted_keys = TrustedAuthorityKeys::default();
+    for link in &authority_chain.links {
+        if let Some(public_key) = &link.grantor_public_key {
+            trusted_keys
+                .entry(link.grantor.clone())
+                .or_default()
+                .push(public_key.clone());
+        }
+    }
+    trusted_keys
+}
+
 /// Construct a fully-valid `AdjudicationContext` that mirrors what
 /// `build_adjudication_context_from_db` would produce when the actor has a
 /// role, active consent, and a one-link authority chain.
 fn full_db_context(actor: &Did) -> AdjudicationContext {
     let grantor = did("did:exo:root-grantor");
+    let authority_chain = AuthorityChain {
+        links: vec![signed_authority_link(&grantor, actor)],
+    };
+    let trusted_authority_keys = trusted_authority_keys_for_chain(&authority_chain);
     AdjudicationContext {
         actor_roles: vec![Role {
             name: "voter".into(),
             branch: GovernmentBranch::Legislative,
         }],
-        authority_chain: AuthorityChain {
-            links: vec![signed_authority_link(&grantor, actor)],
-        },
+        authority_chain,
         consent_records: vec![ConsentRecord {
             subject: grantor.clone(),
             granted_to: actor.clone(),
@@ -115,6 +130,7 @@ fn full_db_context(actor: &Did) -> AdjudicationContext {
         },
         human_override_preserved: true,
         actor_permissions: PermissionSet::new(vec![Permission::new("vote")]),
+        trusted_authority_keys,
         provenance: None,
         quorum_evidence: None,
         active_challenge_reason: None,
@@ -246,14 +262,16 @@ fn revoked_consent_denies() {
     let kernel = adjudication_kernel();
     let actor = did("did:exo:actor006");
     let grantor = did("did:exo:root-grantor");
+    let authority_chain = AuthorityChain {
+        links: vec![signed_authority_link(&grantor, &actor)],
+    };
+    let trusted_authority_keys = trusted_authority_keys_for_chain(&authority_chain);
     let ctx = AdjudicationContext {
         actor_roles: vec![Role {
             name: "voter".into(),
             branch: GovernmentBranch::Legislative,
         }],
-        authority_chain: AuthorityChain {
-            links: vec![signed_authority_link(&grantor, &actor)],
-        },
+        authority_chain,
         consent_records: vec![ConsentRecord {
             subject: grantor.clone(),
             granted_to: actor.clone(),
@@ -263,6 +281,7 @@ fn revoked_consent_denies() {
         bailment_state: BailmentState::None, // safe default when no active consent
         human_override_preserved: true,
         actor_permissions: PermissionSet::new(vec![Permission::new("vote")]),
+        trusted_authority_keys,
         provenance: None,
         quorum_evidence: None,
         active_challenge_reason: None,

--- a/crates/exo-gateway/tests/decision_forum_integration.rs
+++ b/crates/exo-gateway/tests/decision_forum_integration.rs
@@ -31,7 +31,7 @@ use exo_gatekeeper::{
     provenance_signature_message,
     types::{
         AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch, Permission,
-        PermissionSet, Provenance, Role,
+        PermissionSet, Provenance, Role, TrustedAuthorityKeys,
     },
 };
 
@@ -116,14 +116,21 @@ fn transition_action(actor: &Did, from: BctsState, to: BctsState) -> ActionReque
 
 fn transition_context(actor: &Did, from: BctsState, to: BctsState) -> AdjudicationContext {
     let permission = bcts_transition_permission(from, to);
+    let authority_chain = AuthorityChain {
+        links: vec![signed_authority_link(actor, permission.clone())],
+    };
+    let mut trusted_authority_keys = TrustedAuthorityKeys::default();
+    for link in &authority_chain.links {
+        if let Some(public_key) = &link.grantor_public_key {
+            trusted_authority_keys.insert(link.grantor.clone(), vec![public_key.clone()]);
+        }
+    }
     AdjudicationContext {
         actor_roles: vec![Role {
             name: "transition-judge".into(),
             branch: GovernmentBranch::Judicial,
         }],
-        authority_chain: AuthorityChain {
-            links: vec![signed_authority_link(actor, permission.clone())],
-        },
+        authority_chain,
         consent_records: vec![ConsentRecord {
             subject: did("did:exo:bailor"),
             granted_to: actor.clone(),
@@ -137,6 +144,7 @@ fn transition_context(actor: &Did, from: BctsState, to: BctsState) -> Adjudicati
         },
         human_override_preserved: true,
         actor_permissions: PermissionSet::new(vec![permission]),
+        trusted_authority_keys,
         provenance: Some(signed_provenance(actor)),
         quorum_evidence: None,
         active_challenge_reason: None,

--- a/crates/exo-legal/src/nist_compliance_tests.rs
+++ b/crates/exo-legal/src/nist_compliance_tests.rs
@@ -18,7 +18,7 @@ mod nist_compliance {
         provenance_signature_message,
         types::{
             AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch,
-            Permission, PermissionSet, Provenance, Role,
+            Permission, PermissionSet, Provenance, Role, TrustedAuthorityKeys,
         },
     };
     use exo_governance::audit::{self as gov_audit, AuditLog};
@@ -212,6 +212,15 @@ mod nist_compliance {
     /// Build a passing InvariantContext matching the pattern in invariants.rs tests.
     fn passing_context(actor: &Did) -> InvariantContext {
         let root = did("root");
+        let authority_chain = AuthorityChain {
+            links: vec![signed_authority_link(&root, actor)],
+        };
+        let mut trusted_authority_keys = TrustedAuthorityKeys::default();
+        for link in &authority_chain.links {
+            if let Some(public_key) = &link.grantor_public_key {
+                trusted_authority_keys.insert(link.grantor.clone(), vec![public_key.clone()]);
+            }
+        }
         InvariantContext {
             actor: actor.clone(),
             actor_roles: vec![Role {
@@ -229,9 +238,7 @@ mod nist_compliance {
                 scope: "data:test".into(),
                 active: true,
             }],
-            authority_chain: AuthorityChain {
-                links: vec![signed_authority_link(&root, actor)],
-            },
+            authority_chain,
             is_self_grant: false,
             human_override_preserved: true,
             kernel_modification_attempted: false,
@@ -239,6 +246,7 @@ mod nist_compliance {
             provenance: Some(signed_provenance(actor)),
             actor_permissions: PermissionSet::new(vec![Permission::new("read")]),
             requested_permissions: PermissionSet::default(),
+            trusted_authority_keys,
         }
     }
 

--- a/crates/exo-node/src/holons.rs
+++ b/crates/exo-node/src/holons.rs
@@ -51,7 +51,7 @@ use exo_gatekeeper::{
     provenance_signature_message,
     types::{
         AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch, Permission,
-        PermissionSet, Provenance, Role,
+        PermissionSet, Provenance, Role, TrustedAuthorityKeys,
     },
 };
 use serde::Serialize;
@@ -402,14 +402,21 @@ pub fn build_holon_adjudication_context(
     config: &HolonManagerConfig,
 ) -> Result<AdjudicationContext, String> {
     let provenance_timestamp = next_provenance_timestamp(config)?;
+    let authority_chain = AuthorityChain {
+        links: vec![signed_authority_link(holon, config)?],
+    };
+    let mut trusted_authority_keys = TrustedAuthorityKeys::default();
+    for link in &authority_chain.links {
+        if let Some(public_key) = &link.grantor_public_key {
+            trusted_authority_keys.insert(link.grantor.clone(), vec![public_key.clone()]);
+        }
+    }
     Ok(AdjudicationContext {
         actor_roles: vec![Role {
             name: "worker".into(),
             branch: GovernmentBranch::Executive,
         }],
-        authority_chain: AuthorityChain {
-            links: vec![signed_authority_link(holon, config)?],
-        },
+        authority_chain,
         consent_records: vec![ConsentRecord {
             subject: config.root_did.clone(),
             granted_to: holon.id.clone(),
@@ -423,6 +430,7 @@ pub fn build_holon_adjudication_context(
         },
         human_override_preserved: true,
         actor_permissions: holon.capabilities.clone(),
+        trusted_authority_keys,
         provenance: Some(signed_provenance(holon, config, provenance_timestamp)?),
         quorum_evidence: None,
         active_challenge_reason: None,

--- a/crates/exo-node/src/mcp/middleware.rs
+++ b/crates/exo-node/src/mcp/middleware.rs
@@ -23,7 +23,7 @@ use exo_gatekeeper::{
     invariants::InvariantSet,
     kernel::{ActionRequest, AdjudicationContext, Kernel, Verdict},
     mcp::{self, McpContext, McpRule},
-    types::{BailmentState, Permission, PermissionSet},
+    types::{BailmentState, Permission, PermissionSet, TrustedAuthorityKeys},
 };
 use serde::Serialize;
 use serde_json::Value;
@@ -31,7 +31,7 @@ use serde_json::Value;
 use super::{
     error::{McpError, Result},
     protocol::AI_OUTPUT_MARKING,
-    tools::authority::parse_verified_adjudication_context,
+    tools::authority::parse_verified_adjudication_context_with_trusted_authority_keys,
 };
 
 const CONSTITUTIONAL_CONTEXT_FIELD: &str = "constitutional_context";
@@ -223,6 +223,20 @@ impl ConstitutionalMiddleware {
         Ok(())
     }
 
+    fn trusted_authority_keys(&self) -> Result<TrustedAuthorityKeys> {
+        let authority = self.authority.as_ref().ok_or_else(|| {
+            McpError::ConstitutionalViolation(
+                "MCP authority signer is required for verified MCP invocation context".into(),
+            )
+        })?;
+        let mut keys = TrustedAuthorityKeys::default();
+        keys.insert(
+            authority.did.clone(),
+            vec![authority.public_key.as_bytes().to_vec()],
+        );
+        Ok(keys)
+    }
+
     fn parse_invocation_context(
         &self,
         actor_did: &Did,
@@ -241,12 +255,17 @@ impl ConstitutionalMiddleware {
                 "verified MCP invocation context missing adjudication_context".into(),
             )
         })?;
-        let adjudication_context =
-            parse_verified_adjudication_context(adjudication_value, actor_did).map_err(|err| {
-                McpError::ConstitutionalViolation(format!(
-                    "verified MCP invocation context invalid: {err}"
-                ))
-            })?;
+        let trusted_authority_keys = self.trusted_authority_keys()?;
+        let adjudication_context = parse_verified_adjudication_context_with_trusted_authority_keys(
+            adjudication_value,
+            actor_did,
+            trusted_authority_keys,
+        )
+        .map_err(|err| {
+            McpError::ConstitutionalViolation(format!(
+                "verified MCP invocation context invalid: {err}"
+            ))
+        })?;
         self.verify_authority_binding(actor_did, &adjudication_context)?;
         if !Self::action_hash_matches(&adjudication_context, action) {
             return Err(McpError::ConstitutionalViolation(

--- a/crates/exo-node/src/mcp/tools/authority.rs
+++ b/crates/exo-node/src/mcp/tools/authority.rs
@@ -18,7 +18,7 @@ use exo_gatekeeper::{
     kernel::{ActionRequest, AdjudicationContext, Kernel, Verdict},
     types::{
         AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch, Permission,
-        PermissionSet, Provenance, Role,
+        PermissionSet, Provenance, Role, TrustedAuthorityKeys,
     },
 };
 use serde_json::{Value, json};
@@ -218,7 +218,11 @@ fn parse_authority_chain(value: &Value) -> Result<AuthorityChain, Vec<String>> {
     }
 }
 
-fn validate_authority_chain(chain: &AuthorityChain, terminal_actor: &Did) -> Vec<String> {
+fn validate_authority_chain(
+    chain: &AuthorityChain,
+    terminal_actor: &Did,
+    trusted_authority_keys: &TrustedAuthorityKeys,
+) -> Vec<String> {
     let engine = InvariantEngine::new(InvariantSet::with(vec![
         ConstitutionalInvariant::AuthorityChainValid,
     ]));
@@ -235,7 +239,7 @@ fn validate_authority_chain(chain: &AuthorityChain, terminal_actor: &Did) -> Vec
         provenance: None,
         actor_permissions: PermissionSet::default(),
         requested_permissions: PermissionSet::default(),
-        trusted_authority_keys: Default::default(),
+        trusted_authority_keys: trusted_authority_keys.clone(),
     };
     match enforce_all(&engine, &context) {
         Ok(()) => Vec::new(),
@@ -343,6 +347,18 @@ pub(crate) fn parse_verified_adjudication_context(
     context_value: &Value,
     actor: &Did,
 ) -> Result<AdjudicationContext, String> {
+    parse_verified_adjudication_context_with_trusted_authority_keys(
+        context_value,
+        actor,
+        TrustedAuthorityKeys::default(),
+    )
+}
+
+pub(crate) fn parse_verified_adjudication_context_with_trusted_authority_keys(
+    context_value: &Value,
+    actor: &Did,
+    trusted_authority_keys: TrustedAuthorityKeys,
+) -> Result<AdjudicationContext, String> {
     let actor_roles = parse_roles(context_value)?;
     let consent_records = parse_consent_records(context_value)?;
     let bailment_state = parse_bailment_state(context_value)?;
@@ -358,7 +374,7 @@ pub(crate) fn parse_verified_adjudication_context(
         .ok_or_else(|| "context.authority_chain is required".to_owned())?;
     let authority_chain =
         parse_authority_chain(authority_chain_value).map_err(|issues| issues.join("; "))?;
-    let issues = validate_authority_chain(&authority_chain, actor);
+    let issues = validate_authority_chain(&authority_chain, actor, &trusted_authority_keys);
     if !issues.is_empty() {
         return Err(format!(
             "context.authority_chain is invalid: {}",
@@ -373,7 +389,7 @@ pub(crate) fn parse_verified_adjudication_context(
         bailment_state,
         human_override_preserved,
         actor_permissions,
-        trusted_authority_keys: Default::default(),
+        trusted_authority_keys,
         provenance: Some(provenance),
         quorum_evidence: None,
         active_challenge_reason: None,
@@ -524,7 +540,11 @@ pub fn execute_verify_authority_chain(params: &Value, _context: &NodeContext) ->
         }
     };
     if issues.is_empty() {
-        issues.extend(validate_authority_chain(&authority_chain, &terminal));
+        issues.extend(validate_authority_chain(
+            &authority_chain,
+            &terminal,
+            &TrustedAuthorityKeys::default(),
+        ));
     }
     let valid = issues.is_empty();
 
@@ -625,7 +645,8 @@ pub fn execute_check_permission(params: &Value, _context: &NodeContext) -> ToolR
             );
         }
     };
-    let issues = validate_authority_chain(&authority_chain, &actor);
+    let issues =
+        validate_authority_chain(&authority_chain, &actor, &TrustedAuthorityKeys::default());
     if !issues.is_empty() {
         return ToolResult::success(
             json!({

--- a/crates/exo-node/src/mcp/tools/authority.rs
+++ b/crates/exo-node/src/mcp/tools/authority.rs
@@ -235,6 +235,7 @@ fn validate_authority_chain(chain: &AuthorityChain, terminal_actor: &Did) -> Vec
         provenance: None,
         actor_permissions: PermissionSet::default(),
         requested_permissions: PermissionSet::default(),
+        trusted_authority_keys: Default::default(),
     };
     match enforce_all(&engine, &context) {
         Ok(()) => Vec::new(),
@@ -367,6 +368,7 @@ pub(crate) fn parse_verified_adjudication_context(
         bailment_state: parse_bailment_state(context_value)?,
         human_override_preserved,
         actor_permissions: parse_permission_set(context_value, "actor_permissions")?,
+        trusted_authority_keys: Default::default(),
         provenance: Some(parse_provenance(context_value)?),
         quorum_evidence: None,
         active_challenge_reason: None,

--- a/crates/exo-node/src/mcp/tools/authority.rs
+++ b/crates/exo-node/src/mcp/tools/authority.rs
@@ -343,6 +343,16 @@ pub(crate) fn parse_verified_adjudication_context(
     context_value: &Value,
     actor: &Did,
 ) -> Result<AdjudicationContext, String> {
+    let actor_roles = parse_roles(context_value)?;
+    let consent_records = parse_consent_records(context_value)?;
+    let bailment_state = parse_bailment_state(context_value)?;
+    let human_override_preserved = context_value
+        .get("human_override_preserved")
+        .and_then(Value::as_bool)
+        .ok_or_else(|| "context.human_override_preserved must be boolean".to_owned())?;
+    let actor_permissions = parse_permission_set(context_value, "actor_permissions")?;
+    let provenance = parse_provenance(context_value)?;
+
     let authority_chain_value = context_value
         .get("authority_chain")
         .ok_or_else(|| "context.authority_chain is required".to_owned())?;
@@ -356,20 +366,15 @@ pub(crate) fn parse_verified_adjudication_context(
         ));
     }
 
-    let human_override_preserved = context_value
-        .get("human_override_preserved")
-        .and_then(Value::as_bool)
-        .ok_or_else(|| "context.human_override_preserved must be boolean".to_owned())?;
-
     Ok(AdjudicationContext {
-        actor_roles: parse_roles(context_value)?,
+        actor_roles,
         authority_chain,
-        consent_records: parse_consent_records(context_value)?,
-        bailment_state: parse_bailment_state(context_value)?,
+        consent_records,
+        bailment_state,
         human_override_preserved,
-        actor_permissions: parse_permission_set(context_value, "actor_permissions")?,
+        actor_permissions,
         trusted_authority_keys: Default::default(),
-        provenance: Some(parse_provenance(context_value)?),
+        provenance: Some(provenance),
         quorum_evidence: None,
         active_challenge_reason: None,
     })
@@ -1029,7 +1034,7 @@ mod tests {
     }
 
     #[test]
-    fn execute_verify_authority_chain_valid() {
+    fn execute_verify_authority_chain_rejects_untrusted_embedded_grantor_key() {
         let (link, _) = signed_link_json("did:exo:root", "did:exo:leaf", &["read"]);
         let result = execute_verify_authority_chain(
             &json!({
@@ -1040,9 +1045,14 @@ mod tests {
         );
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
-        assert_eq!(v["valid"], true);
+        assert_eq!(v["valid"], false);
         assert_eq!(v["depth"], 1);
-        assert!(v["issues"].as_array().expect("issues").is_empty());
+        let issues = v["issues"].as_array().expect("issues");
+        assert!(issues.iter().any(|issue| {
+            issue.as_str().is_some_and(|text| {
+                text.contains("grantor_public_key is unresolved for grantor DID")
+            })
+        }));
     }
 
     #[test]
@@ -1084,9 +1094,9 @@ mod tests {
         assert_eq!(v["valid"], false);
         let issues = v["issues"].as_array().expect("issues");
         assert!(issues.iter().any(|issue| {
-            issue
-                .as_str()
-                .is_some_and(|text| text.contains("cryptographically invalid"))
+            issue.as_str().is_some_and(|text| {
+                text.contains("grantor_public_key is unresolved for grantor DID")
+            })
         }));
     }
 
@@ -1247,7 +1257,7 @@ mod tests {
     }
 
     #[test]
-    fn execute_check_permission_success() {
+    fn execute_check_permission_rejects_untrusted_embedded_grantor_key() {
         let (link, _) = signed_link_json("did:exo:root", "did:exo:alice", &["read"]);
         let result = execute_check_permission(
             &json!({
@@ -1261,8 +1271,14 @@ mod tests {
         let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
         assert_eq!(v["actor"], "did:exo:alice");
         assert_eq!(v["permission"], "read");
-        assert_eq!(v["granted"], true);
-        assert_eq!(v["source"], "verified_signed_authority_chain");
+        assert_eq!(v["granted"], false);
+        assert_eq!(v["source"], "invalid_authority_chain");
+        let issues = v["issues"].as_array().expect("issues");
+        assert!(issues.iter().any(|issue| {
+            issue.as_str().is_some_and(|text| {
+                text.contains("grantor_public_key is unresolved for grantor DID")
+            })
+        }));
     }
 
     #[test]
@@ -1331,7 +1347,7 @@ mod tests {
     }
 
     #[test]
-    fn execute_adjudicate_action_permitted() {
+    fn execute_adjudicate_action_rejects_context_without_trusted_key_resolver() {
         let action = "read medical record";
         let result = execute_adjudicate_action(
             &json!({
@@ -1342,11 +1358,10 @@ mod tests {
             }),
             &NodeContext::empty(),
         );
-        assert!(!result.is_error);
-        let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
-        assert_eq!(v["verdict"], "Permitted");
-        assert_eq!(v["actor"], "did:exo:alice");
-        assert!(v["violations"].is_null());
+        assert!(result.is_error);
+        let text = result.content[0].text();
+        assert!(text.contains("mcp_verified_context_required"));
+        assert!(text.contains("grantor_public_key is unresolved for grantor DID"));
     }
 
     #[test]
@@ -1366,7 +1381,7 @@ mod tests {
     }
 
     #[test]
-    fn execute_adjudicate_action_denied_self_grant() {
+    fn execute_adjudicate_action_rejects_self_grant_context_without_trusted_key_resolver() {
         let action = "elevate permissions";
         let result = execute_adjudicate_action(
             &json!({
@@ -1378,21 +1393,15 @@ mod tests {
             }),
             &NodeContext::empty(),
         );
-        assert!(!result.is_error);
-        let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
-        assert_eq!(v["verdict"], "Denied");
-        let violations = v["violations"].as_array().expect("violations");
-        assert!(!violations.is_empty());
-        assert!(
-            violations
-                .iter()
-                .any(|violation| violation["invariant"] == "no-self-grant"),
-            "denied self-grant verdict must expose a stable invariant ID"
-        );
+        assert!(result.is_error);
+        let text = result.content[0].text();
+        assert!(text.contains("mcp_verified_context_required"));
+        assert!(text.contains("grantor_public_key is unresolved for grantor DID"));
     }
 
     #[test]
-    fn execute_adjudicate_action_denied_kernel_modification() {
+    fn execute_adjudicate_action_rejects_kernel_modification_context_without_trusted_key_resolver()
+    {
         let action = "patch kernel";
         let result = execute_adjudicate_action(
             &json!({
@@ -1404,9 +1413,10 @@ mod tests {
             }),
             &NodeContext::empty(),
         );
-        assert!(!result.is_error);
-        let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
-        assert_eq!(v["verdict"], "Denied");
+        assert!(result.is_error);
+        let text = result.content[0].text();
+        assert!(text.contains("mcp_verified_context_required"));
+        assert!(text.contains("grantor_public_key is unresolved for grantor DID"));
     }
 
     #[test]

--- a/crates/exochain-sdk/src/kernel.rs
+++ b/crates/exochain-sdk/src/kernel.rs
@@ -44,7 +44,7 @@ use exo_gatekeeper::{
     authority_link_signature_message, provenance_signature_message,
     types::{
         AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch, Permission,
-        PermissionSet, Provenance, Role,
+        PermissionSet, Provenance, Role, TrustedAuthorityKeys,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -505,18 +505,27 @@ impl ConstitutionalKernel {
             }
         };
 
+        let authority_chain = AuthorityChain {
+            links: vec![authority_link],
+        };
+        let mut trusted_authority_keys = TrustedAuthorityKeys::default();
+        for link in &authority_chain.links {
+            if let Some(public_key) = &link.grantor_public_key {
+                trusted_authority_keys.insert(link.grantor.clone(), vec![public_key.clone()]);
+            }
+        }
+
         let context = AdjudicationContext {
             actor_roles: vec![Role {
                 name: "judge".into(),
                 branch: GovernmentBranch::Judicial,
             }],
-            authority_chain: AuthorityChain {
-                links: vec![authority_link],
-            },
+            authority_chain,
             consent_records,
             bailment_state,
             human_override_preserved,
             actor_permissions: permissions,
+            trusted_authority_keys,
             provenance: Some(provenance),
             quorum_evidence: None,
             active_challenge_reason: None,

--- a/crates/exochain-wasm/src/gatekeeper_bindings.rs
+++ b/crates/exochain-wasm/src/gatekeeper_bindings.rs
@@ -106,6 +106,7 @@ pub fn wasm_validation_invariant_request() -> Result<JsValue, JsValue> {
         authority_link_signature_message, provenance_signature_message,
         types::{
             AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, PermissionSet, Provenance,
+            TrustedAuthorityKeys,
         },
     };
 
@@ -124,7 +125,7 @@ pub fn wasm_validation_invariant_request() -> Result<JsValue, JsValue> {
         .map_err(|_| gatekeeper_boundary_error("validation invariant grantor DID failed"))?;
     let permissions = PermissionSet::default();
     let mut authority_link = AuthorityLink {
-        grantor,
+        grantor: grantor.clone(),
         grantee: actor.clone(),
         permissions: permissions.clone(),
         signature: Vec::new(),
@@ -153,6 +154,11 @@ pub fn wasm_validation_invariant_request() -> Result<JsValue, JsValue> {
         .sign(provenance_message.as_bytes())
         .to_bytes()
         .to_vec();
+    let mut trusted_authority_keys = TrustedAuthorityKeys::default();
+    trusted_authority_keys.insert(
+        grantor,
+        vec![authority_keypair.public_key().as_bytes().to_vec()],
+    );
 
     to_js_value(&serde_json::json!({
         "actor": actor,
@@ -181,6 +187,7 @@ pub fn wasm_validation_invariant_request() -> Result<JsValue, JsValue> {
         "provenance": provenance,
         "actor_permissions": permissions,
         "requested_permissions": PermissionSet::default(),
+        "trusted_authority_keys": trusted_authority_keys,
     }))
 }
 
@@ -460,5 +467,26 @@ mod tests {
 
         assert!(!production.contains("format!(\"{r:?}\")"));
         assert!(production.contains("\"rule\": r.id()"));
+    }
+
+    #[test]
+    fn validation_invariant_request_includes_trusted_authority_keys() {
+        let source = include_str!("gatekeeper_bindings.rs");
+        let validation_fixture = source
+            .split("pub fn wasm_validation_invariant_request")
+            .nth(1)
+            .expect("validation fixture is present")
+            .split("pub fn wasm_spawn_holon")
+            .next()
+            .expect("validation fixture body is bounded");
+
+        assert!(
+            validation_fixture.contains("TrustedAuthorityKeys"),
+            "validation invariant fixture must construct a trusted authority key map"
+        );
+        assert!(
+            validation_fixture.contains("\"trusted_authority_keys\""),
+            "validation invariant fixture must emit trusted authority keys for bridge verification"
+        );
     }
 }

--- a/crates/exochain-wasm/src/gatekeeper_bindings.rs
+++ b/crates/exochain-wasm/src/gatekeeper_bindings.rs
@@ -27,6 +27,8 @@ struct WasmInvariantRequest {
     actor_permissions: exo_gatekeeper::types::PermissionSet,
     #[serde(default)]
     requested_permissions: exo_gatekeeper::types::PermissionSet,
+    #[serde(default)]
+    trusted_authority_keys: exo_gatekeeper::types::TrustedAuthorityKeys,
 }
 
 fn default_true() -> bool {
@@ -78,6 +80,7 @@ pub fn wasm_enforce_invariants(request_json: &str) -> Result<JsValue, JsValue> {
         provenance: req.provenance,
         actor_permissions: req.actor_permissions,
         requested_permissions: req.requested_permissions,
+        trusted_authority_keys: req.trusted_authority_keys,
     };
 
     let engine = exo_gatekeeper::InvariantEngine::all();
@@ -280,6 +283,12 @@ mod tests {
         let authority_chain = AuthorityChain {
             links: vec![authority_link],
         };
+        let mut trusted_authority_keys = exo_gatekeeper::types::TrustedAuthorityKeys::default();
+        for link in &authority_chain.links {
+            if let Some(public_key) = &link.grantor_public_key {
+                trusted_authority_keys.insert(link.grantor.clone(), vec![public_key.clone()]);
+            }
+        }
 
         let (provenance_pk, provenance_sk) = exo_core::crypto::generate_keypair();
         let provenance_actor = actor();
@@ -319,6 +328,7 @@ mod tests {
             provenance,
             actor_permissions: PermissionSet::default(),
             requested_permissions: PermissionSet::default(),
+            trusted_authority_keys,
         }
     }
 

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -1869,6 +1869,7 @@ test('wasm_transition_decision_adjudicated', () => {
       bailment_state: 'None',
       human_override_preserved: true,
       actor_permissions: { permissions: [transitionPermission] },
+      trusted_authority_keys: {},
       provenance: null,
       quorum_evidence: null,
       active_challenge_reason: null


### PR DESCRIPTION
## Summary
- Requires `AuthorityChainValid` to resolve each link grantor DID to trusted Ed25519 verification keys before accepting the embedded `grantor_public_key` for signature verification.
- Wires trusted authority key maps through `AdjudicationContext`, gatekeeper callers, WASM/SDK/node/decision-forum test builders, and gateway DB context construction.
- Makes the production-db gateway path fail closed for persisted authority chains whose grantor key is unresolved or not bound to an active DID document verification method.

## Current-main verification
- Confirmed the issue was still live before remediation: `authority_chain_rejects_unresolved_grantor_public_key` failed because core accepted a self-attested grantor key.
- Confirmed the gateway adapter issue was still live before remediation: `adjudication_context_rows_reject_unresolved_authority_grantor_public_key` failed because DB-loaded chain JSON could derive permissions without DID key resolution.
- Imported/external reports were treated as hypotheses; this PR changes only owned EXOCHAIN core and runtime adapter paths.

## Classification
- EXOCHAIN core: `crates/exo-gatekeeper/src/types.rs`, `crates/exo-gatekeeper/src/invariants.rs`, `crates/exo-gatekeeper/src/kernel.rs`, `crates/exo-gatekeeper/src/holon.rs`.
- Core runtime adapter: `crates/exo-gateway/src/server.rs`, `crates/exo-gateway/Cargo.toml`, `crates/exochain-wasm/src/gatekeeper_bindings.rs`, `crates/exochain-sdk/src/kernel.rs`, `crates/exo-node/src/holons.rs`, `crates/exo-node/src/mcp/tools/authority.rs`.
- Core consumers/tests: `crates/decision-forum/*`, `crates/exo-escalation/tests/sybil_adjudication.rs`, `crates/exo-legal/src/nist_compliance_tests.rs`, `crates/exo-gateway/tests/*`.
- Imported evidence / third-party / adjacent surface: none changed.

## Test Plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `git diff --check && git diff --check origin/main...HEAD`
- [x] `bash tools/test_repo_truth.sh`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo check -p exo-gateway --features production-db --all-targets`
- [x] `cargo test -p exo-gatekeeper -- --nocapture`
- [x] `cargo test -p exo-gateway -- --nocapture`
- [x] `cargo test -p exo-gateway --lib --features production-db -- --test-threads=1`
- [x] `cargo test -p decision-forum -- --nocapture`
- [x] `cargo test -p exo-node holon -- --nocapture`
- [x] `cargo test -p exochain-wasm gatekeeper -- --nocapture`
- [x] `cargo clippy -p exo-gatekeeper -p exo-gateway --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc -p exo-gatekeeper -p exo-gateway --no-deps`

## Operational note
Persisted authority-chain rows whose grantor DID has no active Ed25519 DID verification method now fail closed and may need reissue/quarantine rather than silent acceptance. A sibling provenance-key binding remediation remains queued next.
