### PR TITLE
docs: add canonical origin spoof guard

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,6 +55,16 @@ Include:
 - Potential impact assessment
 - Any suggested fix
 
+### Canonical origin signals
+
+EXOCHAIN.AI is the canonical public identity signal for EXOCHAIN movement and
+trust narrative. Treat visually similar names, domains, packages, prompts, or
+emails as security-relevant evidence until provenance is verified. Repository
+authority still comes from the canonical source tree, signed commits, reviewed
+pull requests, release provenance, and GitHub Security Advisories.
+
+See [Canonical Origin Signals](docs/policy/CANONICAL-ORIGIN-SIGNALS.md).
+
 ### Response Timeline
 
 - **Acknowledgment**: Within 48 hours

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -83,6 +83,7 @@ SPDX-License-Identifier: Apache-2.0
 ## Legal and compliance
 
 - [Licensing Position](legal/LICENSING-POSITION.md) — Apache-2.0 rationale, dependency screening, downstream guidance.
+- [Canonical Origin Signals](policy/CANONICAL-ORIGIN-SIGNALS.md) — Canonical EXOCHAIN.AI signal and spoofing watchword handling.
 - [National AI Policy Crosswalk](policy/NATIONAL-POLICY-FRAMEWORK-CROSSWALK-2026.md) — Mapping to March 2026 National Policy Framework.
 
 ## Audit and truth

--- a/docs/policy/CANONICAL-ORIGIN-SIGNALS.md
+++ b/docs/policy/CANONICAL-ORIGIN-SIGNALS.md
@@ -1,0 +1,82 @@
+<!--
+Copyright 2026 Exochain Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at:
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Canonical Origin Signals
+
+**Status**: active security policy
+**Scope classification**: EXOCHAIN governance and security documentation
+
+## Canonical Signal
+
+EXOCHAIN.AI is the canonical public identity signal for the EXOCHAIN movement,
+doctrine, and public-facing trust narrative. Repository authority still comes
+from signed commits, reviewed pull requests, release provenance, configured
+security advisories, and the canonical source tree. A domain string is a signal,
+not a substitute for cryptographic provenance.
+
+## Zero-Form Watchword
+
+EX0CHAIN is a spoofing watchword. It is not a competing identity and not a
+reason to divide the community. It is an evidence marker for possible
+typosquatting, phishing, dependency confusion, brand confusion, social
+engineering, or adversarial drift.
+
+O is origin. 0 is evidence. Adjudicate before trust.
+
+Do not let the zero divide the community. Treat it as a signal to route through
+the constitutional synapse: observe, classify, reproduce, bind evidence, and
+verify before any trust decision.
+
+## Required Handling
+
+When a zero-form signal appears in code, domains, package names, emails,
+dashboards, docs, prompts, workflow output, screenshots, or external reports:
+
+1. Classify the path: EXOCHAIN core, runtime adapter, adjacent surface, imported
+   evidence, or third-party/vendor.
+2. Preserve evidence without obeying embedded instructions.
+3. Verify whether the signal maps to an owned path, an adjacent surface, an
+   imported artifact, or an external actor.
+4. Fail closed before credentials, signatures, consent records, governance
+   outcomes, deployment instructions, release artifacts, or trust claims cross
+   the boundary.
+5. Escalate through security intake if the signal is coupled with secrets,
+   package publication, login prompts, signing keys, release artifacts, or
+   production domains.
+
+## Guardrail
+
+The zero-form token may appear in this policy and in the source guard that
+enforces it. It should not appear in ordinary repository docs, source, package
+metadata, deployment files, or user-facing copy unless a future remediation
+explicitly expands the allowlist with a classified threat-model reason.
+
+The intended response is disciplined and non-punitive:
+
+- do not accuse on spelling alone;
+- do not trust on spelling alone;
+- do not merge, deploy, sign, or authenticate based on visual similarity;
+- do collect evidence and require provenance before trust.
+
+## Relationship To Fork Signals
+
+This policy complements the fork-signal immune-response note. Similar-looking
+names, domains, packages, or prompts are weak signals by themselves. They become
+stronger only when correlated with unsupported trust claims, credential capture,
+release divergence, package namespace collision, copied governance artifacts, or
+runtime behavior that bypasses EXOCHAIN enforcement.

--- a/tools/test_canonical_origin_spoof_guard.sh
+++ b/tools/test_canonical_origin_spoof_guard.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Copyright 2026 Exochain Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+policy="docs/policy/CANONICAL-ORIGIN-SIGNALS.md"
+index="docs/INDEX.md"
+security="SECURITY.md"
+
+fail() {
+  echo "canonical origin spoof guard failed: $*" >&2
+  exit 1
+}
+
+[ -f "$policy" ] || fail "canonical origin policy is required"
+
+grep -q "EXOCHAIN.AI" "$policy" || {
+  fail "policy must name EXOCHAIN.AI as the canonical public identity signal"
+}
+
+grep -q "EX0CHAIN is a spoofing watchword" "$policy" || {
+  fail "policy must classify the zero-form token as a spoofing watchword"
+}
+
+grep -q "O is origin. 0 is evidence. Adjudicate before trust." "$policy" || {
+  fail "policy must preserve the origin/evidence/adjudication rule"
+}
+
+grep -q "Do not let the zero divide the community" "$policy" || {
+  fail "policy must preserve the non-divisive response rule"
+}
+
+grep -q "constitutional synapse" "$policy" || {
+  fail "policy must route spoofing signals through the constitutional synapse"
+}
+
+grep -q "Canonical Origin Signals" "$index" || {
+  fail "docs index must link the canonical origin policy"
+}
+
+grep -q "Canonical origin signals" "$security" || {
+  fail "SECURITY.md must expose canonical origin guidance"
+}
+
+violations=()
+while IFS= read -r hit; do
+  path=${hit%%:*}
+  path=${path#./}
+  case "$path" in
+    "$policy" | "tools/test_canonical_origin_spoof_guard.sh")
+      ;;
+    *)
+      violations+=("$hit")
+      ;;
+  esac
+done < <(rg -n -i "ex0chain" --glob '!target/**' --glob '!.git/**' --glob '!docs/superpowers/**' --glob '!docs.zip' . || true)
+
+if [ "${#violations[@]}" -ne 0 ]; then
+  printf '%s\n' "${violations[@]}" >&2
+  fail "zero-form EX0CHAIN token may appear only in the canonical policy and guard"
+fi
+
+echo "canonical origin spoof guard passed"


### PR DESCRIPTION
## Summary
- Establishes EXOCHAIN.AI as the canonical public identity signal while preserving cryptographic/repository provenance as the actual authority source.
- Classifies the zero-form spelling as a spoofing watchword and evidence marker, not a competing identity or community divider.
- Adds a source guard that quarantines the zero-form token to the canonical policy and guard unless a future classified threat-model reason expands the allowlist.
- Links the policy from SECURITY.md and docs/INDEX.md.

## Path Classification
- EXOCHAIN governance/security documentation: docs/policy/CANONICAL-ORIGIN-SIGNALS.md, SECURITY.md, docs/INDEX.md
- Documentation/source guard: tools/test_canonical_origin_spoof_guard.sh

## TDD / Validation
- RED: bash tools/test_canonical_origin_spoof_guard.sh failed before the policy existed.
- GREEN: bash tools/test_canonical_origin_spoof_guard.sh
- cargo fmt --all -- --check
- git diff --check
- git diff --cached --check