### PR TITLE
fix(gateway): scope conflict recusal lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 301 | `find crates -name '*.rs'` |
-| Rust LOC | 192674 | `wc -l` |
-| Workspace tests | 4,382 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 192908 | `wc -l` |
+| Workspace tests | 4,385 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -45,7 +45,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,382 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,385 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -114,9 +114,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 192674 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 192908 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,382 listed workspace tests
+         cryptographic proofs, 4,385 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          158 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-gateway/src/db.rs
+++ b/crates/exo-gateway/src/db.rs
@@ -36,6 +36,8 @@ pub const MAX_DB_DID_DOCUMENTS: usize = MAX_LOCAL_DID_REGISTRY_DOCUMENTS;
 const DB_POOL_ACQUIRE_TIMEOUT_SECS: u64 = 5;
 const DID_DOCUMENT_CAPACITY_ADVISORY_LOCK_KEY: i64 = 1_014_400_003;
 const LOCATION_CONSENT_SCOPE: &str = "location";
+const BLOCKING_CONFLICT_NATURE_PATTERNS: [&str; 4] =
+    ["%financial%", "%ownership%", "%personal%", "%family%"];
 
 #[derive(Debug, Error)]
 pub enum DbInitError {
@@ -947,6 +949,11 @@ pub async fn update_decision(
 }
 
 /// Load conflict declaration payloads for a declarant, oldest first.
+///
+/// This is a bounded list helper for administrative display and export
+/// surfaces. Vote recusal enforcement must use
+/// `list_blocking_conflict_declaration_payloads_for_recusal_db` so a generic
+/// UI row cap cannot hide a later blocking declaration.
 pub async fn list_conflict_declaration_payloads_db(
     pool: &PgPool,
     declarant_did: &str,
@@ -965,6 +972,40 @@ pub async fn list_conflict_declaration_payloads_db(
     rows.into_iter()
         .map(|row| row.try_get::<JsonValue, _>("payload"))
         .collect()
+}
+
+/// Load at most one blocking conflict declaration for vote recusal enforcement.
+pub async fn list_blocking_conflict_declaration_payloads_for_recusal_db(
+    pool: &PgPool,
+    declarant_did: &str,
+    affected_dids: &[String],
+) -> Result<Vec<JsonValue>, sqlx::Error> {
+    if affected_dids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let blocking_patterns = BLOCKING_CONFLICT_NATURE_PATTERNS
+        .into_iter()
+        .map(ToOwned::to_owned)
+        .collect::<Vec<String>>();
+    let row = sqlx::query(
+        "SELECT payload FROM conflict_declarations
+         WHERE declarant_did = $1
+           AND related_dids ?| $2
+           AND nature LIKE ANY($3)
+         ORDER BY timestamp_physical_ms, timestamp_logical, id_hash
+         LIMIT 1",
+    )
+    .bind(declarant_did)
+    .bind(affected_dids)
+    .bind(blocking_patterns)
+    .fetch_optional(pool)
+    .await?;
+
+    match row {
+        Some(row) => Ok(vec![row.try_get::<JsonValue, _>("payload")?]),
+        None => Ok(Vec::new()),
+    }
 }
 
 /// Row representation of a governance decision from the `decisions` table.
@@ -1749,6 +1790,7 @@ pub async fn update_feedback_issue_status(
 #[cfg(test)]
 mod tests {
     use exo_core::{Did, Timestamp};
+    use exo_governance::conflict::{ActionRequest, check_and_block, check_conflicts};
     use sha2::{Digest, Sha384};
 
     use super::*;
@@ -2117,6 +2159,129 @@ mod tests {
                 "{name} must bind the centralized row limit for every fetch_all query"
             );
         }
+    }
+
+    #[test]
+    fn conflict_recusal_enforcement_uses_scoped_blocking_lookup_not_ui_list_cap() {
+        let source = production_source();
+        let recusal_lookup = function_source(
+            source,
+            "list_blocking_conflict_declaration_payloads_for_recusal_db",
+        );
+
+        assert!(
+            recusal_lookup.contains("related_dids ?|"),
+            "recusal enforcement must scope the DB lookup to affected DIDs"
+        );
+        assert!(
+            recusal_lookup.contains("nature LIKE ANY"),
+            "recusal enforcement must query only blocking conflict natures"
+        );
+        assert!(
+            recusal_lookup.contains("LIMIT 1"),
+            "recusal enforcement only needs one matching blocking declaration to fail closed"
+        );
+        assert!(
+            !recusal_lookup.contains("MAX_DB_LIST_ROWS"),
+            "vote recusal enforcement must not reuse the UI/list cap"
+        );
+    }
+
+    #[tokio::test]
+    async fn conflict_recusal_lookup_finds_blocking_declaration_beyond_ui_list_cap() {
+        let Some(pool) = gateway_test_pool().await else {
+            return;
+        };
+        let actor = Did::new("did:exo:recusal-cap-voter").expect("valid DID");
+        let unrelated = Did::new("did:exo:recusal-cap-unrelated").expect("valid DID");
+        let affected = Did::new("did:exo:recusal-cap-affected").expect("valid DID");
+        sqlx::query("DELETE FROM conflict_declarations WHERE declarant_did = $1")
+            .bind(actor.as_str())
+            .execute(&pool)
+            .await
+            .expect("clean recusal cap fixture before test");
+
+        for idx in 0..MAX_DB_LIST_ROWS {
+            let timestamp = 10_000_i64 + idx;
+            sqlx::query(
+                "INSERT INTO conflict_declarations (id_hash, declarant_did, nature, related_dids, timestamp_physical_ms, timestamp_logical, payload) \
+                 VALUES ($1, $2, $3, $4, $5, $6, $7)",
+            )
+            .bind(format!("recusal-cap-unrelated-{idx}"))
+            .bind(actor.as_str())
+            .bind("advisory")
+            .bind(serde_json::json!([unrelated.as_str()]))
+            .bind(timestamp)
+            .bind(0_i32)
+            .bind(serde_json::json!({
+                "declarant_did": actor.as_str(),
+                "nature": "advisory",
+                "related_dids": [unrelated.as_str()],
+                "timestamp": {
+                    "physical_ms": timestamp,
+                    "logical": 0
+                }
+            }))
+            .execute(&pool)
+            .await
+            .expect("insert unrelated advisory conflict declaration");
+        }
+
+        let blocking_timestamp = 20_000_i64 + MAX_DB_LIST_ROWS;
+        sqlx::query(
+            "INSERT INTO conflict_declarations (id_hash, declarant_did, nature, related_dids, timestamp_physical_ms, timestamp_logical, payload) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7)",
+        )
+        .bind("recusal-cap-blocking")
+        .bind(actor.as_str())
+        .bind("financial ownership")
+        .bind(serde_json::json!([affected.as_str()]))
+        .bind(blocking_timestamp)
+        .bind(0_i32)
+        .bind(serde_json::json!({
+            "declarant_did": actor.as_str(),
+            "nature": "financial ownership",
+            "related_dids": [affected.as_str()],
+            "timestamp": {
+                "physical_ms": blocking_timestamp,
+                "logical": 0
+            }
+        }))
+        .execute(&pool)
+        .await
+        .expect("insert blocking conflict declaration after capped rows");
+
+        let affected_did_strings = vec![affected.as_str().to_owned()];
+        let payloads = list_blocking_conflict_declaration_payloads_for_recusal_db(
+            &pool,
+            actor.as_str(),
+            &affected_did_strings,
+        )
+        .await
+        .expect("load conflict declarations");
+        let declarations = payloads
+            .into_iter()
+            .map(serde_json::from_value)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("decode conflict declarations");
+        let action = ActionRequest {
+            action_id: "recusal-cap-decision".to_owned(),
+            actor_did: actor.clone(),
+            affected_dids: vec![affected],
+            description: "vote on affected decision".to_owned(),
+        };
+        let conflicts = check_conflicts(&actor, &action, &declarations);
+
+        assert!(
+            check_and_block(&actor, &conflicts).is_err(),
+            "recusal enforcement must see blocking conflicts newer than the generic UI list cap"
+        );
+
+        sqlx::query("DELETE FROM conflict_declarations WHERE declarant_did = $1")
+            .bind(actor.as_str())
+            .execute(&pool)
+            .await
+            .expect("clean recusal cap fixture after test");
     }
 
     #[test]

--- a/crates/exo-gateway/src/handlers.rs
+++ b/crates/exo-gateway/src/handlers.rs
@@ -622,7 +622,10 @@ pub async fn vote_handler(
 
     // ── VIOLATION 1 FIX: ConflictAdjudication ───────────────────────────
     // Check if voter has a declared conflict of interest on this decision.
-    let declarations = match state.load_conflict_declarations(&voter_did).await {
+    let declarations = match state
+        .load_blocking_conflict_declarations_for_vote(&voter_did, &affected_dids)
+        .await
+    {
         Ok(declarations) => declarations,
         Err(e) => {
             tracing::error!(error = %e, "failed to load conflict declarations");
@@ -1602,6 +1605,12 @@ mod tests {
             "vote handler must fail closed when the conflict register cannot be loaded"
         );
         assert!(
+            production.contains(
+                ".load_blocking_conflict_declarations_for_vote(&voter_did, &affected_dids)"
+            ),
+            "vote handler must use a scoped blocking-conflict lookup for recusal enforcement"
+        );
+        assert!(
             !production.contains("affected_dids: vec![]"),
             "vote handler must not adjudicate conflicts against an empty affected-DID set"
         );
@@ -1665,7 +1674,7 @@ mod tests {
             .find("require_authenticated_session_user_from_header")
             .expect("vote handler must authenticate a bearer session");
         let conflict_index = vote_handler
-            .find("load_conflict_declarations(&voter_did)")
+            .find("load_blocking_conflict_declarations_for_vote(&voter_did, &affected_dids)")
             .expect("vote handler must retain conflict lookup");
         let kernel_index = vote_handler
             .find("state.kernel.adjudicate")

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -618,6 +618,9 @@ impl AppState {
 
     /// Load conflict declarations for an actor from the DB-backed standing
     /// conflict register.
+    ///
+    /// This method is capped for list/display surfaces. Vote recusal
+    /// enforcement must use `load_blocking_conflict_declarations_for_vote`.
     pub async fn load_conflict_declarations(
         &self,
         actor: &Did,
@@ -628,6 +631,40 @@ impl AppState {
             .map_err(|e| {
                 GatewayError::Internal(format!("failed to load conflict declarations: {e}"))
             })?;
+
+        payloads
+            .into_iter()
+            .map(|payload| decode_conflict_declaration_payload(actor, payload))
+            .collect()
+    }
+
+    /// Load blocking conflict declarations for vote recusal enforcement, scoped
+    /// to the trusted affected DIDs from the stored decision state.
+    pub async fn load_blocking_conflict_declarations_for_vote(
+        &self,
+        actor: &Did,
+        affected_dids: &[Did],
+    ) -> std::result::Result<Vec<ConflictDeclaration>, GatewayError> {
+        if affected_dids.is_empty() {
+            return Err(GatewayError::Internal(
+                "conflict recusal lookup requires at least one affected DID".into(),
+            ));
+        }
+
+        let pool = self.require_db()?;
+        let affected_did_strings = affected_dids
+            .iter()
+            .map(|did| did.as_str().to_owned())
+            .collect::<Vec<String>>();
+        let payloads = db::list_blocking_conflict_declaration_payloads_for_recusal_db(
+            pool,
+            actor.as_str(),
+            &affected_did_strings,
+        )
+        .await
+        .map_err(|e| {
+            GatewayError::Internal(format!("failed to load conflict declarations: {e}"))
+        })?;
 
         payloads
             .into_iter()
@@ -4608,6 +4645,7 @@ mod tests {
     async fn conflict_declaration_loader_fails_closed_without_db_pool() {
         let state = state();
         let actor = Did::new("did:exo:alice").expect("valid DID");
+        let affected = Did::new("did:exo:tenant-a").expect("valid DID");
         let err = state
             .load_conflict_declarations(&actor)
             .await
@@ -4615,6 +4653,28 @@ mod tests {
         assert!(
             err.to_string().contains("database"),
             "error should identify missing DB-backed conflict register, got: {err}"
+        );
+        let err = state
+            .load_blocking_conflict_declarations_for_vote(&actor, &[affected])
+            .await
+            .expect_err("missing recusal register must fail closed");
+        assert!(
+            err.to_string().contains("database"),
+            "error should identify missing DB-backed recusal register, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn conflict_declaration_loader_rejects_empty_recusal_context() {
+        let state = state();
+        let actor = Did::new("did:exo:alice").expect("valid DID");
+        let err = state
+            .load_blocking_conflict_declarations_for_vote(&actor, &[])
+            .await
+            .expect_err("empty affected DID context must fail closed");
+        assert!(
+            err.to_string().contains("affected DID"),
+            "error should identify missing trusted affected DID context, got: {err}"
         );
     }
 


### PR DESCRIPTION
## Summary
- classify `crates/exo-gateway/src/db.rs`, `server.rs`, and `handlers.rs` as core runtime adapter changes for vote-recusal enforcement
- keep the generic conflict declaration list capped for display/export, but stop using that capped list for vote authorization
- add a scoped DB recusal lookup that selects at most one blocking declaration for the trusted affected DIDs, then preserves `check_conflicts` + `check_and_block` enforcement
- update README repository-truth counters to 192908 Rust LOC and 4,385 listed workspace tests

## Finding Verification
- Confirmed current `main` still used `AppState::load_conflict_declarations(&voter_did)` in `vote_handler`
- Confirmed that method delegated to `list_conflict_declaration_payloads_db`, which binds `MAX_DB_LIST_ROWS` before recusal checks
- Wrote the regression guard first and observed it fail because `list_blocking_conflict_declaration_payloads_for_recusal_db` did not exist

## Tests
- `cargo test -p exo-gateway conflict_recusal_enforcement_uses_scoped_blocking_lookup_not_ui_list_cap -- --nocapture` failed before the fix, then passed
- `cargo test -p exo-gateway conflict_recusal -- --nocapture`
- `cargo test -p exo-gateway conflict_declaration_loader -- --nocapture`
- `cargo test -p exo-gateway vote_handler_source_does_not_default_conflict_adjudication -- --nocapture`
- `cargo test -p exo-gateway vote_handler_authenticates_session_actor_before_conflict_and_kernel_checks -- --nocapture`
- `cargo test -p exo-gateway -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `bash tools/repo_truth.sh --json --skip-tests`
- `bash tools/test_repo_truth.sh`
- `cargo test --workspace -- --list | grep -c ': test$'` => 4385
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --release`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check`
- `git diff --check`

## Notes
- Local `DATABASE_URL` is absent, so the DB-backed overflow regression compiled and exercised the no-DB skip path locally; CI DB integration should run with the configured database environment.
- Untracked `docs/heartfield/HEARTFIELD_AI_WHITEPAPER.md` is unrelated and intentionally not included.
