### PR TITLE
fix(wasm): enforce canonical decision invariants

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 181341 | `wc -l` |
-| Workspace tests | 4,253 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 181383 | `wc -l` |
+| Workspace tests | 4,254 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,253 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,254 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 181326 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 181383 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,253 listed workspace tests
+         cryptographic proofs, 4,254 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exochain-wasm/src/decision_forum_bindings.rs
+++ b/crates/exochain-wasm/src/decision_forum_bindings.rs
@@ -19,7 +19,6 @@ struct WasmDecisionTransitionAdjudicatedRequest {
     actor_did: String,
     timestamp_ms: u64,
     timestamp_logical: u32,
-    invariant_set: exo_gatekeeper::invariants::InvariantSet,
     action: exo_gatekeeper::kernel::ActionRequest,
     context: exo_gatekeeper::kernel::AdjudicationContext,
 }
@@ -80,20 +79,31 @@ pub fn wasm_transition_decision_adjudicated(
     constitution: &[u8],
 ) -> Result<JsValue, JsValue> {
     ensure_constitution_bytes(constitution.len())?;
+    let request_value: serde_json::Value = from_json_str(request_json)?;
+    let request_object = request_value
+        .as_object()
+        .ok_or_else(|| JsValue::from_str("JSON parse error"))?;
+    if request_object.contains_key("invariant_set") {
+        return Err(JsValue::from_str(
+            "caller-supplied invariant_set is not allowed; the WASM boundary enforces the canonical invariant set",
+        ));
+    }
     let WasmDecisionTransitionAdjudicatedRequest {
         mut decision,
         to_state,
         actor_did,
         timestamp_ms,
         timestamp_logical,
-        invariant_set,
         action,
         context,
-    } = from_json_str(request_json)?;
+    } = serde_json::from_value(request_value).map_err(|_| JsValue::from_str("JSON parse error"))?;
     let actor = exo_core::Did::new(&actor_did)
         .map_err(|e| JsValue::from_str(&format!("DID error: {e}")))?;
     let ts = exo_core::types::Timestamp::new(timestamp_ms, timestamp_logical);
-    let kernel = exo_gatekeeper::kernel::Kernel::new(constitution, invariant_set);
+    let kernel = exo_gatekeeper::kernel::Kernel::new(
+        constitution,
+        exo_gatekeeper::invariants::InvariantSet::all(),
+    );
 
     decision
         .transition_adjudicated_at(to_state, &actor, ts, &kernel, &action, &context)

--- a/crates/exochain-wasm/src/gatekeeper_bindings.rs
+++ b/crates/exochain-wasm/src/gatekeeper_bindings.rs
@@ -197,8 +197,8 @@ pub fn wasm_validation_invariant_request() -> Result<JsValue, JsValue> {
     use exo_gatekeeper::{
         authority_link_signature_message, provenance_signature_message,
         types::{
-            AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, PermissionSet, Provenance,
-            TrustedAuthorityKeys, TrustedProvenanceKeys,
+            AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, Permission, PermissionSet,
+            Provenance, TrustedAuthorityKeys, TrustedProvenanceKeys,
         },
     };
 
@@ -215,7 +215,7 @@ pub fn wasm_validation_invariant_request() -> Result<JsValue, JsValue> {
         .map_err(|_| gatekeeper_boundary_error("validation invariant actor DID failed"))?;
     let grantor = exo_core::Did::new("did:exo:validation-root")
         .map_err(|_| gatekeeper_boundary_error("validation invariant grantor DID failed"))?;
-    let permissions = PermissionSet::default();
+    let permissions = PermissionSet::new(vec![Permission::new("bcts:transition:Draft->Submitted")]);
     let mut authority_link = AuthorityLink {
         grantor: grantor.clone(),
         grantee: actor.clone(),
@@ -264,13 +264,13 @@ pub fn wasm_validation_invariant_request() -> Result<JsValue, JsValue> {
             bailor: exo_core::Did::new("did:exo:validation-bailor")
                 .map_err(|_| gatekeeper_boundary_error("validation bailor DID failed"))?,
             bailee: actor.clone(),
-            scope: "validation-scope".to_string(),
+            scope: "bcts:transition".to_string(),
         },
         "consent_records": [ConsentRecord {
             subject: exo_core::Did::new("did:exo:validation-bailor")
                 .map_err(|_| gatekeeper_boundary_error("validation subject DID failed"))?,
             granted_to: actor.clone(),
-            scope: "validation-scope".to_string(),
+            scope: "bcts:transition".to_string(),
             active: true,
         }],
         "authority_chain": AuthorityChain {
@@ -281,8 +281,8 @@ pub fn wasm_validation_invariant_request() -> Result<JsValue, JsValue> {
         "kernel_modification_attempted": false,
         "quorum_evidence": null,
         "provenance": provenance,
-        "actor_permissions": permissions,
-        "requested_permissions": PermissionSet::default(),
+        "actor_permissions": permissions.clone(),
+        "requested_permissions": permissions,
         "trusted_authority_keys": trusted_authority_keys,
         "trusted_provenance_keys": trusted_provenance_keys,
     }))

--- a/crates/exochain-wasm/src/lib.rs
+++ b/crates/exochain-wasm/src/lib.rs
@@ -401,6 +401,38 @@ mod source_guard_tests {
     }
 
     #[test]
+    fn wasm_adjudicated_decision_transition_uses_canonical_invariant_set() {
+        let source = include_str!("decision_forum_bindings.rs");
+        let request = source
+            .split("struct WasmDecisionTransitionAdjudicatedRequest")
+            .nth(1)
+            .and_then(|section| section.split("/// Create a new DecisionObject").next())
+            .expect("adjudicated decision request source");
+        let transition = source
+            .split("pub fn wasm_transition_decision_adjudicated(")
+            .nth(1)
+            .and_then(|section| section.split("/// Add a vote").next())
+            .expect("adjudicated decision transition source");
+
+        assert!(
+            !request.contains("invariant_set"),
+            "WASM callers must not choose which constitutional invariants the kernel enforces"
+        );
+        assert!(
+            transition.contains("contains_key(\"invariant_set\")"),
+            "WASM adjudicated transition must reject caller-supplied invariant_set fields"
+        );
+        assert!(
+            transition.contains("InvariantSet::all()"),
+            "WASM adjudicated transition must construct the kernel with all constitutional invariants"
+        );
+        assert!(
+            !transition.contains("Kernel::new(constitution, invariant_set)"),
+            "WASM adjudicated transition must not pass caller-selected invariants to Kernel::new"
+        );
+    }
+
+    #[test]
     fn wasm_messaging_bridge_requires_caller_supplied_envelope_metadata() {
         let source = include_str!("messaging_bindings.rs");
         assert!(

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -1888,32 +1888,32 @@ test('wasm_transition_decision rejects unadjudicated transition', () =>
 
 test('wasm_transition_decision_adjudicated', () => {
   if (!decision) throw new Error('skipped -- no decision from setup');
+  const invariantFixture = wasm.wasm_validation_invariant_request();
   const transitionPermission = 'bcts:transition:Draft->Submitted';
   const request = {
     decision,
     to_state: 'Submitted',
-    actor_did: TEST_DID,
+    actor_did: invariantFixture.actor,
     timestamp_ms: NOW_NUM + 1,
     timestamp_logical: 0,
-    invariant_set: { invariants: [] },
     action: {
-      actor: TEST_DID,
+      actor: invariantFixture.actor,
       action: transitionPermission,
       required_permissions: { permissions: [transitionPermission] },
       is_self_grant: false,
       modifies_kernel: false
     },
     context: {
-      actor_roles: [],
-      authority_chain: { links: [] },
-      consent_records: [],
-      bailment_state: 'None',
-      human_override_preserved: true,
-      actor_permissions: { permissions: [transitionPermission] },
-      trusted_authority_keys: {},
-      trusted_provenance_keys: {},
-      provenance: null,
-      quorum_evidence: null,
+      actor_roles: invariantFixture.actor_roles,
+      authority_chain: invariantFixture.authority_chain,
+      consent_records: invariantFixture.consent_records,
+      bailment_state: invariantFixture.bailment_state,
+      human_override_preserved: invariantFixture.human_override_preserved,
+      actor_permissions: invariantFixture.actor_permissions,
+      trusted_authority_keys: invariantFixture.trusted_authority_keys,
+      trusted_provenance_keys: invariantFixture.trusted_provenance_keys,
+      provenance: invariantFixture.provenance,
+      quorum_evidence: invariantFixture.quorum_evidence,
       active_challenge_reason: null
     }
   };


### PR DESCRIPTION
## Summary
- blocks caller-selected invariant sets at the WASM adjudicated decision transition boundary
- constructs the adjudicating kernel with the canonical full constitutional invariant set
- keeps unadjudicated transition export fail-closed and verifies bridge behavior end-to-end

## Path Classification
- Core runtime adapter: crates/exochain-wasm/src/decision_forum_bindings.rs
- Core runtime adapter: crates/exochain-wasm/src/gatekeeper_bindings.rs
- Core runtime adapter source guards: crates/exochain-wasm/src/lib.rs
- Core runtime adapter bridge tests: packages/exochain-wasm/test/bridge_verification.mjs
- EXOCHAIN core metadata: README.md

## Validation
- cargo test -p exochain-wasm wasm_adjudicated_decision_transition_uses_canonical_invariant_set -- --nocapture
- cargo test -p exochain-wasm wasm_decision_transition_requires_kernel_adjudication -- --nocapture
- cargo test -p exochain-wasm wasm_enforce_invariants_rejects_caller_supplied_trusted_key_maps -- --nocapture
- cargo test -p exochain-wasm
- cargo clippy -p exochain-wasm --all-targets -- -D warnings
- wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm
- node packages/exochain-wasm/test/bridge_verification.mjs
- cargo +nightly fmt --all -- --check
- bash tools/test_repo_truth.sh
- git diff --check
- cargo test --workspace