### PR TITLE
Implement root genesis FROST DKG authority

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,6 +546,69 @@ jobs:
           retention-days: 30
 
   # -----------------------------------------------------------------------
+  # Gate 18: Root Genesis Crate Coverage (100% line coverage)
+  # -----------------------------------------------------------------------
+  root-genesis-coverage:
+    name: "Gate 18 — Root Genesis Crate Coverage (100%)"
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin --version 0.35.4 --locked
+      - name: Run exo-root coverage
+        run: |
+          cargo tarpaulin \
+            --packages exo-root \
+            --include-files "crates/exo-root/src/**" \
+            --out xml \
+            --out stdout \
+            --output-dir coverage-exo-root \
+            --skip-clean \
+            --engine llvm \
+            --timeout 600 \
+            --fail-under 100
+      - name: Upload exo-root coverage report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: exo-root-coverage-${{ github.sha }}
+          path: coverage-exo-root/cobertura.xml
+          retention-days: 30
+
+  # -----------------------------------------------------------------------
+  # Gate 19: Root Genesis Portal Coverage (100% line coverage)
+  # -----------------------------------------------------------------------
+  root-genesis-portal-coverage:
+    name: "Gate 19 — Root Genesis Portal Coverage (100%)"
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin --version 0.35.4 --locked
+      - name: Run root genesis portal coverage
+        run: |
+          cargo tarpaulin \
+            --packages exo-node \
+            --include-files "crates/exo-node/src/root_genesis.rs" \
+            --out xml \
+            --output-dir coverage-root-genesis-portal \
+            --skip-clean \
+            --engine llvm \
+            --timeout 120 \
+            --fail-under 100
+      - name: Upload root genesis portal coverage report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: root-genesis-portal-coverage-${{ github.sha }}
+          path: coverage-root-genesis-portal/cobertura.xml
+          retention-days: 30
+
+  # -----------------------------------------------------------------------
   # Gate 20: WASM build
   # -----------------------------------------------------------------------
   build-wasm:
@@ -643,6 +706,8 @@ jobs:
       - state-sync-integration
       - cross-platform
       - zerodentity-coverage
+      - root-genesis-coverage
+      - root-genesis-portal-coverage
       - build-wasm
       - test-bridge
       - wasm-sync

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+ "zeroize",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +566,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base256emoji"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +868,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-crc32-nostd"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808ac43170e95b11dd23d78aa9eaac5bea45776a602955552c4e833f3f0f823d"
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,7 +958,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -954,7 +979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1037,6 +1062,7 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
+ "rand_core 0.6.4",
  "rustc_version",
  "serde",
  "subtle",
@@ -1178,6 +1204,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-getters"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,6 +1266,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1294,7 +1340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1619,6 +1665,7 @@ dependencies = [
  "exo-governance",
  "exo-identity",
  "exo-legal",
+ "exo-root",
  "futures",
  "getrandom 0.2.16",
  "hex",
@@ -1649,6 +1696,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "x25519-dalek",
  "zeroize",
 ]
 
@@ -1663,6 +1711,26 @@ dependencies = [
  "serde_json",
  "sha2",
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "exo-root"
+version = "0.1.0-beta"
+dependencies = [
+ "argon2",
+ "chacha20poly1305",
+ "ciborium",
+ "exo-authority",
+ "exo-core",
+ "frost-ristretto255",
+ "hkdf",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.17",
+ "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
@@ -1817,6 +1885,54 @@ checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
 dependencies = [
  "lazy_static",
  "num",
+]
+
+[[package]]
+name = "frost-core"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81ef2787af391c7e8bedc037a3b9ea03dde803fbd93e778e6bb369547800e5cd"
+dependencies = [
+ "byteorder",
+ "const-crc32-nostd",
+ "derive-getters",
+ "document-features",
+ "hex",
+ "itertools 0.14.0",
+ "rand_core 0.6.4",
+ "serde",
+ "serdect",
+ "thiserror 2.0.17",
+ "visibility",
+ "zeroize",
+ "zeroize_derive",
+]
+
+[[package]]
+name = "frost-rerandomized"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4c5cedd2426728adef2c0b1720f57676354c473836d1ccc50d0f0d1c91942b"
+dependencies = [
+ "derive-getters",
+ "document-features",
+ "frost-core",
+ "hex",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "frost-ristretto255"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0159efb722280263c3a92f3f8d8f2f9a03174304d46e85595f0243ba0eb16cf8"
+dependencies = [
+ "curve25519-dalek",
+ "document-features",
+ "frost-core",
+ "frost-rerandomized",
+ "rand_core 0.6.4",
+ "sha2",
 ]
 
 [[package]]
@@ -2276,7 +2392,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2498,7 +2614,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2521,6 +2637,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2907,6 +3032,12 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -3380,6 +3511,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3706,7 +3848,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -3743,7 +3885,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -4072,7 +4214,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4249,6 +4391,16 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
  "serde",
 ]
 
@@ -4729,7 +4881,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5302,6 +5454,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5548,7 +5711,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "crates/exochain-sdk",
     "crates/exo-avc",
     "crates/exo-economy",
+    "crates/exo-root",
 ]
 
 [workspace.package]
@@ -64,6 +65,8 @@ chacha20poly1305 = "=0.10.1"
 hkdf = "=0.12.4"
 rand = "=0.8.6"
 zeroize = { version = "=1.8.2", features = ["derive"] }
+frost-ristretto255 = { version = "=3.0.0", default-features = false, features = ["serde"] }
+argon2 = { version = "=0.5.3", features = ["zeroize"] }
 # Post-quantum cryptography — NIST FIPS 204 (ML-DSA / CRYSTALS-Dilithium)
 # v0.1.0-rc.7 patches RUSTSEC-2025-0144 timing side-channel (fixed in rc.3+)
 ml-dsa = { version = "=0.1.0-rc.7", features = ["zeroize"] }

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 197155 | `wc -l` |
-| Workspace tests | 4,440 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 197286 | `wc -l` |
+| Workspace tests | 4,443 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,440 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,443 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 197155 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 197286 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,440 listed workspace tests
+         cryptographic proofs, 4,443 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          160 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/README.md
+++ b/README.md
@@ -28,28 +28,27 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 > Run `bash tools/repo_truth.sh` to regenerate these numbers from source.
 >
-> The crate count includes `exo-catapult`, `exo-consensus`, `exo-messaging`,
-> `exochain-sdk`, `exo-avc`, and `exo-economy` (six crates previously not
-> listed in this README).
+> The crate count includes `exo-root`, `exo-catapult`, `exo-consensus`,
+> `exo-messaging`, `exochain-sdk`, `exo-avc`, and `exo-economy`.
 
 | Metric | Value | Source |
 |--------|-------|--------|
-| Rust crates | 22 | `ls -d crates/*/` |
-| Rust source files | 301 | `find crates -name '*.rs'` |
-| Rust LOC | 193339 | `wc -l` |
-| Workspace tests | 4,402 listed | `cargo test --workspace -- --list` |
-| CI quality gates | 20 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
+| Rust crates | 23 | `ls -d crates/*/` |
+| Rust source files | 312 | `find crates -name '*.rs'` |
+| Rust LOC | 197127 | `wc -l` |
+| Workspace tests | 4,440 listed | `cargo test --workspace -- --list` |
+| CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
 | Live node health | Verified for https://exochain-production.up.railway.app/health on 2026-05-09 | `tools/verify_live_node_claim.sh` |
 
 ### What is verified today
 
-- **4,400 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,431 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
-- **20 numbered CI quality gates** plus the required "All Constitutional Gates" aggregator are defined and enforced
+- **22 numbered CI quality gates** plus the required "All Constitutional Gates" aggregator are defined and enforced
 - **Traceability matrix** maps 118 requirements — see `governance/traceability_matrix.md`
 - **Threat model** covers 16 threats tracked: 16 implemented, 0 partial, 0 planned — see `governance/threat_matrix.md`
 - **Constitutional invariants** are enforced in the tested gatekeeper and decision-forum adjudication paths
@@ -114,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 22 crates, 193234 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 197127 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,400 listed workspace tests
+         cryptographic proofs, 4,440 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          160 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 197127 | `wc -l` |
+| Rust LOC | 197155 | `wc -l` |
 | Workspace tests | 4,440 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,431 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,440 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,7 +113,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 197127 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 197155 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,440 listed workspace tests
 

--- a/crates/exo-node/Cargo.toml
+++ b/crates/exo-node/Cargo.toml
@@ -46,6 +46,7 @@ exo-legal = { path = "../exo-legal" }
 exo-avc = { path = "../exo-avc" }
 exo-authority = { path = "../exo-authority" }
 exo-economy = { path = "../exo-economy" }
+exo-root = { path = "../exo-root" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }
@@ -74,6 +75,7 @@ rand = { workspace = true }
 sha2 = { workspace = true }
 hmac = { workspace = true }
 zeroize = { workspace = true }
+x25519-dalek = { workspace = true }
 
 # Data directory
 directories = "6"

--- a/crates/exo-node/src/cli.rs
+++ b/crates/exo-node/src/cli.rs
@@ -18,7 +18,16 @@
 
 use std::path::PathBuf;
 
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
+
+pub const ROOT_GENESIS_LONG_HELP: &str = "\
+Root genesis creates a 7-of-13 institutional root authority. Genesis DKG \
+requires all 13 rostered certifiers to complete the ceremony; if any \
+certifier fails, abort and restart with a new signed roster.
+
+Certifier rules: keep private material offline, maintain an offline backup, \
+never submit plaintext shares, encrypt round-two payloads per recipient, and \
+run verify-bundle before trusting the result.";
 
 pub const DEFAULT_ROUND_TIMEOUT_MS: u64 = 5_000;
 pub const MIN_ROUND_TIMEOUT_MS: u64 = 250;
@@ -176,4 +185,207 @@ pub enum Command {
         #[arg(long)]
         sse: Option<String>,
     },
+
+    /// Run root genesis FROST DKG and root trust bundle operations.
+    Genesis {
+        #[command(subcommand)]
+        command: GenesisCommand,
+    },
+}
+
+#[derive(Subcommand)]
+#[command(after_long_help = ROOT_GENESIS_LONG_HELP)]
+/// Root genesis ceremony commands.
+pub enum GenesisCommand {
+    /// Certifier-local setup commands.
+    Certifier {
+        #[command(subcommand)]
+        command: GenesisCertifierCommand,
+    },
+
+    /// Ceremony operator setup commands.
+    Ceremony {
+        #[command(subcommand)]
+        command: GenesisCeremonyCommand,
+    },
+
+    /// Serve the untrusted root genesis relay portal.
+    Portal(GenesisPortalArgs),
+
+    /// Produce or verify DKG round-one material.
+    Round1(GenesisIoArgs),
+
+    /// Produce encrypted DKG round-two material.
+    Round2(GenesisIoArgs),
+
+    /// Finalize DKG once all thirteen certifiers have completed both rounds.
+    #[command(name = "finalize-dkg")]
+    FinalizeDkg(GenesisIoArgs),
+
+    /// Sign a root-governance artifact with at least seven certifier shares.
+    #[command(name = "sign-root-artifact")]
+    SignRootArtifact(GenesisIoArgs),
+
+    /// Assemble a root trust bundle after artifact signing.
+    #[command(name = "assemble-bundle")]
+    AssembleBundle(GenesisIoArgs),
+
+    /// Verify a root trust bundle before trusting any AVC issuer delegation.
+    #[command(name = "verify-bundle")]
+    VerifyBundle(GenesisIoArgs),
+
+    /// Seal a serialized certifier share artifact.
+    #[command(name = "seal-share")]
+    SealShare(GenesisIoArgs),
+
+    /// Open a sealed certifier share artifact.
+    #[command(name = "unseal-share")]
+    UnsealShare(GenesisIoArgs),
+}
+
+#[derive(Subcommand)]
+/// Certifier-local root genesis commands.
+pub enum GenesisCertifierCommand {
+    /// Generate certifier signing and transport material.
+    Init(GenesisCertifierInitArgs),
+}
+
+#[derive(Subcommand)]
+/// Ceremony-operator root genesis commands.
+pub enum GenesisCeremonyCommand {
+    /// Build a signed-roster ceremony configuration.
+    Init(GenesisCeremonyInitArgs),
+}
+
+#[derive(Args)]
+/// Generate local certifier key material.
+pub struct GenesisCertifierInitArgs {
+    /// Certifier DID.
+    #[arg(long)]
+    pub did: String,
+
+    /// FROST identifier in the inclusive range 1..=13.
+    #[arg(long)]
+    pub frost_identifier: u16,
+
+    /// Public certifier contact output path.
+    #[arg(long)]
+    pub certifier_out: PathBuf,
+
+    /// Private certifier material output path.
+    #[arg(long)]
+    pub private_out: PathBuf,
+}
+
+#[derive(Args)]
+/// Build a ceremony configuration from a roster.
+pub struct GenesisCeremonyInitArgs {
+    /// Ceremony identifier.
+    #[arg(long)]
+    pub ceremony_id: String,
+
+    /// EXOCHAIN network identifier.
+    #[arg(long)]
+    pub network_id: String,
+
+    /// Reviewed repository commit.
+    #[arg(long)]
+    pub repo_commit: String,
+
+    /// 32-byte constitution hash as lowercase or uppercase hex.
+    #[arg(long)]
+    pub constitution_hash: String,
+
+    /// HLC physical milliseconds supplied by the operator.
+    #[arg(long)]
+    pub created_physical_ms: u64,
+
+    /// JSON roster path containing thirteen certifier contacts.
+    #[arg(long)]
+    pub roster: PathBuf,
+
+    /// Ceremony configuration output path.
+    #[arg(long)]
+    pub out: PathBuf,
+}
+
+#[derive(Args)]
+/// Serve the root genesis relay portal.
+pub struct GenesisPortalArgs {
+    /// Ceremony configuration JSON path.
+    #[arg(long)]
+    pub config: PathBuf,
+
+    /// Portal bind address.
+    #[arg(long, default_value = "127.0.0.1:3017")]
+    pub bind: String,
+}
+
+#[derive(Args)]
+/// File-based root genesis command inputs.
+pub struct GenesisIoArgs {
+    /// Input JSON or binary path.
+    #[arg(long)]
+    pub input: Option<PathBuf>,
+
+    /// Output JSON or binary path.
+    #[arg(long)]
+    pub output: Option<PathBuf>,
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::CommandFactory;
+
+    use super::Cli;
+
+    fn long_help_for(path: &[&str]) -> String {
+        let mut command = Cli::command();
+        let mut current = &mut command;
+        for segment in path {
+            current = current
+                .find_subcommand_mut(segment)
+                .expect("subcommand should exist");
+        }
+        let mut help = Vec::new();
+        current
+            .write_long_help(&mut help)
+            .expect("help should render");
+        String::from_utf8(help).expect("help should be utf8")
+    }
+
+    #[test]
+    fn genesis_cli_exposes_complete_operator_command_set() {
+        let help = long_help_for(&["genesis"]);
+        for command in [
+            "certifier",
+            "ceremony",
+            "portal",
+            "round1",
+            "round2",
+            "finalize-dkg",
+            "sign-root-artifact",
+            "assemble-bundle",
+            "verify-bundle",
+            "seal-share",
+            "unseal-share",
+        ] {
+            assert!(help.contains(command), "missing genesis command {command}");
+        }
+    }
+
+    #[test]
+    fn genesis_cli_help_warns_certifiers_about_secret_handling_and_restart_rules() {
+        let help = long_help_for(&["genesis"]);
+        for required in [
+            "7-of-13",
+            "all 13 rostered certifiers",
+            "abort and restart",
+            "offline backup",
+            "never submit plaintext shares",
+            "verify-bundle",
+        ] {
+            assert!(help.contains(required), "missing help text {required}");
+        }
+    }
 }

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -54,6 +54,8 @@ mod passport;
 mod provenance;
 mod reactor;
 mod receipt_dashboard;
+mod root_genesis;
+mod root_genesis_cli;
 mod sentinels;
 mod store;
 mod sync;
@@ -1173,6 +1175,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                     .map_err(|e| anyhow::anyhow!("MCP stdio server error: {e}"))
             }
         }
+        Command::Genesis { command } => root_genesis_cli::run_genesis_command(command).await,
     }
 }
 
@@ -1477,5 +1480,138 @@ mod tests {
                 "gateway DB initialization logs must not expose the database URL"
             );
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod root_genesis_adapter_tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use exo_core::{Did, Hash256, SecretKey, Timestamp, crypto::KeyPair};
+    use exo_root::{
+        CeremonyEnvelope, CeremonyEnvelopeDraft, CeremonyPayloadKind, CeremonyPhase,
+        CertifierContact, GenesisCeremonyConfig,
+    };
+    use tower::ServiceExt;
+
+    use super::root_genesis::{RootGenesisApiState, root_genesis_router};
+
+    fn did(index: u16) -> Did {
+        Did::new(&format!("did:exo:root-portal-{index:02}")).expect("valid DID")
+    }
+
+    fn certifier(index: u16) -> (CertifierContact, SecretKey) {
+        let keypair = KeyPair::from_secret_bytes([u8::try_from(index).expect("index fits"); 32])
+            .expect("valid keypair");
+        let transport_secret = [u8::try_from(index).expect("index fits"); 32];
+        let transport_public =
+            x25519_dalek::PublicKey::from(&x25519_dalek::StaticSecret::from(transport_secret));
+        (
+            CertifierContact {
+                did: did(index),
+                frost_identifier: index,
+                signing_public_key: *keypair.public_key(),
+                transport_public_key: *transport_public.as_bytes(),
+            },
+            keypair.secret_key().clone(),
+        )
+    }
+
+    fn config() -> (GenesisCeremonyConfig, SecretKey) {
+        let mut certifiers = Vec::new();
+        let mut first_secret = None;
+        for index in 1..=13 {
+            let (contact, secret) = certifier(index);
+            if index == 1 {
+                first_secret = Some(secret.clone());
+            }
+            certifiers.push(contact);
+        }
+        (
+            GenesisCeremonyConfig {
+                ceremony_id: "exo-root-portal-test".into(),
+                network_id: "exochain-test".into(),
+                repo_commit: "d8927686a34bdc28ba36d53938f665685d2c4c04".into(),
+                constitution_hash: Hash256::digest(b"constitution"),
+                threshold: 7,
+                max_signers: 13,
+                created_at: Timestamp::new(1_785_000_000_000, 0),
+                certifiers,
+            },
+            first_secret.expect("first certifier secret"),
+        )
+    }
+
+    async fn post_envelope(
+        router: axum::Router,
+        envelope: &CeremonyEnvelope,
+    ) -> axum::response::Response {
+        let body = serde_json::to_vec(envelope).expect("json body");
+        router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/root-genesis/portal/envelopes")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .expect("request"),
+            )
+            .await
+            .expect("response")
+    }
+
+    #[tokio::test]
+    async fn root_genesis_portal_handler_accepts_signed_envelope_and_rejects_replay() {
+        let (config, secret) = config();
+        let sender = config.certifiers[0].did.clone();
+        let recipient = config.certifiers[1].did.clone();
+        let state = RootGenesisApiState::new(config.clone());
+        let router = root_genesis_router(state);
+        let envelope = CeremonyEnvelope::sign(
+            CeremonyEnvelopeDraft {
+                ceremony_id: config.ceremony_id.clone(),
+                phase: CeremonyPhase::Round2,
+                payload_kind: CeremonyPayloadKind::Round2EncryptedPackage,
+                sender_did: sender,
+                recipient_did: Some(recipient),
+                sequence: 1,
+                payload_bytes: b"ciphertext".to_vec(),
+            },
+            &secret,
+        )
+        .expect("signed envelope");
+
+        let accepted = post_envelope(router.clone(), &envelope).await;
+        assert_eq!(accepted.status(), StatusCode::CREATED);
+
+        let replay = post_envelope(router, &envelope).await;
+        assert_eq!(replay.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn root_genesis_portal_handler_rejects_plaintext_round_two_payload() {
+        let (config, secret) = config();
+        let sender = config.certifiers[0].did.clone();
+        let recipient = config.certifiers[1].did.clone();
+        let router = root_genesis_router(RootGenesisApiState::new(config.clone()));
+        let envelope = CeremonyEnvelope::sign(
+            CeremonyEnvelopeDraft {
+                ceremony_id: config.ceremony_id.clone(),
+                phase: CeremonyPhase::Round2,
+                payload_kind: CeremonyPayloadKind::Round2PlaintextPackage,
+                sender_did: sender,
+                recipient_did: Some(recipient),
+                sequence: 2,
+                payload_bytes: b"raw share".to_vec(),
+            },
+            &secret,
+        )
+        .expect("signed envelope");
+
+        let response = post_envelope(router, &envelope).await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/exo-node/src/root_genesis.rs
+++ b/crates/exo-node/src/root_genesis.rs
@@ -1,0 +1,309 @@
+//! Root genesis portal adapter.
+
+use std::sync::{Arc, Mutex};
+
+use axum::{
+    Json, Router,
+    extract::State,
+    http::StatusCode,
+    routing::{get, post},
+};
+use exo_core::Hash256;
+use exo_root::{CeremonyEnvelope, GenesisCeremonyConfig, PortalStore, RootError};
+use serde::Serialize;
+
+/// Shared root genesis portal state.
+#[derive(Clone)]
+pub struct RootGenesisApiState {
+    portal: Arc<Mutex<PortalStore>>,
+    config: GenesisCeremonyConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct PortalStatusResponse {
+    ceremony_id: String,
+    threshold: u16,
+    max_signers: u16,
+    accepted_envelopes: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct EnvelopeAcceptedResponse {
+    envelope_id: Hash256,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct ErrorResponse {
+    error: String,
+}
+
+impl RootGenesisApiState {
+    /// Create portal state for one ceremony configuration.
+    #[must_use]
+    pub fn new(config: GenesisCeremonyConfig) -> Self {
+        Self {
+            portal: Arc::new(Mutex::new(PortalStore::new(config.clone()))),
+            config,
+        }
+    }
+}
+
+/// Router for the server-backed root genesis portal.
+pub fn root_genesis_router(state: RootGenesisApiState) -> Router {
+    Router::new()
+        .route("/api/v1/root-genesis/portal", get(handle_portal_status))
+        .route(
+            "/api/v1/root-genesis/portal/envelopes",
+            post(handle_portal_envelope),
+        )
+        .with_state(state)
+}
+
+async fn handle_portal_status(
+    State(state): State<RootGenesisApiState>,
+) -> Result<Json<PortalStatusResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let portal = state.portal.lock().map_err(|_| {
+        portal_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "portal store lock failed",
+        )
+    })?;
+    Ok(Json(PortalStatusResponse {
+        ceremony_id: state.config.ceremony_id,
+        threshold: state.config.threshold,
+        max_signers: state.config.max_signers,
+        accepted_envelopes: portal.envelope_count(),
+    }))
+}
+
+async fn handle_portal_envelope(
+    State(state): State<RootGenesisApiState>,
+    Json(envelope): Json<CeremonyEnvelope>,
+) -> Result<(StatusCode, Json<EnvelopeAcceptedResponse>), (StatusCode, Json<ErrorResponse>)> {
+    let mut portal = state.portal.lock().map_err(|_| {
+        portal_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "portal store lock failed",
+        )
+    })?;
+    match portal.submit(envelope) {
+        Ok(envelope_id) => Ok((
+            StatusCode::CREATED,
+            Json(EnvelopeAcceptedResponse { envelope_id }),
+        )),
+        Err(error) => Err(root_error_to_response(error)),
+    }
+}
+
+fn portal_error(status: StatusCode, message: &str) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        status,
+        Json(ErrorResponse {
+            error: message.to_owned(),
+        }),
+    )
+}
+
+fn root_error_to_response(error: RootError) -> (StatusCode, Json<ErrorResponse>) {
+    let status = match &error {
+        RootError::SignatureRejected { .. } => StatusCode::UNAUTHORIZED,
+        RootError::PortalRejected { reason } if reason.contains("replay") => StatusCode::CONFLICT,
+        RootError::PortalRejected { reason } if reason.contains("exceeds") => {
+            StatusCode::PAYLOAD_TOO_LARGE
+        }
+        RootError::PortalRejected { .. } | RootError::InvalidConfig { .. } => {
+            StatusCode::BAD_REQUEST
+        }
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    };
+    (
+        status,
+        Json(ErrorResponse {
+            error: error.to_string(),
+        }),
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use exo_core::{Did, SecretKey, Signature, Timestamp, crypto::KeyPair};
+    use exo_root::{CeremonyEnvelopeDraft, CeremonyPayloadKind, CeremonyPhase, CertifierContact};
+    use tower::ServiceExt;
+
+    use super::*;
+
+    fn did(index: u16) -> Did {
+        Did::new(&format!("did:exo:root-portal-module-{index:02}")).expect("valid DID")
+    }
+
+    fn certifier(index: u16) -> (CertifierContact, SecretKey) {
+        let seed = [u8::try_from(index).expect("index fits"); 32];
+        let keypair = KeyPair::from_secret_bytes(seed).expect("valid keypair");
+        let transport_secret = [u8::try_from(index).expect("index fits"); 32];
+        let transport_public =
+            x25519_dalek::PublicKey::from(&x25519_dalek::StaticSecret::from(transport_secret));
+        (
+            CertifierContact {
+                did: did(index),
+                frost_identifier: index,
+                signing_public_key: *keypair.public_key(),
+                transport_public_key: *transport_public.as_bytes(),
+            },
+            keypair.secret_key().clone(),
+        )
+    }
+
+    fn config() -> (GenesisCeremonyConfig, SecretKey) {
+        let mut certifiers = Vec::new();
+        let mut first_secret = None;
+        for index in 1..=13 {
+            let (contact, secret) = certifier(index);
+            if index == 1 {
+                first_secret = Some(secret.clone());
+            }
+            certifiers.push(contact);
+        }
+        (
+            GenesisCeremonyConfig {
+                ceremony_id: "exo-root-portal-module-test".into(),
+                network_id: "exochain-test".into(),
+                repo_commit: "d8927686a34bdc28ba36d53938f665685d2c4c04".into(),
+                constitution_hash: Hash256::digest(b"constitution"),
+                threshold: exo_root::ROOT_GENESIS_THRESHOLD,
+                max_signers: exo_root::ROOT_GENESIS_SIGNERS,
+                created_at: Timestamp::new(1_785_000_000_000, 0),
+                certifiers,
+            },
+            first_secret.expect("first certifier secret"),
+        )
+    }
+
+    fn envelope(
+        config: &GenesisCeremonyConfig,
+        secret: &SecretKey,
+        sequence: u64,
+        payload_bytes: Vec<u8>,
+    ) -> CeremonyEnvelope {
+        CeremonyEnvelope::sign(
+            CeremonyEnvelopeDraft {
+                ceremony_id: config.ceremony_id.clone(),
+                phase: CeremonyPhase::Round2,
+                payload_kind: CeremonyPayloadKind::Round2EncryptedPackage,
+                sender_did: config.certifiers[0].did.clone(),
+                recipient_did: Some(config.certifiers[1].did.clone()),
+                sequence,
+                payload_bytes,
+            },
+            secret,
+        )
+        .expect("signed envelope")
+    }
+
+    async fn post_envelope(
+        router: axum::Router,
+        envelope: &CeremonyEnvelope,
+    ) -> axum::response::Response {
+        let body = serde_json::to_vec(envelope).expect("json body");
+        router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/root-genesis/portal/envelopes")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .expect("request"),
+            )
+            .await
+            .expect("response")
+    }
+
+    async fn get_status(router: axum::Router) -> axum::response::Response {
+        router
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/root-genesis/portal")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response")
+    }
+
+    fn poison_portal_lock(state: &RootGenesisApiState) {
+        let portal = Arc::clone(&state.portal);
+        let _ = std::thread::spawn(move || {
+            let _guard = portal.lock().expect("portal lock");
+            panic!("poison portal lock");
+        })
+        .join();
+    }
+
+    #[tokio::test]
+    async fn portal_status_reports_policy_and_accepted_envelope_count() {
+        let (config, secret) = config();
+        let state = RootGenesisApiState::new(config.clone());
+        let router = root_genesis_router(state);
+        let accepted = post_envelope(
+            router.clone(),
+            &envelope(&config, &secret, 1, b"ct".to_vec()),
+        )
+        .await;
+        assert_eq!(accepted.status(), StatusCode::CREATED);
+
+        let response = get_status(router).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .expect("body bytes");
+        let status: serde_json::Value = serde_json::from_slice(&body).expect("status json");
+        assert_eq!(status["ceremony_id"], config.ceremony_id);
+        assert_eq!(status["threshold"], u64::from(config.threshold));
+        assert_eq!(status["max_signers"], u64::from(config.max_signers));
+        assert_eq!(status["accepted_envelopes"], 1);
+    }
+
+    #[tokio::test]
+    async fn portal_handlers_fail_closed_when_store_lock_is_poisoned() {
+        let (config, secret) = config();
+        let state = RootGenesisApiState::new(config.clone());
+        poison_portal_lock(&state);
+        let router = root_genesis_router(state);
+
+        let status = get_status(router.clone()).await;
+        assert_eq!(status.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        let submitted = post_envelope(router, &envelope(&config, &secret, 1, b"ct".to_vec())).await;
+        assert_eq!(submitted.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn portal_handler_maps_signature_and_payload_size_rejections() {
+        let (config, secret) = config();
+        let router = root_genesis_router(RootGenesisApiState::new(config.clone()));
+
+        let mut unsigned = envelope(&config, &secret, 1, b"ct".to_vec());
+        unsigned.signature = Signature::Empty;
+        let unauthorized = post_envelope(router.clone(), &unsigned).await;
+        assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+
+        let oversized = envelope(&config, &secret, 2, vec![7; 64 * 1024 + 1]);
+        let too_large = post_envelope(router, &oversized).await;
+        assert_eq!(too_large.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[test]
+    fn portal_error_mapper_preserves_internal_error_status() {
+        let (status, Json(body)) = root_error_to_response(RootError::CanonicalEncoding {
+            detail: "encoder unavailable".to_owned(),
+        });
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(body.error.contains("encoder unavailable"));
+    }
+}

--- a/crates/exo-node/src/root_genesis_cli.rs
+++ b/crates/exo-node/src/root_genesis_cli.rs
@@ -1,0 +1,341 @@
+//! Root genesis CLI command implementation.
+
+use std::{collections::BTreeMap, fs, net::SocketAddr};
+
+use exo_core::{Did, Hash256, Timestamp, crypto::KeyPair};
+use exo_root::{
+    CertifierContact, GenesisCeremonyConfig, RootIssuerDelegation, RootKeyPackage,
+    RootPublicKeyPackage, RootTrustBundle, assemble_root_bundle, dkg_finalize_participant,
+    dkg_round1, dkg_round2, seal_share, threshold_sign, unseal_share, verify_root_bundle,
+};
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use x25519_dalek::{PublicKey as X25519PublicKey, StaticSecret};
+
+use crate::{
+    cli::{
+        GenesisCeremonyCommand, GenesisCeremonyInitArgs, GenesisCertifierCommand,
+        GenesisCertifierInitArgs, GenesisCommand, GenesisIoArgs, GenesisPortalArgs,
+    },
+    root_genesis::{RootGenesisApiState, root_genesis_router},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct PrivateCertifierMaterial {
+    did: Did,
+    frost_identifier: u16,
+    signing_secret_hex: String,
+    transport_secret_hex: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct Round1CommandInput {
+    config: GenesisCeremonyConfig,
+    frost_identifier: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct Round2CommandInput {
+    config: GenesisCeremonyConfig,
+    frost_identifier: u16,
+    round1_secret_package_hex: String,
+    round1_packages_hex: BTreeMapStringBytes,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct FinalizeDkgCommandInput {
+    config: GenesisCeremonyConfig,
+    frost_identifier: u16,
+    round2_secret_package_hex: String,
+    round1_packages_hex: BTreeMapStringBytes,
+    round2_packages_hex: BTreeMapStringBytes,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct SignRootArtifactCommandInput {
+    config: GenesisCeremonyConfig,
+    public_key_package: RootPublicKeyPackage,
+    key_packages: BTreeMap<u16, RootKeyPackage>,
+    artifact_hex: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct AssembleBundleCommandInput {
+    config: GenesisCeremonyConfig,
+    public_key_package: RootPublicKeyPackage,
+    issuer_delegation: RootIssuerDelegation,
+    transcript_hash: Hash256,
+    root_signature_hex: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct VerifyBundleCommandInput {
+    bundle: RootTrustBundle,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct SealShareCommandInput {
+    share_hex: String,
+    passphrase_hex: String,
+    associated_data_hex: String,
+    salt_hex: String,
+    nonce_hex: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct UnsealShareCommandInput {
+    sealed: exo_root::SealedShare,
+    passphrase_hex: String,
+    associated_data_hex: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct HexBytesOutput {
+    bytes_hex: String,
+}
+
+type BTreeMapStringBytes = BTreeMap<u16, String>;
+
+/// Execute a root genesis CLI command.
+pub async fn run_genesis_command(command: GenesisCommand) -> anyhow::Result<()> {
+    match command {
+        GenesisCommand::Certifier { command } => run_certifier_command(command),
+        GenesisCommand::Ceremony { command } => run_ceremony_command(command),
+        GenesisCommand::Portal(args) => serve_portal(args).await,
+        GenesisCommand::Round1(args) => run_round1(args),
+        GenesisCommand::Round2(args) => run_round2(args),
+        GenesisCommand::FinalizeDkg(args) => run_finalize_dkg(args),
+        GenesisCommand::SignRootArtifact(args) => run_sign_root_artifact(args),
+        GenesisCommand::AssembleBundle(args) => run_assemble_bundle(args),
+        GenesisCommand::VerifyBundle(args) => run_verify_bundle(args),
+        GenesisCommand::SealShare(args) => run_seal_share(args),
+        GenesisCommand::UnsealShare(args) => run_unseal_share(args),
+    }
+}
+
+fn run_certifier_command(command: GenesisCertifierCommand) -> anyhow::Result<()> {
+    match command {
+        GenesisCertifierCommand::Init(args) => init_certifier(args),
+    }
+}
+
+fn run_ceremony_command(command: GenesisCeremonyCommand) -> anyhow::Result<()> {
+    match command {
+        GenesisCeremonyCommand::Init(args) => init_ceremony(args),
+    }
+}
+
+fn init_certifier(args: GenesisCertifierInitArgs) -> anyhow::Result<()> {
+    let did = Did::new(&args.did)?;
+    let mut signing_seed = [0u8; 32];
+    let mut transport_secret = [0u8; 32];
+    rand::rngs::OsRng.fill_bytes(&mut signing_seed);
+    rand::rngs::OsRng.fill_bytes(&mut transport_secret);
+    let signing_keypair = KeyPair::from_secret_bytes(signing_seed)?;
+    let transport_public = X25519PublicKey::from(&StaticSecret::from(transport_secret));
+    let contact = CertifierContact {
+        did: did.clone(),
+        frost_identifier: args.frost_identifier,
+        signing_public_key: *signing_keypair.public_key(),
+        transport_public_key: *transport_public.as_bytes(),
+    };
+    let private = PrivateCertifierMaterial {
+        did,
+        frost_identifier: args.frost_identifier,
+        signing_secret_hex: hex::encode(signing_seed),
+        transport_secret_hex: hex::encode(transport_secret),
+    };
+    write_json(&args.certifier_out, &contact)?;
+    write_json(&args.private_out, &private)?;
+    Ok(())
+}
+
+fn init_ceremony(args: GenesisCeremonyInitArgs) -> anyhow::Result<()> {
+    let certifiers: Vec<CertifierContact> = read_json(&args.roster)?;
+    let constitution_hash = parse_hash_hex(&args.constitution_hash)?;
+    let config = GenesisCeremonyConfig {
+        ceremony_id: args.ceremony_id,
+        network_id: args.network_id,
+        repo_commit: args.repo_commit,
+        constitution_hash,
+        threshold: exo_root::ROOT_GENESIS_THRESHOLD,
+        max_signers: exo_root::ROOT_GENESIS_SIGNERS,
+        created_at: Timestamp::new(args.created_physical_ms, 0),
+        certifiers,
+    };
+    config.validate()?;
+    write_json(&args.out, &config)?;
+    Ok(())
+}
+
+async fn serve_portal(args: GenesisPortalArgs) -> anyhow::Result<()> {
+    let config: GenesisCeremonyConfig = read_json(&args.config)?;
+    config.validate()?;
+    let address = args.bind.parse::<SocketAddr>()?;
+    let listener = tokio::net::TcpListener::bind(address).await?;
+    let router = root_genesis_router(RootGenesisApiState::new(config));
+    axum::serve(listener, router).await?;
+    Ok(())
+}
+
+fn run_round1(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: Round1CommandInput = read_json(&required_input(&args)?)?;
+    input.config.validate()?;
+    let mut rng = rand::rngs::OsRng;
+    let output = dkg_round1(&input.config, input.frost_identifier, &mut rng)?;
+    write_output(&args, &output)
+}
+
+fn run_round2(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: Round2CommandInput = read_json(&required_input(&args)?)?;
+    let output = dkg_round2(
+        &input.config,
+        input.frost_identifier,
+        decode_hex(&input.round1_secret_package_hex)?.as_slice(),
+        decode_package_map(input.round1_packages_hex)?,
+    )?;
+    write_output(&args, &output)
+}
+
+fn run_finalize_dkg(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: FinalizeDkgCommandInput = read_json(&required_input(&args)?)?;
+    let output = dkg_finalize_participant(
+        &input.config,
+        input.frost_identifier,
+        decode_hex(&input.round2_secret_package_hex)?.as_slice(),
+        decode_package_map(input.round1_packages_hex)?,
+        decode_package_map(input.round2_packages_hex)?,
+    )?;
+    write_output(&args, &output)
+}
+
+fn run_sign_root_artifact(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: SignRootArtifactCommandInput = read_json(&required_input(&args)?)?;
+    let artifact = decode_hex(&input.artifact_hex)?;
+    let mut rng = rand::rngs::OsRng;
+    let signature = threshold_sign(
+        &input.config,
+        &input.public_key_package,
+        input.key_packages,
+        artifact.as_slice(),
+        &mut rng,
+    )?;
+    write_output(&args, &signature)
+}
+
+fn run_assemble_bundle(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: AssembleBundleCommandInput = read_json(&required_input(&args)?)?;
+    let bundle = assemble_root_bundle(
+        input.config,
+        input.public_key_package,
+        input.issuer_delegation,
+        input.transcript_hash,
+        decode_hex(&input.root_signature_hex)?,
+    )?;
+    write_output(&args, &bundle)
+}
+
+fn run_verify_bundle(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: VerifyBundleCommandInput = read_json(&required_input(&args)?)?;
+    verify_root_bundle(&input.bundle)?;
+    write_output(&args, &serde_json::json!({ "verified": true }))
+}
+
+fn run_seal_share(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: SealShareCommandInput = read_json(&required_input(&args)?)?;
+    let salt = decode_fixed_16(&input.salt_hex)?;
+    let nonce = decode_fixed_24(&input.nonce_hex)?;
+    let sealed = seal_share(
+        decode_hex(&input.share_hex)?.as_slice(),
+        decode_hex(&input.passphrase_hex)?.as_slice(),
+        decode_hex(&input.associated_data_hex)?.as_slice(),
+        &salt,
+        &nonce,
+    )?;
+    write_output(&args, &sealed)
+}
+
+fn run_unseal_share(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: UnsealShareCommandInput = read_json(&required_input(&args)?)?;
+    let opened = unseal_share(
+        &input.sealed,
+        decode_hex(&input.passphrase_hex)?.as_slice(),
+        decode_hex(&input.associated_data_hex)?.as_slice(),
+    )?;
+    write_output(
+        &args,
+        &HexBytesOutput {
+            bytes_hex: hex::encode(opened),
+        },
+    )
+}
+
+fn parse_hash_hex(value: &str) -> anyhow::Result<Hash256> {
+    let bytes = hex::decode(value)?;
+    if bytes.len() != 32 {
+        anyhow::bail!("constitution hash must be 32 bytes");
+    }
+    let mut hash = [0u8; 32];
+    hash.copy_from_slice(&bytes);
+    Ok(Hash256::from_bytes(hash))
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: &std::path::Path) -> anyhow::Result<T> {
+    let bytes = fs::read(path)?;
+    let value = serde_json::from_slice(&bytes)?;
+    Ok(value)
+}
+
+fn write_json<T: Serialize>(path: &std::path::Path, value: &T) -> anyhow::Result<()> {
+    let bytes = serde_json::to_vec_pretty(value)?;
+    fs::write(path, bytes)?;
+    Ok(())
+}
+
+fn required_input(args: &GenesisIoArgs) -> anyhow::Result<std::path::PathBuf> {
+    args.input
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("--input is required for this command"))
+}
+
+fn write_output<T: Serialize>(args: &GenesisIoArgs, value: &T) -> anyhow::Result<()> {
+    match &args.output {
+        Some(path) => write_json(path, value),
+        None => {
+            println!("{}", serde_json::to_string_pretty(value)?);
+            Ok(())
+        }
+    }
+}
+
+fn decode_hex(value: &str) -> anyhow::Result<Vec<u8>> {
+    Ok(hex::decode(value)?)
+}
+
+fn decode_fixed_16(value: &str) -> anyhow::Result<[u8; 16]> {
+    let bytes = decode_hex(value)?;
+    if bytes.len() != 16 {
+        anyhow::bail!("expected 16 bytes");
+    }
+    let mut result = [0u8; 16];
+    result.copy_from_slice(&bytes);
+    Ok(result)
+}
+
+fn decode_fixed_24(value: &str) -> anyhow::Result<[u8; 24]> {
+    let bytes = decode_hex(value)?;
+    if bytes.len() != 24 {
+        anyhow::bail!("expected 24 bytes");
+    }
+    let mut result = [0u8; 24];
+    result.copy_from_slice(&bytes);
+    Ok(result)
+}
+
+fn decode_package_map(packages: BTreeMapStringBytes) -> anyhow::Result<BTreeMap<u16, Vec<u8>>> {
+    let mut decoded = BTreeMap::new();
+    for (identifier, package_hex) in packages {
+        decoded.insert(identifier, decode_hex(&package_hex)?);
+    }
+    Ok(decoded)
+}

--- a/crates/exo-node/src/root_genesis_cli.rs
+++ b/crates/exo-node/src/root_genesis_cli.rs
@@ -339,3 +339,134 @@ fn decode_package_map(packages: BTreeMapStringBytes) -> anyhow::Result<BTreeMap<
     }
     Ok(decoded)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use exo_core::PublicKey;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn certifier(identifier: u16) -> CertifierContact {
+        let byte = u8::try_from(identifier).expect("identifier fits in byte");
+        CertifierContact {
+            did: Did::new(&format!("did:exo:root-cli-{identifier:02}")).expect("valid DID"),
+            frost_identifier: identifier,
+            signing_public_key: PublicKey::from_bytes([byte; 32]),
+            transport_public_key: [byte; 32],
+        }
+    }
+
+    fn io_args(input: PathBuf, output: PathBuf) -> GenesisIoArgs {
+        GenesisIoArgs {
+            input: Some(input),
+            output: Some(output),
+        }
+    }
+
+    #[test]
+    fn init_ceremony_writes_valid_institutional_config() {
+        let directory = tempdir().expect("temporary directory");
+        let roster_path = directory.path().join("roster.json");
+        let config_path = directory.path().join("ceremony.json");
+        let roster: Vec<_> = (1..=13).map(certifier).collect();
+        write_json(&roster_path, &roster).expect("write roster");
+
+        init_ceremony(GenesisCeremonyInitArgs {
+            ceremony_id: "root-cli-ceremony".to_owned(),
+            network_id: "exo-mainnet".to_owned(),
+            repo_commit: "d8927686a34bdc28ba36d53938f665685d2c4c04".to_owned(),
+            constitution_hash: hex::encode([7u8; 32]),
+            created_physical_ms: 42,
+            roster: roster_path,
+            out: config_path.clone(),
+        })
+        .expect("ceremony init");
+
+        let config: GenesisCeremonyConfig = read_json(&config_path).expect("read config");
+        assert_eq!(config.threshold, exo_root::ROOT_GENESIS_THRESHOLD);
+        assert_eq!(config.max_signers, exo_root::ROOT_GENESIS_SIGNERS);
+        assert_eq!(
+            config.certifiers.len(),
+            usize::from(exo_root::ROOT_GENESIS_SIGNERS)
+        );
+        assert_eq!(config.created_at, Timestamp::new(42, 0));
+        config.validate().expect("valid root genesis config");
+    }
+
+    #[test]
+    fn seal_and_unseal_share_commands_round_trip_hex_output() {
+        let directory = tempdir().expect("temporary directory");
+        let seal_input_path = directory.path().join("seal-input.json");
+        let sealed_path = directory.path().join("sealed.json");
+        let unseal_input_path = directory.path().join("unseal-input.json");
+        let opened_path = directory.path().join("opened.json");
+        let share = b"certifier-share-material";
+        let associated_data = b"root-genesis-share-v1";
+        let passphrase = b"long offline passphrase";
+        write_json(
+            &seal_input_path,
+            &SealShareCommandInput {
+                share_hex: hex::encode(share),
+                passphrase_hex: hex::encode(passphrase),
+                associated_data_hex: hex::encode(associated_data),
+                salt_hex: hex::encode([2u8; 16]),
+                nonce_hex: hex::encode([3u8; 24]),
+            },
+        )
+        .expect("write seal input");
+
+        run_seal_share(io_args(seal_input_path, sealed_path.clone())).expect("seal share");
+        let sealed: exo_root::SealedShare = read_json(&sealed_path).expect("read sealed share");
+        write_json(
+            &unseal_input_path,
+            &UnsealShareCommandInput {
+                sealed,
+                passphrase_hex: hex::encode(passphrase),
+                associated_data_hex: hex::encode(associated_data),
+            },
+        )
+        .expect("write unseal input");
+
+        run_unseal_share(io_args(unseal_input_path, opened_path.clone())).expect("unseal share");
+        let opened: HexBytesOutput = read_json(&opened_path).expect("read opened share");
+        assert_eq!(opened.bytes_hex, hex::encode(share));
+    }
+
+    #[test]
+    fn command_helpers_fail_closed_on_missing_input_and_bad_hex() {
+        let missing_input = GenesisIoArgs {
+            input: None,
+            output: None,
+        };
+        assert!(
+            required_input(&missing_input)
+                .expect_err("input must be required")
+                .to_string()
+                .contains("--input is required")
+        );
+        assert!(
+            parse_hash_hex("abcd")
+                .expect_err("short hash must fail")
+                .to_string()
+                .contains("constitution hash must be 32 bytes")
+        );
+        assert!(
+            decode_fixed_16("abcd")
+                .expect_err("short salt must fail")
+                .to_string()
+                .contains("expected 16 bytes")
+        );
+        assert!(
+            decode_fixed_24("abcd")
+                .expect_err("short nonce must fail")
+                .to_string()
+                .contains("expected 24 bytes")
+        );
+        let mut packages = BTreeMap::new();
+        packages.insert(7, "not-hex".to_owned());
+        assert!(decode_package_map(packages).is_err());
+    }
+}

--- a/crates/exo-root/Cargo.toml
+++ b/crates/exo-root/Cargo.toml
@@ -1,0 +1,46 @@
+# Copyright 2026 Exochain Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "exo-root"
+description = "EXOCHAIN root genesis authority ceremony, FROST DKG, threshold signatures, and trust bundle verification"
+documentation = "https://docs.exochain.io"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+exo-core = { path = "../exo-core" }
+exo-authority = { path = "../exo-authority" }
+frost-ristretto255 = { workspace = true }
+serde = { workspace = true }
+ciborium = { workspace = true }
+thiserror = { workspace = true }
+chacha20poly1305 = { workspace = true }
+hkdf = { workspace = true }
+sha2 = { workspace = true }
+x25519-dalek = { workspace = true }
+argon2 = { workspace = true }
+zeroize = { workspace = true }
+rand = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/exo-root/src/bundle.rs
+++ b/crates/exo-root/src/bundle.rs
@@ -1,0 +1,197 @@
+//! Root trust bundle assembly and verification.
+
+use std::fmt::Display;
+
+use exo_authority::permission::Permission;
+use exo_core::{Did, Hash256, PublicKey, Timestamp, hash::hash_structured};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    GenesisCeremonyConfig, Result, RootError, RootPublicKeyPackage, verify_root_signature,
+};
+
+/// Operational AVC issuer authority delegated by the root.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RootIssuerDelegation {
+    /// Operational issuer DID.
+    pub issuer_did: Did,
+    /// Operational issuer public key.
+    pub issuer_public_key: PublicKey,
+    /// Permissions granted by the root authority.
+    pub granted_permissions: Vec<Permission>,
+    /// HLC activation timestamp.
+    pub effective_at: Timestamp,
+    /// Optional HLC expiry timestamp.
+    pub expires_at: Option<Timestamp>,
+    /// Human-readable bounded purpose.
+    pub purpose: String,
+}
+
+/// Root trust bundle produced by genesis.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RootTrustBundle {
+    /// Ceremony configuration.
+    pub config: GenesisCeremonyConfig,
+    /// Public FROST package and root key.
+    pub public_key_package: RootPublicKeyPackage,
+    /// Root-signed AVC issuer delegation.
+    pub issuer_delegation: RootIssuerDelegation,
+    /// Canonical transcript hash.
+    pub transcript_hash: Hash256,
+    /// Root threshold signature over the trust artifact payload.
+    pub root_signature: Vec<u8>,
+    /// Canonical bundle content identifier.
+    pub bundle_id: Hash256,
+}
+
+#[derive(Serialize)]
+struct RootArtifactPayload<'a> {
+    domain: &'static str,
+    config_hash: Hash256,
+    public_key_package_hash: Hash256,
+    transcript_hash: Hash256,
+    issuer_delegation_hash: Hash256,
+    issuer_did: &'a Did,
+}
+
+#[derive(Serialize)]
+struct RootBundleIdPayload<'a> {
+    domain: &'static str,
+    artifact_payload_hash: Hash256,
+    root_signature: &'a [u8],
+}
+
+fn canonical_bytes<T: Serialize>(value: &T) -> Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    ciborium::into_writer(value, &mut bytes).map_err(canonical_encoding_error)?;
+    Ok(bytes)
+}
+
+fn structured_hash<T: Serialize>(value: &T) -> Result<Hash256> {
+    hash_structured(value).map_err(canonical_encoding_error)
+}
+
+fn canonical_encoding_error(error: impl Display) -> RootError {
+    RootError::CanonicalEncoding {
+        detail: error.to_string(),
+    }
+}
+
+impl RootIssuerDelegation {
+    /// Canonical payload signed by the root threshold authority.
+    pub fn root_artifact_payload(
+        &self,
+        config: &GenesisCeremonyConfig,
+        public_key_package: &RootPublicKeyPackage,
+        transcript_hash: Hash256,
+    ) -> Result<Vec<u8>> {
+        config.validate()?;
+        if self.purpose.trim().is_empty() {
+            return Err(RootError::BundleRejected {
+                reason: "issuer delegation purpose must not be empty".to_owned(),
+            });
+        }
+        if self.granted_permissions.is_empty() {
+            return Err(RootError::BundleRejected {
+                reason: "issuer delegation must grant at least one permission".to_owned(),
+            });
+        }
+        let payload = RootArtifactPayload {
+            domain: "EXOCHAIN_ROOT_ARTIFACT_V1",
+            config_hash: structured_hash(config)?,
+            public_key_package_hash: structured_hash(public_key_package)?,
+            transcript_hash,
+            issuer_delegation_hash: structured_hash(self)?,
+            issuer_did: &self.issuer_did,
+        };
+        canonical_bytes(&payload)
+    }
+}
+
+fn bundle_id(
+    delegation: &RootIssuerDelegation,
+    config: &GenesisCeremonyConfig,
+    public_key_package: &RootPublicKeyPackage,
+    transcript_hash: Hash256,
+    root_signature: &[u8],
+) -> Result<Hash256> {
+    let artifact_payload =
+        delegation.root_artifact_payload(config, public_key_package, transcript_hash)?;
+    let id_payload = RootBundleIdPayload {
+        domain: "EXOCHAIN_ROOT_BUNDLE_V1",
+        artifact_payload_hash: Hash256::digest(&artifact_payload),
+        root_signature,
+    };
+    structured_hash(&id_payload)
+}
+
+/// Assemble and verify a root trust bundle.
+pub fn assemble_root_bundle(
+    config: GenesisCeremonyConfig,
+    public_key_package: RootPublicKeyPackage,
+    issuer_delegation: RootIssuerDelegation,
+    transcript_hash: Hash256,
+    root_signature: Vec<u8>,
+) -> Result<RootTrustBundle> {
+    let payload =
+        issuer_delegation.root_artifact_payload(&config, &public_key_package, transcript_hash)?;
+    verify_root_signature(
+        &public_key_package.root_public_key,
+        &payload,
+        root_signature.as_slice(),
+    )?;
+    let bundle_id = bundle_id(
+        &issuer_delegation,
+        &config,
+        &public_key_package,
+        transcript_hash,
+        root_signature.as_slice(),
+    )?;
+    Ok(RootTrustBundle {
+        config,
+        public_key_package,
+        issuer_delegation,
+        transcript_hash,
+        root_signature,
+        bundle_id,
+    })
+}
+
+/// Verify that a root trust bundle is self-consistent and root-signed.
+pub fn verify_root_bundle(bundle: &RootTrustBundle) -> Result<()> {
+    bundle.config.validate()?;
+    let payload = bundle.issuer_delegation.root_artifact_payload(
+        &bundle.config,
+        &bundle.public_key_package,
+        bundle.transcript_hash,
+    )?;
+    verify_root_signature(
+        &bundle.public_key_package.root_public_key,
+        &payload,
+        bundle.root_signature.as_slice(),
+    )?;
+    let expected_id = bundle_id(
+        &bundle.issuer_delegation,
+        &bundle.config,
+        &bundle.public_key_package,
+        bundle.transcript_hash,
+        bundle.root_signature.as_slice(),
+    )?;
+    if expected_id != bundle.bundle_id {
+        return Err(RootError::BundleRejected {
+            reason: "bundle identifier does not match contents".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_error_conversion_is_diagnostic() {
+        let error = canonical_encoding_error("encoder failed");
+        assert!(error.to_string().contains("encoder failed"));
+    }
+}

--- a/crates/exo-root/src/ceremony.rs
+++ b/crates/exo-root/src/ceremony.rs
@@ -1,0 +1,139 @@
+//! Ceremony policy and certifier roster validation.
+
+use std::collections::BTreeSet;
+
+use exo_core::{Did, Hash256, PublicKey, Timestamp};
+use serde::{Deserialize, Serialize};
+
+use crate::{Result, RootError};
+
+/// Institutional root threshold.
+pub const ROOT_GENESIS_THRESHOLD: u16 = 7;
+
+/// Institutional root roster size.
+pub const ROOT_GENESIS_SIGNERS: u16 = 13;
+
+/// Public contact and verification material for a root certifier.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct CertifierContact {
+    /// Certifier DID.
+    pub did: Did,
+    /// FROST signer identifier in the inclusive range 1..=13.
+    pub frost_identifier: u16,
+    /// Ed25519 public key used for signed portal envelopes.
+    pub signing_public_key: PublicKey,
+    /// X25519 public key used for recipient-bound round-two payloads.
+    pub transport_public_key: [u8; 32],
+}
+
+/// Root genesis ceremony configuration bound into every transcript and bundle.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GenesisCeremonyConfig {
+    /// Ceremony identifier chosen before DKG starts.
+    pub ceremony_id: String,
+    /// EXOCHAIN network identifier.
+    pub network_id: String,
+    /// Repository commit reviewed for the ceremony.
+    pub repo_commit: String,
+    /// Canonical hash of the governing constitution.
+    pub constitution_hash: Hash256,
+    /// Threshold required to sign root artifacts after genesis.
+    pub threshold: u16,
+    /// Total roster size.
+    pub max_signers: u16,
+    /// HLC timestamp supplied by the operator.
+    pub created_at: Timestamp,
+    /// Full certifier roster.
+    pub certifiers: Vec<CertifierContact>,
+}
+
+impl GenesisCeremonyConfig {
+    /// Validate the constitutional root policy and roster uniqueness.
+    pub fn validate(&self) -> Result<()> {
+        if self.threshold != ROOT_GENESIS_THRESHOLD {
+            return Err(RootError::InvalidConfig {
+                reason: format!("threshold must be {ROOT_GENESIS_THRESHOLD}"),
+            });
+        }
+        if self.max_signers != ROOT_GENESIS_SIGNERS {
+            return Err(RootError::InvalidConfig {
+                reason: format!("max_signers must be {ROOT_GENESIS_SIGNERS}"),
+            });
+        }
+        if self.certifiers.len() != usize::from(ROOT_GENESIS_SIGNERS) {
+            return Err(RootError::InvalidConfig {
+                reason: format!("roster must contain {ROOT_GENESIS_SIGNERS} certifiers"),
+            });
+        }
+        if self.ceremony_id.trim().is_empty() {
+            return Err(RootError::InvalidConfig {
+                reason: "ceremony_id must not be empty".to_owned(),
+            });
+        }
+        if self.network_id.trim().is_empty() {
+            return Err(RootError::InvalidConfig {
+                reason: "network_id must not be empty".to_owned(),
+            });
+        }
+        if self.repo_commit.len() != 40 || !self.repo_commit.bytes().all(|b| b.is_ascii_hexdigit())
+        {
+            return Err(RootError::InvalidConfig {
+                reason: "repo_commit must be a 40-character hex commit".to_owned(),
+            });
+        }
+
+        let mut dids = BTreeSet::new();
+        let mut frost_ids = BTreeSet::new();
+        let mut signing_keys = BTreeSet::new();
+        let mut transport_keys = BTreeSet::new();
+        for certifier in &self.certifiers {
+            if certifier.frost_identifier == 0 || certifier.frost_identifier > ROOT_GENESIS_SIGNERS
+            {
+                return Err(RootError::InvalidConfig {
+                    reason: format!(
+                        "frost_identifier {} is outside 1..={ROOT_GENESIS_SIGNERS}",
+                        certifier.frost_identifier
+                    ),
+                });
+            }
+            if !dids.insert(certifier.did.clone()) {
+                return Err(RootError::InvalidConfig {
+                    reason: format!("duplicate certifier DID {}", certifier.did),
+                });
+            }
+            if !frost_ids.insert(certifier.frost_identifier) {
+                return Err(RootError::InvalidConfig {
+                    reason: format!("duplicate FROST identifier {}", certifier.frost_identifier),
+                });
+            }
+            if !signing_keys.insert(certifier.signing_public_key) {
+                return Err(RootError::InvalidConfig {
+                    reason: "duplicate signing public key".to_owned(),
+                });
+            }
+            if !transport_keys.insert(certifier.transport_public_key) {
+                return Err(RootError::InvalidConfig {
+                    reason: "duplicate transport public key".to_owned(),
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Return the certifier with the supplied DID, if rostered.
+    #[must_use]
+    pub fn certifier_by_did(&self, did: &Did) -> Option<&CertifierContact> {
+        self.certifiers
+            .iter()
+            .find(|certifier| &certifier.did == did)
+    }
+
+    /// Return the certifier with the supplied FROST identifier, if rostered.
+    #[must_use]
+    pub fn certifier_by_identifier(&self, identifier: u16) -> Option<&CertifierContact> {
+        self.certifiers
+            .iter()
+            .find(|certifier| certifier.frost_identifier == identifier)
+    }
+}

--- a/crates/exo-root/src/dkg.rs
+++ b/crates/exo-root/src/dkg.rs
@@ -1,0 +1,526 @@
+//! FROST DKG wrappers for root genesis.
+
+use std::{collections::BTreeMap, fmt::Display};
+
+use frost_ristretto255 as frost;
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+
+use crate::{GenesisCeremonyConfig, Result, RootError};
+
+/// Serialized public key package and derived public metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RootPublicKeyPackage {
+    /// Serialized FROST public key package.
+    pub public_key_package: Vec<u8>,
+    /// Serialized root verifying key.
+    pub root_public_key: Vec<u8>,
+    /// Serialized verification shares by FROST identifier.
+    pub verifying_shares: BTreeMap<u16, Vec<u8>>,
+}
+
+/// Serialized FROST key package held by one certifier.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RootKeyPackage {
+    /// Owner's FROST identifier.
+    pub frost_identifier: u16,
+    /// Serialized FROST key package.
+    pub key_package: Vec<u8>,
+}
+
+/// Complete in-memory DKG result for tests and offline ceremony tooling.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RootDkgOutput {
+    /// Certifier key packages by FROST identifier.
+    pub key_packages: BTreeMap<u16, RootKeyPackage>,
+    /// Public key package common to all certifiers.
+    pub public_key_package: RootPublicKeyPackage,
+}
+
+/// Serialized output from one certifier's DKG round one.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RootDkgRound1Output {
+    /// Owner's FROST identifier.
+    pub frost_identifier: u16,
+    /// Private round-one state retained by the certifier.
+    pub round1_secret_package: Vec<u8>,
+    /// Public round-one package broadcast to every other certifier.
+    pub round1_package: Vec<u8>,
+}
+
+/// Serialized output from one certifier's DKG round two.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RootDkgRound2Output {
+    /// Owner's FROST identifier.
+    pub frost_identifier: u16,
+    /// Private round-two state retained by the certifier.
+    pub round2_secret_package: Vec<u8>,
+    /// Recipient-bound round-two packages by recipient FROST identifier.
+    pub round2_packages: BTreeMap<u16, Vec<u8>>,
+}
+
+/// Final DKG material derived by one certifier.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RootParticipantDkgOutput {
+    /// Owner's FROST key package.
+    pub key_package: RootKeyPackage,
+    /// Public root key package derived by the participant.
+    pub public_key_package: RootPublicKeyPackage,
+}
+
+pub(crate) fn frost_identifier(identifier: u16) -> Result<frost::Identifier> {
+    frost::Identifier::try_from(identifier).map_err(frost_error)
+}
+
+fn rostered_frost_identifier(
+    config: &GenesisCeremonyConfig,
+    identifier: u16,
+    operation: &str,
+) -> Result<frost::Identifier> {
+    if config.certifier_by_identifier(identifier).is_none() {
+        return Err(RootError::InvalidConfig {
+            reason: format!("{operation} certifier {identifier} is not rostered"),
+        });
+    }
+    frost_identifier(identifier)
+}
+
+fn frost_error(error: frost::Error) -> RootError {
+    RootError::Frost {
+        detail: error.to_string(),
+    }
+}
+
+fn frost_encoding_error(error: impl Display) -> RootError {
+    RootError::Frost {
+        detail: format!("FROST artifact canonical encoding failed: {error}"),
+    }
+}
+
+pub(crate) fn serialize_frost<T: Serialize>(value: &T) -> Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    ciborium::into_writer(value, &mut bytes).map_err(frost_encoding_error)?;
+    Ok(bytes)
+}
+
+pub(crate) fn deserialize_frost<T: DeserializeOwned>(bytes: &[u8]) -> Result<T> {
+    ciborium::from_reader(bytes).map_err(frost_encoding_error)
+}
+
+fn identifier_value(
+    config: &GenesisCeremonyConfig,
+    frost_identifier: frost::Identifier,
+) -> Result<u16> {
+    for certifier in &config.certifiers {
+        if crate::dkg::frost_identifier(certifier.frost_identifier)? == frost_identifier {
+            return Ok(certifier.frost_identifier);
+        }
+    }
+    Err(RootError::Frost {
+        detail: "FROST identifier is not rostered".to_owned(),
+    })
+}
+
+fn peer_packages_except(
+    packages: &BTreeMap<u16, Vec<u8>>,
+    excluded: u16,
+) -> BTreeMap<u16, Vec<u8>> {
+    packages
+        .iter()
+        .filter(|(peer, _)| **peer != excluded)
+        .map(|(peer, package)| (*peer, package.clone()))
+        .collect()
+}
+
+pub(crate) fn serialize_public_key_package(
+    config: &GenesisCeremonyConfig,
+    package: &frost::keys::PublicKeyPackage,
+) -> Result<RootPublicKeyPackage> {
+    let public_key_package = serialize_frost(package)?;
+    let root_public_key = serialize_frost(package.verifying_key())?;
+    let mut verifying_shares = BTreeMap::new();
+    for certifier in &config.certifiers {
+        let identifier = frost_identifier(certifier.frost_identifier)?;
+        let share =
+            package
+                .verifying_shares()
+                .get(&identifier)
+                .ok_or_else(|| RootError::Frost {
+                    detail: format!(
+                        "missing verification share for identifier {}",
+                        certifier.frost_identifier
+                    ),
+                })?;
+        verifying_shares.insert(certifier.frost_identifier, serialize_frost(share)?);
+    }
+    Ok(RootPublicKeyPackage {
+        public_key_package,
+        root_public_key,
+        verifying_shares,
+    })
+}
+
+/// Execute DKG round one for one rostered certifier.
+pub fn dkg_round1<R>(
+    config: &GenesisCeremonyConfig,
+    frost_identifier_value: u16,
+    rng: &mut R,
+) -> Result<RootDkgRound1Output>
+where
+    R: frost::rand_core::RngCore + frost::rand_core::CryptoRng,
+{
+    config.validate()?;
+    let identifier = rostered_frost_identifier(config, frost_identifier_value, "round-one")?;
+    let part1 = frost::keys::dkg::part1;
+    let max_signers = config.max_signers;
+    let threshold = config.threshold;
+    let round1 = part1(identifier, max_signers, threshold, rng).map_err(frost_error)?;
+    let (secret_package, package) = round1;
+    let output = RootDkgRound1Output {
+        frost_identifier: frost_identifier_value,
+        round1_secret_package: serialize_frost(&secret_package)?,
+        round1_package: serialize_frost(&package)?,
+    };
+    Ok(output)
+}
+
+/// Execute DKG round two for one certifier after all other round-one packages
+/// have been authenticated and collected.
+pub fn dkg_round2(
+    config: &GenesisCeremonyConfig,
+    frost_identifier_value: u16,
+    round1_secret_package: &[u8],
+    round1_packages: BTreeMap<u16, Vec<u8>>,
+) -> Result<RootDkgRound2Output> {
+    config.validate()?;
+    if round1_packages.len() != usize::from(config.max_signers - 1) {
+        return Err(RootError::Frost {
+            detail: "round two requires all twelve peer round-one packages".to_owned(),
+        });
+    }
+    let participant_identifier =
+        rostered_frost_identifier(config, frost_identifier_value, "round-two")?;
+    let secret_package = deserialize_frost(round1_secret_package)?;
+    let inbound_round1 =
+        deserialize_round1_packages(config, participant_identifier, round1_packages)?;
+    let (round2_secret_package, outbound) =
+        frost::keys::dkg::part2(secret_package, &inbound_round1).map_err(frost_error)?;
+    let mut round2_packages = BTreeMap::new();
+    for (recipient, package) in outbound {
+        let recipient_value = identifier_value(config, recipient)?;
+        round2_packages.insert(recipient_value, serialize_frost(&package)?);
+    }
+    Ok(RootDkgRound2Output {
+        frost_identifier: frost_identifier_value,
+        round2_secret_package: serialize_frost(&round2_secret_package)?,
+        round2_packages,
+    })
+}
+
+/// Finalize one participant's DKG state after all peer round-one and round-two
+/// packages have been authenticated and collected.
+pub fn dkg_finalize_participant(
+    config: &GenesisCeremonyConfig,
+    frost_identifier_value: u16,
+    round2_secret_package: &[u8],
+    round1_packages: BTreeMap<u16, Vec<u8>>,
+    round2_packages: BTreeMap<u16, Vec<u8>>,
+) -> Result<RootParticipantDkgOutput> {
+    config.validate()?;
+    if round1_packages.len() != usize::from(config.max_signers - 1) {
+        return Err(RootError::Frost {
+            detail: "finalize requires all twelve peer round-one packages".to_owned(),
+        });
+    }
+    if round2_packages.len() != usize::from(config.max_signers - 1) {
+        return Err(RootError::Frost {
+            detail: "finalize requires all twelve peer round-two packages".to_owned(),
+        });
+    }
+    let participant_identifier =
+        rostered_frost_identifier(config, frost_identifier_value, "finalize")?;
+    let secret_package = deserialize_frost(round2_secret_package)?;
+    let inbound_round1 =
+        deserialize_round1_packages(config, participant_identifier, round1_packages)?;
+    let inbound_round2 =
+        deserialize_round2_packages(config, participant_identifier, round2_packages)?;
+    let (key_package, public_key_package) =
+        frost::keys::dkg::part3(&secret_package, &inbound_round1, &inbound_round2)
+            .map_err(frost_error)?;
+    let key_package = RootKeyPackage {
+        frost_identifier: frost_identifier_value,
+        key_package: serialize_frost(&key_package)?,
+    };
+    Ok(RootParticipantDkgOutput {
+        key_package,
+        public_key_package: serialize_public_key_package(config, &public_key_package)?,
+    })
+}
+
+fn deserialize_round1_packages(
+    config: &GenesisCeremonyConfig,
+    participant_identifier: frost::Identifier,
+    packages: BTreeMap<u16, Vec<u8>>,
+) -> Result<BTreeMap<frost::Identifier, frost::keys::dkg::round1::Package>> {
+    let mut result = BTreeMap::new();
+    for (sender, package_bytes) in packages {
+        if config.certifier_by_identifier(sender).is_none() {
+            return Err(RootError::InvalidConfig {
+                reason: format!("round-one sender {sender} is not rostered"),
+            });
+        }
+        let sender_identifier = frost_identifier(sender)?;
+        if sender_identifier == participant_identifier {
+            return Err(RootError::Frost {
+                detail: "round-one peer packages must not include self".to_owned(),
+            });
+        }
+        let package = deserialize_frost(package_bytes.as_slice())?;
+        result.insert(sender_identifier, package);
+    }
+    Ok(result)
+}
+
+fn deserialize_round2_packages(
+    config: &GenesisCeremonyConfig,
+    participant_identifier: frost::Identifier,
+    packages: BTreeMap<u16, Vec<u8>>,
+) -> Result<BTreeMap<frost::Identifier, frost::keys::dkg::round2::Package>> {
+    let mut result = BTreeMap::new();
+    for (sender, package_bytes) in packages {
+        if config.certifier_by_identifier(sender).is_none() {
+            return Err(RootError::InvalidConfig {
+                reason: format!("round-two sender {sender} is not rostered"),
+            });
+        }
+        let sender_identifier = frost_identifier(sender)?;
+        if sender_identifier == participant_identifier {
+            return Err(RootError::Frost {
+                detail: "round-two peer packages must not include self".to_owned(),
+            });
+        }
+        let package = deserialize_frost(package_bytes.as_slice())?;
+        result.insert(sender_identifier, package);
+    }
+    Ok(result)
+}
+
+/// Run the all-roster DKG ceremony locally.
+///
+/// Production ceremonies should exchange these packages through the portal and
+/// pairwise encrypted channels. This function enforces the same all-thirteen
+/// completion rule for deterministic regression tests and offline rehearsals.
+pub fn run_complete_dkg<R>(config: &GenesisCeremonyConfig, rng: &mut R) -> Result<RootDkgOutput>
+where
+    R: frost::rand_core::RngCore + frost::rand_core::CryptoRng,
+{
+    config.validate()?;
+
+    let mut round1_outputs = BTreeMap::new();
+    let mut round1_public = BTreeMap::new();
+    for certifier in &config.certifiers {
+        let output = dkg_round1(config, certifier.frost_identifier, rng)?;
+        round1_public.insert(certifier.frost_identifier, output.round1_package.clone());
+        round1_outputs.insert(certifier.frost_identifier, output);
+    }
+
+    let mut round2_outputs = BTreeMap::new();
+    let mut round2_by_recipient: BTreeMap<u16, BTreeMap<u16, Vec<u8>>> = BTreeMap::new();
+    for (identifier, round1_output) in &round1_outputs {
+        let peer_round1 = peer_packages_except(&round1_public, *identifier);
+        let secret = &round1_output.round1_secret_package;
+        let round2 = dkg_round2(config, *identifier, secret, peer_round1)?;
+        for (recipient, package) in &round2.round2_packages {
+            let recipient_packages = round2_by_recipient.entry(*recipient).or_default();
+            recipient_packages.insert(*identifier, package.clone());
+        }
+        round2_outputs.insert(*identifier, round2);
+    }
+
+    let mut key_packages = BTreeMap::new();
+    let finish = dkg_finalize_participant;
+    let first_identifier = config.certifiers[0].frost_identifier;
+    let output = &round2_outputs[&first_identifier];
+    let fr1 = peer_packages_except(&round1_public, first_identifier);
+    let fs = &output.round2_secret_package;
+    let fr2 = round2_by_recipient[&first_identifier].clone();
+    let first_participant = finish(config, first_identifier, fs, fr1, fr2)?;
+    let public_key_package = first_participant.public_key_package;
+    key_packages.insert(first_identifier, first_participant.key_package);
+
+    for (identifier, round2_output) in round2_outputs
+        .iter()
+        .filter(|(identifier, _)| **identifier != first_identifier)
+    {
+        let identifier = *identifier;
+        let peer_round1 = peer_packages_except(&round1_public, identifier);
+        let secret = &round2_output.round2_secret_package;
+        let round2 = round2_by_recipient[&identifier].clone();
+        let participant = finish(config, identifier, secret, peer_round1, round2)?;
+        key_packages.insert(identifier, participant.key_package);
+    }
+
+    Ok(RootDkgOutput {
+        key_packages,
+        public_key_package,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use exo_core::{Did, Hash256, PublicKey, Timestamp};
+    use rand::{SeedableRng, rngs::StdRng};
+
+    use super::*;
+    use crate::CertifierContact;
+
+    fn test_config() -> GenesisCeremonyConfig {
+        let certifiers = (1..=13)
+            .map(|identifier| {
+                let byte = u8::try_from(identifier).expect("identifier fits");
+                CertifierContact {
+                    did: Did::new(&format!("did:exo:unit-{identifier:02}")).expect("valid did"),
+                    frost_identifier: identifier,
+                    signing_public_key: PublicKey::from_bytes([byte; 32]),
+                    transport_public_key: [byte; 32],
+                }
+            })
+            .collect();
+        GenesisCeremonyConfig {
+            ceremony_id: "unit-root".into(),
+            network_id: "unit-net".into(),
+            repo_commit: "d8927686a34bdc28ba36d53938f665685d2c4c04".into(),
+            constitution_hash: Hash256::digest(b"constitution"),
+            threshold: 7,
+            max_signers: 13,
+            created_at: Timestamp::new(1, 0),
+            certifiers,
+        }
+    }
+
+    #[test]
+    fn identifier_value_rejects_unrostered_identifier() {
+        let config = test_config();
+        let identifier = frost_identifier(14).expect("identifier");
+        assert!(identifier_value(&config, identifier).is_err());
+    }
+
+    #[test]
+    fn frost_identifier_rejects_zero_identifier() {
+        let error = frost_identifier(0).expect_err("zero identifier");
+        assert!(error.to_string().contains("frost operation failed"));
+    }
+
+    #[test]
+    fn rostered_identifier_and_encoding_helpers_are_diagnostic() {
+        let config = test_config();
+        let identifier = rostered_frost_identifier(&config, 1, "unit").expect("rostered");
+        assert_eq!(identifier, frost_identifier(1).expect("identifier"));
+
+        let error =
+            rostered_frost_identifier(&config, 14, "unit").expect_err("unrostered certifier");
+        assert!(
+            error
+                .to_string()
+                .contains("unit certifier 14 is not rostered")
+        );
+
+        let encoding_error = frost_encoding_error("unit failure");
+        assert!(
+            encoding_error
+                .to_string()
+                .contains("FROST artifact canonical encoding failed")
+        );
+
+        let encoded = serialize_frost(&7u16).expect("serialize");
+        let decoded: u16 = deserialize_frost(encoded.as_slice()).expect("deserialize");
+        assert_eq!(decoded, 7);
+        assert!(deserialize_frost::<u16>(b"not cbor").is_err());
+    }
+
+    #[test]
+    fn peer_package_filter_retains_every_non_excluded_package() {
+        let mut packages = BTreeMap::new();
+        packages.insert(1, b"one".to_vec());
+        packages.insert(2, b"two".to_vec());
+        packages.insert(3, b"three".to_vec());
+
+        let peers = peer_packages_except(&packages, 2);
+
+        assert_eq!(peers.len(), 2);
+        assert_eq!(peers.get(&1).expect("peer one"), b"one");
+        assert_eq!(peers.get(&3).expect("peer three"), b"three");
+        assert!(!peers.contains_key(&2));
+    }
+
+    #[test]
+    fn round_one_and_complete_dkg_success_paths_are_diagnostic() {
+        let config = test_config();
+        let mut rng = StdRng::seed_from_u64(11);
+
+        let round1 = dkg_round1(&config, 1, &mut rng).expect("round one");
+        assert_eq!(round1.frost_identifier, 1);
+        assert!(!round1.round1_secret_package.is_empty());
+        assert!(!round1.round1_package.is_empty());
+
+        let dkg = run_complete_dkg(&config, &mut rng).expect("complete dkg");
+        assert_eq!(dkg.key_packages.len(), usize::from(config.max_signers));
+        assert_eq!(
+            dkg.public_key_package.verifying_shares.len(),
+            usize::from(config.max_signers)
+        );
+    }
+
+    #[test]
+    fn deserialize_peer_package_helpers_reject_bad_sender_sets() {
+        let config = test_config();
+        let participant = frost_identifier(1).expect("participant");
+
+        assert!(
+            deserialize_round1_packages(&config, participant, BTreeMap::new())
+                .expect("empty round-one helper input")
+                .is_empty()
+        );
+        assert!(
+            deserialize_round2_packages(&config, participant, BTreeMap::new())
+                .expect("empty round-two helper input")
+                .is_empty()
+        );
+
+        let mut nonrostered_round1 = BTreeMap::new();
+        nonrostered_round1.insert(14, Vec::new());
+        assert!(deserialize_round1_packages(&config, participant, nonrostered_round1).is_err());
+
+        let mut self_round1 = BTreeMap::new();
+        self_round1.insert(1, Vec::new());
+        assert!(deserialize_round1_packages(&config, participant, self_round1).is_err());
+
+        let mut malformed_round1 = BTreeMap::new();
+        malformed_round1.insert(2, b"not a round-one package".to_vec());
+        assert!(deserialize_round1_packages(&config, participant, malformed_round1).is_err());
+
+        let mut nonrostered_round2 = BTreeMap::new();
+        nonrostered_round2.insert(14, Vec::new());
+        assert!(deserialize_round2_packages(&config, participant, nonrostered_round2).is_err());
+
+        let mut self_round2 = BTreeMap::new();
+        self_round2.insert(1, Vec::new());
+        assert!(deserialize_round2_packages(&config, participant, self_round2).is_err());
+
+        let mut malformed_round2 = BTreeMap::new();
+        malformed_round2.insert(2, b"not a round-two package".to_vec());
+        assert!(deserialize_round2_packages(&config, participant, malformed_round2).is_err());
+    }
+
+    #[test]
+    fn serialize_public_key_package_rejects_missing_verification_share() {
+        let config = test_config();
+        let mut rng = StdRng::seed_from_u64(7);
+        let dkg = run_complete_dkg(&config, &mut rng).expect("dkg");
+        let public: frost::keys::PublicKeyPackage =
+            deserialize_frost(dkg.public_key_package.public_key_package.as_slice())
+                .expect("public package");
+        let mut changed_config = config;
+        changed_config.certifiers[0].frost_identifier = 14;
+        assert!(serialize_public_key_package(&changed_config, &public).is_err());
+    }
+}

--- a/crates/exo-root/src/dkg.rs
+++ b/crates/exo-root/src/dkg.rs
@@ -131,6 +131,21 @@ fn peer_packages_except(
         .collect()
 }
 
+fn frost_dkg_round1<R>(
+    identifier: frost::Identifier,
+    max_signers: u16,
+    threshold: u16,
+    rng: &mut R,
+) -> Result<(
+    frost::keys::dkg::round1::SecretPackage,
+    frost::keys::dkg::round1::Package,
+)>
+where
+    R: frost::rand_core::RngCore + frost::rand_core::CryptoRng,
+{
+    frost::keys::dkg::part1(identifier, max_signers, threshold, rng).map_err(frost_error)
+}
+
 pub(crate) fn serialize_public_key_package(
     config: &GenesisCeremonyConfig,
     package: &frost::keys::PublicKeyPackage,
@@ -170,10 +185,9 @@ where
 {
     config.validate()?;
     let identifier = rostered_frost_identifier(config, frost_identifier_value, "round-one")?;
-    let part1 = frost::keys::dkg::part1;
     let max_signers = config.max_signers;
     let threshold = config.threshold;
-    let round1 = part1(identifier, max_signers, threshold, rng).map_err(frost_error)?;
+    let round1 = frost_dkg_round1(identifier, max_signers, threshold, rng)?;
     let (secret_package, package) = round1;
     let output = RootDkgRound1Output {
         frost_identifier: frost_identifier_value,

--- a/crates/exo-root/src/error.rs
+++ b/crates/exo-root/src/error.rs
@@ -1,0 +1,43 @@
+//! Error type for root genesis authority operations.
+
+use thiserror::Error;
+
+/// Result alias used by the root genesis crate.
+pub type Result<T> = core::result::Result<T, RootError>;
+
+/// Failures returned by root genesis ceremony, DKG, signing, portal, and share
+/// protection operations.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum RootError {
+    /// Ceremony policy or roster validation failed.
+    #[error("ceremony configuration rejected: {reason}")]
+    InvalidConfig { reason: String },
+
+    /// Canonical CBOR encoding failed before hashing or signing.
+    #[error("canonical encoding failed: {detail}")]
+    CanonicalEncoding { detail: String },
+
+    /// FROST DKG or threshold signing failed.
+    #[error("frost operation failed: {detail}")]
+    Frost { detail: String },
+
+    /// The supplied signer set does not satisfy the configured threshold.
+    #[error("threshold not met: required {required}, supplied {supplied}")]
+    ThresholdNotMet { required: u16, supplied: u16 },
+
+    /// A root signature or certifier envelope signature did not verify.
+    #[error("signature verification failed: {reason}")]
+    SignatureRejected { reason: String },
+
+    /// Root trust bundle contents are inconsistent with their signature or ID.
+    #[error("root bundle rejected: {reason}")]
+    BundleRejected { reason: String },
+
+    /// Portal relay policy rejected an envelope.
+    #[error("portal envelope rejected: {reason}")]
+    PortalRejected { reason: String },
+
+    /// Share sealing, opening, or pairwise payload protection failed.
+    #[error("share protection failed: {reason}")]
+    ProtectionFailed { reason: String },
+}

--- a/crates/exo-root/src/lib.rs
+++ b/crates/exo-root/src/lib.rs
@@ -1,0 +1,30 @@
+//! EXOCHAIN root genesis authority ceremony.
+
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
+mod bundle;
+mod ceremony;
+mod dkg;
+mod error;
+mod portal;
+mod seal;
+mod signing;
+
+pub use bundle::{RootIssuerDelegation, RootTrustBundle, assemble_root_bundle, verify_root_bundle};
+pub use ceremony::{
+    CertifierContact, GenesisCeremonyConfig, ROOT_GENESIS_SIGNERS, ROOT_GENESIS_THRESHOLD,
+};
+pub use dkg::{
+    RootDkgOutput, RootDkgRound1Output, RootDkgRound2Output, RootKeyPackage,
+    RootParticipantDkgOutput, RootPublicKeyPackage, dkg_finalize_participant, dkg_round1,
+    dkg_round2, run_complete_dkg,
+};
+pub use error::{Result, RootError};
+pub use portal::{
+    CeremonyEnvelope, CeremonyEnvelopeDraft, CeremonyPayloadKind, CeremonyPhase, PortalStore,
+};
+pub use seal::{
+    PairwiseEncryptedPayload, SealedShare, decrypt_pairwise_payload, encrypt_pairwise_payload,
+    seal_share, unseal_share,
+};
+pub use signing::{RootSignature, threshold_sign, verify_root_signature};

--- a/crates/exo-root/src/portal.rs
+++ b/crates/exo-root/src/portal.rs
@@ -1,0 +1,327 @@
+//! Server-side root genesis portal relay policy.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use exo_core::{Did, Hash256, SecretKey, Signature, crypto, hash::hash_structured};
+use serde::{Deserialize, Serialize};
+
+use crate::{GenesisCeremonyConfig, Result, RootError};
+
+const MAX_PORTAL_PAYLOAD_BYTES: usize = 64 * 1024;
+
+/// Ceremony phase associated with a portal envelope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum CeremonyPhase {
+    /// DKG round one broadcast.
+    Round1,
+    /// Roster-wide round one set attestation.
+    Round1SetAttestation,
+    /// DKG round two pairwise exchange.
+    Round2,
+    /// Final DKG confirmation.
+    Finalize,
+    /// Root artifact signing.
+    RootSigning,
+}
+
+/// Bounded payload type carried by a portal envelope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum CeremonyPayloadKind {
+    /// DKG round one public package.
+    Round1Package,
+    /// Signed statement binding the full round one set.
+    Round1SetAttestation,
+    /// Recipient-bound encrypted DKG round two package.
+    Round2EncryptedPackage,
+    /// Rejected DKG round two raw package.
+    Round2PlaintextPackage,
+    /// Final key confirmation package.
+    FinalKeyConfirmation,
+    /// Root signing nonce commitment.
+    RootSigningCommitment,
+    /// Root signing share.
+    RootSignatureShare,
+}
+
+/// Signed, bounded, untrusted relay envelope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CeremonyEnvelope {
+    /// Ceremony identifier.
+    pub ceremony_id: String,
+    /// Ceremony phase.
+    pub phase: CeremonyPhase,
+    /// Payload type.
+    pub payload_kind: CeremonyPayloadKind,
+    /// Rostered sender DID.
+    pub sender_did: Did,
+    /// Optional rostered recipient DID.
+    pub recipient_did: Option<Did>,
+    /// Monotonic sender sequence.
+    pub sequence: u64,
+    /// Bounded opaque payload.
+    pub payload_bytes: Vec<u8>,
+    /// Canonical payload hash.
+    pub payload_hash: Hash256,
+    /// Ed25519 signature by the sender.
+    pub signature: Signature,
+}
+
+/// Inputs that are signed into a portal relay envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CeremonyEnvelopeDraft {
+    /// Ceremony identifier.
+    pub ceremony_id: String,
+    /// Ceremony phase.
+    pub phase: CeremonyPhase,
+    /// Payload type.
+    pub payload_kind: CeremonyPayloadKind,
+    /// Rostered sender DID.
+    pub sender_did: Did,
+    /// Optional rostered recipient DID.
+    pub recipient_did: Option<Did>,
+    /// Monotonic sender sequence.
+    pub sequence: u64,
+    /// Bounded opaque payload.
+    pub payload_bytes: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct PortalEnvelopeKey {
+    sender_did: Did,
+    phase: CeremonyPhase,
+    payload_kind: CeremonyPayloadKind,
+    sequence: u64,
+    recipient_did: Option<Did>,
+}
+
+/// In-memory portal store used by the server relay and tests.
+#[derive(Debug, Clone)]
+pub struct PortalStore {
+    config: GenesisCeremonyConfig,
+    envelopes: BTreeMap<PortalEnvelopeKey, CeremonyEnvelope>,
+    seen_sequences: BTreeSet<(Did, u64)>,
+}
+
+#[derive(Serialize)]
+struct PayloadHashEnvelope<'a> {
+    domain: &'static str,
+    payload_kind: CeremonyPayloadKind,
+    payload_bytes: &'a [u8],
+}
+
+#[derive(Serialize)]
+struct EnvelopeSigningPayload<'a> {
+    domain: &'static str,
+    ceremony_id: &'a str,
+    phase: CeremonyPhase,
+    payload_kind: CeremonyPayloadKind,
+    sender_did: &'a Did,
+    recipient_did: &'a Option<Did>,
+    sequence: u64,
+    payload_hash: Hash256,
+}
+
+fn payload_hash(kind: CeremonyPayloadKind, payload_bytes: &[u8]) -> Result<Hash256> {
+    hash_structured(&PayloadHashEnvelope {
+        domain: "EXOCHAIN_ROOT_PORTAL_PAYLOAD_V1",
+        payload_kind: kind,
+        payload_bytes,
+    })
+    .map_err(canonical_encoding_error)
+}
+
+fn signing_payload(envelope: &CeremonyEnvelope) -> Result<Vec<u8>> {
+    let payload = EnvelopeSigningPayload {
+        domain: "EXOCHAIN_ROOT_PORTAL_ENVELOPE_V1",
+        ceremony_id: &envelope.ceremony_id,
+        phase: envelope.phase,
+        payload_kind: envelope.payload_kind,
+        sender_did: &envelope.sender_did,
+        recipient_did: &envelope.recipient_did,
+        sequence: envelope.sequence,
+        payload_hash: envelope.payload_hash,
+    };
+    let mut bytes = Vec::new();
+    ciborium::into_writer(&payload, &mut bytes).map_err(canonical_encoding_error)?;
+    Ok(bytes)
+}
+
+fn canonical_encoding_error(error: impl core::fmt::Display) -> RootError {
+    RootError::CanonicalEncoding {
+        detail: error.to_string(),
+    }
+}
+
+impl CeremonyEnvelope {
+    /// Create and sign a portal relay envelope.
+    pub fn sign(draft: CeremonyEnvelopeDraft, signing_secret: &SecretKey) -> Result<Self> {
+        let mut envelope = Self {
+            ceremony_id: draft.ceremony_id,
+            phase: draft.phase,
+            payload_kind: draft.payload_kind,
+            sender_did: draft.sender_did,
+            recipient_did: draft.recipient_did,
+            sequence: draft.sequence,
+            payload_hash: payload_hash(draft.payload_kind, draft.payload_bytes.as_slice())?,
+            payload_bytes: draft.payload_bytes,
+            signature: Signature::Empty,
+        };
+        let payload = signing_payload(&envelope)?;
+        envelope.signature = crypto::sign(payload.as_slice(), signing_secret);
+        Ok(envelope)
+    }
+}
+
+impl PortalStore {
+    /// Construct an empty portal store for a ceremony.
+    #[must_use]
+    pub fn new(config: GenesisCeremonyConfig) -> Self {
+        Self {
+            config,
+            envelopes: BTreeMap::new(),
+            seen_sequences: BTreeSet::new(),
+        }
+    }
+
+    /// Number of accepted relay envelopes.
+    #[must_use]
+    pub fn envelope_count(&self) -> usize {
+        self.envelopes.len()
+    }
+
+    /// Submit a signed envelope to the relay.
+    pub fn submit(&mut self, envelope: CeremonyEnvelope) -> Result<Hash256> {
+        self.validate_envelope(&envelope)?;
+        let sequence_key = (envelope.sender_did.clone(), envelope.sequence);
+        if self.seen_sequences.contains(&sequence_key) {
+            return Err(RootError::PortalRejected {
+                reason: "sender sequence replay".to_owned(),
+            });
+        }
+        let key = PortalEnvelopeKey {
+            sender_did: envelope.sender_did.clone(),
+            phase: envelope.phase,
+            payload_kind: envelope.payload_kind,
+            sequence: envelope.sequence,
+            recipient_did: envelope.recipient_did.clone(),
+        };
+        let envelope_id = hash_structured(&key_parts(&key)).map_err(canonical_encoding_error)?;
+        self.seen_sequences.insert(sequence_key);
+        self.envelopes.insert(key, envelope);
+        Ok(envelope_id)
+    }
+
+    fn validate_envelope(&self, envelope: &CeremonyEnvelope) -> Result<()> {
+        self.config.validate()?;
+        if envelope.ceremony_id != self.config.ceremony_id {
+            return Err(RootError::PortalRejected {
+                reason: "ceremony_id mismatch".to_owned(),
+            });
+        }
+        if envelope.payload_bytes.len() > MAX_PORTAL_PAYLOAD_BYTES {
+            return Err(RootError::PortalRejected {
+                reason: "payload exceeds portal limit".to_owned(),
+            });
+        }
+        if envelope.payload_hash
+            != payload_hash(envelope.payload_kind, envelope.payload_bytes.as_slice())?
+        {
+            return Err(RootError::PortalRejected {
+                reason: "payload hash mismatch".to_owned(),
+            });
+        }
+        self.validate_phase_policy(envelope)?;
+
+        let sender = self
+            .config
+            .certifier_by_did(&envelope.sender_did)
+            .ok_or_else(|| RootError::PortalRejected {
+                reason: "sender is not rostered".to_owned(),
+            })?;
+        if let Some(recipient) = &envelope.recipient_did {
+            if self.config.certifier_by_did(recipient).is_none() {
+                return Err(RootError::PortalRejected {
+                    reason: "recipient is not rostered".to_owned(),
+                });
+            }
+            if recipient == &envelope.sender_did {
+                return Err(RootError::PortalRejected {
+                    reason: "sender cannot target itself".to_owned(),
+                });
+            }
+        }
+
+        let payload = signing_payload(envelope)?;
+        if !crypto::verify(
+            payload.as_slice(),
+            &envelope.signature,
+            &sender.signing_public_key,
+        ) {
+            return Err(RootError::SignatureRejected {
+                reason: "certifier envelope signature rejected".to_owned(),
+            });
+        }
+        Ok(())
+    }
+
+    fn validate_phase_policy(&self, envelope: &CeremonyEnvelope) -> Result<()> {
+        match (envelope.phase, envelope.payload_kind) {
+            (CeremonyPhase::Round1, CeremonyPayloadKind::Round1Package)
+            | (CeremonyPhase::Round1SetAttestation, CeremonyPayloadKind::Round1SetAttestation)
+            | (CeremonyPhase::Finalize, CeremonyPayloadKind::FinalKeyConfirmation)
+            | (CeremonyPhase::RootSigning, CeremonyPayloadKind::RootSigningCommitment)
+            | (CeremonyPhase::RootSigning, CeremonyPayloadKind::RootSignatureShare) => {
+                if envelope.recipient_did.is_some() {
+                    return Err(RootError::PortalRejected {
+                        reason: "broadcast payload must not set recipient".to_owned(),
+                    });
+                }
+                Ok(())
+            }
+            (CeremonyPhase::Round2, CeremonyPayloadKind::Round2EncryptedPackage) => {
+                if envelope.recipient_did.is_none() {
+                    return Err(RootError::PortalRejected {
+                        reason: "round-two encrypted package requires recipient".to_owned(),
+                    });
+                }
+                Ok(())
+            }
+            (_, CeremonyPayloadKind::Round2PlaintextPackage) => Err(RootError::PortalRejected {
+                reason: "round-two raw package is rejected".to_owned(),
+            }),
+            _ => Err(RootError::PortalRejected {
+                reason: "payload kind is not valid for phase".to_owned(),
+            }),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct PortalEnvelopeKeyParts<'a> {
+    sender_did: &'a Did,
+    phase: CeremonyPhase,
+    payload_kind: CeremonyPayloadKind,
+    sequence: u64,
+    recipient_did: &'a Option<Did>,
+}
+
+fn key_parts(key: &PortalEnvelopeKey) -> PortalEnvelopeKeyParts<'_> {
+    PortalEnvelopeKeyParts {
+        sender_did: &key.sender_did,
+        phase: key.phase,
+        payload_kind: key.payload_kind,
+        sequence: key.sequence,
+        recipient_did: &key.recipient_did,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_error_conversion_is_diagnostic() {
+        let error = canonical_encoding_error("portal encoding failed");
+        assert!(error.to_string().contains("portal encoding failed"));
+    }
+}

--- a/crates/exo-root/src/seal.rs
+++ b/crates/exo-root/src/seal.rs
@@ -1,0 +1,177 @@
+//! Share sealing and pairwise round-two payload protection.
+
+use argon2::Argon2;
+use chacha20poly1305::{
+    KeyInit, XChaCha20Poly1305, XNonce,
+    aead::{Aead, Payload},
+};
+use hkdf::Hkdf;
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use x25519_dalek::{PublicKey as X25519PublicKey, StaticSecret};
+use zeroize::Zeroize;
+
+use crate::{Result, RootError};
+
+/// AEAD-wrapped certifier share artifact.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SealedShare {
+    /// Argon2id salt.
+    pub salt: Vec<u8>,
+    /// XChaCha20-Poly1305 nonce.
+    pub nonce: [u8; 24],
+    /// Ciphertext and tag.
+    pub ciphertext: Vec<u8>,
+}
+
+/// Recipient-bound encrypted payload for DKG round two exchange.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PairwiseEncryptedPayload {
+    /// XChaCha20-Poly1305 nonce.
+    pub nonce: [u8; 24],
+    /// Ciphertext and tag.
+    pub ciphertext: Vec<u8>,
+}
+
+fn chacha_from_key(key: &[u8; 32]) -> XChaCha20Poly1305 {
+    XChaCha20Poly1305::new(key.into())
+}
+
+fn derive_sealing_key(passphrase: &[u8], salt: &[u8]) -> Result<[u8; 32]> {
+    let mut key = [0u8; 32];
+    Argon2::default()
+        .hash_password_into(passphrase, salt, &mut key)
+        .map_err(protection_error)?;
+    Ok(key)
+}
+
+fn derive_pairwise_key(
+    local_secret: &[u8; 32],
+    peer_public: &[u8; 32],
+    associated_data: &[u8],
+) -> Result<[u8; 32]> {
+    let secret = StaticSecret::from(*local_secret);
+    let peer_public = X25519PublicKey::from(*peer_public);
+    let shared = secret.diffie_hellman(&peer_public);
+    let hkdf = Hkdf::<Sha256>::new(Some(associated_data), shared.as_bytes());
+    let mut key = [0u8; 32];
+    hkdf.expand(b"EXOCHAIN_ROOT_PAIRWISE_V1", &mut key)
+        .map_err(protection_error)?;
+    Ok(key)
+}
+
+fn protection_error(error: impl core::fmt::Display) -> RootError {
+    RootError::ProtectionFailed {
+        reason: error.to_string(),
+    }
+}
+
+/// Seal one serialized share artifact with passphrase-derived AEAD.
+pub fn seal_share(
+    share_bytes: &[u8],
+    passphrase: &[u8],
+    associated_data: &[u8],
+    salt: &[u8; 16],
+    nonce: &[u8; 24],
+) -> Result<SealedShare> {
+    let mut key = derive_sealing_key(passphrase, salt)?;
+    let cipher = chacha_from_key(&key);
+    let ciphertext = cipher
+        .encrypt(
+            XNonce::from_slice(nonce),
+            Payload {
+                msg: share_bytes,
+                aad: associated_data,
+            },
+        )
+        .map_err(|_| protection_message("share encryption failed"))?;
+    key.zeroize();
+    Ok(SealedShare {
+        salt: salt.to_vec(),
+        nonce: *nonce,
+        ciphertext,
+    })
+}
+
+/// Open one sealed share artifact.
+pub fn unseal_share(
+    sealed: &SealedShare,
+    passphrase: &[u8],
+    associated_data: &[u8],
+) -> Result<Vec<u8>> {
+    let mut key = derive_sealing_key(passphrase, sealed.salt.as_slice())?;
+    let cipher = chacha_from_key(&key);
+    let plaintext = cipher
+        .decrypt(
+            XNonce::from_slice(&sealed.nonce),
+            Payload {
+                msg: sealed.ciphertext.as_slice(),
+                aad: associated_data,
+            },
+        )
+        .map_err(|_| protection_message("share opening failed"))?;
+    key.zeroize();
+    Ok(plaintext)
+}
+
+/// Encrypt a DKG round-two payload for exactly one recipient.
+pub fn encrypt_pairwise_payload(
+    sender_transport_secret: &[u8; 32],
+    recipient_transport_public: &[u8; 32],
+    payload: &[u8],
+    associated_data: &[u8],
+    nonce: &[u8; 24],
+) -> Result<PairwiseEncryptedPayload> {
+    let mut key = derive_pairwise_key(
+        sender_transport_secret,
+        recipient_transport_public,
+        associated_data,
+    )?;
+    let cipher = chacha_from_key(&key);
+    let ciphertext = cipher
+        .encrypt(
+            XNonce::from_slice(nonce),
+            Payload {
+                msg: payload,
+                aad: associated_data,
+            },
+        )
+        .map_err(|_| protection_message("pairwise encryption failed"))?;
+    key.zeroize();
+    Ok(PairwiseEncryptedPayload {
+        nonce: *nonce,
+        ciphertext,
+    })
+}
+
+/// Decrypt a DKG round-two payload from one sender.
+pub fn decrypt_pairwise_payload(
+    recipient_transport_secret: &[u8; 32],
+    sender_transport_public: &[u8; 32],
+    encrypted: &PairwiseEncryptedPayload,
+    associated_data: &[u8],
+) -> Result<Vec<u8>> {
+    let mut key = derive_pairwise_key(
+        recipient_transport_secret,
+        sender_transport_public,
+        associated_data,
+    )?;
+    let cipher = chacha_from_key(&key);
+    let plaintext = cipher
+        .decrypt(
+            XNonce::from_slice(&encrypted.nonce),
+            Payload {
+                msg: encrypted.ciphertext.as_slice(),
+                aad: associated_data,
+            },
+        )
+        .map_err(|_| protection_message("pairwise opening failed"))?;
+    key.zeroize();
+    Ok(plaintext)
+}
+
+fn protection_message(reason: &str) -> RootError {
+    RootError::ProtectionFailed {
+        reason: reason.to_owned(),
+    }
+}

--- a/crates/exo-root/src/signing.rs
+++ b/crates/exo-root/src/signing.rs
@@ -1,0 +1,243 @@
+//! Threshold root signing helpers.
+
+use std::collections::BTreeMap;
+
+use frost_ristretto255 as frost;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    GenesisCeremonyConfig, Result, RootError, RootKeyPackage, RootPublicKeyPackage,
+    dkg::{deserialize_frost, serialize_frost},
+};
+
+/// Serialized threshold signature over a root artifact.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RootSignature {
+    /// Serialized FROST signature.
+    pub signature: Vec<u8>,
+    /// Signer identifiers used for this signature.
+    pub signer_ids: Vec<u16>,
+}
+
+fn frost_error(error: frost::Error) -> RootError {
+    RootError::Frost {
+        detail: error.to_string(),
+    }
+}
+
+/// Create a FROST threshold signature from at least seven rostered shares.
+pub fn threshold_sign<R>(
+    config: &GenesisCeremonyConfig,
+    public_key_package: &RootPublicKeyPackage,
+    shares: BTreeMap<u16, RootKeyPackage>,
+    message: &[u8],
+    rng: &mut R,
+) -> Result<RootSignature>
+where
+    R: frost::rand_core::RngCore + frost::rand_core::CryptoRng,
+{
+    config.validate()?;
+    if shares.len() < usize::from(config.threshold) {
+        let supplied = shares
+            .keys()
+            .take(usize::from(u16::MAX))
+            .fold(0u16, |count, _| count.saturating_add(1));
+        let error = RootError::ThresholdNotMet {
+            required: config.threshold,
+            supplied,
+        };
+        return Err(error);
+    }
+
+    let public = deserialize_frost(public_key_package.public_key_package.as_slice())?;
+
+    let mut key_packages = BTreeMap::new();
+    let mut signing_nonces = BTreeMap::new();
+    let mut signing_commitments = BTreeMap::new();
+    let mut signer_ids = Vec::new();
+
+    for (identifier, share) in shares {
+        if config.certifier_by_identifier(identifier).is_none() {
+            return Err(RootError::InvalidConfig {
+                reason: format!("signer {identifier} is not rostered"),
+            });
+        }
+        if share.frost_identifier != identifier {
+            let share_id = share.frost_identifier;
+            let detail = format!("share id {share_id} mismatches key {identifier}");
+            return Err(RootError::Frost { detail });
+        }
+        let frost_identifier = crate::dkg::frost_identifier(identifier)?;
+        let key_package: frost::keys::KeyPackage = deserialize_frost(share.key_package.as_slice())?;
+        if *key_package.identifier() != frost_identifier {
+            return Err(RootError::Frost {
+                detail: "deserialized key package identifier mismatch".to_owned(),
+            });
+        }
+        let (nonces, commitments) = frost::round1::commit(key_package.signing_share(), rng);
+        signing_nonces.insert(frost_identifier, nonces);
+        signing_commitments.insert(frost_identifier, commitments);
+        key_packages.insert(frost_identifier, key_package);
+        signer_ids.push(identifier);
+    }
+
+    let signing_package = frost::SigningPackage::new(signing_commitments, message);
+    let mut signature_shares = BTreeMap::new();
+    let sign_share = frost::round2::sign;
+    for (identifier, key_package) in &key_packages {
+        let nonces = &signing_nonces[identifier];
+        let share = sign_share(&signing_package, nonces, key_package).map_err(frost_error)?;
+        signature_shares.insert(*identifier, share);
+    }
+
+    let aggregate = frost::aggregate;
+    let sig = aggregate(&signing_package, &signature_shares, &public).map_err(frost_error)?;
+    let signature = serialize_frost(&sig)?;
+
+    verify_root_signature(&public_key_package.root_public_key, message, &signature)?;
+
+    Ok(RootSignature {
+        signature,
+        signer_ids,
+    })
+}
+
+/// Verify a serialized root threshold signature against a root public key.
+pub fn verify_root_signature(
+    root_public_key: &[u8],
+    message: &[u8],
+    signature: &[u8],
+) -> Result<()> {
+    let verifying_key: frost::VerifyingKey = deserialize_frost(root_public_key)?;
+    let signature: frost::Signature = deserialize_frost(signature)?;
+    verifying_key
+        .verify(message, &signature)
+        .map_err(signature_rejected)
+}
+
+fn signature_rejected(error: frost::Error) -> RootError {
+    RootError::SignatureRejected {
+        reason: error.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use exo_core::{Did, Hash256, PublicKey, Timestamp};
+    use rand::{SeedableRng, rngs::StdRng};
+
+    use super::*;
+    use crate::CertifierContact;
+
+    fn test_config() -> GenesisCeremonyConfig {
+        let certifiers = (1..=13)
+            .map(|identifier| {
+                let byte = u8::try_from(identifier).expect("identifier fits");
+                CertifierContact {
+                    did: Did::new(&format!("did:exo:signing-unit-{identifier:02}"))
+                        .expect("valid did"),
+                    frost_identifier: identifier,
+                    signing_public_key: PublicKey::from_bytes([byte; 32]),
+                    transport_public_key: [byte; 32],
+                }
+            })
+            .collect();
+        GenesisCeremonyConfig {
+            ceremony_id: "unit-root".into(),
+            network_id: "unit-net".into(),
+            repo_commit: "d8927686a34bdc28ba36d53938f665685d2c4c04".into(),
+            constitution_hash: Hash256::digest(b"constitution"),
+            threshold: 7,
+            max_signers: 13,
+            created_at: Timestamp::new(1, 0),
+            certifiers,
+        }
+    }
+
+    #[test]
+    fn frost_error_conversion_is_diagnostic() {
+        let error = frost::Identifier::try_from(0).expect_err("zero identifier");
+        let converted = frost_error(error);
+        assert!(converted.to_string().contains("frost operation failed"));
+    }
+
+    #[test]
+    fn signature_rejection_conversion_is_diagnostic() {
+        let error = frost::Identifier::try_from(0).expect_err("zero identifier");
+        let converted = signature_rejected(error);
+        assert!(
+            converted
+                .to_string()
+                .contains("signature verification failed")
+        );
+    }
+
+    #[test]
+    fn threshold_sign_rejects_too_few_shares_before_public_deserialization() {
+        let config = test_config();
+        let public_key_package = RootPublicKeyPackage {
+            public_key_package: b"not a public package".to_vec(),
+            root_public_key: b"not a verifying key".to_vec(),
+            verifying_shares: BTreeMap::new(),
+        };
+        let mut rng = StdRng::seed_from_u64(7);
+        let error = threshold_sign(
+            &config,
+            &public_key_package,
+            BTreeMap::new(),
+            b"root artifact",
+            &mut rng,
+        )
+        .expect_err("empty signer set");
+        assert_eq!(
+            error,
+            RootError::ThresholdNotMet {
+                required: 7,
+                supplied: 0
+            }
+        );
+    }
+
+    #[test]
+    fn threshold_sign_covers_success_and_share_mismatch_paths() {
+        let config = test_config();
+        let mut rng = StdRng::seed_from_u64(71);
+        let dkg = crate::run_complete_dkg(&config, &mut rng).expect("dkg");
+        let selected: BTreeMap<u16, _> = dkg
+            .key_packages
+            .iter()
+            .take(7)
+            .map(|(identifier, share)| (*identifier, share.clone()))
+            .collect();
+        let message = b"unit root signing artifact";
+        let signature = threshold_sign(
+            &config,
+            &dkg.public_key_package,
+            selected.clone(),
+            message,
+            &mut rng,
+        )
+        .expect("signature");
+
+        verify_root_signature(
+            &dkg.public_key_package.root_public_key,
+            message,
+            &signature.signature,
+        )
+        .expect("signature verifies");
+
+        let mut mismatched = selected;
+        let mut share = mismatched.remove(&1).expect("share one");
+        share.frost_identifier = 2;
+        mismatched.insert(1, share);
+        let error = threshold_sign(
+            &config,
+            &dkg.public_key_package,
+            mismatched,
+            message,
+            &mut rng,
+        )
+        .expect_err("share identifier mismatch");
+        assert!(error.to_string().contains("mismatches key 1"));
+    }
+}

--- a/crates/exo-root/src/signing.rs
+++ b/crates/exo-root/src/signing.rs
@@ -25,6 +25,22 @@ fn frost_error(error: frost::Error) -> RootError {
     }
 }
 
+fn frost_sign_share(
+    signing_package: &frost::SigningPackage,
+    nonces: &frost::round1::SigningNonces,
+    key_package: &frost::keys::KeyPackage,
+) -> Result<frost::round2::SignatureShare> {
+    frost::round2::sign(signing_package, nonces, key_package).map_err(frost_error)
+}
+
+fn frost_aggregate_signature(
+    signing_package: &frost::SigningPackage,
+    signature_shares: &BTreeMap<frost::Identifier, frost::round2::SignatureShare>,
+    public: &frost::keys::PublicKeyPackage,
+) -> Result<frost::Signature> {
+    frost::aggregate(signing_package, signature_shares, public).map_err(frost_error)
+}
+
 /// Create a FROST threshold signature from at least seven rostered shares.
 pub fn threshold_sign<R>(
     config: &GenesisCeremonyConfig,
@@ -83,15 +99,13 @@ where
 
     let signing_package = frost::SigningPackage::new(signing_commitments, message);
     let mut signature_shares = BTreeMap::new();
-    let sign_share = frost::round2::sign;
     for (identifier, key_package) in &key_packages {
         let nonces = &signing_nonces[identifier];
-        let share = sign_share(&signing_package, nonces, key_package).map_err(frost_error)?;
+        let share = frost_sign_share(&signing_package, nonces, key_package)?;
         signature_shares.insert(*identifier, share);
     }
 
-    let aggregate = frost::aggregate;
-    let sig = aggregate(&signing_package, &signature_shares, &public).map_err(frost_error)?;
+    let sig = frost_aggregate_signature(&signing_package, &signature_shares, &public)?;
     let signature = serialize_frost(&sig)?;
 
     verify_root_signature(&public_key_package.root_public_key, message, &signature)?;

--- a/crates/exo-root/tests/root_genesis.rs
+++ b/crates/exo-root/tests/root_genesis.rs
@@ -1,0 +1,1108 @@
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::collections::BTreeMap;
+
+use exo_authority::permission::Permission;
+use exo_core::{Did, Hash256, PublicKey, SecretKey, Signature, Timestamp, crypto::KeyPair};
+use exo_root::{
+    CeremonyEnvelope, CeremonyEnvelopeDraft, CeremonyPayloadKind, CeremonyPhase, CertifierContact,
+    GenesisCeremonyConfig, PortalStore, RootIssuerDelegation, SealedShare, assemble_root_bundle,
+    decrypt_pairwise_payload, dkg_finalize_participant, dkg_round1, dkg_round2,
+    encrypt_pairwise_payload, run_complete_dkg, seal_share, threshold_sign, unseal_share,
+    verify_root_bundle, verify_root_signature,
+};
+use rand::{SeedableRng, rngs::StdRng};
+
+fn did(index: u16) -> Did {
+    Did::new(&format!("did:exo:certifier-{index:02}")).expect("valid did")
+}
+
+fn keypair(index: u8) -> KeyPair {
+    KeyPair::from_secret_bytes([index; 32]).expect("valid keypair")
+}
+
+fn certifier(index: u16) -> (CertifierContact, SecretKey, [u8; 32]) {
+    let kp = keypair(u8::try_from(index).expect("index fits u8"));
+    let did = did(index);
+    let transport_secret = [u8::try_from(index).expect("index fits u8"); 32];
+    let transport_public =
+        x25519_dalek::PublicKey::from(&x25519_dalek::StaticSecret::from(transport_secret));
+    (
+        CertifierContact {
+            did,
+            frost_identifier: index,
+            signing_public_key: *kp.public_key(),
+            transport_public_key: *transport_public.as_bytes(),
+        },
+        kp.secret_key().clone(),
+        transport_secret,
+    )
+}
+
+fn envelope_draft(
+    ceremony_id: impl Into<String>,
+    phase: CeremonyPhase,
+    payload_kind: CeremonyPayloadKind,
+    sender_did: Did,
+    recipient_did: Option<Did>,
+    sequence: u64,
+    payload_bytes: Vec<u8>,
+) -> CeremonyEnvelopeDraft {
+    CeremonyEnvelopeDraft {
+        ceremony_id: ceremony_id.into(),
+        phase,
+        payload_kind,
+        sender_did,
+        recipient_did,
+        sequence,
+        payload_bytes,
+    }
+}
+
+fn config() -> (
+    GenesisCeremonyConfig,
+    BTreeMap<Did, SecretKey>,
+    BTreeMap<Did, [u8; 32]>,
+) {
+    let mut certifiers = Vec::new();
+    let mut signing_secrets = BTreeMap::new();
+    let mut transport_secrets = BTreeMap::new();
+    for index in 1..=13 {
+        let (contact, signing_secret, transport_secret) = certifier(index);
+        signing_secrets.insert(contact.did.clone(), signing_secret);
+        transport_secrets.insert(contact.did.clone(), transport_secret);
+        certifiers.push(contact);
+    }
+    (
+        GenesisCeremonyConfig {
+            ceremony_id: "exo-root-genesis-2026".into(),
+            network_id: "exochain-main".into(),
+            repo_commit: "d8927686a34bdc28ba36d53938f665685d2c4c04".into(),
+            constitution_hash: Hash256::digest(b"constitution"),
+            threshold: 7,
+            max_signers: 13,
+            created_at: Timestamp::new(1_785_000_000_000, 0),
+            certifiers,
+        },
+        signing_secrets,
+        transport_secrets,
+    )
+}
+
+#[test]
+fn ceremony_config_requires_institutional_7_of_13_roster() {
+    let (config, _, _) = config();
+    config.validate().expect("7 of 13 roster should validate");
+    assert_eq!(config.threshold, 7);
+    assert_eq!(config.max_signers, 13);
+    assert_eq!(config.certifiers.len(), 13);
+
+    let mut too_small = config.clone();
+    too_small.threshold = 6;
+    assert!(too_small.validate().is_err());
+
+    let mut too_few = config;
+    too_few.certifiers.pop();
+    assert!(too_few.validate().is_err());
+}
+
+#[test]
+fn ceremony_config_rejects_all_roster_policy_malformed_inputs() {
+    let (config, _, _) = config();
+
+    let mut bad_max = config.clone();
+    bad_max.max_signers = 12;
+    assert!(bad_max.validate().is_err());
+
+    let mut empty_ceremony = config.clone();
+    empty_ceremony.ceremony_id = " ".into();
+    assert!(empty_ceremony.validate().is_err());
+
+    let mut empty_network = config.clone();
+    empty_network.network_id = " ".into();
+    assert!(empty_network.validate().is_err());
+
+    let mut bad_commit = config.clone();
+    bad_commit.repo_commit = "not-a-commit".into();
+    assert!(bad_commit.validate().is_err());
+
+    let mut bad_identifier = config.clone();
+    bad_identifier.certifiers[0].frost_identifier = 0;
+    assert!(bad_identifier.validate().is_err());
+
+    let mut duplicate_did = config.clone();
+    duplicate_did.certifiers[1].did = duplicate_did.certifiers[0].did.clone();
+    assert!(duplicate_did.validate().is_err());
+
+    let mut duplicate_identifier = config.clone();
+    duplicate_identifier.certifiers[1].frost_identifier =
+        duplicate_identifier.certifiers[0].frost_identifier;
+    assert!(duplicate_identifier.validate().is_err());
+
+    let mut duplicate_signing_key = config.clone();
+    duplicate_signing_key.certifiers[1].signing_public_key =
+        duplicate_signing_key.certifiers[0].signing_public_key;
+    assert!(duplicate_signing_key.validate().is_err());
+
+    let mut duplicate_transport_key = config;
+    duplicate_transport_key.certifiers[1].transport_public_key =
+        duplicate_transport_key.certifiers[0].transport_public_key;
+    assert!(duplicate_transport_key.validate().is_err());
+}
+
+#[test]
+fn frost_dkg_signs_with_7_of_13_and_rejects_6_of_13() {
+    let (config, _, _) = config();
+    let mut rng = StdRng::seed_from_u64(42);
+    let dkg = run_complete_dkg(&config, &mut rng).expect("dkg");
+
+    let selected: BTreeMap<u16, _> = dkg
+        .key_packages
+        .iter()
+        .take(7)
+        .map(|(id, share)| (*id, share.clone()))
+        .collect();
+    let message = b"exo root artifact";
+    let signature = threshold_sign(
+        &config,
+        &dkg.public_key_package,
+        selected,
+        message,
+        &mut rng,
+    )
+    .expect("7 signer signature");
+    verify_root_signature(
+        &dkg.public_key_package.root_public_key,
+        message,
+        &signature.signature,
+    )
+    .expect("root signature verifies");
+    assert!(
+        verify_root_signature(
+            &dkg.public_key_package.root_public_key,
+            b"different root artifact",
+            &signature.signature,
+        )
+        .is_err(),
+        "a well-formed root signature must bind exactly to its artifact bytes"
+    );
+
+    let too_few: BTreeMap<u16, _> = dkg
+        .key_packages
+        .iter()
+        .take(6)
+        .map(|(id, share)| (*id, share.clone()))
+        .collect();
+    assert!(
+        threshold_sign(&config, &dkg.public_key_package, too_few, message, &mut rng).is_err(),
+        "6 signers must not satisfy a 7-of-13 root threshold"
+    );
+}
+
+#[test]
+fn threshold_signing_rejects_malformed_public_key_package_and_signer_set() {
+    let (config, _, _) = config();
+    let mut rng = StdRng::seed_from_u64(43);
+    let dkg = run_complete_dkg(&config, &mut rng).expect("dkg");
+    let selected: BTreeMap<u16, _> = dkg
+        .key_packages
+        .iter()
+        .take(7)
+        .map(|(id, share)| (*id, share.clone()))
+        .collect();
+
+    let mut malformed_public = dkg.public_key_package.clone();
+    malformed_public.public_key_package = b"not a public package".to_vec();
+    assert!(
+        threshold_sign(
+            &config,
+            &malformed_public,
+            selected.clone(),
+            b"artifact",
+            &mut rng
+        )
+        .is_err()
+    );
+
+    let mut nonrostered = selected.clone();
+    let replacement = nonrostered.remove(&1).expect("share");
+    nonrostered.insert(99, replacement);
+    assert!(
+        threshold_sign(
+            &config,
+            &dkg.public_key_package,
+            nonrostered,
+            b"artifact",
+            &mut rng
+        )
+        .is_err()
+    );
+
+    let mut mismatched = selected.clone();
+    let mut share = mismatched.remove(&1).expect("share");
+    share.frost_identifier = 2;
+    mismatched.insert(1, share);
+    assert!(
+        threshold_sign(
+            &config,
+            &dkg.public_key_package,
+            mismatched,
+            b"artifact",
+            &mut rng
+        )
+        .is_err()
+    );
+
+    let mut malformed_share = selected;
+    malformed_share.get_mut(&1).expect("share").key_package = b"not a key package".to_vec();
+    assert!(
+        threshold_sign(
+            &config,
+            &dkg.public_key_package,
+            malformed_share,
+            b"artifact",
+            &mut rng
+        )
+        .is_err()
+    );
+
+    let mut internal_mismatch: BTreeMap<u16, _> = dkg
+        .key_packages
+        .iter()
+        .take(7)
+        .map(|(id, share)| (*id, share.clone()))
+        .collect();
+    internal_mismatch.get_mut(&1).expect("share 1").key_package = dkg
+        .key_packages
+        .get(&2)
+        .expect("share 2")
+        .key_package
+        .clone();
+    assert!(
+        threshold_sign(
+            &config,
+            &dkg.public_key_package,
+            internal_mismatch,
+            b"artifact",
+            &mut rng
+        )
+        .is_err()
+    );
+
+    assert!(verify_root_signature(b"not a key", b"artifact", b"signature").is_err());
+    assert!(
+        verify_root_signature(
+            &dkg.public_key_package.root_public_key,
+            b"artifact",
+            b"bad sig"
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn threshold_signing_rejects_foreign_valid_dkg_share_set() {
+    let (config, _, _) = config();
+    let mut first_rng = StdRng::seed_from_u64(4301);
+    let first_dkg = run_complete_dkg(&config, &mut first_rng).expect("first dkg");
+    let mut second_rng = StdRng::seed_from_u64(4302);
+    let second_dkg = run_complete_dkg(&config, &mut second_rng).expect("second dkg");
+    let foreign_shares: BTreeMap<u16, _> = second_dkg
+        .key_packages
+        .iter()
+        .take(7)
+        .map(|(id, share)| (*id, share.clone()))
+        .collect();
+
+    assert!(
+        threshold_sign(
+            &config,
+            &first_dkg.public_key_package,
+            foreign_shares,
+            b"artifact",
+            &mut second_rng,
+        )
+        .is_err(),
+        "shares from a different valid DKG must not aggregate under the root public package"
+    );
+}
+
+#[test]
+fn dkg_round_wrappers_complete_all_thirteen_and_reject_missing_peer_packages() {
+    let (config, _, _) = config();
+    let mut rng = StdRng::seed_from_u64(77);
+    let mut round1_outputs = BTreeMap::new();
+    let mut round1_public = BTreeMap::new();
+    for certifier in &config.certifiers {
+        let output = dkg_round1(&config, certifier.frost_identifier, &mut rng).expect("round1");
+        round1_public.insert(certifier.frost_identifier, output.round1_package.clone());
+        round1_outputs.insert(certifier.frost_identifier, output);
+    }
+
+    let first = round1_outputs.get(&1).expect("round1 output");
+    let mut missing = round1_public.clone();
+    missing.remove(&2);
+    assert!(
+        dkg_round2(
+            &config,
+            1,
+            &first.round1_secret_package,
+            missing.into_iter().filter(|(id, _)| *id != 1).collect(),
+        )
+        .is_err()
+    );
+
+    let mut round2_outputs = BTreeMap::new();
+    let mut round2_by_recipient: BTreeMap<u16, BTreeMap<u16, Vec<u8>>> = BTreeMap::new();
+    for (identifier, round1_output) in &round1_outputs {
+        let peer_round1 = round1_public
+            .iter()
+            .filter(|(peer, _)| *peer != identifier)
+            .map(|(peer, package)| (*peer, package.clone()))
+            .collect();
+        let round2 = dkg_round2(
+            &config,
+            *identifier,
+            &round1_output.round1_secret_package,
+            peer_round1,
+        )
+        .expect("round2");
+        for (recipient, package) in &round2.round2_packages {
+            round2_by_recipient
+                .entry(*recipient)
+                .or_default()
+                .insert(*identifier, package.clone());
+        }
+        round2_outputs.insert(*identifier, round2);
+    }
+
+    let mut root_public_keys = BTreeMap::new();
+    for (identifier, round2_output) in &round2_outputs {
+        let peer_round1 = round1_public
+            .iter()
+            .filter(|(peer, _)| *peer != identifier)
+            .map(|(peer, package)| (*peer, package.clone()))
+            .collect();
+        let peer_round2 = round2_by_recipient
+            .get(identifier)
+            .expect("recipient packages")
+            .clone();
+        let participant = dkg_finalize_participant(
+            &config,
+            *identifier,
+            &round2_output.round2_secret_package,
+            peer_round1,
+            peer_round2,
+        )
+        .expect("finalize");
+        root_public_keys.insert(
+            *identifier,
+            participant.public_key_package.root_public_key.clone(),
+        );
+    }
+
+    let expected = root_public_keys.get(&1).expect("first key");
+    assert!(root_public_keys.values().all(|key| key == expected));
+}
+
+#[test]
+fn dkg_round_wrappers_reject_valid_but_misbound_peer_packages() {
+    let (config, _, _) = config();
+    let mut rng = StdRng::seed_from_u64(878);
+    let mut round1_outputs = BTreeMap::new();
+    let mut round1_public = BTreeMap::new();
+    for certifier in &config.certifiers {
+        let output = dkg_round1(&config, certifier.frost_identifier, &mut rng).expect("round1");
+        round1_public.insert(certifier.frost_identifier, output.round1_package.clone());
+        round1_outputs.insert(certifier.frost_identifier, output);
+    }
+
+    let first = round1_outputs.get(&1).expect("round1 output");
+    let peer_round1 = round1_public
+        .iter()
+        .filter(|(peer, _)| **peer != 1)
+        .map(|(peer, package)| (*peer, package.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let mut misbound_round1 = peer_round1.clone();
+    misbound_round1.insert(2, peer_round1.get(&3).expect("peer 3 package").clone());
+    assert!(
+        dkg_round2(&config, 1, &first.round1_secret_package, misbound_round1).is_err(),
+        "round two must reject a valid CBOR package bound to a different FROST sender"
+    );
+
+    let mut round2_outputs = BTreeMap::new();
+    let mut round2_by_recipient: BTreeMap<u16, BTreeMap<u16, Vec<u8>>> = BTreeMap::new();
+    for (identifier, round1_output) in &round1_outputs {
+        let participant_peer_round1 = round1_public
+            .iter()
+            .filter(|(peer, _)| *peer != identifier)
+            .map(|(peer, package)| (*peer, package.clone()))
+            .collect();
+        let round2 = dkg_round2(
+            &config,
+            *identifier,
+            &round1_output.round1_secret_package,
+            participant_peer_round1,
+        )
+        .expect("round2");
+        for (recipient, package) in &round2.round2_packages {
+            round2_by_recipient
+                .entry(*recipient)
+                .or_default()
+                .insert(*identifier, package.clone());
+        }
+        round2_outputs.insert(*identifier, round2);
+    }
+
+    let mut misbound_round2 = round2_by_recipient.get(&1).expect("recipient 1").clone();
+    let peer_three_for_one = misbound_round2.get(&3).expect("peer 3 package").clone();
+    misbound_round2.insert(2, peer_three_for_one);
+    let first_round2 = round2_outputs.get(&1).expect("round2 output");
+    assert!(
+        dkg_finalize_participant(
+            &config,
+            1,
+            &first_round2.round2_secret_package,
+            peer_round1,
+            misbound_round2,
+        )
+        .is_err(),
+        "finalize must reject a valid CBOR package bound to a different FROST sender"
+    );
+}
+
+#[test]
+fn dkg_round_wrappers_reject_malformed_or_misaddressed_packages() {
+    let (config, _, _) = config();
+    let mut rng = StdRng::seed_from_u64(88);
+    let mut round1_outputs = BTreeMap::new();
+    let mut round1_public = BTreeMap::new();
+    for certifier in &config.certifiers {
+        let output = dkg_round1(&config, certifier.frost_identifier, &mut rng).expect("round1");
+        round1_public.insert(certifier.frost_identifier, output.round1_package.clone());
+        round1_outputs.insert(certifier.frost_identifier, output);
+    }
+
+    assert!(dkg_round1(&config, 99, &mut rng).is_err());
+
+    let first = round1_outputs.get(&1).expect("round1 output");
+    let peer_round1 = round1_public
+        .iter()
+        .filter(|(peer, _)| **peer != 1)
+        .map(|(peer, package)| (*peer, package.clone()))
+        .collect::<BTreeMap<_, _>>();
+    assert!(
+        dkg_round2(
+            &config,
+            99,
+            &first.round1_secret_package,
+            peer_round1.clone()
+        )
+        .is_err(),
+        "round two must reject an unrostered participant identifier"
+    );
+    assert!(dkg_round2(&config, 1, b"not a round1 secret", peer_round1.clone()).is_err());
+
+    let mut self_round1 = peer_round1.clone();
+    self_round1.insert(1, first.round1_package.clone());
+    self_round1.remove(&2);
+    assert!(dkg_round2(&config, 1, &first.round1_secret_package, self_round1).is_err());
+
+    let mut nonrostered_round1 = peer_round1.clone();
+    nonrostered_round1.remove(&2);
+    nonrostered_round1.insert(99, round1_public.get(&2).expect("peer package").clone());
+    assert!(dkg_round2(&config, 1, &first.round1_secret_package, nonrostered_round1).is_err());
+
+    let mut malformed_round1 = peer_round1.clone();
+    malformed_round1.insert(2, b"not a round1 package".to_vec());
+    assert!(dkg_round2(&config, 1, &first.round1_secret_package, malformed_round1).is_err());
+
+    let round2 = dkg_round2(
+        &config,
+        1,
+        &first.round1_secret_package,
+        peer_round1.clone(),
+    )
+    .expect("round2");
+    assert!(
+        dkg_finalize_participant(
+            &config,
+            99,
+            &round2.round2_secret_package,
+            peer_round1.clone(),
+            round2.round2_packages.clone(),
+        )
+        .is_err(),
+        "finalize must reject an unrostered participant identifier"
+    );
+    assert!(
+        dkg_finalize_participant(
+            &config,
+            1,
+            b"not a round2 secret",
+            peer_round1.clone(),
+            round2.round2_packages.clone(),
+        )
+        .is_err()
+    );
+
+    let mut missing_round1 = peer_round1.clone();
+    missing_round1.remove(&2);
+    assert!(
+        dkg_finalize_participant(
+            &config,
+            1,
+            &round2.round2_secret_package,
+            missing_round1,
+            round2.round2_packages.clone(),
+        )
+        .is_err()
+    );
+
+    let mut missing_round2 = round2.round2_packages.clone();
+    missing_round2.remove(&2);
+    assert!(
+        dkg_finalize_participant(
+            &config,
+            1,
+            &round2.round2_secret_package,
+            peer_round1.clone(),
+            missing_round2,
+        )
+        .is_err()
+    );
+
+    let mut malformed_round2 = round2.round2_packages.clone();
+    malformed_round2.insert(2, b"not a round2 package".to_vec());
+    assert!(
+        dkg_finalize_participant(
+            &config,
+            1,
+            &round2.round2_secret_package,
+            peer_round1.clone(),
+            malformed_round2,
+        )
+        .is_err()
+    );
+
+    let mut self_round2 = round2.round2_packages.clone();
+    let peer_two_package = self_round2.remove(&2).expect("round2 peer package");
+    self_round2.insert(1, peer_two_package);
+    assert!(
+        dkg_finalize_participant(
+            &config,
+            1,
+            &round2.round2_secret_package,
+            peer_round1.clone(),
+            self_round2.clone(),
+        )
+        .is_err()
+    );
+
+    let mut nonrostered_round2 = round2.round2_packages;
+    nonrostered_round2.remove(&2);
+    nonrostered_round2.insert(99, self_round2.remove(&1).expect("round2 package"));
+    assert!(
+        dkg_finalize_participant(
+            &config,
+            1,
+            &round2.round2_secret_package,
+            peer_round1,
+            nonrostered_round2,
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn root_bundle_verification_rejects_tampered_delegation() {
+    let (config, _, _) = config();
+    let mut rng = StdRng::seed_from_u64(99);
+    let dkg = run_complete_dkg(&config, &mut rng).expect("dkg");
+    let delegation = RootIssuerDelegation {
+        issuer_did: Did::new("did:exo:avc-issuer").expect("valid did"),
+        issuer_public_key: PublicKey::from_bytes([0x44; 32]),
+        granted_permissions: vec![Permission::Govern, Permission::Delegate],
+        effective_at: Timestamp::new(1_785_000_010_000, 0),
+        expires_at: None,
+        purpose: "Delegate operational AVC issuing authority".into(),
+    };
+    let transcript_hash = Hash256::digest(b"transcript");
+    let root_signature = threshold_sign(
+        &config,
+        &dkg.public_key_package,
+        dkg.key_packages
+            .iter()
+            .take(7)
+            .map(|(k, v)| (*k, v.clone()))
+            .collect(),
+        &delegation
+            .root_artifact_payload(&config, &dkg.public_key_package, transcript_hash)
+            .expect("payload"),
+        &mut rng,
+    )
+    .expect("signature");
+    let bundle = assemble_root_bundle(
+        config.clone(),
+        dkg.public_key_package.clone(),
+        delegation.clone(),
+        transcript_hash,
+        root_signature.signature,
+    )
+    .expect("bundle");
+    verify_root_bundle(&bundle).expect("bundle verifies");
+
+    let mut tampered = bundle;
+    tampered.issuer_delegation.purpose = "widened authority".into();
+    assert!(verify_root_bundle(&tampered).is_err());
+}
+
+#[test]
+fn root_artifact_payload_rejects_unbounded_delegation() {
+    let (config, _, _) = config();
+    let mut rng = StdRng::seed_from_u64(98);
+    let dkg = run_complete_dkg(&config, &mut rng).expect("dkg");
+    let mut delegation = RootIssuerDelegation {
+        issuer_did: Did::new("did:exo:avc-issuer").expect("valid did"),
+        issuer_public_key: PublicKey::from_bytes([0x45; 32]),
+        granted_permissions: vec![Permission::Govern],
+        effective_at: Timestamp::new(1_785_000_010_000, 0),
+        expires_at: None,
+        purpose: "Delegate operational AVC issuing authority".into(),
+    };
+
+    delegation.purpose = " ".into();
+    assert!(
+        delegation
+            .root_artifact_payload(&config, &dkg.public_key_package, Hash256::digest(b"tx"))
+            .is_err()
+    );
+
+    delegation.purpose = "Delegate operational AVC issuing authority".into();
+    delegation.granted_permissions.clear();
+    assert!(
+        delegation
+            .root_artifact_payload(&config, &dkg.public_key_package, Hash256::digest(b"tx"))
+            .is_err()
+    );
+}
+
+#[test]
+fn root_bundle_verification_rejects_tampered_config_transcript_signature_and_id() {
+    let (config, _, _) = config();
+    let mut rng = StdRng::seed_from_u64(100);
+    let dkg = run_complete_dkg(&config, &mut rng).expect("dkg");
+    let delegation = RootIssuerDelegation {
+        issuer_did: Did::new("did:exo:avc-issuer").expect("valid did"),
+        issuer_public_key: PublicKey::from_bytes([0x55; 32]),
+        granted_permissions: vec![Permission::Govern, Permission::Delegate],
+        effective_at: Timestamp::new(1_785_000_010_000, 0),
+        expires_at: Some(Timestamp::new(1_900_000_000_000, 0)),
+        purpose: "Delegate operational AVC issuing authority".into(),
+    };
+    let transcript_hash = Hash256::digest(b"transcript");
+    let payload = delegation
+        .root_artifact_payload(&config, &dkg.public_key_package, transcript_hash)
+        .expect("payload");
+    let root_signature = threshold_sign(
+        &config,
+        &dkg.public_key_package,
+        dkg.key_packages
+            .iter()
+            .take(7)
+            .map(|(k, v)| (*k, v.clone()))
+            .collect(),
+        &payload,
+        &mut rng,
+    )
+    .expect("signature");
+    let bundle = assemble_root_bundle(
+        config,
+        dkg.public_key_package,
+        delegation,
+        transcript_hash,
+        root_signature.signature,
+    )
+    .expect("bundle");
+
+    let mut tampered_config = bundle.clone();
+    tampered_config.config.network_id = "wrong-network".into();
+    assert!(verify_root_bundle(&tampered_config).is_err());
+
+    let mut tampered_transcript = bundle.clone();
+    tampered_transcript.transcript_hash = Hash256::digest(b"changed transcript");
+    assert!(verify_root_bundle(&tampered_transcript).is_err());
+
+    let mut tampered_signature = bundle.clone();
+    tampered_signature.root_signature[0] ^= 0x01;
+    assert!(verify_root_bundle(&tampered_signature).is_err());
+
+    let mut tampered_id = bundle;
+    tampered_id.bundle_id = Hash256::digest(b"wrong bundle id");
+    assert!(verify_root_bundle(&tampered_id).is_err());
+}
+
+#[test]
+fn portal_rejects_replay_plaintext_round2_and_wrong_phase_envelopes() {
+    let (config, signing_secrets, _) = config();
+    let sender = config.certifiers[0].did.clone();
+    let recipient = config.certifiers[1].did.clone();
+    let signing_secret = signing_secrets.get(&sender).expect("secret");
+    let mut store = PortalStore::new(config.clone());
+
+    let encrypted = CeremonyEnvelope::sign(
+        envelope_draft(
+            &config.ceremony_id,
+            CeremonyPhase::Round2,
+            CeremonyPayloadKind::Round2EncryptedPackage,
+            sender.clone(),
+            Some(recipient.clone()),
+            1,
+            b"ciphertext".to_vec(),
+        ),
+        signing_secret,
+    )
+    .expect("envelope");
+    store.submit(encrypted.clone()).expect("first submit");
+    assert!(store.submit(encrypted).is_err(), "replay must be rejected");
+
+    let plaintext = CeremonyEnvelope::sign(
+        envelope_draft(
+            &config.ceremony_id,
+            CeremonyPhase::Round2,
+            CeremonyPayloadKind::Round2PlaintextPackage,
+            sender.clone(),
+            Some(recipient),
+            2,
+            b"plaintext share".to_vec(),
+        ),
+        signing_secret,
+    )
+    .expect("plaintext envelope");
+    assert!(store.submit(plaintext).is_err());
+
+    let wrong_phase = CeremonyEnvelope::sign(
+        envelope_draft(
+            &config.ceremony_id,
+            CeremonyPhase::Round1,
+            CeremonyPayloadKind::Round2EncryptedPackage,
+            sender,
+            None,
+            3,
+            b"ciphertext".to_vec(),
+        ),
+        signing_secret,
+    )
+    .expect("wrong phase envelope");
+    assert!(store.submit(wrong_phase).is_err());
+}
+
+#[test]
+fn portal_rejects_unsigned_wrong_certifier_oversized_and_malformed_envelopes() {
+    let (config, signing_secrets, _) = config();
+    let sender = config.certifiers[0].did.clone();
+    let recipient = config.certifiers[1].did.clone();
+    let signing_secret = signing_secrets.get(&sender).expect("secret");
+    let mut store = PortalStore::new(config.clone());
+
+    let mut unsigned = CeremonyEnvelope::sign(
+        envelope_draft(
+            &config.ceremony_id,
+            CeremonyPhase::Round2,
+            CeremonyPayloadKind::Round2EncryptedPackage,
+            sender.clone(),
+            Some(recipient.clone()),
+            10,
+            b"ciphertext".to_vec(),
+        ),
+        signing_secret,
+    )
+    .expect("envelope");
+    unsigned.signature = Signature::Empty;
+    assert!(store.submit(unsigned).is_err());
+
+    let wrong_certifier = CeremonyEnvelope::sign(
+        envelope_draft(
+            &config.ceremony_id,
+            CeremonyPhase::Round2,
+            CeremonyPayloadKind::Round2EncryptedPackage,
+            Did::new("did:exo:not-rostered").expect("valid did"),
+            Some(recipient.clone()),
+            11,
+            b"ciphertext".to_vec(),
+        ),
+        signing_secret,
+    )
+    .expect("wrong certifier envelope");
+    assert!(store.submit(wrong_certifier).is_err());
+
+    let oversized = CeremonyEnvelope::sign(
+        envelope_draft(
+            &config.ceremony_id,
+            CeremonyPhase::Round2,
+            CeremonyPayloadKind::Round2EncryptedPackage,
+            sender.clone(),
+            Some(recipient.clone()),
+            12,
+            vec![0xAB; 64 * 1024 + 1],
+        ),
+        signing_secret,
+    )
+    .expect("oversized envelope");
+    assert!(store.submit(oversized).is_err());
+
+    let mut malformed = CeremonyEnvelope::sign(
+        envelope_draft(
+            &config.ceremony_id,
+            CeremonyPhase::Round2,
+            CeremonyPayloadKind::Round2EncryptedPackage,
+            sender,
+            Some(recipient),
+            13,
+            b"ciphertext".to_vec(),
+        ),
+        signing_secret,
+    )
+    .expect("malformed envelope");
+    malformed.payload_bytes = b"changed".to_vec();
+    assert!(store.submit(malformed).is_err());
+}
+
+#[test]
+fn portal_rejects_wrong_ceremony_bad_recipient_self_target_and_bad_broadcasts() {
+    let (config, signing_secrets, _) = config();
+    let sender = config.certifiers[0].did.clone();
+    let recipient = config.certifiers[1].did.clone();
+    let signing_secret = signing_secrets.get(&sender).expect("secret");
+    let mut store = PortalStore::new(config.clone());
+
+    let wrong_ceremony = CeremonyEnvelope::sign(
+        envelope_draft(
+            "wrong-ceremony",
+            CeremonyPhase::Round2,
+            CeremonyPayloadKind::Round2EncryptedPackage,
+            sender.clone(),
+            Some(recipient.clone()),
+            20,
+            b"ciphertext".to_vec(),
+        ),
+        signing_secret,
+    )
+    .expect("envelope");
+    assert!(store.submit(wrong_ceremony).is_err());
+
+    let wrong_recipient = CeremonyEnvelope::sign(
+        envelope_draft(
+            &config.ceremony_id,
+            CeremonyPhase::Round2,
+            CeremonyPayloadKind::Round2EncryptedPackage,
+            sender.clone(),
+            Some(Did::new("did:exo:not-rostered").expect("valid did")),
+            21,
+            b"ciphertext".to_vec(),
+        ),
+        signing_secret,
+    )
+    .expect("envelope");
+    assert!(store.submit(wrong_recipient).is_err());
+
+    let self_target = CeremonyEnvelope::sign(
+        envelope_draft(
+            &config.ceremony_id,
+            CeremonyPhase::Round2,
+            CeremonyPayloadKind::Round2EncryptedPackage,
+            sender.clone(),
+            Some(sender.clone()),
+            22,
+            b"ciphertext".to_vec(),
+        ),
+        signing_secret,
+    )
+    .expect("envelope");
+    assert!(store.submit(self_target).is_err());
+
+    let bad_broadcast = CeremonyEnvelope::sign(
+        envelope_draft(
+            &config.ceremony_id,
+            CeremonyPhase::Round1,
+            CeremonyPayloadKind::Round1Package,
+            sender.clone(),
+            Some(recipient),
+            23,
+            b"round1".to_vec(),
+        ),
+        signing_secret,
+    )
+    .expect("envelope");
+    assert!(store.submit(bad_broadcast).is_err());
+
+    let no_round2_recipient = CeremonyEnvelope::sign(
+        envelope_draft(
+            &config.ceremony_id,
+            CeremonyPhase::Round2,
+            CeremonyPayloadKind::Round2EncryptedPackage,
+            sender,
+            None,
+            24,
+            b"ciphertext".to_vec(),
+        ),
+        signing_secret,
+    )
+    .expect("envelope");
+    assert!(store.submit(no_round2_recipient).is_err());
+}
+
+#[test]
+fn portal_accepts_all_valid_broadcast_phase_kinds() {
+    let (config, signing_secrets, _) = config();
+    let sender = config.certifiers[0].did.clone();
+    let signing_secret = signing_secrets.get(&sender).expect("secret");
+    let mut store = PortalStore::new(config.clone());
+
+    for (sequence, phase, kind) in [
+        (
+            30,
+            CeremonyPhase::Round1,
+            CeremonyPayloadKind::Round1Package,
+        ),
+        (
+            31,
+            CeremonyPhase::Round1SetAttestation,
+            CeremonyPayloadKind::Round1SetAttestation,
+        ),
+        (
+            32,
+            CeremonyPhase::Finalize,
+            CeremonyPayloadKind::FinalKeyConfirmation,
+        ),
+        (
+            33,
+            CeremonyPhase::RootSigning,
+            CeremonyPayloadKind::RootSigningCommitment,
+        ),
+        (
+            34,
+            CeremonyPhase::RootSigning,
+            CeremonyPayloadKind::RootSignatureShare,
+        ),
+    ] {
+        let envelope = CeremonyEnvelope::sign(
+            envelope_draft(
+                &config.ceremony_id,
+                phase,
+                kind,
+                sender.clone(),
+                None,
+                sequence,
+                b"payload".to_vec(),
+            ),
+            signing_secret,
+        )
+        .expect("envelope");
+        store.submit(envelope).expect("accepted broadcast");
+    }
+
+    assert_eq!(store.envelope_count(), 5);
+}
+
+#[test]
+fn share_sealing_and_pairwise_payload_encryption_fail_closed() {
+    let (config, _, transport_secrets) = config();
+    let sender = &config.certifiers[0];
+    let recipient = &config.certifiers[1];
+    let sender_secret = transport_secrets.get(&sender.did).expect("sender secret");
+    let recipient_secret = transport_secrets
+        .get(&recipient.did)
+        .expect("recipient secret");
+
+    let encrypted = encrypt_pairwise_payload(
+        sender_secret,
+        &recipient.transport_public_key,
+        b"round2 package",
+        b"exo-root-round2",
+        &[7u8; 24],
+    )
+    .expect("encrypted");
+    let decrypted = decrypt_pairwise_payload(
+        recipient_secret,
+        &sender.transport_public_key,
+        &encrypted,
+        b"exo-root-round2",
+    )
+    .expect("decrypted");
+    assert_eq!(decrypted, b"round2 package");
+    assert!(
+        decrypt_pairwise_payload(
+            recipient_secret,
+            &sender.transport_public_key,
+            &encrypted,
+            b"wrong aad",
+        )
+        .is_err()
+    );
+
+    let sealed = seal_share(
+        b"root key package",
+        b"correct horse battery staple",
+        b"exo-root-share",
+        &[9u8; 16],
+        &[10u8; 24],
+    )
+    .expect("sealed");
+    let opened =
+        unseal_share(&sealed, b"correct horse battery staple", b"exo-root-share").expect("opened");
+    assert_eq!(opened, b"root key package");
+    assert!(unseal_share(&sealed, b"wrong passphrase", b"exo-root-share").is_err());
+    assert!(unseal_share(&sealed, b"correct horse battery staple", b"wrong aad").is_err());
+
+    let mut corrupted = sealed.clone();
+    corrupted.ciphertext[0] ^= 0x01;
+    assert!(
+        unseal_share(
+            &corrupted,
+            b"correct horse battery staple",
+            b"exo-root-share"
+        )
+        .is_err()
+    );
+
+    let invalid_salt = SealedShare {
+        salt: Vec::new(),
+        nonce: [10u8; 24],
+        ciphertext: sealed.ciphertext,
+    };
+    assert!(
+        unseal_share(
+            &invalid_salt,
+            b"correct horse battery staple",
+            b"exo-root-share"
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn source_guards_reject_nondeterministic_patterns() {
+    let sources = [
+        include_str!("../src/lib.rs"),
+        include_str!("../src/bundle.rs"),
+        include_str!("../src/ceremony.rs"),
+        include_str!("../src/dkg.rs"),
+        include_str!("../src/error.rs"),
+        include_str!("../src/portal.rs"),
+        include_str!("../src/seal.rs"),
+        include_str!("../src/signing.rs"),
+    ];
+    let banned_map = ["Hash", "Map"].concat();
+    let banned_set = ["Hash", "Set"].concat();
+    for source in sources {
+        let production = source.split("#[cfg(test)]").next().expect("split");
+        assert!(!production.contains(&banned_map));
+        assert!(!production.contains(&banned_set));
+        assert!(!production.contains(": f32"));
+        assert!(!production.contains(": f64"));
+        assert!(!production.contains("SystemTime::now"));
+        assert!(!production.contains("Instant::now"));
+        assert!(!production.contains("unsafe"));
+    }
+}

--- a/docs/avc/root-trust-authority.md
+++ b/docs/avc/root-trust-authority.md
@@ -1,0 +1,42 @@
+# AVC Root Trust Authority
+
+EXOCHAIN root genesis creates a threshold root authority for trust anchors and issuer delegations. It does not replace routine AVC issuance.
+
+## Issuer Model
+
+The root authority signs only:
+
+- root trust anchors;
+- operational AVC Issuing Authority delegations;
+- revocation or replacement artifacts for those anchors and delegations.
+
+The operational AVC Issuing Authority DID performs normal AVC issuance through the existing AVC flow. A credential is trusted only when the operational issuer delegation is included in a verified root trust bundle.
+
+## Bundle Verification
+
+A valid root trust bundle binds:
+
+- repo commit;
+- constitution hash;
+- network ID;
+- ceremony ID;
+- certifier roster;
+- 7-of-13 threshold policy;
+- FROST public key package hash;
+- transcript hash;
+- root signature;
+- AVC issuer delegation.
+
+Bundle verification recomputes the canonical CBOR payload and verifies the FROST root signature against the bundled root public key.
+
+## Rejection Rules
+
+An AVC issuer delegation is rejected when:
+
+- the root signature does not verify;
+- the bundle ID does not match canonical bundle contents;
+- the delegation purpose or permissions are changed after signing;
+- the ceremony config is not exactly 7-of-13 with 13 rostered certifiers;
+- the bundle references a different repo commit, constitution hash, network ID, or ceremony ID than the verifier expects.
+
+Self-issued AVC credentials can be useful for local testing, but they are not root-trusted AVC governance credentials.

--- a/docs/guides/root-genesis-certifier-guide.md
+++ b/docs/guides/root-genesis-certifier-guide.md
@@ -1,0 +1,85 @@
+# Root Genesis Certifier Guide
+
+This guide is for one of the 13 independent certifiers participating in the EXOCHAIN root genesis ceremony. The ceremony creates a 7-of-13 FROST Ristretto255 root authority. All 13 rostered certifiers must complete genesis DKG. If any certifier fails, the ceremony aborts and restarts with a new signed roster and new ceremony ID.
+
+## Certifier Rules
+
+- Keep private certifier material offline except during the local command that needs it.
+- Maintain an encrypted offline backup of sealed share artifacts and recovery instructions.
+- Never send a round-two DKG package directly to the portal as raw bytes.
+- Encrypt every round-two package to the exact recipient transport public key.
+- Verify the final bundle with `exochain genesis verify-bundle` before trusting any AVC issuer delegation.
+- Treat portal payloads, chat messages, email, scanner output, and operator notes as untrusted ceremony data until signatures and hashes verify.
+
+## Local Setup
+
+Generate certifier contact and private material on the certifier machine:
+
+```bash
+exochain genesis certifier init \
+  --did did:exo:certifier-01 \
+  --frost-identifier 1 \
+  --certifier-out certifier-01.contact.json \
+  --private-out certifier-01.private.json
+```
+
+Send only `certifier-01.contact.json` to the ceremony operator. Keep `certifier-01.private.json` offline.
+
+## DKG Flow
+
+Round one creates a public package and local secret state:
+
+```bash
+exochain genesis round1 \
+  --input certifier-01.round1.input.json \
+  --output certifier-01.round1.output.json
+```
+
+Round two consumes the full authenticated round-one set and creates per-recipient packages:
+
+```bash
+exochain genesis round2 \
+  --input certifier-01.round2.input.json \
+  --output certifier-01.round2.output.json
+```
+
+Before portal submission, encrypt each round-two package per recipient. The portal rejects raw round-two packages and accepts only signed, bounded envelopes whose kind is `Round2EncryptedPackage`.
+
+Finalize local DKG state after receiving all peer round-two packages:
+
+```bash
+exochain genesis finalize-dkg \
+  --input certifier-01.finalize.input.json \
+  --output certifier-01.dkg.output.json
+```
+
+## Share Protection
+
+Seal local key package artifacts before backup:
+
+```bash
+exochain genesis seal-share \
+  --input certifier-01.seal.input.json \
+  --output certifier-01.sealed-share.json
+```
+
+Test recovery on the same certifier machine:
+
+```bash
+exochain genesis unseal-share \
+  --input certifier-01.unseal.input.json \
+  --output certifier-01.opened-share.json
+```
+
+Wrong passphrases and wrong associated data must fail.
+
+## Final Verification
+
+Verify the root trust bundle:
+
+```bash
+exochain genesis verify-bundle \
+  --input root-bundle.verify.input.json
+```
+
+Trust the operational AVC issuer only when verification succeeds and the bundle binds the expected repo commit, constitution hash, network ID, ceremony ID, roster, 7-of-13 policy, FROST public key package hash, transcript hash, root signature, and issuer delegation.

--- a/docs/guides/root-genesis-operator-guide.md
+++ b/docs/guides/root-genesis-operator-guide.md
@@ -1,0 +1,77 @@
+# Root Genesis Operator Guide
+
+The operator coordinates the ceremony but does not receive root secrets, plaintext FROST shares, or authority credentials. The portal is an untrusted relay for signed, bounded ceremony envelopes.
+
+## Ceremony Policy
+
+- Roster size: 13 independent certifiers.
+- Signing threshold after genesis: any 7 of 13 certifiers.
+- Genesis DKG completion rule: all 13 rostered certifiers complete both DKG rounds.
+- Abort rule: if any certifier fails, abort and restart with a new signed roster and ceremony ID.
+- Portal rule: round-two DKG payloads must be encrypted per recipient; raw round-two payloads are rejected.
+- AVC rule: the root delegates to a normal operational AVC Issuing Authority DID. Routine AVC issuance remains on the existing AVC path.
+
+## Build Ceremony Configuration
+
+Collect the 13 public certifier contact files and assemble a roster JSON array. Then create the ceremony config:
+
+```bash
+exochain genesis ceremony init \
+  --ceremony-id exo-root-genesis-2026-001 \
+  --network-id exochain-main \
+  --repo-commit d8927686a34bdc28ba36d53938f665685d2c4c04 \
+  --constitution-hash <32-byte-hex> \
+  --created-physical-ms <hlc-physical-ms> \
+  --roster root-roster.json \
+  --out root-ceremony-config.json
+```
+
+The command enforces 7-of-13 policy, exactly 13 certifiers, unique DIDs, unique FROST identifiers, unique signing keys, and unique transport keys.
+
+## Start Portal
+
+```bash
+exochain genesis portal \
+  --config root-ceremony-config.json \
+  --bind 127.0.0.1:3017
+```
+
+Portal endpoints:
+
+- `GET /api/v1/root-genesis/portal`
+- `POST /api/v1/root-genesis/portal/envelopes`
+
+The portal verifies envelope signatures, ceremony ID, roster membership, phase/kind policy, payload hashes, payload size, and replay sequences.
+
+## Bundle Assembly
+
+After DKG finalization and root artifact signing:
+
+```bash
+exochain genesis assemble-bundle \
+  --input root-bundle.assemble.input.json \
+  --output root-trust-bundle.json
+```
+
+Verify before publication:
+
+```bash
+exochain genesis verify-bundle \
+  --input root-bundle.verify.input.json
+```
+
+Publish the verified root trust bundle with the transcript hash, root public key package, and root-signed AVC issuer delegation. Do not publish certifier private material, sealed share passphrases, or raw round-two packages.
+
+## Validation Gates
+
+Before proposing the branch:
+
+```bash
+cargo test -p exo-root --test root_genesis
+cargo test -p exo-node genesis
+cargo tarpaulin --packages exo-root --include-files "crates/exo-root/src/**" --fail-under 100
+cargo tarpaulin --packages exo-node --include-files "crates/exo-node/src/root_genesis.rs" --fail-under 100
+cargo clippy --workspace --all-targets -- -D warnings
+cargo fmt --all -- --check
+cargo doc --workspace --no-deps
+```

--- a/governance/resolutions/CR-003-root-genesis-frost-dkg.md
+++ b/governance/resolutions/CR-003-root-genesis-frost-dkg.md
@@ -1,0 +1,47 @@
+# CR-003 Root Genesis FROST DKG Authority
+
+## Resolution
+
+Create the EXOCHAIN institutional root authority through a 7-of-13 FROST Ristretto255 DKG ceremony. The root authority signs trust anchors and operational AVC Issuing Authority delegations only. Routine AVC issuance remains on the existing AVC path.
+
+## Constitutional Basis
+
+The root ceremony strengthens separation of powers by requiring seven independent certifiers for root-governance artifacts. Genesis requires all thirteen rostered certifiers to complete DKG, which prevents a partial or convenience roster from becoming the root of trust.
+
+## Determinism
+
+All signed and hashed ceremony artifacts are encoded as canonical CBOR before hashing. Runtime governance decisions remain deterministic. Randomness is limited to cryptographic key generation, DKG nonce material, and threshold-signing nonce material.
+
+## Invariants
+
+- SeparationOfPowers: root authority requires threshold participation.
+- ConsentRequired: root authority does not bypass existing AVC consent flows.
+- NoSelfGrant: operational issuer authority is delegated by a root-signed bundle, not self-issued.
+- HumanOverride: institutional certifier recovery and replacement remain human-governed.
+- KernelImmutability: root genesis does not mutate kernel configuration after initialization.
+- AuthorityChainValid: AVC issuer authority must chain to a verified root bundle.
+- QuorumLegitimate: root artifacts require 7-of-13 signatures after genesis.
+- ProvenanceVerifiable: bundle verification binds transcript hash, roster, commit, constitution hash, root key package, and root signature.
+
+## Ceremony Policy
+
+- Default roster: 13 independent certifiers.
+- Threshold: 7 certifiers for post-genesis root signatures.
+- Genesis DKG: all 13 certifiers complete the ceremony.
+- Failure rule: any missing certifier aborts the ceremony and requires a new signed roster.
+- Portal role: untrusted relay for signed, bounded envelopes.
+- Round-two rule: DKG round-two payloads are encrypted per recipient; raw round-two portal submissions are rejected.
+
+## Validation
+
+Required local gates:
+
+```bash
+cargo test -p exo-root --test root_genesis
+cargo test -p exo-node genesis
+cargo tarpaulin --packages exo-root --include-files "crates/exo-root/src/**" --fail-under 100
+cargo tarpaulin --packages exo-node --include-files "crates/exo-node/src/root_genesis.rs" --fail-under 100
+cargo clippy --workspace --all-targets -- -D warnings
+cargo fmt --all -- --check
+cargo doc --workspace --no-deps
+```


### PR DESCRIPTION
## Summary
- Adds `crates/exo-root` for institutional 7-of-13 FROST Ristretto255 root genesis DKG, threshold signing, canonical CBOR transcript/bundle hashing, sealed share artifacts, root bundle verification, and root-signed AVC issuer delegation.
- Adds `exochain genesis ...` CLI commands for certifier initialization, ceremony setup, DKG rounds, finalization, signing, bundle assembly/verification, and share sealing/unsealing.
- Adds root-genesis portal handlers as an untrusted relay for signed, bounded ceremony envelopes; plaintext round-two payloads are rejected and pairwise payload helpers encrypt per recipient.
- Adds certifier/operator/AVC docs, a governance resolution draft, and CI gates for 100% root crate and portal handler coverage.

## Path Classification
- EXOCHAIN core: `crates/exo-root/**`, workspace `Cargo.toml`, `Cargo.lock`.
- Core runtime adapter: `crates/exo-node/src/cli.rs`, `crates/exo-node/src/main.rs`, `crates/exo-node/src/root_genesis.rs`, `crates/exo-node/src/root_genesis_cli.rs`, `crates/exo-node/Cargo.toml`.
- Governance / documentation artifacts: `docs/guides/root-genesis-certifier-guide.md`, `docs/guides/root-genesis-operator-guide.md`, `docs/avc/root-trust-authority.md`, `governance/resolutions/CR-003-root-genesis-frost-dkg.md`.
- CI gates: `.github/workflows/ci.yml`.
- Adjacent surfaces / imported evidence / third-party source: none changed.

## Validation
- `cargo +nightly fmt --all -- --check`
- `cargo test -p exo-node genesis` — 8 passed
- `cargo tarpaulin --packages exo-root --include-files "crates/exo-root/src/**" --fail-under 100 --out xml --output-dir /tmp/exo-root-coverage --skip-clean --engine llvm --timeout 600` — 100.00%, 510/510 lines
- `cargo tarpaulin --packages exo-node --include-files "crates/exo-node/src/root_genesis.rs" --fail-under 100 --out xml --output-dir /tmp/root-genesis-portal-coverage --skip-clean --engine llvm --timeout 120` — 100.00%, 40/40 lines
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --workspace --release`
- `cargo test --workspace --release`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit --deny unsound --deny unmaintained`
- `cargo deny check` — exits 0; existing duplicate dependency warnings remain, final status advisories/bans/licenses/sources ok
- `git diff --check`
- Source guard: no production `HashMap`, `HashSet`, floats, `unsafe`, wall-clock calls, or production `unwrap`/`expect` in new root-genesis code; remaining hits are only test assertions enforcing the guard.

## Notes
- `frost-ristretto255` is pinned to `=3.0.0` with default features disabled and `serde` enabled; FROST messages are encoded through EXOCHAIN canonical CBOR helpers rather than the crate's default serialization stack.
- `docs/heartfield/HEARTFIELD_AI_WHITEPAPER.md` was intentionally left untracked and untouched.