### PR TITLE
fix(node): rotate p2p rate limit window

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 301 | `find crates -name '*.rs'` |
-| Rust LOC | 192908 | `wc -l` |
-| Workspace tests | 4,385 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 192960 | `wc -l` |
+| Workspace tests | 4,386 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -45,7 +45,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,385 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,386 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -114,9 +114,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 192908 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 192960 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,385 listed workspace tests
+         cryptographic proofs, 4,386 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          158 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-node/src/network.rs
+++ b/crates/exo-node/src/network.rs
@@ -54,6 +54,7 @@ const IDENTIFY_AGENT_VERSION: &str = "exochain/1.0";
 pub(crate) const NETWORK_PUBLISH_MAX_ATTEMPTS: usize = 3;
 const NETWORK_PUBLISH_RETRY_BACKOFF_MS: u64 = 50;
 const NETWORK_PUBLISH_ACK_TIMEOUT_MS: u64 = 5_000;
+const P2P_RATE_LIMIT_WINDOW_SECS: u64 = 60;
 
 #[derive(serde::Serialize)]
 struct GossipsubMessageIdPayload<'a> {
@@ -286,9 +287,18 @@ pub async fn run_network_loop(
 ) {
     let mut peer_registry = PeerRegistry::new();
     let mut rate_limiter = RateLimiter::new();
+    let mut rate_limit_window =
+        tokio::time::interval(Duration::from_secs(P2P_RATE_LIMIT_WINDOW_SECS));
+    rate_limit_window.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    rate_limit_window.tick().await;
 
     loop {
         tokio::select! {
+            _ = rate_limit_window.tick() => {
+                rate_limiter.reset();
+                tracing::debug!("P2P rate-limit window reset");
+            }
+
             // Process swarm events
             event = swarm.select_next_some() => {
                 match event {
@@ -659,6 +669,48 @@ mod tests {
         assert!(
             production.contains(".max_transmit_size(wire::MAX_WIRE_MESSAGE_BYTES)"),
             "gossipsub must reject oversized wire frames before normal message handling"
+        );
+    }
+
+    #[test]
+    fn production_network_loop_resets_rate_limiter_window() {
+        let source = include_str!("network.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production source section exists");
+        let loop_source = production
+            .split("pub async fn run_network_loop")
+            .nth(1)
+            .expect("network loop source exists")
+            .split("impl NetworkHandle")
+            .next()
+            .expect("network handle source follows loop");
+
+        assert!(
+            production.contains("P2P_RATE_LIMIT_WINDOW_SECS"),
+            "network rate limiter must declare a bounded reset window"
+        );
+        assert!(
+            loop_source.contains("let mut rate_limit_window"),
+            "network loop must keep a rate-limit window timer"
+        );
+        assert!(
+            loop_source.contains("rate_limit_window.tick().await"),
+            "network loop must consume the immediate interval tick before handling traffic"
+        );
+        assert!(
+            loop_source.contains("_ = rate_limit_window.tick()"),
+            "network loop must poll the rate-limit reset window"
+        );
+        assert!(
+            loop_source.contains("rate_limiter.reset()"),
+            "network loop must reset rate-limit state when the window rotates"
+        );
+        assert!(
+            loop_source.find("let mut rate_limiter = RateLimiter::new()")
+                < loop_source.find("rate_limiter.reset()"),
+            "rate limiter must be initialized before its periodic reset"
         );
     }
 


### PR DESCRIPTION
## Summary
- verified the reported P2P slot-exhaustion issue still existed on current `main`: `run_network_loop` constructed one `RateLimiter` before the infinite swarm loop and never reset it.
- added a bounded 60-second P2P rate-limit window in the production network loop, preserving the existing per-peer limiter while clearing tracked peer slots at each window boundary.
- added a regression source guard proving the production loop declares, polls, and applies the reset window; refreshed README repository-truth counts.

## Classification
- `crates/exo-node/src/network.rs` — EXOCHAIN core runtime adapter / P2P ingress boundary.
- `README.md` — repository-truth metadata only.

## Red Proof
- `cargo test -p exo-node production_network_loop_resets_rate_limiter_window -- --nocapture` failed before the implementation because production code had no bounded reset window.

## Validation
- `cargo test -p exo-node production_network_loop_resets_rate_limiter_window -- --nocapture`
- `cargo test -p exo-api rate_limiter -- --nocapture`
- `cargo test -p exo-node network -- --nocapture`
- `cargo test -p exo-node -- --nocapture`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --release`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check` (passed with existing duplicate-crate warnings only)
- `cargo fmt --all`
- `cargo fmt --all -- --check` (passed; stable rustfmt reports existing ignored nightly-only config warnings)
- `bash tools/repo_truth.sh --json --skip-tests`
- `bash tools/test_repo_truth.sh`
- `cargo test --workspace -- --list | grep -c ': test$'`
- `git diff --check`

## Bypass Search
- `rg -n "RateLimiter::new|check_and_increment|rate_limiter.reset|rate_limit_window|P2P_RATE_LIMIT_WINDOW_SECS|SystemTime::now|Instant::now|HashMap|HashSet|unsafe" crates/exo-node/src/network.rs crates/exo-api/src/p2p.rs`

## Original Issue Closure
The original issue no longer reproduces in code: the production P2P loop now periodically calls `rate_limiter.reset()` from a bounded Tokio interval, so attacker-created peer entries cannot occupy `MAX_TRACKED_PEERS` permanently until process restart.
