### PR TITLE
fix(gateway): require sessions for metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 198113 | `wc -l` |
-| Workspace tests | 4,450 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 198166 | `wc -l` |
+| Workspace tests | 4,451 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,450 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,451 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,7 +113,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 198113 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 198166 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,450 listed workspace tests
 

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -2227,7 +2227,11 @@ fn render_gateway_metrics(state: &AppState) -> std::result::Result<String, &'sta
     ))
 }
 
-async fn handle_metrics(State(state): State<AppState>) -> Response {
+async fn handle_metrics(State(state): State<AppState>, headers: HeaderMap) -> Response {
+    if let Err(err) = require_authenticated_session_actor_from_header(&state, &headers).await {
+        return auth_boundary_error_response(err);
+    }
+
     match render_gateway_metrics(&state) {
         Ok(body) => ([(header::CONTENT_TYPE, PROMETHEUS_TEXT_CONTENT_TYPE)], body).into_response(),
         Err(message) => {
@@ -5718,12 +5722,55 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn gateway_metrics_endpoint_returns_prometheus_text_without_secrets() {
+    async fn gateway_metrics_endpoint_requires_authenticated_session() {
         let app = build_router(state());
         let resp = app
             .oneshot(
                 Request::builder()
                     .uri("/gateway/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn gateway_metrics_endpoint_returns_prometheus_text_without_secrets_for_session() {
+        let pool = match gateway_test_pool().await {
+            Some(pool) => pool,
+            None => return,
+        };
+        let token = "gateway-metrics-session-token";
+        let actor = "did:exo:gateway-metrics-operator";
+        sqlx::query("DELETE FROM sessions WHERE token = $1")
+            .bind(token)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO sessions (token, actor_did, created_at, expires_at, revoked) \
+             VALUES ($1, $2, $3, $4, false)",
+        )
+        .bind(token)
+        .bind(actor)
+        .bind(10_000_i64)
+        .bind(TEST_ACTIVE_SESSION_EXPIRES_AT_MS)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let app = build_router(AppState::new(
+            Some(pool.clone()),
+            Arc::new(RwLock::new(LocalDidRegistry::new())),
+        ));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/gateway/metrics")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -5748,7 +5795,7 @@ mod tests {
 
         assert!(body.contains("# HELP exo_gateway_up"));
         assert!(body.contains("exo_gateway_up 1"));
-        assert!(body.contains("exo_gateway_db_configured 0"));
+        assert!(body.contains("exo_gateway_db_configured 1"));
         assert!(body.contains("exo_gateway_uptime_seconds"));
         for forbidden in ["DATABASE_URL", "POSTGRES", "password", "secret", "token"] {
             assert!(
@@ -5758,6 +5805,12 @@ mod tests {
                 "gateway metrics must not expose secret-bearing labels or values: {forbidden}"
             );
         }
+
+        sqlx::query("DELETE FROM sessions WHERE token = $1")
+            .bind(token)
+            .execute(&pool)
+            .await
+            .unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Requires a DB-backed bearer session before `/gateway/metrics` renders Prometheus operational counts.
- Keeps `/health` and `/ready` unauthenticated probes unchanged.
- Updates README repo-truth counters after adding the regression coverage.

## Codex Security Finding
- Row 24: `Unauthenticated metrics leaks gateway operational counts`
- Classification: core runtime adapter (`crates/exo-gateway/src/server.rs`); EXOCHAIN public truth claim counters (`README.md`).

## Verification
- RED: `DATABASE_URL=postgres://bobstewart@localhost:55432/exochain_test cargo test -p exo-gateway gateway_metrics_endpoint_requires_authenticated_session -- --nocapture` failed with unauthenticated `200` before the fix.
- `cargo test -p exo-gateway gateway_metrics_endpoint_requires_authenticated_session -- --nocapture`
- `DATABASE_URL=postgres://bobstewart@localhost:55432/exochain_test cargo test -p exo-gateway gateway_metrics_endpoint_returns_prometheus_text_without_secrets_for_session -- --nocapture`
- `cargo test -p exo-gateway metrics -- --nocapture`
- `DATABASE_URL=postgres://bobstewart@localhost:55432/exochain_test cargo test -p exo-gateway --features production-db metrics -- --nocapture --test-threads=1`
- `cargo test -p exo-gateway -- --nocapture`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `cargo clippy -p exo-gateway --features production-db --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
