### PR TITLE
Bind gateway vote actor kind to session profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 182612 | `wc -l` |
-| Workspace tests | 4,280 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 182777 | `wc -l` |
+| Workspace tests | 4,284 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -27,7 +27,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,280 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,284 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -96,9 +96,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 182612 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 182777 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,280 listed workspace tests
+         cryptographic proofs, 4,284 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-gateway/src/handlers.rs
+++ b/crates/exo-gateway/src/handlers.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sqlx::Row;
 
-use crate::server::{AppState, auth_boundary_error_response};
+use crate::server::{AppState, AuthenticatedSessionUser, auth_boundary_error_response};
 
 // ── Violation 3 fix: CBOR canonical hashing ──────────────────────────────
 
@@ -164,6 +164,7 @@ fn vote_action_hash(
     request: &VoteRequest,
     voter_did: &Did,
     affected_dids: &[Did],
+    actor_kind: &ActorKind,
 ) -> Result<Hash256, String> {
     let mut affected_dids = affected_dids.iter().map(Did::as_str).collect::<Vec<&str>>();
     affected_dids.sort_unstable();
@@ -175,7 +176,7 @@ fn vote_action_hash(
         decision_id: request.decision_id.as_str(),
         affected_dids,
         choice: vote_choice_label(request.choice),
-        actor_kind: &request.actor_kind,
+        actor_kind,
         rationale: request.rationale.as_deref(),
         timestamp_physical_ms: request.timestamp_physical_ms,
         timestamp_logical: request.timestamp_logical,
@@ -189,9 +190,10 @@ fn vote_action_provenance(
     request: &VoteRequest,
     voter_did: &Did,
     affected_dids: &[Did],
+    actor_kind: &ActorKind,
 ) -> Result<Provenance, String> {
     let timestamp = request.caller_supplied_provenance_timestamp()?;
-    let action_hash = vote_action_hash(request, voter_did, affected_dids)?;
+    let action_hash = vote_action_hash(request, voter_did, affected_dids, actor_kind)?;
     let signature = request.provenance_signature()?;
     Ok(Provenance {
         actor: voter_did.clone(),
@@ -408,6 +410,13 @@ impl VoteRequest {
     }
 }
 
+fn trusted_vote_actor_kind(actor: &AuthenticatedSessionUser) -> Result<ActorKind, String> {
+    if actor.status == "Active" {
+        return Ok(ActorKind::Human);
+    }
+    Err("voter is not eligible".to_owned())
+}
+
 /// Handle a vote submission with conflict-of-interest and authority chain checks.
 pub async fn vote_handler(
     State(state): State<AppState>,
@@ -441,6 +450,19 @@ pub async fn vote_handler(
         )
             .into_response();
     }
+    let actor_kind = match trusted_vote_actor_kind(&actor) {
+        Ok(actor_kind) => actor_kind,
+        Err(e) => {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(serde_json::json!({
+                    "error": "voter is not eligible",
+                    "message": e
+                })),
+            )
+                .into_response();
+        }
+    };
     let affected_dids = match body.caller_supplied_affected_dids() {
         Ok(dids) => dids,
         Err(e) => {
@@ -483,7 +505,7 @@ pub async fn vote_handler(
             .into_response();
     }
 
-    let provenance = match vote_action_provenance(&body, &voter_did, &affected_dids) {
+    let provenance = match vote_action_provenance(&body, &voter_did, &affected_dids, &actor_kind) {
         Ok(provenance) => provenance,
         Err(e) => {
             return (
@@ -687,7 +709,7 @@ pub async fn vote_handler(
     let vote = Vote {
         voter_did: voter_did.clone(),
         choice: body.choice,
-        actor_kind: body.actor_kind,
+        actor_kind: actor_kind.clone(),
         timestamp,
         signature_hash,
     };
@@ -888,8 +910,8 @@ mod tests {
             provenance_public_key: hex::encode(public_key.as_bytes()),
             provenance_signature: String::new(),
         };
-        let action_hash =
-            vote_action_hash(&request, &voter_did, &affected).expect("vote action hash");
+        let action_hash = vote_action_hash(&request, &voter_did, &affected, &actor_kind)
+            .expect("vote action hash");
         let mut provenance = Provenance {
             actor: voter_did,
             timestamp: hlc_timestamp_string(provenance_timestamp),
@@ -1001,36 +1023,88 @@ mod tests {
         ))
         .expect("signed vote request");
 
-        let baseline = vote_action_hash(&request, &voter, &affected).expect("vote action hash");
+        let trusted_actor_kind = ActorKind::Human;
+        let baseline = vote_action_hash(&request, &voter, &affected, &trusted_actor_kind)
+            .expect("vote action hash");
 
         let mut changed_decision = request;
         changed_decision.decision_id = "decision-2".to_owned();
         let changed_decision_hash =
-            vote_action_hash(&changed_decision, &voter, &affected).expect("vote action hash");
+            vote_action_hash(&changed_decision, &voter, &affected, &trusted_actor_kind)
+                .expect("vote action hash");
         assert_ne!(baseline, changed_decision_hash);
 
         let mut changed_choice = changed_decision;
         changed_choice.decision_id = "decision-1".to_owned();
         changed_choice.choice = VoteChoice::Reject;
         let changed_choice_hash =
-            vote_action_hash(&changed_choice, &voter, &affected).expect("vote action hash");
+            vote_action_hash(&changed_choice, &voter, &affected, &trusted_actor_kind)
+                .expect("vote action hash");
         assert_ne!(baseline, changed_choice_hash);
 
         let changed_affected = vec![Did::new("did:exo:tenant-c").expect("valid DID")];
-        let changed_affected_hash =
-            vote_action_hash(&changed_choice, &voter, &changed_affected).expect("vote action hash");
+        let changed_affected_hash = vote_action_hash(
+            &changed_choice,
+            &voter,
+            &changed_affected,
+            &trusted_actor_kind,
+        )
+        .expect("vote action hash");
         assert_ne!(baseline, changed_affected_hash);
 
         let reordered_affected = vec![
             Did::new("did:exo:tenant-a").expect("valid DID"),
             Did::new("did:exo:tenant-b").expect("valid DID"),
         ];
-        let reordered_hash = vote_action_hash(&changed_choice, &voter, &reordered_affected)
-            .expect("vote action hash");
+        let reordered_hash = vote_action_hash(
+            &changed_choice,
+            &voter,
+            &reordered_affected,
+            &trusted_actor_kind,
+        )
+        .expect("vote action hash");
         assert_ne!(baseline, reordered_hash);
         assert_eq!(
             changed_choice_hash, reordered_hash,
             "affected DID ordering must not alter the canonical vote action hash"
+        );
+    }
+
+    #[test]
+    fn vote_action_hash_binds_trusted_actor_kind_not_request_body_actor_kind() {
+        let voter = Did::new("did:exo:alice").expect("valid DID");
+        let affected = vec![Did::new("did:exo:tenant-a").expect("valid DID")];
+        let mut request: VoteRequest = serde_json::from_value(signed_vote_request_json(
+            "did:exo:alice",
+            "decision-1",
+            &["did:exo:tenant-a"],
+            VoteChoice::Approve,
+            ActorKind::Human,
+            exo_core::Timestamp::new(7000, 2),
+        ))
+        .expect("signed vote request");
+
+        let trusted_actor_kind = ActorKind::Human;
+        let baseline = vote_action_hash(&request, &voter, &affected, &trusted_actor_kind)
+            .expect("vote action hash");
+        request.actor_kind = ActorKind::AiAgent {
+            delegation_id: "delegation-1".to_owned(),
+            ceiling_class: decision_forum::decision_object::DecisionClass::Routine,
+        };
+        let client_claim_changed =
+            vote_action_hash(&request, &voter, &affected, &trusted_actor_kind)
+                .expect("vote action hash");
+        let trusted_actor_changed =
+            vote_action_hash(&request, &voter, &affected, &request.actor_kind)
+                .expect("vote action hash");
+
+        assert_eq!(
+            baseline, client_claim_changed,
+            "changing only request.actor_kind must not alter a trusted vote action hash"
+        );
+        assert_ne!(
+            baseline, trusted_actor_changed,
+            "changing the trusted actor kind must alter the vote action hash"
         );
     }
 
@@ -1047,8 +1121,8 @@ mod tests {
             exo_core::Timestamp::new(7000, 2),
         ))
         .expect("signed vote request");
-        let provenance =
-            vote_action_provenance(&request, &voter, &affected).expect("vote provenance");
+        let provenance = vote_action_provenance(&request, &voter, &affected, &ActorKind::Human)
+            .expect("vote provenance");
         let message = exo_gatekeeper::provenance_signature_message(&provenance)
             .expect("canonical provenance payload");
         let public_key = exo_core::PublicKey::from_bytes(
@@ -1544,6 +1618,95 @@ mod tests {
         assert!(
             !vote_handler.contains("let eligible_human_voters = eligible_voters"),
             "vote handler must not assume every registered DID is a human eligible voter"
+        );
+    }
+
+    #[test]
+    fn vote_handler_derives_actor_kind_from_authenticated_session_not_body() {
+        let source = include_str!("handlers.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("test module marker present");
+        let vote_handler = production
+            .split("pub async fn vote_handler")
+            .nth(1)
+            .expect("vote handler source present")
+            .split("// Add vote")
+            .next()
+            .expect("vote construction block present");
+
+        assert!(
+            production.contains("fn trusted_vote_actor_kind("),
+            "gateway vote actor kind must be derived at the runtime adapter boundary"
+        );
+        assert!(
+            vote_handler.contains("let actor_kind = match trusted_vote_actor_kind(&actor)")
+                && vote_handler.contains("Ok(actor_kind) => actor_kind"),
+            "vote handler must derive vote actor kind from the authenticated session profile"
+        );
+        assert!(
+            vote_handler
+                .contains("vote_action_provenance(&body, &voter_did, &affected_dids, &actor_kind)"),
+            "vote provenance must bind the trusted actor kind, not the caller-supplied body field"
+        );
+        assert!(
+            vote_handler.contains("actor_kind: actor_kind.clone()"),
+            "stored vote actor kind must come from the authenticated session profile"
+        );
+        assert!(
+            !vote_handler.contains("actor_kind: body.actor_kind"),
+            "vote handler must not let clients self-attest human quorum status"
+        );
+    }
+
+    #[test]
+    fn vote_actor_kind_derivation_requires_active_session_user_profile() {
+        let handler_source = include_str!("handlers.rs");
+        let handler_production = handler_source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("test module marker present");
+        let server_source = include_str!("server.rs");
+
+        assert!(
+            server_source.contains("pub status: String"),
+            "authenticated session profiles must carry user status to vote eligibility boundaries"
+        );
+        assert!(
+            server_source.contains("status: user.status"),
+            "session user resolution must preserve the status loaded from the users table"
+        );
+        assert!(
+            handler_production.contains("actor.status == \"Active\""),
+            "trusted vote actor-kind derivation must only classify active users as human voters"
+        );
+        assert!(
+            handler_production.contains("\"voter is not eligible\""),
+            "vote handler must fail closed when the authenticated user is not vote-eligible"
+        );
+    }
+
+    #[test]
+    fn trusted_vote_actor_kind_accepts_only_active_session_users() {
+        let actor = AuthenticatedSessionUser {
+            did: Did::new("did:exo:active-voter").expect("valid DID"),
+            tenant_id: "tenant-a".to_owned(),
+            status: "Active".to_owned(),
+        };
+        assert_eq!(
+            trusted_vote_actor_kind(&actor).expect("active user is a human voter"),
+            ActorKind::Human
+        );
+
+        let inactive_actor = AuthenticatedSessionUser {
+            did: Did::new("did:exo:inactive-voter").expect("valid DID"),
+            tenant_id: "tenant-a".to_owned(),
+            status: "Suspended".to_owned(),
+        };
+        assert_eq!(
+            trusted_vote_actor_kind(&inactive_actor).expect_err("inactive user must fail closed"),
+            "voter is not eligible"
         );
     }
 

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -294,6 +294,7 @@ pub struct AppState {
 pub struct AuthenticatedSessionUser {
     pub did: Did,
     pub tenant_id: String,
+    pub status: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -467,6 +468,7 @@ impl AppState {
         Ok(AuthenticatedSessionUser {
             did,
             tenant_id: user.tenant_id,
+            status: user.status,
         })
     }
 


### PR DESCRIPTION
## Classification

- `crates/exo-gateway/src/handlers.rs`: core runtime adapter
- `crates/exo-gateway/src/server.rs`: core runtime adapter
- `README.md`: documentation / repository truth

## Finding Confirmed

Gateway REST vote handling accepted client-supplied `actor_kind` and used it in vote provenance hashing and stored `Vote` records. Decision-forum quorum logic treats human and delegated/agent votes differently, so a caller-controlled actor kind could self-attest human quorum status if the handler is mounted or called by an adapter.

## Remediation

- Derive vote actor kind from the authenticated session profile at the gateway boundary.
- Preserve user `status` in `AuthenticatedSessionUser` so vote eligibility is based on trusted session/user state.
- Fail closed for inactive/non-eligible users.
- Keep the request field wire-compatible, but ignore it for trust decisions.
- Bind the trusted actor kind into vote provenance/action hashing and stored votes.

## TDD Evidence

Red tests were added and observed failing before production changes:

- `cargo test -p exo-gateway vote_handler_derives_actor_kind_from_authenticated_session_not_body -- --nocapture`
- `cargo test -p exo-gateway vote_actor_kind_derivation_requires_active_session_user_profile -- --nocapture`

## Validation

- `cargo test -p exo-gateway actor_kind -- --nocapture`
- `cargo test -p exo-gateway`
- `cargo test --workspace`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --release`
- `cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check` (passes with existing duplicate-crate warnings)
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `cargo test --workspace -- --list | grep -c ': test$'` -> `4284`
- Bypass search: only test-source references remain for request-body `actor_kind` use.
