### PR TITLE
Pin governance attestation keys in audit API

### DIFF
--- a/demo/services/audit-api/src/index.js
+++ b/demo/services/audit-api/src/index.js
@@ -25,7 +25,39 @@ const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
 const PORT = process.env.PORT || 3007;
 // Governance health endpoint requires a bearer token (Security panel condition — CR-001 amendment).
 // Set GOVERNANCE_API_TOKEN in the secrets manager; never in env files or Compose.
+// Set GOVERNANCE_ATTESTATION_KEYS as a JSON object mapping trusted signer DID to Ed25519 public key hex.
 const GOVERNANCE_API_TOKEN = process.env.GOVERNANCE_API_TOKEN || null;
+const GOVERNANCE_ATTESTATION_KEYS = parseGovernanceAttestationKeys(
+  process.env.GOVERNANCE_ATTESTATION_KEYS || null,
+);
+
+function parseGovernanceAttestationKeys(value) {
+  const trustedKeys = new Map();
+  if (!value) return trustedKeys;
+
+  let parsed;
+  try {
+    parsed = JSON.parse(value);
+  } catch (e) {
+    throw new Error('GOVERNANCE_ATTESTATION_KEYS must be a JSON object mapping signer DID to Ed25519 public key hex');
+  }
+
+  if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') {
+    throw new Error('GOVERNANCE_ATTESTATION_KEYS must be a JSON object mapping signer DID to Ed25519 public key hex');
+  }
+
+  for (const [signerDid, publicKeyHex] of Object.entries(parsed)) {
+    if (typeof signerDid !== 'string' || !signerDid.startsWith('did:exo:')) {
+      throw new Error('GOVERNANCE_ATTESTATION_KEYS contains an invalid signer DID');
+    }
+    if (typeof publicKeyHex !== 'string' || !/^[0-9a-fA-F]{64}$/.test(publicKeyHex)) {
+      throw new Error(`GOVERNANCE_ATTESTATION_KEYS contains an invalid Ed25519 public key for ${signerDid}`);
+    }
+    trustedKeys.set(signerDid, publicKeyHex.toLowerCase());
+  }
+
+  return trustedKeys;
+}
 
 function json(res, status, data) {
   res.writeHead(status, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Headers': 'Content-Type' });
@@ -146,8 +178,21 @@ export const server = http.createServer(async (req, res) => {
         return json(res, 400, { error: 'run_id, commit_sha, system_health, and findings_digest are required' });
       }
 
-      if (!attestation_signature || !attestation_signer_did || !attestation_public_key) {
-        return json(res, 400, { error: 'attestation_signature, attestation_signer_did, and attestation_public_key are required' });
+      if (!attestation_signature || !attestation_signer_did) {
+        return json(res, 400, { error: 'attestation_signature and attestation_signer_did are required' });
+      }
+
+      const trustedAttestationPublicKey = GOVERNANCE_ATTESTATION_KEYS.get(attestation_signer_did);
+      if (!trustedAttestationPublicKey) {
+        return json(res, 400, { error: `attestation signer ${attestation_signer_did} is not configured` });
+      }
+
+      if (
+        attestation_public_key !== undefined
+        && attestation_public_key !== null
+        && String(attestation_public_key).toLowerCase() !== trustedAttestationPublicKey
+      ) {
+        return json(res, 400, { error: 'attestation_public_key does not match configured signer key' });
       }
 
       try {
@@ -160,7 +205,7 @@ export const server = http.createServer(async (req, res) => {
           attestation_signer_did,
           JSON.stringify(findings),
           JSON.stringify(attestation_signature),
-          attestation_public_key,
+          trustedAttestationPublicKey,
         );
       } catch (e) {
         return json(res, 400, { error: `invalid governance attestation: ${e.message || e}` });

--- a/demo/services/audit-api/src/index.test.js
+++ b/demo/services/audit-api/src/index.test.js
@@ -19,6 +19,9 @@ import supertest from 'supertest';
 
 vi.hoisted(() => {
   process.env.GOVERNANCE_API_TOKEN = 'test-token';
+  process.env.GOVERNANCE_ATTESTATION_KEYS = JSON.stringify({
+    'did:exo:monitor': '11'.repeat(32),
+  });
 });
 
 const mockWasm = vi.hoisted(() => ({
@@ -183,6 +186,59 @@ describe('POST /governance/health attestation gate', () => {
     expect(mockPg.query).not.toHaveBeenCalled();
   });
 
+  it('rejects an unconfigured attestation signer before persistence', async () => {
+    mockPg.query.mockResolvedValue({ rows: [] });
+
+    const res = await request
+      .post('/governance/health')
+      .set('Authorization', 'Bearer test-token')
+      .send({ ...validSnapshot, attestation_signer_did: 'did:exo:rogue' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/not configured/);
+    expect(mockWasm.wasm_verify_governance_attestation).not.toHaveBeenCalled();
+    expect(mockPg.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects caller-supplied attestation keys that do not match configuration', async () => {
+    mockPg.query.mockResolvedValue({ rows: [] });
+
+    const res = await request
+      .post('/governance/health')
+      .set('Authorization', 'Bearer test-token')
+      .send({ ...validSnapshot, attestation_public_key: '22'.repeat(32) });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/does not match configured signer key/);
+    expect(mockWasm.wasm_verify_governance_attestation).not.toHaveBeenCalled();
+    expect(mockPg.query).not.toHaveBeenCalled();
+  });
+
+  it('uses the configured attestation key when the request omits public key material', async () => {
+    const { attestation_public_key, ...snapshotWithoutCallerKey } = validSnapshot;
+    mockPg.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ total: '1' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ seq: 0, prev: '0'.repeat(64) }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await request
+      .post('/governance/health')
+      .set('Authorization', 'Bearer test-token')
+      .send(snapshotWithoutCallerKey);
+
+    expect(res.status).toBe(201);
+    expect(mockWasm.wasm_verify_governance_attestation).toHaveBeenCalledWith(
+      validSnapshot.attestation_signer_did,
+      JSON.stringify(validSnapshot.findings),
+      JSON.stringify(validSnapshot.attestation_signature),
+      '11'.repeat(32),
+    );
+    expect(mockPg.query).toHaveBeenCalled();
+  });
+
   it('persists valid signed health snapshots after attestation verification', async () => {
     mockPg.query
       .mockResolvedValueOnce({ rows: [] })
@@ -202,7 +258,7 @@ describe('POST /governance/health attestation gate', () => {
       validSnapshot.attestation_signer_did,
       JSON.stringify(validSnapshot.findings),
       JSON.stringify(validSnapshot.attestation_signature),
-      validSnapshot.attestation_public_key,
+      '11'.repeat(32),
     );
     expect(mockPg.query).toHaveBeenCalled();
   });

--- a/docs/audit/codex-security-findings-2026-05-16-triage.md
+++ b/docs/audit/codex-security-findings-2026-05-16-triage.md
@@ -54,7 +54,7 @@ Current baseline when this triage was created:
 | P2 | Bailment acceptance trusts caller-supplied bailee key | EXOCHAIN core: `crates/exo-consent/src/bailment.rs`, `crates/exo-consent/src/gatekeeper.rs`; core runtime adapter: `crates/exochain-wasm/src/consent_bindings.rs` | Verified remediated on current main; no code change required | `cargo test -p exo-consent accept_rejects_caller_substituted_bailee_key -- --nocapture`; `cargo test -p exochain-wasm wasm_accept_bailment_rejects_caller_supplied_bailee_key_material -- --nocapture` |
 | P2 | WASM authority verification skips chain topology validation | Core runtime adapter: `crates/exochain-wasm/src/authority_bindings.rs`; EXOCHAIN core: `crates/exo-authority/src/chain.rs` | Verified remediated on current main; no code change required | `cargo test -p exochain-wasm wasm_authority_verification_source_guard_rejects_caller_key_resolver -- --nocapture`; `cargo test -p exo-authority verify_rejects_prebuilt_chain_with_broken_topology -- --nocapture` |
 | P2 | WASM decision transitions can disable all invariants | Core runtime adapter: `crates/exochain-wasm/src/decision_forum_bindings.rs`, `packages/exochain-wasm/test/bridge_verification.mjs`; EXOCHAIN core: `crates/exo-gatekeeper/src/invariants.rs` | Verified remediated on current main; no code change required | `cargo test -p exochain-wasm wasm_decision_transition_requires_kernel_adjudication -- --nocapture`; `node packages/exochain-wasm/test/bridge_verification.mjs` |
-| P2 | Governance attestations trust caller-supplied keys | Adjacent surface: `demo/services/audit-api/src/index.js`; core runtime adapter: `crates/exochain-wasm/src/gatekeeper_bindings.rs` | Queued behind core-owned runtime issues | Prove governance health attestation keys are pinned or registry-resolved before persistence |
+| P2 | Governance attestations trust caller-supplied keys | Adjacent surface: `demo/services/audit-api/src/index.js`; core runtime adapter: `crates/exochain-wasm/src/gatekeeper_bindings.rs` | Remediated with adjacent-surface pinned attestor key boundary | `npx vitest run services/audit-api/src/index.test.js`; `node packages/exochain-wasm/test/bridge_verification.mjs` |
 | P2 | Plaintext hashes leak encrypted message contents | EXOCHAIN core: `crates/exo-messaging/src/envelope.rs`, `crates/exo-messaging/src/compose.rs`, `crates/exo-messaging/src/open.rs` | Remediated by core nonce-derivation fix | `cargo test -p exo-messaging encrypted_envelope_nonce_is_not_public_plaintext_hash_oracle -- --nocapture`; `cargo test -p exo-messaging -- --nocapture` |
 | P2 | Identity erasure deletes third-party conflict records | Core runtime adapter: `crates/exo-gateway/src/server.rs`, `crates/exo-gateway/src/db.rs`, `crates/exo-gateway/src/handlers.rs` | Verified remediated on current main; no code change required | `DATABASE_URL=postgres://$(whoami)@localhost:55432/exochain_test cargo test -p exo-gateway erase_gateway_identity_records_tombstones_did_and_removes_durable_identity_rows -- --nocapture`; `cargo test -p exo-gateway identity_erasure -- --nocapture` |
 | P2 | Unbounded DB DID registration enables storage DoS | Core runtime adapter: `crates/exo-gateway/src/server.rs`, `crates/exo-gateway/src/db.rs`, `crates/exo-gateway/migrations/20260504000003_create_did_documents.sql`; EXOCHAIN core: `crates/exo-identity/src/registry.rs` | Verified remediated on current main; no code change required | `DATABASE_URL=postgres://$(whoami)@localhost:55433/exochain_test cargo test -p exo-gateway insert_did_document_enforces_durable_capacity_limit -- --nocapture`; `cargo test -p exo-gateway db_configured_identity_paths_do_not_depend_on_local_did_memory -- --nocapture` |
@@ -595,6 +595,87 @@ Validation commands:
 ```bash
 cargo test -p exochain-wasm wasm_decision_transition_requires_kernel_adjudication -- --nocapture
 node packages/exochain-wasm/test/bridge_verification.mjs
+```
+
+### P2 - Governance Attestations Trust Caller-Supplied Keys
+
+Disposition on 2026-05-17: remediated in the adjacent audit API by pinning
+governance attestor keys in runtime configuration and rejecting caller-supplied
+key substitution before persistence.
+
+Path classification:
+
+- Adjacent surface: `demo/services/audit-api/src/index.js` and
+  `demo/services/audit-api/src/index.test.js`.
+- Core runtime adapter verification path:
+  `crates/exochain-wasm/src/gatekeeper_bindings.rs` and
+  `packages/exochain-wasm/test/bridge_verification.mjs`.
+- Imported evidence tracking: this file.
+- No EXOCHAIN core Rust source, third-party, generated, or deployment contract
+  path changed.
+
+Adjacent surface intake record:
+
+- Owner/accountable maintainer: Exochain Foundation audit-api maintainers.
+- Deployment status: adjacent internal/demo service, not the canonical
+  EXOCHAIN constitutional trust fabric.
+- Constitutional trust claims: not allowed to claim EXOCHAIN protection by
+  proximity; it may state only that submitted governance health snapshots pass
+  this local attestation gate before this adjacent service persists them.
+- Core state access: does not write canonical EXOCHAIN core state; it writes
+  adjacent `governance_health_snapshots`, `governance_findings`,
+  `governance_trigger_approvals`, and `audit_entries` rows in its configured
+  `DATABASE_URL`.
+- Trust boundary: `/governance/health` requires `GOVERNANCE_API_TOKEN`, resolves
+  `attestation_signer_did` to a pinned public key from
+  `GOVERNANCE_ATTESTATION_KEYS`, optionally rejects a conflicting caller
+  `attestation_public_key`, verifies the signature through
+  `wasm_verify_governance_attestation`, then performs DB writes.
+- Surface-specific test/CI gate:
+  `npx vitest run services/audit-api/src/index.test.js`.
+- Secrets/runtime configuration:
+  `DATABASE_URL`, `GOVERNANCE_API_TOKEN`, and `GOVERNANCE_ATTESTATION_KEYS`.
+  `GOVERNANCE_ATTESTATION_KEYS` is a JSON object mapping trusted signer DID to
+  32-byte Ed25519 public key hex.
+- Rollback/disablement path: remove or rotate `GOVERNANCE_API_TOKEN` to block
+  the route; remove the signer DID from `GOVERNANCE_ATTESTATION_KEYS` to make
+  that signer fail closed before any governance-health DB write.
+
+Reproduction evidence before the fix:
+
+- The POST `/governance/health` path required `attestation_public_key` in the
+  same request body that supplied the signature and signer DID.
+- The route passed that caller-supplied public key directly to
+  `wasm_verify_governance_attestation` before inserting health snapshots and
+  audit rows.
+- The failing regressions showed a rogue signer or mismatched caller key could
+  reach persistence when the WASM signature check was mocked as accepting the
+  supplied key.
+
+Current enforcement evidence:
+
+- The route no longer requires caller public-key material. It resolves the
+  attestor key from `GOVERNANCE_ATTESTATION_KEYS` using the submitted signer
+  DID.
+- Unknown signer DIDs fail closed before any database write and before calling
+  the WASM attestation verifier.
+- If a legacy caller still sends `attestation_public_key`, the route rejects it
+  unless it byte-for-byte matches the configured signer key.
+- Valid snapshots can omit caller public-key material and are verified with the
+  configured signer key before persistence.
+- `GOVERNANCE_ATTESTATION_KEYS` is parsed as a bounded JSON trust-anchor map and
+  rejects malformed signer DIDs or non-32-byte Ed25519 key hex at service
+  startup.
+- The WASM bridge still proves the core attestation verifier accepts valid
+  signatures and rejects invalid signatures once the adjacent API supplies the
+  trusted key.
+
+Validation commands:
+
+```bash
+npx vitest run services/audit-api/src/index.test.js
+node packages/exochain-wasm/test/bridge_verification.mjs
+git diff --check
 ```
 
 ### P2 - Plaintext Hashes Leak Encrypted Message Contents


### PR DESCRIPTION
## Summary

Remediates the P2 finding `Governance attestations trust caller-supplied keys` in the adjacent audit API surface.

The `/governance/health` route no longer accepts caller-provided public key material as the trust anchor for a governance-health attestation. It resolves the signer DID against `GOVERNANCE_ATTESTATION_KEYS`, rejects unknown signers before DB writes, rejects conflicting legacy `attestation_public_key` values, and verifies valid snapshots with the configured trusted key before persistence.

## Path Classification

- Adjacent surface: `demo/services/audit-api/src/index.js`, `demo/services/audit-api/src/index.test.js`
- Core runtime adapter verification path exercised: `crates/exochain-wasm/src/gatekeeper_bindings.rs`, `packages/exochain-wasm/test/bridge_verification.mjs`
- Imported evidence tracking: `docs/audit/codex-security-findings-2026-05-16-triage.md`
- EXOCHAIN core Rust source changed: no
- Deployment contract changed: no

## Adjacent Surface Intake

- Owner/accountable maintainer: Exochain Foundation audit-api maintainers
- Deployment status: adjacent internal/demo service, not the canonical EXOCHAIN constitutional trust fabric
- Constitutional trust claims: cannot claim EXOCHAIN protection by proximity; may state only that submitted governance health snapshots pass this local attestation gate before this adjacent service persists them
- Core state access: does not write canonical EXOCHAIN core state; writes adjacent governance health/audit rows in configured `DATABASE_URL`
- Trust boundary: `/governance/health` requires `GOVERNANCE_API_TOKEN`, resolves `attestation_signer_did` to a pinned public key from `GOVERNANCE_ATTESTATION_KEYS`, optionally rejects a conflicting caller `attestation_public_key`, verifies through `wasm_verify_governance_attestation`, then writes rows
- Surface-specific test/CI gate: `npx vitest run services/audit-api/src/index.test.js`
- Secrets/runtime config: `DATABASE_URL`, `GOVERNANCE_API_TOKEN`, `GOVERNANCE_ATTESTATION_KEYS`
- Rollback/disablement: remove or rotate `GOVERNANCE_API_TOKEN` to block the route; remove a signer DID from `GOVERNANCE_ATTESTATION_KEYS` to make that signer fail closed before any DB write

## Reproduction Before Fix

Failing regressions were added before the production change. They showed that a rogue signer or mismatched caller key could reach the persistence path when the WASM verifier was mocked as accepting the caller-supplied public key, and that omitting caller public-key material was rejected even though the trust anchor should be service-owned configuration.

## Validation

- `npx vitest run services/audit-api/src/index.test.js` passed: 17/17
- `node packages/exochain-wasm/test/bridge_verification.mjs` passed: 160/160
- `rg -n "wasm_verify_governance_attestation|attestation_public_key|GOVERNANCE_ATTESTATION_KEYS" crates packages demo .github tools --glob '!target/**' --glob '!node_modules/**' --glob '!dist/**'`
- `git diff --check`
