### PR TITLE
fix(authority): bind revocations to delegation key

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 198113 | `wc -l` |
-| Workspace tests | 4,450 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 198156 | `wc -l` |
+| Workspace tests | 4,451 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,450 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,451 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 198113 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 198156 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,450 listed workspace tests
+         cryptographic proofs, 4,451 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          160 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-authority/src/delegation.rs
+++ b/crates/exo-authority/src/delegation.rs
@@ -141,6 +141,21 @@ impl AuthorityRevocation {
         };
 
         revocation.validate_structure()?;
+        if revocation.revoked_link.signature.is_empty() {
+            return Err(AuthorityError::InvalidSignature {
+                index: revocation.revoked_link.depth,
+            });
+        }
+        let revoked_link_payload = revocation.revoked_link.signing_payload()?;
+        if !crypto::verify(
+            &revoked_link_payload,
+            &revocation.revoked_link.signature,
+            revoker_public_key,
+        ) {
+            return Err(AuthorityError::InvalidSignature {
+                index: revocation.revoked_link.depth,
+            });
+        }
         let payload = revocation.signing_payload()?;
         let signature = sign_fn(&payload);
         if signature.is_empty() {
@@ -1186,6 +1201,34 @@ mod tests {
         assert_ne!(events[1].event_hash, Hash256::ZERO);
         reg.verify_audit_chain()
             .expect("signed revocation audit event must verify");
+    }
+
+    #[test]
+    fn signed_revoke_delegation_rejects_attacker_supplied_revoker_key() {
+        let mut reg = DelegationRegistry::new();
+        let alice_key = KeyPair::generate();
+        let attacker_key = KeyPair::generate();
+        let alice = did("alice");
+        let attacker_public_key = public_key(&attacker_key);
+        let link =
+            signed_delegate(&mut reg, "alice", "bob", &[Permission::Read], &alice_key).unwrap();
+        let id = link.id().unwrap();
+
+        let result = reg.revoke_delegation_signed(
+            DelegationRevocationGrant {
+                link_id: &id,
+                revoker: &alice,
+                revoked_at: &ts(6_000),
+                revoker_public_key: &attacker_public_key,
+            },
+            |payload| attacker_key.sign(payload),
+        );
+
+        assert!(matches!(
+            result,
+            Err(AuthorityError::InvalidSignature { index: 0 })
+        ));
+        assert_eq!(reg.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Remediates Codex Security CSV row 34: Signed revocation trusts attacker-supplied public keys.
- Classification: `crates/exo-authority/src/delegation.rs` is EXOCHAIN core; the CSV row is imported evidence.
- Verified against current `origin/main` before editing: `revoke_delegation_signed` accepted `revoker_did = original delegator DID` with an attacker-supplied `revoker_public_key`, verified only the revocation payload against that key, and then removed the authority link.

## Remediation
- Require the supplied revoker key to verify the original delegation link signature before creating revocation evidence or mutating the registry.
- Preserve existing revocation artifact validation and audit-chain behavior.
- Add a regression proving an attacker key cannot revoke a link by claiming the delegator DID.

## TDD And Validation
- Red test first: `cargo test -p exo-authority signed_revoke_delegation_rejects_attacker_supplied_revoker_key` failed on current main because the revocation succeeded.
- `cargo test -p exo-authority signed_revoke_delegation_rejects_attacker_supplied_revoker_key`
- `cargo test -p exo-authority`
- `cargo clippy -p exo-authority --all-targets -- -D warnings`
- `cargo fmt --all -- --check` (stable rustfmt warned that nightly-only options are ignored)
- `git diff --check`
- `bash tools/test_repo_truth.sh`
