### PR TITLE
fix(node): bind persisted identity DID to key

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 188579 | `wc -l` |
-| Workspace tests | 4,302 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 188609 | `wc -l` |
+| Workspace tests | 4,303 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -45,7 +45,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,302 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,303 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -114,9 +114,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 188579 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 188609 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,302 listed workspace tests
+         cryptographic proofs, 4,303 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-node/src/identity.rs
+++ b/crates/exo-node/src/identity.rs
@@ -98,6 +98,15 @@ pub fn load_or_create(data_dir: &Path) -> anyhow::Result<NodeIdentity> {
 
         let did_str = std::fs::read_to_string(&did_path)?;
         let did = Did::new(did_str.trim())?;
+        let derived_did = did_from_public_key(keypair.public_key())?;
+        if did != derived_did {
+            anyhow::bail!(
+                "identity.did does not match identity.key public key at {}; stored {}, derived {}",
+                did_path.display(),
+                did,
+                derived_did
+            );
+        }
 
         tracing::info!(did = %did, "Loaded existing identity");
 
@@ -233,6 +242,27 @@ mod tests {
 
         assert_eq!(first.did, second.did);
         assert_eq!(first.public_key_bytes(), second.public_key_bytes());
+    }
+
+    #[test]
+    fn load_or_create_rejects_identity_did_not_bound_to_secret_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = load_or_create(dir.path()).unwrap();
+        std::fs::write(dir.path().join("identity.did"), b"did:exo:forged-validator").unwrap();
+
+        let err = match load_or_create(dir.path()) {
+            Ok(identity) => panic!(
+                "identity.did must not load when it does not derive from identity.key: loaded {} for original {}",
+                identity.did, first.did
+            ),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.to_string()
+                .contains("identity.did does not match identity.key"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Reproduces stale #446 against current main: a forged `identity.did` could be loaded with an unrelated persisted `identity.key`.
- Binds reload acceptance to `did_from_public_key(identity.key.public_key())` and fails closed before exposing the node identity.
- Adds a regression test proving forged persisted DID state is rejected while the surrounding identity tests still pass.

## Path Classification
- `crates/exo-node/src/identity.rs` — core runtime adapter: node identity persistence and signing authority boundary.
- `README.md` — documentation/repo truth counters required by CI hygiene.

## Current-Code Confirmation
- Current `main` did not contain the load-time DID/key binding check or regression test before this branch.
- TDD red confirmed with `cargo test -p exo-node load_or_create_rejects_identity_did_not_bound_to_secret_key -- --nocapture`: the forged DID loaded successfully before the fix.

## Validation
- `cargo test -p exo-node load_or_create_rejects_identity_did_not_bound_to_secret_key -- --nocapture` — failed before fix, passed after fix.
- `cargo test -p exo-node identity::tests -- --nocapture` — passed, 34 tests.
- `cargo test -p exo-node` — passed, 1073 tests.
- `cargo clippy -p exo-node --all-targets -- -D warnings` — passed.
- `bash tools/test_repo_truth.sh` — passed.
- `cargo fmt --all -- --check` — passed with existing stable-channel rustfmt config warnings.
- `git diff --check` — passed.
- Bypass search: `rg -n "identity\.did|load_or_create\(|did_from_public_key" crates/exo-node crates/exo-gateway crates/exo-identity` confirmed `load_or_create` is the shared persisted identity acceptance boundary.

Supersedes stale conflicting PR #446 after re-verification on current main.
