### PR TITLE
fix(zerodentity): bind attestations to session key

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 177768 | `wc -l` |
+| Rust LOC | 177815 | `wc -l` |
 | Workspace tests | 4,152 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -96,7 +96,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 177768 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 177815 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,152 listed workspace tests
 

--- a/crates/exo-node/src/zerodentity/api.rs
+++ b/crates/exo-node/src/zerodentity/api.rs
@@ -323,7 +323,7 @@ async fn verify_signed_write_blocking(
     method: &'static str,
     path_and_query: String,
     body: Bytes,
-) -> ApiResult<String> {
+) -> ApiResult<PublicKey> {
     let token = extract_session_token(headers)
         .ok_or_else(|| json_error(StatusCode::UNAUTHORIZED, "Bearer session token required"))?;
 
@@ -374,7 +374,7 @@ async fn verify_signed_write_blocking(
             ));
         }
 
-        Ok(token)
+        Ok(public_key)
     })
     .await
 }
@@ -792,7 +792,7 @@ pub async fn create_peer_attestation(
     let target_did = parse_did(&req.target_did)?;
 
     let request_path = path_and_query(&uri);
-    let _token = verify_signed_write_blocking(
+    let authenticated_public_key = verify_signed_write_blocking(
         state.clone(),
         &headers,
         attester_did.clone(),
@@ -814,6 +814,11 @@ pub async fn create_peer_attestation(
         .created_ms
         .ok_or_else(|| bad_request("created_ms is required"))?;
     let attester_public_key = parse_public_key(req.attester_public_key.as_deref())?;
+    if attester_public_key.as_bytes() != authenticated_public_key.as_bytes() {
+        return Err(bad_request(
+            "attester_public_key must match authenticated session key",
+        ));
+    }
     let signature = parse_signature(req.signature.as_deref())?;
 
     let response = with_store_blocking(state, move |store| {
@@ -1388,11 +1393,6 @@ mod tests {
         .unwrap()
     }
 
-    fn keypair(seed: u8) -> (PublicKey, SecretKey) {
-        let pair = crypto::KeyPair::from_secret_bytes([seed; 32]).unwrap();
-        (*pair.public_key(), pair.secret_key().clone())
-    }
-
     fn signed_attest_body(
         attester: &Did,
         target: &Did,
@@ -1697,7 +1697,6 @@ mod tests {
         let attester = Did::new("did:exo:alice").unwrap();
         let target = Did::new("did:exo:carol").unwrap();
         let message_hash = Hash256::from_bytes([0u8; 32]);
-        let (public_key, secret_key) = keypair(51);
         let uri = "/api/v1/0dentity/did%3Aexo%3Aalice/attest";
         let body = signed_attest_body(
             &attester,
@@ -1705,8 +1704,8 @@ mod tests {
             AttestationType::Identity,
             Some(message_hash),
             1_700_000_100_000,
-            &public_key,
-            &secret_key,
+            session_keypair.public_key(),
+            session_keypair.secret_key(),
         );
         let resp = signed_post(
             app,
@@ -1731,7 +1730,6 @@ mod tests {
         let app = zerodentity_api_router(state);
         let attester = Did::new("did:exo:alice").unwrap();
         let target = Did::new("did:exo:dave").unwrap();
-        let (public_key, secret_key) = keypair(53);
         let uri = "/api/v1/0dentity/did%3Aexo%3Aalice/attest";
         let mut body = signed_attest_body(
             &attester,
@@ -1739,8 +1737,8 @@ mod tests {
             AttestationType::Trustworthy,
             None,
             1_700_000_200_000,
-            &public_key,
-            &secret_key,
+            session_keypair.public_key(),
+            session_keypair.secret_key(),
         );
         body["message_hash"] = serde_json::Value::String(hex::encode([0u8; 16]));
         let resp = signed_post(

--- a/crates/exo-node/src/zerodentity/tests.rs
+++ b/crates/exo-node/src/zerodentity/tests.rs
@@ -2182,6 +2182,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn attest_rejects_body_key_that_differs_from_authenticated_session_key() {
+        let store = new_shared_store();
+        let app = api_app(store.clone());
+        let attester = td("attest-session-key-a");
+        let target = td("attest-session-key-b");
+        let token = "attest-session-key-token";
+        let session_keypair = test_keypair(20);
+        let (body_public_key, body_secret_key) = keypair(47);
+
+        {
+            let mut s = store.lock().unwrap();
+            s.insert_claim(
+                "e1",
+                &make_claim(&attester, ClaimType::Email, ClaimStatus::Verified, 1_000),
+            )
+            .unwrap();
+            s.insert_session(&make_session_with_public_key(
+                &attester,
+                token,
+                1_000_000,
+                session_keypair.public_key().as_bytes().to_vec(),
+            ))
+            .unwrap();
+        }
+
+        let uri = format!("/api/v1/0dentity/{}/attest", attester.as_str());
+        let resp = post_with_signed_auth(
+            &app,
+            &uri,
+            token,
+            "nonce-body-key-session-mismatch",
+            signed_attest_body(
+                &attester,
+                &target,
+                AttestationType::Identity,
+                None,
+                1_236_500,
+                &body_public_key,
+                &body_secret_key,
+            ),
+            &session_keypair,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        let guard = store.lock().unwrap();
+        assert!(guard.get_claims(&target).unwrap().is_empty());
+        assert!(guard.get_attestation(&attester, &target).unwrap().is_none());
+    }
+
+    #[tokio::test]
     async fn attest_valid_creates_attestation_201() {
         let store = new_shared_store();
         let app = api_app(store.clone());
@@ -2189,7 +2240,6 @@ mod tests {
         let target = td("attest-ok-b");
         let token = "attest-ok-token";
         let session_keypair = test_keypair(15);
-        let (public_key, secret_key) = keypair(41);
 
         {
             let mut s = store.lock().unwrap();
@@ -2220,8 +2270,8 @@ mod tests {
                 AttestationType::Identity,
                 None,
                 signed_created_ms,
-                &public_key,
-                &secret_key,
+                session_keypair.public_key(),
+                session_keypair.secret_key(),
             ),
             &session_keypair,
         )
@@ -2269,7 +2319,6 @@ mod tests {
         let target = td("attest-replay-b");
         let token = "attest-replay-token";
         let session_keypair = test_keypair(16);
-        let (public_key, secret_key) = keypair(42);
         let nonce = "nonce-replay";
 
         {
@@ -2295,8 +2344,8 @@ mod tests {
             AttestationType::Identity,
             None,
             1_237_000,
-            &public_key,
-            &secret_key,
+            session_keypair.public_key(),
+            session_keypair.secret_key(),
         );
         let first =
             post_with_signed_auth(&app, &uri, token, nonce, body.clone(), &session_keypair).await;


### PR DESCRIPTION
## Summary
- require peer-attestation attester_public_key to match the authenticated signed-write session key before any claim or attestation is stored
- update positive peer-attestation fixtures to sign both the write envelope and attestation payload with the authenticated session key
- add a regression proving mismatched body keys are rejected and no target claim or attestation is persisted

## Path classification
- crates/exo-node/src/zerodentity/api.rs: Core runtime adapter
- crates/exo-node/src/zerodentity/tests.rs: Core runtime adapter tests
- README.md: Documentation / repo-truth metadata

## Confirmation before remediation
- Reproduced on current origin/main after PR #402 merge. The new regression initially failed because POST /api/v1/0dentity/:did/attest returned 201 Created when the session write used key A but the attestation body was signed by key B.

## Validation
- cargo test -p exo-node attest_rejects_body_key_that_differs_from_authenticated_session_key -- --nocapture (red before fix, green after)
- cargo test -p exo-node attest -- --nocapture
- cargo test -p exo-node zerodentity -- --nocapture
- cargo test -p exo-node --all-targets
- cargo clippy -p exo-node --all-targets -- -D warnings
- cargo +nightly fmt --all -- --check
- cargo doc -p exo-node --no-deps
- bash tools/test_repo_truth.sh
- git diff --check