### PR TITLE
Harden root-genesis ceremony artifact boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 197286 | `wc -l` |
-| Workspace tests | 4,443 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 197484 | `wc -l` |
+| Workspace tests | 4,445 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 197286 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 197484 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,443 listed workspace tests
+         cryptographic proofs, 4,445 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          160 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -1493,7 +1493,7 @@ mod root_genesis_adapter_tests {
     use exo_core::{Did, Hash256, SecretKey, Timestamp, crypto::KeyPair};
     use exo_root::{
         CeremonyEnvelope, CeremonyEnvelopeDraft, CeremonyPayloadKind, CeremonyPhase,
-        CertifierContact, GenesisCeremonyConfig,
+        CertifierContact, GenesisCeremonyConfig, PairwiseEncryptedPayload,
     };
     use tower::ServiceExt;
 
@@ -1563,6 +1563,16 @@ mod root_genesis_adapter_tests {
             .expect("response")
     }
 
+    fn encrypted_payload_bytes(ciphertext: impl Into<Vec<u8>>) -> Vec<u8> {
+        let payload = PairwiseEncryptedPayload {
+            nonce: [1u8; 24],
+            ciphertext: ciphertext.into(),
+        };
+        let mut bytes = Vec::new();
+        ciborium::into_writer(&payload, &mut bytes).expect("encrypted payload encoding");
+        bytes
+    }
+
     #[tokio::test]
     async fn root_genesis_portal_handler_accepts_signed_envelope_and_rejects_replay() {
         let (config, secret) = config();
@@ -1578,7 +1588,7 @@ mod root_genesis_adapter_tests {
                 sender_did: sender,
                 recipient_did: Some(recipient),
                 sequence: 1,
-                payload_bytes: b"ciphertext".to_vec(),
+                payload_bytes: encrypted_payload_bytes(b"ciphertext"),
             },
             &secret,
         )

--- a/crates/exo-node/src/root_genesis.rs
+++ b/crates/exo-node/src/root_genesis.rs
@@ -132,7 +132,10 @@ mod tests {
         http::{Request, StatusCode},
     };
     use exo_core::{Did, SecretKey, Signature, Timestamp, crypto::KeyPair};
-    use exo_root::{CeremonyEnvelopeDraft, CeremonyPayloadKind, CeremonyPhase, CertifierContact};
+    use exo_root::{
+        CeremonyEnvelopeDraft, CeremonyPayloadKind, CeremonyPhase, CertifierContact,
+        PairwiseEncryptedPayload,
+    };
     use tower::ServiceExt;
 
     use super::*;
@@ -189,6 +192,13 @@ mod tests {
         sequence: u64,
         payload_bytes: Vec<u8>,
     ) -> CeremonyEnvelope {
+        let encrypted_payload = PairwiseEncryptedPayload {
+            nonce: [u8::try_from(sequence).expect("sequence fits"); 24],
+            ciphertext: payload_bytes,
+        };
+        let mut encoded_payload = Vec::new();
+        ciborium::into_writer(&encrypted_payload, &mut encoded_payload)
+            .expect("encrypted payload encoding");
         CeremonyEnvelope::sign(
             CeremonyEnvelopeDraft {
                 ceremony_id: config.ceremony_id.clone(),
@@ -197,7 +207,7 @@ mod tests {
                 sender_did: config.certifiers[0].did.clone(),
                 recipient_did: Some(config.certifiers[1].did.clone()),
                 sequence,
-                payload_bytes,
+                payload_bytes: encoded_payload,
             },
             secret,
         )

--- a/crates/exo-node/src/root_genesis_cli.rs
+++ b/crates/exo-node/src/root_genesis_cli.rs
@@ -1,6 +1,6 @@
 //! Root genesis CLI command implementation.
 
-use std::{collections::BTreeMap, fs, net::SocketAddr};
+use std::{collections::BTreeMap, fs, io::Write, net::SocketAddr};
 
 use exo_core::{Did, Hash256, Timestamp, crypto::KeyPair};
 use exo_root::{
@@ -288,6 +288,29 @@ fn read_json<T: for<'de> Deserialize<'de>>(path: &std::path::Path) -> anyhow::Re
 
 fn write_json<T: Serialize>(path: &std::path::Path, value: &T) -> anyhow::Result<()> {
     let bytes = serde_json::to_vec_pretty(value)?;
+    write_json_bytes(path, bytes.as_slice())?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn write_json_bytes(path: &std::path::Path, bytes: &[u8]) -> anyhow::Result<()> {
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .mode(0o600)
+        .open(path)?;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn write_json_bytes(path: &std::path::Path, bytes: &[u8]) -> anyhow::Result<()> {
     fs::write(path, bytes)?;
     Ok(())
 }
@@ -468,5 +491,32 @@ mod tests {
         let mut packages = BTreeMap::new();
         packages.insert(7, "not-hex".to_owned());
         assert!(decode_package_map(packages).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn json_outputs_are_rewritten_owner_only_even_when_file_exists() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempdir().expect("temporary directory");
+        let output_path = directory.path().join("private-material.json");
+        fs::write(&output_path, b"previous material").expect("seed existing file");
+        fs::set_permissions(&output_path, fs::Permissions::from_mode(0o644))
+            .expect("make existing file too broad");
+
+        write_json(
+            &output_path,
+            &HexBytesOutput {
+                bytes_hex: hex::encode(b"secret"),
+            },
+        )
+        .expect("rewrite output");
+
+        let mode = fs::metadata(&output_path)
+            .expect("output metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
     }
 }

--- a/crates/exo-root/src/bundle.rs
+++ b/crates/exo-root/src/bundle.rs
@@ -7,7 +7,8 @@ use exo_core::{Did, Hash256, PublicKey, Timestamp, hash::hash_structured};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    GenesisCeremonyConfig, Result, RootError, RootPublicKeyPackage, verify_root_signature,
+    GenesisCeremonyConfig, Result, RootError, RootPublicKeyPackage,
+    dkg::validate_public_key_package, verify_root_signature,
 };
 
 /// Operational AVC issuer authority delegated by the root.
@@ -133,6 +134,7 @@ pub fn assemble_root_bundle(
     transcript_hash: Hash256,
     root_signature: Vec<u8>,
 ) -> Result<RootTrustBundle> {
+    validate_public_key_package(&config, &public_key_package)?;
     let payload =
         issuer_delegation.root_artifact_payload(&config, &public_key_package, transcript_hash)?;
     verify_root_signature(
@@ -160,6 +162,7 @@ pub fn assemble_root_bundle(
 /// Verify that a root trust bundle is self-consistent and root-signed.
 pub fn verify_root_bundle(bundle: &RootTrustBundle) -> Result<()> {
     bundle.config.validate()?;
+    validate_public_key_package(&bundle.config, &bundle.public_key_package)?;
     let payload = bundle.issuer_delegation.root_artifact_payload(
         &bundle.config,
         &bundle.public_key_package,

--- a/crates/exo-root/src/dkg.rs
+++ b/crates/exo-root/src/dkg.rs
@@ -174,6 +174,22 @@ pub(crate) fn serialize_public_key_package(
     })
 }
 
+pub(crate) fn validate_public_key_package(
+    config: &GenesisCeremonyConfig,
+    package: &RootPublicKeyPackage,
+) -> Result<()> {
+    let frost_package: frost::keys::PublicKeyPackage =
+        deserialize_frost(package.public_key_package.as_slice())?;
+    let expected = serialize_public_key_package(config, &frost_package)?;
+    if &expected != package {
+        return Err(RootError::BundleRejected {
+            reason: "public key package metadata does not match serialized FROST package"
+                .to_owned(),
+        });
+    }
+    Ok(())
+}
+
 /// Execute DKG round one for one rostered certifier.
 pub fn dkg_round1<R>(
     config: &GenesisCeremonyConfig,

--- a/crates/exo-root/src/portal.rs
+++ b/crates/exo-root/src/portal.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use exo_core::{Did, Hash256, SecretKey, Signature, crypto, hash::hash_structured};
 use serde::{Deserialize, Serialize};
 
-use crate::{GenesisCeremonyConfig, Result, RootError};
+use crate::{GenesisCeremonyConfig, PairwiseEncryptedPayload, Result, RootError};
 
 const MAX_PORTAL_PAYLOAD_BYTES: usize = 64 * 1024;
 
@@ -284,6 +284,7 @@ impl PortalStore {
                         reason: "round-two encrypted package requires recipient".to_owned(),
                     });
                 }
+                validate_encrypted_round2_payload(envelope.payload_bytes.as_slice())?;
                 Ok(())
             }
             (_, CeremonyPayloadKind::Round2PlaintextPackage) => Err(RootError::PortalRejected {
@@ -294,6 +295,19 @@ impl PortalStore {
             }),
         }
     }
+}
+
+fn validate_encrypted_round2_payload(payload_bytes: &[u8]) -> Result<()> {
+    let encrypted: PairwiseEncryptedPayload =
+        ciborium::from_reader(payload_bytes).map_err(|error| RootError::PortalRejected {
+            reason: format!("round-two encrypted package is malformed: {error}"),
+        })?;
+    if encrypted.ciphertext.is_empty() {
+        return Err(RootError::PortalRejected {
+            reason: "round-two encrypted package ciphertext must not be empty".to_owned(),
+        });
+    }
+    Ok(())
 }
 
 #[derive(Serialize)]

--- a/crates/exo-root/tests/root_genesis.rs
+++ b/crates/exo-root/tests/root_genesis.rs
@@ -6,10 +6,10 @@ use exo_authority::permission::Permission;
 use exo_core::{Did, Hash256, PublicKey, SecretKey, Signature, Timestamp, crypto::KeyPair};
 use exo_root::{
     CeremonyEnvelope, CeremonyEnvelopeDraft, CeremonyPayloadKind, CeremonyPhase, CertifierContact,
-    GenesisCeremonyConfig, PortalStore, RootIssuerDelegation, SealedShare, assemble_root_bundle,
-    decrypt_pairwise_payload, dkg_finalize_participant, dkg_round1, dkg_round2,
-    encrypt_pairwise_payload, run_complete_dkg, seal_share, threshold_sign, unseal_share,
-    verify_root_bundle, verify_root_signature,
+    GenesisCeremonyConfig, PairwiseEncryptedPayload, PortalStore, RootIssuerDelegation,
+    SealedShare, assemble_root_bundle, decrypt_pairwise_payload, dkg_finalize_participant,
+    dkg_round1, dkg_round2, encrypt_pairwise_payload, run_complete_dkg, seal_share, threshold_sign,
+    unseal_share, verify_root_bundle, verify_root_signature,
 };
 use rand::{SeedableRng, rngs::StdRng};
 
@@ -57,6 +57,16 @@ fn envelope_draft(
         sequence,
         payload_bytes,
     }
+}
+
+fn encrypted_payload_bytes(ciphertext: impl Into<Vec<u8>>) -> Vec<u8> {
+    let payload = PairwiseEncryptedPayload {
+        nonce: [7u8; 24],
+        ciphertext: ciphertext.into(),
+    };
+    let mut bytes = Vec::new();
+    ciborium::into_writer(&payload, &mut bytes).expect("encrypted payload encoding");
+    bytes
 }
 
 fn config() -> (
@@ -658,6 +668,55 @@ fn root_bundle_verification_rejects_tampered_delegation() {
 }
 
 #[test]
+fn root_bundle_rejects_public_key_package_metadata_mismatch() {
+    let (config, _, _) = config();
+    let mut first_rng = StdRng::seed_from_u64(301);
+    let mut second_rng = StdRng::seed_from_u64(302);
+    let first_dkg = run_complete_dkg(&config, &mut first_rng).expect("first dkg");
+    let second_dkg = run_complete_dkg(&config, &mut second_rng).expect("second dkg");
+    let mut mixed_public = second_dkg.public_key_package.clone();
+    mixed_public.public_key_package = first_dkg.public_key_package.public_key_package;
+    let delegation = RootIssuerDelegation {
+        issuer_did: Did::new("did:exo:avc-issuer").expect("valid did"),
+        issuer_public_key: PublicKey::from_bytes([0x46; 32]),
+        granted_permissions: vec![Permission::Govern],
+        effective_at: Timestamp::new(1_785_000_010_000, 0),
+        expires_at: None,
+        purpose: "Delegate operational AVC issuing authority".into(),
+    };
+    let transcript_hash = Hash256::digest(b"transcript");
+    let payload = delegation
+        .root_artifact_payload(&config, &mixed_public, transcript_hash)
+        .expect("payload");
+    let mut signing_rng = StdRng::seed_from_u64(303);
+    let root_signature = threshold_sign(
+        &config,
+        &second_dkg.public_key_package,
+        second_dkg
+            .key_packages
+            .iter()
+            .take(7)
+            .map(|(k, v)| (*k, v.clone()))
+            .collect(),
+        &payload,
+        &mut signing_rng,
+    )
+    .expect("signature");
+
+    assert!(
+        assemble_root_bundle(
+            config,
+            mixed_public,
+            delegation,
+            transcript_hash,
+            root_signature.signature,
+        )
+        .is_err(),
+        "bundle must reject root key metadata that does not derive from the serialized FROST public package"
+    );
+}
+
+#[test]
 fn root_artifact_payload_rejects_unbounded_delegation() {
     let (config, _, _) = config();
     let mut rng = StdRng::seed_from_u64(98);
@@ -758,7 +817,7 @@ fn portal_rejects_replay_plaintext_round2_and_wrong_phase_envelopes() {
             sender.clone(),
             Some(recipient.clone()),
             1,
-            b"ciphertext".to_vec(),
+            encrypted_payload_bytes(b"ciphertext"),
         ),
         signing_secret,
     )
@@ -772,7 +831,7 @@ fn portal_rejects_replay_plaintext_round2_and_wrong_phase_envelopes() {
             CeremonyPhase::Round2,
             CeremonyPayloadKind::Round2PlaintextPackage,
             sender.clone(),
-            Some(recipient),
+            Some(recipient.clone()),
             2,
             b"plaintext share".to_vec(),
         ),
@@ -780,6 +839,42 @@ fn portal_rejects_replay_plaintext_round2_and_wrong_phase_envelopes() {
     )
     .expect("plaintext envelope");
     assert!(store.submit(plaintext).is_err());
+
+    let mislabeled_plaintext = CeremonyEnvelope::sign(
+        envelope_draft(
+            &config.ceremony_id,
+            CeremonyPhase::Round2,
+            CeremonyPayloadKind::Round2EncryptedPackage,
+            sender.clone(),
+            Some(recipient.clone()),
+            4,
+            b"plaintext share".to_vec(),
+        ),
+        signing_secret,
+    )
+    .expect("mislabeled plaintext envelope");
+    assert!(
+        store.submit(mislabeled_plaintext).is_err(),
+        "round-two plaintext bytes mislabeled as encrypted must be rejected"
+    );
+
+    let empty_ciphertext = CeremonyEnvelope::sign(
+        envelope_draft(
+            &config.ceremony_id,
+            CeremonyPhase::Round2,
+            CeremonyPayloadKind::Round2EncryptedPackage,
+            sender.clone(),
+            Some(recipient.clone()),
+            5,
+            encrypted_payload_bytes(Vec::new()),
+        ),
+        signing_secret,
+    )
+    .expect("empty ciphertext envelope");
+    assert!(
+        store.submit(empty_ciphertext).is_err(),
+        "round-two encrypted package must carry ciphertext"
+    );
 
     let wrong_phase = CeremonyEnvelope::sign(
         envelope_draft(
@@ -789,7 +884,7 @@ fn portal_rejects_replay_plaintext_round2_and_wrong_phase_envelopes() {
             sender,
             None,
             3,
-            b"ciphertext".to_vec(),
+            encrypted_payload_bytes(b"ciphertext"),
         ),
         signing_secret,
     )
@@ -813,7 +908,7 @@ fn portal_rejects_unsigned_wrong_certifier_oversized_and_malformed_envelopes() {
             sender.clone(),
             Some(recipient.clone()),
             10,
-            b"ciphertext".to_vec(),
+            encrypted_payload_bytes(b"ciphertext"),
         ),
         signing_secret,
     )
@@ -829,7 +924,7 @@ fn portal_rejects_unsigned_wrong_certifier_oversized_and_malformed_envelopes() {
             Did::new("did:exo:not-rostered").expect("valid did"),
             Some(recipient.clone()),
             11,
-            b"ciphertext".to_vec(),
+            encrypted_payload_bytes(b"ciphertext"),
         ),
         signing_secret,
     )
@@ -859,7 +954,7 @@ fn portal_rejects_unsigned_wrong_certifier_oversized_and_malformed_envelopes() {
             sender,
             Some(recipient),
             13,
-            b"ciphertext".to_vec(),
+            encrypted_payload_bytes(b"ciphertext"),
         ),
         signing_secret,
     )
@@ -884,7 +979,7 @@ fn portal_rejects_wrong_ceremony_bad_recipient_self_target_and_bad_broadcasts() 
             sender.clone(),
             Some(recipient.clone()),
             20,
-            b"ciphertext".to_vec(),
+            encrypted_payload_bytes(b"ciphertext"),
         ),
         signing_secret,
     )
@@ -899,7 +994,7 @@ fn portal_rejects_wrong_ceremony_bad_recipient_self_target_and_bad_broadcasts() 
             sender.clone(),
             Some(Did::new("did:exo:not-rostered").expect("valid did")),
             21,
-            b"ciphertext".to_vec(),
+            encrypted_payload_bytes(b"ciphertext"),
         ),
         signing_secret,
     )
@@ -914,7 +1009,7 @@ fn portal_rejects_wrong_ceremony_bad_recipient_self_target_and_bad_broadcasts() 
             sender.clone(),
             Some(sender.clone()),
             22,
-            b"ciphertext".to_vec(),
+            encrypted_payload_bytes(b"ciphertext"),
         ),
         signing_secret,
     )
@@ -944,7 +1039,7 @@ fn portal_rejects_wrong_ceremony_bad_recipient_self_target_and_bad_broadcasts() 
             sender,
             None,
             24,
-            b"ciphertext".to_vec(),
+            encrypted_payload_bytes(b"ciphertext"),
         ),
         signing_secret,
     )


### PR DESCRIPTION
## Summary

Remediates the Codex Security follow-up findings from the merged root-genesis FROST DKG work:

- force root-genesis CLI JSON outputs through owner-only Unix file writes (`0600`), including rewrites of pre-existing broad-permission files;
- require round-two portal encrypted payloads to decode as `PairwiseEncryptedPayload` with non-empty ciphertext, blocking plaintext bytes mislabeled as encrypted;
- bind root trust bundle public key metadata to the serialized FROST public key package during both assemble and verify paths.

## Path Classification

- `crates/exo-root/src/portal.rs`: EXOCHAIN core
- `crates/exo-root/src/bundle.rs`: EXOCHAIN core
- `crates/exo-root/src/dkg.rs`: EXOCHAIN core
- `crates/exo-root/tests/root_genesis.rs`: EXOCHAIN core tests
- `crates/exo-node/src/root_genesis_cli.rs`: core runtime adapter
- `crates/exo-node/src/root_genesis.rs`: core runtime adapter tests
- `crates/exo-node/src/main.rs`: core runtime adapter tests
- `README.md`: documentation, repo-truth derived counters only

No adjacent surfaces are changed. Untracked `docs/heartfield/HEARTFIELD_AI_WHITEPAPER.md` is intentionally untouched and not included.

## Codex Security Rescan

Local Codex Security plugin rescan bundle:

`/tmp/codex-security-scans/exochain/5db67055791f7dd8a6e35c7162cc4135c26b1a28_workingtree_20260519T015849Z/report.md`

Result: no reportable findings survived discovery, validation, or attack-path analysis for this remediation diff.

## TDD Evidence

Red tests captured before remediation:

- `cargo test -p exo-node root_genesis_cli::tests::json_outputs_are_rewritten_owner_only_even_when_file_exists -- --nocapture`
- `cargo test -p exo-root portal_rejects_replay_plaintext_round2_and_wrong_phase_envelopes -- --nocapture`
- `cargo test -p exo-root root_bundle_rejects_public_key_package_metadata_mismatch -- --nocapture`

The same tests passed after remediation.

## Validation

- `cargo test -p exo-root`
- `cargo test -p exo-node root_genesis -- --nocapture`
- `cargo clippy -p exo-root --all-targets -- -D warnings`
- `cargo clippy -p exo-node --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- `cargo tarpaulin --packages exo-root --include-files "crates/exo-root/src/**" --out xml --out stdout --output-dir /tmp/exo-root-coverage-security-rescan --skip-clean --engine llvm --timeout 600 --fail-under 100` -> `100.00%`, 526/526 lines
- `cargo tarpaulin --packages exo-node --include-files "crates/exo-node/src/root_genesis.rs" --out xml --out stdout --output-dir /tmp/exo-node-root-genesis-portal-security-rescan --skip-clean --engine llvm --timeout 120 --fail-under 100` -> `100.00%`, 40/40 lines
- `cargo tarpaulin --workspace --exclude exochain-wasm --exclude exo-proofs --out xml --out stdout --output-dir /tmp/exochain-gate3-security-rescan-remediation --skip-clean --engine llvm --timeout 300 --fail-under 90` -> `90.91%`, 20426/22469 lines
