### PR TITLE
fix(release): block dry-run provenance publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,8 @@ jobs:
         run: bash tools/test_ci_supply_chain_hardening.sh
       - name: Release workflow ref binding
         run: bash tools/test_release_workflow_ref_binding.sh
+      - name: Release dry-run publication boundary
+        run: bash tools/test_release_dry_run_boundaries.sh
       - name: Repo truth and public claims
         run: bash tools/test_repo_truth.sh
       - name: Sybil CLI secret boundary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,7 @@ jobs:
     name: "SBOM + SLSA Attestation"
     runs-on: ubuntu-latest
     needs: release-build
+    if: ${{ !inputs.dry_run }}
     permissions:
       attestations: write  # write SLSA attestations to repo
       id-token: write      # GitHub OIDC token for keyless Sigstore signing
@@ -260,6 +261,7 @@ jobs:
     name: "Create GitHub Release"
     runs-on: ubuntu-latest
     needs: [release-build, sbom-and-attest]
+    if: ${{ !inputs.dry_run }}
     permissions:
       contents: write
     steps:
@@ -307,4 +309,4 @@ jobs:
           files: |
             artifacts/**/*.tar.gz
             artifacts/**/*.cdx.json
-          draft: ${{ inputs.dry_run }}
+          draft: false

--- a/tools/test_release_dry_run_boundaries.sh
+++ b/tools/test_release_dry_run_boundaries.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  printf 'release dry-run boundary test failed: %s\n' "$1" >&2
+  exit 1
+}
+
+workflow=".github/workflows/release.yml"
+[[ -f "$workflow" ]] || fail "$workflow is missing"
+
+job_block() {
+  local job="$1"
+  awk -v job="  ${job}:" '
+    $0 == job { capture = 1; print; next }
+    capture && $0 ~ /^  [A-Za-z0-9_-]+:$/ { exit }
+    capture { print }
+  ' "$workflow"
+}
+
+assert_non_dry_run_job() {
+  local job="$1"
+  local block="$2"
+  grep -F 'if: ${{ !inputs.dry_run }}' <<<"$block" >/dev/null \
+    || fail "job $job must be skipped for dry-run releases"
+}
+
+for job in sbom-and-attest github-release; do
+  block=$(job_block "$job")
+  [[ -n "$block" ]] || fail "job $job is missing"
+  assert_non_dry_run_job "$job" "$block"
+done
+
+sbom_block=$(job_block "sbom-and-attest")
+github_release_block=$(job_block "github-release")
+
+grep -F 'attestations: write' <<<"$sbom_block" >/dev/null \
+  || fail "sbom-and-attest must remain the only attestation-writing job"
+grep -F 'actions/attest-build-provenance@' <<<"$sbom_block" >/dev/null \
+  || fail "sbom-and-attest must remain the SLSA attestation job"
+grep -F 'contents: write' <<<"$github_release_block" >/dev/null \
+  || fail "github-release must retain release publishing permission for real releases"
+grep -F 'softprops/action-gh-release@' <<<"$github_release_block" >/dev/null \
+  || fail "github-release must remain the GitHub Release job for real releases"
+
+if grep -F 'draft: ${{ inputs.dry_run }}' "$workflow" >/dev/null; then
+  fail "dry-run releases must not create draft GitHub Releases"
+fi
+
+printf 'release dry-run boundary test passed\n'


### PR DESCRIPTION
## Summary
- classify `.github/workflows/release.yml` and `.github/workflows/ci.yml` as EXOCHAIN core CI/release supply-chain integrity
- skip SLSA provenance attestation and GitHub release publication jobs when `workflow_dispatch` dry_run is true
- add a CI guard proving dry runs cannot publish provenance artifacts or draft releases while real releases retain the attestation and release jobs

## Current-code confirmation
- Confirmed the issue was still active on current `origin/main`: `sbom-and-attest` could run during dry runs with `attestations: write`/OIDC, and `github-release` used `draft: ${{ inputs.dry_run }}` instead of being skipped.

## TDD / validation
- RED: `bash tools/test_release_dry_run_boundaries.sh` failed before the workflow fix with `job sbom-and-attest must be skipped for dry-run releases`
- GREEN: `bash tools/test_release_dry_run_boundaries.sh`
- `bash tools/test_release_workflow_ref_binding.sh`
- `bash -n tools/test_release_dry_run_boundaries.sh`
- `bash tools/test_github_actions_pinned.sh`
- `bash tools/test_ci_supply_chain_hardening.sh`
- `bash tools/test_github_issue_workflow_boundaries.sh`
- `bash tools/test_agent_workflow_bounds.sh`
- `bash tools/test_repo_truth.sh`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`

## Path classification
- EXOCHAIN core: `.github/workflows/release.yml`
- EXOCHAIN core: `.github/workflows/ci.yml`
- EXOCHAIN core CI/security guard: `tools/test_release_dry_run_boundaries.sh`