### PR TITLE
fix(gateway): reject duplicate forwarded rate-limit headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 197484 | `wc -l` |
-| Workspace tests | 4,445 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 197544 | `wc -l` |
+| Workspace tests | 4,446 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -4221,11 +4221,21 @@ fn forwarded_rate_limit_client_ip(
     request: &Request<Body>,
     trusted_rate_limit_proxy_ips: &BTreeSet<IpAddr>,
 ) -> Option<IpAddr> {
-    let header_value = request.headers().get("x-forwarded-for")?.to_str().ok()?;
-    let parsed_ips: Vec<IpAddr> = header_value
-        .split(',')
-        .filter_map(|candidate| candidate.trim().parse::<IpAddr>().ok())
-        .collect();
+    let mut forwarded_headers = request.headers().get_all("x-forwarded-for").iter();
+    let header_value = forwarded_headers.next()?.to_str().ok()?;
+    if forwarded_headers.next().is_some() {
+        return None;
+    }
+
+    let mut parsed_ips = Vec::new();
+    for candidate in header_value.split(',') {
+        let trimmed = candidate.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        let ip = trimmed.parse::<IpAddr>().ok()?;
+        parsed_ips.push(ip);
+    }
 
     parsed_ips
         .iter()
@@ -4504,6 +4514,21 @@ mod tests {
         Request::builder()
             .uri(path)
             .header("x-forwarded-for", forwarded_for)
+            .extension(ConnectInfo(address))
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    fn request_from_duplicate_forwarded_headers(
+        path: &str,
+        address: SocketAddr,
+        first_forwarded_for: &str,
+        second_forwarded_for: &str,
+    ) -> Request<Body> {
+        Request::builder()
+            .uri(path)
+            .header("x-forwarded-for", first_forwarded_for)
+            .header("x-forwarded-for", second_forwarded_for)
             .extension(ConnectInfo(address))
             .body(Body::empty())
             .unwrap()
@@ -4905,6 +4930,41 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(first_client_again.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[tokio::test]
+    async fn gateway_rate_limit_trusted_proxy_duplicate_forwarding_falls_back_to_socket_ip() {
+        let wall = Arc::new(AtomicU64::new(25_000));
+        let trusted_proxy = "10.0.0.10".parse::<IpAddr>().unwrap();
+        let state = rate_limited_state_with_trusted_proxies(1, 60_000, wall, &[trusted_proxy]);
+        let app = apply_gateway_layers(
+            Router::new().route("/probe", get(probe)),
+            state,
+            GLOBAL_CONCURRENCY_LIMIT,
+        );
+
+        let first = app
+            .clone()
+            .oneshot(request_from_duplicate_forwarded_headers(
+                "/probe",
+                "10.0.0.10:1000".parse().unwrap(),
+                "198.51.100.201",
+                "203.0.113.77",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+
+        let second = app
+            .oneshot(request_from_duplicate_forwarded_headers(
+                "/probe",
+                "10.0.0.10:2000".parse().unwrap(),
+                "198.51.100.202",
+                "203.0.113.77",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Remediates Codex Security 2026-05-19 finding: `Trusted proxy rate limit can use spoofed XFF identity`.
- Rejects duplicate `X-Forwarded-For` header fields for trusted-proxy rate-limit identity derivation by falling back to the proxy socket IP.
- Parses the complete single-header comma-separated forwarding chain fail-closed instead of silently dropping malformed entries.
- Adds a regression proving rotated duplicate XFF values cannot bypass the per-client gateway rate limit.
- Refreshes README repo-truth counts required by the CI guard after the Rust LOC and listed-test count changed.

## Path Classification
- `crates/exo-gateway/src/server.rs` — Core runtime adapter: public gateway rate-limit ingress boundary.
- `README.md` — EXOCHAIN core documentation: repo-truth public claim maintained by CI.

## TDD Evidence
- RED: `cargo test -p exo-gateway gateway_rate_limit_trusted_proxy_duplicate_forwarding_falls_back_to_socket_ip -- --nocapture` failed on current `main` with second response `200` instead of expected `429`.
- GREEN: same focused test passes after the parser change.

## Validation
- `cargo test -p exo-gateway gateway_rate_limit_ -- --nocapture`
- `cargo test -p exo-gateway -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `bash tools/test_repo_truth.sh`
- `git diff --check`

## Notes
- Existing untracked `docs/heartfield/HEARTFIELD_AI_WHITEPAPER.md` was left untouched.