### PR TITLE
fix(gatekeeper): enforce authority chain depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 176743 | `wc -l` |
+| Rust LOC | 176793 | `wc -l` |
 | Workspace tests | 4,152 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -96,7 +96,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 176743 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 176793 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,152 listed workspace tests
 

--- a/crates/exo-gatekeeper/src/invariants.rs
+++ b/crates/exo-gatekeeper/src/invariants.rs
@@ -7,8 +7,9 @@ use exo_core::{Did, Hash256, hash::hash_structured};
 use serde::{Deserialize, Serialize};
 
 use crate::types::{
-    AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch, PermissionSet,
-    Provenance, QuorumEvidence, Role, TrustedAuthorityKeys,
+    AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch,
+    MAX_AUTHORITY_CHAIN_LINKS, PermissionSet, Provenance, QuorumEvidence, Role,
+    TrustedAuthorityKeys,
 };
 
 // ---------------------------------------------------------------------------
@@ -409,6 +410,15 @@ fn check_authority_chain_valid(ctx: &InvariantContext) -> Result<(), InvariantVi
             invariant: ConstitutionalInvariant::AuthorityChainValid,
             description: "Authority chain is empty — no delegation path".into(),
             evidence: vec!["authority_chain: empty".into()],
+        });
+    }
+    if ctx.authority_chain.depth() > MAX_AUTHORITY_CHAIN_LINKS {
+        return Err(InvariantViolation {
+            invariant: ConstitutionalInvariant::AuthorityChainValid,
+            description: format!(
+                "Authority chain may contain at most {MAX_AUTHORITY_CHAIN_LINKS} signed links"
+            ),
+            evidence: vec![format!("depth: {}", ctx.authority_chain.depth())],
         });
     }
     let links = &ctx.authority_chain.links;
@@ -1797,6 +1807,44 @@ mod tests {
             err[0].description.contains("grantor_public_key")
                 && err[0].description.contains("unresolved"),
             "self-attested grantor public keys must not satisfy AuthorityChainValid: {err:?}"
+        );
+    }
+
+    #[test]
+    fn authority_chain_rejects_excessive_depth_in_core() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::AuthorityChainValid,
+        ]));
+        let mut ctx = passing_context();
+        let mut links = Vec::new();
+        ctx.trusted_authority_keys = TrustedAuthorityKeys::default();
+        for idx in 0..=MAX_AUTHORITY_CHAIN_LINKS {
+            let grantor = if idx == 0 {
+                "did:exo:root".to_string()
+            } else {
+                format!("did:exo:delegate-{idx}")
+            };
+            let grantee = if idx == MAX_AUTHORITY_CHAIN_LINKS {
+                ctx.actor.to_string()
+            } else {
+                format!("did:exo:delegate-{}", idx + 1)
+            };
+            let (link, pk) = signed_link(&grantor, &grantee);
+            ctx.trusted_authority_keys
+                .insert(link.grantor.clone(), vec![pk.as_bytes().to_vec()]);
+            links.push(link);
+        }
+        ctx.authority_chain = AuthorityChain { links };
+
+        let err = enforce_all(&engine, &ctx).unwrap_err();
+
+        assert_eq!(
+            err[0].invariant,
+            ConstitutionalInvariant::AuthorityChainValid
+        );
+        assert!(
+            err[0].description.contains("at most"),
+            "oversized signed authority chains must fail closed in gatekeeper core: {err:?}"
         );
     }
 

--- a/crates/exo-gatekeeper/src/types.rs
+++ b/crates/exo-gatekeeper/src/types.rs
@@ -286,6 +286,8 @@ pub struct AuthorityLink {
 /// resolved key material for the claimed grantor DID.
 pub type TrustedAuthorityKeys = BTreeMap<Did, Vec<Vec<u8>>>;
 
+pub const MAX_AUTHORITY_CHAIN_LINKS: usize = 5;
+
 const ED25519_SIGNATURE_LEN: usize = 64;
 
 // ---------------------------------------------------------------------------

--- a/crates/exo-node/src/mcp/tools/authority.rs
+++ b/crates/exo-node/src/mcp/tools/authority.rs
@@ -17,8 +17,9 @@ use exo_gatekeeper::{
     },
     kernel::{ActionRequest, AdjudicationContext, Kernel, Verdict},
     types::{
-        AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch, Permission,
-        PermissionSet, Provenance, Role, TrustedAuthorityKeys,
+        AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch,
+        MAX_AUTHORITY_CHAIN_LINKS, Permission, PermissionSet, Provenance, Role,
+        TrustedAuthorityKeys,
     },
 };
 use serde_json::{Value, json};
@@ -30,7 +31,6 @@ use crate::mcp::{
 
 /// Constitution bytes used to initialise the CGR Kernel for adjudication.
 const CONSTITUTION: &[u8] = b"We the people of the EXOCHAIN constitutional trust fabric...";
-const MAX_AUTHORITY_CHAIN_LINKS: usize = 5;
 const MAX_AUTHORITY_DID_BYTES: usize = 512;
 const MAX_AUTHORITY_ACTION_BYTES: usize = 16 * 1024;
 const MAX_PERMISSION_SET_ENTRIES: usize = 64;


### PR DESCRIPTION
## Summary
- adds a core `MAX_AUTHORITY_CHAIN_LINKS` limit to `exo-gatekeeper` authority-chain validation
- reuses the core limit in the MCP authority adapter instead of maintaining a separate local constant
- adds a regression test proving an otherwise signed and trusted over-depth chain fails closed in the kernel
- refreshes repo-truth README counters after the Rust LOC change

## Path classification
- EXOCHAIN core: `crates/exo-gatekeeper/src/invariants.rs`, `crates/exo-gatekeeper/src/types.rs`
- Core runtime adapter: `crates/exo-node/src/mcp/tools/authority.rs`
- Documentation/repo truth: `README.md`

## Verification
- RED observed before production fix: `cargo test -p exo-gatekeeper authority_chain_rejects_excessive_depth_in_core -- --nocapture`
- `cargo test -p exo-gatekeeper authority_chain_rejects_excessive_depth_in_core -- --nocapture`
- `cargo test -p exo-node authority_chain -- --nocapture`
- `cargo test -p exo-gatekeeper -- --nocapture`
- `cargo test -p exo-node mcp::tools::authority -- --nocapture`
- `cargo check -p exo-gatekeeper -p exo-node --all-targets`
- `cargo clippy -p exo-gatekeeper -p exo-node --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p exo-gatekeeper -p exo-node --no-deps`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`