### PR TITLE
fix(messaging): remove plaintext hash from encrypted envelopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 301 | `find crates -name '*.rs'` |
-| Rust LOC | 193224 | `wc -l` |
-| Workspace tests | 4,398 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 193234 | `wc -l` |
+| Workspace tests | 4,400 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -45,7 +45,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,398 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,400 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -114,9 +114,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 193224 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 22 crates, 193234 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,394 listed workspace tests
+         cryptographic proofs, 4,400 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          160 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-messaging/src/compose.rs
+++ b/crates/exo-messaging/src/compose.rs
@@ -193,14 +193,14 @@ pub fn prepare_envelope_for_signing_with_ephemeral(
         MESSAGE_KEX_CONTEXT,
     )?;
 
-    let plaintext_hash = Hash256::digest(plaintext);
+    let plaintext_nonce_input = Hash256::digest(plaintext);
     let nonce = derive_vault_nonce(
         &metadata,
         content_type,
         sender_did,
         recipient_did,
         ephemeral_x25519_keypair.public.as_bytes(),
-        &plaintext_hash,
+        &plaintext_nonce_input,
         release_on_death,
         release_delay_hours,
     )?;
@@ -212,8 +212,7 @@ pub fn prepare_envelope_for_signing_with_ephemeral(
         .encrypt_with_nonce(plaintext, recipient_did.as_str().as_bytes(), &nonce)
         .map_err(|e| MessagingError::EncryptionFailed(e.to_string()))?;
 
-    // 4. Hash plaintext for post-decrypt integrity check
-    // 5. Build envelope (without signature first)
+    // 4. Build envelope (without signature first)
     let envelope = EncryptedEnvelope {
         id: metadata.id.to_string(),
         sender_did: sender_did.clone(),
@@ -222,7 +221,6 @@ pub fn prepare_envelope_for_signing_with_ephemeral(
         ciphertext,
         content_type,
         signature: exo_core::Signature::empty(),
-        plaintext_hash,
         release_on_death,
         release_delay_hours,
         created: metadata.created,
@@ -244,7 +242,7 @@ fn derive_vault_nonce(
     sender_did: &Did,
     recipient_did: &Did,
     ephemeral_public_key: &[u8; 32],
-    plaintext_hash: &Hash256,
+    plaintext_nonce_input: &Hash256,
     release_on_death: bool,
     release_delay_hours: u32,
 ) -> Result<[u8; VAULT_NONCE_SIZE], MessagingError> {
@@ -264,7 +262,7 @@ fn derive_vault_nonce(
         recipient_did.as_str().as_bytes(),
     )?;
     transcript.extend_from_slice(ephemeral_public_key);
-    transcript.extend_from_slice(plaintext_hash.as_bytes());
+    transcript.extend_from_slice(plaintext_nonce_input.as_bytes());
     transcript.push(u8::from(content_type));
     transcript.push(u8::from(release_on_death));
     transcript.extend_from_slice(&release_delay_hours.to_le_bytes());

--- a/crates/exo-messaging/src/envelope.rs
+++ b/crates/exo-messaging/src/envelope.rs
@@ -22,7 +22,7 @@
 
 use std::fmt;
 
-use exo_core::{Did, Hash256, Signature, Timestamp};
+use exo_core::{Did, Signature, Timestamp};
 use serde::{
     Deserialize, Deserializer, Serialize,
     de::{self, SeqAccess, Visitor},
@@ -45,7 +45,6 @@ struct EnvelopeSigningPayload<'a> {
     ephemeral_public_key: &'a [u8; 32],
     ciphertext: &'a [u8],
     content_type: u8,
-    plaintext_hash: &'a Hash256,
     release_on_death: bool,
     release_delay_hours: u32,
     created: &'a Timestamp,
@@ -93,6 +92,7 @@ impl From<ContentType> for u8 {
 /// Format: `[24-byte nonce][ciphertext][16-byte Poly1305 tag]`
 /// (same layout as `VaultEncryptor` in `exo-identity`).
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct EncryptedEnvelope {
     /// Unique message ID.
     pub id: String,
@@ -109,8 +109,6 @@ pub struct EncryptedEnvelope {
     pub content_type: ContentType,
     /// Ed25519 signature over the canonical envelope bytes (excl. signature field).
     pub signature: Signature,
-    /// Blake3 hash of the plaintext (for integrity verification after decrypt).
-    pub plaintext_hash: Hash256,
     /// Whether this message should be released after the sender's death.
     pub release_on_death: bool,
     /// Delay in hours after death verification before release (0 = immediate).
@@ -223,7 +221,6 @@ impl EncryptedEnvelope {
             ephemeral_public_key: &self.ephemeral_public_key,
             ciphertext: &self.ciphertext,
             content_type: u8::from(self.content_type),
-            plaintext_hash: &self.plaintext_hash,
             release_on_death: self.release_on_death,
             release_delay_hours: self.release_delay_hours,
             created: &self.created,
@@ -237,6 +234,7 @@ impl EncryptedEnvelope {
 
 #[cfg(test)]
 mod tests {
+    use exo_core::Hash256;
     use serde::Deserialize;
 
     use super::*;
@@ -296,7 +294,6 @@ mod tests {
         ephemeral_public_key: [u8; 32],
         ciphertext: Vec<u8>,
         content_type: u8,
-        plaintext_hash: Hash256,
         release_on_death: bool,
         release_delay_hours: u32,
         created: Timestamp,
@@ -311,7 +308,6 @@ mod tests {
             ciphertext: vec![1, 1, 2, 3, 5, 8],
             content_type: ContentType::Secret,
             signature: Signature::empty(),
-            plaintext_hash: Hash256::digest(b"plaintext"),
             release_on_death: true,
             release_delay_hours: 72,
             created: Timestamp::new(9_000, 3),
@@ -335,7 +331,6 @@ mod tests {
         assert_eq!(decoded.ephemeral_public_key, envelope.ephemeral_public_key);
         assert_eq!(decoded.ciphertext, envelope.ciphertext);
         assert_eq!(decoded.content_type, u8::from(envelope.content_type));
-        assert_eq!(decoded.plaintext_hash, envelope.plaintext_hash);
         assert_eq!(decoded.release_on_death, envelope.release_on_death);
         assert_eq!(decoded.release_delay_hours, envelope.release_delay_hours);
         assert_eq!(decoded.created, envelope.created);
@@ -352,6 +347,32 @@ mod tests {
         assert!(!debug.contains("ciphertext: [1, 1, 2, 3, 5, 8]"));
         assert!(!debug.contains("signature:"));
         assert!(!debug.contains("plaintext_hash:"));
+    }
+
+    #[test]
+    fn encrypted_envelope_wire_format_does_not_expose_plaintext_hash() {
+        let envelope = sample_envelope();
+        let value = serde_json::to_value(&envelope).expect("serialize envelope");
+
+        assert!(
+            value.get("plaintext_hash").is_none(),
+            "encrypted envelopes must not publish a deterministic plaintext hash"
+        );
+    }
+
+    #[test]
+    fn encrypted_envelope_deserialization_rejects_legacy_plaintext_hash_field() {
+        let envelope = sample_envelope();
+        let mut value = serde_json::to_value(&envelope).expect("serialize envelope");
+        value["plaintext_hash"] =
+            serde_json::to_value(Hash256::digest(b"plaintext")).expect("serialize hash");
+
+        let decoded: Result<EncryptedEnvelope, _> = serde_json::from_value(value);
+
+        assert!(
+            decoded.is_err(),
+            "encrypted envelopes must reject legacy plaintext_hash metadata"
+        );
     }
 
     #[test]

--- a/crates/exo-messaging/src/open.rs
+++ b/crates/exo-messaging/src/open.rs
@@ -17,10 +17,10 @@
 //! Open & Verify — recipient-side message decryption.
 //!
 //! Derives the shared secret from the ephemeral public key + recipient's
-//! X25519 secret key, decrypts the ciphertext, verifies the sender's
-//! Ed25519 signature, and checks the plaintext integrity hash.
+//! X25519 secret key, decrypts the ciphertext, and verifies the sender's
+//! Ed25519 signature over the encrypted envelope.
 
-use exo_core::{Hash256, PublicKey, crypto};
+use exo_core::{PublicKey, crypto};
 use exo_identity::vault::VaultEncryptor;
 
 use crate::{
@@ -69,14 +69,6 @@ pub fn unlock(
         )
         .map_err(|_| MessagingError::DecryptionFailed)?;
 
-    // 4. Verify plaintext integrity hash
-    let computed_hash = Hash256::digest(&plaintext);
-    if computed_hash != envelope.plaintext_hash {
-        return Err(MessagingError::InvalidEnvelope(
-            "plaintext hash mismatch".into(),
-        ));
-    }
-
     Ok(plaintext)
 }
 
@@ -113,7 +105,6 @@ mod tests {
         buf.extend_from_slice(&envelope.ephemeral_public_key);
         buf.extend_from_slice(&envelope.ciphertext);
         buf.extend_from_slice(&[u8::from(envelope.content_type)]);
-        buf.extend_from_slice(envelope.plaintext_hash.as_bytes());
         buf.extend_from_slice(&[u8::from(envelope.release_on_death)]);
         buf.extend_from_slice(&envelope.release_delay_hours.to_le_bytes());
         buf.extend_from_slice(&envelope.created.physical_ms.to_le_bytes());


### PR DESCRIPTION
## Summary
- Removes the public deterministic `plaintext_hash` field from `EncryptedEnvelope` serialization and signing payloads.
- Rejects legacy encrypted-envelope payloads that still include `plaintext_hash` via `serde(deny_unknown_fields)`.
- Keeps plaintext-derived material internal to deterministic nonce derivation only, avoiding a public equality oracle for encrypted message contents.

## Finding Verification
- Finding: P2 plaintext hashes leak encrypted message contents.
- Current-main verification: reproduced before the fix with a failing regression test, `encrypted_envelope_wire_format_does_not_expose_plaintext_hash`, which observed the serialized envelope still exposed `plaintext_hash`.
- Fix boundary: the encrypted-envelope wire/signing format in `crates/exo-messaging`; AEAD authentication plus the signed ciphertext envelope now carry integrity without publishing a deterministic plaintext digest.

## Path Classification
- EXOCHAIN core: `crates/exo-messaging/src/envelope.rs`
- EXOCHAIN core: `crates/exo-messaging/src/compose.rs`
- EXOCHAIN core: `crates/exo-messaging/src/open.rs`
- Repo-truth documentation: `README.md`

## Test Plan
- [x] `cargo test -p exo-messaging encrypted_envelope_wire_format_does_not_expose_plaintext_hash -- --nocapture` failed before the fix and passed after the fix.
- [x] `cargo test -p exo-messaging encrypted_envelope_deserialization_rejects_legacy_plaintext_hash_field -- --nocapture`
- [x] `cargo test -p exo-messaging -- --nocapture`
- [x] `cargo test -p exochain-wasm -- --nocapture`
- [x] `cargo clippy -p exo-messaging --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm`
- [x] `node packages/exochain-wasm/test/bridge_verification.mjs`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace --release`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- [x] `cargo audit`
- [x] `cargo deny check`
- [x] `bash tools/test_repo_truth.sh`

## Bypass Search
- [x] `rg -n "plaintext_hash|plaintext hash|plaintext_hash" crates/exo-messaging README.md` now finds only regression-test assertions.
