### PR TITLE
fix(site): harden contact intake against floods

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -9,6 +9,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
+    "security:contact-intake": "node scripts/test-contact-intake-policy.mjs",
     "security:contact-disclosure": "node scripts/assert-no-contact-submission-disclosure.mjs"
   },
   "dependencies": {

--- a/site/scripts/test-contact-intake-policy.mjs
+++ b/site/scripts/test-contact-intake-policy.mjs
@@ -1,0 +1,129 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import ts from 'typescript';
+
+const siteRoot = process.cwd();
+const policyPath = path.join(siteRoot, 'src/lib/contact-intake-policy.ts');
+const routePath = path.join(siteRoot, 'src/app/api/contact/route.ts');
+const storagePath = path.join(siteRoot, 'src/lib/contact-submissions.ts');
+
+assert.ok(existsSync(policyPath), 'contact intake policy module must exist');
+
+const source = readFileSync(policyPath, 'utf8');
+const compiled = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2022,
+    esModuleInterop: true,
+  },
+  fileName: policyPath,
+});
+const moduleState = { exports: {} };
+vm.runInNewContext(compiled.outputText, {
+  module: moduleState,
+  exports: moduleState.exports,
+  require: () => {
+    throw new Error('contact-intake-policy.ts must remain dependency-free for policy tests');
+  },
+}, { filename: policyPath });
+
+const policy = moduleState.exports;
+
+const valid = policy.validateContactPayload({
+  name: '  Ada Lovelace  ',
+  email: '  ADA@Example.COM ',
+  organization: ' Analytical Engines ',
+  role: 'Researcher',
+  intendedUse: 'Constitutional trust fabric evaluation',
+});
+assert.equal(valid.ok, true, 'valid contact payload must pass server-side policy');
+assert.equal(valid.payload.name, 'Ada Lovelace');
+assert.equal(valid.payload.email, 'ada@example.com');
+assert.equal(valid.payload.organization, 'Analytical Engines');
+
+const missingEmail = policy.validateContactPayload({ name: 'Ada' });
+assert.equal(missingEmail.ok, false);
+assert.equal(missingEmail.status, 400);
+assert.match(missingEmail.error, /email/i);
+
+const malformedEmail = policy.validateContactPayload({
+  name: 'Ada',
+  email: 'not-an-email',
+});
+assert.equal(malformedEmail.ok, false);
+assert.equal(malformedEmail.status, 400);
+assert.match(malformedEmail.error, /valid email/i);
+
+const oversized = policy.validateContactPayload({
+  name: 'Ada',
+  email: 'ada@example.com',
+  intendedUse: 'x'.repeat(policy.CONTACT_FIELD_LIMITS.intendedUse + 1),
+});
+assert.equal(oversized.ok, false);
+assert.equal(oversized.status, 413);
+assert.match(oversized.error, /Intended use/i);
+
+const honeypot = policy.validateContactPayload({
+  name: 'Ada',
+  email: 'ada@example.com',
+  website: 'https://spam.example',
+});
+assert.equal(honeypot.ok, true);
+assert.equal(honeypot.deliver, false, 'honeypot submissions must not queue or send mail');
+
+assert.equal(
+  policy.normalizeClientAddress(' 203.0.113.7, 10.0.0.1 '),
+  '203.0.113.7',
+  'client key must use the first forwarded address',
+);
+assert.equal(
+  policy.normalizeClientAddress(''),
+  'unknown',
+  'missing client address must collapse to a bounded unknown bucket',
+);
+
+const buckets = policy.getContactRateLimitBuckets({
+  email: 'ada@example.com',
+  clientAddress: '203.0.113.7',
+});
+assert.equal(
+  JSON.stringify(buckets.map((bucket) => bucket.bucket)),
+  JSON.stringify([
+    'contact:global:minute',
+    'contact:ip:203.0.113.7:hour',
+    'contact:email:ada@example.com:day',
+    'contact:global:day',
+  ]),
+  'rate limit buckets must cover global, client-address, and normalized-email budgets',
+);
+assert.ok(buckets.every((bucket) => Number.isInteger(bucket.maxRequests)));
+assert.ok(buckets.every((bucket) => Number.isInteger(bucket.windowSeconds)));
+
+const routeSource = readFileSync(routePath, 'utf8');
+assert.match(routeSource, /request\.text\(\)/, 'contact route must bound raw body before JSON parse');
+assert.doesNotMatch(routeSource, /request\.json\(\)/, 'contact route must not parse unbounded JSON directly');
+assert.match(routeSource, /CONTACT_BODY_MAX_BYTES/, 'contact route must enforce a byte limit');
+assert.match(routeSource, /assertContactSubmissionRateLimit/, 'contact route must enforce database-backed rate limits');
+assert.match(routeSource, /getContactRateLimitBuckets/, 'contact route must derive rate-limit buckets from normalized inputs');
+
+const storageSource = readFileSync(storagePath, 'utf8');
+assert.match(storageSource, /site_contact_rate_limits/, 'contact storage must include a rate-limit table');
+assert.match(storageSource, /ON CONFLICT \(bucket\) DO UPDATE/, 'contact rate limit must be atomic per bucket');

--- a/site/src/app/(internet)/contact/ContactForm.tsx
+++ b/site/src/app/(internet)/contact/ContactForm.tsx
@@ -17,6 +17,7 @@
 'use client';
 
 import { FormEvent, useState } from 'react';
+import { CONTACT_FIELD_LIMITS, CONTACT_HONEYPOT_FIELD } from '@/lib/contact-intake-policy';
 
 type SubmitStatus = { type: 'idle' | 'success' | 'error'; message: string };
 
@@ -42,6 +43,7 @@ export function ContactForm() {
           organization: formData.get('organization'),
           role: formData.get('role'),
           intendedUse: formData.get('intendedUse'),
+          [CONTACT_HONEYPOT_FIELD]: formData.get(CONTACT_HONEYPOT_FIELD),
         }),
       });
 
@@ -70,6 +72,7 @@ export function ContactForm() {
           <input
             name="name"
             className="mt-1 w-full border hairline rounded-sm px-3 py-2 bg-transparent"
+            maxLength={CONTACT_FIELD_LIMITS.name}
             required
           />
         </label>
@@ -79,6 +82,7 @@ export function ContactForm() {
             name="email"
             className="mt-1 w-full border hairline rounded-sm px-3 py-2 bg-transparent"
             type="email"
+            maxLength={CONTACT_FIELD_LIMITS.email}
             required
           />
         </label>
@@ -88,6 +92,7 @@ export function ContactForm() {
         <input
           name="organization"
           className="mt-1 w-full border hairline rounded-sm px-3 py-2 bg-transparent"
+          maxLength={CONTACT_FIELD_LIMITS.organization}
         />
       </label>
       <label className="block">
@@ -109,8 +114,18 @@ export function ContactForm() {
         <textarea
           name="intendedUse"
           className="mt-1 w-full border hairline rounded-sm px-3 py-2 bg-transparent min-h-[120px]"
+          maxLength={CONTACT_FIELD_LIMITS.intendedUse}
         />
       </label>
+      <input
+        aria-hidden="true"
+        autoComplete="off"
+        className="hidden"
+        maxLength={CONTACT_FIELD_LIMITS.organization}
+        name={CONTACT_HONEYPOT_FIELD}
+        tabIndex={-1}
+        type="text"
+      />
       <button
         type="submit"
         disabled={isSubmitting}

--- a/site/src/app/api/contact/route.ts
+++ b/site/src/app/api/contact/route.ts
@@ -16,17 +16,17 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import {
+  CONTACT_BODY_MAX_BYTES,
+  getContactRateLimitBuckets,
+  normalizeClientAddress,
+  type ContactPayload,
+  validateContactPayload,
+} from '@/lib/contact-intake-policy';
+import {
+  assertContactSubmissionRateLimit,
   createContactSubmission,
   updateContactSubmissionNotification,
 } from '@/lib/contact-submissions';
-
-type ContactPayload = {
-  name: string;
-  email: string;
-  organization?: string;
-  role?: string;
-  intendedUse?: string;
-};
 
 type EmailConfig = {
   apiKey: string;
@@ -36,6 +36,7 @@ type EmailConfig = {
 
 const RESEND_API_KEY_PREFIX = 're_';
 const CONTACT_QUEUE_ERROR = 'Unable to queue inquiry right now.';
+const CONTACT_RATE_LIMIT_ERROR = 'Too many inquiries. Please try again later.';
 
 export const runtime = 'nodejs';
 
@@ -69,16 +70,6 @@ function getEmailConfig(): EmailConfig | null {
     apiKey,
     toEmail: clean(process.env.CONTACT_TO_EMAIL) || 'support@exochain.io',
     fromEmail: clean(process.env.CONTACT_FROM_EMAIL) || 'support@exochain.io',
-  };
-}
-
-function getPayload(data: Record<string, unknown>): ContactPayload {
-  return {
-    name: clean(data.name),
-    email: clean(data.email),
-    organization: clean(data.organization),
-    role: clean(data.role),
-    intendedUse: clean(data.intendedUse),
   };
 }
 
@@ -146,17 +137,48 @@ async function notifySupport(
 export async function POST(request: NextRequest): Promise<NextResponse> {
   let incoming: ContactPayload;
   try {
-    const body = await request.json();
-    if (typeof body !== 'object' || body === null) {
+    const contentLength = Number(request.headers.get('content-length') || '0');
+    if (Number.isFinite(contentLength) && contentLength > CONTACT_BODY_MAX_BYTES) {
+      return NextResponse.json({ error: 'Payload is too large.' }, { status: 413 });
+    }
+
+    const rawBody = await request.text();
+    if (Buffer.byteLength(rawBody, 'utf8') > CONTACT_BODY_MAX_BYTES) {
+      return NextResponse.json({ error: 'Payload is too large.' }, { status: 413 });
+    }
+
+    const body = JSON.parse(rawBody) as unknown;
+    if (typeof body !== 'object' || body === null || Array.isArray(body)) {
       return NextResponse.json({ error: 'Invalid payload.' }, { status: 400 });
     }
-    incoming = getPayload(body as Record<string, unknown>);
+    const validation = validateContactPayload(body as Record<string, unknown>);
+    if (!validation.ok) {
+      return NextResponse.json({ error: validation.error }, { status: validation.status });
+    }
+    if (!validation.deliver) {
+      return NextResponse.json({ ok: true });
+    }
+    incoming = validation.payload;
   } catch {
     return NextResponse.json({ error: 'Invalid payload format.' }, { status: 400 });
   }
 
-  if (!incoming.name || !incoming.email) {
-    return NextResponse.json({ error: 'Name and email are required.' }, { status: 400 });
+  const clientAddress = normalizeClientAddress(
+    request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip'),
+  );
+  try {
+    const withinRateLimit = await assertContactSubmissionRateLimit(
+      getContactRateLimitBuckets({
+        email: incoming.email,
+        clientAddress,
+      }),
+    );
+    if (!withinRateLimit) {
+      return NextResponse.json({ error: CONTACT_RATE_LIMIT_ERROR }, { status: 429 });
+    }
+  } catch (error) {
+    console.error('Contact form rate-limit check failed.', { error });
+    return NextResponse.json({ error: CONTACT_QUEUE_ERROR }, { status: 503 });
   }
 
   let submissionId: string;
@@ -168,7 +190,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       role: incoming.role || '',
       intendedUse: incoming.intendedUse || '',
       userAgent: clean(request.headers.get('user-agent')),
-      forwardedFor: clean(request.headers.get('x-forwarded-for')),
+      forwardedFor: clientAddress,
     });
     submissionId = submission.id;
   } catch (error) {

--- a/site/src/lib/contact-intake-policy.ts
+++ b/site/src/lib/contact-intake-policy.ts
@@ -1,0 +1,166 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export type ContactPayload = {
+  name: string;
+  email: string;
+  organization: string;
+  role: string;
+  intendedUse: string;
+};
+
+export type ContactRateLimitBucket = {
+  bucket: string;
+  maxRequests: number;
+  windowSeconds: number;
+};
+
+type ContactPayloadResult =
+  | {
+      ok: true;
+      deliver: true;
+      payload: ContactPayload;
+    }
+  | {
+      ok: true;
+      deliver: false;
+      payload: ContactPayload;
+    }
+  | {
+      ok: false;
+      status: 400 | 413;
+      error: string;
+    };
+
+export const CONTACT_BODY_MAX_BYTES = 8192;
+export const CONTACT_HONEYPOT_FIELD = 'website';
+export const CONTACT_FIELD_LIMITS = {
+  name: 120,
+  email: 254,
+  organization: 160,
+  role: 80,
+  intendedUse: 2000,
+  clientAddress: 128,
+};
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function clean(value: unknown, maxLength: number): string {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.trim().slice(0, maxLength);
+}
+
+function hasOversizedField(value: unknown, maxLength: number): boolean {
+  return typeof value === 'string' && value.trim().length > maxLength;
+}
+
+function emptyPayload(): ContactPayload {
+  return {
+    name: '',
+    email: '',
+    organization: '',
+    role: '',
+    intendedUse: '',
+  };
+}
+
+export function validateContactPayload(data: Record<string, unknown>): ContactPayloadResult {
+  if (typeof data[CONTACT_HONEYPOT_FIELD] === 'string' && data[CONTACT_HONEYPOT_FIELD].trim()) {
+    return {
+      ok: true,
+      deliver: false,
+      payload: emptyPayload(),
+    };
+  }
+
+  if (hasOversizedField(data.name, CONTACT_FIELD_LIMITS.name)) {
+    return { ok: false, status: 413, error: 'Name is too long.' };
+  }
+  if (hasOversizedField(data.email, CONTACT_FIELD_LIMITS.email)) {
+    return { ok: false, status: 413, error: 'Email is too long.' };
+  }
+  if (hasOversizedField(data.organization, CONTACT_FIELD_LIMITS.organization)) {
+    return { ok: false, status: 413, error: 'Organization is too long.' };
+  }
+  if (hasOversizedField(data.role, CONTACT_FIELD_LIMITS.role)) {
+    return { ok: false, status: 413, error: 'Role is too long.' };
+  }
+  if (hasOversizedField(data.intendedUse, CONTACT_FIELD_LIMITS.intendedUse)) {
+    return { ok: false, status: 413, error: 'Intended use is too long.' };
+  }
+
+  const payload = {
+    name: clean(data.name, CONTACT_FIELD_LIMITS.name),
+    email: clean(data.email, CONTACT_FIELD_LIMITS.email).toLowerCase(),
+    organization: clean(data.organization, CONTACT_FIELD_LIMITS.organization),
+    role: clean(data.role, CONTACT_FIELD_LIMITS.role),
+    intendedUse: clean(data.intendedUse, CONTACT_FIELD_LIMITS.intendedUse),
+  };
+
+  if (!payload.name) {
+    return { ok: false, status: 400, error: 'Name is required.' };
+  }
+  if (!payload.email) {
+    return { ok: false, status: 400, error: 'Email is required.' };
+  }
+  if (!EMAIL_PATTERN.test(payload.email)) {
+    return { ok: false, status: 400, error: 'A valid email is required.' };
+  }
+
+  return {
+    ok: true,
+    deliver: true,
+    payload,
+  };
+}
+
+export function normalizeClientAddress(value: string | null | undefined): string {
+  const firstAddress = (value || '').split(',')[0]?.trim() || '';
+  if (!firstAddress) {
+    return 'unknown';
+  }
+  return firstAddress.slice(0, CONTACT_FIELD_LIMITS.clientAddress);
+}
+
+export function getContactRateLimitBuckets(input: {
+  email: string;
+  clientAddress: string;
+}): ContactRateLimitBucket[] {
+  return [
+    {
+      bucket: 'contact:global:minute',
+      maxRequests: 30,
+      windowSeconds: 60,
+    },
+    {
+      bucket: `contact:ip:${input.clientAddress}:hour`,
+      maxRequests: 3,
+      windowSeconds: 3600,
+    },
+    {
+      bucket: `contact:email:${input.email}:day`,
+      maxRequests: 5,
+      windowSeconds: 86400,
+    },
+    {
+      bucket: 'contact:global:day',
+      maxRequests: 200,
+      windowSeconds: 86400,
+    },
+  ];
+}

--- a/site/src/lib/contact-submissions.ts
+++ b/site/src/lib/contact-submissions.ts
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Pool, type PoolClient } from 'pg';
+import type { ContactRateLimitBucket } from './contact-intake-policy';
 
 export type ContactSubmissionInput = {
   name: string;
@@ -45,6 +46,10 @@ type ContactSubmissionRow = {
   forwarded_for: string;
   notification_status: string;
   notification_error: string;
+};
+
+type ContactRateLimitRow = {
+  request_count: number | string;
 };
 
 type ContactSubmissionPoolGlobal = typeof globalThis & {
@@ -142,6 +147,19 @@ async function ensureSchemaWithClient(client: PoolClient): Promise<void> {
     CREATE INDEX IF NOT EXISTS site_contact_submissions_email_idx
       ON site_contact_submissions (email)
   `);
+
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS site_contact_rate_limits (
+      bucket TEXT PRIMARY KEY,
+      window_started_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      request_count INTEGER NOT NULL DEFAULT 0
+    )
+  `);
+
+  await client.query(`
+    CREATE INDEX IF NOT EXISTS site_contact_rate_limits_window_idx
+      ON site_contact_rate_limits (window_started_at)
+  `);
 }
 
 export async function ensureContactSubmissionSchema(): Promise<void> {
@@ -208,6 +226,58 @@ export async function createContactSubmission(
   }
 
   return fromRow(row);
+}
+
+async function incrementContactRateLimit(
+  bucket: ContactRateLimitBucket,
+): Promise<number> {
+  await ensureContactSubmissionSchema();
+
+  const result = await getPool().query<ContactRateLimitRow>(
+    `
+      INSERT INTO site_contact_rate_limits (
+        bucket,
+        window_started_at,
+        request_count
+      )
+      VALUES ($1, CURRENT_TIMESTAMP, 1)
+      ON CONFLICT (bucket) DO UPDATE
+      SET window_started_at = CASE
+            WHEN site_contact_rate_limits.window_started_at <=
+              CURRENT_TIMESTAMP - ($2::integer * INTERVAL '1 second')
+            THEN CURRENT_TIMESTAMP
+            ELSE site_contact_rate_limits.window_started_at
+          END,
+          request_count = CASE
+            WHEN site_contact_rate_limits.window_started_at <=
+              CURRENT_TIMESTAMP - ($2::integer * INTERVAL '1 second')
+            THEN 1
+            ELSE site_contact_rate_limits.request_count + 1
+          END
+      RETURNING request_count
+    `,
+    [bucket.bucket, bucket.windowSeconds],
+  );
+
+  const row = result.rows[0];
+  if (!row) {
+    throw new Error('Contact rate-limit update did not return a row.');
+  }
+
+  return Number(row.request_count);
+}
+
+export async function assertContactSubmissionRateLimit(
+  buckets: ContactRateLimitBucket[],
+): Promise<boolean> {
+  for (const bucket of buckets) {
+    const requestCount = await incrementContactRateLimit(bucket);
+    if (requestCount > bucket.maxRequests) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 export async function updateContactSubmissionNotification(


### PR DESCRIPTION
## Summary
- Remediates Codex Security row 29: unauthenticated `/api/contact` could be scripted to flood the support inbox and consume Resend quota.
- Adds a server-side contact intake policy with byte limits, field limits, email validation, normalized client-address buckets, honeypot suppression, and global/IP/email rate-limit buckets.
- Replaces unbounded `request.json()` parsing with bounded raw body parsing before JSON decode.
- Adds a database-backed `site_contact_rate_limits` table with atomic `ON CONFLICT (bucket) DO UPDATE` counters before queueing or sending mail.
- Adds client maxLength controls and a hidden honeypot field, while keeping server controls authoritative.

## Adjacent Surface Intake
- Classification: adjacent surface (`site/` public EXOCHAIN web presence), not EXOCHAIN core trust fabric.
- Owner/accountable maintainer: EXOCHAIN site maintainer / Bob Stewart.
- Deployment status: production public website/contact intake.
- Constitutional trust claims: not allowed to mint, simulate, or claim EXOCHAIN constitutional enforcement decisions.
- Core state access: no read/write access to EXOCHAIN core state, signatures, credentials, governance outcomes, consent records, or provenance records in this change.
- Trust boundary: public unauthenticated contact form queues site-only support inquiries and optionally notifies support through Resend; it must fail closed on queue/rate-limit failures and must not affect core runtime state.
- Test command and CI gate: `npm run security:contact-intake`, `npm run security:contact-disclosure`, `npm run typecheck`, `npm run lint`, `npm run build` from `site/`.
- Secrets inventory/config source: `CONTACT_DATABASE_URL` or `DATABASE_URL` for contact queue/rate-limit storage, `RESEND_API_KEY`, `CONTACT_TO_EMAIL`, `CONTACT_FROM_EMAIL` from runtime environment. No secrets are added or committed.
- Rollback/disablement path: unset or invalidate `RESEND_API_KEY` to queue without sending; unset contact DB configuration to fail contact intake closed with 503.

## Verification
- RED: `npm run security:contact-intake` initially failed because `src/lib/contact-intake-policy.ts` did not exist.
- GREEN: `npm run security:contact-intake` passed.
- `npm run security:contact-disclosure` passed.
- `npm run typecheck` passed.
- `npm run lint` passed.
- `npm run build` passed.
- `git diff --check` passed.
- `bash tools/test_repo_truth.sh` passed.
- `npm audit --audit-level=critical` exited 0. It still reports existing moderate/high advisories requiring breaking Next/eslint upgrades; those are not introduced by this PR.
- Touched-file source guard found no `Date.now`, `new Date`, `Math.random`, `TODO`, `unsafe`, or `request.json()` patterns.

## Original Issue Closure
- Direct `/api/contact` callers now hit server-side body/field validation before queueing.
- Valid submissions must pass global, IP, and email rate-limit buckets before database insertion or Resend notification.
- Bot honeypot submissions are acknowledged without queueing or sending support email.
