### PR TITLE
fix(syntaxis): require verification evidence

### DIFF
--- a/tools/syntaxis/README.md
+++ b/tools/syntaxis/README.md
@@ -10,8 +10,8 @@ The Syntaxis Protocol Engine is an intermediary protocol that translates council
 
 #### Core Governance Nodes (10 nodes)
 - **Identity & Access (3 nodes)**
-  - `identity-verify`: Verifies identity of request initiator
-  - `authority-check`: Checks if subject has required authority
+  - `identity-verify`: Verifies caller-supplied identity evidence bound to the request initiator
+  - `authority-check`: Checks if subject has required authority through delegation evidence
   - `authority-delegate`: Delegates authority between subjects
 
 - **Consent (3 nodes)**

--- a/tools/syntaxis/compiler.js
+++ b/tools/syntaxis/compiler.js
@@ -53,6 +53,14 @@ const STANDARD_BCTS_FLOW = [
   'CLOSED'
 ];
 
+function isObjectRecord(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.length > 0;
+}
+
 /**
  * Proposal type to Syntaxis node mappings
  */
@@ -163,7 +171,11 @@ class SyntaxisCompiler {
     }
 
     // Validate constitutional invariants
-    const invariantChecks = this._validateInvariants(proposal, councilVerdict);
+    const invariantChecks = this._validateInvariants(
+      proposal,
+      councilVerdict,
+      proposalMapping.nodes
+    );
 
     // Build final workflow
     const workflow = {
@@ -414,7 +426,8 @@ class SyntaxisCompiler {
             createdAtHlc,
             proposalId: proposal.id,
             verdictId: councilVerdict.id
-          })
+          }),
+          proof: proposal.identityProof || councilVerdict.identityProof || null
         };
 
       case 'authority-check':
@@ -422,7 +435,8 @@ class SyntaxisCompiler {
           ...baseInputs,
           subjectId: proposal.proposer,
           requiredAuthority: 'GOVERNANCE_PROPOSER',
-          scope: proposal.type
+          scope: proposal.type,
+          delegationChain: proposal.delegationChain || councilVerdict.delegationChain || []
         };
 
       case 'authority-delegate':
@@ -641,13 +655,31 @@ class SyntaxisCompiler {
     };
   }
 
-  _validateInvariants(proposal, verdict) {
-    return {
-      'GOVERNANCE_AUTHORITY': { covered: true, nodeId: 'authority-check' },
-      'CONSENT_COVERAGE': { covered: true, nodeId: 'consent-verify' },
-      'PROOF_VALIDITY': { covered: true, nodeId: 'proof-verify' },
-      'KERNEL_INTEGRITY': { covered: true, nodeId: 'kernel-adjudicate' }
+  _validateInvariants(proposal, verdict, nodeTypes = []) {
+    const evidence = isObjectRecord(verdict.invariantEvidence) ? verdict.invariantEvidence : {};
+    const requirements = {
+      GOVERNANCE_AUTHORITY: 'authority-check',
+      CONSENT_COVERAGE: 'consent-verify',
+      PROOF_VALIDITY: 'proof-verify',
+      KERNEL_INTEGRITY: 'kernel-adjudicate'
     };
+
+    const coverage = {};
+    for (const [invariant, nodeType] of Object.entries(requirements)) {
+      const record = evidence[invariant];
+      const covered = (
+        nodeTypes.includes(nodeType) &&
+        isObjectRecord(record) &&
+        record.nodeType === nodeType &&
+        isNonEmptyString(record.evidenceHash)
+      );
+      coverage[invariant] = {
+        covered,
+        nodeId: nodeType,
+        evidenceHash: covered ? record.evidenceHash : null
+      };
+    }
+    return coverage;
   }
 
   _mapNodesToBCTS(nodes, stateFlow) {

--- a/tools/syntaxis/determinism.test.js
+++ b/tools/syntaxis/determinism.test.js
@@ -46,6 +46,47 @@ function proposal() {
   };
 }
 
+function identityProof(identityId, method, nonce, publicKey = 'ed25519-test-public-key') {
+  return {
+    subjectId: identityId,
+    method,
+    nonce,
+    publicKey,
+    signature: 'ed25519-test-signature',
+    proofHash: `0x${hashCanonical({
+      identityId,
+      method,
+      nonce,
+      publicKey
+    })}`
+  };
+}
+
+function delegationLink({ grantorId, granteeId, authority, scope, previousChainHash = null }) {
+  const signatureHash = `0x${hashCanonical({
+    authority,
+    granteeId,
+    grantorId,
+    scope,
+    signature: 'ed25519-test-signature'
+  })}`;
+  return {
+    grantorId,
+    granteeId,
+    authority,
+    scope,
+    signatureHash,
+    chainHash: `0x${hashCanonical({
+      authority,
+      granteeId,
+      grantorId,
+      previousChainHash,
+      scope,
+      signatureHash
+    })}`
+  };
+}
+
 function run() {
   const compiler = new SyntaxisCompiler();
 
@@ -111,6 +152,98 @@ function run() {
   });
   assert.strictEqual(adjudication.outputs.confidenceBasisPoints, 6666);
   assert.ok(!Object.prototype.hasOwnProperty.call(adjudication.outputs, 'confidence'));
+
+  const shapeOnlyIdentity = NODE_IMPLEMENTATIONS['identity-verify'].execute({
+    inputs: {
+      identity: { id: 'did:exo:shape-only' },
+      verificationMethod: 'cryptographic',
+      nonce: 'nonce-shape-only',
+      timestampHlc: HLC
+    }
+  });
+  assert.strictEqual(
+    shapeOnlyIdentity.outputs.verified,
+    false,
+    'identity-verify must not mark shape-only identity inputs as verified'
+  );
+  assert.strictEqual(shapeOnlyIdentity.nextState, 'VERIFICATION_FAILED');
+
+  const identityNonce = 'nonce-bound';
+  const verifiedIdentity = NODE_IMPLEMENTATIONS['identity-verify'].execute({
+    inputs: {
+      identity: { id: 'did:exo:verified' },
+      verificationMethod: 'cryptographic',
+      nonce: identityNonce,
+      proof: identityProof('did:exo:verified', 'cryptographic', identityNonce),
+      timestampHlc: HLC
+    }
+  });
+  assert.strictEqual(verifiedIdentity.outputs.verified, true);
+  assert.strictEqual(verifiedIdentity.nextState, 'VERIFIED');
+
+  const shapeOnlyAuthority = NODE_IMPLEMENTATIONS['authority-check'].execute({
+    inputs: {
+      subjectId: 'did:exo:shape-only',
+      requiredAuthority: 'GOVERNANCE_PROPOSER',
+      scope: 'security-patch',
+      timestampHlc: HLC
+    }
+  });
+  assert.strictEqual(
+    shapeOnlyAuthority.outputs.authorized,
+    false,
+    'authority-check must not mark subject/scope strings as authorized without delegation evidence'
+  );
+  assert.strictEqual(shapeOnlyAuthority.nextState, 'UNAUTHORIZED');
+
+  const validDelegationChain = [
+    delegationLink({
+      grantorId: 'did:exo:root',
+      granteeId: 'did:exo:verified',
+      authority: 'GOVERNANCE_PROPOSER',
+      scope: 'security-patch'
+    })
+  ];
+  const verifiedAuthority = NODE_IMPLEMENTATIONS['authority-check'].execute({
+    inputs: {
+      subjectId: 'did:exo:verified',
+      requiredAuthority: 'GOVERNANCE_PROPOSER',
+      scope: 'security-patch',
+      delegationChain: validDelegationChain,
+      timestampHlc: HLC
+    }
+  });
+  assert.strictEqual(verifiedAuthority.outputs.authorized, true);
+  assert.strictEqual(verifiedAuthority.nextState, 'AUTHORIZED');
+
+  assert.strictEqual(
+    first.invariantCoverage.GOVERNANCE_AUTHORITY.covered,
+    false,
+    'compiled workflows must not mark governance authority covered without authority evidence'
+  );
+  assert.strictEqual(
+    first.invariantCoverage.PROOF_VALIDITY.covered,
+    false,
+    'compiled workflows must not mark proof validity covered without proof evidence'
+  );
+  assert.strictEqual(
+    first.invariantCoverage.KERNEL_INTEGRITY.covered,
+    false,
+    'compiled workflows must not mark kernel integrity covered without kernel evidence'
+  );
+  const evidencedWorkflow = compiler.compileSyntaxis(
+    {
+      ...verdict(),
+      invariantEvidence: {
+        KERNEL_INTEGRITY: {
+          nodeType: 'kernel-adjudicate',
+          evidenceHash: `0x${'22'.repeat(32)}`
+        }
+      }
+    },
+    proposal()
+  );
+  assert.strictEqual(evidencedWorkflow.invariantCoverage.KERNEL_INTEGRITY.covered, true);
 
   const proofInputs = {
     dataHash: `0x${'11'.repeat(32)}`,

--- a/tools/syntaxis/index.js
+++ b/tools/syntaxis/index.js
@@ -82,8 +82,8 @@ const BCTS_STATES = {
 const NODE_REGISTRY = {
   'identity-verify': {
     category: 'Identity & Access',
-    description: 'Verifies identity of request initiator',
-    requiredInputs: ['identity', 'verificationMethod', 'nonce'],
+    description: 'Verifies identity evidence bound to the request initiator',
+    requiredInputs: ['identity', 'verificationMethod', 'nonce', 'proof'],
     outputs: ['identityId', 'verified', 'verificationTimestamp'],
     bctsTransition: 'IDENTITY_REQUIRED -> IDENTITY_VERIFIED',
     requiredPanels: ['Identity Panel'],
@@ -93,8 +93,8 @@ const NODE_REGISTRY = {
 
   'authority-check': {
     category: 'Identity & Access',
-    description: 'Checks if subject has required authority for action',
-    requiredInputs: ['subjectId', 'requiredAuthority', 'scope'],
+    description: 'Checks if subject has required authority through delegation evidence',
+    requiredInputs: ['subjectId', 'requiredAuthority', 'scope', 'delegationChain'],
     outputs: ['subjectId', 'authorized', 'authorityLevel'],
     bctsTransition: 'IDENTITY_VERIFIED -> AUTHORIZED',
     requiredPanels: ['Identity Panel'],

--- a/tools/syntaxis/nodes.js
+++ b/tools/syntaxis/nodes.js
@@ -18,6 +18,14 @@ function isObjectRecord(value) {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isNonZeroHash(value) {
+  return isNonEmptyString(value) && !/^0x?0+$/.test(value);
+}
+
 /**
  * Base Node class - all node types extend this
  */
@@ -74,16 +82,21 @@ class IdentityVerifyNode extends SyntaxisNode {
     if (!inputs.nonce) {
       errors.push('nonce is required');
     }
+    const proof = inputs.proof || inputs.identity?.proof;
+    if (!isObjectRecord(proof)) {
+      errors.push('proof is required and must be an object');
+    }
     return { valid: errors.length === 0, errors };
   }
 
   execute(context) {
     const { identity, verificationMethod, nonce } = context.inputs;
+    const proof = context.inputs.proof || identity?.proof;
     const timestampHlc = timestampFromContext(context);
-    const verified = this._performVerification(identity, verificationMethod, nonce);
+    const verified = this._performVerification(identity, verificationMethod, nonce, proof);
     return {
       outputs: {
-        identityId: identity.id,
+        identityId: identity?.id,
         verified,
         verificationTimestamp: hlcToString(timestampHlc),
         verificationTimestampHlc: timestampHlc,
@@ -98,9 +111,26 @@ class IdentityVerifyNode extends SyntaxisNode {
     return ['Identity Panel'];
   }
 
-  _performVerification(identity, method, nonce) {
-    // In production, would verify cryptographic signatures, delegation chains, or audit logs
-    return !!(identity && identity.id && nonce);
+  _performVerification(identity, method, nonce, proof) {
+    if (!isObjectRecord(identity) || !isObjectRecord(proof)) {
+      return false;
+    }
+    if (!isNonEmptyString(identity.id) || !isNonEmptyString(method) || !isNonEmptyString(nonce)) {
+      return false;
+    }
+    if (proof.subjectId !== identity.id || proof.method !== method || proof.nonce !== nonce) {
+      return false;
+    }
+    if (!isNonEmptyString(proof.publicKey) || !isNonEmptyString(proof.signature)) {
+      return false;
+    }
+    const expectedProofHash = `0x${hashCanonical({
+      identityId: identity.id,
+      method,
+      nonce,
+      publicKey: proof.publicKey
+    })}`;
+    return proof.proofHash === expectedProofHash;
   }
 }
 
@@ -120,13 +150,16 @@ class AuthorityCheckNode extends SyntaxisNode {
     if (!inputs.scope) {
       errors.push('scope is required');
     }
+    if (!Array.isArray(inputs.delegationChain) || inputs.delegationChain.length === 0) {
+      errors.push('delegationChain must be a non-empty array');
+    }
     return { valid: errors.length === 0, errors };
   }
 
   execute(context) {
-    const { subjectId, requiredAuthority, scope } = context.inputs;
+    const { subjectId, requiredAuthority, scope, delegationChain } = context.inputs;
     const timestampHlc = timestampFromContext(context);
-    const authorized = this._checkAuthority(subjectId, requiredAuthority, scope);
+    const authorized = this._checkAuthority(subjectId, requiredAuthority, scope, delegationChain);
     return {
       outputs: {
         subjectId,
@@ -145,9 +178,49 @@ class AuthorityCheckNode extends SyntaxisNode {
     return ['Identity Panel'];
   }
 
-  _checkAuthority(subjectId, requiredAuthority, scope) {
-    // In production, would check delegated authority in identity registry
-    return !!(subjectId && requiredAuthority && scope);
+  _checkAuthority(subjectId, requiredAuthority, scope, delegationChain) {
+    if (!isNonEmptyString(subjectId) || !isNonEmptyString(requiredAuthority) || !isNonEmptyString(scope)) {
+      return false;
+    }
+    if (!Array.isArray(delegationChain) || delegationChain.length === 0) {
+      return false;
+    }
+
+    let previousChainHash = null;
+    for (const link of delegationChain) {
+      if (!isObjectRecord(link)) {
+        return false;
+      }
+      if (
+        !isNonEmptyString(link.grantorId) ||
+        !isNonEmptyString(link.granteeId) ||
+        !isNonEmptyString(link.authority) ||
+        !isNonEmptyString(link.scope) ||
+        !isNonZeroHash(link.signatureHash) ||
+        !isNonZeroHash(link.chainHash)
+      ) {
+        return false;
+      }
+      const expectedChainHash = `0x${hashCanonical({
+        authority: link.authority,
+        granteeId: link.granteeId,
+        grantorId: link.grantorId,
+        previousChainHash,
+        scope: link.scope,
+        signatureHash: link.signatureHash
+      })}`;
+      if (link.chainHash !== expectedChainHash) {
+        return false;
+      }
+      previousChainHash = link.chainHash;
+    }
+
+    const terminalLink = delegationChain[delegationChain.length - 1];
+    return (
+      terminalLink.granteeId === subjectId &&
+      terminalLink.authority === requiredAuthority &&
+      terminalLink.scope === scope
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- makes identity-verify fail closed unless a proof object is bound to the identity id, verification method, nonce, public key, and proof hash
- makes authority-check fail closed unless a delegationChain is present, hash chained, non-zero signed, and terminally bound to the requested subject/authority/scope
- stops compileSyntaxis from marking invariant coverage as true unless caller-supplied invariantEvidence matches the node type compiled into the workflow
- updates Syntaxis metadata/docs to list proof and delegationChain as required inputs

## Path Classification
- EXOCHAIN core tooling: tools/syntaxis/nodes.js, tools/syntaxis/compiler.js, tools/syntaxis/determinism.test.js, tools/syntaxis/index.js, tools/syntaxis/README.md

## Current-Code Verification
- RED: node tools/syntaxis/determinism.test.js failed before the fix because identity-verify returned verified true for a shape-only identity id plus nonce.
- The same regression file now covers shape-only identity denial, evidence-bound identity acceptance, shape-only authority denial, hash-chained delegation acceptance, and invariant coverage denial without evidence.

## Validation
- node tools/syntaxis/determinism.test.js
- npm test from tools/syntaxis
- python3 tools/syntaxis/test_generate_workflow_input_boundary.py
- bash tools/test_syntaxis_workflow_input_boundary.sh
- bash tools/test_repo_truth.sh
- git diff --check
- bypass search: rg -n "covered: true|return !!\(identity|return !!\(subjectId|In production, would verify|In production, would check" tools/syntaxis -S returned no matches

## Security Notes
This does not claim Syntaxis replaces EXOCHAIN Rust cryptographic verification. It prevents the JS workflow/intake layer from overstating identity, authority, or invariant coverage from shape-only untrusted inputs.