### PR TITLE
fix(gateway): require DID registration proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 176847 | `wc -l` |
+| Rust LOC | 177129 | `wc -l` |
 | Workspace tests | 4,152 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -96,7 +96,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 176847 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 177129 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,152 listed workspace tests
 

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -28,7 +28,7 @@ use exo_gatekeeper::{
 };
 use exo_governance::conflict::ConflictDeclaration;
 use exo_identity::{
-    did::DidDocument,
+    did::{DidDocument, DidRegistrationProof},
     error::IdentityError,
     registry::{DidRegistry, LocalDidRegistry},
 };
@@ -504,12 +504,22 @@ enum RegistryBlockingError {
     Join(String),
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DidRegistrationRequest {
+    document: DidDocument,
+    proof: DidRegistrationProof,
+}
+
 fn identity_registration_log_reason(error: &IdentityError) -> &'static str {
     match error {
         IdentityError::DuplicateDid(_) => "duplicate_did",
         IdentityError::RegistryCapacityExceeded { .. } => "registry_capacity_exceeded",
         IdentityError::InvalidDidDocumentField { .. } => "invalid_did_document_field",
         IdentityError::DidDocumentFieldTooLarge { .. } => "did_document_field_too_large",
+        IdentityError::InvalidRegistrationProof { .. } => "invalid_registration_proof",
+        IdentityError::RegistrationProofPayloadEncoding { .. } => {
+            "registration_proof_payload_encoding_failed"
+        }
         IdentityError::DidRevoked(_) => "did_revoked",
         IdentityError::NonMonotonicTimestamp { .. } => "non_monotonic_timestamp",
         IdentityError::DuplicatePaceDid(_) => "duplicate_pace_did",
@@ -553,6 +563,12 @@ fn did_registration_rejection_response(
             Json(serde_json::json!({ "error": "invalid DID document" })),
         )
             .into_response(),
+        IdentityError::InvalidRegistrationProof { .. }
+        | IdentityError::RegistrationProofPayloadEncoding { .. } => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "invalid DID registration proof" })),
+        )
+            .into_response(),
         _ => (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({ "error": "DID registration rejected" })),
@@ -564,10 +580,11 @@ fn did_registration_rejection_response(
 async fn registry_register_document(
     registry: Arc<RwLock<LocalDidRegistry>>,
     doc: DidDocument,
+    proof: DidRegistrationProof,
 ) -> std::result::Result<(), RegistryBlockingError> {
     tokio::task::spawn_blocking(move || {
         let mut reg = registry.write().unwrap_or_else(|e| e.into_inner());
-        reg.register(doc)
+        reg.register_with_proof(doc, &proof)
             .map_err(RegistryBlockingError::Registration)
     })
     .await
@@ -602,19 +619,13 @@ async fn registry_resolve_document(
     .map_err(|e| RegistryBlockingError::Join(e.to_string()))?
 }
 
-fn validate_did_document_for_registration(
-    doc: &DidDocument,
-) -> std::result::Result<(), IdentityError> {
-    let mut registry = LocalDidRegistry::with_max_documents(1);
-    registry.register(doc.clone())
-}
-
 async fn register_did_document(
     state: &AppState,
     doc: DidDocument,
+    proof: DidRegistrationProof,
 ) -> std::result::Result<(), RegistryBlockingError> {
     if let Some(pool) = state.pool.as_ref() {
-        validate_did_document_for_registration(&doc)
+        exo_identity::registry::verify_did_registration_proof(&doc, &proof)
             .map_err(RegistryBlockingError::Registration)?;
         let inserted = db::insert_did_document(pool, &doc)
             .await
@@ -626,7 +637,7 @@ async fn register_did_document(
         }
         registry_cache_document(Arc::clone(&state.registry), doc).await
     } else {
-        registry_register_document(Arc::clone(&state.registry), doc).await
+        registry_register_document(Arc::clone(&state.registry), doc, proof).await
     }
 }
 
@@ -1859,14 +1870,15 @@ async fn handle_metrics(State(state): State<AppState>) -> Response {
 
 /// POST /api/v1/auth/register — register a new DID document.
 ///
-/// Body: a `DidDocument` JSON object.  Returns 201 on success, 409 if the
-/// DID is already registered.
+/// Body: a DID document plus proof that the caller controls a declared document
+/// key. Returns 201 on success, 409 if the DID is already registered.
 async fn handle_auth_register(
     State(state): State<AppState>,
-    Json(doc): Json<DidDocument>,
+    Json(request): Json<DidRegistrationRequest>,
 ) -> impl IntoResponse {
+    let doc = request.document;
     let did_str = doc.id.as_str().to_owned();
-    match register_did_document(&state, doc).await {
+    match register_did_document(&state, doc, request.proof).await {
         Ok(()) => (
             StatusCode::CREATED,
             Json(serde_json::json!({ "did": did_str, "status": "registered" })),
@@ -2474,10 +2486,11 @@ async fn handle_audit_trail(
 /// agent-specific enrollment workflow while sharing the underlying DID registry.
 async fn handle_agents_enroll(
     State(state): State<AppState>,
-    Json(doc): Json<DidDocument>,
+    Json(request): Json<DidRegistrationRequest>,
 ) -> impl IntoResponse {
+    let doc = request.document;
     let did_str = doc.id.as_str().to_owned();
-    match register_did_document(&state, doc).await {
+    match register_did_document(&state, doc, request.proof).await {
         Ok(()) => (
             StatusCode::CREATED,
             Json(serde_json::json!({ "did": did_str, "status": "enrolled" })),
@@ -4405,6 +4418,51 @@ mod tests {
         }
     }
 
+    fn keyed_doc(did_str: &str, public_key: exo_core::PublicKey) -> DidDocument {
+        let did = Did::new(did_str).expect("valid DID");
+        DidDocument {
+            id: did,
+            public_keys: vec![public_key],
+            authentication: vec![],
+            verification_methods: vec![],
+            hybrid_verification_methods: vec![],
+            service_endpoints: vec![],
+            created: Timestamp::new(1000, 0),
+            updated: Timestamp::new(1000, 0),
+            revoked: false,
+        }
+    }
+
+    #[derive(serde::Serialize)]
+    struct TestDidRegistrationProofPayload<'a> {
+        domain: &'static str,
+        document: &'a DidDocument,
+        signing_public_key: &'a [u8; 32],
+    }
+
+    fn registration_request_body(
+        doc: &DidDocument,
+        public_key: &exo_core::PublicKey,
+        secret_key: &exo_core::SecretKey,
+    ) -> String {
+        let payload = TestDidRegistrationProofPayload {
+            domain: "exo.identity.did_registry.registration.v1",
+            document: doc,
+            signing_public_key: public_key.as_bytes(),
+        };
+        let mut encoded = Vec::new();
+        ciborium::into_writer(&payload, &mut encoded).expect("registration proof payload");
+        let signature = sign(&encoded, secret_key);
+        serde_json::to_string(&serde_json::json!({
+            "document": doc,
+            "proof": {
+                "public_key": public_key,
+                "signature": signature,
+            }
+        }))
+        .expect("registration request JSON")
+    }
+
     fn signing_registry() -> (Arc<RwLock<LocalDidRegistry>>, exo_core::SecretKey) {
         let did = Did::new("did:exo:login-alice").unwrap();
         let (pk, sk) = generate_keypair();
@@ -4836,8 +4894,28 @@ mod tests {
     // --- New DID / auth / agent endpoint tests ---
 
     #[tokio::test]
-    async fn auth_register_returns_201() {
+    async fn auth_register_rejects_bare_did_document_without_registration_proof() {
         let body = serde_json::to_string(&minimal_doc("did:exo:tester")).unwrap();
+        let app = build_router(state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/auth/register")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(resp.status().is_client_error());
+    }
+
+    #[tokio::test]
+    async fn auth_register_accepts_valid_registration_proof() {
+        let (public_key, secret_key) = generate_keypair();
+        let doc = keyed_doc("did:exo:tester", public_key);
+        let body = registration_request_body(&doc, &public_key, &secret_key);
         let app = build_router(state());
         let resp = app
             .oneshot(
@@ -4854,12 +4932,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn auth_register_rejects_registration_proof_from_unlisted_key() {
+        let (document_public_key, _) = generate_keypair();
+        let (attacker_public_key, attacker_secret_key) = generate_keypair();
+        let doc = keyed_doc("did:exo:unlisted-registration-key", document_public_key);
+        let body = registration_request_body(&doc, &attacker_public_key, &attacker_secret_key);
+        let app = build_router(state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/auth/register")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
     async fn auth_register_duplicate_returns_409() {
-        let doc = minimal_doc("did:exo:dup");
+        let (public_key, secret_key) = generate_keypair();
+        let doc = keyed_doc("did:exo:dup", public_key);
         let registry = Arc::new(RwLock::new(LocalDidRegistry::new()));
         registry.write().unwrap().register(doc.clone()).unwrap();
         let st = AppState::new(None, registry);
-        let body = serde_json::to_string(&doc).unwrap();
+        let body = registration_request_body(&doc, &public_key, &secret_key);
         let app = build_router(st);
         let resp = app
             .oneshot(
@@ -4877,7 +4978,7 @@ mod tests {
 
     #[tokio::test]
     async fn auth_register_returns_503_when_local_did_registry_capacity_is_exhausted() {
-        let (pk, _) = generate_keypair();
+        let (pk, sk) = generate_keypair();
         let registry = Arc::new(RwLock::new(LocalDidRegistry::new()));
         {
             let mut guard = registry.write().unwrap();
@@ -4889,7 +4990,8 @@ mod tests {
         }
 
         let st = AppState::new(None, registry);
-        let body = serde_json::to_string(&minimal_doc("did:exo:capacity-overflow")).unwrap();
+        let overflow_doc = keyed_doc("did:exo:capacity-overflow", pk);
+        let body = registration_request_body(&overflow_doc, &pk, &sk);
         let app = build_router(st);
         let resp = app
             .oneshot(
@@ -5320,7 +5422,11 @@ mod tests {
             "/// GET /api/v1/auth/me",
         );
         assert!(
-            auth_register.contains("register_did_document(&state, doc).await"),
+            auth_register.contains("Json(request): Json<DidRegistrationRequest>"),
+            "auth/register must parse a proof-bearing registration envelope, not a bare DID document"
+        );
+        assert!(
+            auth_register.contains("register_did_document(&state, doc, request.proof).await"),
             "auth/register must persist through the AppState DB-backed DID path when a pool is configured"
         );
         assert!(
@@ -5368,7 +5474,11 @@ mod tests {
             "// ---------------------------------------------------------------------------\n// Session auth handlers",
         );
         assert!(
-            agents_enroll.contains("register_did_document(&state, doc).await"),
+            agents_enroll.contains("Json(request): Json<DidRegistrationRequest>"),
+            "agents/enroll must parse a proof-bearing registration envelope, not a bare DID document"
+        );
+        assert!(
+            agents_enroll.contains("register_did_document(&state, doc, request.proof).await"),
             "agents/enroll must share the DB-backed DID persistence path"
         );
 
@@ -5898,7 +6008,9 @@ mod tests {
 
     #[tokio::test]
     async fn agents_enroll_returns_201() {
-        let body = serde_json::to_string(&minimal_doc("did:exo:enrollee")).unwrap();
+        let (public_key, secret_key) = generate_keypair();
+        let doc = keyed_doc("did:exo:enrollee", public_key);
+        let body = registration_request_body(&doc, &public_key, &secret_key);
         let app = build_router(state());
         let resp = app
             .oneshot(
@@ -5912,6 +6024,24 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::CREATED);
+    }
+
+    #[tokio::test]
+    async fn agents_enroll_rejects_bare_did_document_without_registration_proof() {
+        let body = serde_json::to_string(&minimal_doc("did:exo:enrollee-bare")).unwrap();
+        let app = build_router(state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/agents/enroll")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(resp.status().is_client_error());
     }
 
     #[tokio::test]

--- a/crates/exo-identity/src/did.rs
+++ b/crates/exo-identity/src/did.rs
@@ -110,6 +110,13 @@ pub struct RevocationProof {
     pub signature: Signature,
 }
 
+/// Proof that a DID holder controls a key declared in a new DID document.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DidRegistrationProof {
+    pub public_key: PublicKey,
+    pub signature: Signature,
+}
+
 /// A DID document describing a decentralized identity.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DidDocument {

--- a/crates/exo-identity/src/error.rs
+++ b/crates/exo-identity/src/error.rs
@@ -50,6 +50,12 @@ pub enum IdentityError {
     #[error("invalid revocation proof for DID: {0}")]
     InvalidRevocationProof(Did),
 
+    #[error("invalid registration proof for DID {did}: {reason}")]
+    InvalidRegistrationProof { did: Did, reason: String },
+
+    #[error("registration proof payload encoding failed for DID {did}: {reason}")]
+    RegistrationProofPayloadEncoding { did: Did, reason: String },
+
     #[error("revocation proof payload encoding failed for DID {did}: {reason}")]
     RevocationProofPayloadEncoding { did: Did, reason: String },
 

--- a/crates/exo-identity/src/registry.rs
+++ b/crates/exo-identity/src/registry.rs
@@ -4,10 +4,11 @@ use exo_core::{Did, PublicKey, Signature, Timestamp, crypto};
 use serde::Serialize;
 
 use crate::{
-    did::{DidDocument, RevocationProof},
+    did::{DidDocument, DidRegistrationProof, RevocationProof},
     error::IdentityError,
 };
 
+const DID_REGISTRATION_PROOF_DOMAIN: &str = "exo.identity.did_registry.registration.v1";
 const DID_REVOCATION_PROOF_DOMAIN: &str = "exo.identity.did_registry.revocation.v1";
 const DID_KEY_ROTATION_PROOF_DOMAIN: &str = "exo.identity.did_registry.key_rotation.v1";
 pub const MAX_LOCAL_DID_REGISTRY_DOCUMENTS: usize = 16_384;
@@ -22,6 +23,13 @@ const MAX_DID_DOCUMENT_PQ_MULTIBASE_BYTES: usize = 4096;
 const MAX_DID_DOCUMENT_ENDPOINT_BYTES: usize = 2048;
 
 #[derive(Serialize)]
+struct RegistrationProofPayload<'a> {
+    domain: &'static str,
+    document: &'a DidDocument,
+    signing_public_key: &'a [u8; 32],
+}
+
+#[derive(Serialize)]
 struct RevocationProofPayload<'a> {
     domain: &'static str,
     did: &'a Did,
@@ -33,6 +41,30 @@ struct KeyRotationProofPayload<'a> {
     did: &'a Did,
     new_public_key: &'a [u8; 32],
     updated: Timestamp,
+}
+
+/// Build the canonical signable payload for first-time DID registration proofs.
+///
+/// The payload binds the signature to a full DID document and to one declared
+/// Ed25519 key so a key-control proof cannot be replayed across documents,
+/// routes, or later key-management operations.
+pub fn did_registration_proof_payload(
+    doc: &DidDocument,
+    public_key: &PublicKey,
+) -> Result<Vec<u8>, IdentityError> {
+    let payload = RegistrationProofPayload {
+        domain: DID_REGISTRATION_PROOF_DOMAIN,
+        document: doc,
+        signing_public_key: public_key.as_bytes(),
+    };
+    let mut encoded = Vec::new();
+    ciborium::into_writer(&payload, &mut encoded).map_err(|e| {
+        IdentityError::RegistrationProofPayloadEncoding {
+            did: doc.id.clone(),
+            reason: e.to_string(),
+        }
+    })?;
+    Ok(encoded)
 }
 
 /// Build the canonical signable payload for DID revocation proofs.
@@ -81,10 +113,50 @@ pub fn key_rotation_proof_payload(
     Ok(encoded)
 }
 
+/// Verify proof-of-possession for first-time DID document registration.
+///
+/// The signer must be one of the public keys declared by the document. The
+/// signature covers the full document and the signing key under a dedicated
+/// domain separator, preventing first-writer claims that do not prove control of
+/// document key material.
+pub fn verify_did_registration_proof(
+    doc: &DidDocument,
+    proof: &DidRegistrationProof,
+) -> Result<(), IdentityError> {
+    validate_registered_did_document(doc)?;
+
+    if !doc.public_keys.iter().any(|key| key == &proof.public_key) {
+        return Err(IdentityError::InvalidRegistrationProof {
+            did: doc.id.clone(),
+            reason: "proof public key is not declared in the DID document".to_owned(),
+        });
+    }
+
+    let msg = did_registration_proof_payload(doc, &proof.public_key)?;
+    if crypto::verify(&msg, &proof.signature, &proof.public_key) {
+        Ok(())
+    } else {
+        Err(IdentityError::InvalidRegistrationProof {
+            did: doc.id.clone(),
+            reason: "signature does not verify for the declared DID document key".to_owned(),
+        })
+    }
+}
+
 /// A decentralized identifier registry trait.
 pub trait DidRegistry {
     /// Register a new DID document.
     fn register(&mut self, doc: DidDocument) -> Result<(), IdentityError>;
+
+    /// Register a new DID document after proof-of-possession verification.
+    fn register_with_proof(
+        &mut self,
+        doc: DidDocument,
+        proof: &DidRegistrationProof,
+    ) -> Result<(), IdentityError> {
+        verify_did_registration_proof(&doc, proof)?;
+        self.register(doc)
+    }
 
     /// Resolve a DID to its document.
     fn resolve(&self, did: &Did) -> Option<&DidDocument>;
@@ -440,6 +512,18 @@ mod tests {
         sign(&payload, secret_key)
     }
 
+    fn registration_proof(
+        doc: &DidDocument,
+        public_key: PublicKey,
+        secret_key: &SecretKey,
+    ) -> DidRegistrationProof {
+        let payload = did_registration_proof_payload(doc, &public_key).unwrap();
+        DidRegistrationProof {
+            public_key,
+            signature: sign(&payload, secret_key),
+        }
+    }
+
     #[test]
     fn test_register_and_resolve() {
         let (pk, _) = generate_keypair();
@@ -510,6 +594,61 @@ mod tests {
             err.to_string().contains("id"),
             "invalid DID error should identify the id field: {err}"
         );
+        assert_eq!(reg.len(), 0);
+    }
+
+    #[test]
+    fn register_with_proof_accepts_document_signed_by_declared_key() {
+        let (pk, sk) = generate_keypair();
+        let did = make_did("proof-registered");
+        let doc = make_doc(did.clone(), pk);
+        let proof = registration_proof(&doc, pk, &sk);
+
+        let mut reg = LocalDidRegistry::new();
+        reg.register_with_proof(doc, &proof).unwrap();
+
+        let resolved = reg.resolve(&did).unwrap();
+        assert_eq!(resolved.id, did);
+        assert_eq!(resolved.public_keys, vec![pk]);
+    }
+
+    #[test]
+    fn register_with_proof_rejects_key_not_declared_by_document() {
+        let (document_pk, _) = generate_keypair();
+        let (attacker_pk, attacker_sk) = generate_keypair();
+        let doc = make_doc_with_label("proof-unlisted-key", document_pk);
+        let proof = registration_proof(&doc, attacker_pk, &attacker_sk);
+
+        let mut reg = LocalDidRegistry::new();
+        let err = reg
+            .register_with_proof(doc, &proof)
+            .expect_err("registration proof must be bound to a document key");
+
+        assert!(matches!(
+            err,
+            IdentityError::InvalidRegistrationProof { .. }
+        ));
+        assert_eq!(reg.len(), 0);
+    }
+
+    #[test]
+    fn register_with_proof_rejects_raw_did_signature_replay() {
+        let (pk, sk) = generate_keypair();
+        let doc = make_doc_with_label("proof-domain-separated", pk);
+        let proof = DidRegistrationProof {
+            public_key: pk,
+            signature: sign(doc.id.as_str().as_bytes(), &sk),
+        };
+
+        let mut reg = LocalDidRegistry::new();
+        let err = reg
+            .register_with_proof(doc, &proof)
+            .expect_err("registration must require the domain-separated document payload");
+
+        assert!(matches!(
+            err,
+            IdentityError::InvalidRegistrationProof { .. }
+        ));
         assert_eq!(reg.len(), 0);
     }
 


### PR DESCRIPTION
## Summary
- require /api/v1/auth/register and /api/v1/agents/enroll to receive a DID document plus domain-separated proof-of-possession
- add exo-identity registration proof payload/verification and LocalDidRegistry::register_with_proof
- add gateway and identity regression coverage for bare documents, unlisted keys, raw DID signature replay, duplicates, and capacity handling
- refresh derived README Rust LOC via repo-truth

## Path classification
- EXOCHAIN core: crates/exo-identity/src/did.rs, crates/exo-identity/src/error.rs, crates/exo-identity/src/registry.rs
- Core runtime adapter: crates/exo-gateway/src/server.rs
- Documentation/repo-truth: README.md
- Imported evidence / third-party / adjacent: none

## Validation
- red first: cargo test -p exo-gateway registration -- --nocapture (failed on current bare-document behavior and missing proof-envelope support)
- cargo test -p exo-identity --lib -- --nocapture
- cargo test -p exo-gateway --lib -- --test-threads=1
- cargo test -p exo-gateway --lib --features production-db -- --test-threads=1
- cargo check -p exo-identity -p exo-gateway --all-targets
- cargo clippy -p exo-identity -p exo-gateway --all-targets -- -D warnings
- RUSTDOCFLAGS='-D warnings' cargo doc -p exo-identity -p exo-gateway --no-deps
- cargo +nightly fmt --all -- --check
- git diff --check
- bash tools/test_repo_truth.sh
- cargo test -p exo-identity
- cargo test -p exo-gateway --features production-db -- --test-threads=1

## Bypass search
- rg -n "Json\(doc\): Json<DidDocument>|register_did_document\(&state, doc\)|register_did_document\(&state, [^,)]*\)" crates/exo-gateway/src crates/exo-gateway/tests crates/exo-identity/src || true