### PR TITLE
fix(node): protect challenge hold reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 181341 | `wc -l` |
-| Workspace tests | 4,253 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 181377 | `wc -l` |
+| Workspace tests | 4,255 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,253 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,255 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 181326 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 181377 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,253 listed workspace tests
+         cryptographic proofs, 4,255 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-node/src/auth.rs
+++ b/crates/exo-node/src/auth.rs
@@ -138,6 +138,8 @@ fn is_sensitive_read_path(path: &str) -> bool {
         || path.starts_with("/api/v1/receipts/")
         || path.starts_with("/api/v1/provenance/")
         || path.starts_with("/api/v1/avc/")
+        || path == "/api/v1/challenges"
+        || path.starts_with("/api/v1/challenges/")
         || (path.starts_with("/api/v1/economy/") && path != "/api/v1/economy/policy/active")
         || (path.starts_with("/api/v1/agents/") && path.ends_with("/avcs"))
 }
@@ -171,8 +173,8 @@ fn is_zerodentity_local_signed_write(method: &axum::http::Method, path: &str) ->
 /// trust-object reads.
 ///
 /// Public `GET` and `HEAD` requests pass through without authentication unless
-/// they target receipts, provenance, AVCs, economy trust objects, or agent
-/// credential listings. The active economy policy remains public. All
+/// they target receipts, provenance, AVCs, challenge holds, economy trust
+/// objects, or agent credential listings. The active economy policy remains public. All
 /// other methods (`POST`, `PUT`, `DELETE`, `PATCH`) require
 /// `Authorization: Bearer <token>` unless they are exact 0dentity signed-write
 /// routes whose handlers perform identity-session and request-signature checks.
@@ -250,6 +252,8 @@ mod tests {
             .route("/api/v1/provenance/:hash", get(|| async { "provenance" }))
             .route("/api/v1/avc/:id", get(|| async { "credential" }))
             .route("/api/v1/agents/:did/avcs", get(|| async { "credentials" }))
+            .route("/api/v1/challenges", get(|| async { "challenges" }))
+            .route("/api/v1/challenges/:id", get(|| async { "challenge" }))
             .route(
                 "/api/v1/economy/bailment-terms/:id",
                 get(|| async { "bailment terms" }),
@@ -408,6 +412,38 @@ mod tests {
                 Request::builder()
                     .method("GET")
                     .uri("/api/v1/agents/did:exo:alice/avcs")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn challenge_list_get_without_token_rejected() {
+        let app = test_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/challenges")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn challenge_get_without_token_rejected() {
+        let app = test_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/challenges/00000000-0000-0000-0000-000000000000")
                     .body(Body::empty())
                     .unwrap(),
             )


### PR DESCRIPTION
## Classification
- `crates/exo-node/src/auth.rs`: core runtime adapter, node API bearer middleware read boundary.
- `README.md`: repository truth metadata.

## Current-code confirmation
- The external discovery candidate was treated as a hypothesis and reproduced against current `origin/main` before production code changed.
- Red check: `cargo test -p exo-node challenge_list_get_without_token_rejected -- --nocapture` failed with `left: 200 right: 401`, proving unauthenticated `GET /api/v1/challenges` still passed the write-only bearer guard.
- Adjacent candidate closure during triage: DID registration and AVC read-auth candidates already had current passing controls/tests on `origin/main`; this PR only fixes the live challenge read boundary.

## Remediation
- Classified `/api/v1/challenges` and `/api/v1/challenges/*` as sensitive read paths in the node bearer middleware.
- Added unauthenticated read regression tests for both challenge list and single-hold routes.
- Preserved the active economy policy public-read exception and existing 0dentity local signed-write exceptions.

## Validation
- `cargo test -p exo-gateway auth_register_rejects -- --nocapture` -> confirmed DID registration proof boundary already remediated
- `cargo test -p exo-node challenge_list_get_without_token_rejected -- --nocapture` -> red before fix (`200` vs `401`)
- `cargo test -p exo-node challenge_ -- --nocapture`
- `cargo test -p exo-node auth::tests -- --nocapture`
- `cargo test -p exo-node`
- `cargo clippy -p exo-node --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `cargo test --workspace -- --list | rg -c ': test$'` -> `4255`
- `bash tools/test_repo_truth.sh`
- `git diff --check`

## Rebase Repair 2026-05-10
- Merged current `origin/main`; only local conflict was repository truth metadata in `README.md`.
- Revalidated after merge:
  - `cargo test -p exo-node challenge_ -- --nocapture` -> 17 passed
  - `cargo test -p exo-node auth::tests -- --nocapture` -> 33 passed
  - `cargo test -p exo-node` -> 1063 passed
  - `cargo clippy -p exo-node --all-targets -- -D warnings` -> passed
  - `cargo +nightly fmt --all -- --check` -> passed
  - `git diff --check` -> passed
  - `bash tools/test_repo_truth.sh` -> passed
  - `cargo test --workspace` -> passed