### PR TITLE
fix(node): protect 0dentity score reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 181341 | `wc -l` |
-| Workspace tests | 4,253 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 181578 | `wc -l` |
+| Workspace tests | 4,258 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,253 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,258 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 181326 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 181578 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,253 listed workspace tests
+         cryptographic proofs, 4,258 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-node/src/zerodentity/api.rs
+++ b/crates/exo-node/src/zerodentity/api.rs
@@ -2,9 +2,9 @@
 //!
 //! Implements read and attestation endpoints:
 //!
-//! - `GET /api/v1/0dentity/:did/score`         — current score (public)
+//! - `GET /api/v1/0dentity/:did/score`         — current score (owner only)
 //! - `GET /api/v1/0dentity/:did/claims`         — claim list (owner only)
-//! - `GET /api/v1/0dentity/:did/score/history`  — score history (public)
+//! - `GET /api/v1/0dentity/:did/score/history`  — score history (owner only)
 //! - `GET /api/v1/0dentity/:did/fingerprints`   — fingerprint timeline (owner only)
 //! - `POST /api/v1/0dentity/:did/attest`        — peer attestation
 //!
@@ -379,6 +379,30 @@ async fn verify_signed_write_blocking(
     .await
 }
 
+async fn verify_owner_session_blocking(
+    state: ApiState,
+    headers: &HeaderMap,
+    expected_did: Did,
+) -> ApiResult<()> {
+    let token = extract_session_token(headers)
+        .ok_or_else(|| json_error(StatusCode::UNAUTHORIZED, "Bearer session token required"))?;
+
+    let now_ms = now_ms_blocking(state.clone()).await?;
+    with_store_blocking(state, move |store| {
+        let session = store
+            .get_session(&token, now_ms)
+            .map_err(store_error)?
+            .ok_or_else(|| json_error(StatusCode::UNAUTHORIZED, "Invalid or expired session"))?;
+
+        if session.subject_did.as_str() != expected_did.as_str() {
+            return Err(json_error(StatusCode::FORBIDDEN, "Access denied"));
+        }
+
+        Ok(())
+    })
+    .await
+}
+
 fn hex_hash(h: &Hash256) -> String {
     hex::encode(h.as_bytes())
 }
@@ -552,8 +576,10 @@ pub async fn get_score(
     State(state): State<ApiState>,
     Path(did_str): Path<String>,
     Query(params): Query<ScoreQuery>,
+    headers: HeaderMap,
 ) -> Result<Json<ScoreResponse>, (StatusCode, Json<serde_json::Value>)> {
     let did = parse_did(&did_str)?;
+    verify_owner_session_blocking(state.clone(), &headers, did.clone()).await?;
 
     let response = with_store_blocking(state, move |store| {
         // Check if DID exists
@@ -677,9 +703,11 @@ pub async fn score_history(
     State(state): State<ApiState>,
     Path(did_str): Path<String>,
     Query(params): Query<HistoryQuery>,
+    headers: HeaderMap,
 ) -> Result<Json<HistoryResponse>, (StatusCode, Json<serde_json::Value>)> {
     let did = parse_did(&did_str)?;
     let page_bounds = parse_page_bounds(params.limit, params.offset)?;
+    verify_owner_session_blocking(state.clone(), &headers, did.clone()).await?;
 
     let response = with_store_blocking(state, move |store| {
         let snapshots = store
@@ -1045,14 +1073,19 @@ mod tests {
 
     #[tokio::test]
     async fn get_score_redacts_store_read_errors() {
-        let mut store = test_store();
-        store.inject_read_failure(ZerodentityReadFailure::Claims);
-        let app = zerodentity_api_router(test_api_state(store));
+        let state = make_state_with_session("tok-redaction", "did:exo:redaction");
+        state
+            .store
+            .lock()
+            .unwrap()
+            .inject_read_failure(ZerodentityReadFailure::Claims);
+        let app = zerodentity_api_router(state);
 
         let resp = app
             .oneshot(
                 Request::builder()
                     .uri("/api/v1/0dentity/did:exo:redaction/score")
+                    .header("authorization", "Bearer tok-redaction")
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -1119,6 +1152,34 @@ mod tests {
             .unwrap();
 
         assert!(!score_section.contains("now_ms()"));
+    }
+
+    #[test]
+    fn score_and_history_reads_require_owner_session_before_store_reads() {
+        let source = include_str!("api.rs");
+        let score_section = source
+            .split("// GET /api/v1/0dentity/:did/score\n// ---------------------------------------------------------------------------")
+            .nth(1)
+            .expect("score section present")
+            .split("// GET /api/v1/0dentity/:did/claims")
+            .next()
+            .expect("claims marker present");
+        let history_section = source
+            .split("// GET /api/v1/0dentity/:did/score/history\n// ---------------------------------------------------------------------------")
+            .nth(1)
+            .expect("history section present")
+            .split("// GET /api/v1/0dentity/:did/fingerprints")
+            .next()
+            .expect("fingerprints marker present");
+
+        for section in [score_section, history_section] {
+            assert!(section.contains("headers: HeaderMap"));
+            assert!(
+                section.find("verify_owner_session_blocking").unwrap()
+                    < section.find("with_store_blocking").unwrap(),
+                "0dentity score reads must verify owner sessions before reading store state"
+            );
+        }
     }
 
     #[test]
@@ -1272,6 +1333,15 @@ mod tests {
     fn make_state_with_score_history(did_str: &str, timestamps: &[u64]) -> ApiState {
         let mut store = test_store();
         let did = Did::new(did_str).unwrap();
+        let session = IdentitySession {
+            session_token: "tok-history".to_owned(),
+            subject_did: did.clone(),
+            public_key: vec![],
+            created_ms: API_TEST_ACTIVE_SESSION_CREATED_MS,
+            last_active_ms: API_TEST_ACTIVE_SESSION_CREATED_MS,
+            revoked: false,
+        };
+        store.insert_session(&session).unwrap();
         for timestamp in timestamps {
             store.put_score(ZerodentityScore::compute(&did, &[], &[], &[], *timestamp));
         }
@@ -1555,11 +1625,12 @@ mod tests {
 
     #[tokio::test]
     async fn score_history_returns_empty_for_unknown_did() {
-        let app = zerodentity_api_router(make_state());
+        let app = zerodentity_api_router(make_state_with_session("tok-nobody", "did:exo:nobody"));
         let resp = app
             .oneshot(
                 Request::builder()
                     .uri("/api/v1/0dentity/did%3Aexo%3Anobody/score/history")
+                    .header("authorization", "Bearer tok-nobody")
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -1579,6 +1650,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .uri("/api/v1/0dentity/did%3Aexo%3Ahistory/score/history?offset=1&limit=2")
+                    .header("authorization", "Bearer tok-history")
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/crates/exo-node/src/zerodentity/tests.rs
+++ b/crates/exo-node/src/zerodentity/tests.rs
@@ -1523,10 +1523,71 @@ mod tests {
 
     #[tokio::test]
     async fn get_score_unknown_did_returns_404() {
-        let app = api_app(new_shared_store());
+        let store = new_shared_store();
+        let app = api_app(store.clone());
+        let did = td("nobody");
+        let token = "score-unknown-session-token";
 
-        let resp = get_req(&app, "/api/v1/0dentity/did:exo:nobody/score").await;
+        store
+            .lock()
+            .unwrap()
+            .insert_session(&make_session(&did, token, 1_000_000))
+            .unwrap();
+
+        let resp = get_with_auth(
+            &app,
+            &format!("/api/v1/0dentity/{}/score", did.as_str()),
+            token,
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn get_score_without_auth_returns_401() {
+        let store = new_shared_store();
+        let app = api_app(store.clone());
+        let did = td("api-score-noauth");
+
+        store
+            .lock()
+            .unwrap()
+            .insert_claim(
+                "c1",
+                &make_claim(&did, ClaimType::Email, ClaimStatus::Verified, 1_000),
+            )
+            .unwrap();
+
+        let resp = get_req(&app, &format!("/api/v1/0dentity/{}/score", did.as_str())).await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn get_score_wrong_did_session_returns_403() {
+        let store = new_shared_store();
+        let app = api_app(store.clone());
+        let alice = td("api-score-403-alice");
+        let bob = td("api-score-403-bob");
+        let bob_token = "score-bob-session-token";
+
+        {
+            let mut s = store.lock().unwrap();
+            s.insert_claim(
+                "a-c1",
+                &make_claim(&alice, ClaimType::Email, ClaimStatus::Verified, 1_000),
+            )
+            .unwrap();
+            s.insert_session(&make_session(&bob, bob_token, 1_000_000))
+                .unwrap();
+        }
+
+        let resp = get_with_auth(
+            &app,
+            &format!("/api/v1/0dentity/{}/score", alice.as_str()),
+            bob_token,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     }
 
     #[tokio::test]
@@ -1534,9 +1595,12 @@ mod tests {
         let store = new_shared_store();
         let app = api_app(store.clone());
         let did = td("api-score-01");
+        let token = "score-session-token-01";
 
         {
             let mut s = store.lock().unwrap();
+            s.insert_session(&make_session(&did, token, 1_000_000))
+                .unwrap();
             s.insert_claim(
                 "e1",
                 &make_claim(&did, ClaimType::Email, ClaimStatus::Verified, 1_000),
@@ -1549,7 +1613,12 @@ mod tests {
             .unwrap();
         }
 
-        let resp = get_req(&app, &format!("/api/v1/0dentity/{}/score", did.as_str())).await;
+        let resp = get_with_auth(
+            &app,
+            &format!("/api/v1/0dentity/{}/score", did.as_str()),
+            token,
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::OK);
         let body = body_json(resp).await;
         assert_eq!(body["axes"]["communication"].as_u64().unwrap(), 8_700);
@@ -1562,9 +1631,12 @@ mod tests {
         let store = new_shared_store();
         let app = api_app(store.clone());
         let did = td("api-score-evidence-time");
+        let token = "score-session-evidence-time";
 
         {
             let mut s = store.lock().unwrap();
+            s.insert_session(&make_session(&did, token, 1_000_000))
+                .unwrap();
             s.insert_claim(
                 "e1",
                 &make_claim(&did, ClaimType::Email, ClaimStatus::Verified, 1_000),
@@ -1577,7 +1649,12 @@ mod tests {
             .unwrap();
         }
 
-        let resp = get_req(&app, &format!("/api/v1/0dentity/{}/score", did.as_str())).await;
+        let resp = get_with_auth(
+            &app,
+            &format!("/api/v1/0dentity/{}/score", did.as_str()),
+            token,
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::OK);
         let body = body_json(resp).await;
         assert_eq!(body["computed_ms"].as_u64().unwrap(), 2_500);
@@ -1588,19 +1665,23 @@ mod tests {
         let store = new_shared_store();
         let app = api_app(store.clone());
         let did = td("api-score-explicit-time");
+        let token = "score-session-explicit-time";
 
-        store
-            .lock()
-            .unwrap()
-            .insert_claim(
+        {
+            let mut s = store.lock().unwrap();
+            s.insert_session(&make_session(&did, token, 1_000_000))
+                .unwrap();
+            s.insert_claim(
                 "c1",
                 &make_claim(&did, ClaimType::DisplayName, ClaimStatus::Verified, 1_000),
             )
             .unwrap();
+        }
 
-        let resp = get_req(
+        let resp = get_with_auth(
             &app,
             &format!("/api/v1/0dentity/{}/score?as_of_ms=123456", did.as_str()),
+            token,
         )
         .await;
         assert_eq!(resp.status(), StatusCode::OK);
@@ -1613,19 +1694,23 @@ mod tests {
         let store = new_shared_store();
         let app = api_app(store.clone());
         let did = td("api-score-zero-time");
+        let token = "score-session-zero-time";
 
-        store
-            .lock()
-            .unwrap()
-            .insert_claim(
+        {
+            let mut s = store.lock().unwrap();
+            s.insert_session(&make_session(&did, token, 1_000_000))
+                .unwrap();
+            s.insert_claim(
                 "c1",
                 &make_claim(&did, ClaimType::DisplayName, ClaimStatus::Verified, 1_000),
             )
             .unwrap();
+        }
 
-        let resp = get_req(
+        let resp = get_with_auth(
             &app,
             &format!("/api/v1/0dentity/{}/score?as_of_ms=0", did.as_str()),
+            token,
         )
         .await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
@@ -1639,6 +1724,7 @@ mod tests {
     #[tokio::test]
     async fn get_score_is_invariant_to_claim_insertion_order() {
         let did = td("api-score-canonical-order");
+        let token = "score-session-canonical-order";
         let older_post_quantum = make_signed_claim(
             &did,
             ClaimType::Email,
@@ -1657,6 +1743,8 @@ mod tests {
         let ordered_store = new_shared_store();
         {
             let mut s = ordered_store.lock().unwrap();
+            s.insert_session(&make_session(&did, token, 1_000_000))
+                .unwrap();
             s.insert_claim("older", &older_post_quantum).unwrap();
             s.insert_claim("newer", &newer_ed25519).unwrap();
         }
@@ -1665,19 +1753,23 @@ mod tests {
         let reversed_store = new_shared_store();
         {
             let mut s = reversed_store.lock().unwrap();
+            s.insert_session(&make_session(&did, token, 1_000_000))
+                .unwrap();
             s.insert_claim("newer", &newer_ed25519).unwrap();
             s.insert_claim("older", &older_post_quantum).unwrap();
         }
         let reversed_app = api_app(reversed_store);
 
-        let ordered_resp = get_req(
+        let ordered_resp = get_with_auth(
             &ordered_app,
             &format!("/api/v1/0dentity/{}/score", did.as_str()),
+            token,
         )
         .await;
-        let reversed_resp = get_req(
+        let reversed_resp = get_with_auth(
             &reversed_app,
             &format!("/api/v1/0dentity/{}/score", did.as_str()),
+            token,
         )
         .await;
 
@@ -1703,17 +1795,25 @@ mod tests {
         let store = new_shared_store();
         let app = api_app(store.clone());
         let did = td("api-score-02");
+        let token = "score-session-dag-hash";
 
-        store
-            .lock()
-            .unwrap()
-            .insert_claim(
+        {
+            let mut s = store.lock().unwrap();
+            s.insert_session(&make_session(&did, token, 1_000_000))
+                .unwrap();
+            s.insert_claim(
                 "c1",
                 &make_claim(&did, ClaimType::DisplayName, ClaimStatus::Verified, 1_000),
             )
             .unwrap();
+        }
 
-        let resp = get_req(&app, &format!("/api/v1/0dentity/{}/score", did.as_str())).await;
+        let resp = get_with_auth(
+            &app,
+            &format!("/api/v1/0dentity/{}/score", did.as_str()),
+            token,
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::OK);
         let body = body_json(resp).await;
         let hash_str = body["dag_state_hash"].as_str().unwrap();
@@ -1806,12 +1906,69 @@ mod tests {
 
     #[tokio::test]
     async fn score_history_empty_did_returns_empty_snapshots() {
-        let app = api_app(new_shared_store());
+        let store = new_shared_store();
+        let app = api_app(store.clone());
+        let did = td("no-history");
+        let token = "history-empty-session-token";
 
-        let resp = get_req(&app, "/api/v1/0dentity/did:exo:no-history/score/history").await;
+        store
+            .lock()
+            .unwrap()
+            .insert_session(&make_session(&did, token, 1_000_000))
+            .unwrap();
+
+        let resp = get_with_auth(
+            &app,
+            &format!("/api/v1/0dentity/{}/score/history", did.as_str()),
+            token,
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::OK);
         let body = body_json(resp).await;
         assert_eq!(body["snapshots"].as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn score_history_without_auth_returns_401() {
+        let store = new_shared_store();
+        let app = api_app(store.clone());
+        let did = td("api-history-noauth");
+
+        store
+            .lock()
+            .unwrap()
+            .put_score(make_score(&did, 4_000, 1_000));
+
+        let resp = get_req(
+            &app,
+            &format!("/api/v1/0dentity/{}/score/history", did.as_str()),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn score_history_wrong_did_session_returns_403() {
+        let store = new_shared_store();
+        let app = api_app(store.clone());
+        let alice = td("api-history-403-alice");
+        let bob = td("api-history-403-bob");
+        let bob_token = "history-bob-session-token";
+
+        {
+            let mut s = store.lock().unwrap();
+            s.put_score(make_score(&alice, 4_000, 1_000));
+            s.insert_session(&make_session(&bob, bob_token, 1_000_000))
+                .unwrap();
+        }
+
+        let resp = get_with_auth(
+            &app,
+            &format!("/api/v1/0dentity/{}/score/history", alice.as_str()),
+            bob_token,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     }
 
     #[tokio::test]
@@ -1819,9 +1976,12 @@ mod tests {
         let store = new_shared_store();
         let app = api_app(store.clone());
         let did = td("api-history-01");
+        let token = "history-session-token-01";
 
         {
             let mut s = store.lock().unwrap();
+            s.insert_session(&make_session(&did, token, 1_000_000))
+                .unwrap();
             for (bp, ms) in [(1_000u32, 1_000u64), (3_000, 5_000), (6_000, 9_000)] {
                 let mut score = make_score(&did, bp, ms);
                 score.computed_ms = ms;
@@ -1829,9 +1989,10 @@ mod tests {
             }
         }
 
-        let resp = get_req(
+        let resp = get_with_auth(
             &app,
             &format!("/api/v1/0dentity/{}/score/history", did.as_str()),
+            token,
         )
         .await;
         assert_eq!(resp.status(), StatusCode::OK);
@@ -2451,9 +2612,12 @@ mod tests {
         let store = new_shared_store();
         let app = api_app(store.clone());
         let did = td("api-hist-filter");
+        let token = "history-filter-session-token";
 
         {
             let mut s = store.lock().unwrap();
+            s.insert_session(&make_session(&did, token, 1_000_000))
+                .unwrap();
             for (bp, ms) in [(1_000u32, 1_000u64), (2_000, 5_000), (3_000, 10_000)] {
                 let mut score = make_score(&did, bp, ms);
                 score.computed_ms = ms;
@@ -2461,12 +2625,13 @@ mod tests {
             }
         }
 
-        let resp = get_req(
+        let resp = get_with_auth(
             &app,
             &format!(
                 "/api/v1/0dentity/{}/score/history?from_ms=3000&to_ms=7000",
                 did.as_str()
             ),
+            token,
         )
         .await;
         assert_eq!(resp.status(), StatusCode::OK);


### PR DESCRIPTION
## Classification
- `crates/exo-node/src/zerodentity/api.rs`: core runtime adapter, 0dentity API read boundary.
- `crates/exo-node/src/zerodentity/tests.rs`: core runtime adapter regression tests.
- `README.md`: repository truth metadata.

## Current-code confirmation
- The report input was not taken at face value. I confirmed the current branch still exposed `GET /api/v1/0dentity/:did/score` without a bearer session by adding `get_score_without_auth_returns_401` first.
- Red check: `cargo test -p exo-node get_score_without_auth_returns_401 -- --nocapture` failed with `left: 200 right: 401` before the production change.
- Sibling confirmation: score history had the same public read shape, so the fix and tests cover both score and history reads.

## Remediation
- Added `verify_owner_session_blocking` and require a valid bearer identity session for `score` and `score/history` reads.
- Return `401` for missing/invalid/expired sessions and `403` when a valid session belongs to a different DID.
- Kept existing score semantics intact for authorized owners, including unknown DID, explicit `as_of_ms`, deterministic ordering, pagination, redacted store read errors, and history filtering.
- Added a source guard proving score and score history verify owner sessions before reading store state.

## Validation
- `cargo test -p exo-node get_score_without_auth_returns_401 -- --nocapture`
- `cargo test -p exo-node get_score_ -- --nocapture`
- `cargo test -p exo-node score_history_ -- --nocapture`
- `cargo test -p exo-node score_and_history_reads_require_owner_session_before_store_reads -- --nocapture`
- `cargo test -p exo-node zerodentity -- --nocapture`
- `cargo test -p exo-node`
- `cargo clippy -p exo-node --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `cargo test --workspace -- --list | rg -c ': test$'` -> `4258`
- `bash tools/test_repo_truth.sh`
- `git diff --check`
