### PR TITLE
fix(gatekeeper): verify human quorum vote evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 301 | `find crates -name '*.rs'` |
-| Rust LOC | 190562 | `wc -l` |
-| Workspace tests | 4,336 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 191173 | `wc -l` |
+| Workspace tests | 4,345 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -45,7 +45,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,336 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,345 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -114,9 +114,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 190562 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 191173 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,336 listed workspace tests
+         cryptographic proofs, 4,345 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          158 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-gatekeeper/src/invariants.rs
+++ b/crates/exo-gatekeeper/src/invariants.rs
@@ -23,8 +23,9 @@ use exo_core::{Did, Hash256, hash::hash_structured};
 use serde::{Deserialize, Serialize};
 
 use crate::types::{
-    AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch, PermissionSet,
-    Provenance, QuorumEvidence, Role, TrustedAuthorityKeys, TrustedProvenanceKeys,
+    AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch,
+    IndependenceClaim, PermissionSet, Provenance, QuorumEvidence, QuorumVote, ReviewOrder, Role,
+    TrustedAuthorityKeys, TrustedProvenanceKeys, VoiceKind,
 };
 
 // ---------------------------------------------------------------------------
@@ -134,6 +135,7 @@ pub struct InvariantViolation {
 
 const AUTHORITY_LINK_SIGNATURE_DOMAIN: &str = "exo.gatekeeper.authority-link-signature";
 const PROVENANCE_SIGNATURE_DOMAIN: &str = "exo.gatekeeper.provenance-signature";
+const QUORUM_VOTE_SIGNATURE_DOMAIN: &str = "exo.gatekeeper.quorum-vote-signature.v1";
 const SIGNATURE_PAYLOAD_SCHEMA_VERSION: u16 = 1;
 
 #[derive(Serialize)]
@@ -152,6 +154,23 @@ struct ProvenanceSignaturePayload<'a> {
     actor: &'a Did,
     action_hash: &'a [u8],
     timestamp: &'a str,
+    voice_kind: Option<VoiceKind>,
+    independence: Option<IndependenceClaim>,
+    review_order: Option<ReviewOrder>,
+}
+
+#[derive(Serialize)]
+struct QuorumVoteSignaturePayload<'a> {
+    domain: &'static str,
+    schema_version: u16,
+    voter: &'a Did,
+    approved: bool,
+    provenance_actor: &'a Did,
+    provenance_action_hash: &'a [u8],
+    provenance_timestamp: &'a str,
+    voice_kind: Option<VoiceKind>,
+    independence: Option<IndependenceClaim>,
+    review_order: Option<ReviewOrder>,
 }
 
 // ---------------------------------------------------------------------------
@@ -250,6 +269,31 @@ fn bailment_state_evidence(state: &BailmentState) -> Vec<String> {
             ]
         }
         BailmentState::Terminated => vec!["bailment_state: terminated".into()],
+    }
+}
+
+fn voice_kind_evidence_label(value: Option<VoiceKind>) -> &'static str {
+    match value {
+        Some(VoiceKind::Human) => "human",
+        Some(VoiceKind::Synthetic) => "synthetic",
+        Some(VoiceKind::System) => "system",
+        None => "missing",
+    }
+}
+
+fn independence_evidence_label(value: Option<IndependenceClaim>) -> &'static str {
+    match value {
+        Some(IndependenceClaim::Independent) => "independent",
+        Some(IndependenceClaim::Coordinated) => "coordinated",
+        None => "missing",
+    }
+}
+
+fn review_order_evidence_label(value: Option<ReviewOrder>) -> &'static str {
+    match value {
+        Some(ReviewOrder::FirstOrder) => "first-order",
+        Some(ReviewOrder::Derivative) => "derivative",
+        None => "missing",
     }
 }
 
@@ -669,6 +713,13 @@ fn check_quorum_legitimate(ctx: &InvariantContext) -> Result<(), InvariantViolat
     match &ctx.quorum_evidence {
         None => Ok(()),
         Some(evidence) => {
+            let Some(threshold) = usize::try_from(evidence.threshold).ok() else {
+                return Err(InvariantViolation {
+                    invariant: ConstitutionalInvariant::QuorumLegitimate,
+                    description: "Quorum threshold cannot be represented on this platform".into(),
+                    evidence: vec![format!("threshold: {}", evidence.threshold)],
+                });
+            };
             let duplicate_voters = evidence.duplicate_voters();
             if !duplicate_voters.is_empty() {
                 let duplicate_voters = duplicate_voters
@@ -686,27 +737,167 @@ fn check_quorum_legitimate(ctx: &InvariantContext) -> Result<(), InvariantViolat
                 });
             }
 
-            // CR-001 §8.3: synthetic voices SHALL never be counted as distinct
-            // humans. Use is_met_authentic() which excludes Synthetic-voiced
-            // votes from the approval count.
-            if !evidence.is_met_authentic() {
-                let authentic_approvals = evidence.distinct_authentic_approved_voter_count();
+            // CR-001 §8.3: human quorum approvals must be explicit,
+            // independent, first-order human voices with cryptographically
+            // verified provenance resolved through trusted DID keys.
+            let (verified_human_approvals, rejected_vote_evidence) =
+                verified_human_quorum_approvals(evidence, ctx);
+            if verified_human_approvals < threshold {
                 let synthetic_excluded = evidence.synthetic_vote_count();
-                Err(InvariantViolation {
+                let mut violation_evidence = vec![
+                    format!("threshold: {}", evidence.threshold),
+                    format!("verified_human_approvals: {verified_human_approvals}"),
+                    format!("synthetic_votes_excluded: {synthetic_excluded}"),
+                    format!("rejected_approved_votes: {}", rejected_vote_evidence.len()),
+                ];
+                violation_evidence.extend(rejected_vote_evidence);
+                return Err(InvariantViolation {
                     invariant: ConstitutionalInvariant::QuorumLegitimate,
-                    description: "Quorum threshold not met by authentic (non-synthetic) votes"
+                    description: "Quorum threshold not met by verified human vote provenance"
                         .into(),
-                    evidence: vec![
-                        format!("threshold: {}", evidence.threshold),
-                        format!("authentic_approvals: {}", authentic_approvals),
-                        format!("synthetic_votes_excluded: {}", synthetic_excluded),
-                    ],
-                })
-            } else {
-                Ok(())
+                    evidence: violation_evidence,
+                });
             }
+            Ok(())
         }
     }
+}
+
+fn verified_human_quorum_approvals(
+    evidence: &QuorumEvidence,
+    ctx: &InvariantContext,
+) -> (usize, Vec<String>) {
+    let mut approved_voters = std::collections::BTreeSet::new();
+    let mut rejected_vote_evidence = Vec::new();
+
+    for (index, vote) in evidence.votes.iter().enumerate() {
+        if !vote.approved {
+            continue;
+        }
+
+        match verify_human_quorum_vote(vote, index, ctx) {
+            Ok(()) => {
+                approved_voters.insert(vote.voter.clone());
+            }
+            Err(reason) => rejected_vote_evidence.push(reason),
+        }
+    }
+
+    (approved_voters.len(), rejected_vote_evidence)
+}
+
+fn verify_human_quorum_vote(
+    vote: &QuorumVote,
+    index: usize,
+    ctx: &InvariantContext,
+) -> Result<(), String> {
+    let Some(prov) = vote.provenance.as_ref() else {
+        return Err(format!(
+            "vote_index: {index}; voter: {}; provenance: missing",
+            vote.voter
+        ));
+    };
+
+    if prov.actor != vote.voter {
+        return Err(format!(
+            "vote_index: {index}; voter: {}; provenance_actor: {}",
+            vote.voter, prov.actor
+        ));
+    }
+    if !prov.is_human_voice() {
+        return Err(format!(
+            "vote_index: {index}; voter: {}; voice_kind: {}",
+            vote.voter,
+            voice_kind_evidence_label(prov.voice_kind)
+        ));
+    }
+    if !prov.is_independent() {
+        return Err(format!(
+            "vote_index: {index}; voter: {}; independence: {}",
+            vote.voter,
+            independence_evidence_label(prov.independence)
+        ));
+    }
+    if !prov.is_first_order_review() {
+        return Err(format!(
+            "vote_index: {index}; voter: {}; review_order: {}",
+            vote.voter,
+            review_order_evidence_label(prov.review_order)
+        ));
+    }
+
+    let Some(pk_bytes) = prov.public_key.as_ref() else {
+        return Err(format!(
+            "vote_index: {index}; voter: {}; public_key: missing",
+            vote.voter
+        ));
+    };
+    let Ok(pk_arr) = <[u8; 32]>::try_from(pk_bytes.as_slice()) else {
+        return Err(format!(
+            "vote_index: {index}; voter: {}; public_key_len: {}",
+            vote.voter,
+            pk_bytes.len()
+        ));
+    };
+    let Some(trusted_keys) = ctx.trusted_provenance_keys.get(&vote.voter) else {
+        return Err(format!(
+            "vote_index: {index}; voter: {}; public_key: unresolved",
+            vote.voter
+        ));
+    };
+    if !trusted_keys
+        .iter()
+        .any(|trusted_key| trusted_key.as_slice() == pk_bytes.as_slice())
+    {
+        return Err(format!(
+            "vote_index: {index}; voter: {}; public_key: not-bound",
+            vote.voter
+        ));
+    }
+    let Ok(sig_arr) = <[u8; 64]>::try_from(prov.signature.as_slice()) else {
+        return Err(format!(
+            "vote_index: {index}; voter: {}; signature_len: {}",
+            vote.voter,
+            prov.signature.len()
+        ));
+    };
+    let message = provenance_signature_message(prov).map_err(|err| {
+        format!(
+            "vote_index: {index}; voter: {}; signature_payload_error: {err}",
+            vote.voter
+        )
+    })?;
+    let pubkey = exo_core::PublicKey::from_bytes(pk_arr);
+    let provenance_sig = exo_core::Signature::from_bytes(sig_arr);
+    if !exo_core::crypto::verify(message.as_bytes(), &provenance_sig, &pubkey) {
+        return Err(format!(
+            "vote_index: {index}; voter: {}; signature: invalid",
+            vote.voter
+        ));
+    }
+
+    let Ok(vote_sig_arr) = <[u8; 64]>::try_from(vote.signature.as_slice()) else {
+        return Err(format!(
+            "vote_index: {index}; voter: {}; vote_signature_len: {}",
+            vote.voter,
+            vote.signature.len()
+        ));
+    };
+    let vote_message = quorum_vote_signature_message(vote, prov).map_err(|err| {
+        format!(
+            "vote_index: {index}; voter: {}; vote_signature_payload_error: {err}",
+            vote.voter
+        )
+    })?;
+    let vote_sig = exo_core::Signature::from_bytes(vote_sig_arr);
+    if !exo_core::crypto::verify(vote_message.as_bytes(), &vote_sig, &pubkey) {
+        return Err(format!(
+            "vote_index: {index}; voter: {}; vote_signature: invalid",
+            vote.voter
+        ));
+    }
+
+    Ok(())
 }
 
 fn check_provenance_verifiable(ctx: &InvariantContext) -> Result<(), InvariantViolation> {
@@ -814,7 +1005,10 @@ pub fn authority_link_signature_message(link: &AuthorityLink) -> exo_core::Resul
 /// Compute the canonical Ed25519 message for action provenance.
 ///
 /// The message is the hash of a domain-separated CBOR payload that binds the
-/// provenance actor, action hash, and timestamp.
+/// provenance actor, action hash, timestamp, and voice-taxonomy metadata. The
+/// taxonomy fields are security-relevant for quorum counting, so changing a
+/// signed synthetic/coordinated/derivative provenance claim into a human
+/// quorum claim invalidates the signature.
 pub fn provenance_signature_message(prov: &Provenance) -> exo_core::Result<Hash256> {
     hash_structured(&ProvenanceSignaturePayload {
         domain: PROVENANCE_SIGNATURE_DOMAIN,
@@ -822,6 +1016,27 @@ pub fn provenance_signature_message(prov: &Provenance) -> exo_core::Result<Hash2
         actor: &prov.actor,
         action_hash: &prov.action_hash,
         timestamp: &prov.timestamp,
+        voice_kind: prov.voice_kind,
+        independence: prov.independence,
+        review_order: prov.review_order,
+    })
+}
+
+fn quorum_vote_signature_message(
+    vote: &QuorumVote,
+    prov: &Provenance,
+) -> exo_core::Result<Hash256> {
+    hash_structured(&QuorumVoteSignaturePayload {
+        domain: QUORUM_VOTE_SIGNATURE_DOMAIN,
+        schema_version: SIGNATURE_PAYLOAD_SCHEMA_VERSION,
+        voter: &vote.voter,
+        approved: vote.approved,
+        provenance_actor: &prov.actor,
+        provenance_action_hash: &prov.action_hash,
+        provenance_timestamp: &prov.timestamp,
+        voice_kind: prov.voice_kind,
+        independence: prov.independence,
+        review_order: prov.review_order,
     })
 }
 
@@ -1445,7 +1660,7 @@ mod tests {
     }
 
     #[test]
-    fn quorum_passes_met() {
+    fn quorum_rejects_raw_votes_without_verified_vote_provenance() {
         let engine = InvariantEngine::new(InvariantSet::with(vec![
             ConstitutionalInvariant::QuorumLegitimate,
         ]));
@@ -1467,7 +1682,11 @@ mod tests {
                 },
             ],
         });
-        assert!(enforce_all(&engine, &ctx).is_ok());
+
+        let err = enforce_all(&engine, &ctx).unwrap_err();
+
+        assert_eq!(err[0].invariant, ConstitutionalInvariant::QuorumLegitimate);
+        assert!(err[0].description.contains("verified human"));
     }
 
     #[test]
@@ -1636,10 +1855,55 @@ mod tests {
                 signature: vec![sig],
                 public_key: None,
                 voice_kind: Some(vk),
-                independence: None,
-                review_order: None,
+                independence: (vk == VoiceKind::Human).then_some(IndependenceClaim::Independent),
+                review_order: (vk == VoiceKind::Human).then_some(ReviewOrder::FirstOrder),
             }),
         }
+    }
+
+    fn signed_human_quorum_vote(ctx: &mut InvariantContext, voter: &str, sig: u8) -> QuorumVote {
+        signed_human_quorum_vote_with_approval(ctx, voter, sig, true)
+    }
+
+    fn signed_human_quorum_vote_with_approval(
+        ctx: &mut InvariantContext,
+        voter: &str,
+        sig: u8,
+        approved: bool,
+    ) -> QuorumVote {
+        let voter = did(voter);
+        let (pk, sk) = exo_core::crypto::generate_keypair();
+        let mut provenance = Provenance {
+            actor: voter.clone(),
+            timestamp: "2026-05-16T00:00:00Z".to_string(),
+            action_hash: vec![sig; 32],
+            signature: Vec::new(),
+            public_key: Some(pk.as_bytes().to_vec()),
+            voice_kind: Some(VoiceKind::Human),
+            independence: Some(IndependenceClaim::Independent),
+            review_order: Some(ReviewOrder::FirstOrder),
+        };
+        let message = provenance_signature_message(&provenance).expect("canonical provenance");
+        provenance.signature = exo_core::crypto::sign(message.as_bytes(), &sk)
+            .to_bytes()
+            .to_vec();
+        ctx.trusted_provenance_keys
+            .insert(voter.clone(), vec![pk.as_bytes().to_vec()]);
+        let mut vote = QuorumVote {
+            voter,
+            approved,
+            signature: Vec::new(),
+            provenance: Some(provenance),
+        };
+        let vote_message = quorum_vote_signature_message(
+            &vote,
+            vote.provenance.as_ref().expect("signed provenance"),
+        )
+        .expect("canonical vote signature");
+        vote.signature = exo_core::crypto::sign(vote_message.as_bytes(), &sk)
+            .to_bytes()
+            .to_vec();
+        vote
     }
 
     #[test]
@@ -1659,7 +1923,7 @@ mod tests {
         });
         let err = enforce_all(&engine, &ctx).unwrap_err();
         assert_eq!(err[0].invariant, ConstitutionalInvariant::QuorumLegitimate);
-        assert!(err[0].description.contains("authentic"));
+        assert!(err[0].description.contains("verified human"));
         assert!(
             err[0]
                 .evidence
@@ -1675,12 +1939,15 @@ mod tests {
             ConstitutionalInvariant::QuorumLegitimate,
         ]));
         let mut ctx = passing_context();
+        let h1 = signed_human_quorum_vote(&mut ctx, "did:exo:h1", 1);
+        let h2 = signed_human_quorum_vote(&mut ctx, "did:exo:h2", 2);
+        let h3 = signed_human_quorum_vote(&mut ctx, "did:exo:h3", 3);
         ctx.quorum_evidence = Some(QuorumEvidence {
             threshold: 3,
             votes: vec![
-                make_vote("did:exo:h1", true, 1, Some(VoiceKind::Human)),
-                make_vote("did:exo:h2", true, 2, Some(VoiceKind::Human)),
-                make_vote("did:exo:h3", true, 3, Some(VoiceKind::Human)),
+                h1,
+                h2,
+                h3,
                 make_vote("did:exo:ai1", true, 4, Some(VoiceKind::Synthetic)),
                 make_vote("did:exo:ai2", true, 5, Some(VoiceKind::Synthetic)),
             ],
@@ -1720,8 +1987,8 @@ mod tests {
     }
 
     #[test]
-    fn quorum_passes_legacy_votes_no_provenance() {
-        // Legacy votes (provenance=None) are not excluded
+    fn quorum_rejects_legacy_votes_no_provenance() {
+        // Legacy votes (provenance=None) are not verified human quorum votes.
         let engine = InvariantEngine::new(InvariantSet::with(vec![
             ConstitutionalInvariant::QuorumLegitimate,
         ]));
@@ -1743,7 +2010,214 @@ mod tests {
                 },
             ],
         });
-        assert!(enforce_all(&engine, &ctx).is_ok());
+        assert!(enforce_all(&engine, &ctx).is_err());
+    }
+
+    #[test]
+    fn quorum_rejects_votes_without_signed_human_provenance() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::QuorumLegitimate,
+        ]));
+        let mut ctx = passing_context();
+        ctx.quorum_evidence = Some(QuorumEvidence {
+            threshold: 2,
+            votes: vec![
+                QuorumVote {
+                    voter: did("did:exo:v1"),
+                    approved: true,
+                    signature: vec![1],
+                    provenance: None,
+                },
+                QuorumVote {
+                    voter: did("did:exo:v2"),
+                    approved: true,
+                    signature: vec![2],
+                    provenance: None,
+                },
+            ],
+        });
+
+        let err = enforce_all(&engine, &ctx).unwrap_err();
+
+        assert_eq!(err[0].invariant, ConstitutionalInvariant::QuorumLegitimate);
+        assert!(
+            err[0].description.contains("verified human"),
+            "missing vote provenance must fail with a human-verification explanation"
+        );
+    }
+
+    #[test]
+    fn quorum_rejects_non_human_or_non_independent_vote_provenance() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::QuorumLegitimate,
+        ]));
+        let mut ctx = passing_context();
+        let mut coordinated = make_vote("did:exo:h1", true, 1, Some(VoiceKind::Human));
+        coordinated
+            .provenance
+            .as_mut()
+            .expect("human provenance")
+            .independence = Some(IndependenceClaim::Coordinated);
+        coordinated
+            .provenance
+            .as_mut()
+            .expect("human provenance")
+            .review_order = Some(ReviewOrder::FirstOrder);
+        let mut derivative = make_vote("did:exo:h2", true, 2, Some(VoiceKind::Human));
+        derivative
+            .provenance
+            .as_mut()
+            .expect("human provenance")
+            .independence = Some(IndependenceClaim::Independent);
+        derivative
+            .provenance
+            .as_mut()
+            .expect("human provenance")
+            .review_order = Some(ReviewOrder::Derivative);
+
+        ctx.quorum_evidence = Some(QuorumEvidence {
+            threshold: 3,
+            votes: vec![
+                make_vote("did:exo:system", true, 3, Some(VoiceKind::System)),
+                coordinated,
+                derivative,
+            ],
+        });
+
+        let err = enforce_all(&engine, &ctx).unwrap_err();
+
+        assert_eq!(err[0].invariant, ConstitutionalInvariant::QuorumLegitimate);
+        assert!(
+            err[0].evidence.iter().any(|entry| entry.contains("system")),
+            "violation evidence must identify non-human vote provenance"
+        );
+    }
+
+    #[test]
+    fn quorum_rejects_vote_provenance_actor_mismatch() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::QuorumLegitimate,
+        ]));
+        let mut ctx = passing_context();
+        let mut vote = make_vote("did:exo:voter", true, 1, Some(VoiceKind::Human));
+        let provenance = vote.provenance.as_mut().expect("human provenance");
+        provenance.actor = did("did:exo:different-actor");
+        provenance.independence = Some(IndependenceClaim::Independent);
+        provenance.review_order = Some(ReviewOrder::FirstOrder);
+        ctx.quorum_evidence = Some(QuorumEvidence {
+            threshold: 1,
+            votes: vec![vote],
+        });
+
+        let err = enforce_all(&engine, &ctx).unwrap_err();
+
+        assert_eq!(err[0].invariant, ConstitutionalInvariant::QuorumLegitimate);
+        assert!(
+            err[0]
+                .evidence
+                .iter()
+                .any(|entry| entry.contains("provenance_actor")),
+            "violation evidence must identify actor/voter mismatch"
+        );
+    }
+
+    #[test]
+    fn quorum_rejects_tampered_human_voice_metadata_after_signing() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::QuorumLegitimate,
+        ]));
+        let mut ctx = passing_context();
+        let voter = did("did:exo:voter");
+        let (pk, sk) = exo_core::crypto::generate_keypair();
+        let mut provenance = Provenance {
+            actor: voter.clone(),
+            timestamp: "2026-05-16T00:00:00Z".to_string(),
+            action_hash: vec![0x41; 32],
+            signature: Vec::new(),
+            public_key: Some(pk.as_bytes().to_vec()),
+            voice_kind: Some(VoiceKind::Synthetic),
+            independence: Some(IndependenceClaim::Coordinated),
+            review_order: Some(ReviewOrder::Derivative),
+        };
+        let message = provenance_signature_message(&provenance).expect("canonical provenance");
+        provenance.signature = exo_core::crypto::sign(message.as_bytes(), &sk)
+            .to_bytes()
+            .to_vec();
+        provenance.voice_kind = Some(VoiceKind::Human);
+        provenance.independence = Some(IndependenceClaim::Independent);
+        provenance.review_order = Some(ReviewOrder::FirstOrder);
+        ctx.trusted_provenance_keys
+            .insert(voter.clone(), vec![pk.as_bytes().to_vec()]);
+        ctx.quorum_evidence = Some(QuorumEvidence {
+            threshold: 1,
+            votes: vec![QuorumVote {
+                voter,
+                approved: true,
+                signature: vec![1],
+                provenance: Some(provenance),
+            }],
+        });
+
+        let err = enforce_all(&engine, &ctx).unwrap_err();
+
+        assert_eq!(err[0].invariant, ConstitutionalInvariant::QuorumLegitimate);
+        assert!(
+            err[0]
+                .evidence
+                .iter()
+                .any(|entry| entry.contains("signature")),
+            "tampered voice metadata must invalidate the signed vote provenance"
+        );
+    }
+
+    #[test]
+    fn quorum_rejects_unsigned_vote_decision_with_valid_human_provenance() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::QuorumLegitimate,
+        ]));
+        let mut ctx = passing_context();
+        let mut vote = signed_human_quorum_vote(&mut ctx, "did:exo:voter", 1);
+        vote.signature = vec![1];
+        ctx.quorum_evidence = Some(QuorumEvidence {
+            threshold: 1,
+            votes: vec![vote],
+        });
+
+        let err = enforce_all(&engine, &ctx).unwrap_err();
+
+        assert_eq!(err[0].invariant, ConstitutionalInvariant::QuorumLegitimate);
+        assert!(
+            err[0]
+                .evidence
+                .iter()
+                .any(|entry| entry.contains("vote_signature")),
+            "a valid human provenance signature must not authorize an unsigned approval decision"
+        );
+    }
+
+    #[test]
+    fn quorum_rejects_approval_flag_tampering_after_vote_signing() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::QuorumLegitimate,
+        ]));
+        let mut ctx = passing_context();
+        let mut vote = signed_human_quorum_vote_with_approval(&mut ctx, "did:exo:voter", 1, false);
+        vote.approved = true;
+        ctx.quorum_evidence = Some(QuorumEvidence {
+            threshold: 1,
+            votes: vec![vote],
+        });
+
+        let err = enforce_all(&engine, &ctx).unwrap_err();
+
+        assert_eq!(err[0].invariant, ConstitutionalInvariant::QuorumLegitimate);
+        assert!(
+            err[0]
+                .evidence
+                .iter()
+                .any(|entry| entry.contains("vote_signature: invalid")),
+            "approval decisions must be bound to the vote signature"
+        );
     }
 
     #[test]

--- a/crates/exo-gatekeeper/src/types.rs
+++ b/crates/exo-gatekeeper/src/types.rs
@@ -331,7 +331,8 @@ impl QuorumEvidence {
     }
 
     /// Returns `true` if the threshold is met counting only non-synthetic
-    /// approved votes. A vote with `provenance.voice_kind = Synthetic` is
+    /// approved votes with explicit human, independent, first-order provenance.
+    /// Missing, system, synthetic, coordinated, or derivative provenance is
     /// excluded from the human count per CR-001 §8.3.
     pub fn is_met_authentic(&self) -> bool {
         let Some(threshold) = usize::try_from(self.threshold).ok() else {
@@ -378,7 +379,11 @@ impl QuorumEvidence {
         self.votes
             .iter()
             .filter(|vote| {
-                vote.approved && !vote.provenance.as_ref().is_some_and(|p| p.is_synthetic())
+                vote.approved
+                    && vote
+                        .provenance
+                        .as_ref()
+                        .is_some_and(Provenance::is_authentic_human_quorum_voice)
             })
             .map(|vote| vote.voter.clone())
             .collect::<BTreeSet<_>>()
@@ -494,6 +499,19 @@ impl Provenance {
         self.independence == Some(IndependenceClaim::Independent)
     }
 
+    /// Returns `true` when this provenance is explicitly first-order review.
+    /// `None` and derivative review are not equivalent to direct human review.
+    pub fn is_first_order_review(&self) -> bool {
+        self.review_order == Some(ReviewOrder::FirstOrder)
+    }
+
+    /// Returns `true` when all taxonomy fields required for a human quorum
+    /// claim are present and explicit. Cryptographic verification is performed
+    /// by the invariant engine because it needs trusted DID-resolved keys.
+    pub fn is_authentic_human_quorum_voice(&self) -> bool {
+        self.is_human_voice() && self.is_independent() && self.is_first_order_review()
+    }
+
     /// Returns `true` when this is explicitly a synthetic (AI-generated) voice.
     pub fn is_synthetic(&self) -> bool {
         self.voice_kind == Some(VoiceKind::Synthetic)
@@ -584,8 +602,8 @@ mod tests {
                 signature: vec![sig],
                 public_key: None,
                 voice_kind: Some(vk),
-                independence: None,
-                review_order: None,
+                independence: (vk == VoiceKind::Human).then_some(IndependenceClaim::Independent),
+                review_order: (vk == VoiceKind::Human).then_some(ReviewOrder::FirstOrder),
             }),
         }
     }
@@ -715,8 +733,8 @@ mod tests {
     }
 
     #[test]
-    fn quorum_is_met_authentic_legacy_vote_counts() {
-        // Legacy votes (no provenance) are not excluded
+    fn quorum_is_met_authentic_rejects_legacy_votes_without_provenance() {
+        // Legacy votes (no provenance) are not authentic human quorum votes.
         let ev = QuorumEvidence {
             threshold: 2,
             votes: vec![
@@ -734,7 +752,65 @@ mod tests {
                 },
             ],
         };
-        assert!(ev.is_met_authentic());
+        assert!(!ev.is_met_authentic());
+    }
+
+    #[test]
+    fn quorum_is_met_authentic_rejects_votes_without_human_provenance() {
+        let ev = QuorumEvidence {
+            threshold: 2,
+            votes: vec![
+                QuorumVote {
+                    voter: did("did:exo:v1"),
+                    approved: true,
+                    signature: vec![1],
+                    provenance: None,
+                },
+                make_vote("did:exo:system1", true, 2, Some(VoiceKind::System)),
+            ],
+        };
+
+        assert!(
+            !ev.is_met_authentic(),
+            "authentic quorum must not assume missing or system provenance is human"
+        );
+    }
+
+    #[test]
+    fn quorum_is_met_authentic_requires_independent_first_order_human_votes() {
+        let mut coordinated = make_vote("did:exo:h1", true, 1, Some(VoiceKind::Human));
+        coordinated
+            .provenance
+            .as_mut()
+            .expect("human provenance")
+            .independence = Some(IndependenceClaim::Coordinated);
+        coordinated
+            .provenance
+            .as_mut()
+            .expect("human provenance")
+            .review_order = Some(ReviewOrder::FirstOrder);
+
+        let mut derivative = make_vote("did:exo:h2", true, 2, Some(VoiceKind::Human));
+        derivative
+            .provenance
+            .as_mut()
+            .expect("human provenance")
+            .independence = Some(IndependenceClaim::Independent);
+        derivative
+            .provenance
+            .as_mut()
+            .expect("human provenance")
+            .review_order = Some(ReviewOrder::Derivative);
+
+        let ev = QuorumEvidence {
+            threshold: 2,
+            votes: vec![coordinated, derivative],
+        };
+
+        assert!(
+            !ev.is_met_authentic(),
+            "coordinated or derivative human claims must not count as authentic quorum"
+        );
     }
 
     // ── Provenance voice/independence helpers ────────────────────────────────
@@ -753,6 +829,8 @@ mod tests {
         };
         assert!(human_prov.is_human_voice());
         assert!(human_prov.is_independent());
+        assert!(human_prov.is_first_order_review());
+        assert!(human_prov.is_authentic_human_quorum_voice());
         assert!(!human_prov.is_synthetic());
     }
 

--- a/crates/exochain-wasm/src/gatekeeper_bindings.rs
+++ b/crates/exochain-wasm/src/gatekeeper_bindings.rs
@@ -359,7 +359,10 @@ mod tests {
     use exo_gatekeeper::{
         InvariantEngine,
         invariants::{ConstitutionalInvariant, InvariantContext, enforce_all},
-        types::{AuthorityChain, BailmentState, ConsentRecord, PermissionSet},
+        types::{
+            AuthorityChain, BailmentState, ConsentRecord, PermissionSet, QuorumEvidence,
+            QuorumVote, TrustedAuthorityKeys, TrustedProvenanceKeys,
+        },
     };
 
     fn actor() -> Did {
@@ -619,6 +622,62 @@ mod tests {
                 .iter()
                 .any(|description| description.contains("trusted_provenance_keys")),
             "provenance key map boundary violation must be explicit: {descriptions:?}"
+        );
+    }
+
+    #[test]
+    fn wasm_enforce_invariants_rejects_unproven_caller_quorum_evidence() {
+        let mut ctx = minimal_passing_context();
+        ctx.quorum_evidence = Some(QuorumEvidence {
+            threshold: 2,
+            votes: vec![
+                QuorumVote {
+                    voter: Did::new("did:exo:voter-one").expect("valid DID"),
+                    approved: true,
+                    signature: vec![1],
+                    provenance: None,
+                },
+                QuorumVote {
+                    voter: Did::new("did:exo:voter-two").expect("valid DID"),
+                    approved: true,
+                    signature: vec![2],
+                    provenance: None,
+                },
+            ],
+        });
+        ctx.trusted_authority_keys = TrustedAuthorityKeys::default();
+        ctx.trusted_provenance_keys = TrustedProvenanceKeys::default();
+        let req = super::WasmInvariantRequest {
+            actor: ctx.actor,
+            actor_roles: ctx.actor_roles,
+            bailment_state: ctx.bailment_state,
+            consent_records: ctx.consent_records,
+            authority_chain: ctx.authority_chain,
+            is_self_grant: ctx.is_self_grant,
+            human_override_preserved: ctx.human_override_preserved,
+            kernel_modification_attempted: ctx.kernel_modification_attempted,
+            quorum_evidence: ctx.quorum_evidence,
+            provenance: ctx.provenance,
+            actor_permissions: ctx.actor_permissions,
+            requested_permissions: ctx.requested_permissions,
+            trusted_authority_keys: ctx.trusted_authority_keys,
+            trusted_provenance_keys: ctx.trusted_provenance_keys,
+        };
+
+        let response = super::enforce_invariants_response(req);
+        assert_eq!(response["passed"], false);
+
+        let descriptions = response["violations"]
+            .as_array()
+            .expect("violations must be an array")
+            .iter()
+            .filter_map(|violation| violation["description"].as_str())
+            .collect::<Vec<_>>();
+        assert!(
+            descriptions
+                .iter()
+                .any(|description| description.contains("verified human")),
+            "caller-supplied quorum evidence without verified human provenance must fail closed: {descriptions:?}"
         );
     }
 


### PR DESCRIPTION
## Summary
- Remediates the P1 finding that quorum approval counts could be satisfied by caller-provided or synthetic votes without cryptographically verified human provenance.
- Requires each approved quorum vote to carry first-order, independent human provenance signed by a trusted key bound to the voter.
- Adds a quorum-vote signature payload so the approval decision itself cannot be replayed or tampered independently from the provenance record.

## Path classification
- EXOCHAIN core: `crates/exo-gatekeeper/src/invariants.rs`
- EXOCHAIN core: `crates/exo-gatekeeper/src/types.rs`
- Core runtime adapter: `crates/exochain-wasm/src/gatekeeper_bindings.rs`
- Adjacent surface: none
- Imported evidence: none modified
- Third-party/vendor: none

## Verification and remediation notes
- External finding was treated as a hypothesis and reproduced against current code with failing regression tests before production changes.
- The enforcement boundary is `QuorumLegitimate` in `exo-gatekeeper`; the WASM adapter has a regression test proving caller-supplied unproven quorum evidence fails closed.
- Bypass search covered gatekeeper, WASM, decision-forum, exo-governance, and package bridge paths for quorum evidence and provenance signature handling.

## Test plan
- [x] `cargo test -p exo-gatekeeper quorum_rejects_unsigned_vote_decision_with_valid_human_provenance -- --nocapture` failed before the vote-signature fix and passes after it.
- [x] `cargo test -p exo-gatekeeper quorum_ -- --nocapture`
- [x] `cargo test -p exo-gatekeeper`
- [x] `cargo test -p exochain-wasm`
- [x] `cargo test -p decision-forum`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo clippy -p exo-gatekeeper -p exochain-wasm --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo build --workspace --release`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo doc --workspace --no-deps`
- [x] `cargo audit`
- [x] `cargo deny check`

`cargo fmt` still emits the repository's existing stable-rustfmt warnings for nightly-only rustfmt options, and `cargo deny check` still emits existing duplicate-dependency warnings; both commands exit successfully.
