### PR TITLE
fix: harden core npm supply chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,8 @@ jobs:
         run: bash tools/test_github_issue_workflow_boundaries.sh
       - name: CI tool installer supply-chain hardening
         run: bash tools/test_ci_supply_chain_hardening.sh
+      - name: Core npm package supply-chain hardening
+        run: bash tools/test_npm_core_package_hygiene.sh
       - name: Release workflow ref binding
         run: bash tools/test_release_workflow_ref_binding.sh
       - name: Release version input boundary

--- a/docs/audit/GAUNTLET-SUPPLY-CHAIN-VALIDATION-2026-05-15.md
+++ b/docs/audit/GAUNTLET-SUPPLY-CHAIN-VALIDATION-2026-05-15.md
@@ -1,0 +1,86 @@
+<!--
+Copyright 2026 Exochain Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at:
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Gauntlet Supply-Chain Validation - 2026-05-15
+
+This record validates the Gauntlet supply-chain findings against current
+`main` before remediation. The external finding artifacts remain imported
+evidence only:
+
+- `/private/tmp/exochain-gauntlet-findings/Exochain Gauntlet Findings/gauntlet-findings.md`
+- `/private/tmp/exochain-gauntlet-findings/Exochain Gauntlet Findings/gauntlet-deep-analysis.md`
+- `/private/tmp/exochain-gauntlet-findings/Exochain Gauntlet Findings/da-findings.tsv`
+
+Validation target before this branch:
+
+- branch: `main`
+- commit: `9c754477aad4937fcadd4feb85a7aa03b4137c54`
+
+## Path Classification
+
+| Path family | Classification | Notes |
+| --- | --- | --- |
+| `.github/workflows/ci.yml` | EXOCHAIN core | CI gate contract for the canonical trust-fabric repository. |
+| `Cargo.toml`, `Cargo.lock`, `.cargo/audit.toml`, `deny.toml` | EXOCHAIN core | Rust dependency policy and advisory/license gates. |
+| `packages/exochain-sdk/` | Core runtime adapter | JavaScript SDK for core API/runtime interactions. |
+| `tools/cross-impl-test/` | EXOCHAIN core | Cross-implementation canonical hash validation tooling. |
+| `tools/test_*` | EXOCHAIN core | Source guards and CI hygiene gates. |
+| `command-base/` | Adjacent surface | Not part of this core remediation PR. |
+| `/private/tmp/exochain-gauntlet-findings/...` | Imported evidence | Read-only external assessment artifacts. |
+
+## Dispositions
+
+| Finding | Current disposition | Evidence |
+| --- | --- | --- |
+| F-120 AGPL license in Apache-2.0 project | Stale / already remediated for core | `cargo deny check licenses advisories bans sources` passes with `licenses ok`; package license checks in `tools/test_repo_truth.sh` enforce Apache-2.0 on core JS packages. |
+| F-121 `multer` deprecated with known vulnerabilities | Adjacent surface remains queued | Current match is `command-base/app/package.json`, classified adjacent. It was not edited in this core CI/adapter PR. |
+| F-122 Playwright in production dependencies | Current core path not found | Current package-manifest search found no owned core package dependency on Playwright. |
+| F-123 unpinned GitHub Action refs | Stale / already remediated | `tools/test_github_actions_pinned.sh` rejects non-SHA external action refs and is wired into CI Gate 9. |
+| F-124 curl-pipe-shell in CI | Stale / already remediated | `tools/test_ci_supply_chain_hardening.sh` rejects curl-piped installs and unpinned Cargo tool installs in CI/release workflows. |
+| F-125 SemVer ranges on security-critical crates | Stale / already remediated for Rust, live for core JS adapters | Rust workspace dependencies are exact-pinned and guarded by `tools/test_security_critical_dependencies_pinned.sh`. This branch also exact-pins `packages/exochain-sdk` and `tools/cross-impl-test` npm dependencies. |
+| F-126 advisory ignores plus zero-vulnerability claim | Stale / already remediated | `.cargo/audit.toml` documents active ignores; `tools/test_audit_ignore_policy.sh` rejects stale or undocumented active advisories. |
+| F-127 CI comment misleading about ignore list | Stale / already remediated | `tools/test_audit_policy_docs.sh` and `tools/test_audit_ignore_policy.sh` enforce the current audit-deny language and ignore freshness. |
+| F-128 `npm audit || true` suppresses failures | Adjacent surface remains queued | Current `|| true` match is `command-base/app/package.json`, classified adjacent. |
+| F-129 no npm audit in CI | Remediated for core JS adapters | This branch adds `tools/test_npm_core_package_hygiene.sh` and wires it into CI Gate 9. The guard runs `npm audit --audit-level=high --omit=dev` for core JS package directories with lockfiles. |
+| F-130 missing lockfiles in packages | Remediated for core JS adapters | This branch adds `packages/exochain-sdk/package-lock.json` and requires lockfiles for core package manifests with external npm dependencies. |
+| F-131 floating caret versions in production | Remediated for core JS adapters | `@noble/hashes`, `@types/node`, `typescript`, `blake3`, and `cbor` are exact-pinned in owned core JS manifests. Adjacent package ranges remain outside this PR. |
+| F-133 CI Clippy misses module-level allows | Stale / already remediated | CI uses `cargo clippy --workspace --all-targets -- -D warnings`, and `tools/test_repo_truth.sh` verifies the all-targets lint gate plus workspace denial of `unwrap_used` and `expect_used`. |
+
+## Commands Run
+
+The following commands completed with exit code 0 unless noted:
+
+```bash
+bash tools/test_npm_core_package_hygiene.sh
+# First RED run failed as expected because packages/exochain-sdk used semver ranges.
+npm install --package-lock-only --ignore-scripts  # packages/exochain-sdk
+npm install --package-lock-only --ignore-scripts  # tools/cross-impl-test
+npm ci --ignore-scripts                           # packages/exochain-sdk
+npm test                                          # packages/exochain-sdk, 67 passed
+npm ci --ignore-scripts                           # tools/cross-impl-test
+npm test                                          # tools/cross-impl-test, 1 vector passed
+bash tools/test_npm_core_package_hygiene.sh
+bash tools/test_github_actions_pinned.sh
+bash tools/test_ci_supply_chain_hardening.sh
+bash tools/test_security_critical_dependencies_pinned.sh
+bash tools/test_repo_truth.sh
+bash tools/test_audit_ignore_policy.sh
+cargo audit --deny unsound --deny unmaintained
+cargo deny check licenses advisories bans sources
+git diff --check
+```

--- a/packages/exochain-sdk/package-lock.json
+++ b/packages/exochain-sdk/package-lock.json
@@ -1,0 +1,56 @@
+{
+  "name": "@exochain/sdk",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@exochain/sdk",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "devDependencies": {
+        "@types/node": "20.0.0",
+        "typescript": "5.3.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.0.0.tgz",
+      "integrity": "sha512-cD2uPTDnQQCVpmRefonO98/PPijuOnnEy5oytWJFPY1N9aJCz2wJ5kSGWO+zJoed2cY2JxQh6yBuUq4vIn61hw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/packages/exochain-sdk/package.json
+++ b/packages/exochain-sdk/package.json
@@ -49,10 +49,10 @@
     "node": ">=20.0.0"
   },
   "devDependencies": {
-    "@types/node": "^20.0.0",
-    "typescript": "^5.3.0"
+    "@types/node": "20.0.0",
+    "typescript": "5.3.3"
   },
   "dependencies": {
-    "@noble/hashes": "^1.8.0"
+    "@noble/hashes": "1.8.0"
   }
 }

--- a/tools/cross-impl-test/package-lock.json
+++ b/tools/cross-impl-test/package-lock.json
@@ -8,8 +8,8 @@
       "name": "exochain-cross-impl-test",
       "version": "1.0.0",
       "dependencies": {
-        "blake3": "^2.1.7",
-        "cbor": "^9.0.0"
+        "blake3": "2.1.7",
+        "cbor": "9.0.2"
       }
     },
     "node_modules/blake3": {

--- a/tools/cross-impl-test/package.json
+++ b/tools/cross-impl-test/package.json
@@ -7,7 +7,7 @@
     "test": "node index.js"
   },
   "dependencies": {
-    "blake3": "^2.1.7",
-    "cbor": "^9.0.0"
+    "blake3": "2.1.7",
+    "cbor": "9.0.2"
   }
 }

--- a/tools/test_npm_core_package_hygiene.sh
+++ b/tools/test_npm_core_package_hygiene.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Copyright 2026 Exochain Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+fail() {
+  printf 'npm core package hygiene test failed: %s\n' "$1" >&2
+  exit 1
+}
+
+core_package_dirs=(
+  "packages/exochain-sdk"
+  "tools/cross-impl-test"
+)
+
+for package_dir in "${core_package_dirs[@]}"; do
+  package_json="${package_dir}/package.json"
+  [[ -f "$package_json" ]] || fail "$package_json is missing"
+
+  node - "$package_json" <<'NODE'
+const fs = require("fs");
+
+const packagePath = process.argv[2];
+const manifest = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+
+const dependencySections = [
+  "dependencies",
+  "devDependencies",
+  "optionalDependencies",
+];
+
+const exactSemver = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+const allowedInternalSpec = /^(?:file:|workspace:)/;
+const violations = [];
+let hasExternalDependency = false;
+
+for (const section of dependencySections) {
+  for (const [name, spec] of Object.entries(manifest[section] || {})) {
+    if (allowedInternalSpec.test(spec)) {
+      continue;
+    }
+
+    hasExternalDependency = true;
+    if (!exactSemver.test(spec)) {
+      violations.push(`${section}.${name}=${spec}`);
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error(`${packagePath} has non-exact external dependency specs:`);
+  for (const violation of violations) {
+    console.error(`  - ${violation}`);
+  }
+  process.exit(1);
+}
+
+if (hasExternalDependency && !fs.existsSync(packagePath.replace(/package\.json$/, "package-lock.json"))) {
+  console.error(`${packagePath} declares external dependencies but has no package-lock.json`);
+  process.exit(1);
+}
+NODE
+
+  if [[ -f "${package_dir}/package-lock.json" ]]; then
+    (
+      cd "$package_dir"
+      npm audit --audit-level=high --omit=dev
+    )
+  fi
+done
+
+printf 'npm core package hygiene test passed\n'


### PR DESCRIPTION
## Summary
- exact-pin owned core npm package dependencies for the EXOCHAIN SDK and cross-implementation hash tooling
- add a generated npm lockfile for the core SDK and refresh the cross-implementation lock root specs
- add CI-enforced core npm hygiene: exact specs, required lockfiles for external deps, and high-severity npm audit checks
- record Gauntlet supply-chain dispositions, keeping CommandBase-only findings classified as adjacent and queued separately

## Path Classification
- EXOCHAIN core: .github/workflows/ci.yml, tools/test_npm_core_package_hygiene.sh, tools/cross-impl-test/package.json, tools/cross-impl-test/package-lock.json, docs/audit/GAUNTLET-SUPPLY-CHAIN-VALIDATION-2026-05-15.md
- Core runtime adapter: packages/exochain-sdk/package.json, packages/exochain-sdk/package-lock.json
- Adjacent surface excluded: command-base npm audit || true and multer findings remain queued for adjacent-surface remediation

## Verification
- RED: bash tools/test_npm_core_package_hygiene.sh failed before pinning due packages/exochain-sdk semver ranges
- npm install --package-lock-only --ignore-scripts (packages/exochain-sdk)
- npm install --package-lock-only --ignore-scripts (tools/cross-impl-test)
- npm ci --ignore-scripts (packages/exochain-sdk)
- npm test (packages/exochain-sdk, 67 passed)
- npm ci --ignore-scripts (tools/cross-impl-test)
- npm test (tools/cross-impl-test, 1 vector passed)
- bash tools/test_npm_core_package_hygiene.sh
- bash tools/test_github_actions_pinned.sh
- bash tools/test_ci_supply_chain_hardening.sh
- bash tools/test_security_critical_dependencies_pinned.sh
- bash tools/test_repo_truth.sh
- bash tools/test_audit_ignore_policy.sh
- bash tools/test_audit_policy_docs.sh
- cargo audit --deny unsound --deny unmaintained
- cargo deny check licenses advisories bans sources
- git diff --check