### PR TITLE
fix(release): require publish success before release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,8 @@ jobs:
         run: bash tools/test_release_workflow_ref_binding.sh
       - name: Release dry-run publication boundary
         run: bash tools/test_release_dry_run_boundaries.sh
+      - name: Release publish completion boundary
+        run: bash tools/test_release_publish_boundaries.sh
       - name: Repo truth and public claims
         run: bash tools/test_repo_truth.sh
       - name: Sybil CLI secret boundary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,6 +228,7 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
+          set -euo pipefail
           CRATES=(
             exo-core
             exo-identity
@@ -247,9 +248,7 @@ jobs:
           )
           for crate in "${CRATES[@]}"; do
             echo "Publishing $crate..."
-            cargo publish -p "$crate" --allow-dirty || {
-              echo "Warning: $crate publish failed (may already be published)"
-            }
+            cargo publish -p "$crate" --allow-dirty
             # crates.io index propagation delay
             sleep 30
           done
@@ -260,7 +259,7 @@ jobs:
   github-release:
     name: "Create GitHub Release"
     runs-on: ubuntu-latest
-    needs: [release-build, sbom-and-attest]
+    needs: [release-build, sbom-and-attest, publish]
     if: ${{ !inputs.dry_run }}
     permissions:
       contents: write

--- a/tools/test_release_publish_boundaries.sh
+++ b/tools/test_release_publish_boundaries.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  printf 'release publish boundary test failed: %s\n' "$1" >&2
+  exit 1
+}
+
+workflow=".github/workflows/release.yml"
+[[ -f "$workflow" ]] || fail "$workflow is missing"
+
+job_block() {
+  local job="$1"
+  awk -v job="  ${job}:" '
+    $0 == job { capture = 1; print; next }
+    capture && $0 ~ /^  [A-Za-z0-9_-]+:$/ { exit }
+    capture { print }
+  ' "$workflow"
+}
+
+publish_block=$(job_block "publish")
+github_release_block=$(job_block "github-release")
+
+[[ -n "$publish_block" ]] || fail "publish job is missing"
+[[ -n "$github_release_block" ]] || fail "github-release job is missing"
+
+grep -F 'if: ${{ !inputs.dry_run }}' <<<"$publish_block" >/dev/null \
+  || fail "publish job must be skipped for dry-run releases"
+grep -F 'if: ${{ !inputs.dry_run }}' <<<"$github_release_block" >/dev/null \
+  || fail "github-release job must be skipped for dry-run releases"
+
+grep -F 'CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}' <<<"$publish_block" >/dev/null \
+  || fail "publish job must use the crates.io registry token"
+grep -F 'cargo publish -p "$crate" --allow-dirty' <<<"$publish_block" >/dev/null \
+  || fail "publish job must publish every crate in the dependency-ordered loop"
+
+if grep -E 'cargo publish.*\|\|' <<<"$publish_block" >/dev/null; then
+  fail "cargo publish failures must fail the publish job"
+fi
+
+grep -E 'needs:.*publish' <<<"$github_release_block" >/dev/null \
+  || fail "github-release must depend on successful crates.io publication"
+
+printf 'release publish boundary test passed\n'


### PR DESCRIPTION
## Summary
- classify `.github/workflows/release.yml` and `.github/workflows/ci.yml` as EXOCHAIN core CI/release supply-chain integrity
- stop swallowing `cargo publish` failures in the crates.io publication loop
- require the GitHub Release job to depend on successful crates.io publication
- add a CI guard proving publish failures fail closed before release artifacts are published

## Current-code confirmation
- Confirmed active on current `origin/main` after PR #419: `cargo publish -p "$crate" --allow-dirty || { echo "Warning..." }` let publish failures pass, and `github-release` only needed `release-build` plus `sbom-and-attest`.
- Closed Hubble candidate 1 as stale against current `origin/main`: session-expiry regression tests are present on main.

## TDD / validation
- RED: `bash tools/test_release_publish_boundaries.sh` failed before the workflow fix with `cargo publish failures must fail the publish job`
- GREEN: `bash tools/test_release_publish_boundaries.sh`
- `bash -n tools/test_release_publish_boundaries.sh`
- `bash tools/test_release_dry_run_boundaries.sh`
- `bash tools/test_release_workflow_ref_binding.sh`
- `bash tools/test_github_actions_pinned.sh`
- `bash tools/test_ci_supply_chain_hardening.sh`
- `bash tools/test_github_issue_workflow_boundaries.sh`
- `bash tools/test_agent_workflow_bounds.sh`
- `bash tools/test_repo_truth.sh`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`

## Path classification
- EXOCHAIN core: `.github/workflows/release.yml`
- EXOCHAIN core: `.github/workflows/ci.yml`
- EXOCHAIN core CI/security guard: `tools/test_release_publish_boundaries.sh`