### PR TITLE
fix(gatekeeper): require signed human quorum provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 176673 | `wc -l` |
+| Rust LOC | 176743 | `wc -l` |
 | Workspace tests | 4,152 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -96,7 +96,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 176673 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 176743 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,152 listed workspace tests
 

--- a/crates/decision-forum/tests/governance_kernel_integration.rs
+++ b/crates/decision-forum/tests/governance_kernel_integration.rs
@@ -196,13 +196,13 @@ fn valid_adj_context(actor: &Did) -> AdjudicationContext {
         consent_records: vec![ConsentRecord {
             subject: did("did:exo:bailor"),
             granted_to: actor.clone(),
-            scope: "governance:decision".into(),
+            scope: "enact:decision".into(),
             active: true,
         }],
         bailment_state: BailmentState::Active {
             bailor: did("did:exo:bailor"),
             bailee: actor.clone(),
-            scope: "governance:decision".into(),
+            scope: "enact:decision".into(),
         },
         human_override_preserved: true,
         actor_permissions: PermissionSet::new(vec![Permission::new("enact:decision")]),
@@ -237,6 +237,7 @@ fn transition_action(actor: &Did, from: BctsState, to: BctsState) -> ActionReque
 
 fn transition_context(actor: &Did, from: BctsState, to: BctsState) -> AdjudicationContext {
     let permission = bcts_transition_permission(from, to);
+    let scope_label = permission.0.clone();
     let mut context = valid_adj_context(actor);
     context.authority_chain = AuthorityChain {
         links: vec![signed_authority_link_for_permission(
@@ -253,6 +254,14 @@ fn transition_context(actor: &Did, from: BctsState, to: BctsState) -> Adjudicati
         }
     }
     context.actor_permissions = PermissionSet::new(vec![permission]);
+    context.consent_records[0].scope = scope_label.clone();
+    if let BailmentState::Active {
+        scope: bailment_scope,
+        ..
+    } = &mut context.bailment_state
+    {
+        *bailment_scope = scope_label;
+    }
     context
 }
 

--- a/crates/exo-gatekeeper/src/invariants.rs
+++ b/crates/exo-gatekeeper/src/invariants.rs
@@ -576,9 +576,9 @@ fn check_quorum_legitimate(ctx: &InvariantContext) -> Result<(), InvariantViolat
                 });
             }
 
-            // CR-001 §8.3: synthetic voices SHALL never be counted as distinct
-            // humans. Use is_met_authentic() which excludes Synthetic-voiced
-            // votes from the approval count.
+            // CR-001 §8.3: quorum requires signed human voter provenance.
+            // Synthetic, missing-provenance, actor-mismatched, and unsigned
+            // approvals do not count toward the authentic human threshold.
             if !evidence.is_met_authentic() {
                 let authentic_approvals = evidence.distinct_authentic_approved_voter_count();
                 let synthetic_excluded = evidence.synthetic_vote_count();
@@ -1238,18 +1238,8 @@ mod tests {
         ctx.quorum_evidence = Some(QuorumEvidence {
             threshold: 2,
             votes: vec![
-                QuorumVote {
-                    voter: did("did:exo:v1"),
-                    approved: true,
-                    signature: vec![1],
-                    provenance: None,
-                },
-                QuorumVote {
-                    voter: did("did:exo:v2"),
-                    approved: true,
-                    signature: vec![2],
-                    provenance: None,
-                },
+                make_vote("did:exo:v1", true, 1, Some(VoiceKind::Human)),
+                make_vote("did:exo:v2", true, 2, Some(VoiceKind::Human)),
             ],
         });
         assert!(enforce_all(&engine, &ctx).is_ok());
@@ -1413,12 +1403,12 @@ mod tests {
         QuorumVote {
             voter: did(voter),
             approved,
-            signature: vec![sig],
+            signature: vec![sig; 64],
             provenance: voice.map(|vk| Provenance {
                 actor: did(voter),
                 timestamp: "t".into(),
                 action_hash: vec![1],
-                signature: vec![sig],
+                signature: vec![sig; 64],
                 public_key: None,
                 voice_kind: Some(vk),
                 independence: None,
@@ -1505,8 +1495,7 @@ mod tests {
     }
 
     #[test]
-    fn quorum_passes_legacy_votes_no_provenance() {
-        // Legacy votes (provenance=None) are not excluded
+    fn quorum_fails_legacy_votes_no_provenance() {
         let engine = InvariantEngine::new(InvariantSet::with(vec![
             ConstitutionalInvariant::QuorumLegitimate,
         ]));
@@ -1528,7 +1517,34 @@ mod tests {
                 },
             ],
         });
-        assert!(enforce_all(&engine, &ctx).is_ok());
+        let err = enforce_all(&engine, &ctx).unwrap_err();
+        assert_eq!(err[0].invariant, ConstitutionalInvariant::QuorumLegitimate);
+        assert!(
+            err[0].description.contains("authentic"),
+            "votes without provenance must not count as authentic quorum evidence"
+        );
+    }
+
+    #[test]
+    fn quorum_fails_unsigned_human_vote_provenance() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::QuorumLegitimate,
+        ]));
+        let mut ctx = passing_context();
+        let mut vote = make_vote("did:exo:h1", true, 1, Some(VoiceKind::Human));
+        vote.provenance.as_mut().expect("provenance").signature = Vec::new();
+        ctx.quorum_evidence = Some(QuorumEvidence {
+            threshold: 1,
+            votes: vec![vote],
+        });
+
+        let err = enforce_all(&engine, &ctx).unwrap_err();
+
+        assert_eq!(err[0].invariant, ConstitutionalInvariant::QuorumLegitimate);
+        assert!(
+            err[0].description.contains("authentic"),
+            "unsigned human provenance must not count as authentic quorum evidence"
+        );
     }
 
     #[test]

--- a/crates/exo-gatekeeper/src/types.rs
+++ b/crates/exo-gatekeeper/src/types.rs
@@ -286,6 +286,8 @@ pub struct AuthorityLink {
 /// resolved key material for the claimed grantor DID.
 pub type TrustedAuthorityKeys = BTreeMap<Did, Vec<Vec<u8>>>;
 
+const ED25519_SIGNATURE_LEN: usize = 64;
+
 // ---------------------------------------------------------------------------
 // Quorum evidence
 // ---------------------------------------------------------------------------
@@ -307,9 +309,8 @@ impl QuorumEvidence {
         self.distinct_approved_voter_count() >= threshold
     }
 
-    /// Returns `true` if the threshold is met counting only non-synthetic
-    /// approved votes. A vote with `provenance.voice_kind = Synthetic` is
-    /// excluded from the human count per CR-001 §8.3.
+    /// Returns `true` if the threshold is met counting only signed human
+    /// approvals with voter-bound provenance.
     pub fn is_met_authentic(&self) -> bool {
         let Some(threshold) = usize::try_from(self.threshold).ok() else {
             return false;
@@ -349,14 +350,12 @@ impl QuorumEvidence {
             .len()
     }
 
-    /// Count distinct approved voter DIDs that are not synthetic.
+    /// Count distinct approved voter DIDs with signed human provenance.
     #[must_use]
     pub fn distinct_authentic_approved_voter_count(&self) -> usize {
         self.votes
             .iter()
-            .filter(|vote| {
-                vote.approved && !vote.provenance.as_ref().is_some_and(|p| p.is_synthetic())
-            })
+            .filter(|vote| vote.is_authentic_human_approval())
             .map(|vote| vote.voter.clone())
             .collect::<BTreeSet<_>>()
             .len()
@@ -375,6 +374,22 @@ pub struct QuorumVote {
     /// distinct human approval in quorum (CR-001 §8.3).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provenance: Option<Provenance>,
+}
+
+impl QuorumVote {
+    /// Returns whether this vote can count toward an authentic human quorum.
+    ///
+    /// Legacy votes without provenance, synthetic/system voices, actor-mismatched
+    /// provenance, and structurally unsigned votes fail closed.
+    pub fn is_authentic_human_approval(&self) -> bool {
+        self.approved
+            && self.signature.len() == ED25519_SIGNATURE_LEN
+            && self.provenance.as_ref().is_some_and(|provenance| {
+                provenance.actor == self.voter
+                    && provenance.is_human_voice()
+                    && provenance.signature.len() == ED25519_SIGNATURE_LEN
+            })
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -553,12 +568,12 @@ mod tests {
         QuorumVote {
             voter: did(voter),
             approved,
-            signature: vec![sig],
+            signature: vec![sig; ED25519_SIGNATURE_LEN],
             provenance: voice.map(|vk| Provenance {
                 actor: did(voter),
                 timestamp: "t".into(),
                 action_hash: vec![1],
-                signature: vec![sig],
+                signature: vec![sig; ED25519_SIGNATURE_LEN],
                 public_key: None,
                 voice_kind: Some(vk),
                 independence: None,
@@ -692,8 +707,7 @@ mod tests {
     }
 
     #[test]
-    fn quorum_is_met_authentic_legacy_vote_counts() {
-        // Legacy votes (no provenance) are not excluded
+    fn quorum_is_met_authentic_rejects_legacy_votes_without_provenance() {
         let ev = QuorumEvidence {
             threshold: 2,
             votes: vec![
@@ -711,7 +725,38 @@ mod tests {
                 },
             ],
         };
-        assert!(ev.is_met_authentic());
+        assert!(
+            !ev.is_met_authentic(),
+            "votes without provenance must not count as authentic human quorum evidence"
+        );
+    }
+
+    #[test]
+    fn quorum_is_met_authentic_rejects_unsigned_human_votes() {
+        let mut vote = make_vote("did:exo:h1", true, 1, Some(VoiceKind::Human));
+        vote.signature.clear();
+        let ev = QuorumEvidence {
+            threshold: 1,
+            votes: vec![vote],
+        };
+        assert!(
+            !ev.is_met_authentic(),
+            "unsigned votes must not count as authentic human quorum evidence"
+        );
+    }
+
+    #[test]
+    fn quorum_is_met_authentic_rejects_mismatched_provenance_actor() {
+        let mut vote = make_vote("did:exo:h1", true, 1, Some(VoiceKind::Human));
+        vote.provenance.as_mut().expect("provenance").actor = did("did:exo:h2");
+        let ev = QuorumEvidence {
+            threshold: 1,
+            votes: vec![vote],
+        };
+        assert!(
+            !ev.is_met_authentic(),
+            "provenance for a different actor must not count for the voter"
+        );
     }
 
     // ── Provenance voice/independence helpers ────────────────────────────────


### PR DESCRIPTION
## Summary
- changes authentic quorum counting so approved votes only count when they carry signed human provenance for the same voter DID
- rejects legacy/no-provenance votes, unsigned human votes, mismatched provenance actors, duplicate voters, and synthetic votes from `QuorumLegitimate`
- refreshes decision-forum kernel integration fixtures so consent scopes match the governed action/permission after the consent-binding hardening

## Path classification
- EXOCHAIN core: `crates/exo-gatekeeper/src/types.rs`, `crates/exo-gatekeeper/src/invariants.rs`
- Core governance integration test adapter: `crates/decision-forum/tests/governance_kernel_integration.rs`
- Generated truth claim: `README.md`

## TDD evidence
Red tests observed before implementation:
- `cargo test -p exo-gatekeeper quorum_is_met_authentic_rejects_legacy_votes_without_provenance -- --nocapture` failed because no-provenance votes counted as authentic.
- `cargo test -p exo-gatekeeper quorum_fails_legacy_votes_no_provenance -- --nocapture` failed because `QuorumLegitimate` permitted legacy/no-provenance quorum evidence.

Additional regressions added:
- unsigned human votes do not count as authentic quorum evidence
- provenance for a different actor does not count for the voter

## Validation
- `cargo test -p exo-gatekeeper quorum_is_met_authentic -- --nocapture`
- `cargo test -p exo-gatekeeper quorum_fails -- --nocapture`
- `cargo test -p exo-gatekeeper -- --nocapture`
- `cargo test -p decision-forum --test governance_kernel_integration -- --nocapture`
- `cargo test -p decision-forum -- --nocapture`
- `cargo check -p exo-gatekeeper -p decision-forum --all-targets`
- `cargo clippy -p exo-gatekeeper -p decision-forum --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p exo-gatekeeper -p decision-forum --no-deps`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`

## Bypass search
- searched for all `QuorumEvidence` construction; only gatekeeper and decision-forum tests construct it directly in this stack
- kept raw `is_met()` as a structural helper, while `QuorumLegitimate` continues to call `is_met_authentic()` for fail-closed constitutional quorum checks
