### PR TITLE
Require self-certifying DID registration proofs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 182777 | `wc -l` |
-| Workspace tests | 4,284 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 187614 | `wc -l` |
+| Workspace tests | 4,285 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -45,7 +45,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,284 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,285 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -114,9 +114,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 182777 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 187614 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,284 listed workspace tests
+         cryptographic proofs, 4,285 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -4803,8 +4803,8 @@ mod tests {
         }
     }
 
-    fn keyed_doc(did_str: &str, public_key: exo_core::PublicKey) -> DidDocument {
-        let did = Did::new(did_str).expect("valid DID");
+    fn canonical_keyed_doc(public_key: exo_core::PublicKey) -> DidDocument {
+        let did = exo_identity::did::did_from_public_key(&public_key).expect("canonical DID");
         did_document_with_ed25519_key(&did, &public_key)
     }
 
@@ -5387,7 +5387,7 @@ mod tests {
     #[tokio::test]
     async fn auth_register_accepts_valid_registration_proof() {
         let (public_key, secret_key) = generate_keypair();
-        let doc = keyed_doc("did:exo:tester", public_key);
+        let doc = canonical_keyed_doc(public_key);
         let body = registration_request_body(&doc, &public_key, &secret_key);
         let app = build_router(state());
         let resp = app
@@ -5408,7 +5408,9 @@ mod tests {
     async fn auth_register_rejects_registration_proof_from_unlisted_key() {
         let (document_public_key, _) = generate_keypair();
         let (attacker_public_key, attacker_secret_key) = generate_keypair();
-        let doc = keyed_doc("did:exo:unlisted-registration-key", document_public_key);
+        let attacker_did =
+            exo_identity::did::did_from_public_key(&attacker_public_key).expect("canonical DID");
+        let doc = did_document_with_ed25519_key(&attacker_did, &document_public_key);
         let body = registration_request_body(&doc, &attacker_public_key, &attacker_secret_key);
         let app = build_router(state());
         let resp = app
@@ -5429,7 +5431,7 @@ mod tests {
     #[tokio::test]
     async fn auth_register_duplicate_returns_409() {
         let (public_key, secret_key) = generate_keypair();
-        let doc = keyed_doc("did:exo:dup", public_key);
+        let doc = canonical_keyed_doc(public_key);
         let registry = Arc::new(RwLock::new(LocalDidRegistry::new()));
         registry.write().unwrap().register(doc.clone()).unwrap();
         let st = AppState::new(None, registry);
@@ -5463,7 +5465,7 @@ mod tests {
         }
 
         let st = AppState::new(None, registry);
-        let overflow_doc = keyed_doc("did:exo:capacity-overflow", pk);
+        let overflow_doc = canonical_keyed_doc(pk);
         let body = registration_request_body(&overflow_doc, &pk, &sk);
         let app = build_router(st);
         let resp = app
@@ -6609,7 +6611,7 @@ mod tests {
     #[tokio::test]
     async fn agents_enroll_returns_201() {
         let (public_key, secret_key) = generate_keypair();
-        let doc = keyed_doc("did:exo:enrollee", public_key);
+        let doc = canonical_keyed_doc(public_key);
         let body = registration_request_body(&doc, &public_key, &secret_key);
         let app = build_router(state());
         let resp = app

--- a/crates/exo-identity/src/registry.rs
+++ b/crates/exo-identity/src/registry.rs
@@ -20,7 +20,7 @@ use exo_core::{Did, PublicKey, Signature, Timestamp, crypto};
 use serde::Serialize;
 
 use crate::{
-    did::{DidDocument, DidRegistrationProof, RevocationProof},
+    did::{DidDocument, DidRegistrationProof, RevocationProof, did_from_public_key},
     error::IdentityError,
 };
 
@@ -141,6 +141,22 @@ pub fn verify_did_registration_proof(
     proof: &DidRegistrationProof,
 ) -> Result<(), IdentityError> {
     validate_registered_did_document(doc)?;
+
+    let derived_did = did_from_public_key(&proof.public_key).map_err(|e| {
+        IdentityError::InvalidRegistrationProof {
+            did: doc.id.clone(),
+            reason: format!("proof public key cannot derive a canonical EXOCHAIN DID: {e}"),
+        }
+    })?;
+    if derived_did != doc.id {
+        return Err(IdentityError::InvalidRegistrationProof {
+            did: doc.id.clone(),
+            reason: format!(
+                "DID subject must equal canonical DID derived from proof public key: expected {}",
+                derived_did
+            ),
+        });
+    }
 
     if !doc.public_keys.iter().any(|key| key == &proof.public_key) {
         return Err(IdentityError::InvalidRegistrationProof {
@@ -914,7 +930,7 @@ mod tests {
     #[test]
     fn register_with_proof_accepts_document_signed_by_declared_key() {
         let (pk, sk) = generate_keypair();
-        let did = make_did("proof-registered");
+        let did = did_from_public_key(&pk).expect("canonical DID");
         let doc = make_doc(did.clone(), pk);
         let proof = registration_proof(&doc, pk, &sk);
 
@@ -924,6 +940,25 @@ mod tests {
         let resolved = reg.resolve(&did).unwrap();
         assert_eq!(resolved.id, did);
         assert_eq!(resolved.public_keys, vec![pk]);
+    }
+
+    #[test]
+    fn register_with_proof_rejects_non_self_certifying_did() {
+        let (attacker_pk, attacker_sk) = generate_keypair();
+        let victim_did = make_did("unclaimed-victim");
+        let doc = make_doc(victim_did, attacker_pk);
+        let proof = registration_proof(&doc, attacker_pk, &attacker_sk);
+
+        let mut reg = LocalDidRegistry::new();
+        let err = reg
+            .register_with_proof(doc, &proof)
+            .expect_err("registration proof must bind the DID subject to the proof key");
+
+        assert!(matches!(
+            err,
+            IdentityError::InvalidRegistrationProof { .. }
+        ));
+        assert_eq!(reg.len(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Confirmed against current main that DID registration proofs verified a declared key signature without requiring the DID subject to equal the canonical DID derived from the proof public key.
- Enforce self-certifying DID registration by deriving `did:exo:*` from the proof public key before accepting the registration proof.
- Refresh gateway registration fixtures to use canonical DIDs and update README repo-truth metrics.

## Path Classification
- `crates/exo-identity/src/registry.rs`: EXOCHAIN core.
- `crates/exo-gateway/src/server.rs`: Core runtime adapter tests.
- `README.md`: Documentation / repo-truth.

## TDD / Confirmation
- Added `register_with_proof_rejects_non_self_certifying_did` first; it failed before the production change because arbitrary unclaimed `did:exo:*` subjects could be registered by a declared attacker key.
- Existing positive registration proof coverage was updated to use `did_from_public_key`, preserving valid canonical registration behavior.

## Local Validation
- `cargo test -p exo-identity register_with_proof_rejects_non_self_certifying_did -- --nocapture`
- `cargo test -p exo-identity`
- `cargo test -p exo-gateway auth_register -- --nocapture`
- `cargo test -p exo-gateway`
- `cargo clippy -p exo-identity -p exo-gateway --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --release`
- `cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check` (passes with existing duplicate-crate warnings)
- `bash tools/test_repo_truth.sh`
- `cargo test --workspace -- --list` -> 4,285 listed tests
