### PR TITLE
fix(wasm): fail closed on untrusted TNC flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 181484 | `wc -l` |
-| Workspace tests | 4,255 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 181554 | `wc -l` |
+| Workspace tests | 4,256 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,255 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,256 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`

--- a/crates/exochain-wasm/src/decision_forum_bindings.rs
+++ b/crates/exochain-wasm/src/decision_forum_bindings.rs
@@ -326,15 +326,10 @@ pub fn wasm_dry_run_amendment(corpus_json: &str, proposed_json: &str) -> Result<
 // ── TNC Enforcement ──────────────────────────────────────────────
 //
 // TncContext<'a> holds a borrowed &DecisionObject and cannot be deserialized
-// directly.  Each binding takes:
-//   - decision_json: &str — the DecisionObject (owned, deserialized locally)
-//   - flags_json: &str    — JSON object with the seven boolean precondition
-//                           fields: constitutional_hash_valid, consent_verified,
-//                           identity_verified, evidence_complete, quorum_met,
-//                           human_gate_satisfied, authority_chain_verified
-//
-// The TncContext is then constructed on the stack inside each function so the
-// borrow checker is satisfied without requiring an unsafe transmute.
+// directly. Each binding accepts the legacy flags_json shape for API
+// compatibility, but those booleans are untrusted caller claims. The adapter
+// validates that JSON shape and then builds a fail-closed context so a caller
+// cannot convert self-declared booleans into trusted TNC proof state.
 
 #[derive(serde::Deserialize)]
 struct TncFlags {
@@ -356,20 +351,39 @@ struct TncFlags {
     ai_ceilings_externally_verified: bool,
 }
 
+impl TncFlags {
+    fn has_any_asserted_claim(&self) -> bool {
+        self.constitutional_hash_valid
+            || self.consent_verified
+            || self.identity_verified
+            || self.evidence_complete
+            || self.quorum_met
+            || self.human_gate_satisfied
+            || self.authority_chain_verified
+            || self.ai_ceilings_externally_verified
+    }
+}
+
+fn parse_untrusted_tnc_flags(flags_json: &str) -> Result<TncFlags, JsValue> {
+    let flags: TncFlags = from_json_str(flags_json)?;
+    let _caller_asserted_trusted_state = flags.has_any_asserted_claim();
+    Ok(flags)
+}
+
 fn build_tnc_ctx<'a>(
     decision: &'a decision_forum::decision_object::DecisionObject,
-    flags: &TncFlags,
+    _flags: &TncFlags,
 ) -> decision_forum::tnc_enforcer::TncContext<'a> {
     decision_forum::tnc_enforcer::TncContext {
         decision,
-        constitutional_hash_valid: flags.constitutional_hash_valid,
-        consent_verified: flags.consent_verified,
-        identity_verified: flags.identity_verified,
-        evidence_complete: flags.evidence_complete,
-        quorum_met: flags.quorum_met,
-        human_gate_satisfied: flags.human_gate_satisfied,
-        authority_chain_verified: flags.authority_chain_verified,
-        ai_ceilings_externally_verified: flags.ai_ceilings_externally_verified,
+        constitutional_hash_valid: false,
+        consent_verified: false,
+        identity_verified: false,
+        evidence_complete: false,
+        quorum_met: false,
+        human_gate_satisfied: false,
+        authority_chain_verified: false,
+        ai_ceilings_externally_verified: false,
     }
 }
 
@@ -384,7 +398,7 @@ fn tnc_result(r: decision_forum::error::Result<()>) -> Result<JsValue, JsValue> 
 #[wasm_bindgen]
 pub fn wasm_enforce_tnc_01(decision_json: &str, flags_json: &str) -> Result<JsValue, JsValue> {
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let flags: TncFlags = from_json_str(flags_json)?;
+    let flags = parse_untrusted_tnc_flags(flags_json)?;
     tnc_result(decision_forum::tnc_enforcer::enforce_tnc_01(
         &build_tnc_ctx(&decision, &flags),
     ))
@@ -394,7 +408,7 @@ pub fn wasm_enforce_tnc_01(decision_json: &str, flags_json: &str) -> Result<JsVa
 #[wasm_bindgen]
 pub fn wasm_enforce_tnc_02(decision_json: &str, flags_json: &str) -> Result<JsValue, JsValue> {
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let flags: TncFlags = from_json_str(flags_json)?;
+    let flags = parse_untrusted_tnc_flags(flags_json)?;
     tnc_result(decision_forum::tnc_enforcer::enforce_tnc_02(
         &build_tnc_ctx(&decision, &flags),
     ))
@@ -404,7 +418,7 @@ pub fn wasm_enforce_tnc_02(decision_json: &str, flags_json: &str) -> Result<JsVa
 #[wasm_bindgen]
 pub fn wasm_enforce_tnc_03(decision_json: &str, flags_json: &str) -> Result<JsValue, JsValue> {
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let flags: TncFlags = from_json_str(flags_json)?;
+    let flags = parse_untrusted_tnc_flags(flags_json)?;
     tnc_result(decision_forum::tnc_enforcer::enforce_tnc_03(
         &build_tnc_ctx(&decision, &flags),
     ))
@@ -414,7 +428,7 @@ pub fn wasm_enforce_tnc_03(decision_json: &str, flags_json: &str) -> Result<JsVa
 #[wasm_bindgen]
 pub fn wasm_enforce_tnc_04(decision_json: &str, flags_json: &str) -> Result<JsValue, JsValue> {
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let flags: TncFlags = from_json_str(flags_json)?;
+    let flags = parse_untrusted_tnc_flags(flags_json)?;
     tnc_result(decision_forum::tnc_enforcer::enforce_tnc_04(
         &build_tnc_ctx(&decision, &flags),
     ))
@@ -424,7 +438,7 @@ pub fn wasm_enforce_tnc_04(decision_json: &str, flags_json: &str) -> Result<JsVa
 #[wasm_bindgen]
 pub fn wasm_enforce_tnc_05(decision_json: &str, flags_json: &str) -> Result<JsValue, JsValue> {
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let flags: TncFlags = from_json_str(flags_json)?;
+    let flags = parse_untrusted_tnc_flags(flags_json)?;
     tnc_result(decision_forum::tnc_enforcer::enforce_tnc_05(
         &build_tnc_ctx(&decision, &flags),
     ))
@@ -434,7 +448,7 @@ pub fn wasm_enforce_tnc_05(decision_json: &str, flags_json: &str) -> Result<JsVa
 #[wasm_bindgen]
 pub fn wasm_enforce_tnc_06(decision_json: &str, flags_json: &str) -> Result<JsValue, JsValue> {
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let flags: TncFlags = from_json_str(flags_json)?;
+    let flags = parse_untrusted_tnc_flags(flags_json)?;
     tnc_result(decision_forum::tnc_enforcer::enforce_tnc_06(
         &build_tnc_ctx(&decision, &flags),
     ))
@@ -444,7 +458,7 @@ pub fn wasm_enforce_tnc_06(decision_json: &str, flags_json: &str) -> Result<JsVa
 #[wasm_bindgen]
 pub fn wasm_enforce_tnc_07(decision_json: &str, flags_json: &str) -> Result<JsValue, JsValue> {
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let flags: TncFlags = from_json_str(flags_json)?;
+    let flags = parse_untrusted_tnc_flags(flags_json)?;
     tnc_result(decision_forum::tnc_enforcer::enforce_tnc_07(
         &build_tnc_ctx(&decision, &flags),
     ))
@@ -454,7 +468,7 @@ pub fn wasm_enforce_tnc_07(decision_json: &str, flags_json: &str) -> Result<JsVa
 #[wasm_bindgen]
 pub fn wasm_enforce_tnc_08(decision_json: &str, flags_json: &str) -> Result<JsValue, JsValue> {
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let flags: TncFlags = from_json_str(flags_json)?;
+    let flags = parse_untrusted_tnc_flags(flags_json)?;
     tnc_result(decision_forum::tnc_enforcer::enforce_tnc_08(
         &build_tnc_ctx(&decision, &flags),
     ))
@@ -464,7 +478,7 @@ pub fn wasm_enforce_tnc_08(decision_json: &str, flags_json: &str) -> Result<JsVa
 #[wasm_bindgen]
 pub fn wasm_enforce_tnc_09(decision_json: &str, flags_json: &str) -> Result<JsValue, JsValue> {
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let flags: TncFlags = from_json_str(flags_json)?;
+    let flags = parse_untrusted_tnc_flags(flags_json)?;
     tnc_result(decision_forum::tnc_enforcer::enforce_tnc_09(
         &build_tnc_ctx(&decision, &flags),
     ))
@@ -474,7 +488,7 @@ pub fn wasm_enforce_tnc_09(decision_json: &str, flags_json: &str) -> Result<JsVa
 #[wasm_bindgen]
 pub fn wasm_enforce_tnc_10(decision_json: &str, flags_json: &str) -> Result<JsValue, JsValue> {
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let flags: TncFlags = from_json_str(flags_json)?;
+    let flags = parse_untrusted_tnc_flags(flags_json)?;
     tnc_result(decision_forum::tnc_enforcer::enforce_tnc_10(
         &build_tnc_ctx(&decision, &flags),
     ))
@@ -484,7 +498,7 @@ pub fn wasm_enforce_tnc_10(decision_json: &str, flags_json: &str) -> Result<JsVa
 #[wasm_bindgen]
 pub fn wasm_enforce_all_tnc(decision_json: &str, flags_json: &str) -> Result<JsValue, JsValue> {
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let flags: TncFlags = from_json_str(flags_json)?;
+    let flags = parse_untrusted_tnc_flags(flags_json)?;
     match decision_forum::tnc_enforcer::enforce_all(&build_tnc_ctx(&decision, &flags)) {
         Ok(()) => to_js_value(&serde_json::json!({"ok": true, "violations": []})),
         Err(e) => to_js_value(&serde_json::json!({"ok": false, "error": e.to_string()})),
@@ -500,7 +514,7 @@ pub fn wasm_collect_tnc_violations(
     flags_json: &str,
 ) -> Result<JsValue, JsValue> {
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let flags: TncFlags = from_json_str(flags_json)?;
+    let flags = parse_untrusted_tnc_flags(flags_json)?;
     let violations =
         decision_forum::tnc_enforcer::collect_violations(&build_tnc_ctx(&decision, &flags));
     let descriptions: Vec<String> = violations.iter().map(|e| e.to_string()).collect();
@@ -874,6 +888,39 @@ fn ensure_constitution_bytes(len: usize) -> Result<(), JsValue> {
 
 #[cfg(test)]
 mod tests {
+    use decision_forum::decision_object::{
+        ActorKind, AuthorityLink, DecisionClass, DecisionObject, DecisionObjectInput, EvidenceItem,
+    };
+    use exo_core::{Did, Hash256, Timestamp};
+
+    fn decision_with_adapter_supplied_proof_dependencies() -> DecisionObject {
+        let timestamp = Timestamp::new(1_700_000_000_000, 0);
+        let mut decision = DecisionObject::new(DecisionObjectInput {
+            id: uuid::Uuid::from_u128(1),
+            title: "adapter tnc proof boundary".to_owned(),
+            class: DecisionClass::Operational,
+            constitutional_hash: Hash256::digest(b"constitution"),
+            created_at: timestamp,
+        })
+        .expect("valid decision");
+        decision
+            .add_authority_link(AuthorityLink {
+                actor_did: Did::new("did:exo:root").expect("valid DID"),
+                actor_kind: ActorKind::Human,
+                delegation_hash: Hash256::digest(b"delegation"),
+                timestamp,
+            })
+            .expect("valid authority link");
+        decision
+            .add_evidence(EvidenceItem {
+                hash: Hash256::digest(b"evidence"),
+                description: "adapter proof boundary evidence".to_owned(),
+                attached_at: timestamp,
+            })
+            .expect("valid evidence");
+        decision
+    }
+
     #[test]
     fn decision_forum_bridge_does_not_synthesize_clock_metadata() {
         let source = include_str!("decision_forum_bindings.rs");
@@ -889,6 +936,29 @@ mod tests {
         assert!(
             !production.contains("Uuid::new_v4"),
             "decision-forum WASM exports must require caller-supplied UUID metadata"
+        );
+    }
+
+    #[test]
+    fn wasm_tnc_adapter_does_not_trust_caller_supplied_flags() {
+        let decision = decision_with_adapter_supplied_proof_dependencies();
+        let flags = super::TncFlags {
+            constitutional_hash_valid: true,
+            consent_verified: true,
+            identity_verified: true,
+            evidence_complete: true,
+            quorum_met: true,
+            human_gate_satisfied: true,
+            authority_chain_verified: true,
+            ai_ceilings_externally_verified: true,
+        };
+
+        let result =
+            decision_forum::tnc_enforcer::enforce_all(&super::build_tnc_ctx(&decision, &flags));
+
+        assert!(
+            result.is_err(),
+            "WASM TNC adapter must not convert untrusted caller-supplied booleans into trusted TNC proof state"
         );
     }
 }

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -1719,8 +1719,35 @@ const tncFlags = {
   evidence_bundle_complete: true
 };
 
+const canonicalAllTrueTncFlags = {
+  constitutional_hash_valid: true,
+  consent_verified: true,
+  identity_verified: true,
+  evidence_complete: true,
+  quorum_met: true,
+  human_gate_satisfied: true,
+  authority_chain_verified: true,
+  ai_ceilings_externally_verified: true
+};
+
+const structurallyCompleteTncDecision = minDecision ? {
+  ...minDecision,
+  authority_chain: [{
+    actor_did: TEST_DID,
+    actor_kind: 'Human',
+    delegation_hash: EVIDENCE_32_BYTES,
+    timestamp: NOW_TS
+  }],
+  evidence_bundle: [{
+    hash: EVIDENCE_32_BYTES,
+    description: 'bridge TNC proof boundary evidence',
+    attached_at: NOW_TS
+  }]
+} : undefined;
+
 const tncDecJson = minDecision ? JSON.stringify(minDecision) : '{}';
 const tncFlagsJson = JSON.stringify(tncFlags);
+const canonicalAllTrueTncFlagsJson = JSON.stringify(canonicalAllTrueTncFlags);
 
 test('wasm_enforce_tnc_01', () =>
   wasm.wasm_enforce_tnc_01(tncDecJson, tncFlagsJson));
@@ -1754,6 +1781,20 @@ test('wasm_enforce_tnc_10', () =>
 
 test('wasm_enforce_all_tnc', () =>
   wasm.wasm_enforce_all_tnc(tncDecJson, tncFlagsJson));
+
+test('wasm_enforce_all_tnc rejects self-asserted proof flags', () => {
+  if (!structurallyCompleteTncDecision) {
+    throw new Error('skipped -- no decision from setup');
+  }
+  const result = wasm.wasm_enforce_all_tnc(
+    JSON.stringify(structurallyCompleteTncDecision),
+    canonicalAllTrueTncFlagsJson
+  );
+  if (!result || result.ok !== false || !String(result.error).includes('authority chain not verified')) {
+    throw new Error('self-asserted TNC proof flags must fail closed');
+  }
+  return result;
+});
 
 test('wasm_collect_tnc_violations', () =>
   wasm.wasm_collect_tnc_violations(tncDecJson, tncFlagsJson));


### PR DESCRIPTION
## Summary
- Classifies this as a core runtime adapter remediation for the EXOCHAIN WASM decision-forum TNC boundary.
- Treats legacy TNC flags JSON as untrusted caller input instead of trusted proof state.
- Keeps the existing WASM API shape while building fail-closed TNC contexts unless trusted proof verification is added at an owned boundary.
- Adds Rust regression coverage and generated-WASM bridge verification for self-asserted all-true proof flags.
- Refreshes README repo-truth metadata from `bash tools/repo_truth.sh --json`.

## Classification
- Core runtime adapter: `crates/exochain-wasm/src/decision_forum_bindings.rs`
- Core runtime adapter bridge test: `packages/exochain-wasm/test/bridge_verification.mjs`
- Documentation/repo-truth metadata: `README.md`

## Current-code verification before fix
- Confirmed on current `origin/main` that `TncFlags` was deserialized from caller JSON and copied directly into `TncContext` for `wasm_enforce_tnc_01` through `wasm_enforce_tnc_10`, `wasm_enforce_all_tnc`, and `wasm_collect_tnc_violations`.
- Added `wasm_tnc_adapter_does_not_trust_caller_supplied_flags` first and observed the expected RED failure: all true caller flags made `enforce_all` return `Ok(())`.

## Rebase Repair 2026-05-10
Merged current origin/main into this branch, resolved the README repo-truth conflict with generated current counters, rebuilt the WASM package, and re-ran focused, bridge, hygiene, and workspace gates.

## Validation
- RED: `cargo test -p exochain-wasm wasm_tnc_adapter_does_not_trust_caller_supplied_flags -- --nocapture` failed before production changes for the expected reason.
- GREEN: `cargo test -p exochain-wasm wasm_tnc_adapter_does_not_trust_caller_supplied_flags -- --nocapture` passed after the fix.
- `cargo test -p exochain-wasm` passed.
- `wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm` passed.
- `node packages/exochain-wasm/test/bridge_verification.mjs` passed, 158/158 exports covered.
- `cargo clippy -p exochain-wasm --all-targets -- -D warnings` passed.
- `cargo +nightly fmt --all -- --check` passed.
- `bash tools/test_repo_truth.sh` passed.
- `git diff --check` passed.
- `cargo test --workspace` passed.

## Bypass check
- Updated every WASM TNC export that accepted `flags_json` to parse through the same untrusted-flags boundary and build the same fail-closed context.
