### PR TITLE
fix(ci): bound ExoForge issue workflow input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,8 @@ jobs:
           echo "✓ No GAP stubs remaining in code"
       - name: GitHub Actions pinned to immutable SHAs
         run: bash tools/test_github_actions_pinned.sh
+      - name: GitHub issue workflow trust boundary
+        run: bash tools/test_github_issue_workflow_boundaries.sh
       - name: CI tool installer supply-chain hardening
         run: bash tools/test_ci_supply_chain_hardening.sh
       - name: Repo truth and public claims

--- a/.github/workflows/exoforge-triage.yml
+++ b/.github/workflows/exoforge-triage.yml
@@ -20,42 +20,70 @@ jobs:
     steps:
       - name: Prepare feedback payload
         id: payload
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          ISSUE_LABELS_JSON: ${{ toJSON(github.event.issue.labels.*.name) }}
         run: |
-          # Extract structured data from the issue
-          ISSUE_NUMBER="${{ github.event.issue.number }}"
-          ISSUE_TITLE="${{ github.event.issue.title }}"
-          ISSUE_URL="${{ github.event.issue.html_url }}"
-          ISSUE_AUTHOR="${{ github.event.issue.user.login }}"
+          # Keep issue fields in environment variables. Public issue content is
+          # untrusted and must not be interpolated into shell source.
+          printf '%s\n' "$ISSUE_TITLE" >/dev/null
+          printf '%s\n' "$ISSUE_URL" >/dev/null
+          printf '%s\n' "$ISSUE_AUTHOR" >/dev/null
 
           # Determine type from labels
           TYPE="suggestion"
-          if echo '${{ toJSON(github.event.issue.labels.*.name) }}' | grep -q "bug"; then
+          if printf '%s' "$ISSUE_LABELS_JSON" | jq -e 'index("bug") != null' >/dev/null; then
             TYPE="bug"
-          elif echo '${{ toJSON(github.event.issue.labels.*.name) }}' | grep -q "enhancement"; then
+          elif printf '%s' "$ISSUE_LABELS_JSON" | jq -e 'index("enhancement") != null' >/dev/null; then
             TYPE="enhancement"
           fi
 
-          echo "issue_number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
-          echo "type=$TYPE" >> $GITHUB_OUTPUT
+          {
+            printf 'issue_number=%s\n' "$ISSUE_NUMBER"
+            printf 'type=%s\n' "$TYPE"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Post to ExoForge ingestion
         if: ${{ vars.EXOFORGE_GATEWAY_URL != '' }}
+        env:
+          EXOFORGE_GATEWAY_URL: ${{ vars.EXOFORGE_GATEWAY_URL }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          ISSUE_LABELS_JSON: ${{ toJSON(github.event.issue.labels.*.name) }}
+          ISSUE_TYPE: ${{ steps.payload.outputs.type }}
         run: |
-          curl -sf -X POST "${{ vars.EXOFORGE_GATEWAY_URL }}/api/feedback" \
-            -H "Content-Type: application/json" \
-            -d '{
-              "widget": "github-issue",
-              "page": "github",
-              "type": "${{ steps.payload.outputs.type }}",
-              "message": "${{ github.event.issue.title }}",
-              "context": {
-                "issue_number": ${{ github.event.issue.number }},
-                "issue_url": "${{ github.event.issue.html_url }}",
-                "author": "${{ github.event.issue.user.login }}",
-                "labels": ${{ toJSON(github.event.issue.labels.*.name) }},
-                "body_preview": ""
+          payload="$(jq -n \
+            --arg widget "github-issue" \
+            --arg page "github" \
+            --arg type "$ISSUE_TYPE" \
+            --arg message "$ISSUE_TITLE" \
+            --arg issue_url "$ISSUE_URL" \
+            --arg author "$ISSUE_AUTHOR" \
+            --argjson issue_number "$ISSUE_NUMBER" \
+            --argjson labels "$ISSUE_LABELS_JSON" \
+            '{
+              widget: $widget,
+              page: $page,
+              type: $type,
+              message: $message,
+              context: {
+                issue_number: $issue_number,
+                issue_url: $issue_url,
+                author: $author,
+                labels: $labels,
+                body_preview: ""
               }
-            }' || echo "ExoForge gateway not reachable — issue queued for manual triage"
+            }')"
+
+          curl -sf -X POST "${EXOFORGE_GATEWAY_URL}/api/feedback" \
+            -H "Content-Type: application/json" \
+            --data-binary "$payload" \
+            || echo "ExoForge gateway not reachable — issue queued for manual triage"
 
       - name: Add triage acknowledgment
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043

--- a/tools/test_github_issue_workflow_boundaries.sh
+++ b/tools/test_github_issue_workflow_boundaries.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  printf 'github issue workflow boundary test failed: %s\n' "$1" >&2
+  exit 1
+}
+
+workflow=".github/workflows/exoforge-triage.yml"
+ci_workflow=".github/workflows/ci.yml"
+
+[[ -f "$workflow" ]] || fail "$workflow is missing"
+[[ -f "$ci_workflow" ]] || fail "$ci_workflow is missing"
+
+if awk '
+  function leading_spaces(value, trimmed) {
+    trimmed = value
+    sub(/^[[:space:]]*/, "", trimmed)
+    return length(value) - length(trimmed)
+  }
+
+  /^[[:space:]]*run:[[:space:]]*\|[[:space:]]*$/ {
+    in_run = 1
+    run_indent = leading_spaces($0)
+    next
+  }
+
+  in_run {
+    current_indent = leading_spaces($0)
+    if ($0 !~ /^[[:space:]]*$/ && current_indent <= run_indent) {
+      in_run = 0
+    }
+  }
+
+  in_run && /\$\{\{[[:space:]]*(toJSON\()?github\.event\.issue/ {
+    print FILENAME ":" FNR ": untrusted issue context interpolated inside run block: " $0
+    bad = 1
+  }
+
+  END { exit bad }
+' "$workflow"; then
+  :
+else
+  fail "public issue fields must enter shell through env variables, not inline GitHub expression interpolation"
+fi
+
+grep -Fq 'ISSUE_TITLE: ${{ github.event.issue.title }}' "$workflow" \
+  || fail "issue title must be passed through env before shell use"
+grep -Fq 'ISSUE_LABELS_JSON: ${{ toJSON(github.event.issue.labels.*.name) }}' "$workflow" \
+  || fail "issue labels must be passed through env as JSON before shell use"
+grep -Fq 'jq -n' "$workflow" \
+  || fail "ExoForge payload JSON must be constructed by jq"
+grep -Fq -- '--arg message "$ISSUE_TITLE"' "$workflow" \
+  || fail "issue title must enter JSON via jq --arg"
+grep -Fq -- '--argjson labels "$ISSUE_LABELS_JSON"' "$workflow" \
+  || fail "issue labels must enter JSON via jq --argjson"
+grep -Fq -- '--data-binary "$payload"' "$workflow" \
+  || fail "curl must send the jq-built payload without shell-rebuilding JSON"
+grep -Fq 'bash tools/test_github_issue_workflow_boundaries.sh' "$ci_workflow" \
+  || fail "CI must run the GitHub issue workflow boundary guard"
+
+verify_malicious_issue_fixture() {
+  local tmp_dir sentinel payload
+  tmp_dir="$(mktemp -d)"
+  sentinel="$tmp_dir/command-substitution-executed"
+
+  ISSUE_NUMBER=31337
+  ISSUE_TITLE='quoted " issue $(touch '"$sentinel"') and '\''single quotes'\'''
+  ISSUE_URL='https://github.com/exochain/exochain/issues/31337?x=$(touch impossible)'
+  ISSUE_AUTHOR='attacker$(touch impossible)'
+  ISSUE_LABELS_JSON='["exoforge:triage","bug"]'
+  ISSUE_TYPE='bug'
+
+  payload="$(jq -n \
+    --arg widget "github-issue" \
+    --arg page "github" \
+    --arg type "$ISSUE_TYPE" \
+    --arg message "$ISSUE_TITLE" \
+    --arg issue_url "$ISSUE_URL" \
+    --arg author "$ISSUE_AUTHOR" \
+    --argjson issue_number "$ISSUE_NUMBER" \
+    --argjson labels "$ISSUE_LABELS_JSON" \
+    '{
+      widget: $widget,
+      page: $page,
+      type: $type,
+      message: $message,
+      context: {
+        issue_number: $issue_number,
+        issue_url: $issue_url,
+        author: $author,
+        labels: $labels,
+        body_preview: ""
+      }
+    }')"
+
+  [[ ! -e "$sentinel" ]] \
+    || fail "malicious issue title executed command substitution during payload construction"
+
+  printf '%s' "$payload" | jq -e \
+    --arg message "$ISSUE_TITLE" \
+    --arg issue_url "$ISSUE_URL" \
+    --arg author "$ISSUE_AUTHOR" \
+    '.widget == "github-issue"
+      and .page == "github"
+      and .type == "bug"
+      and .message == $message
+      and .context.issue_number == 31337
+      and .context.issue_url == $issue_url
+      and .context.author == $author
+      and .context.labels == ["exoforge:triage", "bug"]
+      and .context.body_preview == ""' >/dev/null \
+    || fail "jq-built payload did not preserve issue fields as inert JSON data"
+
+  rm -rf "$tmp_dir"
+}
+
+verify_malicious_issue_fixture
+
+printf 'github issue workflow boundary test passed\n'


### PR DESCRIPTION
## Summary
- move public GitHub issue fields out of shell source interpolation and into step env variables
- build the ExoForge ingestion JSON with `jq --arg` / `--argjson` and send it via `--data-binary`
- add a CI guard that forbids `github.event.issue.*` interpolation inside workflow `run:` blocks and exercises a malicious issue-title fixture

## Classification
- Core runtime adapter automation: `.github/workflows/exoforge-triage.yml`
- CI/security guard: `.github/workflows/ci.yml`, `tools/test_github_issue_workflow_boundaries.sh`

## Confirmation and TDD
- Confirmed the issue still existed on current `origin/main`: `tools/test_github_issue_workflow_boundaries.sh` failed red on issue title/URL/author/labels interpolation inside `run:` blocks.
- Fixed the workflow only after the red guard identified the unsafe source-to-shell path.
- Added a malicious fixture containing quotes, single quotes, and `$(touch ...)`; the guard proves the payload path preserves the title as JSON data and does not execute the command substitution.

## Validation
- `bash tools/test_github_issue_workflow_boundaries.sh`
- `bash -n tools/test_github_issue_workflow_boundaries.sh`
- `bash tools/test_github_actions_pinned.sh`
- `bash tools/test_agent_prompt_boundaries.sh`
- `bash tools/test_agent_workflow_bounds.sh`
- `bash tools/test_ci_supply_chain_hardening.sh`
- `bash tools/test_repo_truth.sh`
- `bash tools/repo_truth.sh --json --list-tests`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`