### PR TITLE
fix(node): bind MCP action hashes to arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 179427 | `wc -l` |
-| Workspace tests | 4,220 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 179523 | `wc -l` |
+| Workspace tests | 4,222 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,220 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,222 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 179427 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 179523 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,220 listed workspace tests
+         cryptographic proofs, 4,222 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-node/src/mcp/handler.rs
+++ b/crates/exo-node/src/mcp/handler.rs
@@ -748,7 +748,7 @@ impl McpServer {
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
-    use super::*;
+    use super::{super::middleware::mcp_tool_action_hash, *};
     use crate::mcp::protocol::{AI_OUTPUT_GENERATOR, AI_OUTPUT_MARKING};
 
     fn test_server() -> McpServer {
@@ -772,7 +772,7 @@ mod tests {
             .clone()
     }
 
-    fn constitutional_context(actor_did: &str, action: &str) -> Value {
+    fn constitutional_context(actor_did: &str, action: &str, arguments: &Value) -> Value {
         let actor = Did::new(actor_did).expect("valid DID");
         let keypair = exo_core::crypto::KeyPair::from_secret_bytes([0x4D; 32]).unwrap();
         let public_key = *keypair.public_key();
@@ -798,7 +798,8 @@ mod tests {
         authority_link.signature = authority_signature.to_bytes().to_vec();
 
         let timestamp = exo_core::Timestamp::new(1_777_000_000_000, 7).to_string();
-        let action_hash = exo_core::Hash256::digest(action.as_bytes());
+        let action_hash =
+            mcp_tool_action_hash(action, arguments).expect("canonical tool action payload");
         let mut provenance = exo_gatekeeper::types::Provenance {
             actor: actor.clone(),
             timestamp: timestamp.clone(),
@@ -862,10 +863,12 @@ mod tests {
     }
 
     fn tool_call_params(name: &str, arguments: Value) -> Value {
+        let constitutional_context =
+            constitutional_context("did:exo:test-ai-agent", name, &arguments);
         serde_json::json!({
             "name": name,
             "arguments": arguments,
-            "constitutional_context": constitutional_context("did:exo:test-ai-agent", name),
+            "constitutional_context": constitutional_context,
         })
     }
 

--- a/crates/exo-node/src/mcp/middleware.rs
+++ b/crates/exo-node/src/mcp/middleware.rs
@@ -38,13 +38,22 @@ use super::{
 
 const CONSTITUTIONAL_CONTEXT_FIELD: &str = "constitutional_context";
 const MCP_DELEGATION_ID_DOMAIN: &str = "exo.node.mcp.middleware.delegation_id.v1";
+const MCP_TOOL_ACTION_HASH_DOMAIN: &str = "exo.node.mcp.middleware.tool_action_hash.v1";
 
 #[derive(Serialize)]
 struct McpDelegationIdPayload<'a> {
     domain: &'static str,
     actor_did: &'a Did,
     action: &'a str,
+    tool_action_hash: &'a Hash256,
     bcts_scope: &'a str,
+}
+
+#[derive(Serialize)]
+struct McpToolActionHashPayload<'a> {
+    domain: &'static str,
+    action: &'a str,
+    arguments: &'a Value,
 }
 
 /// Constitutional enforcement middleware wrapping every MCP tool invocation.
@@ -167,8 +176,8 @@ impl ConstitutionalMiddleware {
         Ok(PermissionSet::new(permissions))
     }
 
-    fn action_hash_matches(context: &AdjudicationContext, action: &str) -> bool {
-        let expected = Hash256::digest(action.as_bytes()).as_bytes().to_vec();
+    fn action_hash_matches(context: &AdjudicationContext, expected_action_hash: &Hash256) -> bool {
+        let expected = expected_action_hash.as_bytes().to_vec();
         context
             .provenance
             .as_ref()
@@ -274,20 +283,31 @@ impl ConstitutionalMiddleware {
             ))
         })?;
         self.verify_authority_binding(actor_did, &adjudication_context)?;
-        if !Self::action_hash_matches(&adjudication_context, action) {
+
+        let empty_arguments = Value::Object(serde_json::Map::new());
+        let arguments = tool_call_params
+            .get("arguments")
+            .unwrap_or(&empty_arguments);
+        let tool_action_hash = mcp_tool_action_hash(action, arguments).map_err(|err| {
+            McpError::ConstitutionalViolation(format!(
+                "verified MCP invocation context action_hash encoding failed: {err}"
+            ))
+        })?;
+        if !Self::action_hash_matches(&adjudication_context, &tool_action_hash) {
             return Err(McpError::ConstitutionalViolation(
-                "verified MCP invocation context provenance action_hash does not match tool action"
+                "verified MCP invocation context provenance action_hash does not match tool action and arguments"
                     .into(),
             ));
         }
 
         let bcts_scope = Self::parse_required_str(context_value, "bcts_scope")?.to_owned();
         let output_marking = Self::parse_required_str(context_value, "output_marking")?;
-        let delegation_id = mcp_delegation_id(actor_did, action, &bcts_scope).map_err(|err| {
-            McpError::ConstitutionalViolation(format!(
-                "verified MCP invocation context delegation_id encoding failed: {err}"
-            ))
-        })?;
+        let delegation_id = mcp_delegation_id(actor_did, action, &tool_action_hash, &bcts_scope)
+            .map_err(|err| {
+                McpError::ConstitutionalViolation(format!(
+                    "verified MCP invocation context delegation_id encoding failed: {err}"
+                ))
+            })?;
         let mcp_context = McpContext {
             actor_did: actor_did.clone(),
             signer_type: SignerType::Ai { delegation_id },
@@ -352,11 +372,25 @@ impl ConstitutionalMiddleware {
     }
 }
 
-fn mcp_delegation_id(actor_did: &Did, action: &str, bcts_scope: &str) -> exo_core::Result<Hash256> {
+pub(super) fn mcp_tool_action_hash(action: &str, arguments: &Value) -> exo_core::Result<Hash256> {
+    hash_structured(&McpToolActionHashPayload {
+        domain: MCP_TOOL_ACTION_HASH_DOMAIN,
+        action,
+        arguments,
+    })
+}
+
+fn mcp_delegation_id(
+    actor_did: &Did,
+    action: &str,
+    tool_action_hash: &Hash256,
+    bcts_scope: &str,
+) -> exo_core::Result<Hash256> {
     hash_structured(&McpDelegationIdPayload {
         domain: MCP_DELEGATION_ID_DOMAIN,
         actor_did,
         action,
+        tool_action_hash,
         bcts_scope,
     })
 }
@@ -392,6 +426,10 @@ mod tests {
     }
 
     fn signed_tool_call_params(action: &str) -> Value {
+        signed_tool_call_params_with_arguments(action, serde_json::json!({}))
+    }
+
+    fn signed_tool_call_params_with_arguments(action: &str, arguments: Value) -> Value {
         let actor = test_did();
         let keypair = exo_core::crypto::KeyPair::from_secret_bytes([0x4D; 32]).unwrap();
         let public_key = *keypair.public_key();
@@ -417,7 +455,8 @@ mod tests {
         authority_link.signature = authority_signature.to_bytes().to_vec();
 
         let timestamp = exo_core::Timestamp::new(1_777_000_000_000, 7).to_string();
-        let action_hash = Hash256::digest(action.as_bytes());
+        let action_hash =
+            mcp_tool_action_hash(action, &arguments).expect("canonical tool action payload");
         let mut provenance = exo_gatekeeper::types::Provenance {
             actor: actor.clone(),
             timestamp: timestamp.clone(),
@@ -435,6 +474,7 @@ mod tests {
         provenance.signature = provenance_signature.to_bytes().to_vec();
 
         serde_json::json!({
+            "arguments": arguments,
             CONSTITUTIONAL_CONTEXT_FIELD: {
                 "bcts_scope": action,
                 "capabilities": ["mcp:tool_call"],
@@ -534,6 +574,27 @@ mod tests {
         assert!(
             err.to_string().contains("escalated"),
             "expected escalated verdict refusal, got {err}"
+        );
+    }
+
+    #[test]
+    fn middleware_rejects_signed_context_replayed_with_different_arguments() {
+        let mw = signed_middleware();
+        let did = test_did();
+        let action = "exochain_node_status";
+        let mut params = signed_tool_call_params(action);
+        params["arguments"] = serde_json::json!({
+            "target_tenant": "did:exo:other-tenant",
+            "include_sensitive_state": true
+        });
+
+        let err = mw
+            .enforce_tool_call(&did, action, &params)
+            .expect_err("MCP signed context must be bound to the exact tool arguments");
+
+        assert!(
+            err.to_string().contains("action_hash"),
+            "expected argument-bound action_hash refusal, got {err}"
         );
     }
 
@@ -683,6 +744,10 @@ mod tests {
             "MCP delegation IDs must carry an explicit domain separator"
         );
         assert!(
+            production.contains("MCP_TOOL_ACTION_HASH_DOMAIN"),
+            "MCP tool action hashes must carry an explicit domain separator"
+        );
+        assert!(
             production.contains("hash_structured"),
             "MCP delegation IDs must use canonical CBOR structured hashing"
         );
@@ -701,10 +766,13 @@ mod tests {
         let actor = test_did();
         let action = "exochain_node_status";
         let bcts_scope = "mcp:tools";
+        let arguments = serde_json::json!({});
+        let tool_action_hash =
+            mcp_tool_action_hash(action, &arguments).expect("canonical tool action hash");
 
-        let structured =
-            mcp_delegation_id(&actor, action, bcts_scope).expect("canonical delegation id");
-        let repeat = mcp_delegation_id(&actor, action, bcts_scope)
+        let structured = mcp_delegation_id(&actor, action, &tool_action_hash, bcts_scope)
+            .expect("canonical delegation id");
+        let repeat = mcp_delegation_id(&actor, action, &tool_action_hash, bcts_scope)
             .expect("canonical delegation id is deterministic");
         let mut legacy_payload = Vec::new();
         legacy_payload.extend_from_slice(actor.as_str().as_bytes());
@@ -718,11 +786,36 @@ mod tests {
         assert_ne!(structured, legacy);
         assert_ne!(
             structured,
-            mcp_delegation_id(&actor, "other_action", bcts_scope).expect("canonical delegation id")
+            mcp_delegation_id(&actor, "other_action", &tool_action_hash, bcts_scope)
+                .expect("canonical delegation id")
         );
         assert_ne!(
             structured,
-            mcp_delegation_id(&actor, action, "other_scope").expect("canonical delegation id")
+            mcp_delegation_id(&actor, action, &tool_action_hash, "other_scope")
+                .expect("canonical delegation id")
         );
+        let other_arguments = serde_json::json!({"changed": true});
+        let other_tool_action_hash =
+            mcp_tool_action_hash(action, &other_arguments).expect("canonical tool action hash");
+        assert_ne!(
+            structured,
+            mcp_delegation_id(&actor, action, &other_tool_action_hash, bcts_scope)
+                .expect("canonical delegation id")
+        );
+    }
+
+    #[test]
+    fn tool_action_hash_binds_arguments() {
+        let action = "exochain_node_status";
+        let first = mcp_tool_action_hash(action, &serde_json::json!({"tenant": "alpha"}))
+            .expect("canonical tool action hash");
+        let repeat = mcp_tool_action_hash(action, &serde_json::json!({"tenant": "alpha"}))
+            .expect("canonical tool action hash");
+        let changed = mcp_tool_action_hash(action, &serde_json::json!({"tenant": "beta"}))
+            .expect("canonical tool action hash");
+
+        assert_eq!(first, repeat);
+        assert_ne!(first, changed);
+        assert_ne!(first, Hash256::digest(action.as_bytes()));
     }
 }


### PR DESCRIPTION
## Summary
- bind verified MCP invocation provenance action hashes to canonical tool arguments, not just the tool name
- include the argument-bound action hash in AI delegation IDs so replay with altered arguments changes authority context
- update MCP handler fixtures and repo-truth README counts

## Classification
- Core runtime adapter: `crates/exo-node/src/mcp/middleware.rs`
- Core runtime adapter tests: `crates/exo-node/src/mcp/handler.rs`
- Documentation/repo truth metadata: `README.md`

## Confirmation and TDD
- Confirmed issue still existed on current main before fixing: `middleware_rejects_signed_context_replayed_with_different_arguments` failed because a signed context for `exochain_node_status` could be replayed after changing `params.arguments`.
- Wrote the failing regression before production changes, then made it pass by hashing `{domain, action, arguments}` through canonical CBOR.

## Validation
- `cargo test -p exo-node middleware_rejects_signed_context_replayed_with_different_arguments -- --nocapture`
- `cargo test -p exo-node mcp::middleware -- --nocapture`
- `cargo test -p exo-node mcp::handler -- --nocapture`
- `cargo test -p exo-node --all-targets -- --nocapture`
- `cargo clippy -p exo-node --all-targets -- -D warnings`
- `cargo doc -p exo-node --no-deps`
- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `bash tools/repo_truth.sh --json --list-tests`