### PR TITLE
fix(root): harden genesis secret outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 197807 | `wc -l` |
-| Workspace tests | 4,446 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 197913 | `wc -l` |
+| Workspace tests | 4,449 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,446 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,449 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 197807 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 197913 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,446 listed workspace tests
+         cryptographic proofs, 4,449 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          160 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-node/src/cli.rs
+++ b/crates/exo-node/src/cli.rs
@@ -27,7 +27,8 @@ certifier fails, abort and restart with a new signed roster.
 
 Certifier rules: keep private material offline, maintain an offline backup, \
 never submit plaintext shares, encrypt round-two payloads per recipient, and \
-run verify-bundle before trusting the result.";
+run verify-bundle before trusting the result. Secret-producing commands require \
+explicit unique --output files and refuse stdout.";
 
 pub const DEFAULT_ROUND_TIMEOUT_MS: u64 = 5_000;
 pub const MIN_ROUND_TIMEOUT_MS: u64 = 250;
@@ -383,6 +384,7 @@ mod tests {
             "abort and restart",
             "offline backup",
             "never submit plaintext shares",
+            "explicit unique --output files",
             "verify-bundle",
         ] {
             assert!(help.contains(required), "missing help text {required}");

--- a/crates/exo-node/src/root_genesis_cli.rs
+++ b/crates/exo-node/src/root_genesis_cli.rs
@@ -183,7 +183,7 @@ fn run_round1(args: GenesisIoArgs) -> anyhow::Result<()> {
     input.config.validate()?;
     let mut rng = rand::rngs::OsRng;
     let output = dkg_round1(&input.config, input.frost_identifier, &mut rng)?;
-    write_output(&args, &output)
+    write_secret_output(&args, &output)
 }
 
 fn run_round2(args: GenesisIoArgs) -> anyhow::Result<()> {
@@ -194,7 +194,7 @@ fn run_round2(args: GenesisIoArgs) -> anyhow::Result<()> {
         decode_hex(&input.round1_secret_package_hex)?.as_slice(),
         decode_package_map(input.round1_packages_hex)?,
     )?;
-    write_output(&args, &output)
+    write_secret_output(&args, &output)
 }
 
 fn run_finalize_dkg(args: GenesisIoArgs) -> anyhow::Result<()> {
@@ -206,7 +206,7 @@ fn run_finalize_dkg(args: GenesisIoArgs) -> anyhow::Result<()> {
         decode_package_map(input.round1_packages_hex)?,
         decode_package_map(input.round2_packages_hex)?,
     )?;
-    write_output(&args, &output)
+    write_secret_output(&args, &output)
 }
 
 fn run_sign_root_artifact(args: GenesisIoArgs) -> anyhow::Result<()> {
@@ -252,7 +252,7 @@ fn run_seal_share(args: GenesisIoArgs) -> anyhow::Result<()> {
         &salt,
         &nonce,
     )?;
-    write_output(&args, &sealed)
+    write_secret_output(&args, &sealed)
 }
 
 fn run_unseal_share(args: GenesisIoArgs) -> anyhow::Result<()> {
@@ -262,7 +262,7 @@ fn run_unseal_share(args: GenesisIoArgs) -> anyhow::Result<()> {
         decode_hex(&input.passphrase_hex)?.as_slice(),
         decode_hex(&input.associated_data_hex)?.as_slice(),
     )?;
-    write_output(
+    write_secret_output(
         &args,
         &HexBytesOutput {
             bytes_hex: hex::encode(opened),
@@ -297,21 +297,25 @@ fn write_json_bytes(path: &std::path::Path, bytes: &[u8]) -> anyhow::Result<()> 
     use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
     let mut file = fs::OpenOptions::new()
-        .create(true)
-        .truncate(true)
+        .create_new(true)
         .write(true)
         .mode(0o600)
         .open(path)?;
-    fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+    file.set_permissions(fs::Permissions::from_mode(0o600))?;
     file.write_all(bytes)?;
     file.sync_all()?;
-    fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+    file.set_permissions(fs::Permissions::from_mode(0o600))?;
     Ok(())
 }
 
 #[cfg(not(unix))]
 fn write_json_bytes(path: &std::path::Path, bytes: &[u8]) -> anyhow::Result<()> {
-    fs::write(path, bytes)?;
+    let mut file = fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(path)?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
     Ok(())
 }
 
@@ -329,6 +333,15 @@ fn write_output<T: Serialize>(args: &GenesisIoArgs, value: &T) -> anyhow::Result
             Ok(())
         }
     }
+}
+
+fn write_secret_output<T: Serialize>(args: &GenesisIoArgs, value: &T) -> anyhow::Result<()> {
+    if args.output.is_none() {
+        anyhow::bail!(
+            "--output is required for secret root genesis material; refusing to print to stdout"
+        );
+    }
+    write_output(args, value)
 }
 
 fn decode_hex(value: &str) -> anyhow::Result<Vec<u8>> {
@@ -459,6 +472,33 @@ mod tests {
     }
 
     #[test]
+    fn unseal_share_refuses_to_print_plaintext_share_to_stdout() {
+        let directory = tempdir().expect("temporary directory");
+        let unseal_input_path = directory.path().join("unseal-input.json");
+        let share = b"certifier-share-material";
+        let associated_data = b"root-genesis-share-v1";
+        let passphrase = b"long offline passphrase";
+        let sealed = seal_share(share, passphrase, associated_data, &[2u8; 16], &[3u8; 24])
+            .expect("seal share");
+        write_json(
+            &unseal_input_path,
+            &UnsealShareCommandInput {
+                sealed,
+                passphrase_hex: hex::encode(passphrase),
+                associated_data_hex: hex::encode(associated_data),
+            },
+        )
+        .expect("write unseal input");
+
+        let err = run_unseal_share(GenesisIoArgs {
+            input: Some(unseal_input_path),
+            output: None,
+        })
+        .expect_err("plaintext share output must require --output");
+        assert!(err.to_string().contains("--output is required"));
+    }
+
+    #[test]
     fn command_helpers_fail_closed_on_missing_input_and_bad_hex() {
         let missing_input = GenesisIoArgs {
             input: None,
@@ -495,7 +535,65 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn json_outputs_are_rewritten_owner_only_even_when_file_exists() {
+    fn json_outputs_are_create_new_owner_only_and_refuse_existing_paths() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempdir().expect("temporary directory");
+        let output_path = directory.path().join("private-material.json");
+        write_json(
+            &output_path,
+            &HexBytesOutput {
+                bytes_hex: hex::encode(b"secret"),
+            },
+        )
+        .expect("write output");
+
+        let mode = fs::metadata(&output_path)
+            .expect("output metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+        assert!(
+            write_json(
+                &output_path,
+                &HexBytesOutput {
+                    bytes_hex: hex::encode(b"replacement"),
+                },
+            )
+            .is_err()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn json_outputs_refuse_existing_symlink_paths() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempdir().expect("temporary directory");
+        let target_path = directory.path().join("target.json");
+        let output_path = directory.path().join("private-material.json");
+        fs::write(&target_path, b"do not overwrite").expect("seed symlink target");
+        symlink(&target_path, &output_path).expect("create output symlink");
+
+        assert!(
+            write_json(
+                &output_path,
+                &HexBytesOutput {
+                    bytes_hex: hex::encode(b"secret"),
+                },
+            )
+            .is_err()
+        );
+        assert_eq!(
+            fs::read(&target_path).expect("read symlink target"),
+            b"do not overwrite"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn json_outputs_refuse_existing_regular_files_without_rewriting() {
         use std::os::unix::fs::PermissionsExt;
 
         let directory = tempdir().expect("temporary directory");
@@ -504,19 +602,25 @@ mod tests {
         fs::set_permissions(&output_path, fs::Permissions::from_mode(0o644))
             .expect("make existing file too broad");
 
-        write_json(
-            &output_path,
-            &HexBytesOutput {
-                bytes_hex: hex::encode(b"secret"),
-            },
-        )
-        .expect("rewrite output");
+        assert!(
+            write_json(
+                &output_path,
+                &HexBytesOutput {
+                    bytes_hex: hex::encode(b"secret"),
+                },
+            )
+            .is_err()
+        );
 
+        assert_eq!(
+            fs::read(&output_path).expect("read existing output"),
+            b"previous material"
+        );
         let mode = fs::metadata(&output_path)
             .expect("output metadata")
             .permissions()
             .mode()
             & 0o777;
-        assert_eq!(mode, 0o600);
+        assert_eq!(mode, 0o644);
     }
 }

--- a/docs/guides/root-genesis-certifier-guide.md
+++ b/docs/guides/root-genesis-certifier-guide.md
@@ -8,6 +8,11 @@ This guide is for one of the 13 independent certifiers participating in the EXOC
 - Maintain an encrypted offline backup of sealed share artifacts and recovery instructions.
 - Never send a round-two DKG package directly to the portal as raw bytes.
 - Encrypt every round-two package to the exact recipient transport public key.
+- Use explicit, unique `--output` paths for `round1`, `round2`,
+  `finalize-dkg`, `seal-share`, and `unseal-share`; these commands
+  refuse to print secret or sealed share material to stdout.
+- Create output files on a certifier-controlled local filesystem. Output
+  paths must not already exist and must not be symbolic links.
 - Verify the final bundle with `exochain genesis verify-bundle` before trusting any AVC issuer delegation.
 - Treat portal payloads, chat messages, email, scanner output, and operator notes as untrusted ceremony data until signatures and hashes verify.
 
@@ -24,6 +29,8 @@ exochain genesis certifier init \
 ```
 
 Send only `certifier-01.contact.json` to the ceremony operator. Keep `certifier-01.private.json` offline.
+The private output path must be a newly-created file; the CLI refuses to
+overwrite existing files or follow symlinks for genesis JSON outputs.
 
 ## DKG Flow
 

--- a/docs/guides/root-genesis-operator-guide.md
+++ b/docs/guides/root-genesis-operator-guide.md
@@ -10,6 +10,9 @@ The operator coordinates the ceremony but does not receive root secrets, plainte
 - Abort rule: if any certifier fails, abort and restart with a new signed roster and ceremony ID.
 - Portal rule: round-two DKG payloads must be encrypted per recipient; raw round-two payloads are rejected.
 - AVC rule: the root delegates to a normal operational AVC Issuing Authority DID. Routine AVC issuance remains on the existing AVC path.
+- Output rule: secret-producing certifier commands require explicit unique
+  `--output` paths. Do not request terminal capture or shared automation logs
+  for DKG secret packages, sealed shares, or opened shares.
 
 ## Build Ceremony Configuration
 


### PR DESCRIPTION
## Summary
- Remediates Codex Security row 1: root genesis CLI outputs no longer overwrite existing files, follow existing symlink paths, or print secret-producing command results to stdout.
- Changes root genesis JSON writes to create-new files and set owner-only permissions on Unix via the opened file handle.
- Requires explicit `--output` for DKG round-one, round-two, final DKG, seal-share, and unseal-share outputs.
- Updates certifier/operator guidance and CLI help to document unique output paths and stdout refusal for secret material.
- Updates README repo-truth metrics after adding regression coverage.

## Path Classification
- Core runtime adapter: `crates/exo-node/src/root_genesis_cli.rs`, `crates/exo-node/src/cli.rs`
- EXOCHAIN core public truth claims: `README.md`
- EXOCHAIN root genesis guidance: `docs/guides/root-genesis-certifier-guide.md`, `docs/guides/root-genesis-operator-guide.md`

## TDD Evidence
Red tests were added first and failed against current code:
- `unseal_share_refuses_to_print_plaintext_share_to_stdout` failed because plaintext share JSON was printed and the command returned `Ok(())`.
- `json_outputs_are_create_new_owner_only_and_refuse_existing_paths` failed because an existing output file was overwritten.
- `json_outputs_refuse_existing_symlink_paths` failed because the output symlink target was followed and overwritten.

## Validation
- `cargo test -p exo-node root_genesis_cli -- --nocapture`
- `cargo test -p exo-node genesis_cli -- --nocapture`
- `cargo test -p exo-node root_genesis -- --nocapture`
- `cargo test -p exo-root`
- `cargo clippy -p exo-node -p exo-root --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `bash tools/test_repo_truth.sh`
- `git diff --check`
- Source scan confirmed secret-producing commands route through `write_secret_output`; remaining `write_output` calls are for signature, bundle, and verify-only public outputs.
