### PR TITLE
fix(wasm): reject caller supplied trusted key maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 179336 | `wc -l` |
-| Workspace tests | 4,219 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 179427 | `wc -l` |
+| Workspace tests | 4,220 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,219 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,220 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 179336 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 179427 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,219 listed workspace tests
+         cryptographic proofs, 4,220 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exochain-wasm/src/gatekeeper_bindings.rs
+++ b/crates/exochain-wasm/src/gatekeeper_bindings.rs
@@ -8,6 +8,10 @@ use crate::serde_bridge::*;
 ///
 /// All fields map 1-to-1 onto `exo_gatekeeper::invariants::InvariantContext`.
 /// Booleans default to safe values (false / true for human_override_preserved).
+///
+/// The public WASM boundary cannot prove that caller-provided trusted key maps
+/// came from DID resolution. Non-empty trusted key maps are deserialized only so
+/// `wasm_enforce_invariants` can fail closed with an explicit violation.
 #[derive(serde::Deserialize)]
 struct WasmInvariantRequest {
     actor: exo_core::Did,
@@ -75,6 +79,17 @@ pub fn wasm_reduce_combinator(combinator_json: &str, input_json: &str) -> Result
 #[wasm_bindgen]
 pub fn wasm_enforce_invariants(request_json: &str) -> Result<JsValue, JsValue> {
     let req: WasmInvariantRequest = from_json_str(request_json)?;
+    to_js_value(&enforce_invariants_response(req))
+}
+
+fn enforce_invariants_response(req: WasmInvariantRequest) -> serde_json::Value {
+    let boundary_violations = caller_supplied_trusted_key_violations(&req);
+    if !boundary_violations.is_empty() {
+        return serde_json::json!({
+            "passed": false,
+            "violations": boundary_violations
+        });
+    }
 
     let context = exo_gatekeeper::invariants::InvariantContext {
         actor: req.actor,
@@ -96,15 +111,45 @@ pub fn wasm_enforce_invariants(request_json: &str) -> Result<JsValue, JsValue> {
     let engine = exo_gatekeeper::InvariantEngine::all();
 
     match exo_gatekeeper::invariants::enforce_all(&engine, &context) {
-        Ok(()) => to_js_value(&serde_json::json!({
+        Ok(()) => serde_json::json!({
             "passed": true,
             "violations": []
-        })),
-        Err(violations) => to_js_value(&serde_json::json!({
+        }),
+        Err(violations) => serde_json::json!({
             "passed": false,
             "violations": violations
-        })),
+        }),
     }
+}
+
+fn caller_supplied_trusted_key_violations(
+    req: &WasmInvariantRequest,
+) -> Vec<exo_gatekeeper::invariants::InvariantViolation> {
+    let mut violations = Vec::new();
+
+    if !req.trusted_authority_keys.is_empty() {
+        violations.push(exo_gatekeeper::invariants::InvariantViolation {
+            invariant: exo_gatekeeper::invariants::ConstitutionalInvariant::AuthorityChainValid,
+            description: "WASM invariant boundary cannot trust caller-supplied \
+                trusted_authority_keys; submit authority-bearing requests to a core runtime \
+                adapter with trusted DID resolution"
+                .to_string(),
+            evidence: vec!["field: trusted_authority_keys".to_string()],
+        });
+    }
+
+    if !req.trusted_provenance_keys.is_empty() {
+        violations.push(exo_gatekeeper::invariants::InvariantViolation {
+            invariant: exo_gatekeeper::invariants::ConstitutionalInvariant::ProvenanceVerifiable,
+            description: "WASM invariant boundary cannot trust caller-supplied \
+                trusted_provenance_keys; submit provenance-bearing requests to a core runtime \
+                adapter with trusted DID resolution"
+                .to_string(),
+            evidence: vec!["field: trusted_provenance_keys".to_string()],
+        });
+    }
+
+    violations
 }
 
 /// Compute the canonical BLAKE3/CBOR digest for governance monitor findings.
@@ -512,6 +557,52 @@ mod tests {
         assert!(
             result.is_ok(),
             "WasmInvariantRequest must deserialize from valid JSON"
+        );
+    }
+
+    #[test]
+    fn wasm_enforce_invariants_rejects_caller_supplied_trusted_key_maps() {
+        let ctx = minimal_passing_context();
+        let req = super::WasmInvariantRequest {
+            actor: ctx.actor,
+            actor_roles: ctx.actor_roles,
+            bailment_state: ctx.bailment_state,
+            consent_records: ctx.consent_records,
+            authority_chain: ctx.authority_chain,
+            is_self_grant: ctx.is_self_grant,
+            human_override_preserved: ctx.human_override_preserved,
+            kernel_modification_attempted: ctx.kernel_modification_attempted,
+            quorum_evidence: ctx.quorum_evidence,
+            provenance: ctx.provenance,
+            actor_permissions: ctx.actor_permissions,
+            requested_permissions: ctx.requested_permissions,
+            trusted_authority_keys: ctx.trusted_authority_keys,
+            trusted_provenance_keys: ctx.trusted_provenance_keys,
+        };
+
+        let response = super::enforce_invariants_response(req);
+        assert_eq!(
+            response["passed"], false,
+            "WASM public enforcement must not treat caller-supplied trusted key maps as authoritative"
+        );
+
+        let descriptions = response["violations"]
+            .as_array()
+            .expect("violations must be an array")
+            .iter()
+            .filter_map(|violation| violation["description"].as_str())
+            .collect::<Vec<_>>();
+        assert!(
+            descriptions
+                .iter()
+                .any(|description| description.contains("trusted_authority_keys")),
+            "authority key map boundary violation must be explicit: {descriptions:?}"
+        );
+        assert!(
+            descriptions
+                .iter()
+                .any(|description| description.contains("trusted_provenance_keys")),
+            "provenance key map boundary violation must be explicit: {descriptions:?}"
         );
     }
 

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -2347,10 +2347,17 @@ test('wasm_anchor_economy_value_contribution_node', () => {
 test('wasm_validation_invariant_request', () => {
   const request = wasm.wasm_validation_invariant_request();
   const result = wasm.wasm_enforce_invariants(JSON.stringify(request));
-  if (!result.passed || result.violations.length !== 0) {
-    throw new Error('validation invariant request must satisfy all invariants');
+  if (result.passed) {
+    throw new Error('public invariant enforcement must reject replayed trusted key maps');
   }
-  return request;
+  const descriptions = (result.violations || []).map((violation) => violation.description || '');
+  if (!descriptions.some((description) => description.includes('trusted_authority_keys'))) {
+    throw new Error('authority trusted-key boundary violation must be explicit');
+  }
+  if (!descriptions.some((description) => description.includes('trusted_provenance_keys'))) {
+    throw new Error('provenance trusted-key boundary violation must be explicit');
+  }
+  return { request, result };
 });
 
 // =========================================================================


### PR DESCRIPTION
## Summary
- fail closed when public `wasm_enforce_invariants` receives caller-supplied `trusted_authority_keys` or `trusted_provenance_keys`
- add a regression test proving a valid internally generated context cannot be replayed through the public WASM boundary as authoritative trusted key material
- update the Node bridge verification harness to expect explicit trusted-key boundary violations
- refresh derived README repository-truth counters

## Classification
- Core runtime adapter: `crates/exochain-wasm/src/gatekeeper_bindings.rs`
- Core runtime adapter bridge test: `packages/exochain-wasm/test/bridge_verification.mjs`
- Documentation metadata: `README.md` repository-truth counters

## Current-state verification before fix
- Added `wasm_enforce_invariants_rejects_caller_supplied_trusted_key_maps` first.
- Red proof on current main: `cargo test -p exochain-wasm wasm_enforce_invariants_rejects_caller_supplied_trusted_key_maps -- --nocapture` failed because the public WASM bridge returned `passed: true` for a request carrying caller-supplied trusted key maps.

## Validation
- `cargo test -p exochain-wasm wasm_enforce_invariants_rejects_caller_supplied_trusted_key_maps -- --nocapture`
- `cargo test -p exochain-wasm --all-targets -- --nocapture`
- `cargo test -p exo-gatekeeper trusted -- --nocapture`
- `wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm`
- `node packages/exochain-wasm/test/bridge_verification.mjs`
- `cargo test --workspace --all-targets`
- `cargo clippy -p exochain-wasm -p exo-gatekeeper --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc -p exochain-wasm -p exo-gatekeeper --no-deps`
- `cargo doc --workspace --no-deps`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `bash tools/repo_truth.sh --json --list-tests`