### PR TITLE
fix(identity): bind DID verification methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 181484 | `wc -l` |
-| Workspace tests | 4,255 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 181701 | `wc -l` |
+| Workspace tests | 4,258 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,255 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,258 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`

--- a/crates/exo-gateway/src/auth.rs
+++ b/crates/exo-gateway/src/auth.rs
@@ -498,7 +498,7 @@ mod tests {
     use exo_core::crypto::{generate_keypair, sign};
     use exo_identity::{
         did::{DidDocument, VerificationMethod},
-        registry::LocalDidRegistry,
+        registry::{DidRegistry, LocalDidRegistry},
     };
 
     use super::*;
@@ -545,6 +545,46 @@ mod tests {
         let mut reg = LocalDidRegistry::new();
         reg.register(doc).unwrap();
         (reg, sk)
+    }
+
+    struct StaticDidRegistry {
+        did: Did,
+        doc: DidDocument,
+    }
+
+    impl DidRegistry for StaticDidRegistry {
+        fn register(
+            &mut self,
+            _doc: DidDocument,
+        ) -> std::result::Result<(), exo_identity::error::IdentityError> {
+            unreachable!("auth tests resolve only")
+        }
+
+        fn resolve(&self, did: &Did) -> Option<&DidDocument> {
+            if did == &self.did {
+                Some(&self.doc)
+            } else {
+                None
+            }
+        }
+
+        fn revoke(
+            &mut self,
+            _did: &Did,
+            _proof: &exo_identity::did::RevocationProof,
+        ) -> std::result::Result<(), exo_identity::error::IdentityError> {
+            unreachable!("auth tests resolve only")
+        }
+
+        fn rotate_key(
+            &mut self,
+            _did: &Did,
+            _new_key: &exo_core::PublicKey,
+            _proof: &Signature,
+            _updated: Timestamp,
+        ) -> std::result::Result<(), exo_identity::error::IdentityError> {
+            unreachable!("auth tests resolve only")
+        }
     }
 
     fn signed_request(mut request: Request, secret_key: &exo_core::SecretKey) -> Request {
@@ -709,6 +749,54 @@ mod tests {
         };
 
         assert!(authenticate(&request, &reg, auth_metadata()).is_err());
+    }
+
+    #[test]
+    fn auth_rejects_active_method_not_bound_to_document_key() {
+        let did = Did::new("did:exo:alice").unwrap();
+        let (declared_pk, _) = generate_keypair();
+        let (method_pk, method_sk) = generate_keypair();
+        let method_multibase = format!("z{}", bs58::encode(method_pk.as_bytes()).into_string());
+        let doc = DidDocument {
+            id: did.clone(),
+            public_keys: vec![declared_pk],
+            authentication: vec![],
+            verification_methods: vec![VerificationMethod {
+                id: "did:exo:alice#key-1".into(),
+                key_type: "Ed25519VerificationKey2020".into(),
+                controller: did.clone(),
+                public_key_multibase: method_multibase,
+                version: 1,
+                active: true,
+                valid_from: 0,
+                revoked_at: None,
+            }],
+            hybrid_verification_methods: vec![],
+            service_endpoints: vec![],
+            created: Timestamp::ZERO,
+            updated: Timestamp::ZERO,
+            revoked: false,
+        };
+        let reg = StaticDidRegistry {
+            did: did.clone(),
+            doc,
+        };
+        let request = signed_request(
+            Request {
+                actor_did: did.as_str().to_owned(),
+                action: "read".into(),
+                body_hash: Hash256::digest(b"body"),
+                signature: Signature::Empty,
+                timestamp: req_ts(),
+            },
+            &method_sk,
+        );
+
+        let err = authenticate(&request, &reg, auth_metadata()).unwrap_err();
+        assert!(
+            err.to_string().contains("not declared"),
+            "auth must fail closed when a custom registry returns an unbound active method: {err}"
+        );
     }
 
     #[test]

--- a/crates/exo-identity/src/did_verification.rs
+++ b/crates/exo-identity/src/did_verification.rs
@@ -12,6 +12,8 @@ use exo_core::{Did, PublicKey, crypto};
 
 use crate::did::{DidDocument, VerificationMethod};
 
+const ED25519_VERIFICATION_KEY_TYPE: &str = "Ed25519VerificationKey2020";
+
 /// Errors specific to DID verification operations.
 #[derive(Debug, thiserror::Error)]
 pub enum DidVerificationError {
@@ -23,6 +25,11 @@ pub enum DidVerificationError {
     #[error("verification method revoked: {0}")]
     MethodRevoked(String),
 
+    /// Verification method is not controlled by, rooted in, or key-bound to
+    /// the DID document that presents it.
+    #[error("verification method not bound to DID document: {0}")]
+    MethodNotDocumentBound(String),
+
     /// Cryptographic operation failed (e.g., invalid multibase encoding,
     /// wrong key length, unsupported multibase prefix).
     #[error("cryptographic error: {0}")]
@@ -31,6 +38,81 @@ pub enum DidVerificationError {
     /// Signature verification failed.
     #[error("invalid signature")]
     InvalidSignature,
+}
+
+fn decode_ed25519_multibase_public_key(encoded: &str) -> Result<PublicKey, DidVerificationError> {
+    let pub_key_bytes = if let Some(encoded_key) = encoded.strip_prefix('z') {
+        bs58::decode(encoded_key)
+            .into_vec()
+            .map_err(|e| DidVerificationError::CryptoError(format!("base58 decode: {e}")))?
+    } else {
+        return Err(DidVerificationError::CryptoError(
+            "unsupported multibase prefix (expected 'z' for base58btc)".to_string(),
+        ));
+    };
+
+    let pub_key_array: [u8; 32] = pub_key_bytes.try_into().map_err(|_| {
+        DidVerificationError::CryptoError("public key must be 32 bytes".to_string())
+    })?;
+
+    Ok(PublicKey::from_bytes(pub_key_array))
+}
+
+/// Validate that an active Ed25519 DID verification method is controlled by
+/// the document DID, rooted at the document fragment namespace, and backed by
+/// key material declared in the document's `public_keys`.
+///
+/// This prevents a registered DID document from proving possession of one
+/// public key while presenting a different active authentication key.
+pub fn validate_verification_method_document_binding(
+    doc: &DidDocument,
+    method: &VerificationMethod,
+) -> Result<PublicKey, DidVerificationError> {
+    if doc.revoked {
+        return Err(DidVerificationError::MethodRevoked(
+            doc.id.as_str().to_owned(),
+        ));
+    }
+
+    if !method.active || method.revoked_at.is_some() {
+        return Err(DidVerificationError::MethodRevoked(method.id.clone()));
+    }
+
+    if method.key_type != ED25519_VERIFICATION_KEY_TYPE {
+        return Err(DidVerificationError::MethodNotDocumentBound(format!(
+            "{} has unsupported key type {}",
+            method.id, method.key_type
+        )));
+    }
+
+    if method.controller != doc.id {
+        return Err(DidVerificationError::MethodNotDocumentBound(format!(
+            "{} controller {} does not match document DID {}",
+            method.id, method.controller, doc.id
+        )));
+    }
+
+    let document_fragment_prefix = format!("{}#", doc.id);
+    if !method.id.starts_with(&document_fragment_prefix) {
+        return Err(DidVerificationError::MethodNotDocumentBound(format!(
+            "{} is not rooted under document DID {}",
+            method.id, doc.id
+        )));
+    }
+
+    let public_key = decode_ed25519_multibase_public_key(&method.public_key_multibase)?;
+    if !doc
+        .public_keys
+        .iter()
+        .any(|declared| declared == &public_key)
+    {
+        return Err(DidVerificationError::MethodNotDocumentBound(format!(
+            "{} key is not declared in the DID document public_keys",
+            method.id
+        )));
+    }
+
+    Ok(public_key)
 }
 
 /// Abstract key vault interface for secure key storage.
@@ -75,26 +157,7 @@ pub fn verify_did_signature(
         .find(|m| m.id == key_id)
         .ok_or_else(|| DidVerificationError::MethodNotFound(key_id.to_string()))?;
 
-    if !method.active {
-        return Err(DidVerificationError::MethodRevoked(key_id.to_string()));
-    }
-
-    // Decode multibase base58btc public key (prefix 'z')
-    let pub_key_bytes = if let Some(encoded_key) = method.public_key_multibase.strip_prefix('z') {
-        bs58::decode(encoded_key)
-            .into_vec()
-            .map_err(|e| DidVerificationError::CryptoError(format!("base58 decode: {e}")))?
-    } else {
-        return Err(DidVerificationError::CryptoError(
-            "unsupported multibase prefix (expected 'z' for base58btc)".to_string(),
-        ));
-    };
-
-    let pub_key_array: [u8; 32] = pub_key_bytes.try_into().map_err(|_| {
-        DidVerificationError::CryptoError("public key must be 32 bytes".to_string())
-    })?;
-
-    let public_key = PublicKey::from_bytes(pub_key_array);
+    let public_key = validate_verification_method_document_binding(doc, method)?;
 
     if crypto::verify(message, signature, &public_key) {
         Ok(())
@@ -160,6 +223,8 @@ pub fn rotate_verification_key(
         revoked_at: None,
     };
 
+    doc.public_keys.clear();
+    doc.public_keys.push(PublicKey::from_bytes(*new_public_key));
     doc.verification_methods.push(new_method.clone());
     doc.updated = exo_core::Timestamp::new(current_time_ms, 0);
 
@@ -264,6 +329,26 @@ mod tests {
         let key_id = format!("{}#key-1", did);
         let err = verify_did_signature(&doc, &key_id, message, &signature).unwrap_err();
         assert!(matches!(err, DidVerificationError::MethodRevoked(_)));
+    }
+
+    #[test]
+    fn verify_rejects_method_key_not_declared_by_document() {
+        let (declared_pk, _) = generate_keypair();
+        let (method_pk, method_sk) = generate_keypair();
+        let did = test_did();
+        let mut doc = make_doc_with_verification(did.clone(), declared_pk);
+        doc.verification_methods[0].public_key_multibase =
+            format!("z{}", bs58::encode(method_pk.as_bytes()).into_string());
+
+        let message = b"method key must be document-bound";
+        let signature = sign(message, &method_sk);
+        let key_id = format!("{}#key-1", did);
+
+        let err = verify_did_signature(&doc, &key_id, message, &signature).unwrap_err();
+        assert!(
+            err.to_string().contains("not declared"),
+            "verification should reject active methods whose keys are not declared by the DID document: {err}"
+        );
     }
 
     #[test]

--- a/crates/exo-identity/src/registry.rs
+++ b/crates/exo-identity/src/registry.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 
 use crate::{
     did::{DidDocument, DidRegistrationProof, RevocationProof},
+    did_verification::validate_verification_method_document_binding,
     error::IdentityError,
 };
 
@@ -332,6 +333,15 @@ fn validate_registered_did_document(doc: &DidDocument) -> Result<(), IdentityErr
             &method.public_key_multibase,
             MAX_DID_DOCUMENT_FIELD_BYTES,
         )?;
+        if method.active {
+            validate_verification_method_document_binding(doc, method).map_err(|e| {
+                IdentityError::InvalidDidDocumentField {
+                    did: did.to_owned(),
+                    field: "verification_methods".to_owned(),
+                    reason: e.to_string(),
+                }
+            })?;
+        }
     }
     for method in &doc.hybrid_verification_methods {
         ensure_byte_bound(
@@ -478,7 +488,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::did::DidDocument;
+    use crate::did::{DidDocument, VerificationMethod};
 
     fn make_did(label: &str) -> Did {
         Did::new(&format!("did:exo:{label}")).expect("valid did")
@@ -522,6 +532,20 @@ mod tests {
             public_key,
             signature: sign(&payload, secret_key),
         }
+    }
+
+    fn add_active_verification_method(doc: &mut DidDocument, public_key: PublicKey) {
+        let multibase = format!("z{}", bs58::encode(public_key.as_bytes()).into_string());
+        doc.verification_methods.push(VerificationMethod {
+            id: format!("{}#key-1", doc.id),
+            key_type: "Ed25519VerificationKey2020".to_owned(),
+            controller: doc.id.clone(),
+            public_key_multibase: multibase,
+            version: 1,
+            active: true,
+            valid_from: 1000,
+            revoked_at: None,
+        });
     }
 
     #[test]
@@ -628,6 +652,26 @@ mod tests {
             err,
             IdentityError::InvalidRegistrationProof { .. }
         ));
+        assert_eq!(reg.len(), 0);
+    }
+
+    #[test]
+    fn register_with_proof_rejects_active_method_not_bound_to_declared_key() {
+        let (document_pk, document_sk) = generate_keypair();
+        let (method_pk, _) = generate_keypair();
+        let mut doc = make_doc_with_label("proof-method-unbound-key", document_pk);
+        add_active_verification_method(&mut doc, method_pk);
+        let proof = registration_proof(&doc, document_pk, &document_sk);
+
+        let mut reg = LocalDidRegistry::new();
+        let err = reg
+            .register_with_proof(doc, &proof)
+            .expect_err("active verification methods must be bound to declared document keys");
+
+        assert!(
+            err.to_string().contains("verification_methods"),
+            "error should identify verification method binding failure: {err}"
+        );
         assert_eq!(reg.len(), 0);
     }
 


### PR DESCRIPTION
## Summary
- Classifies this as EXOCHAIN core plus core runtime adapter remediation for DID document registration and gateway authentication.
- Adds a shared active verification-method binding check: method must be active, unrevoked, Ed25519, controller-bound to the document DID, rooted under the document DID fragment namespace, and backed by a public key declared in the DID document.
- Applies that check during local DID document registration and direct DID signature verification, including gateway auth paths backed by custom registries.
- Updates key rotation to keep `DidDocument.public_keys` aligned with the newly active verification method.
- Refreshes README repo-truth metadata from `bash tools/repo_truth.sh --json`.

## Classification
- EXOCHAIN core: `crates/exo-identity/src/did_verification.rs`, `crates/exo-identity/src/registry.rs`
- Core runtime adapter: `crates/exo-gateway/src/auth.rs`
- Documentation/repo-truth metadata: `README.md`

## Current-code verification before fix
- Confirmed on current `origin/main` that `verify_did_registration_proof` only proved possession of a key listed in `doc.public_keys` while active `verification_methods` could carry different key material.
- Confirmed `verify_did_signature` decoded and trusted the selected method key without checking document controller/id/key declaration binding.
- Confirmed gateway auth selected the first active verification method and accepted a valid signature under an unbound method key from a custom registry document.

## RED tests observed
- `cargo test -p exo-identity register_with_proof_rejects_active_method_not_bound_to_declared_key -- --nocapture` failed because registration accepted the unbound active method.
- `cargo test -p exo-identity verify_rejects_method_key_not_declared_by_document -- --nocapture` failed because direct DID verification accepted the unbound method key.
- `cargo test -p exo-gateway auth_rejects_active_method_not_bound_to_document_key -- --nocapture` failed because gateway auth accepted the unbound method key.
- The pre-existing `verify_after_rotation` test failed after adding the binding check until rotation was updated to refresh declared public keys.

## Rebase Repair 2026-05-10
Merged current origin/main into this branch, resolved the README repo-truth conflict with generated current counters, and re-ran focused, touched-crate, hygiene, and workspace gates.

## Validation
- `cargo test -p exo-identity register_with_proof_rejects_active_method_not_bound_to_declared_key -- --nocapture` passed.
- `cargo test -p exo-identity verify_rejects_method_key_not_declared_by_document -- --nocapture` passed.
- `cargo test -p exo-identity verify_after_rotation -- --nocapture` passed.
- `cargo test -p exo-gateway auth_rejects_active_method_not_bound_to_document_key -- --nocapture` passed.
- `cargo test -p exo-identity` passed.
- `cargo test -p exo-gateway` passed.
- `cargo clippy -p exo-identity -p exo-gateway --all-targets -- -D warnings` passed.
- `cargo +nightly fmt --all -- --check` passed.
- `git diff --check` passed.
- `bash tools/test_repo_truth.sh` passed.
- `cargo test --workspace` passed.

## Bypass check
- Searched DID signature and active-method call sites with `rg`; gateway auth remains the runtime consumer of `verify_did_signature`, and both registration and direct verification now use the same binding helper.
