### PR TITLE
docs: document exo consensus module scoring

### DIFF
--- a/crates/exo-consensus/README.md
+++ b/crates/exo-consensus/README.md
@@ -1,0 +1,93 @@
+<!--
+Copyright 2026 Exochain Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at:
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# exo-consensus
+
+`exo-consensus` is the deterministic AI-panel deliberation crate for EXOCHAIN
+governance evidence. It runs model-panel rounds, binds structured model
+responses to commitments, canonicalizes key claims, measures convergence,
+records devil's-advocate review, emits minority reports, and produces a hashed
+`DeliberationResult`.
+
+## Classification
+
+This crate is EXOCHAIN core. Its output can be used as evidence by governance
+and adjudication flows, so it must preserve the same determinism constraints as
+the rest of the Rust trust fabric.
+
+The trust boundary is narrow: `exo-consensus` is not BFT finality. It does not
+append DAG nodes, elect leaders, sign validator votes, update consent state, or
+grant constitutional authority. A deliberation record is evidence for a caller
+that still has to pass the gatekeeper, DAG, authority, consent, and provenance
+checks required by the runtime path that consumes it.
+
+## Deterministic Deliberation Flow
+
+1. A caller constructs a `Panel` for the decision class and supplies a
+   deterministic response provider.
+2. Each panelist response is validated, committed, revealed, and verified before
+   it becomes a `ModelPosition`.
+3. The crate derives canonical key-claim sets by trimming, lowercasing, sorting,
+   deduplicating, and removing empty claims.
+4. Convergence is computed from structured key claims in basis points.
+5. If the round converges or reaches the panel's maximum round count, the
+   configured devil's advocate reviews the result.
+6. Finalization derives consensus claims, minority reports, the Panel Confidence
+   Index, and a canonical hash for the `DeliberationResult`.
+
+Callers supply HLC timestamps through `RoundExecutionTiming` and
+`FinalizationTiming`. The crate must not read system time inside production
+logic.
+
+## Panel Confidence Index
+
+The Panel Confidence Index is a bounded basis-point score in the range
+`0..=10000`. The score uses no floating-point arithmetic and is calculated from
+integer components:
+
+| Component | Weight | Source |
+| --- | ---: | --- |
+| Model agreement | 50% model agreement | `models_agreeing / total_models * 5000` |
+| Convergence speed | 30% convergence speed | Faster convergence across the allowed round budget contributes up to 3000 bps. |
+| Devil's advocate | 20% devil's advocate | A serious objection removes the 2000 bps advocate component. |
+
+minority reports reduce the agreement component. During finalization, panelists
+whose structured claims fall below the consensus-claim threshold are recorded as
+minority reports; the session then sets `models_agreeing` to
+`panelists_count - minority_reports_count` before calculating the Panel
+Confidence Index.
+
+All inputs are defensively bounded in `calculate_panel_confidence`: agreeing
+models are capped at total models, convergence speed is capped by the maximum
+round count, and the theoretical maximum remains 10000 bps.
+
+## Constitutional Constraints
+
+The crate follows the core EXOCHAIN constraints:
+
+- no floating-point arithmetic in scoring or consensus logic;
+- sorted deterministic collections for canonical claim handling;
+- caller-provided HLC timestamps instead of system time;
+- typed errors with enough context for diagnosis;
+- no authority, consent, provenance, or governance outcome minted outside the
+  consuming core runtime path.
+
+Any adapter or adjacent surface that presents `exo-consensus` output as an
+EXOCHAIN trust decision must prove the runtime call path into core enforcement
+and must fail closed when that enforcement rejects, times out, or is
+unavailable.

--- a/crates/exo-consensus/src/lib.rs
+++ b/crates/exo-consensus/src/lib.rs
@@ -14,6 +14,25 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//! Deterministic AI-panel deliberation for EXOCHAIN governance evidence.
+//!
+//! This crate coordinates model-panel rounds, structured claim commitments,
+//! convergence scoring, minority-report generation, devil's-advocate review,
+//! and final deliberation records. It is EXOCHAIN core source because these
+//! records can become governance evidence, but this module is not BFT finality:
+//! it does not append DAG nodes, elect leaders, sign validator votes, or decide
+//! constitutional authorization on its own.
+//!
+//! The Panel Confidence Index is computed in basis points with integer-only
+//! arithmetic. The current weighting is 50% model agreement, 30% convergence
+//! speed, and 20% devil's-advocate clearance. Minority reports reduce the
+//! agreement input by lowering the number of panelists treated as agreeing
+//! before the score is calculated.
+//!
+//! Determinism rules apply here: structured claims are canonicalized with
+//! sorted sets, hashes bind canonical serialized records, callers supply HLC
+//! timestamps, and scoring must use no floating-point arithmetic.
+
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 
 pub mod advocate;

--- a/docs/audit/GAUNTLET-EXO-CONSENSUS-MODULE-DOCS-REMEDIATION-2026-05-15.md
+++ b/docs/audit/GAUNTLET-EXO-CONSENSUS-MODULE-DOCS-REMEDIATION-2026-05-15.md
@@ -1,0 +1,79 @@
+<!--
+Copyright 2026 Exochain Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at:
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Gauntlet F-154 exo-consensus Module Docs Remediation - 2026-05-15
+
+## Imported Evidence
+
+- Source: Wally Fipps Gauntlet findings corpus.
+- Finding: F-154, "AI consensus crate no module README".
+- Reported path: `exo-consensus/src/lib.rs`.
+- Severity: Medium.
+
+The external corpus remains imported evidence. This remediation verifies the
+claim against current owned source and commits only the source guard,
+documentation, and this audit record.
+
+## Path Classification
+
+| Path | Classification | Notes |
+| --- | --- | --- |
+| `crates/exo-consensus/src/lib.rs` | EXOCHAIN core | Crate root for AI-panel deliberation evidence. |
+| `crates/exo-consensus/README.md` | EXOCHAIN core | Crate documentation for deterministic deliberation and PCI weighting. |
+| `tools/test_exo_consensus_module_docs.sh` | EXOCHAIN core CI/source guard | Prevents regression to undocumented PCI weighting and trust boundary. |
+| `docs/audit/GAUNTLET-EXO-CONSENSUS-MODULE-DOCS-REMEDIATION-2026-05-15.md` | Imported-evidence triage record | Captures disposition and validation evidence. |
+
+## Verification
+
+Current `main` did not have `crates/exo-consensus/README.md`, and
+`crates/exo-consensus/src/lib.rs` did not contain crate-level module docs. The
+finding is valid for current owned EXOCHAIN core source.
+
+## Remediation
+
+- Added `tools/test_exo_consensus_module_docs.sh` before the documentation fix.
+- Documented `exo-consensus` as deterministic AI-panel deliberation evidence,
+  not BFT finality.
+- Documented the Panel Confidence Index weighting:
+  - 50% model agreement;
+  - 30% convergence speed;
+  - 20% devil's advocate.
+- Documented basis-point arithmetic, no floating-point arithmetic, HLC caller
+  timing, canonical claim handling, and minority-report treatment.
+
+## TDD Evidence
+
+RED:
+
+```bash
+bash tools/test_exo_consensus_module_docs.sh
+# exo-consensus module docs test failed: crate README is required
+```
+
+GREEN commands are recorded after remediation.
+
+```bash
+bash tools/test_exo_consensus_module_docs.sh
+cargo test -p exo-consensus panel_confidence -- --nocapture
+cargo test -p exo-consensus minority_report -- --nocapture
+cargo test -p exo-consensus -- --nocapture
+cargo clippy -p exo-consensus --all-targets -- -D warnings
+cargo doc -p exo-consensus --no-deps
+cargo fmt --all -- --check
+git diff --check
+```

--- a/tools/test_exo_consensus_module_docs.sh
+++ b/tools/test_exo_consensus_module_docs.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Copyright 2026 Exochain Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+readme="crates/exo-consensus/README.md"
+lib="crates/exo-consensus/src/lib.rs"
+
+fail() {
+  echo "exo-consensus module docs test failed: $*" >&2
+  exit 1
+}
+
+[ -f "$readme" ] || fail "crate README is required"
+
+grep -q "^//!" "$lib" || fail "crate root must contain module-level Rust docs"
+grep -q "Panel Confidence Index" "$lib" || fail "crate root docs must name the Panel Confidence Index"
+grep -q "basis points" "$lib" || fail "crate root docs must document basis-point arithmetic"
+grep -q "not BFT finality" "$lib" || fail "crate root docs must state the trust boundary"
+
+grep -q "Panel Confidence Index" "$readme" || fail "README must document the Panel Confidence Index"
+grep -q "50% model agreement" "$readme" || fail "README must document the agreement weight"
+grep -q "30% convergence speed" "$readme" || fail "README must document the speed weight"
+grep -q "20% devil's advocate" "$readme" || fail "README must document the advocate weight"
+grep -q "basis points" "$readme" || fail "README must document basis-point scoring"
+grep -q "minority reports reduce the agreement component" "$readme" || fail "README must document minority-report PCI treatment"
+grep -q "no floating-point arithmetic" "$readme" || fail "README must document deterministic arithmetic constraints"
+grep -q "not BFT finality" "$readme" || fail "README must state the trust boundary"
+
+echo "exo-consensus module docs test passed"


### PR DESCRIPTION
## Summary
- Remediates Gauntlet F-154 after verifying current main still lacked an exo-consensus README and crate-level module docs.
- Adds a source guard for exo-consensus module docs, PCI weighting, deterministic basis-point scoring, minority-report treatment, and the non-BFT-finality trust boundary.
- Documents exo-consensus as EXOCHAIN core deliberation evidence, not a standalone constitutional authorization or ledger-finality mechanism.

## Path Classification
- EXOCHAIN core: crates/exo-consensus/src/lib.rs, crates/exo-consensus/README.md
- EXOCHAIN core CI/source guard: tools/test_exo_consensus_module_docs.sh
- Imported-evidence triage record: docs/audit/GAUNTLET-EXO-CONSENSUS-MODULE-DOCS-REMEDIATION-2026-05-15.md

## TDD / Validation
- RED: bash tools/test_exo_consensus_module_docs.sh failed with missing crate README before docs were added.
- GREEN: bash tools/test_exo_consensus_module_docs.sh
- cargo test -p exo-consensus panel_confidence -- --nocapture
- cargo test -p exo-consensus minority_report -- --nocapture
- cargo test -p exo-consensus -- --nocapture
- cargo clippy -p exo-consensus --all-targets -- -D warnings
- cargo doc -p exo-consensus --no-deps
- cargo fmt --all -- --check
- git diff --check
- git diff --cached --check