### PR TITLE
fix(governance): bind deliberation vote signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 181863 | `wc -l` |
-| Workspace tests | 4,263 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 182044 | `wc -l` |
+| Workspace tests | 4,267 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,263 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,267 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 181863 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 182044 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,263 listed workspace tests
+         cryptographic proofs, 4,267 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-governance/src/deliberation.rs
+++ b/crates/exo-governance/src/deliberation.rs
@@ -7,8 +7,8 @@ use uuid::Uuid;
 use crate::{
     errors::GovernanceError,
     quorum::{
-        Approval, IndependenceAttestation, PublicKeyResolver, QuorumPolicy, QuorumResult, Role,
-        compute_quorum_verified,
+        Approval, ApprovalScope, IndependenceAttestation, PublicKeyResolver, QuorumPolicy,
+        QuorumResult, Role, compute_quorum_verified,
     },
 };
 
@@ -18,6 +18,17 @@ pub enum Position {
     For,
     Against,
     Abstain,
+}
+
+impl Position {
+    #[must_use]
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Position::For => "For",
+            Position::Against => "Against",
+            Position::Abstain => "Abstain",
+        }
+    }
 }
 
 /// A signed vote cast by a participant in a deliberation.
@@ -177,6 +188,12 @@ fn approvals_from_for_votes(delib: &Deliberation) -> Vec<Approval> {
             timestamp: delib.created,
             signature: v.signature.clone(),
             independence_attestation: v.independence_attestation.clone(),
+            scope: Some(ApprovalScope::DeliberationVote {
+                deliberation_id: delib.id,
+                proposal_hash: delib.proposal_hash,
+                position: v.position.as_str().to_string(),
+                reasoning_hash: v.reasoning_hash,
+            }),
         })
         .collect()
 }
@@ -313,6 +330,10 @@ mod tests {
             !close_verified.contains("compute_quorum(&approvals"),
             "production deliberation closure must not call structural quorum"
         );
+        assert!(
+            before_tests.contains("ApprovalScope::DeliberationVote"),
+            "production deliberation approvals must bind signatures to deliberation context"
+        );
     }
 
     fn vote(name: &str, pos: Position) -> Vote {
@@ -357,20 +378,26 @@ mod tests {
         attestation
     }
 
-    fn signed_vote(
+    fn signed_vote_for_deliberation(
+        delib: &Deliberation,
         name: &str,
         pos: Position,
         role: Role,
         keypair: &crypto::KeyPair,
-        timestamp: Timestamp,
     ) -> Vote {
         let attestation = signed_attestation(name, keypair);
         let mut approval = Approval {
             approver_did: did(name),
             role: role.clone(),
-            timestamp,
+            timestamp: delib.created,
             signature: Signature::Empty,
             independence_attestation: Some(attestation.clone()),
+            scope: Some(ApprovalScope::DeliberationVote {
+                deliberation_id: delib.id,
+                proposal_hash: delib.proposal_hash,
+                position: pos.as_str().to_string(),
+                reasoning_hash: [0u8; 32],
+            }),
         };
         let payload = approval
             .signing_payload()
@@ -512,17 +539,12 @@ mod tests {
         keys.insert(did("b"), *key_b.public_key());
 
         let mut d = open(b"p", &[did("a"), did("b"), did("c")]);
-        let created = d.created;
-        cast_vote(
-            &mut d,
-            signed_vote("a", Position::For, Role::Contributor, &key_a, created),
-        )
-        .unwrap();
-        cast_vote(
-            &mut d,
-            signed_vote("b", Position::For, Role::Contributor, &key_b, created),
-        )
-        .unwrap();
+        let vote_a =
+            signed_vote_for_deliberation(&d, "a", Position::For, Role::Contributor, &key_a);
+        let vote_b =
+            signed_vote_for_deliberation(&d, "b", Position::For, Role::Contributor, &key_b);
+        cast_vote(&mut d, vote_a).unwrap();
+        cast_vote(&mut d, vote_b).unwrap();
         cast_vote(&mut d, vote("c", Position::Against)).unwrap();
         assert!(matches!(
             close_verified(&mut d, &policy(2), &resolver(&keys)),
@@ -540,12 +562,9 @@ mod tests {
         keys.insert(did("a"), *key_a.public_key());
 
         let mut d = open(b"p", &[did("a"), did("b"), did("c")]);
-        let created = d.created;
-        cast_vote(
-            &mut d,
-            signed_vote("a", Position::For, Role::Contributor, &key_a, created),
-        )
-        .unwrap();
+        let vote_a =
+            signed_vote_for_deliberation(&d, "a", Position::For, Role::Contributor, &key_a);
+        cast_vote(&mut d, vote_a).unwrap();
         cast_vote(&mut d, vote("b", Position::Against)).unwrap();
         cast_vote(&mut d, vote("c", Position::Against)).unwrap();
         assert!(matches!(
@@ -571,17 +590,12 @@ mod tests {
         keys.insert(did("b"), *key_b.public_key());
 
         let mut d = open(b"p", &[did("a"), did("b"), did("c")]);
-        let created = d.created;
-        cast_vote(
-            &mut d,
-            signed_vote("a", Position::For, Role::Contributor, &key_a, created),
-        )
-        .unwrap();
-        cast_vote(
-            &mut d,
-            signed_vote("b", Position::For, Role::Contributor, &key_b, created),
-        )
-        .unwrap();
+        let vote_a =
+            signed_vote_for_deliberation(&d, "a", Position::For, Role::Contributor, &key_a);
+        let vote_b =
+            signed_vote_for_deliberation(&d, "b", Position::For, Role::Contributor, &key_b);
+        cast_vote(&mut d, vote_a).unwrap();
+        cast_vote(&mut d, vote_b).unwrap();
         cast_vote(&mut d, vote("c", Position::Abstain)).unwrap();
         assert!(matches!(
             close_verified(&mut d, &policy(2), &resolver(&keys)),
@@ -600,12 +614,9 @@ mod tests {
         keys.insert(alice, *alice_key.public_key());
 
         let mut d = open(b"p", &[did("alice")]);
-        let created = d.created;
-        cast_vote(
-            &mut d,
-            signed_vote("alice", Position::For, Role::Steward, &alice_key, created),
-        )
-        .unwrap();
+        let vote_alice =
+            signed_vote_for_deliberation(&d, "alice", Position::For, Role::Steward, &alice_key);
+        cast_vote(&mut d, vote_alice).unwrap();
 
         let quorum_policy = QuorumPolicy {
             min_approvals: 1,
@@ -631,8 +642,8 @@ mod tests {
         keys.insert(alice, *alice_key.public_key());
 
         let mut d = open(b"p", &[did("alice")]);
-        let created = d.created;
-        let mut forged = signed_vote("alice", Position::For, Role::Steward, &alice_key, created);
+        let mut forged =
+            signed_vote_for_deliberation(&d, "alice", Position::For, Role::Steward, &alice_key);
         forged.signature = test_sig();
         cast_vote(&mut d, forged).unwrap();
 
@@ -655,8 +666,8 @@ mod tests {
     fn close_without_resolver_fails_closed_for_unverified_quorum() {
         let alice_key = keypair(1);
         let mut d = open(b"p", &[did("alice")]);
-        let created = d.created;
-        let mut forged = signed_vote("alice", Position::For, Role::Steward, &alice_key, created);
+        let mut forged =
+            signed_vote_for_deliberation(&d, "alice", Position::For, Role::Steward, &alice_key);
         forged.signature = test_sig();
         cast_vote(&mut d, forged).unwrap();
 
@@ -683,12 +694,9 @@ mod tests {
         keys.insert(alice, *alice_key.public_key());
 
         let mut d = open(b"p", &[did("alice")]);
-        let created = d.created;
-        cast_vote(
-            &mut d,
-            signed_vote("alice", Position::For, Role::Steward, &alice_key, created),
-        )
-        .unwrap();
+        let vote_alice =
+            signed_vote_for_deliberation(&d, "alice", Position::For, Role::Steward, &alice_key);
+        cast_vote(&mut d, vote_alice).unwrap();
 
         let quorum_policy = QuorumPolicy {
             min_approvals: 1,
@@ -705,6 +713,111 @@ mod tests {
                 abstentions: 0
             }
         ));
+    }
+
+    #[test]
+    fn close_verified_rejects_vote_signature_replayed_to_other_deliberation() {
+        let alice_key = keypair(1);
+        let alice = did("alice");
+        let mut keys = BTreeMap::new();
+        keys.insert(alice, *alice_key.public_key());
+
+        let source = open_with_id(0xD210, b"proposal-a", &[did("alice")]);
+        let mut replay_target = open_deliberation(
+            delib_id(0xD211),
+            source.created,
+            b"proposal-b",
+            &[did("alice")],
+        )
+        .expect("deterministic target deliberation");
+        let vote_signed_for_source = signed_vote_for_deliberation(
+            &source,
+            "alice",
+            Position::For,
+            Role::Steward,
+            &alice_key,
+        );
+
+        cast_vote(&mut replay_target, vote_signed_for_source).unwrap();
+
+        let quorum_policy = QuorumPolicy {
+            min_approvals: 1,
+            min_independent: 1,
+            required_roles: vec![Role::Steward],
+            timeout: Timestamp::new(999_999, 0),
+        };
+
+        match close_verified(&mut replay_target, &quorum_policy, &resolver(&keys)) {
+            DeliberationResult::NoQuorum { reason } => {
+                assert!(
+                    reason.contains("verified"),
+                    "replayed deliberation vote signatures must fail verified quorum"
+                );
+            }
+            other => panic!("replayed vote must not close another deliberation: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn close_verified_rejects_vote_signature_replayed_to_other_position() {
+        let alice_key = keypair(1);
+        let alice = did("alice");
+        let mut keys = BTreeMap::new();
+        keys.insert(alice, *alice_key.public_key());
+
+        let mut d = open(b"p", &[did("alice")]);
+        let mut vote_alice =
+            signed_vote_for_deliberation(&d, "alice", Position::Against, Role::Steward, &alice_key);
+        vote_alice.position = Position::For;
+        cast_vote(&mut d, vote_alice).unwrap();
+
+        let quorum_policy = QuorumPolicy {
+            min_approvals: 1,
+            min_independent: 1,
+            required_roles: vec![Role::Steward],
+            timeout: Timestamp::new(999_999, 0),
+        };
+
+        match close_verified(&mut d, &quorum_policy, &resolver(&keys)) {
+            DeliberationResult::NoQuorum { reason } => {
+                assert!(
+                    reason.contains("verified"),
+                    "vote position changes must invalidate scoped signatures"
+                );
+            }
+            other => panic!("position-replayed vote must not close deliberation: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn close_verified_rejects_vote_signature_replayed_to_other_reasoning_hash() {
+        let alice_key = keypair(1);
+        let alice = did("alice");
+        let mut keys = BTreeMap::new();
+        keys.insert(alice, *alice_key.public_key());
+
+        let mut d = open(b"p", &[did("alice")]);
+        let mut vote_alice =
+            signed_vote_for_deliberation(&d, "alice", Position::For, Role::Steward, &alice_key);
+        vote_alice.reasoning_hash = [7u8; 32];
+        cast_vote(&mut d, vote_alice).unwrap();
+
+        let quorum_policy = QuorumPolicy {
+            min_approvals: 1,
+            min_independent: 1,
+            required_roles: vec![Role::Steward],
+            timeout: Timestamp::new(999_999, 0),
+        };
+
+        match close_verified(&mut d, &quorum_policy, &resolver(&keys)) {
+            DeliberationResult::NoQuorum { reason } => {
+                assert!(
+                    reason.contains("verified"),
+                    "reasoning-hash changes must invalidate scoped signatures"
+                );
+            }
+            other => panic!("reasoning-replayed vote must not close deliberation: {other:?}"),
+        }
     }
     #[test]
     fn close_does_not_overwrite_cancelled_deliberation() {

--- a/crates/exo-governance/src/quorum.rs
+++ b/crates/exo-governance/src/quorum.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeSet;
 
 use exo_core::{Did, PublicKey, Signature, Timestamp, crypto};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::{
     challenge::{Challenge, ChallengeStatus},
@@ -119,25 +120,55 @@ pub struct Approval {
     pub timestamp: Timestamp,
     pub signature: Signature,
     pub independence_attestation: Option<IndependenceAttestation>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<ApprovalScope>,
+}
+
+/// Optional context that binds a quorum approval to one governed action.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ApprovalScope {
+    DeliberationVote {
+        deliberation_id: Uuid,
+        proposal_hash: [u8; 32],
+        position: String,
+        reasoning_hash: [u8; 32],
+    },
 }
 
 impl Approval {
     /// Canonical CBOR payload that the approver signs.
     ///
-    /// The approval signature binds the approver, role, timestamp, and attached
-    /// independence attestation. The `signature` field itself is excluded.
+    /// The approval signature binds the approver, role, timestamp, attached
+    /// independence attestation, and optional action scope. The `signature`
+    /// field itself is excluded. Unscoped approvals retain the v1 payload for
+    /// compatibility; scoped approvals use v2 so signatures cannot be replayed
+    /// into a different governed action.
     pub fn signing_payload(&self) -> Result<Vec<u8>, GovernanceError> {
-        let tuple = (
-            "exo.governance.quorum.approval.v1",
-            &self.approver_did,
-            &self.role,
-            &self.timestamp,
-            &self.independence_attestation,
-        );
         let mut buf = Vec::new();
-        ciborium::ser::into_writer(&tuple, &mut buf).map_err(|e| {
-            GovernanceError::Serialization(format!("approval canonical encoding failed: {e}"))
-        })?;
+        if let Some(scope) = &self.scope {
+            let tuple = (
+                "exo.governance.quorum.approval.v2",
+                &self.approver_did,
+                &self.role,
+                &self.timestamp,
+                &self.independence_attestation,
+                scope,
+            );
+            ciborium::ser::into_writer(&tuple, &mut buf).map_err(|e| {
+                GovernanceError::Serialization(format!("approval canonical encoding failed: {e}"))
+            })?;
+        } else {
+            let tuple = (
+                "exo.governance.quorum.approval.v1",
+                &self.approver_did,
+                &self.role,
+                &self.timestamp,
+                &self.independence_attestation,
+            );
+            ciborium::ser::into_writer(&tuple, &mut buf).map_err(|e| {
+                GovernanceError::Serialization(format!("approval canonical encoding failed: {e}"))
+            })?;
+        }
         Ok(buf)
     }
 
@@ -561,6 +592,7 @@ mod tests {
             } else {
                 None
             },
+            scope: None,
         }
     }
 
@@ -647,6 +679,7 @@ mod tests {
                 timestamp: Timestamp::new(1000, 0),
                 signature: test_sig(),
                 independence_attestation: Some(invalid_attestation(&d)),
+                scope: None,
             },
         ];
         assert_verified_quorum_required(compute_quorum(&approvals, &default_policy()));
@@ -1046,16 +1079,7 @@ mod tests {
     }
 
     fn approval_signing_payload_for_test(approval: &Approval) -> Vec<u8> {
-        let tuple = (
-            "exo.governance.quorum.approval.v1",
-            &approval.approver_did,
-            &approval.role,
-            &approval.timestamp,
-            &approval.independence_attestation,
-        );
-        let mut buf = Vec::new();
-        ciborium::ser::into_writer(&tuple, &mut buf).expect("approval payload");
-        buf
+        approval.signing_payload().expect("approval payload")
     }
 
     fn properly_signed_approval(
@@ -1081,6 +1105,7 @@ mod tests {
             timestamp,
             signature: Signature::Empty,
             independence_attestation: attestation,
+            scope: None,
         };
         let payload = approval_signing_payload_for_test(&approval);
         approval.signature = crypto::sign(&payload, sk);
@@ -1323,6 +1348,7 @@ mod tests {
             timestamp: Timestamp::new(1000, 0),
             signature: Signature::Ed25519([9u8; 64]),
             independence_attestation: Some(att),
+            scope: None,
         };
         let resolver =
             |d: &Did| -> Option<PublicKey> { if *d == alice { Some(pk_alice) } else { None } };
@@ -1342,6 +1368,45 @@ mod tests {
     }
 
     #[test]
+    fn approval_signing_payload_binds_optional_scope() {
+        let alice = did("alice");
+        let base = Approval {
+            approver_did: alice,
+            role: Role::Steward,
+            timestamp: Timestamp::new(1000, 0),
+            signature: Signature::Empty,
+            independence_attestation: None,
+            scope: None,
+        };
+        let unscoped = base.signing_payload().expect("unscoped payload");
+        let mut scoped_a = base.clone();
+        scoped_a.scope = Some(ApprovalScope::DeliberationVote {
+            deliberation_id: Uuid::from_u128(0xA001),
+            proposal_hash: [1u8; 32],
+            position: "For".to_string(),
+            reasoning_hash: [2u8; 32],
+        });
+        let mut scoped_b = scoped_a.clone();
+        scoped_b.scope = Some(ApprovalScope::DeliberationVote {
+            deliberation_id: Uuid::from_u128(0xA002),
+            proposal_hash: [1u8; 32],
+            position: "For".to_string(),
+            reasoning_hash: [2u8; 32],
+        });
+
+        assert_ne!(
+            unscoped,
+            scoped_a.signing_payload().expect("scoped payload"),
+            "scoped quorum approvals must not share the legacy unscoped signature payload"
+        );
+        assert_ne!(
+            scoped_a.signing_payload().expect("scoped payload"),
+            scoped_b.signing_payload().expect("changed scoped payload"),
+            "changing approval scope must change the canonical signature payload"
+        );
+    }
+
+    #[test]
     fn compute_quorum_verified_requires_attestation_from_approver() {
         let (pk_alice, sk_alice) = crypto::generate_keypair();
         let (pk_bob, sk_bob) = crypto::generate_keypair();
@@ -1354,6 +1419,7 @@ mod tests {
             timestamp: Timestamp::new(1000, 0),
             signature: Signature::Empty,
             independence_attestation: Some(alice_att),
+            scope: None,
         };
         let payload = approval_signing_payload_for_test(&bob_approval);
         bob_approval.signature = crypto::sign(&payload, &sk_bob);
@@ -1395,6 +1461,7 @@ mod tests {
             timestamp: Timestamp::new(10_000, 0),
             signature: test_sig(),
             independence_attestation: Some(att),
+            scope: None,
         }];
         let policy = QuorumPolicy {
             min_approvals: 1,
@@ -1423,6 +1490,7 @@ mod tests {
             timestamp: Timestamp::new(1000, 0),
             signature: test_sig(),
             independence_attestation: None,
+            scope: None,
         };
         // Replace DID with one whose as_str() is empty via a direct constructor.
         // Did::new rejects empties, so fabricate one by cloning and mutating


### PR DESCRIPTION
## Classification
- EXOCHAIN core: crates/exo-governance/src/deliberation.rs
- EXOCHAIN core: crates/exo-governance/src/quorum.rs
- Documentation metadata: README.md repo-truth counters only

## Finding validation
Current code converted deliberation For votes into generic quorum approvals. The quorum signature payload bound approver, role, timestamp, and independence attestation, but not the deliberation ID, proposal hash, vote position, or reasoning hash. A valid vote signature from one deliberation could therefore be replayed into another deliberation with matching identity and timestamp.

## Remediation
- Added optional ApprovalScope with a DeliberationVote scope.
- Kept unscoped approval payloads on the existing v1 domain for compatibility.
- Scoped approvals use a v2 domain and bind deliberation_id, proposal_hash, position, and reasoning_hash.
- Deliberation closure now derives scoped approvals before verified quorum evaluation.
- Added regression tests for replay across deliberation, position, and reasoning hash.

## TDD evidence
Red test before fix:
- cargo test -p exo-governance close_verified_rejects_vote_signature_replayed_to_other_deliberation -- --nocapture failed with an unexpected Approved quorum.

Green validation:
- cargo test -p exo-governance close_verified_rejects_vote_signature_replayed_to_other_deliberation -- --nocapture
- cargo test -p exo-governance close_verified_rejects_vote_signature_replayed -- --nocapture
- cargo test -p exo-governance approval_signing_payload_binds_optional_scope -- --nocapture
- cargo test -p exo-governance production_deliberation_closure_uses_verified_quorum_only -- --nocapture
- cargo test -p exo-governance
- cargo clippy -p exo-governance --all-targets -- -D warnings
- cargo +nightly fmt --all -- --check
- git diff --check
- bash tools/test_repo_truth.sh
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo build --workspace --release
- cargo doc --workspace --no-deps
- cargo audit
- cargo deny check

cargo deny exits 0; duplicate-crate warnings remain pre-existing workspace warnings.