### PR TITLE
fix(gateway): allow dashboard root CSP execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 187758 | `wc -l` |
-| Workspace tests | 4,287 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 188017 | `wc -l` |
+| Workspace tests | 4,290 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -45,7 +45,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,286 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,290 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -88,6 +88,7 @@ const GATEWAY_RATE_LIMIT_MAX_CLIENTS: usize = 16_384;
 const STRICT_TRANSPORT_SECURITY_VALUE: &str = "max-age=63072000; includeSubDomains";
 const CONTENT_SECURITY_POLICY_VALUE: &str =
     "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'";
+const CONTENT_SECURITY_POLICY_DASHBOARD_VALUE: &str = "default-src 'none'; style-src 'self' 'sha256-yJRhW9tEgjF5ZLILQcXDB6QDKvp1zziUPN6LHRtguoY='; script-src 'self' 'sha256-alo6f0Wtj7BryL8VG8ykQizNQTJHPzVuk5uHRX6v0no='; connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'";
 const PERMISSIONS_POLICY_VALUE: &str = "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
 const PROMETHEUS_TEXT_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
 const LAYOUT_TEMPLATE_MAX_ID_BYTES: usize = 128;
@@ -3572,8 +3573,14 @@ fn insert_static_response_header(headers: &mut HeaderMap, name: &'static str, va
 }
 
 async fn attach_gateway_security_headers(request: Request<Body>, next: Next) -> Response {
+    let path = request.uri().path().to_owned();
     let mut response = next.run(request).await;
     let headers = response.headers_mut();
+    let content_security_policy = if path == "/" {
+        CONTENT_SECURITY_POLICY_DASHBOARD_VALUE
+    } else {
+        CONTENT_SECURITY_POLICY_VALUE
+    };
 
     insert_static_response_header(headers, "x-content-type-options", "nosniff");
     insert_static_response_header(headers, "x-frame-options", "DENY");
@@ -3583,11 +3590,7 @@ async fn attach_gateway_security_headers(request: Request<Body>, next: Next) -> 
         "strict-transport-security",
         STRICT_TRANSPORT_SECURITY_VALUE,
     );
-    insert_static_response_header(
-        headers,
-        "content-security-policy",
-        CONTENT_SECURITY_POLICY_VALUE,
-    );
+    insert_static_response_header(headers, "content-security-policy", content_security_policy);
     insert_static_response_header(headers, "permissions-policy", PERMISSIONS_POLICY_VALUE);
 
     response
@@ -4783,6 +4786,26 @@ mod tests {
                 .and_then(|v| v.to_str().ok()),
             Some(
                 "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()",
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn gateway_root_path_allows_dashboard_assets_csp() {
+        let app = build_router(state());
+
+        let resp = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        let headers = resp.headers();
+        assert_eq!(
+            headers
+                .get("content-security-policy")
+                .and_then(|v| v.to_str().ok()),
+            Some(
+                "default-src 'none'; style-src 'self' 'sha256-yJRhW9tEgjF5ZLILQcXDB6QDKvp1zziUPN6LHRtguoY='; script-src 'self' 'sha256-alo6f0Wtj7BryL8VG8ykQizNQTJHPzVuk5uHRX6v0no='; connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'"
             )
         );
     }

--- a/crates/exo-node/src/dashboard.rs
+++ b/crates/exo-node/src/dashboard.rs
@@ -251,6 +251,10 @@ const DASHBOARD_HTML: &str = r##"<!DOCTYPE html>
     border-color: var(--accent-dim);
   }
 
+  .validator-item-placeholder {
+    color: var(--text-dim);
+  }
+
   .validator-dot {
     width: 6px;
     height: 6px;
@@ -345,6 +349,16 @@ const DASHBOARD_HTML: &str = r##"<!DOCTYPE html>
 
   .update-dot.flash { opacity: 1; }
 
+  .dashboard-meta {
+    font-size: 0.75rem;
+    color: var(--text-dim);
+    font-family: var(--mono);
+  }
+
+  .dashboard-node-did {
+    user-select: all;
+  }
+
   /* Responsive */
   @media (max-width: 640px) {
     header { padding: 1rem; }
@@ -397,14 +411,14 @@ const DASHBOARD_HTML: &str = r##"<!DOCTYPE html>
         <span class="quorum-badge" id="quorum-info">—</span>
       </div>
       <ul class="validator-list" id="validator-list">
-        <li class="validator-item"><span style="color:var(--text-dim)">loading...</span></li>
+        <li class="validator-item validator-item-placeholder"><span>loading...</span></li>
       </ul>
     </div>
 
     <div class="activity-section">
       <div class="section-header">
         <span class="section-title">Activity</span>
-        <span style="font-size:0.75rem;color:var(--text-dim);font-family:var(--mono)" id="update-count"></span>
+        <span class="dashboard-meta" id="update-count"></span>
       </div>
       <div class="activity-log" id="activity-log"></div>
     </div>
@@ -412,7 +426,7 @@ const DASHBOARD_HTML: &str = r##"<!DOCTYPE html>
 
   <footer>
     <div>
-      <span id="node-did" style="user-select:all">—</span>
+      <span class="dashboard-node-did" id="node-did">—</span>
     </div>
     <div class="update-indicator">
       <div class="update-dot" id="update-dot"></div>
@@ -726,6 +740,14 @@ mod tests {
         assert!(
             !DASHBOARD_HTML.contains("innerHTML"),
             "dashboard must not render dynamic status, version, error, or DID data through innerHTML"
+        );
+    }
+
+    #[test]
+    fn dashboard_html_uses_no_inline_style_attributes() {
+        assert!(
+            !DASHBOARD_HTML.contains("style=\""),
+            "dashboard HTML should not rely on inline style attributes for CSP safety"
         );
     }
 }


### PR DESCRIPTION
## Scope
- Restrict this CSP change to the dashboard root path only ().
- Keep strict CSP defaults for all other routes.
- Add regression test to assert root CSP still includes required dashboard allowances.

## Validation
- cargo test -p exo-gateway gateway_layers_attach_security_headers
- cargo test -p exo-gateway gateway_root_path_allows_dashboard_assets_csp
- cargo test -p exo-node dashboard_returns_html
