### PR TITLE
fix(gateway): bind auth signatures to request envelope

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 177815 | `wc -l` |
+| Rust LOC | 178075 | `wc -l` |
 | Workspace tests | 4,152 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -96,7 +96,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 177815 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 178075 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,152 listed workspace tests
 

--- a/crates/exo-gateway/src/auth.rs
+++ b/crates/exo-gateway/src/auth.rs
@@ -7,6 +7,7 @@
 //!   2. Non-empty / non-zero signature bytes
 //!   3. Timestamp freshness (±`FRESHNESS_WINDOW_MS`)
 //!   4. Ed25519 signature via `exo_identity::did_verification::verify_did_signature`
+//!      over a domain-separated canonical CBOR authentication envelope
 //!      against the first active verification method in the resolved DID document
 //!
 //! ## Multi-credential support
@@ -26,6 +27,7 @@ use crate::error::{GatewayError, Result};
 /// Maximum age (or future skew) of a request timestamp in milliseconds.
 /// Requests outside this window are rejected to prevent replay attacks.
 const FRESHNESS_WINDOW_MS: u64 = 300_000; // 5 minutes
+const GATEWAY_AUTH_SIGNING_DOMAIN: &str = "exo.gateway.auth.request.v1";
 
 // ---------------------------------------------------------------------------
 // Existing types (backward-compatible)
@@ -68,6 +70,47 @@ impl AuthenticationMetadata {
         }
         Ok(Self { observed_at })
     }
+}
+
+#[derive(Serialize)]
+struct RequestSigningPayload<'a> {
+    domain: &'static str,
+    actor_did: &'a str,
+    action: &'a str,
+    body_hash: Hash256,
+    request_timestamp_physical_ms: u64,
+    request_timestamp_logical: u32,
+    observed_at_physical_ms: u64,
+    observed_at_logical: u32,
+}
+
+/// Build the canonical bytes signed by DID-authenticated gateway requests.
+///
+/// The signature binds both the signed body hash and security-sensitive request
+/// metadata consumed after authentication, so a signature for one action cannot
+/// be replayed as a different action with the same body.
+///
+/// # Errors
+///
+/// Returns `GatewayError::Internal` if canonical CBOR serialization fails.
+pub fn request_signing_payload(
+    request: &Request,
+    metadata: AuthenticationMetadata,
+) -> Result<Vec<u8>> {
+    let payload = RequestSigningPayload {
+        domain: GATEWAY_AUTH_SIGNING_DOMAIN,
+        actor_did: &request.actor_did,
+        action: &request.action,
+        body_hash: request.body_hash,
+        request_timestamp_physical_ms: request.timestamp.physical_ms,
+        request_timestamp_logical: request.timestamp.logical,
+        observed_at_physical_ms: metadata.observed_at.physical_ms,
+        observed_at_logical: metadata.observed_at.logical,
+    };
+    let mut encoded = Vec::new();
+    ciborium::into_writer(&payload, &mut encoded)
+        .map_err(|e| GatewayError::Internal(format!("gateway auth payload CBOR: {e:?}")))?;
+    Ok(encoded)
 }
 
 // ---------------------------------------------------------------------------
@@ -322,15 +365,13 @@ pub fn authenticate(
             reason: "no active verification method for DID".into(),
         })?;
 
-    // 6. Cryptographically verify the Ed25519 signature over body_hash.
-    verify_did_signature(
-        doc,
-        &method.id,
-        request.body_hash.as_bytes(),
-        &request.signature,
-    )
-    .map_err(|e| GatewayError::AuthenticationFailed {
-        reason: format!("signature verification failed: {e}"),
+    // 6. Cryptographically verify the Ed25519 signature over the full
+    //    authentication envelope consumed by downstream authorization.
+    let signing_payload = request_signing_payload(request, metadata)?;
+    verify_did_signature(doc, &method.id, &signing_payload, &request.signature).map_err(|e| {
+        GatewayError::AuthenticationFailed {
+            reason: format!("signature verification failed: {e}"),
+        }
     })?;
 
     Ok(AuthenticatedActor {
@@ -506,25 +547,168 @@ mod tests {
         (reg, sk)
     }
 
+    fn signed_request(mut request: Request, secret_key: &exo_core::SecretKey) -> Request {
+        request.signature = sign(
+            &request_signing_payload(&request, auth_metadata()).unwrap(),
+            secret_key,
+        );
+        request
+    }
+
     // -----------------------------------------------------------------------
-    // Original authenticate() tests (unchanged)
+    // authenticate() tests
     // -----------------------------------------------------------------------
 
     #[test]
     fn auth_valid() {
         let (reg, sk) = registry_with_alice();
         let body_hash = Hash256::ZERO;
-        let signature = sign(body_hash.as_bytes(), &sk);
-        let r = Request {
+        let r = signed_request(
+            Request {
+                actor_did: "did:exo:alice".into(),
+                action: "read".into(),
+                body_hash,
+                signature: Signature::Empty,
+                timestamp: req_ts(),
+            },
+            &sk,
+        );
+        let a = authenticate(&r, &reg, auth_metadata()).unwrap();
+        assert_eq!(a.did.as_str(), "did:exo:alice");
+        assert_eq!(a.authenticated_at, auth_metadata().observed_at);
+    }
+
+    #[test]
+    fn auth_rejects_action_changed_after_signing() {
+        let (reg, sk) = registry_with_alice();
+        let body_hash = Hash256::digest(b"same body, different action");
+        let mut request = signed_request(
+            Request {
+                actor_did: "did:exo:alice".into(),
+                action: "read".into(),
+                body_hash,
+                signature: Signature::Empty,
+                timestamp: req_ts(),
+            },
+            &sk,
+        );
+        request.action = "submit_governance_vote".into();
+
+        assert!(authenticate(&request, &reg, auth_metadata()).is_err());
+    }
+
+    #[test]
+    fn auth_rejects_observed_at_changed_after_signing() {
+        let (reg, sk) = registry_with_alice();
+        let body_hash = Hash256::digest(b"same body, different observed time");
+        let request = signed_request(
+            Request {
+                actor_did: "did:exo:alice".into(),
+                action: "read".into(),
+                body_hash,
+                signature: Signature::Empty,
+                timestamp: req_ts(),
+            },
+            &sk,
+        );
+        let tampered_metadata =
+            AuthenticationMetadata::new(Timestamp::new(req_ts().physical_ms + 1, 0)).unwrap();
+
+        assert!(authenticate(&request, &reg, tampered_metadata).is_err());
+    }
+
+    #[test]
+    fn auth_rejects_timestamp_changed_after_signing() {
+        let (reg, sk) = registry_with_alice();
+        let body_hash = Hash256::digest(b"same body, different request timestamp");
+        let mut request = signed_request(
+            Request {
+                actor_did: "did:exo:alice".into(),
+                action: "read".into(),
+                body_hash,
+                signature: Signature::Empty,
+                timestamp: req_ts(),
+            },
+            &sk,
+        );
+        request.timestamp = Timestamp::new(req_ts().physical_ms + 1, 0);
+
+        assert!(authenticate(&request, &reg, auth_metadata()).is_err());
+    }
+
+    #[test]
+    fn auth_rejects_body_hash_changed_after_signing() {
+        let (reg, sk) = registry_with_alice();
+        let mut request = signed_request(
+            Request {
+                actor_did: "did:exo:alice".into(),
+                action: "read".into(),
+                body_hash: Hash256::digest(b"original body"),
+                signature: Signature::Empty,
+                timestamp: req_ts(),
+            },
+            &sk,
+        );
+        request.body_hash = Hash256::digest(b"tampered body");
+
+        assert!(authenticate(&request, &reg, auth_metadata()).is_err());
+    }
+
+    #[test]
+    fn request_signing_payload_is_domain_separated_cbor() {
+        #[derive(Deserialize)]
+        struct DecodedPayload {
+            domain: String,
+            actor_did: String,
+            action: String,
+            body_hash: Hash256,
+            request_timestamp_physical_ms: u64,
+            request_timestamp_logical: u32,
+            observed_at_physical_ms: u64,
+            observed_at_logical: u32,
+        }
+
+        let body_hash = Hash256::digest(b"canonical body hash");
+        let request = Request {
             actor_did: "did:exo:alice".into(),
-            action: "read".into(),
+            action: "read".to_owned(),
+            body_hash,
+            signature: Signature::Empty,
+            timestamp: req_ts(),
+        };
+        let payload = request_signing_payload(&request, auth_metadata()).unwrap();
+        let decoded: DecodedPayload = ciborium::from_reader(payload.as_slice()).unwrap();
+
+        assert_eq!(decoded.domain, GATEWAY_AUTH_SIGNING_DOMAIN);
+        assert_eq!(decoded.actor_did, "did:exo:alice");
+        assert_eq!(decoded.action, "read");
+        assert_eq!(decoded.body_hash, body_hash);
+        assert_eq!(decoded.request_timestamp_physical_ms, req_ts().physical_ms);
+        assert_eq!(decoded.request_timestamp_logical, req_ts().logical);
+        assert_eq!(
+            decoded.observed_at_physical_ms,
+            auth_metadata().observed_at.physical_ms
+        );
+        assert_eq!(
+            decoded.observed_at_logical,
+            auth_metadata().observed_at.logical
+        );
+    }
+
+    #[test]
+    fn auth_rejects_body_hash_only_signature_for_action_request() {
+        let (reg, sk) = registry_with_alice();
+        let body_hash = Hash256::digest(b"same body, different action");
+        let signature = sign(body_hash.as_bytes(), &sk);
+        let request = Request {
+            actor_did: "did:exo:alice".into(),
+            action: "submit_governance_vote".into(),
             body_hash,
             signature,
             timestamp: req_ts(),
         };
-        let a = authenticate(&r, &reg, auth_metadata()).unwrap();
-        assert_eq!(a.did.as_str(), "did:exo:alice");
-        assert_eq!(a.authenticated_at, auth_metadata().observed_at);
+
+        assert!(authenticate(&request, &reg, auth_metadata()).is_err());
     }
 
     #[test]
@@ -728,6 +912,24 @@ mod tests {
     }
 
     #[test]
+    fn auth_production_does_not_verify_raw_body_hash_signatures() {
+        let source = include_str!("auth.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production section");
+
+        assert!(
+            !production.contains("request.body_hash.as_bytes()"),
+            "gateway auth must bind DID signatures to the canonical request envelope"
+        );
+        assert!(
+            production.contains("request_signing_payload(request, metadata)"),
+            "gateway auth must route signature verification through the canonical payload helper"
+        );
+    }
+
+    #[test]
     fn auth_production_does_not_format_request_dids_into_errors() {
         let source = include_str!("auth.rs");
         let production = source
@@ -755,11 +957,20 @@ mod tests {
     fn credential_did_signature_valid() {
         let (reg, sk) = registry_with_alice();
         let body_hash = Hash256::ZERO;
-        let signature = sign(body_hash.as_bytes(), &sk);
+        let request = signed_request(
+            Request {
+                actor_did: "did:exo:alice".into(),
+                action: String::new(),
+                body_hash,
+                signature: Signature::Empty,
+                timestamp: req_ts(),
+            },
+            &sk,
+        );
         let cred = Credential::DidSignature {
             actor_did: "did:exo:alice".into(),
             body_hash,
-            signature,
+            signature: request.signature,
             timestamp: req_ts(),
         };
         let api_reg = ApiKeyRegistry::new();

--- a/crates/exo-gateway/src/routes.rs
+++ b/crates/exo-gateway/src/routes.rs
@@ -113,6 +113,7 @@ mod tests {
     };
 
     use super::*;
+    use crate::auth::request_signing_payload;
 
     /// Create a registry with `did:exo:alice` and return the registry +
     /// a signed request using alice's key.
@@ -144,14 +145,15 @@ mod tests {
         reg.register(doc).unwrap();
 
         let body_hash = Hash256::digest(b"route-test");
-        let signature = sign(body_hash.as_bytes(), &sk);
-        let req = Request {
+        let mut req = Request {
             actor_did: "did:exo:alice".into(),
             action: "create".into(),
             body_hash,
-            signature,
+            signature: exo_core::Signature::Empty,
             timestamp: Timestamp::new(7_000, 1),
         };
+        let auth_metadata = AuthenticationMetadata::new(Timestamp::new(7_000, 1)).unwrap();
+        req.signature = sign(&request_signing_payload(&req, auth_metadata).unwrap(), &sk);
         (reg, req)
     }
 

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -47,6 +47,8 @@ use tower_http::trace::TraceLayer;
 const MAX_REQUEST_BODY_BYTES: usize = 1024 * 1024;
 const MAX_DID_DOCUMENT_BODY_BYTES: usize = 64 * 1024;
 
+#[cfg(test)]
+use crate::auth::request_signing_payload;
 use crate::{
     auth::{AuthenticatedActor, AuthenticationMetadata, Request as AuthRequest, authenticate},
     db,
@@ -1441,20 +1443,42 @@ fn session_login_payload_hash(
     Ok(Hash256::digest(&encoded))
 }
 
+fn session_login_auth_request(
+    did: &str,
+    metadata: &SessionIssueMetadata,
+    timestamp: Timestamp,
+    signature: Signature,
+) -> Result<AuthRequest> {
+    let body_hash = session_login_payload_hash(did, metadata, &timestamp)?;
+    Ok(AuthRequest {
+        actor_did: did.to_owned(),
+        action: "gateway_session_login".to_owned(),
+        body_hash,
+        signature,
+        timestamp,
+    })
+}
+
+#[cfg(test)]
+fn session_login_auth_signing_payload(
+    did: &str,
+    metadata: &SessionIssueMetadata,
+    timestamp: Timestamp,
+    observed_at: Timestamp,
+) -> Result<Vec<u8>> {
+    let auth_metadata = AuthenticationMetadata::new(observed_at)?;
+    let request = session_login_auth_request(did, metadata, timestamp, Signature::Empty)?;
+    request_signing_payload(&request, auth_metadata)
+}
+
 fn authenticate_session_login(
     did: &str,
     metadata: &SessionIssueMetadata,
     proof: &SessionLoginProof,
     registry: &dyn DidRegistry,
 ) -> Result<AuthenticatedActor> {
-    let body_hash = session_login_payload_hash(did, metadata, &proof.timestamp)?;
-    let request = AuthRequest {
-        actor_did: did.to_owned(),
-        action: "gateway_session_login".to_owned(),
-        body_hash,
-        signature: proof.signature.clone(),
-        timestamp: proof.timestamp,
-    };
+    let request =
+        session_login_auth_request(did, metadata, proof.timestamp, proof.signature.clone())?;
     let auth_metadata = AuthenticationMetadata::new(proof.observed_at)?;
     authenticate(&request, registry, auth_metadata)
 }
@@ -2508,8 +2532,8 @@ async fn handle_agents_enroll(
 /// POST /api/v1/auth/login — authenticate a DID and issue a session token.
 ///
 /// Body includes the actor DID, session metadata, HLC authentication metadata,
-/// and an Ed25519 `signature` hex string over the canonical domain-tagged
-/// session-login payload.
+/// and an Ed25519 `signature` hex string over the canonical gateway
+/// authentication envelope for the domain-tagged session-login payload hash.
 ///
 /// Returns a 256-bit bearer session token stored in the `sessions` table:
 /// ```sql
@@ -6961,8 +6985,10 @@ mod tests {
         };
         let timestamp = Timestamp::new(10_000, 0);
         let observed_at = Timestamp::new(10_000, 0);
-        let body_hash = session_login_payload_hash(did, &metadata, &timestamp).unwrap();
-        let signature = sign(body_hash.as_bytes(), &sk);
+        let signature = sign(
+            &session_login_auth_signing_payload(did, &metadata, timestamp, observed_at).unwrap(),
+            &sk,
+        );
         let body = serde_json::json!({
             "did": did,
             "createdAt": metadata.created_at,
@@ -7050,9 +7076,16 @@ mod tests {
             expires_at: 20_000,
         };
         let timestamp = Timestamp::new(10_000, 0);
-        let body_hash =
-            session_login_payload_hash("did:exo:login-alice", &metadata, &timestamp).unwrap();
-        let signature = sign(body_hash.as_bytes(), &sk);
+        let signature = sign(
+            &session_login_auth_signing_payload(
+                "did:exo:login-alice",
+                &metadata,
+                timestamp,
+                timestamp,
+            )
+            .unwrap(),
+            &sk,
+        );
         let proof = SessionLoginProof {
             timestamp,
             observed_at: timestamp,
@@ -7074,12 +7107,17 @@ mod tests {
             expires_at: 20_000,
         };
         let timestamp = Timestamp::new(10_000, 0);
-        let body_hash =
-            session_login_payload_hash("did:exo:login-alice", &metadata, &timestamp).unwrap();
+        let payload = session_login_auth_signing_payload(
+            "did:exo:login-alice",
+            &metadata,
+            timestamp,
+            timestamp,
+        )
+        .unwrap();
         let proof = SessionLoginProof {
             timestamp,
             observed_at: timestamp,
-            signature: sign(body_hash.as_bytes(), &wrong_sk),
+            signature: sign(&payload, &wrong_sk),
         };
         let guard = registry.read().unwrap();
 
@@ -7100,13 +7138,17 @@ mod tests {
             expires_at: 30_000,
         };
         let timestamp = Timestamp::new(10_000, 0);
-        let body_hash =
-            session_login_payload_hash("did:exo:login-alice", &signed_metadata, &timestamp)
-                .unwrap();
+        let payload = session_login_auth_signing_payload(
+            "did:exo:login-alice",
+            &signed_metadata,
+            timestamp,
+            timestamp,
+        )
+        .unwrap();
         let proof = SessionLoginProof {
             timestamp,
             observed_at: timestamp,
-            signature: sign(body_hash.as_bytes(), &sk),
+            signature: sign(&payload, &sk),
         };
         let guard = registry.read().unwrap();
 
@@ -7125,12 +7167,17 @@ mod tests {
         };
         let timestamp = Timestamp::new(1, 0);
         let observed_at = Timestamp::new(400_000, 0);
-        let body_hash =
-            session_login_payload_hash("did:exo:login-alice", &metadata, &timestamp).unwrap();
+        let payload = session_login_auth_signing_payload(
+            "did:exo:login-alice",
+            &metadata,
+            timestamp,
+            observed_at,
+        )
+        .unwrap();
         let proof = SessionLoginProof {
             timestamp,
             observed_at,
-            signature: sign(body_hash.as_bytes(), &sk),
+            signature: sign(&payload, &sk),
         };
         let guard = registry.read().unwrap();
         let err = authenticate_session_login("did:exo:login-alice", &metadata, &proof, &*guard)


### PR DESCRIPTION
## Summary
- verify DID authentication signatures over a domain-separated canonical CBOR gateway auth envelope instead of only body_hash bytes
- bind actor DID, action, body hash, request timestamp, and observed authentication time into the signed payload
- update route and session-login signing fixtures to use the canonical auth envelope
- add regressions for body-hash-only signatures and post-signing action, body hash, timestamp, and observed-time mutation

## Path classification
- crates/exo-gateway/src/auth.rs: Core runtime adapter
- crates/exo-gateway/src/routes.rs: Core runtime adapter tests/helpers
- crates/exo-gateway/src/server.rs: Core runtime adapter session-login call path and tests
- README.md: Documentation / repo-truth metadata

## Confirmation before remediation
- Reproduced on current origin/main after PR #403 merge. The red regression auth_rejects_body_hash_only_signature_for_action_request initially failed because authenticate accepted a signature over only body_hash bytes for an action request.

## Validation
- cargo test -p exo-gateway auth_rejects_body_hash_only_signature_for_action_request -- --nocapture (red before fix, green after)
- cargo test -p exo-gateway auth_rejects -- --nocapture
- cargo test -p exo-gateway auth_production_does_not_verify_raw_body_hash_signatures -- --nocapture
- cargo test -p exo-gateway --all-targets
- cargo clippy -p exo-gateway --all-targets -- -D warnings
- cargo +nightly fmt --all -- --check
- cargo doc -p exo-gateway --no-deps
- bash tools/test_repo_truth.sh
- git diff --check