### PR TITLE
style(site): apply public brand guidelines

### DIFF
--- a/site/src/app/(internet)/brand/page.tsx
+++ b/site/src/app/(internet)/brand/page.tsx
@@ -20,13 +20,28 @@ import { Logo } from '@/components/chrome/Logo';
 
 export const metadata = { title: 'Brand & Press Kit' };
 
+const colors = [
+  { name: 'Vault', value: '#081E26', note: 'Primary dark background' },
+  { name: 'Deep Teal', value: '#0E4459', note: 'Retained AVC foundation' },
+  { name: 'Cerulean', value: '#186B8C', note: 'Institutional headings' },
+  { name: 'Signal', value: '#2C96BF', note: 'Links and active states' },
+  { name: 'Ice', value: '#91D8E8', note: 'Support only' },
+  { name: 'Charter Gold', value: '#B8955A', note: 'Legal/governance accent' },
+  { name: 'Midnight', value: '#1A2B35', note: 'Panels and cards' },
+  { name: 'Frost', value: '#C8D8DC', note: 'Borders and dividers' },
+  { name: 'Porcelain', value: '#F0F4F5', note: 'Light surface' },
+  { name: 'White', value: '#FFFFFF', note: 'Type on dark fields' }
+];
+
 export default function Page() {
   return (
     <>
       <Section className="pt-16 pb-8">
         <Eyebrow>Brand</Eyebrow>
-        <H1 className="mt-3">Brand & press kit.</H1>
-        <Lede className="mt-5 max-w-prose">
+        <H1 className="mt-3 font-light tracking-normal text-brand-vault">
+          Brand & visual identity.
+        </H1>
+        <Lede className="mt-5 max-w-prose text-brand-midnight/80">
           EXOCHAIN&apos;s brand reads as evidentiary trust substrate, not crypto
           startup. Use the marks and language consistently with the
           guidance below.
@@ -38,13 +53,13 @@ export default function Page() {
           <Card>
             <CardHeader title="Wordmark" />
             <CardBody>
-              <div className="py-6"><Logo /></div>
+              <div className="py-6 text-brand-vault"><Logo /></div>
             </CardBody>
           </Card>
           <Card>
             <CardHeader title="Mark" />
             <CardBody>
-              <div className="py-6"><Logo variant="mark" className="h-10 w-10" /></div>
+              <div className="py-6 text-brand-vault"><Logo variant="mark" className="h-10 w-10" /></div>
             </CardBody>
           </Card>
         </div>
@@ -52,31 +67,54 @@ export default function Page() {
       <Section className="py-8">
         <H2>Voice</H2>
         <ul className="mt-3 list-disc pl-5 text-sm space-y-1.5 max-w-prose">
-          <li>Serious, technical, trustworthy, future-forward.</li>
+          <li>Serious, technical, trustworthy, and operationally mature.</li>
           <li>Custody and accountability — not crypto buzzwords.</li>
-          <li>Avoid mystical or hype-laden language on public copy.</li>
-          <li>Use the listed vocabulary consistently (see Glossary).</li>
+          <li>Generous whitespace and thin strokes signal precision.</li>
+          <li>Use monospace for hashes, receipt IDs, and credential strings.</li>
         </ul>
       </Section>
       <Section className="py-8">
         <H2>Color tokens</H2>
-        <div className="mt-5 grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
-          {[
-            { name: 'ink', value: '#0B0E14' },
-            { name: 'vellum', value: '#F5F2EA' },
-            { name: 'custody', value: '#3FB6C8' },
-            { name: 'signal', value: '#D9A24E' },
-            { name: 'verify', value: '#5A8C5C' },
-            { name: 'alert', value: '#C0524A' }
-          ].map((t) => (
-            <div key={t.name} className="border hairline rounded-md overflow-hidden">
+        <div className="mt-5 grid grid-cols-2 md:grid-cols-5 gap-3 text-sm">
+          {colors.map((t) => (
+            <div key={t.name} className="border hairline rounded-md overflow-hidden bg-brand-white/40">
               <div className="h-12" style={{ background: t.value }} />
-              <div className="px-3 py-2 flex items-center justify-between text-xs font-mono">
-                <span>{t.name}</span>
-                <span>{t.value}</span>
+              <div className="px-3 py-2 text-xs">
+                <div className="flex items-center justify-between font-mono">
+                  <span>{t.name}</span>
+                  <span>{t.value}</span>
+                </div>
+                <p className="mt-1 text-[11px] leading-snug text-brand-midnight/65">
+                  {t.note}
+                </p>
               </div>
             </div>
           ))}
+        </div>
+      </Section>
+      <Section className="py-8">
+        <H2>Do / avoid</H2>
+        <div className="mt-5 grid md:grid-cols-2 gap-5 text-sm">
+          <Card>
+            <CardHeader title="Do" />
+            <CardBody>
+              <ul className="list-disc pl-5 space-y-1.5">
+                <li>Keep marks one color and legible at small sizes.</li>
+                <li>Use Charter Gold sparingly: one accent per screen.</li>
+                <li>Use flat fields, precise borders, and calm spacing.</li>
+              </ul>
+            </CardBody>
+          </Card>
+          <Card>
+            <CardHeader title="Avoid" />
+            <CardBody>
+              <ul className="list-disc pl-5 space-y-1.5">
+                <li>No neon glow, bloom, or crypto particle effects.</li>
+                <li>No chain-link or hexagon iconography.</li>
+                <li>No all-caps body copy.</li>
+              </ul>
+            </CardBody>
+          </Card>
         </div>
       </Section>
     </>

--- a/site/src/app/(internet)/contact/ContactForm.tsx
+++ b/site/src/app/(internet)/contact/ContactForm.tsx
@@ -126,7 +126,7 @@ export function ContactForm() {
         </p>
       )}
       <p className="text-xs text-ink/60 dark:text-vellum-soft/60">
-        Submissions are delivered to support@exochain.io.
+        Submissions are queued for support review.
       </p>
     </form>
   );

--- a/site/src/app/(internet)/layout.tsx
+++ b/site/src/app/(internet)/layout.tsx
@@ -23,7 +23,7 @@ export default function InternetLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-dvh flex flex-col">
+    <div className="exo-public min-h-dvh flex flex-col bg-brand-porcelain text-brand-vault">
       <PublicNav />
       <div className="flex-1">{children}</div>
       <PublicFooter />

--- a/site/src/app/(internet)/page.tsx
+++ b/site/src/app/(internet)/page.tsx
@@ -28,14 +28,15 @@ import { mockNetworkMetrics } from '@/lib/mock-data';
 export default function HomePage() {
   return (
     <>
-      <Section className="surface-grain pt-16 md:pt-24 pb-12">
+      <Section className="pt-16 md:pt-24 pb-12">
         <div className="grid md:grid-cols-[1.2fr_1fr] gap-10 items-end">
           <div>
+            <div className="mb-6 h-px w-24 bg-brand-charter" />
             <Eyebrow>EXOCHAIN · custody-native blockchain · alpha</Eyebrow>
-            <H1 className="mt-4">
+            <H1 className="mt-4 font-light tracking-normal text-brand-vault">
               EXOCHAIN is chain-of-custody for autonomous execution.
             </H1>
-            <Lede className="mt-6 max-w-prose">
+            <Lede className="mt-6 max-w-prose text-brand-midnight/80">
               Credential autonomous intent, verify delegated authority, and
               preserve evidentiary custody for agents, holons, humans, and
               AI-native systems.
@@ -52,20 +53,24 @@ export default function HomePage() {
               </LinkButton>
             </div>
             <div className="mt-6 flex flex-wrap items-center gap-2 text-sm">
-              <Pill tone="signal">alpha</Pill>
-              <Pill tone="custody">zero-priced launch</Pill>
-              <span className="text-ink/60 dark:text-vellum-soft/60">
+              <Pill tone="neutral" className="border border-brand-charter/40 bg-brand-charter/10 text-brand-vault">
+                alpha
+              </Pill>
+              <Pill tone="neutral" className="border border-brand-signal/25 bg-brand-signal/10 text-brand-cerulean">
+                zero-priced launch
+              </Pill>
+              <span className="text-brand-midnight/65 dark:text-vellum-soft/60">
                 Network mode: {mockNetworkMetrics.networkMode} · last release{' '}
                 <span className="font-mono">
                   {mockNetworkMetrics.lastReleaseTag}
                 </span>{' '}
-                · <Link href="/status" className="underline">status</Link>
+                · <Link href="/status" className="underline decoration-brand-signal/40 underline-offset-4">status</Link>
               </span>
             </div>
           </div>
-          <div className="border hairline rounded-md p-4">
+          <div className="border hairline rounded-md bg-brand-white/45 p-4">
             <CustodyFlowDiagram />
-            <p className="text-xs text-ink/60 dark:text-vellum-soft/60 mt-3">
+            <p className="text-xs text-brand-midnight/65 dark:text-vellum-soft/60 mt-3">
               Human → AVC → Agent → EXOCHAIN → Trust Receipt. Revocation
               cascades back through the credential graph.
             </p>
@@ -74,12 +79,12 @@ export default function HomePage() {
       </Section>
 
       <Section className="py-12">
-        <div className="border hairline rounded-md p-6 md:p-10">
+        <div className="border hairline rounded-md bg-brand-white/35 p-6 md:p-10">
           <Eyebrow>The frame</Eyebrow>
-          <p className="mt-3 text-2xl md:text-3xl font-semibold tracking-tightish leading-tight max-w-3xl">
+          <p className="mt-3 text-2xl md:text-3xl font-semibold tracking-normal leading-tight max-w-3xl text-brand-vault">
             Blockchain is the mechanism. Chain-of-custody is the purpose.
           </p>
-          <p className="mt-4 text-ink/75 dark:text-vellum-soft/75 max-w-2xl">
+          <p className="mt-4 text-brand-midnight/75 dark:text-vellum-soft/75 max-w-2xl">
             EXOCHAIN preserves every property you expect from a serious
             distributed ledger — deterministic ordering, cryptographic
             signatures, quorum, finality — and reframes the chain as a
@@ -93,7 +98,7 @@ export default function HomePage() {
 
       <Section className="py-12">
         <Eyebrow>The stack</Eyebrow>
-        <H2 className="mt-3 max-w-2xl">
+        <H2 className="mt-3 max-w-2xl tracking-normal text-brand-vault">
           Identity proves who an actor is. AVC proves what it may pursue.
           EXOCHAIN proves what actually happened.
         </H2>

--- a/site/src/app/globals.css
+++ b/site/src/app/globals.css
@@ -47,6 +47,31 @@ html.dark body {
   background-image: var(--grain);
 }
 
+.exo-public {
+  background: #F0F4F5;
+  color: #081E26;
+}
+
+.exo-public .surface-grain {
+  background-image: none;
+}
+
+.exo-public .hairline {
+  border-color: #C8D8DC;
+}
+
+.exo-public .text-eyebrow {
+  color: #186B8C;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+.exo-public .tracking-eyebrow,
+.exo-public .tracking-tightish {
+  letter-spacing: 0;
+}
+
 .text-eyebrow {
   font-family: theme('fontFamily.mono');
   font-size: 11px;

--- a/site/src/components/chrome/PublicFooter.tsx
+++ b/site/src/components/chrome/PublicFooter.tsx
@@ -66,13 +66,17 @@ export function PublicFooter() {
     <footer className="mt-24 border-t hairline">
       <div className="max-w-page mx-auto px-6 md:px-10 py-12 grid gap-10 md:grid-cols-5">
         <div className="md:col-span-1">
-          <Logo />
-          <p className="mt-4 text-sm text-ink/70 dark:text-vellum-soft/70 max-w-xs">
+          <Logo className="text-brand-vault dark:text-brand-white" />
+          <p className="mt-4 text-sm text-brand-midnight/75 dark:text-brand-white/70 max-w-xs">
             Chain-of-custody for autonomous execution.
           </p>
           <div className="mt-4 flex flex-wrap gap-2">
-            <Pill tone="signal">alpha</Pill>
-            <Pill tone="custody">zero-priced launch</Pill>
+            <Pill tone="neutral" className="border border-brand-charter/40 bg-brand-charter/10 text-brand-vault">
+              alpha
+            </Pill>
+            <Pill tone="neutral" className="border border-brand-signal/25 bg-brand-signal/10 text-brand-cerulean">
+              zero-priced launch
+            </Pill>
           </div>
         </div>
         {cols.map((col) => (
@@ -85,7 +89,7 @@ export function PublicFooter() {
                 <li key={l.href}>
                   <Link
                     href={l.href}
-                    className="text-ink/80 hover:text-ink dark:text-vellum-soft/80 dark:hover:text-vellum-soft"
+                    className="text-brand-midnight/80 hover:text-brand-vault dark:text-brand-white/75 dark:hover:text-brand-white"
                   >
                     {l.label}
                   </Link>
@@ -96,7 +100,7 @@ export function PublicFooter() {
         ))}
       </div>
       <div className="border-t hairline">
-        <div className="max-w-page mx-auto px-6 md:px-10 py-5 flex flex-wrap items-center gap-3 justify-between text-xs text-ink/60 dark:text-vellum-soft/60">
+        <div className="max-w-page mx-auto px-6 md:px-10 py-5 flex flex-wrap items-center gap-3 justify-between text-xs text-brand-midnight/65 dark:text-brand-white/60">
           <div>
             © {new Date().getFullYear()} EXOCHAIN — Apache-2.0 reference
             implementation.

--- a/site/src/components/chrome/PublicNav.tsx
+++ b/site/src/components/chrome/PublicNav.tsx
@@ -33,9 +33,9 @@ const PRIMARY_LINKS = [
 
 export function PublicNav() {
   return (
-    <header className="sticky top-0 z-30 backdrop-blur bg-vellum-soft/80 dark:bg-ink-deep/80 border-b hairline">
+    <header className="sticky top-0 z-30 bg-brand-porcelain/95 dark:bg-brand-vault/95 border-b hairline">
       <div className="max-w-page mx-auto px-6 md:px-10 h-14 flex items-center justify-between gap-4">
-        <Link href="/" aria-label="EXOCHAIN home">
+        <Link href="/" aria-label="EXOCHAIN home" className="text-brand-vault dark:text-brand-white">
           <Logo />
         </Link>
         <nav className="hidden lg:flex items-center gap-5 text-sm">
@@ -43,7 +43,7 @@ export function PublicNav() {
             <Link
               key={l.href}
               href={l.href}
-              className="text-ink/70 hover:text-ink dark:text-vellum-soft/70 dark:hover:text-vellum-soft"
+              className="text-brand-midnight/70 hover:text-brand-vault dark:text-brand-white/70 dark:hover:text-brand-white"
             >
               {l.label}
             </Link>

--- a/site/src/components/ui/Button.tsx
+++ b/site/src/components/ui/Button.tsx
@@ -21,15 +21,15 @@ type Variant = 'primary' | 'secondary' | 'ghost' | 'danger';
 type Size = 'sm' | 'md' | 'lg';
 
 const base =
-  'inline-flex items-center justify-center font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-custody disabled:opacity-50 disabled:pointer-events-none whitespace-nowrap';
+  'inline-flex items-center justify-center font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-signal disabled:opacity-50 disabled:pointer-events-none whitespace-nowrap';
 
 const variants: Record<Variant, string> = {
   primary:
-    'bg-ink text-vellum-soft hover:bg-slate-800 dark:bg-vellum-soft dark:text-ink dark:hover:bg-vellum',
+    'bg-brand-vault text-brand-white hover:bg-brand-midnight dark:bg-brand-white dark:text-brand-vault dark:hover:bg-brand-porcelain',
   secondary:
-    'border border-ink/20 text-ink hover:bg-ink/5 dark:border-vellum-soft/20 dark:text-vellum-soft dark:hover:bg-vellum-soft/10',
+    'border border-brand-frost text-brand-vault hover:bg-brand-white/60 dark:border-brand-frost/40 dark:text-brand-white dark:hover:bg-brand-white/10',
   ghost:
-    'text-ink/80 hover:text-ink hover:bg-ink/5 dark:text-vellum-soft/80 dark:hover:text-vellum-soft dark:hover:bg-vellum-soft/10',
+    'text-brand-cerulean hover:text-brand-vault hover:bg-brand-white/50 dark:text-brand-ice dark:hover:text-brand-white dark:hover:bg-brand-white/10',
   danger:
     'bg-alert-deep text-white hover:bg-alert dark:bg-alert dark:hover:bg-alert-deep'
 };

--- a/site/tailwind.config.ts
+++ b/site/tailwind.config.ts
@@ -55,6 +55,20 @@ const config: Config = {
           deep: '#9C6F26',
           soft: '#F1C681'
         },
+        brand: {
+          vault: '#081E26',
+          teal: {
+            deep: '#0E4459'
+          },
+          cerulean: '#186B8C',
+          signal: '#2C96BF',
+          ice: '#91D8E8',
+          charter: '#B8955A',
+          midnight: '#1A2B35',
+          frost: '#C8D8DC',
+          porcelain: '#F0F4F5',
+          white: '#FFFFFF'
+        },
         alert: {
           DEFAULT: '#C0524A',
           deep: '#8E342D',


### PR DESCRIPTION
## Summary
- Applies the brand one-sheet palette to the public website shell, homepage, buttons, footer, and brand page without adding assets, dependencies, fonts, or runtime behavior.
- Removes public grain treatment, keeps the SVG mark one-color, and adds public-scope CSS overrides for brand color and spacing.
- Updates the contact form helper copy to match the database-backed queue behavior.

## Path classification
- `site/src/app/(internet)/brand/page.tsx` — Adjacent surface
- `site/src/app/(internet)/contact/ContactForm.tsx` — Adjacent surface
- `site/src/app/(internet)/layout.tsx` — Adjacent surface
- `site/src/app/(internet)/page.tsx` — Adjacent surface
- `site/src/app/globals.css` — Adjacent surface
- `site/src/components/chrome/PublicFooter.tsx` — Adjacent surface
- `site/src/components/chrome/PublicNav.tsx` — Adjacent surface
- `site/src/components/ui/Button.tsx` — Adjacent surface
- `site/tailwind.config.ts` — Adjacent surface

## Adjacent surface intake
- Owner/accountable maintainer: Exochain Foundation site maintainers.
- Deployment status: production public website served from `/site` by Railway.
- Constitutional trust claims: public marketing/docs surface only; this change does not add or expand constitutional trust claims.
- Core state access: no read/write access to EXOCHAIN core state, signatures, credentials, governance outcomes, consent records, or provenance records is added or changed.
- Trust boundary: `/site` renders public website pages and the existing contact queue path; EXOCHAIN core enforcement remains outside this surface.
- Test command and CI gate: `npm run typecheck`, `npm run lint`, `npm run build` from `/site`.
- Secrets/runtime config: no new secrets or runtime config; no dependency, API, database schema, or Railway config changes.
- Rollback/disablement path: revert this commit or redeploy the previous Railway revision.

## Core regression firewall
- No `crates/`, `packages/exochain-wasm/`, `governance/`, `tools/`, CI, deployment contract, or core runtime adapter files changed.
- No credential, signature, consent, governance action, tenant identifier, webhook, or external-write ingress path changed.

## Test plan
- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Chrome smoke on local production build: `/`, `/brand`, `/contact`
- [x] Lighthouse benchmark before/after: JS unchanged; generated CSS +2,041 bytes; request counts unchanged on measured pages.
