### PR TITLE
fix(wasm): enforce canonical decision invariants

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 301 | `find crates -name '*.rs'` |
-| Rust LOC | 192204 | `wc -l` |
+| Rust LOC | 192240 | `wc -l` |
 | Workspace tests | 4,376 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
@@ -114,7 +114,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 192204 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 192240 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,376 listed workspace tests
 

--- a/crates/exochain-wasm/src/decision_forum_bindings.rs
+++ b/crates/exochain-wasm/src/decision_forum_bindings.rs
@@ -29,15 +29,28 @@ const MAX_WASM_FORUM_PUBLIC_KEYS: usize = 1_024;
 const MAX_WASM_FORUM_CONSTITUTION_BYTES: usize = 1_048_576;
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 struct WasmDecisionTransitionAdjudicatedRequest {
     decision: decision_forum::decision_object::DecisionObject,
     to_state: exo_core::bcts::BctsState,
     actor_did: String,
     timestamp_ms: u64,
     timestamp_logical: u32,
-    invariant_set: exo_gatekeeper::invariants::InvariantSet,
     action: exo_gatekeeper::kernel::ActionRequest,
     context: exo_gatekeeper::kernel::AdjudicationContext,
+}
+
+fn parse_decision_transition_adjudicated_request(
+    request_json: &str,
+) -> Result<WasmDecisionTransitionAdjudicatedRequest, JsValue> {
+    let request_value: serde_json::Value = from_json_str(request_json)?;
+    if request_value.get("invariant_set").is_some() {
+        return Err(JsValue::from_str(
+            "caller-supplied invariant_set is rejected; WASM decision transitions enforce canonical constitutional invariants",
+        ));
+    }
+
+    serde_json::from_value(request_value).map_err(|_| JsValue::from_str("JSON parse error"))
 }
 
 /// Create a new DecisionObject with full BCTS lifecycle
@@ -102,14 +115,16 @@ pub fn wasm_transition_decision_adjudicated(
         actor_did,
         timestamp_ms,
         timestamp_logical,
-        invariant_set,
         action,
         context,
-    } = from_json_str(request_json)?;
+    } = parse_decision_transition_adjudicated_request(request_json)?;
     let actor = exo_core::Did::new(&actor_did)
         .map_err(|e| JsValue::from_str(&format!("DID error: {e}")))?;
     let ts = exo_core::types::Timestamp::new(timestamp_ms, timestamp_logical);
-    let kernel = exo_gatekeeper::kernel::Kernel::new(constitution, invariant_set);
+    let kernel = exo_gatekeeper::kernel::Kernel::new(
+        constitution,
+        exo_gatekeeper::invariants::InvariantSet::all(),
+    );
 
     decision
         .transition_adjudicated_at(to_state, &actor, ts, &kernel, &action, &context)

--- a/crates/exochain-wasm/src/lib.rs
+++ b/crates/exochain-wasm/src/lib.rs
@@ -437,6 +437,27 @@ mod source_guard_tests {
                 && source.contains("request_json"),
             "WASM adjudicated decision transition must use a typed bounded request JSON instead of a wide argument list"
         );
+        let adjudicated_transition = source
+            .split("pub fn wasm_transition_decision_adjudicated(")
+            .nth(1)
+            .and_then(|section| section.split("/// Add a vote").next())
+            .expect("adjudicated decision transition export source");
+        assert!(
+            adjudicated_transition.contains("InvariantSet::all()"),
+            "WASM adjudicated decision transition must enforce the canonical complete invariant set"
+        );
+        assert!(
+            !adjudicated_transition.contains("Kernel::new(constitution, invariant_set)"),
+            "WASM adjudicated decision transition must not build a kernel from caller-supplied invariants"
+        );
+        assert!(
+            source
+                .split("struct WasmDecisionTransitionAdjudicatedRequest")
+                .nth(1)
+                .and_then(|section| section.split("/// Create a new DecisionObject").next())
+                .is_some_and(|section| !section.contains("invariant_set:")),
+            "WASM adjudicated decision transition request must not deserialize caller-supplied invariants"
+        );
         assert!(
             !source.contains(
                 "timestamp_logical: u32,\n    constitution: &[u8],\n    invariant_set_json: &str,"

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -1957,16 +1957,15 @@ test('wasm_transition_decision rejects unadjudicated transition', () =>
     'unadjudicated decision transitions are disabled'
   ));
 
-test('wasm_transition_decision_adjudicated', () => {
+function minimalDecisionTransitionRequest() {
   if (!decision) throw new Error('skipped -- no decision from setup');
   const transitionPermission = 'bcts:transition:Draft->Submitted';
-  const request = {
+  return {
     decision,
     to_state: 'Submitted',
     actor_did: TEST_DID,
     timestamp_ms: NOW_NUM + 1,
     timestamp_logical: 0,
-    invariant_set: { invariants: [] },
     action: {
       actor: TEST_DID,
       action: transitionPermission,
@@ -1988,9 +1987,32 @@ test('wasm_transition_decision_adjudicated', () => {
       active_challenge_reason: null
     }
   };
-  return wasm.wasm_transition_decision_adjudicated(
-    JSON.stringify(request),
-    new TextEncoder().encode('bridge constitution')
+}
+
+test('wasm_transition_decision_adjudicated rejects caller-supplied invariant set', () => {
+  const request = minimalDecisionTransitionRequest();
+  request.invariant_set = { invariants: [] };
+
+  return expectErrorContains(
+    'wasm_transition_decision_adjudicated',
+    () => wasm.wasm_transition_decision_adjudicated(
+      JSON.stringify(request),
+      new TextEncoder().encode('bridge constitution')
+    ),
+    'caller-supplied invariant_set is rejected'
+  );
+});
+
+test('wasm_transition_decision_adjudicated enforces canonical invariants', () => {
+  const request = minimalDecisionTransitionRequest();
+
+  return expectErrorContains(
+    'wasm_transition_decision_adjudicated',
+    () => wasm.wasm_transition_decision_adjudicated(
+      JSON.stringify(request),
+      new TextEncoder().encode('bridge constitution')
+    ),
+    'BCTS transition denied by kernel'
   );
 });
 


### PR DESCRIPTION
## Summary
- Reject caller-supplied `invariant_set` at the WASM decision-transition boundary.
- Construct the decision transition kernel with `InvariantSet::all()` so the bridge cannot run with an empty or fabricated invariant set.
- Add regression coverage proving the stale audit finding was live, then blocked, and update README repository truth counters.

## Finding
- Source: `codex-security-findings-2026-05-16T13-25-31.366Z.csv`, row #10.
- Title: WASM decision transitions can disable all invariants.
- Verified against current `main` before remediation: `wasm_transition_decision_adjudicated` accepted a caller-provided `invariant_set`, and the bridge test exercised the path with `{ invariants: [] }`.

## Path Classification
- `crates/exochain-wasm/src/decision_forum_bindings.rs` — core runtime adapter.
- `crates/exochain-wasm/src/lib.rs` — core runtime adapter source guard.
- `packages/exochain-wasm/test/bridge_verification.mjs` — adapter verification test.
- `README.md` — repository truth metadata.

## Red Tests Added First
- `cargo test -p exochain-wasm wasm_decision_transition_requires_kernel_adjudication -- --nocapture` failed before the fix because the adapter did not enforce `InvariantSet::all()`.
- `node packages/exochain-wasm/test/bridge_verification.mjs` failed before the fix on the new caller-supplied invariant rejection and canonical-invariant enforcement cases.

## Validation
- `cargo test -p exochain-wasm wasm_decision_transition_requires_kernel_adjudication -- --nocapture`
- `cargo test -p exochain-wasm decision_transition -- --nocapture`
- `wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm`
- `node packages/exochain-wasm/test/bridge_verification.mjs` (`160/160 passed`)
- `cargo test -p exochain-wasm`
- `cargo test -p decision-forum`
- `cargo test -p exo-gatekeeper`
- `cargo clippy -p exochain-wasm --all-targets -- -D warnings`
- `cargo clippy -p decision-forum --all-targets -- -D warnings`
- `cargo clippy -p exo-gatekeeper --all-targets -- -D warnings`
- WASM export parity: `158` JS exports and `158` Rust `#[wasm_bindgen]` exports
- `git diff --check`
- `cargo fmt --all -- --check`
- `bash tools/repo_truth.sh --json --skip-tests`
- `cargo test --workspace -- --list | grep -c ': test$'` (`4376`)
- `bash tools/test_repo_truth.sh`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --release`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check`

## Bypass Search
- Searched WASM adapter, decision-forum, bridge tests, and generated WASM package for `invariant_set`, `InvariantSet::all()`, `Kernel::new(`, `wasm_transition_decision_adjudicated`, and transition call paths.
- Confirmed the adjudicated WASM transition now rejects `invariant_set` and uses only the canonical complete invariant set.
