### PR TITLE
fix(node): require snapshot commit certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 178075 | `wc -l` |
+| Rust LOC | 178681 | `wc -l` |
 | Workspace tests | 4,152 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | None (pre-release) | `git tag -l` |
@@ -96,7 +96,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 178075 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 178681 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,152 listed workspace tests
 

--- a/crates/exo-node/src/store.rs
+++ b/crates/exo-node/src/store.rs
@@ -465,6 +465,36 @@ impl SqliteDagStore {
         Ok(certs)
     }
 
+    /// Load the persisted commit certificate for a committed node hash.
+    pub fn load_certificate_for_hash(
+        &self,
+        hash: &Hash256,
+    ) -> DagResult<Option<CommitCertificate>> {
+        let mut stmt = self
+            .conn
+            .prepare_cached("SELECT cbor_data FROM commit_certificates WHERE node_hash = ?1")
+            .map_err(store_err)?;
+
+        let result: Result<Vec<u8>, rusqlite::Error> =
+            stmt.query_row(params![hash.0.as_slice()], |row| row.get(0));
+
+        match result {
+            Ok(bytes) => {
+                let certificate: CommitCertificate = ciborium::from_reader(bytes.as_slice())
+                    .map_err(|e| store_err(format!("CBOR decode certificate: {e}")))?;
+                if certificate.node_hash != *hash {
+                    return Err(store_err(
+                        "commit_certificates.node_hash does not match CBOR certificate node_hash",
+                    ));
+                }
+                validate_commit_certificate(&certificate)?;
+                Ok(Some(certificate))
+            }
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(store_err(format!("commit_certificates.cbor_data: {e}"))),
+        }
+    }
+
     // -----------------------------------------------------------------
     // Validator set persistence
     // -----------------------------------------------------------------
@@ -807,17 +837,31 @@ impl SqliteDagStore {
         Ok(())
     }
 
-    /// Persist and mark a batch of DAG nodes as committed atomically.
-    pub fn put_committed_many_sync(&mut self, nodes: &[(DagNode, u64)]) -> DagResult<()> {
+    /// Persist nodes, commit markers, and finality certificates atomically.
+    pub fn put_committed_many_with_certificates_sync(
+        &mut self,
+        nodes: &[(DagNode, u64)],
+        certificates: &[CommitCertificate],
+    ) -> DagResult<()> {
+        if nodes.len() != certificates.len() {
+            return Err(store_err(format!(
+                "committed batch must include one certificate per node: got {} certificates for {} nodes",
+                certificates.len(),
+                nodes.len()
+            )));
+        }
+
         let tx = self.conn.transaction().map_err(store_err)?;
-        for (node, height) in nodes {
+        for ((node, height), certificate) in nodes.iter().zip(certificates) {
+            if certificate.node_hash != node.hash {
+                return Err(store_err(format!(
+                    "commit certificate node_hash {} does not match DAG node hash {}",
+                    certificate.node_hash, node.hash
+                )));
+            }
             Self::insert_node_tx(&tx, node)?;
-            let height = sqlite_u64_to_i64(*height, "committed.height")?;
-            tx.execute(
-                "INSERT OR REPLACE INTO committed (hash, height) VALUES (?1, ?2)",
-                params![node.hash.0.as_slice(), height],
-            )
-            .map_err(store_err)?;
+            Self::insert_committed_tx(&tx, &node.hash, *height)?;
+            Self::insert_certificate_tx(&tx, certificate)?;
         }
         tx.commit().map_err(store_err)?;
         Ok(())
@@ -1076,6 +1120,19 @@ mod tests {
         let creator = Did::new("did:exo:test").expect("valid");
         let sign_fn = make_sign_fn();
         append(&mut dag, &[], b"genesis", &creator, &*sign_fn, &mut clock).unwrap()
+    }
+
+    fn commit_certificate_for(hash: Hash256, round: u64) -> CommitCertificate {
+        CommitCertificate {
+            node_hash: hash,
+            round,
+            votes: vec![Vote {
+                voter: Did::new("did:exo:v0").unwrap(),
+                round,
+                node_hash: hash,
+                signature: Signature::from_bytes([7u8; 64]),
+            }],
+        }
     }
 
     fn temp_store() -> SqliteDagStore {
@@ -1490,20 +1547,10 @@ mod tests {
 
     #[test]
     fn certificate_persistence_roundtrip() {
-        use exo_core::types::Signature;
         let mut store = temp_store();
         let mut hash = [0u8; 32];
         hash[0] = 0xCD;
-        let cert = CommitCertificate {
-            node_hash: Hash256::from_bytes(hash),
-            round: 3,
-            votes: vec![Vote {
-                voter: Did::new("did:exo:v0").unwrap(),
-                round: 3,
-                node_hash: Hash256::from_bytes(hash),
-                signature: Signature::from_bytes([1u8; 64]),
-            }],
-        };
+        let cert = commit_certificate_for(Hash256::from_bytes(hash), 3);
         store.save_certificate(&cert).unwrap();
 
         let loaded = store.load_certificates().unwrap();
@@ -1511,6 +1558,104 @@ mod tests {
         assert_eq!(loaded[0].round, 3);
         assert_eq!(loaded[0].node_hash, Hash256::from_bytes(hash));
         assert_eq!(loaded[0].votes.len(), 1);
+    }
+
+    #[test]
+    fn load_certificate_for_hash_returns_matching_certificate_only() {
+        let mut store = temp_store();
+        let hash = Hash256::digest(b"cert-target");
+        let cert = commit_certificate_for(hash, 3);
+        store.save_certificate(&cert).unwrap();
+
+        let loaded = store
+            .load_certificate_for_hash(&hash)
+            .unwrap()
+            .expect("certificate should exist");
+        assert_eq!(loaded, cert);
+        assert!(
+            store
+                .load_certificate_for_hash(&Hash256::digest(b"missing-cert"))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn load_certificate_for_hash_rejects_cbor_node_hash_mismatch() {
+        let store = temp_store();
+        let row_hash = Hash256::digest(b"row-node");
+        let cert = commit_certificate_for(Hash256::digest(b"cbor-node"), 3);
+        let mut cbor = Vec::new();
+        ciborium::into_writer(&cert, &mut cbor).unwrap();
+        store
+            .conn
+            .execute(
+                "INSERT INTO commit_certificates (node_hash, round, cbor_data)
+                 VALUES (?1, ?2, ?3)",
+                rusqlite::params![row_hash.0.as_slice(), 3_i64, cbor],
+            )
+            .unwrap();
+
+        let err = store.load_certificate_for_hash(&row_hash).unwrap_err();
+
+        assert!(err.to_string().contains("CBOR certificate node_hash"));
+    }
+
+    #[test]
+    fn put_committed_many_with_certificates_persists_finality_rows() {
+        let mut store = temp_store();
+        let node = make_test_node();
+        let certificate = commit_certificate_for(node.hash, 1);
+
+        store
+            .put_committed_many_with_certificates_sync(
+                &[(node.clone(), 1)],
+                std::slice::from_ref(&certificate),
+            )
+            .unwrap();
+
+        assert!(store.contains_sync(&node.hash).unwrap());
+        assert!(store.is_committed(&node.hash).unwrap());
+        assert_eq!(
+            store.load_certificate_for_hash(&node.hash).unwrap(),
+            Some(certificate)
+        );
+    }
+
+    #[test]
+    fn put_committed_many_with_certificates_rejects_mismatched_certificate_without_partial_rows() {
+        let mut store = temp_store();
+        let node = make_test_node();
+        let certificate = commit_certificate_for(Hash256::digest(b"wrong-node"), 1);
+
+        let err = store
+            .put_committed_many_with_certificates_sync(&[(node.clone(), 1)], &[certificate])
+            .unwrap_err();
+
+        assert!(err.to_string().contains("does not match DAG node hash"));
+        assert!(!store.contains_sync(&node.hash).unwrap());
+        assert!(!store.is_committed(&node.hash).unwrap());
+        assert!(store.load_certificates().unwrap().is_empty());
+    }
+
+    #[test]
+    fn put_committed_many_with_certificates_rolls_back_when_certificate_is_rejected() {
+        let mut store = temp_store();
+        let node = make_test_node();
+        let mut certificate = commit_certificate_for(node.hash, 1);
+        certificate.votes[0].signature = Signature::Empty;
+
+        let err = store
+            .put_committed_many_with_certificates_sync(&[(node.clone(), 1)], &[certificate])
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("commit_certificates.votes[0].signature")
+        );
+        assert!(!store.contains_sync(&node.hash).unwrap());
+        assert!(!store.is_committed(&node.hash).unwrap());
+        assert!(store.load_certificates().unwrap().is_empty());
     }
 
     #[test]

--- a/crates/exo-node/src/sync.rs
+++ b/crates/exo-node/src/sync.rs
@@ -18,13 +18,14 @@
 //! layer.
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     sync::{Arc, Mutex},
 };
 
-use exo_core::types::{Did, PublicKey};
+use exo_core::types::{Did, Hash256, PublicKey};
 use exo_dag::{
     append::verify_node_creator_signature,
+    consensus::{CommitCertificate, ConsensusConfig},
     dag::{DagNode, compute_node_hash},
     error::{DagError, Result as DagResult},
 };
@@ -147,6 +148,98 @@ fn validate_incoming_sync_node(
 
     let resolver = |did: &Did| public_keys.get(did).copied();
     verify_node_creator_signature(node, &resolver)
+}
+
+fn validate_snapshot_commit_certificates(
+    nodes_with_heights: &[(DagNode, u64)],
+    certificates: &[CommitCertificate],
+    public_keys: &BTreeMap<Did, PublicKey>,
+) -> DagResult<()> {
+    if certificates.len() != nodes_with_heights.len() {
+        return Err(DagError::StoreError(format!(
+            "snapshot chunk must include one commit certificate per node: got {} certificates for {} nodes",
+            certificates.len(),
+            nodes_with_heights.len()
+        )));
+    }
+
+    for ((node, _height), certificate) in nodes_with_heights.iter().zip(certificates) {
+        validate_snapshot_commit_certificate(certificate, &node.hash, public_keys)?;
+    }
+
+    Ok(())
+}
+
+fn validate_snapshot_commit_certificate(
+    certificate: &CommitCertificate,
+    node_hash: &Hash256,
+    public_keys: &BTreeMap<Did, PublicKey>,
+) -> DagResult<()> {
+    if certificate.node_hash != *node_hash {
+        return Err(DagError::StoreError(format!(
+            "snapshot commit certificate node_hash {} does not match DAG node hash {}",
+            certificate.node_hash, node_hash
+        )));
+    }
+
+    let validators: BTreeSet<Did> = public_keys.keys().cloned().collect();
+    let quorum = ConsensusConfig::new(validators.clone(), 0).quorum_size();
+    if quorum == 0 {
+        return Err(DagError::StoreError(
+            "snapshot commit certificate cannot be validated with an empty validator set".into(),
+        ));
+    }
+
+    let mut distinct_voters = BTreeSet::new();
+    for vote in &certificate.votes {
+        if !validators.contains(&vote.voter) {
+            return Err(DagError::StoreError(format!(
+                "snapshot commit certificate contains vote from non-validator {}",
+                vote.voter
+            )));
+        }
+        if vote.round != certificate.round {
+            return Err(DagError::StoreError(format!(
+                "snapshot commit certificate vote from {} is for round {}, expected {}",
+                vote.voter, vote.round, certificate.round
+            )));
+        }
+        if vote.node_hash != certificate.node_hash {
+            return Err(DagError::StoreError(format!(
+                "snapshot commit certificate vote from {} references wrong node hash",
+                vote.voter
+            )));
+        }
+        if !distinct_voters.insert(vote.voter.clone()) {
+            return Err(DagError::StoreError(format!(
+                "snapshot commit certificate contains duplicate vote from {} in round {}",
+                vote.voter, vote.round
+            )));
+        }
+
+        let Some(public_key) = public_keys.get(&vote.voter) else {
+            return Err(DagError::StoreError(format!(
+                "snapshot commit certificate vote from {} has no configured public key",
+                vote.voter
+            )));
+        };
+        if !vote.verify_signature(public_key) {
+            return Err(DagError::StoreError(format!(
+                "snapshot commit certificate vote from {} has invalid signature",
+                vote.voter
+            )));
+        }
+    }
+
+    if distinct_voters.len() < quorum {
+        return Err(DagError::StoreError(format!(
+            "snapshot commit certificate has insufficient quorum: required {}, got {}",
+            quorum,
+            distinct_voters.len()
+        )));
+    }
+
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -322,22 +415,36 @@ impl SyncEngine {
         loop {
             let to_height = snapshot_chunk_to_height(current_from, chunk_size, local_height);
 
-            let nodes = match with_store_blocking(
+            let (nodes, certificates) = match with_store_blocking(
                 Arc::clone(&self.store),
                 "handle_snapshot_request_chunk",
                 move |store| {
-                    store
+                    let nodes = store
                         .committed_dag_nodes_in_range(current_from, to_height)
                         .map_err(|e| {
                             anyhow::anyhow!("committed nodes {current_from}..={to_height}: {e}")
-                        })
+                        })?;
+                    let mut certificates = Vec::with_capacity(nodes.len());
+                    for node in &nodes {
+                        let certificate =
+                            store
+                                .load_certificate_for_hash(&node.hash)?
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "missing commit certificate for snapshot node {}",
+                                        node.hash
+                                    )
+                                })?;
+                        certificates.push(certificate);
+                    }
+                    Ok((nodes, certificates))
                 },
             )
             .await
             {
-                Ok(nodes) => nodes,
+                Ok(nodes_and_certificates) => nodes_and_certificates,
                 Err(e) => {
-                    tracing::warn!(err = %e, "Failed to query committed nodes");
+                    tracing::warn!(err = %e, "Failed to query committed nodes and certificates");
                     return;
                 }
             };
@@ -349,6 +456,7 @@ impl SyncEngine {
                 sender: self.config.node_did.clone(),
                 from_height: current_from,
                 nodes,
+                certificates,
                 to_height,
                 has_more,
             });
@@ -416,6 +524,7 @@ impl SyncEngine {
         // Store the nodes and mark them as committed.
         let from_height = msg.from_height;
         let nodes = msg.nodes;
+        let certificates = msg.certificates;
         let public_keys = self.config.validator_public_keys.clone();
         if let Err(e) = with_store_blocking(
             Arc::clone(&self.store),
@@ -433,7 +542,15 @@ impl SyncEngine {
                     accepted_nodes.insert(node.hash, node.clone());
                 }
 
-                store.put_committed_many_sync(&nodes_with_heights)?;
+                validate_snapshot_commit_certificates(
+                    &nodes_with_heights,
+                    &certificates,
+                    &public_keys,
+                )?;
+                store.put_committed_many_with_certificates_sync(
+                    &nodes_with_heights,
+                    &certificates,
+                )?;
                 Ok(())
             },
         )
@@ -685,9 +802,12 @@ pub async fn run_sync_engine(mut engine: SyncEngine, mut net_events: mpsc::Recei
 mod tests {
     use exo_core::{
         crypto::KeyPair,
-        types::{Did, PublicKey, Signature},
+        types::{Did, Hash256, PublicKey, Signature},
     };
-    use exo_dag::dag::{Dag, DeterministicDagClock, append};
+    use exo_dag::{
+        consensus::Vote,
+        dag::{Dag, DeterministicDagClock, append},
+    };
     use tokio::sync::mpsc;
 
     use super::*;
@@ -716,6 +836,28 @@ mod tests {
     fn make_sign_fn() -> Box<dyn Fn(&[u8]) -> Signature> {
         let keypair = test_keypair();
         Box::new(move |data: &[u8]| keypair.sign(data))
+    }
+
+    fn commit_certificate_for(node_hash: Hash256, round: u64) -> CommitCertificate {
+        let mut vote = Vote {
+            voter: test_did(),
+            round,
+            node_hash,
+            signature: Signature::Empty,
+        };
+        let payload = vote.signing_payload().unwrap();
+        vote.signature = test_keypair().sign(&payload);
+        CommitCertificate {
+            node_hash,
+            votes: vec![vote],
+            round,
+        }
+    }
+
+    fn invalid_commit_certificate_for(node_hash: Hash256, round: u64) -> CommitCertificate {
+        let mut certificate = commit_certificate_for(node_hash, round);
+        certificate.votes[0].signature = Signature::from_bytes([9u8; 64]);
+        certificate
     }
 
     fn test_did() -> Did {
@@ -784,6 +926,28 @@ mod tests {
     }
 
     #[test]
+    fn production_snapshot_sync_requires_commit_certificate_persistence() {
+        let source = include_str!("sync.rs");
+        let production = source
+            .split("// ---------------------------------------------------------------------------\n// Tests")
+            .next()
+            .expect("tests marker present");
+
+        assert!(
+            production.contains("validate_snapshot_commit_certificates"),
+            "snapshot sync must validate commit certificates before accepting committed nodes"
+        );
+        assert!(
+            production.contains("put_committed_many_with_certificates_sync"),
+            "snapshot sync must persist nodes, commit markers, and certificates atomically"
+        );
+        assert!(
+            !production.contains("put_committed_many_sync(&nodes_with_heights)"),
+            "snapshot sync must not mark externally supplied nodes committed without certificates"
+        );
+    }
+
+    #[test]
     fn next_sync_from_height_rejects_u64_max() {
         let err = next_sync_from_height(u64::MAX).expect_err("u64::MAX cannot advance");
 
@@ -832,6 +996,9 @@ mod tests {
             store.put_sync(node).unwrap();
             let committed_height = u64::try_from(i + 1).expect("test height fits in u64");
             store.mark_committed_sync(&hash, committed_height).unwrap();
+            store
+                .save_certificate(&commit_certificate_for(hash, committed_height))
+                .unwrap();
             hashes.push(hash);
             parents = vec![hash];
         }
@@ -909,6 +1076,10 @@ mod tests {
                 assert_eq!(chunk.from_height, 1);
                 assert_eq!(chunk.to_height, 5);
                 assert_eq!(chunk.nodes.len(), 5);
+                assert_eq!(chunk.certificates.len(), 5);
+                for (node, certificate) in chunk.nodes.iter().zip(&chunk.certificates) {
+                    assert_eq!(certificate.node_hash, node.hash);
+                }
                 assert!(chunk.has_more);
             }
             _ => panic!("Expected StateSnapshotChunk"),
@@ -920,6 +1091,10 @@ mod tests {
                 assert_eq!(chunk.from_height, 6);
                 assert_eq!(chunk.to_height, 10);
                 assert_eq!(chunk.nodes.len(), 5);
+                assert_eq!(chunk.certificates.len(), 5);
+                for (node, certificate) in chunk.nodes.iter().zip(&chunk.certificates) {
+                    assert_eq!(certificate.node_hash, node.hash);
+                }
                 assert!(!chunk.has_more);
             }
             _ => panic!("Expected StateSnapshotChunk"),
@@ -931,6 +1106,49 @@ mod tests {
             events.push(ev);
         }
         assert_eq!(events.len(), 2, "Should emit 2 ServedSnapshot events");
+    }
+
+    #[tokio::test]
+    async fn sync_engine_refuses_to_serve_snapshot_node_without_certificate() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = SqliteDagStore::open(dir.path()).unwrap();
+        let sign_fn = make_sign_fn();
+        let did = test_did();
+        let mut dag = Dag::new();
+        let mut clock = DeterministicDagClock::new();
+        let node = append(
+            &mut dag,
+            &[],
+            b"uncertified-local-snapshot-node",
+            &did,
+            &*sign_fn,
+            &mut clock,
+        )
+        .unwrap();
+        store.put_sync(node.clone()).unwrap();
+        store.mark_committed_sync(&node.hash, 1).unwrap();
+        let store = Arc::new(Mutex::new(store));
+
+        let (net_handle, published) = acking_network_handle();
+        let (event_tx, mut event_rx) = mpsc::channel(32);
+        let engine = SyncEngine::new(sync_config(5, 200), store, net_handle, event_tx);
+
+        let request = StateSnapshotRequestMsg {
+            sender: Did::new("did:exo:requester").unwrap(),
+            from_height: 1,
+            chunk_size: 5,
+        };
+
+        engine.handle_snapshot_request(request).await;
+
+        assert!(
+            published.lock().unwrap().is_empty(),
+            "snapshot serving must fail closed when a committed node lacks a certificate"
+        );
+        assert!(
+            event_rx.try_recv().is_err(),
+            "failed snapshot serving must not emit served events"
+        );
     }
 
     #[tokio::test]
@@ -973,6 +1191,10 @@ mod tests {
             sender: Did::new("did:exo:sender").unwrap(),
             from_height: 1,
             nodes: vec![node1.clone(), node2.clone()],
+            certificates: vec![
+                commit_certificate_for(node1.hash, 1),
+                commit_certificate_for(node2.hash, 2),
+            ],
             to_height: 2,
             has_more: false,
         };
@@ -985,6 +1207,7 @@ mod tests {
             assert!(st.contains_sync(&node1.hash).unwrap());
             assert!(st.contains_sync(&node2.hash).unwrap());
             assert_eq!(st.committed_height_value().unwrap(), 2);
+            assert_eq!(st.load_certificates().unwrap().len(), 2);
         }
 
         // Verify sync completed.
@@ -1002,6 +1225,171 @@ mod tests {
             .iter()
             .any(|e| matches!(e, SyncEvent::Complete { .. }));
         assert!(complete, "Should emit SyncEvent::Complete");
+    }
+
+    #[tokio::test]
+    async fn snapshot_chunk_without_commit_certificate_is_rejected_without_commit() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SqliteDagStore::open(dir.path()).unwrap();
+        let store = Arc::new(Mutex::new(store));
+
+        let (cmd_tx, _cmd_rx) = mpsc::channel(256);
+        let net_handle = NetworkHandle::new(cmd_tx);
+
+        let (event_tx, mut event_rx) = mpsc::channel(32);
+        let mut engine = SyncEngine::new(
+            sync_config(100, 200),
+            Arc::clone(&store),
+            net_handle,
+            event_tx,
+        );
+
+        let sign_fn = make_sign_fn();
+        let did = test_did();
+        let mut dag = Dag::new();
+        let mut clock = DeterministicDagClock::new();
+        let node = append(
+            &mut dag,
+            &[],
+            b"certless-snapshot-node",
+            &did,
+            &*sign_fn,
+            &mut clock,
+        )
+        .unwrap();
+
+        engine.syncing = true;
+        let chunk = StateSnapshotChunkMsg {
+            sender: Did::new("did:exo:sender").unwrap(),
+            from_height: 1,
+            nodes: vec![node.clone()],
+            certificates: vec![],
+            to_height: 1,
+            has_more: false,
+        };
+
+        engine.handle_snapshot_chunk(chunk).await;
+
+        let st = store.lock().unwrap();
+        assert!(
+            !st.contains_sync(&node.hash).unwrap(),
+            "certificate-less snapshot chunks must not persist DAG nodes"
+        );
+        assert_eq!(st.committed_height_value().unwrap(), 0);
+        assert!(
+            event_rx.try_recv().is_err(),
+            "certificate-less snapshot chunks must not emit progress or completion"
+        );
+    }
+
+    #[tokio::test]
+    async fn snapshot_chunk_rejects_certificate_for_different_node_without_commit() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SqliteDagStore::open(dir.path()).unwrap();
+        let store = Arc::new(Mutex::new(store));
+
+        let (cmd_tx, _cmd_rx) = mpsc::channel(256);
+        let net_handle = NetworkHandle::new(cmd_tx);
+
+        let (event_tx, mut event_rx) = mpsc::channel(32);
+        let mut engine = SyncEngine::new(
+            sync_config(100, 200),
+            Arc::clone(&store),
+            net_handle,
+            event_tx,
+        );
+
+        let sign_fn = make_sign_fn();
+        let did = test_did();
+        let mut dag = Dag::new();
+        let mut clock = DeterministicDagClock::new();
+        let node = append(
+            &mut dag,
+            &[],
+            b"mismatched-certificate-snapshot-node",
+            &did,
+            &*sign_fn,
+            &mut clock,
+        )
+        .unwrap();
+
+        engine.syncing = true;
+        let chunk = StateSnapshotChunkMsg {
+            sender: Did::new("did:exo:sender").unwrap(),
+            from_height: 1,
+            nodes: vec![node.clone()],
+            certificates: vec![commit_certificate_for(Hash256::digest(b"wrong-node"), 1)],
+            to_height: 1,
+            has_more: false,
+        };
+
+        engine.handle_snapshot_chunk(chunk).await;
+
+        let st = store.lock().unwrap();
+        assert!(
+            !st.contains_sync(&node.hash).unwrap(),
+            "snapshot chunks with mismatched certificates must not persist DAG nodes"
+        );
+        assert_eq!(st.committed_height_value().unwrap(), 0);
+        assert!(
+            event_rx.try_recv().is_err(),
+            "mismatched certificates must not emit progress or completion"
+        );
+    }
+
+    #[tokio::test]
+    async fn snapshot_chunk_rejects_invalid_commit_certificate_without_commit() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SqliteDagStore::open(dir.path()).unwrap();
+        let store = Arc::new(Mutex::new(store));
+
+        let (cmd_tx, _cmd_rx) = mpsc::channel(256);
+        let net_handle = NetworkHandle::new(cmd_tx);
+
+        let (event_tx, mut event_rx) = mpsc::channel(32);
+        let mut engine = SyncEngine::new(
+            sync_config(100, 200),
+            Arc::clone(&store),
+            net_handle,
+            event_tx,
+        );
+
+        let sign_fn = make_sign_fn();
+        let did = test_did();
+        let mut dag = Dag::new();
+        let mut clock = DeterministicDagClock::new();
+        let node = append(
+            &mut dag,
+            &[],
+            b"invalid-certificate-snapshot-node",
+            &did,
+            &*sign_fn,
+            &mut clock,
+        )
+        .unwrap();
+
+        engine.syncing = true;
+        let chunk = StateSnapshotChunkMsg {
+            sender: Did::new("did:exo:sender").unwrap(),
+            from_height: 1,
+            nodes: vec![node.clone()],
+            certificates: vec![invalid_commit_certificate_for(node.hash, 1)],
+            to_height: 1,
+            has_more: false,
+        };
+
+        engine.handle_snapshot_chunk(chunk).await;
+
+        let st = store.lock().unwrap();
+        assert!(
+            !st.contains_sync(&node.hash).unwrap(),
+            "snapshot chunks with invalid certificates must not persist DAG nodes"
+        );
+        assert_eq!(st.committed_height_value().unwrap(), 0);
+        assert!(
+            event_rx.try_recv().is_err(),
+            "invalid certificates must not emit progress or completion"
+        );
     }
 
     #[tokio::test]
@@ -1041,6 +1429,7 @@ mod tests {
             sender: Did::new("did:exo:sender").unwrap(),
             from_height: 1,
             nodes: vec![node.clone()],
+            certificates: vec![commit_certificate_for(node.hash, 1)],
             to_height: 1,
             has_more: false,
         };
@@ -1141,6 +1530,7 @@ mod tests {
             sender: Did::new("did:exo:unsolicited-sender").unwrap(),
             from_height: 1,
             nodes: vec![node.clone()],
+            certificates: vec![],
             to_height: 1,
             has_more: false,
         };
@@ -1212,6 +1602,11 @@ mod tests {
             sender: Did::new("did:exo:sender").unwrap(),
             from_height: u64::MAX - 1,
             nodes: vec![node1.clone(), node2.clone(), node3.clone()],
+            certificates: vec![
+                commit_certificate_for(node1.hash, 1),
+                commit_certificate_for(node2.hash, 2),
+                commit_certificate_for(node3.hash, 3),
+            ],
             to_height: u64::MAX,
             has_more: false,
         };
@@ -1284,7 +1679,8 @@ mod tests {
         let chunk = StateSnapshotChunkMsg {
             sender: Did::new("did:exo:sender").unwrap(),
             from_height: 1,
-            nodes: vec![node],
+            nodes: vec![node.clone()],
+            certificates: vec![commit_certificate_for(node.hash, 1)],
             to_height: 1,
             has_more: false,
         };
@@ -1359,6 +1755,10 @@ mod tests {
             sender: Did::new("did:exo:sender").unwrap(),
             from_height: 1,
             nodes: vec![node1.clone(), node2.clone()],
+            certificates: vec![
+                commit_certificate_for(node1.hash, 1),
+                commit_certificate_for(node2.hash, 2),
+            ],
             to_height: 2,
             has_more: false,
         };

--- a/crates/exo-node/src/wire.rs
+++ b/crates/exo-node/src/wire.rs
@@ -403,6 +403,20 @@ where
     WireCommitCertificateSerde::deserialize(deserializer).map(Into::into)
 }
 
+fn deserialize_snapshot_commit_certificates<'de, D>(
+    deserializer: D,
+) -> Result<Vec<CommitCertificate>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let certificates = deserialize_bounded_vec::<
+        D,
+        WireCommitCertificateSerde,
+        MAX_DAG_NODES_PER_MESSAGE,
+    >(deserializer, "snapshot commit certificates")?;
+    Ok(certificates.into_iter().map(Into::into).collect())
+}
+
 // ---------------------------------------------------------------------------
 // Wire message envelope
 // ---------------------------------------------------------------------------
@@ -587,6 +601,9 @@ pub struct StateSnapshotChunkMsg {
     /// Committed DAG nodes in height order.
     #[serde(deserialize_with = "deserialize_dag_nodes")]
     pub nodes: Vec<DagNode>,
+    /// Commit certificates proving finality for each node in `nodes`.
+    #[serde(default, deserialize_with = "deserialize_snapshot_commit_certificates")]
+    pub certificates: Vec<CommitCertificate>,
     /// The committed height this chunk reaches.
     pub to_height: u64,
     /// Whether there are more chunks.
@@ -669,6 +686,25 @@ mod tests {
             round: 1,
             node_hash: test_hash(b"node"),
             signature: Signature::empty(),
+        }
+    }
+
+    fn test_commit_certificate(node_hash: Hash256, vote_count: usize) -> CommitCertificate {
+        let votes = (0..vote_count)
+            .map(|index| {
+                let signature_byte = u8::try_from(index + 1).unwrap_or(u8::MAX);
+                Vote {
+                    voter: Did::new(&format!("did:exo:snapshot-voter-{index}")).unwrap(),
+                    round: 1,
+                    node_hash,
+                    signature: Signature::from_bytes([signature_byte; 64]),
+                }
+            })
+            .collect();
+        CommitCertificate {
+            node_hash,
+            votes,
+            round: 1,
         }
     }
 
@@ -848,10 +884,12 @@ mod tests {
     fn roundtrip_state_snapshot_chunk_preserves_post_quantum_node_signature() {
         let mut node = test_node(vec![]);
         node.signature = Signature::PostQuantum(vec![7u8; 128]);
+        let certificate = test_commit_certificate(node.hash, 1);
         let msg = WireMessage::StateSnapshotChunk(StateSnapshotChunkMsg {
             sender: test_did(),
             from_height: 12,
             nodes: vec![node],
+            certificates: vec![certificate.clone()],
             to_height: 12,
             has_more: true,
         });
@@ -864,6 +902,7 @@ mod tests {
                 assert_eq!(chunk.from_height, 12);
                 assert_eq!(chunk.to_height, 12);
                 assert!(chunk.has_more);
+                assert_eq!(chunk.certificates, vec![certificate]);
                 match &chunk.nodes[0].signature {
                     Signature::PostQuantum(pq) => assert_eq!(pq, &vec![7u8; 128]),
                     other => panic!("expected post-quantum signature, got {other:?}"),
@@ -1066,6 +1105,27 @@ mod tests {
     }
 
     #[test]
+    fn decode_rejects_state_snapshot_chunk_with_too_many_commit_certificates() {
+        let node_hash = test_hash(b"snapshot-node");
+        let certificates = (0..=EXPECTED_MAX_DAG_NODES_PER_MESSAGE)
+            .map(|_| test_commit_certificate(node_hash, 1))
+            .collect();
+        let msg = WireMessage::StateSnapshotChunk(StateSnapshotChunkMsg {
+            sender: test_did(),
+            from_height: 1,
+            nodes: vec![test_node(vec![])],
+            certificates,
+            to_height: 1,
+            has_more: false,
+        });
+        let bytes = encode(&msg).unwrap();
+
+        let err = decode(&bytes).expect_err("oversized snapshot certificates must fail");
+
+        assert!(err.contains("snapshot commit certificates"));
+    }
+
+    #[test]
     fn deserialize_rejects_short_ed25519_signature_from_untrusted_envelope() {
         let msg = WireMessage::GovernanceEvent(GovernanceEventMsg {
             sender: test_did(),
@@ -1091,6 +1151,7 @@ mod tests {
             sender: test_did(),
             from_height: 12,
             nodes: vec![node],
+            certificates: vec![],
             to_height: 12,
             has_more: false,
         });


### PR DESCRIPTION
Classification:
- EXOCHAIN core runtime adapter: crates/exo-node/src/sync.rs, crates/exo-node/src/store.rs, crates/exo-node/src/wire.rs
- Documentation metadata: README.md Rust LOC counter

Finding verified against current main:
- State snapshot sync accepted validly signed DAG nodes from snapshot chunks and marked them committed without requiring quorum commit certificates.
- Red test before production changes: cargo test -p exo-node snapshot_chunk_without_commit_certificate_is_rejected_without_commit -- --nocapture failed because the certless node persisted and committed.

Fix:
- StateSnapshotChunkMsg now carries bounded commit certificates.
- Snapshot receive validates one certificate per node, checks node hash binding, validator membership, duplicate voters, vote round/hash binding, vote signatures, and quorum before commit.
- Snapshot storage now persists DAG node, committed height, and commit certificate atomically.
- Snapshot serving fails closed if a local committed node is missing its certificate.
- Removed the old certless committed-batch helper from the sync storage path.

Regression coverage:
- Reject certless snapshot chunks without persistence or events.
- Reject mismatched and invalid certificates without persistence.
- Preserve positive snapshot sync with persisted certificates.
- Refuse to serve snapshots missing certificates.
- Bound snapshot certificate vector decoding on the wire.
- Store tests cover certificate lookup, CBOR node-hash mismatch, atomic persistence, and rollback.

Validation run:
- cargo test -p exo-node snapshot -- --nocapture
- cargo test -p exo-node certificate -- --nocapture
- cargo test -p exo-node sync -- --nocapture
- cargo test -p exo-node wire -- --nocapture
- cargo test -p exo-node --all-targets
- cargo clippy -p exo-node --all-targets -- -D warnings
- cargo +nightly fmt --all -- --check
- cargo doc -p exo-node --no-deps
- bash tools/test_repo_truth.sh
- git diff --check

Bypass search:
- Snapshot receive no longer calls the certless committed-batch helper.
- Snapshot serve includes certificates and fails closed on missing certificate rows.
- Wire deserialization bounds both DAG nodes and snapshot certificates.
