### PR TITLE
docs: prove consensus quorum formula

### DIFF
--- a/crates/exo-dag/src/consensus.rs
+++ b/crates/exo-dag/src/consensus.rs
@@ -73,7 +73,25 @@ impl ConsensusConfig {
         }
     }
 
-    /// The quorum size required for a commit: > 2/3 of validators.
+    /// The quorum size required for a commit: strictly greater than two thirds
+    /// of validators.
+    ///
+    /// For validator count `n > 0`, this uses:
+    ///
+    /// `quorum_size(n) = n - floor((n - 1) / 3)`
+    ///
+    /// That is equivalent to the strict threshold:
+    ///
+    /// `floor(2n / 3) + 1`
+    ///
+    /// Case proof by `n mod 3`:
+    ///
+    /// - `n = 3k`: `3k - floor((3k - 1) / 3) = 3k - (k - 1) = 2k + 1`;
+    ///   `floor(2n / 3) + 1 = floor(6k / 3) + 1 = 2k + 1`.
+    /// - `n = 3k + 1`: `3k + 1 - floor(3k / 3) = 2k + 1`;
+    ///   `floor((6k + 2) / 3) + 1 = 2k + 1`.
+    /// - `n = 3k + 2`: `3k + 2 - floor((3k + 1) / 3) = 2k + 2`;
+    ///   `floor((6k + 4) / 3) + 1 = 2k + 2`.
     #[must_use]
     pub fn quorum_size(&self) -> usize {
         let n = self.validators.len();
@@ -667,6 +685,22 @@ mod tests {
         let c0 = ConsensusConfig::new(BTreeSet::new(), 1000);
         assert_eq!(c0.quorum_size(), 0);
         assert_eq!(c0.fault_tolerance, 0);
+    }
+
+    #[test]
+    fn quorum_size_matches_strict_two_thirds_threshold_for_representative_validator_sets() {
+        for validator_count in 1..=128 {
+            let config = ConsensusConfig::new(make_validators(validator_count), 1000);
+            let strict_two_thirds = ((2 * validator_count) / 3) + 1;
+            assert_eq!(
+                config.quorum_size(),
+                strict_two_thirds,
+                "quorum mismatch for validator_count={validator_count}"
+            );
+        }
+
+        let empty = ConsensusConfig::new(BTreeSet::new(), 1000);
+        assert_eq!(empty.quorum_size(), 0);
     }
 
     #[test]

--- a/docs/audit/GAUNTLET-CONSENSUS-QUORUM-FORMULA-REMEDIATION-2026-05-15.md
+++ b/docs/audit/GAUNTLET-CONSENSUS-QUORUM-FORMULA-REMEDIATION-2026-05-15.md
@@ -1,0 +1,78 @@
+<!--
+Copyright 2026 Exochain Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at:
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Gauntlet F-156 Consensus Quorum Formula Remediation - 2026-05-15
+
+## Imported Evidence
+
+- Source: Wally Fipps Gauntlet findings corpus.
+- Finding: F-156, "BFT quorum_size formula equivalence unproven".
+- Reported path: `consensus.rs:48-54`.
+- Severity: Low.
+
+The external corpus remains imported evidence. This remediation verifies the
+claim against current owned source and commits only the source guard,
+documentation/test update, and this audit record.
+
+## Path Classification
+
+| Path | Classification | Notes |
+| --- | --- | --- |
+| `crates/exo-dag/src/consensus.rs` | EXOCHAIN core | DAG-BFT quorum math and representative formula regression test. |
+| `tools/test_consensus_quorum_formula_docs.sh` | EXOCHAIN core CI/source guard | Prevents regression to undocumented quorum formula equivalence. |
+| `docs/audit/GAUNTLET-CONSENSUS-QUORUM-FORMULA-REMEDIATION-2026-05-15.md` | Imported-evidence triage record | Captures disposition and validation evidence. |
+
+## Verification
+
+Current `main` implemented `n - ((n - 1) / 3)` and had representative quorum
+size tests, but did not prove inline that the formula equals the strict
+`> 2/3` threshold. The finding is valid as a documentation/proof gap, not a
+runtime behavior bug.
+
+## Remediation
+
+- Added `tools/test_consensus_quorum_formula_docs.sh` before changing source.
+- Documented the implemented formula:
+  `quorum_size(n) = n - floor((n - 1) / 3)`.
+- Documented its equivalence to `floor(2n / 3) + 1`, the minimum integer
+  strictly greater than two thirds.
+- Added the `n = 3k`, `n = 3k + 1`, and `n = 3k + 2` case proof inline.
+- Added a representative regression test covering validator counts `1..=128`
+  plus the empty-set boundary.
+
+## TDD Evidence
+
+RED:
+
+```bash
+bash tools/test_consensus_quorum_formula_docs.sh
+# consensus quorum formula docs test failed: quorum_size docs must state the implemented formula
+```
+
+GREEN commands are recorded after remediation.
+
+```bash
+bash tools/test_consensus_quorum_formula_docs.sh
+cargo test -p exo-dag quorum_size -- --nocapture
+cargo test -p exo-dag consensus -- --nocapture
+cargo test -p exo-dag -- --nocapture
+cargo clippy -p exo-dag --all-targets -- -D warnings
+cargo doc -p exo-dag --no-deps
+cargo fmt --all -- --check
+git diff --check
+```

--- a/tools/test_consensus_quorum_formula_docs.sh
+++ b/tools/test_consensus_quorum_formula_docs.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Copyright 2026 Exochain Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+consensus="crates/exo-dag/src/consensus.rs"
+
+fail() {
+  echo "consensus quorum formula docs test failed: $*" >&2
+  exit 1
+}
+
+grep -q "quorum_size(n) = n - floor((n - 1) / 3)" "$consensus" || {
+  fail "quorum_size docs must state the implemented formula"
+}
+
+grep -q "floor(2n / 3) + 1" "$consensus" || {
+  fail "quorum_size docs must state equivalence to the strict >2/3 threshold"
+}
+
+grep -q "strictly greater than two thirds" "$consensus" || {
+  fail "quorum_size docs must spell out the >2/3 threshold in words"
+}
+
+grep -q "n = 3k" "$consensus" || {
+  fail "quorum_size docs must prove the n = 3k case"
+}
+
+grep -q "n = 3k + 1" "$consensus" || {
+  fail "quorum_size docs must prove the n = 3k + 1 case"
+}
+
+grep -q "n = 3k + 2" "$consensus" || {
+  fail "quorum_size docs must prove the n = 3k + 2 case"
+}
+
+grep -q "quorum_size_matches_strict_two_thirds_threshold_for_representative_validator_sets" "$consensus" || {
+  fail "consensus tests must prove the formula across representative validator-set sizes"
+}
+
+echo "consensus quorum formula docs test passed"


### PR DESCRIPTION
## Summary
- Remediates Gauntlet F-156 after verifying current main implemented the quorum formula but did not prove equivalence to the strict >2/3 threshold inline.
- Adds a source guard requiring the implemented formula, strict threshold equivalence, and n mod 3 proof cases to remain documented.
- Adds a representative regression test for validator counts 1..=128 plus the empty-validator boundary.

## Path Classification
- EXOCHAIN core: crates/exo-dag/src/consensus.rs
- EXOCHAIN core CI/source guard: tools/test_consensus_quorum_formula_docs.sh
- Imported-evidence triage record: docs/audit/GAUNTLET-CONSENSUS-QUORUM-FORMULA-REMEDIATION-2026-05-15.md

## TDD / Validation
- RED: bash tools/test_consensus_quorum_formula_docs.sh failed before docs/test were added.
- GREEN: bash tools/test_consensus_quorum_formula_docs.sh
- cargo test -p exo-dag quorum_size -- --nocapture
- cargo test -p exo-dag consensus -- --nocapture
- cargo test -p exo-dag -- --nocapture
- cargo clippy -p exo-dag --all-targets -- -D warnings
- cargo doc -p exo-dag --no-deps
- cargo fmt --all -- --check
- git diff --check
- git diff --cached --check