### PR TITLE
fix(authority): require trusted wasm verification boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 301 | `find crates -name '*.rs'` |
-| Rust LOC | 193125 | `wc -l` |
-| Workspace tests | 4,394 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 193224 | `wc -l` |
+| Workspace tests | 4,398 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -45,7 +45,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,388 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,398 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -114,7 +114,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 193125 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 193224 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,394 listed workspace tests
 

--- a/crates/exo-authority/src/chain.rs
+++ b/crates/exo-authority/src/chain.rs
@@ -190,6 +190,17 @@ pub fn build_chain_with_depth(
     links: &[AuthorityLink],
     max_depth: usize,
 ) -> Result<AuthorityChain, AuthorityError> {
+    validate_chain_topology(links, max_depth)?;
+    Ok(AuthorityChain {
+        links: links.to_vec(),
+        max_depth,
+    })
+}
+
+fn validate_chain_topology(
+    links: &[AuthorityLink],
+    max_depth: usize,
+) -> Result<(), AuthorityError> {
     if links.is_empty() {
         return Err(AuthorityError::EmptyChain);
     }
@@ -223,10 +234,7 @@ pub fn build_chain_with_depth(
         }
     }
 
-    Ok(AuthorityChain {
-        links: links.to_vec(),
-        max_depth,
-    })
+    Ok(())
 }
 
 /// Verify an authority chain with cryptographic signature verification.
@@ -256,6 +264,7 @@ where
             max_depth: chain.max_depth,
         });
     }
+    validate_chain_topology(&chain.links, chain.max_depth)?;
 
     let mut prev_scope: Option<PermissionSet> = None;
 
@@ -701,6 +710,48 @@ mod tests {
         assert!(matches!(
             verify_chain(&chain, &now(), reg.resolver()),
             Err(AuthorityError::InvalidSignature { index: 0 })
+        ));
+    }
+
+    #[test]
+    fn verify_rejects_prebuilt_chain_with_broken_topology() {
+        let mut reg = KeyRegistry::new();
+        reg.register("root");
+        reg.register("charlie");
+
+        let chain = AuthorityChain {
+            links: vec![
+                signed_link(&reg, "root", "alice", vec![Permission::Read], 0, None),
+                signed_link(&reg, "charlie", "bob", vec![Permission::Read], 1, None),
+            ],
+            max_depth: DEFAULT_MAX_DEPTH,
+        };
+
+        assert!(matches!(
+            verify_chain(&chain, &now(), reg.resolver()),
+            Err(AuthorityError::ChainBroken { index: 1, .. })
+        ));
+    }
+
+    #[test]
+    fn verify_rejects_prebuilt_chain_with_forged_depth() {
+        let mut reg = KeyRegistry::new();
+        reg.register("root");
+        let chain = AuthorityChain {
+            links: vec![signed_link(
+                &reg,
+                "root",
+                "alice",
+                vec![Permission::Read],
+                7,
+                None,
+            )],
+            max_depth: DEFAULT_MAX_DEPTH,
+        };
+
+        assert!(matches!(
+            verify_chain(&chain, &now(), reg.resolver()),
+            Err(AuthorityError::ChainBroken { index: 0, .. })
         ));
     }
 

--- a/crates/exochain-wasm/src/authority_bindings.rs
+++ b/crates/exochain-wasm/src/authority_bindings.rs
@@ -16,14 +16,25 @@
 
 //! Authority bindings: delegation chain verification, permission checking
 
-use std::collections::BTreeMap;
-
 use wasm_bindgen::prelude::*;
 
 use crate::serde_bridge::*;
 
 const MAX_WASM_AUTHORITY_LINKS: usize = 1_024;
-const MAX_WASM_AUTHORITY_KEYS: usize = 1_024;
+const AUTHORITY_CHAIN_TRUSTED_ADAPTER_REQUIRED: &str =
+    "authority-chain verification requires a trusted core runtime adapter";
+const AUTHORITY_CHAIN_CALLER_KEYS_REJECTED: &str =
+    "public WASM callers cannot supply delegator keys or DID key bindings";
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+fn authority_boundary_error(_message: &str) -> JsValue {
+    JsValue::NULL
+}
+
+#[cfg(not(all(test, not(target_arch = "wasm32"))))]
+fn authority_boundary_error(message: &str) -> JsValue {
+    JsValue::from_str(message)
+}
 
 /// Build and validate an authority chain from delegation links
 #[wasm_bindgen]
@@ -61,42 +72,74 @@ pub fn wasm_has_permission(chain_json: &str, permission_json: &str) -> Result<bo
     Ok(exo_authority::chain::has_permission(&chain, &permission))
 }
 
-/// Verify an authority chain against a public-key lookup table.
+/// Refuse public authority-chain verification at the WASM boundary.
 ///
-/// `chain_json`   — JSON `AuthorityChain`.
-/// `now_ms`       — Current timestamp in milliseconds (hybrid logical clock).
-/// `keys_json`    — JSON array of `[did_str, public_key_hex]` pairs used to
-///                  resolve each delegator's Ed25519 public key.
-///
-/// Returns `{ok: true}` if the chain is cryptographically valid and all links
-/// are unexpired, or `{ok: false, error: "..."}`.
+/// Authentic authority-chain verification requires trusted DID key resolution,
+/// so public callers cannot provide key maps through this export.
 #[wasm_bindgen]
 pub fn wasm_verify_authority_chain(
     chain_json: &str,
     now_ms: u64,
     keys_json: &str,
 ) -> Result<JsValue, JsValue> {
-    let chain: exo_authority::AuthorityChain = from_json_str(chain_json)?;
-    let now = exo_core::types::Timestamp::new(now_ms, 0);
-    let key_pairs: Vec<(String, String)> =
-        from_json_bounded_vec(keys_json, "authority public keys", MAX_WASM_AUTHORITY_KEYS)?;
+    let _ = (chain_json, now_ms, keys_json);
+    Err(authority_boundary_error(&format!(
+        "{AUTHORITY_CHAIN_TRUSTED_ADAPTER_REQUIRED}; {AUTHORITY_CHAIN_CALLER_KEYS_REJECTED}"
+    )))
+}
 
-    // Build deterministic lookup table from the caller-supplied key list.
-    let mut lookup: BTreeMap<exo_core::Did, exo_core::PublicKey> = BTreeMap::new();
-    for (did_str, key_hex) in &key_pairs {
-        let did = exo_core::Did::new(did_str)
-            .map_err(|e| JsValue::from_str(&format!("DID error: {e}")))?;
-        let key_bytes =
-            hex::decode(key_hex).map_err(|e| JsValue::from_str(&format!("hex: {e}")))?;
-        let arr: [u8; 32] = key_bytes
-            .try_into()
-            .map_err(|_| JsValue::from_str("public key must be 32 bytes"))?;
-        lookup.insert(did, exo_core::PublicKey::from_bytes(arr));
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn wasm_authority_verification_rejects_caller_supplied_did_key_bindings() {
+        let chain_json = serde_json::json!({
+            "links": [],
+            "max_depth": 5
+        })
+        .to_string();
+        let caller_keys_json = serde_json::json!([["did:exo:root", "11".repeat(32)]]).to_string();
+
+        let result = super::wasm_verify_authority_chain(&chain_json, 1_000, &caller_keys_json);
+
+        assert!(
+            result.is_err(),
+            "public WASM authority verification must fail closed before trusting caller-supplied DID key bindings"
+        );
     }
 
-    let resolve = |did: &exo_core::Did| lookup.get(did).copied();
-    match exo_authority::chain::verify_chain(&chain, &now, resolve) {
-        Ok(()) => to_js_value(&serde_json::json!({"ok": true})),
-        Err(e) => to_js_value(&serde_json::json!({"ok": false, "error": e.to_string()})),
+    #[test]
+    fn wasm_authority_verification_source_guard_rejects_caller_key_resolver() {
+        let source = include_str!("authority_bindings.rs");
+        let production = source
+            .split("mod tests")
+            .next()
+            .expect("production section");
+        let verify_body = production
+            .split("pub fn wasm_verify_authority_chain")
+            .nth(1)
+            .expect("WASM authority verifier")
+            .split("mod tests")
+            .next()
+            .expect("WASM authority verifier body");
+
+        assert!(
+            production
+                .contains("authority-chain verification requires a trusted core runtime adapter")
+                && verify_body.contains("AUTHORITY_CHAIN_TRUSTED_ADAPTER_REQUIRED"),
+            "WASM authority verification must require a trusted adapter"
+        );
+        assert!(
+            production.contains("public WASM callers cannot supply delegator keys")
+                && verify_body.contains("AUTHORITY_CHAIN_CALLER_KEYS_REJECTED"),
+            "WASM authority verification must reject caller-supplied key bindings"
+        );
+        assert!(
+            !verify_body.contains("from_json_bounded_vec(keys_json"),
+            "WASM authority verification must not parse caller-supplied DID key maps"
+        );
+        assert!(
+            !verify_body.contains("verify_chain(&chain"),
+            "public WASM authority verification must not call core verification with a caller-controlled resolver"
+        );
     }
 }

--- a/crates/exochain-wasm/src/lib.rs
+++ b/crates/exochain-wasm/src/lib.rs
@@ -262,7 +262,12 @@ mod source_guard_tests {
             (
                 "authority_bindings.rs",
                 include_str!("authority_bindings.rs"),
-                "MAX_WASM_AUTHORITY_KEYS",
+                "AUTHORITY_CHAIN_TRUSTED_ADAPTER_REQUIRED",
+            ),
+            (
+                "authority_bindings.rs",
+                include_str!("authority_bindings.rs"),
+                "AUTHORITY_CHAIN_CALLER_KEYS_REJECTED",
             ),
             (
                 "identity_bindings.rs",

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -1330,12 +1330,16 @@ test('wasm_has_permission', () => {
   );
 });
 
-test('wasm_verify_authority_chain', () => {
+test('wasm_verify_authority_chain rejects caller-supplied keys', () => {
   if (!chain) throw new Error('skipped -- no chain from setup');
-  return wasm.wasm_verify_authority_chain(
-    JSON.stringify(chain),
-    NOW_MS,
-    JSON.stringify([])
+  return expectErrorContains(
+    'wasm_verify_authority_chain',
+    () => wasm.wasm_verify_authority_chain(
+      JSON.stringify(chain),
+      NOW_MS,
+      JSON.stringify([[TEST_DID, signer1.publicKeyHex]])
+    ),
+    'trusted core runtime adapter'
   );
 });
 


### PR DESCRIPTION
## Summary
- Classifies and remediates P2 WASM authority verification as core runtime adapter + EXOCHAIN core authority-chain validation.
- Moves authority-chain topology validation into core verification so deserialized/prebuilt chains cannot bypass continuity/depth checks.
- Changes the public WASM authority verifier to fail closed instead of trusting caller-supplied DID key maps, with Rust source guards and Node bridge coverage.
- Refreshes README repo-truth counts required by the hygiene guard after the new Rust tests.

## Path classification
- EXOCHAIN core: `crates/exo-authority/src/chain.rs`
- Core runtime adapter: `crates/exochain-wasm/src/authority_bindings.rs`, `crates/exochain-wasm/src/lib.rs`, `packages/exochain-wasm/test/bridge_verification.mjs`
- Documentation / repo-truth: `README.md`

## Validation
- `cargo test -p exochain-wasm wasm_non_governance_vec_inputs_use_explicit_count_bounds -- --nocapture`
- `cargo test -p exo-authority -- --nocapture`
- `cargo test -p exochain-wasm -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm`
- `node packages/exochain-wasm/test/bridge_verification.mjs`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --release`
- `RUSTDOCFLAGS=' -D warnings' cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check`
- `bash tools/test_repo_truth.sh`

## Notes
- `cargo deny check` completed successfully with pre-existing duplicate dependency warnings only.
- Unrelated untracked `docs/heartfield/HEARTFIELD_AI_WHITEPAPER.md` was intentionally excluded.