### PR TITLE
fix(syntaxis): bind BCTS gates to workflow nodes

### DIFF
--- a/tools/syntaxis/README.md
+++ b/tools/syntaxis/README.md
@@ -210,16 +210,68 @@ console.log(`Status: ${deployment.status}`);
 ### Compiling from Council Verdict
 
 ```javascript
+const { deterministicId, hashCanonical } = require('./determinism');
+
+const createdAtHlc = { physicalMs: 1700000000000, logical: 0 };
+const nonce = deterministicId('nonce', {
+  createdAtHlc,
+  proposalId: 'proposal_001',
+  verdictId: 'verdict_001'
+});
+const publicKey = 'ed25519-security-public-key';
+const signatureHash = `0x${hashCanonical({
+  authority: 'GOVERNANCE_PROPOSER',
+  granteeId: 'SECURITY_TEAM',
+  grantorId: 'did:exo:root',
+  scope: 'security-patch',
+  signature: 'ed25519-delegation-signature'
+})}`;
+
 // Create council verdict with panel assessments
 const verdict = {
   id: 'verdict_001',
   status: 'APPROVED',
-  affectedPanels: ['Governance Panel', 'Kernel Panel'],
+  affectedPanels: ['Identity Panel', 'Governance Panel', 'Consent Panel', 'Kernel Panel'],
   panelAssessments: {
+    'Identity Panel': 'FOR',
     'Governance Panel': 'FOR',
+    'Consent Panel': 'FOR',
     'Kernel Panel': 'FOR'
   },
-  consentResponses: {},
+  identityProof: {
+    subjectId: 'SECURITY_TEAM',
+    method: 'cryptographic',
+    nonce,
+    publicKey,
+    signature: 'ed25519-identity-signature',
+    proofHash: `0x${hashCanonical({
+      identityId: 'SECURITY_TEAM',
+      method: 'cryptographic',
+      nonce,
+      publicKey
+    })}`
+  },
+  delegationChain: [{
+    grantorId: 'did:exo:root',
+    granteeId: 'SECURITY_TEAM',
+    authority: 'GOVERNANCE_PROPOSER',
+    scope: 'security-patch',
+    signatureHash,
+    chainHash: `0x${hashCanonical({
+      authority: 'GOVERNANCE_PROPOSER',
+      granteeId: 'SECURITY_TEAM',
+      grantorId: 'did:exo:root',
+      previousChainHash: null,
+      scope: 'security-patch',
+      signatureHash
+    })}`
+  }],
+  consentResponses: {
+    'Identity Panel': { consent: true },
+    'Governance Panel': { consent: true },
+    'Consent Panel': { consent: true },
+    'Kernel Panel': { consent: true }
+  },
   systemState: {},
   precedingProposals: []
 };
@@ -234,7 +286,8 @@ const proposal = {
   requiresConsent: true,
   requiredConsentBasisPoints: 8000,
   faultTolerant: true,
-  createdAtHlc
+  createdAtHlc,
+  evidence: [{ hash: 'security-patch-evidence-hash' }]
 };
 
 // Compile to workflow

--- a/tools/syntaxis/compiler.js
+++ b/tools/syntaxis/compiler.js
@@ -69,6 +69,110 @@ const STANDARD_BCTS_FLOW = [
   'CLOSED'
 ];
 
+const BCTS_REQUIRED_GATE_TRANSITIONS = [
+  {
+    currentState: 'IDENTITY_REQUIRED',
+    nextState: 'IDENTITY_VERIFIED',
+    nodeTypes: ['identity-verify']
+  },
+  {
+    currentState: 'AUTHORITY_CHECK',
+    nextState: 'AUTHORIZED',
+    nodeTypes: ['authority-check']
+  },
+  {
+    currentState: 'AUTHORIZED',
+    nextState: 'CONSENT_PHASE',
+    nodeTypes: ['consent-request']
+  },
+  {
+    currentState: 'CONSENT_PHASE',
+    nextState: 'CONSENT_VERIFIED',
+    nodeTypes: ['consent-verify']
+  },
+  {
+    currentState: 'CONSENT_VERIFIED',
+    nextState: 'GOVERNANCE_REVIEW',
+    nodeTypes: ['governance-propose']
+  },
+  {
+    currentState: 'GOVERNANCE_REVIEW',
+    nextState: 'GOVERNANCE_PASSED',
+    nodeTypes: ['governance-vote']
+  },
+  {
+    currentState: 'GOVERNANCE_PASSED',
+    nextState: 'EXECUTION_READY',
+    nodeTypes: ['governance-resolve']
+  }
+];
+
+const BCTS_NODE_TRANSITIONS = {
+  'identity-verify': [
+    { currentState: 'IDENTITY_REQUIRED', nextState: 'IDENTITY_VERIFIED' }
+  ],
+  'authority-check': [
+    { currentState: 'AUTHORITY_CHECK', nextState: 'AUTHORIZED' }
+  ],
+  'consent-request': [
+    { currentState: 'AUTHORIZED', nextState: 'CONSENT_PHASE' }
+  ],
+  'consent-verify': [
+    { currentState: 'CONSENT_PHASE', nextState: 'CONSENT_VERIFIED' }
+  ],
+  'governance-propose': [
+    { currentState: 'CONSENT_VERIFIED', nextState: 'GOVERNANCE_REVIEW' }
+  ],
+  'governance-vote': [
+    { currentState: 'GOVERNANCE_REVIEW', nextState: 'GOVERNANCE_PASSED' }
+  ],
+  'governance-resolve': [
+    { currentState: 'GOVERNANCE_PASSED', nextState: 'EXECUTION_READY' }
+  ],
+  'kernel-adjudicate': [
+    { currentState: 'EXECUTION_READY', nextState: 'EXECUTING' }
+  ],
+  'invariant-check': [
+    { currentState: 'EXECUTION_READY', nextState: 'EXECUTING' }
+  ],
+  'proof-generate': [
+    { currentState: 'EXECUTION_READY', nextState: 'EXECUTING' }
+  ],
+  'proof-verify': [
+    { currentState: 'EXECUTING', nextState: 'COMPLETED' }
+  ],
+  'dag-append': [
+    { currentState: 'COMPLETED', nextState: 'FINALIZED' }
+  ],
+  'escalation-trigger': [
+    { currentState: 'EXECUTION_READY', nextState: 'EXECUTING' }
+  ],
+  'human-override': [
+    { currentState: 'EXECUTING', nextState: 'COMPLETED' }
+  ],
+  'tenant-isolate': [
+    { currentState: 'EXECUTION_READY', nextState: 'EXECUTING' }
+  ],
+  'mcp-enforce': [
+    { currentState: 'EXECUTING', nextState: 'COMPLETED' }
+  ],
+  'combinator-sequence': [
+    { currentState: 'EXECUTION_READY', nextState: 'EXECUTING' }
+  ],
+  'combinator-parallel': [
+    { currentState: 'EXECUTION_READY', nextState: 'EXECUTING' }
+  ],
+  'combinator-choice': [
+    { currentState: 'EXECUTION_READY', nextState: 'EXECUTING' }
+  ],
+  'combinator-guard': [
+    { currentState: 'EXECUTION_READY', nextState: 'EXECUTING' }
+  ],
+  'combinator-transform': [
+    { currentState: 'EXECUTION_READY', nextState: 'EXECUTING' }
+  ]
+};
+
 function isObjectRecord(value) {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
@@ -82,37 +186,114 @@ function isNonEmptyString(value) {
  */
 const PROPOSAL_TYPE_MAPPINGS = {
   'governance-amendment': {
-    nodes: ['governance-propose', 'consent-request', 'governance-vote', 'governance-resolve', 'kernel-adjudicate'],
+    nodes: [
+      'identity-verify',
+      'authority-check',
+      'consent-request',
+      'consent-verify',
+      'governance-propose',
+      'governance-vote',
+      'governance-resolve',
+      'kernel-adjudicate'
+    ],
     requiredPanels: ['Governance Panel', 'Consent Panel', 'Kernel Panel'],
     stateFlow: STANDARD_BCTS_FLOW
   },
   'feature-implementation': {
-    nodes: ['governance-propose', 'authority-delegate', 'proof-generate', 'tenant-isolate', 'combinator-sequence'],
+    nodes: [
+      'identity-verify',
+      'authority-check',
+      'consent-request',
+      'consent-verify',
+      'governance-propose',
+      'governance-vote',
+      'governance-resolve',
+      'authority-delegate',
+      'proof-generate',
+      'proof-verify',
+      'tenant-isolate',
+      'combinator-sequence'
+    ],
     requiredPanels: ['Governance Panel', 'Identity Panel', 'Kernel Panel', 'Infrastructure Panel'],
     stateFlow: STANDARD_BCTS_FLOW
   },
   'bug-fix': {
-    nodes: ['governance-propose', 'proof-generate', 'proof-verify', 'combinator-sequence', 'dag-append'],
+    nodes: [
+      'identity-verify',
+      'authority-check',
+      'consent-request',
+      'consent-verify',
+      'governance-propose',
+      'governance-vote',
+      'governance-resolve',
+      'proof-generate',
+      'proof-verify',
+      'combinator-sequence',
+      'dag-append'
+    ],
     requiredPanels: ['Governance Panel', 'Kernel Panel'],
     stateFlow: STANDARD_BCTS_FLOW
   },
   'security-patch': {
-    nodes: ['governance-propose', 'identity-verify', 'proof-generate', 'kernel-adjudicate', 'invariant-check'],
+    nodes: [
+      'identity-verify',
+      'authority-check',
+      'consent-request',
+      'consent-verify',
+      'governance-propose',
+      'governance-vote',
+      'governance-resolve',
+      'proof-generate',
+      'proof-verify',
+      'kernel-adjudicate',
+      'invariant-check'
+    ],
     requiredPanels: ['Governance Panel', 'Identity Panel', 'Kernel Panel'],
     stateFlow: STANDARD_BCTS_FLOW
   },
   'infrastructure-change': {
-    nodes: ['governance-propose', 'authority-check', 'tenant-isolate', 'combinator-parallel', 'mcp-enforce'],
+    nodes: [
+      'identity-verify',
+      'authority-check',
+      'consent-request',
+      'consent-verify',
+      'governance-propose',
+      'governance-vote',
+      'governance-resolve',
+      'tenant-isolate',
+      'combinator-parallel',
+      'mcp-enforce'
+    ],
     requiredPanels: ['Governance Panel', 'Identity Panel', 'Infrastructure Panel', 'AI Panel'],
     stateFlow: STANDARD_BCTS_FLOW
   },
   'escalation-resolution': {
-    nodes: ['escalation-trigger', 'kernel-adjudicate', 'human-override', 'consent-verify'],
+    nodes: [
+      'identity-verify',
+      'authority-check',
+      'consent-request',
+      'consent-verify',
+      'governance-propose',
+      'governance-vote',
+      'governance-resolve',
+      'escalation-trigger',
+      'kernel-adjudicate',
+      'human-override'
+    ],
     requiredPanels: ['Escalation Panel', 'Kernel Panel', 'Executive Panel', 'Consent Panel'],
     stateFlow: STANDARD_BCTS_FLOW
   },
   'access-control-update': {
-    nodes: ['identity-verify', 'authority-delegate', 'consent-request', 'authority-check', 'governance-vote'],
+    nodes: [
+      'identity-verify',
+      'authority-check',
+      'consent-request',
+      'consent-verify',
+      'governance-propose',
+      'governance-vote',
+      'governance-resolve',
+      'authority-delegate'
+    ],
     requiredPanels: ['Identity Panel', 'Governance Panel', 'Consent Panel'],
     stateFlow: STANDARD_BCTS_FLOW
   }
@@ -300,6 +481,9 @@ class SyntaxisCompiler {
           errors.push(`Invalid state transition: ${currentState} -> ${nextState}`);
         }
       }
+      this._validateBctsGateCoverage(workflow, errors);
+      this._validateBctsMappings(workflow, errors);
+      this._validateBctsMappingCoverage(workflow, errors);
     }
 
     return {
@@ -700,13 +884,125 @@ class SyntaxisCompiler {
 
   _mapNodesToBCTS(nodes, stateFlow) {
     const mapping = {};
-    for (let i = 0; i < nodes.length && i < stateFlow.length; i++) {
-      mapping[nodes[i].id] = {
-        currentState: stateFlow[i],
-        nextState: stateFlow[i + 1] || 'COMPLETED'
-      };
+    for (const node of nodes) {
+      const transitions = BCTS_NODE_TRANSITIONS[node.type] || [];
+      const transition = transitions.find(candidate => this._stateFlowIncludesTransition(
+        stateFlow,
+        candidate.currentState,
+        candidate.nextState
+      ));
+      if (transition) {
+        mapping[node.id] = {
+          currentState: transition.currentState,
+          nextState: transition.nextState
+        };
+      }
     }
     return mapping;
+  }
+
+  _validateBctsGateCoverage(workflow, errors) {
+    const nodeTypes = (workflow.nodes || []).map(node => node.type);
+    for (const requirement of BCTS_REQUIRED_GATE_TRANSITIONS) {
+      if (!this._stateFlowIncludesTransition(
+        workflow.stateFlow,
+        requirement.currentState,
+        requirement.nextState
+      )) {
+        continue;
+      }
+      const covered = requirement.nodeTypes.some(nodeType => nodeTypes.includes(nodeType));
+      if (!covered) {
+        errors.push(
+          `Missing BCTS gate node for ${requirement.currentState} -> ${requirement.nextState}: requires ${requirement.nodeTypes.join(' or ')}`
+        );
+      }
+    }
+  }
+
+  _validateBctsMappings(workflow, errors) {
+    const nodesById = Object.create(null);
+    for (const node of workflow.nodes || []) {
+      nodesById[node.id] = node;
+    }
+
+    for (const [nodeId, mapping] of Object.entries(workflow.bctsMappings || {})) {
+      const node = nodesById[nodeId];
+      if (!node) {
+        errors.push(`BCTS mapping references unknown node: ${nodeId}`);
+        continue;
+      }
+      if (!this._stateFlowIncludesTransition(
+        workflow.stateFlow,
+        mapping.currentState,
+        mapping.nextState
+      )) {
+        errors.push(
+          `BCTS mapping for node ${nodeId} references non-workflow transition: ${mapping.currentState} -> ${mapping.nextState}`
+        );
+        continue;
+      }
+      if (!this._nodeTypeCanClaimBctsTransition(
+        node.type,
+        mapping.currentState,
+        mapping.nextState
+      )) {
+        errors.push(
+          `BCTS mapping for node ${nodeId} (${node.type}) cannot claim ${mapping.currentState} -> ${mapping.nextState}`
+        );
+      }
+    }
+  }
+
+  _validateBctsMappingCoverage(workflow, errors) {
+    const nodesById = Object.create(null);
+    for (const node of workflow.nodes || []) {
+      nodesById[node.id] = node;
+    }
+
+    for (const requirement of BCTS_REQUIRED_GATE_TRANSITIONS) {
+      if (!this._stateFlowIncludesTransition(
+        workflow.stateFlow,
+        requirement.currentState,
+        requirement.nextState
+      )) {
+        continue;
+      }
+      const covered = Object.entries(workflow.bctsMappings || {}).some(([nodeId, mapping]) => {
+        const node = nodesById[nodeId];
+        return (
+          node &&
+          requirement.nodeTypes.includes(node.type) &&
+          mapping.currentState === requirement.currentState &&
+          mapping.nextState === requirement.nextState
+        );
+      });
+      if (!covered) {
+        errors.push(
+          `Missing BCTS mapping for ${requirement.currentState} -> ${requirement.nextState}: requires ${requirement.nodeTypes.join(' or ')}`
+        );
+      }
+    }
+  }
+
+  _stateFlowIncludesTransition(stateFlow, currentState, nextState) {
+    if (!Array.isArray(stateFlow)) {
+      return false;
+    }
+    for (let i = 0; i < stateFlow.length - 1; i++) {
+      if (stateFlow[i] === currentState && stateFlow[i + 1] === nextState) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  _nodeTypeCanClaimBctsTransition(nodeType, currentState, nextState) {
+    const transitions = BCTS_NODE_TRANSITIONS[nodeType] || [];
+    return transitions.some(transition => (
+      transition.currentState === currentState &&
+      transition.nextState === nextState
+    ));
   }
 
   _canParallelize(nodes) {

--- a/tools/syntaxis/determinism.test.js
+++ b/tools/syntaxis/determinism.test.js
@@ -103,15 +103,49 @@ function delegationLink({ grantorId, granteeId, authority, scope, previousChainH
   };
 }
 
+function bctsReadyInputs(proposalOverrides = {}, verdictOverrides = {}) {
+  const readyProposal = { ...proposal(), ...proposalOverrides };
+  const readyVerdict = { ...verdict(), ...verdictOverrides };
+  const createdAtHlc = readyProposal.createdAtHlc || readyVerdict.createdAtHlc;
+  const nonce = deterministicId('nonce', {
+    createdAtHlc,
+    proposalId: readyProposal.id,
+    verdictId: readyVerdict.id
+  });
+  return {
+    verdict: {
+      ...readyVerdict,
+      identityProof: identityProof(readyProposal.proposer, 'cryptographic', nonce),
+      delegationChain: [
+        delegationLink({
+          grantorId: 'did:exo:root',
+          granteeId: readyProposal.proposer,
+          authority: 'GOVERNANCE_PROPOSER',
+          scope: readyProposal.type
+        })
+      ],
+      consentResponses: {
+        alice: { consent: true },
+        bob: { consent: true },
+        carol: { consent: true },
+        dave: { consent: true },
+        erin: { consent: false }
+      }
+    },
+    proposal: readyProposal
+  };
+}
+
 function run() {
   const compiler = new SyntaxisCompiler();
 
-  const first = compiler.compileSyntaxis(verdict(), proposal());
-  const second = compiler.compileSyntaxis(verdict(), proposal());
+  const governanceInputs = bctsReadyInputs();
+  const first = compiler.compileSyntaxis(governanceInputs.verdict, governanceInputs.proposal);
+  const second = compiler.compileSyntaxis(governanceInputs.verdict, governanceInputs.proposal);
   assert.deepStrictEqual(first, second, 'same Syntaxis inputs must produce identical workflow output');
   assert.deepStrictEqual(
     compiler.validateSyntaxisWorkflow(first),
-    { valid: true, errors: [], nodeCount: 5, dependencyCount: 4 },
+    { valid: true, errors: [], nodeCount: 8, dependencyCount: 7 },
     'compiled Syntaxis workflow must satisfy the BCTS transition validator'
   );
   const missingNodeHlc = JSON.parse(JSON.stringify(first));
@@ -337,16 +371,72 @@ function run() {
     'proof-verify validation must require the proof statement, not just proofId/proofHash'
   );
 
-  const bugFixWorkflow = compiler.compileSyntaxis(verdict(), {
-    ...proposal(),
+  const bugFixInputs = bctsReadyInputs({
     id: 'proposal-bugfix-001',
     type: 'bug-fix',
     proposer: 'ENGINEERING_PANEL'
   });
+  const bugFixWorkflow = compiler.compileSyntaxis(bugFixInputs.verdict, bugFixInputs.proposal);
+  assert.deepStrictEqual(
+    bugFixWorkflow.nodes.slice(0, 4).map(node => node.type),
+    ['identity-verify', 'authority-check', 'consent-request', 'consent-verify'],
+    'compiled bug-fix workflows must include identity, authority, request, and consent gates before execution nodes'
+  );
   assert.deepStrictEqual(
     compiler.validateSyntaxisWorkflow(bugFixWorkflow),
-    { valid: true, errors: [], nodeCount: 5, dependencyCount: 4 },
-    'compiled bug-fix workflows must satisfy proof node validation'
+    { valid: true, errors: [], nodeCount: 11, dependencyCount: 10 },
+    'compiled bug-fix workflows must satisfy proof and BCTS gate node validation'
+  );
+  const governanceProposalNode = bugFixWorkflow.nodes.find(node => node.type === 'governance-propose');
+  assert.notDeepStrictEqual(
+    bugFixWorkflow.bctsMappings[governanceProposalNode.id],
+    { currentState: 'INITIALIZED', nextState: 'IDENTITY_REQUIRED' },
+    'governance-propose must not be mapped as evidence for the identity BCTS gate'
+  );
+  assert.strictEqual(
+    bugFixWorkflow.bctsMappings[bugFixWorkflow.nodes.find(node => node.type === 'identity-verify').id].nextState,
+    'IDENTITY_VERIFIED',
+    'identity BCTS transition must be bound to the identity-verify node'
+  );
+  const missingGateWorkflow = {
+    ...bugFixWorkflow,
+    nodes: bugFixWorkflow.nodes.filter(node => ![
+      'identity-verify',
+      'authority-check',
+      'consent-request',
+      'consent-verify'
+    ].includes(node.type)),
+    dependencies: {},
+    initialNode: bugFixWorkflow.nodes.find(node => node.type === 'governance-propose').id,
+    bctsMappings: {
+      [governanceProposalNode.id]: {
+        currentState: 'INITIALIZED',
+        nextState: 'IDENTITY_REQUIRED'
+      }
+    }
+  };
+  const missingGateValidation = compiler.validateSyntaxisWorkflow(missingGateWorkflow);
+  assert.strictEqual(
+    missingGateValidation.valid,
+    false,
+    'validation must reject BCTS state flows that claim required gates without gate nodes'
+  );
+  assert.ok(
+    missingGateValidation.errors.some(error => error.includes('Missing BCTS gate node for IDENTITY_REQUIRED -> IDENTITY_VERIFIED')),
+    'validation error must identify the missing identity gate'
+  );
+  const missingMappingValidation = compiler.validateSyntaxisWorkflow({
+    ...bugFixWorkflow,
+    bctsMappings: {}
+  });
+  assert.strictEqual(
+    missingMappingValidation.valid,
+    false,
+    'validation must reject workflows that omit BCTS mappings for required gates'
+  );
+  assert.ok(
+    missingMappingValidation.errors.some(error => error.includes('Missing BCTS mapping for IDENTITY_REQUIRED -> IDENTITY_VERIFIED')),
+    'validation error must identify the missing identity BCTS mapping'
   );
   const proofGenerateNode = bugFixWorkflow.nodes.find(node => node.type === 'proof-generate');
   const proofVerifyNode = bugFixWorkflow.nodes.find(node => node.type === 'proof-verify');
@@ -364,6 +454,23 @@ function run() {
   assert.strictEqual(compiledProofVerification.outputs.verified, true);
 
   const builder = new SolutionsBuilder();
+  for (const templateSummary of builder.listTemplates()) {
+    const template = builder.getTemplate(templateSummary.type);
+    for (const requiredNodeType of [
+      'identity-verify',
+      'authority-check',
+      'consent-request',
+      'consent-verify',
+      'governance-propose',
+      'governance-vote',
+      'governance-resolve'
+    ]) {
+      assert.ok(
+        template.nodeSequence.includes(requiredNodeType),
+        `solution template ${templateSummary.type} must include ${requiredNodeType} before claiming STANDARD_BCTS_FLOW`
+      );
+    }
+  }
   const solutionA = builder.createSolution('security-patch', {
     name: 'Critical Security Patch',
     author: 'SECURITY_TEAM',
@@ -395,6 +502,11 @@ function run() {
     environment: 'PRODUCTION',
     deploymentHlc: DEPLOY_HLC
   });
+  assert.deepStrictEqual(
+    builder.compiler.validateSyntaxisWorkflow(deploymentA.workflow),
+    { valid: true, errors: [], nodeCount: 11, dependencyCount: 10 },
+    'solution deployments must generate workflows with validated BCTS gate evidence'
+  );
   const deploymentB = new SolutionsBuilder().deploySolution(solutionA, {
     path: '/exoforge/deployments',
     environment: 'PRODUCTION',

--- a/tools/syntaxis/solutions-builder.js
+++ b/tools/syntaxis/solutions-builder.js
@@ -27,10 +27,21 @@ const {
   advanceHlc,
   compareHlc,
   deterministicId,
+  hashCanonical,
   hlcToString,
   normalizeBasisPoints,
   normalizeHlc
 } = require('./determinism');
+
+const REQUIRED_STANDARD_BCTS_NODE_TYPES = [
+  'identity-verify',
+  'authority-check',
+  'consent-request',
+  'consent-verify',
+  'governance-propose',
+  'governance-vote',
+  'governance-resolve'
+];
 
 /**
  * Pre-built solution templates for common workflows
@@ -43,12 +54,13 @@ const SOLUTION_TEMPLATES = {
     category: 'GOVERNANCE',
     nodeSequence: [
       'identity-verify',
+      'authority-check',
       'consent-request',
+      'consent-verify',
       'governance-propose',
       'governance-vote',
       'governance-resolve',
-      'kernel-adjudicate',
-      'dag-append'
+      'kernel-adjudicate'
     ],
     requiredPanels: ['Identity Panel', 'Governance Panel', 'Consent Panel', 'Kernel Panel'],
     stateFlow: STANDARD_BCTS_FLOW,
@@ -74,11 +86,17 @@ const SOLUTION_TEMPLATES = {
     description: 'Template for implementing new features safely with isolation',
     category: 'INFRASTRUCTURE',
     nodeSequence: [
-      'governance-propose',
+      'identity-verify',
       'authority-check',
+      'consent-request',
+      'consent-verify',
+      'governance-propose',
+      'governance-vote',
+      'governance-resolve',
+      'proof-generate',
+      'proof-verify',
       'authority-delegate',
       'tenant-isolate',
-      'proof-generate',
       'combinator-parallel',
       'combinator-sequence',
       'dag-append'
@@ -107,7 +125,13 @@ const SOLUTION_TEMPLATES = {
     description: 'Template for deploying bug fixes with proof verification',
     category: 'MAINTENANCE',
     nodeSequence: [
+      'identity-verify',
+      'authority-check',
+      'consent-request',
+      'consent-verify',
       'governance-propose',
+      'governance-vote',
+      'governance-resolve',
       'proof-generate',
       'proof-verify',
       'invariant-check',
@@ -139,8 +163,13 @@ const SOLUTION_TEMPLATES = {
     category: 'SECURITY',
     nodeSequence: [
       'identity-verify',
-      'escalation-trigger',
+      'authority-check',
+      'consent-request',
+      'consent-verify',
       'governance-propose',
+      'governance-vote',
+      'governance-resolve',
+      'escalation-trigger',
       'kernel-adjudicate',
       'invariant-check',
       'proof-generate',
@@ -173,8 +202,13 @@ const SOLUTION_TEMPLATES = {
     description: 'Template for infrastructure modifications with multi-tenant isolation',
     category: 'INFRASTRUCTURE',
     nodeSequence: [
-      'governance-propose',
+      'identity-verify',
       'authority-check',
+      'consent-request',
+      'consent-verify',
+      'governance-propose',
+      'governance-vote',
+      'governance-resolve',
       'tenant-isolate',
       'mcp-enforce',
       'combinator-parallel',
@@ -209,11 +243,12 @@ const SOLUTION_TEMPLATES = {
     nodeSequence: [
       'identity-verify',
       'authority-check',
-      'authority-delegate',
       'consent-request',
       'consent-verify',
       'governance-propose',
       'governance-vote',
+      'governance-resolve',
+      'authority-delegate',
       'dag-append'
     ],
     requiredPanels: ['Identity Panel', 'Governance Panel', 'Consent Panel', 'Kernel Panel'],
@@ -240,11 +275,16 @@ const SOLUTION_TEMPLATES = {
     description: 'Template for resolving governance disputes through escalation',
     category: 'GOVERNANCE',
     nodeSequence: [
+      'identity-verify',
+      'authority-check',
+      'consent-request',
+      'consent-verify',
+      'governance-propose',
+      'governance-vote',
+      'governance-resolve',
       'escalation-trigger',
       'kernel-adjudicate',
-      'consent-verify',
       'human-override',
-      'governance-resolve',
       'dag-append'
     ],
     requiredPanels: ['Escalation Panel', 'Kernel Panel', 'Executive Panel', 'Consent Panel', 'Governance Panel'],
@@ -541,6 +581,16 @@ class SolutionsBuilder {
       }
     }
 
+    if (this._usesStandardBctsFlow(solution.stateFlow)) {
+      for (const requiredNodeType of REQUIRED_STANDARD_BCTS_NODE_TYPES) {
+        if (!(solution.nodeSequence || []).includes(requiredNodeType)) {
+          errors.push(
+            `STANDARD_BCTS_FLOW solution is missing required gate node: ${requiredNodeType}`
+          );
+        }
+      }
+    }
+
     if (!solution.config || typeof solution.config !== 'object') {
       errors.push('config is required');
     }
@@ -551,22 +601,16 @@ class SolutionsBuilder {
     };
   }
 
+  _usesStandardBctsFlow(stateFlow) {
+    return (
+      Array.isArray(stateFlow) &&
+      stateFlow.length === STANDARD_BCTS_FLOW.length &&
+      stateFlow.every((state, index) => state === STANDARD_BCTS_FLOW[index])
+    );
+  }
+
   _generateWorkflowFromSolution(solution) {
     // Create a minimal council verdict for workflow generation
-    const mockVerdict = {
-      id: `verdict_${solution.solutionId}`,
-      status: 'APPROVED',
-      affectedPanels: solution.requiredPanels,
-      panelAssessments: solution.requiredPanels.reduce((acc, panel) => {
-        acc[panel] = 'FOR';
-        return acc;
-      }, {}),
-      consentResponses: {},
-      systemState: {},
-      precedingProposals: []
-    };
-
-    // Create a proposal object from solution
     const proposal = {
       id: solution.solutionId,
       type: solution.solutionType,
@@ -578,15 +622,96 @@ class SolutionsBuilder {
       faultTolerant: solution.config.faultTolerant,
       rollbackOnFailure: solution.config.rollbackOnFailure,
       maxDuration: solution.config.maxDuration,
+      evidence: [{ hash: deterministicId('solution_evidence', { solutionId: solution.solutionId }) }],
       createdAtHlc: solution.createdAtHlc
     };
     if (Object.prototype.hasOwnProperty.call(solution.config, 'consentThresholdBasisPoints')) {
       proposal.requiredConsentBasisPoints = solution.config.consentThresholdBasisPoints;
     }
 
+    const verdictId = `verdict_${solution.solutionId}`;
+    const nonce = deterministicId('nonce', {
+      createdAtHlc: solution.createdAtHlc,
+      proposalId: proposal.id,
+      verdictId
+    });
+    const mockVerdict = {
+      id: verdictId,
+      status: 'APPROVED',
+      affectedPanels: solution.requiredPanels,
+      panelAssessments: solution.requiredPanels.reduce((acc, panel) => {
+        acc[panel] = 'FOR';
+        return acc;
+      }, {}),
+      identityProof: this._buildIdentityProof(solution.metadata.author, 'cryptographic', nonce),
+      delegationChain: [
+        this._buildDelegationLink({
+          grantorId: 'did:exo:root',
+          granteeId: solution.metadata.author,
+          authority: 'GOVERNANCE_PROPOSER',
+          scope: solution.solutionType
+        })
+      ],
+      consentResponses: this._buildConsentResponses(solution.requiredPanels),
+      systemState: {},
+      precedingProposals: [
+        deterministicId('solution_parent', { solutionId: solution.solutionId })
+      ]
+    };
+
     // Compile workflow
     const workflow = this.compiler.compileSyntaxis(mockVerdict, proposal);
     return workflow;
+  }
+
+  _buildIdentityProof(identityId, method, nonce) {
+    const publicKey = `ed25519-${identityId}-public-key`;
+    return {
+      subjectId: identityId,
+      method,
+      nonce,
+      publicKey,
+      signature: `ed25519-${identityId}-signature`,
+      proofHash: `0x${hashCanonical({
+        identityId,
+        method,
+        nonce,
+        publicKey
+      })}`
+    };
+  }
+
+  _buildDelegationLink({ grantorId, granteeId, authority, scope, previousChainHash = null }) {
+    const signatureHash = `0x${hashCanonical({
+      authority,
+      granteeId,
+      grantorId,
+      scope,
+      signature: 'ed25519-solution-delegation-signature'
+    })}`;
+    return {
+      grantorId,
+      granteeId,
+      authority,
+      scope,
+      signatureHash,
+      chainHash: `0x${hashCanonical({
+        authority,
+        granteeId,
+        grantorId,
+        previousChainHash,
+        scope,
+        signatureHash
+      })}`
+    };
+  }
+
+  _buildConsentResponses(requiredPanels) {
+    const responses = {};
+    for (const panel of requiredPanels) {
+      responses[panel] = { consent: true };
+    }
+    return responses;
   }
 
   _executeDeploymentStages(solution, workflow, deploymentHlc) {

--- a/tools/syntaxis/test.js
+++ b/tools/syntaxis/test.js
@@ -26,11 +26,53 @@ const {
   BCTS_TRANSITIONS,
   BCTS_STATES
 } = require('./index');
+const { deterministicId, hashCanonical } = require('./determinism');
 
 const CREATED_AT_HLC = { physicalMs: 1700000000000, logical: 0 };
 const SECURITY_HLC = { physicalMs: 1700000000000, logical: 1 };
 const INFRA_HLC = { physicalMs: 1700000000000, logical: 2 };
 const DEPLOYMENT_HLC = { physicalMs: 1700000000001, logical: 0 };
+
+function identityProof(identityId, method, nonce, publicKey = 'ed25519-demo-public-key') {
+  return {
+    subjectId: identityId,
+    method,
+    nonce,
+    publicKey,
+    signature: 'ed25519-demo-signature',
+    proofHash: `0x${hashCanonical({
+      identityId,
+      method,
+      nonce,
+      publicKey
+    })}`
+  };
+}
+
+function delegationLink({ grantorId, granteeId, authority, scope, previousChainHash = null }) {
+  const signatureHash = `0x${hashCanonical({
+    authority,
+    granteeId,
+    grantorId,
+    scope,
+    signature: 'ed25519-demo-delegation-signature'
+  })}`;
+  return {
+    grantorId,
+    granteeId,
+    authority,
+    scope,
+    signatureHash,
+    chainHash: `0x${hashCanonical({
+      authority,
+      granteeId,
+      grantorId,
+      previousChainHash,
+      scope,
+      signatureHash
+    })}`
+  };
+}
 
 /**
  * Run all tests
@@ -148,6 +190,29 @@ async function runTests() {
       maxDuration: 604800000,
       createdAtHlc: CREATED_AT_HLC
     };
+    const proofNonce = deterministicId('nonce', {
+      createdAtHlc: CREATED_AT_HLC,
+      proposalId: mockProposal.id,
+      verdictId: mockCouncilVerdict.id
+    });
+    mockCouncilVerdict.identityProof = identityProof(
+      mockProposal.proposer,
+      'cryptographic',
+      proofNonce
+    );
+    mockCouncilVerdict.delegationChain = [
+      delegationLink({
+        grantorId: 'did:exo:root',
+        granteeId: mockProposal.proposer,
+        authority: 'GOVERNANCE_PROPOSER',
+        scope: mockProposal.type
+      })
+    ];
+    mockCouncilVerdict.consentResponses = {
+      'Identity Panel': { consent: true },
+      'Governance Panel': { consent: true },
+      'Consent Panel': { consent: true }
+    };
 
     const workflow = engine.compileSyntaxis(mockCouncilVerdict, mockProposal);
     console.log(`Workflow ID: ${workflow.workflowId}`);
@@ -166,6 +231,7 @@ async function runTests() {
     console.log(`Dependencies: ${validation.dependencyCount}`);
     if (validation.errors.length > 0) {
       console.log('Errors:', validation.errors);
+      throw new Error('Compiled workflow validation failed');
     } else {
       console.log('No validation errors');
     }


### PR DESCRIPTION
## Summary
- Remediates Codex Security row 30: Syntaxis BCTS validation accepted workflows that claimed standard identity, authority, consent, and governance transitions without the required gate nodes.
- Updates compiler proposal mappings so STANDARD_BCTS_FLOW workflows generate explicit identity, authority, consent, governance proposal, vote, and resolution nodes before execution nodes.
- Replaces positional `bctsMappings` with semantic node-to-transition bindings, and rejects forged/missing mappings for required BCTS gates.
- Aligns Syntaxis solution templates and deployment-generated workflow evidence with the same BCTS gate requirements.
- Updates the README and demo harness so examples provide identity proof, delegation, and consent evidence.

## Path Classification
- Core runtime adapter/tooling: `tools/syntaxis/compiler.js`, `tools/syntaxis/solutions-builder.js`, `tools/syntaxis/determinism.test.js`, `tools/syntaxis/test.js`, `tools/syntaxis/README.md`.
- No EXOCHAIN Rust crate, governance kernel, deployment, or adjacent product files changed.
- Imported evidence remained read-only.

## Verification
- RED: `node determinism.test.js` failed before the fix because compiled workflows still had the old gate-less shape and because empty BCTS mappings were accepted.
- GREEN: `npm test` in `tools/syntaxis` passed.
- `git diff --check` passed.
- `bash tools/test_repo_truth.sh` passed.
- `cargo fmt --all -- --check` exited 0; rustfmt emitted existing nightly-only config warnings.
- Touched-file source guard found no new `Date.now`, `new Date`, `Math.`, `HashMap`, `HashSet`, `TODO`, `SystemTime`, `Instant`, or `unsafe` patterns except the existing deterministic source-guard assertions in `determinism.test.js`.

## Original Issue Closure
- `validateSyntaxisWorkflow` now fails closed when a workflow claims STANDARD_BCTS_FLOW but omits required BCTS gate nodes.
- Validation also fails closed when `bctsMappings` is absent, references unknown nodes, points at non-workflow transitions, or lets a node type claim a transition it cannot enforce.
