### PR TITLE
fix(wasm): reject caller-governed verification inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 301 | `find crates -name '*.rs'` |
-| Rust LOC | 193057 | `wc -l` |
-| Workspace tests | 4,388 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 193018 | `wc -l` |
+| Workspace tests | 4,390 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -114,9 +114,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 193057 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 193018 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,388 listed workspace tests
+         cryptographic proofs, 4,390 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          158 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exochain-wasm/src/decision_forum_bindings.rs
+++ b/crates/exochain-wasm/src/decision_forum_bindings.rs
@@ -24,8 +24,6 @@ use crate::serde_bridge::*;
 
 const MAX_WASM_FORUM_EMERGENCY_ACTIONS: usize = 4_096;
 const MAX_WASM_FORUM_CHALLENGES: usize = 4_096;
-const MAX_WASM_FORUM_SIGNATURES: usize = 1_024;
-const MAX_WASM_FORUM_PUBLIC_KEYS: usize = 1_024;
 const MAX_WASM_FORUM_CONSTITUTION_BYTES: usize = 1_048_576;
 
 #[derive(Deserialize)]
@@ -286,24 +284,16 @@ pub fn wasm_ratify_constitution(
     public_keys_json: &str,
     timestamp_ms: u64,
 ) -> Result<JsValue, JsValue> {
-    let mut corpus: decision_forum::constitution::ConstitutionCorpus = from_json_str(corpus_json)?;
-    let quorum: decision_forum::constitution::ConstitutionQuorum = from_json_str(quorum_json)?;
-    let sigs = parse_signature_pairs(signatures_json)?;
-    let public_keys = parse_public_key_pairs(public_keys_json)?;
-    let eligible: std::collections::BTreeSet<exo_core::Did> = public_keys.keys().cloned().collect();
-    let resolver = |did: &exo_core::Did| public_keys.get(did).copied();
-
-    let ts = exo_core::types::Timestamp::new(timestamp_ms, 0);
-    decision_forum::constitution::ratify_verified(
-        &mut corpus,
-        &sigs,
-        &quorum,
-        ts,
-        &eligible,
-        &resolver,
-    )
-    .map_err(|e| JsValue::from_str(&format!("Ratify error: {e}")))?;
-    to_js_value(&corpus)
+    let _ = (
+        corpus_json,
+        signatures_json,
+        quorum_json,
+        public_keys_json,
+        timestamp_ms,
+    );
+    Err(JsValue::from_str(
+        "constitutional ratification requires a trusted core runtime adapter; public WASM callers cannot supply signer keys or eligible signer sets",
+    ))
 }
 
 /// Amend a constitutional corpus by adding or updating an article.
@@ -322,26 +312,17 @@ pub fn wasm_amend_constitution(
     public_keys_json: &str,
     timestamp_ms: u64,
 ) -> Result<JsValue, JsValue> {
-    let mut corpus: decision_forum::constitution::ConstitutionCorpus = from_json_str(corpus_json)?;
-    let amendment: decision_forum::constitution::Article = from_json_str(amendment_json)?;
-    let quorum: decision_forum::constitution::ConstitutionQuorum = from_json_str(quorum_json)?;
-    let sigs = parse_signature_pairs(signatures_json)?;
-    let public_keys = parse_public_key_pairs(public_keys_json)?;
-    let eligible: std::collections::BTreeSet<exo_core::Did> = public_keys.keys().cloned().collect();
-    let resolver = |did: &exo_core::Did| public_keys.get(did).copied();
-    let ts = exo_core::types::Timestamp::new(timestamp_ms, 0);
-
-    decision_forum::constitution::amend_verified(
-        &mut corpus,
-        amendment,
-        &sigs,
-        &quorum,
-        ts,
-        &eligible,
-        &resolver,
-    )
-    .map_err(|e| JsValue::from_str(&format!("Amend error: {e}")))?;
-    to_js_value(&corpus)
+    let _ = (
+        corpus_json,
+        amendment_json,
+        signatures_json,
+        quorum_json,
+        public_keys_json,
+        timestamp_ms,
+    );
+    Err(JsValue::from_str(
+        "constitutional amendment requires a trusted core runtime adapter; public WASM callers cannot supply signer keys or eligible signer sets",
+    ))
 }
 
 /// Dry-run a constitutional amendment — returns conflict descriptions.
@@ -895,45 +876,6 @@ fn parse_public_key_hex(public_key_hex: &str) -> Result<exo_core::PublicKey, JsV
     Ok(exo_core::PublicKey::from_bytes(arr))
 }
 
-fn parse_signature_pairs(
-    signatures_json: &str,
-) -> Result<Vec<(exo_core::Did, exo_core::Signature)>, JsValue> {
-    let sig_pairs: Vec<(String, String)> = from_json_bounded_vec(
-        signatures_json,
-        "forum signatures",
-        MAX_WASM_FORUM_SIGNATURES,
-    )?;
-    let mut sigs = Vec::new();
-    for (did_str, sig_hex) in &sig_pairs {
-        let did = exo_core::Did::new(did_str)
-            .map_err(|e| JsValue::from_str(&format!("DID error: {e}")))?;
-        let sig_bytes =
-            hex::decode(sig_hex).map_err(|e| JsValue::from_str(&format!("hex: {e}")))?;
-        let arr: [u8; 64] = sig_bytes
-            .try_into()
-            .map_err(|_| JsValue::from_str("signature must be 64 bytes"))?;
-        sigs.push((did, exo_core::Signature::from_bytes(arr)));
-    }
-    Ok(sigs)
-}
-
-fn parse_public_key_pairs(
-    public_keys_json: &str,
-) -> Result<std::collections::BTreeMap<exo_core::Did, exo_core::PublicKey>, JsValue> {
-    let key_pairs: Vec<(String, String)> = from_json_bounded_vec(
-        public_keys_json,
-        "forum public keys",
-        MAX_WASM_FORUM_PUBLIC_KEYS,
-    )?;
-    let mut public_keys = std::collections::BTreeMap::new();
-    for (did_str, public_key_hex) in &key_pairs {
-        let did = exo_core::Did::new(did_str)
-            .map_err(|e| JsValue::from_str(&format!("DID error: {e}")))?;
-        public_keys.insert(did, parse_public_key_hex(public_key_hex)?);
-    }
-    Ok(public_keys)
-}
-
 fn ensure_constitution_bytes(len: usize) -> Result<(), JsValue> {
     if len > MAX_WASM_FORUM_CONSTITUTION_BYTES {
         return Err(JsValue::from_str(
@@ -1023,5 +965,36 @@ mod tests {
             production.contains("verify_forum_authority_with_key"),
             "WASM authority verification must call the cryptographic core verifier"
         );
+    }
+
+    #[test]
+    fn wasm_constitution_exports_reject_caller_supplied_signer_keys() {
+        let source = include_str!("decision_forum_bindings.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production section");
+
+        for export_name in ["wasm_ratify_constitution", "wasm_amend_constitution"] {
+            let body = production
+                .split(&format!("pub fn {export_name}"))
+                .nth(1)
+                .unwrap_or_else(|| panic!("{export_name} export must exist"))
+                .split("///")
+                .next()
+                .expect("export body must be bounded by next doc comment");
+            assert!(
+                body.contains("trusted core runtime adapter"),
+                "{export_name} must fail closed at the public WASM boundary"
+            );
+            assert!(
+                !body.contains("parse_public_key_pairs(public_keys_json)"),
+                "{export_name} must not parse caller-supplied signer keys"
+            );
+            assert!(
+                !body.contains("public_keys.keys().cloned().collect()"),
+                "{export_name} must not derive eligible signers from caller-supplied keys"
+            );
+        }
     }
 }

--- a/crates/exochain-wasm/src/governance_bindings.rs
+++ b/crates/exochain-wasm/src/governance_bindings.rs
@@ -21,9 +21,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::serde_bridge::*;
 
-const MAX_WASM_PUBLIC_KEYS: usize = 512;
 const MAX_WASM_CLEARANCE_REGISTRY_ENTRIES: usize = 512;
-const MAX_WASM_APPROVALS: usize = 1_024;
 const MAX_WASM_CONFLICT_DECLARATIONS: usize = 1_024;
 const MAX_WASM_AUDIT_ENTRIES: usize = 4_096;
 const MAX_WASM_DELIBERATION_PARTICIPANTS: usize = 1_024;
@@ -115,25 +113,6 @@ fn parse_timestamp(
     })
 }
 
-fn parse_public_key_map(
-    public_keys_json: &str,
-) -> Result<std::collections::BTreeMap<exo_core::Did, exo_core::PublicKey>, JsValue> {
-    let key_pairs: Vec<(String, String)> =
-        parse_bounded_vec(public_keys_json, "public keys", MAX_WASM_PUBLIC_KEYS)?;
-    let mut keys = std::collections::BTreeMap::new();
-    for (did_str, public_key_hex) in &key_pairs {
-        let did = exo_core::Did::new(did_str)
-            .map_err(|e| JsValue::from_str(&format!("DID error: {e}")))?;
-        let bytes =
-            hex::decode(public_key_hex).map_err(|e| JsValue::from_str(&format!("hex: {e}")))?;
-        let arr: [u8; 32] = bytes
-            .try_into()
-            .map_err(|_| JsValue::from_str("public key must be 32 bytes"))?;
-        keys.insert(did, exo_core::PublicKey::from_bytes(arr));
-    }
-    Ok(keys)
-}
-
 fn parse_clearance_registry(
     registry_json: &str,
 ) -> Result<exo_governance::clearance::ClearanceRegistry, JsValue> {
@@ -162,28 +141,10 @@ pub fn wasm_compute_quorum(
     policy_json: &str,
     public_keys_json: &str,
 ) -> Result<JsValue, JsValue> {
-    let approvals: Vec<exo_governance::quorum::Approval> =
-        parse_bounded_vec(approvals_json, "approvals", MAX_WASM_APPROVALS)?;
-    let policy: exo_governance::quorum::QuorumPolicy = from_json_str(policy_json)?;
-    let public_keys = parse_public_key_map(public_keys_json)?;
-    let resolver = |did: &exo_core::Did| public_keys.get(did).copied();
-    let result = exo_governance::quorum::compute_quorum_verified(&approvals, &policy, &resolver);
-    // QuorumResult doesn't derive Serialize, so format it manually
-    let json = match result {
-        exo_governance::quorum::QuorumResult::Met {
-            independent_count,
-            total_count,
-        } => {
-            serde_json::json!({"status": "Met", "independent_count": independent_count, "total_count": total_count})
-        }
-        exo_governance::quorum::QuorumResult::NotMet { reason } => {
-            serde_json::json!({"status": "NotMet", "reason": reason})
-        }
-        exo_governance::quorum::QuorumResult::Contested { challenge } => {
-            serde_json::json!({"status": "Contested", "challenge": challenge})
-        }
-    };
-    to_js_value(&json)
+    let _ = (approvals_json, policy_json, public_keys_json);
+    Err(governance_boundary_error(
+        "verified quorum requires a trusted core runtime adapter; public WASM callers cannot supply signer keys or voter roles",
+    ))
 }
 
 /// Check clearance level for an actor on an action
@@ -354,41 +315,10 @@ pub fn wasm_close_deliberation(
     quorum_policy_json: &str,
     public_keys_json: &str,
 ) -> Result<JsValue, JsValue> {
-    use exo_governance::deliberation::DeliberationResult;
-
-    let mut delib: exo_governance::deliberation::Deliberation = from_json_str(deliberation_json)?;
-    let policy: exo_governance::quorum::QuorumPolicy = from_json_str(quorum_policy_json)?;
-    let public_keys = parse_public_key_map(public_keys_json)?;
-    let resolver = |did: &exo_core::Did| public_keys.get(did).copied();
-    let result = exo_governance::deliberation::close_verified(&mut delib, &policy, &resolver);
-
-    let json = match result {
-        DeliberationResult::Approved {
-            votes_for,
-            votes_against,
-            abstentions,
-        } => serde_json::json!({
-            "result": "Approved",
-            "votes_for": votes_for,
-            "votes_against": votes_against,
-            "abstentions": abstentions,
-        }),
-        DeliberationResult::Rejected {
-            votes_for,
-            votes_against,
-            abstentions,
-        } => serde_json::json!({
-            "result": "Rejected",
-            "votes_for": votes_for,
-            "votes_against": votes_against,
-            "abstentions": abstentions,
-        }),
-        DeliberationResult::NoQuorum { reason } => serde_json::json!({
-            "result": "NoQuorum",
-            "reason": reason,
-        }),
-    };
-    to_js_value(&json)
+    let _ = (deliberation_json, quorum_policy_json, public_keys_json);
+    Err(governance_boundary_error(
+        "verified deliberation closure requires a trusted core runtime adapter; public WASM callers cannot supply signer keys or voter roles",
+    ))
 }
 
 // ── Succession ───────────────────────────────────────────────────
@@ -668,22 +598,29 @@ mod tests {
 
     #[test]
     fn parse_bounded_vec_accepts_items_at_the_configured_limit() {
-        let input = vec!["did:exo:bounded"; MAX_WASM_PUBLIC_KEYS];
+        let input = vec!["did:exo:bounded"; MAX_WASM_CLEARANCE_REGISTRY_ENTRIES];
         let json = serde_json::to_string(&input).expect("serialize bounded input");
 
-        let parsed: Vec<String> = parse_bounded_vec(&json, "public keys", MAX_WASM_PUBLIC_KEYS)
-            .expect("input at the limit is accepted");
+        let parsed: Vec<String> = parse_bounded_vec(
+            &json,
+            "clearance registry",
+            MAX_WASM_CLEARANCE_REGISTRY_ENTRIES,
+        )
+        .expect("input at the limit is accepted");
 
-        assert_eq!(parsed.len(), MAX_WASM_PUBLIC_KEYS);
+        assert_eq!(parsed.len(), MAX_WASM_CLEARANCE_REGISTRY_ENTRIES);
     }
 
     #[test]
     fn parse_bounded_vec_rejects_items_over_the_configured_limit() {
-        let input = vec!["did:exo:bounded"; MAX_WASM_PUBLIC_KEYS + 1];
+        let input = vec!["did:exo:bounded"; MAX_WASM_CLEARANCE_REGISTRY_ENTRIES + 1];
         let json = serde_json::to_string(&input).expect("serialize oversized input");
 
-        let parsed: Result<Vec<String>, JsValue> =
-            parse_bounded_vec(&json, "public keys", MAX_WASM_PUBLIC_KEYS);
+        let parsed: Result<Vec<String>, JsValue> = parse_bounded_vec(
+            &json,
+            "clearance registry",
+            MAX_WASM_CLEARANCE_REGISTRY_ENTRIES,
+        );
 
         assert!(parsed.is_err(), "one item over the limit must fail closed");
     }
@@ -710,10 +647,11 @@ mod tests {
 
     #[test]
     fn registry_relationship_bound_counts_all_nested_registry_vectors() {
-        let relationships =
-            MAX_WASM_REGISTRY_RELATIONSHIPS - MAX_WASM_PUBLIC_KEYS - MAX_WASM_APPROVALS;
-        let total = MAX_WASM_PUBLIC_KEYS
-            .saturating_add(MAX_WASM_APPROVALS)
+        let relationships = MAX_WASM_REGISTRY_RELATIONSHIPS
+            - MAX_WASM_CLEARANCE_REGISTRY_ENTRIES
+            - MAX_WASM_CONFLICT_DECLARATIONS;
+        let total = MAX_WASM_CLEARANCE_REGISTRY_ENTRIES
+            .saturating_add(MAX_WASM_CONFLICT_DECLARATIONS)
             .saturating_add(relationships)
             .saturating_add(1);
 
@@ -725,6 +663,51 @@ mod tests {
             )
             .is_err(),
             "aggregate nested registry relationships must be bounded"
+        );
+    }
+
+    #[test]
+    fn wasm_governance_verified_paths_reject_caller_supplied_keys_and_roles() {
+        let source = include_str!("governance_bindings.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production section");
+        let quorum_body = production
+            .split("pub fn wasm_compute_quorum")
+            .nth(1)
+            .expect("quorum export present")
+            .split("/// Check clearance")
+            .next()
+            .expect("quorum export body");
+        let close_body = production
+            .split("pub fn wasm_close_deliberation")
+            .nth(1)
+            .expect("close deliberation export present")
+            .split("/// Challenge")
+            .next()
+            .expect("close deliberation export body");
+
+        for (name, body) in [
+            ("wasm_compute_quorum", quorum_body),
+            ("wasm_close_deliberation", close_body),
+        ] {
+            assert!(
+                body.contains("trusted core runtime adapter"),
+                "{name} must fail closed at the public WASM boundary"
+            );
+            assert!(
+                !body.contains("parse_public_key_map(public_keys_json)"),
+                "{name} must not parse caller-supplied DID key bindings"
+            );
+        }
+        assert!(
+            !quorum_body.contains("compute_quorum_verified(&approvals, &policy, &resolver)"),
+            "wasm_compute_quorum must not call verified quorum with a caller-controlled resolver"
+        );
+        assert!(
+            !close_body.contains("close_verified(&mut delib, &policy, &resolver)"),
+            "wasm_close_deliberation must not close using caller-supplied vote roles and keys"
         );
     }
 }

--- a/crates/exochain-wasm/src/lib.rs
+++ b/crates/exochain-wasm/src/lib.rs
@@ -157,15 +157,24 @@ mod source_guard_tests {
     }
 
     #[test]
-    fn wasm_governance_close_uses_verified_deliberation_quorum() {
+    fn wasm_governance_close_requires_trusted_runtime_adapter() {
         let source = include_str!("governance_bindings.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production section");
         assert!(
-            source.contains("close_verified"),
-            "WASM deliberation close must use cryptographically verified quorum closure"
+            production
+                .contains("verified deliberation closure requires a trusted core runtime adapter"),
+            "public WASM deliberation close must fail closed without a trusted runtime adapter"
         );
         assert!(
-            !source.contains("deliberation::close(&mut delib"),
+            !production.contains("deliberation::close(&mut delib"),
             "WASM deliberation close must not call the structural-only close path"
+        );
+        assert!(
+            !production.contains("close_verified(&mut delib, &policy, &resolver)"),
+            "public WASM deliberation close must not trust caller-supplied signer keys and roles"
         );
     }
 
@@ -186,9 +195,7 @@ mod source_guard_tests {
     fn wasm_governance_bridge_bounds_untrusted_collection_inputs() {
         let source = include_str!("governance_bindings.rs");
         for required in [
-            "MAX_WASM_PUBLIC_KEYS",
             "MAX_WASM_CLEARANCE_REGISTRY_ENTRIES",
-            "MAX_WASM_APPROVALS",
             "MAX_WASM_CONFLICT_DECLARATIONS",
             "MAX_WASM_AUDIT_ENTRIES",
             "MAX_WASM_DELIBERATION_PARTICIPANTS",
@@ -356,8 +363,6 @@ mod source_guard_tests {
         for required in [
             "MAX_WASM_FORUM_EMERGENCY_ACTIONS",
             "MAX_WASM_FORUM_CHALLENGES",
-            "MAX_WASM_FORUM_SIGNATURES",
-            "MAX_WASM_FORUM_PUBLIC_KEYS",
         ] {
             assert!(
                 source.contains(required),

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -1607,10 +1607,14 @@ test('wasm_close_deliberation', () => {
     required_roles: [],
     timeout: { physical_ms: NOW_NUM + 86400000, logical: 0 }
   };
-  return wasm.wasm_close_deliberation(
-    JSON.stringify(deliberation),
-    JSON.stringify(quorumPolicy),
-    JSON.stringify([])
+  return expectErrorContains(
+    'wasm_close_deliberation',
+    () => wasm.wasm_close_deliberation(
+      JSON.stringify(deliberation),
+      JSON.stringify(quorumPolicy),
+      JSON.stringify([])
+    ),
+    'trusted core runtime adapter'
   );
 });
 
@@ -1671,10 +1675,14 @@ test('wasm_compute_quorum', () => {
     required_roles: [],
     timeout: { physical_ms: NOW_NUM + 86400000, logical: 0 }
   };
-  return wasm.wasm_compute_quorum(
-    JSON.stringify(approvals),
-    JSON.stringify(policy),
-    JSON.stringify([])
+  return expectErrorContains(
+    'wasm_compute_quorum',
+    () => wasm.wasm_compute_quorum(
+      JSON.stringify(approvals),
+      JSON.stringify(policy),
+      JSON.stringify([])
+    ),
+    'trusted core runtime adapter'
   );
 });
 
@@ -2122,12 +2130,16 @@ test('wasm_ratify_constitution', () => {
   const corpus = { version: 1, hash: ZERO_32_BYTES, articles: [], ratified_at: null, amendment_count: 0 };
   const sigs = [];
   const quorum = { required_signatures: 0, required_fraction_pct: 0 };
-  return wasm.wasm_ratify_constitution(
-    JSON.stringify(corpus),
-    JSON.stringify(sigs),
-    JSON.stringify(quorum),
-    JSON.stringify([]),
-    NOW_MS
+  return expectErrorContains(
+    'wasm_ratify_constitution',
+    () => wasm.wasm_ratify_constitution(
+      JSON.stringify(corpus),
+      JSON.stringify(sigs),
+      JSON.stringify(quorum),
+      JSON.stringify([]),
+      NOW_MS
+    ),
+    'trusted core runtime adapter'
   );
 });
 
@@ -2136,13 +2148,17 @@ test('wasm_amend_constitution', () => {
   const amendment = { id: 'art-1', title: 'Test', tier: 'Articles', text_hash: ZERO_32_BYTES, status: 'Active' };
   const sigs = [];
   const quorum = { required_signatures: 0, required_fraction_pct: 0 };
-  return wasm.wasm_amend_constitution(
-    JSON.stringify(corpus),
-    JSON.stringify(amendment),
-    JSON.stringify(sigs),
-    JSON.stringify(quorum),
-    JSON.stringify([]),
-    NOW_MS
+  return expectErrorContains(
+    'wasm_amend_constitution',
+    () => wasm.wasm_amend_constitution(
+      JSON.stringify(corpus),
+      JSON.stringify(amendment),
+      JSON.stringify(sigs),
+      JSON.stringify(quorum),
+      JSON.stringify([]),
+      NOW_MS
+    ),
+    'trusted core runtime adapter'
   );
 });
 


### PR DESCRIPTION
## Summary
- fail closed public WASM constitution ratification/amendment exports that previously accepted caller-supplied signer keys and eligible signer sets
- fail closed public WASM quorum/deliberation closure exports that previously accepted caller-supplied signer keys and vote roles
- update Rust source guards and JS bridge smoke expectations to prove these public boundaries require a trusted core runtime adapter

## Classification
- `crates/exochain-wasm/src/decision_forum_bindings.rs`: Core runtime adapter
- `crates/exochain-wasm/src/governance_bindings.rs`: Core runtime adapter
- `crates/exochain-wasm/src/lib.rs`: Core runtime adapter test guard
- `packages/exochain-wasm/test/bridge_verification.mjs`: Core runtime adapter smoke test

## Verification
- `cargo test -p exochain-wasm wasm_constitution_exports_reject_caller_supplied_signer_keys -- --nocapture`
- `cargo test -p exochain-wasm wasm_governance_verified_paths_reject_caller_supplied_keys_and_roles -- --nocapture`
- `cargo test -p exochain-wasm wasm_governance_close_requires_trusted_runtime_adapter -- --nocapture`
- `cargo test -p exo-governance production_deliberation_closure_uses_verified_quorum_only -- --nocapture`
- `cargo test -p exochain-wasm`
- `cargo test -p exo-governance`
- `wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm`
- `node packages/exochain-wasm/test/bridge_verification.mjs` (160/160 passed)
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --workspace --release`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check`
