### PR TITLE
fix(gateway): protect identity score reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 181341 | `wc -l` |
-| Workspace tests | 4,253 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 181484 | `wc -l` |
+| Workspace tests | 4,255 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,253 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,255 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 181326 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 181484 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,253 listed workspace tests
+         cryptographic proofs, 4,255 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -2217,6 +2217,7 @@ async fn handle_agent_get(
 async fn handle_identity_score(
     State(state): State<AppState>,
     Path(did_str): Path<String>,
+    headers: HeaderMap,
 ) -> impl IntoResponse {
     let did = match Did::new(&did_str) {
         Ok(d) => d,
@@ -2228,6 +2229,41 @@ async fn handle_identity_score(
                 .into_response();
         }
     };
+    let actor = match state
+        .require_authenticated_session_user_from_header(&headers)
+        .await
+    {
+        Ok(actor) => actor,
+        Err(e) => return auth_boundary_error_response(e),
+    };
+    let db = match state.require_db() {
+        Ok(pool) => pool,
+        Err(e) => return auth_boundary_error_response(e),
+    };
+    let target_user = match db::find_user_by_did(db, did.as_str()).await {
+        Ok(row) => row,
+        Err(e) => return internal_error_response(e, "identity score", "identity score failed"),
+    };
+    let target_is_same_tenant_user = target_user
+        .as_ref()
+        .is_some_and(|user| user.tenant_id.as_str() == actor.tenant_id.as_str());
+    let target_is_same_tenant_agent = if target_is_same_tenant_user {
+        false
+    } else {
+        match db::find_agent_by_did(db, did.as_str(), actor.tenant_id.as_str()).await {
+            Ok(row) => row.is_some(),
+            Err(e) => {
+                return internal_error_response(e, "identity score", "identity score failed");
+            }
+        }
+    };
+    if !target_is_same_tenant_user && !target_is_same_tenant_agent {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "identity score not found" })),
+        )
+            .into_response();
+    }
     match resolve_did_document(&state, did).await {
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -5247,8 +5283,7 @@ mod tests {
             "/api/v1/decisions/some-id",
             "/api/v1/auth/me",
             "/api/v1/agents",
-            // identity score for unregistered DID returns 404 by design;
-            // excluded here — tested separately in identity_score_* tests
+            "/api/v1/identity/did:exo:route-exists/score",
             "/api/v1/users",
             // audit returns 503 (no DB) not 404 — route exists
             "/api/v1/audit/decision-123",
@@ -5583,6 +5618,11 @@ mod tests {
             "async fn handle_agent_get",
             "/// GET /api/v1/identity/:did/score",
         );
+        let identity_score = source_between(
+            source,
+            "async fn handle_identity_score",
+            "/// DELETE /api/v1/identity/:did",
+        );
         let users_list = source_between(
             source,
             "async fn handle_users_list",
@@ -5607,6 +5647,7 @@ mod tests {
         for (name, handler, state_read) in [
             ("agents list", agents_list, "state.require_db"),
             ("agent get", agent_get, "resolve_did_document"),
+            ("identity score", identity_score, "resolve_did_document"),
             ("users list", users_list, "state.require_db"),
             ("decision create", decision_create, "state.require_db"),
             ("decision get", decision_get, "state.require_db"),
@@ -5964,6 +6005,38 @@ mod tests {
         assert!(
             identity_score.contains("resolve_did_document(&state, did).await"),
             "identity score must resolve persisted DID documents after a restart"
+        );
+        assert!(
+            identity_score.contains("require_authenticated_session_user_from_header"),
+            "identity score must authenticate a DB-backed tenant user before resolving DID state"
+        );
+        assert!(
+            identity_score.contains("db::find_user_by_did(db, did.as_str())"),
+            "identity score must check whether target users are in the authenticated tenant"
+        );
+        assert!(
+            identity_score
+                .contains("db::find_agent_by_did(db, did.as_str(), actor.tenant_id.as_str())"),
+            "identity score must check whether target agents are in the authenticated tenant"
+        );
+        let auth = identity_score
+            .find("require_authenticated_session_user_from_header")
+            .expect("identity score must authenticate a DB-backed tenant user");
+        let target_user = identity_score
+            .find("db::find_user_by_did(db, did.as_str())")
+            .expect("identity score must check target user tenant membership");
+        let target_agent = identity_score
+            .find("db::find_agent_by_did(db, did.as_str(), actor.tenant_id.as_str())")
+            .expect("identity score must check target agent tenant membership");
+        let resolve = identity_score
+            .find("resolve_did_document(&state, did).await")
+            .expect("identity score must resolve persisted DID documents after tenant check");
+        assert!(
+            auth < target_user
+                && auth < target_agent
+                && target_user < resolve
+                && target_agent < resolve,
+            "identity score must authenticate and prove tenant membership before DID resolution"
         );
 
         let users_list = source_between(
@@ -6801,7 +6874,7 @@ mod tests {
     // --- Identity score endpoint tests ---
 
     #[tokio::test]
-    async fn identity_score_unregistered_did_returns_404() {
+    async fn identity_score_unregistered_did_without_session_returns_401() {
         let app = build_router(state());
         let resp = app
             .oneshot(
@@ -6812,11 +6885,11 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]
-    async fn identity_score_registered_did_returns_200() {
+    async fn identity_score_registered_did_without_session_returns_401() {
         let doc = minimal_doc("did:exo:scored");
         let registry = Arc::new(RwLock::new(LocalDidRegistry::new()));
         registry.write().unwrap().register(doc).unwrap();
@@ -6831,13 +6904,83 @@ mod tests {
             )
             .await
             .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn identity_score_same_tenant_registered_did_returns_200() {
+        let Some(pool) = gateway_test_pool().await else {
+            return;
+        };
+        let reader = "did:exo:identity-score-reader";
+        let target = "did:exo:identity-score-target";
+        let token = "identity-score-reader-token";
+        let tenant = "tenant-identity-score";
+        cleanup_identity_erasure_route_fixture(&pool, reader).await;
+        cleanup_identity_erasure_route_fixture(&pool, target).await;
+        insert_test_user(&pool, reader, tenant).await;
+        insert_test_session(&pool, token, reader).await;
+        insert_test_user(&pool, target, tenant).await;
+        insert_test_did_document(&pool, target).await;
+
+        let registry = Arc::new(RwLock::new(LocalDidRegistry::new()));
+        let app = build_router(AppState::new(Some(pool.clone()), registry));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/v1/identity/{target}/score"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
         assert_eq!(resp.status(), StatusCode::OK);
         let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
             .await
             .unwrap();
         let val: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(val["did"], target);
         assert_eq!(val["registered"], true);
         assert!(val["score_bps"].as_u64().unwrap() > 0);
+
+        cleanup_identity_erasure_route_fixture(&pool, reader).await;
+        cleanup_identity_erasure_route_fixture(&pool, target).await;
+    }
+
+    #[tokio::test]
+    async fn identity_score_cross_tenant_registered_did_returns_404() {
+        let Some(pool) = gateway_test_pool().await else {
+            return;
+        };
+        let reader = "did:exo:identity-score-tenant-a-reader";
+        let target = "did:exo:identity-score-tenant-b-target";
+        let token = "identity-score-tenant-a-token";
+        cleanup_identity_erasure_route_fixture(&pool, reader).await;
+        cleanup_identity_erasure_route_fixture(&pool, target).await;
+        insert_test_user(&pool, reader, "tenant-identity-score-a").await;
+        insert_test_session(&pool, token, reader).await;
+        insert_test_user(&pool, target, "tenant-identity-score-b").await;
+        insert_test_did_document(&pool, target).await;
+
+        let registry = Arc::new(RwLock::new(LocalDidRegistry::new()));
+        let app = build_router(AppState::new(Some(pool.clone()), registry));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/v1/identity/{target}/score"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        cleanup_identity_erasure_route_fixture(&pool, reader).await;
+        cleanup_identity_erasure_route_fixture(&pool, target).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- classify as core runtime adapter hardening for the gateway identity-score read path
- require a DB-backed authenticated tenant session before resolving identity-score DID state
- allow same-tenant user or agent score reads and return non-enumerating 404 for cross-tenant targets
- add red/green behavioral tests plus source guards for auth-before-resolution
- update README repo-truth counters for Rust LOC and workspace test count

## Current-Code Confirmation
- Verified current `origin/main` exposed `GET /api/v1/identity/:did/score` without a session and resolved DID state before authentication.
- Red test observed current behavior: `identity_score_registered_did_without_session_returns_401` failed with `left: 200`, `right: 401`.
- Source guard also failed before the fix: `identity score must authenticate the bearer session`.

## Path Classification
- `crates/exo-gateway/src/server.rs` — core runtime adapter; gateway HTTP read path over identity/trust state.
- `README.md` — documentation/repo-truth metadata; derived Rust LOC and workspace test counters only.

## Validation
- RED: `cargo test -p exo-gateway identity_score_registered_did_without_session_returns_401 -- --nocapture` failed as expected before production change.
- RED: `cargo test -p exo-gateway sensitive_read_handlers_require_session_before_state_reads -- --nocapture` failed as expected before production change.
- GREEN: `cargo test -p exo-gateway identity_score -- --nocapture`
- `cargo test -p exo-gateway sensitive_read_handlers_require_session_before_state_reads -- --nocapture`
- `cargo test -p exo-gateway db_configured_identity_paths_do_not_depend_on_local_did_memory -- --nocapture`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `cargo test -p exo-gateway`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`

## Notes
- No imported evidence, docs.zip, docs/superpowers, adjacent surfaces, or third-party/vendor code changed.
- This does not claim adjacent-surface protection; it narrows a gateway core-runtime read boundary.
