### PR TITLE
fix(decision-forum): require verified vote provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 176928 | `wc -l` |
+| Rust LOC | 177847 | `wc -l` |
 | Workspace tests | 4,152 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -96,7 +96,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 176928 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 177847 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,152 listed workspace tests
 

--- a/crates/decision-forum/src/decision_object.rs
+++ b/crates/decision-forum/src/decision_object.rs
@@ -8,17 +8,21 @@
 
 use exo_core::{
     bcts::BctsState,
+    crypto,
     hash::hash_structured,
-    types::{DeterministicMap, Did, Hash256, Timestamp},
+    types::{DeterministicMap, Did, Hash256, PublicKey, Signature, Timestamp},
 };
 use exo_gatekeeper::{
     kernel::{ActionRequest, AdjudicationContext, Kernel, Verdict},
-    types::Permission,
+    types::{Permission, VoiceKind},
 };
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::error::{ForumError, Result};
+use crate::{
+    constitution::PublicKeyResolver,
+    error::{ForumError, Result},
+};
 
 /// Classification of a decision, determining quorum, authority, and gate requirements.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -60,6 +64,14 @@ pub enum ActorKind {
     },
 }
 
+/// Cryptographic evidence binding a vote to the voter and decision.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VoteProvenance {
+    pub public_key: PublicKey,
+    pub signature: Signature,
+    pub voice_kind: VoiceKind,
+}
+
 /// A single vote cast on a decision.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Vote {
@@ -68,6 +80,8 @@ pub struct Vote {
     pub actor_kind: ActorKind,
     pub timestamp: Timestamp,
     pub signature_hash: Hash256,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<VoteProvenance>,
 }
 
 /// Vote choice.
@@ -106,6 +120,21 @@ pub struct LifecycleReceipt {
 }
 
 const BCTS_TRANSITION_ACTION_PREFIX: &str = "bcts:transition";
+const DECISION_VOTE_SIGNATURE_DOMAIN: &str = "decision.forum.vote_signature.v1";
+const DECISION_VOTE_SIGNATURE_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Debug, Serialize)]
+struct VoteSignaturePayload<'a> {
+    domain: &'static str,
+    schema_version: u16,
+    decision_id: &'a Uuid,
+    decision_class: DecisionClass,
+    constitutional_hash: &'a Hash256,
+    voter_did: &'a Did,
+    choice: VoteChoice,
+    actor_kind: &'a ActorKind,
+    timestamp: &'a Timestamp,
+}
 
 /// Stable action name used when submitting a BCTS state transition to the
 /// constitutional kernel.
@@ -118,6 +147,71 @@ pub fn bcts_transition_action_name(from: BctsState, to: BctsState) -> String {
 #[must_use]
 pub fn bcts_transition_permission(from: BctsState, to: BctsState) -> Permission {
     Permission::new(bcts_transition_action_name(from, to))
+}
+
+/// Canonical domain-separated message bytes to sign for a decision vote.
+pub fn vote_signature_message(decision: &DecisionObject, vote: &Vote) -> Result<Vec<u8>> {
+    let digest = hash_structured(&VoteSignaturePayload {
+        domain: DECISION_VOTE_SIGNATURE_DOMAIN,
+        schema_version: DECISION_VOTE_SIGNATURE_SCHEMA_VERSION,
+        decision_id: &decision.id,
+        decision_class: decision.class,
+        constitutional_hash: &decision.constitutional_hash,
+        voter_did: &vote.voter_did,
+        choice: vote.choice,
+        actor_kind: &vote.actor_kind,
+        timestamp: &vote.timestamp,
+    })?;
+    Ok(digest.as_ref().to_vec())
+}
+
+impl Vote {
+    /// Returns true when the vote carries internally consistent human provenance
+    /// evidence. Decision-bound signature verification still requires the
+    /// surrounding [`DecisionObject`].
+    #[must_use]
+    pub fn has_human_provenance_evidence(&self) -> bool {
+        matches!(self.actor_kind, ActorKind::Human)
+            && self.choice == VoteChoice::Approve
+            && self.has_consistent_signature_evidence_for_voice(VoiceKind::Human)
+    }
+
+    fn has_consistent_signature_evidence_for_voice(&self, expected_voice: VoiceKind) -> bool {
+        self.timestamp != Timestamp::ZERO
+            && self.signature_hash != Hash256::ZERO
+            && self.provenance.as_ref().is_some_and(|provenance| {
+                provenance.voice_kind == expected_voice
+                    && !provenance.signature.is_empty()
+                    && !provenance.signature.ed25519_component_is_zero()
+                    && Hash256::digest(&provenance.signature.to_bytes()) == self.signature_hash
+            })
+    }
+
+    fn expected_voice_kind(&self) -> VoiceKind {
+        match self.actor_kind {
+            ActorKind::Human => VoiceKind::Human,
+            ActorKind::AiAgent { .. } => VoiceKind::Synthetic,
+        }
+    }
+}
+
+fn actor_kind_label(actor_kind: &ActorKind) -> &'static str {
+    match actor_kind {
+        ActorKind::Human => "Human",
+        ActorKind::AiAgent { .. } => "AiAgent",
+    }
+}
+
+fn voice_kind_label(voice_kind: VoiceKind) -> &'static str {
+    match voice_kind {
+        VoiceKind::Human => "Human",
+        VoiceKind::Synthetic => "Synthetic",
+        VoiceKind::System => "System",
+    }
+}
+
+fn no_voter_public_key(_: &Did) -> Option<PublicKey> {
+    None
 }
 
 /// The core Decision Object.
@@ -284,6 +378,17 @@ impl DecisionObject {
 
     /// Add a vote to this decision.
     pub fn add_vote(&mut self, vote: Vote) -> Result<()> {
+        self.add_vote_with_key_resolver(vote, &no_voter_public_key)
+    }
+
+    /// Add a vote after resolving the voter's public key from trusted identity
+    /// state. Use this at runtime boundaries; [`Self::add_vote`] intentionally
+    /// fails closed because a vote's embedded public key is not self-authenticating.
+    pub fn add_vote_with_key_resolver<R: PublicKeyResolver>(
+        &mut self,
+        vote: Vote,
+        resolve_voter_public_key: &R,
+    ) -> Result<()> {
         if self.is_terminal() {
             return Err(ForumError::DecisionImmutable);
         }
@@ -293,8 +398,119 @@ impl DecisionObject {
                 reason: format!("duplicate vote from {}", vote.voter_did),
             });
         }
+        self.verify_vote_signature_with_key_resolver(&vote, resolve_voter_public_key)?;
         self.votes.push(vote);
         Ok(())
+    }
+
+    /// Verify a vote's decision-bound signature and provenance metadata.
+    pub fn verify_vote_signature(&self, vote: &Vote) -> Result<()> {
+        self.verify_vote_signature_with_key_resolver(vote, &no_voter_public_key)
+    }
+
+    /// Verify a vote's decision-bound signature and ensure its signing key is
+    /// resolved from trusted voter identity state.
+    pub fn verify_vote_signature_with_key_resolver<R: PublicKeyResolver>(
+        &self,
+        vote: &Vote,
+        resolve_voter_public_key: &R,
+    ) -> Result<()> {
+        validate_timestamp(vote.timestamp, "vote timestamp")?;
+
+        if vote.signature_hash == Hash256::ZERO {
+            return Err(ForumError::InvalidProvenance {
+                reason: format!(
+                    "vote from {} must include non-zero signature hash",
+                    vote.voter_did
+                ),
+            });
+        }
+
+        let provenance = vote
+            .provenance
+            .as_ref()
+            .ok_or_else(|| ForumError::InvalidProvenance {
+                reason: format!(
+                    "vote from {} must include signature provenance",
+                    vote.voter_did
+                ),
+            })?;
+
+        let expected_voice = vote.expected_voice_kind();
+        if provenance.voice_kind != expected_voice {
+            return Err(ForumError::InvalidProvenance {
+                reason: format!(
+                    "vote from {} declares {} actor with {} voice provenance",
+                    vote.voter_did,
+                    actor_kind_label(&vote.actor_kind),
+                    voice_kind_label(provenance.voice_kind)
+                ),
+            });
+        }
+
+        let resolved_public_key = resolve_voter_public_key
+            .resolve(&vote.voter_did)
+            .ok_or_else(|| ForumError::InvalidProvenance {
+                reason: format!(
+                    "vote from {} voter public key is unresolved",
+                    vote.voter_did
+                ),
+            })?;
+        if resolved_public_key != provenance.public_key {
+            return Err(ForumError::InvalidProvenance {
+                reason: format!(
+                    "vote from {} provenance public key does not match resolved voter public key",
+                    vote.voter_did
+                ),
+            });
+        }
+
+        if provenance.signature.is_empty() || provenance.signature.ed25519_component_is_zero() {
+            return Err(ForumError::InvalidProvenance {
+                reason: format!(
+                    "vote from {} must include a non-empty signature",
+                    vote.voter_did
+                ),
+            });
+        }
+
+        let actual_signature_hash = Hash256::digest(&provenance.signature.to_bytes());
+        if vote.signature_hash != actual_signature_hash {
+            return Err(ForumError::InvalidProvenance {
+                reason: format!(
+                    "vote from {} signature hash does not match provenance signature",
+                    vote.voter_did
+                ),
+            });
+        }
+
+        let message = vote_signature_message(self, vote)?;
+        if !crypto::verify(&message, &provenance.signature, &provenance.public_key) {
+            return Err(ForumError::InvalidProvenance {
+                reason: format!("vote from {} signature failed verification", vote.voter_did),
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Returns true if this vote is a verified human approval for this decision.
+    #[must_use]
+    pub fn is_verified_human_approval(&self, vote: &Vote) -> bool {
+        vote.has_human_provenance_evidence() && self.verify_vote_signature(vote).is_ok()
+    }
+
+    /// Returns true if this vote is a verified human approval with voter key
+    /// resolution against trusted identity state.
+    pub fn is_verified_human_approval_with_key_resolver<R: PublicKeyResolver>(
+        &self,
+        vote: &Vote,
+        resolve_voter_public_key: &R,
+    ) -> bool {
+        vote.has_human_provenance_evidence()
+            && self
+                .verify_vote_signature_with_key_resolver(vote, resolve_voter_public_key)
+                .is_ok()
     }
 
     /// Add evidence to this decision.
@@ -440,7 +656,7 @@ mod tests {
         provenance_signature_message,
         types::{
             AuthorityChain, AuthorityLink as GatekeeperAuthorityLink, BailmentState, ConsentRecord,
-            GovernmentBranch, PermissionSet, Provenance, Role, TrustedAuthorityKeys,
+            GovernmentBranch, PermissionSet, Provenance, Role, TrustedAuthorityKeys, VoiceKind,
         },
     };
 
@@ -571,6 +787,50 @@ mod tests {
             created_at: clock.now().expect("HLC timestamp"),
         })
         .expect("valid decision")
+    }
+
+    fn signed_vote_for(
+        decision: &DecisionObject,
+        voter_did: Did,
+        choice: VoteChoice,
+        actor_kind: ActorKind,
+        voice_kind: VoiceKind,
+        timestamp: Timestamp,
+    ) -> Vote {
+        let (public_key, secret_key) = exo_core::crypto::generate_keypair();
+        let mut vote = Vote {
+            voter_did,
+            choice,
+            actor_kind,
+            timestamp,
+            signature_hash: Hash256::ZERO,
+            provenance: None,
+        };
+        let message = vote_signature_message(decision, &vote).expect("vote signing payload");
+        let signature = exo_core::crypto::sign(&message, &secret_key);
+        vote.signature_hash = Hash256::digest(&signature.to_bytes());
+        vote.provenance = Some(VoteProvenance {
+            public_key,
+            signature,
+            voice_kind,
+        });
+        vote
+    }
+
+    fn resolver_for_vote(vote: &Vote) -> impl Fn(&Did) -> Option<PublicKey> + use<> {
+        let voter_did = vote.voter_did.clone();
+        let public_key = vote
+            .provenance
+            .as_ref()
+            .map(|provenance| provenance.public_key);
+        move |did| {
+            if did == &voter_did { public_key } else { None }
+        }
+    }
+
+    fn add_resolved_vote(decision: &mut DecisionObject, vote: Vote) -> Result<()> {
+        let resolver = resolver_for_vote(&vote);
+        decision.add_vote_with_key_resolver(vote, &resolver)
     }
 
     #[test]
@@ -801,6 +1061,7 @@ mod tests {
                 actor_kind: ActorKind::Human,
                 timestamp: clock.now().expect("HLC timestamp"),
                 signature_hash: Hash256::ZERO,
+                provenance: None,
             })
             .is_err()
         );
@@ -842,24 +1103,148 @@ mod tests {
         let actor = test_did();
         let mut d = make_decision(&mut clock);
         let ts = clock.now().expect("HLC timestamp");
-        d.add_vote(Vote {
-            voter_did: actor.clone(),
-            choice: VoteChoice::Approve,
-            actor_kind: ActorKind::Human,
-            timestamp: ts,
-            signature_hash: Hash256::ZERO,
-        })
-        .expect("ok");
+        let first_vote = signed_vote_for(
+            &d,
+            actor.clone(),
+            VoteChoice::Approve,
+            ActorKind::Human,
+            VoiceKind::Human,
+            ts,
+        );
+        add_resolved_vote(&mut d, first_vote).expect("ok");
+        let second_vote = signed_vote_for(
+            &d,
+            actor.clone(),
+            VoteChoice::Reject,
+            ActorKind::Human,
+            VoiceKind::Human,
+            ts,
+        );
+        let err = d.add_vote(second_vote).unwrap_err();
+        assert!(err.to_string().contains("duplicate"));
+    }
+
+    #[test]
+    fn add_vote_rejects_missing_signature_evidence() {
+        let mut clock = test_clock();
+        let actor = test_did();
+        let mut d = make_decision(&mut clock);
+
         let err = d
             .add_vote(Vote {
-                voter_did: actor.clone(),
-                choice: VoteChoice::Reject,
+                voter_did: actor,
+                choice: VoteChoice::Approve,
                 actor_kind: ActorKind::Human,
-                timestamp: ts,
+                timestamp: clock.now().expect("HLC timestamp"),
                 signature_hash: Hash256::ZERO,
+                provenance: None,
             })
-            .unwrap_err();
-        assert!(err.to_string().contains("duplicate"));
+            .expect_err("votes without signature evidence must fail closed");
+
+        assert!(matches!(err, ForumError::InvalidProvenance { .. }));
+        assert!(d.votes.is_empty());
+    }
+
+    #[test]
+    fn add_vote_rejects_unresolved_voter_public_key() {
+        let mut clock = test_clock();
+        let mut d = make_decision(&mut clock);
+        let ts = clock.now().expect("HLC timestamp");
+        let vote = signed_vote_for(
+            &d,
+            test_did(),
+            VoteChoice::Approve,
+            ActorKind::Human,
+            VoiceKind::Human,
+            ts,
+        );
+
+        let err = d
+            .add_vote(vote)
+            .expect_err("votes with self-supplied but unresolved keys must fail closed");
+        assert!(err.to_string().contains("voter public key is unresolved"));
+        assert!(d.votes.is_empty());
+    }
+
+    #[test]
+    fn add_vote_rejects_missing_hlc_timestamp() {
+        let actor = test_did();
+        let mut clock = test_clock();
+        let mut d = make_decision(&mut clock);
+
+        let err = d
+            .add_vote(Vote {
+                voter_did: actor,
+                choice: VoteChoice::Approve,
+                actor_kind: ActorKind::Human,
+                timestamp: Timestamp::ZERO,
+                signature_hash: Hash256::digest(b"vote-signature"),
+                provenance: None,
+            })
+            .expect_err("votes without HLC provenance must fail closed");
+
+        assert!(matches!(err, ForumError::InvalidProvenance { .. }));
+        assert!(d.votes.is_empty());
+    }
+
+    #[test]
+    fn add_vote_rejects_signature_replayed_for_different_decision() {
+        let mut clock = test_clock();
+        let source = make_decision(&mut clock);
+        let mut target = DecisionObject::new(DecisionObjectInput {
+            id: Uuid::from_u128(2),
+            title: "Different Decision".into(),
+            class: DecisionClass::Operational,
+            constitutional_hash: Hash256::digest(b"const-v1"),
+            created_at: clock.now().expect("HLC timestamp"),
+        })
+        .expect("valid decision");
+
+        let vote = signed_vote_for(
+            &source,
+            test_did(),
+            VoteChoice::Approve,
+            ActorKind::Human,
+            VoiceKind::Human,
+            clock.now().expect("HLC timestamp"),
+        );
+        let resolver = resolver_for_vote(&vote);
+
+        let err = target
+            .add_vote_with_key_resolver(vote, &resolver)
+            .expect_err("vote signatures must be bound to one decision");
+
+        assert!(matches!(err, ForumError::InvalidProvenance { .. }));
+        assert!(
+            err.to_string().contains("signature failed verification"),
+            "error should identify signature verification failure, got: {err}"
+        );
+        assert!(target.votes.is_empty());
+    }
+
+    #[test]
+    fn add_vote_rejects_human_actor_with_synthetic_voice_provenance() {
+        let mut clock = test_clock();
+        let mut d = make_decision(&mut clock);
+        let vote = signed_vote_for(
+            &d,
+            test_did(),
+            VoteChoice::Approve,
+            ActorKind::Human,
+            VoiceKind::Synthetic,
+            clock.now().expect("HLC timestamp"),
+        );
+
+        let err = d
+            .add_vote(vote)
+            .expect_err("human actor votes must carry human voice provenance");
+
+        assert!(matches!(err, ForumError::InvalidProvenance { .. }));
+        assert!(
+            err.to_string().contains("Synthetic voice provenance"),
+            "error should identify voice-kind mismatch, got: {err}"
+        );
+        assert!(d.votes.is_empty());
     }
 
     #[test]

--- a/crates/decision-forum/src/human_gate.rs
+++ b/crates/decision-forum/src/human_gate.rs
@@ -4,9 +4,11 @@
 //! distinguishes human vs AI signatures cryptographically, blocks AI
 //! from satisfying HUMAN_GATE_REQUIRED, and enforces AI delegation ceilings.
 
+use exo_core::{Did, PublicKey};
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    constitution::PublicKeyResolver,
     decision_object::{ActorKind, DecisionClass, DecisionObject, Vote},
     error::{ForumError, Result},
 };
@@ -44,10 +46,22 @@ pub fn ai_within_ceiling(policy: &HumanGatePolicy, class: DecisionClass) -> bool
 /// Validate that a decision's votes satisfy the human gate policy.
 /// Returns Ok(()) if the gate is satisfied, or an error if not.
 pub fn enforce_human_gate(policy: &HumanGatePolicy, decision: &DecisionObject) -> Result<()> {
+    enforce_human_gate_with_key_resolver(policy, decision, &no_voter_public_key)
+}
+
+/// Validate that a decision's votes satisfy the human gate policy using
+/// trusted voter-key resolution.
+pub fn enforce_human_gate_with_key_resolver<R: PublicKeyResolver>(
+    policy: &HumanGatePolicy,
+    decision: &DecisionObject,
+    resolve_voter_public_key: &R,
+) -> Result<()> {
     // Check AI ceiling: if decision class exceeds AI ceiling, AI votes alone
     // are not sufficient.
     if decision.class > policy.ai_ceiling {
-        let has_human_vote = decision.votes.iter().any(is_human_vote);
+        let has_human_vote = decision.votes.iter().any(|vote| {
+            decision.is_verified_human_approval_with_key_resolver(vote, resolve_voter_public_key)
+        });
         if !has_human_vote && !decision.votes.is_empty() {
             return Err(ForumError::AiCeilingExceeded {
                 reason: format!(
@@ -62,7 +76,14 @@ pub fn enforce_human_gate(policy: &HumanGatePolicy, decision: &DecisionObject) -
     // Check human gate: classes requiring human approval must have at least
     // one human vote.
     if requires_human_approval(policy, decision.class) {
-        let human_count = decision.votes.iter().filter(|v| is_human_vote(v)).count();
+        let human_count = decision
+            .votes
+            .iter()
+            .filter(|vote| {
+                decision
+                    .is_verified_human_approval_with_key_resolver(vote, resolve_voter_public_key)
+            })
+            .count();
         if human_count == 0 {
             return Err(ForumError::HumanGateRequired);
         }
@@ -74,7 +95,7 @@ pub fn enforce_human_gate(policy: &HumanGatePolicy, decision: &DecisionObject) -
 /// Determine if a vote was cast by a human actor.
 #[must_use]
 pub fn is_human_vote(vote: &Vote) -> bool {
-    matches!(vote.actor_kind, ActorKind::Human)
+    matches!(vote.actor_kind, ActorKind::Human) && vote.has_human_provenance_evidence()
 }
 
 /// Determine if a vote was cast by an AI agent.
@@ -83,44 +104,105 @@ pub fn is_ai_vote(vote: &Vote) -> bool {
     matches!(vote.actor_kind, ActorKind::AiAgent { .. })
 }
 
+fn no_voter_public_key(_: &Did) -> Option<PublicKey> {
+    None
+}
+
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::{
+        collections::BTreeMap,
+        sync::atomic::{AtomicU64, Ordering},
+    };
 
     use exo_core::{
         hlc::HybridClock,
-        types::{Did, Hash256},
+        types::{Hash256, PublicKey},
     };
+    use exo_gatekeeper::types::VoiceKind;
 
     use super::*;
-    use crate::decision_object::{DecisionObjectInput, VoteChoice};
+    use crate::decision_object::{
+        DecisionObjectInput, VoteChoice, VoteProvenance, vote_signature_message,
+    };
 
     fn test_clock() -> HybridClock {
         let counter = AtomicU64::new(1000);
         HybridClock::with_wall_clock(move || counter.fetch_add(1, Ordering::Relaxed))
     }
 
-    fn human_vote(clock: &mut HybridClock) -> Vote {
-        Vote {
-            voter_did: Did::new("did:exo:human-alice").expect("ok"),
+    fn signed_vote(
+        decision: &DecisionObject,
+        voter_did: Did,
+        actor_kind: ActorKind,
+        voice_kind: VoiceKind,
+        clock: &mut HybridClock,
+    ) -> Vote {
+        let (public_key, secret_key) = exo_core::crypto::generate_keypair();
+        let mut vote = Vote {
+            voter_did,
             choice: VoteChoice::Approve,
-            actor_kind: ActorKind::Human,
+            actor_kind,
             timestamp: clock.now().expect("HLC timestamp"),
-            signature_hash: Hash256::digest(b"human-sig"),
-        }
+            signature_hash: Hash256::ZERO,
+            provenance: None,
+        };
+        let message = vote_signature_message(decision, &vote).expect("vote signing payload");
+        let signature = exo_core::crypto::sign(&message, &secret_key);
+        vote.signature_hash = Hash256::digest(&signature.to_bytes());
+        vote.provenance = Some(VoteProvenance {
+            public_key,
+            signature,
+            voice_kind,
+        });
+        vote
     }
 
-    fn ai_vote(clock: &mut HybridClock) -> Vote {
-        Vote {
-            voter_did: Did::new("did:exo:ai-agent-1").expect("ok"),
-            choice: VoteChoice::Approve,
-            actor_kind: ActorKind::AiAgent {
+    fn human_vote(decision: &DecisionObject, clock: &mut HybridClock) -> Vote {
+        signed_vote(
+            decision,
+            Did::new("did:exo:human-alice").expect("ok"),
+            ActorKind::Human,
+            VoiceKind::Human,
+            clock,
+        )
+    }
+
+    fn ai_vote(decision: &DecisionObject, clock: &mut HybridClock) -> Vote {
+        signed_vote(
+            decision,
+            Did::new("did:exo:ai-agent-1").expect("ok"),
+            ActorKind::AiAgent {
                 delegation_id: "d1".into(),
                 ceiling_class: DecisionClass::Operational,
             },
-            timestamp: clock.now().expect("HLC timestamp"),
-            signature_hash: Hash256::digest(b"ai-sig"),
-        }
+            VoiceKind::Synthetic,
+            clock,
+        )
+    }
+
+    fn resolver_for_decision(decision: &DecisionObject) -> impl Fn(&Did) -> Option<PublicKey> {
+        let keys: BTreeMap<Did, PublicKey> = decision
+            .votes
+            .iter()
+            .filter_map(|vote| {
+                vote.provenance
+                    .as_ref()
+                    .map(|provenance| (vote.voter_did.clone(), provenance.public_key))
+            })
+            .collect();
+        move |did| keys.get(did).copied()
+    }
+
+    fn add_resolved_vote(decision: &mut DecisionObject, vote: Vote) -> Result<()> {
+        let voter_did = vote.voter_did.clone();
+        let public_key = vote
+            .provenance
+            .as_ref()
+            .map(|provenance| provenance.public_key);
+        decision.add_vote_with_key_resolver(vote, &move |did: &Did| {
+            if did == &voter_did { public_key } else { None }
+        })
     }
 
     fn make_decision(class: DecisionClass, clock: &mut HybridClock) -> DecisionObject {
@@ -139,7 +221,8 @@ mod tests {
         let mut clock = test_clock();
         let policy = HumanGatePolicy::default();
         let mut d = make_decision(DecisionClass::Routine, &mut clock);
-        d.add_vote(ai_vote(&mut clock)).expect("ok");
+        let vote = ai_vote(&d, &mut clock);
+        add_resolved_vote(&mut d, vote).expect("ok");
         assert!(enforce_human_gate(&policy, &d).is_ok());
     }
 
@@ -148,7 +231,8 @@ mod tests {
         let mut clock = test_clock();
         let policy = HumanGatePolicy::default();
         let mut d = make_decision(DecisionClass::Strategic, &mut clock);
-        d.add_vote(ai_vote(&mut clock)).expect("ok");
+        let vote = ai_vote(&d, &mut clock);
+        add_resolved_vote(&mut d, vote).expect("ok");
         let err = enforce_human_gate(&policy, &d).unwrap_err();
         assert_eq!(
             err.to_string(),
@@ -177,8 +261,10 @@ mod tests {
         let mut clock = test_clock();
         let policy = HumanGatePolicy::default();
         let mut d = make_decision(DecisionClass::Strategic, &mut clock);
-        d.add_vote(human_vote(&mut clock)).expect("ok");
-        assert!(enforce_human_gate(&policy, &d).is_ok());
+        let vote = human_vote(&d, &mut clock);
+        add_resolved_vote(&mut d, vote).expect("ok");
+        let resolver = resolver_for_decision(&d);
+        assert!(enforce_human_gate_with_key_resolver(&policy, &d, &resolver).is_ok());
     }
 
     #[test]
@@ -186,7 +272,8 @@ mod tests {
         let mut clock = test_clock();
         let policy = HumanGatePolicy::default();
         let mut d = make_decision(DecisionClass::Constitutional, &mut clock);
-        d.add_vote(ai_vote(&mut clock)).expect("ok");
+        let vote = ai_vote(&d, &mut clock);
+        add_resolved_vote(&mut d, vote).expect("ok");
         assert!(enforce_human_gate(&policy, &d).is_err());
     }
 
@@ -216,10 +303,38 @@ mod tests {
     #[test]
     fn is_human_vs_ai() {
         let mut clock = test_clock();
-        assert!(is_human_vote(&human_vote(&mut clock)));
-        assert!(!is_human_vote(&ai_vote(&mut clock)));
-        assert!(is_ai_vote(&ai_vote(&mut clock)));
-        assert!(!is_ai_vote(&human_vote(&mut clock)));
+        let d = make_decision(DecisionClass::Routine, &mut clock);
+        assert!(is_human_vote(&human_vote(&d, &mut clock)));
+        assert!(!is_human_vote(&ai_vote(&d, &mut clock)));
+        assert!(is_ai_vote(&ai_vote(&d, &mut clock)));
+        assert!(!is_ai_vote(&human_vote(&d, &mut clock)));
+    }
+
+    #[test]
+    fn caller_asserted_human_without_signature_evidence_does_not_satisfy_gate() {
+        let mut clock = test_clock();
+        let policy = HumanGatePolicy::default();
+        let mut d = make_decision(DecisionClass::Strategic, &mut clock);
+        d.votes.push(Vote {
+            voter_did: Did::new("did:exo:forged-human").expect("valid DID"),
+            choice: VoteChoice::Approve,
+            actor_kind: ActorKind::Human,
+            timestamp: clock.now().expect("HLC timestamp"),
+            signature_hash: Hash256::ZERO,
+            provenance: None,
+        });
+
+        let err = enforce_human_gate(&policy, &d)
+            .expect_err("self-asserted human votes must not satisfy human gate");
+
+        assert!(matches!(
+            err,
+            ForumError::HumanGateRequired | ForumError::AiCeilingExceeded { .. }
+        ));
+        assert!(
+            !is_human_vote(&d.votes[0]),
+            "human vote classification must require verified provenance evidence"
+        );
     }
 
     #[test]

--- a/crates/decision-forum/src/quorum.rs
+++ b/crates/decision-forum/src/quorum.rs
@@ -4,10 +4,11 @@
 //! graceful degradation on quorum failure, and independence-aware counting
 //! via exo_governance::quorum.
 
-use exo_core::types::DeterministicMap;
+use exo_core::types::{DeterministicMap, Did, PublicKey};
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    constitution::PublicKeyResolver,
     decision_object::{DecisionClass, DecisionObject, VoteChoice},
     error::{ForumError, Result},
 };
@@ -97,21 +98,42 @@ pub fn check_quorum(
     registry: &QuorumRegistry,
     decision: &DecisionObject,
 ) -> Result<QuorumCheckResult> {
+    check_quorum_with_key_resolver(registry, decision, &no_voter_public_key)
+}
+
+/// Check if quorum is met using trusted voter-key resolution for vote
+/// authenticity.
+pub fn check_quorum_with_key_resolver<R: PublicKeyResolver>(
+    registry: &QuorumRegistry,
+    decision: &DecisionObject,
+    resolve_voter_public_key: &R,
+) -> Result<QuorumCheckResult> {
     let req = registry
         .requirement_for(decision.class)
         .ok_or(ForumError::QuorumPolicyMissing)?;
     validate_requirement(req)?;
 
-    let total_votes = decision.votes.len();
-    let approve_count = decision
+    let verified_votes: Vec<_> = decision
         .votes
+        .iter()
+        .filter(|vote| {
+            decision
+                .verify_vote_signature_with_key_resolver(vote, resolve_voter_public_key)
+                .is_ok()
+        })
+        .collect();
+
+    let total_votes = verified_votes.len();
+    let approve_count = verified_votes
         .iter()
         .filter(|v| v.choice == VoteChoice::Approve)
         .count();
     let human_count = decision
         .votes
         .iter()
-        .filter(|v| matches!(v.actor_kind, crate::decision_object::ActorKind::Human))
+        .filter(|vote| {
+            decision.is_verified_human_approval_with_key_resolver(vote, resolve_voter_public_key)
+        })
         .count();
 
     if total_votes < req.min_votes {
@@ -152,6 +174,10 @@ pub fn check_quorum(
     })
 }
 
+fn no_voter_public_key(_: &Did) -> Option<PublicKey> {
+    None
+}
+
 /// Verify quorum preconditions BEFORE a vote is initiated (TNC-07).
 /// Returns true if enough eligible voters and eligible human voters exist to
 /// potentially meet quorum.
@@ -182,12 +208,16 @@ fn validate_requirement(req: &QuorumRequirement) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::{
+        collections::BTreeMap,
+        sync::atomic::{AtomicU64, Ordering},
+    };
 
     use exo_core::{
         hlc::HybridClock,
         types::{Did, Hash256},
     };
+    use exo_gatekeeper::types::VoiceKind;
     use uuid::Uuid;
 
     use super::*;
@@ -198,37 +228,68 @@ mod tests {
         HybridClock::with_wall_clock(move || counter.fetch_add(1, Ordering::Relaxed))
     }
 
-    fn human_approve_vote(name: &str, clock: &mut HybridClock) -> Vote {
-        Vote {
+    fn signed_vote(
+        decision: &DecisionObject,
+        name: &str,
+        choice: VoteChoice,
+        actor_kind: ActorKind,
+        voice_kind: VoiceKind,
+        clock: &mut HybridClock,
+    ) -> Vote {
+        let (public_key, secret_key) = exo_core::crypto::generate_keypair();
+        let mut vote = Vote {
             voter_did: Did::new(&format!("did:exo:{name}")).expect("ok"),
-            choice: VoteChoice::Approve,
-            actor_kind: ActorKind::Human,
+            choice,
+            actor_kind,
             timestamp: clock.now().expect("HLC timestamp"),
-            signature_hash: Hash256::digest(name.as_bytes()),
-        }
+            signature_hash: Hash256::ZERO,
+            provenance: None,
+        };
+        let message = vote_signature_message(decision, &vote).expect("vote signing payload");
+        let signature = exo_core::crypto::sign(&message, &secret_key);
+        vote.signature_hash = Hash256::digest(&signature.to_bytes());
+        vote.provenance = Some(VoteProvenance {
+            public_key,
+            signature,
+            voice_kind,
+        });
+        vote
     }
 
-    fn ai_approve_vote(name: &str, clock: &mut HybridClock) -> Vote {
-        Vote {
-            voter_did: Did::new(&format!("did:exo:{name}")).expect("ok"),
-            choice: VoteChoice::Approve,
-            actor_kind: ActorKind::AiAgent {
+    fn human_approve_vote(decision: &DecisionObject, name: &str, clock: &mut HybridClock) -> Vote {
+        signed_vote(
+            decision,
+            name,
+            VoteChoice::Approve,
+            ActorKind::Human,
+            VoiceKind::Human,
+            clock,
+        )
+    }
+
+    fn ai_approve_vote(decision: &DecisionObject, name: &str, clock: &mut HybridClock) -> Vote {
+        signed_vote(
+            decision,
+            name,
+            VoteChoice::Approve,
+            ActorKind::AiAgent {
                 delegation_id: "d1".into(),
                 ceiling_class: DecisionClass::Operational,
             },
-            timestamp: clock.now().expect("HLC timestamp"),
-            signature_hash: Hash256::digest(name.as_bytes()),
-        }
+            VoiceKind::Synthetic,
+            clock,
+        )
     }
 
-    fn reject_vote(name: &str, clock: &mut HybridClock) -> Vote {
-        Vote {
-            voter_did: Did::new(&format!("did:exo:{name}")).expect("ok"),
-            choice: VoteChoice::Reject,
-            actor_kind: ActorKind::Human,
-            timestamp: clock.now().expect("HLC timestamp"),
-            signature_hash: Hash256::digest(name.as_bytes()),
-        }
+    fn reject_vote(decision: &DecisionObject, name: &str, clock: &mut HybridClock) -> Vote {
+        signed_vote(
+            decision,
+            name,
+            VoteChoice::Reject,
+            ActorKind::Human,
+            VoiceKind::Human,
+            clock,
+        )
     }
 
     fn make_decision(title: &str, class: DecisionClass, clock: &mut HybridClock) -> DecisionObject {
@@ -242,14 +303,39 @@ mod tests {
         .expect("valid decision")
     }
 
+    fn resolver_for_decision(decision: &DecisionObject) -> impl Fn(&Did) -> Option<PublicKey> {
+        let keys: BTreeMap<Did, PublicKey> = decision
+            .votes
+            .iter()
+            .filter_map(|vote| {
+                vote.provenance
+                    .as_ref()
+                    .map(|provenance| (vote.voter_did.clone(), provenance.public_key))
+            })
+            .collect();
+        move |did| keys.get(did).copied()
+    }
+
+    fn add_resolved_vote(decision: &mut DecisionObject, vote: Vote) -> Result<()> {
+        let voter_did = vote.voter_did.clone();
+        let public_key = vote
+            .provenance
+            .as_ref()
+            .map(|provenance| provenance.public_key);
+        decision.add_vote_with_key_resolver(vote, &move |did: &Did| {
+            if did == &voter_did { public_key } else { None }
+        })
+    }
+
     #[test]
     fn routine_quorum_met() {
         let mut clock = test_clock();
         let reg = QuorumRegistry::with_defaults();
         let mut d = make_decision("test", DecisionClass::Routine, &mut clock);
-        d.add_vote(human_approve_vote("alice", &mut clock))
-            .expect("ok");
-        match check_quorum(&reg, &d).expect("ok") {
+        let vote = human_approve_vote(&d, "alice", &mut clock);
+        add_resolved_vote(&mut d, vote).expect("ok");
+        let resolver = resolver_for_decision(&d);
+        match check_quorum_with_key_resolver(&reg, &d, &resolver).expect("ok") {
             QuorumCheckResult::Met { total_votes, .. } => assert_eq!(total_votes, 1),
             other => panic!("expected Met, got {other:?}"),
         }
@@ -260,9 +346,10 @@ mod tests {
         let mut clock = test_clock();
         let reg = QuorumRegistry::with_defaults();
         let mut d = make_decision("test", DecisionClass::Operational, &mut clock);
-        d.add_vote(human_approve_vote("alice", &mut clock))
-            .expect("ok");
-        match check_quorum(&reg, &d).expect("ok") {
+        let vote = human_approve_vote(&d, "alice", &mut clock);
+        add_resolved_vote(&mut d, vote).expect("ok");
+        let resolver = resolver_for_decision(&d);
+        match check_quorum_with_key_resolver(&reg, &d, &resolver).expect("ok") {
             QuorumCheckResult::Degraded {
                 available,
                 required,
@@ -280,11 +367,14 @@ mod tests {
         let mut clock = test_clock();
         let reg = QuorumRegistry::with_defaults();
         let mut d = make_decision("test", DecisionClass::Operational, &mut clock);
-        d.add_vote(human_approve_vote("alice", &mut clock))
-            .expect("ok");
-        d.add_vote(ai_approve_vote("bot1", &mut clock)).expect("ok");
-        d.add_vote(ai_approve_vote("bot2", &mut clock)).expect("ok");
-        match check_quorum(&reg, &d).expect("ok") {
+        let vote = human_approve_vote(&d, "alice", &mut clock);
+        add_resolved_vote(&mut d, vote).expect("ok");
+        let vote = ai_approve_vote(&d, "bot1", &mut clock);
+        add_resolved_vote(&mut d, vote).expect("ok");
+        let vote = ai_approve_vote(&d, "bot2", &mut clock);
+        add_resolved_vote(&mut d, vote).expect("ok");
+        let resolver = resolver_for_decision(&d);
+        match check_quorum_with_key_resolver(&reg, &d, &resolver).expect("ok") {
             QuorumCheckResult::Met {
                 total_votes,
                 approve_count,
@@ -302,11 +392,14 @@ mod tests {
         let mut clock = test_clock();
         let reg = QuorumRegistry::with_defaults();
         let mut d = make_decision("test", DecisionClass::Operational, &mut clock);
-        d.add_vote(human_approve_vote("alice", &mut clock))
-            .expect("ok");
-        d.add_vote(reject_vote("bob", &mut clock)).expect("ok");
-        d.add_vote(reject_vote("carol", &mut clock)).expect("ok");
-        match check_quorum(&reg, &d).expect("ok") {
+        let vote = human_approve_vote(&d, "alice", &mut clock);
+        add_resolved_vote(&mut d, vote).expect("ok");
+        let vote = reject_vote(&d, "bob", &mut clock);
+        add_resolved_vote(&mut d, vote).expect("ok");
+        let vote = reject_vote(&d, "carol", &mut clock);
+        add_resolved_vote(&mut d, vote).expect("ok");
+        let resolver = resolver_for_decision(&d);
+        match check_quorum_with_key_resolver(&reg, &d, &resolver).expect("ok") {
             QuorumCheckResult::NotMet { reason } => {
                 assert!(reason.contains("approval percentage"));
             }
@@ -320,14 +413,45 @@ mod tests {
         let reg = QuorumRegistry::with_defaults();
         let mut d = make_decision("test", DecisionClass::Strategic, &mut clock);
         for i in 0..5 {
-            d.add_vote(ai_approve_vote(&format!("bot{i}"), &mut clock))
-                .expect("ok");
+            let vote = ai_approve_vote(&d, &format!("bot{i}"), &mut clock);
+            add_resolved_vote(&mut d, vote).expect("ok");
         }
-        match check_quorum(&reg, &d).expect("ok") {
+        let resolver = resolver_for_decision(&d);
+        match check_quorum_with_key_resolver(&reg, &d, &resolver).expect("ok") {
             QuorumCheckResult::NotMet { reason } => {
                 assert!(reason.contains("human"));
             }
             other => panic!("expected NotMet, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn caller_asserted_human_votes_without_signature_evidence_do_not_satisfy_human_floor() {
+        let mut clock = test_clock();
+        let reg = QuorumRegistry::with_defaults();
+        let mut d = make_decision("test", DecisionClass::Strategic, &mut clock);
+
+        for i in 0..3 {
+            d.votes.push(Vote {
+                voter_did: Did::new(&format!("did:exo:forged-human-{i}")).expect("ok"),
+                choice: VoteChoice::Approve,
+                actor_kind: ActorKind::Human,
+                timestamp: clock.now().expect("HLC timestamp"),
+                signature_hash: Hash256::ZERO,
+                provenance: None,
+            });
+        }
+        for i in 0..5 {
+            let vote = ai_approve_vote(&d, &format!("bot{i}"), &mut clock);
+            add_resolved_vote(&mut d, vote).expect("ok");
+        }
+
+        let resolver = resolver_for_decision(&d);
+        match check_quorum_with_key_resolver(&reg, &d, &resolver).expect("ok") {
+            QuorumCheckResult::NotMet { reason } => {
+                assert_eq!(reason, "insufficient human votes: 0 < 3");
+            }
+            other => panic!("expected NotMet for unverified human votes, got {other:?}"),
         }
     }
 
@@ -380,9 +504,8 @@ mod tests {
             });
             let mut decision =
                 make_decision("invalid threshold", DecisionClass::Routine, &mut clock);
-            decision
-                .add_vote(human_approve_vote("alice", &mut clock))
-                .expect("vote accepted");
+            let vote = human_approve_vote(&decision, "alice", &mut clock);
+            add_resolved_vote(&mut decision, vote).expect("vote accepted");
 
             let err = check_quorum(&reg, &decision).expect_err("invalid threshold must fail");
             assert!(matches!(

--- a/crates/decision-forum/src/tnc_enforcer.rs
+++ b/crates/decision-forum/src/tnc_enforcer.rs
@@ -232,7 +232,7 @@ mod tests {
         provenance_signature_message,
         types::{
             AuthorityChain, AuthorityLink as GatekeeperAuthorityLink, BailmentState, ConsentRecord,
-            GovernmentBranch, PermissionSet, Provenance, Role, TrustedAuthorityKeys,
+            GovernmentBranch, PermissionSet, Provenance, Role, TrustedAuthorityKeys, VoiceKind,
         },
     };
     use uuid::Uuid;
@@ -283,6 +283,47 @@ mod tests {
         })
         .expect("ok");
         d
+    }
+
+    fn signed_ai_vote(
+        decision: &DecisionObject,
+        voter: &str,
+        delegation_id: &str,
+        ceiling_class: DecisionClass,
+        clock: &mut HybridClock,
+    ) -> Vote {
+        let (public_key, secret_key) = exo_core::crypto::generate_keypair();
+        let mut vote = Vote {
+            voter_did: Did::new(voter).expect("ok"),
+            choice: VoteChoice::Approve,
+            actor_kind: ActorKind::AiAgent {
+                delegation_id: delegation_id.into(),
+                ceiling_class,
+            },
+            timestamp: clock.now().expect("HLC timestamp"),
+            signature_hash: Hash256::ZERO,
+            provenance: None,
+        };
+        let message = vote_signature_message(decision, &vote).expect("vote signing payload");
+        let signature = exo_core::crypto::sign(&message, &secret_key);
+        vote.signature_hash = Hash256::digest(&signature.to_bytes());
+        vote.provenance = Some(VoteProvenance {
+            public_key,
+            signature,
+            voice_kind: VoiceKind::Synthetic,
+        });
+        vote
+    }
+
+    fn add_resolved_vote(decision: &mut DecisionObject, vote: Vote) -> Result<()> {
+        let voter_did = vote.voter_did.clone();
+        let public_key = vote
+            .provenance
+            .as_ref()
+            .map(|provenance| provenance.public_key);
+        decision.add_vote_with_key_resolver(vote, &move |did: &Did| {
+            if did == &voter_did { public_key } else { None }
+        })
     }
 
     fn signed_authority_link(
@@ -494,18 +535,14 @@ mod tests {
             timestamp: clock.now().expect("HLC timestamp"),
         })
         .expect("ok");
-        let ts = clock.now().expect("HLC timestamp");
-        d.add_vote(Vote {
-            voter_did: Did::new("did:exo:ai-bot").expect("ok"),
-            choice: VoteChoice::Approve,
-            actor_kind: ActorKind::AiAgent {
-                delegation_id: "d1".into(),
-                ceiling_class: DecisionClass::Operational,
-            },
-            timestamp: ts,
-            signature_hash: Hash256::ZERO,
-        })
-        .expect("ok");
+        let vote = signed_ai_vote(
+            &d,
+            "did:exo:ai-bot",
+            "d1",
+            DecisionClass::Operational,
+            &mut clock,
+        );
+        add_resolved_vote(&mut d, vote).expect("ok");
         let ctx = passing_ctx(&d);
         let err = enforce_tnc_09(&ctx).unwrap_err();
         assert!(matches!(err, ForumError::TncViolation { tnc_id: 9, .. }));
@@ -565,17 +602,14 @@ mod tests {
             timestamp: clock.now().expect("HLC timestamp"),
         })
         .expect("ok");
-        d.add_vote(Vote {
-            voter_did: Did::new("did:exo:ai-agent").expect("ok"),
-            choice: VoteChoice::Approve,
-            actor_kind: ActorKind::AiAgent {
-                delegation_id: "del-001".into(),
-                ceiling_class: DecisionClass::Operational, // self-declared
-            },
-            timestamp: clock.now().expect("HLC timestamp"),
-            signature_hash: Hash256::ZERO,
-        })
-        .expect("ok");
+        let vote = signed_ai_vote(
+            &d,
+            "did:exo:ai-agent",
+            "del-001",
+            DecisionClass::Operational,
+            &mut clock,
+        );
+        add_resolved_vote(&mut d, vote).expect("ok");
         let mut ctx = passing_ctx(&d);
         ctx.ai_ceilings_externally_verified = false; // not verified — fail-closed
         let err = enforce_tnc_09(&ctx).unwrap_err();
@@ -601,17 +635,14 @@ mod tests {
             timestamp: clock.now().expect("HLC timestamp"),
         })
         .expect("ok");
-        d.add_vote(Vote {
-            voter_did: Did::new("did:exo:ai-agent").expect("ok"),
-            choice: VoteChoice::Approve,
-            actor_kind: ActorKind::AiAgent {
-                delegation_id: "del-001".into(),
-                ceiling_class: DecisionClass::Routine,
-            },
-            timestamp: clock.now().expect("HLC timestamp"),
-            signature_hash: Hash256::ZERO,
-        })
-        .expect("ok");
+        let vote = signed_ai_vote(
+            &d,
+            "did:exo:ai-agent",
+            "del-001",
+            DecisionClass::Routine,
+            &mut clock,
+        );
+        add_resolved_vote(&mut d, vote).expect("ok");
         let mut ctx = passing_ctx(&d);
         ctx.ai_ceilings_externally_verified = false;
         assert!(enforce_tnc_09(&ctx).is_ok());
@@ -629,17 +660,14 @@ mod tests {
             timestamp: clock.now().expect("HLC timestamp"),
         })
         .expect("ok");
-        d.add_vote(Vote {
-            voter_did: Did::new("did:exo:ai-agent").expect("ok"),
-            choice: VoteChoice::Approve,
-            actor_kind: ActorKind::AiAgent {
-                delegation_id: "del-001".into(),
-                ceiling_class: DecisionClass::Operational,
-            },
-            timestamp: clock.now().expect("HLC timestamp"),
-            signature_hash: Hash256::ZERO,
-        })
-        .expect("ok");
+        let vote = signed_ai_vote(
+            &d,
+            "did:exo:ai-agent",
+            "del-001",
+            DecisionClass::Operational,
+            &mut clock,
+        );
+        add_resolved_vote(&mut d, vote).expect("ok");
         let mut ctx = passing_ctx(&d);
         ctx.ai_ceilings_externally_verified = true;
         assert!(enforce_tnc_09(&ctx).is_ok());
@@ -657,17 +685,14 @@ mod tests {
             timestamp: clock.now().expect("HLC timestamp"),
         })
         .expect("ok");
-        d.add_vote(Vote {
-            voter_did: Did::new("did:exo:ai-agent").expect("ok"),
-            choice: VoteChoice::Approve,
-            actor_kind: ActorKind::AiAgent {
-                delegation_id: "del-001".into(),
-                ceiling_class: DecisionClass::Operational, // registry says Operational
-            },
-            timestamp: clock.now().expect("HLC timestamp"),
-            signature_hash: Hash256::ZERO,
-        })
-        .expect("ok");
+        let vote = signed_ai_vote(
+            &d,
+            "did:exo:ai-agent",
+            "del-001",
+            DecisionClass::Operational,
+            &mut clock,
+        );
+        add_resolved_vote(&mut d, vote).expect("ok");
         let mut ctx = passing_ctx(&d);
         ctx.ai_ceilings_externally_verified = true;
         let err = enforce_tnc_09(&ctx).unwrap_err();

--- a/crates/exo-escalation/tests/sybil_adjudication.rs
+++ b/crates/exo-escalation/tests/sybil_adjudication.rs
@@ -295,7 +295,7 @@ fn quarantine_pauses_contested_actions_via_kernel() {
     let actor = did("did:exo:contested-actor");
     let action = ActionRequest {
         actor: actor.clone(),
-        action: "approve governance proposal".into(),
+        action: "data:governance:approve".into(),
         required_permissions: PermissionSet::new(vec![Permission::new("read")]),
         is_self_grant: false,
         modifies_kernel: false,

--- a/crates/exo-gateway/src/handlers.rs
+++ b/crates/exo-gateway/src/handlers.rs
@@ -5,7 +5,10 @@
 //!   2. Vote handler MUST call `Kernel::adjudicate` and gate on `Verdict::Permitted` (TNC-01)
 //!   3. `write_audit` MUST use `ciborium::into_writer` before blake3, not serde_json (TransparencyAccountability)
 
-use std::io::{self, Write};
+use std::{
+    collections::BTreeMap,
+    io::{self, Write},
+};
 
 use axum::{
     Json,
@@ -14,17 +17,18 @@ use axum::{
     response::IntoResponse,
 };
 use decision_forum::{
-    decision_object::{ActorKind, DecisionObject, Vote, VoteChoice},
-    quorum::{QuorumCheckResult, QuorumRegistry, check_quorum, verify_quorum_precondition},
+    decision_object::{ActorKind, DecisionObject, Vote, VoteChoice, VoteProvenance},
+    quorum::{QuorumCheckResult, QuorumRegistry, verify_quorum_precondition},
 };
-use exo_core::{Did, Signature, Timestamp, hash::hash_structured, types::Hash256};
+use exo_core::{Did, PublicKey, Signature, Timestamp, hash::hash_structured, types::Hash256};
 use exo_gatekeeper::{
     kernel::{ActionRequest as GatekeeperActionRequest, Verdict},
-    types::{Permission, PermissionSet, Provenance},
+    types::{Permission, PermissionSet, Provenance, VoiceKind},
 };
 use exo_governance::conflict::{
     ActionRequest as ConflictActionRequest, check_and_block, check_conflicts,
 };
+use exo_identity::did::DidDocument;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sqlx::Row;
@@ -34,8 +38,6 @@ use crate::server::{AppState, auth_boundary_error_response};
 // ── Violation 3 fix: CBOR canonical hashing ──────────────────────────────
 
 const MAX_CANONICAL_CBOR_HASH_BYTES: usize = 64 * 1024;
-const VOTE_SIGNATURE_HASH_DOMAIN: &str = "exo.gateway.vote_signature_hash.v1";
-const VOTE_SIGNATURE_HASH_SCHEMA_VERSION: u16 = 1;
 const VOTE_ACTION_PROVENANCE_HASH_DOMAIN: &str = "exo.gateway.vote_action_provenance.v1";
 const VOTE_ACTION_PROVENANCE_HASH_SCHEMA_VERSION: u16 = 1;
 
@@ -99,15 +101,6 @@ fn canonical_hash(payload: &Value) -> Result<blake3::Hash, String> {
 }
 
 #[derive(Serialize)]
-struct VoteSignatureHashInput<'a> {
-    domain: &'static str,
-    schema_version: u16,
-    voter_did: &'a Did,
-    decision_id: &'a str,
-    choice: &'static str,
-}
-
-#[derive(Serialize)]
 struct VoteActionHashInput<'a> {
     domain: &'static str,
     schema_version: u16,
@@ -129,23 +122,6 @@ fn vote_choice_label(choice: VoteChoice) -> &'static str {
         VoteChoice::Reject => "Reject",
         VoteChoice::Abstain => "Abstain",
     }
-}
-
-fn vote_signature_hash(
-    voter_did: &Did,
-    decision_id: &str,
-    choice: VoteChoice,
-) -> Result<Hash256, String> {
-    let payload = VoteSignatureHashInput {
-        domain: VOTE_SIGNATURE_HASH_DOMAIN,
-        schema_version: VOTE_SIGNATURE_HASH_SCHEMA_VERSION,
-        voter_did,
-        decision_id,
-        choice: vote_choice_label(choice),
-    };
-    Ok(Hash256::from_bytes(
-        *canonical_cbor_hash(&payload)?.as_bytes(),
-    ))
 }
 
 fn decode_fixed_hex<const N: usize>(encoded: &str, field: &str) -> Result<[u8; N], String> {
@@ -203,6 +179,82 @@ fn vote_action_provenance(
         independence: None,
         review_order: None,
     })
+}
+
+fn decode_multibase_ed25519_key(
+    encoded: &str,
+    field: &str,
+) -> std::result::Result<Option<[u8; 32]>, String> {
+    let Some(encoded) = encoded.strip_prefix('z') else {
+        return Ok(None);
+    };
+    let bytes = bs58::decode(encoded)
+        .into_vec()
+        .map_err(|e| format!("{field} is not valid base58btc: {e}"))?;
+    let key = bytes
+        .try_into()
+        .map_err(|bytes: Vec<u8>| format!("{field} must be 32 bytes, got {}", bytes.len()))?;
+    Ok(Some(key))
+}
+
+fn did_document_authorizes_vote_key(
+    doc: &DidDocument,
+    public_key: &PublicKey,
+) -> std::result::Result<bool, String> {
+    if doc.revoked {
+        return Ok(false);
+    }
+
+    if doc
+        .public_keys
+        .iter()
+        .any(|candidate| candidate == public_key)
+    {
+        return Ok(true);
+    }
+
+    for method in &doc.verification_methods {
+        if !method.active
+            || method.revoked_at.is_some()
+            || method.controller != doc.id
+            || method.key_type != "Ed25519VerificationKey2020"
+        {
+            continue;
+        }
+        let Some(key) =
+            decode_multibase_ed25519_key(&method.public_key_multibase, "verification method key")?
+        else {
+            continue;
+        };
+        if &key == public_key.as_bytes() {
+            return Ok(true);
+        }
+    }
+
+    for method in &doc.hybrid_verification_methods {
+        if !method.active
+            || method.revoked_at.is_some()
+            || method.controller != doc.id
+            || method.key_type != "HybridKeyEd25519MlDsa652020"
+        {
+            continue;
+        }
+        if method.classical_public_key == *public_key {
+            return Ok(true);
+        }
+        let Some(key) = decode_multibase_ed25519_key(
+            &method.classical_public_key_multibase,
+            "hybrid verification method classical key",
+        )?
+        else {
+            continue;
+        };
+        if &key == public_key.as_bytes() {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -361,6 +413,8 @@ pub struct VoteRequest {
     pub provenance_timestamp_logical: u32,
     pub provenance_public_key: String,
     pub provenance_signature: String,
+    pub vote_public_key: String,
+    pub vote_signature: String,
 }
 
 impl VoteRequest {
@@ -405,6 +459,27 @@ impl VoteRequest {
             &self.provenance_signature,
             "provenance_signature",
         )?))
+    }
+
+    fn vote_public_key(&self) -> Result<PublicKey, String> {
+        Ok(PublicKey::from_bytes(decode_fixed_hex(
+            &self.vote_public_key,
+            "vote_public_key",
+        )?))
+    }
+
+    fn vote_signature(&self) -> Result<Signature, String> {
+        Ok(Signature::from_bytes(decode_fixed_hex(
+            &self.vote_signature,
+            "vote_signature",
+        )?))
+    }
+
+    fn vote_voice_kind(&self) -> VoiceKind {
+        match self.actor_kind {
+            ActorKind::Human => VoiceKind::Human,
+            ActorKind::AiAgent { .. } => VoiceKind::Synthetic,
+        }
     }
 }
 
@@ -671,27 +746,126 @@ pub async fn vote_handler(
                 .into_response();
         }
     };
-    let signature_hash = match vote_signature_hash(&voter_did, &body.decision_id, body.choice) {
-        Ok(hash) => hash,
+    let vote_public_key = match body.vote_public_key() {
+        Ok(public_key) => public_key,
         Err(e) => {
-            tracing::error!(error = %e, "failed to hash vote signature payload");
             return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": "vote signature hash failed"})),
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": e})),
             )
                 .into_response();
         }
     };
+    let voter_document = match state.resolve_did_document_for_actor(&voter_did).await {
+        Ok(Some(doc)) => doc,
+        Ok(None) => {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(
+                    serde_json::json!({"error": "vote public key is not registered for voter DID"}),
+                ),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "failed to resolve voter DID document");
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({"error": "identity registry unavailable"})),
+            )
+                .into_response();
+        }
+    };
+    match did_document_authorizes_vote_key(&voter_document, &vote_public_key) {
+        Ok(true) => {}
+        Ok(false) => {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(
+                    serde_json::json!({"error": "vote public key is not registered for voter DID"}),
+                ),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "voter DID document contains invalid vote key material");
+            return (
+                StatusCode::FORBIDDEN,
+                Json(
+                    serde_json::json!({"error": "vote public key is not registered for voter DID"}),
+                ),
+            )
+                .into_response();
+        }
+    }
+    let mut resolved_vote_keys = BTreeMap::new();
+    for existing_vote in &decision.votes {
+        let Some(provenance) = existing_vote.provenance.as_ref() else {
+            continue;
+        };
+        let existing_doc = match state
+            .resolve_did_document_for_actor(&existing_vote.voter_did)
+            .await
+        {
+            Ok(Some(doc)) => doc,
+            Ok(None) => continue,
+            Err(e) => {
+                tracing::error!(
+                    error = %e,
+                    voter = %existing_vote.voter_did,
+                    "failed to resolve existing voter DID document"
+                );
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(serde_json::json!({"error": "identity registry unavailable"})),
+                )
+                    .into_response();
+            }
+        };
+        match did_document_authorizes_vote_key(&existing_doc, &provenance.public_key) {
+            Ok(true) => {
+                resolved_vote_keys.insert(existing_vote.voter_did.clone(), provenance.public_key);
+            }
+            Ok(false) => {}
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    voter = %existing_vote.voter_did,
+                    "existing voter DID document contains invalid vote key material"
+                );
+            }
+        }
+    }
+    resolved_vote_keys.insert(voter_did.clone(), vote_public_key);
+
+    let vote_signature = match body.vote_signature() {
+        Ok(signature) => signature,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": e})),
+            )
+                .into_response();
+        }
+    };
+    let resolve_vote_public_key = |did: &Did| resolved_vote_keys.get(did).copied();
+    let vote_voice_kind = body.vote_voice_kind();
+    let vote_signature_hash = Hash256::digest(&vote_signature.to_bytes());
     let vote = Vote {
         voter_did: voter_did.clone(),
         choice: body.choice,
         actor_kind: body.actor_kind,
         timestamp,
-        signature_hash,
+        signature_hash: vote_signature_hash,
+        provenance: Some(VoteProvenance {
+            public_key: vote_public_key,
+            signature: vote_signature,
+            voice_kind: vote_voice_kind,
+        }),
     };
 
     // Add vote — rejects duplicates (TNC-07 voter independence).
-    if let Err(e) = decision.add_vote(vote) {
+    if let Err(e) = decision.add_vote_with_key_resolver(vote, &resolve_vote_public_key) {
         tracing::error!(error = %e, "decision rejected vote");
         return (
             StatusCode::CONFLICT,
@@ -701,7 +875,11 @@ pub async fn vote_handler(
     }
 
     // Check quorum post-vote to include status in response.
-    let quorum_result = match check_quorum(&registry, &decision) {
+    let quorum_result = match decision_forum::quorum::check_quorum_with_key_resolver(
+        &registry,
+        &decision,
+        &resolve_vote_public_key,
+    ) {
         Ok(r) => r,
         Err(e) => {
             tracing::error!(error = %e, "quorum evaluation failed");
@@ -871,6 +1049,7 @@ mod tests {
             .map(|did| Did::new(did).expect("valid affected DID"))
             .collect::<Vec<_>>();
         let (public_key, secret_key) = exo_core::crypto::generate_keypair();
+        let (vote_public_key, vote_secret_key) = exo_core::crypto::generate_keypair();
         let provenance_timestamp = Timestamp::new(timestamp.physical_ms, timestamp.logical);
         let request = VoteRequest {
             decision_id: decision_id.to_owned(),
@@ -885,6 +1064,11 @@ mod tests {
             provenance_timestamp_logical: provenance_timestamp.logical,
             provenance_public_key: hex::encode(public_key.as_bytes()),
             provenance_signature: String::new(),
+            vote_public_key: hex::encode(vote_public_key.as_bytes()),
+            vote_signature: hex::encode(
+                exo_core::crypto::sign(b"unit-test-placeholder-vote-signature", &vote_secret_key)
+                    .to_bytes(),
+            ),
         };
         let action_hash =
             vote_action_hash(&request, &voter_did, &affected).expect("vote action hash");
@@ -916,6 +1100,8 @@ mod tests {
             "provenance_timestamp_logical": provenance_timestamp.logical,
             "provenance_public_key": hex::encode(public_key.as_bytes()),
             "provenance_signature": hex::encode(provenance.signature),
+            "vote_public_key": hex::encode(vote_public_key.as_bytes()),
+            "vote_signature": request.vote_signature,
         })
     }
 
@@ -959,26 +1145,6 @@ mod tests {
         assert!(
             err.contains("canonical CBOR payload exceeds"),
             "error should identify the canonical CBOR hash budget: {err}"
-        );
-    }
-
-    #[test]
-    fn vote_signature_hash_is_domain_separated_cbor() {
-        let voter = Did::new("did:exo:alice").expect("valid DID");
-
-        let first = vote_signature_hash(&voter, "decision-1", VoteChoice::Approve)
-            .expect("vote signature hash");
-        let second = vote_signature_hash(&voter, "decision-1", VoteChoice::Approve)
-            .expect("vote signature hash");
-        let changed_choice = vote_signature_hash(&voter, "decision-1", VoteChoice::Reject)
-            .expect("vote signature hash");
-        let legacy_debug_concat = Hash256::digest(b"did:exo:alice:decision-1:Approve");
-
-        assert_eq!(first, second);
-        assert_ne!(first, changed_choice);
-        assert_ne!(
-            first, legacy_debug_concat,
-            "vote signature_hash must not match the legacy raw concat/Debug preimage"
         );
     }
 
@@ -1308,6 +1474,26 @@ mod tests {
     }
 
     #[test]
+    fn vote_request_requires_decision_bound_vote_signature_material() {
+        let mut without_vote_signature = signed_vote_request_json(
+            "did:exo:alice",
+            "decision-1",
+            &["did:exo:tenant-a"],
+            VoteChoice::Approve,
+            ActorKind::Human,
+            exo_core::Timestamp::new(7000, 2),
+        );
+        let request_obj = without_vote_signature.as_object_mut().expect("object");
+        request_obj.remove("vote_public_key");
+        request_obj.remove("vote_signature");
+
+        assert!(
+            serde_json::from_value::<VoteRequest>(without_vote_signature).is_err(),
+            "vote requests must include decision-bound vote signature material"
+        );
+    }
+
+    #[test]
     fn vote_request_rejects_zero_timestamp() {
         let mut request_json = signed_vote_request_json(
             "did:exo:alice",
@@ -1509,7 +1695,7 @@ mod tests {
     }
 
     #[test]
-    fn vote_signature_hash_source_uses_canonical_cbor_not_debug_concat() {
+    fn vote_handler_uses_submitted_vote_signature_not_structural_hash() {
         let source = include_str!("handlers.rs");
         let production = source
             .split("#[cfg(test)]")
@@ -1524,8 +1710,12 @@ mod tests {
             .expect("vote handler source end");
 
         assert!(
-            vote_handler.contains("vote_signature_hash("),
-            "vote handler must route signature_hash construction through canonical helper"
+            vote_handler.contains("body.vote_signature()"),
+            "vote handler must require caller-submitted vote signatures"
+        );
+        assert!(
+            vote_handler.contains("Hash256::digest(&vote_signature.to_bytes())"),
+            "vote signature_hash must be the hash of the submitted signature"
         );
         assert!(
             !vote_handler.contains("format!(\"{}:{}:{:?}\""),

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -405,6 +405,13 @@ impl AppState {
             .map_err(|e| GatewayError::Internal(e.to_string()))
     }
 
+    /// Resolve a DID document from the gateway's trusted identity registry.
+    pub async fn resolve_did_document_for_actor(&self, did: &Did) -> Result<Option<DidDocument>> {
+        resolve_did_document(self, did.clone())
+            .await
+            .map_err(|e| GatewayError::Internal(format!("DID registry lookup failed: {e}")))
+    }
+
     /// Load conflict declarations for an actor from the DB-backed standing
     /// conflict register.
     pub async fn load_conflict_declarations(

--- a/crates/exo-gateway/tests/decision_forum_integration.rs
+++ b/crates/exo-gateway/tests/decision_forum_integration.rs
@@ -15,14 +15,18 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use decision_forum::{
     decision_object::{
         ActorKind, DecisionClass, DecisionObject, DecisionObjectInput, Vote, VoteChoice,
-        bcts_transition_action_name, bcts_transition_permission,
+        VoteProvenance, bcts_transition_action_name, bcts_transition_permission,
+        vote_signature_message,
     },
-    quorum::{QuorumCheckResult, QuorumRegistry, check_quorum, verify_quorum_precondition},
+    quorum::{
+        QuorumCheckResult, QuorumRegistry, check_quorum_with_key_resolver,
+        verify_quorum_precondition,
+    },
 };
 use exo_core::{
     bcts::BctsState,
     hlc::HybridClock,
-    types::{Did, Hash256},
+    types::{Did, Hash256, PublicKey},
 };
 use exo_gatekeeper::{
     authority_link_signature_message,
@@ -31,7 +35,7 @@ use exo_gatekeeper::{
     provenance_signature_message,
     types::{
         AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch, Permission,
-        PermissionSet, Provenance, Role, TrustedAuthorityKeys,
+        PermissionSet, Provenance, Role, TrustedAuthorityKeys, VoiceKind,
     },
 };
 
@@ -59,14 +63,65 @@ fn routine_decision(clock: &mut HybridClock) -> DecisionObject {
     .expect("valid decision")
 }
 
-fn human_approve(name: &str, clock: &mut HybridClock) -> Vote {
-    Vote {
+fn human_vote(
+    decision: &DecisionObject,
+    name: &str,
+    choice: VoteChoice,
+    clock: &mut HybridClock,
+) -> Vote {
+    let (public_key, secret_key) = exo_core::crypto::generate_keypair();
+    let mut vote = Vote {
         voter_did: did(&format!("did:exo:{name}")),
-        choice: VoteChoice::Approve,
+        choice,
         actor_kind: ActorKind::Human,
         timestamp: clock.now().expect("HLC timestamp"),
-        signature_hash: Hash256::digest(name.as_bytes()),
+        signature_hash: Hash256::ZERO,
+        provenance: None,
+    };
+    let message = vote_signature_message(decision, &vote).expect("vote signing payload");
+    let signature = exo_core::crypto::sign(&message, &secret_key);
+    vote.signature_hash = Hash256::digest(&signature.to_bytes());
+    vote.provenance = Some(VoteProvenance {
+        public_key,
+        signature,
+        voice_kind: VoiceKind::Human,
+    });
+    vote
+}
+
+fn human_approve(decision: &DecisionObject, name: &str, clock: &mut HybridClock) -> Vote {
+    human_vote(decision, name, VoteChoice::Approve, clock)
+}
+
+fn resolver_for_vote(vote: &Vote) -> impl Fn(&Did) -> Option<PublicKey> + use<> {
+    let voter_did = vote.voter_did.clone();
+    let public_key = vote
+        .provenance
+        .as_ref()
+        .map(|provenance| provenance.public_key);
+    move |did| {
+        if did == &voter_did { public_key } else { None }
     }
+}
+
+fn resolver_for_decision(decision: &DecisionObject) -> impl Fn(&Did) -> Option<PublicKey> + use<> {
+    let keys: std::collections::BTreeMap<Did, PublicKey> = decision
+        .votes
+        .iter()
+        .filter_map(|vote| {
+            vote.provenance
+                .as_ref()
+                .map(|provenance| (vote.voter_did.clone(), provenance.public_key))
+        })
+        .collect();
+    move |did| keys.get(did).copied()
+}
+
+fn add_resolved_vote(decision: &mut DecisionObject, vote: Vote) {
+    let resolver = resolver_for_vote(&vote);
+    decision
+        .add_vote_with_key_resolver(vote, &resolver)
+        .expect("vote should be accepted");
 }
 
 fn signed_authority_link(actor: &Did, permission: Permission) -> AuthorityLink {
@@ -190,12 +245,13 @@ fn vote_accepted_quorum_status_met() {
     );
 
     // Add the vote — must succeed.
-    decision
-        .add_vote(human_approve("alice", &mut clock))
-        .expect("vote should be accepted");
+    let vote = human_approve(&decision, "alice", &mut clock);
+    add_resolved_vote(&mut decision, vote);
 
     // Post-vote quorum check.
-    match check_quorum(&registry, &decision).expect("quorum check ok") {
+    let resolver = resolver_for_decision(&decision);
+    match check_quorum_with_key_resolver(&registry, &decision, &resolver).expect("quorum check ok")
+    {
         QuorumCheckResult::Met {
             total_votes,
             approve_count,
@@ -221,20 +277,12 @@ fn duplicate_voter_rejected() {
     let mut decision = routine_decision(&mut clock);
 
     // First vote from alice — must succeed.
-    decision
-        .add_vote(human_approve("alice", &mut clock))
-        .expect("first vote should be accepted");
+    let vote = human_approve(&decision, "alice", &mut clock);
+    add_resolved_vote(&mut decision, vote);
 
     // Second vote from the same DID — must fail.
-    let err = decision
-        .add_vote(Vote {
-            voter_did: did("did:exo:alice"),
-            choice: VoteChoice::Reject,
-            actor_kind: ActorKind::Human,
-            timestamp: clock.now().expect("HLC timestamp"),
-            signature_hash: Hash256::digest(b"alice-second"),
-        })
-        .unwrap_err();
+    let vote = human_vote(&decision, "alice", VoteChoice::Reject, &mut clock);
+    let err = decision.add_vote(vote).unwrap_err();
 
     assert!(
         err.to_string().contains("duplicate"),
@@ -275,9 +323,8 @@ fn terminal_decision_rejects_votes() {
     assert!(decision.is_terminal(), "decision must be in terminal state");
 
     // Attempting to vote on a closed decision must fail.
-    let err = decision
-        .add_vote(human_approve("bob", &mut clock))
-        .unwrap_err();
+    let vote = human_approve(&decision, "bob", &mut clock);
+    let err = decision.add_vote(vote).unwrap_err();
 
     assert!(
         err.to_string().contains("immutable") || err.to_string().contains("terminal"),

--- a/crates/exochain-wasm/src/decision_forum_bindings.rs
+++ b/crates/exochain-wasm/src/decision_forum_bindings.rs
@@ -101,15 +101,24 @@ pub fn wasm_transition_decision_adjudicated(
     to_js_value(&decision)
 }
 
-/// Add a vote to a DecisionObject
+/// Add a vote to a DecisionObject.
+///
+/// `public_keys_json` is a JSON array of `[did_str, public_key_hex]` trusted
+/// voter key pairs resolved by the embedding host.
 #[wasm_bindgen]
-pub fn wasm_add_vote(decision_json: &str, vote_json: &str) -> Result<JsValue, JsValue> {
+pub fn wasm_add_vote(
+    decision_json: &str,
+    vote_json: &str,
+    public_keys_json: &str,
+) -> Result<JsValue, JsValue> {
     let mut decision: decision_forum::decision_object::DecisionObject =
         from_json_str(decision_json)?;
     let vote: decision_forum::decision_object::Vote = from_json_str(vote_json)?;
+    let public_keys = parse_public_key_pairs(public_keys_json)?;
+    let resolver = |did: &exo_core::Did| public_keys.get(did).copied();
 
     decision
-        .add_vote(vote)
+        .add_vote_with_key_resolver(vote, &resolver)
         .map_err(|e| JsValue::from_str(&format!("Vote error: {e}")))?;
     to_js_value(&decision)
 }
@@ -511,11 +520,22 @@ pub fn wasm_collect_tnc_violations(
 
 /// Enforce the human gate for a decision — Err if human approval is required
 /// but not present in the vote set.
+///
+/// `public_keys_json` is a JSON array of `[did_str, public_key_hex]` trusted
+/// voter key pairs resolved by the embedding host.
 #[wasm_bindgen]
-pub fn wasm_enforce_human_gate(policy_json: &str, decision_json: &str) -> Result<JsValue, JsValue> {
+pub fn wasm_enforce_human_gate(
+    policy_json: &str,
+    decision_json: &str,
+    public_keys_json: &str,
+) -> Result<JsValue, JsValue> {
     let policy: decision_forum::human_gate::HumanGatePolicy = from_json_str(policy_json)?;
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    match decision_forum::human_gate::enforce_human_gate(&policy, &decision) {
+    let public_keys = parse_public_key_pairs(public_keys_json)?;
+    let resolver = |did: &exo_core::Did| public_keys.get(did).copied();
+    match decision_forum::human_gate::enforce_human_gate_with_key_resolver(
+        &policy, &decision, &resolver,
+    ) {
         Ok(()) => to_js_value(&serde_json::json!({"ok": true})),
         Err(e) => to_js_value(&serde_json::json!({"ok": false, "error": e.to_string()})),
     }
@@ -562,13 +582,20 @@ pub fn wasm_is_ai_vote(vote_json: &str) -> Result<bool, JsValue> {
 /// Returns `{status, total_votes, approve_count, approve_pct}` on Met,
 /// or `{status, reason}` on NotMet / Degraded.
 #[wasm_bindgen]
-pub fn wasm_check_quorum(registry_json: &str, decision_json: &str) -> Result<JsValue, JsValue> {
+pub fn wasm_check_quorum(
+    registry_json: &str,
+    decision_json: &str,
+    public_keys_json: &str,
+) -> Result<JsValue, JsValue> {
     use decision_forum::quorum::QuorumCheckResult;
 
     let registry: decision_forum::quorum::QuorumRegistry = from_json_str(registry_json)?;
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let result = decision_forum::quorum::check_quorum(&registry, &decision)
-        .map_err(|e| JsValue::from_str(&format!("Quorum error: {e}")))?;
+    let public_keys = parse_public_key_pairs(public_keys_json)?;
+    let resolver = |did: &exo_core::Did| public_keys.get(did).copied();
+    let result =
+        decision_forum::quorum::check_quorum_with_key_resolver(&registry, &decision, &resolver)
+            .map_err(|e| JsValue::from_str(&format!("Quorum error: {e}")))?;
 
     // QuorumCheckResult doesn't implement Serialize — flatten manually.
     let json = match result {

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -1820,7 +1820,7 @@ test('wasm_add_evidence', () => {
   return wasm.wasm_add_evidence(decJson, JSON.stringify(ev));
 });
 
-test('wasm_add_vote', () => {
+test('wasm_add_vote rejects unresolved vote provenance', () => {
   // decision_forum::decision_object::Vote
   const vote = {
     voter_did: TEST_DID,
@@ -1829,7 +1829,11 @@ test('wasm_add_vote', () => {
     timestamp: NOW_TS,
     signature_hash: ZERO_32_BYTES
   };
-  return wasm.wasm_add_vote(decJson, JSON.stringify(vote));
+  return expectErrorContains(
+    'wasm_add_vote',
+    () => wasm.wasm_add_vote(decJson, JSON.stringify(vote), JSON.stringify([])),
+    'signature'
+  );
 });
 
 test('wasm_transition_decision rejects unadjudicated transition', () =>
@@ -1889,7 +1893,8 @@ test('wasm_check_quorum', () => {
   };
   return wasm.wasm_check_quorum(
     JSON.stringify(registry),
-    decJson
+    decJson,
+    JSON.stringify([])
   );
 });
 
@@ -1903,7 +1908,8 @@ test('wasm_enforce_human_gate', () => {
   };
   return wasm.wasm_enforce_human_gate(
     JSON.stringify(policy),
-    decJson
+    decJson,
+    JSON.stringify([])
   );
 });
 


### PR DESCRIPTION
## Summary
- Adds decision-bound `VoteProvenance` and canonical vote signature verification in `decision-forum`, with fail-closed default behavior when voter DID public keys cannot be resolved from trusted identity state.
- Updates human gate and quorum counting so only resolver-verified votes count; caller-asserted `ActorKind::Human` no longer satisfies human floors or approval gates.
- Plumbs trusted voter-key resolution through the gateway REST vote adapter and WASM decision-forum bindings; updates bridge verification to expect unresolved vote provenance to fail closed.

## Path Classification
- EXOCHAIN core: `crates/decision-forum/src/decision_object.rs`, `crates/decision-forum/src/human_gate.rs`, `crates/decision-forum/src/quorum.rs`, `crates/decision-forum/src/tnc_enforcer.rs`.
- Core runtime adapter: `crates/exo-gateway/src/handlers.rs`, `crates/exo-gateway/src/server.rs`, `crates/exo-gateway/tests/decision_forum_integration.rs`, `crates/exochain-wasm/src/decision_forum_bindings.rs`, `packages/exochain-wasm/test/bridge_verification.mjs`.
- Core integration test fixture: `crates/exo-escalation/tests/sybil_adjudication.rs` updates stale consent-scope fixture data exposed by stricter current gates.
- Repo truth metadata: `README.md` updates generated Rust LOC.
- Imported evidence/adjacent surfaces/third-party: none edited.

## Verification
- Red tests confirmed the current issue before remediation:
  - `cargo test -p decision-forum add_vote_rejects_missing_signature_evidence -- --nocapture`
  - `cargo test -p decision-forum caller_asserted_human_without_signature_evidence_does_not_satisfy_gate -- --nocapture`
  - `cargo test -p decision-forum caller_asserted_human_votes_without_signature_evidence_do_not_satisfy_human_floor -- --nocapture`
  - `cargo test -p decision-forum add_vote_rejects_unresolved_voter_public_key -- --nocapture`
- `cargo test -p decision-forum -- --nocapture`
- `cargo test -p exo-gateway --test decision_forum_integration -- --nocapture`
- `cargo test -p exo-gateway --lib -- --nocapture`
- `cargo test -p exochain-wasm decision_forum -- --nocapture`
- `cargo check --workspace --all-targets`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --release`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check` (existing duplicate-crate warnings only; ended `advisories ok, bans ok, licenses ok, sources ok`)
- `wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm`
- `node packages/exochain-wasm/test/bridge_verification.mjs` (154/154 passed)
- `./tools/cross-impl-test/compare.sh` (TypeScript skipped because `EXO_TS_ROOT` unset; Rust/Node canonical vectors and Rust determinism passed)

## Follow-Up Triage Seeds
- Gateway session expiry appears to trust caller-supplied observed time in protected session paths.
- Public DID registration/enroll paths should be triaged for proof-of-possession before DID binding.
