### PR TITLE
fix(node): protect economy trust object reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 181283 | `wc -l` |
-| Workspace tests | 4,251 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 181326 | `wc -l` |
+| Workspace tests | 4,253 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,247 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,253 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 180765 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 181326 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,247 listed workspace tests
+         cryptographic proofs, 4,253 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-node/src/auth.rs
+++ b/crates/exo-node/src/auth.rs
@@ -5,9 +5,10 @@
 //! mutating endpoint requires this token in the `Authorization:
 //! Bearer <token>` header unless the route has a stricter local verifier.
 //! Public status and dashboard reads remain unauthenticated, while trust-object
-//! reads that disclose receipts, provenance, or credentials also require the
-//! bearer token. Exact 0dentity signed-write routes pass through so their
-//! handlers can verify DID-scoped session tokens and request signatures.
+//! reads that disclose receipts, provenance, economy records, or credentials
+//! also require the bearer token. Exact 0dentity signed-write routes pass
+//! through so their handlers can verify DID-scoped session tokens and request
+//! signatures.
 
 use std::{
     io::{ErrorKind, Write},
@@ -137,6 +138,7 @@ fn is_sensitive_read_path(path: &str) -> bool {
         || path.starts_with("/api/v1/receipts/")
         || path.starts_with("/api/v1/provenance/")
         || path.starts_with("/api/v1/avc/")
+        || (path.starts_with("/api/v1/economy/") && path != "/api/v1/economy/policy/active")
         || (path.starts_with("/api/v1/agents/") && path.ends_with("/avcs"))
 }
 
@@ -169,7 +171,8 @@ fn is_zerodentity_local_signed_write(method: &axum::http::Method, path: &str) ->
 /// trust-object reads.
 ///
 /// Public `GET` and `HEAD` requests pass through without authentication unless
-/// they target receipts, provenance, AVCs, or agent credential listings. All
+/// they target receipts, provenance, AVCs, economy trust objects, or agent
+/// credential listings. The active economy policy remains public. All
 /// other methods (`POST`, `PUT`, `DELETE`, `PATCH`) require
 /// `Authorization: Bearer <token>` unless they are exact 0dentity signed-write
 /// routes whose handlers perform identity-session and request-signature checks.
@@ -247,6 +250,14 @@ mod tests {
             .route("/api/v1/provenance/:hash", get(|| async { "provenance" }))
             .route("/api/v1/avc/:id", get(|| async { "credential" }))
             .route("/api/v1/agents/:did/avcs", get(|| async { "credentials" }))
+            .route(
+                "/api/v1/economy/bailment-terms/:id",
+                get(|| async { "bailment terms" }),
+            )
+            .route(
+                "/api/v1/economy/policy/active",
+                get(|| async { "active policy" }),
+            )
             .route(
                 "/api/v1/0dentity/:did/attest",
                 post(|| async { "signed-attest" }),
@@ -403,6 +414,38 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn economy_trust_object_get_without_token_rejected() {
+        let app = test_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/economy/bailment-terms/0000000000000000000000000000000000000000000000000000000000000000")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn economy_active_policy_get_without_token_passes() {
+        let app = test_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/economy/policy/active")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- require the node admin bearer token for `GET /api/v1/economy/*` trust-object reads
- keep `/api/v1/economy/policy/active` public so pricing policy inspection remains unauthenticated
- update README repo-truth counters derived from the changed Rust LOC and workspace test list

## Path Classification
- Core runtime adapter: `crates/exo-node/src/auth.rs`
- Documentation/public truth counters: `README.md`

## Current-Code Confirmation
External and agent findings were treated as hypotheses. I confirmed this one against current `origin/main` before changing production code:
- Added `auth::tests::economy_trust_object_get_without_token_rejected` first.
- The new test failed red on current code because unauthenticated `GET /api/v1/economy/bailment-terms/:id` returned `200` instead of `401`.
- Tightened `is_sensitive_read_path` so economy trust-object reads are protected by the existing bearer guard.
- Added a negative-control test proving `/api/v1/economy/policy/active` remains public.

## Validation
- `cargo test -p exo-node economy_ -- --nocapture`
- `cargo test -p exo-node auth::tests -- --nocapture`
- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p exo-node --all-targets -- -D warnings`
- `bash tools/test_repo_truth.sh`
- `git diff --check`

## Bypass Search
- Confirmed node extra routers are wrapped in `auth::require_bearer_on_writes` in `crates/exo-node/src/main.rs`.
- Confirmed `is_sensitive_read_path` already protected receipts, provenance, AVCs, and agent AVC listings.
- Added the economy namespace to the same centralized read classifier so sibling economy trust-object GET routes inherit the protection consistently.
