### PR TITLE
Fix GraphQL feature test DID fixture

### DIFF
--- a/crates/exo-gateway/src/graphql.rs
+++ b/crates/exo-gateway/src/graphql.rs
@@ -2010,7 +2010,7 @@ mod tests {
                     id: "did:exo:alice#key-1".into(),
                     controller: Did::new("did:exo:alice").unwrap(),
                     key_type: "Ed25519VerificationKey2020".into(),
-                    public_key_multibase: "zABC".into(),
+                    public_key_multibase: "z4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi".into(),
                     version: 1,
                     active: true,
                     valid_from: 0,


### PR DESCRIPTION
Classification: Core runtime adapter test fixture (crates/exo-gateway/src/graphql.rs).\n\nFinding verification: Wally F-001 is already remediated on current main by the default-off unaudited GraphQL router and mutation execution guard. While verifying the feature-on GraphQL suite, the registered-DID resolver test failed because its fixture used a 2-byte multibase key that no longer passes DID registry validation.\n\nChange: replace the invalid fixture key with a valid 32-byte base58btc multibase key. No production code path changes.\n\nValidation:\n- cargo test -p exo-gateway --features unaudited-gateway-graphql-api query_resolve_identity_registered_did -- --nocapture\n- cargo test -p exo-gateway --features unaudited-gateway-graphql-api graphql -- --nocapture\n- cargo test -p exo-gateway graphql -- --nocapture\n- cargo test -p exo-gateway -- --nocapture\n- cargo test -p exo-gateway --features unaudited-gateway-graphql-api -- --nocapture\n- cargo clippy -p exo-gateway --all-targets -- -D warnings\n- cargo clippy -p exo-gateway --all-targets --features unaudited-gateway-graphql-api -- -D warnings\n- cargo fmt --all -- --check\n- git diff --check\n\nCore impact: test-only fixture update enabling maximal F-001 verification; no gateway runtime behavior changed.