### PR TITLE
fix(identity): bind DID verification methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 188609 | `wc -l` |
-| Workspace tests | 4,303 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 188818 | `wc -l` |
+| Workspace tests | 4,306 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -45,7 +45,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,303 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,306 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -114,9 +114,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 188609 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 188818 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,303 listed workspace tests
+         cryptographic proofs, 4,306 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-gateway/src/auth.rs
+++ b/crates/exo-gateway/src/auth.rs
@@ -514,7 +514,7 @@ mod tests {
     use exo_core::crypto::{generate_keypair, sign};
     use exo_identity::{
         did::{DidDocument, VerificationMethod},
-        registry::LocalDidRegistry,
+        registry::{DidRegistry, LocalDidRegistry},
     };
 
     use super::*;
@@ -561,6 +561,46 @@ mod tests {
         let mut reg = LocalDidRegistry::new();
         reg.register(doc).unwrap();
         (reg, sk)
+    }
+
+    struct StaticDidRegistry {
+        did: Did,
+        doc: DidDocument,
+    }
+
+    impl DidRegistry for StaticDidRegistry {
+        fn register(
+            &mut self,
+            _doc: DidDocument,
+        ) -> std::result::Result<(), exo_identity::error::IdentityError> {
+            unreachable!("auth tests resolve only")
+        }
+
+        fn resolve(&self, did: &Did) -> Option<&DidDocument> {
+            if did == &self.did {
+                Some(&self.doc)
+            } else {
+                None
+            }
+        }
+
+        fn revoke(
+            &mut self,
+            _did: &Did,
+            _proof: &exo_identity::did::RevocationProof,
+        ) -> std::result::Result<(), exo_identity::error::IdentityError> {
+            unreachable!("auth tests resolve only")
+        }
+
+        fn rotate_key(
+            &mut self,
+            _did: &Did,
+            _new_key: &exo_core::PublicKey,
+            _proof: &Signature,
+            _updated: Timestamp,
+        ) -> std::result::Result<(), exo_identity::error::IdentityError> {
+            unreachable!("auth tests resolve only")
+        }
     }
 
     fn signed_request(mut request: Request, secret_key: &exo_core::SecretKey) -> Request {
@@ -725,6 +765,54 @@ mod tests {
         };
 
         assert!(authenticate(&request, &reg, auth_metadata()).is_err());
+    }
+
+    #[test]
+    fn auth_rejects_active_method_not_bound_to_document_key() {
+        let did = Did::new("did:exo:alice").unwrap();
+        let (declared_pk, _) = generate_keypair();
+        let (method_pk, method_sk) = generate_keypair();
+        let method_multibase = format!("z{}", bs58::encode(method_pk.as_bytes()).into_string());
+        let doc = DidDocument {
+            id: did.clone(),
+            public_keys: vec![declared_pk],
+            authentication: vec![],
+            verification_methods: vec![VerificationMethod {
+                id: "did:exo:alice#key-1".into(),
+                key_type: "Ed25519VerificationKey2020".into(),
+                controller: did.clone(),
+                public_key_multibase: method_multibase,
+                version: 1,
+                active: true,
+                valid_from: 0,
+                revoked_at: None,
+            }],
+            hybrid_verification_methods: vec![],
+            service_endpoints: vec![],
+            created: Timestamp::ZERO,
+            updated: Timestamp::ZERO,
+            revoked: false,
+        };
+        let reg = StaticDidRegistry {
+            did: did.clone(),
+            doc,
+        };
+        let request = signed_request(
+            Request {
+                actor_did: did.as_str().to_owned(),
+                action: "read".into(),
+                body_hash: Hash256::digest(b"body"),
+                signature: Signature::Empty,
+                timestamp: req_ts(),
+            },
+            &method_sk,
+        );
+
+        let err = authenticate(&request, &reg, auth_metadata()).unwrap_err();
+        assert!(
+            err.to_string().contains("not declared"),
+            "auth must fail closed when a custom registry returns an unbound active method: {err}"
+        );
     }
 
     #[test]

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -43,6 +43,8 @@ use exo_gatekeeper::{
     },
 };
 use exo_governance::conflict::ConflictDeclaration;
+#[cfg(feature = "production-db")]
+use exo_identity::did_verification::validate_verification_method_document_binding;
 use exo_identity::{
     did::{DidDocument, DidRegistrationProof},
     error::IdentityError,
@@ -1878,34 +1880,16 @@ fn effective_authority_permissions(
 fn active_did_document_ed25519_keys(doc: &DidDocument, key_context: &str) -> Result<Vec<Vec<u8>>> {
     let mut keys = Vec::new();
     for method in &doc.verification_methods {
-        if !method.active
-            || method.controller != doc.id
-            || method.key_type != "Ed25519VerificationKey2020"
-        {
+        if !method.active {
             continue;
         }
-        let encoded = method
-            .public_key_multibase
-            .strip_prefix('z')
-            .ok_or_else(|| {
-                GatewayError::Internal(format!(
-                    "{key_context} DID document key '{}' uses unsupported multibase prefix",
-                    method.id,
-                ))
-            })?;
-        let key = bs58::decode(encoded).into_vec().map_err(|e| {
+        let key = validate_verification_method_document_binding(doc, method).map_err(|e| {
             GatewayError::Internal(format!(
-                "{key_context} DID document key '{}' is not valid base58btc: {e}",
+                "{key_context} DID document key '{}' is not trusted: {e}",
                 method.id,
             ))
         })?;
-        if key.len() != 32 {
-            return Err(GatewayError::Internal(format!(
-                "{key_context} DID document key '{}' is {} bytes, expected 32",
-                method.id,
-                key.len()
-            )));
-        }
+        let key = key.as_bytes().to_vec();
         if !keys.contains(&key) {
             keys.push(key);
         }
@@ -4883,6 +4867,25 @@ mod tests {
             updated: Timestamp::ZERO,
             revoked: false,
         }
+    }
+
+    #[cfg(feature = "production-db")]
+    #[test]
+    fn active_did_document_ed25519_keys_rejects_unbound_active_method() {
+        let did = Did::new("did:exo:db-trust-actor").unwrap();
+        let (declared_pk, _) = generate_keypair();
+        let (method_pk, _) = generate_keypair();
+        let mut doc = did_document_with_ed25519_key(&did, &declared_pk);
+        doc.verification_methods[0].public_key_multibase =
+            format!("z{}", bs58::encode(method_pk.as_bytes()).into_string());
+
+        let err = active_did_document_ed25519_keys(&doc, "test trust key")
+            .expect_err("DB trust-key extraction must reject unbound active methods");
+
+        assert!(
+            err.to_string().contains("not declared"),
+            "error should identify the unbound active method: {err}"
+        );
     }
 
     fn signing_registry() -> (Arc<RwLock<LocalDidRegistry>>, exo_core::SecretKey) {

--- a/crates/exo-identity/src/did_verification.rs
+++ b/crates/exo-identity/src/did_verification.rs
@@ -28,6 +28,8 @@ use exo_core::{Did, PublicKey, crypto};
 
 use crate::did::{DidDocument, VerificationMethod};
 
+const ED25519_VERIFICATION_KEY_TYPE: &str = "Ed25519VerificationKey2020";
+
 /// Errors specific to DID verification operations.
 #[derive(Debug, thiserror::Error)]
 pub enum DidVerificationError {
@@ -39,6 +41,11 @@ pub enum DidVerificationError {
     #[error("verification method revoked: {0}")]
     MethodRevoked(String),
 
+    /// Verification method is not controlled by, rooted in, or key-bound to
+    /// the DID document that presents it.
+    #[error("verification method not bound to DID document: {0}")]
+    MethodNotDocumentBound(String),
+
     /// Cryptographic operation failed (e.g., invalid multibase encoding,
     /// wrong key length, unsupported multibase prefix).
     #[error("cryptographic error: {0}")]
@@ -47,6 +54,81 @@ pub enum DidVerificationError {
     /// Signature verification failed.
     #[error("invalid signature")]
     InvalidSignature,
+}
+
+fn decode_ed25519_multibase_public_key(encoded: &str) -> Result<PublicKey, DidVerificationError> {
+    let pub_key_bytes = if let Some(encoded_key) = encoded.strip_prefix('z') {
+        bs58::decode(encoded_key)
+            .into_vec()
+            .map_err(|e| DidVerificationError::CryptoError(format!("base58 decode: {e}")))?
+    } else {
+        return Err(DidVerificationError::CryptoError(
+            "unsupported multibase prefix (expected 'z' for base58btc)".to_string(),
+        ));
+    };
+
+    let pub_key_array: [u8; 32] = pub_key_bytes.try_into().map_err(|_| {
+        DidVerificationError::CryptoError("public key must be 32 bytes".to_string())
+    })?;
+
+    Ok(PublicKey::from_bytes(pub_key_array))
+}
+
+/// Validate that an active Ed25519 DID verification method is controlled by
+/// the document DID, rooted at the document fragment namespace, and backed by
+/// key material declared in the document's `public_keys`.
+///
+/// This prevents a registered DID document from proving possession of one
+/// public key while presenting a different active authentication key.
+pub fn validate_verification_method_document_binding(
+    doc: &DidDocument,
+    method: &VerificationMethod,
+) -> Result<PublicKey, DidVerificationError> {
+    if doc.revoked {
+        return Err(DidVerificationError::MethodRevoked(
+            doc.id.as_str().to_owned(),
+        ));
+    }
+
+    if !method.active || method.revoked_at.is_some() {
+        return Err(DidVerificationError::MethodRevoked(method.id.clone()));
+    }
+
+    if method.key_type != ED25519_VERIFICATION_KEY_TYPE {
+        return Err(DidVerificationError::MethodNotDocumentBound(format!(
+            "{} has unsupported key type {}",
+            method.id, method.key_type
+        )));
+    }
+
+    if method.controller != doc.id {
+        return Err(DidVerificationError::MethodNotDocumentBound(format!(
+            "{} controller {} does not match document DID {}",
+            method.id, method.controller, doc.id
+        )));
+    }
+
+    let document_fragment_prefix = format!("{}#", doc.id);
+    if !method.id.starts_with(&document_fragment_prefix) {
+        return Err(DidVerificationError::MethodNotDocumentBound(format!(
+            "{} is not rooted under document DID {}",
+            method.id, doc.id
+        )));
+    }
+
+    let public_key = decode_ed25519_multibase_public_key(&method.public_key_multibase)?;
+    if !doc
+        .public_keys
+        .iter()
+        .any(|declared| declared == &public_key)
+    {
+        return Err(DidVerificationError::MethodNotDocumentBound(format!(
+            "{} key is not declared in the DID document public_keys",
+            method.id
+        )));
+    }
+
+    Ok(public_key)
 }
 
 /// Abstract key vault interface for secure key storage.
@@ -91,26 +173,7 @@ pub fn verify_did_signature(
         .find(|m| m.id == key_id)
         .ok_or_else(|| DidVerificationError::MethodNotFound(key_id.to_string()))?;
 
-    if !method.active {
-        return Err(DidVerificationError::MethodRevoked(key_id.to_string()));
-    }
-
-    // Decode multibase base58btc public key (prefix 'z')
-    let pub_key_bytes = if let Some(encoded_key) = method.public_key_multibase.strip_prefix('z') {
-        bs58::decode(encoded_key)
-            .into_vec()
-            .map_err(|e| DidVerificationError::CryptoError(format!("base58 decode: {e}")))?
-    } else {
-        return Err(DidVerificationError::CryptoError(
-            "unsupported multibase prefix (expected 'z' for base58btc)".to_string(),
-        ));
-    };
-
-    let pub_key_array: [u8; 32] = pub_key_bytes.try_into().map_err(|_| {
-        DidVerificationError::CryptoError("public key must be 32 bytes".to_string())
-    })?;
-
-    let public_key = PublicKey::from_bytes(pub_key_array);
+    let public_key = validate_verification_method_document_binding(doc, method)?;
 
     if crypto::verify(message, signature, &public_key) {
         Ok(())
@@ -176,6 +239,8 @@ pub fn rotate_verification_key(
         revoked_at: None,
     };
 
+    doc.public_keys.clear();
+    doc.public_keys.push(PublicKey::from_bytes(*new_public_key));
     doc.verification_methods.push(new_method.clone());
     doc.updated = exo_core::Timestamp::new(current_time_ms, 0);
 
@@ -283,6 +348,26 @@ mod tests {
     }
 
     #[test]
+    fn verify_rejects_method_key_not_declared_by_document() {
+        let (declared_pk, _) = generate_keypair();
+        let (method_pk, method_sk) = generate_keypair();
+        let did = test_did();
+        let mut doc = make_doc_with_verification(did.clone(), declared_pk);
+        doc.verification_methods[0].public_key_multibase =
+            format!("z{}", bs58::encode(method_pk.as_bytes()).into_string());
+
+        let message = b"method key must be document-bound";
+        let signature = sign(message, &method_sk);
+        let key_id = format!("{}#key-1", did);
+
+        let err = verify_did_signature(&doc, &key_id, message, &signature).unwrap_err();
+        assert!(
+            err.to_string().contains("not declared"),
+            "verification should reject active methods whose keys are not declared by the DID document: {err}"
+        );
+    }
+
+    #[test]
     fn verify_bad_multibase_prefix_fails() {
         let (pk, sk) = generate_keypair();
         let did = test_did();
@@ -323,6 +408,7 @@ mod tests {
         // New key active
         assert_eq!(new_method.version, 2);
         assert!(new_method.active);
+        assert_eq!(doc.public_keys, vec![new_pk]);
         assert_eq!(doc.verification_methods.len(), 2);
         assert_eq!(doc.updated.physical_ms, 2000);
     }

--- a/crates/exo-identity/src/registry.rs
+++ b/crates/exo-identity/src/registry.rs
@@ -21,6 +21,7 @@ use serde::Serialize;
 
 use crate::{
     did::{DidDocument, DidRegistrationProof, RevocationProof, did_from_public_key},
+    did_verification::validate_verification_method_document_binding,
     error::IdentityError,
 };
 
@@ -484,6 +485,15 @@ fn validate_registered_did_document(doc: &DidDocument) -> Result<(), IdentityErr
             method.active,
             method.revoked_at,
         )?;
+        if method.active {
+            validate_verification_method_document_binding(doc, method).map_err(|e| {
+                IdentityError::InvalidDidDocumentField {
+                    did: did.to_owned(),
+                    field: "verification_methods".to_owned(),
+                    reason: e.to_string(),
+                }
+            })?;
+        }
     }
     for method in &doc.hybrid_verification_methods {
         ensure_byte_bound(
@@ -977,6 +987,28 @@ mod tests {
             err,
             IdentityError::InvalidRegistrationProof { .. }
         ));
+        assert_eq!(reg.len(), 0);
+    }
+
+    #[test]
+    fn register_with_proof_rejects_active_method_not_bound_to_declared_key() {
+        let (document_pk, document_sk) = generate_keypair();
+        let (method_pk, _) = generate_keypair();
+        let did = did_from_public_key(&document_pk).expect("canonical DID");
+        let mut doc = make_doc(did, document_pk);
+        doc.verification_methods
+            .push(verification_method(&doc.id, method_pk, 1));
+        let proof = registration_proof(&doc, document_pk, &document_sk);
+
+        let mut reg = LocalDidRegistry::new();
+        let err = reg
+            .register_with_proof(doc, &proof)
+            .expect_err("active verification methods must be bound to declared document keys");
+
+        assert!(
+            err.to_string().contains("verification_methods"),
+            "error should identify verification method binding failure: {err}"
+        );
         assert_eq!(reg.len(), 0);
     }
 


### PR DESCRIPTION
## Summary
- Reproduces stale #445 against current main: active DID verification methods could use key material not declared by the DID document.
- Adds a shared `validate_verification_method_document_binding` boundary and uses it for DID signature verification, DID registration validation, gateway auth, and production-db authority/provenance trust-key extraction.
- Keeps rotated DID documents valid under the new invariant by rebinding `public_keys` to the rotated active key.

## Path Classification
- `crates/exo-identity/src/did_verification.rs` — EXOCHAIN core identity verification boundary.
- `crates/exo-identity/src/registry.rs` — EXOCHAIN core DID registry validation boundary.
- `crates/exo-gateway/src/auth.rs` — core runtime adapter authentication boundary.
- `crates/exo-gateway/src/server.rs` — core runtime adapter production-db authority/provenance trust-key boundary.
- `README.md` — documentation/repo truth counters required by CI hygiene.

## Current-Code Confirmation
- Current `main` did not contain a document-binding validator for active DID verification methods.
- TDD red was confirmed before production changes:
  - `verify_rejects_method_key_not_declared_by_document` accepted the unbound method signature.
  - `register_with_proof_rejects_active_method_not_bound_to_declared_key` accepted a self-certifying document with an unbound active method.
  - `auth_rejects_active_method_not_bound_to_document_key` authenticated a request signed by an unbound method key from a custom registry.
  - `active_did_document_ed25519_keys_rejects_unbound_active_method` accepted an unbound production-db trust key.

## Validation
- `cargo test -p exo-identity verify_rejects_method_key_not_declared_by_document -- --nocapture` — failed before fix, passed after fix.
- `cargo test -p exo-identity register_with_proof_rejects_active_method_not_bound_to_declared_key -- --nocapture` — failed before fix, passed after fix.
- `cargo test -p exo-gateway auth_rejects_active_method_not_bound_to_document_key -- --nocapture` — failed before fix, passed after fix.
- `cargo test -p exo-identity rotate_key_success -- --nocapture` — failed before rotation rebinding, passed after fix.
- `cargo test -p exo-gateway --features production-db active_did_document_ed25519_keys_rejects_unbound_active_method -- --nocapture` — failed before fix, passed after fix.
- `cargo test -p exo-identity` — passed, 186 unit tests plus 12 integration tests.
- `cargo test -p exo-gateway auth::tests -- --nocapture` — passed, 40 tests.
- `cargo clippy -p exo-identity --all-targets -- -D warnings` — passed.
- `cargo clippy -p exo-gateway --all-targets --features production-db -- -D warnings` — passed.
- `bash tools/test_repo_truth.sh` — passed.
- `cargo fmt --all -- --check` — passed with existing stable-channel rustfmt config warnings.
- `git diff --check` — passed.
- Bypass search: `rg -n "bs58::decode\(|strip_prefix\('z'\)|verify_did_signature\(|active_did_document_ed25519_keys|validate_verification_method_document_binding" crates/exo-identity/src/did_verification.rs crates/exo-identity/src/registry.rs crates/exo-gateway/src/auth.rs crates/exo-gateway/src/server.rs`.

Supersedes stale PR #445 after re-verification on current main.
