### PR TITLE
fix(authority): preserve signed delegation depths

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 198113 | `wc -l` |
-| Workspace tests | 4,450 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 198178 | `wc -l` |
+| Workspace tests | 4,453 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,450 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,453 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 198113 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 198178 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,450 listed workspace tests
+         cryptographic proofs, 4,453 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          160 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-authority/src/chain.rs
+++ b/crates/exo-authority/src/chain.rs
@@ -177,7 +177,7 @@ impl AuthorityChain {
 /// - Non-empty
 /// - Continuity: each link's delegate == next link's delegator
 /// - Depth limits
-/// - Depth values are correct (0, 1, 2, ...)
+/// - Depth values are consecutive and preserve their signed absolute offset
 ///
 /// # Errors
 /// Returns `AuthorityError` if validation fails.
@@ -212,12 +212,32 @@ fn validate_chain_topology(
         });
     }
 
-    // Validate continuity and depth values
+    let base_depth = links[0].depth;
+
+    // Validate continuity and signed absolute depth values.
     for (i, link) in links.iter().enumerate() {
-        if link.depth != i {
+        let expected_depth = base_depth
+            .checked_add(i)
+            .ok_or(AuthorityError::DepthExceeded {
+                depth: base_depth,
+                max_depth,
+            })?;
+        if link.depth != expected_depth {
             return Err(AuthorityError::ChainBroken {
                 index: i,
-                reason: format!("expected depth {i}, got {}", link.depth),
+                reason: format!("expected depth {expected_depth}, got {}", link.depth),
+            });
+        }
+        let chain_depth = expected_depth
+            .checked_add(1)
+            .ok_or(AuthorityError::DepthExceeded {
+                depth: expected_depth,
+                max_depth,
+            })?;
+        if chain_depth > max_depth {
+            return Err(AuthorityError::DepthExceeded {
+                depth: chain_depth,
+                max_depth,
             });
         }
         if i > 0 {
@@ -471,6 +491,20 @@ mod tests {
     }
 
     #[test]
+    fn build_accepts_subchain_with_signed_depth_offset() {
+        let links = vec![
+            fake_link("alice", "bob", vec![Permission::Read], 1, None),
+            fake_link("bob", "charlie", vec![Permission::Read], 2, None),
+        ];
+
+        let chain = build_chain(&links).unwrap();
+
+        assert_eq!(chain.depth(), 2);
+        assert_eq!(chain.root().unwrap(), &did("alice"));
+        assert_eq!(chain.leaf().unwrap(), &did("charlie"));
+    }
+
+    #[test]
     fn build_rejects_empty() {
         assert_eq!(build_chain(&[]), Err(AuthorityError::EmptyChain));
     }
@@ -553,6 +587,21 @@ mod tests {
             signed_link(&reg, "alice", "bob", vec![Permission::Read], 1, None),
         ];
         let chain = build_chain(&links).unwrap();
+        assert!(verify_chain(&chain, &now(), reg.resolver()).is_ok());
+    }
+
+    #[test]
+    fn verify_accepts_subchain_with_signed_depth_offset() {
+        let mut reg = KeyRegistry::new();
+        reg.register("alice");
+        reg.register("bob");
+        let links = vec![
+            signed_link(&reg, "alice", "bob", vec![Permission::Read], 1, None),
+            signed_link(&reg, "bob", "charlie", vec![Permission::Read], 2, None),
+        ];
+
+        let chain = build_chain(&links).unwrap();
+
         assert!(verify_chain(&chain, &now(), reg.resolver()).is_ok());
     }
 
@@ -734,7 +783,7 @@ mod tests {
     }
 
     #[test]
-    fn verify_rejects_prebuilt_chain_with_forged_depth() {
+    fn verify_rejects_prebuilt_chain_with_over_max_depth() {
         let mut reg = KeyRegistry::new();
         reg.register("root");
         let chain = AuthorityChain {
@@ -751,7 +800,7 @@ mod tests {
 
         assert!(matches!(
             verify_chain(&chain, &now(), reg.resolver()),
-            Err(AuthorityError::ChainBroken { index: 0, .. })
+            Err(AuthorityError::DepthExceeded { .. })
         ));
     }
 

--- a/crates/exo-authority/src/delegation.rs
+++ b/crates/exo-authority/src/delegation.rs
@@ -515,10 +515,6 @@ impl DelegationRegistry {
     pub fn find_chain(&self, from: &Did, to: &Did) -> Option<AuthorityChain> {
         let mut path = Vec::new();
         if self.find_path_dfs(from, to, &mut path, 0, DEFAULT_MAX_DEPTH) {
-            // Re-number depths
-            for (i, link) in path.iter_mut().enumerate() {
-                link.depth = i;
-            }
             chain::build_chain(&path).ok()
         } else {
             None
@@ -980,6 +976,26 @@ mod tests {
             (did("bob").as_str().to_owned(), public_key(&bob_key)),
         ]);
 
+        assert!(chain::verify_chain(&chain, &now(), |did| keys.get(did.as_str()).copied()).is_ok());
+    }
+
+    #[test]
+    fn find_chain_preserves_signed_depth_for_subchain_verification() {
+        let mut reg = DelegationRegistry::new();
+        let root_key = KeyPair::generate();
+        let alice_key = KeyPair::generate();
+        signed_delegate(&mut reg, "root", "alice", &[Permission::Read], &root_key).unwrap();
+        signed_delegate(&mut reg, "alice", "bob", &[Permission::Read], &alice_key).unwrap();
+
+        let chain = reg
+            .find_chain(&did("alice"), &did("bob"))
+            .expect("subchain should resolve");
+        let keys = std::collections::BTreeMap::from([(
+            did("alice").as_str().to_owned(),
+            public_key(&alice_key),
+        )]);
+
+        assert_eq!(chain.links[0].depth, 1);
         assert!(chain::verify_chain(&chain, &now(), |did| keys.get(did.as_str()).copied()).is_ok());
     }
 


### PR DESCRIPTION
## Summary
- Classifies row 38 (`Signed delegation depth is mutated during chain lookup`) as an EXOCHAIN core authority issue.
- Stops `DelegationRegistry::find_chain` from rewriting signed `AuthorityLink.depth` values.
- Updates chain topology validation to accept consecutive signed depth offsets for legitimate subchains while still rejecting broken topology and over-max absolute depths.
- Refreshes repo-truth README counters derived from this branch.

## Verification
- RED first: `cargo test -p exo-authority find_chain_preserves_signed_depth_for_subchain_verification` failed because `find_chain` returned depth `0` for a link signed at depth `1`.
- RED lower-level contract: `cargo test -p exo-authority subchain_with_signed_depth_offset` failed before topology validation accepted signed depth offsets.
- `cargo test -p exo-authority signed_depth`
- `cargo test -p exo-authority`
- `cargo clippy -p exo-authority --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`

## Path Classification
- `crates/exo-authority/src/chain.rs`: EXOCHAIN core
- `crates/exo-authority/src/delegation.rs`: EXOCHAIN core
- `README.md`: documentation / repo-truth counter refresh
- `/Users/bobstewart/Downloads/codex-security-findings-2026-05-19T15-37-10.140Z.csv`: imported evidence, not modified