### PR TITLE
test: cover non self certifying gateway registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 188557 | `wc -l` |
-| Workspace tests | 4,301 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 188579 | `wc -l` |
+| Workspace tests | 4,302 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -45,7 +45,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,301 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,302 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -114,9 +114,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 188557 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 188579 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,301 listed workspace tests
+         cryptographic proofs, 4,302 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -5428,6 +5428,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn auth_register_rejects_non_self_certifying_did_claim() {
+        let (public_key, secret_key) = generate_keypair();
+        let mut doc = minimal_doc("did:exo:claimed-by-attacker-key");
+        doc.public_keys.push(public_key);
+        let body = registration_request_body(&doc, &public_key, &secret_key);
+        let app = build_router(state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/auth/register")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
     async fn auth_register_rejects_registration_proof_from_unlisted_key() {
         let (document_public_key, _) = generate_keypair();
         let (attacker_public_key, attacker_secret_key) = generate_keypair();


### PR DESCRIPTION
## Summary
- Adds a gateway-level regression for arbitrary non-self-certifying DID registration claims.
- Confirms the stale/conflicting #448 production fix is already present on current `main`, then carries forward the useful missing route test as an isolated core runtime adapter PR.
- Updates README repo-truth counts after adding the new Rust test.

## Path Classification
- `crates/exo-gateway/src/server.rs`: Core runtime adapter test surface for HTTP DID registration.
- `README.md`: Repository truth metadata updated from `tools/repo_truth.sh`.
- EXOCHAIN core production code changes: none.
- Adjacent surface / imported evidence / third-party changes: none.

## Current-Code Confirmation
- `verify_did_registration_proof` on current `main` already requires the DID subject to match `did_from_public_key(proof.public_key)`.
- Existing identity regression `register_with_proof_rejects_non_self_certifying_did` passes on current `main`.
- Existing gateway registration tests cover valid self-certifying registration and proof key membership, but did not include the explicit arbitrary DID label route regression from stale PR #448.

## Validation
- `rg -n "auth_register_rejects_non_self_certifying_did_claim" crates/exo-gateway/src/server.rs` returned no match before this test was added.
- `cargo test -p exo-gateway auth_register_rejects_non_self_certifying_did_claim -- --nocapture`
- `cargo test -p exo-gateway auth_register_ -- --nocapture`
- `cargo test -p exo-gateway agents_enroll_returns_201 -- --nocapture`
- `cargo test -p exo-identity register_with_proof_rejects_non_self_certifying_did -- --nocapture`
- `bash tools/test_repo_truth.sh`
- `git diff --check`
- `cargo fmt --all -- --check` (stable rustfmt emitted existing nightly-config warnings, exit 0)
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`