### PR TITLE
fix(node): protect ExoForge read surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 181341 | `wc -l` |
-| Workspace tests | 4,253 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 181437 | `wc -l` |
+| Workspace tests | 4,259 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,253 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,259 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 181326 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 181437 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,253 listed workspace tests
+         cryptographic proofs, 4,259 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-node/src/auth.rs
+++ b/crates/exo-node/src/auth.rs
@@ -138,6 +138,8 @@ fn is_sensitive_read_path(path: &str) -> bool {
         || path.starts_with("/api/v1/receipts/")
         || path.starts_with("/api/v1/provenance/")
         || path.starts_with("/api/v1/avc/")
+        || path == "/exoforge"
+        || path.starts_with("/api/v1/forge/")
         || (path.starts_with("/api/v1/economy/") && path != "/api/v1/economy/policy/active")
         || (path.starts_with("/api/v1/agents/") && path.ends_with("/avcs"))
 }
@@ -171,8 +173,9 @@ fn is_zerodentity_local_signed_write(method: &axum::http::Method, path: &str) ->
 /// trust-object reads.
 ///
 /// Public `GET` and `HEAD` requests pass through without authentication unless
-/// they target receipts, provenance, AVCs, economy trust objects, or agent
-/// credential listings. The active economy policy remains public. All
+/// they target receipts, provenance, AVCs, economy trust objects, ExoForge
+/// build-orchestration state, or agent credential listings. The active economy
+/// policy remains public. All
 /// other methods (`POST`, `PUT`, `DELETE`, `PATCH`) require
 /// `Authorization: Bearer <token>` unless they are exact 0dentity signed-write
 /// routes whose handlers perform identity-session and request-signature checks.
@@ -258,6 +261,10 @@ mod tests {
                 "/api/v1/economy/policy/active",
                 get(|| async { "active policy" }),
             )
+            .route("/exoforge", get(|| async { "forge dashboard" }))
+            .route("/api/v1/forge/tasks", get(|| async { "forge tasks" }))
+            .route("/api/v1/forge/stats", get(|| async { "forge stats" }))
+            .route("/api/v1/forge/activity", get(|| async { "forge activity" }))
             .route(
                 "/api/v1/0dentity/:did/attest",
                 post(|| async { "signed-attest" }),
@@ -463,6 +470,95 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn exoforge_dashboard_get_without_token_rejected() {
+        let app = test_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/exoforge")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn exoforge_tasks_get_without_token_rejected() {
+        let app = test_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/forge/tasks")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn exoforge_stats_get_without_token_rejected() {
+        let app = test_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/forge/stats")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn exoforge_activity_get_without_token_rejected() {
+        let app = test_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/forge/activity")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn exoforge_read_get_with_correct_token_passes() {
+        let app = test_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/forge/tasks")
+                    .header("authorization", "Bearer test-token-abc123")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn sensitive_read_paths_include_exoforge_surfaces() {
+        assert!(is_sensitive_read_path("/exoforge"));
+        assert!(is_sensitive_read_path("/api/v1/forge/tasks"));
+        assert!(is_sensitive_read_path("/api/v1/forge/stats"));
+        assert!(is_sensitive_read_path("/api/v1/forge/activity"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
**Classification**
- `crates/exo-node/src/auth.rs`: core runtime adapter protecting an adjacent surface mounted in the node runtime
- `README.md`: repository truth metadata

**Current-Code Confirmation / Red Tests**
- Confirmed current `is_sensitive_read_path` did not include `/exoforge` or `/api/v1/forge/*`.
- Confirmed ExoForge is mounted into the node runtime at `/exoforge` and `/api/v1/forge/{tasks,stats,activity}`.
- Added unauthenticated GET regressions for those four read surfaces and verified they failed before the fix with `200` instead of `401`.

**Remediation**
- Treat `/exoforge` and `/api/v1/forge/*` as sensitive read paths in the shared node bearer middleware.
- Preserve authenticated access with a positive bearer-token regression.
- Added a direct source-level guard that ExoForge read surfaces remain in the sensitive-read set.

**Validation**
- `cargo test -p exo-node exoforge_ -- --nocapture` failed before fix, passed after fix
- `cargo test -p exo-node auth::tests -- --nocapture`
- `cargo test -p exo-node`
- `cargo clippy -p exo-node --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `bash tools/repo_truth.sh --json --skip-tests | jq '{rust_loc, rust_source_files}'` -> `181422`, `300`
- `cargo test --workspace -- --list | rg -c ': test$'` -> `4259`
- `git diff --check`
- `bash tools/test_repo_truth.sh`

**Rebase Repair 2026-05-10**
- Merged current `origin/main`; only local conflict was repository truth metadata in `README.md`.
- Revalidated after merge:
  - `cargo test -p exo-node exoforge_ -- --nocapture` -> 8 passed
  - `cargo test -p exo-node auth::tests -- --nocapture` -> 37 passed
  - `cargo test -p exo-node` -> 1067 passed
  - `cargo clippy -p exo-node --all-targets -- -D warnings` -> passed
  - `cargo +nightly fmt --all -- --check` -> passed
  - `git diff --check` -> passed
  - `bash tools/test_repo_truth.sh` -> passed
  - `cargo test --workspace -- --list | rg -c ': test$'` -> 4266
  - `cargo test --workspace` -> passed