### PR TITLE
fix(gatekeeper): bind consent records to active bailment

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 179249 | `wc -l` |
-| Workspace tests | 4,215 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 179314 | `wc -l` |
+| Workspace tests | 4,218 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,215 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,218 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 179249 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 179314 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,215 listed workspace tests
+         cryptographic proofs, 4,218 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-gatekeeper/src/invariants.rs
+++ b/crates/exo-gatekeeper/src/invariants.rs
@@ -280,23 +280,43 @@ fn check_separation_of_powers(ctx: &InvariantContext) -> Result<(), InvariantVio
 }
 
 fn check_consent_required(ctx: &InvariantContext) -> Result<(), InvariantViolation> {
-    if !ctx.bailment_state.is_active() {
+    let (bailor, bailee, scope) = match &ctx.bailment_state {
+        BailmentState::Active {
+            bailor,
+            bailee,
+            scope,
+        } => (bailor, bailee, scope),
+        _ => {
+            return Err(InvariantViolation {
+                invariant: ConstitutionalInvariant::ConsentRequired,
+                description: "No active bailment for this action".into(),
+                evidence: bailment_state_evidence(&ctx.bailment_state),
+            });
+        }
+    };
+
+    if bailee != &ctx.actor {
         return Err(InvariantViolation {
             invariant: ConstitutionalInvariant::ConsentRequired,
-            description: "No active bailment for this action".into(),
-            evidence: bailment_state_evidence(&ctx.bailment_state),
+            description: "Active bailment is not granted to actor".into(),
+            evidence: vec![
+                format!("actor: {}", ctx.actor),
+                format!("bailment_bailee: {bailee}"),
+            ],
         });
     }
-    let has_active = ctx
-        .consent_records
-        .iter()
-        .any(|c| c.granted_to == ctx.actor && c.active);
+
+    let has_active = ctx.consent_records.iter().any(|c| {
+        c.subject == *bailor && c.granted_to == ctx.actor && c.scope == *scope && c.active
+    });
     if !has_active {
         return Err(InvariantViolation {
             invariant: ConstitutionalInvariant::ConsentRequired,
-            description: "No active consent record for actor".into(),
+            description: "No active consent record matching actor, bailor, and scope".into(),
             evidence: vec![
                 format!("actor: {}", ctx.actor),
+                format!("bailor: {bailor}"),
+                format!("scope: {scope}"),
                 format!("records: {}", ctx.consent_records.len()),
             ],
         });
@@ -916,6 +936,52 @@ mod tests {
         let mut ctx = passing_context();
         ctx.consent_records[0].granted_to = did("did:exo:other");
         assert!(enforce_all(&engine, &ctx).is_err());
+    }
+
+    #[test]
+    fn consent_fails_when_bailment_bailee_is_not_actor() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::ConsentRequired,
+        ]));
+        let mut ctx = passing_context();
+        ctx.bailment_state = BailmentState::Active {
+            bailor: did("did:exo:bailor"),
+            bailee: did("did:exo:other-bailee"),
+            scope: "data:medical".into(),
+        };
+
+        assert!(
+            enforce_all(&engine, &ctx).is_err(),
+            "ConsentRequired must bind the active bailment bailee to the actor"
+        );
+    }
+
+    #[test]
+    fn consent_fails_when_record_subject_does_not_match_bailor() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::ConsentRequired,
+        ]));
+        let mut ctx = passing_context();
+        ctx.consent_records[0].subject = did("did:exo:unrelated-subject");
+
+        assert!(
+            enforce_all(&engine, &ctx).is_err(),
+            "ConsentRequired must bind the consent subject to the active bailment bailor"
+        );
+    }
+
+    #[test]
+    fn consent_fails_when_record_scope_does_not_match_bailment_scope() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::ConsentRequired,
+        ]));
+        let mut ctx = passing_context();
+        ctx.consent_records[0].scope = "data:genomics".into();
+
+        assert!(
+            enforce_all(&engine, &ctx).is_err(),
+            "ConsentRequired must bind the consent record scope to the active bailment scope"
+        );
     }
 
     #[test]

--- a/crates/exo-node/src/holons.rs
+++ b/crates/exo-node/src/holons.rs
@@ -431,7 +431,7 @@ pub fn build_holon_adjudication_context(
         bailment_state: BailmentState::Active {
             bailor: config.root_did.clone(),
             bailee: holon.id.clone(),
-            scope: "infrastructure".into(),
+            scope: "infrastructure-monitoring".into(),
         },
         human_override_preserved: true,
         actor_permissions: holon.capabilities.clone(),

--- a/crates/exochain-wasm/src/gatekeeper_bindings.rs
+++ b/crates/exochain-wasm/src/gatekeeper_bindings.rs
@@ -213,17 +213,16 @@ pub fn wasm_validation_invariant_request() -> Result<JsValue, JsValue> {
     );
 
     to_js_value(&serde_json::json!({
-        "actor": actor,
+        "actor": actor.clone(),
         "actor_roles": [],
         "bailment_state": BailmentState::Active {
             bailor: exo_core::Did::new("did:exo:validation-bailor")
                 .map_err(|_| gatekeeper_boundary_error("validation bailor DID failed"))?,
-            bailee: exo_core::Did::new("did:exo:validation-bailee")
-                .map_err(|_| gatekeeper_boundary_error("validation bailee DID failed"))?,
+            bailee: actor.clone(),
             scope: "validation-scope".to_string(),
         },
         "consent_records": [ConsentRecord {
-            subject: exo_core::Did::new("did:exo:validation-subject")
+            subject: exo_core::Did::new("did:exo:validation-bailor")
                 .map_err(|_| gatekeeper_boundary_error("validation subject DID failed"))?,
             granted_to: actor.clone(),
             scope: "validation-scope".to_string(),
@@ -309,7 +308,7 @@ mod tests {
     fn active_bailment() -> BailmentState {
         BailmentState::Active {
             bailor: Did::new("did:exo:bailor").expect("valid"),
-            bailee: Did::new("did:exo:bailee").expect("valid"),
+            bailee: actor(),
             scope: "test-scope".to_string(),
         }
     }
@@ -380,7 +379,7 @@ mod tests {
             actor_roles: vec![],
             bailment_state: active_bailment(),
             consent_records: vec![ConsentRecord {
-                subject: Did::new("did:exo:subject").expect("valid"),
+                subject: Did::new("did:exo:bailor").expect("valid"),
                 granted_to: actor(),
                 scope: "test-scope".to_string(),
                 active: true,


### PR DESCRIPTION
## Classification
- EXOCHAIN core: `crates/exo-gatekeeper/src/invariants.rs`
- Core runtime adapters/fixtures: `crates/exo-node/src/holons.rs`, `crates/exochain-wasm/src/gatekeeper_bindings.rs`
- Documentation metadata: `README.md` repo-truth counts only

## Verification Before Fix
- Confirmed current `ConsentRequired` accepted unrelated active consent as long as any record was active and granted to the actor.
- Added regression tests first for bailee, subject, and scope mismatch.
- Proved red on current `origin/main` with `cargo test -p exo-gatekeeper consent_fails_when -- --nocapture`; all three tests failed because the invariant permitted the mismatched contexts.

## Remediation
- `ConsentRequired` now requires an active bailment whose `bailee` is the actor.
- Consent records must match the same active bailment `bailor`, actor/grantee, and scope.
- Updated node holon and WASM adapter fixtures to use coherent bailor/bailee/scope contexts instead of stale permissive fixtures.

## Validation
- `cargo test -p exo-gatekeeper consent_fails_when -- --nocapture`
- `cargo test -p exo-gatekeeper --all-targets -- --nocapture`
- `cargo test -p exo-gateway adjudication_context_rows -- --nocapture`
- `cargo test -p exo-node mcp -- --nocapture`
- `cargo test -p decision-forum --all-targets -- --nocapture`
- `cargo test -p exo-escalation --all-targets -- --nocapture`
- `cargo test -p exo-legal --all-targets -- --nocapture`
- `cargo test -p exochain-sdk kernel -- --nocapture`
- `cargo test -p exochain-wasm --all-targets -- --nocapture`
- `cargo test -p exo-gateway --all-targets -- --nocapture`
- `cargo test -p exo-node --all-targets -- --nocapture`
- `cargo test --workspace --all-targets`
- `cargo clippy -p exo-gatekeeper -p exo-node -p exochain-wasm --all-targets -- -D warnings`
- `cargo doc -p exo-gatekeeper -p exo-node -p exochain-wasm --no-deps`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `bash tools/repo_truth.sh --json --list-tests`

Repo truth after this change: Rust LOC `179314`; listed workspace tests `4218`.
