### PR TITLE
fix(node): bind persisted identity DID to key

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 181721 | `wc -l` |
-| Workspace tests | 4,260 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 181751 | `wc -l` |
+| Workspace tests | 4,261 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,260 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,261 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 181721 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 181751 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,260 listed workspace tests
+         cryptographic proofs, 4,261 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-node/src/identity.rs
+++ b/crates/exo-node/src/identity.rs
@@ -82,6 +82,15 @@ pub fn load_or_create(data_dir: &Path) -> anyhow::Result<NodeIdentity> {
 
         let did_str = std::fs::read_to_string(&did_path)?;
         let did = Did::new(did_str.trim())?;
+        let derived_did = did_from_public_key(keypair.public_key())?;
+        if did != derived_did {
+            anyhow::bail!(
+                "identity.did does not match identity.key public key at {}; stored {}, derived {}",
+                did_path.display(),
+                did,
+                derived_did
+            );
+        }
 
         tracing::info!(did = %did, "Loaded existing identity");
 
@@ -217,6 +226,27 @@ mod tests {
 
         assert_eq!(first.did, second.did);
         assert_eq!(first.public_key_bytes(), second.public_key_bytes());
+    }
+
+    #[test]
+    fn load_or_create_rejects_identity_did_not_bound_to_secret_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = load_or_create(dir.path()).unwrap();
+        std::fs::write(dir.path().join("identity.did"), b"did:exo:forged-validator").unwrap();
+
+        let err = match load_or_create(dir.path()) {
+            Ok(identity) => panic!(
+                "identity.did must not load when it does not derive from identity.key: loaded {} for original {}",
+                identity.did, first.did
+            ),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.to_string()
+                .contains("identity.did does not match identity.key"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- verifies the node identity DID stored on disk still derives from the persisted identity.key before returning NodeIdentity
- fails closed when identity.did is tampered or mismatched instead of letting consensus, signer, or receipt paths consume an unbound DID/key pair
- updates README repo-truth counters generated from tools/repo_truth.sh

## Path Classification
- EXOCHAIN core: crates/exo-node/src/identity.rs
- EXOCHAIN core metadata: README.md generated repo-truth counters

## Current-Code Verification
- Reproduced on this branch before the fix with cargo test -p exo-node identity::tests::load_or_create_rejects_identity_did_not_bound_to_secret_key -- --nocapture; the test failed because a forged identity.did loaded with the original signing key.
- Nearby bypass check: parse_validator_public_key_entry already derives validator DID from supplied public keys, so the missing boundary was the persisted local identity reload path.

## Tests
- RED: cargo test -p exo-node identity::tests::load_or_create_rejects_identity_did_not_bound_to_secret_key -- --nocapture failed before the fix for the expected reason
- GREEN: cargo test -p exo-node identity::tests::load_or_create_rejects_identity_did_not_bound_to_secret_key -- --nocapture
- cargo test -p exo-node identity::tests -- --nocapture
- cargo test -p exo-node
- cargo clippy -p exo-node --all-targets -- -D warnings
- cargo +nightly fmt --all -- --check
- git diff --check
- bash tools/test_repo_truth.sh
- cargo test --workspace

## Security Notes
External and sidecar findings were treated as hypotheses. This PR only changes the owned EXOCHAIN core node identity boundary and does not mix adjacent-surface hardening.