### PR TITLE
fix(adapters): require actor-bound provenance signers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 177129 | `wc -l` |
+| Rust LOC | 177495 | `wc -l` |
 | Workspace tests | 4,152 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -96,7 +96,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 177129 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 177495 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,152 listed workspace tests
 

--- a/crates/exo-node/src/holons.rs
+++ b/crates/exo-node/src/holons.rs
@@ -13,8 +13,9 @@
 //! # Audit status — Onyx-4 R5 (default-off runtime)
 //!
 //! The infrastructure Holon adjudication context now requires a configured
-//! Ed25519 authority key and signer. The authority chain and provenance are
-//! signed over the same canonical payloads enforced by `exo-gatekeeper`.
+//! Ed25519 authority key and signer plus a distinct DID-bound actor signer for
+//! each Holon. Authority chains and provenance are signed over the same
+//! canonical payloads enforced by `exo-gatekeeper`.
 //!
 //! The runtime background manager is therefore disabled by default behind the
 //! `unaudited-infrastructure-holons` feature flag. Enabling the feature means
@@ -35,7 +36,7 @@
 
 #![cfg_attr(not(feature = "unaudited-infrastructure-holons"), allow(dead_code))]
 
-use std::{sync::Arc, time::Duration};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use exo_core::{
     PublicKey, Signature,
@@ -131,8 +132,16 @@ pub struct HolonManagerConfig {
     pub root_did: Did,
     /// Ed25519 public key for `root_did`.
     pub root_public_key: PublicKey,
-    /// Signs canonical authority/provenance payload hashes for infrastructure Holon context.
+    /// Signs canonical authority payload hashes for infrastructure Holon context.
     pub root_signer: Arc<dyn Fn(&[u8]) -> Signature + Send + Sync>,
+    /// DID used for the topology Holon actor.
+    pub topology_holon_did: Did,
+    /// DID used for the scaling Holon actor.
+    pub scaling_holon_did: Did,
+    /// DID used for the health Holon actor.
+    pub health_holon_did: Did,
+    /// DID-bound Holon actor public keys and signers used for provenance.
+    pub holon_actor_keys: BTreeMap<Did, HolonActorKey>,
     /// Supplies deterministic HLC metadata for each signed Holon provenance record.
     pub provenance_timestamp_source: Arc<dyn Fn() -> Result<Timestamp, String> + Send + Sync>,
     /// How often to run the topology optimizer (seconds).
@@ -143,12 +152,34 @@ pub struct HolonManagerConfig {
     pub health_interval_secs: u64,
 }
 
+/// DID-bound actor key and signer for one infrastructure Holon.
+#[derive(Clone)]
+pub struct HolonActorKey {
+    /// Public key resolved for the Holon actor DID.
+    pub public_key: PublicKey,
+    /// Signs canonical provenance payloads for the Holon actor DID.
+    pub signer: Arc<dyn Fn(&[u8]) -> Signature + Send + Sync>,
+}
+
+impl std::fmt::Debug for HolonActorKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HolonActorKey")
+            .field("public_key", &self.public_key)
+            .field("signer", &"<holon-actor-signer>")
+            .finish()
+    }
+}
+
 impl std::fmt::Debug for HolonManagerConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HolonManagerConfig")
             .field("node_did", &self.node_did)
             .field("root_did", &self.root_did)
             .field("root_public_key", &self.root_public_key)
+            .field("topology_holon_did", &self.topology_holon_did)
+            .field("scaling_holon_did", &self.scaling_holon_did)
+            .field("health_holon_did", &self.health_holon_did)
+            .field("holon_actor_key_count", &self.holon_actor_keys.len())
             .field("provenance_timestamp_source", &"<deterministic-hlc-source>")
             .field("topology_interval_secs", &self.topology_interval_secs)
             .field("scaling_interval_secs", &self.scaling_interval_secs)
@@ -222,6 +253,11 @@ pub fn create_topology_holon(node_did: &Did) -> Holon {
         "did:exo:archon-topology",
     );
 
+    create_topology_holon_with_did(holon_did)
+}
+
+/// Create the topology optimizer Holon for an already-resolved Holon DID.
+pub fn create_topology_holon_with_did(holon_did: Did) -> Holon {
     holon::spawn(
         holon_did,
         PermissionSet::new(vec![
@@ -260,6 +296,11 @@ pub fn create_scaling_holon(node_did: &Did) -> Holon {
         "did:exo:archon-scaling",
     );
 
+    create_scaling_holon_with_did(holon_did)
+}
+
+/// Create the scaling advisor Holon for an already-resolved Holon DID.
+pub fn create_scaling_holon_with_did(holon_did: Did) -> Holon {
     holon::spawn(
         holon_did,
         PermissionSet::new(vec![
@@ -298,6 +339,11 @@ pub fn create_health_holon(node_did: &Did) -> Holon {
         "did:exo:archon-health",
     );
 
+    create_health_holon_with_did(holon_did)
+}
+
+/// Create the health monitor Holon for an already-resolved Holon DID.
+pub fn create_health_holon_with_did(holon_did: Did) -> Holon {
     holon::spawn(
         holon_did,
         PermissionSet::new(vec![
@@ -359,7 +405,7 @@ fn signed_authority_link(
 
 fn signed_provenance(
     holon: &Holon,
-    config: &HolonManagerConfig,
+    actor_key: &HolonActorKey,
     provenance_timestamp: Timestamp,
 ) -> Result<Provenance, String> {
     let timestamp = provenance_timestamp.to_string();
@@ -377,14 +423,14 @@ fn signed_provenance(
         timestamp,
         action_hash,
         signature: Vec::new(),
-        public_key: Some(config.root_public_key.as_bytes().to_vec()),
+        public_key: Some(actor_key.public_key.as_bytes().to_vec()),
         voice_kind: None,
         independence: None,
         review_order: None,
     };
     let message = provenance_signature_message(&provenance)
         .map_err(|err| format!("failed to encode provenance signature payload: {err}"))?;
-    let signature = (config.root_signer)(message.as_bytes());
+    let signature = (actor_key.signer)(message.as_bytes());
     provenance.signature = signature.to_bytes().to_vec();
     Ok(provenance)
 }
@@ -402,6 +448,12 @@ pub fn build_holon_adjudication_context(
     config: &HolonManagerConfig,
 ) -> Result<AdjudicationContext, String> {
     let provenance_timestamp = next_provenance_timestamp(config)?;
+    let actor_key = config.holon_actor_keys.get(&holon.id).ok_or_else(|| {
+        format!(
+            "Holon actor signer is required for DID-bound provenance: {}",
+            holon.id
+        )
+    })?;
     let authority_chain = AuthorityChain {
         links: vec![signed_authority_link(holon, config)?],
     };
@@ -414,7 +466,7 @@ pub fn build_holon_adjudication_context(
     let mut trusted_provenance_keys = TrustedProvenanceKeys::default();
     trusted_provenance_keys.insert(
         holon.id.clone(),
-        vec![config.root_public_key.as_bytes().to_vec()],
+        vec![actor_key.public_key.as_bytes().to_vec()],
     );
     Ok(AdjudicationContext {
         actor_roles: vec![Role {
@@ -437,7 +489,7 @@ pub fn build_holon_adjudication_context(
         actor_permissions: holon.capabilities.clone(),
         trusted_authority_keys,
         trusted_provenance_keys,
-        provenance: Some(signed_provenance(holon, config, provenance_timestamp)?),
+        provenance: Some(signed_provenance(holon, actor_key, provenance_timestamp)?),
         quorum_evidence: None,
         active_challenge_reason: None,
     })
@@ -641,9 +693,9 @@ pub async fn run_holon_manager(
 ) {
     let kernel = create_infrastructure_kernel();
 
-    let mut topology_holon = create_topology_holon(&config.node_did);
-    let mut scaling_holon = create_scaling_holon(&config.node_did);
-    let mut health_holon = create_health_holon(&config.node_did);
+    let mut topology_holon = create_topology_holon_with_did(config.topology_holon_did.clone());
+    let mut scaling_holon = create_scaling_holon_with_did(config.scaling_holon_did.clone());
+    let mut health_holon = create_health_holon_with_did(config.health_holon_did.clone());
 
     let mut topology_timer =
         tokio::time::interval(Duration::from_secs(config.topology_interval_secs));
@@ -964,16 +1016,43 @@ mod tests {
         scaling_interval_secs: u64,
         health_interval_secs: u64,
     ) -> HolonManagerConfig {
+        let node_did = test_did();
+        let topology_holon_did = create_topology_holon(&node_did).id;
+        let scaling_holon_did = create_scaling_holon(&node_did).id;
+        let health_holon_did = create_health_holon(&node_did).id;
         let keypair = exo_core::crypto::KeyPair::from_secret_bytes([0x48; 32]).unwrap();
         let root_public_key = *keypair.public_key();
         let root_secret_key = keypair.secret_key().clone();
+        let mut holon_actor_keys = BTreeMap::new();
+        for (holon_did, secret_seed) in [
+            (topology_holon_did.clone(), [0x51; 32]),
+            (scaling_holon_did.clone(), [0x52; 32]),
+            (health_holon_did.clone(), [0x53; 32]),
+        ] {
+            let keypair = exo_core::crypto::KeyPair::from_secret_bytes(secret_seed).unwrap();
+            let public_key = *keypair.public_key();
+            let secret_key = keypair.secret_key().clone();
+            holon_actor_keys.insert(
+                holon_did,
+                HolonActorKey {
+                    public_key,
+                    signer: Arc::new(move |message: &[u8]| {
+                        exo_core::crypto::sign(message, &secret_key)
+                    }),
+                },
+            );
+        }
         HolonManagerConfig {
-            node_did: test_did(),
+            node_did,
             root_did: Did::new("did:exo:test-root").unwrap(),
             root_public_key,
             root_signer: Arc::new(move |message: &[u8]| {
                 exo_core::crypto::sign(message, &root_secret_key)
             }),
+            topology_holon_did,
+            scaling_holon_did,
+            health_holon_did,
+            holon_actor_keys,
             provenance_timestamp_source: deterministic_provenance_timestamp_source(1),
             topology_interval_secs,
             scaling_interval_secs,
@@ -1003,6 +1082,10 @@ mod tests {
         assert!(
             src.contains("Ed25519 authority key"),
             "module doc must call out the signed adjudication authority"
+        );
+        assert!(
+            src.contains("distinct DID-bound actor signer"),
+            "module doc must call out per-Holon provenance actor signers"
         );
     }
 
@@ -1053,6 +1136,24 @@ mod tests {
         assert!(
             production.contains("hash_structured"),
             "Holon provenance action hashes must use canonical structured hashing"
+        );
+    }
+
+    #[test]
+    fn production_holon_source_does_not_synthesize_root_key_as_actor_provenance() {
+        let source = include_str!("holons.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("test module marker present");
+        assert!(
+            !production.contains("trusted_provenance_keys.insert(\n        holon.id.clone(),\n        vec![config.root_public_key.as_bytes().to_vec()],"),
+            "Holon trusted provenance keys must come from DID-bound Holon actor keys, not the root authority key"
+        );
+        assert!(
+            !production
+                .contains("\n        public_key: Some(config.root_public_key.as_bytes().to_vec())"),
+            "Holon provenance must not be signed as the Holon actor with the root authority key"
         );
     }
 
@@ -1174,6 +1275,19 @@ mod tests {
         assert!(
             result.is_err(),
             "Holon context construction must fail closed on zero provenance HLC metadata"
+        );
+    }
+
+    #[test]
+    fn holon_context_rejects_root_key_synthesized_as_holon_provenance_key() {
+        let mut config = test_config();
+        let h = create_health_holon(&test_did());
+        config.holon_actor_keys.remove(&h.id);
+        let err = build_holon_adjudication_context(&h, &config)
+            .expect_err("Holon provenance must require a DID-bound Holon signer");
+        assert!(
+            err.contains("Holon actor signer"),
+            "unexpected error: {err}"
         );
     }
 

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -56,7 +56,7 @@ use clap::Parser;
 use cli::{Cli, Command};
 use exo_core::types::{Did, PublicKey};
 #[cfg(feature = "unaudited-infrastructure-holons")]
-use holons::{HolonEvent, HolonManagerConfig};
+use holons::{HolonActorKey, HolonEvent, HolonManagerConfig};
 use libp2p_core::Multiaddr;
 use network::{NetworkConfig, NetworkEvent, NetworkHandle};
 use reactor::{ReactorConfig, ReactorEvent};
@@ -611,11 +611,48 @@ async fn start_node(
         let holon_authority_did = holon_identity.did.clone();
         let holon_authority_public_key = *holon_identity.public_key();
         let holon_authority_signer = Arc::new(move |message: &[u8]| holon_identity.sign(message));
+
+        let holon_identity_dir = data_dir.join("holons");
+        std::fs::create_dir_all(&holon_identity_dir)?;
+        let topology_holon_dir = holon_identity_dir.join("topology");
+        let scaling_holon_dir = holon_identity_dir.join("scaling");
+        let health_holon_dir = holon_identity_dir.join("health");
+        std::fs::create_dir_all(&topology_holon_dir)?;
+        std::fs::create_dir_all(&scaling_holon_dir)?;
+        std::fs::create_dir_all(&health_holon_dir)?;
+
+        let topology_holon_identity = identity::load_or_create(&topology_holon_dir)?;
+        let topology_holon_did = topology_holon_identity.did.clone();
+        let topology_holon_actor_key = HolonActorKey {
+            public_key: *topology_holon_identity.public_key(),
+            signer: Arc::new(move |message: &[u8]| topology_holon_identity.sign(message)),
+        };
+        let scaling_holon_identity = identity::load_or_create(&scaling_holon_dir)?;
+        let scaling_holon_did = scaling_holon_identity.did.clone();
+        let scaling_holon_actor_key = HolonActorKey {
+            public_key: *scaling_holon_identity.public_key(),
+            signer: Arc::new(move |message: &[u8]| scaling_holon_identity.sign(message)),
+        };
+        let health_holon_identity = identity::load_or_create(&health_holon_dir)?;
+        let health_holon_did = health_holon_identity.did.clone();
+        let health_holon_actor_key = HolonActorKey {
+            public_key: *health_holon_identity.public_key(),
+            signer: Arc::new(move |message: &[u8]| health_holon_identity.sign(message)),
+        };
+
+        let mut holon_actor_keys = BTreeMap::new();
+        holon_actor_keys.insert(topology_holon_did.clone(), topology_holon_actor_key);
+        holon_actor_keys.insert(scaling_holon_did.clone(), scaling_holon_actor_key);
+        holon_actor_keys.insert(health_holon_did.clone(), health_holon_actor_key);
         let holon_config = HolonManagerConfig {
             node_did: node_identity.did.clone(),
             root_did: holon_authority_did,
             root_public_key: holon_authority_public_key,
             root_signer: holon_authority_signer,
+            topology_holon_did,
+            scaling_holon_did,
+            health_holon_did,
+            holon_actor_keys,
             provenance_timestamp_source: holons::hlc_provenance_timestamp_source(),
             topology_interval_secs: 60,
             scaling_interval_secs: 300,

--- a/crates/exo-node/src/mcp/middleware.rs
+++ b/crates/exo-node/src/mcp/middleware.rs
@@ -234,6 +234,11 @@ impl ConstitutionalMiddleware {
                 "MCP authority signer is required for verified MCP invocation context".into(),
             )
         })?;
+        if actor_did != &authority.did {
+            return Err(McpError::ConstitutionalViolation(
+                "MCP actor provenance key must be resolved independently of the configured authority signer".into(),
+            ));
+        }
         let public_key = authority.public_key.as_bytes().to_vec();
         let mut trusted_authority_keys = TrustedAuthorityKeys::default();
         trusted_authority_keys.insert(authority.did.clone(), vec![public_key.clone()]);
@@ -377,6 +382,10 @@ mod tests {
         Did::new("did:exo:ai-agent-mcp").expect("valid DID")
     }
 
+    fn other_did() -> Did {
+        Did::new("did:exo:other-mcp-actor").expect("valid DID")
+    }
+
     fn signed_middleware() -> ConstitutionalMiddleware {
         let keypair = exo_core::crypto::KeyPair::from_secret_bytes([0x4D; 32]).unwrap();
         let public_key = *keypair.public_key();
@@ -389,7 +398,11 @@ mod tests {
     }
 
     fn signed_tool_call_params(action: &str) -> Value {
-        let actor = test_did();
+        signed_tool_call_params_for_actor(action, &test_did())
+    }
+
+    fn signed_tool_call_params_for_actor(action: &str, actor: &Did) -> Value {
+        let authority = test_did();
         let keypair = exo_core::crypto::KeyPair::from_secret_bytes([0x4D; 32]).unwrap();
         let public_key = *keypair.public_key();
         let secret_key = keypair.secret_key().clone();
@@ -402,7 +415,7 @@ mod tests {
                 .collect(),
         );
         let mut authority_link = exo_gatekeeper::types::AuthorityLink {
-            grantor: actor.clone(),
+            grantor: authority.clone(),
             grantee: actor.clone(),
             permissions: permission_set,
             signature: Vec::new(),
@@ -444,7 +457,7 @@ mod tests {
                     ],
                     "authority_chain": [
                         {
-                        "grantor": actor.as_str(),
+                        "grantor": authority.as_str(),
                         "grantee": actor.as_str(),
                         "permissions": permissions,
                         "signature": hex::encode(authority_link.signature),
@@ -453,7 +466,7 @@ mod tests {
                     ],
                     "consent_records": [
                         {
-                            "subject": actor.as_str(),
+                            "subject": authority.as_str(),
                             "granted_to": actor.as_str(),
                             "scope": "mcp:tools",
                             "active": true,
@@ -461,7 +474,7 @@ mod tests {
                     ],
                     "bailment_state": {
                         "state": "Active",
-                        "bailor": actor.as_str(),
+                        "bailor": authority.as_str(),
                         "bailee": actor.as_str(),
                         "scope": "mcp:tools",
                     },
@@ -487,6 +500,24 @@ mod tests {
         assert!(
             mw.enforce_tool_call(&did, action, &signed_tool_call_params(action))
                 .is_ok()
+        );
+    }
+
+    #[test]
+    fn middleware_rejects_authority_key_synthesized_as_other_actor_provenance() {
+        let mw = signed_middleware();
+        let actor = other_did();
+        let action = "exochain_node_status";
+        let err = mw
+            .enforce_tool_call(
+                &actor,
+                action,
+                &signed_tool_call_params_for_actor(action, &actor),
+            )
+            .expect_err("middleware must not map authority key to arbitrary actor DID");
+        assert!(
+            err.to_string().contains("provenance"),
+            "unexpected error: {err}"
         );
     }
 
@@ -644,6 +675,20 @@ mod tests {
         assert!(
             production.contains("violation.rule.id()"),
             "MCP middleware errors must expose explicit stable MCP rule identifiers"
+        );
+    }
+
+    #[test]
+    fn production_source_does_not_synthesize_authority_key_as_actor_provenance() {
+        let src = std::fs::read_to_string("src/mcp/middleware.rs")
+            .expect("middleware.rs readable from crate root");
+        let production = src
+            .split("// ===========================================================================\n// Tests")
+            .next()
+            .expect("middleware production section must be present");
+        assert!(
+            production.contains("actor_did != &authority.did"),
+            "MCP middleware must not map the configured authority key to a different actor DID without a resolver"
         );
     }
 

--- a/crates/exochain-sdk/src/kernel.rs
+++ b/crates/exochain-sdk/src/kernel.rs
@@ -30,9 +30,9 @@
 //! use exo_core::Did;
 //!
 //! let authority = exochain_sdk::identity::Identity::generate("authority");
+//! let actor = exochain_sdk::identity::Identity::generate("alice");
 //! let kernel = ConstitutionalKernel::with_authority_identity(authority);
-//! let actor = Did::new("did:exo:alice").expect("valid");
-//! let verdict = kernel.adjudicate(&actor, "data:medical:read");
+//! let verdict = kernel.adjudicate_as(&actor, "data:medical:read");
 //! assert!(verdict.is_permitted());
 //! ```
 
@@ -141,7 +141,7 @@ impl KernelVerdict {
 ///
 /// Provides a minimal adjudication interface suitable for common SDK use
 /// cases: a single actor performing an action, with caller-supplied authority
-/// signing material, signed provenance, and an active bailment from that
+/// signing material, actor-signed provenance, and an active bailment from that
 /// authority. Callers needing fine-grained control over the adjudication
 /// context should use [`exo_gatekeeper::Kernel`] directly.
 ///
@@ -152,12 +152,12 @@ impl KernelVerdict {
 /// use exo_core::Did;
 ///
 /// let authority = exochain_sdk::identity::Identity::generate("authority");
+/// let actor = exochain_sdk::identity::Identity::generate("alice");
 /// let kernel = ConstitutionalKernel::with_authority_identity(authority);
 /// assert!(kernel.verify_integrity());
 /// assert_eq!(kernel.invariant_count(), 8);
 ///
-/// let actor = Did::new("did:exo:alice").expect("valid");
-/// let verdict = kernel.adjudicate(&actor, "read:profile");
+/// let verdict = kernel.adjudicate_as(&actor, "read:profile");
 /// assert!(verdict.is_permitted());
 /// ```
 pub struct ConstitutionalKernel {
@@ -172,6 +172,44 @@ struct KernelAuthority {
     did: Did,
     public_key: PublicKey,
     signer: AuthoritySigner,
+}
+
+#[derive(Clone, Copy)]
+struct AdjudicationFlags {
+    is_self_grant: bool,
+    modifies_kernel: bool,
+    include_bailment: bool,
+    human_override_preserved: bool,
+}
+
+impl AdjudicationFlags {
+    const DEFAULT: Self = Self {
+        is_self_grant: false,
+        modifies_kernel: false,
+        include_bailment: true,
+        human_override_preserved: true,
+    };
+
+    const SELF_GRANT: Self = Self {
+        is_self_grant: true,
+        ..Self::DEFAULT
+    };
+
+    const KERNEL_MODIFICATION: Self = Self {
+        modifies_kernel: true,
+        ..Self::DEFAULT
+    };
+
+    const WITHOUT_BAILMENT: Self = Self {
+        include_bailment: false,
+        ..Self::DEFAULT
+    };
+}
+
+struct ActorProvenanceSigner<'a> {
+    actor: &'a Did,
+    public_key: &'a PublicKey,
+    signer: &'a dyn Fn(&[u8]) -> Signature,
 }
 
 impl ConstitutionalKernel {
@@ -199,8 +237,9 @@ impl ConstitutionalKernel {
     ///
     /// This is the common SDK path: the identity's DID becomes the authority
     /// grantor and bailor for the default adjudication context, and its secret
-    /// key signs the canonical authority/provenance payloads that the kernel
-    /// verifies.
+    /// key signs the canonical authority payloads that the kernel verifies.
+    /// Actor provenance must still be signed by the actor identity through
+    /// [`Self::adjudicate_as`].
     ///
     /// # Examples
     ///
@@ -267,14 +306,17 @@ impl ConstitutionalKernel {
     /// - An active bailment from the configured authority to `actor` scoped to
     ///   `action`.
     /// - Full human-override preservation.
-    /// - Signed provenance with timestamp `"sdk"`.
+    /// - Signed provenance with timestamp `"sdk"` when `actor` is the
+    ///   authority DID itself.
     ///
     /// If the kernel was created with [`Self::new`] rather than
     /// [`Self::with_authority`] or [`Self::with_authority_identity`], this
     /// method fails closed with a denied verdict.
     ///
-    /// Callers needing richer context should reach for
-    /// [`exo_gatekeeper::Kernel`] directly.
+    /// Passing an arbitrary DID without its signer fails closed. Use
+    /// [`Self::adjudicate_as`] when acting for a distinct SDK identity, or
+    /// reach for [`exo_gatekeeper::Kernel`] directly when building a fully
+    /// resolved adjudication context.
     ///
     /// The action is flagged as `is_self_grant = false` and
     /// `modifies_kernel = false` by default. Helpers are available for the
@@ -287,17 +329,28 @@ impl ConstitutionalKernel {
     ///
     /// ```
     /// use exochain_sdk::kernel::ConstitutionalKernel;
-    /// use exo_core::Did;
     ///
     /// let authority = exochain_sdk::identity::Identity::generate("authority");
+    /// let actor = authority.did().clone();
     /// let kernel = ConstitutionalKernel::with_authority_identity(authority);
-    /// let actor = Did::new("did:exo:alice").expect("valid");
     /// let verdict = kernel.adjudicate(&actor, "data:read");
     /// assert!(verdict.is_permitted());
     /// ```
     #[must_use]
     pub fn adjudicate(&self, actor: &Did, action: &str) -> KernelVerdict {
-        self.adjudicate_internal(actor, action, false, false, true, true)
+        self.adjudicate_internal(actor, action, AdjudicationFlags::DEFAULT)
+    }
+
+    /// Adjudicate `action` performed by `actor` using actor-signed
+    /// provenance and authority-signed delegation.
+    ///
+    /// This is the normal SDK path for actions performed by a principal other
+    /// than the configured authority. The actor identity signs the provenance
+    /// payload, and the trusted provenance key map is populated from that
+    /// same actor identity rather than from the authority signer.
+    #[must_use]
+    pub fn adjudicate_as(&self, actor: &crate::identity::Identity, action: &str) -> KernelVerdict {
+        self.adjudicate_identity_internal(actor, action, AdjudicationFlags::DEFAULT)
     }
 
     /// Same as [`Self::adjudicate`] but sets `is_self_grant = true` so the
@@ -310,17 +363,26 @@ impl ConstitutionalKernel {
     ///
     /// ```
     /// use exochain_sdk::kernel::ConstitutionalKernel;
-    /// use exo_core::Did;
     ///
     /// let authority = exochain_sdk::identity::Identity::generate("authority");
+    /// let actor = exochain_sdk::identity::Identity::generate("self-granter");
     /// let kernel = ConstitutionalKernel::with_authority_identity(authority);
-    /// let actor = Did::new("did:exo:self-granter").expect("valid");
-    /// let verdict = kernel.adjudicate_self_grant(&actor, "escalate-self");
+    /// let verdict = kernel.adjudicate_self_grant_as(&actor, "escalate-self");
     /// assert!(verdict.is_denied());
     /// ```
     #[must_use]
     pub fn adjudicate_self_grant(&self, actor: &Did, action: &str) -> KernelVerdict {
-        self.adjudicate_internal(actor, action, true, false, true, true)
+        self.adjudicate_internal(actor, action, AdjudicationFlags::SELF_GRANT)
+    }
+
+    /// Same as [`Self::adjudicate_as`] but sets `is_self_grant = true`.
+    #[must_use]
+    pub fn adjudicate_self_grant_as(
+        &self,
+        actor: &crate::identity::Identity,
+        action: &str,
+    ) -> KernelVerdict {
+        self.adjudicate_identity_internal(actor, action, AdjudicationFlags::SELF_GRANT)
     }
 
     /// Same as [`Self::adjudicate`] but sets `modifies_kernel = true` so the
@@ -330,17 +392,26 @@ impl ConstitutionalKernel {
     ///
     /// ```
     /// use exochain_sdk::kernel::ConstitutionalKernel;
-    /// use exo_core::Did;
     ///
     /// let authority = exochain_sdk::identity::Identity::generate("authority");
+    /// let actor = exochain_sdk::identity::Identity::generate("patcher");
     /// let kernel = ConstitutionalKernel::with_authority_identity(authority);
-    /// let actor = Did::new("did:exo:patcher").expect("valid");
-    /// let verdict = kernel.adjudicate_kernel_modification(&actor, "patch-kernel");
+    /// let verdict = kernel.adjudicate_kernel_modification_as(&actor, "patch-kernel");
     /// assert!(verdict.is_denied());
     /// ```
     #[must_use]
     pub fn adjudicate_kernel_modification(&self, actor: &Did, action: &str) -> KernelVerdict {
-        self.adjudicate_internal(actor, action, false, true, true, true)
+        self.adjudicate_internal(actor, action, AdjudicationFlags::KERNEL_MODIFICATION)
+    }
+
+    /// Same as [`Self::adjudicate_as`] but sets `modifies_kernel = true`.
+    #[must_use]
+    pub fn adjudicate_kernel_modification_as(
+        &self,
+        actor: &crate::identity::Identity,
+        action: &str,
+    ) -> KernelVerdict {
+        self.adjudicate_identity_internal(actor, action, AdjudicationFlags::KERNEL_MODIFICATION)
     }
 
     /// Same as [`Self::adjudicate`] but omits the default bailment so the
@@ -350,17 +421,26 @@ impl ConstitutionalKernel {
     ///
     /// ```
     /// use exochain_sdk::kernel::ConstitutionalKernel;
-    /// use exo_core::Did;
     ///
     /// let authority = exochain_sdk::identity::Identity::generate("authority");
+    /// let actor = exochain_sdk::identity::Identity::generate("unauth");
     /// let kernel = ConstitutionalKernel::with_authority_identity(authority);
-    /// let actor = Did::new("did:exo:unauth").expect("valid");
-    /// let verdict = kernel.adjudicate_without_bailment(&actor, "read-data");
+    /// let verdict = kernel.adjudicate_without_bailment_as(&actor, "read-data");
     /// assert!(verdict.is_denied());
     /// ```
     #[must_use]
     pub fn adjudicate_without_bailment(&self, actor: &Did, action: &str) -> KernelVerdict {
-        self.adjudicate_internal(actor, action, false, false, false, true)
+        self.adjudicate_internal(actor, action, AdjudicationFlags::WITHOUT_BAILMENT)
+    }
+
+    /// Same as [`Self::adjudicate_as`] but omits the default bailment.
+    #[must_use]
+    pub fn adjudicate_without_bailment_as(
+        &self,
+        actor: &crate::identity::Identity,
+        action: &str,
+    ) -> KernelVerdict {
+        self.adjudicate_identity_internal(actor, action, AdjudicationFlags::WITHOUT_BAILMENT)
     }
 
     /// Verify that the kernel's stored constitution hash matches the
@@ -415,9 +495,10 @@ impl ConstitutionalKernel {
     }
 
     fn signed_provenance(
-        authority: &KernelAuthority,
         actor: &Did,
         action: &str,
+        actor_public_key: &PublicKey,
+        actor_signer: &dyn Fn(&[u8]) -> Signature,
     ) -> exo_core::Result<Provenance> {
         let timestamp = "sdk".to_owned();
         let action_hash = Hash256::digest(action.as_bytes()).as_bytes().to_vec();
@@ -427,25 +508,40 @@ impl ConstitutionalKernel {
             timestamp,
             action_hash,
             signature: Vec::new(),
-            public_key: Some(authority.public_key.as_bytes().to_vec()),
+            public_key: Some(actor_public_key.as_bytes().to_vec()),
             voice_kind: None,
             independence: None,
             review_order: None,
         };
         let message = provenance_signature_message(&provenance)?;
-        let signature = (authority.signer)(message.as_bytes());
+        let signature = actor_signer(message.as_bytes());
         provenance.signature = signature.to_bytes().to_vec();
         Ok(provenance)
+    }
+
+    fn adjudicate_identity_internal(
+        &self,
+        actor: &crate::identity::Identity,
+        action: &str,
+        flags: AdjudicationFlags,
+    ) -> KernelVerdict {
+        let signer = |message: &[u8]| actor.sign(message);
+        self.adjudicate_internal_with_actor_provenance(
+            action,
+            flags,
+            ActorProvenanceSigner {
+                actor: actor.did(),
+                public_key: actor.public_key(),
+                signer: &signer,
+            },
+        )
     }
 
     fn adjudicate_internal(
         &self,
         actor: &Did,
         action: &str,
-        is_self_grant: bool,
-        modifies_kernel: bool,
-        include_bailment: bool,
-        human_override_preserved: bool,
+        flags: AdjudicationFlags,
     ) -> KernelVerdict {
         let Some(authority) = self.authority.as_ref() else {
             return KernelVerdict::Denied {
@@ -454,28 +550,58 @@ impl ConstitutionalKernel {
                 ],
             };
         };
+        if actor != &authority.did {
+            return KernelVerdict::Denied {
+                violations: vec![
+                    "ProvenanceVerifiable: SDK actor identity signer is required for non-authority actor provenance".into(),
+                ],
+            };
+        }
+        self.adjudicate_internal_with_actor_provenance(
+            action,
+            flags,
+            ActorProvenanceSigner {
+                actor,
+                public_key: &authority.public_key,
+                signer: authority.signer.as_ref(),
+            },
+        )
+    }
 
+    fn adjudicate_internal_with_actor_provenance(
+        &self,
+        action: &str,
+        flags: AdjudicationFlags,
+        actor_provenance: ActorProvenanceSigner<'_>,
+    ) -> KernelVerdict {
+        let Some(authority) = self.authority.as_ref() else {
+            return KernelVerdict::Denied {
+                violations: vec![
+                    "AuthorityChainValid: SDK authority signer is required for adjudication".into(),
+                ],
+            };
+        };
         let permissions = PermissionSet::new(vec![Permission::new("read")]);
         let request = ActionRequest {
-            actor: actor.clone(),
+            actor: actor_provenance.actor.clone(),
             action: action.to_owned(),
             required_permissions: permissions.clone(),
-            is_self_grant,
-            modifies_kernel,
+            is_self_grant: flags.is_self_grant,
+            modifies_kernel: flags.modifies_kernel,
         };
 
         let scope = action.to_owned();
 
-        let (bailment_state, consent_records) = if include_bailment {
+        let (bailment_state, consent_records) = if flags.include_bailment {
             (
                 BailmentState::Active {
                     bailor: authority.did.clone(),
-                    bailee: actor.clone(),
+                    bailee: actor_provenance.actor.clone(),
                     scope: scope.clone(),
                 },
                 vec![ConsentRecord {
                     subject: authority.did.clone(),
-                    granted_to: actor.clone(),
+                    granted_to: actor_provenance.actor.clone(),
                     scope,
                     active: true,
                 }],
@@ -484,7 +610,11 @@ impl ConstitutionalKernel {
             (BailmentState::None, Vec::new())
         };
 
-        let authority_link = match Self::signed_authority_link(authority, actor, &permissions) {
+        let authority_link = match Self::signed_authority_link(
+            authority,
+            actor_provenance.actor,
+            &permissions,
+        ) {
             Ok(link) => link,
             Err(err) => {
                 return KernelVerdict::Denied {
@@ -494,7 +624,12 @@ impl ConstitutionalKernel {
                 };
             }
         };
-        let provenance = match Self::signed_provenance(authority, actor, action) {
+        let provenance = match Self::signed_provenance(
+            actor_provenance.actor,
+            action,
+            actor_provenance.public_key,
+            actor_provenance.signer,
+        ) {
             Ok(provenance) => provenance,
             Err(err) => {
                 return KernelVerdict::Denied {
@@ -516,8 +651,8 @@ impl ConstitutionalKernel {
         }
         let mut trusted_provenance_keys = TrustedProvenanceKeys::default();
         trusted_provenance_keys.insert(
-            actor.clone(),
-            vec![authority.public_key.as_bytes().to_vec()],
+            actor_provenance.actor.clone(),
+            vec![actor_provenance.public_key.as_bytes().to_vec()],
         );
 
         let context = AdjudicationContext {
@@ -528,7 +663,7 @@ impl ConstitutionalKernel {
             authority_chain,
             consent_records,
             bailment_state,
-            human_override_preserved,
+            human_override_preserved: flags.human_override_preserved,
             actor_permissions: permissions,
             trusted_authority_keys,
             trusted_provenance_keys,
@@ -606,12 +741,32 @@ mod tests {
     #[test]
     fn valid_action_permitted() {
         let k = signed_kernel();
-        let actor = did("did:exo:valid-actor");
-        let verdict = k.adjudicate(&actor, "read-medical-record");
+        let actor = crate::identity::Identity::generate("valid-actor");
+        let verdict = k.adjudicate_as(&actor, "read-medical-record");
         assert!(
             verdict.is_permitted(),
             "expected Permitted, got {verdict:?}"
         );
+    }
+
+    #[test]
+    fn adjudicate_rejects_authority_key_synthesized_as_actor_provenance_key() {
+        let k = signed_kernel();
+        let actor = did("did:exo:arbitrary-actor");
+        let verdict = k.adjudicate(&actor, "read-medical-record");
+        assert!(
+            verdict.is_denied(),
+            "authority signer must not be accepted as arbitrary actor provenance, got {verdict:?}"
+        );
+        match verdict {
+            KernelVerdict::Denied { violations } => {
+                assert!(
+                    violations.iter().any(|v| v.contains("Provenance")),
+                    "denial must identify provenance key binding: {violations:?}"
+                );
+            }
+            other => panic!("expected Denied, got {other:?}"),
+        }
     }
 
     #[test]
@@ -631,8 +786,8 @@ mod tests {
     #[test]
     fn self_grant_denied() {
         let k = signed_kernel();
-        let actor = did("did:exo:self-granter");
-        let verdict = k.adjudicate_self_grant(&actor, "escalate-self");
+        let actor = crate::identity::Identity::generate("self-granter");
+        let verdict = k.adjudicate_self_grant_as(&actor, "escalate-self");
         assert!(verdict.is_denied(), "expected Denied, got {verdict:?}");
         match verdict {
             KernelVerdict::Denied { violations } => {
@@ -650,16 +805,16 @@ mod tests {
     #[test]
     fn kernel_modification_denied() {
         let k = signed_kernel();
-        let actor = did("did:exo:patcher");
-        let verdict = k.adjudicate_kernel_modification(&actor, "patch-kernel");
+        let actor = crate::identity::Identity::generate("patcher");
+        let verdict = k.adjudicate_kernel_modification_as(&actor, "patch-kernel");
         assert!(verdict.is_denied(), "expected Denied, got {verdict:?}");
     }
 
     #[test]
     fn no_bailment_denied() {
         let k = signed_kernel();
-        let actor = did("did:exo:unauth");
-        let verdict = k.adjudicate_without_bailment(&actor, "read-data");
+        let actor = crate::identity::Identity::generate("unauth");
+        let verdict = k.adjudicate_without_bailment_as(&actor, "read-data");
         assert!(verdict.is_denied(), "expected Denied, got {verdict:?}");
     }
 
@@ -672,6 +827,20 @@ mod tests {
         assert!(
             !source.contains("format!(\"{:?}: {}\", v.invariant, v.description)"),
             "SDK violation labels must use stable invariant IDs"
+        );
+    }
+
+    #[test]
+    fn sdk_source_does_not_synthesize_authority_key_as_actor_provenance() {
+        let source = include_str!("kernel.rs")
+            .split("// ===========================================================================\n// Tests")
+            .next()
+            .expect("production section");
+        assert!(
+            !source.contains(
+                "trusted_provenance_keys.insert(\n            actor.clone(),\n            vec![authority.public_key.as_bytes().to_vec()],"
+            ),
+            "SDK trusted provenance keys must come from actor identity material, not authority key substitution"
         );
     }
 

--- a/crates/exochain-sdk/src/lib.rs
+++ b/crates/exochain-sdk/src/lib.rs
@@ -85,9 +85,10 @@
 //! assert_eq!(&chain.terminal, bob.did());
 //!
 //! // 5. Ask the kernel whether bob may perform the action.
-//! // The SDK kernel requires caller-supplied authority signing material.
+//! // The SDK kernel requires caller-supplied authority signing material and
+//! // actor-signed provenance for the acting identity.
 //! let kernel = ConstitutionalKernel::with_authority_identity(root);
-//! let verdict = kernel.adjudicate(bob.did(), "data:medical:read");
+//! let verdict = kernel.adjudicate_as(&bob, "data:medical:read");
 //! assert!(verdict.is_permitted(), "expected Permitted, got {verdict:?}");
 //! # Ok::<(), exochain_sdk::error::ExoError>(())
 //! ```


### PR DESCRIPTION
## Classification

- Core runtime adapter: `crates/exochain-sdk/src/kernel.rs`, `crates/exochain-sdk/src/lib.rs`, `crates/exo-node/src/holons.rs`, `crates/exo-node/src/main.rs`, `crates/exo-node/src/mcp/middleware.rs`
- Documentation generated truth claim: `README.md`

## Problem

The current adapter paths could synthesize trusted actor provenance key maps from an authority/root signer. That weakens `ProvenanceVerifiable` because an adapter can make the authority key stand in for an arbitrary actor DID.

## Remediation

- SDK: adds `adjudicate_as(&Identity, ...)` so non-authority actors must provide actor-signed provenance. Bare `adjudicate(&Did, ...)` now only permits the configured authority DID and fails closed for arbitrary actors without signer material.
- Infrastructure Holons: adds per-Holon DID-bound actor keys and signs provenance with each Holon actor key, while keeping the root signer for authority-chain payloads only.
- MCP middleware: refuses to resolve arbitrary actor provenance from the configured authority signer.
- Adds regression/source-guard coverage for the SDK, Holon, and MCP adapter paths.

## TDD / Verification

Red tests observed before fix:

- `cargo test -p exochain-sdk adjudicate_rejects_authority_key_synthesized_as_actor_provenance_key -- --nocapture`
- `cargo test -p exo-node holon_context_rejects_root_key_synthesized_as_holon_provenance_key -- --nocapture`
- `cargo test -p exo-node middleware_rejects_authority_key_synthesized_as_other_actor_provenance -- --nocapture`

Green validation after fix:

- `cargo test -p exochain-sdk kernel -- --nocapture`
- `cargo test -p exochain-sdk -- --nocapture`
- `cargo test -p exo-node mcp::middleware -- --nocapture`
- `cargo test -p exo-node holon -- --nocapture`
- `cargo test -p exo-node --features unaudited-infrastructure-holons holon -- --nocapture`
- `cargo test -p exo-node handler_tools_call -- --nocapture`
- `cargo test -p exo-node -- --nocapture`
- `cargo check -p exochain-sdk -p exo-node --all-targets`
- `cargo clippy -p exochain-sdk -p exo-node --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p exochain-sdk -p exo-node --no-deps`\n- `cargo +nightly fmt --all -- --check`\n- `git diff --check`\n- `bash tools/test_repo_truth.sh`\n\nBypass search checked production SDK/node adapter sources for authority/root-key provenance substitution patterns.\n