### PR TITLE
fix(gateway): trust configured proxy rate limit identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 301 | `find crates -name '*.rs'` |
-| Rust LOC | 192437 | `wc -l` |
-| Workspace tests | 4,377 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 192674 | `wc -l` |
+| Workspace tests | 4,382 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -45,7 +45,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,377 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,382 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -114,9 +114,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 192437 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 192674 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,377 listed workspace tests
+         cryptographic proofs, 4,382 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          158 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-gateway/src/main.rs
+++ b/crates/exo-gateway/src/main.rs
@@ -20,15 +20,16 @@
 //!
 //! ## Environment variables
 //!
-//! | Variable        | Default           | Description                              |
-//! |-----------------|-------------------|------------------------------------------|
-//! | `BIND_ADDRESS`  | `127.0.0.1:8443`  | TCP address to bind                      |
-//! | `DATABASE_URL`  | *(none)*          | PostgreSQL connection string             |
+//! | Variable                         | Default          | Description                              |
+//! |----------------------------------|------------------|------------------------------------------|
+//! | `BIND_ADDRESS`                   | `127.0.0.1:8443` | TCP address to bind                      |
+//! | `DATABASE_URL`                   | *(none)*         | PostgreSQL connection string             |
+//! | `TRUSTED_RATE_LIMIT_PROXY_IPS`   | *(empty)*        | Comma-separated trusted proxy IPs        |
 //!
 //! If `DATABASE_URL` is unset the server starts without a database pool.
 //! The `/ready` probe will return 503 until a pool is configured.
 
-use exo_gateway::server::{GatewayConfig, serve};
+use exo_gateway::server::{GatewayConfig, parse_trusted_rate_limit_proxy_ips, serve};
 use tracing_subscriber::EnvFilter;
 
 fn init_tracing() {
@@ -50,9 +51,20 @@ async fn main() {
 
     // Build config from environment, falling back to defaults.
     let bind_address = std::env::var("BIND_ADDRESS").unwrap_or_else(|_| "127.0.0.1:8443".into());
+    let trusted_rate_limit_proxy_ips = match std::env::var("TRUSTED_RATE_LIMIT_PROXY_IPS") {
+        Ok(raw) => match parse_trusted_rate_limit_proxy_ips(&raw) {
+            Ok(ips) => ips,
+            Err(error) => {
+                tracing::error!("Invalid TRUSTED_RATE_LIMIT_PROXY_IPS: {error}");
+                std::process::exit(1);
+            }
+        },
+        Err(_) => Default::default(),
+    };
 
     let config = GatewayConfig {
         bind_address,
+        trusted_rate_limit_proxy_ips,
         ..GatewayConfig::default()
     };
 
@@ -127,6 +139,27 @@ mod tests {
         assert!(
             init_tracing.contains(".json()"),
             "gateway runtime logging must emit structured JSON"
+        );
+    }
+
+    #[test]
+    fn gateway_main_parses_trusted_rate_limit_proxy_configuration() {
+        let production = match SOURCE.split("#[cfg(test)]").next() {
+            Some(source) => source,
+            None => panic!("production source precedes tests"),
+        };
+
+        assert!(
+            production.contains("TRUSTED_RATE_LIMIT_PROXY_IPS"),
+            "gateway runtime must expose explicit trusted proxy rate-limit configuration"
+        );
+        assert!(
+            production.contains("parse_trusted_rate_limit_proxy_ips(&raw)"),
+            "gateway runtime must parse trusted proxy IPs through the fail-closed server parser"
+        );
+        assert!(
+            production.contains("std::process::exit(1)"),
+            "invalid trusted proxy configuration must fail closed at startup"
         );
     }
 }

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -18,7 +18,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt,
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
     sync::{Arc, Mutex, RwLock},
 };
 
@@ -220,6 +220,7 @@ pub struct GatewayConfig {
     pub bind_address: String,
     pub tls_config: Option<TlsConfig>,
     pub max_connections: u32,
+    pub trusted_rate_limit_proxy_ips: BTreeSet<IpAddr>,
 }
 
 impl Default for GatewayConfig {
@@ -228,8 +229,26 @@ impl Default for GatewayConfig {
             bind_address: "127.0.0.1:8443".into(),
             tls_config: None,
             max_connections: 1024,
+            trusted_rate_limit_proxy_ips: BTreeSet::new(),
         }
     }
+}
+
+pub fn parse_trusted_rate_limit_proxy_ips(raw: &str) -> Result<BTreeSet<IpAddr>> {
+    let mut trusted_proxies = BTreeSet::new();
+    for value in raw.split(',') {
+        let candidate = value.trim();
+        if candidate.is_empty() {
+            continue;
+        }
+        let proxy_ip = candidate.parse::<IpAddr>().map_err(|error| {
+            GatewayError::BadRequest(format!(
+                "trusted_rate_limit_proxy_ips contains invalid IP '{candidate}': {error}"
+            ))
+        })?;
+        trusted_proxies.insert(proxy_ip);
+    }
+    Ok(trusted_proxies)
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +334,9 @@ pub struct AppState {
     session_time_source: SessionTimeSource,
     /// Default-on per-client request-rate admission state.
     rate_limiter: Arc<Mutex<GatewayRateLimiter>>,
+    /// Explicitly trusted immediate peer IPs whose forwarded client identity may
+    /// be used for gateway rate limiting.
+    trusted_rate_limit_proxy_ips: BTreeSet<IpAddr>,
 }
 
 /// Non-secret authenticated session profile used to carry tenant scope across
@@ -413,6 +435,21 @@ impl AppState {
             registry,
             HybridClock::new(),
             SessionTimeSource::DatabaseWhenAvailable,
+            BTreeSet::new(),
+        )
+    }
+
+    pub fn new_with_trusted_rate_limit_proxy_ips(
+        pool: Option<sqlx::PgPool>,
+        registry: Arc<RwLock<LocalDidRegistry>>,
+        trusted_rate_limit_proxy_ips: BTreeSet<IpAddr>,
+    ) -> Self {
+        Self::new_with_clock_and_session_time_source(
+            pool,
+            registry,
+            HybridClock::new(),
+            SessionTimeSource::DatabaseWhenAvailable,
+            trusted_rate_limit_proxy_ips,
         )
     }
 
@@ -427,6 +464,7 @@ impl AppState {
             registry,
             clock,
             SessionTimeSource::InjectedClock,
+            BTreeSet::new(),
         )
     }
 
@@ -435,6 +473,7 @@ impl AppState {
         registry: Arc<RwLock<LocalDidRegistry>>,
         mut clock: HybridClock,
         session_time_source: SessionTimeSource,
+        trusted_rate_limit_proxy_ips: BTreeSet<IpAddr>,
     ) -> Self {
         // Bootstrap kernel with the all-invariants set.
         // constitution bytes are hashed for immutability verification.
@@ -454,6 +493,7 @@ impl AppState {
             clock: Arc::new(Mutex::new(clock)),
             session_time_source,
             rate_limiter: Arc::new(Mutex::new(GatewayRateLimiter::default())),
+            trusted_rate_limit_proxy_ips,
         }
     }
 
@@ -4133,12 +4173,47 @@ fn build_unlayered_router(state: AppState) -> Router {
         .merge(gql_router)
 }
 
-fn gateway_rate_limit_key(request: &Request<Body>) -> String {
+fn gateway_socket_rate_limit_ip(request: &Request<Body>) -> Option<IpAddr> {
     request
         .extensions()
         .get::<ConnectInfo<SocketAddr>>()
-        .map(|ConnectInfo(address)| address.ip().to_string())
-        .unwrap_or_else(|| "unknown-client".to_owned())
+        .map(|ConnectInfo(address)| address.ip())
+}
+
+fn forwarded_rate_limit_client_ip(
+    request: &Request<Body>,
+    trusted_rate_limit_proxy_ips: &BTreeSet<IpAddr>,
+) -> Option<IpAddr> {
+    let header_value = request.headers().get("x-forwarded-for")?.to_str().ok()?;
+    let parsed_ips: Vec<IpAddr> = header_value
+        .split(',')
+        .filter_map(|candidate| candidate.trim().parse::<IpAddr>().ok())
+        .collect();
+
+    parsed_ips
+        .iter()
+        .rev()
+        .copied()
+        .find(|ip| !trusted_rate_limit_proxy_ips.contains(ip))
+}
+
+fn gateway_rate_limit_key(
+    request: &Request<Body>,
+    trusted_rate_limit_proxy_ips: &BTreeSet<IpAddr>,
+) -> String {
+    let Some(socket_ip) = gateway_socket_rate_limit_ip(request) else {
+        return "unknown-client".to_owned();
+    };
+
+    if trusted_rate_limit_proxy_ips.contains(&socket_ip) {
+        if let Some(client_ip) =
+            forwarded_rate_limit_client_ip(request, trusted_rate_limit_proxy_ips)
+        {
+            return client_ip.to_string();
+        }
+    }
+
+    socket_ip.to_string()
 }
 
 fn gateway_rate_limit_response(retry_after_ms: u64) -> Response {
@@ -4156,7 +4231,7 @@ async fn enforce_gateway_rate_limit(
     request: Request<Body>,
     next: Next,
 ) -> Response {
-    let client_key = gateway_rate_limit_key(&request);
+    let client_key = gateway_rate_limit_key(&request, &state.trusted_rate_limit_proxy_ips);
     let now_ms = match state.try_now_ms() {
         Ok(now_ms) => now_ms,
         Err(message) => {
@@ -4265,7 +4340,11 @@ pub async fn serve_with_extra_routes(
 ) -> Result<()> {
     validate_tls_config(config.tls_config.as_ref())?;
     let registry = Arc::new(RwLock::new(LocalDidRegistry::new()));
-    let state = AppState::new(pool, registry);
+    let state = AppState::new_with_trusted_rate_limit_proxy_ips(
+        pool,
+        registry,
+        config.trusted_rate_limit_proxy_ips.clone(),
+    );
     let app = build_router_with_extra_routes(state, extra);
 
     if let Some(tls_config) = config.tls_config.as_ref() {
@@ -4324,7 +4403,7 @@ pub async fn serve_with_extra_routes(
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use std::{
-        net::SocketAddr,
+        net::{IpAddr, SocketAddr},
         sync::atomic::{AtomicU64, Ordering},
         time::Duration,
     };
@@ -4370,6 +4449,17 @@ mod tests {
             window_ms,
             8,
         )));
+        state
+    }
+
+    fn rate_limited_state_with_trusted_proxies(
+        max_requests_per_window: u32,
+        window_ms: u64,
+        wall: Arc<AtomicU64>,
+        trusted_proxies: &[IpAddr],
+    ) -> AppState {
+        let mut state = rate_limited_state(max_requests_per_window, window_ms, wall);
+        state.trusted_rate_limit_proxy_ips = trusted_proxies.iter().copied().collect();
         state
     }
 
@@ -4714,6 +4804,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gateway_rate_limit_trusted_proxy_uses_verified_forwarded_client_ip() {
+        let wall = Arc::new(AtomicU64::new(25_000));
+        let trusted_proxy = "10.0.0.10".parse::<IpAddr>().unwrap();
+        let state = rate_limited_state_with_trusted_proxies(1, 60_000, wall, &[trusted_proxy]);
+        let app = apply_gateway_layers(
+            Router::new().route("/probe", get(probe)),
+            state,
+            GLOBAL_CONCURRENCY_LIMIT,
+        );
+
+        let first_client = app
+            .clone()
+            .oneshot(request_from(
+                "/probe",
+                "10.0.0.10:1000".parse().unwrap(),
+                "198.51.100.200, 203.0.113.77",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(first_client.status(), StatusCode::OK);
+
+        let second_client_same_proxy = app
+            .clone()
+            .oneshot(request_from(
+                "/probe",
+                "10.0.0.10:2000".parse().unwrap(),
+                "198.51.100.200, 203.0.113.88",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(second_client_same_proxy.status(), StatusCode::OK);
+
+        let first_client_again = app
+            .oneshot(request_from(
+                "/probe",
+                "10.0.0.10:3000".parse().unwrap(),
+                "198.51.100.200, 203.0.113.77",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(first_client_again.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[tokio::test]
     async fn gateway_rate_limit_uses_socket_ip_not_spoofable_forwarded_headers() {
         let wall = Arc::new(AtomicU64::new(25_000));
         let state = rate_limited_state(1, 60_000, wall);
@@ -4757,6 +4891,39 @@ mod tests {
             different_socket_ip_same_forwarded_header.status(),
             StatusCode::OK
         );
+    }
+
+    #[tokio::test]
+    async fn gateway_rate_limit_trusted_proxy_malformed_forwarding_falls_back_to_socket_ip() {
+        let wall = Arc::new(AtomicU64::new(25_000));
+        let trusted_proxy = "10.0.0.10".parse::<IpAddr>().unwrap();
+        let state = rate_limited_state_with_trusted_proxies(1, 60_000, wall, &[trusted_proxy]);
+        let app = apply_gateway_layers(
+            Router::new().route("/probe", get(probe)),
+            state,
+            GLOBAL_CONCURRENCY_LIMIT,
+        );
+
+        let first = app
+            .clone()
+            .oneshot(request_from(
+                "/probe",
+                "10.0.0.10:1000".parse().unwrap(),
+                "not-an-ip",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+
+        let second = app
+            .oneshot(request_from(
+                "/probe",
+                "10.0.0.10:2000".parse().unwrap(),
+                "also-not-an-ip",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
     }
 
     #[tokio::test]
@@ -4815,8 +4982,24 @@ mod tests {
         );
         assert!(
             production.contains("ConnectInfo<SocketAddr>")
-                && !production.contains("x-forwarded-for"),
-            "gateway rate limiting must key clients from socket identity, not spoofable forwarding headers"
+                && production.contains("trusted_rate_limit_proxy_ips")
+                && production.contains("x-forwarded-for"),
+            "gateway rate limiting must keep socket identity as the default and gate forwarded client identity behind trusted proxy configuration"
+        );
+        let key_derivation = source_between(
+            production,
+            "fn gateway_rate_limit_key",
+            "fn gateway_rate_limit_response",
+        );
+        let trusted_proxy_check = key_derivation
+            .find("trusted_rate_limit_proxy_ips.contains(&socket_ip)")
+            .expect("forwarded headers must be gated by trusted proxy membership");
+        let forwarded_header_read = key_derivation
+            .find("forwarded_rate_limit_client_ip")
+            .expect("trusted proxy handling must delegate forwarded client parsing");
+        assert!(
+            trusted_proxy_check < forwarded_header_read,
+            "gateway must prove the peer is trusted before reading forwarded client identity"
         );
     }
 
@@ -5267,6 +5450,27 @@ mod tests {
         let j = serde_json::to_string(&c).unwrap();
         let r: GatewayConfig = serde_json::from_str(&j).unwrap();
         assert_eq!(r.bind_address, c.bind_address);
+        assert!(r.trusted_rate_limit_proxy_ips.is_empty());
+    }
+
+    #[test]
+    fn parse_trusted_rate_limit_proxy_ips_accepts_unique_comma_separated_ips() {
+        let parsed = parse_trusted_rate_limit_proxy_ips("10.0.0.10, 192.0.2.10,10.0.0.10").unwrap();
+
+        assert_eq!(parsed.len(), 2);
+        assert!(parsed.contains(&"10.0.0.10".parse::<IpAddr>().unwrap()));
+        assert!(parsed.contains(&"192.0.2.10".parse::<IpAddr>().unwrap()));
+    }
+
+    #[test]
+    fn parse_trusted_rate_limit_proxy_ips_rejects_malformed_ips() {
+        let err = parse_trusted_rate_limit_proxy_ips("10.0.0.10,not-an-ip")
+            .expect_err("malformed trusted proxy configuration must fail closed");
+
+        assert!(
+            err.to_string().contains("not-an-ip"),
+            "error should identify the malformed trusted proxy entry: {err}"
+        );
     }
     #[test]
     fn tls_config_serde() {


### PR DESCRIPTION
## Summary
- Adds explicit `TRUSTED_RATE_LIMIT_PROXY_IPS` configuration for gateway rate limiting.
- Keeps socket IP as the default key for all untrusted peers.
- Uses forwarded client IPs only after the immediate peer IP is in the trusted proxy set; malformed forwarding falls back to socket IP.
- Updates repo truth metrics after adding gateway regression coverage.

## Path Classification
- `crates/exo-gateway/src/server.rs` — Core runtime adapter: HTTP admission/rate-limit boundary.
- `crates/exo-gateway/src/main.rs` — Core runtime adapter: deployment configuration boundary.
- `README.md` — Documentation/repo truth metadata tied to test and LOC deltas.

## Validation
- Red first: `cargo test -p exo-gateway gateway_rate_limit_trusted_proxy_uses_verified_forwarded_client_ip -- --nocapture` failed before implementation because `trusted_rate_limit_proxy_ips` did not exist.
- `cargo test -p exo-gateway gateway_rate_limit -- --nocapture`
- `cargo test -p exo-gateway parse_trusted_rate_limit_proxy_ips -- --nocapture`
- `cargo test -p exo-gateway gateway_main_parses_trusted_rate_limit_proxy_configuration -- --nocapture`
- `cargo test -p exo-gateway config_serde -- --nocapture`
- `cargo test -p exo-gateway -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `bash tools/repo_truth.sh --json --skip-tests`
- `bash tools/test_repo_truth.sh`
- `cargo test --workspace -- --list | grep -c ': test$'` => 4382\n- `cargo test --workspace`\n- `cargo clippy --workspace --all-targets -- -D warnings`\n- `cargo build --workspace --release`\n- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`\n- `cargo audit`\n- `cargo deny check`\n- `git diff --check`\n\n## Bypass Search\n- Searched `gateway_rate_limit_key`, `forwarded_rate_limit_client_ip`, `trusted_rate_limit_proxy_ips`, `TRUSTED_RATE_LIMIT_PROXY_IPS`, `x-forwarded-for`, and `ConnectInfo<SocketAddr>` across gateway runtime files.\n- Extra routes remain wrapped by the same gateway rate-limit layer.\n