### PR TITLE
fix(gatekeeper): bind consent to actor and scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 176479 | `wc -l` |
+| Rust LOC | 176673 | `wc -l` |
 | Workspace tests | 4,152 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -96,7 +96,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 176479 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 176673 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,152 listed workspace tests
 

--- a/crates/exo-gatekeeper/src/holon.rs
+++ b/crates/exo-gatekeeper/src/holon.rs
@@ -239,13 +239,13 @@ mod tests {
             consent_records: vec![ConsentRecord {
                 subject: did("did:exo:owner"),
                 granted_to: actor.clone(),
-                scope: "data".into(),
+                scope: "holon_step".into(),
                 active: true,
             }],
             bailment_state: BailmentState::Active {
                 bailor: did("did:exo:owner"),
                 bailee: actor.clone(),
-                scope: "data".into(),
+                scope: "holon_step".into(),
             },
             human_override_preserved: true,
             actor_permissions: PermissionSet::new(vec![Permission::new("read")]),

--- a/crates/exo-gatekeeper/src/invariants.rs
+++ b/crates/exo-gatekeeper/src/invariants.rs
@@ -89,6 +89,7 @@ impl InvariantSet {
 #[derive(Debug, Clone)]
 pub struct InvariantContext {
     pub actor: Did,
+    pub action: String,
     pub actor_roles: Vec<Role>,
     pub bailment_state: BailmentState,
     pub consent_records: Vec<ConsentRecord>,
@@ -279,28 +280,94 @@ fn check_separation_of_powers(ctx: &InvariantContext) -> Result<(), InvariantVio
 }
 
 fn check_consent_required(ctx: &InvariantContext) -> Result<(), InvariantViolation> {
-    if !ctx.bailment_state.is_active() {
+    let (bailor, bailee, bailment_scope) = match &ctx.bailment_state {
+        BailmentState::Active {
+            bailor,
+            bailee,
+            scope,
+        } => (bailor, bailee, scope),
+        _ => {
+            return Err(InvariantViolation {
+                invariant: ConstitutionalInvariant::ConsentRequired,
+                description: "No active bailment for this action".into(),
+                evidence: bailment_state_evidence(&ctx.bailment_state),
+            });
+        }
+    };
+
+    if bailee != &ctx.actor {
         return Err(InvariantViolation {
             invariant: ConstitutionalInvariant::ConsentRequired,
-            description: "No active bailment for this action".into(),
-            evidence: bailment_state_evidence(&ctx.bailment_state),
+            description: "Active bailment bailee does not match action actor".into(),
+            evidence: vec![format!("actor: {}", ctx.actor), format!("bailee: {bailee}")],
         });
     }
-    let has_active = ctx
-        .consent_records
-        .iter()
-        .any(|c| c.granted_to == ctx.actor && c.active);
+
+    if !scope_authorizes_request(bailment_scope, &ctx.action, &ctx.requested_permissions) {
+        return Err(InvariantViolation {
+            invariant: ConstitutionalInvariant::ConsentRequired,
+            description: "Active bailment scope does not authorize requested action".into(),
+            evidence: vec![
+                format!("action: {}", ctx.action),
+                format!("scope: {bailment_scope}"),
+            ],
+        });
+    }
+
+    let has_active = ctx.consent_records.iter().any(|c| {
+        c.active && c.granted_to == ctx.actor && c.subject == *bailor && c.scope == *bailment_scope
+    });
     if !has_active {
         return Err(InvariantViolation {
             invariant: ConstitutionalInvariant::ConsentRequired,
-            description: "No active consent record for actor".into(),
+            description: "No active consent record matching actor, bailor, and scope".into(),
             evidence: vec![
                 format!("actor: {}", ctx.actor),
+                format!("bailor: {bailor}"),
+                format!("scope: {bailment_scope}"),
                 format!("records: {}", ctx.consent_records.len()),
             ],
         });
     }
     Ok(())
+}
+
+fn scope_authorizes_request(scope: &str, action: &str, requested: &PermissionSet) -> bool {
+    let scope = scope.trim();
+    if scope.is_empty() {
+        return false;
+    }
+
+    let action = action.trim();
+    if !action.is_empty()
+        && (scope == action
+            || action.starts_with(scope)
+                && action
+                    .as_bytes()
+                    .get(scope.len())
+                    .is_some_and(|separator| matches!(separator, b':' | b'/' | b'.')))
+    {
+        return true;
+    }
+
+    if requested.is_empty() {
+        return action.is_empty();
+    }
+
+    requested
+        .permissions
+        .iter()
+        .any(|permission| scope_authorizes_permission(scope, permission.0.trim()))
+}
+
+fn scope_authorizes_permission(scope: &str, permission: &str) -> bool {
+    if permission.is_empty() {
+        return false;
+    }
+    scope == permission
+        || scope
+            .strip_suffix(permission)
+            .is_some_and(|prefix| matches!(prefix.as_bytes().last(), Some(b':' | b'/' | b'.')))
 }
 
 fn check_no_self_grant(ctx: &InvariantContext) -> Result<(), InvariantViolation> {
@@ -666,6 +733,7 @@ mod tests {
         );
         InvariantContext {
             actor: actor.clone(),
+            action: "data:medical".into(),
             actor_roles: vec![Role {
                 name: "judge".into(),
                 branch: GovernmentBranch::Judicial,
@@ -891,6 +959,73 @@ mod tests {
         let mut ctx = passing_context();
         ctx.consent_records[0].granted_to = did("did:exo:other");
         assert!(enforce_all(&engine, &ctx).is_err());
+    }
+
+    #[test]
+    fn consent_fails_active_bailment_for_different_bailee() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::ConsentRequired,
+        ]));
+        let mut ctx = passing_context();
+        ctx.bailment_state = BailmentState::Active {
+            bailor: did("did:exo:bailor"),
+            bailee: did("did:exo:other-bailee"),
+            scope: "data:medical".into(),
+        };
+
+        let err = enforce_all(&engine, &ctx).unwrap_err();
+
+        assert_eq!(err[0].invariant, ConstitutionalInvariant::ConsentRequired);
+        assert!(
+            err[0].description.contains("bailee"),
+            "ConsentRequired must bind active bailment to the action actor: {err:?}"
+        );
+    }
+
+    #[test]
+    fn consent_fails_unrelated_active_scope() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::ConsentRequired,
+        ]));
+        let mut ctx = passing_context();
+        ctx.requested_permissions = PermissionSet::new(vec![Permission::new("advance_pace")]);
+        ctx.bailment_state = BailmentState::Active {
+            bailor: did("did:exo:bailor"),
+            bailee: ctx.actor.clone(),
+            scope: "data:vote".into(),
+        };
+        ctx.consent_records = vec![ConsentRecord {
+            subject: did("did:exo:bailor"),
+            granted_to: ctx.actor.clone(),
+            scope: "data:vote".into(),
+            active: true,
+        }];
+
+        let err = enforce_all(&engine, &ctx).unwrap_err();
+
+        assert_eq!(err[0].invariant, ConstitutionalInvariant::ConsentRequired);
+        assert!(
+            err[0].description.contains("scope"),
+            "ConsentRequired must bind active consent scope to the requested action: {err:?}"
+        );
+    }
+
+    #[test]
+    fn consent_fails_unrelated_action_without_requested_permissions() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::ConsentRequired,
+        ]));
+        let mut ctx = passing_context();
+        ctx.action = "advance_pace".into();
+        ctx.requested_permissions = PermissionSet::new(vec![]);
+
+        let err = enforce_all(&engine, &ctx).unwrap_err();
+
+        assert_eq!(err[0].invariant, ConstitutionalInvariant::ConsentRequired);
+        assert!(
+            err[0].description.contains("scope"),
+            "ConsentRequired must bind a non-empty action even when no permission set is provided: {err:?}"
+        );
     }
 
     #[test]

--- a/crates/exo-gatekeeper/src/kernel.rs
+++ b/crates/exo-gatekeeper/src/kernel.rs
@@ -110,6 +110,7 @@ impl Kernel {
 
         let inv_ctx = InvariantContext {
             actor: action.actor.clone(),
+            action: action.action.clone(),
             actor_roles: context.actor_roles.clone(),
             bailment_state: context.bailment_state.clone(),
             consent_records: context.consent_records.clone(),
@@ -274,7 +275,7 @@ mod tests {
     fn valid_action(actor: &Did) -> ActionRequest {
         ActionRequest {
             actor: actor.clone(),
-            action: "read medical record".into(),
+            action: "data:medical".into(),
             required_permissions: PermissionSet::new(vec![Permission::new("read")]),
             is_self_grant: false,
             modifies_kernel: false,

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -7745,7 +7745,7 @@ mod tests {
         )
         .bind(root.to_string())
         .bind(did)
-        .bind("pace:advance")
+        .bind("advance_pace")
         .bind("constitutional_pace")
         .bind("active")
         .bind(1_000_i64)
@@ -8351,10 +8351,18 @@ mod tests {
     }
 
     fn db_consent_row(actor: &Did, subject_did: &str) -> crate::db::ConsentRecordRow {
+        db_consent_row_with_scope(actor, subject_did, "data:vote")
+    }
+
+    fn db_consent_row_with_scope(
+        actor: &Did,
+        subject_did: &str,
+        scope: &str,
+    ) -> crate::db::ConsentRecordRow {
         crate::db::ConsentRecordRow {
             subject_did: subject_did.to_string(),
             actor_did: actor.as_str().to_string(),
-            scope: "data:vote".to_string(),
+            scope: scope.to_string(),
             bailment_type: "standard".to_string(),
             status: "active".to_string(),
             created_at: 1,
@@ -8513,7 +8521,11 @@ mod tests {
             )],
         };
         let role_rows = vec![db_role_row(&actor, "worker", "executive")];
-        let consent_rows = vec![db_consent_row(&actor, root.as_str())];
+        let consent_rows = vec![db_consent_row_with_scope(
+            &actor,
+            root.as_str(),
+            "advance_pace",
+        )];
         let chain_row =
             db_authority_chain_row(&actor, serde_json::to_value(&authority_chain).unwrap());
         let trusted_authority_keys = trusted_authority_keys_for_test_chain(&authority_chain);
@@ -8539,6 +8551,44 @@ mod tests {
         assert!(
             verdict.is_permitted(),
             "F-010: action permission backed by DB authority-chain scope must be permitted"
+        );
+    }
+
+    #[test]
+    fn adjudication_context_rows_reject_unrelated_active_consent_scope_for_action() {
+        let kernel = adjudication_kernel();
+        let actor = Did::new("did:exo:pace-agent").unwrap();
+        let root = Did::new("did:exo:root-grantor").unwrap();
+        let authority_chain = AuthorityChain {
+            links: vec![signed_authority_link_for_permissions(
+                &root,
+                &actor,
+                PermissionSet::new(vec![Permission::new("advance_pace")]),
+            )],
+        };
+        let role_rows = vec![db_role_row(&actor, "worker", "executive")];
+        let consent_rows = vec![db_consent_row_with_scope(
+            &actor,
+            root.as_str(),
+            "data:vote",
+        )];
+        let chain_row =
+            db_authority_chain_row(&actor, serde_json::to_value(&authority_chain).unwrap());
+        let trusted_authority_keys = trusted_authority_keys_for_test_chain(&authority_chain);
+
+        let ctx = build_adjudication_context_from_rows(
+            &actor,
+            &role_rows,
+            &consent_rows,
+            Some(&chain_row),
+            trusted_authority_keys,
+        )
+        .unwrap();
+        let verdict = kernel.adjudicate(&action_for_permission(&actor, "advance_pace"), &ctx);
+
+        assert!(
+            !verdict.is_permitted(),
+            "active consent for an unrelated scope must not authorize advance_pace"
         );
     }
 

--- a/crates/exo-legal/src/nist_compliance_tests.rs
+++ b/crates/exo-legal/src/nist_compliance_tests.rs
@@ -223,6 +223,7 @@ mod nist_compliance {
         }
         InvariantContext {
             actor: actor.clone(),
+            action: "data:test".into(),
             actor_roles: vec![Role {
                 name: "operator".into(),
                 branch: GovernmentBranch::Executive,

--- a/crates/exo-node/src/holons.rs
+++ b/crates/exo-node/src/holons.rs
@@ -71,6 +71,8 @@ pub const INFRASTRUCTURE_HOLONS_FEATURE: &str = "unaudited-infrastructure-holons
 pub const INFRASTRUCTURE_HOLONS_INITIATIVE: &str =
     "Initiatives/fix-onyx-4-r5-holons-stub-context.md";
 
+const INFRASTRUCTURE_HOLON_STEP_SCOPE: &str = "holon_step";
+
 /// Whether the unaudited infrastructure Holon runtime is compiled in.
 #[must_use]
 pub const fn infrastructure_holons_enabled() -> bool {
@@ -420,13 +422,13 @@ pub fn build_holon_adjudication_context(
         consent_records: vec![ConsentRecord {
             subject: config.root_did.clone(),
             granted_to: holon.id.clone(),
-            scope: "infrastructure-monitoring".into(),
+            scope: INFRASTRUCTURE_HOLON_STEP_SCOPE.into(),
             active: true,
         }],
         bailment_state: BailmentState::Active {
             bailor: config.root_did.clone(),
             bailee: holon.id.clone(),
-            scope: "infrastructure".into(),
+            scope: INFRASTRUCTURE_HOLON_STEP_SCOPE.into(),
         },
         human_override_preserved: true,
         actor_permissions: holon.capabilities.clone(),

--- a/crates/exo-node/src/mcp/handler.rs
+++ b/crates/exo-node/src/mcp/handler.rs
@@ -838,7 +838,7 @@ mod tests {
                     {
                         "subject": actor.as_str(),
                         "granted_to": actor.as_str(),
-                        "scope": "mcp:tools",
+                        "scope": action,
                         "active": true,
                     }
                 ],
@@ -846,7 +846,7 @@ mod tests {
                     "state": "Active",
                     "bailor": actor.as_str(),
                     "bailee": actor.as_str(),
-                    "scope": "mcp:tools",
+                    "scope": action,
                 },
                 "human_override_preserved": true,
                 "actor_permissions": ["mcp:tool_call"],

--- a/crates/exo-node/src/mcp/middleware.rs
+++ b/crates/exo-node/src/mcp/middleware.rs
@@ -448,7 +448,7 @@ mod tests {
                         {
                             "subject": actor.as_str(),
                             "granted_to": actor.as_str(),
-                            "scope": "mcp:tools",
+                            "scope": action,
                             "active": true,
                         }
                     ],
@@ -456,7 +456,7 @@ mod tests {
                         "state": "Active",
                         "bailor": actor.as_str(),
                         "bailee": actor.as_str(),
-                        "scope": "mcp:tools",
+                        "scope": action,
                     },
                     "human_override_preserved": true,
                     "actor_permissions": ["mcp:tool_call"],

--- a/crates/exo-node/src/mcp/tools/authority.rs
+++ b/crates/exo-node/src/mcp/tools/authority.rs
@@ -228,6 +228,7 @@ fn validate_authority_chain(
     ]));
     let context = InvariantContext {
         actor: terminal_actor.clone(),
+        action: String::new(),
         actor_roles: Vec::new(),
         bailment_state: BailmentState::None,
         consent_records: Vec::new(),

--- a/crates/exochain-wasm/src/gatekeeper_bindings.rs
+++ b/crates/exochain-wasm/src/gatekeeper_bindings.rs
@@ -126,6 +126,8 @@ pub fn wasm_validation_invariant_request() -> Result<JsValue, JsValue> {
         .map_err(|_| gatekeeper_boundary_error("validation invariant actor DID failed"))?;
     let grantor = exo_core::Did::new("did:exo:validation-root")
         .map_err(|_| gatekeeper_boundary_error("validation invariant grantor DID failed"))?;
+    let bailor = exo_core::Did::new("did:exo:validation-bailor")
+        .map_err(|_| gatekeeper_boundary_error("validation bailor DID failed"))?;
     let permissions = PermissionSet::default();
     let mut authority_link = AuthorityLink {
         grantor: grantor.clone(),
@@ -165,17 +167,15 @@ pub fn wasm_validation_invariant_request() -> Result<JsValue, JsValue> {
 
     to_js_value(&serde_json::json!({
         "actor": actor,
+        "action": "validation-scope",
         "actor_roles": [],
         "bailment_state": BailmentState::Active {
-            bailor: exo_core::Did::new("did:exo:validation-bailor")
-                .map_err(|_| gatekeeper_boundary_error("validation bailor DID failed"))?,
-            bailee: exo_core::Did::new("did:exo:validation-bailee")
-                .map_err(|_| gatekeeper_boundary_error("validation bailee DID failed"))?,
+            bailor: bailor.clone(),
+            bailee: actor.clone(),
             scope: "validation-scope".to_string(),
         },
         "consent_records": [ConsentRecord {
-            subject: exo_core::Did::new("did:exo:validation-subject")
-                .map_err(|_| gatekeeper_boundary_error("validation subject DID failed"))?,
+            subject: bailor,
             granted_to: actor.clone(),
             scope: "validation-scope".to_string(),
             active: true,

--- a/crates/exochain-wasm/src/gatekeeper_bindings.rs
+++ b/crates/exochain-wasm/src/gatekeeper_bindings.rs
@@ -11,6 +11,8 @@ use crate::serde_bridge::*;
 #[derive(serde::Deserialize)]
 struct WasmInvariantRequest {
     actor: exo_core::Did,
+    #[serde(default)]
+    action: String,
     actor_roles: Vec<exo_gatekeeper::types::Role>,
     bailment_state: exo_gatekeeper::types::BailmentState,
     consent_records: Vec<exo_gatekeeper::types::ConsentRecord>,
@@ -69,6 +71,7 @@ pub fn wasm_enforce_invariants(request_json: &str) -> Result<JsValue, JsValue> {
 
     let context = exo_gatekeeper::invariants::InvariantContext {
         actor: req.actor,
+        action: req.action,
         actor_roles: req.actor_roles,
         bailment_state: req.bailment_state,
         consent_records: req.consent_records,
@@ -256,7 +259,7 @@ mod tests {
     fn active_bailment() -> BailmentState {
         BailmentState::Active {
             bailor: Did::new("did:exo:bailor").expect("valid"),
-            bailee: Did::new("did:exo:bailee").expect("valid"),
+            bailee: actor(),
             scope: "test-scope".to_string(),
         }
     }
@@ -319,10 +322,11 @@ mod tests {
 
         InvariantContext {
             actor: actor(),
+            action: "test-scope".to_string(),
             actor_roles: vec![],
             bailment_state: active_bailment(),
             consent_records: vec![ConsentRecord {
-                subject: Did::new("did:exo:subject").expect("valid"),
+                subject: Did::new("did:exo:bailor").expect("valid"),
                 granted_to: actor(),
                 scope: "test-scope".to_string(),
                 active: true,


### PR DESCRIPTION
## Summary
- binds `ConsentRequired` to the active bailment bailee, bailor, scope, and requested action/permission instead of accepting any active consent for the actor
- carries action metadata through kernel, gateway, WASM, MCP authority, Holon, and legal compliance adapters
- adds gateway and Holon adapter regressions for unrelated active consent scopes and updates repo-truth LOC

## Path classification
- EXOCHAIN core: `crates/exo-gatekeeper/src/invariants.rs`, `crates/exo-gatekeeper/src/kernel.rs`, `crates/exo-gatekeeper/src/holon.rs`
- Core runtime adapter: `crates/exo-gateway/src/server.rs`, `crates/exo-node/src/holons.rs`, `crates/exo-node/src/mcp/tools/authority.rs`, `crates/exochain-wasm/src/gatekeeper_bindings.rs`
- Core compliance test adapter: `crates/exo-legal/src/nist_compliance_tests.rs`
- Generated truth claim: `README.md`

## TDD evidence
Red tests observed before implementation:
- `cargo test -p exo-gatekeeper consent_fails -- --nocapture` failed because active bailment for a different bailee and unrelated active scope were permitted.
- `cargo test -p exo-node topology_holon_step_succeeds_with_peers -- --nocapture` failed after core enforcement because the Holon adapter used a stale scope unrelated to `holon_step`.
- `cargo test -p exo-gatekeeper consent_fails_unrelated_action_without_requested_permissions -- --nocapture` failed because non-empty actions with an empty permission set could still fall through legacy-compatible scope handling.

## Validation
- `cargo test -p exo-gatekeeper -- --nocapture`
- `cargo test -p exo-gateway --lib adjudication_context_rows -- --nocapture`
- `RUSTFLAGS='-D warnings' cargo test -p exo-gateway --lib --features production-db -- --test-threads=1`
- `cargo test -p exo-legal -- --nocapture`
- `cargo test -p exo-node authority -- --nocapture`
- `cargo test -p exo-node holon -- --nocapture`
- `cargo test -p exo-node --features unaudited-infrastructure-holons holon -- --nocapture`
- `cargo test -p exochain-wasm gatekeeper -- --nocapture`
- `cargo check -p exo-gatekeeper -p exo-gateway -p exo-legal -p exo-node -p exochain-wasm --all-targets`
- `cargo clippy -p exo-gatekeeper -p exo-gateway -p exo-legal -p exo-node -p exochain-wasm --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p exo-gatekeeper -p exo-gateway -p exo-legal -p exo-node -p exochain-wasm --no-deps`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`

## Bypass search
- searched consent/bailment scope construction across `exo-gatekeeper`, `exo-gateway`, `exo-node`, and `exochain-wasm`
- found and fixed the infrastructure Holon scope mismatch so legitimate governed Holon steps remain permitted only with matching `holon_step` consent
