### PR TITLE
Zeroize WASM X25519 secret buffers

### DIFF
--- a/crates/exo-gateway/src/db.rs
+++ b/crates/exo-gateway/src/db.rs
@@ -1718,11 +1718,7 @@ mod tests {
         hex::encode(Sha384::digest(bytes))
     }
 
-    fn applied_gateway_migrations() -> Vec<(
-        &'static str,
-        &'static [u8],
-        &'static str,
-    )> {
+    fn applied_gateway_migrations() -> Vec<(&'static str, &'static [u8], &'static str)> {
         vec![
             (
                 "20260316000001_initial_schema.sql",
@@ -1811,7 +1807,8 @@ mod tests {
             ),
             (
                 "20260510000001_scope_decision_ids_by_tenant.sql",
-                include_bytes!("../migrations/20260510000001_scope_decision_ids_by_tenant.sql").as_slice(),
+                include_bytes!("../migrations/20260510000001_scope_decision_ids_by_tenant.sql")
+                    .as_slice(),
                 "8de5b45554e6c821e34b575aac7479ff5b147b86254e8bee58596118b71c679f2e65db909193ce033613dc74e5efd024",
             ),
         ]
@@ -1851,8 +1848,7 @@ mod tests {
         disk_names.sort();
 
         assert_eq!(
-            source_names,
-            disk_names,
+            source_names, disk_names,
             "migration checksum list must mirror disk migration set exactly"
         );
     }

--- a/crates/exo-messaging/src/kex.rs
+++ b/crates/exo-messaging/src/kex.rs
@@ -104,8 +104,9 @@ pub struct X25519SecretKey([u8; 32]);
 
 impl X25519SecretKey {
     pub fn from_bytes(bytes: [u8; 32]) -> Result<Self, MessagingError> {
+        let bytes = zeroize::Zeroizing::new(bytes);
         validate_x25519_secret_key(&bytes)?;
-        Ok(Self(bytes))
+        Ok(Self(*bytes))
     }
 
     /// Create from hex string.
@@ -120,9 +121,9 @@ impl X25519SecretKey {
                 bytes.len()
             )));
         }
-        let mut arr = [0u8; 32];
-        arr.copy_from_slice(&bytes);
-        Self::from_bytes(arr)
+        let mut arr = zeroize::Zeroizing::new([0u8; 32]);
+        arr.copy_from_slice(bytes.as_slice());
+        Self::from_bytes(*arr)
     }
 
     /// Derive the public key corresponding to this secret key.
@@ -407,6 +408,38 @@ mod tests {
         assert!(
             !source.contains(&["our_secret", ".0"].concat()),
             "internal key exchange must use the bounded secret-key accessor"
+        );
+    }
+
+    #[test]
+    fn x25519_secret_key_decoding_zeroizes_rust_owned_buffers() {
+        let source = include_str!("kex.rs");
+        let secret_impl = source
+            .split("impl X25519SecretKey {")
+            .nth(1)
+            .and_then(|rest| {
+                rest.split("impl core::fmt::Debug for X25519SecretKey")
+                    .next()
+            })
+            .expect("secret-key impl block must be present");
+        let from_bytes = secret_impl
+            .split("pub fn from_bytes(bytes: [u8; 32])")
+            .nth(1)
+            .and_then(|rest| rest.split("/// Create from hex string.").next())
+            .expect("X25519SecretKey::from_bytes must be present");
+        assert!(
+            from_bytes.contains("zeroize::Zeroizing::new(bytes)"),
+            "X25519SecretKey::from_bytes must zeroize its source stack buffer"
+        );
+
+        let from_hex = secret_impl
+            .split("pub fn from_hex(hex: &str)")
+            .nth(1)
+            .and_then(|rest| rest.split("/// Derive the public key corresponding").next())
+            .expect("X25519SecretKey::from_hex must be present");
+        assert!(
+            from_hex.matches("zeroize::Zeroizing::new").count() >= 2,
+            "X25519SecretKey::from_hex must zeroize both decoded Vec and stack array buffers"
         );
     }
 

--- a/crates/exochain-wasm/src/lib.rs
+++ b/crates/exochain-wasm/src/lib.rs
@@ -691,7 +691,13 @@ mod source_guard_tests {
 
     #[test]
     fn wasm_secret_key_decoding_zeroizes_rust_owned_buffers() {
-        let sources = [("identity_bindings.rs", include_str!("identity_bindings.rs"))];
+        let sources = [
+            ("identity_bindings.rs", include_str!("identity_bindings.rs")),
+            (
+                "messaging_bindings.rs",
+                include_str!("messaging_bindings.rs"),
+            ),
+        ];
 
         for (path, source) in sources {
             assert!(
@@ -699,6 +705,20 @@ mod source_guard_tests {
                 "{path} must wrap decoded secret-key buffers in zeroize::Zeroizing"
             );
         }
+
+        let messaging_source = include_str!("messaging_bindings.rs");
+        let x25519_helper = messaging_source
+            .split("fn parse_x25519_keypair_hex")
+            .nth(1)
+            .and_then(|rest| {
+                rest.split("/// Attach a caller-produced Ed25519 signature")
+                    .next()
+            })
+            .expect("messaging X25519 secret parser must be present");
+        assert!(
+            x25519_helper.contains("Zeroizing::new("),
+            "messaging X25519 secret parser must zeroize Rust-owned decoded buffers"
+        );
     }
 
     #[test]

--- a/crates/exochain-wasm/src/messaging_bindings.rs
+++ b/crates/exochain-wasm/src/messaging_bindings.rs
@@ -20,6 +20,7 @@ use std::collections::BTreeMap;
 
 use serde::Deserialize;
 use wasm_bindgen::prelude::*;
+use zeroize::Zeroizing;
 
 use crate::serde_bridge::*;
 
@@ -164,14 +165,16 @@ fn parse_x25519_keypair_hex(
     label: &str,
     secret_hex: &str,
 ) -> Result<exo_messaging::X25519KeyPair, JsValue> {
-    let bytes = hex::decode(secret_hex)
-        .map_err(|e| JsValue::from_str(&format!("{label} must be hex: {e}")))?;
+    let bytes = Zeroizing::new(
+        hex::decode(secret_hex)
+            .map_err(|e| JsValue::from_str(&format!("{label} must be hex: {e}")))?,
+    );
     if bytes.len() != 32 {
         return Err(JsValue::from_str(&format!("{label} must be 32 bytes")));
     }
-    let mut secret = [0u8; 32];
-    secret.copy_from_slice(&bytes);
-    exo_messaging::X25519KeyPair::from_secret_bytes(secret)
+    let mut secret = Zeroizing::new([0u8; 32]);
+    secret.copy_from_slice(bytes.as_slice());
+    exo_messaging::X25519KeyPair::from_secret_bytes(*secret)
         .map_err(|e| JsValue::from_str(&format!("invalid {label}: {e}")))
 }
 


### PR DESCRIPTION
Path classification: Core runtime adapter: crates/exochain-wasm/src/lib.rs and crates/exochain-wasm/src/messaging_bindings.rs. EXOCHAIN core/runtime messaging: crates/exo-messaging/src/kex.rs. Core runtime adapter CI gate formatting: crates/exo-gateway/src/db.rs, rustfmt-only to clear pre-existing Gate 5 drift on current main. Remediation: zeroize Rust-owned decoded Vec and stack-array buffers for X25519 secret-key material crossing the WASM messaging boundary and the underlying messaging key decoder. TDD evidence: wasm_secret_key_decoding_zeroizes_rust_owned_buffers and x25519_secret_key_decoding_zeroizes_rust_owned_buffers both failed before the fix and pass after. Validation: cargo test -p exochain-sdk -- --nocapture; cargo test -p exochain-wasm -- --nocapture; cargo test -p exo-messaging -- --nocapture; cargo test -p exo-gateway applied_gateway_migrations_match_disk_set -- --nocapture; cargo test -p exo-gateway applied_gateway_migration_checksums_are_immutable -- --nocapture; cargo fmt --all -- --check; rustfmt --check crates/exo-messaging/src/kex.rs crates/exochain-wasm/src/lib.rs crates/exochain-wasm/src/messaging_bindings.rs; cargo clippy -p exo-messaging -p exochain-wasm --all-targets -- -D warnings.