### PR TITLE
fix(mcp): retain bounded audit log suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 198113 | `wc -l` |
-| Workspace tests | 4,450 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 198259 | `wc -l` |
+| Workspace tests | 4,452 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,450 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,452 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 198113 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 198259 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,450 listed workspace tests
+         cryptographic proofs, 4,452 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          160 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-gatekeeper/src/mcp_audit.rs
+++ b/crates/exo-gatekeeper/src/mcp_audit.rs
@@ -119,13 +119,15 @@ fn hash_record(r: &McpAuditRecord) -> Result<[u8; 32], GatekeeperError> {
 // MCP audit log
 // ---------------------------------------------------------------------------
 
-/// Append-only, BLAKE3 hash-chained log of MCP enforcement events.
+/// Bounded, BLAKE3 hash-chained log of MCP enforcement events.
 ///
 /// Structurally mirrors `exo_governance::audit::AuditLog` but is
 /// self-contained within exo-gatekeeper to preserve branch separation.
 #[derive(Debug, Clone, Default)]
 pub struct McpAuditLog {
     pub records: Vec<McpAuditRecord>,
+    retained_chain_start_hash: [u8; 32],
+    dropped_record_count: u64,
 }
 
 impl McpAuditLog {
@@ -143,7 +145,7 @@ impl McpAuditLog {
     pub fn head_hash(&self) -> Result<[u8; 32], GatekeeperError> {
         match self.records.last() {
             Some(record) => hash_record(record),
-            None => Ok([0u8; 32]),
+            None => Ok(self.retained_chain_start_hash),
         }
     }
 
@@ -156,6 +158,41 @@ impl McpAuditLog {
     pub fn is_empty(&self) -> bool {
         self.records.is_empty()
     }
+
+    #[must_use]
+    pub fn dropped_record_count(&self) -> u64 {
+        self.dropped_record_count
+    }
+
+    #[must_use]
+    pub fn retained_chain_start_hash(&self) -> [u8; 32] {
+        self.retained_chain_start_hash
+    }
+
+    #[must_use]
+    pub fn next_record_sequence(&self) -> Option<u128> {
+        let retained_record_count = u128::try_from(self.records.len()).ok()?;
+        u128::from(self.dropped_record_count)
+            .checked_add(retained_record_count)?
+            .checked_add(1)
+    }
+
+    fn prune_oldest_record_for_retention(&mut self) -> Result<(), GatekeeperError> {
+        if self.records.is_empty() {
+            return Err(GatekeeperError::McpAuditInvalidRecord {
+                reason: "cannot prune an empty MCP audit log".into(),
+            });
+        }
+
+        let dropped = self.records.remove(0);
+        self.retained_chain_start_hash = hash_record(&dropped)?;
+        self.dropped_record_count = self.dropped_record_count.checked_add(1).ok_or_else(|| {
+            GatekeeperError::McpAuditInvalidRecord {
+                reason: "MCP audit dropped record count overflow".into(),
+            }
+        })?;
+        Ok(())
+    }
 }
 
 /// Append a pre-built record to the log.
@@ -165,20 +202,16 @@ impl McpAuditLog {
 /// does not match the current log head — indicating either an ordering error
 /// or tampering.
 pub fn append(log: &mut McpAuditLog, record: McpAuditRecord) -> Result<(), GatekeeperError> {
-    if log.records.len() >= MAX_MCP_AUDIT_RECORDS {
-        return Err(GatekeeperError::McpAuditInvalidRecord {
-            reason: format!(
-                "MCP audit log capacity exceeded: {} >= {}",
-                log.records.len(),
-                MAX_MCP_AUDIT_RECORDS
-            ),
-        });
-    }
     if record.chain_hash != log.head_hash()? {
         return Err(GatekeeperError::McpAuditChainBroken {
             index: log.records.len(),
         });
     }
+
+    while log.records.len() >= MAX_MCP_AUDIT_RECORDS {
+        log.prune_oldest_record_for_retention()?;
+    }
+
     log.records.push(record);
     Ok(())
 }
@@ -188,7 +221,7 @@ pub fn append(log: &mut McpAuditLog, record: McpAuditRecord) -> Result<(), Gatek
 /// # Errors
 /// Returns [`GatekeeperError::McpAuditChainBroken`] at the first broken link.
 pub fn verify_chain(log: &McpAuditLog) -> Result<(), GatekeeperError> {
-    let mut prev = [0u8; 32];
+    let mut prev = log.retained_chain_start_hash;
     for (i, record) in log.records.iter().enumerate() {
         if record.chain_hash != prev {
             return Err(GatekeeperError::McpAuditChainBroken { index: i });
@@ -538,10 +571,19 @@ mod tests {
     }
 
     #[test]
-    fn append_rejects_log_at_capacity_without_growing_records() {
-        let mut log = McpAuditLog {
-            records: vec![sample_record(); MAX_MCP_AUDIT_RECORDS],
-        };
+    fn append_at_capacity_retains_bounded_suffix_and_keeps_chain_verifiable() {
+        let mut log = McpAuditLog::new();
+        for _ in 0..MAX_MCP_AUDIT_RECORDS {
+            append_ok(
+                &mut log,
+                McpRule::Mcp001BctsScope,
+                McpEnforcementOutcome::Allowed,
+            );
+        }
+        let first_original_id = log.records[0].id;
+        let first_original_hash =
+            hash_record(&log.records[0]).expect("first MCP audit record hash");
+        let expected_first_retained_id = log.records[1].id;
         let record = create_record(
             &log,
             record_id(0xF001),
@@ -552,13 +594,53 @@ mod tests {
             None,
         )
         .expect("capacity regression record has valid deterministic metadata");
+        let appended_id = record.id;
 
-        let err = append(&mut log, record).expect_err("full MCP audit log must reject append");
+        append(&mut log, record).expect("full MCP audit log must retain a bounded suffix");
 
         assert_eq!(log.len(), MAX_MCP_AUDIT_RECORDS);
-        assert!(
-            err.to_string().contains("capacity"),
-            "capacity rejection should be explicit: {err}"
+        assert_eq!(log.dropped_record_count(), 1);
+        assert_eq!(log.retained_chain_start_hash(), first_original_hash);
+        assert_ne!(log.records[0].id, first_original_id);
+        assert_eq!(log.records[0].id, expected_first_retained_id);
+        assert_eq!(
+            log.records
+                .last()
+                .expect("retained MCP audit log is non-empty")
+                .id,
+            appended_id
         );
+        verify_chain(&log).expect("retained MCP audit suffix must remain hash-chain verifiable");
+        let expected_next_sequence =
+            u128::try_from(MAX_MCP_AUDIT_RECORDS).expect("capacity fits u128") + 2;
+        assert_eq!(log.next_record_sequence(), Some(expected_next_sequence));
+    }
+
+    #[test]
+    fn retained_chain_anchor_tamper_is_detected() {
+        let mut log = McpAuditLog::new();
+        for _ in 0..MAX_MCP_AUDIT_RECORDS {
+            append_ok(
+                &mut log,
+                McpRule::Mcp001BctsScope,
+                McpEnforcementOutcome::Allowed,
+            );
+        }
+        let record = create_record(
+            &log,
+            record_id(0xF101),
+            ts(31_000),
+            McpRule::Mcp002NoSelfEscalation,
+            did("agent"),
+            McpEnforcementOutcome::Blocked,
+            None,
+        )
+        .expect("capacity regression record has valid deterministic metadata");
+        append(&mut log, record).expect("full MCP audit log must retain a bounded suffix");
+
+        let mut tampered = log.clone();
+        tampered.retained_chain_start_hash = [0x99u8; 32];
+
+        assert!(verify_chain(&tampered).is_err());
     }
 }

--- a/crates/exo-node/src/mcp/handler.rs
+++ b/crates/exo-node/src/mcp/handler.rs
@@ -75,19 +75,15 @@ fn json_rpc_internal_error(id: Option<Value>, public_message: &'static str) -> J
 }
 
 fn next_mcp_audit_record_id(log: &McpAuditLog) -> std::result::Result<Uuid, McpError> {
-    let next_index = match log.len().checked_add(1) {
+    let next_index = match log.next_record_sequence() {
         Some(next_index) => next_index,
-        None => return Err(McpError::Internal("MCP audit log length overflow".into())),
-    };
-    let id_value = match u128::try_from(next_index) {
-        Ok(id_value) => id_value,
-        Err(error) => {
-            return Err(McpError::Internal(format!(
-                "MCP audit record id conversion failed: {error}"
-            )));
+        None => {
+            return Err(McpError::Internal(
+                "MCP audit record sequence overflow".into(),
+            ));
         }
     };
-    let record_id = Uuid::from_u128(id_value);
+    let record_id = Uuid::from_u128(next_index);
     if record_id.is_nil() {
         return Err(McpError::Internal(
             "MCP audit record id derivation produced nil UUID".into(),
@@ -791,6 +787,36 @@ mod tests {
             .clone()
     }
 
+    fn fill_mcp_audit_log_to_capacity(server: &McpServer) {
+        let actor = Did::new("did:exo:test-ai-agent").expect("valid DID");
+        let mut log = server
+            .mcp_audit_log
+            .lock()
+            .expect("MCP audit log mutex should not be poisoned in tests");
+
+        for i in 0..exo_gatekeeper::mcp_audit::MAX_MCP_AUDIT_RECORDS {
+            let sequence = u128::try_from(i)
+                .expect("MCP audit test index fits u128")
+                .checked_add(1)
+                .expect("MCP audit test sequence does not overflow");
+            let timestamp_ms = u64::try_from(i)
+                .expect("MCP audit test index fits u64")
+                .checked_add(50_000)
+                .expect("MCP audit test timestamp does not overflow");
+            let record = mcp_audit::create_record(
+                &log,
+                Uuid::from_u128(sequence),
+                Timestamp::new(timestamp_ms, 0),
+                McpRule::Mcp001BctsScope,
+                actor.clone(),
+                McpEnforcementOutcome::Allowed,
+                None,
+            )
+            .expect("deterministic MCP audit record");
+            mcp_audit::append(&mut log, record).expect("append deterministic MCP audit record");
+        }
+    }
+
     fn constitutional_context(actor_did: &str, action: &str, arguments: &Value) -> Value {
         let actor = Did::new(actor_did).expect("valid DID");
         let keypair = exo_core::crypto::KeyPair::from_secret_bytes([0x4D; 32]).unwrap();
@@ -1012,6 +1038,44 @@ mod tests {
             assert_eq!(record.actor.as_str(), "did:exo:test-ai-agent");
             assert_ne!(record.timestamp, Timestamp::ZERO);
             assert_eq!(record.outcome, McpEnforcementOutcome::Allowed);
+        }
+    }
+
+    #[test]
+    fn handler_tools_call_survives_full_mcp_audit_log_with_bounded_retention() {
+        let server = test_server();
+        fill_mcp_audit_log_to_capacity(&server);
+
+        let msg = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 304,
+            "method": "tools/call",
+            "params": tool_call_params("exochain_node_status", serde_json::json!({}))
+        })
+        .to_string();
+
+        let response = server.handle_message(&msg).unwrap();
+        let parsed: JsonRpcResponse = serde_json::from_str(&response).unwrap();
+        assert!(
+            parsed.error.is_none(),
+            "full MCP audit log must not turn valid tool calls into internal errors: {:?}",
+            parsed.error
+        );
+
+        let audit = mcp_audit_snapshot(&server);
+        assert_eq!(
+            audit.len(),
+            exo_gatekeeper::mcp_audit::MAX_MCP_AUDIT_RECORDS
+        );
+        exo_gatekeeper::mcp_audit::verify_chain(&audit)
+            .expect("retained MCP audit chain must verify after capacity rollover");
+
+        let retained_tail = &audit.records[audit.len() - McpRule::all().len()..audit.len()];
+        let audited_rules: Vec<McpRule> = retained_tail.iter().map(|record| record.rule).collect();
+        assert_eq!(audited_rules, McpRule::all());
+        for record in retained_tail {
+            assert_eq!(record.outcome, McpEnforcementOutcome::Allowed);
+            assert_eq!(record.actor.as_str(), "did:exo:test-ai-agent");
         }
     }
 


### PR DESCRIPTION
## Summary
- Remediates Codex Security row 25: MCP audit log exhaustion caused valid tool calls to fail with JSON-RPC `-32603` once the in-memory audit `Vec` reached `MAX_MCP_AUDIT_RECORDS`.
- Changes `McpAuditLog` from reject-at-capacity to bounded retention: it drops the oldest retained record, stores that dropped record hash as the retained suffix anchor, and keeps `verify_chain` tamper-evident across the retained suffix.
- Updates MCP handler audit record sequencing so rollover continues monotonically instead of reusing IDs.
- Updates README repo-truth counters after adding regression coverage.

## Path Classification
- `crates/exo-gatekeeper/src/mcp_audit.rs` — EXOCHAIN core.
- `crates/exo-node/src/mcp/handler.rs` — core runtime adapter.
- `README.md` — documentation / repo-truth generated counters.

## Finding Verification
- Reproduced against current `origin/main` before production changes.
- Red test evidence:
  - `cargo test -p exo-gatekeeper append_at_capacity_retains_bounded_suffix_and_keeps_chain_verifiable -- --nocapture` failed with `MCP audit log capacity exceeded: 10000 >= 10000`.
  - `cargo test -p exo-node handler_tools_call_survives_full_mcp_audit_log_with_bounded_retention -- --nocapture` failed because a valid `exochain_node_status` call returned JSON-RPC `-32603`.

## Validation
- `cargo test -p exo-gatekeeper mcp_audit::tests:: -- --nocapture` — pass, 18 tests.
- `cargo test -p exo-node handler_tools_call_survives_full_mcp_audit_log_with_bounded_retention -- --nocapture` — pass.
- `cargo test -p exo-node mcp -- --nocapture` — pass, 374 tests.
- `cargo test -p exo-gatekeeper -- --nocapture` — pass, 286 tests.
- `cargo test -p exo-node -- --nocapture` — pass, 1102 tests.
- `cargo test -p exo-legal -- --nocapture` — pass, 215 tests.
- `cargo clippy -p exo-gatekeeper -p exo-node -p exo-legal --all-targets -- -D warnings` — pass.
- `cargo fmt --all -- --check` — pass with existing rustfmt unstable-option warnings.
- `git diff --check` — pass.
- `bash tools/test_repo_truth.sh` — pass.

## Bypass Search
- Searched MCP append and audit call sites across `exo-node`, `exo-gatekeeper`, and `exo-legal`.
- The only MCP tool-call audit append path remains `record_mcp_tool_call_outcome -> append_mcp_audit_record -> mcp_audit::append`.
- Legal transparency/reporting consumers continue to verify the retained hash chain and reject tampered anchors.
