### PR TITLE
fix(identity): bind Shamir coefficients to private entropy

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 198113 | `wc -l` |
-| Workspace tests | 4,450 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 198222 | `wc -l` |
+| Workspace tests | 4,452 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,450 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,452 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 198113 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 198222 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,450 listed workspace tests
+         cryptographic proofs, 4,452 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          160 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-identity/src/shamir.rs
+++ b/crates/exo-identity/src/shamir.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::IdentityError;
 
-/// Minimum caller-supplied entropy bytes required for threshold Shamir splitting.
+/// Minimum private dealer entropy bytes required for threshold Shamir splitting.
 pub const SHAMIR_ENTROPY_MIN_BYTES: usize = 32;
 
 #[inline]
@@ -84,6 +84,9 @@ impl ShamirConfig {
 }
 
 /// A single share produced by Shamir secret splitting, with a blake3 commitment to the original secret.
+///
+/// Shares intentionally do not contain the private dealer entropy used for
+/// coefficient derivation.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Share {
     pub index: u8,
@@ -110,14 +113,18 @@ pub fn split(secret: &[u8], config: &ShamirConfig) -> Result<Vec<Share>, Identit
         return Err(IdentityError::InvalidShamirEntropy {
             min_bytes: SHAMIR_ENTROPY_MIN_BYTES,
             got_bytes: 0,
-            reason: "threshold greater than one requires caller-supplied entropy".into(),
+            reason: "threshold greater than one requires private dealer entropy".into(),
         });
     }
 
     split_with_entropy(secret, config, &[])
 }
 
-/// Split a secret using caller-supplied entropy to derive deterministic Shamir coefficients.
+/// Split a secret using private dealer entropy to derive deterministic Shamir coefficients.
+///
+/// The entropy must remain unavailable to share holders. Coefficients are also
+/// bound to the secret so a holder who learns only the entropy, public
+/// commitment, and one share cannot recompute the polynomial below threshold.
 pub fn split_with_entropy(
     secret: &[u8],
     config: &ShamirConfig,
@@ -149,6 +156,7 @@ pub fn split_with_entropy(
         coeffs[0] = secret_byte;
         for (coeff_idx, coeff) in coeffs.iter_mut().enumerate().skip(1) {
             *coeff = derive_shamir_coefficient(
+                secret,
                 entropy,
                 &commitment,
                 config,
@@ -182,7 +190,8 @@ fn validate_shamir_entropy(config: &ShamirConfig, entropy: &[u8]) -> Result<(), 
         return Err(IdentityError::InvalidShamirEntropy {
             min_bytes: SHAMIR_ENTROPY_MIN_BYTES,
             got_bytes: entropy.len(),
-            reason: "threshold greater than one requires at least 32 entropy bytes".into(),
+            reason: "threshold greater than one requires at least 32 private dealer entropy bytes"
+                .into(),
         });
     }
 
@@ -190,7 +199,7 @@ fn validate_shamir_entropy(config: &ShamirConfig, entropy: &[u8]) -> Result<(), 
         return Err(IdentityError::InvalidShamirEntropy {
             min_bytes: SHAMIR_ENTROPY_MIN_BYTES,
             got_bytes: entropy.len(),
-            reason: "caller-supplied Shamir entropy must not be all-zero".into(),
+            reason: "private dealer Shamir entropy must not be all-zero".into(),
         });
     }
 
@@ -207,6 +216,7 @@ fn encode_usize_for_shamir(value: usize, field: &'static str) -> Result<[u8; 8],
 }
 
 fn derive_shamir_coefficient(
+    secret: &[u8],
     entropy: &[u8],
     commitment: &[u8; 32],
     config: &ShamirConfig,
@@ -220,12 +230,13 @@ fn derive_shamir_coefficient(
     let coeff_idx = encode_usize_for_shamir(coeff_idx, "coefficient_idx")?;
 
     let mut hasher = blake3::Hasher::new();
-    hasher.update(b"exo.identity.shamir.coefficient.v1");
+    hasher.update(b"exo.identity.shamir.coefficient.v2");
+    hasher.update(&secret_len);
+    hasher.update(secret);
     hasher.update(&entropy_len);
     hasher.update(entropy);
     hasher.update(commitment);
     hasher.update(&[config.threshold, config.shares]);
-    hasher.update(&secret_len);
     hasher.update(&byte_idx);
     hasher.update(&coeff_idx);
     let digest = hasher.finalize();
@@ -395,7 +406,7 @@ mod tests {
     }
 
     #[test]
-    fn split_requires_caller_supplied_entropy_for_threshold_above_one() {
+    fn split_requires_private_dealer_entropy_for_threshold_above_one() {
         let config = ShamirConfig {
             threshold: 2,
             shares: 3,
@@ -403,7 +414,7 @@ mod tests {
 
         assert!(
             split(b"entropy must be explicit", &config).is_err(),
-            "threshold > 1 Shamir splitting must fail closed unless entropy is caller supplied"
+            "threshold > 1 Shamir splitting must fail closed unless private dealer entropy is supplied"
         );
     }
 
@@ -435,6 +446,83 @@ mod tests {
         assert_ne!(
             first.iter().map(|share| &share.data).collect::<Vec<_>>(),
             second.iter().map(|share| &share.data).collect::<Vec<_>>()
+        );
+    }
+
+    fn derive_public_entropy_coefficient_for_regression(
+        entropy: &[u8],
+        commitment: &[u8; 32],
+        config: &ShamirConfig,
+        secret_len: usize,
+        byte_idx: usize,
+        coeff_idx: usize,
+    ) -> Result<u8, IdentityError> {
+        let entropy_len = encode_usize_for_shamir(entropy.len(), "entropy_len")?;
+        let secret_len = encode_usize_for_shamir(secret_len, "secret_len")?;
+        let byte_idx = encode_usize_for_shamir(byte_idx, "byte_idx")?;
+        let coeff_idx = encode_usize_for_shamir(coeff_idx, "coefficient_idx")?;
+
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"exo.identity.shamir.coefficient.v1");
+        hasher.update(&entropy_len);
+        hasher.update(entropy);
+        hasher.update(commitment);
+        hasher.update(&[config.threshold, config.shares]);
+        hasher.update(&secret_len);
+        hasher.update(&byte_idx);
+        hasher.update(&coeff_idx);
+        let digest = hasher.finalize();
+        Ok(digest.as_bytes()[0])
+    }
+
+    fn recover_single_share_with_public_entropy_regression(
+        share: &Share,
+        config: &ShamirConfig,
+        entropy: &[u8],
+    ) -> Result<Vec<u8>, IdentityError> {
+        let k: usize = config.threshold.into();
+        let mut recovered = Vec::with_capacity(share.data.len());
+
+        for (byte_idx, &share_byte) in share.data.iter().enumerate() {
+            let mut public_terms: u8 = 0;
+            let mut x_pow = share.index;
+            for coeff_idx in 1..k {
+                let coeff = derive_public_entropy_coefficient_for_regression(
+                    entropy,
+                    &share.commitment,
+                    config,
+                    share.data.len(),
+                    byte_idx,
+                    coeff_idx,
+                )?;
+                public_terms ^= gf256_mul(coeff, x_pow);
+                x_pow = gf256_mul(x_pow, share.index);
+            }
+            recovered.push(share_byte ^ public_terms);
+        }
+
+        Ok(recovered)
+    }
+
+    #[test]
+    fn known_entropy_and_single_share_cannot_recover_secret_below_threshold() {
+        let secret = b"known entropy must not collapse threshold";
+        let config = ShamirConfig {
+            threshold: 3,
+            shares: 5,
+        };
+        let shares = split_with_entropy(secret, &config, TEST_SHAMIR_ENTROPY).unwrap();
+
+        let recovered = recover_single_share_with_public_entropy_regression(
+            &shares[0],
+            &config,
+            TEST_SHAMIR_ENTROPY,
+        )
+        .expect("public-entropy regression recovery should be deterministic");
+
+        assert_ne!(
+            recovered, secret,
+            "a single share plus known dealer entropy must not recover the secret"
         );
     }
 
@@ -792,6 +880,27 @@ mod tests {
         assert!(
             !split_source.contains("fill_bytes"),
             "Shamir coefficients must not use internal RNG byte filling"
+        );
+    }
+
+    #[test]
+    fn coefficient_derivation_binds_secret_not_public_entropy_alone() {
+        let source = include_str!("shamir.rs");
+        let derivation_source = source
+            .split("fn derive_shamir_coefficient(")
+            .nth(1)
+            .expect("coefficient derivation source exists")
+            .split("fn validate_shares")
+            .next()
+            .expect("coefficient derivation source ends before share validation");
+
+        assert!(
+            derivation_source.contains("exo.identity.shamir.coefficient.v2"),
+            "Shamir coefficient derivation must use the secret-bound v2 domain"
+        );
+        assert!(
+            derivation_source.contains("hasher.update(secret)"),
+            "known dealer entropy and a public share commitment must not be enough to derive coefficients"
         );
     }
 

--- a/crates/exochain-wasm/src/identity_bindings.rs
+++ b/crates/exochain-wasm/src/identity_bindings.rs
@@ -80,7 +80,7 @@ pub fn wasm_shamir_split(secret: &[u8], threshold: u8, shares: u8) -> Result<JsV
     to_js_value(&result)
 }
 
-/// Split a secret using Shamir's Secret Sharing with caller-supplied entropy.
+/// Split a secret using Shamir's Secret Sharing with private dealer entropy.
 #[wasm_bindgen]
 pub fn wasm_shamir_split_with_entropy(
     secret: &[u8],

--- a/crates/exochain-wasm/src/lib.rs
+++ b/crates/exochain-wasm/src/lib.rs
@@ -638,7 +638,7 @@ mod source_guard_tests {
     }
 
     #[test]
-    fn wasm_shamir_split_exposes_caller_supplied_entropy_boundary() {
+    fn wasm_shamir_split_exposes_private_dealer_entropy_boundary() {
         let source = include_str!("identity_bindings.rs");
         let production = source
             .split("// ===========================================================================")
@@ -647,7 +647,7 @@ mod source_guard_tests {
 
         assert!(
             production.contains("wasm_shamir_split_with_entropy"),
-            "WASM Shamir splitting must expose a caller-supplied entropy entrypoint"
+            "WASM Shamir splitting must expose a private dealer entropy entrypoint"
         );
         assert!(
             production.contains("exo_identity::shamir::split_with_entropy"),
@@ -655,7 +655,7 @@ mod source_guard_tests {
         );
         assert!(
             production.contains("entropy"),
-            "WASM Shamir split boundary must keep entropy explicit in the public API"
+            "WASM Shamir split boundary must keep private dealer entropy explicit in the API"
         );
     }
 

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -803,13 +803,13 @@ test('wasm_terminate_bailment_signed rejects caller-supplied DID key material', 
 
 console.log('\n--- Shamir ---');
 
-const SHAMIR_ENTROPY = new TextEncoder().encode('exo-wasm-shamir-entropy-v1-explicit');
+const SHAMIR_ENTROPY = new TextEncoder().encode('exo-wasm-shamir-entropy-v2-private-dealer');
 
-test('wasm_shamir_split rejects missing caller entropy', () =>
+test('wasm_shamir_split rejects missing private dealer entropy', () =>
   expectErrorContains(
     'wasm_shamir_split',
     () => wasm.wasm_shamir_split(TEXT_BYTES, 2, 3),
-    'caller-supplied entropy'
+    'private dealer entropy'
   ));
 
 test('wasm_shamir_split_with_entropy', () =>


### PR DESCRIPTION
## Summary
- Classifies row 26 as EXOCHAIN core with a WASM runtime-adapter boundary.
- Confirms the reported Shamir entropy concern was live with a red regression proving the old public-entropy coefficient derivation let one share plus known entropy recover the secret below threshold.
- Moves coefficient derivation to a secret-bound v2 domain and clarifies the API contract as private dealer entropy that is never embedded in shares.
- Updates WASM bridge/source guards and repo-truth README counters.

## Path Classification
- EXOCHAIN core: crates/exo-identity/src/shamir.rs
- Core runtime adapter: crates/exochain-wasm/src/identity_bindings.rs, crates/exochain-wasm/src/lib.rs, packages/exochain-wasm/test/bridge_verification.mjs
- Documentation/truth metadata: README.md

## Validation
- cargo test -p exo-identity -- --nocapture
- cargo test -p exochain-wasm shamir -- --nocapture
- wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm
- node packages/exochain-wasm/test/bridge_verification.mjs
- cargo clippy -p exo-identity -p exochain-wasm --all-targets -- -D warnings
- cargo fmt --all -- --check && git diff --check
- bash tools/test_repo_truth.sh