### PR TITLE
fix(escalation): bind challenge admissions to admitter DID

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 179075 | `wc -l` |
-| Workspace tests | 4,212 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 179143 | `wc -l` |
+| Workspace tests | 4,214 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,212 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,214 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 179075 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 179143 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,212 listed workspace tests
+         cryptographic proofs, 4,214 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-escalation/src/challenge.rs
+++ b/crates/exo-escalation/src/challenge.rs
@@ -9,6 +9,7 @@
 //! rather than `Verdict::Denied`.
 
 use exo_core::{Did, PublicKey, SecretKey, Signature, Timestamp, crypto};
+use exo_identity::did::did_from_public_key;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -259,6 +260,17 @@ fn validate_challenge_admission_metadata(
             reason: "challenge admission requires a non-zero Ed25519 public key".into(),
         });
     }
+    let derived_did = did_from_public_key(&admission.admitter_public_key).map_err(|e| {
+        EscalationError::InvalidProvenance {
+            reason: format!("challenge admission admitter public key did derivation failed: {e}"),
+        }
+    })?;
+    if derived_did != admission.admitted_by {
+        return Err(EscalationError::InvalidProvenance {
+            reason: "challenge admission admitted_by DID is not bound to admitter public key"
+                .into(),
+        });
+    }
     Ok(())
 }
 
@@ -387,7 +399,7 @@ mod tests {
             action_id: action_id(),
             ground,
             admitted_at: ts(1000),
-            admitted_by: did("reviewer"),
+            admitted_by: did_from_public_key(keypair.public_key()).unwrap(),
             admitter_public_key: *keypair.public_key(),
             evidence_hash: [0xEEu8; 32],
             authority_chain_hash: [0xACu8; 32],
@@ -409,11 +421,15 @@ mod tests {
     #[test]
     fn admit_creates_pause_eligible_hold() {
         let hold = admit_challenge(signed_admission()).unwrap();
+        let keypair = keypair(7);
         assert_eq!(hold.status, ContestStatus::PauseEligible);
         assert_eq!(hold.ground, SybilChallengeGround::ConcealedCommonControl);
         assert_eq!(hold.action_id, action_id());
         assert_eq!(hold.id, uuid(1));
-        assert_eq!(hold.admitted_by, did("reviewer"));
+        assert_eq!(
+            hold.admitted_by,
+            did_from_public_key(keypair.public_key()).unwrap()
+        );
         assert_eq!(hold.evidence_hash, [0xEEu8; 32]);
         assert_eq!(hold.authority_chain_hash, [0xACu8; 32]);
         assert!(!hold.admission_signature.is_empty());
@@ -469,6 +485,24 @@ mod tests {
         )
         .unwrap();
         signed.admission.admitter_public_key = *wrong_keypair.public_key();
+        assert!(verify_challenge_admission(&signed).is_err());
+    }
+
+    #[test]
+    fn verify_challenge_admission_rejects_mismatched_admitter_did_key() {
+        let attacker_keypair = keypair(9);
+        let mut admission = admission_with(
+            uuid(9),
+            SybilChallengeGround::QuorumContamination,
+            &attacker_keypair,
+        );
+        admission.admitted_by = did("victim-reviewer");
+        let payload = challenge_admission_payload(&admission).unwrap();
+        let signed = SignedChallengeAdmission {
+            admission,
+            admission_signature: crypto::sign(&payload, attacker_keypair.secret_key()),
+        };
+
         assert!(verify_challenge_admission(&signed).is_err());
     }
 

--- a/crates/exo-escalation/tests/sybil_adjudication.rs
+++ b/crates/exo-escalation/tests/sybil_adjudication.rs
@@ -37,6 +37,7 @@ use exo_governance::{
     audit::AuditLog,
     clearance::{ClearanceAssignment, ClearanceLevel, ClearanceRegistry},
 };
+use exo_identity::did::did_from_public_key;
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -85,7 +86,7 @@ fn signed_challenge(
             action_id,
             ground,
             admitted_at,
-            admitted_by: did("did:exo:reviewer"),
+            admitted_by: did_from_public_key(keypair.public_key()).unwrap(),
             admitter_public_key: *keypair.public_key(),
             evidence_hash: [0xEEu8; 32],
             authority_chain_hash: [0xACu8; 32],

--- a/crates/exo-identity/src/did.rs
+++ b/crates/exo-identity/src/did.rs
@@ -11,6 +11,23 @@
 use exo_core::{Did, PqPublicKey, PublicKey, Signature, Timestamp, crypto};
 use serde::{Deserialize, Serialize};
 
+/// Derive the self-certifying EXOCHAIN DID bound to an Ed25519 public key.
+///
+/// The canonical node/participant DID format is
+/// `did:exo:<base58(blake3(public_key))>`. Runtime adapters use this helper
+/// whenever they need to prove that a caller-supplied DID is cryptographically
+/// bound to a caller-supplied public key without trusting a separate registry
+/// lookup.
+///
+/// # Errors
+/// Returns the core DID validation error if the derived string does not satisfy
+/// the `did:exo:*` syntax.
+pub fn did_from_public_key(public_key: &PublicKey) -> exo_core::Result<Did> {
+    let hash = blake3::hash(public_key.as_bytes());
+    let encoded = bs58::encode(hash.as_bytes()).into_string();
+    Did::new(&format!("did:exo:{encoded}"))
+}
+
 /// Authentication method associated with a DID.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AuthenticationMethod {
@@ -166,6 +183,20 @@ mod tests {
             updated: Timestamp::new(1000, 0),
             revoked: false,
         }
+    }
+
+    #[test]
+    fn did_from_public_key_is_deterministic_and_key_bound() {
+        let (first_pk, _first_sk) = generate_keypair();
+        let (second_pk, _second_sk) = generate_keypair();
+
+        let first = did_from_public_key(&first_pk).unwrap();
+        let repeat = did_from_public_key(&first_pk).unwrap();
+        let second = did_from_public_key(&second_pk).unwrap();
+
+        assert_eq!(first, repeat);
+        assert_ne!(first, second);
+        assert!(first.as_str().starts_with("did:exo:"));
     }
 
     fn rotation_signature(

--- a/crates/exo-node/src/challenges.rs
+++ b/crates/exo-node/src/challenges.rs
@@ -580,6 +580,7 @@ mod tests {
     use exo_escalation::challenge::{
         ChallengeAdmission, SybilChallengeGround, sign_challenge_admission,
     };
+    use exo_identity::did::did_from_public_key;
     use tower::ServiceExt;
 
     use super::*;
@@ -596,16 +597,16 @@ mod tests {
         Timestamp::new(ms, 0)
     }
 
-    fn did(s: &str) -> Did {
-        Did::new(s).unwrap()
-    }
-
     fn uuid(byte: u8) -> Uuid {
         Uuid::from_bytes([byte; 16])
     }
 
     fn keypair(seed: u8) -> exo_core::crypto::KeyPair {
         exo_core::crypto::KeyPair::from_secret_bytes([seed; 32]).unwrap()
+    }
+    fn reviewer_did() -> Did {
+        let keypair = keypair(7);
+        did_from_public_key(keypair.public_key()).unwrap()
     }
 
     #[test]
@@ -675,7 +676,7 @@ mod tests {
                 action_id,
                 ground,
                 admitted_at,
-                admitted_by: did("did:exo:reviewer"),
+                admitted_by: reviewer_did(),
                 admitter_public_key: *keypair.public_key(),
                 evidence_hash: [0xEEu8; 32],
                 authority_chain_hash: [0xACu8; 32],
@@ -693,7 +694,7 @@ mod tests {
         detail: &str,
     ) -> serde_json::Value {
         let keypair = keypair(7);
-        let actor = did("did:exo:reviewer");
+        let actor = reviewer_did();
         let payload =
             challenge_transition_signing_payload(hold, transition, &actor, &at, detail).unwrap();
         let signature = exo_core::crypto::sign(&payload, keypair.secret_key());
@@ -758,7 +759,7 @@ mod tests {
         assert_eq!(result.ground, "QuorumContamination");
         assert_eq!(result.status, "PauseEligible");
         assert_eq!(result.id, uuid(1).to_string());
-        assert_eq!(result.admitted_by, "did:exo:reviewer");
+        assert_eq!(result.admitted_by, reviewer_did().to_string());
         assert_eq!(result.admission_signature_algorithm, "Ed25519");
         assert!(!result.audit_log.is_empty());
 

--- a/crates/exo-node/src/telegram.rs
+++ b/crates/exo-node/src/telegram.rs
@@ -1723,6 +1723,7 @@ mod tests {
         use exo_escalation::challenge::{
             self, ChallengeAdmission, SybilChallengeGround, sign_challenge_admission,
         };
+        use exo_identity::did::did_from_public_key;
 
         let store: SharedChallengeStore = Arc::new(Mutex::new(ChallengeStore::new()));
         {
@@ -1733,7 +1734,7 @@ mod tests {
                 action_id: [1u8; 32],
                 ground: SybilChallengeGround::QuorumContamination,
                 admitted_at: exo_core::types::Timestamp::new(1000, 0),
-                admitted_by: Did::new("did:exo:reviewer").unwrap(),
+                admitted_by: did_from_public_key(keypair.public_key()).unwrap(),
                 admitter_public_key: *keypair.public_key(),
                 evidence_hash: [0xEEu8; 32],
                 authority_chain_hash: [0xACu8; 32],


### PR DESCRIPTION
## Summary

Binds Sybil challenge admissions to the admitting actor's self-certifying EXOCHAIN DID instead of trusting the request-supplied DID/public-key pair independently.

## Finding Confirmation

Classification:
- EXOCHAIN core: `crates/exo-identity/src/did.rs`, `crates/exo-escalation/src/challenge.rs`, `crates/exo-escalation/tests/sybil_adjudication.rs`
- Core runtime adapter: `crates/exo-node/src/challenges.rs`, `crates/exo-node/src/telegram.rs`
- Documentation metadata: `README.md` repo-truth counters

Current `main` at `8b183b74` accepted a signed `SignedChallengeAdmission` where `admitted_by = did:exo:victim-reviewer` but `admitter_public_key` belonged to an unrelated key that signed the payload. The signature proved only the supplied key signed the payload, not that the key was bound to the claimed DID.

Red test first:
- `cargo test -p exo-escalation verify_challenge_admission_rejects_mismatched_admitter_did_key -- --nocapture`
- Failed before the fix with `assertion failed: verify_challenge_admission(&signed).is_err()`.

## Remediation

- Added `exo_identity::did::did_from_public_key`, the canonical `did:exo:<base58(blake3(public_key))>` derivation helper.
- Updated `verify_challenge_admission` to derive the DID from `admitter_public_key` and reject any admission where `admitted_by` does not match.
- Updated challenge API and Telegram test fixtures to use key-bound DIDs.
- Added identity-level determinism/key-binding coverage for the derivation helper.

## Validation

- `cargo test -p exo-escalation verify_challenge_admission_rejects_mismatched_admitter_did_key -- --nocapture`
- `cargo test -p exo-identity did_from_public_key_is_deterministic_and_key_bound -- --nocapture`
- `cargo test -p exo-identity --all-targets -- --nocapture`
- `cargo test -p exo-escalation --all-targets -- --nocapture`
- `cargo test -p exo-node challenges -- --nocapture`
- `cargo test -p exo-node --all-targets`
- `cargo clippy -p exo-identity --all-targets -- -D warnings`
- `cargo clippy -p exo-escalation --all-targets -- -D warnings`
- `cargo clippy -p exo-node --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `cargo doc -p exo-identity -p exo-escalation -p exo-node --no-deps`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `bash tools/repo_truth.sh --json --list-tests`
