### PR TITLE
fix(zerodentity): expire bearer sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 177568 | `wc -l` |
+| Rust LOC | 177768 | `wc -l` |
 | Workspace tests | 4,152 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -96,7 +96,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 177568 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 177768 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,152 listed workspace tests
 

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -891,9 +891,7 @@ async fn start_node(
     // Build 0dentity routers.
     let zd_onboarding_state =
         zerodentity::onboarding::OnboardingState::new(std::sync::Arc::clone(&zerodentity_store));
-    let zd_api_state = zerodentity::api::ApiState {
-        store: std::sync::Arc::clone(&zerodentity_store),
-    };
+    let zd_api_state = zerodentity::api::ApiState::new(std::sync::Arc::clone(&zerodentity_store));
     let zerodentity_onboarding_router =
         zerodentity::onboarding::onboarding_router(zd_onboarding_state);
     let zerodentity_api_router = zerodentity::api::zerodentity_api_router(zd_api_state);

--- a/crates/exo-node/src/zerodentity/api.rs
+++ b/crates/exo-node/src/zerodentity/api.rs
@@ -24,6 +24,7 @@ use axum::{
 };
 use exo_core::{
     crypto,
+    hlc::HybridClock,
     types::{Did, Hash256, PublicKey, Signature, Timestamp},
 };
 use serde::{Deserialize, Serialize};
@@ -49,6 +50,36 @@ use super::{
 #[derive(Clone)]
 pub struct ApiState {
     pub store: Arc<Mutex<ZerodentityStore>>,
+    clock: Arc<Mutex<HybridClock>>,
+}
+
+impl ApiState {
+    #[must_use]
+    pub fn new(store: Arc<Mutex<ZerodentityStore>>) -> Self {
+        Self::new_with_clock(store, HybridClock::new())
+    }
+
+    #[must_use]
+    pub fn new_with_clock(store: Arc<Mutex<ZerodentityStore>>, clock: HybridClock) -> Self {
+        Self {
+            store,
+            clock: Arc::new(Mutex::new(clock)),
+        }
+    }
+
+    fn now_ms(&self) -> ApiResult<u64> {
+        let mut clock = self
+            .clock
+            .lock()
+            .map_err(|_| json_error(StatusCode::INTERNAL_SERVER_ERROR, "Clock lock error"))?;
+        clock
+            .now()
+            .map(|timestamp| timestamp.physical_ms)
+            .map_err(|err| {
+                tracing::error!(error = %err, "0dentity API HLC exhausted");
+                json_error(StatusCode::INTERNAL_SERVER_ERROR, "Clock exhausted")
+            })
+    }
 }
 
 type ApiError = (StatusCode, Json<serde_json::Value>);
@@ -244,6 +275,15 @@ where
     })?
 }
 
+async fn now_ms_blocking(state: ApiState) -> ApiResult<u64> {
+    tokio::task::spawn_blocking(move || state.now_ms())
+        .await
+        .map_err(|e| {
+            tracing::error!(err = %e, "0dentity API clock task failed");
+            json_error(StatusCode::INTERNAL_SERVER_ERROR, "Clock task failed")
+        })?
+}
+
 fn path_and_query(uri: &axum::http::Uri) -> String {
     uri.path_and_query()
         .map_or_else(|| uri.path().to_owned(), |value| value.as_str().to_owned())
@@ -287,10 +327,11 @@ async fn verify_signed_write_blocking(
     let token = extract_session_token(headers)
         .ok_or_else(|| json_error(StatusCode::UNAUTHORIZED, "Bearer session token required"))?;
 
+    let now_ms = now_ms_blocking(state.clone()).await?;
     let headers = headers.clone();
     with_store_blocking(state, move |store| {
         let session = store
-            .get_session(&token)
+            .get_session(&token, now_ms)
             .map_err(store_error)?
             .ok_or_else(|| json_error(StatusCode::UNAUTHORIZED, "Invalid or expired session"))?;
 
@@ -573,10 +614,11 @@ pub async fn list_claims(
         )
     })?;
 
+    let now_ms = now_ms_blocking(state.clone()).await?;
     let response = with_store_blocking(state, move |store| {
         // Verify session belongs to this DID.
         let session = store
-            .get_session(&token)
+            .get_session(&token, now_ms)
             .map_err(store_error)?
             .ok_or_else(|| {
                 (
@@ -694,9 +736,10 @@ pub async fn list_fingerprints(
         )
     })?;
 
+    let now_ms = now_ms_blocking(state.clone()).await?;
     let response = with_store_blocking(state, move |store| {
         let session = store
-            .get_session(&token)
+            .get_session(&token, now_ms)
             .map_err(store_error)?
             .ok_or_else(|| {
                 (
@@ -969,8 +1012,12 @@ mod tests {
     use crate::zerodentity::{
         attestation::attestation_signing_payload,
         store::{ZerodentityReadFailure, ZerodentityStore},
-        types::{ClaimStatus, ClaimType, IdentityClaim, IdentitySession},
+        types::{ClaimStatus, ClaimType, IDENTITY_SESSION_TTL_MS, IdentityClaim, IdentitySession},
     };
+
+    const API_TEST_NOW_MS: u64 = 1_700_000_000_000;
+    const API_TEST_ACTIVE_SESSION_CREATED_MS: u64 = API_TEST_NOW_MS - 1_000;
+    const API_TEST_EXPIRED_SESSION_CREATED_MS: u64 = API_TEST_NOW_MS - IDENTITY_SESSION_TTL_MS - 1;
 
     fn test_store() -> ZerodentityStore {
         let keypair = KeyPair::from_secret_bytes([31u8; 32]).unwrap();
@@ -980,19 +1027,22 @@ mod tests {
         store
     }
 
+    fn test_api_state(store: ZerodentityStore) -> ApiState {
+        ApiState::new_with_clock(
+            Arc::new(Mutex::new(store)),
+            HybridClock::with_wall_clock(|| API_TEST_NOW_MS),
+        )
+    }
+
     fn make_state() -> ApiState {
-        ApiState {
-            store: Arc::new(Mutex::new(test_store())),
-        }
+        test_api_state(test_store())
     }
 
     #[tokio::test]
     async fn get_score_redacts_store_read_errors() {
         let mut store = test_store();
         store.inject_read_failure(ZerodentityReadFailure::Claims);
-        let app = zerodentity_api_router(ApiState {
-            store: Arc::new(Mutex::new(store)),
-        });
+        let app = zerodentity_api_router(test_api_state(store));
 
         let resp = app
             .oneshot(
@@ -1124,31 +1174,41 @@ mod tests {
     }
 
     fn make_state_with_session(token: &str, did_str: &str) -> ApiState {
+        make_state_with_session_at(token, did_str, API_TEST_ACTIVE_SESSION_CREATED_MS)
+    }
+
+    fn make_state_with_session_at(token: &str, did_str: &str, created_ms: u64) -> ApiState {
         let mut store = test_store();
         let did = Did::new(did_str).unwrap();
         let session = IdentitySession {
             session_token: token.to_owned(),
             subject_did: did,
             public_key: vec![],
-            created_ms: 0,
-            last_active_ms: 0,
+            created_ms,
+            last_active_ms: created_ms,
             revoked: false,
         };
         store.insert_session(&session).unwrap();
-        ApiState {
-            store: Arc::new(Mutex::new(store)),
-        }
+        test_api_state(store)
     }
 
     fn make_state_with_session_and_claim(token: &str, did_str: &str) -> ApiState {
+        make_state_with_session_and_claim_at(token, did_str, API_TEST_ACTIVE_SESSION_CREATED_MS)
+    }
+
+    fn make_state_with_session_and_claim_at(
+        token: &str,
+        did_str: &str,
+        created_ms: u64,
+    ) -> ApiState {
         let mut store = test_store();
         let did = Did::new(did_str).unwrap();
         let session = IdentitySession {
             session_token: token.to_owned(),
             subject_did: did.clone(),
             public_key: vec![],
-            created_ms: 0,
-            last_active_ms: 0,
+            created_ms,
+            last_active_ms: created_ms,
             revoked: false,
         };
         store.insert_session(&session).unwrap();
@@ -1164,9 +1224,7 @@ mod tests {
             dag_node_hash: Hash256::digest(b"dag-node"),
         };
         store.insert_claim("claim-001", &claim).unwrap();
-        ApiState {
-            store: Arc::new(Mutex::new(store)),
-        }
+        test_api_state(store)
     }
 
     fn make_state_with_session_and_claims(
@@ -1180,8 +1238,8 @@ mod tests {
             session_token: token.to_owned(),
             subject_did: did.clone(),
             public_key: vec![],
-            created_ms: 0,
-            last_active_ms: 0,
+            created_ms: API_TEST_ACTIVE_SESSION_CREATED_MS,
+            last_active_ms: API_TEST_ACTIVE_SESSION_CREATED_MS,
             revoked: false,
         };
         store.insert_session(&session).unwrap();
@@ -1203,9 +1261,7 @@ mod tests {
                 .unwrap();
         }
 
-        ApiState {
-            store: Arc::new(Mutex::new(store)),
-        }
+        test_api_state(store)
     }
 
     fn make_state_with_score_history(did_str: &str, timestamps: &[u64]) -> ApiState {
@@ -1215,9 +1271,7 @@ mod tests {
             store.put_score(ZerodentityScore::compute(&did, &[], &[], &[], *timestamp));
         }
 
-        ApiState {
-            store: Arc::new(Mutex::new(store)),
-        }
+        test_api_state(store)
     }
 
     fn make_state_with_signed_session_and_claim(
@@ -1225,14 +1279,28 @@ mod tests {
         did_str: &str,
         keypair: &KeyPair,
     ) -> ApiState {
+        make_state_with_signed_session_and_claim_at(
+            token,
+            did_str,
+            keypair,
+            API_TEST_ACTIVE_SESSION_CREATED_MS,
+        )
+    }
+
+    fn make_state_with_signed_session_and_claim_at(
+        token: &str,
+        did_str: &str,
+        keypair: &KeyPair,
+        created_ms: u64,
+    ) -> ApiState {
         let mut store = test_store();
         let did = Did::new(did_str).unwrap();
         let session = IdentitySession {
             session_token: token.to_owned(),
             subject_did: did.clone(),
             public_key: keypair.public_key().as_bytes().to_vec(),
-            created_ms: 0,
-            last_active_ms: 0,
+            created_ms,
+            last_active_ms: created_ms,
             revoked: false,
         };
         store.insert_session(&session).unwrap();
@@ -1248,9 +1316,7 @@ mod tests {
             dag_node_hash: Hash256::digest(b"dag-node"),
         };
         store.insert_claim("claim-001", &claim).unwrap();
-        ApiState {
-            store: Arc::new(Mutex::new(store)),
-        }
+        test_api_state(store)
     }
 
     fn request_signature_headers(
@@ -1727,6 +1793,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn list_claims_rejects_expired_session() {
+        let state = make_state_with_session_and_claim_at(
+            "tok-expired",
+            "did:exo:alice",
+            API_TEST_EXPIRED_SESSION_CREATED_MS,
+        );
+        let app = zerodentity_api_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/0dentity/did%3Aexo%3Aalice/claims")
+                    .header("authorization", "Bearer tok-expired")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["error"], "Invalid or expired session");
+    }
+
+    #[tokio::test]
     async fn list_claims_pagination_with_offset() {
         let state = make_state_with_session_and_claim("tok-alice", "did:exo:alice");
         let app = zerodentity_api_router(state);
@@ -1843,6 +1934,29 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn delete_identity_rejects_expired_session_before_erasure() {
+        let keypair = test_keypair(44);
+        let state = make_state_with_signed_session_and_claim_at(
+            "tok-expired",
+            "did:exo:alice",
+            &keypair,
+            API_TEST_EXPIRED_SESSION_CREATED_MS,
+        );
+        let app = zerodentity_api_router(state);
+        let resp = signed_delete(
+            app,
+            "/api/v1/0dentity/did%3Aexo%3Aalice",
+            "tok-expired",
+            "nonce-api-delete-expired",
+            serde_json::json!({ "erased_ms": 7_777_000 }),
+            &keypair,
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]

--- a/crates/exo-node/src/zerodentity/store.rs
+++ b/crates/exo-node/src/zerodentity/store.rs
@@ -568,12 +568,16 @@ impl ZerodentityStore {
     // Read — sessions
     // -----------------------------------------------------------------------
 
-    /// Retrieve an identity session by token.
+    /// Retrieve an identity session by token at a trusted timestamp.
     ///
     /// Returns `None` if no matching session exists or if the session has been
-    /// revoked.
-    pub fn get_session(&self, token: &str) -> anyhow::Result<Option<IdentitySession>> {
-        Ok(self.sessions.get(token).filter(|s| !s.revoked).cloned())
+    /// revoked or expired.
+    pub fn get_session(&self, token: &str, now_ms: u64) -> anyhow::Result<Option<IdentitySession>> {
+        Ok(self
+            .sessions
+            .get(token)
+            .filter(|s| !s.revoked && now_ms >= s.created_ms && !s.is_expired_at(now_ms))
+            .cloned())
     }
 
     // -----------------------------------------------------------------------
@@ -1285,7 +1289,7 @@ mod tests {
         }
 
         // Session revoked
-        assert!(store.get_session("tok-erase").unwrap().is_none());
+        assert!(store.get_session("tok-erase", 7_000).unwrap().is_none());
 
         // Erasure receipt emitted
         let receipts: Vec<_> = store

--- a/crates/exo-node/src/zerodentity/tests.rs
+++ b/crates/exo-node/src/zerodentity/tests.rs
@@ -35,13 +35,15 @@ mod tests {
         store::{SharedZerodentityStore, ZerodentityStore, new_shared_store},
         types::{
             AttestationType, BehavioralSample, BehavioralSignalType, DeviceFingerprint,
-            FingerprintSignal,
+            FingerprintSignal, IDENTITY_SESSION_TTL_MS,
         },
     };
 
     // -----------------------------------------------------------------------
     // Test helpers
     // -----------------------------------------------------------------------
+
+    const API_TEST_NOW_MS: u64 = 1_001_000;
 
     fn td(id: &str) -> Did {
         Did::new(&format!("did:exo:{id}")).unwrap()
@@ -292,7 +294,10 @@ mod tests {
 
     fn api_app(store: SharedZerodentityStore) -> Router {
         configure_test_receipt_signer(&store);
-        zerodentity_api_router(ApiState { store })
+        zerodentity_api_router(ApiState::new_with_clock(
+            store,
+            HybridClock::with_wall_clock(|| API_TEST_NOW_MS),
+        ))
     }
 
     fn configure_test_receipt_signer(store: &SharedZerodentityStore) {
@@ -597,15 +602,76 @@ mod tests {
         store
             .insert_session(&make_session(&did, token, 1_000_000))
             .unwrap();
-        assert!(store.get_session(token).unwrap().is_some());
+        assert!(store.get_session(token, 1_000_001).unwrap().is_some());
 
         let mut revoked = make_session(&did, token, 1_000_000);
         revoked.revoked = true;
         store.insert_session(&revoked).unwrap();
 
         assert!(
-            store.get_session(token).unwrap().is_none(),
+            store.get_session(token, 1_000_001).unwrap().is_none(),
             "revoked session must be hidden"
+        );
+    }
+
+    #[test]
+    fn store_session_expiry_hides_session_at_deadline() {
+        let did = td("store-session-expiry");
+        let mut store = ZerodentityStore::new();
+        let token = "expired-test-token";
+        let created_ms = 1_000_000;
+
+        store
+            .insert_session(&make_session(&did, token, created_ms))
+            .unwrap();
+
+        assert!(
+            store
+                .get_session(token, created_ms + IDENTITY_SESSION_TTL_MS - 1)
+                .unwrap()
+                .is_some(),
+            "session must remain active before its absolute expiry deadline"
+        );
+        assert!(
+            store
+                .get_session(token, created_ms + IDENTITY_SESSION_TTL_MS)
+                .unwrap()
+                .is_none(),
+            "session must be hidden at its absolute expiry deadline"
+        );
+    }
+
+    #[test]
+    fn store_session_expiry_fails_closed_on_deadline_overflow() {
+        let did = td("store-session-overflow");
+        let mut store = ZerodentityStore::new();
+        let token = "overflow-test-token";
+        let created_ms = u64::MAX - 1;
+
+        store
+            .insert_session(&make_session(&did, token, created_ms))
+            .unwrap();
+
+        assert!(
+            store.get_session(token, created_ms).unwrap().is_none(),
+            "session expiry arithmetic overflow must not create an immortal session"
+        );
+    }
+
+    #[test]
+    fn store_session_lookup_hides_future_created_sessions() {
+        let did = td("store-session-future");
+        let mut store = ZerodentityStore::new();
+        let token = "future-session-token";
+        let created_ms = 2_000_000;
+
+        store
+            .insert_session(&make_session(&did, token, created_ms))
+            .unwrap();
+
+        assert!(
+            store.get_session(token, created_ms - 1).unwrap().is_none(),
+            "sessions with future creation timestamps must fail closed"
         );
     }
 
@@ -1000,11 +1066,10 @@ mod tests {
     #[tokio::test]
     async fn verify_otp_correct_code_returns_verified_and_session_token() {
         let store = new_shared_store();
-        let app = onboarding_app(store.clone());
+        let app = onboarding_app_with_fixed_clock(store.clone(), 1_001_000);
         let keypair = test_keypair(1);
         let did = derived_did(&keypair);
-        // Far-future dispatched_ms so TTL check won't trigger on wall clock
-        let dispatched_ms = u64::MAX / 2;
+        let dispatched_ms = 1_000_000;
 
         let mut rng = seeded_rng(0xCAFE_0001);
         let (challenge, code) =
@@ -1035,7 +1100,7 @@ mod tests {
         let session = store
             .lock()
             .unwrap()
-            .get_session(session_token)
+            .get_session(session_token, 1_001_000)
             .unwrap()
             .unwrap();
         assert_eq!(session.public_key, keypair.public_key().as_bytes().to_vec());

--- a/crates/exo-node/src/zerodentity/types.rs
+++ b/crates/exo-node/src/zerodentity/types.rs
@@ -472,6 +472,9 @@ pub struct PeerAttestation {
 // IdentitySession
 // ---------------------------------------------------------------------------
 
+/// Absolute 0dentity bearer-session lifetime: 24 hours.
+pub const IDENTITY_SESSION_TTL_MS: u64 = 24 * 60 * 60 * 1_000;
+
 /// An authenticated session for a DID.
 ///
 /// Created after successful OTP verification; carries the session token and
@@ -503,6 +506,22 @@ impl fmt::Debug for IdentitySession {
             .field("last_active_ms", &self.last_active_ms)
             .field("revoked", &self.revoked)
             .finish()
+    }
+}
+
+impl IdentitySession {
+    /// Return the exclusive expiry deadline for this session, or `None` when
+    /// the timestamp arithmetic overflows and the session must fail closed.
+    #[must_use]
+    pub fn expires_at_ms(&self) -> Option<u64> {
+        self.created_ms.checked_add(IDENTITY_SESSION_TTL_MS)
+    }
+
+    /// Returns true when the session is expired at `now_ms`.
+    #[must_use]
+    pub fn is_expired_at(&self, now_ms: u64) -> bool {
+        self.expires_at_ms()
+            .is_none_or(|expires_at| now_ms >= expires_at)
     }
 }
 


### PR DESCRIPTION
## Summary
- Classifies this as core runtime adapter remediation for 0dentity bearer-session authorization.
- Confirms the current store accepted any non-revoked session indefinitely: the red tests returned HTTP 200 before the fix for stale owner-read and signed-write sessions.
- Adds a 24-hour absolute session TTL, future-created-session rejection, and overflow fail-closed semantics at `ZerodentityStore::get_session`.
- Feeds session lookup from a trusted HLC on `ApiState` for claims, fingerprints, attestations, and identity-erasure signed writes.
- Keeps test clocks deterministic through `HybridClock::with_wall_clock`.
- Updates README repo-truth LOC derived from `tools/repo_truth.sh`.

## Validation
- RED confirmed: `cargo test -p exo-node zerodentity::api::tests::list_claims_rejects_expired_session -- --nocapture` failed with HTTP 200 before the fix.
- RED confirmed: `cargo test -p exo-node zerodentity::api::tests::delete_identity_rejects_expired_session_before_erasure -- --nocapture` failed with HTTP 200 before the fix.
- `cargo test -p exo-node expired_session -- --nocapture`
- `cargo test -p exo-node store_session_expiry -- --nocapture`
- `cargo test -p exo-node zerodentity -- --nocapture`
- `cargo test -p exo-node --all-targets`
- `cargo clippy -p exo-node --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `cargo doc -p exo-node --no-deps`

## Path Classification
- `crates/exo-node/src/zerodentity/types.rs`: core runtime adapter.
- `crates/exo-node/src/zerodentity/store.rs`: core runtime adapter.
- `crates/exo-node/src/zerodentity/api.rs`: core runtime adapter.
- `crates/exo-node/src/zerodentity/tests.rs`: core runtime adapter tests.
- `crates/exo-node/src/main.rs`: core runtime adapter wiring.
- `README.md`: repository truth documentation required by CI guard.
