### PR TITLE
fix(syntaxis): validate workflow codegen input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,8 @@ jobs:
         run: bash tools/test_agent_prompt_boundaries.sh
       - name: Agent workflow loop-bound contract
         run: bash tools/test_agent_workflow_bounds.sh
+      - name: Syntaxis workflow input boundary
+        run: bash tools/test_syntaxis_workflow_input_boundary.sh
       - name: Core fuzz target compile contract
         run: bash tools/test_core_fuzz_targets.sh
 

--- a/tools/syntaxis/generate_workflow.py
+++ b/tools/syntaxis/generate_workflow.py
@@ -34,11 +34,22 @@ Composition types:
 """
 
 import json
-import os
+import re
 import sys
 import textwrap
 from pathlib import Path
-from datetime import datetime, timezone
+
+
+WORKFLOW_NAME_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
+STEP_ID_RE = re.compile(r"^[a-z][a-z0-9]*(?:[_-][a-z0-9]+)*$")
+SAFE_TOKEN_RE = re.compile(r"^[a-z][a-z0-9]*(?:[_-][a-z0-9]+)*$")
+COMPOSITIONS = frozenset(("sequence", "parallel", "choice", "guarded_sequence"))
+MAX_DESCRIPTION_CHARS = 2048
+MAX_STEPS = 128
+
+
+class WorkflowValidationError(ValueError):
+    """Raised when untrusted workflow JSON fails the codegen boundary."""
 
 
 def load_node_registry() -> dict:
@@ -59,6 +70,89 @@ def to_snake_case(name: str) -> str:
 def to_pascal_case(name: str) -> str:
     """Convert kebab-case to PascalCase."""
     return "".join(word.capitalize() for word in name.split("-"))
+
+
+def require_string(value: object, field: str) -> str:
+    """Return a string field or raise a validation error."""
+    if not isinstance(value, str):
+        raise WorkflowValidationError(f"{field} must be a string")
+    return value
+
+
+def validate_safe_token(value: str, field: str, pattern: re.Pattern[str]) -> None:
+    """Validate a token before it is used in Rust identifiers or file names."""
+    if not pattern.fullmatch(value):
+        raise WorkflowValidationError(
+            f"{field} contains characters outside the allowed lowercase ASCII token format"
+        )
+
+
+def validate_doc_text(value: str, field: str) -> None:
+    """Validate free text before rendering it as Rust doc comments."""
+    if len(value) > MAX_DESCRIPTION_CHARS:
+        raise WorkflowValidationError(
+            f"{field} must be at most {MAX_DESCRIPTION_CHARS} characters"
+        )
+    for char in value:
+        if ord(char) < 32 and char not in ("\n", "\t"):
+            raise WorkflowValidationError(f"{field} contains a forbidden control character")
+
+
+def rust_doc_comment(text: str) -> str:
+    """Render free text as line-based Rust doc comments."""
+    lines = text.split("\n")
+    return "\n".join(f"//! {line}" if line else "//!" for line in lines)
+
+
+def validate_workflow(workflow: object, registry: dict) -> None:
+    """Validate untrusted workflow JSON before any Rust or paths are generated."""
+    if not isinstance(workflow, dict):
+        raise WorkflowValidationError("workflow must be a JSON object")
+
+    name = require_string(workflow.get("name"), "workflow.name")
+    validate_safe_token(name, "workflow.name", WORKFLOW_NAME_RE)
+
+    description = workflow.get("description", f"Workflow: {name}")
+    validate_doc_text(require_string(description, "workflow.description"), "workflow.description")
+
+    composition = workflow.get("composition", "sequence")
+    composition = require_string(composition, "workflow.composition")
+    if composition not in COMPOSITIONS:
+        raise WorkflowValidationError(
+            f"workflow.composition must be one of: {', '.join(sorted(COMPOSITIONS))}"
+        )
+
+    error_strategy = workflow.get("error_strategy", "fail_fast")
+    error_strategy = require_string(error_strategy, "workflow.error_strategy")
+    validate_safe_token(error_strategy, "workflow.error_strategy", SAFE_TOKEN_RE)
+
+    steps = workflow.get("steps")
+    if not isinstance(steps, list):
+        raise WorkflowValidationError("workflow.steps must be a non-empty list")
+    if not steps:
+        raise WorkflowValidationError("workflow.steps must contain at least one step")
+    if len(steps) > MAX_STEPS:
+        raise WorkflowValidationError(f"workflow.steps may contain at most {MAX_STEPS} steps")
+
+    seen_step_ids: set[str] = set()
+    for index, step in enumerate(steps):
+        field = f"workflow.steps[{index}]"
+        if not isinstance(step, dict):
+            raise WorkflowValidationError(f"{field} must be an object")
+
+        node_type = require_string(step.get("node"), f"{field}.node")
+        if node_type not in registry["nodes"]:
+            raise WorkflowValidationError(f"{field}.node is not in registry: {node_type}")
+
+        step_id = require_string(step.get("id"), f"{field}.id")
+        validate_safe_token(step_id, f"{field}.id", STEP_ID_RE)
+        normalized_step_id = to_snake_case(step_id)
+        if normalized_step_id in seen_step_ids:
+            raise WorkflowValidationError(f"{field}.id duplicates another generated step id")
+        seen_step_ids.add(normalized_step_id)
+
+        if "config" in step and not isinstance(step["config"], dict):
+            raise WorkflowValidationError(f"{field}.config must be an object when provided")
 
 
 def collect_invariants(steps: list[dict], registry: dict) -> list[str]:
@@ -92,7 +186,7 @@ def generate_step_combinator(step: dict, registry: dict) -> str:
     config = step.get("config", {})
 
     if not node_def:
-        return f'// Unknown node type: {node_type}\nCombinator::Identity'
+        raise WorkflowValidationError(f"node type is not in registry: {node_type}")
 
     # Build predicate keys from node inputs
     required_keys = node_def.get("inputs", [])
@@ -143,6 +237,7 @@ def generate_workflow_module(workflow: dict, registry: dict) -> str:
 
     snake_name = to_snake_case(name)
     pascal_name = to_pascal_case(name)
+    description_doc = textwrap.indent(rust_doc_comment(description), "        ")
 
     invariants = collect_invariants(steps, registry)
     crate_imports = collect_crate_imports(steps, registry)
@@ -162,7 +257,7 @@ def generate_workflow_module(workflow: dict, registry: dict) -> str:
         "choice": "Choice",
         "guarded_sequence": "Sequence",
     }
-    combinator_type = composition_map.get(composition, "Sequence")
+    combinator_type = composition_map[composition]
 
     # Invariant variant list for the check function
     invariant_checks = "\n".join(
@@ -190,7 +285,7 @@ def generate_workflow_module(workflow: dict, registry: dict) -> str:
     return textwrap.dedent(f"""\
         //! Workflow: {name}
         //!
-        //! {description}
+{description_doc}
         //!
         //! Generated by Syntaxis workflow codegen.
         //! DO NOT EDIT MANUALLY --- regenerate from the workflow definition.
@@ -465,23 +560,14 @@ def main() -> None:
 
     registry = load_node_registry()
 
-    # Validate workflow
-    name = workflow.get("name")
-    if not name:
-        print("Error: workflow must have a 'name' field")
+    try:
+        validate_workflow(workflow, registry)
+    except WorkflowValidationError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
 
-    steps = workflow.get("steps", [])
-    if not steps:
-        print("Error: workflow must have at least one step")
-        sys.exit(1)
-
-    # Validate all node types exist in registry
-    for step in steps:
-        node_type = step.get("node")
-        if node_type not in registry["nodes"]:
-            print(f"Warning: node type '{node_type}' not found in registry")
-
+    name = workflow["name"]
+    steps = workflow["steps"]
     snake_name = to_snake_case(name)
 
     # Generate output directory

--- a/tools/syntaxis/test_generate_workflow_input_boundary.py
+++ b/tools/syntaxis/test_generate_workflow_input_boundary.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Regression tests for untrusted Syntaxis workflow codegen input."""
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GENERATOR = REPO_ROOT / "tools" / "syntaxis" / "generate_workflow.py"
+
+
+class GenerateWorkflowInputBoundaryTests(unittest.TestCase):
+    def run_generator(self, workflow: dict, output_dir: Path) -> subprocess.CompletedProcess[str]:
+        workflow_file = output_dir.parent / "workflow.json"
+        workflow_file.write_text(json.dumps(workflow), encoding="utf-8")
+        return subprocess.run(
+            [
+                sys.executable,
+                str(GENERATOR),
+                str(workflow_file),
+                "--output-dir",
+                str(output_dir),
+            ],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def minimal_workflow(self, **overrides: object) -> dict:
+        workflow = {
+            "name": "consent-gated-action",
+            "description": "Verify identity before consent-gated action.",
+            "steps": [{"node": "identity-verify", "id": "step_1"}],
+            "composition": "sequence",
+            "error_strategy": "fail_fast",
+        }
+        workflow.update(overrides)
+        return workflow
+
+    def test_rejects_workflow_name_path_traversal(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            output_dir = root / "generated"
+            result = self.run_generator(
+                self.minimal_workflow(name="../outside"),
+                output_dir,
+            )
+
+            self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertFalse((root / "outside.rs").exists())
+            self.assertFalse((root / "outside_integration.rs").exists())
+
+    def test_rejects_step_id_rust_string_injection(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            output_dir = Path(temp) / "generated"
+            result = self.run_generator(
+                self.minimal_workflow(
+                    steps=[
+                        {
+                            "node": "identity-verify",
+                            "id": "step_1\";\npub fn injected() {}\n//",
+                        }
+                    ]
+                ),
+                output_dir,
+            )
+
+            self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertFalse((output_dir / "consent_gated_action.rs").exists())
+
+    def test_rejects_unknown_node_types(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            output_dir = Path(temp) / "generated"
+            result = self.run_generator(
+                self.minimal_workflow(
+                    steps=[{"node": "not-in-registry", "id": "step_1"}]
+                ),
+                output_dir,
+            )
+
+            self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("not-in-registry", result.stdout + result.stderr)
+
+    def test_multiline_description_remains_doc_comment(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            output_dir = Path(temp) / "generated"
+            result = self.run_generator(
+                self.minimal_workflow(
+                    description="first line\npub fn injected() {}",
+                ),
+                output_dir,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            generated = (output_dir / "consent_gated_action.rs").read_text(
+                encoding="utf-8"
+            )
+            self.assertIn("//! first line", generated)
+            self.assertIn("//! pub fn injected() {}", generated)
+            self.assertNotIn("\npub fn injected() {}", generated)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_syntaxis_workflow_input_boundary.sh
+++ b/tools/test_syntaxis_workflow_input_boundary.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 tools/syntaxis/test_generate_workflow_input_boundary.py


### PR DESCRIPTION
## Classification

- `tools/syntaxis/generate_workflow.py`: core runtime adapter codegen bridge for governance workflows.
- `tools/syntaxis/test_generate_workflow_input_boundary.py`: core runtime adapter regression tests.
- `tools/test_syntaxis_workflow_input_boundary.sh`: core runtime adapter CI guard.
- `.github/workflows/ci.yml`: core runtime adapter CI gate.

## Current finding validation

External/input-derived finding treated as a hypothesis and checked against current `origin/main` (`4b83b9ca`). The Syntaxis workflow JSON was still able to control generated Rust identifiers, comments, string literals, and output filenames before a fail-closed validation boundary.

TDD red step: `bash tools/test_syntaxis_workflow_input_boundary.sh` failed against current code with four reproductions:

- `name: "../outside"` wrote `outside.rs` outside the requested output directory.
- A step id containing Rust syntax was accepted into generated Rust strings/identifiers.
- Unknown node types were warnings and generated `Combinator::Identity` instead of failing closed.
- Multiline description text could escape Rust doc comments into live generated Rust.

## Remediation

- Adds a fail-closed workflow validator before any output directory or generated file is created.
- Restricts workflow names, step IDs, composition, error strategy, step shape, duplicate generated IDs, and node types.
- Renders free-text descriptions as line-based Rust doc comments so multiline text cannot become live Rust.
- Converts unknown node fallback into a hard validation error.
- Wires the Syntaxis input-boundary test into Gate 9 repo hygiene.

## Validation

- `bash tools/test_syntaxis_workflow_input_boundary.sh`
- `python3 -m py_compile tools/syntaxis/generate_workflow.py tools/syntaxis/test_generate_workflow_input_boundary.py`
- `bash tools/test_github_actions_pinned.sh`
- `bash tools/test_ci_supply_chain_hardening.sh`
- `bash tools/test_agent_prompt_boundaries.sh`
- `bash tools/test_agent_workflow_bounds.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_github_issue_workflow_boundaries.sh`
- `bash tools/test_sybil_cli_secret_boundaries.sh`
- `bash tools/test_audit_policy_docs.sh`
- `bash tools/test_consensus_liveness_docs.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `bash tools/test_no_orphan_rust_modules.sh`
- `bash tools/test_railway_entrypoint_args.sh`
- `bash tools/test_deployment_readiness_probes.sh`
- `bash tools/test_docker_production_db_feature.sh`
- `bash tools/test_core_fuzz_targets.sh`
- `git diff --check`
