### PR TITLE
fix(forum): require verified human vote identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 181484 | `wc -l` |
-| Workspace tests | 4,255 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 181704 | `wc -l` |
+| Workspace tests | 4,258 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,255 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,258 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 181484 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 181704 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,255 listed workspace tests
+         cryptographic proofs, 4,258 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/decision-forum/src/human_gate.rs
+++ b/crates/decision-forum/src/human_gate.rs
@@ -1,9 +1,12 @@
 //! Human oversight enforcement (GOV-007, TNC-02, TNC-09).
 //!
 //! Enforces that certain decision classes require human approval,
-//! distinguishes human vs AI signatures cryptographically, blocks AI
+//! distinguishes verified human voters from declared actor metadata, blocks AI
 //! from satisfying HUMAN_GATE_REQUIRED, and enforces AI delegation ceilings.
 
+use std::collections::BTreeSet;
+
+use exo_core::types::Did;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -44,11 +47,28 @@ pub fn ai_within_ceiling(policy: &HumanGatePolicy, class: DecisionClass) -> bool
 /// Validate that a decision's votes satisfy the human gate policy.
 /// Returns Ok(()) if the gate is satisfied, or an error if not.
 pub fn enforce_human_gate(policy: &HumanGatePolicy, decision: &DecisionObject) -> Result<()> {
+    enforce_human_gate_with_verified_humans(policy, decision, &BTreeSet::new())
+}
+
+/// Validate the human gate using a trusted set of externally verified human
+/// voter DIDs.  The set must come from an identity registry, credential
+/// verifier, or runtime adapter that authenticated the DID as human; the
+/// self-declared `Vote.actor_kind` field is never sufficient by itself.
+pub fn enforce_human_gate_with_verified_humans(
+    policy: &HumanGatePolicy,
+    decision: &DecisionObject,
+    verified_human_voters: &BTreeSet<Did>,
+) -> Result<()> {
+    let has_verified_human_vote = decision
+        .votes
+        .iter()
+        .any(|vote| is_verified_human_vote(vote, verified_human_voters));
+
     // Check AI ceiling: if decision class exceeds AI ceiling, AI votes alone
     // are not sufficient.
     if decision.class > policy.ai_ceiling {
-        let has_human_vote = decision.votes.iter().any(is_human_vote);
-        if !has_human_vote && !decision.votes.is_empty() {
+        let has_ai_vote = decision.votes.iter().any(is_ai_vote);
+        if has_ai_vote && !has_verified_human_vote {
             return Err(ForumError::AiCeilingExceeded {
                 reason: format!(
                     "{} exceeds AI ceiling {}",
@@ -62,7 +82,11 @@ pub fn enforce_human_gate(policy: &HumanGatePolicy, decision: &DecisionObject) -
     // Check human gate: classes requiring human approval must have at least
     // one human vote.
     if requires_human_approval(policy, decision.class) {
-        let human_count = decision.votes.iter().filter(|v| is_human_vote(v)).count();
+        let human_count = decision
+            .votes
+            .iter()
+            .filter(|vote| is_verified_human_vote(vote, verified_human_voters))
+            .count();
         if human_count == 0 {
             return Err(ForumError::HumanGateRequired);
         }
@@ -71,10 +95,27 @@ pub fn enforce_human_gate(policy: &HumanGatePolicy, decision: &DecisionObject) -
     Ok(())
 }
 
-/// Determine if a vote was cast by a human actor.
+/// Determine if a vote was cast by a verified human actor.
+///
+/// This legacy helper has no trusted identity registry argument, so it fails
+/// closed. Use [`is_verified_human_vote`] when a verified DID set is available.
 #[must_use]
 pub fn is_human_vote(vote: &Vote) -> bool {
+    is_verified_human_vote(vote, &BTreeSet::new())
+}
+
+/// Determine if a vote declares a human actor kind without treating that
+/// declaration as verification.
+#[must_use]
+pub fn is_declared_human_vote(vote: &Vote) -> bool {
     matches!(vote.actor_kind, ActorKind::Human)
+}
+
+/// Determine if a vote is both declared human and backed by a trusted human
+/// identity record for the same voter DID.
+#[must_use]
+pub fn is_verified_human_vote(vote: &Vote, verified_human_voters: &BTreeSet<Did>) -> bool {
+    matches!(vote.actor_kind, ActorKind::Human) && verified_human_voters.contains(&vote.voter_did)
 }
 
 /// Determine if a vote was cast by an AI agent.
@@ -177,8 +218,27 @@ mod tests {
         let mut clock = test_clock();
         let policy = HumanGatePolicy::default();
         let mut d = make_decision(DecisionClass::Strategic, &mut clock);
-        d.add_vote(human_vote(&mut clock)).expect("ok");
-        assert!(enforce_human_gate(&policy, &d).is_ok());
+        let vote = human_vote(&mut clock);
+        let mut verified_human_voters = BTreeSet::new();
+        verified_human_voters.insert(vote.voter_did.clone());
+        d.add_vote(vote).expect("ok");
+        assert!(
+            enforce_human_gate_with_verified_humans(&policy, &d, &verified_human_voters).is_ok()
+        );
+    }
+
+    #[test]
+    fn human_gate_rejects_unverified_human_actor_kind() {
+        let mut clock = test_clock();
+        let policy = HumanGatePolicy::default();
+        let mut d = make_decision(DecisionClass::Strategic, &mut clock);
+        d.add_vote(human_vote(&mut clock))
+            .expect("declared human vote");
+
+        let err = enforce_human_gate(&policy, &d)
+            .expect_err("self-declared human actor_kind must not satisfy human gate");
+
+        assert!(matches!(err, ForumError::HumanGateRequired));
     }
 
     #[test]
@@ -216,10 +276,16 @@ mod tests {
     #[test]
     fn is_human_vs_ai() {
         let mut clock = test_clock();
-        assert!(is_human_vote(&human_vote(&mut clock)));
-        assert!(!is_human_vote(&ai_vote(&mut clock)));
+        let human = human_vote(&mut clock);
+        let mut verified_human_voters = BTreeSet::new();
+        verified_human_voters.insert(human.voter_did.clone());
+
+        assert!(is_declared_human_vote(&human));
+        assert!(!is_human_vote(&human));
+        assert!(is_verified_human_vote(&human, &verified_human_voters));
+        assert!(!is_declared_human_vote(&ai_vote(&mut clock)));
         assert!(is_ai_vote(&ai_vote(&mut clock)));
-        assert!(!is_ai_vote(&human_vote(&mut clock)));
+        assert!(!is_ai_vote(&human));
     }
 
     #[test]

--- a/crates/decision-forum/src/quorum.rs
+++ b/crates/decision-forum/src/quorum.rs
@@ -4,12 +4,15 @@
 //! graceful degradation on quorum failure, and independence-aware counting
 //! via exo_governance::quorum.
 
-use exo_core::types::DeterministicMap;
+use std::collections::BTreeSet;
+
+use exo_core::types::{DeterministicMap, Did};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     decision_object::{DecisionClass, DecisionObject, VoteChoice},
     error::{ForumError, Result},
+    human_gate::is_verified_human_vote,
 };
 
 /// Quorum policy for a specific decision class.
@@ -97,6 +100,17 @@ pub fn check_quorum(
     registry: &QuorumRegistry,
     decision: &DecisionObject,
 ) -> Result<QuorumCheckResult> {
+    check_quorum_with_verified_humans(registry, decision, &BTreeSet::new())
+}
+
+/// Check if quorum is met using a trusted set of externally verified human
+/// voter DIDs. Human vote floors are satisfied only when the vote is declared
+/// human and the voter DID appears in this set.
+pub fn check_quorum_with_verified_humans(
+    registry: &QuorumRegistry,
+    decision: &DecisionObject,
+    verified_human_voters: &BTreeSet<Did>,
+) -> Result<QuorumCheckResult> {
     let req = registry
         .requirement_for(decision.class)
         .ok_or(ForumError::QuorumPolicyMissing)?;
@@ -111,7 +125,7 @@ pub fn check_quorum(
     let human_count = decision
         .votes
         .iter()
-        .filter(|v| matches!(v.actor_kind, crate::decision_object::ActorKind::Human))
+        .filter(|vote| is_verified_human_vote(vote, verified_human_voters))
         .count();
 
     if total_votes < req.min_votes {
@@ -242,6 +256,15 @@ mod tests {
         .expect("valid decision")
     }
 
+    fn verified_human_voters(decision: &DecisionObject) -> BTreeSet<Did> {
+        decision
+            .votes
+            .iter()
+            .filter(|vote| matches!(vote.actor_kind, ActorKind::Human))
+            .map(|vote| vote.voter_did.clone())
+            .collect()
+    }
+
     #[test]
     fn routine_quorum_met() {
         let mut clock = test_clock();
@@ -249,7 +272,7 @@ mod tests {
         let mut d = make_decision("test", DecisionClass::Routine, &mut clock);
         d.add_vote(human_approve_vote("alice", &mut clock))
             .expect("ok");
-        match check_quorum(&reg, &d).expect("ok") {
+        match check_quorum_with_verified_humans(&reg, &d, &verified_human_voters(&d)).expect("ok") {
             QuorumCheckResult::Met { total_votes, .. } => assert_eq!(total_votes, 1),
             other => panic!("expected Met, got {other:?}"),
         }
@@ -262,7 +285,7 @@ mod tests {
         let mut d = make_decision("test", DecisionClass::Operational, &mut clock);
         d.add_vote(human_approve_vote("alice", &mut clock))
             .expect("ok");
-        match check_quorum(&reg, &d).expect("ok") {
+        match check_quorum_with_verified_humans(&reg, &d, &verified_human_voters(&d)).expect("ok") {
             QuorumCheckResult::Degraded {
                 available,
                 required,
@@ -284,7 +307,7 @@ mod tests {
             .expect("ok");
         d.add_vote(ai_approve_vote("bot1", &mut clock)).expect("ok");
         d.add_vote(ai_approve_vote("bot2", &mut clock)).expect("ok");
-        match check_quorum(&reg, &d).expect("ok") {
+        match check_quorum_with_verified_humans(&reg, &d, &verified_human_voters(&d)).expect("ok") {
             QuorumCheckResult::Met {
                 total_votes,
                 approve_count,
@@ -306,7 +329,7 @@ mod tests {
             .expect("ok");
         d.add_vote(reject_vote("bob", &mut clock)).expect("ok");
         d.add_vote(reject_vote("carol", &mut clock)).expect("ok");
-        match check_quorum(&reg, &d).expect("ok") {
+        match check_quorum_with_verified_humans(&reg, &d, &verified_human_voters(&d)).expect("ok") {
             QuorumCheckResult::NotMet { reason } => {
                 assert!(reason.contains("approval percentage"));
             }
@@ -328,6 +351,31 @@ mod tests {
                 assert!(reason.contains("human"));
             }
             other => panic!("expected NotMet, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn check_quorum_rejects_unverified_human_actor_kind() {
+        let mut clock = test_clock();
+        let reg = QuorumRegistry::with_defaults();
+        let mut d = make_decision(
+            "declared humans are not verified humans",
+            DecisionClass::Strategic,
+            &mut clock,
+        );
+        for name in ["alice", "bob", "carol", "dave", "erin"] {
+            d.add_vote(human_approve_vote(name, &mut clock))
+                .expect("declared human vote accepted into decision object");
+        }
+
+        match check_quorum(&reg, &d).expect("quorum check ok") {
+            QuorumCheckResult::NotMet { reason } => {
+                assert!(
+                    reason.contains("human"),
+                    "unverified declared-human votes must not satisfy human quorum: {reason}"
+                );
+            }
+            other => panic!("expected NotMet for unverified human actor_kind, got {other:?}"),
         }
     }
 

--- a/crates/exo-gateway/src/db.rs
+++ b/crates/exo-gateway/src/db.rs
@@ -493,6 +493,25 @@ pub async fn find_user_by_did(
     ).bind(did).fetch_optional(pool).await
 }
 
+/// Return active human user DIDs from the provided candidate vote set.
+pub async fn active_human_user_dids_for_votes(
+    pool: &PgPool,
+    tenant_id: &str,
+    voter_dids: &[String],
+) -> Result<Vec<String>, sqlx::Error> {
+    if voter_dids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    sqlx::query_scalar::<_, String>(
+        "SELECT did FROM users WHERE tenant_id = $1 AND status = 'Active' AND did = ANY($2) ORDER BY did",
+    )
+    .bind(tenant_id)
+    .bind(voter_dids)
+    .fetch_all(pool)
+    .await
+}
+
 /// List users for a tenant ordered by creation time.
 pub async fn list_users_db(
     pool: &PgPool,

--- a/crates/exo-gateway/src/handlers.rs
+++ b/crates/exo-gateway/src/handlers.rs
@@ -15,7 +15,10 @@ use axum::{
 };
 use decision_forum::{
     decision_object::{ActorKind, DecisionObject, Vote, VoteChoice},
-    quorum::{QuorumCheckResult, QuorumRegistry, check_quorum, verify_quorum_precondition},
+    quorum::{
+        QuorumCheckResult, QuorumRegistry, check_quorum_with_verified_humans,
+        verify_quorum_precondition,
+    },
 };
 use exo_core::{Did, Signature, Timestamp, hash::hash_structured, types::Hash256};
 use exo_gatekeeper::{
@@ -441,6 +444,16 @@ pub async fn vote_handler(
         )
             .into_response();
     }
+    if !matches!(body.actor_kind, ActorKind::Human) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "forbidden",
+                "message": "vote handler requires an authenticated active human user profile"
+            })),
+        )
+            .into_response();
+    }
     let affected_dids = match body.caller_supplied_affected_dids() {
         Ok(dids) => dids,
         Err(e) => {
@@ -685,7 +698,7 @@ pub async fn vote_handler(
     let vote = Vote {
         voter_did: voter_did.clone(),
         choice: body.choice,
-        actor_kind: body.actor_kind,
+        actor_kind: ActorKind::Human,
         timestamp,
         signature_hash,
     };
@@ -701,17 +714,32 @@ pub async fn vote_handler(
     }
 
     // Check quorum post-vote to include status in response.
-    let quorum_result = match check_quorum(&registry, &decision) {
-        Ok(r) => r,
+    let verified_human_voter_dids = match state
+        .verified_human_voter_dids(&actor.tenant_id, &decision.votes)
+        .await
+    {
+        Ok(voters) => voters,
         Err(e) => {
-            tracing::error!(error = %e, "quorum evaluation failed");
+            tracing::error!(error = %e, "failed to derive verified human voters");
             return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": "quorum evaluation failed"})),
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({"error": "human voter registry unavailable"})),
             )
                 .into_response();
         }
     };
+    let quorum_result =
+        match check_quorum_with_verified_humans(&registry, &decision, &verified_human_voter_dids) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::error!(error = %e, "quorum evaluation failed");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": "quorum evaluation failed"})),
+                )
+                    .into_response();
+            }
+        };
 
     // Serialize updated DecisionObject back to JSON for DB persistence.
     let updated_payload = match serde_json::to_value(&decision) {
@@ -1567,6 +1595,31 @@ mod tests {
         assert!(
             !vote_handler.contains("format!(\"{}:{}:{:?}\""),
             "vote signature_hash must not use raw concat or Debug formatting"
+        );
+    }
+
+    #[test]
+    fn vote_handler_rejects_unbound_human_actor_kind() {
+        let source = include_str!("handlers.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("test module marker present");
+        let vote_handler = production
+            .split("pub async fn vote_handler")
+            .nth(1)
+            .expect("vote handler source present")
+            .split("// ── Health handler")
+            .next()
+            .expect("vote handler source end");
+
+        assert!(
+            vote_handler.contains("verified_human_voter_dids"),
+            "vote handler must derive verified human voters from the authenticated tenant profile, not request JSON"
+        );
+        assert!(
+            !vote_handler.contains("actor_kind: body.actor_kind"),
+            "vote handler must not persist caller-supplied actor_kind as the proof of human status"
         );
     }
 

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -16,7 +16,9 @@ use axum::{
     routing::{get, post},
 };
 use axum_server::tls_rustls::RustlsConfig;
-use decision_forum::decision_object::{DecisionClass, DecisionObject, DecisionObjectInput};
+use decision_forum::decision_object::{
+    ActorKind, DecisionClass, DecisionObject, DecisionObjectInput, Vote,
+};
 use exo_core::{Did, Hash256, Signature, Timestamp, hash::hash_structured, hlc::HybridClock};
 use exo_gatekeeper::{
     invariants::InvariantSet,
@@ -491,6 +493,38 @@ impl AppState {
             .map_err(|e| {
                 GatewayError::Internal(format!("failed to count quorum eligible voters: {e}"))
             })
+    }
+
+    /// Derive the trusted human voter set for decision-forum votes from active
+    /// tenant user records. Caller-supplied `Vote.actor_kind` is only a selector
+    /// for candidate DIDs; it is not treated as proof.
+    pub async fn verified_human_voter_dids(
+        &self,
+        tenant_id: &str,
+        votes: &[Vote],
+    ) -> Result<BTreeSet<Did>> {
+        let pool = self.require_db()?;
+        let voter_dids = votes
+            .iter()
+            .filter(|vote| matches!(vote.actor_kind, ActorKind::Human))
+            .map(|vote| vote.voter_did.as_str().to_owned())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let rows = db::active_human_user_dids_for_votes(pool, tenant_id, &voter_dids)
+            .await
+            .map_err(|e| {
+                GatewayError::Internal(format!("failed to derive verified human voters: {e}"))
+            })?;
+        rows.into_iter()
+            .map(|did| {
+                Did::new(&did).map_err(|e| {
+                    GatewayError::Internal(format!(
+                        "active human voter DID from database is invalid: {e}"
+                    ))
+                })
+            })
+            .collect()
     }
 
     /// Load conflict declarations for an actor from the DB-backed standing


### PR DESCRIPTION
## Classification
- EXOCHAIN core: crates/decision-forum/src/human_gate.rs, crates/decision-forum/src/quorum.rs
- Core runtime adapter: crates/exo-gateway/src/db.rs, crates/exo-gateway/src/server.rs, crates/exo-gateway/src/handlers.rs
- Documentation/repo truth: README.md

## External Finding Disposition
Current code still allowed self-declared Vote.actor_kind = Human to satisfy human-gate and human-quorum checks. This PR verifies the issue against current main, adds failing regressions first, and then moves human-vote proof to a trusted active-user tenant registry boundary in the gateway adapter. Imported reports remain read-only.

## Remediation
- decision-forum legacy human-gate and quorum helpers fail closed when no verified human DID set is supplied.
- Added verified-human APIs that require a BTreeSet<Did> from a trusted adapter/identity registry.
- Gateway vote handling now requires the authenticated session user to match voter_did, rejects non-human actor_kind on the user-session route, persists the vote as human only after authentication, and checks quorum with active tenant users from the database rather than request JSON.

## Red Tests Added
- human_gate_rejects_unverified_human_actor_kind
- check_quorum_rejects_unverified_human_actor_kind
- vote_handler_rejects_unbound_human_actor_kind

## Rebase Repair 2026-05-10
Merged current origin/main into this branch, resolved the README repo-truth conflict with generated current counters, and re-ran focused, touched-crate, hygiene, and workspace gates.

## Validation
- cargo test -p decision-forum human_gate_rejects_unverified_human_actor_kind -- --nocapture
- cargo test -p decision-forum check_quorum_rejects_unverified_human_actor_kind -- --nocapture
- cargo test -p exo-gateway vote_handler_rejects_unbound_human_actor_kind -- --nocapture
- cargo test -p decision-forum human_gate:: -- --nocapture
- cargo test -p decision-forum quorum:: -- --nocapture
- cargo test -p exo-gateway handlers::tests -- --nocapture
- cargo test -p decision-forum
- cargo test -p exo-gateway
- cargo test -p exochain-wasm decision_forum_bindings::tests -- --nocapture
- cargo test -p exochain-wasm
- cargo clippy -p decision-forum -p exo-gateway -p exochain-wasm --all-targets -- -D warnings
- cargo clippy -p decision-forum -p exo-gateway --all-targets -- -D warnings
- cargo +nightly fmt --all -- --check
- bash tools/test_repo_truth.sh
- git diff --check
- cargo test --workspace
