### PR TITLE
fix(release): build from verified release ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,8 @@ jobs:
         run: bash tools/test_github_issue_workflow_boundaries.sh
       - name: CI tool installer supply-chain hardening
         run: bash tools/test_ci_supply_chain_hardening.sh
+      - name: Release workflow ref binding
+        run: bash tools/test_release_workflow_ref_binding.sh
       - name: Repo truth and public claims
         run: bash tools/test_repo_truth.sh
       - name: Sybil CLI secret boundary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,19 @@ jobs:
           - x86_64-unknown-linux-gnu
           - aarch64-unknown-linux-gnu
     steps:
+      - name: Resolve release source ref
+        id: release-ref
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            printf 'ref=%s\n' "${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          else
+            printf 'ref=refs/tags/v${{ inputs.version }}\n' >> "$GITHUB_OUTPUT"
+          fi
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ steps.release-ref.outputs.ref }}
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           targets: ${{ matrix.target }}
@@ -132,7 +144,19 @@ jobs:
       id-token: write      # GitHub OIDC token for keyless Sigstore signing
 
     steps:
+      - name: Resolve release source ref
+        id: release-ref
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            printf 'ref=%s\n' "${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          else
+            printf 'ref=refs/tags/v${{ inputs.version }}\n' >> "$GITHUB_OUTPUT"
+          fi
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ steps.release-ref.outputs.ref }}
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
 
@@ -184,7 +208,19 @@ jobs:
     needs: [release-build, sbom-and-attest]
     if: ${{ !inputs.dry_run }}
     steps:
+      - name: Resolve release source ref
+        id: release-ref
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            printf 'ref=%s\n' "${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          else
+            printf 'ref=refs/tags/v${{ inputs.version }}\n' >> "$GITHUB_OUTPUT"
+          fi
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ steps.release-ref.outputs.ref }}
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
 
       - name: Publish crates in dependency order

--- a/tools/test_release_workflow_ref_binding.sh
+++ b/tools/test_release_workflow_ref_binding.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  printf 'release workflow ref-binding test failed: %s\n' "$1" >&2
+  exit 1
+}
+
+workflow=".github/workflows/release.yml"
+[[ -f "$workflow" ]] || fail "$workflow is missing"
+
+job_block() {
+  local job="$1"
+  awk -v job="  ${job}:" '
+    $0 == job { capture = 1; print; next }
+    capture && $0 ~ /^  [A-Za-z0-9_-]+:$/ { exit }
+    capture { print }
+  ' "$workflow"
+}
+
+for job in release-build sbom-and-attest publish; do
+  block=$(job_block "$job")
+  [[ -n "$block" ]] || fail "job $job is missing"
+  grep -F 'id: release-ref' <<<"$block" >/dev/null \
+    || fail "job $job must resolve the release source ref before checkout"
+  grep -F 'refs/tags/v${{ inputs.version }}' <<<"$block" >/dev/null \
+    || fail "job $job must use the signed version tag for non-dry-run releases"
+  grep -F '${GITHUB_SHA}' <<<"$block" >/dev/null \
+    || fail "job $job must keep dry-run builds anchored to the dispatched workflow SHA"
+  grep -F 'ref: ${{ steps.release-ref.outputs.ref }}' <<<"$block" >/dev/null \
+    || fail "job $job checkout must use the resolved release source ref"
+done
+
+printf 'release workflow ref-binding test passed\n'


### PR DESCRIPTION
## Summary
- bind release-build, SBOM/attestation, and crates.io publish checkouts to a resolved release source ref
- use the dispatched workflow SHA for dry runs and `refs/tags/v${{ inputs.version }}` for real releases
- add a CI guard proving release source-consuming jobs checkout the resolved ref

## Classification
- `.github/workflows/release.yml`: EXOCHAIN core CI/release supply-chain integrity
- `.github/workflows/ci.yml`: CI/security guard wiring
- `tools/test_release_workflow_ref_binding.sh`: CI/security guard

## Current-main reproduction
Validated on current `origin/main` before changing the workflow:
- `verify-signed-tag` verified `refs/tags/v${{ inputs.version }}` for non-dry-run releases.
- `release-build`, `sbom-and-attest`, and `publish` then used default `actions/checkout` behavior, so artifacts/SBOMs/published crates were built from the workflow ref rather than the verified tag.

## Red test
- `bash tools/test_release_workflow_ref_binding.sh` failed before the fix with: `job release-build must resolve the release source ref before checkout`.

## Validation
- `bash tools/test_release_workflow_ref_binding.sh`
- `bash -n tools/test_release_workflow_ref_binding.sh`
- `bash tools/test_github_actions_pinned.sh`
- `bash tools/test_ci_supply_chain_hardening.sh`
- `bash tools/test_github_issue_workflow_boundaries.sh`
- `bash tools/test_agent_workflow_bounds.sh`
- `bash tools/test_repo_truth.sh`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
