### PR TITLE
fix(avc): require verified human approval evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 181341 | `wc -l` |
-| Workspace tests | 4,253 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 181423 | `wc -l` |
+| Workspace tests | 4,256 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,253 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,256 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 181326 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 181423 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,253 listed workspace tests
+         cryptographic proofs, 4,256 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-avc/src/validation.rs
+++ b/crates/exo-avc/src/validation.rs
@@ -265,6 +265,7 @@ fn evaluate_action(
     enforce_data_class(&credential.authority_scope, action, reasons);
     enforce_counterparty(&credential.authority_scope, action, reasons);
     enforce_budget(&credential.constraints, action, reasons);
+    enforce_human_approval_constraint(&credential.constraints, reasons, human_approval_required);
     enforce_risk(
         &credential.constraints,
         action,
@@ -328,6 +329,24 @@ fn enforce_budget(
     }
 }
 
+fn require_human_approval(
+    reasons: &mut BTreeSet<AvcReasonCode>,
+    human_approval_required: &mut bool,
+) {
+    reasons.insert(AvcReasonCode::HumanApprovalMissing);
+    *human_approval_required = true;
+}
+
+fn enforce_human_approval_constraint(
+    constraints: &AvcConstraints,
+    reasons: &mut BTreeSet<AvcReasonCode>,
+    human_approval_required: &mut bool,
+) {
+    if constraints.human_approval_required {
+        require_human_approval(reasons, human_approval_required);
+    }
+}
+
 fn enforce_risk(
     constraints: &AvcConstraints,
     action: &AvcActionRequest,
@@ -343,9 +362,8 @@ fn enforce_risk(
         }
     }
     if let Some(threshold) = constraints.approval_threshold_bp {
-        if estimate >= threshold && !action.requires_human_approval {
-            reasons.insert(AvcReasonCode::HumanApprovalMissing);
-            *human_approval_required = true;
+        if estimate >= threshold {
+            require_human_approval(reasons, human_approval_required);
         }
     }
 }
@@ -804,7 +822,7 @@ mod tests {
     }
 
     #[test]
-    fn risk_above_threshold_with_explicit_approval_does_not_flag() {
+    fn risk_above_threshold_with_action_approval_flag_still_requires_verified_evidence() {
         let h = Harness::new();
         let mut draft = baseline_draft();
         draft.constraints.max_action_risk_bp = Some(10_000);
@@ -817,7 +835,71 @@ mod tests {
         let mut request = baseline_request(cred, ts(1_500_000));
         request.action = Some(action);
         let result = validate_avc(&request, &h.registry).unwrap();
-        assert_eq!(result.decision, AvcDecision::Allow);
+        assert_eq!(result.decision, AvcDecision::HumanApprovalRequired);
+        assert_eq!(
+            result.reason_codes,
+            vec![AvcReasonCode::HumanApprovalMissing]
+        );
+    }
+
+    #[test]
+    fn risk_threshold_cannot_be_satisfied_by_caller_boolean() {
+        let h = Harness::new();
+        let mut draft = baseline_draft();
+        draft.constraints.max_action_risk_bp = Some(10_000);
+        draft.constraints.approval_threshold_bp = Some(5_000);
+        let cred = h.issue(draft);
+        let actor = cred.subject_did.clone();
+        let mut action = baseline_action(actor);
+        action.estimated_risk_bp = Some(7_500);
+        action.requires_human_approval = true;
+        let mut request = baseline_request(cred, ts(1_500_000));
+        request.action = Some(action);
+
+        let result = validate_avc(&request, &h.registry).unwrap();
+
+        assert_eq!(result.decision, AvcDecision::HumanApprovalRequired);
+        assert_eq!(
+            result.reason_codes,
+            vec![AvcReasonCode::HumanApprovalMissing]
+        );
+    }
+
+    #[test]
+    fn signed_human_approval_constraint_requires_verified_approval_evidence() {
+        let h = Harness::new();
+        let mut draft = baseline_draft();
+        draft.constraints.human_approval_required = true;
+        let cred = h.issue(draft);
+        let actor = cred.subject_did.clone();
+        let mut action = baseline_action(actor);
+        action.requires_human_approval = true;
+        let mut request = baseline_request(cred, ts(1_500_000));
+        request.action = Some(action);
+
+        let result = validate_avc(&request, &h.registry).unwrap();
+
+        assert_eq!(result.decision, AvcDecision::HumanApprovalRequired);
+        assert_eq!(
+            result.reason_codes,
+            vec![AvcReasonCode::HumanApprovalMissing]
+        );
+    }
+
+    #[test]
+    fn action_human_approval_flag_is_not_approval_evidence_source_guard() {
+        let source = include_str!("validation.rs");
+        let risk_enforcer = source
+            .split("fn enforce_risk")
+            .nth(1)
+            .expect("risk enforcer present")
+            .split("fn enforce_forbidden_action")
+            .next()
+            .expect("forbidden action marker present");
+        assert!(
+            !risk_enforcer.contains("requires_human_approval"),
+            "action.requires_human_approval is an action flag, not verified approval evidence"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- requires verified human approval evidence for AVC validation paths that cross human-approval thresholds
- prevents caller-supplied action approval flags from satisfying the human approval evidence requirement
- preserves fail-closed AVC validation and repo-truth counters after merging current main

## Path Classification
- EXOCHAIN core: crates/exo-avc/src/validation.rs
- EXOCHAIN core metadata: README.md

## Validation
- cargo test -p exo-avc risk_above_threshold_returns_human_approval_required -- --nocapture
- cargo test -p exo-avc risk_above_threshold_with_action_approval_flag_still_requires_verified_evidence -- --nocapture
- cargo test -p exo-avc signed_human_approval_constraint_requires_verified_approval_evidence -- --nocapture
- cargo test -p exo-avc action_human_approval_flag_is_not_approval_evidence_source_guard -- --nocapture
- cargo test -p exo-avc
- cargo clippy -p exo-avc --all-targets -- -D warnings
- cargo +nightly fmt --all -- --check
- bash tools/test_repo_truth.sh
- git diff --check
- cargo test --workspace