### PR TITLE
fix(site): harden contact email configuration

### DIFF
--- a/site/.env.example
+++ b/site/.env.example
@@ -24,3 +24,9 @@ EXO_GATEWAY_URL=                         # exo-gateway base URL once available
 EXO_OIDC_ISSUER=                         # OIDC issuer URL (v0.5+)
 EXO_OIDC_CLIENT_ID=                      # OIDC client id (v0.5+)
 EXO_OIDC_CLIENT_SECRET=                  # OIDC client secret (v0.5+)
+
+# Contact form email delivery. RESEND_API_KEY must be a server-only Resend key
+# beginning with "re_"; do not quote the value in Railway.
+RESEND_API_KEY=
+CONTACT_FROM_EMAIL=support@exochain.io
+CONTACT_TO_EMAIL=support@exochain.io

--- a/site/src/app/api/contact/route.ts
+++ b/site/src/app/api/contact/route.ts
@@ -24,11 +24,47 @@ type ContactPayload = {
   intendedUse?: string;
 };
 
+type EmailConfig = {
+  apiKey: string;
+  fromEmail: string;
+  toEmail: string;
+};
+
+const RESEND_API_KEY_PREFIX = 're_';
+const CONTACT_DELIVERY_ERROR = 'Unable to send email right now.';
+const EMAIL_TRANSPORT_CONFIG_ERROR = 'Email transport is not configured.';
+
 function clean(value: unknown): string {
   if (typeof value !== 'string') {
     return '';
   }
   return value.trim();
+}
+
+function normalizeSecret(value: string | undefined): string {
+  let normalized = value?.trim() || '';
+  const hasDoubleQuotes = normalized.startsWith('"') && normalized.endsWith('"');
+  const hasSingleQuotes = normalized.startsWith("'") && normalized.endsWith("'");
+
+  if (normalized.length >= 2 && (hasDoubleQuotes || hasSingleQuotes)) {
+    normalized = normalized.slice(1, -1).trim();
+  }
+
+  return normalized;
+}
+
+function getEmailConfig(): EmailConfig | null {
+  const apiKey = normalizeSecret(process.env.RESEND_API_KEY);
+
+  if (!apiKey || !apiKey.startsWith(RESEND_API_KEY_PREFIX)) {
+    return null;
+  }
+
+  return {
+    apiKey,
+    toEmail: clean(process.env.CONTACT_TO_EMAIL) || 'support@exochain.io',
+    fromEmail: clean(process.env.CONTACT_FROM_EMAIL) || 'support@exochain.io',
+  };
 }
 
 function getPayload(data: Record<string, unknown>): ContactPayload {
@@ -70,26 +106,22 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'Name and email are required.' }, { status: 400 });
   }
 
-  const toEmail = process.env.CONTACT_TO_EMAIL || 'support@exochain.io';
-  const fromEmail = process.env.CONTACT_FROM_EMAIL || 'support@exochain.io';
-  const apiKey = process.env.RESEND_API_KEY;
+  const emailConfig = getEmailConfig();
 
-  if (!apiKey) {
-    return NextResponse.json(
-      { error: 'Email transport is not configured.' },
-      { status: 503 },
-    );
+  if (!emailConfig) {
+    console.error('Contact form email transport is missing a valid Resend API key.');
+    return NextResponse.json({ error: EMAIL_TRANSPORT_CONFIG_ERROR }, { status: 503 });
   }
 
   const response = await fetch('https://api.resend.com/emails', {
     method: 'POST',
     headers: {
-      Authorization: `Bearer ${apiKey}`,
+      Authorization: `Bearer ${emailConfig.apiKey}`,
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      from: fromEmail,
-      to: [toEmail],
+      from: emailConfig.fromEmail,
+      to: [emailConfig.toEmail],
       reply_to: incoming.email,
       subject: `Inquiry from ${incoming.name} (${incoming.email})`,
       text: toText(incoming),
@@ -98,10 +130,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   if (!response.ok) {
     const detail = await response.text();
-    return NextResponse.json(
-      { error: `Failed to send email: ${detail || 'provider error.'}` },
-      { status: 502 },
-    );
+    console.error('Contact form email provider failure.', {
+      status: response.status,
+      detail: detail.slice(0, 500),
+    });
+    return NextResponse.json({ error: CONTACT_DELIVERY_ERROR }, { status: 502 });
   }
 
   return NextResponse.json({ ok: true });


### PR DESCRIPTION
## Summary
- normalize and validate the server-only Resend API key before calling Resend
- stop returning raw provider error bodies from the contact form API
- document required contact-form Railway variables in `site/.env.example`

## Classification
- `site/src/app/api/contact/route.ts` — Adjacent surface
- `site/.env.example` — Adjacent surface
- No EXOCHAIN core, core runtime adapter, governance, CI, or deployment contract paths changed.

## Adjacent Surface Intake
- Owner/accountable maintainer: EXOCHAIN website operations, Bob Stewart
- Deployment status: production on Railway service `just-truth`, root directory `/site`
- Constitutional trust claims: this contact form is not an EXOCHAIN enforcement path and does not prove constitutional enforcement
- Core state access: no read/write access to core state, signatures, credentials, governance outcomes, consent records, or provenance records
- Trust boundary: public browser form -> Next.js `/api/contact` route -> Resend email API; failures stay inside the route and fail closed
- Test command and CI gate: `npm run typecheck`, `npm run lint`, `npm run build`
- Secrets/config: `RESEND_API_KEY`, `CONTACT_FROM_EMAIL`, `CONTACT_TO_EMAIL` in Railway service variables; `RESEND_API_KEY` must be a server-only key beginning with `re_`
- Rollback/disablement: revert this commit or roll back the Railway deployment; clearing/malforming `RESEND_API_KEY` disables delivery with HTTP 503

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Local smoke: `re_invalid...` provider response returns generic 502
- Local smoke: malformed API key returns 503 without calling provider
- Production smoke after Railway redeploy still returns Resend 401 on current `main`; Railway `RESEND_API_KEY` remains invalid and must be replaced with a valid Resend key for delivery to succeed.

## Sources
- Resend send-email API docs: https://resend.com/docs/api-reference/emails/send-email