### PR TITLE
fix(release): validate version input boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,8 @@ jobs:
         run: bash tools/test_ci_supply_chain_hardening.sh
       - name: Release workflow ref binding
         run: bash tools/test_release_workflow_ref_binding.sh
+      - name: Release version input boundary
+        run: bash tools/test_release_version_input_boundary.sh
       - name: Release dry-run publication boundary
         run: bash tools/test_release_dry_run_boundaries.sh
       - name: Release publish completion boundary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,16 +31,42 @@ jobs:
     uses: ./.github/workflows/ci.yml
 
   # -----------------------------------------------------------------------
+  # Validate untrusted workflow-dispatch inputs before release jobs consume them
+  # -----------------------------------------------------------------------
+  validate-release-inputs:
+    name: "Validate Release Inputs"
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.validate.outputs.version }}
+      tag: ${{ steps.validate.outputs.tag }}
+    steps:
+      - name: Validate release version
+        id: validate
+        env:
+          RELEASE_VERSION_INPUT: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          version="$RELEASE_VERSION_INPUT"
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z-]*(\.[0-9A-Za-z][0-9A-Za-z-]*)*)?$ ]]; then
+            echo "Invalid release version: expected major.minor.patch with optional prerelease suffix." >&2
+            exit 1
+          fi
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+          printf 'tag=v%s\n' "$version" >> "$GITHUB_OUTPUT"
+
+  # -----------------------------------------------------------------------
   # Manual approval gate
   # -----------------------------------------------------------------------
   approve:
     name: "Maintainer Approval"
     runs-on: ubuntu-latest
-    needs: ci
+    needs: [ci, validate-release-inputs]
     environment: release
     steps:
       - name: Approval confirmed
-        run: echo "Release ${{ inputs.version }} approved by maintainer."
+        env:
+          RELEASE_VERSION: ${{ needs.validate-release-inputs.outputs.version }}
+        run: printf 'Release %s approved by maintainer.\n' "$RELEASE_VERSION"
 
   # -----------------------------------------------------------------------
   # Signed tag gate for real releases
@@ -48,24 +74,26 @@ jobs:
   verify-signed-tag:
     name: "Verify Signed Release Tag"
     runs-on: ubuntu-latest
-    needs: approve
+    needs: [approve, validate-release-inputs]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
       - name: Require signed tag for non-dry-run release
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          RELEASE_TAG: ${{ needs.validate-release-inputs.outputs.tag }}
         run: |
           set -euo pipefail
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
+          if [ "$DRY_RUN" = "true" ]; then
             echo "Dry run: signed tag requirement is skipped."
             exit 0
           fi
 
-          tag="v${{ inputs.version }}"
           git fetch --tags --force
-          git rev-parse "refs/tags/${tag}" >/dev/null
-          git tag -v "${tag}"
+          git rev-parse "refs/tags/${RELEASE_TAG}" >/dev/null
+          git tag -v "${RELEASE_TAG}"
 
   # -----------------------------------------------------------------------
   # Build release artifacts
@@ -73,7 +101,7 @@ jobs:
   release-build:
     name: "Build Release Artifacts"
     runs-on: ubuntu-latest
-    needs: [approve, verify-signed-tag]
+    needs: [approve, verify-signed-tag, validate-release-inputs]
     strategy:
       matrix:
         target:
@@ -82,12 +110,15 @@ jobs:
     steps:
       - name: Resolve release source ref
         id: release-ref
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          RELEASE_TAG: ${{ needs.validate-release-inputs.outputs.tag }}
         run: |
           set -euo pipefail
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
+          if [ "$DRY_RUN" = "true" ]; then
             printf 'ref=%s\n' "${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
           else
-            printf 'ref=refs/tags/v${{ inputs.version }}\n' >> "$GITHUB_OUTPUT"
+            printf 'ref=refs/tags/%s\n' "$RELEASE_TAG" >> "$GITHUB_OUTPUT"
           fi
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -110,17 +141,19 @@ jobs:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
 
       - name: Package artifacts
+        env:
+          RELEASE_VERSION: ${{ needs.validate-release-inputs.outputs.version }}
         run: |
           mkdir -p dist
           cp target/${{ matrix.target }}/release/libexo_*.rlib dist/ 2>/dev/null || true
           cp target/${{ matrix.target }}/release/libexo_*.so dist/ 2>/dev/null || true
-          tar czf exochain-${{ inputs.version }}-${{ matrix.target }}.tar.gz -C dist .
+          tar czf "exochain-${RELEASE_VERSION}-${{ matrix.target }}.tar.gz" -C dist .
 
       - name: Upload artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: exochain-${{ inputs.version }}-${{ matrix.target }}
-          path: exochain-${{ inputs.version }}-${{ matrix.target }}.tar.gz
+          name: exochain-${{ needs.validate-release-inputs.outputs.version }}-${{ matrix.target }}
+          path: exochain-${{ needs.validate-release-inputs.outputs.version }}-${{ matrix.target }}.tar.gz
 
   # -----------------------------------------------------------------------
   # Generate SBOM and SLSA provenance attestation
@@ -138,7 +171,7 @@ jobs:
   sbom-and-attest:
     name: "SBOM + SLSA Attestation"
     runs-on: ubuntu-latest
-    needs: release-build
+    needs: [release-build, validate-release-inputs]
     if: ${{ !inputs.dry_run }}
     permissions:
       attestations: write  # write SLSA attestations to repo
@@ -147,12 +180,15 @@ jobs:
     steps:
       - name: Resolve release source ref
         id: release-ref
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          RELEASE_TAG: ${{ needs.validate-release-inputs.outputs.tag }}
         run: |
           set -euo pipefail
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
+          if [ "$DRY_RUN" = "true" ]; then
             printf 'ref=%s\n' "${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
           else
-            printf 'ref=refs/tags/v${{ inputs.version }}\n' >> "$GITHUB_OUTPUT"
+            printf 'ref=refs/tags/%s\n' "$RELEASE_TAG" >> "$GITHUB_OUTPUT"
           fi
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -178,20 +214,22 @@ jobs:
         run: cargo install cargo-cyclonedx --version 0.5.9 --locked
 
       - name: Generate CycloneDX SBOM
+        env:
+          RELEASE_VERSION: ${{ needs.validate-release-inputs.outputs.version }}
         run: |
           cargo cyclonedx -f json --workspace
           # Rename outputs to include version for unambiguous identification
           for f in *.cdx.json; do
-            mv "$f" "exochain-${{ inputs.version }}-${f}"
+            mv "$f" "exochain-${RELEASE_VERSION}-${f}"
           done
           echo "SBOM artifacts:"
-          ls -lh exochain-${{ inputs.version }}-*.cdx.json
+          ls -lh "exochain-${RELEASE_VERSION}"-*.cdx.json
 
       - name: Upload SBOM artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: sbom-${{ inputs.version }}
-          path: exochain-${{ inputs.version }}-*.cdx.json
+          name: sbom-${{ needs.validate-release-inputs.outputs.version }}
+          path: exochain-${{ needs.validate-release-inputs.outputs.version }}-*.cdx.json
           retention-days: 2555  # 7 years — governance software retention policy
 
       # ── SLSA provenance attestation ──────────────────────────────────────
@@ -206,17 +244,20 @@ jobs:
   publish:
     name: "Publish to crates.io"
     runs-on: ubuntu-latest
-    needs: [release-build, sbom-and-attest]
+    needs: [release-build, sbom-and-attest, validate-release-inputs]
     if: ${{ !inputs.dry_run }}
     steps:
       - name: Resolve release source ref
         id: release-ref
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          RELEASE_TAG: ${{ needs.validate-release-inputs.outputs.tag }}
         run: |
           set -euo pipefail
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
+          if [ "$DRY_RUN" = "true" ]; then
             printf 'ref=%s\n' "${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
           else
-            printf 'ref=refs/tags/v${{ inputs.version }}\n' >> "$GITHUB_OUTPUT"
+            printf 'ref=refs/tags/%s\n' "$RELEASE_TAG" >> "$GITHUB_OUTPUT"
           fi
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -259,7 +300,7 @@ jobs:
   github-release:
     name: "Create GitHub Release"
     runs-on: ubuntu-latest
-    needs: [release-build, sbom-and-attest, publish]
+    needs: [release-build, sbom-and-attest, publish, validate-release-inputs]
     if: ${{ !inputs.dry_run }}
     permissions:
       contents: write
@@ -274,10 +315,10 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
-          tag_name: v${{ inputs.version }}
-          name: "EXOCHAIN v${{ inputs.version }}"
+          tag_name: ${{ needs.validate-release-inputs.outputs.tag }}
+          name: "EXOCHAIN ${{ needs.validate-release-inputs.outputs.tag }}"
           body: |
-            ## EXOCHAIN v${{ inputs.version }}
+            ## EXOCHAIN ${{ needs.validate-release-inputs.outputs.tag }}
 
             Constitutional trust fabric release.
 
@@ -298,7 +339,7 @@ jobs:
             in the Sigstore Rekor transparency log. Verify any release archive:
 
             ```sh
-            gh attestation verify exochain-${{ inputs.version }}-<TARGET>.tar.gz \
+            gh attestation verify exochain-${{ needs.validate-release-inputs.outputs.version }}-<TARGET>.tar.gz \
               --owner exochain
             ```
 

--- a/tools/test_release_version_input_boundary.sh
+++ b/tools/test_release_version_input_boundary.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  printf 'release version input boundary test failed: %s\n' "$1" >&2
+  exit 1
+}
+
+workflow=".github/workflows/release.yml"
+ci_workflow=".github/workflows/ci.yml"
+
+[[ -f "$workflow" ]] || fail "$workflow is missing"
+[[ -f "$ci_workflow" ]] || fail "$ci_workflow is missing"
+
+job_block() {
+  local job="$1"
+  awk -v job="  ${job}:" '
+    $0 == job { capture = 1; print; next }
+    capture && $0 ~ /^  [A-Za-z0-9_-]+:$/ { exit }
+    capture { print }
+  ' "$workflow"
+}
+
+validate_block=$(job_block "validate-release-inputs")
+[[ -n "$validate_block" ]] || fail "release workflow must validate dispatch inputs before release jobs"
+
+grep -F 'version: ${{ steps.validate.outputs.version }}' <<<"$validate_block" >/dev/null \
+  || fail "validated release version must be exposed as a job output"
+grep -F 'tag: ${{ steps.validate.outputs.tag }}' <<<"$validate_block" >/dev/null \
+  || fail "validated release tag must be exposed as a job output"
+grep -F 'id: validate' <<<"$validate_block" >/dev/null \
+  || fail "validation job must have a stable validate step id"
+grep -F 'RELEASE_VERSION_INPUT: ${{ inputs.version }}' <<<"$validate_block" >/dev/null \
+  || fail "raw dispatch version may only enter the validation step through an environment variable"
+grep -E '\^\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+\(-\[0-9A-Za-z\]' <<<"$validate_block" >/dev/null \
+  || fail "release version validator must reject anything outside the bounded semver subset"
+grep -F 'printf '\''version=%s\n'\'' "$version" >> "$GITHUB_OUTPUT"' <<<"$validate_block" >/dev/null \
+  || fail "validation step must write the sanitized version to GITHUB_OUTPUT"
+grep -F 'printf '\''tag=v%s\n'\'' "$version" >> "$GITHUB_OUTPUT"' <<<"$validate_block" >/dev/null \
+  || fail "validation step must derive the release tag from the sanitized version"
+
+raw_version_refs=$(grep -nF '${{ inputs.version }}' "$workflow" || true)
+raw_version_count=$(printf '%s\n' "$raw_version_refs" | sed '/^$/d' | wc -l | tr -d ' ')
+if [ "$raw_version_count" -ne 1 ]; then
+  printf '%s\n' "$raw_version_refs" >&2
+  fail "raw inputs.version must appear exactly once, inside validate-release-inputs"
+fi
+case "$raw_version_refs" in
+  *'RELEASE_VERSION_INPUT: ${{ inputs.version }}'*) ;;
+  *) fail "the only raw inputs.version reference must be the validation step environment binding" ;;
+esac
+
+grep -F '${{ needs.validate-release-inputs.outputs.version }}' "$workflow" >/dev/null \
+  || fail "release jobs must consume the sanitized version output"
+grep -F '${{ needs.validate-release-inputs.outputs.tag }}' "$workflow" >/dev/null \
+  || fail "release jobs must consume the sanitized tag output"
+
+for job in approve verify-signed-tag release-build sbom-and-attest publish github-release; do
+  block=$(job_block "$job")
+  [[ -n "$block" ]] || fail "job $job is missing"
+  grep -F 'validate-release-inputs' <<<"$block" >/dev/null \
+    || fail "job $job must depend on the release input validation job"
+done
+
+grep -F 'bash tools/test_release_version_input_boundary.sh' "$ci_workflow" >/dev/null \
+  || fail "CI repo hygiene must run the release version input boundary guard"
+
+printf 'release version input boundary test passed\n'

--- a/tools/test_release_workflow_ref_binding.sh
+++ b/tools/test_release_workflow_ref_binding.sh
@@ -23,8 +23,10 @@ for job in release-build sbom-and-attest publish; do
   [[ -n "$block" ]] || fail "job $job is missing"
   grep -F 'id: release-ref' <<<"$block" >/dev/null \
     || fail "job $job must resolve the release source ref before checkout"
-  grep -F 'refs/tags/v${{ inputs.version }}' <<<"$block" >/dev/null \
-    || fail "job $job must use the signed version tag for non-dry-run releases"
+  grep -F 'RELEASE_TAG: ${{ needs.validate-release-inputs.outputs.tag }}' <<<"$block" >/dev/null \
+    || fail "job $job must consume the validated release tag"
+  grep -F 'printf '\''ref=refs/tags/%s\n'\'' "$RELEASE_TAG" >> "$GITHUB_OUTPUT"' <<<"$block" >/dev/null \
+    || fail "job $job must use the signed validated tag for non-dry-run releases"
   grep -F '${GITHUB_SHA}' <<<"$block" >/dev/null \
     || fail "job $job must keep dry-run builds anchored to the dispatched workflow SHA"
   grep -F 'ref: ${{ steps.release-ref.outputs.ref }}' <<<"$block" >/dev/null \


### PR DESCRIPTION
## Classification

- `.github/workflows/release.yml`: core runtime adapter, release/deployment contract.
- `.github/workflows/ci.yml`: core runtime adapter CI gate.
- `tools/test_release_version_input_boundary.sh`: core runtime adapter regression guard.
- `tools/test_release_workflow_ref_binding.sh`: core runtime adapter regression guard.

## Current finding validation

External/input-derived finding treated as a hypothesis and checked against current `origin/main` (`4b83b9ca`). The release workflow directly interpolated `inputs.version` into shell commands, signed-tag refs, artifact names, SBOM names, and GitHub Release metadata before any strict validation boundary.

TDD red step: after adding `tools/test_release_version_input_boundary.sh`, the guard failed on current workflow with:

`release version input boundary test failed: release workflow must validate dispatch inputs before release jobs`

## Remediation

- Adds a `validate-release-inputs` job that accepts the raw dispatch `version` only once via environment, rejects anything outside a bounded semver/prerelease subset, and exports sanitized `version` and derived `tag` outputs.
- Updates release jobs to depend on `validate-release-inputs` and consume the sanitized outputs instead of raw `inputs.version`.
- Updates release ref-binding tests to require the validated tag.
- Wires the new version-boundary guard into Gate 9 repo hygiene.

## Validation

- `bash tools/test_release_version_input_boundary.sh`
- `bash tools/test_release_workflow_ref_binding.sh`
- `bash tools/test_release_dry_run_boundaries.sh`
- `bash tools/test_release_publish_boundaries.sh`
- `bash tools/test_github_actions_pinned.sh`
- `bash tools/test_ci_supply_chain_hardening.sh`
- `bash tools/test_github_issue_workflow_boundaries.sh`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_sybil_cli_secret_boundaries.sh`
- `bash tools/test_agent_prompt_boundaries.sh`
- `bash tools/test_agent_workflow_bounds.sh`
- `bash tools/test_audit_policy_docs.sh`
- `bash tools/test_consensus_liveness_docs.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `bash tools/test_deployment_readiness_probes.sh`
- `bash tools/test_docker_production_db_feature.sh`
- `bash tools/test_core_fuzz_targets.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); YAML.load_file(".github/workflows/ci.yml")'`
- `git diff --check`
