### PR TITLE
fix(node): preserve 0dentity signed-write auth boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 180672 | `wc -l` |
-| Workspace tests | 4,244 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 180765 | `wc -l` |
+| Workspace tests | 4,247 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,244 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,247 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 180672 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 180765 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,244 listed workspace tests
+         cryptographic proofs, 4,247 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-node/src/auth.rs
+++ b/crates/exo-node/src/auth.rs
@@ -2,10 +2,12 @@
 //!
 //! On startup the node generates a random 256-bit admin token, persists it to
 //! a restrictive local file, and never writes token material to logs. Every
-//! mutating endpoint (`POST`) requires this token in the
-//! `Authorization: Bearer <token>` header. Public status and dashboard reads
-//! remain unauthenticated, while trust-object reads that disclose receipts,
-//! provenance, or credentials also require the bearer token.
+//! mutating endpoint requires this token in the `Authorization:
+//! Bearer <token>` header unless the route has a stricter local verifier.
+//! Public status and dashboard reads remain unauthenticated, while trust-object
+//! reads that disclose receipts, provenance, or credentials also require the
+//! bearer token. Exact 0dentity signed-write routes pass through so their
+//! handlers can verify DID-scoped session tokens and request signatures.
 
 use std::{
     io::{ErrorKind, Write},
@@ -138,22 +140,49 @@ fn is_sensitive_read_path(path: &str) -> bool {
         || (path.starts_with("/api/v1/agents/") && path.ends_with("/avcs"))
 }
 
+fn is_zerodentity_local_signed_write(method: &axum::http::Method, path: &str) -> bool {
+    const PREFIX: &str = "/api/v1/0dentity/";
+
+    let Some(rest) = path.strip_prefix(PREFIX) else {
+        return false;
+    };
+    if rest.is_empty() {
+        return false;
+    }
+
+    let mut segments = rest.split('/');
+    let Some(did_segment) = segments.next() else {
+        return false;
+    };
+    if did_segment.is_empty() {
+        return false;
+    }
+
+    if method == axum::http::Method::POST {
+        return matches!((segments.next(), segments.next()), (Some("attest"), None));
+    }
+
+    method == axum::http::Method::DELETE && segments.next().is_none()
+}
+
 /// axum middleware: require bearer token on mutating requests and sensitive
 /// trust-object reads.
 ///
 /// Public `GET` and `HEAD` requests pass through without authentication unless
 /// they target receipts, provenance, AVCs, or agent credential listings. All
 /// other methods (`POST`, `PUT`, `DELETE`, `PATCH`) require
-/// `Authorization: Bearer <token>`.
+/// `Authorization: Bearer <token>` unless they are exact 0dentity signed-write
+/// routes whose handlers perform identity-session and request-signature checks.
 pub async fn require_bearer_on_writes(
     auth: BearerAuth,
     request: Request<Body>,
     next: Next,
 ) -> Result<Response, StatusCode> {
     let method = request.method().clone();
+    let path = request.uri().path();
     let is_public_read = (method == axum::http::Method::GET || method == axum::http::Method::HEAD)
-        && !is_sensitive_read_path(request.uri().path());
-    if is_public_read {
+        && !is_sensitive_read_path(path);
+    if is_public_read || is_zerodentity_local_signed_write(&method, path) {
         return Ok(next.run(request).await);
     }
 
@@ -197,7 +226,7 @@ mod tests {
         body::Body,
         http::{Request, StatusCode},
         middleware,
-        routing::{get, post},
+        routing::{delete, get, post},
     };
     use tower::ServiceExt;
 
@@ -218,6 +247,18 @@ mod tests {
             .route("/api/v1/provenance/:hash", get(|| async { "provenance" }))
             .route("/api/v1/avc/:id", get(|| async { "credential" }))
             .route("/api/v1/agents/:did/avcs", get(|| async { "credentials" }))
+            .route(
+                "/api/v1/0dentity/:did/attest",
+                post(|| async { "signed-attest" }),
+            )
+            .route(
+                "/api/v1/0dentity/:did",
+                delete(|| async { "signed-delete" }),
+            )
+            .route(
+                "/api/v1/0dentity/:did/score",
+                post(|| async { "unexpected-write" }),
+            )
             .route("/write", post(|| async { "ok" }))
             .layer(middleware::from_fn(move |req, next| {
                 let a = auth.clone();
@@ -429,6 +470,57 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn zerodentity_attest_post_with_identity_session_bearer_reaches_local_signed_verifier() {
+        let app = test_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/0dentity/did:exo:alice/attest")
+                    .header("Authorization", "Bearer identity-session-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn zerodentity_delete_with_identity_session_bearer_reaches_local_signed_verifier() {
+        let app = test_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/api/v1/0dentity/did:exo:alice")
+                    .header("Authorization", "Bearer identity-session-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn unknown_zerodentity_write_still_requires_admin_bearer() {
+        let app = test_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/0dentity/did:exo:alice/score")
+                    .header("Authorization", "Bearer identity-session-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     }
 
     #[tokio::test]

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -903,7 +903,8 @@ async fn start_node(
     );
 
     // Merge metrics + governance + passport + dashboard into a single extra router
-    // and apply bearer-token auth middleware (protects POST, allows GET).
+    // and apply bearer-token auth middleware. 0dentity signed writes use their
+    // local DID session and request-signature verifiers.
     // NOTE: /health and /ready are provided by the gateway's own router.
     let extra_router = metrics_router
         .merge(governance_router)


### PR DESCRIPTION
## Summary
- keeps exact 0dentity signed-write routes out of the global node admin bearer middleware so their local DID session and request-signature verifiers can run
- limits the pass-through to POST /api/v1/0dentity/:did/attest and DELETE /api/v1/0dentity/:did; unknown 0dentity writes still require the node admin bearer
- refreshes README repo-truth counters after the new regression tests

## Classification
- Core runtime adapter: crates/exo-node/src/auth.rs, crates/exo-node/src/main.rs
- Documentation/public truth claim: README.md
- EXOCHAIN core: none
- Adjacent/imported/vendor: none

## Current-code confirmation
The node-level write middleware wrapped merged routers before 0dentity handlers, so POST /api/v1/0dentity/:did/attest and DELETE /api/v1/0dentity/:did saw identity-session bearer tokens as invalid admin bearer tokens and returned 403 before the local signed-write verifier could run.

## Red test evidence
Before the fix, cargo test -p exo-node auth::tests:: -- --nocapture failed the new signed-write pass-through tests with 403 vs 200 while the unknown 0dentity write negative test still returned 403.

## Validation
- cargo test -p exo-node auth::tests:: -- --nocapture: passed, 29 tests
- cargo test -p exo-node --all-targets -- --nocapture: passed, 1054 tests
- cargo clippy -p exo-node --all-targets -- -D warnings: passed
- cargo doc -p exo-node --no-deps: passed
- cargo +nightly fmt --all -- --check: passed
- bash tools/test_repo_truth.sh: passed
- git diff --check: passed

## Bypass search
Checked the route matcher is exact: only POST /api/v1/0dentity/:did/attest and DELETE /api/v1/0dentity/:did pass through; POST /api/v1/0dentity/:did/score remains forbidden without the admin bearer.