### PR TITLE
fix(consent): resolve bailment acceptance keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 301 | `find crates -name '*.rs'` |
-| Rust LOC | 193018 | `wc -l` |
-| Workspace tests | 4,390 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 193125 | `wc -l` |
+| Workspace tests | 4,394 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -114,12 +114,12 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 193018 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 193125 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,390 listed workspace tests
+         cryptographic proofs, 4,394 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
-         158 verified bridge exports — Rust -> WebAssembly -> JavaScript
+         160 verified bridge exports — Rust -> WebAssembly -> JavaScript
 
 Layer 3: CommandBase.ai     (command-base/)
          Adjacent cockpit adapter for cognitiveplane.ai

--- a/crates/exo-consent/src/bailment.rs
+++ b/crates/exo-consent/src/bailment.rs
@@ -242,19 +242,20 @@ pub fn termination_signing_payload(
 /// public key — an attacker with any non-empty byte sequence could flip a
 /// bailment to Active. This was a silent authentication bypass.
 ///
-/// Callers now MUST supply the bailee's public key. The signature is
-/// verified against the canonical payload from [`signing_payload`] before
-/// the status transition. Empty and zero-byte signatures are explicitly
-/// rejected.
+/// Callers now MUST supply a trusted resolver for `bailment.bailee_did`. The
+/// signature is verified against the canonical payload from [`signing_payload`]
+/// and the resolved bailee key before the status transition. Empty and
+/// zero-byte signatures are explicitly rejected.
 ///
 /// # Errors
 /// - `InvalidState` if not in `Proposed` status.
 /// - `InvalidSignature` if the signature is empty, a zero sentinel, or
-///   fails to verify against `bailee_public_key`.
+///   key cannot be resolved or the signature fails to verify against the
+///   resolved bailee key.
 /// - `Serialization` on canonical encoding failure.
 pub fn accept(
     bailment: &mut Bailment,
-    bailee_public_key: &PublicKey,
+    resolve_bailee_public_key: impl FnOnce(&Did) -> Option<PublicKey>,
     bailee_signature: &Signature,
 ) -> Result<(), ConsentError> {
     if bailment.status != BailmentStatus::Proposed {
@@ -274,13 +275,15 @@ pub fn accept(
         return Err(ConsentError::InvalidSignature);
     }
 
+    let bailee_public_key =
+        resolve_bailee_public_key(&bailment.bailee_did).ok_or(ConsentError::InvalidSignature)?;
     let payload = signing_payload(bailment)?;
-    if !crypto::verify(&payload, bailee_signature, bailee_public_key) {
+    if !crypto::verify(&payload, bailee_signature, &bailee_public_key) {
         return Err(ConsentError::InvalidSignature);
     }
 
     bailment.signature = bailee_signature.clone();
-    bailment.bailee_public_key = Some(*bailee_public_key);
+    bailment.bailee_public_key = Some(bailee_public_key);
     bailment.status = BailmentStatus::Active;
     Ok(())
 }
@@ -482,9 +485,22 @@ mod tests {
         (pk, sk, sig)
     }
 
+    fn accept_with_resolved_bailee_key(
+        b: &mut Bailment,
+        public_key: PublicKey,
+        signature: &Signature,
+    ) -> Result<(), ConsentError> {
+        let bailee_did = b.bailee_did.clone();
+        accept(
+            b,
+            |did| (did == &bailee_did).then_some(public_key),
+            signature,
+        )
+    }
+
     fn accept_test_bailment(b: &mut Bailment) {
         let (pk, _sk, sig) = sign_as_bailee(b);
-        accept(b, &pk, &sig).expect("test bailment accepts");
+        accept_with_resolved_bailee_key(b, pk, &sig).expect("test bailment accepts");
     }
 
     fn ts(ms: u64) -> Timestamp {
@@ -647,7 +663,7 @@ mod tests {
     fn accept_transitions_to_active() {
         let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
-        assert!(accept(&mut b, &pk, &sig).is_ok());
+        assert!(accept_with_resolved_bailee_key(&mut b, pk, &sig).is_ok());
         assert_eq!(b.status, BailmentStatus::Active);
         assert!(!b.signature.is_empty());
         assert_eq!(b.bailee_public_key, Some(pk));
@@ -660,7 +676,7 @@ mod tests {
         let (pk, _sk, sig) = sign_as_bailee(&b);
         b.status = BailmentStatus::Active;
         assert_eq!(
-            accept(&mut b, &pk, &sig),
+            accept_with_resolved_bailee_key(&mut b, pk, &sig),
             Err(ConsentError::InvalidState {
                 expected: "Proposed".into(),
                 actual: "Active".into()
@@ -673,7 +689,7 @@ mod tests {
         let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk) = crypto::generate_keypair();
         assert_eq!(
-            accept(&mut b, &pk, &Signature::empty()),
+            accept_with_resolved_bailee_key(&mut b, pk, &Signature::empty()),
             Err(ConsentError::InvalidSignature)
         );
     }
@@ -691,7 +707,7 @@ mod tests {
         // through unchecked.
         let junk = Signature::from_bytes([1u8; 64]);
         assert_eq!(
-            accept(&mut b, &pk, &junk),
+            accept_with_resolved_bailee_key(&mut b, pk, &junk),
             Err(ConsentError::InvalidSignature)
         );
         // Critically: status must remain Proposed.
@@ -707,7 +723,7 @@ mod tests {
         let (pk, _sk) = crypto::generate_keypair();
         let zeros = Signature::from_bytes([0u8; 64]);
         assert_eq!(
-            accept(&mut b, &pk, &zeros),
+            accept_with_resolved_bailee_key(&mut b, pk, &zeros),
             Err(ConsentError::InvalidSignature)
         );
         assert_eq!(b.status, BailmentStatus::Proposed);
@@ -725,10 +741,40 @@ mod tests {
         let sig = crypto::sign(&payload, &sk_a);
         // Signed by key A, verifying against key B — must fail.
         assert_eq!(
-            accept(&mut b, &pk_b, &sig),
+            accept_with_resolved_bailee_key(&mut b, pk_b, &sig),
             Err(ConsentError::InvalidSignature)
         );
         assert_eq!(b.status, BailmentStatus::Proposed);
+    }
+
+    #[test]
+    fn accept_rejects_caller_substituted_bailee_key() {
+        let mut b = propose_test(b"t", BailmentType::Custody);
+        let (trusted_pk, _trusted_sk) = crypto::generate_keypair();
+        let (attacker_pk, attacker_sk) = crypto::generate_keypair();
+        let payload = signing_payload(&b).unwrap();
+        let attacker_sig = crypto::sign(&payload, &attacker_sk);
+
+        assert_ne!(trusted_pk, attacker_pk);
+        let err = accept_with_resolved_bailee_key(&mut b, trusted_pk, &attacker_sig)
+            .expect_err("caller-supplied bailee key material must not activate a bailment");
+
+        assert_eq!(err, ConsentError::InvalidSignature);
+        assert_eq!(b.status, BailmentStatus::Proposed);
+        assert!(b.bailee_public_key.is_none());
+    }
+
+    #[test]
+    fn accept_rejects_unresolved_bailee_key() {
+        let mut b = propose_test(b"t", BailmentType::Custody);
+        let (_pk, _sk, sig) = sign_as_bailee(&b);
+
+        let err =
+            accept(&mut b, |_| None, &sig).expect_err("unresolved bailee key must fail closed");
+
+        assert_eq!(err, ConsentError::InvalidSignature);
+        assert_eq!(b.status, BailmentStatus::Proposed);
+        assert!(b.bailee_public_key.is_none());
     }
 
     /// A signature over a DIFFERENT bailment's payload must not
@@ -741,7 +787,7 @@ mod tests {
         let payload2 = signing_payload(&b2).unwrap();
         let sig_on_b2 = crypto::sign(&payload2, &sk);
         assert_eq!(
-            accept(&mut b1, &pk, &sig_on_b2),
+            accept_with_resolved_bailee_key(&mut b1, pk, &sig_on_b2),
             Err(ConsentError::InvalidSignature)
         );
         assert_eq!(b1.status, BailmentStatus::Proposed);
@@ -757,7 +803,7 @@ mod tests {
         // bailee signed. Should be rejected.
         b.bailee_did = charlie();
         assert_eq!(
-            accept(&mut b, &pk, &sig),
+            accept_with_resolved_bailee_key(&mut b, pk, &sig),
             Err(ConsentError::InvalidSignature)
         );
         assert_eq!(b.status, BailmentStatus::Proposed);
@@ -769,7 +815,7 @@ mod tests {
         let (pk, _sk, sig) = sign_as_bailee(&b);
         b.terms_hash = terms_hash(b"t-swapped").expect("canonical terms hash");
         assert_eq!(
-            accept(&mut b, &pk, &sig),
+            accept_with_resolved_bailee_key(&mut b, pk, &sig),
             Err(ConsentError::InvalidSignature)
         );
     }
@@ -923,7 +969,7 @@ mod tests {
     fn terminate_by_bailor() {
         let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
-        accept(&mut b, &pk, &sig).ok();
+        accept_with_resolved_bailee_key(&mut b, pk, &sig).ok();
         assert!(terminate(&mut b, &alice()).is_ok());
         assert_eq!(b.status, BailmentStatus::Terminated);
     }
@@ -932,7 +978,7 @@ mod tests {
     fn terminate_by_bailee() {
         let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
-        accept(&mut b, &pk, &sig).ok();
+        accept_with_resolved_bailee_key(&mut b, pk, &sig).ok();
         assert!(terminate(&mut b, &bob()).is_ok());
         assert_eq!(b.status, BailmentStatus::Terminated);
     }
@@ -941,7 +987,7 @@ mod tests {
     fn terminate_rejects_unauthorized() {
         let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
-        accept(&mut b, &pk, &sig).ok();
+        accept_with_resolved_bailee_key(&mut b, pk, &sig).ok();
         assert!(matches!(
             terminate(&mut b, &charlie()),
             Err(ConsentError::Unauthorized(_))
@@ -952,7 +998,7 @@ mod tests {
     fn terminate_rejects_already_terminated() {
         let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
-        accept(&mut b, &pk, &sig).ok();
+        accept_with_resolved_bailee_key(&mut b, pk, &sig).ok();
         terminate(&mut b, &alice()).ok();
         assert!(matches!(
             terminate(&mut b, &alice()),
@@ -1066,7 +1112,7 @@ mod tests {
     fn is_active_with_no_expiry() {
         let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
-        accept(&mut b, &pk, &sig).ok();
+        accept_with_resolved_bailee_key(&mut b, pk, &sig).ok();
         assert!(is_active(&b, &ts(5000)));
     }
 
@@ -1074,7 +1120,7 @@ mod tests {
     fn is_active_before_expiry() {
         let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
-        accept(&mut b, &pk, &sig).ok();
+        accept_with_resolved_bailee_key(&mut b, pk, &sig).ok();
         b.expires = Some(ts(10000));
         assert!(is_active(&b, &ts(5000)));
     }
@@ -1083,7 +1129,7 @@ mod tests {
     fn not_active_after_expiry() {
         let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
-        accept(&mut b, &pk, &sig).ok();
+        accept_with_resolved_bailee_key(&mut b, pk, &sig).ok();
         b.expires = Some(ts(1000));
         assert!(!is_active(&b, &ts(5000)));
     }
@@ -1116,7 +1162,7 @@ mod tests {
     fn not_active_at_exact_expiry() {
         let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
-        accept(&mut b, &pk, &sig).ok();
+        accept_with_resolved_bailee_key(&mut b, pk, &sig).ok();
         b.expires = Some(ts(5000));
         assert!(!is_active(&b, &ts(5000)));
     }
@@ -1131,7 +1177,7 @@ mod tests {
     fn not_active_when_terminated() {
         let mut b = propose_test(b"t", BailmentType::Custody);
         let (pk, _sk, sig) = sign_as_bailee(&b);
-        accept(&mut b, &pk, &sig).ok();
+        accept_with_resolved_bailee_key(&mut b, pk, &sig).ok();
         terminate(&mut b, &alice()).ok();
         assert!(!is_active(&b, &ts(1000)));
     }

--- a/crates/exo-consent/src/gatekeeper.rs
+++ b/crates/exo-consent/src/gatekeeper.rs
@@ -371,7 +371,9 @@ mod tests {
         let (pk, sk) = exo_core::crypto::generate_keypair();
         let payload = bailment::signing_payload(&b).expect("canonical payload");
         let sig = exo_core::crypto::sign(&payload, &sk);
-        bailment::accept(&mut b, &pk, &sig).expect("test bailment accepts");
+        let bailee_did = b.bailee_did.clone();
+        bailment::accept(&mut b, |did| (did == &bailee_did).then_some(pk), &sig)
+            .expect("test bailment accepts");
         b.expires = exp;
         b
     }

--- a/crates/exo-consent/src/policy.rs
+++ b/crates/exo-consent/src/policy.rs
@@ -186,7 +186,9 @@ mod tests {
         let (pk, sk) = exo_core::crypto::generate_keypair();
         let payload = bailment::signing_payload(&b).expect("canonical payload");
         let sig = exo_core::crypto::sign(&payload, &sk);
-        bailment::accept(&mut b, &pk, &sig).expect("test bailment accepts");
+        let bailee_did = b.bailee_did.clone();
+        bailment::accept(&mut b, |did| (did == &bailee_did).then_some(pk), &sig)
+            .expect("test bailment accepts");
         b.expires = exp;
         b
     }

--- a/crates/exochain-wasm/src/consent_bindings.rs
+++ b/crates/exochain-wasm/src/consent_bindings.rs
@@ -36,6 +36,12 @@ fn untrusted_wasm_bailment_termination_error() -> JsValue {
     )
 }
 
+fn untrusted_wasm_bailment_acceptance_error() -> JsValue {
+    consent_bridge_error(
+        "WASM bailment acceptance cannot trust caller-supplied DID key material; use wasm_bailment_signing_payload and submit the signed request to a core runtime adapter with a trusted DID registry",
+    )
+}
+
 /// Propose a new bailment (consent-conditioned data sharing)
 #[wasm_bindgen]
 pub fn wasm_propose_bailment(
@@ -72,33 +78,25 @@ pub fn wasm_bailment_is_active(bailment_json: &str, now_json: &str) -> Result<bo
     Ok(exo_consent::bailment::is_active(&bailment, &now))
 }
 
-/// Accept a proposed bailment (bailee countersigns, status → Active).
+/// Refuse WASM-local bailment acceptance from caller-supplied identity data.
 ///
-/// `bailee_public_key_json` — JSON-serialized bailee PublicKey. Required
-/// to verify `signature_json` against the canonical bailment payload.
-/// Closes GAP-012: previously this binding passed the signature through
-/// unchecked, which flipped bailments to Active on any non-empty bytes.
-///
-/// `signature_json` — JSON-serialized bailee Signature over
-/// `exo_consent::bailment::signing_payload(&bailment)`.
+/// WASM can construct the canonical payload for external signing, but it cannot
+/// prove that a caller-supplied bailee DID-to-key binding came from the trusted
+/// EXOCHAIN identity registry. Submit the signed payload to a core runtime
+/// adapter that owns trusted DID resolution instead.
 #[wasm_bindgen]
 pub fn wasm_accept_bailment(
-    bailment_json: &str,
-    bailee_public_key_json: &str,
-    signature_json: &str,
+    _bailment_json: &str,
+    _bailee_public_key_json: &str,
+    _signature_json: &str,
 ) -> Result<JsValue, JsValue> {
-    let mut bailment: exo_consent::Bailment = from_json_str(bailment_json)?;
-    let pk: exo_core::PublicKey = from_json_str(bailee_public_key_json)?;
-    let sig: exo_core::Signature = from_json_str(signature_json)?;
-    exo_consent::bailment::accept(&mut bailment, &pk, &sig)
-        .map_err(|e| JsValue::from_str(&format!("Accept error: {e}")))?;
-    to_js_value(&bailment)
+    Err(untrusted_wasm_bailment_acceptance_error())
 }
 
 /// Compute the canonical signing payload for a bailment.
 ///
-/// Returns the CBOR bytes that the bailee must sign for
-/// [`wasm_accept_bailment`] to succeed. Mirrors
+/// Returns the CBOR bytes that the bailee must sign before submitting the
+/// signed request to a trusted core runtime adapter. Mirrors
 /// [`exo_consent::bailment::signing_payload`].
 ///
 /// # Errors
@@ -179,8 +177,13 @@ mod tests {
         let acceptance_payload =
             exo_consent::bailment::signing_payload(&bailment).expect("acceptance payload");
         let acceptance_signature = crypto::sign(&acceptance_payload, &bailee_sk);
-        exo_consent::bailment::accept(&mut bailment, &bailee_pk, &acceptance_signature)
-            .expect("accept");
+        let bailee_did = bailment.bailee_did.clone();
+        exo_consent::bailment::accept(
+            &mut bailment,
+            |did| (did == &bailee_did).then_some(bailee_pk),
+            &acceptance_signature,
+        )
+        .expect("accept");
         bailment
     }
 
@@ -226,6 +229,37 @@ mod tests {
         );
 
         assert!(result.is_err(), "missing actor key must fail");
+    }
+
+    #[test]
+    fn wasm_accept_bailment_rejects_caller_supplied_bailee_key_material() {
+        let bailor = did("did:exo:alice");
+        let bailee = did("did:exo:bob");
+        let bailment = exo_consent::bailment::propose(
+            &bailor,
+            &bailee,
+            b"wasm acceptance terms",
+            exo_consent::BailmentType::Custody,
+            "wasm-acceptance-test",
+            Timestamp::new(1_000, 0),
+        )
+        .expect("proposal");
+        let bailment_json = serde_json::to_string(&bailment).expect("bailment json");
+        let (attacker_pk, attacker_sk) = crypto::generate_keypair();
+        let payload =
+            exo_consent::bailment::signing_payload(&bailment).expect("acceptance payload");
+        let attacker_signature = crypto::sign(&payload, &attacker_sk);
+
+        let result = wasm_accept_bailment(
+            &bailment_json,
+            &serde_json::to_string(&attacker_pk).expect("public key json"),
+            &signature_json(&attacker_signature),
+        );
+
+        assert!(
+            result.is_err(),
+            "WASM bailment acceptance must not trust a caller-supplied DID-to-key binding"
+        );
     }
 
     #[test]

--- a/crates/exochain-wasm/src/lib.rs
+++ b/crates/exochain-wasm/src/lib.rs
@@ -140,6 +140,29 @@ mod source_guard_tests {
     }
 
     #[test]
+    fn wasm_consent_acceptance_refuses_caller_supplied_bailee_keys() {
+        let source = include_str!("consent_bindings.rs");
+        let acceptance = source
+            .split("pub fn wasm_accept_bailment(")
+            .nth(1)
+            .and_then(|section| {
+                section
+                    .split("pub fn wasm_bailment_signing_payload(")
+                    .next()
+            })
+            .expect("wasm_accept_bailment source");
+
+        assert!(
+            acceptance.contains("untrusted_wasm_bailment_acceptance_error"),
+            "WASM bailment acceptance must fail closed without trusted DID resolution"
+        );
+        assert!(
+            !acceptance.contains("exo_consent::bailment::accept("),
+            "WASM bailment acceptance must not call core accept without trusted DID resolution"
+        );
+    }
+
+    #[test]
     fn wasm_governance_bridge_requires_caller_supplied_metadata() {
         let source = include_str!("governance_bindings.rs");
         let forbidden = [

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -722,9 +722,9 @@ test('wasm_bailment_is_active', () => {
 });
 
 // Build the canonical bailment signing payload and sign it with a
-// fresh ephemeral bailee keypair. Since GAP-012 landed (PR #109),
-// `wasm_accept_bailment` cryptographically verifies this signature;
-// arbitrary bytes no longer flip the bailment Active.
+// fresh ephemeral bailee keypair. WASM exposes the payload for external
+// signing, but acceptance itself must go through a trusted core runtime
+// adapter with DID resolution.
 const bailPayload = bailment
   ? wasm.wasm_bailment_signing_payload(JSON.stringify(bailment))
   : null;
@@ -744,26 +744,25 @@ test('wasm_bailment_signing_payload', () => {
   return wasm.wasm_bailment_signing_payload(JSON.stringify(bailment));
 });
 
-test('wasm_accept_bailment', () => {
+test('wasm_accept_bailment rejects caller-supplied bailee key material', () => {
   if (!bailment || !bailSig) throw new Error('skipped -- no bailment from setup');
-  return wasm.wasm_accept_bailment(
-    JSON.stringify(bailment),
-    JSON.stringify(bailPubKeyBytes),
-    JSON.stringify(bailSig.signature)
+  return expectErrorContains(
+    'wasm_accept_bailment',
+    () => wasm.wasm_accept_bailment(
+      JSON.stringify(bailment),
+      JSON.stringify(bailPubKeyBytes),
+      JSON.stringify(bailSig.signature)
+    ),
+    'cannot trust caller-supplied DID key material'
   );
 });
 
-const activeBailment = setup(() =>
-  (bailment && bailSig) && wasm.wasm_accept_bailment(
-    JSON.stringify(bailment),
-    JSON.stringify(bailPubKeyBytes),
-    JSON.stringify(bailSig.signature)
-  ));
+const terminationBailment = bailment;
 
 test('wasm_bailment_termination_payload', () => {
-  if (!activeBailment) throw new Error('skipped -- no active bailment from setup');
+  if (!terminationBailment) throw new Error('skipped -- no bailment from setup');
   const payload = wasm.wasm_bailment_termination_payload(
-    JSON.stringify(activeBailment),
+    JSON.stringify(terminationBailment),
     TEST_DID
   );
   if (!payload || payload.length === 0) {
@@ -773,11 +772,11 @@ test('wasm_bailment_termination_payload', () => {
 });
 
 test('wasm_terminate_bailment rejects unsigned termination', () => {
-  if (!activeBailment) throw new Error('skipped -- no active bailment from setup');
+  if (!terminationBailment) throw new Error('skipped -- no bailment from setup');
   return expectErrorContains(
     'wasm_terminate_bailment',
     () => wasm.wasm_terminate_bailment(
-      JSON.stringify(activeBailment),
+      JSON.stringify(terminationBailment),
       TEST_DID
     ),
     'unsigned bailment termination is disabled'
@@ -785,11 +784,11 @@ test('wasm_terminate_bailment rejects unsigned termination', () => {
 });
 
 test('wasm_terminate_bailment_signed rejects caller-supplied DID key material', () => {
-  if (!activeBailment) throw new Error('skipped -- no active bailment from setup');
+  if (!terminationBailment) throw new Error('skipped -- no bailment from setup');
   return expectErrorContains(
     'wasm_terminate_bailment_signed',
     () => wasm.wasm_terminate_bailment_signed(
-      JSON.stringify(activeBailment),
+      JSON.stringify(terminationBailment),
       TEST_DID,
       JSON.stringify([[TEST_DID, signer1.publicKeyHex]]),
       JSON.stringify(signatureJsonFromHex(signer1.signHex(TEXT_BYTES)))


### PR DESCRIPTION
## Summary
- Classifies this remediation as EXOCHAIN core plus core runtime adapter hardening.
- Changes `exo_consent::bailment::accept` so acceptance verifies against a trusted resolver for `bailment.bailee_did`, not caller-supplied key material.
- Makes WASM-local bailment acceptance fail closed because the bridge cannot trust caller-provided DID-to-key bindings; WASM still exposes the canonical signing payload for trusted runtime adapters.

## Finding Validation
- Source finding: Codex Security CSV row 17, "Bailment acceptance trusts caller-supplied bailee key".
- Verified against current `main` before remediation: a signature from an attacker-controlled key could be paired with that same caller-supplied key and activate the bailment.
- Red tests were added first for core acceptance and WASM acceptance, and failed before the fix.
- Bypass search checked sibling `bailment::accept` and `wasm_accept_bailment` call paths; the remaining CommandBase call is adjacent and now fails closed through WASM rather than activating core state.

## Path Classification
- `crates/exo-consent/src/bailment.rs`: EXOCHAIN core.
- `crates/exo-consent/src/gatekeeper.rs`: EXOCHAIN core test/helper update.
- `crates/exo-consent/src/policy.rs`: EXOCHAIN core test/helper update.
- `crates/exochain-wasm/src/consent_bindings.rs`: Core runtime adapter.
- `crates/exochain-wasm/src/lib.rs`: Core runtime adapter source guard.
- `packages/exochain-wasm/test/bridge_verification.mjs`: Core runtime adapter smoke test.
- `README.md`: Repository truth counters.

## Test Plan
- [x] `cargo test -p exo-consent bailee_key -- --nocapture`
- [x] `cargo test -p exochain-wasm caller_supplied_bailee_key -- --nocapture`
- [x] `cargo test -p exochain-wasm wasm_consent_acceptance_refuses_caller_supplied_bailee_keys -- --nocapture`
- [x] `cargo test -p exo-consent`
- [x] `cargo test -p exochain-wasm`
- [x] `wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm`
- [x] `node packages/exochain-wasm/test/bridge_verification.mjs` (`160/160`)
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `bash tools/test_repo_truth.sh`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo build --workspace --release`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- [x] `cargo audit`
- [x] `cargo deny check`
