### PR TITLE
fix(gateway): commit vote audit atomically

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 198113 | `wc -l` |
-| Workspace tests | 4,450 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 198178 | `wc -l` |
+| Workspace tests | 4,451 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,450 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,451 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 198113 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 198178 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,450 listed workspace tests
+         cryptographic proofs, 4,451 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          160 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-gateway/src/handlers.rs
+++ b/crates/exo-gateway/src/handlers.rs
@@ -49,7 +49,7 @@ use exo_governance::conflict::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use sqlx::Row;
+use sqlx::{Postgres, Row, Transaction};
 
 use crate::server::{AppState, AuthenticatedSessionUser, auth_boundary_error_response};
 
@@ -317,8 +317,8 @@ fn build_audit_entry(
 }
 
 /// Write an audit entry using CBOR-hashed event payload.
-async fn write_audit(
-    state: &AppState,
+async fn write_audit_in_transaction(
+    tx: &mut Transaction<'_, Postgres>,
     event_type: &str,
     actor: &str,
     tenant_id: &str,
@@ -326,17 +326,15 @@ async fn write_audit(
     timestamp: Timestamp,
     payload: &Value,
 ) -> Result<(), String> {
-    let db = state.require_db().map_err(|e| e.to_string())?;
-    let mut tx = db.begin().await.map_err(|e| e.to_string())?;
     sqlx::query("LOCK TABLE audit_entries IN EXCLUSIVE MODE")
-        .execute(&mut *tx)
+        .execute(&mut **tx)
         .await
         .map_err(|e| e.to_string())?;
     let last = sqlx::query_as::<_, crate::db::AuditRow>(
         "SELECT sequence, prev_hash, event_hash, event_type, actor, tenant_id, decision_id, timestamp_physical_ms, timestamp_logical, entry_hash
          FROM audit_entries ORDER BY sequence DESC LIMIT 1",
     )
-    .fetch_optional(&mut *tx)
+    .fetch_optional(&mut **tx)
     .await
     .map_err(|e| e.to_string())?;
     let entry = build_audit_entry(
@@ -362,9 +360,35 @@ async fn write_audit(
     .bind(entry.timestamp_physical_ms)
     .bind(entry.timestamp_logical)
     .bind(&entry.entry_hash)
-    .execute(&mut *tx)
+    .execute(&mut **tx)
     .await
     .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Write an audit entry using CBOR-hashed event payload.
+#[cfg(all(test, feature = "production-db"))]
+async fn write_audit(
+    state: &AppState,
+    event_type: &str,
+    actor: &str,
+    tenant_id: &str,
+    decision_id: &str,
+    timestamp: Timestamp,
+    payload: &Value,
+) -> Result<(), String> {
+    let db = state.require_db().map_err(|e| e.to_string())?;
+    let mut tx = db.begin().await.map_err(|e| e.to_string())?;
+    write_audit_in_transaction(
+        &mut tx,
+        event_type,
+        actor,
+        tenant_id,
+        decision_id,
+        timestamp,
+        payload,
+    )
+    .await?;
     tx.commit().await.map_err(|e| e.to_string())?;
     Ok(())
 }
@@ -818,6 +842,16 @@ pub async fn vote_handler(
         }
     };
 
+    let audit_payload = serde_json::json!({
+        "event": "VoteCast",
+        "decision_id": body.decision_id.as_str(),
+        "tenant_id": tenant_id.as_str(),
+        "voter": body.voter_did.as_str(),
+        "choice": body.choice,
+        "timestamp_physical_ms": timestamp.physical_ms,
+        "timestamp_logical": timestamp.logical,
+    });
+
     // Persist updated decision.
     if let Err(e) =
         sqlx::query("UPDATE decisions SET payload = $1 WHERE id_hash = $2 AND tenant_id = $3")
@@ -834,27 +868,10 @@ pub async fn vote_handler(
         )
             .into_response();
     }
-    if let Err(e) = tx.commit().await {
-        tracing::error!(error = %e, "failed to commit vote transaction");
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": "decision persistence failed"})),
-        )
-            .into_response();
-    }
 
     // ── VIOLATION 3 FIX: CBOR canonical audit hash ──────────────────────
-    let audit_payload = serde_json::json!({
-        "event": "VoteCast",
-        "decision_id": body.decision_id.as_str(),
-        "tenant_id": tenant_id.as_str(),
-        "voter": body.voter_did.as_str(),
-        "choice": body.choice,
-        "timestamp_physical_ms": timestamp.physical_ms,
-        "timestamp_logical": timestamp.logical,
-    });
-    if let Err(e) = write_audit(
-        &state,
+    if let Err(e) = write_audit_in_transaction(
+        &mut tx,
         "VoteCast",
         &body.voter_did,
         &tenant_id,
@@ -868,6 +885,14 @@ pub async fn vote_handler(
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({"error": "audit write failed"})),
+        )
+            .into_response();
+    }
+    if let Err(e) = tx.commit().await {
+        tracing::error!(error = %e, "failed to commit vote transaction");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "decision persistence failed"})),
         )
             .into_response();
     }
@@ -1739,6 +1764,46 @@ mod tests {
         assert!(
             !vote_handler.contains(".execute(db)"),
             "vote handler must not update the mutable decision outside the transaction"
+        );
+    }
+
+    #[test]
+    fn vote_handler_writes_audit_in_vote_transaction_before_commit() {
+        let source = include_str!("handlers.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("test module marker present");
+        let vote_handler = production
+            .split("pub async fn vote_handler")
+            .nth(1)
+            .expect("vote handler source present")
+            .split("// ── Health handler")
+            .next()
+            .expect("vote handler source end");
+
+        let update_index = vote_handler
+            .find("UPDATE decisions SET payload = $1 WHERE id_hash = $2 AND tenant_id = $3")
+            .expect("vote handler must persist the updated decision");
+        let audit_index = vote_handler
+            .find("write_audit_in_transaction(")
+            .expect("vote handler must write the audit entry inside the vote transaction");
+        let commit_index = vote_handler
+            .find("tx.commit().await")
+            .expect("vote handler must commit the vote transaction");
+        let audit_call = &vote_handler[audit_index..commit_index];
+
+        assert!(
+            update_index < audit_index && audit_index < commit_index,
+            "decision mutation and VoteCast audit entry must commit atomically"
+        );
+        assert!(
+            audit_call.contains("&mut tx"),
+            "VoteCast audit entry must be written through the existing vote transaction"
+        );
+        assert!(
+            !vote_handler.contains("write_audit(\n        &state"),
+            "vote handler must not commit the decision before a separate audit transaction"
         );
     }
 


### PR DESCRIPTION
## Summary
- Remediates Codex Security CSV row 32: Audit hash cap can persist unaudited votes.
- Classification: `crates/exo-gateway/src/handlers.rs` is a core runtime adapter; the CSV row is imported evidence.
- Verified against current `origin/main` before editing: `vote_handler` committed the decision update transaction before calling `write_audit`, which opened a separate audit transaction.

## Remediation
- Split the audit writer so the vote path can insert `VoteCast` audit entries through the existing vote transaction.
- Move `tx.commit().await` after the decision update and audit insert both succeed.
- Keep the migrated audit route test helper available only for the `production-db` test target.

## TDD And Validation
- Red test first: `cargo test -p exo-gateway vote_handler_writes_audit_in_vote_transaction_before_commit` failed on current main because the vote handler had no in-transaction audit write.
- `cargo test -p exo-gateway vote_handler_writes_audit_in_vote_transaction_before_commit`
- `cargo test -p exo-gateway vote_handler_`
- `cargo test -p exo-gateway audit_`
- `cargo test -p exo-gateway`
- `cargo test -p exo-gateway --features production-db vote_audit_write_is_read_by_audit_route_from_migrated_schema`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `cargo fmt --all -- --check` (stable rustfmt warned that nightly-only options are ignored)
- `git diff --check`
- `bash tools/test_repo_truth.sh`
