### PR TITLE
fix(avc): verify issuer signatures before storing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 177353 | `wc -l` |
+| Rust LOC | 177568 | `wc -l` |
 | Workspace tests | 4,152 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -96,7 +96,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 177353 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 177568 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,152 listed workspace tests
 

--- a/crates/exo-avc/src/registry.rs
+++ b/crates/exo-avc/src/registry.rs
@@ -34,6 +34,8 @@ pub trait AvcRegistryRead {
 
 /// Mutating registry interface used by node API handlers and tests.
 pub trait AvcRegistryWrite: AvcRegistryRead {
+    /// Store a credential only after its issuer key resolves and its
+    /// issuer signature verifies against the canonical signing payload.
     fn put_credential(
         &mut self,
         credential: AutonomousVolitionCredential,
@@ -142,6 +144,41 @@ impl InMemoryAvcRegistry {
         Ok(())
     }
 
+    fn validate_credential(
+        &self,
+        credential: &AutonomousVolitionCredential,
+    ) -> Result<(), AvcError> {
+        if credential.signature.is_empty() {
+            return Err(AvcError::InvalidInput {
+                reason: format!(
+                    "credential signature for issuer {} must not be empty",
+                    credential.issuer_did
+                ),
+            });
+        }
+
+        let public_key = self
+            .public_keys
+            .get(&credential.issuer_did)
+            .ok_or_else(|| AvcError::InvalidInput {
+                reason: format!(
+                    "credential issuer key for {} is unresolved",
+                    credential.issuer_did
+                ),
+            })?;
+        let payload = credential.signing_payload()?;
+        if !crypto::verify(&payload, &credential.signature, public_key) {
+            return Err(AvcError::InvalidInput {
+                reason: format!(
+                    "credential signature for issuer {} is invalid",
+                    credential.issuer_did
+                ),
+            });
+        }
+
+        Ok(())
+    }
+
     /// Get the receipt with the given hash, if present.
     #[must_use]
     pub fn get_receipt(&self, receipt_hash: &Hash256) -> Option<AvcTrustReceipt> {
@@ -193,6 +230,7 @@ impl AvcRegistryWrite for InMemoryAvcRegistry {
         &mut self,
         credential: AutonomousVolitionCredential,
     ) -> Result<Hash256, AvcError> {
+        self.validate_credential(&credential)?;
         let id = credential.id()?;
         self.by_subject
             .entry(credential.subject_did.clone())
@@ -287,7 +325,14 @@ mod tests {
     }
 
     fn sample_credential() -> AutonomousVolitionCredential {
-        issue_avc(baseline_draft(), |_| fixed_signature()).unwrap()
+        let issuer = keypair(0x11);
+        issue_avc(baseline_draft(), |bytes| issuer.sign(bytes)).unwrap()
+    }
+
+    fn put_issuer_key(reg: &mut InMemoryAvcRegistry) -> KeyPair {
+        let issuer = keypair(0x11);
+        reg.put_public_key(did("issuer"), issuer.public);
+        issuer
     }
 
     fn register_sample_credential_and_issuer_key(
@@ -295,9 +340,8 @@ mod tests {
     ) -> (Hash256, KeyPair) {
         let cred = sample_credential();
         let id = cred.id().unwrap();
-        let issuer_keypair = keypair(0x11);
+        let issuer_keypair = put_issuer_key(reg);
         reg.put_credential(cred).unwrap();
-        reg.put_public_key(did("issuer"), issuer_keypair.public);
         (id, issuer_keypair)
     }
 
@@ -323,6 +367,7 @@ mod tests {
     #[test]
     fn put_get_credential_round_trips() {
         let mut reg = fresh_registry();
+        put_issuer_key(&mut reg);
         let cred = sample_credential();
         let id = reg.put_credential(cred.clone()).unwrap();
         assert_eq!(reg.get_credential(&id).unwrap(), cred);
@@ -330,14 +375,73 @@ mod tests {
     }
 
     #[test]
+    fn put_credential_rejects_empty_signature_without_storing() {
+        let mut reg = fresh_registry();
+        put_issuer_key(&mut reg);
+        let mut cred = sample_credential();
+        let id = cred.id().unwrap();
+        cred.signature = Signature::empty();
+
+        let err = reg.put_credential(cred).unwrap_err();
+        match err {
+            AvcError::InvalidInput { reason } => assert!(reason.contains("signature")),
+            other => panic!("expected invalid input for unsigned credential, got {other:?}"),
+        }
+        assert_eq!(reg.credential_count(), 0);
+        assert!(reg.get_credential(&id).is_none());
+    }
+
+    #[test]
+    fn put_credential_rejects_unresolved_issuer_key_without_storing() {
+        let mut reg = fresh_registry();
+        let cred = sample_credential();
+        let id = cred.id().unwrap();
+
+        let err = reg.put_credential(cred).unwrap_err();
+        match err {
+            AvcError::InvalidInput { reason } => {
+                assert!(reason.contains("issuer"));
+                assert!(reason.contains("unresolved"));
+            }
+            other => panic!("expected invalid input for unresolved issuer, got {other:?}"),
+        }
+        assert_eq!(reg.credential_count(), 0);
+        assert!(reg.get_credential(&id).is_none());
+    }
+
+    #[test]
+    fn put_credential_rejects_wrong_signature_key_without_storing() {
+        let mut reg = fresh_registry();
+        put_issuer_key(&mut reg);
+        let attacker = keypair(0x22);
+        let mut cred = sample_credential();
+        let payload = cred.signing_payload().unwrap();
+        cred.signature = attacker.sign(&payload);
+        let id = cred.id().unwrap();
+
+        let err = reg.put_credential(cred).unwrap_err();
+        match err {
+            AvcError::InvalidInput { reason } => {
+                assert!(reason.contains("signature"));
+                assert!(reason.contains("invalid"));
+            }
+            other => panic!("expected invalid input for wrong signer, got {other:?}"),
+        }
+        assert_eq!(reg.credential_count(), 0);
+        assert!(reg.get_credential(&id).is_none());
+    }
+
+    #[test]
     fn list_credentials_for_subject_returns_subject_only() {
         let mut reg = fresh_registry();
+        put_issuer_key(&mut reg);
         let cred1 = sample_credential();
         reg.put_credential(cred1.clone()).unwrap();
         // Add an unrelated subject
         let mut draft2 = baseline_draft();
         draft2.subject_did = did("agent-other");
-        let cred2 = issue_avc(draft2, |_| fixed_signature()).unwrap();
+        let issuer = keypair(0x11);
+        let cred2 = issue_avc(draft2, |bytes| issuer.sign(bytes)).unwrap();
         reg.put_credential(cred2).unwrap();
 
         let listed = reg.list_credentials_for_subject(&cred1.subject_did);
@@ -386,6 +490,7 @@ mod tests {
         let id = cred.id().unwrap();
         let attacker = did("attacker");
         let attacker_keypair = keypair(0x22);
+        put_issuer_key(&mut reg);
         reg.put_credential(cred).unwrap();
         reg.put_public_key(attacker.clone(), attacker_keypair.public);
 
@@ -428,11 +533,15 @@ mod tests {
     #[test]
     fn put_revocation_rejects_unresolved_revoker_key_without_marking_revoked() {
         let mut reg = fresh_registry();
-        let cred = sample_credential();
-        let id = cred.id().unwrap();
+        let mut draft = baseline_draft();
+        draft.principal_did = did("principal");
         let issuer_keypair = keypair(0x11);
+        let cred = issue_avc(draft, |bytes| issuer_keypair.sign(bytes)).unwrap();
+        let id = cred.id().unwrap();
+        reg.put_public_key(did("issuer"), issuer_keypair.public);
         reg.put_credential(cred).unwrap();
-        let revocation = sample_issuer_revocation(id, &issuer_keypair);
+        let principal_keypair = keypair(0x22);
+        let revocation = signed_revocation(id, did("principal"), &principal_keypair);
 
         let err = reg.put_revocation(revocation).unwrap_err();
         match err {

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -434,6 +434,112 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn issue_rejects_invalid_issuer_signature_without_storing_credential() {
+        let state = fresh_state();
+        let app = avc_router(Arc::clone(&state));
+        let mut credential = baseline_credential();
+        credential.delegated_intent.purpose = "tampered after signing".into();
+        let forged_id = credential.id().unwrap();
+        let body = serde_json::to_vec(&IssueRequest { credential }).unwrap();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/avc/issue")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let registry = state.registry.lock().unwrap();
+        assert_eq!(
+            registry.credential_count(),
+            0,
+            "invalid issuer signatures must not be stored"
+        );
+        assert!(
+            registry.get_credential(&forged_id).is_none(),
+            "forged credential id must remain absent"
+        );
+    }
+
+    #[tokio::test]
+    async fn issue_rejects_unknown_issuer_without_storing_credential() {
+        let state = fresh_state();
+        let app = avc_router(Arc::clone(&state));
+        let mut credential = baseline_credential();
+        credential.issuer_did = Did::new("did:exo:unknown-issuer").unwrap();
+        let forged_id = credential.id().unwrap();
+        let body = serde_json::to_vec(&IssueRequest { credential }).unwrap();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/avc/issue")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let registry = state.registry.lock().unwrap();
+        assert_eq!(
+            registry.credential_count(),
+            0,
+            "unresolved issuers must not be stored"
+        );
+        assert!(
+            registry.get_credential(&forged_id).is_none(),
+            "unknown-issuer credential id must remain absent"
+        );
+    }
+
+    #[tokio::test]
+    async fn delegate_rejects_invalid_child_signature_without_storing_credential() {
+        let state = fresh_state();
+        let app = avc_router(Arc::clone(&state));
+        let mut credential = baseline_credential();
+        credential.parent_avc_id = Some(Hash256::from_bytes([0x42; 32]));
+        credential.delegated_intent.purpose = "tampered delegated purpose".into();
+        let forged_id = credential.id().unwrap();
+        let body = serde_json::to_vec(&DelegateRequest {
+            child_credential: credential,
+        })
+        .unwrap();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/avc/delegate")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let registry = state.registry.lock().unwrap();
+        assert_eq!(
+            registry.credential_count(),
+            0,
+            "invalid delegated credentials must not be stored"
+        );
+        assert!(
+            registry.get_credential(&forged_id).is_none(),
+            "forged delegated credential id must remain absent"
+        );
+    }
+
+    #[tokio::test]
     async fn validate_returns_allow_for_valid_credential() {
         let state = fresh_state();
         let app = avc_router(Arc::clone(&state));


### PR DESCRIPTION
## Summary
- Classifies this as EXOCHAIN core plus core runtime adapter remediation.
- Confirms the current registry and issue/delegate routes accepted AVC credentials before issuer evidence was verified.
- Moves issuer public-key resolution and canonical signature verification into `InMemoryAvcRegistry::put_credential` so direct registry writers and HTTP routes share the fail-closed boundary.
- Adds regression coverage for empty signatures, unresolved issuer keys, wrong signing keys, issue-route forged credentials, unknown issuers, and delegate-route forged child credentials.
- Updates README repo-truth LOC derived from `tools/repo_truth.sh`.

## Validation
- RED confirmed: `cargo test -p exo-avc put_credential_rejects_unresolved_issuer_key_without_storing -- --nocapture` failed with `Ok` before the fix.
- RED confirmed: `cargo test -p exo-node issue_rejects_invalid_issuer_signature_without_storing_credential -- --nocapture` failed with HTTP 200 before the fix.
- `cargo test -p exo-avc -- --nocapture`
- `cargo test -p exo-node avc -- --nocapture`
- `cargo test -p exo-avc -p exo-node --all-targets`
- `cargo clippy -p exo-avc -p exo-node --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`

## Path Classification
- `crates/exo-avc/src/registry.rs`: EXOCHAIN core.
- `crates/exo-node/src/avc.rs`: core runtime adapter.
- `README.md`: repository truth documentation required by CI guard.
