### PR TITLE
fix: harden commandbase governance heuristics

### DIFF
--- a/command-base/EXOCHAIN_SURFACE_INTAKE.md
+++ b/command-base/EXOCHAIN_SURFACE_INTAKE.md
@@ -16,16 +16,28 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# CommandBase EXOCHAIN Economy Adapter Intake
+# CommandBase EXOCHAIN Adjacent Surface Intake
 
 - Owner/accountable maintainer: EXOCHAIN operator / CommandBase maintainer.
 - Deployment status: internal cockpit adapter.
-- Constitutional trust claims: CommandBase may display EXOCHAIN-recorded HonorGood and mission-economics objects only when responses come from the configured EXOCHAIN API.
-- Core state access: read/write through `EXOCHAIN_API_BASE_URL` and optional bearer token only.
-- Trust boundary: CommandBase never computes authoritative settlements, anchors, receipts, or legal effects. It forwards operator requests to EXOCHAIN and displays EXOCHAIN responses.
-- Test command: `node --test command-base/app/lib/auth.security.test.js command-base/app/auth-bootstrap.test.js`.
+- Constitutional trust claims: CommandBase may display EXOCHAIN-recorded HonorGood
+  and mission-economics objects only when responses come from the configured
+  EXOCHAIN API. CommandBase-local governance receipts, review-panel votes, and
+  heuristic invariant checks are adjacent audit records and must not be described
+  as EXOCHAIN constitutional-kernel enforcement.
+- Core state access: read/write through `EXOCHAIN_API_BASE_URL` and optional
+  bearer token only.
+- Trust boundary: CommandBase never computes authoritative settlements, anchors,
+  EXOCHAIN receipts, governance outcomes, consent decisions, authority chains, or
+  legal effects. It forwards operator requests to EXOCHAIN and displays EXOCHAIN
+  responses. CommandBase-local heuristic checks may write local audit-trail
+  records, but they must not extend a trusted EXOCHAIN receipt hash chain.
+- Test command: `node --test command-base/app/lib/auth.security.test.js
+  command-base/app/auth-bootstrap.test.js command-base/app/services/governance.test.js`.
 - Secrets inventory: `EXOCHAIN_API_BASE_URL`; optional `EXOCHAIN_API_TOKEN` and optional
   `EXOCHAIN_AUTH_SECRET` (required if WASM auth backend is unavailable); optional
   `COMMAND_BASE_AUTH_BOOTSTRAP_TOKEN` for non-loopback operator auth bootstrap. Tokens
   are not logged or returned by status routes.
-- Rollback/disablement: unset `EXOCHAIN_API_BASE_URL` to force HonorGood cockpit actions to fail closed.
+- Rollback/disablement: unset `EXOCHAIN_API_BASE_URL` to force HonorGood cockpit
+  actions to fail closed. Disable CommandBase governance automation routes if
+  local audit records are mistaken for EXOCHAIN core receipts.

--- a/command-base/app/services/governance.js
+++ b/command-base/app/services/governance.js
@@ -52,6 +52,70 @@ module.exports = function(db, broadcast, helpers) {
     return 'pass';
   }
 
+  function outputTokenSet(output) {
+    return new Set(
+      String(output || '')
+        .toLowerCase()
+        .split(/[^a-z0-9]+/)
+        .filter(Boolean)
+    );
+  }
+
+  function hasAllTokens(tokens, required) {
+    return required.every((token) => tokens.has(token));
+  }
+
+  function hasAnyToken(tokens, candidates) {
+    return candidates.some((token) => tokens.has(token));
+  }
+
+  function classifyHeuristicOutput(output) {
+    const text = String(output || '');
+    const lower = text.toLowerCase();
+    const tokens = outputTokenSet(text);
+    const mentionsGovernanceReceipts =
+      hasAllTokens(tokens, ['governance', 'receipts']) ||
+      hasAllTokens(tokens, ['governance', 'receipt']);
+    const mentionsReceiptHash = hasAllTokens(tokens, ['receipt', 'hash']);
+    const destructiveReceiptVerb = hasAnyToken(tokens, [
+      'delete',
+      'drop',
+      'erase',
+      'purge',
+      'remove',
+      'truncate',
+    ]);
+    const updateReceiptHashVerb = hasAnyToken(tokens, [
+      'modify',
+      'overwrite',
+      'replace',
+      'set',
+      'update',
+    ]);
+
+    return {
+      evalCall: /\beval\s*\(/.test(text),
+      innerHtmlUserInput: tokens.has('innerhtml') && tokens.has('user'),
+      plaintextPassword: tokens.has('password') && tokens.has('plain'),
+      hardcodedApiKey: tokens.has('api') && tokens.has('key') && hasAnyToken(tokens, ['hardcod', 'hardcoded']),
+      dropTable: hasAllTokens(tokens, ['drop', 'table']),
+      deleteWithoutWhere: hasAllTokens(tokens, ['delete', 'from']) && !tokens.has('where'),
+      governanceReceiptMutation:
+        mentionsGovernanceReceipts &&
+        (destructiveReceiptVerb || (mentionsReceiptHash && updateReceiptHashVerb)),
+      governanceInsertWithoutProvenance:
+        hasAllTokens(tokens, ['insert', 'into']) &&
+        tokens.has('governance') &&
+        !tokens.has('hash') &&
+        !tokens.has('provenance'),
+      orchestratorBypass:
+        tokens.has('gray') && tokens.has('bypass') && tokens.has('direct'),
+      unassignedInProgress:
+        hasAllTokens(tokens, ['assigned', 'to']) && tokens.has('null') && hasAllTokens(tokens, ['in', 'progress']),
+      permissiveCors: tokens.has('cors') && lower.includes("'*'"),
+    };
+  }
+
   // ── Governance helper: create an ExoChain-quality receipt ──
 
   function createReceipt(db, actionType, entityType, entityId, actor, description, payload, projectId, opts = {}) {
@@ -111,58 +175,58 @@ module.exports = function(db, broadcast, helpers) {
   function validateAgainstInvariants(taskId, output) {
     const invariants = db.prepare('SELECT * FROM constitutional_invariants').all();
     const violations = [];
+    const heuristic = classifyHeuristicOutput(output);
 
     for (const inv of invariants) {
-      const lowerOutput = (output || '').toLowerCase();
       const invName = (inv.name || '').toLowerCase();
       // FIX: Use enforcement_level from DB to determine severity.
       // 'block' = blocks task, 'warn' = logs but allows, 'audit' = logs only
       const enfLevel = inv.enforcement_level || inv.severity || 'block';
 
       if (invName.includes('security') || invName.includes('authorization')) {
-        if (/\beval\s*\(/.test(output) || (lowerOutput.includes('innerhtml') && lowerOutput.includes('user'))) {
+        if (heuristic.evalCall || heuristic.innerHtmlUserInput) {
           violations.push({ invariant_id: inv.id, name: inv.name, severity: enfLevel, detail: 'Potential XSS: eval() or unescaped innerHTML with user input detected' });
         }
-        if (lowerOutput.includes('password') && lowerOutput.includes('plain')) {
+        if (heuristic.plaintextPassword) {
           violations.push({ invariant_id: inv.id, name: inv.name, severity: enfLevel, detail: 'Plaintext password handling detected' });
         }
-        if (lowerOutput.includes('api_key') && lowerOutput.includes('hardcod')) {
+        if (heuristic.hardcodedApiKey) {
           violations.push({ invariant_id: inv.id, name: inv.name, severity: enfLevel, detail: 'Hardcoded API key detected' });
         }
       }
 
       if (invName.includes('data') || invName.includes('integrity') || invName.includes('silent')) {
-        if (lowerOutput.includes('drop table') || (lowerOutput.includes('delete from') && !lowerOutput.includes('where'))) {
+        if (heuristic.dropTable || heuristic.deleteWithoutWhere) {
           violations.push({ invariant_id: inv.id, name: inv.name, severity: enfLevel, detail: 'Destructive SQL without WHERE clause detected' });
         }
       }
 
       if (invName.includes('governance') || invName.includes('chain') || invName.includes('immutable') || invName.includes('history')) {
-        if (lowerOutput.includes('governance_receipts') && (lowerOutput.includes('delete') || lowerOutput.includes('update.*receipt_hash'))) {
-          violations.push({ invariant_id: inv.id, name: inv.name, severity: enfLevel, detail: 'Attempt to modify governance chain detected' });
+        if (heuristic.governanceReceiptMutation) {
+          violations.push({ invariant_id: inv.id, name: inv.name, severity: enfLevel, detail: 'Attempt to modify governance chain or receipt hash detected' });
         }
       }
 
       if (invName.includes('provenance')) {
-        if (lowerOutput.includes('insert into') && !lowerOutput.includes('hash') && !lowerOutput.includes('provenance') && lowerOutput.includes('governance')) {
+        if (heuristic.governanceInsertWithoutProvenance) {
           violations.push({ invariant_id: inv.id, name: inv.name, severity: enfLevel, detail: 'Governance insert without provenance tracking' });
         }
       }
 
       if (invName.includes('orchestrator') || invName.includes('single')) {
-        if (lowerOutput.includes('gray') && lowerOutput.includes('bypass') && lowerOutput.includes('direct')) {
+        if (heuristic.orchestratorBypass) {
           violations.push({ invariant_id: inv.id, name: inv.name, severity: enfLevel, detail: 'Potential orchestrator bypass detected' });
         }
       }
 
       if (invName.includes('assignment') || invName.includes('accountability')) {
-        if (lowerOutput.includes('assigned_to') && lowerOutput.includes('null') && lowerOutput.includes('in_progress')) {
+        if (heuristic.unassignedInProgress) {
           violations.push({ invariant_id: inv.id, name: inv.name, severity: enfLevel, detail: 'Task progressing without assignment detected' });
         }
       }
 
       if (invName.includes('security') || invName.includes('authorization')) {
-        if (lowerOutput.includes('cors') && lowerOutput.includes("'*'")) {
+        if (heuristic.permissiveCors) {
           violations.push({ invariant_id: inv.id, name: inv.name, severity: enfLevel, detail: 'Permissive CORS wildcard detected' });
         }
       }
@@ -187,24 +251,45 @@ module.exports = function(db, broadcast, helpers) {
 
     try {
       const invariantIds = violations.map(v => v.invariant_id).filter(Boolean);
-      createReceipt(db, 'invariant_check', 'task', taskId, 'System',
-        `Invariant validation: ${passed ? 'PASSED' : 'BLOCKED'} — ${violations.length} violations (${blockCount} blocking, ${warnCount} warnings)`,
-        { task_id: taskId, passed, violations_count: violations.length, block_count: blockCount, warn_count: warnCount, violations: violations.slice(0, 10) },
+      const invariantsChecked = JSON.stringify(invariants.map(i => i.code));
+      const auditSummary = {
+        task_id: taskId,
+        passed,
+        validation_source: 'commandbase_heuristic_output_scan',
+        receipt_created: false,
+        violations_count: violations.length,
+        block_count: blockCount,
+        warn_count: warnCount,
+        invariant_ids_violated: invariantIds,
+        enforcement_levels: [...new Set(violations.map(v => v.severity))],
+      };
+      // This path inspects untrusted agent text with CommandBase-local heuristics.
+      // It must not mint or extend a governance receipt hash chain.
+      db.prepare(`INSERT INTO governance_audit_trail (action_type, actor_name, target_type, target_id, branch, before_state, after_state, invariants_checked, receipt_id, created_at)
+        VALUES (?,?,?,?,?,?,?,?,?,?)`).run(
+        'heuristic_invariant_check',
+        'System',
+        'task',
+        taskId,
+        'judicial',
         null,
-        {
-          branch: 'judicial',
-          adjudication: passed ? 'pass' : 'fail',
-          // FIX: Link receipt to the first violated invariant for forensic traceability
-          invariant_id: invariantIds.length > 0 ? invariantIds[0] : null,
-          invariants_checked: JSON.stringify(invariants.map(i => i.code)),
-          metadata: { invariant_ids_violated: invariantIds, enforcement_levels: [...new Set(violations.map(v => v.severity))] }
-        }
+        JSON.stringify(auditSummary),
+        invariantsChecked,
+        null,
+        now
       );
     } catch (e) {
-      console.warn('[InvariantCheck] Receipt creation error:', e.message);
+      console.warn('[InvariantCheck] Heuristic audit error:', e.message);
     }
 
-    return { passed, violations, block_count: blockCount, warn_count: warnCount };
+    return {
+      passed,
+      violations,
+      block_count: blockCount,
+      warn_count: warnCount,
+      receipt_created: false,
+      validation_source: 'commandbase_heuristic_output_scan',
+    };
   }
 
   // ══════════════════════════════════════════════════════════════

--- a/command-base/app/services/governance.test.js
+++ b/command-base/app/services/governance.test.js
@@ -22,6 +22,7 @@ const { join } = require('node:path');
 const test = require('node:test');
 
 const source = readFileSync(join(__dirname, 'governance.js'), 'utf8');
+const createGovernanceService = require('./governance');
 
 function functionSource(name) {
   const start = source.indexOf(`function ${name}`);
@@ -47,5 +48,111 @@ test('assignAdjudicationStage uses deterministic adjudicator ordering', () => {
     body,
     /ORDER\s+BY[\s\S]+ASC[\s\S]+id\s+ASC/i,
     'adjudicator ordering must use a stable id tie-breaker',
+  );
+});
+
+function createGovernanceDb(invariants) {
+  const rows = {
+    governance_receipts: [],
+    governance_audit_trail: [],
+    invariant_updates: [],
+  };
+
+  return {
+    rows,
+    prepare(sql) {
+      const normalized = sql.replace(/\s+/g, ' ');
+
+      if (normalized.includes('SELECT * FROM constitutional_invariants')) {
+        return { all: () => invariants };
+      }
+
+      if (normalized.includes('UPDATE constitutional_invariants SET last_validated_at')) {
+        return {
+          run: (...params) => {
+            rows.invariant_updates.push(params);
+            return { changes: 1 };
+          },
+        };
+      }
+
+      if (normalized.includes('SELECT id, receipt_hash, payload_hash, previous_hash FROM governance_receipts')) {
+        return {
+          get: () => rows.governance_receipts.at(-1),
+        };
+      }
+
+      if (normalized.includes('SELECT receipt_hash FROM governance_receipts WHERE id = ? - 1')) {
+        return {
+          get: (id) => rows.governance_receipts.find((receipt) => receipt.id === id - 1),
+        };
+      }
+
+      if (normalized.includes('INSERT INTO governance_receipts')) {
+        return {
+          run: (...params) => {
+            const id = rows.governance_receipts.length + 1;
+            rows.governance_receipts.push({
+              id,
+              action_type: params[1],
+              receipt_hash: params[8],
+              previous_hash: params[7],
+            });
+            return { lastInsertRowid: id };
+          },
+        };
+      }
+
+      if (normalized.includes('INSERT INTO governance_audit_trail')) {
+        return {
+          run: (...params) => {
+            const id = rows.governance_audit_trail.length + 1;
+            rows.governance_audit_trail.push({ id, params });
+            return { lastInsertRowid: id };
+          },
+        };
+      }
+
+      throw new Error(`unexpected SQL in governance test: ${sql}`);
+    },
+  };
+}
+
+function governanceServiceFor(invariants) {
+  const db = createGovernanceDb(invariants);
+  return {
+    db,
+    service: createGovernanceService(db, () => {}, {
+      localNow: () => '2026-05-15T00:00:00.000-04:00',
+    }),
+  };
+}
+
+test('validateAgainstInvariants blocks receipt hash mutation without regex spelling', () => {
+  const { service } = governanceServiceFor([
+    { id: 7, code: 'INV-CHAIN', name: 'Governance Chain Immutable', enforcement_level: 'block' },
+  ]);
+
+  const result = service.validateAgainstInvariants(
+    42,
+    "operator output: UPDATE governance_receipts SET receipt_hash = 'abc' WHERE id = 1",
+  );
+
+  assert.equal(result.passed, false);
+  assert.equal(result.block_count, 1);
+  assert.match(result.violations[0].detail, /governance chain/i);
+});
+
+test('validateAgainstInvariants does not append a governance receipt from heuristic output scan', () => {
+  const { db, service } = governanceServiceFor([
+    { id: 9, code: 'INV-GOV', name: 'Governance Integrity', enforcement_level: 'warn' },
+  ]);
+
+  service.validateAgainstInvariants(101, 'routine status output with no structured governance evidence');
+
+  assert.equal(
+    db.rows.governance_receipts.length,
+    0,
+    'heuristic validation of untrusted output must not mutate the receipt hash chain',
   );
 });

--- a/docs/audit/GAUNTLET-COMMANDBASE-GOVERNANCE-HEURISTIC-REMEDIATION-2026-05-15.md
+++ b/docs/audit/GAUNTLET-COMMANDBASE-GOVERNANCE-HEURISTIC-REMEDIATION-2026-05-15.md
@@ -1,0 +1,77 @@
+<!--
+Copyright 2026 Exochain Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at:
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Gauntlet CommandBase Governance Heuristic Remediation - 2026-05-15
+
+This record covers the adjacent CommandBase remediation for Wally Fipps Gauntlet
+F-042 and F-043. The external artifacts remain imported evidence and were not
+committed as source files:
+
+- `/private/tmp/exochain-gauntlet-findings/Exochain Gauntlet Findings/gauntlet-findings.md`
+- `/private/tmp/exochain-gauntlet-findings/Exochain Gauntlet Findings/gauntlet-deep-analysis.md`
+- `/private/tmp/exochain-gauntlet-findings/Exochain Gauntlet Findings/da-findings.tsv`
+
+## Path Classification
+
+| Path | Classification | Notes |
+| --- | --- | --- |
+| `command-base/app/services/governance.js` | Adjacent surface | CommandBase-local governance receipt and heuristic invariant-check service. |
+| `command-base/app/services/governance.test.js` | Adjacent surface | Regression coverage for the adjacent heuristic boundary. |
+| `command-base/EXOCHAIN_SURFACE_INTAKE.md` | Adjacent surface | Ownership and trust-boundary intake record. |
+| `docs/audit/GAUNTLET-COMMANDBASE-GOVERNANCE-HEURISTIC-REMEDIATION-2026-05-15.md` | EXOCHAIN core | Owned audit/triage governance artifact summarizing imported evidence and adjacent remediation without committing external artifacts. |
+
+## Findings
+
+| Finding | Disposition | Remediation |
+| --- | --- | --- |
+| F-042 governance receipts from regex scan of LLM output | Remediated for CommandBase adjacent surface | `validateAgainstInvariants` no longer calls `createReceipt` or appends to `governance_receipts` from heuristic scans of untrusted output. It writes an audit-trail record with `receipt_created: false` instead. |
+| F-043 `validateAgainstInvariants` regex patterns trivially evaded | Remediated for CommandBase adjacent surface | Receipt-chain mutation detection now tokenizes output and catches normal `UPDATE governance_receipts SET receipt_hash = ...` wording rather than the previous literal `update.*receipt_hash` substring. |
+
+This remediation does not claim EXOCHAIN core constitutional enforcement for
+CommandBase. CommandBase-local heuristic checks remain adjacent audit signals.
+
+## Red-Green Evidence
+
+Red command:
+
+```bash
+node --test command-base/app/services/governance.test.js
+```
+
+Observed failures before the fix:
+
+- `validateAgainstInvariants blocks receipt hash mutation without regex spelling`
+  failed with `true !== false`.
+- `validateAgainstInvariants does not append a governance receipt from heuristic
+  output scan` failed with `1 !== 0`.
+
+Green commands:
+
+```bash
+node --test command-base/app/services/governance.test.js
+node --test command-base/app/services/governance.test.js command-base/app/lib/auth.security.test.js command-base/app/auth-bootstrap.test.js
+npm --prefix command-base/app audit --audit-level=high
+bash tools/test_repo_truth.sh
+cargo fmt --all -- --check
+git diff --check
+```
+
+All green commands completed with exit code 0. The combined CommandBase auth
+test required local socket binding outside the sandbox; the sandboxed attempt
+failed with `listen EPERM: operation not permitted 0.0.0.0`, and the approved
+rerun passed.


### PR DESCRIPTION
## Summary
- remediates adjacent CommandBase F-042 by preventing heuristic invariant scans from appending to the governance receipt hash chain
- remediates adjacent CommandBase F-043 by replacing the literal update.*receipt_hash check with deterministic token-based receipt-chain mutation detection
- updates CommandBase intake to state that local governance receipts and heuristic checks are adjacent audit signals, not EXOCHAIN constitutional-kernel enforcement

## Path Classification
- Adjacent surface: command-base/app/services/governance.js
- Adjacent surface: command-base/app/services/governance.test.js
- Adjacent surface: command-base/EXOCHAIN_SURFACE_INTAKE.md
- EXOCHAIN core governance artifact: docs/audit/GAUNTLET-COMMANDBASE-GOVERNANCE-HEURISTIC-REMEDIATION-2026-05-15.md

## Red-Green Evidence
Red: node --test command-base/app/services/governance.test.js failed before implementation because receipt-hash mutation passed and heuristic validation appended one governance receipt.

Green:
- node --test command-base/app/services/governance.test.js
- node --test command-base/app/services/governance.test.js command-base/app/lib/auth.security.test.js command-base/app/auth-bootstrap.test.js
- npm --prefix command-base/app audit --audit-level=high
- bash tools/test_repo_truth.sh
- cargo fmt --all -- --check
- git diff --check
- git diff --cached --check

Note: the combined CommandBase auth test needed local socket binding outside the sandbox; the sandboxed run failed with listen EPERM, then the approved rerun passed.