### PR TITLE
fix(workflows): stop repeated failure loops

### DIFF
--- a/.archon/workflows/exochain-continuous-governance.yaml
+++ b/.archon/workflows/exochain-continuous-governance.yaml
@@ -12,8 +12,9 @@ loop:
   exit_condition: "COMPLETE"
   stop_conditions:
     - "monitor output contains <promise>COMPLETE</promise>"
+    - "same validation or remediation failure fingerprint observed twice"
     - "max_iterations reached"
-  escalation_path: "file backlog items and stop when max_iterations is reached"
+  escalation_path: "file backlog items, file council escalation for repeated failure fingerprints, and stop when max_iterations is reached"
   fresh_context: true
 
 prompt: |
@@ -75,6 +76,10 @@ prompt: |
 
   If the system scores A or B with no Critical/High findings, output:
   <promise>COMPLETE</promise>
+
+  If the same validation or remediation failure fingerprint appears twice
+  without new repository evidence, file a council escalation backlog item and
+  stop instead of continuing the loop.
 
   Otherwise, file the findings as backlog items via the
   `exochain-self-improvement-cycle` workflow and continue scanning.

--- a/.archon/workflows/exochain-self-improvement-cycle.yaml
+++ b/.archon/workflows/exochain-self-improvement-cycle.yaml
@@ -15,9 +15,9 @@ loop:
   stop_conditions:
     - "$create_pr.output contains a pull request URL"
     - "$validate_constitution.output.governance_disposition == 'BLOCK'"
-    - "$remediate.output repeats the same validation failure"
+    - "$remediate.output reports the same validation failure fingerprint twice"
     - "max_iterations reached"
-  escalation_path: "escalate_blocked"
+  escalation_path: "escalate_blocked after a repeated validation failure fingerprint or max_iterations"
   fresh_context: true
 
 nodes:

--- a/tools/test_agent_workflow_bounds.sh
+++ b/tools/test_agent_workflow_bounds.sh
@@ -52,6 +52,7 @@ for workflow in .archon/workflows/*.yaml; do
     require_pattern "$workflow" '^[[:space:]]*exit_condition:' "exit condition"
     require_pattern "$workflow" 'stop_conditions:' "stop_conditions list"
     require_pattern "$workflow" 'escalat' "escalation path"
+    require_pattern "$workflow" 'same .*failure fingerprint.*twice' "repeated validation/remediation failure stop condition"
     extract_positive_bound "$workflow"
   fi
 done


### PR DESCRIPTION
## Classification

- `.archon/workflows/exochain-continuous-governance.yaml`: core runtime adapter, autonomous governance workflow.
- `.archon/workflows/exochain-self-improvement-cycle.yaml`: core runtime adapter, bounded remediation loop.
- `tools/test_agent_workflow_bounds.sh`: core runtime adapter regression guard.

## Current finding validation

External/input-derived finding treated as a hypothesis and checked against current `origin/main` (`4b83b9ca`). Recursive workflow bounds existed, but the guard did not require the project rule that a remediation loop must stop or escalate when the same validation/remediation failure is observed twice.

TDD red step: after extending `tools/test_agent_workflow_bounds.sh`, `bash tools/test_agent_workflow_bounds.sh` failed with:

`agent workflow bound test failed: .archon/workflows/exochain-continuous-governance.yaml missing repeated validation/remediation failure stop condition`

## Remediation

- Adds a repeated failure fingerprint stop condition to the continuous governance loop.
- Makes the self-improvement loop explicit that repeated validation failure fingerprints stop/escalate after two observations.
- Updates the loop-bound regression guard to require `same ... failure fingerprint ... twice` for recursive/autonomous workflows.

## Validation

- `bash tools/test_agent_workflow_bounds.sh`
- `bash tools/test_agent_prompt_boundaries.sh`
- `ruby -e 'require "yaml"; Dir[".archon/workflows/*.yaml"].each { |path| YAML.load_file(path) }'`
- `bash tools/test_github_actions_pinned.sh`
- `bash tools/test_repo_truth.sh`
- `bash tools/test_cr001_status.sh`
- `bash tools/test_gap_registry_truth.sh`
- `git diff --check`
