### PR TITLE
fix(zerodentity): fail closed without trusted session clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 | Metric | Value | Source |
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
-| Rust source files | 300 | `find crates -name '*.rs'` |
-| Rust LOC | 189851 | `wc -l` |
-| Workspace tests | 4,324 listed | `cargo test --workspace -- --list` |
+| Rust source files | 301 | `find crates -name '*.rs'` |
+| Rust LOC | 190014 | `wc -l` |
+| Workspace tests | 4,328 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |

--- a/crates/exo-node/src/zerodentity/api.rs
+++ b/crates/exo-node/src/zerodentity/api.rs
@@ -53,6 +53,7 @@ use super::{
     },
     device_behavioral_axes_enabled,
     session_auth::{public_key_from_session_bytes, request_signing_payload, signature_from_hex},
+    session_clock::{SessionClock, SessionClockError, TRUSTED_SESSION_CLOCK_UNAVAILABLE},
     store::ZerodentityStore,
     types::{
         AttestationType, BehavioralSample, DeviceFingerprint, IdentityClaim, ZerodentityScore,
@@ -66,35 +67,41 @@ use super::{
 #[derive(Clone)]
 pub struct ApiState {
     pub store: Arc<Mutex<ZerodentityStore>>,
-    clock: Arc<Mutex<HybridClock>>,
+    session_clock: SessionClock,
 }
 
 impl ApiState {
     #[must_use]
     pub fn new(store: Arc<Mutex<ZerodentityStore>>) -> Self {
-        Self::new_with_clock(store, HybridClock::new())
+        Self {
+            store,
+            session_clock: SessionClock::unavailable(),
+        }
     }
 
     #[must_use]
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn new_with_clock(store: Arc<Mutex<ZerodentityStore>>, clock: HybridClock) -> Self {
         Self {
             store,
-            clock: Arc::new(Mutex::new(clock)),
+            session_clock: SessionClock::trusted(clock),
         }
     }
 
     fn now_ms(&self) -> ApiResult<u64> {
-        let mut clock = self
-            .clock
-            .lock()
-            .map_err(|_| json_error(StatusCode::INTERNAL_SERVER_ERROR, "Clock lock error"))?;
-        clock
-            .now()
-            .map(|timestamp| timestamp.physical_ms)
-            .map_err(|err| {
+        self.session_clock.now_ms().map_err(|err| match err {
+            SessionClockError::Unavailable => json_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                TRUSTED_SESSION_CLOCK_UNAVAILABLE,
+            ),
+            SessionClockError::LockPoisoned => {
+                json_error(StatusCode::INTERNAL_SERVER_ERROR, "Clock lock error")
+            }
+            SessionClockError::Exhausted(err) => {
                 tracing::error!(error = %err, "0dentity API HLC exhausted");
                 json_error(StatusCode::INTERNAL_SERVER_ERROR, "Clock exhausted")
-            })
+            }
+        })
     }
 }
 
@@ -1236,6 +1243,66 @@ mod tests {
         assert!(
             !handlers.contains("verify_signed_write("),
             "0dentity async handlers must use the blocking signed-write verifier"
+        );
+    }
+
+    #[test]
+    fn production_api_state_does_not_install_deterministic_session_clock() {
+        let source = include_str!("api.rs");
+        let constructor = source
+            .split("pub fn new(store: Arc<Mutex<ZerodentityStore>>) -> Self")
+            .nth(1)
+            .and_then(|section| section.split("pub fn new_with_clock").next())
+            .expect("ApiState::new constructor present");
+
+        assert!(!constructor.contains("HybridClock::new()"));
+        assert!(constructor.contains("SessionClock::unavailable()"));
+    }
+
+    #[tokio::test]
+    async fn production_api_state_fails_closed_without_trusted_session_clock() {
+        let mut store = test_store();
+        let did = Did::new("did:exo:prod-clock").unwrap();
+        let session = IdentitySession {
+            session_token: "tok-prod-clock".to_owned(),
+            subject_did: did.clone(),
+            public_key: vec![],
+            created_ms: 1_000_000,
+            last_active_ms: 1_000_000,
+            revoked: false,
+        };
+        store.insert_session(&session).unwrap();
+        let claim = IdentityClaim {
+            claim_hash: Hash256::digest(b"prod-clock-claim"),
+            subject_did: did,
+            claim_type: ClaimType::Email,
+            status: ClaimStatus::Verified,
+            created_ms: 1_000_000,
+            verified_ms: Some(1_000_000),
+            expires_ms: None,
+            signature: Signature::Empty,
+            dag_node_hash: Hash256::digest(b"prod-clock-dag-node"),
+        };
+        store.insert_claim("claim-prod-clock", &claim).unwrap();
+
+        let app = zerodentity_api_router(ApiState::new(Arc::new(Mutex::new(store))));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/0dentity/did:exo:prod-clock/claims")
+                    .header("authorization", "Bearer tok-prod-clock")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let body_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            body_json["error"],
+            "Trusted 0dentity session clock unavailable"
         );
     }
 

--- a/crates/exo-node/src/zerodentity/mod.rs
+++ b/crates/exo-node/src/zerodentity/mod.rs
@@ -47,6 +47,7 @@
 pub mod otp;
 pub mod scoring;
 pub(crate) mod session_auth;
+pub(crate) mod session_clock;
 pub mod store;
 pub mod types;
 

--- a/crates/exo-node/src/zerodentity/onboarding.rs
+++ b/crates/exo-node/src/zerodentity/onboarding.rs
@@ -51,6 +51,7 @@ use super::{
         bootstrap_signing_payload, did_from_public_key, public_key_from_hex,
         session_token_from_bootstrap, signature_from_hex,
     },
+    session_clock::{SessionClock, SessionClockError, TRUSTED_SESSION_CLOCK_UNAVAILABLE},
     store::ZerodentityStore,
     types::{ClaimType, IdentitySession, OtpChallenge, OtpState, ZerodentityScore},
 };
@@ -69,35 +70,41 @@ type OnboardingResult<T> = Result<T, OnboardingError>;
 #[derive(Clone)]
 pub struct OnboardingState {
     pub store: Arc<Mutex<ZerodentityStore>>,
-    clock: Arc<Mutex<HybridClock>>,
+    session_clock: SessionClock,
 }
 
 impl OnboardingState {
     #[must_use]
     pub fn new(store: Arc<Mutex<ZerodentityStore>>) -> Self {
-        Self::new_with_clock(store, HybridClock::new())
+        Self {
+            store,
+            session_clock: SessionClock::unavailable(),
+        }
     }
 
     #[must_use]
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn new_with_clock(store: Arc<Mutex<ZerodentityStore>>, clock: HybridClock) -> Self {
         Self {
             store,
-            clock: Arc::new(Mutex::new(clock)),
+            session_clock: SessionClock::trusted(clock),
         }
     }
 
     fn now_ms(&self) -> Result<u64, (StatusCode, Json<serde_json::Value>)> {
-        let mut clock = self
-            .clock
-            .lock()
-            .map_err(|_| json_error(StatusCode::INTERNAL_SERVER_ERROR, "Clock lock error"))?;
-        clock
-            .now()
-            .map(|timestamp| timestamp.physical_ms)
-            .map_err(|err| {
+        self.session_clock.now_ms().map_err(|err| match err {
+            SessionClockError::Unavailable => json_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                TRUSTED_SESSION_CLOCK_UNAVAILABLE,
+            ),
+            SessionClockError::LockPoisoned => {
+                json_error(StatusCode::INTERNAL_SERVER_ERROR, "Clock lock error")
+            }
+            SessionClockError::Exhausted(err) => {
                 tracing::error!(error = %err, "0dentity onboarding HLC exhausted");
                 json_error(StatusCode::INTERNAL_SERVER_ERROR, "Clock exhausted")
-            })
+            }
+        })
     }
 }
 
@@ -841,6 +848,30 @@ mod tests {
             !handlers.contains("state.store.lock()"),
             "0dentity onboarding async handlers must route store locks through blocking helpers"
         );
+    }
+
+    #[test]
+    fn production_onboarding_state_fails_closed_without_trusted_session_clock() {
+        let state = OnboardingState::new(Arc::new(Mutex::new(ZerodentityStore::new())));
+        let err = state
+            .now_ms()
+            .expect_err("production onboarding state must require a trusted session clock");
+
+        assert_eq!(err.0, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(err.1["error"], "Trusted 0dentity session clock unavailable");
+    }
+
+    #[test]
+    fn production_onboarding_state_does_not_install_deterministic_session_clock() {
+        let source = include_str!("onboarding.rs");
+        let constructor = source
+            .split("pub fn new(store: Arc<Mutex<ZerodentityStore>>) -> Self")
+            .nth(1)
+            .and_then(|section| section.split("pub fn new_with_clock").next())
+            .expect("OnboardingState::new constructor present");
+
+        assert!(!constructor.contains("HybridClock::new()"));
+        assert!(constructor.contains("SessionClock::unavailable()"));
     }
 
     #[test]

--- a/crates/exo-node/src/zerodentity/session_clock.rs
+++ b/crates/exo-node/src/zerodentity/session_clock.rs
@@ -1,0 +1,64 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Trusted 0dentity session clock boundary.
+
+use std::sync::{Arc, Mutex};
+
+use exo_core::{error::ExoError, hlc::HybridClock};
+
+pub(crate) const TRUSTED_SESSION_CLOCK_UNAVAILABLE: &str =
+    "Trusted 0dentity session clock unavailable";
+
+#[derive(Clone)]
+pub(crate) enum SessionClock {
+    #[cfg_attr(not(test), allow(dead_code))]
+    Trusted(Arc<Mutex<HybridClock>>),
+    Unavailable,
+}
+
+impl SessionClock {
+    #[must_use]
+    pub(crate) fn unavailable() -> Self {
+        Self::Unavailable
+    }
+
+    #[must_use]
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn trusted(clock: HybridClock) -> Self {
+        Self::Trusted(Arc::new(Mutex::new(clock)))
+    }
+
+    pub(crate) fn now_ms(&self) -> Result<u64, SessionClockError> {
+        match self {
+            Self::Unavailable => Err(SessionClockError::Unavailable),
+            Self::Trusted(clock) => {
+                let mut clock = clock.lock().map_err(|_| SessionClockError::LockPoisoned)?;
+                clock
+                    .now()
+                    .map(|timestamp| timestamp.physical_ms)
+                    .map_err(SessionClockError::Exhausted)
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum SessionClockError {
+    Unavailable,
+    LockPoisoned,
+    Exhausted(ExoError),
+}

--- a/crates/exo-node/src/zerodentity/tests.rs
+++ b/crates/exo-node/src/zerodentity/tests.rs
@@ -298,7 +298,7 @@ mod tests {
     }
 
     fn onboarding_app(store: SharedZerodentityStore) -> Router {
-        onboarding_router(OnboardingState::new(store))
+        onboarding_app_with_fixed_clock(store, API_TEST_NOW_MS)
     }
 
     fn onboarding_app_with_fixed_clock(store: SharedZerodentityStore, now_ms: u64) -> Router {


### PR DESCRIPTION
## Summary
- Classifies 0dentity API/onboarding as a core runtime adapter session boundary.
- Removes deterministic `HybridClock::new()` from production 0dentity session-time constructors.
- Adds a shared `SessionClock` boundary so production `ApiState::new` / `OnboardingState::new` fail closed with 503 unless a trusted HLC is injected.
- Keeps deterministic injected clocks in tests and updates repo-truth counts.

## Finding
Codex Security P0: Bearer session TTL uses deterministic counter. Confirmed current `main` constructed 0dentity production session clocks from deterministic HLC, so session issuance/validation could be coupled to request count instead of a trusted time boundary.

## Path Classification
- `crates/exo-node/src/zerodentity/api.rs` — Core runtime adapter
- `crates/exo-node/src/zerodentity/onboarding.rs` — Core runtime adapter
- `crates/exo-node/src/zerodentity/session_clock.rs` — Core runtime adapter
- `crates/exo-node/src/zerodentity/mod.rs` — Core runtime adapter module wiring
- `crates/exo-node/src/zerodentity/tests.rs` — Core runtime adapter tests
- `README.md` — Documentation/repo-truth generated metrics

## TDD / Verification
Red before fix:
- `cargo test -p exo-node trusted_session_clock -- --nocapture` failed with production API returning 200 and onboarding returning deterministic `1000000`.

Green after fix:
- `cargo test -p exo-node session_clock -- --nocapture`
- `cargo test -p exo-node zerodentity -- --nocapture`
- `cargo test -p exo-node`
- `cargo clippy -p exo-node --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `bash tools/test_repo_truth.sh`
- `git diff --check`
- Bypass search: `rg -n "get_session\(|insert_session\(|now_ms_blocking\(|ApiState::new\(|OnboardingState::new\(|HybridClock::new\(\)|SystemTime::now|Instant::now|Utc::now" crates/exo-node/src/zerodentity crates/exo-node/src/main.rs`

## Notes
This intentionally fails closed for default production 0dentity session paths until a trusted runtime session clock is injected. That is safer than preserving deterministic request-counter TTL behavior and respects the repository no-wall-clock rule.
