### PR TITLE
fix(identity): require self-certifying DID registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 181721 | `wc -l` |
-| Workspace tests | 4,260 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 181780 | `wc -l` |
+| Workspace tests | 4,262 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,260 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,262 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 181721 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 181780 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,260 listed workspace tests
+         cryptographic proofs, 4,262 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -5326,7 +5326,8 @@ mod tests {
     #[tokio::test]
     async fn auth_register_accepts_valid_registration_proof() {
         let (public_key, secret_key) = generate_keypair();
-        let doc = keyed_doc("did:exo:tester", public_key);
+        let did = exo_identity::did::did_from_public_key(&public_key).unwrap();
+        let doc = did_document_with_ed25519_key(&did, &public_key);
         let body = registration_request_body(&doc, &public_key, &secret_key);
         let app = build_router(state());
         let resp = app
@@ -5341,6 +5342,27 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::CREATED);
+    }
+
+    #[tokio::test]
+    async fn auth_register_rejects_non_self_certifying_did_claim() {
+        let (public_key, secret_key) = generate_keypair();
+        let doc = keyed_doc("did:exo:claimed-by-attacker-key", public_key);
+        let body = registration_request_body(&doc, &public_key, &secret_key);
+        let app = build_router(state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/auth/register")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]
@@ -5368,7 +5390,8 @@ mod tests {
     #[tokio::test]
     async fn auth_register_duplicate_returns_409() {
         let (public_key, secret_key) = generate_keypair();
-        let doc = keyed_doc("did:exo:dup", public_key);
+        let did = exo_identity::did::did_from_public_key(&public_key).unwrap();
+        let doc = did_document_with_ed25519_key(&did, &public_key);
         let registry = Arc::new(RwLock::new(LocalDidRegistry::new()));
         registry.write().unwrap().register(doc.clone()).unwrap();
         let st = AppState::new(None, registry);
@@ -5402,7 +5425,8 @@ mod tests {
         }
 
         let st = AppState::new(None, registry);
-        let overflow_doc = keyed_doc("did:exo:capacity-overflow", pk);
+        let overflow_did = exo_identity::did::did_from_public_key(&pk).unwrap();
+        let overflow_doc = did_document_with_ed25519_key(&overflow_did, &pk);
         let body = registration_request_body(&overflow_doc, &pk, &sk);
         let app = build_router(st);
         let resp = app
@@ -6546,7 +6570,8 @@ mod tests {
     #[tokio::test]
     async fn agents_enroll_returns_201() {
         let (public_key, secret_key) = generate_keypair();
-        let doc = keyed_doc("did:exo:enrollee", public_key);
+        let did = exo_identity::did::did_from_public_key(&public_key).unwrap();
+        let doc = did_document_with_ed25519_key(&did, &public_key);
         let body = registration_request_body(&doc, &public_key, &secret_key);
         let app = build_router(state());
         let resp = app

--- a/crates/exo-identity/src/registry.rs
+++ b/crates/exo-identity/src/registry.rs
@@ -125,6 +125,22 @@ pub fn verify_did_registration_proof(
 ) -> Result<(), IdentityError> {
     validate_registered_did_document(doc)?;
 
+    let expected_did = crate::did::did_from_public_key(&proof.public_key).map_err(|e| {
+        IdentityError::InvalidRegistrationProof {
+            did: doc.id.clone(),
+            reason: format!("proof public key cannot derive a valid self-certifying DID: {e}"),
+        }
+    })?;
+    if doc.id != expected_did {
+        return Err(IdentityError::InvalidRegistrationProof {
+            did: doc.id.clone(),
+            reason: format!(
+                "document id is not bound to the registration proof key: expected {}",
+                expected_did
+            ),
+        });
+    }
+
     if !doc.public_keys.iter().any(|key| key == &proof.public_key) {
         return Err(IdentityError::InvalidRegistrationProof {
             did: doc.id.clone(),
@@ -600,7 +616,7 @@ mod tests {
     #[test]
     fn register_with_proof_accepts_document_signed_by_declared_key() {
         let (pk, sk) = generate_keypair();
-        let did = make_did("proof-registered");
+        let did = crate::did::did_from_public_key(&pk).unwrap();
         let doc = make_doc(did.clone(), pk);
         let proof = registration_proof(&doc, pk, &sk);
 
@@ -610,6 +626,24 @@ mod tests {
         let resolved = reg.resolve(&did).unwrap();
         assert_eq!(resolved.id, did);
         assert_eq!(resolved.public_keys, vec![pk]);
+    }
+
+    #[test]
+    fn register_with_proof_rejects_did_not_derived_from_declared_key() {
+        let (pk, sk) = generate_keypair();
+        let doc = make_doc_with_label("claimed-by-attacker-key", pk);
+        let proof = registration_proof(&doc, pk, &sk);
+
+        let mut reg = LocalDidRegistry::new();
+        let err = reg
+            .register_with_proof(doc, &proof)
+            .expect_err("registration must bind did:exo id to the declared signing key");
+
+        assert!(matches!(
+            err,
+            IdentityError::InvalidRegistrationProof { .. }
+        ));
+        assert_eq!(reg.len(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Classification
- `crates/exo-identity/src/registry.rs`: EXOCHAIN core identity registry proof boundary.
- `crates/exo-gateway/src/server.rs`: core runtime adapter exposing DID registration over HTTP.
- `README.md`: repository truth metadata.

## Current-Code Confirmation
- The external/agent candidate was treated as a hypothesis and reproduced against current `origin/main` before production code changed.
- Red check: `cargo test -p exo-identity register_with_proof_rejects_did_not_derived_from_declared_key -- --nocapture` failed because a proof for an attacker-controlled key could register an arbitrary human-readable `did:exo:*` label.
- Red check: `cargo test -p exo-gateway auth_register_rejects_non_self_certifying_did_claim -- --nocapture` failed with `201` vs `400`, proving the HTTP registration boundary accepted the same claim.
- Snapshot-sync quorum and AVC persistence candidates were also checked first and were already remediated on current `main` via existing focused tests.

## Remediation
- `verify_did_registration_proof` now requires `doc.id` to equal `exo_identity::did::did_from_public_key(proof.public_key)` before first registration.
- Gateway registration and agent-enrollment fixtures now use self-certifying derived DIDs for legitimate positive paths.
- Added identity-core and gateway HTTP regressions for non-self-certifying DID claims.

## Validation
- RED before fix:
  - `cargo test -p exo-identity register_with_proof_rejects_did_not_derived_from_declared_key -- --nocapture` -> failed
  - `cargo test -p exo-gateway auth_register_rejects_non_self_certifying_did_claim -- --nocapture` -> failed (`201` vs `400`)
- GREEN after fix:
  - `cargo test -p exo-identity register_with_proof_rejects_did_not_derived_from_declared_key -- --nocapture`
  - `cargo test -p exo-gateway auth_register_rejects_non_self_certifying_did_claim -- --nocapture`
  - `cargo test -p exo-identity registry::tests -- --nocapture`
  - `cargo test -p exo-gateway auth_register_ -- --nocapture`
  - `cargo test -p exo-gateway agents_enroll_returns_201 -- --nocapture`
  - `cargo test -p exo-identity`
  - `cargo test -p exo-gateway`
  - `cargo clippy -p exo-identity -p exo-gateway --all-targets -- -D warnings`
  - `cargo test --workspace -- --list | rg -c ': test$'` -> `4262`
  - `cargo +nightly fmt --all -- --check`
  - `git diff --check`
  - `bash tools/test_repo_truth.sh`
  - `cargo test --workspace`