### PR TITLE
fix(gateway): preserve third-party conflict records

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 301 | `find crates -name '*.rs'` |
-| Rust LOC | 192240 | `wc -l` |
+| Rust LOC | 192288 | `wc -l` |
 | Workspace tests | 4,376 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
@@ -114,7 +114,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 192240 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 192288 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,376 listed workspace tests
 

--- a/crates/exo-gateway/src/db.rs
+++ b/crates/exo-gateway/src/db.rs
@@ -424,7 +424,7 @@ pub async fn erase_gateway_identity_records(
 
     let conflict_declarations_deleted = sqlx::query(
         "DELETE FROM conflict_declarations \
-         WHERE declarant_did = $1 OR related_dids @> jsonb_build_array($1::text)",
+         WHERE declarant_did = $1",
     )
     .bind(did)
     .execute(&mut *tx)
@@ -2205,6 +2205,15 @@ mod tests {
             helper.contains("revoked = true") && helper.contains("erased_at_ms"),
             "DID document erasure must tombstone the DID instead of deleting the reuse guard"
         );
+        assert!(
+            helper.contains("DELETE FROM conflict_declarations")
+                && helper.contains("WHERE declarant_did = $1"),
+            "identity erasure may remove only conflict declarations authored by the erased DID"
+        );
+        assert!(
+            !helper.contains("related_dids @> jsonb_build_array($1::text)"),
+            "identity erasure must not delete third-party conflict declarations that merely reference the erased DID"
+        );
     }
 
     #[test]
@@ -2331,7 +2340,9 @@ mod tests {
             return Ok(());
         };
         let did = "did:exo:erasure-db-subject";
+        let third_party_declarant = "did:exo:erasure-db-third-party-declarant";
         cleanup_identity_erasure_fixture(&pool, did).await?;
+        cleanup_identity_erasure_fixture(&pool, third_party_declarant).await?;
 
         let doc = minimal_doc(did);
         insert_did_document(&pool, &doc).await?;
@@ -2516,6 +2527,27 @@ mod tests {
         .bind(serde_json::json!({"declarant_did": did}))
         .execute(&pool)
         .await?;
+        sqlx::query(
+            "INSERT INTO conflict_declarations (id_hash, declarant_did, nature, related_dids, timestamp_physical_ms, timestamp_logical, payload) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7)",
+        )
+        .bind("erasure-db-third-party-conflict")
+        .bind(third_party_declarant)
+        .bind("third-party conflict")
+        .bind(serde_json::json!([did]))
+        .bind(1_001_i64)
+        .bind(0_i32)
+        .bind(serde_json::json!({
+            "declarant_did": third_party_declarant,
+            "nature": "third-party conflict",
+            "related_dids": [did],
+            "timestamp": {
+                "physical_ms": 1_001_i64,
+                "logical": 0_i32
+            }
+        }))
+        .execute(&pool)
+        .await?;
 
         let summary = erase_gateway_identity_records(&pool, did, 9_000).await?;
 
@@ -2570,12 +2602,28 @@ mod tests {
             "SELECT COUNT(*) FROM delegations WHERE delegator = $1 OR delegatee = $1",
             "SELECT COUNT(*) FROM layout_templates WHERE user_did = $1",
             "SELECT COUNT(*) FROM feedback_issues WHERE reporter_did = $1",
-            "SELECT COUNT(*) FROM conflict_declarations WHERE declarant_did = $1 OR related_dids @> jsonb_build_array($1::text)",
+            "SELECT COUNT(*) FROM conflict_declarations WHERE declarant_did = $1",
         ] {
             assert_eq!(count_rows_by_did(&pool, statement, did).await?, 0);
         }
+        let third_party_conflicts_remaining: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM conflict_declarations \
+             WHERE id_hash = $1 \
+               AND declarant_did = $2 \
+               AND related_dids @> jsonb_build_array($3::text)",
+        )
+        .bind("erasure-db-third-party-conflict")
+        .bind(third_party_declarant)
+        .bind(did)
+        .fetch_one(&pool)
+        .await?;
+        assert_eq!(
+            third_party_conflicts_remaining, 1,
+            "identity erasure must preserve third-party conflict declarations that reference the erased DID"
+        );
 
         cleanup_identity_erasure_fixture(&pool, did).await?;
+        cleanup_identity_erasure_fixture(&pool, third_party_declarant).await?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- Restrict gateway identity erasure so it deletes only conflict declarations authored by the erased DID.
- Preserve third-party conflict declarations that reference the erased DID in `related_dids`, preventing identity erasure from mutating another declarant's governance integrity record.
- Add a source guard and DB-backed regression fixture proving the production helper no longer contains the third-party deletion predicate.
- Update README repository truth counters after the Rust LOC change.

## Finding
- Source: `codex-security-findings-2026-05-16T13-25-31.366Z.csv`, row #7.
- Title: Identity erasure deletes third-party conflict records.
- Verified against current `main` before remediation: `erase_gateway_identity_records` deleted from `conflict_declarations` where `declarant_did = $1 OR related_dids @> jsonb_build_array($1::text)`.

## Path Classification
- `crates/exo-gateway/src/db.rs` — core runtime adapter, DB-backed gateway identity/conflict register boundary.
- `README.md` — repository truth metadata only.

## Red Test Added First
- `cargo test -p exo-gateway gateway_identity_erasure_has_durable_tombstone_schema_and_helper -- --nocapture` failed before the fix with: identity erasure must not delete third-party conflict declarations that merely reference the erased DID.

## Remediation
- Changed the production erasure SQL to `DELETE FROM conflict_declarations WHERE declarant_did = $1`.
- Extended the erasure regression to insert both an erased actor-authored conflict declaration and a third-party declaration referencing the erased DID, then verify only the erased actor-authored row is deleted.

## Validation
- Red before fix: `cargo test -p exo-gateway gateway_identity_erasure_has_durable_tombstone_schema_and_helper -- --nocapture`
- `cargo test -p exo-gateway gateway_identity_erasure_has_durable_tombstone_schema_and_helper -- --nocapture`
- `cargo test -p exo-gateway erase_gateway_identity_records_tombstones_did_and_removes_durable_identity_rows -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo test -p exo-gateway --lib -- --nocapture`
- `cargo test -p exo-gateway`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `bash tools/repo_truth.sh --json --skip-tests` (`rust_loc=192288`)
- `bash tools/test_repo_truth.sh`
- `git diff --check`
- Bypass search: `rg -n "DELETE FROM conflict_declarations|related_dids @> jsonb_build_array\(\$1::text\)" crates/exo-gateway/src/db.rs`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --release`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check` (existing duplicate-crate warnings only; advisories/bans/licenses/sources OK)
- `cargo test --workspace -- --list | grep -c ': test$'` (`4376`)
