### PR TITLE
fix(forum): require verified human vote identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 189319 | `wc -l` |
-| Workspace tests | 4,313 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 189578 | `wc -l` |
+| Workspace tests | 4,318 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -45,7 +45,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,306 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,318 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -114,9 +114,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 189319 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 189578 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,313 listed workspace tests
+         cryptographic proofs, 4,318 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          157 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/decision-forum/src/human_gate.rs
+++ b/crates/decision-forum/src/human_gate.rs
@@ -17,9 +17,12 @@
 //! Human oversight enforcement (GOV-007, TNC-02, TNC-09).
 //!
 //! Enforces that certain decision classes require human approval,
-//! distinguishes human vs AI signatures cryptographically, blocks AI
+//! distinguishes verified human voters from declared actor metadata, blocks AI
 //! from satisfying HUMAN_GATE_REQUIRED, and enforces AI delegation ceilings.
 
+use std::collections::BTreeSet;
+
+use exo_core::types::Did;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -60,11 +63,28 @@ pub fn ai_within_ceiling(policy: &HumanGatePolicy, class: DecisionClass) -> bool
 /// Validate that a decision's votes satisfy the human gate policy.
 /// Returns Ok(()) if the gate is satisfied, or an error if not.
 pub fn enforce_human_gate(policy: &HumanGatePolicy, decision: &DecisionObject) -> Result<()> {
+    enforce_human_gate_with_verified_humans(policy, decision, &BTreeSet::new())
+}
+
+/// Validate the human gate using a trusted set of externally verified human
+/// voter DIDs. The set must come from an identity registry, credential
+/// verifier, or runtime adapter that authenticated the DID as human; the
+/// self-declared `Vote.actor_kind` field is never sufficient by itself.
+pub fn enforce_human_gate_with_verified_humans(
+    policy: &HumanGatePolicy,
+    decision: &DecisionObject,
+    verified_human_voters: &BTreeSet<Did>,
+) -> Result<()> {
+    let has_verified_human_vote = decision
+        .votes
+        .iter()
+        .any(|vote| is_verified_human_vote(vote, verified_human_voters));
+
     // Check AI ceiling: if decision class exceeds AI ceiling, AI votes alone
     // are not sufficient.
     if decision.class > policy.ai_ceiling {
-        let has_human_vote = decision.votes.iter().any(is_human_vote);
-        if !has_human_vote && !decision.votes.is_empty() {
+        let has_ai_vote = decision.votes.iter().any(is_ai_vote);
+        if has_ai_vote && !has_verified_human_vote {
             return Err(ForumError::AiCeilingExceeded {
                 reason: format!(
                     "{} exceeds AI ceiling {}",
@@ -78,7 +98,11 @@ pub fn enforce_human_gate(policy: &HumanGatePolicy, decision: &DecisionObject) -
     // Check human gate: classes requiring human approval must have at least
     // one human vote.
     if requires_human_approval(policy, decision.class) {
-        let human_count = decision.votes.iter().filter(|v| is_human_vote(v)).count();
+        let human_count = decision
+            .votes
+            .iter()
+            .filter(|vote| is_verified_human_vote(vote, verified_human_voters))
+            .count();
         if human_count == 0 {
             return Err(ForumError::HumanGateRequired);
         }
@@ -87,10 +111,27 @@ pub fn enforce_human_gate(policy: &HumanGatePolicy, decision: &DecisionObject) -
     Ok(())
 }
 
-/// Determine if a vote was cast by a human actor.
+/// Determine if a vote was cast by a verified human actor.
+///
+/// This legacy helper has no trusted identity registry argument, so it fails
+/// closed. Use [`is_verified_human_vote`] when a verified DID set is available.
 #[must_use]
 pub fn is_human_vote(vote: &Vote) -> bool {
+    is_verified_human_vote(vote, &BTreeSet::new())
+}
+
+/// Determine if a vote declares a human actor kind without treating that
+/// declaration as verification.
+#[must_use]
+pub fn is_declared_human_vote(vote: &Vote) -> bool {
     matches!(vote.actor_kind, ActorKind::Human)
+}
+
+/// Determine if a vote is both declared human and backed by a trusted human
+/// identity record for the same voter DID.
+#[must_use]
+pub fn is_verified_human_vote(vote: &Vote, verified_human_voters: &BTreeSet<Did>) -> bool {
+    matches!(vote.actor_kind, ActorKind::Human) && verified_human_voters.contains(&vote.voter_did)
 }
 
 /// Determine if a vote was cast by an AI agent.
@@ -193,8 +234,27 @@ mod tests {
         let mut clock = test_clock();
         let policy = HumanGatePolicy::default();
         let mut d = make_decision(DecisionClass::Strategic, &mut clock);
-        d.add_vote(human_vote(&mut clock)).expect("ok");
-        assert!(enforce_human_gate(&policy, &d).is_ok());
+        let vote = human_vote(&mut clock);
+        let mut verified_human_voters = BTreeSet::new();
+        verified_human_voters.insert(vote.voter_did.clone());
+        d.add_vote(vote).expect("ok");
+        assert!(
+            enforce_human_gate_with_verified_humans(&policy, &d, &verified_human_voters).is_ok()
+        );
+    }
+
+    #[test]
+    fn human_gate_rejects_unverified_human_actor_kind() {
+        let mut clock = test_clock();
+        let policy = HumanGatePolicy::default();
+        let mut d = make_decision(DecisionClass::Strategic, &mut clock);
+        d.add_vote(human_vote(&mut clock))
+            .expect("declared human vote");
+
+        let err = enforce_human_gate(&policy, &d)
+            .expect_err("self-declared human actor_kind must not satisfy human gate");
+
+        assert!(matches!(err, ForumError::HumanGateRequired));
     }
 
     #[test]
@@ -232,10 +292,16 @@ mod tests {
     #[test]
     fn is_human_vs_ai() {
         let mut clock = test_clock();
-        assert!(is_human_vote(&human_vote(&mut clock)));
-        assert!(!is_human_vote(&ai_vote(&mut clock)));
+        let human = human_vote(&mut clock);
+        let mut verified_human_voters = BTreeSet::new();
+        verified_human_voters.insert(human.voter_did.clone());
+
+        assert!(is_declared_human_vote(&human));
+        assert!(!is_human_vote(&human));
+        assert!(is_verified_human_vote(&human, &verified_human_voters));
+        assert!(!is_declared_human_vote(&ai_vote(&mut clock)));
         assert!(is_ai_vote(&ai_vote(&mut clock)));
-        assert!(!is_ai_vote(&human_vote(&mut clock)));
+        assert!(!is_ai_vote(&human));
     }
 
     #[test]

--- a/crates/decision-forum/src/quorum.rs
+++ b/crates/decision-forum/src/quorum.rs
@@ -20,12 +20,15 @@
 //! graceful degradation on quorum failure, and independence-aware counting
 //! via exo_governance::quorum.
 
-use exo_core::types::DeterministicMap;
+use std::collections::BTreeSet;
+
+use exo_core::types::{DeterministicMap, Did};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     decision_object::{DecisionClass, DecisionObject, VoteChoice},
     error::{ForumError, Result},
+    human_gate::is_verified_human_vote,
 };
 
 /// Quorum policy for a specific decision class.
@@ -113,6 +116,17 @@ pub fn check_quorum(
     registry: &QuorumRegistry,
     decision: &DecisionObject,
 ) -> Result<QuorumCheckResult> {
+    check_quorum_with_verified_humans(registry, decision, &BTreeSet::new())
+}
+
+/// Check if quorum is met using a trusted set of externally verified human
+/// voter DIDs. Human vote floors are satisfied only when the vote is declared
+/// human and the voter DID appears in this set.
+pub fn check_quorum_with_verified_humans(
+    registry: &QuorumRegistry,
+    decision: &DecisionObject,
+    verified_human_voters: &BTreeSet<Did>,
+) -> Result<QuorumCheckResult> {
     let req = registry
         .requirement_for(decision.class)
         .ok_or(ForumError::QuorumPolicyMissing)?;
@@ -127,7 +141,7 @@ pub fn check_quorum(
     let human_count = decision
         .votes
         .iter()
-        .filter(|v| matches!(v.actor_kind, crate::decision_object::ActorKind::Human))
+        .filter(|vote| is_verified_human_vote(vote, verified_human_voters))
         .count();
 
     if total_votes < req.min_votes {
@@ -258,6 +272,15 @@ mod tests {
         .expect("valid decision")
     }
 
+    fn verified_human_voters(decision: &DecisionObject) -> BTreeSet<Did> {
+        decision
+            .votes
+            .iter()
+            .filter(|vote| matches!(vote.actor_kind, ActorKind::Human))
+            .map(|vote| vote.voter_did.clone())
+            .collect()
+    }
+
     #[test]
     fn routine_quorum_met() {
         let mut clock = test_clock();
@@ -265,7 +288,7 @@ mod tests {
         let mut d = make_decision("test", DecisionClass::Routine, &mut clock);
         d.add_vote(human_approve_vote("alice", &mut clock))
             .expect("ok");
-        match check_quorum(&reg, &d).expect("ok") {
+        match check_quorum_with_verified_humans(&reg, &d, &verified_human_voters(&d)).expect("ok") {
             QuorumCheckResult::Met { total_votes, .. } => assert_eq!(total_votes, 1),
             other => panic!("expected Met, got {other:?}"),
         }
@@ -278,7 +301,7 @@ mod tests {
         let mut d = make_decision("test", DecisionClass::Operational, &mut clock);
         d.add_vote(human_approve_vote("alice", &mut clock))
             .expect("ok");
-        match check_quorum(&reg, &d).expect("ok") {
+        match check_quorum_with_verified_humans(&reg, &d, &verified_human_voters(&d)).expect("ok") {
             QuorumCheckResult::Degraded {
                 available,
                 required,
@@ -300,7 +323,7 @@ mod tests {
             .expect("ok");
         d.add_vote(ai_approve_vote("bot1", &mut clock)).expect("ok");
         d.add_vote(ai_approve_vote("bot2", &mut clock)).expect("ok");
-        match check_quorum(&reg, &d).expect("ok") {
+        match check_quorum_with_verified_humans(&reg, &d, &verified_human_voters(&d)).expect("ok") {
             QuorumCheckResult::Met {
                 total_votes,
                 approve_count,
@@ -322,7 +345,7 @@ mod tests {
             .expect("ok");
         d.add_vote(reject_vote("bob", &mut clock)).expect("ok");
         d.add_vote(reject_vote("carol", &mut clock)).expect("ok");
-        match check_quorum(&reg, &d).expect("ok") {
+        match check_quorum_with_verified_humans(&reg, &d, &verified_human_voters(&d)).expect("ok") {
             QuorumCheckResult::NotMet { reason } => {
                 assert!(reason.contains("approval percentage"));
             }
@@ -344,6 +367,31 @@ mod tests {
                 assert!(reason.contains("human"));
             }
             other => panic!("expected NotMet, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn check_quorum_rejects_unverified_human_actor_kind() {
+        let mut clock = test_clock();
+        let reg = QuorumRegistry::with_defaults();
+        let mut d = make_decision(
+            "declared humans are not verified humans",
+            DecisionClass::Strategic,
+            &mut clock,
+        );
+        for name in ["alice", "bob", "carol", "dave", "erin"] {
+            d.add_vote(human_approve_vote(name, &mut clock))
+                .expect("declared human vote accepted into decision object");
+        }
+
+        match check_quorum(&reg, &d).expect("quorum check ok") {
+            QuorumCheckResult::NotMet { reason } => {
+                assert!(
+                    reason.contains("human"),
+                    "unverified declared-human votes must not satisfy human quorum: {reason}"
+                );
+            }
+            other => panic!("expected NotMet for unverified human actor_kind, got {other:?}"),
         }
     }
 

--- a/crates/exo-gateway/src/db.rs
+++ b/crates/exo-gateway/src/db.rs
@@ -509,6 +509,25 @@ pub async fn find_user_by_did(
     ).bind(did).fetch_optional(pool).await
 }
 
+/// Return active human user DIDs from the provided candidate vote set.
+pub async fn active_human_user_dids_for_votes(
+    pool: &PgPool,
+    tenant_id: &str,
+    voter_dids: &[String],
+) -> Result<Vec<String>, sqlx::Error> {
+    if voter_dids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    sqlx::query_scalar::<_, String>(
+        "SELECT did FROM users WHERE tenant_id = $1 AND status = 'Active' AND did = ANY($2) ORDER BY did",
+    )
+    .bind(tenant_id)
+    .bind(voter_dids)
+    .fetch_all(pool)
+    .await
+}
+
 /// List users for a tenant ordered by creation time.
 pub async fn list_users_db(
     pool: &PgPool,
@@ -2724,6 +2743,26 @@ mod tests {
         assert!(
             count.contains("eligible_human_voters: active_human_users"),
             "human quorum eligibility must not include agents or unrelated DIDs"
+        );
+    }
+
+    #[test]
+    fn active_human_user_vote_lookup_is_tenant_scoped_and_candidate_bounded() {
+        let source = production_source();
+        let lookup = function_source(source, "active_human_user_dids_for_votes");
+
+        assert!(
+            lookup.contains("tenant_id: &str"),
+            "verified human voter lookup must require an explicit tenant scope"
+        );
+        assert!(
+            compact_sql(lookup)
+                .contains("FROM users WHERE tenant_id = $1 AND status = 'Active' AND did = ANY($2) ORDER BY did"),
+            "verified human voter lookup must only return active users from the authenticated tenant and candidate vote set"
+        );
+        assert!(
+            contains_in_order(lookup, ".bind(tenant_id)", ".bind(voter_dids)"),
+            "verified human voter lookup must bind tenant scope before the candidate vote set"
         );
     }
 

--- a/crates/exo-gateway/src/handlers.rs
+++ b/crates/exo-gateway/src/handlers.rs
@@ -31,7 +31,10 @@ use axum::{
 };
 use decision_forum::{
     decision_object::{ActorKind, DecisionObject, Vote, VoteChoice},
-    quorum::{QuorumCheckResult, QuorumRegistry, check_quorum, verify_quorum_precondition},
+    quorum::{
+        QuorumCheckResult, QuorumRegistry, check_quorum_with_verified_humans,
+        verify_quorum_precondition,
+    },
 };
 use exo_core::{Did, Signature, Timestamp, hash::hash_structured, types::Hash256};
 use exo_gatekeeper::{
@@ -741,17 +744,32 @@ pub async fn vote_handler(
     }
 
     // Check quorum post-vote to include status in response.
-    let quorum_result = match check_quorum(&registry, &decision) {
-        Ok(r) => r,
+    let verified_human_voter_dids = match state
+        .verified_human_voter_dids(&actor.tenant_id, &decision.votes)
+        .await
+    {
+        Ok(voters) => voters,
         Err(e) => {
-            tracing::error!(error = %e, "quorum evaluation failed");
+            tracing::error!(error = %e, "failed to derive verified human voters");
             return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": "quorum evaluation failed"})),
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({"error": "human voter registry unavailable"})),
             )
                 .into_response();
         }
     };
+    let quorum_result =
+        match check_quorum_with_verified_humans(&registry, &decision, &verified_human_voter_dids) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::error!(error = %e, "quorum evaluation failed");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": "quorum evaluation failed"})),
+                )
+                    .into_response();
+            }
+        };
 
     // Serialize updated DecisionObject back to JSON for DB persistence.
     let updated_payload = match serde_json::to_value(&decision) {
@@ -1673,6 +1691,31 @@ mod tests {
         assert!(
             !vote_handler.contains("actor_kind: body.actor_kind"),
             "vote handler must not let clients self-attest human quorum status"
+        );
+    }
+
+    #[test]
+    fn vote_handler_checks_quorum_with_verified_human_voters() {
+        let source = include_str!("handlers.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("test module marker present");
+        let vote_handler = production
+            .split("pub async fn vote_handler")
+            .nth(1)
+            .expect("vote handler source present")
+            .split("// ── Health handler")
+            .next()
+            .expect("vote handler source end");
+
+        assert!(
+            vote_handler.contains("verified_human_voter_dids"),
+            "vote handler must derive verified human voters from the authenticated tenant profile, not request JSON"
+        );
+        assert!(
+            vote_handler.contains("check_quorum_with_verified_humans"),
+            "vote handler must evaluate post-vote human quorum with the verified human voter set"
         );
     }
 

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -32,7 +32,9 @@ use axum::{
     routing::{get, post},
 };
 use axum_server::tls_rustls::RustlsConfig;
-use decision_forum::decision_object::{DecisionClass, DecisionObject, DecisionObjectInput};
+use decision_forum::decision_object::{
+    ActorKind, DecisionClass, DecisionObject, DecisionObjectInput, Vote,
+};
 use exo_core::{Did, Hash256, Signature, Timestamp, hash::hash_structured, hlc::HybridClock};
 use exo_gatekeeper::{
     invariants::InvariantSet,
@@ -512,6 +514,38 @@ impl AppState {
             .map_err(|e| {
                 GatewayError::Internal(format!("failed to count quorum eligible voters: {e}"))
             })
+    }
+
+    /// Derive the trusted human voter set for decision-forum votes from active
+    /// tenant user records. Caller-supplied `Vote.actor_kind` is only a selector
+    /// for candidate DIDs; it is not treated as proof.
+    pub async fn verified_human_voter_dids(
+        &self,
+        tenant_id: &str,
+        votes: &[Vote],
+    ) -> Result<BTreeSet<Did>> {
+        let pool = self.require_db()?;
+        let voter_dids = votes
+            .iter()
+            .filter(|vote| matches!(vote.actor_kind, ActorKind::Human))
+            .map(|vote| vote.voter_did.as_str().to_owned())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let rows = db::active_human_user_dids_for_votes(pool, tenant_id, &voter_dids)
+            .await
+            .map_err(|e| {
+                GatewayError::Internal(format!("failed to derive verified human voters: {e}"))
+            })?;
+        rows.into_iter()
+            .map(|did| {
+                Did::new(&did).map_err(|e| {
+                    GatewayError::Internal(format!(
+                        "active human voter DID from database is invalid: {e}"
+                    ))
+                })
+            })
+            .collect()
     }
 
     /// Load conflict declarations for an actor from the DB-backed standing

--- a/crates/exochain-wasm/src/lib.rs
+++ b/crates/exochain-wasm/src/lib.rs
@@ -379,6 +379,35 @@ mod source_guard_tests {
     }
 
     #[test]
+    fn wasm_decision_forum_human_vote_exports_fail_closed_without_verified_registry() {
+        let source = include_str!("decision_forum_bindings.rs");
+
+        assert!(
+            source.contains("decision_forum::human_gate::enforce_human_gate(&policy, &decision)"),
+            "legacy WASM human-gate export must use the fail-closed core helper when no trusted human registry is available"
+        );
+        assert!(
+            source.contains("decision_forum::human_gate::is_human_vote(&vote)"),
+            "legacy WASM human-vote export must use the fail-closed core helper, not declared actor metadata"
+        );
+        assert!(
+            source.contains("decision_forum::quorum::check_quorum(&registry, &decision)"),
+            "legacy WASM quorum export must use the fail-closed core helper when no trusted human registry is available"
+        );
+
+        for forbidden in [
+            "is_declared_human_vote",
+            "check_quorum_with_verified_humans",
+            "verified_human_voters",
+        ] {
+            assert!(
+                !source.contains(forbidden),
+                "legacy WASM decision-forum exports must not accept or synthesize verified human status via {forbidden}"
+            );
+        }
+    }
+
+    #[test]
     fn wasm_decision_transition_requires_kernel_adjudication() {
         let source = include_str!("decision_forum_bindings.rs");
         let legacy_transition = source


### PR DESCRIPTION
## Classification
- EXOCHAIN core: `crates/decision-forum/src/human_gate.rs`, `crates/decision-forum/src/quorum.rs`
- Core runtime adapter: `crates/exo-gateway/src/db.rs`, `crates/exo-gateway/src/handlers.rs`, `crates/exo-gateway/src/server.rs`, `crates/exochain-wasm/src/lib.rs`
- Documentation/repo truth: `README.md`

## External Finding Disposition
Re-verified stale PR #442 against current `main` after #510. The gateway vote handler already derived the stored vote actor kind from the authenticated active session user, but the decision-forum core still allowed self-declared `Vote.actor_kind = Human` to satisfy human-gate and human-quorum checks. Gateway post-vote quorum also still called the legacy quorum helper, so persisted/self-declared human votes could influence human quorum floors.

## Red Tests Added
- `human_gate_rejects_unverified_human_actor_kind`
- `check_quorum_rejects_unverified_human_actor_kind`
- `vote_handler_checks_quorum_with_verified_human_voters`
- WASM source guard: `wasm_decision_forum_human_vote_exports_fail_closed_without_verified_registry`

## Remediation
- Legacy forum helpers now fail closed when no trusted verified-human DID set is supplied.
- Added `enforce_human_gate_with_verified_humans`, `is_verified_human_vote`, and `check_quorum_with_verified_humans` for callers with a trusted human voter registry.
- Gateway derives verified human voters from active tenant `users` rows bounded by the candidate vote set, then uses that trusted set for post-vote quorum.
- WASM legacy decision-forum exports remain fail-closed and cannot accept/synthesize verified human status.

## Validation
Red before fix:
- `cargo test -p decision-forum human_gate_rejects_unverified_human_actor_kind -- --nocapture` failed because self-declared human passed.
- `cargo test -p decision-forum check_quorum_rejects_unverified_human_actor_kind -- --nocapture` failed because unverified human votes produced `Met`.
- `cargo test -p exo-gateway vote_handler_checks_quorum_with_verified_human_voters -- --nocapture` failed because the gateway did not derive/use verified human voters.

Green after fix:
- `cargo test -p decision-forum human_gate_rejects_unverified_human_actor_kind -- --nocapture`
- `cargo test -p decision-forum check_quorum_rejects_unverified_human_actor_kind -- --nocapture`
- `cargo test -p exo-gateway vote_handler_checks_quorum_with_verified_human_voters -- --nocapture`
- `cargo test -p decision-forum`
- `cargo test -p exo-gateway`
- `cargo test -p exochain-wasm`
- `cargo clippy -p decision-forum -p exo-gateway -p exochain-wasm --all-targets -- -D warnings`
- `bash tools/test_repo_truth.sh`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
- `cargo build --workspace --release`

## Bypass Search
Searched for `enforce_human_gate`, `is_human_vote`, `check_quorum`, verified-human APIs, and `actor_kind: body.actor_kind` across `crates/` and `packages/`. Remaining legacy decision-forum/WASM calls route through fail-closed helpers; gateway uses `check_quorum_with_verified_humans`; SDK/node quorum helpers are separate non-decision-forum APIs and do not satisfy decision-forum human vote floors.
