### PR TITLE
fix(gateway): cap DB DID registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 301 | `find crates -name '*.rs'` |
-| Rust LOC | 192288 | `wc -l` |
-| Workspace tests | 4,376 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 192437 | `wc -l` |
+| Workspace tests | 4,377 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -45,7 +45,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,376 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,377 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -114,9 +114,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 192288 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 192437 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,376 listed workspace tests
+         cryptographic proofs, 4,377 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          158 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-gateway/src/db.rs
+++ b/crates/exo-gateway/src/db.rs
@@ -23,7 +23,7 @@
 use std::time::Duration;
 
 use decision_forum::decision_object::DecisionClass;
-use exo_identity::did::DidDocument;
+use exo_identity::{did::DidDocument, registry::MAX_LOCAL_DID_REGISTRY_DOCUMENTS};
 use serde_json::Value as JsonValue;
 use sqlx::{
     Row,
@@ -32,7 +32,9 @@ use sqlx::{
 use thiserror::Error;
 
 pub const MAX_DB_LIST_ROWS: i64 = 1_000;
+pub const MAX_DB_DID_DOCUMENTS: usize = MAX_LOCAL_DID_REGISTRY_DOCUMENTS;
 const DB_POOL_ACQUIRE_TIMEOUT_SECS: u64 = 5;
+const DID_DOCUMENT_CAPACITY_ADVISORY_LOCK_KEY: i64 = 1_014_400_003;
 const LOCATION_CONSENT_SCOPE: &str = "location";
 
 #[derive(Debug, Error)]
@@ -95,6 +97,13 @@ pub enum DidDocumentPersistenceError {
     DocumentDidMismatch {
         row_did: String,
         document_did: String,
+    },
+    #[error(
+        "DID document registry capacity exceeded: max_documents={max_documents}, attempted_documents={attempted_documents}"
+    )]
+    RegistryCapacityExceeded {
+        max_documents: usize,
+        attempted_documents: usize,
     },
     #[error("DID document persistence query failed")]
     Query {
@@ -202,6 +211,14 @@ pub async fn insert_did_document(
     pool: &PgPool,
     doc: &DidDocument,
 ) -> Result<bool, DidDocumentPersistenceError> {
+    insert_did_document_with_capacity(pool, doc, MAX_DB_DID_DOCUMENTS).await
+}
+
+async fn insert_did_document_with_capacity(
+    pool: &PgPool,
+    doc: &DidDocument,
+    max_documents: usize,
+) -> Result<bool, DidDocumentPersistenceError> {
     let did = doc.id.as_str();
     let document =
         serde_json::to_value(doc).map_err(|source| DidDocumentPersistenceError::Serialize {
@@ -210,6 +227,45 @@ pub async fn insert_did_document(
         })?;
     let created_at_ms = timestamp_ms_to_i64(did, "created", doc.created.physical_ms)?;
     let updated_at_ms = timestamp_ms_to_i64(did, "updated", doc.updated.physical_ms)?;
+
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|source| DidDocumentPersistenceError::Query { source })?;
+    sqlx::query("SELECT pg_advisory_xact_lock($1)")
+        .bind(DID_DOCUMENT_CAPACITY_ADVISORY_LOCK_KEY)
+        .execute(&mut *tx)
+        .await
+        .map_err(|source| DidDocumentPersistenceError::Query { source })?;
+
+    let existing_did: bool =
+        sqlx::query_scalar("SELECT EXISTS (SELECT 1 FROM did_documents WHERE did = $1)")
+            .bind(did)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(|source| DidDocumentPersistenceError::Query { source })?;
+    if existing_did {
+        tx.commit()
+            .await
+            .map_err(|source| DidDocumentPersistenceError::Query { source })?;
+        return Ok(false);
+    }
+
+    let document_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) AS document_count FROM did_documents")
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(|source| DidDocumentPersistenceError::Query { source })?;
+    let existing_documents = match usize::try_from(document_count) {
+        Ok(count) => count,
+        Err(_) => max_documents,
+    };
+    if existing_documents >= max_documents {
+        return Err(DidDocumentPersistenceError::RegistryCapacityExceeded {
+            max_documents,
+            attempted_documents: existing_documents.saturating_add(1),
+        });
+    }
 
     let result = sqlx::query(
         "INSERT INTO did_documents (did, document, created_at_ms, updated_at_ms, revoked) \
@@ -221,9 +277,13 @@ pub async fn insert_did_document(
     .bind(created_at_ms)
     .bind(updated_at_ms)
     .bind(doc.revoked)
-    .execute(pool)
+    .execute(&mut *tx)
     .await
     .map_err(|source| DidDocumentPersistenceError::Query { source })?;
+
+    tx.commit()
+        .await
+        .map_err(|source| DidDocumentPersistenceError::Query { source })?;
 
     Ok(result.rows_affected() > 0)
 }
@@ -2112,9 +2172,27 @@ mod tests {
 
         let source = production_source();
         let insert_source = function_source(source, "insert_did_document");
+        assert!(
+            source.contains("MAX_DB_DID_DOCUMENTS"),
+            "DB-backed DID registration must define a durable registry capacity limit"
+        );
+        assert!(
+            insert_source.contains("insert_did_document_with_capacity"),
+            "public DID persistence must route through the capacity-enforcing insert helper"
+        );
+        assert!(
+            source.contains("pg_advisory_xact_lock"),
+            "DID capacity checks must be serialized to avoid concurrent over-capacity inserts"
+        );
+        assert!(
+            source.contains("SELECT COUNT(*) AS document_count FROM did_documents"),
+            "DB-backed DID registration must check the durable did_documents row count before inserting"
+        );
         assert!(insert_source.contains("INSERT INTO did_documents"));
-        assert!(insert_source.contains("ON CONFLICT (did) DO NOTHING"));
-        assert!(insert_source.contains("rows_affected()"));
+        assert!(
+            source.contains("DidDocumentPersistenceError::RegistryCapacityExceeded"),
+            "durable DID capacity exhaustion must be a typed error, not an unbounded insert"
+        );
 
         let lookup_source = function_source(source, "find_did_document");
         assert!(lookup_source.contains("FROM did_documents"));
@@ -2286,6 +2364,50 @@ mod tests {
                 .fetch_one(&pool)
                 .await?;
         assert_eq!(count, 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn insert_did_document_enforces_durable_capacity_limit()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let Some(pool) = gateway_test_pool().await else {
+            return Ok(());
+        };
+        let first_did = "did:exo:durable-capacity-first";
+        let second_did = "did:exo:durable-capacity-second";
+        cleanup_identity_erasure_fixture(&pool, first_did).await?;
+        cleanup_identity_erasure_fixture(&pool, second_did).await?;
+
+        assert!(
+            insert_did_document_with_capacity(&pool, &minimal_doc(first_did), 1).await?,
+            "first DID document should fit inside the durable capacity budget"
+        );
+        let err = insert_did_document_with_capacity(&pool, &minimal_doc(second_did), 1)
+            .await
+            .expect_err("second distinct DID document must be rejected at the durable cap");
+
+        assert!(
+            matches!(
+                err,
+                DidDocumentPersistenceError::RegistryCapacityExceeded {
+                    max_documents: 1,
+                    attempted_documents: 2
+                }
+            ),
+            "expected typed durable capacity error, got {err}"
+        );
+        let stored_second: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM did_documents WHERE did = $1")
+                .bind(second_did)
+                .fetch_one(&pool)
+                .await?;
+        assert_eq!(
+            stored_second, 0,
+            "over-capacity DID document must not be persisted"
+        );
+
+        cleanup_identity_erasure_fixture(&pool, first_did).await?;
+        cleanup_identity_erasure_fixture(&pool, second_did).await?;
         Ok(())
     }
 

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -802,9 +802,21 @@ async fn register_did_document(
     if let Some(pool) = state.pool.as_ref() {
         exo_identity::registry::verify_did_registration_proof(&doc, &proof)
             .map_err(RegistryBlockingError::Registration)?;
-        let inserted = db::insert_did_document(pool, &doc)
-            .await
-            .map_err(|e| RegistryBlockingError::Persistence(e.to_string()))?;
+        let inserted = match db::insert_did_document(pool, &doc).await {
+            Ok(inserted) => inserted,
+            Err(db::DidDocumentPersistenceError::RegistryCapacityExceeded {
+                max_documents,
+                attempted_documents,
+            }) => {
+                return Err(RegistryBlockingError::Registration(
+                    IdentityError::RegistryCapacityExceeded {
+                        max_documents,
+                        attempted_documents,
+                    },
+                ));
+            }
+            Err(e) => return Err(RegistryBlockingError::Persistence(e.to_string())),
+        };
         if !inserted {
             return Err(RegistryBlockingError::Registration(
                 IdentityError::DuplicateDid(doc.id.clone()),
@@ -6183,6 +6195,21 @@ mod tests {
     #[test]
     fn db_configured_identity_paths_do_not_depend_on_local_did_memory() {
         let source = include_str!("server.rs");
+
+        let register_did_document = source_between(
+            source,
+            "async fn register_did_document",
+            "async fn resolve_did_document",
+        );
+        assert!(
+            register_did_document
+                .contains("db::DidDocumentPersistenceError::RegistryCapacityExceeded"),
+            "DB-backed DID registration must map durable capacity exhaustion into the registry rejection path"
+        );
+        assert!(
+            register_did_document.contains("IdentityError::RegistryCapacityExceeded"),
+            "durable DID capacity exhaustion must reuse the same fail-closed response as LocalDidRegistry capacity"
+        );
 
         let auth_register = source_between(
             source,


### PR DESCRIPTION
## Summary
- Remediates Codex Security CSV row #8: `Unbounded DB DID registration enables storage DoS`.
- Adds a durable DB-backed DID registration cap equal to `MAX_LOCAL_DID_REGISTRY_DOCUMENTS`.
- Serializes DB DID capacity checks with a transaction-level PostgreSQL advisory lock before insert, preventing concurrent distinct registrations from racing past the durable count.
- Maps durable DB capacity exhaustion back into the existing `IdentityError::RegistryCapacityExceeded` path so `/api/v1/auth/register` and `/api/v1/agents/enroll` fail closed with the same 503 response as the local registry.

## Path Classification
- `crates/exo-gateway/src/db.rs` — core runtime adapter; durable DID persistence boundary.
- `crates/exo-gateway/src/server.rs` — core runtime adapter; DID registration HTTP route boundary.
- `README.md` — repository truth metadata.

## Verification Against Current Main
Before remediation, current `main` at `9f8ffb86` had `insert_did_document` inserting into `did_documents` without `MAX_DB_DID_DOCUMENTS`, `pg_advisory_xact_lock`, or a durable `COUNT(*)` capacity guard. The finding still reproduced as missing enforcement.

## Red Test
- Added `insert_did_document_enforces_durable_capacity_limit` first.
- Confirmed red with:
  - `cargo test -p exo-gateway insert_did_document_enforces_durable_capacity_limit -- --nocapture`
- Red failure was expected: missing `insert_did_document_with_capacity` and missing `DidDocumentPersistenceError::RegistryCapacityExceeded`.

## Remediation
- Added `MAX_DB_DID_DOCUMENTS` bound tied to `MAX_LOCAL_DID_REGISTRY_DOCUMENTS`.
- Added `insert_did_document_with_capacity` using a DB transaction, `pg_advisory_xact_lock`, duplicate check, durable `COUNT(*)`, and typed capacity failure before insert.
- Added DB and route source guards for the capacity helper and response mapping.
- Preserved duplicate-DID behavior as a conflict instead of capacity failure.

## Validation
- `cargo test -p exo-gateway insert_did_document_enforces_durable_capacity_limit -- --nocapture`
- `cargo test -p exo-gateway did_documents_have_durable_schema_and_persistence_helpers -- --nocapture`
- `cargo test -p exo-gateway db_configured_identity_paths_do_not_depend_on_local_did_memory -- --nocapture`
- `cargo fmt --all`
- `cargo test -p exo-gateway -- --nocapture`
- `cargo fmt --all -- --check`
- bypass search: `rg -n "insert_did_document|insert_did_document_with_capacity|MAX_DB_DID_DOCUMENTS|pg_advisory_xact_lock|SELECT COUNT\(\*\) AS document_count FROM did_documents|DidDocumentPersistenceError::RegistryCapacityExceeded|IdentityError::RegistryCapacityExceeded" crates/exo-gateway/src/db.rs crates/exo-gateway/src/server.rs`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `bash tools/repo_truth.sh --json --skip-tests`
- `bash tools/test_repo_truth.sh`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --release`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check` (existing duplicate-crate warnings; advisories/bans/licenses/sources all ok)
- `git diff --check`
- `cargo test --workspace -- --list | grep -c ': test$'` => `4377`
