### PR TITLE
fix(wasm): fail closed on untrusted TNC flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 188818 | `wc -l` |
-| Workspace tests | 4,306 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 188931 | `wc -l` |
+| Workspace tests | 4,307 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -114,9 +114,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 188818 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 188931 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,306 listed workspace tests
+         cryptographic proofs, 4,307 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exochain-wasm/src/decision_forum_bindings.rs
+++ b/crates/exochain-wasm/src/decision_forum_bindings.rs
@@ -344,10 +344,10 @@ pub fn wasm_dry_run_amendment(corpus_json: &str, proposed_json: &str) -> Result<
 // TncContext<'a> holds a borrowed &DecisionObject and cannot be deserialized
 // directly.  Each binding takes:
 //   - decision_json: &str — the DecisionObject (owned, deserialized locally)
-//   - flags_json: &str    — JSON object with the seven boolean precondition
-//                           fields: constitutional_hash_valid, consent_verified,
-//                           identity_verified, evidence_complete, quorum_met,
-//                           human_gate_satisfied, authority_chain_verified
+//   - flags_json: &str    — untrusted JSON object carrying caller-asserted
+//                           boolean precondition claims. The bridge parses this
+//                           object for shape compatibility only; caller claims
+//                           never satisfy TNC proof obligations.
 //
 // The TncContext is then constructed on the stack inside each function so the
 // borrow checker is satisfied without requiring an unsafe transmute.
@@ -372,20 +372,39 @@ struct TncFlags {
     ai_ceilings_externally_verified: bool,
 }
 
+impl TncFlags {
+    fn has_any_asserted_claim(&self) -> bool {
+        self.constitutional_hash_valid
+            || self.consent_verified
+            || self.identity_verified
+            || self.evidence_complete
+            || self.quorum_met
+            || self.human_gate_satisfied
+            || self.authority_chain_verified
+            || self.ai_ceilings_externally_verified
+    }
+}
+
+fn parse_untrusted_tnc_flags(flags_json: &str) -> Result<TncFlags, JsValue> {
+    let flags: TncFlags = from_json_str(flags_json)?;
+    let _caller_asserted_proofs = flags.has_any_asserted_claim();
+    Ok(flags)
+}
+
 fn build_tnc_ctx<'a>(
     decision: &'a decision_forum::decision_object::DecisionObject,
-    flags: &TncFlags,
+    _flags: &TncFlags,
 ) -> decision_forum::tnc_enforcer::TncContext<'a> {
     decision_forum::tnc_enforcer::TncContext {
         decision,
-        constitutional_hash_valid: flags.constitutional_hash_valid,
-        consent_verified: flags.consent_verified,
-        identity_verified: flags.identity_verified,
-        evidence_complete: flags.evidence_complete,
-        quorum_met: flags.quorum_met,
-        human_gate_satisfied: flags.human_gate_satisfied,
-        authority_chain_verified: flags.authority_chain_verified,
-        ai_ceilings_externally_verified: flags.ai_ceilings_externally_verified,
+        constitutional_hash_valid: false,
+        consent_verified: false,
+        identity_verified: false,
+        evidence_complete: false,
+        quorum_met: false,
+        human_gate_satisfied: false,
+        authority_chain_verified: false,
+        ai_ceilings_externally_verified: false,
     }
 }
 
@@ -400,7 +419,7 @@ fn tnc_result(r: decision_forum::error::Result<()>) -> Result<JsValue, JsValue> 
 #[wasm_bindgen]
 pub fn wasm_enforce_tnc_01(decision_json: &str, flags_json: &str) -> Result<JsValue, JsValue> {
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let flags: TncFlags = from_json_str(flags_json)?;
+    let flags = parse_untrusted_tnc_flags(flags_json)?;
     tnc_result(decision_forum::tnc_enforcer::enforce_tnc_01(
         &build_tnc_ctx(&decision, &flags),
     ))
@@ -410,7 +429,7 @@ pub fn wasm_enforce_tnc_01(decision_json: &str, flags_json: &str) -> Result<JsVa
 #[wasm_bindgen]
 pub fn wasm_enforce_tnc_02(decision_json: &str, flags_json: &str) -> Result<JsValue, JsValue> {
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let flags: TncFlags = from_json_str(flags_json)?;
+    let flags = parse_untrusted_tnc_flags(flags_json)?;
     tnc_result(decision_forum::tnc_enforcer::enforce_tnc_02(
         &build_tnc_ctx(&decision, &flags),
     ))
@@ -420,7 +439,7 @@ pub fn wasm_enforce_tnc_02(decision_json: &str, flags_json: &str) -> Result<JsVa
 #[wasm_bindgen]
 pub fn wasm_enforce_tnc_03(decision_json: &str, flags_json: &str) -> Result<JsValue, JsValue> {
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let flags: TncFlags = from_json_str(flags_json)?;
+    let flags = parse_untrusted_tnc_flags(flags_json)?;
     tnc_result(decision_forum::tnc_enforcer::enforce_tnc_03(
         &build_tnc_ctx(&decision, &flags),
     ))
@@ -430,7 +449,7 @@ pub fn wasm_enforce_tnc_03(decision_json: &str, flags_json: &str) -> Result<JsVa
 #[wasm_bindgen]
 pub fn wasm_enforce_tnc_04(decision_json: &str, flags_json: &str) -> Result<JsValue, JsValue> {
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let flags: TncFlags = from_json_str(flags_json)?;
+    let flags = parse_untrusted_tnc_flags(flags_json)?;
     tnc_result(decision_forum::tnc_enforcer::enforce_tnc_04(
         &build_tnc_ctx(&decision, &flags),
     ))
@@ -440,7 +459,7 @@ pub fn wasm_enforce_tnc_04(decision_json: &str, flags_json: &str) -> Result<JsVa
 #[wasm_bindgen]
 pub fn wasm_enforce_tnc_05(decision_json: &str, flags_json: &str) -> Result<JsValue, JsValue> {
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let flags: TncFlags = from_json_str(flags_json)?;
+    let flags = parse_untrusted_tnc_flags(flags_json)?;
     tnc_result(decision_forum::tnc_enforcer::enforce_tnc_05(
         &build_tnc_ctx(&decision, &flags),
     ))
@@ -450,7 +469,7 @@ pub fn wasm_enforce_tnc_05(decision_json: &str, flags_json: &str) -> Result<JsVa
 #[wasm_bindgen]
 pub fn wasm_enforce_tnc_06(decision_json: &str, flags_json: &str) -> Result<JsValue, JsValue> {
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let flags: TncFlags = from_json_str(flags_json)?;
+    let flags = parse_untrusted_tnc_flags(flags_json)?;
     tnc_result(decision_forum::tnc_enforcer::enforce_tnc_06(
         &build_tnc_ctx(&decision, &flags),
     ))
@@ -460,7 +479,7 @@ pub fn wasm_enforce_tnc_06(decision_json: &str, flags_json: &str) -> Result<JsVa
 #[wasm_bindgen]
 pub fn wasm_enforce_tnc_07(decision_json: &str, flags_json: &str) -> Result<JsValue, JsValue> {
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let flags: TncFlags = from_json_str(flags_json)?;
+    let flags = parse_untrusted_tnc_flags(flags_json)?;
     tnc_result(decision_forum::tnc_enforcer::enforce_tnc_07(
         &build_tnc_ctx(&decision, &flags),
     ))
@@ -470,7 +489,7 @@ pub fn wasm_enforce_tnc_07(decision_json: &str, flags_json: &str) -> Result<JsVa
 #[wasm_bindgen]
 pub fn wasm_enforce_tnc_08(decision_json: &str, flags_json: &str) -> Result<JsValue, JsValue> {
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let flags: TncFlags = from_json_str(flags_json)?;
+    let flags = parse_untrusted_tnc_flags(flags_json)?;
     tnc_result(decision_forum::tnc_enforcer::enforce_tnc_08(
         &build_tnc_ctx(&decision, &flags),
     ))
@@ -480,7 +499,7 @@ pub fn wasm_enforce_tnc_08(decision_json: &str, flags_json: &str) -> Result<JsVa
 #[wasm_bindgen]
 pub fn wasm_enforce_tnc_09(decision_json: &str, flags_json: &str) -> Result<JsValue, JsValue> {
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let flags: TncFlags = from_json_str(flags_json)?;
+    let flags = parse_untrusted_tnc_flags(flags_json)?;
     tnc_result(decision_forum::tnc_enforcer::enforce_tnc_09(
         &build_tnc_ctx(&decision, &flags),
     ))
@@ -490,7 +509,7 @@ pub fn wasm_enforce_tnc_09(decision_json: &str, flags_json: &str) -> Result<JsVa
 #[wasm_bindgen]
 pub fn wasm_enforce_tnc_10(decision_json: &str, flags_json: &str) -> Result<JsValue, JsValue> {
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let flags: TncFlags = from_json_str(flags_json)?;
+    let flags = parse_untrusted_tnc_flags(flags_json)?;
     tnc_result(decision_forum::tnc_enforcer::enforce_tnc_10(
         &build_tnc_ctx(&decision, &flags),
     ))
@@ -500,7 +519,7 @@ pub fn wasm_enforce_tnc_10(decision_json: &str, flags_json: &str) -> Result<JsVa
 #[wasm_bindgen]
 pub fn wasm_enforce_all_tnc(decision_json: &str, flags_json: &str) -> Result<JsValue, JsValue> {
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let flags: TncFlags = from_json_str(flags_json)?;
+    let flags = parse_untrusted_tnc_flags(flags_json)?;
     match decision_forum::tnc_enforcer::enforce_all(&build_tnc_ctx(&decision, &flags)) {
         Ok(()) => to_js_value(&serde_json::json!({"ok": true, "violations": []})),
         Err(e) => to_js_value(&serde_json::json!({"ok": false, "error": e.to_string()})),
@@ -516,7 +535,7 @@ pub fn wasm_collect_tnc_violations(
     flags_json: &str,
 ) -> Result<JsValue, JsValue> {
     let decision: decision_forum::decision_object::DecisionObject = from_json_str(decision_json)?;
-    let flags: TncFlags = from_json_str(flags_json)?;
+    let flags = parse_untrusted_tnc_flags(flags_json)?;
     let violations =
         decision_forum::tnc_enforcer::collect_violations(&build_tnc_ctx(&decision, &flags));
     let descriptions: Vec<String> = violations.iter().map(|e| e.to_string()).collect();
@@ -890,6 +909,11 @@ fn ensure_constitution_bytes(len: usize) -> Result<(), JsValue> {
 
 #[cfg(test)]
 mod tests {
+    use decision_forum::decision_object::{
+        ActorKind, AuthorityLink, DecisionClass, DecisionObject, DecisionObjectInput,
+    };
+    use exo_core::{Hash256, Timestamp, types::Did};
+
     #[test]
     fn decision_forum_bridge_does_not_synthesize_clock_metadata() {
         let source = include_str!("decision_forum_bindings.rs");
@@ -905,6 +929,45 @@ mod tests {
         assert!(
             !production.contains("Uuid::new_v4"),
             "decision-forum WASM exports must require caller-supplied UUID metadata"
+        );
+    }
+
+    #[test]
+    fn wasm_tnc_adapter_does_not_trust_caller_supplied_flags() {
+        let mut decision = DecisionObject::new(DecisionObjectInput {
+            id: uuid::Uuid::parse_str("00000000-0000-0000-0000-000000000901").expect("valid UUID"),
+            title: "Caller-supplied TNC flags".into(),
+            class: DecisionClass::Routine,
+            constitutional_hash: Hash256::from_bytes([1_u8; 32]),
+            created_at: Timestamp::new(1_700_000_000_000, 0),
+        })
+        .expect("valid decision");
+        decision
+            .add_authority_link(AuthorityLink {
+                actor_did: Did::new("did:exo:authority-root").expect("valid DID"),
+                actor_kind: ActorKind::Human,
+                delegation_hash: Hash256::from_bytes([2_u8; 32]),
+                timestamp: Timestamp::new(1_700_000_000_001, 0),
+            })
+            .expect("valid authority link");
+
+        let caller_flags = super::TncFlags {
+            constitutional_hash_valid: true,
+            consent_verified: true,
+            identity_verified: true,
+            evidence_complete: true,
+            quorum_met: true,
+            human_gate_satisfied: true,
+            authority_chain_verified: true,
+            ai_ceilings_externally_verified: true,
+        };
+
+        let ctx = super::build_tnc_ctx(&decision, &caller_flags);
+        let err = decision_forum::tnc_enforcer::enforce_all(&ctx)
+            .expect_err("caller-provided WASM flags cannot satisfy TNC proof obligations");
+        assert!(
+            err.to_string().contains("authority chain not verified"),
+            "unexpected TNC rejection: {err}"
         );
     }
 }

--- a/crates/exochain-wasm/tests/wasm_bindings_test.rs
+++ b/crates/exochain-wasm/tests/wasm_bindings_test.rs
@@ -35,12 +35,22 @@ wasm_bindgen_test_configure!(run_in_node_experimental);
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 fn js_to_json(val: JsValue) -> serde_json::Value {
-    let s = val.as_string().expect("JsValue should be a JSON string");
+    let s = val.as_string().unwrap_or_else(|| {
+        js_sys::JSON::stringify(&val)
+            .expect("JsValue should stringify")
+            .as_string()
+            .expect("stringified JsValue should be a string")
+    });
     serde_json::from_str(&s).expect("JsValue string should be valid JSON")
 }
 
 fn js_str(val: JsValue) -> String {
-    val.as_string().expect("expected string JsValue")
+    val.as_string().unwrap_or_else(|| {
+        js_sys::JSON::stringify(&val)
+            .expect("JsValue should stringify")
+            .as_string()
+            .expect("stringified JsValue should be a string")
+    })
 }
 
 const TEST_TS_JSON: &str = r#"{"physical_ms":1700000000000,"logical":0}"#;
@@ -89,7 +99,8 @@ fn test_merkle_proof_and_verify() {
     let root = exochain_wasm::wasm_merkle_root(&leaves_json).expect("root");
 
     for index in 0..4usize {
-        let proof_json = exochain_wasm::wasm_merkle_proof(&leaves_json, index).expect("proof");
+        let proof_json =
+            js_str(exochain_wasm::wasm_merkle_proof(&leaves_json, index).expect("proof"));
 
         let valid =
             exochain_wasm::wasm_verify_merkle_proof(&root, &leaves[index], &proof_json, index)
@@ -154,10 +165,15 @@ fn test_verify_rejects_wrong_key() {
 // ── Core: Events ──────────────────────────────────────────────────────────────
 
 #[wasm_bindgen_test]
-fn test_compute_event_id_is_unique() {
-    let id1 = exochain_wasm::wasm_compute_event_id();
-    let id2 = exochain_wasm::wasm_compute_event_id();
-    assert_ne!(id1, id2, "correlation IDs must be unique");
+fn test_compute_event_id_is_deterministic_for_caller_seed() {
+    let id1 = exochain_wasm::wasm_compute_event_id(b"event-seed-1").expect("event id");
+    let id2 = exochain_wasm::wasm_compute_event_id(b"event-seed-1").expect("event id");
+    let id3 = exochain_wasm::wasm_compute_event_id(b"event-seed-2").expect("event id");
+    assert_eq!(id1, id2, "same caller seed must produce the same event ID");
+    assert_ne!(
+        id1, id3,
+        "different caller seeds must produce distinct event IDs"
+    );
     assert!(!id1.is_empty());
 }
 
@@ -344,7 +360,7 @@ fn test_begin_due_process_transitions_status() {
 // ── Decision Forum: TNC ───────────────────────────────────────────────────────
 
 #[wasm_bindgen_test]
-fn test_enforce_all_tnc_passes_when_all_flags_set() {
+fn test_enforce_all_tnc_rejects_self_asserted_flags() {
     let hash_hex = "2".repeat(64);
     let decision_json = js_str(
         exochain_wasm::wasm_create_decision(
@@ -369,7 +385,13 @@ fn test_enforce_all_tnc_passes_when_all_flags_set() {
     let result =
         exochain_wasm::wasm_enforce_all_tnc(&decision_json, flags).expect("enforce_all_tnc");
     let json = js_to_json(result);
-    assert!(json["ok"].as_bool().unwrap());
+    assert!(!json["ok"].as_bool().unwrap());
+    assert!(
+        json["error"]
+            .as_str()
+            .expect("error string")
+            .contains("authority chain not verified")
+    );
 }
 
 #[wasm_bindgen_test]
@@ -395,15 +417,42 @@ fn test_collect_tnc_violations_when_flags_clear() {
 // ── Gatekeeper: Introspection ─────────────────────────────────────────────────
 
 #[wasm_bindgen_test]
-fn test_list_invariants_returns_8() {
-    let result = exochain_wasm::wasm_list_invariants().expect("list_invariants");
+fn test_enforce_invariants_returns_structured_result() {
+    let request = r#"{
+        "actor": "did:exo:test-actor",
+        "actor_roles": [],
+        "bailment_state": {
+            "Active": {
+                "bailor": "did:exo:bailor",
+                "bailee": "did:exo:test-actor",
+                "scope": "data"
+            }
+        },
+        "consent_records": [{
+            "subject": "did:exo:subject",
+            "granted_to": "did:exo:test-actor",
+            "scope": "data",
+            "active": true
+        }],
+        "authority_chain": { "links": [] }
+    }"#;
+    let result = exochain_wasm::wasm_enforce_invariants(request).expect("enforce_invariants");
     let json = js_to_json(result);
-    assert_eq!(json.as_array().unwrap().len(), 8);
+    assert!(
+        json.get("passed")
+            .and_then(serde_json::Value::as_bool)
+            .is_some()
+    );
+    assert!(
+        json.get("violations")
+            .and_then(serde_json::Value::as_array)
+            .is_some()
+    );
 }
 
 #[wasm_bindgen_test]
 fn test_list_mcp_rules_nonempty() {
-    let result = exochain_wasm::wasm_list_mcp_rules().expect("list_mcp_rules");
+    let result = exochain_wasm::wasm_mcp_rules().expect("mcp_rules");
     let json = js_to_json(result);
     assert!(!json.as_array().unwrap().is_empty());
 }
@@ -414,11 +463,12 @@ fn test_list_mcp_rules_nonempty() {
 fn test_pace_escalate_then_deescalate() {
     let escalated = exochain_wasm::wasm_pace_escalate(r#""Normal""#).expect("escalate");
     let escalated_str = js_str(escalated);
-    assert_ne!(escalated_str.trim_matches('"'), "Normal");
+    assert_ne!(escalated_str, "Normal");
 
-    let deescalated = exochain_wasm::wasm_pace_deescalate(&escalated_str).expect("deescalate");
+    let escalated_json = serde_json::to_string(&escalated_str).expect("state json");
+    let deescalated = exochain_wasm::wasm_pace_deescalate(&escalated_json).expect("deescalate");
     let result = js_str(deescalated);
-    assert_eq!(result.trim_matches('"'), "Normal");
+    assert_eq!(result, "Normal");
 }
 
 // ── Consent: Bailment ────────────────────────────────────────────────────────

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -1737,6 +1737,42 @@ const tncFlags = {
 
 const tncDecJson = minDecision ? JSON.stringify(minDecision) : '{}';
 const tncFlagsJson = JSON.stringify(tncFlags);
+const canonicalAllTrueTncFlags = {
+  constitutional_hash_valid: true,
+  consent_verified: true,
+  identity_verified: true,
+  evidence_complete: true,
+  quorum_met: true,
+  human_gate_satisfied: true,
+  authority_chain_verified: true,
+  ai_ceilings_externally_verified: true
+};
+const structurallyCompleteTncDecision = minDecision ? {
+  ...minDecision,
+  authority_chain: [{
+    actor_did: TEST_DID,
+    actor_kind: 'Human',
+    delegation_hash: ZERO_32_BYTES,
+    timestamp: NOW_TS
+  }],
+  votes: [],
+  evidence_bundle: [],
+  receipt_chain: []
+} : {};
+
+test('wasm_enforce_all_tnc rejects self-asserted proof flags', () => {
+  const result = wasm.wasm_enforce_all_tnc(
+    JSON.stringify(structurallyCompleteTncDecision),
+    JSON.stringify(canonicalAllTrueTncFlags)
+  );
+  if (result.ok !== false) {
+    throw new Error('self-asserted TNC proof flags must fail closed');
+  }
+  if (!String(result.error).includes('authority chain not verified')) {
+    throw new Error(`unexpected TNC error: ${result.error}`);
+  }
+  return result;
+});
 
 test('wasm_enforce_tnc_01', () =>
   wasm.wasm_enforce_tnc_01(tncDecJson, tncFlagsJson));


### PR DESCRIPTION
## Summary

Supersedes stale/conflicting #444 after verifying the finding still reproduced on current `main`.

The WASM decision-forum TNC bridge previously copied caller-supplied `flags_json` booleans into `TncContext`, allowing a JS caller to self-assert proof obligations such as `authority_chain_verified`, consent, quorum, evidence completeness, and AI ceiling verification. This patch keeps the JSON shape for API compatibility but treats those booleans as untrusted caller claims and constructs fail-closed proof state inside the Rust adapter.

## Path Classification

- `crates/exochain-wasm/src/decision_forum_bindings.rs` — Core runtime adapter
- `crates/exochain-wasm/tests/wasm_bindings_test.rs` — Core runtime adapter test harness
- `packages/exochain-wasm/test/bridge_verification.mjs` — Core runtime adapter bridge verification
- `README.md` — Documentation / repo-truth counters only

No adjacent surfaces or imported evidence were modified.

## Verification

Red evidence before fix:

- `cargo test -p exochain-wasm wasm_tnc_adapter_does_not_trust_caller_supplied_flags -- --nocapture` failed because self-asserted all-true flags returned `Ok(())`.
- `node packages/exochain-wasm/test/bridge_verification.mjs` failed the new `wasm_enforce_all_tnc rejects self-asserted proof flags` assertion against the stale generated WASM artifact, with unrelated stale-artifact failures also present before rebuilding.

Green validation after fix:

- `cargo test -p exochain-wasm wasm_tnc_adapter_does_not_trust_caller_supplied_flags -- --nocapture`
- `cargo test -p exochain-wasm -- --nocapture`
- `cargo clippy -p exochain-wasm --all-targets -- -D warnings`
- `wasm-pack test --node crates/exochain-wasm`
- `wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm`
- `node packages/exochain-wasm/test/bridge_verification.mjs` — 158/158 passed
- `bash tools/test_repo_truth.sh`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`

## Bypass Search

`rg -n "from_json_str\\(flags_json\\)|TncFlags|parse_untrusted_tnc_flags|build_tnc_ctx|authority_chain_verified: flags|ai_ceilings_externally_verified: flags|constitutional_hash_valid: flags" crates/exochain-wasm/src packages/exochain-wasm/test crates/exochain-wasm/tests`

Result: all WASM TNC ingress paths now parse through `parse_untrusted_tnc_flags`; no call site still copies `flags.*` into trusted TNC proof state.
