### PR TITLE
Update README repo truth metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 188057 | `wc -l` |
-| Workspace tests | 4,291 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 188557 | `wc -l` |
+| Workspace tests | 4,301 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -45,7 +45,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,290 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,301 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -114,9 +114,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 187719 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 188557 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,286 listed workspace tests
+         cryptographic proofs, 4,301 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript


### PR DESCRIPTION
Path classification: README.md — EXOCHAIN core documentation / documentation claims integrity. Verification: bash tools/test_repo_truth.sh; bash tools/test_cr001_status.sh; bash tools/test_gap_registry_truth.sh; bash tools/test_coverage_policy.sh; git diff --check. Scope: docs-only remediation for stale repo truth metrics; no crates, runtime adapters, adjacent surfaces, CI, governance, deployment contracts, secrets, or core behavior changed.