### PR TITLE
fix(forum): require trusted authority signatures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -562,16 +562,17 @@ jobs:
       - name: Build WASM
         run: wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm
       - name: Verify WASM exports
-        # Expected export count = 157. Baseline was 110 before
+        # Expected export count = 158. Baseline was 110 before
         # decision-forum, messaging, death-trigger, and franchise/NewCo
         # scaffold were added; the adjudicated decision transition bridge
         # adds the current security boundary, and the HonorGood economy bridge
         # adds the current settlement/provenance anchor helpers. The Catapult
-        # receipt-chain bridge adds explicit actor-key signature verification.
+        # receipt-chain bridge adds explicit actor-key signature verification,
+        # and the forum authority bridge adds trusted-root-key verification.
         run: |
           COUNT=$(grep -c "module.exports.wasm_" packages/exochain-wasm/wasm/exochain_wasm.js)
           echo "Found $COUNT WASM exports"
-          [ "$COUNT" -eq 157 ] || (echo "Expected 157 exports, got $COUNT" && exit 1)
+          [ "$COUNT" -eq 158 ] || (echo "Expected 158 exports, got $COUNT" && exit 1)
       - name: Upload WASM artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
@@ -606,16 +607,17 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Verify Rust exports match JS expectations
-        # Expected #[wasm_bindgen] count = 157. Baseline was 110 before the
+        # Expected #[wasm_bindgen] count = 158. Baseline was 110 before the
         # Sprint-4 additions (decision-forum, messaging, death-trigger,
         # franchise/NewCo scaffold); the adjudicated decision transition bridge
         # adds the current security boundary, the HonorGood economy bridge
         # adds the current settlement/provenance anchor helpers, and Catapult
-        # signed receipt-chain verification adds an explicit key-registry path.
+        # signed receipt-chain verification adds an explicit key-registry path,
+        # and forum authority verification adds a trusted-root-key path.
         run: |
           RUST_COUNT=$(grep -r '#\[wasm_bindgen\]' crates/exochain-wasm/src/ | wc -l | tr -d ' ')
           echo "Rust #[wasm_bindgen] exports: $RUST_COUNT"
-          [ "$RUST_COUNT" -eq 157 ] || (echo "WASM export count changed from 157 to $RUST_COUNT — update bridge tests" && exit 1)
+          [ "$RUST_COUNT" -eq 158 ] || (echo "WASM export count changed from 158 to $RUST_COUNT — update bridge tests" && exit 1)
 
   # -----------------------------------------------------------------------
   # Constitutional gate: all must pass

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 189578 | `wc -l` |
-| Workspace tests | 4,318 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 189710 | `wc -l` |
+| Workspace tests | 4,322 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -45,7 +45,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,318 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,322 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -114,12 +114,12 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 189578 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 189710 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,318 listed workspace tests
+         cryptographic proofs, 4,322 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
-         157 verified bridge exports — Rust -> WebAssembly -> JavaScript
+         158 verified bridge exports — Rust -> WebAssembly -> JavaScript
 
 Layer 3: CommandBase.ai     (command-base/)
          Adjacent cockpit adapter for cognitiveplane.ai

--- a/crates/decision-forum/src/authority.rs
+++ b/crates/decision-forum/src/authority.rs
@@ -17,12 +17,18 @@
 //! Forum authority management.
 //!
 //! Verifies forum-level authority bindings: root DID, constitution hash,
-//! rules, and signature validation.
+//! rules, and cryptographic signature validation.
 
-use exo_core::types::{Did, Hash256, Signature};
+use exo_core::{
+    crypto,
+    hash::hash_structured,
+    types::{Did, Hash256, PublicKey, Signature},
+};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{ForumError, Result};
+
+const FORUM_AUTHORITY_SIGNATURE_DOMAIN: &str = "decision.forum.authority_signature.v1";
 
 /// A named rule within the forum authority.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -40,8 +46,15 @@ pub struct ForumAuthority {
     pub signature: Signature,
 }
 
-/// Verify that a forum authority binding is structurally valid.
-pub fn verify_forum_authority(authority: &ForumAuthority) -> Result<()> {
+#[derive(Debug, Clone, Serialize)]
+struct ForumAuthoritySignaturePayload<'a> {
+    domain: &'static str,
+    root_did: &'a Did,
+    constitution_hash: &'a Hash256,
+    rules: &'a [ForumRule],
+}
+
+fn verify_forum_authority_structure(authority: &ForumAuthority) -> Result<()> {
     if authority.signature.is_empty() {
         return Err(ForumError::AuthorityInvalid {
             reason: "empty signature".into(),
@@ -58,6 +71,46 @@ pub fn verify_forum_authority(authority: &ForumAuthority) -> Result<()> {
         });
     }
     Ok(())
+}
+
+/// Canonical message bytes to sign for a forum authority binding.
+pub fn forum_authority_signature_message(authority: &ForumAuthority) -> Result<Vec<u8>> {
+    let digest = hash_structured(&ForumAuthoritySignaturePayload {
+        domain: FORUM_AUTHORITY_SIGNATURE_DOMAIN,
+        root_did: &authority.root_did,
+        constitution_hash: &authority.constitution_hash,
+        rules: &authority.rules,
+    })?;
+    Ok(digest.as_ref().to_vec())
+}
+
+/// Verify a forum authority binding against a trusted root public key.
+///
+/// The caller must resolve `root_public_key` from a trusted registry for
+/// `authority.root_did`; the key must not come from untrusted authority JSON.
+pub fn verify_forum_authority_with_key(
+    authority: &ForumAuthority,
+    root_public_key: &PublicKey,
+) -> Result<()> {
+    verify_forum_authority_structure(authority)?;
+    let message = forum_authority_signature_message(authority)?;
+    if !crypto::verify(&message, &authority.signature, root_public_key) {
+        return Err(ForumError::AuthorityInvalid {
+            reason: "signature is not valid for trusted root public key".into(),
+        });
+    }
+    Ok(())
+}
+
+/// Fail-closed legacy verifier.
+///
+/// Authenticity cannot be established from a `ForumAuthority` object alone
+/// because the trusted root public key belongs to the caller's trust boundary,
+/// not to the untrusted authority payload.
+pub fn verify_forum_authority(_authority: &ForumAuthority) -> Result<()> {
+    Err(ForumError::AuthorityInvalid {
+        reason: "trusted root public key required for forum authority verification".into(),
+    })
 }
 
 #[cfg(test)]
@@ -85,30 +138,70 @@ mod tests {
         }
     }
 
+    fn signed_auth() -> (ForumAuthority, PublicKey) {
+        let (public_key, secret_key) = exo_core::crypto::generate_keypair();
+        let mut authority = auth();
+        authority.signature = Signature::Empty;
+        let message =
+            forum_authority_signature_message(&authority).expect("canonical authority payload");
+        authority.signature = exo_core::crypto::sign(&message, &secret_key);
+        (authority, public_key)
+    }
+
     #[test]
     fn valid_authority() {
-        verify_forum_authority(&auth()).expect("ok");
+        let (authority, public_key) = signed_auth();
+        verify_forum_authority_with_key(&authority, &public_key).expect("ok");
+    }
+
+    #[test]
+    fn verify_forum_authority_rejects_unverified_non_empty_signature() {
+        let err = verify_forum_authority(&auth()).unwrap_err();
+        assert!(
+            err.to_string().contains("public key"),
+            "ForumAuthority authenticity must not be accepted from a non-empty signature alone"
+        );
+    }
+
+    #[test]
+    fn verify_forum_authority_with_key_rejects_forged_non_empty_signature() {
+        let (public_key, _secret_key) = exo_core::crypto::generate_keypair();
+        let err = verify_forum_authority_with_key(&auth(), &public_key).unwrap_err();
+        assert!(
+            err.to_string().contains("signature"),
+            "ForumAuthority must verify the signature against a trusted root public key"
+        );
+    }
+
+    #[test]
+    fn forum_authority_signature_binds_rules() {
+        let (mut authority, public_key) = signed_auth();
+        authority.rules.push(ForumRule {
+            name: "r2".into(),
+            hash: Hash256::digest(b"r2"),
+        });
+        assert!(verify_forum_authority_with_key(&authority, &public_key).is_err());
     }
 
     #[test]
     fn empty_sig() {
-        let mut a = auth();
+        let (mut a, public_key) = signed_auth();
         a.signature = Signature::from_bytes([0u8; 64]);
-        assert!(verify_forum_authority(&a).is_err());
+        assert!(verify_forum_authority_with_key(&a, &public_key).is_err());
     }
 
     #[test]
     fn zero_hash() {
-        let mut a = auth();
+        let (mut a, public_key) = signed_auth();
         a.constitution_hash = Hash256::ZERO;
-        assert!(verify_forum_authority(&a).is_err());
+        assert!(verify_forum_authority_with_key(&a, &public_key).is_err());
     }
 
     #[test]
     fn no_rules() {
-        let mut a = auth();
+        let (mut a, public_key) = signed_auth();
         a.rules.clear();
-        assert!(verify_forum_authority(&a).is_err());
+        assert!(verify_forum_authority_with_key(&a, &public_key).is_err());
     }
 
     #[test]

--- a/crates/exochain-wasm/src/decision_forum_bindings.rs
+++ b/crates/exochain-wasm/src/decision_forum_bindings.rs
@@ -830,11 +830,29 @@ pub fn wasm_is_due_process_expired(action_json: &str, now_ms: u64) -> Result<boo
 
 // ── Forum Authority ──────────────────────────────────────────────
 
-/// Verify the integrity and authenticity of a ForumAuthority object.
+/// Legacy ForumAuthority verifier.
+///
+/// This export fails closed because authenticity requires a trusted root
+/// public key supplied from the caller's trust boundary. Use
+/// `wasm_verify_forum_authority_with_key` for cryptographic verification.
 #[wasm_bindgen]
 pub fn wasm_verify_forum_authority(authority_json: &str) -> Result<JsValue, JsValue> {
     let authority: decision_forum::authority::ForumAuthority = from_json_str(authority_json)?;
     match decision_forum::authority::verify_forum_authority(&authority) {
+        Ok(()) => to_js_value(&serde_json::json!({"ok": true})),
+        Err(e) => to_js_value(&serde_json::json!({"ok": false, "error": e.to_string()})),
+    }
+}
+
+/// Verify the integrity and authenticity of a ForumAuthority object.
+#[wasm_bindgen]
+pub fn wasm_verify_forum_authority_with_key(
+    authority_json: &str,
+    root_public_key_hex: &str,
+) -> Result<JsValue, JsValue> {
+    let authority: decision_forum::authority::ForumAuthority = from_json_str(authority_json)?;
+    let root_public_key = parse_public_key_hex(root_public_key_hex)?;
+    match decision_forum::authority::verify_forum_authority_with_key(&authority, &root_public_key) {
         Ok(()) => to_js_value(&serde_json::json!({"ok": true})),
         Err(e) => to_js_value(&serde_json::json!({"ok": false, "error": e.to_string()})),
     }
@@ -852,6 +870,14 @@ fn parse_hash(value: &str, label: &str) -> Result<exo_core::Hash256, JsValue> {
         .try_into()
         .map_err(|_| JsValue::from_str(&format!("{label} must be 32 bytes")))?;
     Ok(exo_core::Hash256::from_bytes(arr))
+}
+
+fn parse_public_key_hex(public_key_hex: &str) -> Result<exo_core::PublicKey, JsValue> {
+    let bytes = hex::decode(public_key_hex).map_err(|e| JsValue::from_str(&format!("hex: {e}")))?;
+    let arr: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| JsValue::from_str("public key must be 32 bytes"))?;
+    Ok(exo_core::PublicKey::from_bytes(arr))
 }
 
 fn parse_signature_pairs(
@@ -888,12 +914,7 @@ fn parse_public_key_pairs(
     for (did_str, public_key_hex) in &key_pairs {
         let did = exo_core::Did::new(did_str)
             .map_err(|e| JsValue::from_str(&format!("DID error: {e}")))?;
-        let bytes =
-            hex::decode(public_key_hex).map_err(|e| JsValue::from_str(&format!("hex: {e}")))?;
-        let arr: [u8; 32] = bytes
-            .try_into()
-            .map_err(|_| JsValue::from_str("public key must be 32 bytes"))?;
-        public_keys.insert(did, exo_core::PublicKey::from_bytes(arr));
+        public_keys.insert(did, parse_public_key_hex(public_key_hex)?);
     }
     Ok(public_keys)
 }
@@ -968,6 +989,24 @@ mod tests {
         assert!(
             err.to_string().contains("authority chain not verified"),
             "unexpected TNC rejection: {err}"
+        );
+    }
+
+    #[test]
+    fn forum_authority_wasm_verifier_requires_trusted_public_key() {
+        let source = include_str!("decision_forum_bindings.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production section");
+
+        assert!(
+            production.contains("wasm_verify_forum_authority_with_key"),
+            "WASM authority verification must expose a trusted-public-key verification path"
+        );
+        assert!(
+            production.contains("verify_forum_authority_with_key"),
+            "WASM authority verification must call the cryptographic core verifier"
         );
     }
 }

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -1826,6 +1826,23 @@ test('wasm_verify_forum_authority', () => {
   return wasm.wasm_verify_forum_authority(JSON.stringify(authority));
 });
 
+test('wasm_verify_forum_authority_with_key rejects untrusted signature', () => {
+  const authority = {
+    root_did: TEST_DID,
+    constitution_hash: EVIDENCE_32_BYTES,
+    rules: [{ name: 'TestRule', hash: EVIDENCE_32_BYTES }],
+    signature: ephResult.signature
+  };
+  const result = wasm.wasm_verify_forum_authority_with_key(
+    JSON.stringify(authority),
+    ephResult.public_key
+  );
+  if (result.ok !== false) {
+    throw new Error('forged forum authority signature must fail closed');
+  }
+  return result;
+});
+
 // =========================================================================
 // Module 21 — Challenge Lifecycle
 // =========================================================================


### PR DESCRIPTION
## Summary
- Re-verifies stale PR #441 against current `main` and confirms the issue still existed: `ForumAuthority` authenticity was structural-only because any non-empty signature was accepted without a trusted public key.
- Adds a domain-separated canonical forum-authority signature payload and `verify_forum_authority_with_key`, which verifies against a trusted root public key supplied by the caller trust boundary.
- Leaves the legacy JSON-only verifier fail-closed because authenticity cannot be established from untrusted authority JSON alone.
- Adds a WASM trusted-root-key verification export and bridge harness coverage for the fail-closed forged-signature path.

## Classification
- EXOCHAIN core: `crates/decision-forum/src/authority.rs`
- Core runtime adapter: `crates/exochain-wasm/src/decision_forum_bindings.rs`, `packages/exochain-wasm/test/bridge_verification.mjs`
- CI/repo truth: `.github/workflows/ci.yml`, `README.md`

## Red tests before fix
- `cargo test -p decision-forum verify_forum_authority_rejects_unverified_non_empty_signature -- --nocapture` failed because `verify_forum_authority(&auth())` returned `Ok(())` for a forged non-empty signature.
- `cargo test -p exochain-wasm forum_authority_wasm_verifier_requires_trusted_public_key -- --nocapture` failed because the WASM adapter exposed no trusted-public-key verification path.

## Validation
- `cargo test -p decision-forum verify_forum_authority_rejects_unverified_non_empty_signature -- --nocapture`
- `cargo test -p exochain-wasm forum_authority_wasm_verifier_requires_trusted_public_key -- --nocapture`
- `cargo test -p decision-forum`
- `cargo test -p exochain-wasm`
- `wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm`
- `node packages/exochain-wasm/test/bridge_verification.mjs` (159/159 passed)
- `bash tools/test_repo_truth.sh`
- `cargo fmt --all -- --check`
- `cargo clippy -p decision-forum -p exochain-wasm --all-targets -- -D warnings`
- `git diff --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
- `cargo build --workspace --release`

## Bypass search
- `rg -n "verify_forum_authority\(|verify_forum_authority_with_key|forum_authority_signature_message|wasm_verify_forum_authority" crates packages -g '*.rs' -g '*.mjs'`
- Remaining legacy JSON-only paths now fail closed; successful forum-authority authenticity requires `verify_forum_authority_with_key` or `wasm_verify_forum_authority_with_key` with a caller-supplied trusted root public key.
