### PR TITLE
fix(ci): pin cargo tool installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin --version 0.35.4 --locked
       - name: Run coverage
         # exochain-wasm: excluded — wasm bindings are exercised by the JS
         # bridge tests (Gate 21), not tarpaulin.
@@ -131,7 +131,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Install cargo-audit
-        run: cargo install cargo-audit
+        run: cargo install cargo-audit --version 0.22.1 --locked
       - name: Audit dependencies (strict — vulnerabilities, unsound, unmaintained)
         # Historically this denied all warning classes, including yanked.
         # Gate 6 denies the three classes we can act on immediately:
@@ -279,7 +279,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Install cargo-cyclonedx
-        run: cargo install cargo-cyclonedx
+        run: cargo install cargo-cyclonedx --version 0.5.9 --locked
       - name: Generate CycloneDX SBOM (validation only)
         run: cargo cyclonedx --manifest-path Cargo.toml --format json
       - name: Validate SBOM output
@@ -312,7 +312,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Install cargo-machete
-        run: cargo install cargo-machete
+        run: cargo install cargo-machete --version 0.9.2 --locked
       - name: Check for unused dependencies
         run: cargo machete
 
@@ -369,7 +369,7 @@ jobs:
           done
           pg_isready -h localhost -U exochain -d exochain_test
       - name: Install sqlx-cli (postgres only, no default TLS)
-        run: cargo install sqlx-cli --no-default-features --features postgres,rustls
+        run: cargo install sqlx-cli --version 0.8.6 --locked --no-default-features --features postgres,rustls
       - name: Run migrations
         run: sqlx migrate run --source crates/exo-gateway/migrations
       - name: Run DB-backed gateway library tests
@@ -498,7 +498,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin --version 0.35.4 --locked
       - name: Run 0dentity module coverage
         run: |
           cargo tarpaulin \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
 
       # ── SBOM ─────────────────────────────────────────────────────────────
       - name: Install cargo-cyclonedx
-        run: cargo install cargo-cyclonedx
+        run: cargo install cargo-cyclonedx --version 0.5.9 --locked
 
       - name: Generate CycloneDX SBOM
         run: |

--- a/tools/test_ci_supply_chain_hardening.sh
+++ b/tools/test_ci_supply_chain_hardening.sh
@@ -7,11 +7,29 @@ fail() {
 }
 
 workflow=".github/workflows/ci.yml"
+release_workflow=".github/workflows/release.yml"
 [[ -f "$workflow" ]] || fail "$workflow is missing"
+[[ -f "$release_workflow" ]] || fail "$release_workflow is missing"
 
 if grep -nE 'curl[^\n]*(\|[[:space:]]*(sh|bash)|>[[:space:]]*/tmp/)' "$workflow"; then
   fail "GitHub Actions workflow must not install tools through curl-piped shell scripts"
 fi
+
+cargo_install_lines=0
+for checked_workflow in "$workflow" "$release_workflow"; do
+  while IFS=: read -r line_no line; do
+    [[ -n "$line_no" ]] || continue
+    cargo_install_lines=$((cargo_install_lines + 1))
+    if ! grep -Eq -- '--version[[:space:]]+[0-9]+\.[0-9]+\.[0-9]+([[:space:]]|$)' <<<"$line"; then
+      fail "$checked_workflow:$line_no cargo install must pin an explicit x.y.z --version: $line"
+    fi
+    if ! grep -Fq -- '--locked' <<<"$line"; then
+      fail "$checked_workflow:$line_no cargo install must use --locked: $line"
+    fi
+  done < <(grep -nE 'run:[[:space:]]+cargo install[[:space:]]+' "$checked_workflow" || true)
+done
+
+[[ "$cargo_install_lines" -gt 0 ]] || fail "expected workflows to contain Cargo tool installs"
 
 install_block=$(
   awk '


### PR DESCRIPTION
## Summary
- pin every Cargo-installed tool in CI and release workflows with explicit `--version x.y.z` and `--locked`
- extend the CI supply-chain hardening guard to scan both `.github/workflows/ci.yml` and `.github/workflows/release.yml`
- preserve the existing wasm-pack pinning and curl-pipe guard

## Classification
- `.github/workflows/ci.yml`: EXOCHAIN core CI/release supply-chain gate
- `.github/workflows/release.yml`: EXOCHAIN core CI/release supply-chain gate
- `tools/test_ci_supply_chain_hardening.sh`: CI/security guard

## Current-main reproduction
Confirmed still active on current `origin/main` before the fix: mutable `cargo install` lines existed for `cargo-tarpaulin`, `cargo-audit`, `cargo-cyclonedx`, `cargo-machete`, `sqlx-cli`, and release `cargo-cyclonedx`.

## Red test
- `bash tools/test_ci_supply_chain_hardening.sh` failed before the workflow fix with: `.github/workflows/ci.yml:68 cargo install must pin an explicit x.y.z --version`

## Validation
- `bash tools/test_ci_supply_chain_hardening.sh`
- `bash -n tools/test_ci_supply_chain_hardening.sh`
- `bash tools/test_github_actions_pinned.sh`
- `bash tools/test_github_issue_workflow_boundaries.sh`
- `bash tools/test_repo_truth.sh`
- `bash tools/repo_truth.sh --json --list-tests`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
