### PR TITLE
fix(node): bound MCP Merkle proof indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 198113 | `wc -l` |
-| Workspace tests | 4,450 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 198259 | `wc -l` |
+| Workspace tests | 4,454 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,450 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,454 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 198113 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 198259 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,450 listed workspace tests
+         cryptographic proofs, 4,454 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          160 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-node/src/mcp/tools/ledger.rs
+++ b/crates/exo-node/src/mcp/tools/ledger.rs
@@ -303,12 +303,27 @@ pub fn verify_inclusion_definition() -> ToolDefinition {
                 "target_index": {
                     "type": "integer",
                     "description": "Zero-based index of the event hash in the original Merkle tree."
+                },
+                "leaf_count": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Total number of leaves in the original Merkle tree."
                 }
             },
-            "required": ["event_hash", "proof_hashes", "root_hash", "target_index"],
+            "required": ["event_hash", "proof_hashes", "root_hash", "target_index", "leaf_count"],
             "additionalProperties": false,
         }),
     }
+}
+
+fn expected_merkle_proof_depth(leaf_count: usize) -> usize {
+    let mut depth = 0;
+    let mut level_width = leaf_count;
+    while level_width > 1 {
+        level_width = level_width.div_ceil(2);
+        depth += 1;
+    }
+    depth
 }
 
 fn decode_hash256_hex(field: &str, value: &str) -> Result<Hash256, String> {
@@ -379,6 +394,26 @@ pub fn execute_verify_inclusion(params: &Value, _context: &NodeContext) -> ToolR
             );
         }
     };
+    let leaf_count = match params.get("leaf_count").and_then(Value::as_u64) {
+        Some(0) => {
+            return ToolResult::error(
+                json!({"error": "invalid leaf_count: value must be greater than zero"}).to_string(),
+            );
+        }
+        Some(n) => match usize::try_from(n) {
+            Ok(count) => count,
+            Err(_) => {
+                return ToolResult::error(
+                    json!({"error": "invalid leaf_count: value does not fit usize"}).to_string(),
+                );
+            }
+        },
+        None => {
+            return ToolResult::error(
+                json!({"error": "missing required parameter: leaf_count"}).to_string(),
+            );
+        }
+    };
 
     let event_hash = match decode_hash256_hex("event_hash", event_hash_raw) {
         Ok(hash) => hash,
@@ -407,6 +442,30 @@ pub fn execute_verify_inclusion(params: &Value, _context: &NodeContext) -> ToolR
         }
     }
 
+    if target_index >= leaf_count {
+        return ToolResult::error(
+            json!({
+                "error": format!(
+                    "target_index {target_index} is outside leaf_count {leaf_count}"
+                )
+            })
+            .to_string(),
+        );
+    }
+
+    let expected_proof_depth = expected_merkle_proof_depth(leaf_count);
+    if proof.len() != expected_proof_depth {
+        return ToolResult::error(
+            json!({
+                "error": format!(
+                    "proof_hashes depth {} does not match leaf_count {leaf_count} depth {expected_proof_depth}",
+                    proof.len()
+                )
+            })
+            .to_string(),
+        );
+    }
+
     let computed_root = merkle_root_from_proof(&event_hash, &proof, target_index);
     let verified = verify_merkle_proof(&root_hash, &event_hash, &proof, target_index);
 
@@ -417,6 +476,7 @@ pub fn execute_verify_inclusion(params: &Value, _context: &NodeContext) -> ToolR
         "verified": verified,
         "proof_depth": proof.len(),
         "target_index": target_index,
+        "leaf_count": leaf_count,
     });
     ToolResult::success(response.to_string())
 }
@@ -834,6 +894,7 @@ mod tests {
             "proof_hashes": proof_hashes,
             "root_hash": expected_root.to_string(),
             "target_index": target_index,
+            "leaf_count": leaves.len(),
         });
         let result = execute_verify_inclusion(&params, &NodeContext::empty());
         assert!(!result.is_error);
@@ -857,6 +918,7 @@ mod tests {
             "proof_hashes": proof_hashes,
             "root_hash": expected_root.to_string(),
             "target_index": target_index,
+            "leaf_count": leaves.len(),
         });
         let result = execute_verify_inclusion(&params, &NodeContext::empty());
         assert!(!result.is_error);
@@ -882,6 +944,7 @@ mod tests {
             "proof_hashes": proof_hashes,
             "root_hash": root.to_string(),
             "target_index": target_index,
+            "leaf_count": leaves.len(),
         });
         let result = execute_verify_inclusion(&params, &NodeContext::empty());
         assert!(!result.is_error);
@@ -928,11 +991,37 @@ mod tests {
             "proof_hashes": [sibling.to_string()],
             "root_hash": Hash256::digest(b"wrong-root").to_string(),
             "target_index": 0,
+            "leaf_count": 2,
         });
         let result = execute_verify_inclusion(&params, &NodeContext::empty());
         assert!(!result.is_error);
         let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
         assert_eq!(v["verified"], false);
+    }
+
+    #[test]
+    fn execute_verify_inclusion_rejects_target_index_outside_leaf_count() {
+        let leaves = [
+            Hash256::digest(b"event-left"),
+            Hash256::digest(b"event-right"),
+        ];
+        let expected_root = merkle_root(&leaves);
+        let proof = merkle_proof(&leaves, 0).expect("core proof");
+        let proof_hashes: Vec<String> = proof.iter().map(ToString::to_string).collect();
+
+        let params = json!({
+            "event_hash": leaves[0].to_string(),
+            "proof_hashes": proof_hashes,
+            "root_hash": expected_root.to_string(),
+            "target_index": 2,
+            "leaf_count": leaves.len(),
+        });
+
+        let result = execute_verify_inclusion(&params, &NodeContext::empty());
+
+        assert!(result.is_error);
+        assert!(result.content[0].text().contains("target_index"));
+        assert!(result.content[0].text().contains("leaf_count"));
     }
 
     #[test]
@@ -942,6 +1031,7 @@ mod tests {
             "proof_hashes": [],
             "root_hash": "0000",
             "target_index": 0,
+            "leaf_count": 1,
         });
         let result = execute_verify_inclusion(&params, &NodeContext::empty());
         assert!(result.is_error);
@@ -954,6 +1044,7 @@ mod tests {
             "proof_hashes": [],
             "root_hash": Hash256::digest(b"root").to_string(),
             "target_index": 0,
+            "leaf_count": 1,
         });
         let result = execute_verify_inclusion(&params, &NodeContext::empty());
         assert!(result.is_error);
@@ -968,6 +1059,7 @@ mod tests {
             "proof_hashes": [],
             "root_hash": "0000",
             "target_index": 0,
+            "leaf_count": 1,
         });
         let result = execute_verify_inclusion(&params, &NodeContext::empty());
         assert!(result.is_error);
@@ -982,6 +1074,7 @@ mod tests {
             "proof_hashes": ["1234"],
             "root_hash": Hash256::digest(b"root").to_string(),
             "target_index": 0,
+            "leaf_count": 1,
         });
         let result = execute_verify_inclusion(&params, &NodeContext::empty());
         assert!(result.is_error);
@@ -999,6 +1092,7 @@ mod tests {
             "proof_hashes": proof_hashes,
             "root_hash": Hash256::digest(b"root").to_string(),
             "target_index": 0,
+            "leaf_count": 1,
         });
 
         let result = execute_verify_inclusion(&params, &NodeContext::empty());
@@ -1020,6 +1114,19 @@ mod tests {
     }
 
     #[test]
+    fn verify_inclusion_definition_requires_leaf_count() {
+        let def = verify_inclusion_definition();
+
+        assert_eq!(def.input_schema["properties"]["leaf_count"]["minimum"], 1);
+        assert!(
+            def.input_schema["required"]
+                .as_array()
+                .expect("required fields")
+                .contains(&json!("leaf_count"))
+        );
+    }
+
+    #[test]
     fn execute_verify_inclusion_requires_target_index() {
         let params = json!({
             "event_hash": Hash256::digest(b"event").to_string(),
@@ -1029,6 +1136,44 @@ mod tests {
         let result = execute_verify_inclusion(&params, &NodeContext::empty());
         assert!(result.is_error);
         assert!(result.content[0].text().contains("target_index"));
+    }
+
+    #[test]
+    fn execute_verify_inclusion_requires_leaf_count() {
+        let params = json!({
+            "event_hash": Hash256::digest(b"event").to_string(),
+            "proof_hashes": [],
+            "root_hash": Hash256::digest(b"root").to_string(),
+            "target_index": 0,
+        });
+        let result = execute_verify_inclusion(&params, &NodeContext::empty());
+        assert!(result.is_error);
+        assert!(result.content[0].text().contains("leaf_count"));
+    }
+
+    #[test]
+    fn execute_verify_inclusion_rejects_inconsistent_leaf_count_depth() {
+        let leaves = [
+            Hash256::digest(b"event-left"),
+            Hash256::digest(b"event-right"),
+        ];
+        let expected_root = merkle_root(&leaves);
+        let proof = merkle_proof(&leaves, 0).expect("core proof");
+        let proof_hashes: Vec<String> = proof.iter().map(ToString::to_string).collect();
+
+        let params = json!({
+            "event_hash": leaves[0].to_string(),
+            "proof_hashes": proof_hashes,
+            "root_hash": expected_root.to_string(),
+            "target_index": 2,
+            "leaf_count": 3,
+        });
+
+        let result = execute_verify_inclusion(&params, &NodeContext::empty());
+
+        assert!(result.is_error);
+        assert!(result.content[0].text().contains("proof_hashes depth"));
+        assert!(result.content[0].text().contains("leaf_count"));
     }
 
     // -- get_checkpoint -------------------------------------------------------

--- a/crates/exo-node/src/mcp/tools/proofs.rs
+++ b/crates/exo-node/src/mcp/tools/proofs.rs
@@ -1069,6 +1069,7 @@ mod tests {
                 "proof_hashes": generated["proof_hashes"].clone(),
                 "root_hash": generated["root_hash"].clone(),
                 "target_index": generated["target_index"].clone(),
+                "leaf_count": generated["leaf_count"].clone(),
             }),
             &NodeContext::empty(),
         );


### PR DESCRIPTION
## Summary
- Classifies row 37 (`MCP Merkle verifier accepts unbounded target indexes`) as a core runtime adapter issue in `crates/exo-node/src/mcp/tools/ledger.rs`.
- Requires `leaf_count` for `exochain_verify_inclusion`, rejects `target_index >= leaf_count`, and rejects proofs whose depth does not match the declared tree size.
- Threads generated Merkle proof `leaf_count` into the verifier compatibility test and refreshes repo-truth README counters.

## Verification
- RED first: `cargo test -p exo-node execute_verify_inclusion_rejects_target_index_outside_leaf_count` failed on current behavior because index 2 was accepted for a two-leaf proof.
- `cargo test -p exo-node verify_inclusion`
- `cargo test -p exo-node execute_generate_merkle_proof`
- `cargo test -p exo-node`
- `cargo clippy -p exo-node --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`

## Path Classification
- `crates/exo-node/src/mcp/tools/ledger.rs`: core runtime adapter
- `crates/exo-node/src/mcp/tools/proofs.rs`: core runtime adapter
- `README.md`: documentation / repo-truth counter refresh
- `/Users/bobstewart/Downloads/codex-security-findings-2026-05-19T15-37-10.140Z.csv`: imported evidence, not modified