### PR TITLE
fix(node): disable unaudited CrossChecked receipt anchoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 197544 | `wc -l` |
+| Rust LOC | 197614 | `wc -l` |
 | Workspace tests | 4,446 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,443 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,446 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 197484 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 197614 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,445 listed workspace tests
+         cryptographic proofs, 4,446 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          160 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-node/Cargo.toml
+++ b/crates/exo-node/Cargo.toml
@@ -148,6 +148,18 @@ default = []
 # governance lifecycle.
 unaudited-admin-governance-shortcut = []
 
+# CrossChecked receipt anchoring was introduced as a convenience adapter for
+# customer-zero integration work. The route mints a node-signed TrustReceipt
+# from external CrossChecked metadata, but this crate does not yet have a
+# trusted CrossChecked authority resolver, proof fetcher, or tenant/workspace
+# authorization contract. The production default is therefore fail-closed.
+#
+# Do NOT enable this in production. Enabling it means: "I accept that
+# POST /api/v1/receipts can anchor CrossChecked metadata under the legacy,
+# unaudited adapter contract and does not prove the external receipt or
+# authority chain."
+unaudited-crosschecked-receipt-anchor = []
+
 # GAP (Onyx pass 3, RED #2 and follow-on trust-surface scans): several
 # MCP tools return truthy-shaped responses without persisting to any
 # store, invoking the reactor, appending to the DAG, delivering a

--- a/crates/exo-node/src/api.rs
+++ b/crates/exo-node/src/api.rs
@@ -47,7 +47,9 @@ use axum::{
 use chrono::{DateTime, Utc};
 #[cfg(feature = "unaudited-admin-governance-shortcut")]
 use exo_core::types::PublicKey;
-use exo_core::types::{Did, Hash256, ReceiptOutcome, Signature, Timestamp, TrustReceipt};
+use exo_core::types::{Did, Hash256, Signature, TrustReceipt};
+#[cfg(feature = "unaudited-crosschecked-receipt-anchor")]
+use exo_core::types::{ReceiptOutcome, Timestamp};
 use serde::{Deserialize, Serialize};
 use tower::limit::ConcurrencyLimitLayer;
 
@@ -305,6 +307,7 @@ async fn load_receipts_by_actor(
     })?
 }
 
+#[cfg(feature = "unaudited-crosschecked-receipt-anchor")]
 async fn save_crosschecked_receipt(
     store: Arc<Mutex<SqliteDagStore>>,
     receipt: TrustReceipt,
@@ -633,81 +636,104 @@ async fn handle_crosschecked_receipt_anchor(
     State(api): State<Arc<NodeApiState>>,
     Json(req): Json<CrossCheckedReceiptAnchorRequest>,
 ) -> Result<Json<CrossCheckedReceiptAnchorResponse>, (StatusCode, String)> {
-    if req.source != "crosschecked" {
+    #[cfg(not(feature = "unaudited-crosschecked-receipt-anchor"))]
+    {
+        let _ = (api, req);
+        tracing::warn!(
+            "refusing POST /api/v1/receipts: CrossChecked receipt anchoring is \
+             disabled by default because this node cannot verify external proof \
+             URLs, CrossChecked signatures, tenant authorization, or authority chains"
+        );
         return Err((
-            StatusCode::BAD_REQUEST,
-            "source must be crosschecked".to_string(),
+            StatusCode::FORBIDDEN,
+            serde_json::json!({
+                "error": "crosschecked_receipt_anchor_disabled",
+                "message": "Node-signed CrossChecked receipt anchoring is disabled by default. A trusted runtime adapter must verify the external receipt proof, tenant/workspace authorization, and authority chain before EXOCHAIN mints a trust receipt.",
+                "feature_flag": "unaudited-crosschecked-receipt-anchor",
+                "refusal_source": "exo-node/api.rs::handle_crosschecked_receipt_anchor",
+            })
+            .to_string(),
         ));
     }
-    for (field, value) in [
-        ("idempotency_key", req.idempotency_key.as_str()),
-        ("external_event_id", req.external_event_id.as_str()),
-        ("tenant_id", req.tenant_id.as_str()),
-        ("workspace_id", req.workspace_id.as_str()),
-        ("event_type", req.event_type.as_str()),
-        ("public_proof_url", req.public_proof_url.as_str()),
-    ] {
-        if value.trim().is_empty() {
-            return Err((StatusCode::BAD_REQUEST, format!("{field} is required")));
+
+    #[cfg(feature = "unaudited-crosschecked-receipt-anchor")]
+    {
+        if req.source != "crosschecked" {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "source must be crosschecked".to_string(),
+            ));
         }
-    }
-    let action_hash = parse_hash256_hex(&req.external_receipt_hash, "external_receipt_hash")?;
-    let _payload_hash = parse_hash256_hex(&req.payload_hash, "payload_hash")?;
-    let authority_chain_hash = Hash256::digest(
-        format!(
-            "source={};idempotency_key={};external_event_id={};external_receipt_hash={};payload_hash={};tenant_id={};workspace_id={};event_type={};emitted_at={};public_proof_url={}",
-            req.source,
-            req.idempotency_key,
-            req.external_event_id,
-            req.external_receipt_hash,
-            req.payload_hash,
-            req.tenant_id,
-            req.workspace_id,
-            req.event_type,
-            req.emitted_at.to_rfc3339(),
-            req.public_proof_url
+        for (field, value) in [
+            ("idempotency_key", req.idempotency_key.as_str()),
+            ("external_event_id", req.external_event_id.as_str()),
+            ("tenant_id", req.tenant_id.as_str()),
+            ("workspace_id", req.workspace_id.as_str()),
+            ("event_type", req.event_type.as_str()),
+            ("public_proof_url", req.public_proof_url.as_str()),
+        ] {
+            if value.trim().is_empty() {
+                return Err((StatusCode::BAD_REQUEST, format!("{field} is required")));
+            }
+        }
+        let action_hash = parse_hash256_hex(&req.external_receipt_hash, "external_receipt_hash")?;
+        let _payload_hash = parse_hash256_hex(&req.payload_hash, "payload_hash")?;
+        let authority_chain_hash = Hash256::digest(
+            format!(
+                "source={};idempotency_key={};external_event_id={};external_receipt_hash={};payload_hash={};tenant_id={};workspace_id={};event_type={};emitted_at={};public_proof_url={}",
+                req.source,
+                req.idempotency_key,
+                req.external_event_id,
+                req.external_receipt_hash,
+                req.payload_hash,
+                req.tenant_id,
+                req.workspace_id,
+                req.event_type,
+                req.emitted_at.to_rfc3339(),
+                req.public_proof_url
+            )
+            .as_bytes(),
+        );
+        let physical_ms = req.emitted_at.timestamp_millis();
+        let physical_ms = u64::try_from(physical_ms).map_err(|_| {
+            (
+                StatusCode::BAD_REQUEST,
+                "emitted_at must be at or after the Unix epoch".to_string(),
+            )
+        })?;
+        let receipt = TrustReceipt::new(
+            api.node_did.clone(),
+            authority_chain_hash,
+            None,
+            "crosschecked.receipt.anchor.v1".to_string(),
+            action_hash,
+            ReceiptOutcome::Executed,
+            Timestamp {
+                physical_ms,
+                logical: 0,
+            },
+            &*api.sign_fn,
         )
-        .as_bytes(),
-    );
-    let physical_ms = req.emitted_at.timestamp_millis();
-    let physical_ms = u64::try_from(physical_ms).map_err(|_| {
-        (
-            StatusCode::BAD_REQUEST,
-            "emitted_at must be at or after the Unix epoch".to_string(),
-        )
-    })?;
-    let receipt = TrustReceipt::new(
-        api.node_did.clone(),
-        authority_chain_hash,
-        None,
-        "crosschecked.receipt.anchor.v1".to_string(),
-        action_hash,
-        ReceiptOutcome::Executed,
-        Timestamp {
-            physical_ms,
-            logical: 0,
-        },
-        &*api.sign_fn,
-    )
-    .map_err(|e| {
-        tracing::error!(err = %e, "CrossChecked trust receipt creation failed");
-        internal_error_response("CrossChecked receipt anchor failed")
-    })?;
-    let receipt_hash = receipt.receipt_hash;
-    save_crosschecked_receipt(Arc::clone(&api.store), receipt).await?;
-    let loaded = load_receipt_by_hash(Arc::clone(&api.store), receipt_hash).await?;
-    if loaded.is_none() {
-        return Err(internal_error_response(
-            "CrossChecked receipt anchor read-after-write failed",
-        ));
+        .map_err(|e| {
+            tracing::error!(err = %e, "CrossChecked trust receipt creation failed");
+            internal_error_response("CrossChecked receipt anchor failed")
+        })?;
+        let receipt_hash = receipt.receipt_hash;
+        save_crosschecked_receipt(Arc::clone(&api.store), receipt).await?;
+        let loaded = load_receipt_by_hash(Arc::clone(&api.store), receipt_hash).await?;
+        if loaded.is_none() {
+            return Err(internal_error_response(
+                "CrossChecked receipt anchor read-after-write failed",
+            ));
+        }
+        let hash_hex = hex::encode(receipt_hash.0);
+        Ok(Json(CrossCheckedReceiptAnchorResponse {
+            status: "anchored".to_string(),
+            exochain_receipt_hash: hash_hex.clone(),
+            anchor_hash: hash_hex,
+            verified_at: req.emitted_at,
+        }))
     }
-    let hash_hex = hex::encode(receipt_hash.0);
-    Ok(Json(CrossCheckedReceiptAnchorResponse {
-        status: "anchored".to_string(),
-        exochain_receipt_hash: hash_hex.clone(),
-        anchor_hash: hash_hex,
-        verified_at: req.emitted_at,
-    }))
 }
 
 /// `GET /api/v1/receipts/:hash` — look up a trust receipt by content hash.
@@ -863,6 +889,21 @@ mod tests {
 
     fn test_api_state() -> Arc<NodeApiState> {
         test_api_state_with_validator_flag(true)
+    }
+
+    fn crosschecked_receipt_anchor_body() -> serde_json::Value {
+        serde_json::json!({
+            "source": "crosschecked",
+            "idempotency_key": "crosschecked:test-event",
+            "external_event_id": "00000000-0000-0000-0000-000000000001",
+            "external_receipt_hash": "11".repeat(32),
+            "payload_hash": "22".repeat(32),
+            "tenant_id": "00000000-0000-0000-0000-000000000101",
+            "workspace_id": "00000000-0000-0000-0000-000000000102",
+            "event_type": "synthetic.receipt.check",
+            "emitted_at": "2026-05-12T12:00:00Z",
+            "public_proof_url": "https://crosschecked.ai/verify?receipt=00000000-0000-0000-0000-000000000001"
+        })
     }
 
     #[cfg(feature = "unaudited-admin-governance-shortcut")]
@@ -1347,24 +1388,52 @@ mod tests {
         assert_eq!(result["outcome"], "executed");
     }
 
+    #[cfg(not(feature = "unaudited-crosschecked-receipt-anchor"))]
     #[tokio::test]
-    async fn crosschecked_receipt_anchor_writes_readable_trust_receipt() {
+    async fn crosschecked_receipt_anchor_refuses_untrusted_external_metadata_by_default() {
         let state = test_api_state();
         let app = governance_router(Arc::clone(&state));
-        let external_hash = "11".repeat(32);
-        let payload_hash = "22".repeat(32);
-        let body = serde_json::json!({
-            "source": "crosschecked",
-            "idempotency_key": "crosschecked:test-event",
-            "external_event_id": "00000000-0000-0000-0000-000000000001",
-            "external_receipt_hash": external_hash,
-            "payload_hash": payload_hash,
-            "tenant_id": "00000000-0000-0000-0000-000000000101",
-            "workspace_id": "00000000-0000-0000-0000-000000000102",
-            "event_type": "synthetic.receipt.check",
-            "emitted_at": "2026-05-12T12:00:00Z",
-            "public_proof_url": "https://crosschecked.ai/verify?receipt=00000000-0000-0000-0000-000000000001"
-        });
+        let body = crosschecked_receipt_anchor_body();
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/receipts")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["error"], "crosschecked_receipt_anchor_disabled");
+        assert_eq!(
+            result["feature_flag"],
+            "unaudited-crosschecked-receipt-anchor"
+        );
+        let receipts = state
+            .store
+            .lock()
+            .unwrap()
+            .load_receipts_by_actor("did:exo:v0", 10)
+            .unwrap();
+        assert!(
+            receipts.is_empty(),
+            "refused CrossChecked anchor must not persist a node-signed trust receipt"
+        );
+    }
+
+    #[cfg(feature = "unaudited-crosschecked-receipt-anchor")]
+    #[tokio::test]
+    async fn crosschecked_receipt_anchor_writes_receipt_with_unaudited_feature_enabled() {
+        let state = test_api_state();
+        let app = governance_router(Arc::clone(&state));
+        let body = crosschecked_receipt_anchor_body();
+        let external_hash = body["external_receipt_hash"].as_str().unwrap().to_owned();
 
         let resp = app
             .oneshot(

--- a/crates/exo-node/src/store.rs
+++ b/crates/exo-node/src/store.rs
@@ -560,6 +560,7 @@ impl SqliteDagStore {
     }
 
     /// Save a trust receipt to the database.
+    #[cfg(any(test, feature = "unaudited-crosschecked-receipt-anchor"))]
     pub fn save_receipt(&mut self, receipt: &TrustReceipt) -> DagResult<()> {
         validate_signature(&receipt.signature, "trust_receipts.signature")?;
         let timestamp_ms =


### PR DESCRIPTION
## Summary

Remediates Codex Security 2026-05-19 MEDIUM finding: CrossChecked anchors sign unverified ambiguous receipts.

The current node route accepted external CrossChecked metadata at `POST /api/v1/receipts` and minted a node-signed `TrustReceipt` without a trusted CrossChecked authority resolver, external proof verifier, tenant/workspace authorization check, or verified authority-chain binding. Production now fails closed by default with `403 crosschecked_receipt_anchor_disabled` and persists no receipt.

The legacy customer-zero adapter behavior remains available only behind explicit feature flag `unaudited-crosschecked-receipt-anchor`, with a Cargo feature warning that it must not be enabled in production.

## Path Classification

- `crates/exo-node/src/api.rs` — core runtime adapter: node API trust-receipt minting boundary.
- `crates/exo-node/src/store.rs` — core runtime adapter persistence helper gated to tests or explicit unaudited adapter feature.
- `crates/exo-node/Cargo.toml` — core runtime adapter build feature controlling the unaudited integration path.
- `README.md` — repo-truth documentation counts regenerated after Rust LOC changed.

## TDD Evidence

RED, before implementation:

- `cargo test -p exo-node crosschecked_receipt_anchor_refuses_untrusted_external_metadata_by_default -- --nocapture`
- Failed with the route returning `200` instead of expected `403`, proving the test reproduced the vulnerable behavior.

GREEN, after implementation:

- Default path rejects untrusted external CrossChecked metadata and verifies no trust receipt is persisted.
- Feature path preserves legacy behavior only when `unaudited-crosschecked-receipt-anchor` is explicitly enabled.

## Validation

- `cargo test -p exo-node api::tests::crosschecked_receipt_anchor -- --nocapture` — 1 passed.
- `cargo test -p exo-node --features unaudited-crosschecked-receipt-anchor crosschecked_receipt_anchor_writes_receipt_with_unaudited_feature_enabled -- --nocapture` — 1 passed.
- `cargo test -p exo-node -- --nocapture` — 1101 passed.
- `cargo clippy -p exo-node --all-targets -- -D warnings` — passed.
- `cargo clippy -p exo-node --features unaudited-crosschecked-receipt-anchor --all-targets -- -D warnings` — passed.
- `cargo fmt --all -- --check` — passed with existing stable-rustfmt warnings about ignored nightly-only options.
- `bash tools/test_repo_truth.sh` — passed.
- `git diff --check` — passed.

## Notes

- `docs/heartfield/HEARTFIELD_AI_WHITEPAPER.md` is untracked local user work and was left untouched.
