### PR TITLE
docs(audit): mark settlement authority finding remediated

### DIFF
--- a/docs/audit/codex-security-findings-2026-05-16-triage.md
+++ b/docs/audit/codex-security-findings-2026-05-16-triage.md
@@ -42,7 +42,7 @@ Current baseline when this triage was created:
 |---|---|---|---|---|
 | P0 | Session expiry uses deterministic HLC in production | Core runtime adapter: `crates/exo-gateway/src/server.rs`; EXOCHAIN core support: `crates/exo-core/src/hlc.rs` | Verified remediated on current main; no code change required | `cargo test -p exo-gateway production_app_state_uses_database_time_for_db_backed_session_expiry -- --nocapture`; `cargo test -p exo-gateway production_session_auth_rejects_epoch_expired_token -- --nocapture` |
 | P0 | Bearer session TTL uses deterministic counter | Core runtime adapter: `crates/exo-node/src/zerodentity/api.rs`, `crates/exo-node/src/main.rs`; EXOCHAIN core support: `crates/exo-node/src/zerodentity/*`, `crates/exo-core/src/hlc.rs` | Verified remediated on current main; no code change required | `cargo test -p exo-node production_api_state -- --nocapture`; `cargo test -p exo-node store_session -- --nocapture` |
-| P1 | Client-supplied authority accepted for settlements | EXOCHAIN core: `crates/exo-economy/src/settlement.rs`, `crates/exo-economy/src/value_contribution.rs`; core runtime adapter: `crates/exo-node/src/economy.rs` | Queued | Prove settlement authority cannot be supplied solely by the caller |
+| P1 | Client-supplied authority accepted for settlements | EXOCHAIN core: `crates/exo-economy/src/settlement.rs`, `crates/exo-economy/src/value_contribution.rs`; core runtime adapter: `crates/exo-node/src/economy.rs` | Verified remediated on current main; no code change required | `cargo test -p exo-node automated_settlement_rejects_client_supplied_preconditions -- --nocapture`; `cargo test -p exo-economy automated_settlement_rejects_authority_proof_not_bound_to_adoption -- --nocapture` |
 | P1 | Vote conflict checks trust caller-supplied affected DIDs | Core runtime adapter: `crates/exo-gateway/src/handlers.rs`; EXOCHAIN core: `crates/exo-governance/src/conflict.rs` | Queued | Prove vote conflict adjudication derives affected parties from owned decision state |
 | P1 | MCP trusts unsigned consent and override context | Core runtime adapter: `crates/exo-node/src/mcp/tools/authority.rs`, `crates/exo-node/src/mcp/middleware.rs` | Queued | Prove MCP authority tools reject unsigned or caller-fabricated consent and override context |
 | P1 | Quorum counts unproven non-human votes as authentic | EXOCHAIN core: `crates/exo-gatekeeper/src/types.rs`, `crates/exo-gatekeeper/src/invariants.rs`; core runtime adapter: `crates/exochain-wasm/src/gatekeeper_bindings.rs` | Queued | Prove quorum vote provenance is verified for every counted voter class |
@@ -135,6 +135,38 @@ Validation commands:
 cargo test -p exo-node production_api_state -- --nocapture
 cargo test -p exo-node list_claims_rejects_expired_session -- --nocapture
 cargo test -p exo-node store_session -- --nocapture
+```
+
+### P1 - Client-Supplied Authority Accepted For Settlements
+
+Disposition on 2026-05-17: verified already remediated on current `main`.
+
+Path classification:
+
+- EXOCHAIN core: `crates/exo-economy/src/settlement.rs` and
+  `crates/exo-economy/src/value_contribution.rs`.
+- Core runtime adapter: `crates/exo-node/src/economy.rs`.
+- Imported evidence tracking: this file.
+
+Current enforcement evidence:
+
+- The node economy API rejects client-supplied automated-settlement
+  preconditions instead of trusting request-provided `authority_valid` flags.
+- Runtime automated settlement derives preconditions from stored offer,
+  acceptance, adoption, contribution-node, wrapper, ruleset, and value-event
+  records.
+- Request `automation_authority_ref` must match the stored contribution
+  acceptance authority envelope and adoption proof hash.
+- Core settlement preconditions fail closed when delegated authority is invalid
+  or a dispute is active.
+
+Validation commands:
+
+```bash
+cargo test -p exo-node automated_settlement_rejects_client_supplied_preconditions -- --nocapture
+cargo test -p exo-node automated_settlement_rejects_request_authority_not_bound_to_stored_acceptance -- --nocapture
+cargo test -p exo-economy automated_settlement_rejects_authority_proof_not_bound_to_adoption -- --nocapture
+cargo test -p exo-economy automated_preconditions_fail_closed_for_missing_authority_and_active_dispute -- --nocapture
 ```
 
 ### P2 - WASM Decision Transitions Can Disable All Invariants


### PR DESCRIPTION
## Summary
- Records the P1 client-supplied settlement authority finding as verified remediated on current `main`.
- Captures the current boundary: node economy routes reject caller-supplied automated-settlement preconditions, derive authority from stored state, and require request authority to match stored acceptance/adoption records.
- Leaves runtime code unchanged because focused validation shows the reported issue no longer reproduces.

## Path Classification
- Imported evidence tracking: `docs/audit/codex-security-findings-2026-05-16-triage.md`
- Verified EXOCHAIN core paths, unchanged: `crates/exo-economy/src/settlement.rs`, `crates/exo-economy/src/value_contribution.rs`
- Verified core runtime adapter path, unchanged: `crates/exo-node/src/economy.rs`

## Verification
- [x] `cargo test -p exo-node automated_settlement_rejects_client_supplied_preconditions -- --nocapture`
- [x] `cargo test -p exo-node automated_settlement_rejects_request_authority_not_bound_to_stored_acceptance -- --nocapture`
- [x] `cargo test -p exo-economy automated_settlement_rejects_authority_proof_not_bound_to_adoption -- --nocapture`
- [x] `cargo test -p exo-economy automated_preconditions_fail_closed_for_missing_authority_and_active_dispute -- --nocapture`
- [x] `git diff --check`
