### PR TITLE
fix(node): require typed consensus proposal payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 181721 | `wc -l` |
-| Workspace tests | 4,260 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 181863 | `wc -l` |
+| Workspace tests | 4,263 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,260 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,263 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 181721 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 181863 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,260 listed workspace tests
+         cryptographic proofs, 4,263 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-node/src/api.rs
+++ b/crates/exo-node/src/api.rs
@@ -700,6 +700,16 @@ mod tests {
         test_api_state_with_validator_flag(true)
     }
 
+    #[cfg(feature = "unaudited-admin-governance-shortcut")]
+    fn validator_change_payload_hex_for_test() -> String {
+        let change = ValidatorChange::AddValidator {
+            did: Did::new("did:exo:v4").unwrap(),
+        };
+        let mut payload = Vec::new();
+        ciborium::into_writer(&change, &mut payload).unwrap();
+        hex::encode(payload)
+    }
+
     #[tokio::test]
     async fn status_endpoint_returns_consensus_state() {
         let state = test_api_state();
@@ -729,7 +739,7 @@ mod tests {
         let state = test_api_state();
         let app = governance_router(state);
 
-        let payload = hex::encode(b"test governance decision");
+        let payload = validator_change_payload_hex_for_test();
         let body = serde_json::json!({ "payload_hex": payload });
 
         let resp = app

--- a/crates/exo-node/src/reactor.rs
+++ b/crates/exo-node/src/reactor.rs
@@ -54,7 +54,7 @@ use crate::{
     store::SqliteDagStore,
     wire::{
         ConsensusCommitMsg, ConsensusProposalMsg, ConsensusVoteMsg, GovernanceEventMsg,
-        GovernanceEventType, WireMessage, topics,
+        GovernanceEventType, ValidatorChange, WireMessage, topics,
     },
 };
 
@@ -124,6 +124,19 @@ fn governance_event_signing_payload(event: &GovernanceEventMsg) -> Result<Vec<u8
     ciborium::ser::into_writer(&payload, &mut bytes)
         .map_err(|e| format!("governance event signing payload: {e}"))?;
     Ok(bytes)
+}
+
+fn validate_governance_proposal_payload(payload: &[u8]) -> Result<ValidatorChange, String> {
+    let change: ValidatorChange = ciborium::from_reader(payload)
+        .map_err(|e| format!("proposal payload must be canonical ValidatorChange CBOR: {e}"))?;
+    match &change {
+        ValidatorChange::AddValidator { did } | ValidatorChange::RemoveValidator { did } => {
+            if did.as_str().trim().is_empty() {
+                return Err("proposal payload validator DID must not be empty".into());
+            }
+        }
+    }
+    Ok(change)
 }
 
 fn checked_committed_height(committed_len: usize) -> Result<u64, String> {
@@ -707,6 +720,14 @@ fn validate_proposal<R: consensus::PublicKeyResolver>(
             msg.proposal.node_hash, msg.node.hash
         ));
     }
+    let payload_hash = Hash256::digest(&msg.payload);
+    if payload_hash != msg.node.payload_hash {
+        return Err(format!(
+            "proposal payload hash {} does not match attached node payload hash {}",
+            payload_hash, msg.node.payload_hash
+        ));
+    }
+    validate_governance_proposal_payload(&msg.payload)?;
     verify_node_creator_signature(&msg.node, resolver)
         .map_err(|e| format!("proposal DAG node creator signature invalid: {e}"))?;
     Ok(())
@@ -1285,6 +1306,8 @@ pub async fn submit_proposal(
     .await
     .map_err(|e| anyhow::anyhow!("{e}"))?;
 
+    validate_governance_proposal_payload(payload).map_err(|e| anyhow::anyhow!("{e}"))?;
+
     // Get current tips as parents.
     let tips = with_store_blocking(Arc::clone(store), "submit_proposal_tips", |store| {
         store.tips_sync().map_err(|e| format!("tips: {e}"))
@@ -1377,6 +1400,7 @@ pub async fn submit_proposal(
     let proposal_msg = WireMessage::ConsensusProposal(ConsensusProposalMsg {
         proposal,
         node: node.clone(),
+        payload: payload.to_vec(),
         signature,
     });
 
@@ -1544,11 +1568,45 @@ mod tests {
         }
     }
 
+    fn validator_change_payload_for_test() -> Vec<u8> {
+        let change = crate::wire::ValidatorChange::AddValidator {
+            did: Did::new("did:exo:v4").unwrap(),
+        };
+        let mut payload = Vec::new();
+        ciborium::into_writer(&change, &mut payload).unwrap();
+        payload
+    }
+
+    fn validator_remove_payload_for_test() -> Vec<u8> {
+        let change = crate::wire::ValidatorChange::RemoveValidator {
+            did: Did::new("did:exo:v4").unwrap(),
+        };
+        let mut payload = Vec::new();
+        ciborium::into_writer(&change, &mut payload).unwrap();
+        payload
+    }
+
     fn proposal_msg_for(
         proposer: Did,
         proposer_index: usize,
         round: u64,
         node: DagNode,
+    ) -> ConsensusProposalMsg {
+        proposal_msg_for_payload(
+            proposer,
+            proposer_index,
+            round,
+            node,
+            validator_change_payload_for_test(),
+        )
+    }
+
+    fn proposal_msg_for_payload(
+        proposer: Did,
+        proposer_index: usize,
+        round: u64,
+        node: DagNode,
+        payload: Vec<u8>,
     ) -> ConsensusProposalMsg {
         let proposal = Proposal {
             proposer,
@@ -1559,6 +1617,7 @@ mod tests {
         ConsensusProposalMsg {
             proposal,
             node,
+            payload,
             signature,
         }
     }
@@ -1856,7 +1915,8 @@ mod tests {
         drop(cmd_rx);
         let net_handle = NetworkHandle::new(cmd_tx);
 
-        let _result = submit_proposal(&state, &store, &net_handle, b"test payload").await;
+        let payload = validator_change_payload_for_test();
+        let _result = submit_proposal(&state, &store, &net_handle, &payload).await;
         // The publish will fail because no network loop is running, but the DAG node
         // and proposal should still be created locally.
         // In this test setup, the channel receiver is dropped so publish returns Err.
@@ -1891,6 +1951,32 @@ mod tests {
             result.unwrap_err().to_string().contains("not a validator"),
             "Error should mention validator"
         );
+    }
+
+    #[tokio::test]
+    async fn submit_proposal_rejects_untyped_payload_without_mutating_state() {
+        let validators = make_validators(4);
+        let config = config_for(Did::new("did:exo:v0").unwrap(), true, validators);
+
+        let state = create_reactor_state(&config, make_sign_fn(), None);
+        let (_dir, store) = temp_store();
+        let (cmd_tx, _cmd_rx) = mpsc::channel(32);
+        let net_handle = NetworkHandle::new(cmd_tx);
+
+        let result = submit_proposal(
+            &state,
+            &store,
+            &net_handle,
+            b"not a typed governance proposal",
+        )
+        .await;
+
+        assert!(
+            result.unwrap_err().to_string().contains("proposal payload"),
+            "opaque proposal payloads must fail before append/store/vote"
+        );
+        assert_eq!(state.lock().unwrap().dag.len(), 0);
+        assert!(store.lock().unwrap().tips_sync().unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -2749,12 +2835,16 @@ mod tests {
     // ==== GAP-014 defense-in-depth regression tests ====================
 
     fn make_node_for_test() -> exo_dag::dag::DagNode {
+        make_node_for_payload(&validator_change_payload_for_test())
+    }
+
+    fn make_node_for_payload(payload: &[u8]) -> exo_dag::dag::DagNode {
         use exo_dag::dag::{Dag, append};
         let mut dag = Dag::new();
         let mut clock = DeterministicDagClock::new();
         let did = Did::new("did:exo:v0").unwrap();
         let sf = make_sign_fn();
-        append(&mut dag, &[], b"x", &did, &*sf, &mut clock).unwrap()
+        append(&mut dag, &[], payload, &did, &*sf, &mut clock).unwrap()
     }
 
     #[test]
@@ -2770,6 +2860,7 @@ mod tests {
                 node_hash: node.hash,
             },
             node,
+            payload: validator_change_payload_for_test(),
             signature: Signature::from_bytes([0u8; 64]),
         };
         let err = validate_proposal(&msg, &validators, &resolver).unwrap_err();
@@ -2784,10 +2875,46 @@ mod tests {
         let validators = make_validators(1);
         let proposer = Did::new("did:exo:v0").unwrap();
         let resolver = validator_keys_for_single(&proposer, key_for_validator_index(0));
-        let node = make_node_for_test();
-        let msg = proposal_msg_for(proposer, 0, 0, node);
+        let payload = validator_change_payload_for_test();
+        let node = make_node_for_payload(&payload);
+        let msg = proposal_msg_for_payload(proposer, 0, 0, node, payload);
 
         validate_proposal(&msg, &validators, &resolver).unwrap();
+    }
+
+    #[test]
+    fn validate_proposal_rejects_untyped_governance_payload() {
+        let validators = make_validators(1);
+        let proposer = Did::new("did:exo:v0").unwrap();
+        let resolver = validator_keys_for_single(&proposer, key_for_validator_index(0));
+        let payload = b"not a typed governance proposal".to_vec();
+        let node = make_node_for_payload(&payload);
+        let msg = proposal_msg_for_payload(proposer, 0, 0, node, payload);
+
+        let err = validate_proposal(&msg, &validators, &resolver).unwrap_err();
+
+        assert!(
+            err.contains("proposal payload"),
+            "network proposals must reject opaque governance payloads before voting, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_proposal_rejects_payload_hash_mismatch() {
+        let validators = make_validators(1);
+        let proposer = Did::new("did:exo:v0").unwrap();
+        let resolver = validator_keys_for_single(&proposer, key_for_validator_index(0));
+        let node_payload = validator_change_payload_for_test();
+        let node = make_node_for_payload(&node_payload);
+        let msg_payload = validator_remove_payload_for_test();
+        let msg = proposal_msg_for_payload(proposer, 0, 0, node, msg_payload);
+
+        let err = validate_proposal(&msg, &validators, &resolver).unwrap_err();
+
+        assert!(
+            err.contains("proposal payload hash"),
+            "network proposals must bind supplied payload bytes to the DAG node hash, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/exo-node/src/wire.rs
+++ b/crates/exo-node/src/wire.rs
@@ -512,6 +512,9 @@ pub struct ConsensusProposalMsg {
     /// The full DAG node being proposed (so validators can verify it).
     #[serde(deserialize_with = "deserialize_dag_node")]
     pub node: DagNode,
+    /// Canonical governance proposal payload bytes hashed by the DAG node.
+    #[serde(deserialize_with = "deserialize_governance_payload")]
+    pub payload: Vec<u8>,
     /// Signature over the proposal by the proposer.
     #[serde(deserialize_with = "deserialize_bounded_signature")]
     pub signature: Signature,
@@ -812,6 +815,7 @@ mod tests {
                 node_hash,
             },
             node: test_node(vec![test_hash(b"parent-1"), test_hash(b"parent-2")]),
+            payload: b"validator-change".to_vec(),
             signature: Signature::Hybrid {
                 classical: [4u8; 64],
                 pq: vec![5u8; 96],
@@ -826,6 +830,7 @@ mod tests {
                 assert_eq!(proposal.proposal.round, 9);
                 assert_eq!(proposal.proposal.node_hash, node_hash);
                 assert_eq!(proposal.node.parents.len(), 2);
+                assert_eq!(proposal.payload, b"validator-change");
                 match proposal.signature {
                     Signature::Hybrid { classical, pq } => {
                         assert_eq!(classical, [4u8; 64]);


### PR DESCRIPTION
## Summary
- require consensus proposals to carry the canonical governance payload bytes they claim in the DAG node
- reject opaque/untyped governance payloads before local DAG append, proposal storage, or vote/publish side effects
- bind network proposal payload bytes to `DagNode.payload_hash` before accepting the proposal
- update the unaudited admin governance shortcut test fixture and repo-truth README metrics

## Path classification
- `crates/exo-node/src/reactor.rs`: core runtime adapter, consensus proposal validation and local proposal submission boundary
- `crates/exo-node/src/wire.rs`: core runtime adapter, consensus wire envelope
- `crates/exo-node/src/api.rs`: core runtime adapter test fixture for the admin governance proposal path
- `README.md`: documentation / repo-truth derived metadata

## Finding validation
The current code accepted consensus proposals whose signed `Proposal` and signed DAG node were valid while the governance payload was omitted from the wire envelope and could remain opaque. A malicious or buggy peer could ask validators to vote on a node hash without presenting typed governance semantics at the consensus proposal boundary.

Regression tests first demonstrated this against current code:
- `validate_proposal_rejects_untyped_governance_payload` failed because opaque bytes were accepted
- `submit_proposal_rejects_untyped_payload_without_mutating_state` failed because opaque bytes mutated local DAG/store state before publish failure

## Validation
- `cargo test -p exo-node untyped -- --nocapture`
- `cargo test -p exo-node validate_proposal_ -- --nocapture`
- `cargo test -p exo-node submit_proposal_ -- --nocapture`
- `cargo test -p exo-node roundtrip_consensus_proposal -- --nocapture`
- `cargo test -p exo-node --features unaudited-admin-governance-shortcut propose_endpoint_creates_dag_node -- --nocapture`
- `cargo test -p exo-node`
- `cargo clippy -p exo-node --all-targets -- -D warnings`
- `cargo clippy -p exo-node --features unaudited-admin-governance-shortcut --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --release`
- `cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check`

## Notes
This intentionally changes the consensus proposal wire envelope to fail closed for peers that do not supply payload bytes. Currently accepted governance proposal payloads are explicit `ValidatorChange` CBOR values; additional governance proposal kinds should be admitted only by extending this typed validator and adding matching tests.