### PR TITLE
fix(gateway): scope quorum eligibility by tenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 179660 | `wc -l` |
-| Workspace tests | 4,225 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 179993 | `wc -l` |
+| Workspace tests | 4,228 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,225 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,228 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 179660 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 179993 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,225 listed workspace tests
+         cryptographic proofs, 4,228 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-gateway/src/db.rs
+++ b/crates/exo-gateway/src/db.rs
@@ -6,6 +6,7 @@
 
 use std::time::Duration;
 
+use decision_forum::decision_object::DecisionClass;
 use exo_identity::did::DidDocument;
 use serde_json::Value as JsonValue;
 use sqlx::{
@@ -548,6 +549,73 @@ pub struct PublicUserRow {
     pub status: String,
     pub pace_status: String,
     pub mfa_enabled: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QuorumEligibilityCounts {
+    pub eligible_voters: usize,
+    pub eligible_human_voters: usize,
+}
+
+fn decision_class_rank(class: DecisionClass) -> i32 {
+    match class {
+        DecisionClass::Routine => 0,
+        DecisionClass::Operational => 1,
+        DecisionClass::Strategic => 2,
+        DecisionClass::Constitutional => 3,
+    }
+}
+
+fn count_result_to_usize(label: &'static str, value: i64) -> Result<usize, sqlx::Error> {
+    usize::try_from(value)
+        .map_err(|_| sqlx::Error::Protocol(format!("{label} returned invalid count {value}")))
+}
+
+/// Count quorum-eligible voters for a tenant and decision class.
+pub async fn count_quorum_eligible_voters(
+    pool: &PgPool,
+    tenant_id: &str,
+    decision_class: DecisionClass,
+) -> Result<QuorumEligibilityCounts, sqlx::Error> {
+    let active_human_users = count_result_to_usize(
+        "active_human_users",
+        sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM users WHERE tenant_id = $1 AND status = 'Active'",
+        )
+        .bind(tenant_id)
+        .fetch_one(pool)
+        .await?,
+    )?;
+    let active_delegated_agents = count_result_to_usize(
+        "active_delegated_agents",
+        sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT COUNT(*) FROM agents
+            WHERE tenant_id = $1
+              AND status = 'Active'
+              AND delegation_id IS NOT NULL
+              AND CASE max_decision_class
+                  WHEN 'Routine' THEN 0
+                  WHEN 'Operational' THEN 1
+                  WHEN 'Strategic' THEN 2
+                  WHEN 'Constitutional' THEN 3
+                  ELSE -1
+              END >= $2
+            "#,
+        )
+        .bind(tenant_id)
+        .bind(decision_class_rank(decision_class))
+        .fetch_one(pool)
+        .await?,
+    )?;
+    let eligible_voters = active_human_users
+        .checked_add(active_delegated_agents)
+        .ok_or_else(|| sqlx::Error::Protocol("quorum eligible voter count overflowed".into()))?;
+
+    Ok(QuorumEligibilityCounts {
+        eligible_voters,
+        eligible_human_voters: active_human_users,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -2459,6 +2527,37 @@ mod tests {
         );
     }
 
+    #[test]
+    fn quorum_eligibility_counts_are_tenant_scoped_and_human_bounded() {
+        let source = production_source();
+        let count = function_source(source, "count_quorum_eligible_voters");
+
+        assert!(
+            count.contains("tenant_id: &str"),
+            "quorum eligibility counting must require an explicit tenant scope"
+        );
+        assert!(
+            compact_sql(count).contains("FROM users WHERE tenant_id = $1 AND status = 'Active'"),
+            "human quorum eligibility must count only active users inside the authenticated tenant"
+        );
+        assert!(
+            compact_sql(count).contains("FROM agents WHERE tenant_id = $1 AND status = 'Active'"),
+            "agent quorum eligibility must count only active agents inside the authenticated tenant"
+        );
+        assert!(
+            count.contains("delegation_id IS NOT NULL"),
+            "AI agents must not be quorum-eligible without a delegated authority boundary"
+        );
+        assert!(
+            count.contains("max_decision_class"),
+            "AI quorum eligibility must be bounded by the agent's maximum decision class"
+        );
+        assert!(
+            count.contains("eligible_human_voters: active_human_users"),
+            "human quorum eligibility must not include agents or unrelated DIDs"
+        );
+    }
+
     #[tokio::test]
     async fn decision_writes_allow_same_hash_across_tenants_without_overwrite()
     -> std::result::Result<(), Box<dyn std::error::Error>> {
@@ -2528,6 +2627,188 @@ mod tests {
                 .execute(&pool)
                 .await?;
         }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn quorum_eligibility_counts_ignore_other_tenants_and_ineligible_agents()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let Some(pool) = gateway_test_pool().await else {
+            return Ok(());
+        };
+        let tenant_a = "tenant-quorum-a";
+        let tenant_b = "tenant-quorum-b";
+        let user_dids = [
+            "did:exo:quorum-a-human-1",
+            "did:exo:quorum-a-human-2",
+            "did:exo:quorum-a-human-3",
+            "did:exo:quorum-a-inactive-human",
+            "did:exo:quorum-b-human-1",
+        ];
+        let agent_dids = [
+            "did:exo:quorum-a-agent-routine",
+            "did:exo:quorum-a-agent-operational",
+            "did:exo:quorum-a-agent-strategic",
+            "did:exo:quorum-a-agent-undelegated",
+            "did:exo:quorum-a-agent-inactive",
+            "did:exo:quorum-b-agent-constitutional",
+        ];
+        for did in user_dids {
+            sqlx::query("DELETE FROM users WHERE did = $1")
+                .bind(did)
+                .execute(&pool)
+                .await?;
+        }
+        for did in agent_dids {
+            sqlx::query("DELETE FROM agents WHERE did = $1")
+                .bind(did)
+                .execute(&pool)
+                .await?;
+        }
+
+        for (idx, did) in user_dids.iter().take(3).enumerate() {
+            insert_user(
+                &pool,
+                did,
+                "Quorum Human",
+                &format!("quorum-human-{idx}@example.invalid"),
+                &serde_json::json!(["member"]),
+                tenant_a,
+                i64::try_from(idx + 1)?,
+                "Active",
+                "Verified",
+                "hash",
+                "salt",
+                true,
+            )
+            .await?;
+        }
+        insert_user(
+            &pool,
+            "did:exo:quorum-a-inactive-human",
+            "Inactive Human",
+            "quorum-inactive@example.invalid",
+            &serde_json::json!(["member"]),
+            tenant_a,
+            10,
+            "Suspended",
+            "Verified",
+            "hash",
+            "salt",
+            true,
+        )
+        .await?;
+        insert_user(
+            &pool,
+            "did:exo:quorum-b-human-1",
+            "Other Tenant Human",
+            "quorum-other@example.invalid",
+            &serde_json::json!(["member"]),
+            tenant_b,
+            11,
+            "Active",
+            "Verified",
+            "hash",
+            "salt",
+            true,
+        )
+        .await?;
+
+        for (did, delegation_id, status, max_class) in [
+            (
+                "did:exo:quorum-a-agent-routine",
+                Some("delegation-routine"),
+                "Active",
+                "Routine",
+            ),
+            (
+                "did:exo:quorum-a-agent-operational",
+                Some("delegation-operational"),
+                "Active",
+                "Operational",
+            ),
+            (
+                "did:exo:quorum-a-agent-strategic",
+                Some("delegation-strategic"),
+                "Active",
+                "Strategic",
+            ),
+            (
+                "did:exo:quorum-a-agent-undelegated",
+                None,
+                "Active",
+                "Constitutional",
+            ),
+            (
+                "did:exo:quorum-a-agent-inactive",
+                Some("delegation-inactive"),
+                "Suspended",
+                "Constitutional",
+            ),
+        ] {
+            insert_agent(
+                &pool,
+                did,
+                "Quorum Agent",
+                "delegate",
+                "did:exo:quorum-a-human-1",
+                tenant_a,
+                &serde_json::json!(["vote"]),
+                "Trusted",
+                100,
+                delegation_id,
+                "Verified",
+                20,
+                status,
+                max_class,
+            )
+            .await?;
+        }
+        insert_agent(
+            &pool,
+            "did:exo:quorum-b-agent-constitutional",
+            "Other Tenant Agent",
+            "delegate",
+            "did:exo:quorum-b-human-1",
+            tenant_b,
+            &serde_json::json!(["vote"]),
+            "Trusted",
+            100,
+            Some("delegation-other"),
+            "Verified",
+            21,
+            "Active",
+            "Constitutional",
+        )
+        .await?;
+
+        let routine = count_quorum_eligible_voters(&pool, tenant_a, DecisionClass::Routine).await?;
+        assert_eq!(routine.eligible_human_voters, 3);
+        assert_eq!(routine.eligible_voters, 6);
+
+        let operational =
+            count_quorum_eligible_voters(&pool, tenant_a, DecisionClass::Operational).await?;
+        assert_eq!(operational.eligible_human_voters, 3);
+        assert_eq!(operational.eligible_voters, 5);
+
+        let strategic =
+            count_quorum_eligible_voters(&pool, tenant_a, DecisionClass::Strategic).await?;
+        assert_eq!(strategic.eligible_human_voters, 3);
+        assert_eq!(strategic.eligible_voters, 4);
+
+        for did in user_dids {
+            sqlx::query("DELETE FROM users WHERE did = $1")
+                .bind(did)
+                .execute(&pool)
+                .await?;
+        }
+        for did in agent_dids {
+            sqlx::query("DELETE FROM agents WHERE did = $1")
+                .bind(did)
+                .execute(&pool)
+                .await?;
+        }
+
         Ok(())
     }
 

--- a/crates/exo-gateway/src/handlers.rs
+++ b/crates/exo-gateway/src/handlers.rs
@@ -619,13 +619,14 @@ pub async fn vote_handler(
             .into_response();
     }
 
-    // Verify quorum precondition (TNC-07): enough eligible voters must exist
-    // before accepting the vote. This gateway registry currently stores
-    // voter DIDs, so its cardinality is both the total and human-eligible
-    // count supplied to the decision-forum precondition.
+    // Verify quorum precondition (TNC-07): enough tenant-scoped eligible
+    // voters must exist before accepting the vote.
     let registry = QuorumRegistry::with_defaults();
-    let eligible_voters = match state.registry_len().await {
-        Ok(len) => len,
+    let eligible = match state
+        .quorum_eligible_voter_counts(&actor.tenant_id, decision.class)
+        .await
+    {
+        Ok(counts) => counts,
         Err(e) => {
             tracing::error!(error = %e, "failed to count eligible voters");
             return (
@@ -635,12 +636,11 @@ pub async fn vote_handler(
                 .into_response();
         }
     };
-    let eligible_human_voters = eligible_voters;
     match verify_quorum_precondition(
         &registry,
         decision.class,
-        eligible_voters,
-        eligible_human_voters,
+        eligible.eligible_voters,
+        eligible.eligible_human_voters,
     ) {
         Ok(true) => { /* enough eligible voters — proceed */ }
         Ok(false) => {
@@ -1505,6 +1505,43 @@ mod tests {
                 "UPDATE decisions SET payload = $1 WHERE id_hash = $2 AND tenant_id = $3"
             ),
             "vote handler must update only the decision row in the actor tenant"
+        );
+    }
+
+    #[test]
+    fn vote_handler_quorum_precondition_uses_tenant_scoped_db_eligibility() {
+        let source = include_str!("handlers.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("test module marker present");
+        let vote_handler = production
+            .split("pub async fn vote_handler")
+            .nth(1)
+            .expect("vote handler source present")
+            .split("// Build the typed Vote")
+            .next()
+            .expect("vote handler quorum block present");
+
+        assert!(
+            vote_handler.contains("quorum_eligible_voter_counts(&actor.tenant_id, decision.class)"),
+            "vote handler must derive quorum eligibility from the authenticated tenant and decision class"
+        );
+        assert!(
+            vote_handler.contains("eligible.eligible_voters"),
+            "vote handler must pass tenant-scoped total eligible voters to the quorum precondition"
+        );
+        assert!(
+            vote_handler.contains("eligible.eligible_human_voters"),
+            "vote handler must pass tenant-scoped human eligible voters to the quorum precondition"
+        );
+        assert!(
+            !vote_handler.contains("state.registry_len().await"),
+            "vote handler must not use the global in-memory DID registry as a quorum eligibility source"
+        );
+        assert!(
+            !vote_handler.contains("let eligible_human_voters = eligible_voters"),
+            "vote handler must not assume every registered DID is a human eligible voter"
         );
     }
 

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -411,6 +411,21 @@ impl AppState {
             .map_err(|e| GatewayError::Internal(e.to_string()))
     }
 
+    /// Return tenant-scoped quorum eligibility counts from persisted gateway
+    /// identity records.
+    pub async fn quorum_eligible_voter_counts(
+        &self,
+        tenant_id: &str,
+        decision_class: DecisionClass,
+    ) -> Result<db::QuorumEligibilityCounts> {
+        let pool = self.require_db()?;
+        db::count_quorum_eligible_voters(pool, tenant_id, decision_class)
+            .await
+            .map_err(|e| {
+                GatewayError::Internal(format!("failed to count quorum eligible voters: {e}"))
+            })
+    }
+
     /// Load conflict declarations for an actor from the DB-backed standing
     /// conflict register.
     pub async fn load_conflict_declarations(


### PR DESCRIPTION
## Summary
- Replace REST vote quorum precondition input from the global in-memory DID registry length with DB-backed, tenant-scoped eligibility counts.
- Count active human users only within the authenticated actor tenant, and count active delegated agents only when their `max_decision_class` can satisfy the current decision class.
- Add regression guards proving the vote handler does not use global registry cardinality or assume every DID is human eligible.
- Update README repo-truth counts from the verified source-derived values.

## Classification
- `crates/exo-gateway/src/db.rs`: Core runtime adapter, gateway persistence and quorum eligibility boundary.
- `crates/exo-gateway/src/server.rs`: Core runtime adapter, authenticated gateway state boundary.
- `crates/exo-gateway/src/handlers.rs`: Core runtime adapter, REST vote path.
- `README.md`: Documentation/repo-truth metadata only.

## Current-code confirmation
On current `origin/main`, `vote_handler` still called `state.registry_len().await` and then set `eligible_human_voters = eligible_voters`, so non-tenant and non-human DID registrations could satisfy the pre-vote quorum feasibility gate. The finding was therefore active before this change.

## TDD / Red Tests
These failed before implementation:
- `cargo test -p exo-gateway vote_handler_quorum_precondition_uses_tenant_scoped_db_eligibility -- --nocapture`
- `cargo test -p exo-gateway quorum_eligibility_counts_are_tenant_scoped_and_human_bounded -- --nocapture`

## Validation
Passed:
- `cargo test -p exo-gateway vote_handler_quorum_precondition_uses_tenant_scoped_db_eligibility -- --nocapture`
- `cargo test -p exo-gateway quorum_eligibility -- --nocapture`
- `cargo test -p exo-gateway --all-targets -- --nocapture`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `cargo doc -p exo-gateway --no-deps`
- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/repo_truth.sh --json --list-tests`
- `bash tools/test_repo_truth.sh`

## Subagent sanity check disposition
A read-only explorer reported a session-expiry issue from the root worktree, but that worktree was behind current `origin/main`; the current gateway suite includes and passes `session_auth_rejects_expired_token_despite_backdated_header_time` and `auth_refresh_rejects_expired_session_despite_backdated_body_time`, so that item is stale.
