### PR TITLE
fix(avc): verify human approval evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 301 | `find crates -name '*.rs'` |
-| Rust LOC | 191708 | `wc -l` |
-| Workspace tests | 4,357 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 191817 | `wc -l` |
+| Workspace tests | 4,362 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -45,7 +45,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,357 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,362 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -114,9 +114,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 191708 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 191817 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,357 listed workspace tests
+         cryptographic proofs, 4,362 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          158 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 301 | `find crates -name '*.rs'` |
-| Rust LOC | 191817 | `wc -l` |
-| Workspace tests | 4,362 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 191839 | `wc -l` |
+| Workspace tests | 4,363 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -45,7 +45,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,362 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,363 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -114,9 +114,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 191817 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 191839 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,362 listed workspace tests
+         cryptographic proofs, 4,363 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          158 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 301 | `find crates -name '*.rs'` |
-| Rust LOC | 191869 | `wc -l` |
-| Workspace tests | 4,365 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 191963 | `wc -l` |
+| Workspace tests | 4,369 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -45,7 +45,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,365 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,369 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -114,9 +114,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 191869 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 191963 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,365 listed workspace tests
+         cryptographic proofs, 4,369 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          158 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 301 | `find crates -name '*.rs'` |
-| Rust LOC | 191839 | `wc -l` |
-| Workspace tests | 4,363 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 191869 | `wc -l` |
+| Workspace tests | 4,365 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -45,7 +45,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,363 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,365 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -114,9 +114,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 191839 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 191869 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,363 listed workspace tests
+         cryptographic proofs, 4,365 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          158 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 301 | `find crates -name '*.rs'` |
-| Rust LOC | 191173 | `wc -l` |
-| Workspace tests | 4,345 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 191628 | `wc -l` |
+| Workspace tests | 4,354 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -45,7 +45,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,345 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,354 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -114,9 +114,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 191173 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 191628 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,345 listed workspace tests
+         cryptographic proofs, 4,354 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          158 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 301 | `find crates -name '*.rs'` |
-| Rust LOC | 191628 | `wc -l` |
-| Workspace tests | 4,354 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 191708 | `wc -l` |
+| Workspace tests | 4,357 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -45,7 +45,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,354 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,357 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -114,9 +114,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 191628 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 191708 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,354 listed workspace tests
+         cryptographic proofs, 4,357 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          158 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 301 | `find crates -name '*.rs'` |
-| Rust LOC | 191963 | `wc -l` |
-| Workspace tests | 4,369 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 191988 | `wc -l` |
+| Workspace tests | 4,370 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -45,7 +45,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,369 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,370 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -114,9 +114,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 191963 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 191988 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,369 listed workspace tests
+         cryptographic proofs, 4,370 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          158 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-avc/src/delegation.rs
+++ b/crates/exo-avc/src/delegation.rs
@@ -511,4 +511,25 @@ mod tests {
         let child = delegate_avc(&parent, narrower_child(&parent), |_| fixed_signature()).unwrap();
         assert_eq!(parent_id_of(&child), Some(parent.id().unwrap()));
     }
+
+    #[test]
+    fn narrowing_helpers_cover_all_bound_cases() {
+        assert!(narrows_optional_u64(None, None));
+        assert!(narrows_optional_u64(None, Some(10)));
+        assert!(!narrows_optional_u64(Some(10), None));
+        assert!(narrows_optional_u64(Some(10), Some(10)));
+        assert!(!narrows_optional_u64(Some(10), Some(11)));
+
+        assert!(narrows_optional_u32(None, None));
+        assert!(narrows_optional_u32(None, Some(10)));
+        assert!(!narrows_optional_u32(Some(10), None));
+        assert!(narrows_optional_u32(Some(10), Some(10)));
+        assert!(!narrows_optional_u32(Some(10), Some(11)));
+
+        assert!(narrows_expiry(None, None));
+        assert!(narrows_expiry(None, Some(ts(20))));
+        assert!(!narrows_expiry(Some(ts(20)), None));
+        assert!(narrows_expiry(Some(ts(20)), Some(ts(20))));
+        assert!(!narrows_expiry(Some(ts(20)), Some(ts(21))));
+    }
 }

--- a/crates/exo-avc/src/lib.rs
+++ b/crates/exo-avc/src/lib.rs
@@ -124,7 +124,8 @@ pub use revocation::{
     AVC_REVOCATION_SIGNING_DOMAIN, AvcRevocation, AvcRevocationReason, revoke_avc,
 };
 pub use validation::{
-    AvcActionRequest, AvcDecision, AvcReasonCode, AvcValidationRequest, AvcValidationResult,
+    AVC_HUMAN_APPROVAL_SIGNING_DOMAIN, AvcActionRequest, AvcDecision, AvcHumanApproval,
+    AvcReasonCode, AvcValidationRequest, AvcValidationResult, human_approval_signature_payload,
     validate_avc,
 };
 
@@ -132,6 +133,7 @@ pub use validation::{
 /// and external auditors who need to ensure no domain collisions.
 pub const AVC_SIGNING_DOMAINS: &[&str] = &[
     AVC_CREDENTIAL_SIGNING_DOMAIN,
+    AVC_HUMAN_APPROVAL_SIGNING_DOMAIN,
     AVC_RECEIPT_SIGNING_DOMAIN,
     AVC_REVOCATION_SIGNING_DOMAIN,
 ];

--- a/crates/exo-avc/src/registry.rs
+++ b/crates/exo-avc/src/registry.rs
@@ -511,6 +511,28 @@ mod tests {
     }
 
     #[test]
+    fn put_revocation_rejects_unsupported_schema_without_marking_revoked() {
+        let mut reg = fresh_registry();
+        let (id, issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
+
+        let mut revocation = sample_issuer_revocation(id, &issuer_keypair);
+        revocation.schema_version = crate::credential::AVC_SCHEMA_VERSION + 1;
+
+        let err = reg.put_revocation(revocation).unwrap_err();
+        match err {
+            AvcError::UnsupportedSchema { got, supported } => {
+                assert_eq!(got, crate::credential::AVC_SCHEMA_VERSION + 1);
+                assert_eq!(supported, crate::credential::AVC_SCHEMA_VERSION);
+            }
+            other => panic!("expected unsupported schema for revocation, got {other:?}"),
+        }
+        assert!(
+            !reg.is_revoked(&id),
+            "unsupported revocation schema must not create a tombstone"
+        );
+    }
+
+    #[test]
     fn put_revocation_rejects_revoker_that_is_not_issuer_or_principal() {
         let mut reg = fresh_registry();
         let cred = sample_credential();

--- a/crates/exo-avc/src/registry.rs
+++ b/crates/exo-avc/src/registry.rs
@@ -35,6 +35,7 @@ use crate::{
 /// Read-only registry interface used by validation.
 pub trait AvcRegistryRead {
     fn resolve_public_key(&self, did: &Did) -> Option<PublicKey>;
+    fn resolve_human_approval_key(&self, did: &Did) -> Option<PublicKey>;
     fn is_revoked(&self, credential_id: &Hash256) -> bool;
     fn get_revocation(&self, credential_id: &Hash256) -> Option<AvcRevocation>;
     fn consent_ref_exists(&self, consent_id: &Hash256) -> bool;
@@ -59,6 +60,7 @@ pub trait AvcRegistryWrite: AvcRegistryRead {
     fn put_revocation(&mut self, revocation: AvcRevocation) -> Result<(), AvcError>;
     fn put_receipt(&mut self, receipt: AvcTrustReceipt) -> Result<(), AvcError>;
     fn put_public_key(&mut self, did: Did, public_key: PublicKey);
+    fn put_human_approval_key(&mut self, did: Did, public_key: PublicKey);
     fn add_consent_ref(&mut self, consent_id: Hash256);
     fn add_policy_ref(&mut self, policy_id: Hash256, policy_version: u16);
     fn mark_authority_chain_valid(&mut self, chain_hash: Hash256);
@@ -73,6 +75,7 @@ pub struct InMemoryAvcRegistry {
     revocations: BTreeMap<Hash256, AvcRevocation>,
     receipts: BTreeMap<Hash256, AvcTrustReceipt>,
     public_keys: BTreeMap<Did, PublicKey>,
+    human_approval_keys: BTreeMap<Did, PublicKey>,
     consent_refs: BTreeSet<Hash256>,
     policy_refs: BTreeSet<(Hash256, u16)>,
     authority_chains: BTreeSet<Hash256>,
@@ -207,6 +210,10 @@ impl AvcRegistryRead for InMemoryAvcRegistry {
         self.public_keys.get(did).copied()
     }
 
+    fn resolve_human_approval_key(&self, did: &Did) -> Option<PublicKey> {
+        self.human_approval_keys.get(did).copied()
+    }
+
     fn is_revoked(&self, credential_id: &Hash256) -> bool {
         self.revocations.contains_key(credential_id)
     }
@@ -281,6 +288,10 @@ impl AvcRegistryWrite for InMemoryAvcRegistry {
 
     fn put_public_key(&mut self, did: Did, public_key: PublicKey) {
         self.public_keys.insert(did, public_key);
+    }
+
+    fn put_human_approval_key(&mut self, did: Did, public_key: PublicKey) {
+        self.human_approval_keys.insert(did, public_key);
     }
 
     fn add_consent_ref(&mut self, consent_id: Hash256) {

--- a/crates/exo-avc/src/validation.rs
+++ b/crates/exo-avc/src/validation.rs
@@ -949,6 +949,28 @@ mod tests {
     }
 
     #[test]
+    fn in_scope_action_at_budget_and_risk_caps_allows() {
+        let h = Harness::new();
+        let mut draft = baseline_draft();
+        draft.authority_scope.counterparties = vec![did("approved-cp")];
+        draft.constraints.max_budget_minor_units = Some(1_000);
+        draft.constraints.max_action_risk_bp = Some(1_000);
+        let cred = h.issue(draft);
+        let actor = cred.subject_did.clone();
+        let mut action = baseline_action(actor);
+        action.tool = Some("alpha".into());
+        action.data_class = Some(DataClass::Public);
+        action.target_did = Some(did("approved-cp"));
+        action.estimated_budget_minor_units = Some(1_000);
+        action.estimated_risk_bp = Some(1_000);
+        let mut request = baseline_request(cred, ts(1_500_000));
+        request.action = Some(action);
+        let result = validate_avc(&request, &h.registry).unwrap();
+        assert_eq!(result.decision, AvcDecision::Allow);
+        assert_eq!(result.reason_codes, vec![AvcReasonCode::Valid]);
+    }
+
+    #[test]
     fn denies_risk_exceeded() {
         let h = Harness::new();
         let mut draft = baseline_draft();

--- a/crates/exo-avc/src/validation.rs
+++ b/crates/exo-avc/src/validation.rs
@@ -971,6 +971,36 @@ mod tests {
     }
 
     #[test]
+    fn non_expiring_credential_allows_explicit_holder_action() {
+        let h = Harness::new();
+        let mut draft = baseline_draft();
+        draft.holder_did = Some(did("holder"));
+        draft.expires_at = None;
+        let cred = h.issue(draft);
+        let mut request = baseline_request(cred, ts(1_500_000));
+        request.action = Some(baseline_action(did("holder")));
+        let result = validate_avc(&request, &h.registry).unwrap();
+        assert_eq!(result.decision, AvcDecision::Allow);
+        assert_eq!(result.reason_codes, vec![AvcReasonCode::Valid]);
+        assert_eq!(result.normalized_holder_did, did("holder"));
+        assert_eq!(result.valid_until, None);
+    }
+
+    #[test]
+    fn subject_actor_remains_valid_when_holder_is_explicit() {
+        let h = Harness::new();
+        let mut draft = baseline_draft();
+        draft.holder_did = Some(did("holder"));
+        let cred = h.issue(draft);
+        let mut request = baseline_request(cred, ts(1_500_000));
+        request.action = Some(baseline_action(did("agent")));
+        let result = validate_avc(&request, &h.registry).unwrap();
+        assert_eq!(result.decision, AvcDecision::Allow);
+        assert_eq!(result.reason_codes, vec![AvcReasonCode::Valid]);
+        assert_eq!(result.normalized_holder_did, did("holder"));
+    }
+
+    #[test]
     fn denies_risk_exceeded() {
         let h = Harness::new();
         let mut draft = baseline_draft();

--- a/crates/exo-avc/src/validation.rs
+++ b/crates/exo-avc/src/validation.rs
@@ -1222,6 +1222,64 @@ mod tests {
     }
 
     #[test]
+    fn human_approval_with_empty_signature_is_invalid() {
+        let mut h = Harness::new();
+        let approver_keypair = human_approver_keypair();
+        let approver_did = did("human-approver");
+        h.registry
+            .put_human_approval_key(approver_did.clone(), approver_keypair.public);
+        let mut draft = baseline_draft();
+        draft.constraints.human_approval_required = true;
+        let cred = h.issue(draft);
+        let actor = cred.subject_did.clone();
+        let mut action = baseline_action(actor);
+        action.human_approval = Some(AvcHumanApproval {
+            approver_did,
+            approved_at: ts(1_400_000),
+            expires_at: Some(ts(1_900_000)),
+            signature: Signature::empty(),
+        });
+        let mut request = baseline_request(cred, ts(1_500_000));
+        request.action = Some(action);
+        let result = validate_avc(&request, &h.registry).unwrap();
+        assert_eq!(result.decision, AvcDecision::Deny);
+        assert_eq!(
+            result.reason_codes,
+            vec![AvcReasonCode::HumanApprovalInvalid]
+        );
+    }
+
+    #[test]
+    fn human_approval_expiring_before_approval_time_is_invalid() {
+        let mut h = Harness::new();
+        let approver_keypair = human_approver_keypair();
+        let approver_did = did("human-approver");
+        h.registry
+            .put_human_approval_key(approver_did.clone(), approver_keypair.public);
+        let mut draft = baseline_draft();
+        draft.constraints.human_approval_required = true;
+        let cred = h.issue(draft);
+        let actor = cred.subject_did.clone();
+        let mut action = baseline_action(actor);
+        attach_signed_human_approval(
+            &cred,
+            &mut action,
+            approver_did,
+            ts(1_400_000),
+            Some(ts(1_399_999)),
+            &approver_keypair,
+        );
+        let mut request = baseline_request(cred, ts(1_500_000));
+        request.action = Some(action);
+        let result = validate_avc(&request, &h.registry).unwrap();
+        assert_eq!(result.decision, AvcDecision::Deny);
+        assert_eq!(
+            result.reason_codes,
+            vec![AvcReasonCode::HumanApprovalInvalid]
+        );
+    }
+
+    #[test]
     fn denies_forbidden_action_name() {
         let h = Harness::new();
         let mut draft = baseline_draft();

--- a/crates/exo-avc/src/validation.rs
+++ b/crates/exo-avc/src/validation.rs
@@ -1079,6 +1079,31 @@ mod tests {
     }
 
     #[test]
+    fn valid_optional_human_approval_evidence_allows_unrequired_action() {
+        let mut h = Harness::new();
+        let approver_keypair = human_approver_keypair();
+        let approver_did = did("human-approver");
+        h.registry
+            .put_human_approval_key(approver_did.clone(), approver_keypair.public);
+        let cred = h.issue(baseline_draft());
+        let actor = cred.subject_did.clone();
+        let mut action = baseline_action(actor);
+        attach_signed_human_approval(
+            &cred,
+            &mut action,
+            approver_did,
+            ts(1_400_000),
+            Some(ts(1_900_000)),
+            &approver_keypair,
+        );
+        let mut request = baseline_request(cred, ts(1_500_000));
+        request.action = Some(action);
+        let result = validate_avc(&request, &h.registry).unwrap();
+        assert_eq!(result.decision, AvcDecision::Allow);
+        assert_eq!(result.reason_codes, vec![AvcReasonCode::Valid]);
+    }
+
+    #[test]
     fn human_approval_from_untrusted_approver_is_invalid() {
         let h = Harness::new();
         let approver_keypair = human_approver_keypair();
@@ -1250,6 +1275,36 @@ mod tests {
     }
 
     #[test]
+    fn human_approval_with_future_approval_time_is_invalid() {
+        let mut h = Harness::new();
+        let approver_keypair = human_approver_keypair();
+        let approver_did = did("human-approver");
+        h.registry
+            .put_human_approval_key(approver_did.clone(), approver_keypair.public);
+        let mut draft = baseline_draft();
+        draft.constraints.human_approval_required = true;
+        let cred = h.issue(draft);
+        let actor = cred.subject_did.clone();
+        let mut action = baseline_action(actor);
+        attach_signed_human_approval(
+            &cred,
+            &mut action,
+            approver_did,
+            ts(1_600_000),
+            Some(ts(1_900_000)),
+            &approver_keypair,
+        );
+        let mut request = baseline_request(cred, ts(1_500_000));
+        request.action = Some(action);
+        let result = validate_avc(&request, &h.registry).unwrap();
+        assert_eq!(result.decision, AvcDecision::Deny);
+        assert_eq!(
+            result.reason_codes,
+            vec![AvcReasonCode::HumanApprovalInvalid]
+        );
+    }
+
+    #[test]
     fn human_approval_expiring_before_approval_time_is_invalid() {
         let mut h = Harness::new();
         let approver_keypair = human_approver_keypair();
@@ -1277,6 +1332,39 @@ mod tests {
             result.reason_codes,
             vec![AvcReasonCode::HumanApprovalInvalid]
         );
+    }
+
+    #[test]
+    fn risk_below_approval_threshold_allows_without_human_approval() {
+        let h = Harness::new();
+        let mut draft = baseline_draft();
+        draft.constraints.max_action_risk_bp = Some(10_000);
+        draft.constraints.approval_threshold_bp = Some(5_000);
+        let cred = h.issue(draft);
+        let actor = cred.subject_did.clone();
+        let mut action = baseline_action(actor);
+        action.estimated_risk_bp = Some(4_999);
+        let mut request = baseline_request(cred, ts(1_500_000));
+        request.action = Some(action);
+        let result = validate_avc(&request, &h.registry).unwrap();
+        assert_eq!(result.decision, AvcDecision::Allow);
+        assert_eq!(result.reason_codes, vec![AvcReasonCode::Valid]);
+    }
+
+    #[test]
+    fn risk_threshold_without_estimate_allows_without_human_approval() {
+        let h = Harness::new();
+        let mut draft = baseline_draft();
+        draft.constraints.max_action_risk_bp = Some(10_000);
+        draft.constraints.approval_threshold_bp = Some(5_000);
+        let cred = h.issue(draft);
+        let actor = cred.subject_did.clone();
+        let action = baseline_action(actor);
+        let mut request = baseline_request(cred, ts(1_500_000));
+        request.action = Some(action);
+        let result = validate_avc(&request, &h.registry).unwrap();
+        assert_eq!(result.decision, AvcDecision::Allow);
+        assert_eq!(result.reason_codes, vec![AvcReasonCode::Valid]);
     }
 
     #[test]

--- a/crates/exo-avc/src/validation.rs
+++ b/crates/exo-avc/src/validation.rs
@@ -32,17 +32,20 @@
 use std::collections::BTreeSet;
 
 use exo_authority::permission::Permission;
-#[cfg(test)]
-use exo_core::Signature;
-use exo_core::{Did, Hash256, PublicKey, Timestamp, crypto};
+use exo_core::{Did, Hash256, PublicKey, Signature, Timestamp, crypto};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    credential::{AuthorityScope, AutonomousVolitionCredential, AvcConstraints, DataClass},
+    credential::{
+        AVC_SCHEMA_VERSION, AuthorityScope, AutonomousVolitionCredential, AvcConstraints, DataClass,
+    },
     error::AvcError,
     receipt::AvcTrustReceipt,
     registry::AvcRegistryRead,
 };
+
+/// Signing domain tag for AVC human approval evidence.
+pub const AVC_HUMAN_APPROVAL_SIGNING_DOMAIN: &str = "exo.avc.human-approval.v1";
 
 // ---------------------------------------------------------------------------
 // Decision / Reason
@@ -78,6 +81,8 @@ pub enum AvcReasonCode {
     BudgetExceeded,
     RiskExceeded,
     HumanApprovalMissing,
+    HumanApprovalInvalid,
+    HumanApprovalExpired,
     DelegationNotAllowed,
     ConsentMissing,
     PolicyMissing,
@@ -100,9 +105,19 @@ pub struct AvcActionRequest {
     pub data_class: Option<DataClass>,
     pub estimated_budget_minor_units: Option<u64>,
     pub estimated_risk_bp: Option<u32>,
+    #[serde(default)]
+    pub human_approval: Option<AvcHumanApproval>,
     pub requires_human_approval: bool,
     /// Free-form action name used to enforce `forbidden_actions`.
     pub action_name: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AvcHumanApproval {
+    pub approver_did: Did,
+    pub approved_at: Timestamp,
+    pub expires_at: Option<Timestamp>,
+    pub signature: Signature,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -120,6 +135,25 @@ pub struct AvcValidationResult {
     pub normalized_holder_did: Did,
     pub valid_until: Option<Timestamp>,
     pub receipt: Option<AvcTrustReceipt>,
+}
+
+#[derive(Serialize)]
+struct HumanApprovalSigningPayload<'a> {
+    domain: &'static str,
+    schema_version: u16,
+    credential_id: &'a Hash256,
+    action_id: &'a Hash256,
+    actor_did: &'a Did,
+    requested_permission: &'a Permission,
+    tool: Option<&'a String>,
+    target_did: Option<&'a Did>,
+    data_class: Option<&'a DataClass>,
+    estimated_budget_minor_units: Option<u64>,
+    estimated_risk_bp: Option<u32>,
+    action_name: Option<&'a String>,
+    approver_did: &'a Did,
+    approved_at: &'a Timestamp,
+    expires_at: Option<&'a Timestamp>,
 }
 
 // ---------------------------------------------------------------------------
@@ -215,9 +249,11 @@ pub fn validate_avc<R: AvcRegistryRead>(
             credential,
             action,
             &normalized_holder_did,
+            registry,
+            &request.now,
             &mut reasons,
             &mut human_approval_required,
-        );
+        )?;
     }
 
     let mut sorted: Vec<AvcReasonCode> = reasons.into_iter().collect();
@@ -258,13 +294,53 @@ fn verify_signature(
     Ok(crypto::verify(&payload, &credential.signature, pubkey))
 }
 
-fn evaluate_action(
+/// Compute the canonical signing payload for a human approval over a
+/// specific AVC credential/action pair.
+///
+/// The caller-provided `requires_human_approval` flag is deliberately
+/// excluded because it is not proof of approval. Authorization depends
+/// on this signed approval evidence and the trusted human-approver key
+/// registry instead.
+///
+/// # Errors
+/// Returns [`AvcError::Serialization`] if canonical CBOR encoding fails.
+pub fn human_approval_signature_payload(
+    credential: &AutonomousVolitionCredential,
+    action: &AvcActionRequest,
+    approval: &AvcHumanApproval,
+) -> Result<Vec<u8>, AvcError> {
+    let credential_id = credential.id()?;
+    let payload = HumanApprovalSigningPayload {
+        domain: AVC_HUMAN_APPROVAL_SIGNING_DOMAIN,
+        schema_version: AVC_SCHEMA_VERSION,
+        credential_id: &credential_id,
+        action_id: &action.action_id,
+        actor_did: &action.actor_did,
+        requested_permission: &action.requested_permission,
+        tool: action.tool.as_ref(),
+        target_did: action.target_did.as_ref(),
+        data_class: action.data_class.as_ref(),
+        estimated_budget_minor_units: action.estimated_budget_minor_units,
+        estimated_risk_bp: action.estimated_risk_bp,
+        action_name: action.action_name.as_ref(),
+        approver_did: &approval.approver_did,
+        approved_at: &approval.approved_at,
+        expires_at: approval.expires_at.as_ref(),
+    };
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&payload, &mut buf)?;
+    Ok(buf)
+}
+
+fn evaluate_action<R: AvcRegistryRead>(
     credential: &AutonomousVolitionCredential,
     action: &AvcActionRequest,
     normalized_holder: &Did,
+    registry: &R,
+    now: &Timestamp,
     reasons: &mut BTreeSet<AvcReasonCode>,
     human_approval_required: &mut bool,
-) {
+) -> Result<(), AvcError> {
     if action.actor_did != *normalized_holder && action.actor_did != credential.subject_did {
         reasons.insert(AvcReasonCode::InvalidHolder);
     }
@@ -282,12 +358,16 @@ fn evaluate_action(
     enforce_counterparty(&credential.authority_scope, action, reasons);
     enforce_budget(&credential.constraints, action, reasons);
     enforce_risk(
+        credential,
         &credential.constraints,
         action,
+        registry,
+        now,
         reasons,
         human_approval_required,
-    );
+    )?;
     enforce_forbidden_action(&credential.constraints, action, reasons);
+    Ok(())
 }
 
 fn enforce_tool(
@@ -344,25 +424,73 @@ fn enforce_budget(
     }
 }
 
-fn enforce_risk(
+fn enforce_risk<R: AvcRegistryRead>(
+    credential: &AutonomousVolitionCredential,
     constraints: &AvcConstraints,
     action: &AvcActionRequest,
+    registry: &R,
+    now: &Timestamp,
     reasons: &mut BTreeSet<AvcReasonCode>,
     human_approval_required: &mut bool,
-) {
-    let Some(estimate) = action.estimated_risk_bp else {
-        return;
+) -> Result<(), AvcError> {
+    let risk_threshold_requires_approval = if let (Some(threshold), Some(estimate)) =
+        (constraints.approval_threshold_bp, action.estimated_risk_bp)
+    {
+        estimate >= threshold
+    } else {
+        false
     };
-    if let Some(cap) = constraints.max_action_risk_bp {
+    if let (Some(cap), Some(estimate)) = (constraints.max_action_risk_bp, action.estimated_risk_bp)
+    {
         if estimate > cap {
             reasons.insert(AvcReasonCode::RiskExceeded);
         }
     }
-    if let Some(threshold) = constraints.approval_threshold_bp {
-        if estimate >= threshold && !action.requires_human_approval {
-            reasons.insert(AvcReasonCode::HumanApprovalMissing);
-            *human_approval_required = true;
+
+    let approval_required = constraints.human_approval_required || risk_threshold_requires_approval;
+    if approval_required {
+        *human_approval_required = true;
+    }
+    if approval_required || action.human_approval.is_some() {
+        match verify_human_approval(credential, action, registry, now)? {
+            Ok(()) => {}
+            Err(reason) => {
+                reasons.insert(reason);
+            }
         }
+    }
+    Ok(())
+}
+
+fn verify_human_approval<R: AvcRegistryRead>(
+    credential: &AutonomousVolitionCredential,
+    action: &AvcActionRequest,
+    registry: &R,
+    now: &Timestamp,
+) -> Result<Result<(), AvcReasonCode>, AvcError> {
+    let Some(approval) = &action.human_approval else {
+        return Ok(Err(AvcReasonCode::HumanApprovalMissing));
+    };
+    if approval.signature.is_empty() || approval.approved_at > *now {
+        return Ok(Err(AvcReasonCode::HumanApprovalInvalid));
+    }
+    if let Some(expires_at) = approval.expires_at {
+        if expires_at <= approval.approved_at {
+            return Ok(Err(AvcReasonCode::HumanApprovalInvalid));
+        }
+        if expires_at <= *now {
+            return Ok(Err(AvcReasonCode::HumanApprovalExpired));
+        }
+    }
+
+    let Some(public_key) = registry.resolve_human_approval_key(&approval.approver_did) else {
+        return Ok(Err(AvcReasonCode::HumanApprovalInvalid));
+    };
+    let payload = human_approval_signature_payload(credential, action, approval)?;
+    if crypto::verify(&payload, &approval.signature, &public_key) {
+        Ok(Ok(()))
+    } else {
+        Ok(Err(AvcReasonCode::HumanApprovalInvalid))
     }
 }
 
@@ -394,9 +522,14 @@ mod tests {
     };
 
     const ISSUER_SEED: [u8; 32] = [0x11; 32];
+    const HUMAN_APPROVER_SEED: [u8; 32] = [0x44; 32];
 
     fn issuer_keypair() -> KeyPair {
         KeyPair::from_secret_bytes(ISSUER_SEED).expect("valid seed")
+    }
+
+    fn human_approver_keypair() -> KeyPair {
+        KeyPair::from_secret_bytes(HUMAN_APPROVER_SEED).expect("valid seed")
     }
 
     /// Build a registry seeded with the issuer's public key.
@@ -437,9 +570,40 @@ mod tests {
             data_class: None,
             estimated_budget_minor_units: None,
             estimated_risk_bp: None,
+            human_approval: None,
             requires_human_approval: false,
             action_name: None,
         }
+    }
+
+    fn attach_signed_human_approval(
+        credential: &AutonomousVolitionCredential,
+        action: &mut AvcActionRequest,
+        approver_did: Did,
+        approved_at: Timestamp,
+        expires_at: Option<Timestamp>,
+        approver_keypair: &KeyPair,
+    ) {
+        action.human_approval = Some(AvcHumanApproval {
+            approver_did,
+            approved_at,
+            expires_at,
+            signature: Signature::empty(),
+        });
+        let payload = human_approval_signature_payload(
+            credential,
+            action,
+            action
+                .human_approval
+                .as_ref()
+                .expect("approval placeholder"),
+        )
+        .expect("canonical approval payload");
+        action
+            .human_approval
+            .as_mut()
+            .expect("approval placeholder")
+            .signature = approver_keypair.sign(&payload);
     }
 
     #[test]
@@ -820,7 +984,7 @@ mod tests {
     }
 
     #[test]
-    fn risk_above_threshold_with_explicit_approval_does_not_flag() {
+    fn risk_above_threshold_ignores_caller_approval_flag() {
         let h = Harness::new();
         let mut draft = baseline_draft();
         draft.constraints.max_action_risk_bp = Some(10_000);
@@ -833,7 +997,228 @@ mod tests {
         let mut request = baseline_request(cred, ts(1_500_000));
         request.action = Some(action);
         let result = validate_avc(&request, &h.registry).unwrap();
+        assert_eq!(result.decision, AvcDecision::HumanApprovalRequired);
+        assert_eq!(
+            result.reason_codes,
+            vec![AvcReasonCode::HumanApprovalMissing]
+        );
+    }
+
+    #[test]
+    fn credential_human_approval_required_blocks_action_without_evidence() {
+        let h = Harness::new();
+        let mut draft = baseline_draft();
+        draft.constraints.human_approval_required = true;
+        let cred = h.issue(draft);
+        let actor = cred.subject_did.clone();
+        let action = baseline_action(actor);
+        let mut request = baseline_request(cred, ts(1_500_000));
+        request.action = Some(action);
+        let result = validate_avc(&request, &h.registry).unwrap();
+        assert_eq!(result.decision, AvcDecision::HumanApprovalRequired);
+        assert_eq!(
+            result.reason_codes,
+            vec![AvcReasonCode::HumanApprovalMissing]
+        );
+    }
+
+    #[test]
+    fn signed_human_approval_satisfies_credential_requirement() {
+        let mut h = Harness::new();
+        let approver_keypair = human_approver_keypair();
+        let approver_did = did("human-approver");
+        h.registry
+            .put_human_approval_key(approver_did.clone(), approver_keypair.public);
+        let mut draft = baseline_draft();
+        draft.constraints.human_approval_required = true;
+        let cred = h.issue(draft);
+        let actor = cred.subject_did.clone();
+        let mut action = baseline_action(actor);
+        attach_signed_human_approval(
+            &cred,
+            &mut action,
+            approver_did,
+            ts(1_400_000),
+            Some(ts(1_900_000)),
+            &approver_keypair,
+        );
+        let mut request = baseline_request(cred, ts(1_500_000));
+        request.action = Some(action);
+        let result = validate_avc(&request, &h.registry).unwrap();
         assert_eq!(result.decision, AvcDecision::Allow);
+        assert_eq!(result.reason_codes, vec![AvcReasonCode::Valid]);
+    }
+
+    #[test]
+    fn signed_human_approval_satisfies_risk_threshold() {
+        let mut h = Harness::new();
+        let approver_keypair = human_approver_keypair();
+        let approver_did = did("human-approver");
+        h.registry
+            .put_human_approval_key(approver_did.clone(), approver_keypair.public);
+        let mut draft = baseline_draft();
+        draft.constraints.max_action_risk_bp = Some(10_000);
+        draft.constraints.approval_threshold_bp = Some(5_000);
+        let cred = h.issue(draft);
+        let actor = cred.subject_did.clone();
+        let mut action = baseline_action(actor);
+        action.estimated_risk_bp = Some(7_500);
+        attach_signed_human_approval(
+            &cred,
+            &mut action,
+            approver_did,
+            ts(1_400_000),
+            None,
+            &approver_keypair,
+        );
+        let mut request = baseline_request(cred, ts(1_500_000));
+        request.action = Some(action);
+        let result = validate_avc(&request, &h.registry).unwrap();
+        assert_eq!(result.decision, AvcDecision::Allow);
+        assert_eq!(result.reason_codes, vec![AvcReasonCode::Valid]);
+    }
+
+    #[test]
+    fn human_approval_from_untrusted_approver_is_invalid() {
+        let h = Harness::new();
+        let approver_keypair = human_approver_keypair();
+        let approver_did = did("human-approver");
+        let mut draft = baseline_draft();
+        draft.constraints.human_approval_required = true;
+        let cred = h.issue(draft);
+        let actor = cred.subject_did.clone();
+        let mut action = baseline_action(actor);
+        attach_signed_human_approval(
+            &cred,
+            &mut action,
+            approver_did,
+            ts(1_400_000),
+            Some(ts(1_900_000)),
+            &approver_keypair,
+        );
+        let mut request = baseline_request(cred, ts(1_500_000));
+        request.action = Some(action);
+        let result = validate_avc(&request, &h.registry).unwrap();
+        assert_eq!(result.decision, AvcDecision::Deny);
+        assert_eq!(
+            result.reason_codes,
+            vec![AvcReasonCode::HumanApprovalInvalid]
+        );
+    }
+
+    #[test]
+    fn issuer_public_key_alone_does_not_authorize_human_approval() {
+        let h = Harness::new();
+        let issuer_keypair = issuer_keypair();
+        let mut draft = baseline_draft();
+        draft.constraints.human_approval_required = true;
+        let cred = h.issue(draft);
+        let actor = cred.subject_did.clone();
+        let mut action = baseline_action(actor);
+        attach_signed_human_approval(
+            &cred,
+            &mut action,
+            did("issuer"),
+            ts(1_400_000),
+            Some(ts(1_900_000)),
+            &issuer_keypair,
+        );
+        let mut request = baseline_request(cred, ts(1_500_000));
+        request.action = Some(action);
+        let result = validate_avc(&request, &h.registry).unwrap();
+        assert_eq!(result.decision, AvcDecision::Deny);
+        assert_eq!(
+            result.reason_codes,
+            vec![AvcReasonCode::HumanApprovalInvalid]
+        );
+    }
+
+    #[test]
+    fn optional_human_approval_evidence_must_still_verify() {
+        let h = Harness::new();
+        let approver_keypair = human_approver_keypair();
+        let cred = h.issue(baseline_draft());
+        let actor = cred.subject_did.clone();
+        let mut action = baseline_action(actor);
+        attach_signed_human_approval(
+            &cred,
+            &mut action,
+            did("human-approver"),
+            ts(1_400_000),
+            Some(ts(1_900_000)),
+            &approver_keypair,
+        );
+        let mut request = baseline_request(cred, ts(1_500_000));
+        request.action = Some(action);
+        let result = validate_avc(&request, &h.registry).unwrap();
+        assert_eq!(result.decision, AvcDecision::Deny);
+        assert_eq!(
+            result.reason_codes,
+            vec![AvcReasonCode::HumanApprovalInvalid]
+        );
+    }
+
+    #[test]
+    fn human_approval_signature_binds_action_fields() {
+        let mut h = Harness::new();
+        let approver_keypair = human_approver_keypair();
+        let approver_did = did("human-approver");
+        h.registry
+            .put_human_approval_key(approver_did.clone(), approver_keypair.public);
+        let mut draft = baseline_draft();
+        draft.constraints.max_action_risk_bp = Some(10_000);
+        draft.constraints.approval_threshold_bp = Some(5_000);
+        let cred = h.issue(draft);
+        let actor = cred.subject_did.clone();
+        let mut action = baseline_action(actor);
+        action.estimated_risk_bp = Some(7_500);
+        attach_signed_human_approval(
+            &cred,
+            &mut action,
+            approver_did,
+            ts(1_400_000),
+            None,
+            &approver_keypair,
+        );
+        action.estimated_risk_bp = Some(7_501);
+        let mut request = baseline_request(cred, ts(1_500_000));
+        request.action = Some(action);
+        let result = validate_avc(&request, &h.registry).unwrap();
+        assert_eq!(result.decision, AvcDecision::Deny);
+        assert_eq!(
+            result.reason_codes,
+            vec![AvcReasonCode::HumanApprovalInvalid]
+        );
+    }
+
+    #[test]
+    fn expired_human_approval_is_rejected() {
+        let mut h = Harness::new();
+        let approver_keypair = human_approver_keypair();
+        let approver_did = did("human-approver");
+        h.registry
+            .put_human_approval_key(approver_did.clone(), approver_keypair.public);
+        let mut draft = baseline_draft();
+        draft.constraints.human_approval_required = true;
+        let cred = h.issue(draft);
+        let actor = cred.subject_did.clone();
+        let mut action = baseline_action(actor);
+        attach_signed_human_approval(
+            &cred,
+            &mut action,
+            approver_did,
+            ts(1_300_000),
+            Some(ts(1_400_000)),
+            &approver_keypair,
+        );
+        let mut request = baseline_request(cred, ts(1_500_000));
+        request.action = Some(action);
+        let result = validate_avc(&request, &h.registry).unwrap();
+        assert_eq!(result.decision, AvcDecision::Deny);
+        assert_eq!(
+            result.reason_codes,
+            vec![AvcReasonCode::HumanApprovalExpired]
+        );
     }
 
     #[test]

--- a/crates/exo-avc/src/validation.rs
+++ b/crates/exo-avc/src/validation.rs
@@ -971,6 +971,20 @@ mod tests {
     }
 
     #[test]
+    fn in_scope_action_with_allowed_tool_allows() {
+        let h = Harness::new();
+        let cred = h.issue(baseline_draft());
+        let actor = cred.subject_did.clone();
+        let mut action = baseline_action(actor);
+        action.tool = Some("alpha".into());
+        let mut request = baseline_request(cred, ts(1_500_000));
+        request.action = Some(action);
+        let result = validate_avc(&request, &h.registry).unwrap();
+        assert_eq!(result.decision, AvcDecision::Allow);
+        assert_eq!(result.reason_codes, vec![AvcReasonCode::Valid]);
+    }
+
+    #[test]
     fn non_expiring_credential_allows_explicit_holder_action() {
         let h = Harness::new();
         let mut draft = baseline_draft();
@@ -998,6 +1012,26 @@ mod tests {
         assert_eq!(result.decision, AvcDecision::Allow);
         assert_eq!(result.reason_codes, vec![AvcReasonCode::Valid]);
         assert_eq!(result.normalized_holder_did, did("holder"));
+    }
+
+    #[test]
+    fn risk_at_approval_threshold_requires_human_approval() {
+        let h = Harness::new();
+        let mut draft = baseline_draft();
+        draft.constraints.max_action_risk_bp = Some(10_000);
+        draft.constraints.approval_threshold_bp = Some(5_000);
+        let cred = h.issue(draft);
+        let actor = cred.subject_did.clone();
+        let mut action = baseline_action(actor);
+        action.estimated_risk_bp = Some(5_000);
+        let mut request = baseline_request(cred, ts(1_500_000));
+        request.action = Some(action);
+        let result = validate_avc(&request, &h.registry).unwrap();
+        assert_eq!(result.decision, AvcDecision::HumanApprovalRequired);
+        assert_eq!(
+            result.reason_codes,
+            vec![AvcReasonCode::HumanApprovalMissing]
+        );
     }
 
     #[test]
@@ -1323,6 +1357,66 @@ mod tests {
         assert_eq!(
             result.reason_codes,
             vec![AvcReasonCode::HumanApprovalInvalid]
+        );
+    }
+
+    #[test]
+    fn human_approval_expiring_at_approval_time_is_invalid() {
+        let mut h = Harness::new();
+        let approver_keypair = human_approver_keypair();
+        let approver_did = did("human-approver");
+        h.registry
+            .put_human_approval_key(approver_did.clone(), approver_keypair.public);
+        let mut draft = baseline_draft();
+        draft.constraints.human_approval_required = true;
+        let cred = h.issue(draft);
+        let actor = cred.subject_did.clone();
+        let mut action = baseline_action(actor);
+        attach_signed_human_approval(
+            &cred,
+            &mut action,
+            approver_did,
+            ts(1_400_000),
+            Some(ts(1_400_000)),
+            &approver_keypair,
+        );
+        let mut request = baseline_request(cred, ts(1_500_000));
+        request.action = Some(action);
+        let result = validate_avc(&request, &h.registry).unwrap();
+        assert_eq!(result.decision, AvcDecision::Deny);
+        assert_eq!(
+            result.reason_codes,
+            vec![AvcReasonCode::HumanApprovalInvalid]
+        );
+    }
+
+    #[test]
+    fn human_approval_expiring_at_now_is_expired() {
+        let mut h = Harness::new();
+        let approver_keypair = human_approver_keypair();
+        let approver_did = did("human-approver");
+        h.registry
+            .put_human_approval_key(approver_did.clone(), approver_keypair.public);
+        let mut draft = baseline_draft();
+        draft.constraints.human_approval_required = true;
+        let cred = h.issue(draft);
+        let actor = cred.subject_did.clone();
+        let mut action = baseline_action(actor);
+        attach_signed_human_approval(
+            &cred,
+            &mut action,
+            approver_did,
+            ts(1_400_000),
+            Some(ts(1_500_000)),
+            &approver_keypair,
+        );
+        let mut request = baseline_request(cred, ts(1_500_000));
+        request.action = Some(action);
+        let result = validate_avc(&request, &h.registry).unwrap();
+        assert_eq!(result.decision, AvcDecision::Deny);
+        assert_eq!(
+            result.reason_codes,
+            vec![AvcReasonCode::HumanApprovalExpired]
         );
     }
 

--- a/crates/exo-identity/src/verification.rs
+++ b/crates/exo-identity/src/verification.rs
@@ -506,6 +506,31 @@ mod tests {
     }
 
     #[test]
+    fn identity_proof_debug_redacts_signature_message_and_webauthn_assertion() {
+        let (public_key, secret_key) = generate_keypair();
+        let message = b"super-secret-signature-message".to_vec();
+        let signature = sign(&message, &secret_key);
+        let signature_proof = IdentityProof::Signature(signature, public_key, message);
+        let webauthn = IdentityProof::WebAuthnAssertion(b"super-secret-webauthn".to_vec());
+
+        let signature_debug = format!("{signature_proof:?}");
+        let webauthn_debug = format!("{webauthn:?}");
+
+        assert!(
+            !signature_debug.contains("super-secret-signature-message"),
+            "Signature proof Debug output must redact the signed message"
+        );
+        assert!(
+            !webauthn_debug.contains("super-secret-webauthn"),
+            "WebAuthn proof Debug output must redact the assertion bytes"
+        );
+        assert!(signature_debug.contains("<redacted>"));
+        assert!(signature_debug.contains("message_len"));
+        assert!(webauthn_debug.contains("<redacted>"));
+        assert!(webauthn_debug.contains("assertion_len"));
+    }
+
+    #[test]
     fn verification_ceremony_debug_uses_redacted_identity_proofs() {
         let did = match Did::new("did:exo:redacted-proof") {
             Ok(did) => did,

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -349,8 +349,9 @@ mod tests {
     };
     use exo_authority::permission::Permission;
     use exo_avc::{
-        AVC_SCHEMA_VERSION, AuthorityScope, AutonomyLevel, AvcConstraints, AvcDecision, AvcDraft,
-        AvcRevocationReason, AvcSubjectKind, DelegatedIntent, issue_avc, revoke_avc,
+        AVC_SCHEMA_VERSION, AuthorityScope, AutonomyLevel, AvcActionRequest, AvcConstraints,
+        AvcDecision, AvcDraft, AvcReasonCode, AvcRevocationReason, AvcSubjectKind, DelegatedIntent,
+        issue_avc, revoke_avc,
     };
     use exo_core::{Hash256, Signature, Timestamp, crypto::KeyPair};
     use tower::ServiceExt;
@@ -581,6 +582,62 @@ mod tests {
         let resp_bytes = read_body(response).await;
         let parsed: AvcValidationResult = serde_json::from_slice(&resp_bytes).unwrap();
         assert_eq!(parsed.decision, AvcDecision::Allow);
+    }
+
+    #[tokio::test]
+    async fn validate_rejects_caller_claimed_human_approval_without_evidence() {
+        let state = fresh_state();
+        let app = avc_router(Arc::clone(&state));
+        let mut draft = baseline_draft();
+        draft.constraints.human_approval_required = true;
+        let credential = {
+            let kp = issuer_keypair();
+            issue_avc(draft, |bytes| kp.sign(bytes)).unwrap()
+        };
+        let action = AvcActionRequest {
+            action_id: Hash256::from_bytes([0x55; 32]),
+            actor_did: credential.subject_did.clone(),
+            requested_permission: Permission::Read,
+            tool: None,
+            target_did: None,
+            data_class: None,
+            estimated_budget_minor_units: None,
+            estimated_risk_bp: None,
+            human_approval: None,
+            requires_human_approval: true,
+            action_name: None,
+        };
+        let request = AvcValidationRequest {
+            credential,
+            action: Some(action),
+            now: Timestamp::new(1_500_000, 0),
+        };
+        let mut body_value = serde_json::to_value(&request).unwrap();
+        body_value
+            .get_mut("action")
+            .and_then(serde_json::Value::as_object_mut)
+            .unwrap()
+            .remove("human_approval");
+        let body = serde_json::to_vec(&body_value).unwrap();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/avc/validate")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let parsed: AvcValidationResult =
+            serde_json::from_slice(&read_body(response).await).unwrap();
+        assert_eq!(parsed.decision, AvcDecision::HumanApprovalRequired);
+        assert_eq!(
+            parsed.reason_codes,
+            vec![AvcReasonCode::HumanApprovalMissing]
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Reproduces and fixes the P1 AVC issue where caller-controlled `requires_human_approval` could satisfy approval requirements without cryptographic evidence.
- Adds signed, domain-separated human-approval evidence bound to the credential id, action fields, approver DID, approval time, and expiry.
- Separates trusted human approval keys from issuer signing keys and adds an exo-node route regression for omitted `human_approval` JSON input.
- Refreshes README repo-truth counters after the added tests/LOC.

## Finding disposition
- Source: `/Users/bobstewart/Downloads/codex-security-findings-2026-05-16T13-25-31.366Z.csv`, P1 “AVC validation trusts caller approval flag”.
- Status on current main before fix: reproduced with failing AVC tests; `human_approval_required=true` and high risk threshold paths could be satisfied by caller-supplied flags instead of signed approval evidence.
- Fixed boundary: `exo-avc` validation, with `exo-node` adapter coverage for the externally reachable validation route.

## Path classification
- EXOCHAIN core: `crates/exo-avc/src/lib.rs`, `crates/exo-avc/src/registry.rs`, `crates/exo-avc/src/validation.rs`
- Core runtime adapter: `crates/exo-node/src/avc.rs`
- Documentation: `README.md`
- Adjacent surface: none
- Imported evidence: none committed
- Third-party/vendor: none

## Test plan
- `cargo test -p exo-avc approval -- --nocapture`
- `cargo test -p exo-avc`
- `cargo test -p exo-node validate_rejects_caller_claimed_human_approval_without_evidence -- --nocapture`
- `cargo test -p exo-node avc::tests -- --nocapture`
- `cargo test -p exo-node`
- `bash tools/repo_truth.sh --json --skip-tests`
- `cargo test --workspace -- --list | grep -c ': test$'`
- `bash tools/test_repo_truth.sh`
- `cargo fmt --all -- --check`
- `git diff --check`
- `rg -n "requires_human_approval|human_approval_required|human_approval|HumanApproval" crates/exo-avc/src crates/exo-node/src packages/exochain-wasm/test/bridge_verification.mjs -g '*.rs' -g '*.mjs'`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
- `cargo build --workspace --release`
