### PR TITLE
Bind consent scope to requested permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 180650 | `wc -l` |
+| Rust LOC | 180672 | `wc -l` |
 | Workspace tests | 4,244 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
@@ -96,7 +96,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 180650 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 180672 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,244 listed workspace tests
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 179993 | `wc -l` |
-| Workspace tests | 4,228 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 180650 | `wc -l` |
+| Workspace tests | 4,244 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,228 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,244 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 179993 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 180650 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,228 listed workspace tests
+         cryptographic proofs, 4,244 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/decision-forum/tests/governance_kernel_integration.rs
+++ b/crates/decision-forum/tests/governance_kernel_integration.rs
@@ -258,6 +258,17 @@ fn transition_context(actor: &Did, from: BctsState, to: BctsState) -> Adjudicati
                 .insert(link.grantor.clone(), vec![public_key.clone()]);
         }
     }
+    context.consent_records = vec![ConsentRecord {
+        subject: did("did:exo:bailor"),
+        granted_to: actor.clone(),
+        scope: "bcts:transition".into(),
+        active: true,
+    }];
+    context.bailment_state = BailmentState::Active {
+        bailor: did("did:exo:bailor"),
+        bailee: actor.clone(),
+        scope: "bcts:transition".into(),
+    };
     context.actor_permissions = PermissionSet::new(vec![permission]);
     context
 }

--- a/crates/exo-escalation/tests/sybil_adjudication.rs
+++ b/crates/exo-escalation/tests/sybil_adjudication.rs
@@ -161,13 +161,13 @@ fn valid_kernel_context(actor: &Did, challenge_reason: Option<String>) -> Adjudi
         consent_records: vec![ConsentRecord {
             subject: did("did:exo:bailor"),
             granted_to: actor.clone(),
-            scope: "data:governance".into(),
+            scope: "governance:read".into(),
             active: true,
         }],
         bailment_state: BailmentState::Active {
             bailor: did("did:exo:bailor"),
             bailee: actor.clone(),
-            scope: "data:governance".into(),
+            scope: "governance:read".into(),
         },
         human_override_preserved: true,
         actor_permissions: PermissionSet::new(vec![Permission::new("read")]),

--- a/crates/exo-gatekeeper/src/holon.rs
+++ b/crates/exo-gatekeeper/src/holon.rs
@@ -245,13 +245,13 @@ mod tests {
             consent_records: vec![ConsentRecord {
                 subject: did("did:exo:owner"),
                 granted_to: actor.clone(),
-                scope: "data".into(),
+                scope: "data:read".into(),
                 active: true,
             }],
             bailment_state: BailmentState::Active {
                 bailor: did("did:exo:owner"),
                 bailee: actor.clone(),
-                scope: "data".into(),
+                scope: "data:read".into(),
             },
             human_override_preserved: true,
             actor_permissions: PermissionSet::new(vec![Permission::new("read")]),

--- a/crates/exo-gatekeeper/src/invariants.rs
+++ b/crates/exo-gatekeeper/src/invariants.rs
@@ -321,7 +321,146 @@ fn check_consent_required(ctx: &InvariantContext) -> Result<(), InvariantViolati
             ],
         });
     }
+    if !consent_scope_covers_requested_permissions(scope, &ctx.requested_permissions) {
+        return Err(InvariantViolation {
+            invariant: ConstitutionalInvariant::ConsentRequired,
+            description: "Active consent scope does not cover requested permission".into(),
+            evidence: vec![
+                format!("actor: {}", ctx.actor),
+                format!("scope: {scope}"),
+                format!(
+                    "requested_permissions: {}",
+                    permission_set_evidence_label(&ctx.requested_permissions)
+                ),
+            ],
+        });
+    }
     Ok(())
+}
+
+fn consent_scope_covers_requested_permissions(
+    scope: &str,
+    requested_permissions: &PermissionSet,
+) -> bool {
+    requested_permissions
+        .permissions
+        .iter()
+        .all(|permission| consent_scope_covers_permission(scope, &permission.0))
+}
+
+fn consent_scope_covers_permission(scope: &str, permission: &str) -> bool {
+    let scope = scope.trim();
+    let permission = permission.trim();
+    if permission.is_empty() || scope.is_empty() {
+        return false;
+    }
+    if scope.eq_ignore_ascii_case(permission) {
+        return true;
+    }
+
+    consent_scope_clauses(scope)
+        .iter()
+        .any(|scope_clause| consent_scope_clause_covers_permission(scope_clause, permission))
+}
+
+fn consent_scope_clauses(scope: &str) -> Vec<&str> {
+    scope
+        .split([',', ';'])
+        .map(str::trim)
+        .filter(|scope_clause| !scope_clause.is_empty())
+        .collect()
+}
+
+fn consent_scope_clause_covers_permission(scope_clause: &str, permission: &str) -> bool {
+    if scope_clause.eq_ignore_ascii_case(permission) {
+        return true;
+    }
+
+    let scope_tokens = scope_permission_tokens(scope_clause);
+    let permission_tokens = scope_permission_tokens(permission);
+    if scope_tokens.is_empty() || permission_tokens.is_empty() {
+        return false;
+    }
+    if permission_tokens.len() == 1
+        && scope_tokens
+            .last()
+            .is_some_and(|last| last == &permission_tokens[0])
+    {
+        return true;
+    }
+    if scope_tokens.len() > 1
+        && permission_tokens.len() >= scope_tokens.len()
+        && permission_tokens.starts_with(&scope_tokens)
+    {
+        return true;
+    }
+    if scope_tokens.len() > 1
+        && permission_tokens.len() > 1
+        && scope_tokens.last() == permission_tokens.last()
+        && scope_tokens
+            .last()
+            .is_some_and(|token| !is_generic_permission_action_token(token))
+    {
+        return true;
+    }
+
+    canonical_scope_tokens(scope_tokens) == canonical_scope_tokens(permission_tokens)
+}
+
+fn is_generic_permission_action_token(token: &str) -> bool {
+    matches!(
+        token,
+        "attest"
+            | "create"
+            | "delete"
+            | "execute"
+            | "grant"
+            | "propose"
+            | "publish"
+            | "read"
+            | "recommend"
+            | "revoke"
+            | "sign"
+            | "update"
+            | "validate"
+            | "verify"
+            | "write"
+    )
+}
+
+fn scope_permission_tokens(value: &str) -> Vec<String> {
+    value
+        .split([':', '_', '.', '/', '-', ' '])
+        .filter_map(|token| {
+            let token = token.trim();
+            if token.is_empty() {
+                None
+            } else {
+                Some(token.to_ascii_lowercase())
+            }
+        })
+        .collect()
+}
+
+fn canonical_scope_tokens(mut tokens: Vec<String>) -> Vec<String> {
+    tokens.sort();
+    tokens.dedup();
+    tokens
+}
+
+fn permission_set_evidence_label(permissions: &PermissionSet) -> String {
+    let mut labels: Vec<&str> = permissions
+        .permissions
+        .iter()
+        .map(|permission| permission.0.as_str())
+        .collect();
+    labels.sort_unstable();
+    labels.dedup();
+    if labels.is_empty() {
+        "none".to_string()
+    } else {
+        labels.join(",")
+    }
 }
 
 fn check_no_self_grant(ctx: &InvariantContext) -> Result<(), InvariantViolation> {
@@ -981,6 +1120,109 @@ mod tests {
         assert!(
             enforce_all(&engine, &ctx).is_err(),
             "ConsentRequired must bind the consent record scope to the active bailment scope"
+        );
+    }
+
+    #[test]
+    fn consent_fails_when_scope_does_not_cover_requested_permission() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::ConsentRequired,
+        ]));
+        let mut ctx = passing_context();
+        ctx.bailment_state = BailmentState::Active {
+            bailor: did("did:exo:bailor"),
+            bailee: ctx.actor.clone(),
+            scope: "data:profile".into(),
+        };
+        ctx.consent_records[0].scope = "data:profile".into();
+        ctx.requested_permissions = PermissionSet::new(vec![Permission::new("advance_pace")]);
+
+        assert!(
+            enforce_all(&engine, &ctx).is_err(),
+            "ConsentRequired must reject active consent whose scope does not cover the requested permission"
+        );
+    }
+
+    #[test]
+    fn consent_passes_when_scope_covers_requested_permission() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::ConsentRequired,
+        ]));
+        let mut ctx = passing_context();
+        ctx.bailment_state = BailmentState::Active {
+            bailor: did("did:exo:bailor"),
+            bailee: ctx.actor.clone(),
+            scope: "pace:advance".into(),
+        };
+        ctx.consent_records[0].scope = "pace:advance".into();
+        ctx.requested_permissions = PermissionSet::new(vec![Permission::new("advance_pace")]);
+
+        assert!(
+            enforce_all(&engine, &ctx).is_ok(),
+            "ConsentRequired must accept the established pace:advance scope for advance_pace"
+        );
+    }
+
+    #[test]
+    fn consent_passes_when_resource_scope_covers_requested_permission_object() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::ConsentRequired,
+        ]));
+        let mut ctx = passing_context();
+        ctx.bailment_state = BailmentState::Active {
+            bailor: did("did:exo:bailor"),
+            bailee: ctx.actor.clone(),
+            scope: "governance:decision".into(),
+        };
+        ctx.consent_records[0].scope = "governance:decision".into();
+        ctx.requested_permissions = PermissionSet::new(vec![Permission::new("enact:decision")]);
+
+        assert!(
+            enforce_all(&engine, &ctx).is_ok(),
+            "ConsentRequired must accept resource consent for a permission on the same object class"
+        );
+    }
+
+    #[test]
+    fn consent_passes_when_explicit_scope_list_covers_all_requested_permissions() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::ConsentRequired,
+        ]));
+        let mut ctx = passing_context();
+        ctx.bailment_state = BailmentState::Active {
+            bailor: did("did:exo:bailor"),
+            bailee: ctx.actor.clone(),
+            scope: "network.peers.read;network.topology.recommend".into(),
+        };
+        ctx.consent_records[0].scope = "network.peers.read;network.topology.recommend".into();
+        ctx.requested_permissions = PermissionSet::new(vec![
+            Permission::new("network.peers.read"),
+            Permission::new("network.topology.recommend"),
+        ]);
+
+        assert!(
+            enforce_all(&engine, &ctx).is_ok(),
+            "ConsentRequired must accept explicit multi-permission consent scopes"
+        );
+    }
+
+    #[test]
+    fn consent_fails_when_scope_only_shares_non_object_token_with_permission() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::ConsentRequired,
+        ]));
+        let mut ctx = passing_context();
+        ctx.bailment_state = BailmentState::Active {
+            bailor: did("did:exo:bailor"),
+            bailee: ctx.actor.clone(),
+            scope: "data:profile".into(),
+        };
+        ctx.consent_records[0].scope = "data:profile".into();
+        ctx.requested_permissions = PermissionSet::new(vec![Permission::new("profile:delete")]);
+
+        assert!(
+            enforce_all(&engine, &ctx).is_err(),
+            "ConsentRequired must not treat a shared verb or middle token as object consent"
         );
     }
 

--- a/crates/exo-gatekeeper/src/kernel.rs
+++ b/crates/exo-gatekeeper/src/kernel.rs
@@ -311,13 +311,13 @@ mod tests {
             consent_records: vec![ConsentRecord {
                 subject: did("did:exo:bailor"),
                 granted_to: actor.clone(),
-                scope: "data:medical".into(),
+                scope: "data:read".into(),
                 active: true,
             }],
             bailment_state: BailmentState::Active {
                 bailor: did("did:exo:bailor"),
                 bailee: actor.clone(),
-                scope: "data:medical".into(),
+                scope: "data:read".into(),
             },
             human_override_preserved: true,
             actor_permissions: PermissionSet::new(vec![Permission::new("read")]),

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -9086,10 +9086,18 @@ mod tests {
     }
 
     fn db_consent_row(actor: &Did, subject_did: &str) -> crate::db::ConsentRecordRow {
+        db_consent_row_with_scope(actor, subject_did, "data:vote")
+    }
+
+    fn db_consent_row_with_scope(
+        actor: &Did,
+        subject_did: &str,
+        scope: &str,
+    ) -> crate::db::ConsentRecordRow {
         crate::db::ConsentRecordRow {
             subject_did: subject_did.to_string(),
             actor_did: actor.as_str().to_string(),
-            scope: "data:vote".to_string(),
+            scope: scope.to_string(),
             bailment_type: "standard".to_string(),
             status: "active".to_string(),
             created_at: 1,
@@ -9254,7 +9262,11 @@ mod tests {
             )],
         };
         let role_rows = vec![db_role_row(&actor, "worker", "executive")];
-        let consent_rows = vec![db_consent_row(&actor, root.as_str())];
+        let consent_rows = vec![db_consent_row_with_scope(
+            &actor,
+            root.as_str(),
+            "pace:advance",
+        )];
         let chain_row =
             db_authority_chain_row(&actor, serde_json::to_value(&authority_chain).unwrap());
         let trusted_authority_keys = trusted_authority_keys_for_test_chain(&authority_chain);
@@ -9281,6 +9293,45 @@ mod tests {
         assert!(
             verdict.is_permitted(),
             "F-010: action permission backed by DB authority-chain scope must be permitted"
+        );
+    }
+
+    #[test]
+    fn adjudication_context_rows_reject_consent_scope_that_does_not_cover_action_permission() {
+        let kernel = adjudication_kernel();
+        let actor = Did::new("did:exo:pace-agent").unwrap();
+        let root = Did::new("did:exo:root-grantor").unwrap();
+        let authority_chain = AuthorityChain {
+            links: vec![signed_authority_link_for_permissions(
+                &root,
+                &actor,
+                PermissionSet::new(vec![Permission::new("advance_pace")]),
+            )],
+        };
+        let role_rows = vec![db_role_row(&actor, "worker", "executive")];
+        let consent_rows = vec![db_consent_row_with_scope(
+            &actor,
+            root.as_str(),
+            "data:profile",
+        )];
+        let chain_row =
+            db_authority_chain_row(&actor, serde_json::to_value(&authority_chain).unwrap());
+        let trusted_authority_keys = trusted_authority_keys_for_test_chain(&authority_chain);
+
+        let ctx = build_adjudication_context_from_rows(
+            &actor,
+            &role_rows,
+            &consent_rows,
+            Some(&chain_row),
+            trusted_authority_keys,
+            TrustedProvenanceKeys::default(),
+        )
+        .unwrap();
+        let verdict = kernel.adjudicate(&action_for_permission(&actor, "advance_pace"), &ctx);
+
+        assert!(
+            !verdict.is_permitted(),
+            "advance_pace authority must not convert unrelated profile consent into action consent"
         );
     }
 
@@ -9331,7 +9382,11 @@ mod tests {
             )],
         };
         let role_rows = vec![db_role_row(&actor, "worker", "executive")];
-        let consent_rows = vec![db_consent_row(&actor, root.as_str())];
+        let consent_rows = vec![db_consent_row_with_scope(
+            &actor,
+            root.as_str(),
+            "pace:advance",
+        )];
         let chain_row =
             db_authority_chain_row(&actor, serde_json::to_value(&authority_chain).unwrap());
         let trusted_authority_keys = trusted_authority_keys_for_test_chain(&authority_chain);
@@ -9372,7 +9427,11 @@ mod tests {
             )],
         };
         let role_rows = vec![db_role_row(&actor, "worker", "executive")];
-        let consent_rows = vec![db_consent_row(&actor, root.as_str())];
+        let consent_rows = vec![db_consent_row_with_scope(
+            &actor,
+            root.as_str(),
+            "pace:advance",
+        )];
         let chain_row =
             db_authority_chain_row(&actor, serde_json::to_value(&authority_chain).unwrap());
         let trusted_authority_keys = trusted_authority_keys_for_test_chain(&authority_chain);

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -3988,7 +3988,7 @@ mod tests {
     };
     use exo_core::{
         Timestamp,
-        crypto::{generate_keypair, sign},
+        crypto::{KeyPair, generate_keypair, sign},
         hlc::HybridClock,
     };
     use exo_identity::did::{DidDocument, VerificationMethod};
@@ -4673,7 +4673,7 @@ mod tests {
     ) -> serde_json::Value {
         let actor = Did::new(actor_did).unwrap();
         let target = Did::new(target_did).unwrap();
-        let (public_key, secret_key) = generate_keypair();
+        let (public_key, secret_key) = advance_pace_provenance_keypair(actor_did);
         let timestamp = Timestamp::new(u64::try_from(queued_at).unwrap(), 0);
         let metadata = AdvancePaceMetadata {
             queued_at,
@@ -4705,6 +4705,18 @@ mod tests {
             "provenancePublicKey": hex::encode(public_key.as_bytes()),
             "provenanceSignature": hex::encode(provenance.signature),
         })
+    }
+
+    fn advance_pace_provenance_keypair(
+        actor_did: &str,
+    ) -> (exo_core::PublicKey, exo_core::SecretKey) {
+        let seed_hash = Hash256::digest(
+            format!("exo.gateway.advance_pace.test.provenance-key.v1:{actor_did}").as_bytes(),
+        );
+        let mut seed = [0u8; 32];
+        seed.copy_from_slice(seed_hash.as_bytes());
+        let keypair = KeyPair::from_secret_bytes(seed).unwrap();
+        (*keypair.public_key(), keypair.secret_key().clone())
     }
 
     async fn insert_test_user(pool: &sqlx::PgPool, did: &str, tenant_id: &str) {
@@ -8396,6 +8408,10 @@ mod tests {
             fixture.contains("db::insert_did_document(pool, &grantor_doc)"),
             "DB-backed advance-pace fixture must register the authority grantor DID document so trusted grantor keys are resolved from durable state"
         );
+        assert!(
+            fixture.contains("db::insert_did_document(pool, &actor_doc)"),
+            "DB-backed advance-pace fixture must register the actor DID document so action provenance keys are resolved from durable state"
+        );
     }
 
     fn source_between<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
@@ -8483,6 +8499,12 @@ mod tests {
         assert!(
             db::insert_did_document(pool, &grantor_doc).await.unwrap(),
             "advance-pace root DID document should insert into the live DB fixture"
+        );
+        let (actor_public_key, _) = advance_pace_provenance_keypair(did);
+        let actor_doc = did_document_with_ed25519_key(&actor, &actor_public_key);
+        assert!(
+            db::insert_did_document(pool, &actor_doc).await.unwrap(),
+            "advance-pace actor DID document should insert into the live DB fixture"
         );
         sqlx::query(
             "INSERT INTO authority_chains (actor_did, chain_json, valid_from, expires_at) \

--- a/crates/exo-node/src/holons.rs
+++ b/crates/exo-node/src/holons.rs
@@ -397,6 +397,17 @@ fn next_provenance_timestamp(config: &HolonManagerConfig) -> Result<Timestamp, S
     Ok(timestamp)
 }
 
+fn capability_scope(capabilities: &PermissionSet) -> String {
+    let mut permissions: Vec<&str> = capabilities
+        .permissions
+        .iter()
+        .map(|permission| permission.0.as_str())
+        .collect();
+    permissions.sort_unstable();
+    permissions.dedup();
+    permissions.join(";")
+}
+
 pub fn build_holon_adjudication_context(
     holon: &Holon,
     config: &HolonManagerConfig,
@@ -416,6 +427,7 @@ pub fn build_holon_adjudication_context(
         holon.id.clone(),
         vec![config.root_public_key.as_bytes().to_vec()],
     );
+    let consent_scope = capability_scope(&holon.capabilities);
     Ok(AdjudicationContext {
         actor_roles: vec![Role {
             name: "worker".into(),
@@ -425,13 +437,13 @@ pub fn build_holon_adjudication_context(
         consent_records: vec![ConsentRecord {
             subject: config.root_did.clone(),
             granted_to: holon.id.clone(),
-            scope: "infrastructure-monitoring".into(),
+            scope: consent_scope.clone(),
             active: true,
         }],
         bailment_state: BailmentState::Active {
             bailor: config.root_did.clone(),
             bailee: holon.id.clone(),
-            scope: "infrastructure-monitoring".into(),
+            scope: consent_scope,
         },
         human_override_preserved: true,
         actor_permissions: holon.capabilities.clone(),

--- a/crates/exo-node/src/mcp/handler.rs
+++ b/crates/exo-node/src/mcp/handler.rs
@@ -839,7 +839,7 @@ mod tests {
                     {
                         "subject": actor.as_str(),
                         "granted_to": actor.as_str(),
-                        "scope": "mcp:tools",
+                        "scope": "mcp:tool_call",
                         "active": true,
                     }
                 ],
@@ -847,7 +847,7 @@ mod tests {
                     "state": "Active",
                     "bailor": actor.as_str(),
                     "bailee": actor.as_str(),
-                    "scope": "mcp:tools",
+                    "scope": "mcp:tool_call",
                 },
                 "human_override_preserved": true,
                 "actor_permissions": ["mcp:tool_call"],

--- a/crates/exo-node/src/mcp/middleware.rs
+++ b/crates/exo-node/src/mcp/middleware.rs
@@ -498,7 +498,7 @@ mod tests {
                         {
                             "subject": actor.as_str(),
                             "granted_to": actor.as_str(),
-                            "scope": "mcp:tools",
+                            "scope": "mcp:tool_call",
                             "active": true,
                         }
                     ],
@@ -506,7 +506,7 @@ mod tests {
                         "state": "Active",
                         "bailor": actor.as_str(),
                         "bailee": actor.as_str(),
-                        "scope": "mcp:tools",
+                        "scope": "mcp:tool_call",
                     },
                     "human_override_preserved": true,
                     "actor_permissions": ["mcp:tool_call"],

--- a/crates/exochain-sdk/src/kernel.rs
+++ b/crates/exochain-sdk/src/kernel.rs
@@ -265,7 +265,7 @@ impl ConstitutionalKernel {
     /// - A one-link authority chain from the configured authority to `actor`
     ///   granting `read`.
     /// - An active bailment from the configured authority to `actor` scoped to
-    ///   `action`.
+    ///   the requested permission set.
     /// - Full human-override preservation.
     /// - Signed provenance with timestamp `"sdk"`.
     ///
@@ -438,6 +438,17 @@ impl ConstitutionalKernel {
         Ok(provenance)
     }
 
+    fn permission_scope(permissions: &PermissionSet) -> String {
+        let mut labels: Vec<&str> = permissions
+            .permissions
+            .iter()
+            .map(|permission| permission.0.as_str())
+            .collect();
+        labels.sort_unstable();
+        labels.dedup();
+        labels.join(";")
+    }
+
     fn adjudicate_internal(
         &self,
         actor: &Did,
@@ -464,7 +475,7 @@ impl ConstitutionalKernel {
             modifies_kernel,
         };
 
-        let scope = action.to_owned();
+        let scope = Self::permission_scope(&permissions);
 
         let (bailment_state, consent_records) = if include_bailment {
             (


### PR DESCRIPTION
## Summary
- Enforce `ConsentRequired` so an active bailment/consent scope must cover every requested permission, not merely match actor, bailor, and scope fields.
- Add deterministic scope matching for exact scopes, permission-object scopes, prefix scopes, and explicit comma/semicolon multi-permission scope lists.
- Align gateway DB adjudication, infrastructure holons, MCP test contexts, SDK default adjudication, and cross-crate integration fixtures with permission-covering consent scopes.
- Refresh README repo-truth metrics required by Gate 9 after the Rust/test counts changed on this branch.
- Bind the DB-backed advance-pace positive fixture's action provenance key to the actor DID document so Gate 13 exercises the tightened provenance and consent boundary instead of falling back to denial.

## Current-code confirmation
- This was confirmed against current `origin/main` after PR #422. Gatekeeper already rejected mismatched bailor/bailee/scope records, but it did not bind the active scope to `ctx.requested_permissions`.
- Red evidence before the fix:
  - `cargo test -p exo-gatekeeper consent_fails_when_scope_does_not_cover_requested_permission -- --nocapture` failed because `data:profile` consent permitted `advance_pace`.
  - `cargo test -p exo-gateway adjudication_context_rows_reject_consent_scope_that_does_not_cover_action_permission -- --nocapture` failed because a DB row with `data:profile` consent permitted `advance_pace`.
  - `cargo test -p exo-gatekeeper consent_ -- --nocapture` failed on the added non-object-token test before tightening the matcher.
  - GitHub Gate 13 failed after the first push because DB-backed advance-pace route fixtures had not registered the actor provenance key required by `ProvenanceVerifiable`.
  - `cargo test -p exo-gateway advance_pace_authorization_fixture_registers_trusted_grantor_document -- --nocapture` failed before the fixture registered `actor_doc`.

## Validation
- `cargo test -p exo-gatekeeper consent_ -- --nocapture`
- `cargo test -p exo-gateway adjudication_context_rows -- --nocapture`
- `cargo test -p exo-gateway --all-targets -- --nocapture`
- `cargo test -p exo-gateway --lib --features production-db advance_pace_persists -- --test-threads=1 --nocapture`
- `cargo test -p exo-gateway advance_pace_authorization_fixture_registers_trusted_grantor_document -- --nocapture`
- `cargo test -p exo-gateway adjudication_context_rows_permit_bound_provenance_actor_public_key -- --nocapture`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `cargo doc -p exo-gateway --no-deps`
- `cargo test -p exo-gatekeeper --all-targets -- --nocapture`
- `cargo test -p decision-forum --test governance_kernel_integration -- --nocapture`
- `cargo test -p exo-escalation --test sybil_adjudication quarantine_pauses_contested_actions_via_kernel -- --nocapture`
- `cargo test -p exo-node --bin exochain holon -- --nocapture`
- `cargo test -p exo-node --bin exochain mcp::middleware::tests::middleware_ -- --nocapture`
- `cargo test -p exo-node --bin exochain mcp::handler::tests::handler_tools_call -- --nocapture`
- `cargo test -p exochain-sdk kernel::tests:: -- --nocapture`
- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_github_actions_pinned.sh`
- `bash tools/test_github_issue_workflow_boundaries.sh`
- `bash tools/test_ci_supply_chain_hardening.sh`
- `bash tools/test_release_workflow_ref_binding.sh`
- `bash tools/test_release_dry_run_boundaries.sh`
- `bash tools/test_release_publish_boundaries.sh`
- `bash tools/test_sybil_cli_secret_boundaries.sh`
- `bash tools/test_audit_policy_docs.sh`
- `bash tools/test_consensus_liveness_docs.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`

## Path classification
- EXOCHAIN core: `crates/exo-gatekeeper/src/invariants.rs`, `crates/exo-gatekeeper/src/kernel.rs`, `crates/exo-gatekeeper/src/holon.rs`, `crates/decision-forum/tests/governance_kernel_integration.rs`, `crates/exo-escalation/tests/sybil_adjudication.rs`
- Core runtime adapter: `crates/exo-gateway/src/server.rs`, `crates/exo-node/src/holons.rs`, `crates/exo-node/src/mcp/handler.rs`, `crates/exo-node/src/mcp/middleware.rs`, `crates/exochain-sdk/src/kernel.rs`
- Documentation/public claim truth: `README.md`
- Adjacent surface: none
- Imported evidence: none
- Third-party/vendor: none

## Notes
- External/subagent findings were treated as hypotheses. This PR fixes only the currently reproduced core consent-scope boundary.
- Local Docker was unavailable for live Postgres reproduction (`docker.sock` missing), so the production-db filter was compiled locally and the live DB proof is delegated to GitHub Gate 13.
