### PR TITLE
fix(site): queue contact submissions in Postgres

### DIFF
--- a/site/.env.example
+++ b/site/.env.example
@@ -27,6 +27,7 @@ EXO_OIDC_CLIENT_SECRET=                  # OIDC client secret (v0.5+)
 
 # Contact form email delivery. RESEND_API_KEY must be a server-only Resend key
 # beginning with "re_"; do not quote the value in Railway.
+CONTACT_DATABASE_URL=
 RESEND_API_KEY=
 CONTACT_FROM_EMAIL=support@exochain.io
 CONTACT_TO_EMAIL=support@exochain.io

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "^14.2.35",
+        "pg": "^8.20.0",
         "react": "18.3.1",
         "react-dom": "18.3.1"
       },
       "devDependencies": {
         "@types/node": "20.14.10",
+        "@types/pg": "^8.20.0",
         "@types/react": "18.3.3",
         "@types/react-dom": "18.3.0",
         "autoprefixer": "10.4.19",
@@ -558,6 +560,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -4458,6 +4472,95 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4648,6 +4751,45 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -5164,6 +5306,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stable-hash": {
@@ -6188,6 +6339,15 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/yaml": {
       "version": "2.8.4",

--- a/site/package.json
+++ b/site/package.json
@@ -12,11 +12,13 @@
   },
   "dependencies": {
     "next": "^14.2.35",
+    "pg": "^8.20.0",
     "react": "18.3.1",
     "react-dom": "18.3.1"
   },
   "devDependencies": {
     "@types/node": "20.14.10",
+    "@types/pg": "^8.20.0",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
     "autoprefixer": "10.4.19",

--- a/site/src/app/api/contact/route.ts
+++ b/site/src/app/api/contact/route.ts
@@ -15,6 +15,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { NextRequest, NextResponse } from 'next/server';
+import {
+  createContactSubmission,
+  updateContactSubmissionNotification,
+} from '@/lib/contact-submissions';
 
 type ContactPayload = {
   name: string;
@@ -31,8 +35,9 @@ type EmailConfig = {
 };
 
 const RESEND_API_KEY_PREFIX = 're_';
-const CONTACT_DELIVERY_ERROR = 'Unable to send email right now.';
-const EMAIL_TRANSPORT_CONFIG_ERROR = 'Email transport is not configured.';
+const CONTACT_QUEUE_ERROR = 'Unable to queue inquiry right now.';
+
+export const runtime = 'nodejs';
 
 function clean(value: unknown): string {
   if (typeof value !== 'string') {
@@ -90,6 +95,54 @@ function toText(payload: ContactPayload): string {
     .join('\n');
 }
 
+async function notifySupport(
+  submissionId: string,
+  payload: ContactPayload,
+): Promise<void> {
+  const emailConfig = getEmailConfig();
+
+  if (!emailConfig) {
+    console.error('Contact form email transport is missing a valid Resend API key.', {
+      submissionId,
+    });
+    await updateContactSubmissionNotification(submissionId, 'not_configured', 'missing valid Resend API key');
+    return;
+  }
+
+  const response = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${emailConfig.apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: emailConfig.fromEmail,
+      to: [emailConfig.toEmail],
+      reply_to: payload.email,
+      subject: `Inquiry from ${payload.name} (${payload.email})`,
+      text: toText(payload),
+    }),
+  });
+
+  if (!response.ok) {
+    const detail = await response.text();
+    const sanitizedDetail = detail.slice(0, 500);
+    console.error('Contact form email provider failure.', {
+      submissionId,
+      status: response.status,
+      detail: sanitizedDetail,
+    });
+    await updateContactSubmissionNotification(
+      submissionId,
+      'failed',
+      `provider status ${response.status}: ${sanitizedDetail}`,
+    );
+    return;
+  }
+
+  await updateContactSubmissionNotification(submissionId, 'sent', '');
+}
+
 export async function POST(request: NextRequest): Promise<NextResponse> {
   let incoming: ContactPayload;
   try {
@@ -106,35 +159,30 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'Name and email are required.' }, { status: 400 });
   }
 
-  const emailConfig = getEmailConfig();
-
-  if (!emailConfig) {
-    console.error('Contact form email transport is missing a valid Resend API key.');
-    return NextResponse.json({ error: EMAIL_TRANSPORT_CONFIG_ERROR }, { status: 503 });
+  let submissionId: string;
+  try {
+    const submission = await createContactSubmission({
+      name: incoming.name,
+      email: incoming.email,
+      organization: incoming.organization || '',
+      role: incoming.role || '',
+      intendedUse: incoming.intendedUse || '',
+      userAgent: clean(request.headers.get('user-agent')),
+      forwardedFor: clean(request.headers.get('x-forwarded-for')),
+    });
+    submissionId = submission.id;
+  } catch (error) {
+    console.error('Contact form database queue failure.', { error });
+    return NextResponse.json({ error: CONTACT_QUEUE_ERROR }, { status: 503 });
   }
 
-  const response = await fetch('https://api.resend.com/emails', {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${emailConfig.apiKey}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      from: emailConfig.fromEmail,
-      to: [emailConfig.toEmail],
-      reply_to: incoming.email,
-      subject: `Inquiry from ${incoming.name} (${incoming.email})`,
-      text: toText(incoming),
-    }),
-  });
-
-  if (!response.ok) {
-    const detail = await response.text();
-    console.error('Contact form email provider failure.', {
-      status: response.status,
-      detail: detail.slice(0, 500),
+  try {
+    await notifySupport(submissionId, incoming);
+  } catch (error) {
+    console.error('Contact form notification status update failed.', {
+      submissionId,
+      error,
     });
-    return NextResponse.json({ error: CONTACT_DELIVERY_ERROR }, { status: 502 });
   }
 
   return NextResponse.json({ ok: true });

--- a/site/src/app/internal/support/page.tsx
+++ b/site/src/app/internal/support/page.tsx
@@ -16,34 +16,104 @@
 
 import { IntPageHead } from '@/components/content/IntPageHead';
 import { Card, CardBody, CardHeader } from '@/components/ui/Card';
+import { DataTable, type Column } from '@/components/ui/DataTable';
 import { Pill } from '@/components/ui/Pill';
+import {
+  listRecentContactSubmissions,
+  type ContactSubmission,
+} from '@/lib/contact-submissions';
 
 export const metadata = { title: 'Support queue' };
+export const dynamic = 'force-dynamic';
 
-const TICKETS = [
-  { id: 't_0102', subject: 'Webhook signature header missing on retries', org: 'Aperture', severity: 'P2', sla: '4h' },
-  { id: 't_0101', subject: 'AVC validation reason code clarification', org: 'Northwind', severity: 'P3', sla: '2d' }
+const COLUMNS: Column<ContactSubmission>[] = [
+  {
+    key: 'submittedAt',
+    header: 'Submitted',
+    width: '180px',
+    render: (row) => <span className="font-mono text-xs">{row.submittedAt}</span>,
+  },
+  {
+    key: 'name',
+    header: 'Contact',
+    width: '260px',
+    render: (row) => (
+      <div>
+        <div className="font-medium">{row.name}</div>
+        <div className="font-mono text-xs text-ink/60 dark:text-vellum-soft/60">{row.email}</div>
+      </div>
+    ),
+  },
+  {
+    key: 'organization',
+    header: 'Organization',
+    width: '180px',
+  },
+  {
+    key: 'intendedUse',
+    header: 'Intended use',
+    render: (row) => (
+      <div>
+        <div>{row.intendedUse || '—'}</div>
+        <div className="mt-1 font-mono text-xs text-ink/50 dark:text-vellum-soft/50">
+          {row.role || 'No role selected'}
+        </div>
+      </div>
+    ),
+  },
+  {
+    key: 'notificationStatus',
+    header: 'Email',
+    width: '140px',
+    render: (row) => (
+      <Pill tone={row.notificationStatus === 'sent' ? 'signal' : 'alert'}>
+        {row.notificationStatus}
+      </Pill>
+    ),
+  },
 ];
 
-export default function Page() {
+async function getSubmissions(): Promise<{
+  rows: ContactSubmission[];
+  error: string;
+}> {
+  try {
+    return { rows: await listRecentContactSubmissions(), error: '' };
+  } catch (error) {
+    console.error('Unable to load contact submissions.', { error });
+    return {
+      rows: [],
+      error: 'Contact submission database is not reachable.',
+    };
+  }
+}
+
+export default async function Page() {
+  const { rows, error } = await getSubmissions();
+
   return (
     <>
       <IntPageHead
         eyebrow="Intranet · support"
         title="Support queue"
-        lede="Open tickets with owner and SLA."
+        lede="Recent public contact inquiries and support handoffs."
       />
-      <div className="grid md:grid-cols-2 gap-5">
-        {TICKETS.map(t => (
-          <Card key={t.id}>
-            <CardHeader title={t.subject} right={<Pill tone="signal">{t.severity}</Pill>} />
-            <CardBody className="text-sm">
-              <div className="font-mono text-xs">{t.id} · {t.org}</div>
-              <div className="mt-1">SLA <span className="font-mono">{t.sla}</span></div>
-            </CardBody>
-          </Card>
-        ))}
-      </div>
+      <Card>
+        <CardHeader title="Public contact submissions" />
+        <CardBody>
+          {error ? (
+            <div className="border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-300">
+              {error}
+            </div>
+          ) : (
+            <DataTable
+              columns={COLUMNS}
+              rows={rows}
+              empty="No contact submissions are queued."
+            />
+          )}
+        </CardBody>
+      </Card>
     </>
   );
 }

--- a/site/src/lib/contact-submissions.ts
+++ b/site/src/lib/contact-submissions.ts
@@ -1,0 +1,253 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { Pool, type PoolClient } from 'pg';
+
+export type ContactSubmissionInput = {
+  name: string;
+  email: string;
+  organization: string;
+  role: string;
+  intendedUse: string;
+  userAgent: string;
+  forwardedFor: string;
+};
+
+export type ContactSubmission = ContactSubmissionInput & {
+  id: string;
+  submittedAt: string;
+  notificationStatus: string;
+  notificationError: string;
+};
+
+type ContactSubmissionRow = {
+  id: string;
+  submitted_at: string;
+  name: string;
+  email: string;
+  organization: string;
+  role: string;
+  intended_use: string;
+  user_agent: string;
+  forwarded_for: string;
+  notification_status: string;
+  notification_error: string;
+};
+
+type ContactSubmissionPoolGlobal = typeof globalThis & {
+  __exoContactSubmissionPool?: Pool;
+  __exoContactSubmissionSchemaReady?: Promise<void>;
+};
+
+const CONTACT_DATABASE_URL_ENV = 'CONTACT_DATABASE_URL';
+const DATABASE_URL_ENV = 'DATABASE_URL';
+const MAX_TEXT_LENGTH = 1000;
+
+function normalizeSecret(value: string | undefined): string {
+  let normalized = value?.trim() || '';
+  const hasDoubleQuotes = normalized.startsWith('"') && normalized.endsWith('"');
+  const hasSingleQuotes = normalized.startsWith("'") && normalized.endsWith("'");
+
+  if (normalized.length >= 2 && (hasDoubleQuotes || hasSingleQuotes)) {
+    normalized = normalized.slice(1, -1).trim();
+  }
+
+  return normalized;
+}
+
+function getDatabaseUrl(): string {
+  const contactDatabaseUrl = normalizeSecret(process.env[CONTACT_DATABASE_URL_ENV]);
+  const databaseUrl = normalizeSecret(process.env[DATABASE_URL_ENV]);
+  const resolved = contactDatabaseUrl || databaseUrl;
+
+  if (!resolved) {
+    throw new Error(
+      `Contact submission database is not configured. Set ${CONTACT_DATABASE_URL_ENV} on the site service.`,
+    );
+  }
+
+  return resolved;
+}
+
+function getPool(): Pool {
+  const globalState = globalThis as ContactSubmissionPoolGlobal;
+
+  if (!globalState.__exoContactSubmissionPool) {
+    globalState.__exoContactSubmissionPool = new Pool({
+      connectionString: getDatabaseUrl(),
+      max: 4,
+      ssl: { rejectUnauthorized: false },
+    });
+  }
+
+  return globalState.__exoContactSubmissionPool;
+}
+
+function truncate(value: string): string {
+  return value.slice(0, MAX_TEXT_LENGTH);
+}
+
+function fromRow(row: ContactSubmissionRow): ContactSubmission {
+  return {
+    id: row.id,
+    submittedAt: row.submitted_at,
+    name: row.name,
+    email: row.email,
+    organization: row.organization,
+    role: row.role,
+    intendedUse: row.intended_use,
+    userAgent: row.user_agent,
+    forwardedFor: row.forwarded_for,
+    notificationStatus: row.notification_status,
+    notificationError: row.notification_error,
+  };
+}
+
+async function ensureSchemaWithClient(client: PoolClient): Promise<void> {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS site_contact_submissions (
+      id BIGSERIAL PRIMARY KEY,
+      submitted_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      name TEXT NOT NULL,
+      email TEXT NOT NULL,
+      organization TEXT NOT NULL DEFAULT '',
+      role TEXT NOT NULL DEFAULT '',
+      intended_use TEXT NOT NULL DEFAULT '',
+      user_agent TEXT NOT NULL DEFAULT '',
+      forwarded_for TEXT NOT NULL DEFAULT '',
+      notification_status TEXT NOT NULL DEFAULT 'pending',
+      notification_error TEXT NOT NULL DEFAULT ''
+    )
+  `);
+
+  await client.query(`
+    CREATE INDEX IF NOT EXISTS site_contact_submissions_submitted_at_idx
+      ON site_contact_submissions (submitted_at DESC, id DESC)
+  `);
+
+  await client.query(`
+    CREATE INDEX IF NOT EXISTS site_contact_submissions_email_idx
+      ON site_contact_submissions (email)
+  `);
+}
+
+export async function ensureContactSubmissionSchema(): Promise<void> {
+  const globalState = globalThis as ContactSubmissionPoolGlobal;
+
+  if (!globalState.__exoContactSubmissionSchemaReady) {
+    globalState.__exoContactSubmissionSchemaReady = (async () => {
+      const client = await getPool().connect();
+      try {
+        await ensureSchemaWithClient(client);
+      } finally {
+        client.release();
+      }
+    })();
+  }
+
+  return globalState.__exoContactSubmissionSchemaReady;
+}
+
+export async function createContactSubmission(
+  input: ContactSubmissionInput,
+): Promise<ContactSubmission> {
+  await ensureContactSubmissionSchema();
+
+  const result = await getPool().query<ContactSubmissionRow>(
+    `
+      INSERT INTO site_contact_submissions (
+        name,
+        email,
+        organization,
+        role,
+        intended_use,
+        user_agent,
+        forwarded_for
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7)
+      RETURNING
+        id::text,
+        submitted_at::text,
+        name,
+        email,
+        organization,
+        role,
+        intended_use,
+        user_agent,
+        forwarded_for,
+        notification_status,
+        notification_error
+    `,
+    [
+      truncate(input.name),
+      truncate(input.email),
+      truncate(input.organization),
+      truncate(input.role),
+      truncate(input.intendedUse),
+      truncate(input.userAgent),
+      truncate(input.forwardedFor),
+    ],
+  );
+
+  const row = result.rows[0];
+  if (!row) {
+    throw new Error('Contact submission insert did not return a row.');
+  }
+
+  return fromRow(row);
+}
+
+export async function updateContactSubmissionNotification(
+  id: string,
+  status: 'sent' | 'not_configured' | 'failed',
+  error: string,
+): Promise<void> {
+  await ensureContactSubmissionSchema();
+
+  await getPool().query(
+    `
+      UPDATE site_contact_submissions
+      SET notification_status = $2,
+          notification_error = $3
+      WHERE id = $1
+    `,
+    [id, status, truncate(error)],
+  );
+}
+
+export async function listRecentContactSubmissions(): Promise<ContactSubmission[]> {
+  await ensureContactSubmissionSchema();
+
+  const result = await getPool().query<ContactSubmissionRow>(`
+    SELECT
+      id::text,
+      submitted_at::text,
+      name,
+      email,
+      organization,
+      role,
+      intended_use,
+      user_agent,
+      forwarded_for,
+      notification_status,
+      notification_error
+    FROM site_contact_submissions
+    ORDER BY submitted_at DESC, id DESC
+    LIMIT 50
+  `);
+
+  return result.rows.map(fromRow);
+}


### PR DESCRIPTION
## Summary
- provisioned Railway Postgres service `Postgres-vxVA` for website contact submissions
- wired Railway `just-truth` service variable `CONTACT_DATABASE_URL` to that database
- persist valid `/api/contact` submissions before attempting email notification
- keep email delivery best-effort and store notification status in `site_contact_submissions`
- show recent public contact submissions in `/internal/support`

## Classification
- `site/src/app/api/contact/route.ts` — Adjacent surface
- `site/src/lib/contact-submissions.ts` — Adjacent surface
- `site/src/app/internal/support/page.tsx` — Adjacent surface
- `site/package.json`, `site/package-lock.json`, `site/.env.example` — Adjacent surface
- Railway service `Postgres-vxVA` — Adjacent surface database for website contact queue
- No EXOCHAIN core, core runtime adapter, governance, CI, or deployment contract paths changed.

## Adjacent Surface Intake
- Owner/accountable maintainer: EXOCHAIN website operations, Bob Stewart
- Deployment status: production on Railway service `just-truth`, root directory `/site`
- Constitutional trust claims: the contact form is not an EXOCHAIN enforcement path and does not prove constitutional enforcement
- Core state access: no read/write access to core state, signatures, credentials, governance outcomes, consent records, or provenance records
- Trust boundary: public browser form -> Next.js `/api/contact` route -> Railway Postgres `site_contact_submissions`; email notification is best-effort only
- Test command and CI gate: `npm run typecheck`, `npm run lint`, `npm run build`
- Secrets/config: `CONTACT_DATABASE_URL` on `just-truth`; `RESEND_API_KEY`, `CONTACT_FROM_EMAIL`, `CONTACT_TO_EMAIL` remain email-only
- Rollback/disablement: revert this commit or roll back the Railway deployment; remove/rotate `CONTACT_DATABASE_URL` to disable DB queue writes

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`
- `npm view pg license` -> MIT
- `npm view @types/pg license` -> MIT
- Local smoke against Railway database public URL: POST `/api/contact` returned `200 {"ok":true}`
- DB read-back confirmed row id `1`, email `bob+db-smoke@bobstewart.com`, notification status `not_configured`

## Note
- `npm audit --omit=dev` still reports existing Next/PostCSS advisories with a breaking Next 16 fix path. This change did not introduce those packages; `pg` and `@types/pg` are MIT licensed.