### PR TITLE
fix(gatekeeper): bind provenance signatures to trusted actor keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 176440 | `wc -l` |
+| Rust LOC | 176847 | `wc -l` |
 | Workspace tests | 4,152 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -96,7 +96,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 176440 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 176847 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,152 listed workspace tests
 

--- a/crates/decision-forum/src/decision_object.rs
+++ b/crates/decision-forum/src/decision_object.rs
@@ -441,6 +441,7 @@ mod tests {
         types::{
             AuthorityChain, AuthorityLink as GatekeeperAuthorityLink, BailmentState, ConsentRecord,
             GovernmentBranch, PermissionSet, Provenance, Role, TrustedAuthorityKeys,
+            TrustedProvenanceKeys,
         },
     };
 
@@ -514,6 +515,11 @@ mod tests {
                 trusted_authority_keys.insert(link.grantor.clone(), vec![public_key.clone()]);
             }
         }
+        let provenance = signed_provenance(actor);
+        let mut trusted_provenance_keys = TrustedProvenanceKeys::default();
+        if let Some(public_key) = &provenance.public_key {
+            trusted_provenance_keys.insert(actor.clone(), vec![public_key.clone()]);
+        }
         AdjudicationContext {
             actor_roles: vec![Role {
                 name: "transition-judge".into(),
@@ -534,7 +540,8 @@ mod tests {
             human_override_preserved: true,
             actor_permissions: PermissionSet::new(vec![permission]),
             trusted_authority_keys,
-            provenance: Some(signed_provenance(actor)),
+            trusted_provenance_keys,
+            provenance: Some(provenance),
             quorum_evidence: None,
             active_challenge_reason: None,
         }

--- a/crates/decision-forum/src/tnc_enforcer.rs
+++ b/crates/decision-forum/src/tnc_enforcer.rs
@@ -233,6 +233,7 @@ mod tests {
         types::{
             AuthorityChain, AuthorityLink as GatekeeperAuthorityLink, BailmentState, ConsentRecord,
             GovernmentBranch, PermissionSet, Provenance, Role, TrustedAuthorityKeys,
+            TrustedProvenanceKeys,
         },
     };
     use uuid::Uuid;
@@ -345,6 +346,11 @@ mod tests {
                 trusted_authority_keys.insert(link.grantor.clone(), vec![public_key.clone()]);
             }
         }
+        let provenance = signed_provenance(actor);
+        let mut trusted_provenance_keys = TrustedProvenanceKeys::default();
+        if let Some(public_key) = &provenance.public_key {
+            trusted_provenance_keys.insert(actor.clone(), vec![public_key.clone()]);
+        }
         AdjudicationContext {
             actor_roles: vec![Role {
                 name: "transition-judge".into(),
@@ -365,7 +371,8 @@ mod tests {
             human_override_preserved: true,
             actor_permissions: PermissionSet::new(vec![permission]),
             trusted_authority_keys,
-            provenance: Some(signed_provenance(actor)),
+            trusted_provenance_keys,
+            provenance: Some(provenance),
             quorum_evidence: None,
             active_challenge_reason: None,
         }

--- a/crates/decision-forum/tests/governance_kernel_integration.rs
+++ b/crates/decision-forum/tests/governance_kernel_integration.rs
@@ -44,7 +44,7 @@ use exo_gatekeeper::{
     types::{
         AuthorityChain, AuthorityLink as GkAuthorityLink, BailmentState, ConsentRecord,
         GovernmentBranch, Permission, PermissionSet, Provenance, QuorumEvidence, QuorumVote, Role,
-        TrustedAuthorityKeys,
+        TrustedAuthorityKeys, TrustedProvenanceKeys,
     },
 };
 use uuid::Uuid;
@@ -187,6 +187,11 @@ fn valid_adj_context(actor: &Did) -> AdjudicationContext {
             trusted_authority_keys.insert(link.grantor.clone(), vec![public_key.clone()]);
         }
     }
+    let provenance = signed_provenance(actor);
+    let mut trusted_provenance_keys = TrustedProvenanceKeys::default();
+    if let Some(public_key) = &provenance.public_key {
+        trusted_provenance_keys.insert(actor.clone(), vec![public_key.clone()]);
+    }
     AdjudicationContext {
         actor_roles: vec![Role {
             name: "judge".into(),
@@ -207,7 +212,8 @@ fn valid_adj_context(actor: &Did) -> AdjudicationContext {
         human_override_preserved: true,
         actor_permissions: PermissionSet::new(vec![Permission::new("enact:decision")]),
         trusted_authority_keys,
-        provenance: Some(signed_provenance(actor)),
+        trusted_provenance_keys,
+        provenance: Some(provenance),
         quorum_evidence: None,
         active_challenge_reason: None,
     }

--- a/crates/exo-escalation/tests/sybil_adjudication.rs
+++ b/crates/exo-escalation/tests/sybil_adjudication.rs
@@ -30,7 +30,7 @@ use exo_gatekeeper::{
     provenance_signature_message,
     types::{
         AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch, Permission,
-        PermissionSet, Provenance, Role, TrustedAuthorityKeys,
+        PermissionSet, Provenance, Role, TrustedAuthorityKeys, TrustedProvenanceKeys,
     },
 };
 use exo_governance::{
@@ -146,6 +146,11 @@ fn valid_kernel_context(actor: &Did, challenge_reason: Option<String>) -> Adjudi
             trusted_authority_keys.insert(link.grantor.clone(), vec![public_key.clone()]);
         }
     }
+    let provenance = signed_provenance(actor);
+    let mut trusted_provenance_keys = TrustedProvenanceKeys::default();
+    if let Some(public_key) = &provenance.public_key {
+        trusted_provenance_keys.insert(actor.clone(), vec![public_key.clone()]);
+    }
     AdjudicationContext {
         actor_roles: vec![Role {
             name: "judge".into(),
@@ -166,7 +171,8 @@ fn valid_kernel_context(actor: &Did, challenge_reason: Option<String>) -> Adjudi
         human_override_preserved: true,
         actor_permissions: PermissionSet::new(vec![Permission::new("read")]),
         trusted_authority_keys,
-        provenance: Some(signed_provenance(actor)),
+        trusted_provenance_keys,
+        provenance: Some(provenance),
         quorum_evidence: None,
         active_challenge_reason: challenge_reason,
     }

--- a/crates/exo-gatekeeper/src/holon.rs
+++ b/crates/exo-gatekeeper/src/holon.rs
@@ -187,7 +187,7 @@ mod tests {
         link
     }
 
-    fn signed_provenance(actor: &Did) -> Provenance {
+    fn signed_provenance(actor: &Did) -> (Provenance, exo_core::PublicKey) {
         let (pk, sk) = exo_core::crypto::generate_keypair();
         let timestamp = "2025-01-01T00:00:00Z".to_owned();
         let action_hash = vec![1];
@@ -205,7 +205,7 @@ mod tests {
             provenance_signature_message(&provenance).expect("canonical provenance payload");
         let signature = exo_core::crypto::sign(message.as_bytes(), &sk);
         provenance.signature = signature.to_bytes().to_vec();
-        provenance
+        (provenance, pk)
     }
 
     fn test_kernel() -> Kernel {
@@ -230,6 +230,12 @@ mod tests {
                 trusted_authority_keys.insert(link.grantor.clone(), vec![public_key.clone()]);
             }
         }
+        let (provenance, provenance_public_key) = signed_provenance(actor);
+        let mut trusted_provenance_keys = TrustedProvenanceKeys::default();
+        trusted_provenance_keys.insert(
+            actor.clone(),
+            vec![provenance_public_key.as_bytes().to_vec()],
+        );
         AdjudicationContext {
             actor_roles: vec![Role {
                 name: "worker".into(),
@@ -250,7 +256,8 @@ mod tests {
             human_override_preserved: true,
             actor_permissions: PermissionSet::new(vec![Permission::new("read")]),
             trusted_authority_keys,
-            provenance: Some(signed_provenance(actor)),
+            trusted_provenance_keys,
+            provenance: Some(provenance),
             quorum_evidence: None,
             active_challenge_reason: None,
         }

--- a/crates/exo-gatekeeper/src/invariants.rs
+++ b/crates/exo-gatekeeper/src/invariants.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::{
     AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch, PermissionSet,
-    Provenance, QuorumEvidence, Role, TrustedAuthorityKeys,
+    Provenance, QuorumEvidence, Role, TrustedAuthorityKeys, TrustedProvenanceKeys,
 };
 
 // ---------------------------------------------------------------------------
@@ -101,6 +101,7 @@ pub struct InvariantContext {
     pub actor_permissions: PermissionSet,
     pub requested_permissions: PermissionSet,
     pub trusted_authority_keys: TrustedAuthorityKeys,
+    pub trusted_provenance_keys: TrustedProvenanceKeys,
 }
 
 // ---------------------------------------------------------------------------
@@ -564,6 +565,24 @@ fn check_provenance_verifiable(ctx: &InvariantContext) -> Result<(), InvariantVi
                         description: "Provenance public_key is not 32 bytes".into(),
                         evidence: vec![format!("key_len: {}", pk_bytes.len())],
                     })?;
+            let trusted_keys = ctx
+                .trusted_provenance_keys
+                .get(&prov.actor)
+                .ok_or_else(|| InvariantViolation {
+                    invariant: ConstitutionalInvariant::ProvenanceVerifiable,
+                    description: "Provenance public_key is unresolved for actor DID".into(),
+                    evidence: vec![format!("actor: {}", prov.actor)],
+                })?;
+            if !trusted_keys
+                .iter()
+                .any(|trusted_key| trusted_key.as_slice() == pk_bytes.as_slice())
+            {
+                return Err(InvariantViolation {
+                    invariant: ConstitutionalInvariant::ProvenanceVerifiable,
+                    description: "Provenance public_key is not bound to actor DID".into(),
+                    evidence: vec![format!("actor: {}", prov.actor)],
+                });
+            }
             let sig_arr: [u8; 64] =
                 prov.signature
                     .as_slice()
@@ -658,11 +677,16 @@ mod tests {
     fn passing_context() -> InvariantContext {
         let actor = did("did:exo:actor1");
         let (authority_link, authority_public_key) = signed_link("did:exo:root", actor.as_str());
-        let (provenance, _, _) = signed_provenance(actor.as_str());
+        let (provenance, provenance_public_key, _) = signed_provenance(actor.as_str());
         let mut trusted_authority_keys = TrustedAuthorityKeys::default();
         trusted_authority_keys.insert(
             authority_link.grantor.clone(),
             vec![authority_public_key.as_bytes().to_vec()],
+        );
+        let mut trusted_provenance_keys = TrustedProvenanceKeys::default();
+        trusted_provenance_keys.insert(
+            actor.clone(),
+            vec![provenance_public_key.as_bytes().to_vec()],
         );
         InvariantContext {
             actor: actor.clone(),
@@ -692,6 +716,7 @@ mod tests {
             actor_permissions: PermissionSet::new(vec![Permission::new("read")]),
             requested_permissions: PermissionSet::default(),
             trusted_authority_keys,
+            trusted_provenance_keys,
         }
     }
 
@@ -1461,6 +1486,42 @@ mod tests {
         );
     }
 
+    #[test]
+    fn provenance_validation_requires_trusted_actor_key_resolution() {
+        let source = production_source();
+        let checker = source
+            .split("fn check_provenance_verifiable")
+            .nth(1)
+            .and_then(|section| {
+                section
+                    .split("pub fn authority_link_signature_message")
+                    .next()
+            })
+            .expect("provenance invariant checker must exist");
+        let compact_checker = checker
+            .chars()
+            .filter(|ch| !ch.is_whitespace())
+            .collect::<String>();
+
+        assert!(
+            compact_checker.contains("ctx.trusted_provenance_keys"),
+            "ProvenanceVerifiable must consult runtime-resolved trusted actor keys"
+        );
+        assert!(
+            checker.contains("public_key is unresolved for actor DID"),
+            "ProvenanceVerifiable must fail closed when the actor DID has no resolved key"
+        );
+        assert!(
+            checker.contains("public_key is not bound to actor DID"),
+            "ProvenanceVerifiable must reject self-attested keys not bound to the actor DID"
+        );
+        assert!(
+            compact_checker.find("ctx.trusted_provenance_keys").unwrap()
+                < compact_checker.find("exo_core::crypto::verify").unwrap(),
+            "actor key binding must be checked before accepting the Ed25519 signature"
+        );
+    }
+
     fn signed_provenance(
         actor_str: &str,
     ) -> (Provenance, exo_core::PublicKey, exo_core::SecretKey) {
@@ -1484,15 +1545,57 @@ mod tests {
         (prov, pk, sk)
     }
 
+    fn trust_provenance_key(
+        ctx: &mut InvariantContext,
+        actor: Did,
+        public_key: &exo_core::PublicKey,
+    ) {
+        ctx.trusted_provenance_keys = TrustedProvenanceKeys::default();
+        ctx.trusted_provenance_keys
+            .insert(actor, vec![public_key.as_bytes().to_vec()]);
+    }
+
     #[test]
     fn provenance_passes_valid_ed25519_signature() {
         let engine = InvariantEngine::new(InvariantSet::with(vec![
             ConstitutionalInvariant::ProvenanceVerifiable,
         ]));
         let mut ctx = passing_context();
-        let (prov, _pk, _sk) = signed_provenance("did:exo:actor1");
+        let (prov, pk, _sk) = signed_provenance("did:exo:actor1");
+        trust_provenance_key(&mut ctx, prov.actor.clone(), &pk);
         ctx.provenance = Some(prov);
         assert!(enforce_all(&engine, &ctx).is_ok());
+    }
+
+    #[test]
+    fn provenance_rejects_unresolved_actor_public_key() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::ProvenanceVerifiable,
+        ]));
+        let mut ctx = passing_context();
+        let (prov, _pk, _sk) = signed_provenance("did:exo:actor1");
+        ctx.provenance = Some(prov);
+        ctx.trusted_provenance_keys = TrustedProvenanceKeys::default();
+
+        let err = enforce_all(&engine, &ctx).unwrap_err();
+        assert!(err[0].description.contains("unresolved for actor DID"));
+    }
+
+    #[test]
+    fn provenance_rejects_actor_public_key_not_bound_to_actor_did() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::ProvenanceVerifiable,
+        ]));
+        let mut ctx = passing_context();
+        let (prov, _pk, _sk) = signed_provenance("did:exo:actor1");
+        let (other_pk, _) = exo_core::crypto::generate_keypair();
+        ctx.provenance = Some(prov);
+        ctx.trusted_provenance_keys = TrustedProvenanceKeys::default();
+        ctx.trusted_provenance_keys
+            .insert(ctx.actor.clone(), vec![other_pk.as_bytes().to_vec()]);
+
+        let err = enforce_all(&engine, &ctx).unwrap_err();
+        assert!(err[0].description.contains("not bound to actor DID"));
     }
 
     #[test]
@@ -1501,7 +1604,8 @@ mod tests {
             ConstitutionalInvariant::ProvenanceVerifiable,
         ]));
         let mut ctx = passing_context();
-        let (mut prov, _pk, _sk) = signed_provenance("did:exo:actor1");
+        let (mut prov, pk, _sk) = signed_provenance("did:exo:actor1");
+        trust_provenance_key(&mut ctx, prov.actor.clone(), &pk);
         prov.signature[0] ^= 0xFF; // corrupt
         ctx.provenance = Some(prov);
         let err = enforce_all(&engine, &ctx).unwrap_err();
@@ -1517,6 +1621,7 @@ mod tests {
         let (mut prov, _pk, _sk) = signed_provenance("did:exo:actor1");
         let (other_pk, _) = exo_core::crypto::generate_keypair();
         prov.public_key = Some(other_pk.as_bytes().to_vec());
+        trust_provenance_key(&mut ctx, prov.actor.clone(), &other_pk);
         ctx.provenance = Some(prov);
         let err = enforce_all(&engine, &ctx).unwrap_err();
         assert!(err[0].description.contains("cryptographically invalid"));
@@ -1549,6 +1654,8 @@ mod tests {
         ]));
         let mut ctx = passing_context();
         let (pk, _sk) = exo_core::crypto::generate_keypair();
+        let actor = ctx.actor.clone();
+        trust_provenance_key(&mut ctx, actor, &pk);
         ctx.provenance = Some(Provenance {
             actor: ctx.actor.clone(),
             timestamp: "t".into(),
@@ -1571,6 +1678,7 @@ mod tests {
         let mut ctx = passing_context();
         let (pk, sk) = exo_core::crypto::generate_keypair();
         let actor = ctx.actor.clone();
+        trust_provenance_key(&mut ctx, actor.clone(), &pk);
         let action_hash = vec![0xde, 0xad, 0xbe, 0xef];
         let timestamp = "2026-01-01T00:00:00Z".to_string();
         let mut payload = Vec::new();

--- a/crates/exo-gatekeeper/src/kernel.rs
+++ b/crates/exo-gatekeeper/src/kernel.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     types::{
         AuthorityChain, BailmentState, ConsentRecord, PermissionSet, Provenance, QuorumEvidence,
-        Role, TrustedAuthorityKeys,
+        Role, TrustedAuthorityKeys, TrustedProvenanceKeys,
     },
 };
 
@@ -69,6 +69,7 @@ pub struct AdjudicationContext {
     pub human_override_preserved: bool,
     pub actor_permissions: PermissionSet,
     pub trusted_authority_keys: TrustedAuthorityKeys,
+    pub trusted_provenance_keys: TrustedProvenanceKeys,
     pub provenance: Option<Provenance>,
     pub quorum_evidence: Option<QuorumEvidence>,
     /// When set, the action is under an active Sybil challenge hold.
@@ -122,6 +123,7 @@ impl Kernel {
             actor_permissions: context.actor_permissions.clone(),
             requested_permissions: action.required_permissions.clone(),
             trusted_authority_keys: context.trusted_authority_keys.clone(),
+            trusted_provenance_keys: context.trusted_provenance_keys.clone(),
         };
 
         match enforce_all(&self.invariant_engine, &inv_ctx) {
@@ -220,7 +222,10 @@ mod tests {
     use super::*;
     use crate::{
         invariants::{authority_link_signature_message, provenance_signature_message},
-        types::{AuthorityLink, GovernmentBranch, Permission, QuorumVote, TrustedAuthorityKeys},
+        types::{
+            AuthorityLink, GovernmentBranch, Permission, QuorumVote, TrustedAuthorityKeys,
+            TrustedProvenanceKeys,
+        },
     };
 
     const CONSTITUTION: &[u8] = b"We the people of the EXOCHAIN...";
@@ -246,7 +251,7 @@ mod tests {
         link
     }
 
-    fn signed_provenance(actor: &Did) -> Provenance {
+    fn signed_provenance(actor: &Did) -> (Provenance, exo_core::PublicKey) {
         let (pk, sk) = exo_core::crypto::generate_keypair();
         let timestamp = "2025-01-01T00:00:00Z".to_owned();
         let action_hash = vec![1, 2, 3];
@@ -264,7 +269,7 @@ mod tests {
             provenance_signature_message(&provenance).expect("canonical provenance payload");
         let signature = exo_core::crypto::sign(message.as_bytes(), &sk);
         provenance.signature = signature.to_bytes().to_vec();
-        provenance
+        (provenance, pk)
     }
 
     fn test_kernel() -> Kernel {
@@ -291,6 +296,12 @@ mod tests {
                 trusted_authority_keys.insert(link.grantor.clone(), vec![public_key.clone()]);
             }
         }
+        let (provenance, provenance_public_key) = signed_provenance(actor);
+        let mut trusted_provenance_keys = TrustedProvenanceKeys::default();
+        trusted_provenance_keys.insert(
+            actor.clone(),
+            vec![provenance_public_key.as_bytes().to_vec()],
+        );
         AdjudicationContext {
             actor_roles: vec![Role {
                 name: "judge".into(),
@@ -311,7 +322,8 @@ mod tests {
             human_override_preserved: true,
             actor_permissions: PermissionSet::new(vec![Permission::new("read")]),
             trusted_authority_keys,
-            provenance: Some(signed_provenance(actor)),
+            trusted_provenance_keys,
+            provenance: Some(provenance),
             quorum_evidence: None,
             active_challenge_reason: None,
         }
@@ -532,6 +544,7 @@ mod tests {
                 human_override_preserved: true,
                 actor_permissions: PermissionSet::new(vec![Permission::new("vote")]),
                 trusted_authority_keys: TrustedAuthorityKeys::default(),
+                trusted_provenance_keys: TrustedProvenanceKeys::default(),
                 provenance: None,
                 quorum_evidence: None,
                 active_challenge_reason: None,

--- a/crates/exo-gatekeeper/src/types.rs
+++ b/crates/exo-gatekeeper/src/types.rs
@@ -286,6 +286,13 @@ pub struct AuthorityLink {
 /// resolved key material for the claimed grantor DID.
 pub type TrustedAuthorityKeys = BTreeMap<Did, Vec<Vec<u8>>>;
 
+/// DID-resolved Ed25519 public keys trusted for actor provenance.
+///
+/// Provenance objects still carry the key used for signature verification, but
+/// the invariant engine only accepts that key when it matches independently
+/// resolved key material for the claimed actor DID.
+pub type TrustedProvenanceKeys = BTreeMap<Did, Vec<Vec<u8>>>;
+
 // ---------------------------------------------------------------------------
 // Quorum evidence
 // ---------------------------------------------------------------------------

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -23,6 +23,7 @@ use exo_gatekeeper::{
     kernel::{ActionRequest as GkActionRequest, AdjudicationContext, Kernel, Verdict},
     types::{
         AuthorityChain, BailmentState, Permission, PermissionSet, Provenance, TrustedAuthorityKeys,
+        TrustedProvenanceKeys,
     },
 };
 use exo_governance::conflict::ConflictDeclaration;
@@ -488,6 +489,7 @@ fn deny_all_adjudication_context() -> AdjudicationContext {
         human_override_preserved: true,
         actor_permissions: PermissionSet::default(),
         trusted_authority_keys: TrustedAuthorityKeys::default(),
+        trusted_provenance_keys: TrustedProvenanceKeys::default(),
         provenance: None,
         quorum_evidence: None,
         active_challenge_reason: None,
@@ -1510,6 +1512,7 @@ fn build_adjudication_context_from_rows(
     consent_rows: &[crate::db::ConsentRecordRow],
     chain_row: Option<&crate::db::AuthorityChainRow>,
     trusted_authority_keys: TrustedAuthorityKeys,
+    trusted_provenance_keys: TrustedProvenanceKeys,
 ) -> Result<AdjudicationContext> {
     use exo_gatekeeper::types::{
         AuthorityChain as GkChain, BailmentState as GkBailment, ConsentRecord, GovernmentBranch,
@@ -1586,6 +1589,7 @@ fn build_adjudication_context_from_rows(
         human_override_preserved: true,
         actor_permissions,
         trusted_authority_keys,
+        trusted_provenance_keys,
         // Provenance is per-action, not per-actor; callers that need full
         // ProvenanceVerifiable enforcement must attach it before adjudication.
         provenance: None,
@@ -1620,7 +1624,7 @@ fn effective_authority_permissions(
 }
 
 #[cfg(feature = "production-db")]
-fn active_did_document_ed25519_keys(doc: &DidDocument) -> Result<Vec<Vec<u8>>> {
+fn active_did_document_ed25519_keys(doc: &DidDocument, key_context: &str) -> Result<Vec<Vec<u8>>> {
     let mut keys = Vec::new();
     for method in &doc.verification_methods {
         if !method.active
@@ -1634,19 +1638,19 @@ fn active_did_document_ed25519_keys(doc: &DidDocument) -> Result<Vec<Vec<u8>>> {
             .strip_prefix('z')
             .ok_or_else(|| {
                 GatewayError::Internal(format!(
-                    "authority grantor DID document key '{}' uses unsupported multibase prefix",
-                    method.id
+                    "{key_context} DID document key '{}' uses unsupported multibase prefix",
+                    method.id,
                 ))
             })?;
         let key = bs58::decode(encoded).into_vec().map_err(|e| {
             GatewayError::Internal(format!(
-                "authority grantor DID document key '{}' is not valid base58btc: {e}",
-                method.id
+                "{key_context} DID document key '{}' is not valid base58btc: {e}",
+                method.id,
             ))
         })?;
         if key.len() != 32 {
             return Err(GatewayError::Internal(format!(
-                "authority grantor DID document key '{}' is {} bytes, expected 32",
+                "{key_context} DID document key '{}' is {} bytes, expected 32",
                 method.id,
                 key.len()
             )));
@@ -1679,10 +1683,34 @@ async fn load_trusted_authority_keys(
         else {
             continue;
         };
-        let keys = active_did_document_ed25519_keys(&doc)?;
+        let keys = active_did_document_ed25519_keys(&doc, "authority grantor")?;
         if !keys.is_empty() {
             trusted_keys.insert(link.grantor.clone(), keys);
         }
+    }
+    Ok(trusted_keys)
+}
+
+#[cfg(feature = "production-db")]
+async fn load_trusted_provenance_keys(
+    pool: &sqlx::PgPool,
+    actor: &Did,
+) -> Result<TrustedProvenanceKeys> {
+    let mut trusted_keys = TrustedProvenanceKeys::default();
+    let Some(doc) = db::find_did_document(pool, actor.as_str())
+        .await
+        .map_err(|e| {
+            GatewayError::Internal(format!(
+                "provenance actor DID document lookup failed for '{}': {e}",
+                actor
+            ))
+        })?
+    else {
+        return Ok(trusted_keys);
+    };
+    let keys = active_did_document_ed25519_keys(&doc, "provenance actor")?;
+    if !keys.is_empty() {
+        trusted_keys.insert(actor.clone(), keys);
     }
     Ok(trusted_keys)
 }
@@ -1728,6 +1756,7 @@ async fn build_adjudication_context_from_db(
         }
         None => TrustedAuthorityKeys::default(),
     };
+    let trusted_provenance_keys = load_trusted_provenance_keys(pool, actor).await?;
 
     build_adjudication_context_from_rows(
         actor,
@@ -1735,6 +1764,7 @@ async fn build_adjudication_context_from_db(
         &consent_rows,
         chain_row.as_ref(),
         trusted_authority_keys,
+        trusted_provenance_keys,
     )
 }
 
@@ -3953,6 +3983,37 @@ mod tests {
     }
 
     #[test]
+    fn adjudication_db_context_resolves_provenance_actor_keys() {
+        let source = include_str!("server.rs");
+        let db_resolver = source
+            .split("async fn build_adjudication_context_from_db")
+            .nth(1)
+            .and_then(|section| section.split("// ---------------------------------------------------------------------------").next())
+            .expect("DB adjudication resolver source present");
+        let row_builder = source
+            .split("fn build_adjudication_context_from_rows")
+            .nth(1)
+            .and_then(|section| section.split("fn effective_authority_permissions").next())
+            .expect("DB row builder source present");
+
+        assert!(
+            db_resolver.contains("load_trusted_provenance_keys(pool, actor).await"),
+            "production DB adjudication must resolve trusted provenance actor keys from DID documents"
+        );
+        assert!(
+            row_builder.contains("trusted_provenance_keys"),
+            "DB row builder must carry resolved actor keys into AdjudicationContext"
+        );
+        assert!(
+            db_resolver.find("load_trusted_provenance_keys").unwrap()
+                < db_resolver
+                    .find("build_adjudication_context_from_rows")
+                    .unwrap(),
+            "trusted provenance keys must be resolved before returning the adjudication context"
+        );
+    }
+
+    #[test]
     fn shutdown_signal_setup_failures_are_not_silent_or_panicking() {
         let source = include_str!("server.rs");
         let shutdown_signal = source_between(
@@ -5440,6 +5501,7 @@ mod tests {
             &[],
             None,
             TrustedAuthorityKeys::default(),
+            TrustedProvenanceKeys::default(),
         )
         .expect_err("unknown role branch must be rejected")
         .to_string();
@@ -5469,6 +5531,7 @@ mod tests {
             &consent_rows,
             Some(&chain_row),
             TrustedAuthorityKeys::default(),
+            TrustedProvenanceKeys::default(),
         )
         .expect_err("malformed authority chain JSON must be rejected")
         .to_string();
@@ -8179,6 +8242,7 @@ mod tests {
     use exo_gatekeeper::{
         authority_link_signature_message,
         invariants::ConstitutionalInvariant,
+        provenance_signature_message,
         types::{
             AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch, Role,
         },
@@ -8248,6 +8312,26 @@ mod tests {
         trusted_keys
     }
 
+    fn signed_action_provenance_for_test(actor: &Did) -> (Provenance, TrustedProvenanceKeys) {
+        let (public_key, secret_key) = generate_keypair();
+        let mut provenance = Provenance {
+            actor: actor.clone(),
+            timestamp: Timestamp::new(1_700_000_000_000, 0).to_string(),
+            action_hash: Hash256::digest(b"advance_pace").as_bytes().to_vec(),
+            signature: Vec::new(),
+            public_key: Some(public_key.as_bytes().to_vec()),
+            voice_kind: None,
+            independence: None,
+            review_order: None,
+        };
+        let message = provenance_signature_message(&provenance)
+            .expect("canonical provenance signature payload");
+        provenance.signature = sign(message.as_bytes(), &secret_key).to_bytes().to_vec();
+        let mut trusted_provenance_keys = TrustedProvenanceKeys::default();
+        trusted_provenance_keys.insert(actor.clone(), vec![public_key.as_bytes().to_vec()]);
+        (provenance, trusted_provenance_keys)
+    }
+
     fn valid_db_context(actor: &Did) -> AdjudicationContext {
         let root = Did::new("did:exo:root-grantor").unwrap();
         let authority_chain = AuthorityChain {
@@ -8274,6 +8358,7 @@ mod tests {
             human_override_preserved: true,
             actor_permissions: PermissionSet::new(vec![Permission::new("vote")]),
             trusted_authority_keys,
+            trusted_provenance_keys: TrustedProvenanceKeys::default(),
             provenance: None,
             quorum_evidence: None,
             active_challenge_reason: None,
@@ -8359,6 +8444,7 @@ mod tests {
             &[],
             None,
             TrustedAuthorityKeys::default(),
+            TrustedProvenanceKeys::default(),
         );
 
         assert_internal_error_contains(result, "unknown role branch");
@@ -8375,6 +8461,7 @@ mod tests {
             &[],
             None,
             TrustedAuthorityKeys::default(),
+            TrustedProvenanceKeys::default(),
         );
 
         assert_internal_error_contains(result, "unknown governed role name");
@@ -8391,6 +8478,7 @@ mod tests {
             &[],
             None,
             TrustedAuthorityKeys::default(),
+            TrustedProvenanceKeys::default(),
         );
 
         assert_internal_error_contains(result, "does not match governed branch");
@@ -8407,6 +8495,7 @@ mod tests {
             &consent_rows,
             None,
             TrustedAuthorityKeys::default(),
+            TrustedProvenanceKeys::default(),
         );
 
         assert_internal_error_contains(result, "consent subject DID");
@@ -8428,6 +8517,7 @@ mod tests {
             &[],
             Some(&chain_row),
             TrustedAuthorityKeys::default(),
+            TrustedProvenanceKeys::default(),
         );
 
         assert_internal_error_contains(result, "authority chain JSON");
@@ -8451,6 +8541,7 @@ mod tests {
             &consent_rows,
             Some(&chain_row),
             valid_context.trusted_authority_keys.clone(),
+            valid_context.trusted_provenance_keys.clone(),
         )
         .unwrap();
         let verdict = kernel.adjudicate(&vote_action(&actor), &ctx);
@@ -8485,6 +8576,7 @@ mod tests {
             &consent_rows,
             Some(&chain_row),
             trusted_authority_keys,
+            TrustedProvenanceKeys::default(),
         )
         .unwrap();
         let verdict = kernel.adjudicate(&action_for_permission(&actor, "advance_pace"), &ctx);
@@ -8526,6 +8618,7 @@ mod tests {
             &consent_rows,
             Some(&chain_row),
             TrustedAuthorityKeys::default(),
+            TrustedProvenanceKeys::default(),
         )
         .unwrap();
         let verdict = kernel.adjudicate(&action_for_permission(&actor, "advance_pace"), &ctx);
@@ -8533,6 +8626,84 @@ mod tests {
         assert!(
             !verdict.is_permitted(),
             "DB-loaded authority chains must not trust self-attested unresolved grantor keys"
+        );
+    }
+
+    #[test]
+    fn adjudication_context_rows_reject_unresolved_provenance_actor_public_key() {
+        let kernel = Kernel::new(b"exochain-constitution-v1", InvariantSet::all());
+        let actor = Did::new("did:exo:pace-agent").unwrap();
+        let root = Did::new("did:exo:root-grantor").unwrap();
+        let authority_chain = AuthorityChain {
+            links: vec![signed_authority_link_for_permissions(
+                &root,
+                &actor,
+                PermissionSet::new(vec![Permission::new("advance_pace")]),
+            )],
+        };
+        let role_rows = vec![db_role_row(&actor, "worker", "executive")];
+        let consent_rows = vec![db_consent_row(&actor, root.as_str())];
+        let chain_row =
+            db_authority_chain_row(&actor, serde_json::to_value(&authority_chain).unwrap());
+        let trusted_authority_keys = trusted_authority_keys_for_test_chain(&authority_chain);
+        let (provenance, _trusted_provenance_keys) = signed_action_provenance_for_test(&actor);
+
+        let mut ctx = build_adjudication_context_from_rows(
+            &actor,
+            &role_rows,
+            &consent_rows,
+            Some(&chain_row),
+            trusted_authority_keys,
+            TrustedProvenanceKeys::default(),
+        )
+        .unwrap();
+        ctx.provenance = Some(provenance);
+        let verdict = kernel.adjudicate(&action_for_permission(&actor, "advance_pace"), &ctx);
+
+        match verdict {
+            Verdict::Denied { violations } => {
+                assert!(violations.iter().any(|violation| {
+                    violation.description.contains("unresolved for actor DID")
+                }))
+            }
+            other => panic!("unresolved provenance actor key must deny, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn adjudication_context_rows_permit_bound_provenance_actor_public_key() {
+        let kernel = Kernel::new(b"exochain-constitution-v1", InvariantSet::all());
+        let actor = Did::new("did:exo:pace-agent").unwrap();
+        let root = Did::new("did:exo:root-grantor").unwrap();
+        let authority_chain = AuthorityChain {
+            links: vec![signed_authority_link_for_permissions(
+                &root,
+                &actor,
+                PermissionSet::new(vec![Permission::new("advance_pace")]),
+            )],
+        };
+        let role_rows = vec![db_role_row(&actor, "worker", "executive")];
+        let consent_rows = vec![db_consent_row(&actor, root.as_str())];
+        let chain_row =
+            db_authority_chain_row(&actor, serde_json::to_value(&authority_chain).unwrap());
+        let trusted_authority_keys = trusted_authority_keys_for_test_chain(&authority_chain);
+        let (provenance, trusted_provenance_keys) = signed_action_provenance_for_test(&actor);
+
+        let mut ctx = build_adjudication_context_from_rows(
+            &actor,
+            &role_rows,
+            &consent_rows,
+            Some(&chain_row),
+            trusted_authority_keys,
+            trusted_provenance_keys,
+        )
+        .unwrap();
+        ctx.provenance = Some(provenance);
+        let verdict = kernel.adjudicate(&action_for_permission(&actor, "advance_pace"), &ctx);
+
+        assert!(
+            verdict.is_permitted(),
+            "DB-loaded action provenance must pass when its key is bound to actor DID"
         );
     }
 

--- a/crates/exo-gateway/tests/adjudication_db_integration.rs
+++ b/crates/exo-gateway/tests/adjudication_db_integration.rs
@@ -26,7 +26,7 @@ use exo_gatekeeper::{
     invariants::{ConstitutionalInvariant, InvariantSet},
     types::{
         AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch, Permission,
-        PermissionSet, Role, TrustedAuthorityKeys,
+        PermissionSet, Role, TrustedAuthorityKeys, TrustedProvenanceKeys,
     },
 };
 use exo_gateway::server::AppState;
@@ -131,6 +131,7 @@ fn full_db_context(actor: &Did) -> AdjudicationContext {
         human_override_preserved: true,
         actor_permissions: PermissionSet::new(vec![Permission::new("vote")]),
         trusted_authority_keys,
+        trusted_provenance_keys: TrustedProvenanceKeys::default(),
         provenance: None,
         quorum_evidence: None,
         active_challenge_reason: None,
@@ -282,6 +283,7 @@ fn revoked_consent_denies() {
         human_override_preserved: true,
         actor_permissions: PermissionSet::new(vec![Permission::new("vote")]),
         trusted_authority_keys,
+        trusted_provenance_keys: TrustedProvenanceKeys::default(),
         provenance: None,
         quorum_evidence: None,
         active_challenge_reason: None,

--- a/crates/exo-gateway/tests/decision_forum_integration.rs
+++ b/crates/exo-gateway/tests/decision_forum_integration.rs
@@ -31,7 +31,7 @@ use exo_gatekeeper::{
     provenance_signature_message,
     types::{
         AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch, Permission,
-        PermissionSet, Provenance, Role, TrustedAuthorityKeys,
+        PermissionSet, Provenance, Role, TrustedAuthorityKeys, TrustedProvenanceKeys,
     },
 };
 
@@ -125,6 +125,11 @@ fn transition_context(actor: &Did, from: BctsState, to: BctsState) -> Adjudicati
             trusted_authority_keys.insert(link.grantor.clone(), vec![public_key.clone()]);
         }
     }
+    let provenance = signed_provenance(actor);
+    let mut trusted_provenance_keys = TrustedProvenanceKeys::default();
+    if let Some(public_key) = &provenance.public_key {
+        trusted_provenance_keys.insert(actor.clone(), vec![public_key.clone()]);
+    }
     AdjudicationContext {
         actor_roles: vec![Role {
             name: "transition-judge".into(),
@@ -145,7 +150,8 @@ fn transition_context(actor: &Did, from: BctsState, to: BctsState) -> Adjudicati
         human_override_preserved: true,
         actor_permissions: PermissionSet::new(vec![permission]),
         trusted_authority_keys,
-        provenance: Some(signed_provenance(actor)),
+        trusted_provenance_keys,
+        provenance: Some(provenance),
         quorum_evidence: None,
         active_challenge_reason: None,
     }

--- a/crates/exo-legal/src/nist_compliance_tests.rs
+++ b/crates/exo-legal/src/nist_compliance_tests.rs
@@ -19,6 +19,7 @@ mod nist_compliance {
         types::{
             AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch,
             Permission, PermissionSet, Provenance, Role, TrustedAuthorityKeys,
+            TrustedProvenanceKeys,
         },
     };
     use exo_governance::audit::{self as gov_audit, AuditLog};
@@ -187,7 +188,7 @@ mod nist_compliance {
         link
     }
 
-    fn signed_provenance(actor: &Did) -> Provenance {
+    fn signed_provenance(actor: &Did) -> (Provenance, exo_core::PublicKey) {
         let (public_key, secret_key) = exo_core::crypto::generate_keypair();
         let timestamp = "2026-03-20T00:00:00Z".to_owned();
         let action_hash = vec![1, 2, 3];
@@ -206,7 +207,7 @@ mod nist_compliance {
             provenance_signature_message(&provenance).expect("canonical provenance payload");
         let signature = exo_core::crypto::sign(message.as_bytes(), &secret_key);
         provenance.signature = signature.to_bytes().to_vec();
-        provenance
+        (provenance, public_key)
     }
 
     /// Build a passing InvariantContext matching the pattern in invariants.rs tests.
@@ -221,6 +222,12 @@ mod nist_compliance {
                 trusted_authority_keys.insert(link.grantor.clone(), vec![public_key.clone()]);
             }
         }
+        let (provenance, provenance_public_key) = signed_provenance(actor);
+        let mut trusted_provenance_keys = TrustedProvenanceKeys::default();
+        trusted_provenance_keys.insert(
+            actor.clone(),
+            vec![provenance_public_key.as_bytes().to_vec()],
+        );
         InvariantContext {
             actor: actor.clone(),
             actor_roles: vec![Role {
@@ -243,10 +250,11 @@ mod nist_compliance {
             human_override_preserved: true,
             kernel_modification_attempted: false,
             quorum_evidence: None,
-            provenance: Some(signed_provenance(actor)),
+            provenance: Some(provenance),
             actor_permissions: PermissionSet::new(vec![Permission::new("read")]),
             requested_permissions: PermissionSet::default(),
             trusted_authority_keys,
+            trusted_provenance_keys,
         }
     }
 

--- a/crates/exo-node/src/holons.rs
+++ b/crates/exo-node/src/holons.rs
@@ -51,7 +51,7 @@ use exo_gatekeeper::{
     provenance_signature_message,
     types::{
         AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch, Permission,
-        PermissionSet, Provenance, Role, TrustedAuthorityKeys,
+        PermissionSet, Provenance, Role, TrustedAuthorityKeys, TrustedProvenanceKeys,
     },
 };
 use serde::Serialize;
@@ -411,6 +411,11 @@ pub fn build_holon_adjudication_context(
             trusted_authority_keys.insert(link.grantor.clone(), vec![public_key.clone()]);
         }
     }
+    let mut trusted_provenance_keys = TrustedProvenanceKeys::default();
+    trusted_provenance_keys.insert(
+        holon.id.clone(),
+        vec![config.root_public_key.as_bytes().to_vec()],
+    );
     Ok(AdjudicationContext {
         actor_roles: vec![Role {
             name: "worker".into(),
@@ -431,6 +436,7 @@ pub fn build_holon_adjudication_context(
         human_override_preserved: true,
         actor_permissions: holon.capabilities.clone(),
         trusted_authority_keys,
+        trusted_provenance_keys,
         provenance: Some(signed_provenance(holon, config, provenance_timestamp)?),
         quorum_evidence: None,
         active_challenge_reason: None,

--- a/crates/exo-node/src/mcp/middleware.rs
+++ b/crates/exo-node/src/mcp/middleware.rs
@@ -23,7 +23,9 @@ use exo_gatekeeper::{
     invariants::InvariantSet,
     kernel::{ActionRequest, AdjudicationContext, Kernel, Verdict},
     mcp::{self, McpContext, McpRule},
-    types::{BailmentState, Permission, PermissionSet, TrustedAuthorityKeys},
+    types::{
+        BailmentState, Permission, PermissionSet, TrustedAuthorityKeys, TrustedProvenanceKeys,
+    },
 };
 use serde::Serialize;
 use serde_json::Value;
@@ -31,7 +33,7 @@ use serde_json::Value;
 use super::{
     error::{McpError, Result},
     protocol::AI_OUTPUT_MARKING,
-    tools::authority::parse_verified_adjudication_context_with_trusted_authority_keys,
+    tools::authority::parse_verified_adjudication_context_with_trusted_keys,
 };
 
 const CONSTITUTIONAL_CONTEXT_FIELD: &str = "constitutional_context";
@@ -223,18 +225,21 @@ impl ConstitutionalMiddleware {
         Ok(())
     }
 
-    fn trusted_authority_keys(&self) -> Result<TrustedAuthorityKeys> {
+    fn trusted_context_keys(
+        &self,
+        actor_did: &Did,
+    ) -> Result<(TrustedAuthorityKeys, TrustedProvenanceKeys)> {
         let authority = self.authority.as_ref().ok_or_else(|| {
             McpError::ConstitutionalViolation(
                 "MCP authority signer is required for verified MCP invocation context".into(),
             )
         })?;
-        let mut keys = TrustedAuthorityKeys::default();
-        keys.insert(
-            authority.did.clone(),
-            vec![authority.public_key.as_bytes().to_vec()],
-        );
-        Ok(keys)
+        let public_key = authority.public_key.as_bytes().to_vec();
+        let mut trusted_authority_keys = TrustedAuthorityKeys::default();
+        trusted_authority_keys.insert(authority.did.clone(), vec![public_key.clone()]);
+        let mut trusted_provenance_keys = TrustedProvenanceKeys::default();
+        trusted_provenance_keys.insert(actor_did.clone(), vec![public_key]);
+        Ok((trusted_authority_keys, trusted_provenance_keys))
     }
 
     fn parse_invocation_context(
@@ -255,11 +260,13 @@ impl ConstitutionalMiddleware {
                 "verified MCP invocation context missing adjudication_context".into(),
             )
         })?;
-        let trusted_authority_keys = self.trusted_authority_keys()?;
-        let adjudication_context = parse_verified_adjudication_context_with_trusted_authority_keys(
+        let (trusted_authority_keys, trusted_provenance_keys) =
+            self.trusted_context_keys(actor_did)?;
+        let adjudication_context = parse_verified_adjudication_context_with_trusted_keys(
             adjudication_value,
             actor_did,
             trusted_authority_keys,
+            trusted_provenance_keys,
         )
         .map_err(|err| {
             McpError::ConstitutionalViolation(format!(

--- a/crates/exo-node/src/mcp/tools/authority.rs
+++ b/crates/exo-node/src/mcp/tools/authority.rs
@@ -18,7 +18,7 @@ use exo_gatekeeper::{
     kernel::{ActionRequest, AdjudicationContext, Kernel, Verdict},
     types::{
         AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch, Permission,
-        PermissionSet, Provenance, Role, TrustedAuthorityKeys,
+        PermissionSet, Provenance, Role, TrustedAuthorityKeys, TrustedProvenanceKeys,
     },
 };
 use serde_json::{Value, json};
@@ -240,6 +240,7 @@ fn validate_authority_chain(
         actor_permissions: PermissionSet::default(),
         requested_permissions: PermissionSet::default(),
         trusted_authority_keys: trusted_authority_keys.clone(),
+        trusted_provenance_keys: Default::default(),
     };
     match enforce_all(&engine, &context) {
         Ok(()) => Vec::new(),
@@ -347,17 +348,19 @@ pub(crate) fn parse_verified_adjudication_context(
     context_value: &Value,
     actor: &Did,
 ) -> Result<AdjudicationContext, String> {
-    parse_verified_adjudication_context_with_trusted_authority_keys(
+    parse_verified_adjudication_context_with_trusted_keys(
         context_value,
         actor,
         TrustedAuthorityKeys::default(),
+        TrustedProvenanceKeys::default(),
     )
 }
 
-pub(crate) fn parse_verified_adjudication_context_with_trusted_authority_keys(
+pub(crate) fn parse_verified_adjudication_context_with_trusted_keys(
     context_value: &Value,
     actor: &Did,
     trusted_authority_keys: TrustedAuthorityKeys,
+    trusted_provenance_keys: TrustedProvenanceKeys,
 ) -> Result<AdjudicationContext, String> {
     let actor_roles = parse_roles(context_value)?;
     let consent_records = parse_consent_records(context_value)?;
@@ -390,6 +393,7 @@ pub(crate) fn parse_verified_adjudication_context_with_trusted_authority_keys(
         human_override_preserved,
         actor_permissions,
         trusted_authority_keys,
+        trusted_provenance_keys,
         provenance: Some(provenance),
         quorum_evidence: None,
         active_challenge_reason: None,

--- a/crates/exochain-sdk/src/kernel.rs
+++ b/crates/exochain-sdk/src/kernel.rs
@@ -44,7 +44,7 @@ use exo_gatekeeper::{
     authority_link_signature_message, provenance_signature_message,
     types::{
         AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch, Permission,
-        PermissionSet, Provenance, Role, TrustedAuthorityKeys,
+        PermissionSet, Provenance, Role, TrustedAuthorityKeys, TrustedProvenanceKeys,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -514,6 +514,11 @@ impl ConstitutionalKernel {
                 trusted_authority_keys.insert(link.grantor.clone(), vec![public_key.clone()]);
             }
         }
+        let mut trusted_provenance_keys = TrustedProvenanceKeys::default();
+        trusted_provenance_keys.insert(
+            actor.clone(),
+            vec![authority.public_key.as_bytes().to_vec()],
+        );
 
         let context = AdjudicationContext {
             actor_roles: vec![Role {
@@ -526,6 +531,7 @@ impl ConstitutionalKernel {
             human_override_preserved,
             actor_permissions: permissions,
             trusted_authority_keys,
+            trusted_provenance_keys,
             provenance: Some(provenance),
             quorum_evidence: None,
             active_challenge_reason: None,

--- a/crates/exochain-wasm/src/gatekeeper_bindings.rs
+++ b/crates/exochain-wasm/src/gatekeeper_bindings.rs
@@ -29,6 +29,8 @@ struct WasmInvariantRequest {
     requested_permissions: exo_gatekeeper::types::PermissionSet,
     #[serde(default)]
     trusted_authority_keys: exo_gatekeeper::types::TrustedAuthorityKeys,
+    #[serde(default)]
+    trusted_provenance_keys: exo_gatekeeper::types::TrustedProvenanceKeys,
 }
 
 fn default_true() -> bool {
@@ -81,6 +83,7 @@ pub fn wasm_enforce_invariants(request_json: &str) -> Result<JsValue, JsValue> {
         actor_permissions: req.actor_permissions,
         requested_permissions: req.requested_permissions,
         trusted_authority_keys: req.trusted_authority_keys,
+        trusted_provenance_keys: req.trusted_provenance_keys,
     };
 
     let engine = exo_gatekeeper::InvariantEngine::all();
@@ -106,7 +109,7 @@ pub fn wasm_validation_invariant_request() -> Result<JsValue, JsValue> {
         authority_link_signature_message, provenance_signature_message,
         types::{
             AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, PermissionSet, Provenance,
-            TrustedAuthorityKeys,
+            TrustedAuthorityKeys, TrustedProvenanceKeys,
         },
     };
 
@@ -159,6 +162,11 @@ pub fn wasm_validation_invariant_request() -> Result<JsValue, JsValue> {
         grantor,
         vec![authority_keypair.public_key().as_bytes().to_vec()],
     );
+    let mut trusted_provenance_keys = TrustedProvenanceKeys::default();
+    trusted_provenance_keys.insert(
+        actor.clone(),
+        vec![provenance_keypair.public_key().as_bytes().to_vec()],
+    );
 
     to_js_value(&serde_json::json!({
         "actor": actor,
@@ -188,6 +196,7 @@ pub fn wasm_validation_invariant_request() -> Result<JsValue, JsValue> {
         "actor_permissions": permissions,
         "requested_permissions": PermissionSet::default(),
         "trusted_authority_keys": trusted_authority_keys,
+        "trusted_provenance_keys": trusted_provenance_keys,
     }))
 }
 
@@ -315,6 +324,11 @@ mod tests {
             provenance_signature_message(&provenance).expect("canonical provenance payload");
         let provenance_sig = exo_core::crypto::sign(provenance_message.as_bytes(), &provenance_sk);
         provenance.signature = provenance_sig.to_bytes().to_vec();
+        let mut trusted_provenance_keys = exo_gatekeeper::types::TrustedProvenanceKeys::default();
+        trusted_provenance_keys.insert(
+            provenance.actor.clone(),
+            vec![provenance_pk.as_bytes().to_vec()],
+        );
         let provenance = Some(provenance);
 
         InvariantContext {
@@ -336,6 +350,7 @@ mod tests {
             actor_permissions: PermissionSet::default(),
             requested_permissions: PermissionSet::default(),
             trusted_authority_keys,
+            trusted_provenance_keys,
         }
     }
 
@@ -487,6 +502,27 @@ mod tests {
         assert!(
             validation_fixture.contains("\"trusted_authority_keys\""),
             "validation invariant fixture must emit trusted authority keys for bridge verification"
+        );
+    }
+
+    #[test]
+    fn validation_invariant_request_includes_trusted_provenance_keys() {
+        let source = include_str!("gatekeeper_bindings.rs");
+        let validation_fixture = source
+            .split("pub fn wasm_validation_invariant_request")
+            .nth(1)
+            .expect("validation fixture is present")
+            .split("pub fn wasm_spawn_holon")
+            .next()
+            .expect("validation fixture body is bounded");
+
+        assert!(
+            validation_fixture.contains("TrustedProvenanceKeys"),
+            "validation invariant fixture must construct a trusted provenance key map"
+        );
+        assert!(
+            validation_fixture.contains("\"trusted_provenance_keys\""),
+            "validation invariant fixture must emit trusted provenance keys for bridge verification"
         );
     }
 }

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -1870,6 +1870,7 @@ test('wasm_transition_decision_adjudicated', () => {
       human_override_preserved: true,
       actor_permissions: { permissions: [transitionPermission] },
       trusted_authority_keys: {},
+      trusted_provenance_keys: {},
       provenance: null,
       quorum_evidence: null,
       active_challenge_reason: null


### PR DESCRIPTION
## Classification
- EXOCHAIN core: gatekeeper provenance invariant, kernel context, tests.
- Core runtime adapter: gateway DB adjudication context key resolution and advance-pace fixtures.

## Current Verification
- Rebased onto current main after #390 merged.
- Previous #391 was closed when its stacked base was consumed; this PR replaces it against main.

## Validation
- cargo test -p exo-gateway --features production-db --lib -- --nocapture
- cargo test -p exo-gateway --features production-db --lib agent_advance_pace_persists_agent_pace_status_after_kernel_permit -- --nocapture
- cargo test -p exo-gateway --features production-db --lib user_advance_pace_persists_user_pace_status_after_kernel_permit -- --nocapture
- cargo test -p exo-gateway --test adjudication_db_integration -- --nocapture
- cargo clippy -p exo-gateway -p exo-gatekeeper --all-targets --features production-db -- -D warnings
- cargo +nightly fmt --all -- --check
- bash tools/test_repo_truth.sh
- git diff --check HEAD~1..HEAD

Replaces closed PR #391.