### PR TITLE
fix(messaging): hide plaintext from nonce derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 22 | `ls -d crates/*/` |
 | Rust source files | 301 | `find crates -name '*.rs'` |
-| Rust LOC | 193234 | `wc -l` |
-| Workspace tests | 4,400 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 193339 | `wc -l` |
+| Workspace tests | 4,402 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |

--- a/crates/exo-messaging/src/compose.rs
+++ b/crates/exo-messaging/src/compose.rs
@@ -21,8 +21,10 @@
 //! plaintext with XChaCha20-Poly1305, and signs the envelope with the sender's
 //! Ed25519 key.
 
-use exo_core::{Did, Hash256, PublicKey, SecretKey, Signature, Timestamp};
+use exo_core::{Did, PublicKey, SecretKey, Signature, Timestamp};
 use exo_identity::vault::{VAULT_NONCE_SIZE, VaultEncryptor};
+use hkdf::Hkdf;
+use sha2::Sha256;
 use uuid::Uuid;
 
 use crate::{
@@ -193,14 +195,13 @@ pub fn prepare_envelope_for_signing_with_ephemeral(
         MESSAGE_KEX_CONTEXT,
     )?;
 
-    let plaintext_nonce_input = Hash256::digest(plaintext);
     let nonce = derive_vault_nonce(
+        &shared_key,
         &metadata,
         content_type,
         sender_did,
         recipient_did,
         ephemeral_x25519_keypair.public.as_bytes(),
-        &plaintext_nonce_input,
         release_on_death,
         release_delay_hours,
     )?;
@@ -237,17 +238,16 @@ fn caller_supplied_ephemeral_required() -> MessagingError {
 
 #[allow(clippy::too_many_arguments)]
 fn derive_vault_nonce(
+    shared_key: &[u8; 32],
     metadata: &ComposeMetadata,
     content_type: ContentType,
     sender_did: &Did,
     recipient_did: &Did,
     ephemeral_public_key: &[u8; 32],
-    plaintext_nonce_input: &Hash256,
     release_on_death: bool,
     release_delay_hours: u32,
 ) -> Result<[u8; VAULT_NONCE_SIZE], MessagingError> {
     let mut transcript = Vec::new();
-    transcript.extend_from_slice(MESSAGE_VAULT_NONCE_DOMAIN);
     append_len_prefixed(&mut transcript, "id", metadata.id.as_bytes())?;
     transcript.extend_from_slice(&metadata.created.physical_ms.to_le_bytes());
     transcript.extend_from_slice(&metadata.created.logical.to_le_bytes());
@@ -262,14 +262,14 @@ fn derive_vault_nonce(
         recipient_did.as_str().as_bytes(),
     )?;
     transcript.extend_from_slice(ephemeral_public_key);
-    transcript.extend_from_slice(plaintext_nonce_input.as_bytes());
     transcript.push(u8::from(content_type));
     transcript.push(u8::from(release_on_death));
     transcript.extend_from_slice(&release_delay_hours.to_le_bytes());
 
-    let digest = Hash256::digest(&transcript);
+    let hk = Hkdf::<Sha256>::new(Some(MESSAGE_VAULT_NONCE_DOMAIN), shared_key);
     let mut nonce = [0u8; VAULT_NONCE_SIZE];
-    nonce.copy_from_slice(&digest.as_bytes()[..VAULT_NONCE_SIZE]);
+    hk.expand(&transcript, &mut nonce)
+        .map_err(|e| MessagingError::EncryptionFailed(e.to_string()))?;
     Ok(nonce)
 }
 
@@ -322,7 +322,7 @@ pub fn attach_verified_signature(
 
 #[cfg(test)]
 mod tests {
-    use exo_core::{Timestamp, crypto::generate_keypair};
+    use exo_core::{Hash256, Timestamp, crypto::generate_keypair};
     use uuid::Uuid;
 
     use super::*;
@@ -338,6 +338,48 @@ mod tests {
     fn x25519_keypair(seed: u8) -> kex::X25519KeyPair {
         kex::X25519KeyPair::from_secret_bytes([seed; 32])
             .expect("valid deterministic X25519 keypair")
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn legacy_public_plaintext_hash_nonce(
+        metadata: &ComposeMetadata,
+        content_type: ContentType,
+        sender_did: &Did,
+        recipient_did: &Did,
+        ephemeral_public_key: &[u8; 32],
+        plaintext: &[u8],
+        release_on_death: bool,
+        release_delay_hours: u32,
+    ) -> [u8; VAULT_NONCE_SIZE] {
+        let plaintext_nonce_input = Hash256::digest(plaintext);
+        let mut transcript = Vec::new();
+        transcript.extend_from_slice(MESSAGE_VAULT_NONCE_DOMAIN);
+        append_len_prefixed(&mut transcript, "id", metadata.id.as_bytes())
+            .expect("append id to legacy nonce transcript");
+        transcript.extend_from_slice(&metadata.created.physical_ms.to_le_bytes());
+        transcript.extend_from_slice(&metadata.created.logical.to_le_bytes());
+        append_len_prefixed(
+            &mut transcript,
+            "sender_did",
+            sender_did.as_str().as_bytes(),
+        )
+        .expect("append sender did to legacy nonce transcript");
+        append_len_prefixed(
+            &mut transcript,
+            "recipient_did",
+            recipient_did.as_str().as_bytes(),
+        )
+        .expect("append recipient did to legacy nonce transcript");
+        transcript.extend_from_slice(ephemeral_public_key);
+        transcript.extend_from_slice(plaintext_nonce_input.as_bytes());
+        transcript.push(u8::from(content_type));
+        transcript.push(u8::from(release_on_death));
+        transcript.extend_from_slice(&release_delay_hours.to_le_bytes());
+
+        let digest = Hash256::digest(&transcript);
+        let mut nonce = [0u8; VAULT_NONCE_SIZE];
+        nonce.copy_from_slice(&digest.as_bytes()[..VAULT_NONCE_SIZE]);
+        nonce
     }
 
     #[test]
@@ -555,6 +597,69 @@ mod tests {
             !production.contains(".encrypt("),
             "compose must not call the implicit vault encryption entrypoint"
         );
+    }
+
+    #[test]
+    fn encrypted_envelope_nonce_is_not_public_plaintext_hash_oracle() {
+        let sender_did = Did::new("did:exo:alice").unwrap();
+        let recipient_did = Did::new("did:exo:bob").unwrap();
+        let recipient_kp = x25519_keypair(0x27);
+        let ephemeral_kp = x25519_keypair(0x37);
+        let metadata = metadata();
+        let plaintext = b"known plaintext candidate";
+        let content_type = ContentType::Secret;
+        let release_on_death = true;
+        let release_delay_hours = 24;
+
+        let envelope = prepare_envelope_for_signing_with_ephemeral(
+            plaintext,
+            content_type,
+            &sender_did,
+            &recipient_did,
+            &recipient_kp.public,
+            &ephemeral_kp,
+            metadata,
+            release_on_death,
+            release_delay_hours,
+        )
+        .expect("prepare envelope");
+
+        let legacy_nonce = legacy_public_plaintext_hash_nonce(
+            &metadata,
+            content_type,
+            &sender_did,
+            &recipient_did,
+            ephemeral_kp.public.as_bytes(),
+            plaintext,
+            release_on_death,
+            release_delay_hours,
+        );
+
+        assert_ne!(
+            &envelope.ciphertext[..VAULT_NONCE_SIZE],
+            &legacy_nonce[..],
+            "visible ciphertext nonce must not be derived from public metadata plus guessed plaintext"
+        );
+    }
+
+    #[test]
+    fn compose_path_does_not_feed_plaintext_hash_into_visible_nonce() {
+        let source = include_str!("compose.rs");
+        let production = source
+            .split("// ===========================================================================")
+            .next()
+            .expect("production section");
+
+        for pattern in [
+            "Hash256::digest(plaintext)",
+            "plaintext_nonce_input",
+            "transcript.extend_from_slice(plaintext",
+        ] {
+            assert!(
+                !production.contains(pattern),
+                "compose production path must not expose plaintext-derived material through the visible vault nonce via {pattern}"
+            );
+        }
     }
 
     #[test]

--- a/docs/audit/codex-security-findings-2026-05-16-triage.md
+++ b/docs/audit/codex-security-findings-2026-05-16-triage.md
@@ -55,7 +55,7 @@ Current baseline when this triage was created:
 | P2 | WASM authority verification skips chain topology validation | Core runtime adapter: `crates/exochain-wasm/src/authority_bindings.rs`; EXOCHAIN core: `crates/exo-authority/src/chain.rs` | Verified remediated on current main; no code change required | `cargo test -p exochain-wasm wasm_authority_verification_source_guard_rejects_caller_key_resolver -- --nocapture`; `cargo test -p exo-authority verify_rejects_prebuilt_chain_with_broken_topology -- --nocapture` |
 | P2 | WASM decision transitions can disable all invariants | Core runtime adapter: `crates/exochain-wasm/src/decision_forum_bindings.rs`, `packages/exochain-wasm/test/bridge_verification.mjs`; EXOCHAIN core: `crates/exo-gatekeeper/src/invariants.rs` | Verified remediated on current main; no code change required | `cargo test -p exochain-wasm wasm_decision_transition_requires_kernel_adjudication -- --nocapture`; `node packages/exochain-wasm/test/bridge_verification.mjs` |
 | P2 | Governance attestations trust caller-supplied keys | Adjacent surface: `demo/services/audit-api/src/index.js`; core runtime adapter: `crates/exochain-wasm/src/gatekeeper_bindings.rs` | Queued behind core-owned runtime issues | Prove governance health attestation keys are pinned or registry-resolved before persistence |
-| P2 | Plaintext hashes leak encrypted message contents | EXOCHAIN core: `crates/exo-messaging/src/envelope.rs`, `crates/exo-messaging/src/compose.rs`, `crates/exo-messaging/src/open.rs` | Queued | Prove encrypted-envelope metadata cannot be used as a plaintext equality oracle |
+| P2 | Plaintext hashes leak encrypted message contents | EXOCHAIN core: `crates/exo-messaging/src/envelope.rs`, `crates/exo-messaging/src/compose.rs`, `crates/exo-messaging/src/open.rs` | Remediated by core nonce-derivation fix | `cargo test -p exo-messaging encrypted_envelope_nonce_is_not_public_plaintext_hash_oracle -- --nocapture`; `cargo test -p exo-messaging -- --nocapture` |
 | P2 | Identity erasure deletes third-party conflict records | Core runtime adapter: `crates/exo-gateway/src/server.rs`, `crates/exo-gateway/src/db.rs`, `crates/exo-gateway/src/handlers.rs` | Queued | Prove identity erasure tombstones subject-owned data without deleting independent conflict records |
 | P2 | Unbounded DB DID registration enables storage DoS | Core runtime adapter: `crates/exo-gateway/src/server.rs`, `crates/exo-gateway/src/db.rs`, `crates/exo-gateway/migrations/20260504000003_create_did_documents.sql`; EXOCHAIN core: `crates/exo-identity/src/registry.rs` | Queued | Prove tenant-scoped DID registration has durable quota or admission control |
 | P2 | Gateway rate limit collapses clients behind proxies | Core runtime adapter: `crates/exo-gateway/src/server.rs` | Queued | Prove rate limiting uses a trusted deployment identity and avoids spoofed forwarded headers |
@@ -595,4 +595,52 @@ Validation commands:
 ```bash
 cargo test -p exochain-wasm wasm_decision_transition_requires_kernel_adjudication -- --nocapture
 node packages/exochain-wasm/test/bridge_verification.mjs
+```
+
+### P2 - Plaintext Hashes Leak Encrypted Message Contents
+
+Disposition on 2026-05-17: remediated in EXOCHAIN core by removing
+plaintext-derived material from visible vault nonce derivation.
+
+Path classification:
+
+- EXOCHAIN core: `crates/exo-messaging/src/compose.rs`.
+- EXOCHAIN core verification paths:
+  `crates/exo-messaging/src/envelope.rs` and
+  `crates/exo-messaging/src/open.rs`.
+- Imported evidence tracking: this file.
+- No adjacent-surface, third-party, generated, or deployment path changed.
+
+Reproduction evidence before the fix:
+
+- `encrypted_envelope_nonce_is_not_public_plaintext_hash_oracle` failed because
+  the visible 24-byte ciphertext prefix equaled the nonce derived from public
+  envelope metadata plus `Hash256::digest(plaintext)`.
+- `compose_path_does_not_feed_plaintext_hash_into_visible_nonce` failed because
+  the production compose path contained `Hash256::digest(plaintext)` and fed
+  `plaintext_nonce_input` into the nonce transcript.
+
+Current enforcement evidence:
+
+- `EncryptedEnvelope` still has no public `plaintext_hash` field and rejects
+  legacy wire input containing that field.
+- The compose path derives the visible XChaCha nonce through HKDF-SHA256 keyed
+  by the ECDH shared message key, with public envelope fields used only as HKDF
+  info.
+- The visible nonce transcript no longer includes plaintext, plaintext hashes,
+  or caller-visible plaintext-derived material.
+- The round-trip open path still decrypts messages with the recipient X25519
+  secret and verifies the canonical signed envelope.
+
+Validation commands:
+
+```bash
+cargo test -p exo-messaging encrypted_envelope_nonce_is_not_public_plaintext_hash_oracle -- --nocapture
+cargo test -p exo-messaging compose_path_does_not_feed_plaintext_hash_into_visible_nonce -- --nocapture
+cargo test -p exo-messaging -- --nocapture
+cargo test -p exo-messaging --release -- --nocapture
+cargo clippy -p exo-messaging --all-targets -- -D warnings
+cargo fmt --all -- --check
+RUSTDOCFLAGS="-D warnings" cargo doc -p exo-messaging --no-deps
+git diff --check
 ```


### PR DESCRIPTION
## Summary
- Remediates the EXOCHAIN core messaging plaintext equality oracle by deriving the visible vault nonce from the ECDH shared message key via HKDF-SHA256 instead of `Hash256::digest(plaintext)`.
- Adds regression coverage proving the ciphertext nonce no longer matches the legacy public metadata + guessed plaintext nonce.
- Updates the imported-evidence triage ledger and the README repo-truth counts affected by the added tests.

## Path Classification
- EXOCHAIN core: `crates/exo-messaging/src/compose.rs`
- Imported evidence tracking: `docs/audit/codex-security-findings-2026-05-16-triage.md`
- Documentation/public-claim metadata: `README.md`
- No adjacent-surface, third-party, generated, or deployment path changed.

## Validation
- RED before fix: `cargo test -p exo-messaging encrypted_envelope_nonce_is_not_public_plaintext_hash_oracle -- --nocapture` failed with nonce equality.
- RED before fix: `cargo test -p exo-messaging compose_path_does_not_feed_plaintext_hash_into_visible_nonce -- --nocapture` failed on `Hash256::digest(plaintext)`.
- `cargo test -p exo-messaging encrypted_envelope_nonce_is_not_public_plaintext_hash_oracle -- --nocapture`
- `cargo test -p exo-messaging compose_path_does_not_feed_plaintext_hash_into_visible_nonce -- --nocapture`
- `cargo test -p exo-messaging -- --nocapture`
- `cargo test -p exo-messaging --release -- --nocapture`
- `cargo clippy -p exo-messaging --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p exo-messaging --no-deps`
- `bash tools/test_repo_truth.sh`
- `git diff --check`
- Production-section searches confirmed no plaintext-derived nonce or plaintext-hash metadata remains outside tests.
