### PR TITLE
docs: clarify signature empty trust boundary

### DIFF
--- a/crates/exo-core/src/types.rs
+++ b/crates/exo-core/src/types.rs
@@ -220,7 +220,12 @@ pub enum Signature {
     PostQuantum(Vec<u8>),
     /// Hybrid: classical Ed25519 + post-quantum signature.
     Hybrid { classical: [u8; 64], pq: Vec<u8> },
-    /// Empty placeholder — used before acceptance / during construction.
+    /// Empty placeholder.
+    ///
+    /// Signature::Empty is an unsigned construction sentinel.
+    /// It is permitted only while building a value that has not reached a trust
+    /// boundary. It must be rejected before persistence, verification,
+    /// authorization, consensus, or trust-record finalization.
     Empty,
 }
 
@@ -433,15 +438,26 @@ impl Signature {
     }
 
     /// The empty signature placeholder.
+    ///
+    /// This is the explicit unsigned construction sentinel. Do not persist it
+    /// or treat it as acceptable proof at a trust boundary.
     pub const EMPTY: Self = Self::Empty;
 
     /// Create an empty (placeholder) signature.
+    ///
+    /// Use this only for in-memory construction before a real signature is
+    /// attached. Verification paths reject it.
     #[must_use]
     pub const fn empty() -> Self {
         Self::Empty
     }
 
-    /// Check if this signature is the empty placeholder.
+    /// Check if this signature is the empty placeholder or an all-zero/null
+    /// sentinel for the represented algorithm.
+    ///
+    /// Do not use is_empty() as proof that a non-empty signature is valid. It is
+    /// a structural null-sentinel check only; callers that cross a trust
+    /// boundary must run algorithm-specific cryptographic verification.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         match self {

--- a/docs/audit/GAUNTLET-SIGNATURE-EMPTY-BOUNDARY-REMEDIATION-2026-05-15.md
+++ b/docs/audit/GAUNTLET-SIGNATURE-EMPTY-BOUNDARY-REMEDIATION-2026-05-15.md
@@ -1,0 +1,87 @@
+<!--
+Copyright 2026 Exochain Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at:
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Gauntlet F-155 Signature::Empty Boundary Remediation - 2026-05-15
+
+## Imported Evidence
+
+- Source: Wally Fipps Gauntlet findings corpus.
+- Finding: F-155, "Signature::EMPTY boundary implicit".
+- Reported path: `types.rs:311-320`.
+- Severity: Medium.
+
+The external corpus remains imported evidence. This remediation verifies the
+claim against current owned source and commits only the source guard,
+documentation update, and this audit record.
+
+## Path Classification
+
+| Path | Classification | Notes |
+| --- | --- | --- |
+| `crates/exo-core/src/types.rs` | EXOCHAIN core | Canonical signature type and sentinel boundary docs. |
+| `crates/exo-core/src/crypto.rs` | EXOCHAIN core | Existing verification path explicitly rejects `Signature::Empty`; unchanged. |
+| `tools/test_signature_empty_boundary_docs.sh` | EXOCHAIN core CI/source guard | Prevents regression to implicit sentinel-boundary docs. |
+| `docs/audit/GAUNTLET-SIGNATURE-EMPTY-BOUNDARY-REMEDIATION-2026-05-15.md` | Imported-evidence triage record | Captures disposition and validation evidence. |
+
+## Verification
+
+Current `main` already had the important runtime behavior:
+
+- `crypto::verify` returns `false` for `Signature::Empty`.
+- `Signature::as_bytes()` panics for `Signature::Empty` instead of returning a
+  zero sentinel.
+- Existing tests cover empty-signature rejection and non-Ed25519 downgrade
+  prevention.
+
+The remaining live issue was documentation: the `Signature::Empty` type docs did
+not spell out when the sentinel is acceptable and when it is a security
+violation.
+
+## Remediation
+
+- Added `tools/test_signature_empty_boundary_docs.sh` before changing docs.
+- Documented `Signature::Empty` as an unsigned construction sentinel.
+- Documented that it is acceptable only before a value reaches a trust boundary.
+- Documented that it must be rejected before persistence, verification,
+  authorization, consensus, or trust-record finalization.
+- Documented that `is_empty()` is only a structural null-sentinel check and must
+  not be treated as proof that a non-empty signature is valid.
+
+## TDD Evidence
+
+RED:
+
+```bash
+bash tools/test_signature_empty_boundary_docs.sh
+# Signature::Empty boundary docs test failed: types.rs must define Signature::Empty as an unsigned construction sentinel
+```
+
+GREEN:
+
+```bash
+bash tools/test_signature_empty_boundary_docs.sh
+cargo test -p exo-core signature_empty -- --nocapture
+cargo test -p exo-core signature_as_bytes -- --nocapture
+cargo test -p exo-core signature -- --nocapture
+cargo test -p exo-core crypto::tests:: -- --nocapture
+cargo test -p exo-core -- --nocapture
+cargo clippy -p exo-core --all-targets -- -D warnings
+cargo doc -p exo-core --no-deps
+cargo fmt --all -- --check
+git diff --check
+```

--- a/tools/test_signature_empty_boundary_docs.sh
+++ b/tools/test_signature_empty_boundary_docs.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Copyright 2026 Exochain Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+types="crates/exo-core/src/types.rs"
+crypto="crates/exo-core/src/crypto.rs"
+
+fail() {
+  echo "Signature::Empty boundary docs test failed: $*" >&2
+  exit 1
+}
+
+grep -q "Signature::Empty is an unsigned construction sentinel" "$types" || {
+  fail "types.rs must define Signature::Empty as an unsigned construction sentinel"
+}
+
+grep -q "permitted only while building" "$types" || {
+  fail "types.rs must document the acceptable pre-boundary use"
+}
+
+grep -q "not reached a trust" "$types" || {
+  fail "types.rs must document the acceptable pre-boundary use"
+}
+
+grep -q "boundary. It must be rejected" "$types" || {
+  fail "types.rs must document the acceptable pre-boundary use"
+}
+
+grep -q "must be rejected before persistence" "$types" || {
+  fail "types.rs must document the security boundary"
+}
+
+grep -q "trust-record finalization" "$types" || {
+  fail "types.rs must document the security boundary"
+}
+
+grep -q "Do not use is_empty() as proof that a non-empty signature is valid" "$types" || {
+  fail "types.rs must warn against structural-only signature validation"
+}
+
+grep -q "Signature::Empty => return false" "$crypto" || {
+  fail "crypto verification must explicitly reject Signature::Empty"
+}
+
+grep -q "signature_as_bytes_panics_for_empty_instead_of_returning_zero_sentinel" "$types" || {
+  fail "types.rs tests must keep as_bytes from returning a zero sentinel for Signature::Empty"
+}
+
+echo "Signature::Empty boundary docs test passed"


### PR DESCRIPTION
## Summary
- Remediates Gauntlet F-155 after verifying current main already rejects Signature::Empty in cryptographic verification but leaves the acceptable/security-violation boundary implicit.
- Adds a source guard requiring explicit Signature::Empty trust-boundary documentation and preserving the existing verification/as_bytes sentinel checks.
- Clarifies Signature::Empty is an unsigned construction sentinel only, not acceptable proof at persistence, verification, authorization, consensus, or trust-record finalization boundaries.

## Path Classification
- EXOCHAIN core: crates/exo-core/src/types.rs
- EXOCHAIN core verification reference: crates/exo-core/src/crypto.rs unchanged; existing verify path rejects Signature::Empty
- EXOCHAIN core CI/source guard: tools/test_signature_empty_boundary_docs.sh
- Imported-evidence triage record: docs/audit/GAUNTLET-SIGNATURE-EMPTY-BOUNDARY-REMEDIATION-2026-05-15.md

## TDD / Validation
- RED: bash tools/test_signature_empty_boundary_docs.sh failed before docs were added.
- GREEN: bash tools/test_signature_empty_boundary_docs.sh
- cargo test -p exo-core signature_empty -- --nocapture
- cargo test -p exo-core signature_as_bytes -- --nocapture
- cargo test -p exo-core signature -- --nocapture
- cargo test -p exo-core crypto::tests:: -- --nocapture
- cargo test -p exo-core -- --nocapture
- cargo clippy -p exo-core --all-targets -- -D warnings
- cargo doc -p exo-core --no-deps
- cargo fmt --all -- --check
- git diff --check
- git diff --cached --check