### PR TITLE
fix(gatekeeper): require trusted quorum vote provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 181341 | `wc -l` |
-| Workspace tests | 4,253 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 181556 | `wc -l` |
+| Workspace tests | 4,259 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,253 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,259 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 181326 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 181556 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,253 listed workspace tests
+         cryptographic proofs, 4,259 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-gatekeeper/src/invariants.rs
+++ b/crates/exo-gatekeeper/src/invariants.rs
@@ -3,6 +3,8 @@
 //! Every action in the constitutional fabric must satisfy a set of invariants.
 //! Failed invariants produce detailed violation reports with evidence.
 
+use std::collections::BTreeSet;
+
 use exo_core::{Did, Hash256, hash::hash_structured};
 use serde::{Deserialize, Serialize};
 
@@ -118,7 +120,8 @@ pub struct InvariantViolation {
 
 const AUTHORITY_LINK_SIGNATURE_DOMAIN: &str = "exo.gatekeeper.authority-link-signature";
 const PROVENANCE_SIGNATURE_DOMAIN: &str = "exo.gatekeeper.provenance-signature";
-const SIGNATURE_PAYLOAD_SCHEMA_VERSION: u16 = 1;
+const AUTHORITY_LINK_SIGNATURE_PAYLOAD_SCHEMA_VERSION: u16 = 1;
+const PROVENANCE_SIGNATURE_PAYLOAD_SCHEMA_VERSION: u16 = 2;
 
 #[derive(Serialize)]
 struct AuthorityLinkSignaturePayload<'a> {
@@ -136,6 +139,9 @@ struct ProvenanceSignaturePayload<'a> {
     actor: &'a Did,
     action_hash: &'a [u8],
     timestamp: &'a str,
+    voice_kind: Option<&'a crate::types::VoiceKind>,
+    independence: Option<&'a crate::types::IndependenceClaim>,
+    review_order: Option<&'a crate::types::ReviewOrder>,
 }
 
 // ---------------------------------------------------------------------------
@@ -669,19 +675,29 @@ fn check_quorum_legitimate(ctx: &InvariantContext) -> Result<(), InvariantViolat
                 });
             }
 
-            // CR-001 §8.3: synthetic voices SHALL never be counted as distinct
-            // humans. Use is_met_authentic() which excludes Synthetic-voiced
-            // votes from the approval count.
-            if !evidence.is_met_authentic() {
-                let authentic_approvals = evidence.distinct_authentic_approved_voter_count();
+            // CR-001 §8.3: quorum requires signed human voter provenance.
+            // Synthetic, missing-provenance, actor-mismatched, unsigned, and
+            // untrusted approvals do not count toward the authentic threshold.
+            let verified_approvals =
+                verified_human_quorum_approval_voters(evidence, &ctx.trusted_provenance_keys);
+            let Some(threshold) = usize::try_from(evidence.threshold).ok() else {
+                return Err(InvariantViolation {
+                    invariant: ConstitutionalInvariant::QuorumLegitimate,
+                    description: "Quorum threshold cannot be represented on this platform".into(),
+                    evidence: vec![format!("threshold: {}", evidence.threshold)],
+                });
+            };
+            if verified_approvals.len() < threshold {
+                let structurally_authentic = evidence.distinct_authentic_approved_voter_count();
                 let synthetic_excluded = evidence.synthetic_vote_count();
                 Err(InvariantViolation {
                     invariant: ConstitutionalInvariant::QuorumLegitimate,
-                    description: "Quorum threshold not met by authentic (non-synthetic) votes"
-                        .into(),
+                    description:
+                        "Quorum threshold not met by authentic verified signed human votes".into(),
                     evidence: vec![
                         format!("threshold: {}", evidence.threshold),
-                        format!("authentic_approvals: {}", authentic_approvals),
+                        format!("authentic_approvals: {}", verified_approvals.len()),
+                        format!("structurally_authentic_approvals: {structurally_authentic}"),
                         format!("synthetic_votes_excluded: {}", synthetic_excluded),
                     ],
                 })
@@ -690,6 +706,56 @@ fn check_quorum_legitimate(ctx: &InvariantContext) -> Result<(), InvariantViolat
             }
         }
     }
+}
+
+fn verified_human_quorum_approval_voters(
+    evidence: &QuorumEvidence,
+    trusted_keys: &TrustedProvenanceKeys,
+) -> BTreeSet<Did> {
+    evidence
+        .votes
+        .iter()
+        .filter(|vote| quorum_vote_has_verified_human_provenance(vote, trusted_keys))
+        .map(|vote| vote.voter.clone())
+        .collect()
+}
+
+fn quorum_vote_has_verified_human_provenance(
+    vote: &crate::types::QuorumVote,
+    trusted_keys: &TrustedProvenanceKeys,
+) -> bool {
+    if !vote.is_authentic_human_approval() {
+        return false;
+    }
+
+    let Some(provenance) = vote.provenance.as_ref() else {
+        return false;
+    };
+    let Some(public_key_bytes) = provenance.public_key.as_ref() else {
+        return false;
+    };
+    let Ok(public_key_array) = public_key_bytes.as_slice().try_into() else {
+        return false;
+    };
+    let Some(trusted_actor_keys) = trusted_keys.get(&provenance.actor) else {
+        return false;
+    };
+    if !trusted_actor_keys
+        .iter()
+        .any(|trusted_key| trusted_key.as_slice() == public_key_bytes.as_slice())
+    {
+        return false;
+    }
+
+    let Ok(signature_array) = provenance.signature.as_slice().try_into() else {
+        return false;
+    };
+    let Ok(message) = provenance_signature_message(provenance) else {
+        return false;
+    };
+    let public_key = exo_core::PublicKey::from_bytes(public_key_array);
+    let signature = exo_core::Signature::from_bytes(signature_array);
+    exo_core::crypto::verify(message.as_bytes(), &signature, &public_key)
 }
 
 fn check_provenance_verifiable(ctx: &InvariantContext) -> Result<(), InvariantViolation> {
@@ -787,7 +853,7 @@ pub fn authority_link_signature_message(link: &AuthorityLink) -> exo_core::Resul
 
     hash_structured(&AuthorityLinkSignaturePayload {
         domain: AUTHORITY_LINK_SIGNATURE_DOMAIN,
-        schema_version: SIGNATURE_PAYLOAD_SCHEMA_VERSION,
+        schema_version: AUTHORITY_LINK_SIGNATURE_PAYLOAD_SCHEMA_VERSION,
         grantor: &link.grantor,
         grantee: &link.grantee,
         permissions,
@@ -797,14 +863,18 @@ pub fn authority_link_signature_message(link: &AuthorityLink) -> exo_core::Resul
 /// Compute the canonical Ed25519 message for action provenance.
 ///
 /// The message is the hash of a domain-separated CBOR payload that binds the
-/// provenance actor, action hash, and timestamp.
+/// provenance actor, action hash, timestamp, voice taxonomy, independence, and
+/// review order.
 pub fn provenance_signature_message(prov: &Provenance) -> exo_core::Result<Hash256> {
     hash_structured(&ProvenanceSignaturePayload {
         domain: PROVENANCE_SIGNATURE_DOMAIN,
-        schema_version: SIGNATURE_PAYLOAD_SCHEMA_VERSION,
+        schema_version: PROVENANCE_SIGNATURE_PAYLOAD_SCHEMA_VERSION,
         actor: &prov.actor,
         action_hash: &prov.action_hash,
         timestamp: &prov.timestamp,
+        voice_kind: prov.voice_kind.as_ref(),
+        independence: prov.independence.as_ref(),
+        review_order: prov.review_order.as_ref(),
     })
 }
 
@@ -1433,22 +1503,13 @@ mod tests {
             ConstitutionalInvariant::QuorumLegitimate,
         ]));
         let mut ctx = passing_context();
+        let (vote1, pk1) = signed_human_quorum_vote("did:exo:v1");
+        let (vote2, pk2) = signed_human_quorum_vote("did:exo:v2");
+        trust_provenance_key(&mut ctx, did("did:exo:v1"), &pk1);
+        trust_provenance_key(&mut ctx, did("did:exo:v2"), &pk2);
         ctx.quorum_evidence = Some(QuorumEvidence {
             threshold: 2,
-            votes: vec![
-                QuorumVote {
-                    voter: did("did:exo:v1"),
-                    approved: true,
-                    signature: vec![1],
-                    provenance: None,
-                },
-                QuorumVote {
-                    voter: did("did:exo:v2"),
-                    approved: true,
-                    signature: vec![2],
-                    provenance: None,
-                },
-            ],
+            votes: vec![vote1, vote2],
         });
         assert!(enforce_all(&engine, &ctx).is_ok());
     }
@@ -1611,18 +1672,32 @@ mod tests {
         QuorumVote {
             voter: did(voter),
             approved,
-            signature: vec![sig],
+            signature: vec![sig; 64],
             provenance: voice.map(|vk| Provenance {
                 actor: did(voter),
                 timestamp: "t".into(),
                 action_hash: vec![1],
-                signature: vec![sig],
-                public_key: None,
+                signature: vec![sig; 64],
+                public_key: Some(vec![sig; 32]),
                 voice_kind: Some(vk),
                 independence: None,
                 review_order: None,
             }),
         }
+    }
+
+    fn signed_human_quorum_vote(voter: &str) -> (QuorumVote, exo_core::PublicKey) {
+        let (provenance, public_key, _secret_key) = signed_provenance(voter);
+        let signature = provenance.signature.clone();
+        (
+            QuorumVote {
+                voter: did(voter),
+                approved: true,
+                signature,
+                provenance: Some(provenance),
+            },
+            public_key,
+        )
     }
 
     #[test]
@@ -1658,12 +1733,18 @@ mod tests {
             ConstitutionalInvariant::QuorumLegitimate,
         ]));
         let mut ctx = passing_context();
+        let (vote1, pk1) = signed_human_quorum_vote("did:exo:h1");
+        let (vote2, pk2) = signed_human_quorum_vote("did:exo:h2");
+        let (vote3, pk3) = signed_human_quorum_vote("did:exo:h3");
+        trust_provenance_key(&mut ctx, did("did:exo:h1"), &pk1);
+        trust_provenance_key(&mut ctx, did("did:exo:h2"), &pk2);
+        trust_provenance_key(&mut ctx, did("did:exo:h3"), &pk3);
         ctx.quorum_evidence = Some(QuorumEvidence {
             threshold: 3,
             votes: vec![
-                make_vote("did:exo:h1", true, 1, Some(VoiceKind::Human)),
-                make_vote("did:exo:h2", true, 2, Some(VoiceKind::Human)),
-                make_vote("did:exo:h3", true, 3, Some(VoiceKind::Human)),
+                vote1,
+                vote2,
+                vote3,
                 make_vote("did:exo:ai1", true, 4, Some(VoiceKind::Synthetic)),
                 make_vote("did:exo:ai2", true, 5, Some(VoiceKind::Synthetic)),
             ],
@@ -1703,8 +1784,7 @@ mod tests {
     }
 
     #[test]
-    fn quorum_passes_legacy_votes_no_provenance() {
-        // Legacy votes (provenance=None) are not excluded
+    fn quorum_fails_legacy_votes_no_provenance() {
         let engine = InvariantEngine::new(InvariantSet::with(vec![
             ConstitutionalInvariant::QuorumLegitimate,
         ]));
@@ -1726,6 +1806,70 @@ mod tests {
                 },
             ],
         });
+        let err = enforce_all(&engine, &ctx).unwrap_err();
+        assert_eq!(err[0].invariant, ConstitutionalInvariant::QuorumLegitimate);
+        assert!(
+            err[0].description.contains("authentic"),
+            "votes without provenance must not count as authentic quorum evidence"
+        );
+    }
+
+    #[test]
+    fn quorum_fails_unsigned_human_vote_provenance() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::QuorumLegitimate,
+        ]));
+        let mut ctx = passing_context();
+        let mut vote = make_vote("did:exo:h1", true, 1, Some(VoiceKind::Human));
+        vote.provenance.as_mut().expect("provenance").signature = Vec::new();
+        ctx.quorum_evidence = Some(QuorumEvidence {
+            threshold: 1,
+            votes: vec![vote],
+        });
+
+        let err = enforce_all(&engine, &ctx).unwrap_err();
+
+        assert_eq!(err[0].invariant, ConstitutionalInvariant::QuorumLegitimate);
+        assert!(
+            err[0].description.contains("authentic"),
+            "unsigned human provenance must not count as authentic quorum evidence"
+        );
+    }
+
+    #[test]
+    fn quorum_fails_untrusted_signed_human_vote_provenance() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::QuorumLegitimate,
+        ]));
+        let mut ctx = passing_context();
+        let (vote, _pk) = signed_human_quorum_vote("did:exo:h1");
+        ctx.quorum_evidence = Some(QuorumEvidence {
+            threshold: 1,
+            votes: vec![vote],
+        });
+
+        let err = enforce_all(&engine, &ctx).unwrap_err();
+
+        assert_eq!(err[0].invariant, ConstitutionalInvariant::QuorumLegitimate);
+        assert!(
+            err[0].description.contains("authentic"),
+            "signed human quorum provenance must resolve to a trusted actor key"
+        );
+    }
+
+    #[test]
+    fn quorum_passes_trusted_signed_human_vote_provenance() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::QuorumLegitimate,
+        ]));
+        let mut ctx = passing_context();
+        let (vote, pk) = signed_human_quorum_vote("did:exo:h1");
+        trust_provenance_key(&mut ctx, did("did:exo:h1"), &pk);
+        ctx.quorum_evidence = Some(QuorumEvidence {
+            threshold: 1,
+            votes: vec![vote],
+        });
+
         assert!(enforce_all(&engine, &ctx).is_ok());
     }
 
@@ -1858,9 +2002,10 @@ mod tests {
         actor: Did,
         public_key: &exo_core::PublicKey,
     ) {
-        ctx.trusted_provenance_keys = TrustedProvenanceKeys::default();
         ctx.trusted_provenance_keys
-            .insert(actor, vec![public_key.as_bytes().to_vec()]);
+            .entry(actor)
+            .or_default()
+            .push(public_key.as_bytes().to_vec());
     }
 
     #[test]
@@ -1916,6 +2061,23 @@ mod tests {
         trust_provenance_key(&mut ctx, prov.actor.clone(), &pk);
         prov.signature[0] ^= 0xFF; // corrupt
         ctx.provenance = Some(prov);
+        let err = enforce_all(&engine, &ctx).unwrap_err();
+        assert!(err[0].description.contains("cryptographically invalid"));
+    }
+
+    #[test]
+    fn provenance_rejects_voice_metadata_tampering_after_signature() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::ProvenanceVerifiable,
+        ]));
+        let mut ctx = passing_context();
+        let (mut prov, pk, _sk) = signed_provenance("did:exo:actor1");
+        trust_provenance_key(&mut ctx, prov.actor.clone(), &pk);
+        prov.voice_kind = Some(VoiceKind::Synthetic);
+        prov.independence = Some(IndependenceClaim::Coordinated);
+        prov.review_order = Some(ReviewOrder::Derivative);
+        ctx.provenance = Some(prov);
+
         let err = enforce_all(&engine, &ctx).unwrap_err();
         assert!(err[0].description.contains("cryptographically invalid"));
     }

--- a/crates/exo-gatekeeper/src/types.rs
+++ b/crates/exo-gatekeeper/src/types.rs
@@ -293,6 +293,8 @@ pub type TrustedAuthorityKeys = BTreeMap<Did, Vec<Vec<u8>>>;
 /// resolved key material for the claimed actor DID.
 pub type TrustedProvenanceKeys = BTreeMap<Did, Vec<Vec<u8>>>;
 
+const ED25519_SIGNATURE_LEN: usize = 64;
+
 // ---------------------------------------------------------------------------
 // Quorum evidence
 // ---------------------------------------------------------------------------
@@ -314,9 +316,8 @@ impl QuorumEvidence {
         self.distinct_approved_voter_count() >= threshold
     }
 
-    /// Returns `true` if the threshold is met counting only non-synthetic
-    /// approved votes. A vote with `provenance.voice_kind = Synthetic` is
-    /// excluded from the human count per CR-001 §8.3.
+    /// Returns `true` if the threshold is met counting only signed human
+    /// approvals with voter-bound provenance.
     pub fn is_met_authentic(&self) -> bool {
         let Some(threshold) = usize::try_from(self.threshold).ok() else {
             return false;
@@ -356,14 +357,12 @@ impl QuorumEvidence {
             .len()
     }
 
-    /// Count distinct approved voter DIDs that are not synthetic.
+    /// Count distinct approved voter DIDs with signed human provenance.
     #[must_use]
     pub fn distinct_authentic_approved_voter_count(&self) -> usize {
         self.votes
             .iter()
-            .filter(|vote| {
-                vote.approved && !vote.provenance.as_ref().is_some_and(|p| p.is_synthetic())
-            })
+            .filter(|vote| vote.is_authentic_human_approval())
             .map(|vote| vote.voter.clone())
             .collect::<BTreeSet<_>>()
             .len()
@@ -382,6 +381,30 @@ pub struct QuorumVote {
     /// distinct human approval in quorum (CR-001 §8.3).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provenance: Option<Provenance>,
+}
+
+impl QuorumVote {
+    /// Returns whether this vote is structurally eligible for authentic quorum.
+    ///
+    /// Cryptographic trust resolution happens in the invariant engine because
+    /// it needs runtime DID key material. This structural check still fails
+    /// closed for legacy votes, synthetic/system voices, actor mismatches, and
+    /// malformed signatures.
+    #[must_use]
+    pub fn is_authentic_human_approval(&self) -> bool {
+        self.approved
+            && self.signature.len() == ED25519_SIGNATURE_LEN
+            && self.provenance.as_ref().is_some_and(|provenance| {
+                provenance.actor == self.voter
+                    && provenance.is_human_voice()
+                    && provenance.signature.len() == ED25519_SIGNATURE_LEN
+                    && self.signature == provenance.signature
+                    && provenance
+                        .public_key
+                        .as_ref()
+                        .is_some_and(|key| key.len() == 32)
+            })
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -560,13 +583,13 @@ mod tests {
         QuorumVote {
             voter: did(voter),
             approved,
-            signature: vec![sig],
+            signature: vec![sig; ED25519_SIGNATURE_LEN],
             provenance: voice.map(|vk| Provenance {
                 actor: did(voter),
                 timestamp: "t".into(),
                 action_hash: vec![1],
-                signature: vec![sig],
-                public_key: None,
+                signature: vec![sig; ED25519_SIGNATURE_LEN],
+                public_key: Some(vec![sig; 32]),
                 voice_kind: Some(vk),
                 independence: None,
                 review_order: None,
@@ -699,8 +722,7 @@ mod tests {
     }
 
     #[test]
-    fn quorum_is_met_authentic_legacy_vote_counts() {
-        // Legacy votes (no provenance) are not excluded
+    fn quorum_is_met_authentic_rejects_legacy_votes_without_provenance() {
         let ev = QuorumEvidence {
             threshold: 2,
             votes: vec![
@@ -718,7 +740,38 @@ mod tests {
                 },
             ],
         };
-        assert!(ev.is_met_authentic());
+        assert!(
+            !ev.is_met_authentic(),
+            "votes without provenance must not count as authentic human quorum evidence"
+        );
+    }
+
+    #[test]
+    fn quorum_is_met_authentic_rejects_unsigned_human_votes() {
+        let mut vote = make_vote("did:exo:h1", true, 1, Some(VoiceKind::Human));
+        vote.signature.clear();
+        let ev = QuorumEvidence {
+            threshold: 1,
+            votes: vec![vote],
+        };
+        assert!(
+            !ev.is_met_authentic(),
+            "unsigned votes must not count as authentic human quorum evidence"
+        );
+    }
+
+    #[test]
+    fn quorum_is_met_authentic_rejects_mismatched_provenance_actor() {
+        let mut vote = make_vote("did:exo:h1", true, 1, Some(VoiceKind::Human));
+        vote.provenance.as_mut().expect("provenance").actor = did("did:exo:h2");
+        let ev = QuorumEvidence {
+            threshold: 1,
+            votes: vec![vote],
+        };
+        assert!(
+            !ev.is_met_authentic(),
+            "provenance for a different actor must not count for the voter"
+        );
     }
 
     // ── Provenance voice/independence helpers ────────────────────────────────


### PR DESCRIPTION
## Summary
- Remediates the current `origin/main` quorum issue where legacy or self-attested vote evidence could satisfy `QuorumLegitimate` without trusted human provenance.
- Requires quorum votes to be approved, voter-bound, human-voiced, Ed25519-shaped, and verified against runtime-resolved trusted provenance keys before counting toward the threshold.
- Binds provenance voice metadata (`voice_kind`, `independence`, `review_order`) into the canonical domain-separated CBOR signature payload so human/synthetic metadata cannot be changed after signing.

## Classification
- `crates/exo-gatekeeper/src/invariants.rs`: EXOCHAIN core
- `crates/exo-gatekeeper/src/types.rs`: EXOCHAIN core

## Current-state reproduction
Verified against current main before the fix:
- `cargo test -p exo-gatekeeper quorum_is_met_authentic_rejects_legacy_votes_without_provenance -- --nocapture` failed because legacy no-provenance votes still counted.
- `cargo test -p exo-gatekeeper quorum_fails_legacy_votes_no_provenance -- --nocapture` failed because `QuorumLegitimate` accepted legacy votes.
- `cargo test -p exo-gatekeeper quorum_fails_untrusted_signed_human_vote_provenance -- --nocapture` failed because signed-looking but untrusted human votes were accepted.
- `cargo test -p exo-gatekeeper provenance_rejects_voice_metadata_tampering_after_signature -- --nocapture` failed because voice metadata was not bound to the signed provenance payload.

## Rebase Repair 2026-05-10
Merged current origin/main into this branch, resolved the README repo-truth conflict with generated current counters, and re-ran focused, touched-crate, hygiene, and workspace gates.

## Validation
- `cargo test -p exo-gatekeeper quorum_ -- --nocapture` PASS, 21 passed
- `cargo test -p exo-gatekeeper provenance_ -- --nocapture` PASS, 20 passed
- `cargo test -p exo-gatekeeper` PASS, 283 passed
- `cargo test -p decision-forum` PASS, 218 unit + 13 integration passed
- `cargo test -p exo-gateway --test decision_forum_integration -- --nocapture` PASS, 3 passed
- `cargo test --workspace` PASS, full workspace and doctests passed
- `cargo clippy -p exo-gatekeeper -p decision-forum --all-targets -- -D warnings` PASS
- `cargo clippy --workspace --all-targets -- -D warnings` PASS before rebase repair
- `cargo +nightly fmt --all -- --check` PASS
- `bash tools/test_repo_truth.sh` PASS
- `git diff --check` PASS

## Bypass search
Searched quorum/provenance sibling paths for direct counting and signature helpers:
- `rg -n "is_met_authentic|distinct_authentic_approved_voter_count|is_authentic_human_approval|QuorumVote|voice_kind|provenance_signature_message|trusted_provenance_keys" crates/exo-gatekeeper crates/decision-forum crates/exo-gateway`

No remaining core path was found that can count legacy, synthetic, mismatched, unsigned, or untrusted quorum votes as authentic approvals.
