### PR TITLE
fix: fail closed demo database config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,8 @@ jobs:
         run: bash tools/test_repo_truth.sh
       - name: Sybil CLI secret boundary
         run: bash tools/test_sybil_cli_secret_boundaries.sh
+      - name: Demo shared secret boundary
+        run: bash tools/test_demo_shared_secret_boundaries.sh
       - name: Audit policy documentation truth
         run: bash tools/test_audit_policy_docs.sh
       - name: Consensus liveness documentation truth

--- a/demo/EXOCHAIN_SURFACE_INTAKE.md
+++ b/demo/EXOCHAIN_SURFACE_INTAKE.md
@@ -1,0 +1,58 @@
+<!--
+Copyright 2026 Exochain Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at:
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# EXOCHAIN Demo Surface Intake
+
+Owner and accountable maintainer: EXOCHAIN Foundation demo maintainers.
+
+Deployment status: `prototype`.
+
+Constitutional trust claims: The demo surface is not allowed to claim
+constitutional enforcement. It may demonstrate data shapes, API ergonomics, and
+local WASM helpers, but it is not the canonical EXOCHAIN trust fabric.
+
+Core state access: The demo surface must not read or write production EXOCHAIN
+core state, production signatures, production credentials, governance outcomes,
+consent records, authority records, provenance records, or tenant data. Demo
+services may use local prototype PostgreSQL state only through an explicit
+runtime `DATABASE_URL`.
+
+Trust boundary: `demo/` is adjacent surface code. Calls into
+`@exochain/exochain-wasm` are local helper calls and do not create authority,
+consent, provenance, or governance outcomes unless a separate verified core
+runtime adapter adjudicates the action.
+
+Surface-specific test command:
+
+```bash
+bash tools/test_demo_shared_secret_boundaries.sh
+```
+
+CI gate: `.github/workflows/ci.yml` Gate 9 (`Demo shared secret boundary`).
+
+Secrets inventory and configuration source:
+
+| Secret or config | Source | Rule |
+| --- | --- | --- |
+| `DATABASE_URL` | Runtime environment or local `.env` ignored by Git | Required for shared demo DB pool creation; no hardcoded fallback. |
+| `GOVERNANCE_API_TOKEN` | Runtime environment for `demo/services/audit-api` | Missing token fails protected governance writes closed. |
+
+Rollback or disablement path: unset `DATABASE_URL` or stop the demo compose
+stack. Shared demo DB access fails closed when `DATABASE_URL` is missing or
+blank, so disabling the surface does not require touching EXOCHAIN core runtime
+state.

--- a/demo/packages/shared/src/index.js
+++ b/demo/packages/shared/src/index.js
@@ -20,10 +20,18 @@ import pg from 'pg';
 let pool = null;
 let wasmModule = null;
 
+function requiredDatabaseUrl() {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl || !databaseUrl.trim()) {
+    throw new Error('DATABASE_URL must be configured for @exochain/shared');
+  }
+  return databaseUrl;
+}
+
 export function getPool() {
   if (!pool) {
     pool = new pg.Pool({
-      connectionString: process.env.DATABASE_URL || 'postgres://exochain:exochain_dev@localhost:5432/exochain',
+      connectionString: requiredDatabaseUrl(),
     });
   }
   return pool;

--- a/demo/packages/shared/src/index.test.js
+++ b/demo/packages/shared/src/index.test.js
@@ -1,0 +1,58 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+async function loadFreshSharedModule(label) {
+  return import(`./index.js?case=${label}-${Date.now()}`);
+}
+
+test('getPool fails closed when DATABASE_URL is missing', async () => {
+  const previousDatabaseUrl = process.env.DATABASE_URL;
+  delete process.env.DATABASE_URL;
+  try {
+    const shared = await loadFreshSharedModule('missing-database-url');
+    assert.throws(
+      () => shared.getPool(),
+      /DATABASE_URL must be configured for @exochain\/shared/,
+    );
+  } finally {
+    if (previousDatabaseUrl === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = previousDatabaseUrl;
+    }
+  }
+});
+
+test('getPool uses the explicit runtime DATABASE_URL without fallback', async () => {
+  const previousDatabaseUrl = process.env.DATABASE_URL;
+  const runtimeDatabaseUrl = 'postgres://demo-user:demo-pass@demo-db:5432/demo';
+  process.env.DATABASE_URL = runtimeDatabaseUrl;
+  try {
+    const shared = await loadFreshSharedModule('explicit-database-url');
+    const pool = shared.getPool();
+    assert.equal(pool.options.connectionString, runtimeDatabaseUrl);
+    await pool.end();
+  } finally {
+    if (previousDatabaseUrl === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = previousDatabaseUrl;
+    }
+  }
+});

--- a/docs/audit/GAUNTLET-SECRETS-CONFIG-VALIDATION-2026-05-15.md
+++ b/docs/audit/GAUNTLET-SECRETS-CONFIG-VALIDATION-2026-05-15.md
@@ -1,0 +1,85 @@
+<!--
+Copyright 2026 Exochain Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at:
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Gauntlet Secrets and Config Validation - 2026-05-15
+
+This record validates selected Wally Fipps Gauntlet secrets/configuration
+findings against current `main`. The source artifacts remain imported evidence
+and were not committed as source files:
+
+- `/private/tmp/exochain-gauntlet-findings/Exochain Gauntlet Findings/gauntlet-findings.md`
+- `/private/tmp/exochain-gauntlet-findings/Exochain Gauntlet Findings/gauntlet-deep-analysis.md`
+- `/private/tmp/exochain-gauntlet-findings/Exochain Gauntlet Findings/da-findings.tsv`
+- `/Users/bobstewart/Library/Mobile Documents/com~apple~CloudDocs/Exochain-audit-report-run2.html`
+
+Validation target:
+
+- branch: `main`
+- commit: `068468e8a6876a406b6317ba8e7ed14adf45d626`
+
+## Path Classification
+
+| Path family | Classification | Notes |
+| --- | --- | --- |
+| `docker-compose.yml` | Core runtime adapter | Local EXOCHAIN gateway/API compose contract with required runtime secrets. |
+| `docker-compose.ci.yml` | Core runtime adapter | CI-only Postgres fixture using isolated test credentials. |
+| `.github/workflows/ci.yml` | EXOCHAIN core | Gate 9 hygiene and adjacent demo secret-boundary source guard. |
+| `.gitignore` | EXOCHAIN core | Repo hygiene boundary for local env files and generated artifacts. |
+| `crates/exo-node/src/auth.rs`, `crates/exo-node/src/main.rs` | Core runtime adapter | Admin bearer-token generation, persistence, and startup logging. |
+| `tools/sybil-cli/graph_schema.py` | EXOCHAIN core support tool | Sybil graph tooling used by governance analysis. |
+| `demo/packages/shared/` | Adjacent surface | Prototype demo shared DB helper; not canonical EXOCHAIN core. |
+| `demo/services/audit-api/` | Adjacent surface | Prototype demo audit API; validates protected governance writes locally. |
+| `demo/EXOCHAIN_SURFACE_INTAKE.md` | Adjacent-surface intake | Ownership, trust boundary, secret inventory, test command, and CI gate for `demo/`. |
+| `command-base/` | Adjacent surface | CommandBase is not covered by this demo-focused adjacent remediation commit. |
+| `/private/tmp/exochain-gauntlet-findings/...` | Imported evidence | Read-only external assessment artifacts. |
+
+## Dispositions
+
+| Finding | Current disposition | Evidence |
+| --- | --- | --- |
+| F-012 hardcoded DB password in root compose | Stale / already remediated | `docker-compose.yml` requires `POSTGRES_PASSWORD` through `${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD...}`. The literal `test` password appears only in `docker-compose.ci.yml`, which is explicitly CI-only and paired with the Gate 13 test database URL. |
+| F-013 JWT secret soft fallback in root compose | Stale / already remediated | `docker-compose.yml` requires `JWT_SECRET` and `LIVESAFE_JWT_SECRET` through fail-fast compose guards rather than development defaults. |
+| F-014 DB connection string fallback in demo package | Reproduced and remediated | `demo/packages/shared/src/index.js` no longer embeds `postgres://exochain:exochain_dev@localhost:5432/exochain` or any `DATABASE_URL ||` fallback. `getPool()` now fails closed when `DATABASE_URL` is missing or blank. |
+| F-015 Neo4j password literal in `sybil-cli` | Stale / already remediated | `tools/sybil-cli/graph_schema.py` reads `NEO4J_URI`, `NEO4J_USERNAME`, and `NEO4J_PASSWORD` from required environment variables and fails closed when any are missing. |
+| F-016 `GOVERNANCE_API_TOKEN` degrades to open | Stale / already remediated for the checked demo route | `demo/services/audit-api` stores a missing token as `null` and rejects protected governance writes unless the bearer token matches the configured runtime secret. |
+| F-017 `.gitignore` missing `.env` exclusion | Stale / already remediated | `.gitignore` excludes `.env` and `*.env.local`; Gate 9 rejects tracked env files except examples. |
+| F-018 admin bearer token logged plaintext | Stale / already remediated | Node startup stores the admin token in zeroizing storage, writes it through the restrictive auth writer, and source guards reject logging even partial token material. |
+| F-019 changelog claims A-043 fix without matching code | Stale / already remediated | The A-043 changelog entry matches current root compose fail-fast secret guards and the current `.env` hygiene rule. |
+| F-020 webhook secret seeded as empty string | Adjacent CommandBase finding, not remediated in this commit | Current matches are under `command-base/`, which is adjacent surface code with a separate intake. This branch did not blend CommandBase changes with the demo DB fallback fix. |
+
+## Commands Run
+
+All commands below completed with exit code 0 unless explicitly noted.
+
+```bash
+node --test demo/packages/shared/src/index.test.js
+bash tools/test_demo_shared_secret_boundaries.sh
+bash tools/test_sybil_cli_secret_boundaries.sh
+cargo test -p exo-node admin_token -- --nocapture
+node --test command-base/app/lib/auth.security.test.js
+npm --prefix demo test -- --project services services/audit-api/src/index.test.js
+git ls-files '*.env' '.env*'
+```
+
+`node --test demo/packages/shared/src/index.test.js` was first run before the
+production change and failed because `getPool()` did not throw when
+`DATABASE_URL` was absent. The same command passed after removing the fallback.
+
+The first sandboxed run of the demo audit-api Vitest command failed with
+`listen EPERM` while binding an ephemeral local port. The same command passed
+when rerun with local bind permission.

--- a/tools/test_demo_shared_secret_boundaries.sh
+++ b/tools/test_demo_shared_secret_boundaries.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Copyright 2026 Exochain Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+fail() {
+  printf 'demo shared secret boundary test failed: %s\n' "$1" >&2
+  exit 1
+}
+
+source_file="demo/packages/shared/src/index.js"
+test_file="demo/packages/shared/src/index.test.js"
+
+[[ -f "$source_file" ]] || fail "missing $source_file"
+[[ -f "$test_file" ]] || fail "missing $test_file"
+
+if grep -En 'postgres://[^[:space:]"'\'']+' "$source_file"; then
+  fail "$source_file must not embed a PostgreSQL connection string fallback"
+fi
+
+if grep -En 'process\.env\.DATABASE_URL[[:space:]]*\|\|' "$source_file"; then
+  fail "$source_file must fail closed instead of using an OR fallback for DATABASE_URL"
+fi
+
+node --test "$test_file"
+
+printf 'demo shared secret boundary test passed\n'


### PR DESCRIPTION
## Summary

- Removes the hardcoded demo Postgres fallback from `demo/packages/shared`; `getPool()` now fails closed unless `DATABASE_URL` is explicitly configured.
- Adds a regression test and Gate 9 CI guard for the demo shared DB secret boundary.
- Adds `demo/EXOCHAIN_SURFACE_INTAKE.md` so the adjacent demo surface has an explicit owner, prototype status, trust boundary, secret inventory, test command, CI gate, and disablement path.
- Records F-012 through F-020 dispositions from the imported Gauntlet evidence, with F-014 remediated in this PR and CommandBase F-020 intentionally left isolated from this demo-surface change.

## Path Classification

- `.github/workflows/ci.yml`: EXOCHAIN core CI gate.
- `tools/test_demo_shared_secret_boundaries.sh`: EXOCHAIN core CI/source guard for adjacent demo secret boundary.
- `demo/EXOCHAIN_SURFACE_INTAKE.md`: Adjacent-surface intake.
- `demo/packages/shared/src/index.js`: Adjacent surface.
- `demo/packages/shared/src/index.test.js`: Adjacent-surface test.
- `docs/audit/GAUNTLET-SECRETS-CONFIG-VALIDATION-2026-05-15.md`: EXOCHAIN core governance artifact.
- External HTML, zip, and extracted Gauntlet files: imported evidence, not committed.

## Validation

All commands completed with exit code 0 unless noted.

```bash
node --test demo/packages/shared/src/index.test.js
bash tools/test_demo_shared_secret_boundaries.sh
bash tools/test_sybil_cli_secret_boundaries.sh
cargo test -p exo-node admin_token -- --nocapture
node --test command-base/app/lib/auth.security.test.js
npm --prefix demo test -- --project services services/audit-api/src/index.test.js
bash tools/test_repo_truth.sh
bash tools/test_github_actions_pinned.sh
bash tools/test_ci_supply_chain_hardening.sh
cargo fmt --all -- --check
git diff --check
git diff --cached --check
```

TDD note: `node --test demo/packages/shared/src/index.test.js` failed before the production change because `getPool()` did not reject missing `DATABASE_URL`; it passed after the fallback was removed.

Sandbox note: the first unprivileged `npm --prefix demo test -- --project services services/audit-api/src/index.test.js` run failed with `listen EPERM` on local port binding. The same command passed when rerun with local bind permission.
