### PR TITLE
fix(authority): prevent delegation depth squatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 198113 | `wc -l` |
-| Workspace tests | 4,450 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 198149 | `wc -l` |
+| Workspace tests | 4,451 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,450 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,451 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 198113 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 198149 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,450 listed workspace tests
+         cryptographic proofs, 4,451 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          160 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-authority/src/delegation.rs
+++ b/crates/exo-authority/src/delegation.rs
@@ -596,7 +596,7 @@ impl DelegationRegistry {
     }
 
     fn compute_depth(&self, did: &Did) -> Result<usize, AuthorityError> {
-        let mut max_depth = 0usize;
+        let mut shallowest_depth = None;
         if let Some(ids) = self.by_delegate.get(did.as_str()) {
             for id in ids {
                 if let Some(link) = self.links.get(id) {
@@ -607,16 +607,13 @@ impl DelegationRegistry {
                                 depth: link.depth,
                                 max_depth: DEFAULT_MAX_DEPTH,
                             })?;
-                    if candidate > max_depth {
-                        max_depth = candidate;
-                    }
-                    if max_depth >= DEFAULT_MAX_DEPTH {
-                        return Ok(max_depth);
-                    }
+                    shallowest_depth = Some(
+                        shallowest_depth.map_or(candidate, |current: usize| current.min(candidate)),
+                    );
                 }
             }
         }
-        Ok(max_depth)
+        Ok(shallowest_depth.unwrap_or(0))
     }
 }
 
@@ -1056,7 +1053,7 @@ mod tests {
     }
 
     #[test]
-    fn delegate_uses_max_parent_depth_for_multi_parent_delegator() {
+    fn delegate_uses_shallowest_parent_depth_for_multi_parent_delegator() {
         let mut reg = DelegationRegistry::new();
         let key = KeyPair::generate();
 
@@ -1067,7 +1064,46 @@ mod tests {
 
         let link = signed_delegate(&mut reg, "shared", "leaf", &[Permission::Read], &key).unwrap();
 
-        assert_eq!(link.depth, 3);
+        assert_eq!(link.depth, 1);
+    }
+
+    #[test]
+    fn delegate_depth_squatting_does_not_block_shallow_parent_grant() {
+        let mut reg = DelegationRegistry::new();
+        let key = KeyPair::generate();
+
+        signed_delegate(
+            &mut reg,
+            "legitimate-root",
+            "victim",
+            &[Permission::Read],
+            &key,
+        )
+        .unwrap();
+        for i in 0..DEFAULT_MAX_DEPTH {
+            let from = format!("attacker-{i}");
+            let to = if i + 1 == DEFAULT_MAX_DEPTH {
+                "victim".to_owned()
+            } else {
+                format!("attacker-{}", i + 1)
+            };
+            signed_delegate(&mut reg, &from, &to, &[Permission::Read], &key).unwrap();
+        }
+
+        let link = signed_delegate(
+            &mut reg,
+            "victim",
+            "legitimate-delegate",
+            &[Permission::Read],
+            &key,
+        )
+        .expect("unaccepted deep incoming grants must not poison a valid shallow parent chain");
+
+        assert_eq!(link.depth, 1);
+        let chain = reg
+            .find_chain(&did("legitimate-root"), &did("legitimate-delegate"))
+            .expect("shallow legitimate chain should remain resolvable");
+        assert_eq!(chain.depth(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Remediates Codex Security CSV row 33: Max-depth delegation squatting can block valid grants.
- Classification: `crates/exo-authority/src/delegation.rs` is EXOCHAIN core; the CSV row is imported evidence.
- Verified against current `origin/main` before editing: `compute_depth` used the maximum incoming delegation depth, so a deep unilateral incoming chain could force `DepthExceeded` for a victim with a valid shallow parent chain.

## Remediation
- Choose the shallowest incoming parent depth when assigning a new delegation depth.
- Preserve the existing max-depth rejection when no shallow parent path can support another link.
- Add a regression proving attacker-created deep incoming grants do not poison a legitimate shallow parent grant.

## TDD And Validation
- Red test first: `cargo test -p exo-authority delegate_depth_squatting_does_not_block_shallow_parent_grant` failed with `DepthExceeded { depth: 6, max_depth: 5 }` on current main.
- `cargo test -p exo-authority delegate_depth_squatting_does_not_block_shallow_parent_grant`
- `cargo test -p exo-authority`
- `cargo clippy -p exo-authority --all-targets -- -D warnings`
- `cargo fmt --all -- --check` (stable rustfmt warned that nightly-only options are ignored)
- `git diff --check`
- `bash tools/test_repo_truth.sh`
