### PR TITLE
fix(node): require signed MCP context evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 301 | `find crates -name '*.rs'` |
-| Rust LOC | 190330 | `wc -l` |
-| Workspace tests | 4,334 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 190562 | `wc -l` |
+| Workspace tests | 4,336 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -45,7 +45,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,322 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,336 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -114,9 +114,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 189710 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 190562 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,322 listed workspace tests
+         cryptographic proofs, 4,336 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          158 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-node/src/mcp/handler.rs
+++ b/crates/exo-node/src/mcp/handler.rs
@@ -765,7 +765,10 @@ impl McpServer {
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::{super::middleware::mcp_tool_action_hash, *};
-    use crate::mcp::protocol::{AI_OUTPUT_GENERATOR, AI_OUTPUT_MARKING};
+    use crate::mcp::{
+        protocol::{AI_OUTPUT_GENERATOR, AI_OUTPUT_MARKING},
+        tools::authority::adjudication_context_evidence_message_from_json,
+    };
 
     fn test_server() -> McpServer {
         let did = Did::new("did:exo:test-ai-agent").expect("valid DID");
@@ -832,7 +835,7 @@ mod tests {
             exo_core::crypto::sign(provenance_message.as_bytes(), &secret_key);
         provenance.signature = provenance_signature.to_bytes().to_vec();
 
-        serde_json::json!({
+        let mut context = serde_json::json!({
             "bcts_scope": action,
             "capabilities": ["mcp:tool_call"],
             "output_marking": AI_OUTPUT_MARKING,
@@ -875,7 +878,19 @@ mod tests {
                     "public_key": public_key_hex,
                 }
             }
-        })
+        });
+        let evidence_message = adjudication_context_evidence_message_from_json(
+            &context["adjudication_context"],
+            &actor,
+        )
+        .expect("canonical context evidence payload");
+        let evidence_signature = exo_core::crypto::sign(evidence_message.as_bytes(), &secret_key);
+        context["adjudication_context"]["context_evidence"] = serde_json::json!({
+            "signer": actor.as_str(),
+            "public_key": public_key_hex,
+            "signature": hex::encode(evidence_signature.to_bytes()),
+        });
+        context
     }
 
     fn tool_call_params(name: &str, arguments: Value) -> Value {

--- a/crates/exo-node/src/mcp/middleware.rs
+++ b/crates/exo-node/src/mcp/middleware.rs
@@ -28,9 +28,10 @@
 //! Tool-call params must include a top-level `constitutional_context` object.
 //! The middleware parses that object, verifies the signed authority chain and
 //! provenance through the same gatekeeper logic as `exochain_adjudicate_action`,
-//! derives MCP rule facts from the parsed context, and refuses the call when
-//! the context is absent or invalid. It does not fabricate consent, provenance,
-//! output marking, or human-override evidence.
+//! verifies a domain-separated evidence signature over the full adjudication
+//! context, derives MCP rule facts from the parsed context, and refuses the call
+//! when the context is absent or invalid. It does not fabricate consent,
+//! provenance, output marking, or human-override evidence.
 
 use std::sync::Arc;
 
@@ -46,6 +47,8 @@ use exo_gatekeeper::{
 use serde::Serialize;
 use serde_json::Value;
 
+#[cfg(test)]
+use super::tools::authority::adjudication_context_evidence_message_from_json;
 use super::{
     error::{McpError, Result},
     protocol::AI_OUTPUT_MARKING,
@@ -445,6 +448,24 @@ mod tests {
         signed_tool_call_params_with_arguments(action, serde_json::json!({}))
     }
 
+    fn refresh_context_evidence(params: &mut Value) {
+        let actor = test_did();
+        let keypair = exo_core::crypto::KeyPair::from_secret_bytes([0x4D; 32]).unwrap();
+        let public_key_hex = hex::encode(keypair.public_key().as_bytes());
+        let evidence_message = adjudication_context_evidence_message_from_json(
+            &params[CONSTITUTIONAL_CONTEXT_FIELD]["adjudication_context"],
+            &actor,
+        )
+        .expect("canonical context evidence payload");
+        let evidence_signature =
+            exo_core::crypto::sign(evidence_message.as_bytes(), keypair.secret_key());
+        params[CONSTITUTIONAL_CONTEXT_FIELD]["adjudication_context"]["context_evidence"] = serde_json::json!({
+            "signer": actor.as_str(),
+            "public_key": public_key_hex,
+            "signature": hex::encode(evidence_signature.to_bytes()),
+        });
+    }
+
     fn signed_tool_call_params_with_arguments(action: &str, arguments: Value) -> Value {
         let actor = test_did();
         let keypair = exo_core::crypto::KeyPair::from_secret_bytes([0x4D; 32]).unwrap();
@@ -489,7 +510,7 @@ mod tests {
             exo_core::crypto::sign(provenance_message.as_bytes(), &secret_key);
         provenance.signature = provenance_signature.to_bytes().to_vec();
 
-        serde_json::json!({
+        let mut params = serde_json::json!({
             "arguments": arguments,
             CONSTITUTIONAL_CONTEXT_FIELD: {
                 "bcts_scope": action,
@@ -535,7 +556,9 @@ mod tests {
                 }
                 }
             }
-        })
+        });
+        refresh_context_evidence(&mut params);
+        params
     }
 
     #[test]
@@ -582,6 +605,7 @@ mod tests {
         let mut params = signed_tool_call_params(action);
         params[CONSTITUTIONAL_CONTEXT_FIELD]["adjudication_context"]["actor_permissions"] =
             serde_json::json!(["unrelated:permission"]);
+        refresh_context_evidence(&mut params);
 
         let err = mw
             .enforce_tool_call(&did, action, &params)
@@ -611,6 +635,48 @@ mod tests {
         assert!(
             err.to_string().contains("action_hash"),
             "expected argument-bound action_hash refusal, got {err}"
+        );
+    }
+
+    #[test]
+    fn middleware_rejects_adjudication_context_tampering_after_signing() {
+        let mw = signed_middleware();
+        let did = test_did();
+        let action = "exochain_node_status";
+        let mut params = signed_tool_call_params(action);
+        params[CONSTITUTIONAL_CONTEXT_FIELD]["adjudication_context"]["consent_records"][0]["scope"] =
+            serde_json::json!("mcp:tool_call,attacker:extra");
+        params[CONSTITUTIONAL_CONTEXT_FIELD]["adjudication_context"]["bailment_state"]["scope"] =
+            serde_json::json!("mcp:tool_call,attacker:extra");
+
+        let err = mw
+            .enforce_tool_call(&did, action, &params)
+            .expect_err("MCP adjudication context evidence must reject caller tampering");
+
+        assert!(
+            err.to_string().contains("context_evidence"),
+            "expected context-evidence refusal, got {err}"
+        );
+    }
+
+    #[test]
+    fn middleware_rejects_context_without_context_evidence_signature() {
+        let mw = signed_middleware();
+        let did = test_did();
+        let action = "exochain_node_status";
+        let mut params = signed_tool_call_params(action);
+        params[CONSTITUTIONAL_CONTEXT_FIELD]["adjudication_context"]
+            .as_object_mut()
+            .expect("adjudication context object")
+            .remove("context_evidence");
+
+        let err = mw
+            .enforce_tool_call(&did, action, &params)
+            .expect_err("MCP adjudication context must carry signed context evidence");
+
+        assert!(
+            err.to_string().contains("context_evidence"),
+            "expected context-evidence refusal, got {err}"
         );
     }
 

--- a/crates/exo-node/src/mcp/resources/readme.rs
+++ b/crates/exo-node/src/mcp/resources/readme.rs
@@ -37,7 +37,8 @@ MCP rules and 8 kernel invariants on every action. Read this document first.
     `self_escalation`
   - `adjudication_context` containing actor roles, signed authority chain,
     active consent records, active bailment state, actor permissions, human
-    override evidence, and signed provenance
+    override evidence, signed provenance, and a `context_evidence` signature
+    binding those fields to the same tool action evidence
 - The middleware derives its MCP facts from that verified context. Missing or
   invalid context is refused before tool execution.
 - Every `ToolResult` returned by the server carries metadata:

--- a/crates/exo-node/src/mcp/tools/authority.rs
+++ b/crates/exo-node/src/mcp/tools/authority.rs
@@ -22,9 +22,7 @@
 // mutually-exclusive `#[cfg(feature = "...")]` branch.
 #![allow(clippy::needless_return)]
 
-use exo_core::Did;
-#[cfg(test)]
-use exo_core::Hash256;
+use exo_core::{Did, Hash256, PublicKey, Signature, hash::hash_structured};
 #[cfg(test)]
 use exo_gatekeeper::{authority_link_signature_message, provenance_signature_message};
 use exo_gatekeeper::{
@@ -37,6 +35,7 @@ use exo_gatekeeper::{
         PermissionSet, Provenance, Role, TrustedAuthorityKeys, TrustedProvenanceKeys,
     },
 };
+use serde::Serialize;
 use serde_json::{Value, json};
 
 use crate::mcp::{
@@ -53,6 +52,38 @@ const MAX_PERMISSION_SET_ENTRIES: usize = 64;
 const MAX_PERMISSION_NAME_BYTES: usize = 256;
 const ED25519_SIGNATURE_HEX_CHARS: usize = 128;
 const ED25519_PUBLIC_KEY_HEX_CHARS: usize = 64;
+const ADJUDICATION_CONTEXT_EVIDENCE_DOMAIN: &str = "exo.node.mcp.adjudication_context_evidence.v1";
+const ADJUDICATION_CONTEXT_EVIDENCE_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Serialize)]
+struct AdjudicationContextEvidencePayload<'a> {
+    domain: &'static str,
+    schema_version: u32,
+    actor: &'a Did,
+    actor_roles: &'a [Role],
+    authority_chain: &'a AuthorityChain,
+    consent_records: &'a [ConsentRecord],
+    bailment_state: &'a BailmentState,
+    human_override_preserved: bool,
+    actor_permissions: &'a PermissionSet,
+    provenance: &'a Provenance,
+}
+
+struct ParsedAdjudicationContext {
+    actor_roles: Vec<Role>,
+    authority_chain: AuthorityChain,
+    consent_records: Vec<ConsentRecord>,
+    bailment_state: BailmentState,
+    human_override_preserved: bool,
+    actor_permissions: PermissionSet,
+    provenance: Provenance,
+}
+
+struct AdjudicationContextEvidence {
+    signer: Did,
+    public_key: Vec<u8>,
+    signature: Vec<u8>,
+}
 
 fn authority_tool_refused(tool_name: &str) -> ToolResult {
     tracing::warn!(
@@ -360,6 +391,123 @@ fn parse_provenance(value: &Value) -> Result<Provenance, String> {
     })
 }
 
+fn parse_adjudication_context_parts(
+    context_value: &Value,
+) -> Result<ParsedAdjudicationContext, String> {
+    let actor_roles = parse_roles(context_value)?;
+    let consent_records = parse_consent_records(context_value)?;
+    let bailment_state = parse_bailment_state(context_value)?;
+    let human_override_preserved = context_value
+        .get("human_override_preserved")
+        .and_then(Value::as_bool)
+        .ok_or_else(|| "context.human_override_preserved must be boolean".to_owned())?;
+    let actor_permissions = parse_permission_set(context_value, "actor_permissions")?;
+    let provenance = parse_provenance(context_value)?;
+    let authority_chain_value = context_value
+        .get("authority_chain")
+        .ok_or_else(|| "context.authority_chain is required".to_owned())?;
+    let authority_chain =
+        parse_authority_chain(authority_chain_value).map_err(|issues| issues.join("; "))?;
+
+    Ok(ParsedAdjudicationContext {
+        actor_roles,
+        authority_chain,
+        consent_records,
+        bailment_state,
+        human_override_preserved,
+        actor_permissions,
+        provenance,
+    })
+}
+
+fn adjudication_context_evidence_message(
+    actor: &Did,
+    context: &ParsedAdjudicationContext,
+) -> exo_core::Result<Hash256> {
+    hash_structured(&AdjudicationContextEvidencePayload {
+        domain: ADJUDICATION_CONTEXT_EVIDENCE_DOMAIN,
+        schema_version: ADJUDICATION_CONTEXT_EVIDENCE_SCHEMA_VERSION,
+        actor,
+        actor_roles: &context.actor_roles,
+        authority_chain: &context.authority_chain,
+        consent_records: &context.consent_records,
+        bailment_state: &context.bailment_state,
+        human_override_preserved: context.human_override_preserved,
+        actor_permissions: &context.actor_permissions,
+        provenance: &context.provenance,
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn adjudication_context_evidence_message_from_json(
+    context_value: &Value,
+    actor: &Did,
+) -> Result<Hash256, String> {
+    let context = parse_adjudication_context_parts(context_value)?;
+    adjudication_context_evidence_message(actor, &context)
+        .map_err(|err| format!("context.context_evidence canonical payload failed: {err}"))
+}
+
+fn parse_adjudication_context_evidence(
+    context_value: &Value,
+) -> Result<AdjudicationContextEvidence, String> {
+    let evidence = context_value
+        .get("context_evidence")
+        .ok_or_else(|| "context.context_evidence is required".to_owned())?;
+    Ok(AdjudicationContextEvidence {
+        signer: parse_did_field(evidence, "signer")
+            .map_err(|err| format!("context.context_evidence: {err}"))?,
+        public_key: parse_hex_field(evidence, "public_key", 32)
+            .map_err(|err| format!("context.context_evidence: {err}"))?,
+        signature: parse_hex_field(evidence, "signature", 64)
+            .map_err(|err| format!("context.context_evidence: {err}"))?,
+    })
+}
+
+fn validate_adjudication_context_evidence(
+    context_value: &Value,
+    actor: &Did,
+    trusted_provenance_keys: &TrustedProvenanceKeys,
+    context: &ParsedAdjudicationContext,
+) -> Result<(), String> {
+    let evidence = parse_adjudication_context_evidence(context_value)?;
+    if evidence.signer != *actor {
+        return Err("context.context_evidence signer must match actor".to_owned());
+    }
+    let trusted_keys = trusted_provenance_keys
+        .get(&evidence.signer)
+        .ok_or_else(|| {
+            "context.context_evidence public_key is unresolved for signer DID".to_owned()
+        })?;
+    if !trusted_keys
+        .iter()
+        .any(|trusted_key| trusted_key.as_slice() == evidence.public_key.as_slice())
+    {
+        return Err("context.context_evidence public_key is not bound to signer DID".to_owned());
+    }
+
+    let public_key_bytes: [u8; 32] = evidence
+        .public_key
+        .as_slice()
+        .try_into()
+        .map_err(|_| "context.context_evidence public_key is not 32 bytes".to_owned())?;
+    let signature_bytes: [u8; 64] = evidence
+        .signature
+        .as_slice()
+        .try_into()
+        .map_err(|_| "context.context_evidence signature is not 64 bytes".to_owned())?;
+    let message = adjudication_context_evidence_message(actor, context)
+        .map_err(|err| format!("context.context_evidence canonical payload failed: {err}"))?;
+    let public_key = PublicKey::from_bytes(public_key_bytes);
+    let signature = Signature::from_bytes(signature_bytes);
+    if !exo_core::crypto::verify(message.as_bytes(), &signature, &public_key) {
+        return Err(
+            "context.context_evidence Ed25519 signature is cryptographically invalid".to_owned(),
+        );
+    }
+    Ok(())
+}
+
 pub(crate) fn parse_verified_adjudication_context(
     context_value: &Value,
     actor: &Did,
@@ -378,28 +526,30 @@ pub(crate) fn parse_verified_adjudication_context_with_trusted_keys(
     trusted_authority_keys: TrustedAuthorityKeys,
     trusted_provenance_keys: TrustedProvenanceKeys,
 ) -> Result<AdjudicationContext, String> {
-    let actor_roles = parse_roles(context_value)?;
-    let consent_records = parse_consent_records(context_value)?;
-    let bailment_state = parse_bailment_state(context_value)?;
-    let human_override_preserved = context_value
-        .get("human_override_preserved")
-        .and_then(Value::as_bool)
-        .ok_or_else(|| "context.human_override_preserved must be boolean".to_owned())?;
-    let actor_permissions = parse_permission_set(context_value, "actor_permissions")?;
-    let provenance = parse_provenance(context_value)?;
-
-    let authority_chain_value = context_value
-        .get("authority_chain")
-        .ok_or_else(|| "context.authority_chain is required".to_owned())?;
-    let authority_chain =
-        parse_authority_chain(authority_chain_value).map_err(|issues| issues.join("; "))?;
-    let issues = validate_authority_chain(&authority_chain, actor, &trusted_authority_keys);
+    let context = parse_adjudication_context_parts(context_value)?;
+    let issues = validate_authority_chain(&context.authority_chain, actor, &trusted_authority_keys);
     if !issues.is_empty() {
         return Err(format!(
             "context.authority_chain is invalid: {}",
             issues.join("; ")
         ));
     }
+    validate_adjudication_context_evidence(
+        context_value,
+        actor,
+        &trusted_provenance_keys,
+        &context,
+    )?;
+
+    let ParsedAdjudicationContext {
+        actor_roles,
+        authority_chain,
+        consent_records,
+        bailment_state,
+        human_override_preserved,
+        actor_permissions,
+        provenance,
+    } = context;
 
     Ok(AdjudicationContext {
         actor_roles,
@@ -737,7 +887,7 @@ pub fn adjudicate_action_definition() -> ToolDefinition {
                 },
                 "context": {
                     "type": "object",
-                    "description": "Caller-supplied verified adjudication context: roles, signed authority_chain, consent_records, bailment_state, actor_permissions, human_override_preserved, and signed provenance."
+                    "description": "Caller-supplied verified adjudication context: roles, signed authority_chain, consent_records, bailment_state, actor_permissions, human_override_preserved, signed provenance, and context_evidence signature."
                 }
             },
             "required": ["actor_did", "action", "required_permissions", "context"],
@@ -793,7 +943,7 @@ pub fn execute_adjudicate_action(params: &Value, _context: &NodeContext) -> Tool
         None => {
             return tool_error(
                 "mcp_verified_context_required",
-                "exochain_adjudicate_action requires caller-supplied context with authority_chain, consent_records, bailment_state, actor_permissions, human_override_preserved, and provenance",
+                "exochain_adjudicate_action requires caller-supplied context with authority_chain, consent_records, bailment_state, actor_permissions, human_override_preserved, provenance, and context_evidence",
             );
         }
     };


### PR DESCRIPTION
## Summary
- Classification: `crates/exo-node/src/mcp/*` are core runtime adapter paths; `README.md` and the MCP README resource are documentation/repo-truth updates required by validation.
- Adds a domain-separated canonical CBOR `context_evidence` signature over MCP adjudication context fields: actor roles, authority chain, consent records, bailment state, human override, actor permissions, and provenance.
- Verifies the context evidence signer and public key against the trusted provenance key map before MCP facts are derived, so caller-side JSON edits to consent/bailment/override fields fail closed.
- Updates MCP test fixtures and docs to emit the signed evidence, while preserving action/argument binding via the existing provenance `action_hash`.

## Verification
- RED first: `cargo test -p exo-node middleware_rejects_adjudication_context_tampering_after_signing -- --nocapture` failed on current code because the tampered context returned `Ok(())`.
- `cargo test -p exo-node middleware_ -- --nocapture`
- `cargo test -p exo-node handler_ -- --nocapture`
- `cargo test -p exo-node adjudicate_action -- --nocapture`
- `cargo test -p exo-node mcp -- --nocapture`
- `cargo test -p exo-node`
- `cargo clippy -p exo-node --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash tools/repo_truth.sh --json`
- `bash tools/test_repo_truth.sh`

## Bypass Search
- `rg -n "parse_verified_adjudication_context|parse_verified_adjudication_context_with_trusted_keys|context_evidence|consent_records|bailment_state|human_override_preserved|actor_permissions|constitutional_context|adjudication_context" crates/exo-node/src/mcp -g "*.rs"`
- Result: production MCP tool calls flow through `parse_verified_adjudication_context_with_trusted_keys`; unsigned context fields are no longer accepted without verified `context_evidence`.
