### PR TITLE
fix(node): reject escalated mcp verdicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 179314 | `wc -l` |
-| Workspace tests | 4,218 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 179336 | `wc -l` |
+| Workspace tests | 4,219 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,218 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,219 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 179314 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 179336 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,218 listed workspace tests
+         cryptographic proofs, 4,219 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-node/src/mcp/middleware.rs
+++ b/crates/exo-node/src/mcp/middleware.rs
@@ -5,7 +5,7 @@
 //! 2. Enforces all 6 MCP rules (via exo-gatekeeper)
 //! 3. Adjudicates the supplied `AdjudicationContext` in the CGR Kernel
 //! 4. Adjudicates the action against all 8 constitutional invariants
-//! 5. Returns Permitted/Denied/Escalated verdict
+//! 5. Permits only `Permitted` verdicts for tool execution
 //!
 //! # Verified Context Requirement
 //!
@@ -331,6 +331,9 @@ impl ConstitutionalMiddleware {
                     violations.iter().map(|v| v.description.clone()).collect();
                 Err(McpError::ConstitutionalViolation(descriptions.join("; ")))
             }
+            Verdict::Escalated { reason } => Err(McpError::ConstitutionalViolation(format!(
+                "kernel verdict escalated; tool execution requires review: {reason}"
+            ))),
             _ => Ok(verdict),
         }
     }
@@ -513,6 +516,25 @@ mod tests {
             .adjudicate(&did, action, &invocation.adjudication_context)
             .unwrap();
         assert!(verdict.is_permitted());
+    }
+
+    #[test]
+    fn middleware_enforce_tool_call_rejects_escalated_kernel_verdict() {
+        let mw = signed_middleware();
+        let did = test_did();
+        let action = "exochain_node_status";
+        let mut params = signed_tool_call_params(action);
+        params[CONSTITUTIONAL_CONTEXT_FIELD]["adjudication_context"]["actor_permissions"] =
+            serde_json::json!(["unrelated:permission"]);
+
+        let err = mw
+            .enforce_tool_call(&did, action, &params)
+            .expect_err("MCP middleware must not execute tools after an escalated kernel verdict");
+
+        assert!(
+            err.to_string().contains("escalated"),
+            "expected escalated verdict refusal, got {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- reject MCP tool execution when the core kernel returns an `Escalated` verdict
- add a regression test proving an escalated AuthorityChainValid verdict is not treated as executable
- refresh derived README repository truth counts after adding the test

## Classification
- Core runtime adapter: `crates/exo-node/src/mcp/middleware.rs`
- Documentation metadata: `README.md` repository-truth counters

## Current-state verification before fix
- Added `middleware_enforce_tool_call_rejects_escalated_kernel_verdict` first.
- Red proof on current main: `cargo test -p exo-node middleware_enforce_tool_call_rejects_escalated_kernel_verdict -- --nocapture` failed because `enforce_tool_call` returned `Ok(())` after a kernel `Escalated` verdict.

## Validation
- `cargo test -p exo-node middleware_enforce_tool_call_rejects_escalated_kernel_verdict -- --nocapture`
- `cargo test -p exo-node mcp::middleware -- --nocapture`
- `cargo test -p exo-gatekeeper kernel -- --nocapture`
- `cargo test -p exo-node --all-targets -- --nocapture`
- `cargo test --workspace --all-targets`
- `cargo clippy -p exo-node --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc -p exo-node --no-deps`
- `cargo doc --workspace --no-deps`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `bash tools/repo_truth.sh --json --list-tests`