### PR TITLE
fix(messaging): bind death verification timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 198113 | `wc -l` |
-| Workspace tests | 4,450 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 198305 | `wc -l` |
+| Workspace tests | 4,454 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |

--- a/crates/exo-messaging/src/death_trigger.rs
+++ b/crates/exo-messaging/src/death_trigger.rs
@@ -56,11 +56,11 @@ pub struct DeathVerificationCreationMetadata {
 }
 
 impl DeathVerificationCreationMetadata {
-    /// Validate caller-supplied creation metadata.
+    /// Validate externally supplied creation metadata before signature checks bind it.
     pub fn new(created_at: Timestamp) -> Result<Self, MessagingError> {
         if created_at == Timestamp::ZERO {
             return Err(MessagingError::InvalidDeathVerification(
-                "created_at must be caller-supplied and non-zero".to_owned(),
+                "created_at must be non-zero".to_owned(),
             ));
         }
         Ok(Self { created_at })
@@ -74,11 +74,11 @@ pub struct DeathConfirmationMetadata {
 }
 
 impl DeathConfirmationMetadata {
-    /// Validate caller-supplied confirmation metadata.
+    /// Validate externally supplied confirmation metadata before signature checks bind it.
     pub fn new(confirmed_at: Timestamp) -> Result<Self, MessagingError> {
         if confirmed_at == Timestamp::ZERO {
             return Err(MessagingError::InvalidDeathVerification(
-                "confirmed_at must be caller-supplied and non-zero".to_owned(),
+                "confirmed_at must be non-zero".to_owned(),
             ));
         }
         Ok(Self { confirmed_at })
@@ -92,11 +92,11 @@ pub struct DeathRejectionMetadata {
 }
 
 impl DeathRejectionMetadata {
-    /// Validate caller-supplied rejection metadata.
+    /// Validate externally supplied rejection metadata.
     pub fn new(rejected_at: Timestamp) -> Result<Self, MessagingError> {
         if rejected_at == Timestamp::ZERO {
             return Err(MessagingError::InvalidDeathVerification(
-                "rejected_at must be caller-supplied and non-zero".to_owned(),
+                "rejected_at must be non-zero".to_owned(),
             ));
         }
         Ok(Self { rejected_at })
@@ -140,20 +140,23 @@ struct ConfirmationSigningPayload<'a> {
     required_confirmations: u8,
     claim_nonce: &'a [u8],
     trustee_did: &'a str,
+    confirmed_at_physical_ms: u64,
+    confirmed_at_logical: u32,
     authorized_trustees: Vec<AuthorizedTrusteeSigningEntry<'a>>,
 }
 
 /// Canonical CBOR payload signed for the initiator's first confirmation.
 ///
 /// The payload binds the subject, initiator, threshold, authorized trustee set,
-/// caller-supplied claim nonce, and confirming trustee DID. The signature itself
-/// and HLC timestamps are excluded so callers can sign before the state exists.
+/// caller-supplied claim nonce, confirming trustee DID, and the HLC timestamp
+/// that will be stored with the confirmation. The signature itself is excluded.
 pub fn initial_confirmation_signing_payload(
     subject_did: &Did,
     initiated_by: &Did,
     required_confirmations: u8,
     authorized_trustees: &BTreeMap<Did, PublicKey>,
     claim_nonce: &[u8],
+    created_at: &Timestamp,
 ) -> Result<Vec<u8>, MessagingError> {
     confirmation_signing_payload_for(
         subject_did,
@@ -162,6 +165,7 @@ pub fn initial_confirmation_signing_payload(
         authorized_trustees,
         claim_nonce,
         initiated_by,
+        created_at,
     )
 }
 
@@ -172,6 +176,7 @@ fn confirmation_signing_payload_for(
     authorized_trustees: &BTreeMap<Did, PublicKey>,
     claim_nonce: &[u8],
     trustee_did: &Did,
+    confirmed_at: &Timestamp,
 ) -> Result<Vec<u8>, MessagingError> {
     let trustee_entries = authorized_trustees
         .iter()
@@ -187,6 +192,8 @@ fn confirmation_signing_payload_for(
         required_confirmations,
         claim_nonce,
         trustee_did: trustee_did.as_str(),
+        confirmed_at_physical_ms: confirmed_at.physical_ms,
+        confirmed_at_logical: confirmed_at.logical,
         authorized_trustees: trustee_entries,
     };
     let mut encoded = Vec::new();
@@ -221,6 +228,7 @@ impl DeathVerification {
             required_confirmations,
             &authorized_trustees,
             &claim_nonce,
+            &metadata.created_at,
         )?;
         if !exo_core::crypto::verify(
             &signing_payload,
@@ -252,6 +260,7 @@ impl DeathVerification {
     pub fn confirmation_signing_payload(
         &self,
         trustee_did: &Did,
+        metadata: &DeathConfirmationMetadata,
     ) -> Result<Vec<u8>, MessagingError> {
         confirmation_signing_payload_for(
             &self.subject_did,
@@ -260,6 +269,7 @@ impl DeathVerification {
             &self.authorized_trustees,
             &self.claim_nonce,
             trustee_did,
+            &metadata.confirmed_at,
         )
     }
 
@@ -273,6 +283,12 @@ impl DeathVerification {
     ) -> Result<bool, MessagingError> {
         if self.status != DeathVerificationStatus::Pending {
             return Err(MessagingError::DeathTriggerAlreadyResolved);
+        }
+        if metadata.confirmed_at < self.created {
+            return Err(MessagingError::InvalidDeathVerification(format!(
+                "confirmed_at {} must not precede created_at {}",
+                metadata.confirmed_at, self.created
+            )));
         }
         let expected_public_key = *self
             .authorized_trustees
@@ -293,7 +309,7 @@ impl DeathVerification {
         if expected_public_key != trustee_public_key {
             return Err(MessagingError::SignatureVerificationFailed);
         }
-        let signing_payload = self.confirmation_signing_payload(&trustee_did)?;
+        let signing_payload = self.confirmation_signing_payload(&trustee_did, &metadata)?;
         if !exo_core::crypto::verify(&signing_payload, &signature, &expected_public_key) {
             return Err(MessagingError::SignatureVerificationFailed);
         }
@@ -322,6 +338,12 @@ impl DeathVerification {
     pub fn reject(&mut self, metadata: DeathRejectionMetadata) -> Result<(), MessagingError> {
         if self.status != DeathVerificationStatus::Pending {
             return Err(MessagingError::DeathTriggerAlreadyResolved);
+        }
+        if metadata.rejected_at < self.created {
+            return Err(MessagingError::InvalidDeathVerification(format!(
+                "rejected_at {} must not precede created_at {}",
+                metadata.rejected_at, self.created
+            )));
         }
         self.status = DeathVerificationStatus::Rejected;
         self.resolved_at = Some(metadata.rejected_at);
@@ -432,6 +454,7 @@ mod tests {
         required_confirmations: u8,
         authorized_trustees: &BTreeMap<Did, PublicKey>,
         claim_nonce: &[u8],
+        created_at: Timestamp,
         keypair: &KeyPair,
     ) -> Signature {
         let payload = initial_confirmation_signing_payload(
@@ -440,6 +463,7 @@ mod tests {
             required_confirmations,
             authorized_trustees,
             claim_nonce,
+            &created_at,
         )
         .unwrap();
         sign(&payload, keypair.secret_key())
@@ -453,12 +477,14 @@ mod tests {
         claim_nonce: Vec<u8>,
         keypair: &KeyPair,
     ) -> DeathVerification {
+        let metadata = creation_metadata(1_000);
         let signature = initial_signature(
             subject,
             initiated_by,
             required_confirmations,
             &authorized_trustees,
             &claim_nonce,
+            metadata.created_at,
             keypair,
         );
         DeathVerification::new(
@@ -468,7 +494,7 @@ mod tests {
             authorized_trustees,
             claim_nonce,
             signature,
-            creation_metadata(1_000),
+            metadata,
         )
         .unwrap()
     }
@@ -476,10 +502,12 @@ mod tests {
     fn confirmation_signature(
         verification: &DeathVerification,
         trustee_did: &Did,
+        confirmed_at: Timestamp,
         keypair: &KeyPair,
     ) -> Signature {
+        let metadata = DeathConfirmationMetadata::new(confirmed_at).unwrap();
         let payload = verification
-            .confirmation_signing_payload(trustee_did)
+            .confirmation_signing_payload(trustee_did, &metadata)
             .unwrap();
         sign(&payload, keypair.secret_key())
     }
@@ -508,7 +536,15 @@ mod tests {
             Err(MessagingError::SignatureVerificationFailed)
         ));
 
-        let signature = initial_signature(&subject, &bob, 2, &authorized, &nonce, &bob_key);
+        let signature = initial_signature(
+            &subject,
+            &bob,
+            2,
+            &authorized,
+            &nonce,
+            timestamp(1_002),
+            &bob_key,
+        );
         let dv = DeathVerification::new(
             subject,
             bob.clone(),
@@ -527,13 +563,56 @@ mod tests {
     }
 
     #[test]
+    fn initiator_signature_rejects_replayed_created_at_metadata() {
+        let subject = did("alice");
+        let bob = did("bob");
+        let carol = did("carol");
+        let bob_key = keypair(1);
+        let carol_key = keypair(2);
+        let authorized = authorized_trustees(&[(&bob, &bob_key), (&carol, &carol_key)]);
+        let nonce = b"r6-claim-created-at-replay".to_vec();
+        let signature = initial_signature(
+            &subject,
+            &bob,
+            2,
+            &authorized,
+            &nonce,
+            timestamp(1_000),
+            &bob_key,
+        );
+
+        let result = DeathVerification::new(
+            subject,
+            bob,
+            2,
+            authorized,
+            nonce,
+            signature,
+            creation_metadata(9_999),
+        );
+
+        assert!(matches!(
+            result,
+            Err(MessagingError::SignatureVerificationFailed)
+        ));
+    }
+
+    #[test]
     fn one_trustee_death_verification_rejected_even_with_valid_signature() {
         let subject = did("alice");
         let bob = did("bob");
         let bob_key = keypair(1);
         let authorized = authorized_trustees(&[(&bob, &bob_key)]);
         let nonce = b"r6-claim-one-trustee".to_vec();
-        let signature = initial_signature(&subject, &bob, 1, &authorized, &nonce, &bob_key);
+        let signature = initial_signature(
+            &subject,
+            &bob,
+            1,
+            &authorized,
+            &nonce,
+            timestamp(1_003),
+            &bob_key,
+        );
 
         let result = DeathVerification::new(
             subject,
@@ -598,7 +677,7 @@ mod tests {
             b"r6-claim-3".to_vec(),
             &bob_key,
         );
-        let signature = confirmation_signature(&dv, &carol, &wrong_key);
+        let signature = confirmation_signature(&dv, &carol, timestamp(2_001), &wrong_key);
 
         let result = dv.confirm(
             carol,
@@ -636,7 +715,8 @@ mod tests {
             b"r6-claim-b".to_vec(),
             &bob_key,
         );
-        let replayed_signature = confirmation_signature(&dv_a, &carol, &carol_key);
+        let replayed_signature =
+            confirmation_signature(&dv_a, &carol, timestamp(2_002), &carol_key);
 
         let result = dv_b.confirm(
             carol,
@@ -666,7 +746,7 @@ mod tests {
             b"r6-claim-4".to_vec(),
             &bob_key,
         );
-        let signature = confirmation_signature(&dv, &carol, &carol_key);
+        let signature = confirmation_signature(&dv, &carol, timestamp(2_003), &carol_key);
         dv.subject_did = did("mallory");
 
         let result = dv.confirm(
@@ -701,7 +781,7 @@ mod tests {
             &bob_key,
         );
 
-        let carol_signature = confirmation_signature(&dv, &carol, &carol_key);
+        let carol_signature = confirmation_signature(&dv, &carol, timestamp(2_004), &carol_key);
         let met = dv
             .confirm(
                 carol.clone(),
@@ -713,7 +793,7 @@ mod tests {
         assert!(!met);
         assert_eq!(dv.confirmations_remaining(), 1);
 
-        let dave_signature = confirmation_signature(&dv, &dave, &dave_key);
+        let dave_signature = confirmation_signature(&dv, &dave, timestamp(2_005), &dave_key);
         let met = dv
             .confirm(
                 dave,
@@ -726,6 +806,67 @@ mod tests {
         assert_eq!(dv.status, DeathVerificationStatus::Verified);
         assert!(dv.should_release());
         assert!(dv.resolved_at.is_some());
+    }
+
+    #[test]
+    fn trustee_signature_rejects_replayed_confirmed_at_metadata() {
+        let subject = did("alice");
+        let bob = did("bob");
+        let carol = did("carol");
+        let bob_key = keypair(1);
+        let carol_key = keypair(2);
+        let authorized = authorized_trustees(&[(&bob, &bob_key), (&carol, &carol_key)]);
+        let mut dv = signed_verification(
+            &subject,
+            &bob,
+            2,
+            authorized,
+            b"r6-confirmed-at-replay".to_vec(),
+            &bob_key,
+        );
+        let signature = confirmation_signature(&dv, &carol, timestamp(2_000), &carol_key);
+
+        let result = dv.confirm(
+            carol,
+            *carol_key.public_key(),
+            signature,
+            confirmation_metadata(9_998),
+        );
+
+        assert!(matches!(
+            result,
+            Err(MessagingError::SignatureVerificationFailed)
+        ));
+    }
+
+    #[test]
+    fn confirmation_timestamp_before_creation_rejected() {
+        let subject = did("alice");
+        let bob = did("bob");
+        let carol = did("carol");
+        let bob_key = keypair(1);
+        let carol_key = keypair(2);
+        let authorized = authorized_trustees(&[(&bob, &bob_key), (&carol, &carol_key)]);
+        let mut dv = signed_verification(
+            &subject,
+            &bob,
+            2,
+            authorized,
+            b"r6-confirmed-before-created".to_vec(),
+            &bob_key,
+        );
+        let signature = confirmation_signature(&dv, &carol, timestamp(999), &carol_key);
+
+        let result = dv.confirm(
+            carol,
+            *carol_key.public_key(),
+            signature,
+            confirmation_metadata(999),
+        );
+
+        assert!(
+            matches!(result, Err(MessagingError::InvalidDeathVerification(reason)) if reason.contains("confirmed_at"))
+        );
     }
 
     #[test]
@@ -747,7 +888,7 @@ mod tests {
             b"r6-claim-6".to_vec(),
             &bob_key,
         );
-        let signature = confirmation_signature(&dv, &carol, &carol_key);
+        let signature = confirmation_signature(&dv, &carol, timestamp(2_006), &carol_key);
         dv.confirm(
             carol.clone(),
             *carol_key.public_key(),
@@ -787,7 +928,7 @@ mod tests {
             b"r6-claim-7".to_vec(),
             &bob_key,
         );
-        let carol_signature = confirmation_signature(&dv, &carol, &carol_key);
+        let carol_signature = confirmation_signature(&dv, &carol, timestamp(2_008), &carol_key);
         dv.confirm(
             carol,
             *carol_key.public_key(),
@@ -796,7 +937,7 @@ mod tests {
         )
         .unwrap();
 
-        let dave_signature = confirmation_signature(&dv, &dave, &dave_key);
+        let dave_signature = confirmation_signature(&dv, &dave, timestamp(2_009), &dave_key);
         let result = dv.confirm(
             dave,
             *dave_key.public_key(),
@@ -829,7 +970,7 @@ mod tests {
         assert_eq!(dv.status, DeathVerificationStatus::Rejected);
         assert!(!dv.should_release());
 
-        let carol_signature = confirmation_signature(&dv, &carol, &carol_key);
+        let carol_signature = confirmation_signature(&dv, &carol, timestamp(2_010), &carol_key);
         let result = dv.confirm(
             carol,
             *carol_key.public_key(),
@@ -869,7 +1010,8 @@ mod tests {
         );
         assert_eq!(dv.confirmations_remaining(), 2);
 
-        let alternate_signature = confirmation_signature(&dv, &alternate, &alternate_key);
+        let alternate_signature =
+            confirmation_signature(&dv, &alternate, timestamp(2_011), &alternate_key);
         dv.confirm(
             alternate,
             *alternate_key.public_key(),
@@ -879,7 +1021,8 @@ mod tests {
         .unwrap();
         assert_eq!(dv.confirmations_remaining(), 1);
 
-        let contingency_signature = confirmation_signature(&dv, &contingency, &contingency_key);
+        let contingency_signature =
+            confirmation_signature(&dv, &contingency, timestamp(2_012), &contingency_key);
         let verified = dv
             .confirm(
                 contingency,
@@ -903,7 +1046,7 @@ mod tests {
     }
 
     #[test]
-    fn creation_preserves_caller_supplied_timestamps() {
+    fn creation_preserves_signed_timestamp_metadata() {
         let subject = did("alice");
         let bob = did("bob");
         let carol = did("carol");
@@ -911,7 +1054,15 @@ mod tests {
         let carol_key = keypair(2);
         let authorized = authorized_trustees(&[(&bob, &bob_key), (&carol, &carol_key)]);
         let nonce = b"r6-claim-created-at".to_vec();
-        let signature = initial_signature(&subject, &bob, 2, &authorized, &nonce, &bob_key);
+        let signature = initial_signature(
+            &subject,
+            &bob,
+            2,
+            &authorized,
+            &nonce,
+            timestamp(7_001),
+            &bob_key,
+        );
         let metadata = creation_metadata(7_001);
 
         let dv = DeathVerification::new(subject, bob, 2, authorized, nonce, signature, metadata)
@@ -933,7 +1084,7 @@ mod tests {
     }
 
     #[test]
-    fn confirm_preserves_caller_supplied_timestamp() {
+    fn confirm_preserves_signed_timestamp_metadata() {
         let subject = did("alice");
         let bob = did("bob");
         let carol = did("carol");
@@ -948,7 +1099,7 @@ mod tests {
             b"r6-claim-confirm-time".to_vec(),
             &bob_key,
         );
-        let signature = confirmation_signature(&dv, &carol, &carol_key);
+        let signature = confirmation_signature(&dv, &carol, timestamp(7_002), &carol_key);
 
         let verified = dv
             .confirm(
@@ -974,7 +1125,7 @@ mod tests {
     }
 
     #[test]
-    fn reject_preserves_caller_supplied_timestamp() {
+    fn reject_preserves_validated_rejection_timestamp() {
         let subject = did("alice");
         let bob = did("bob");
         let carol = did("carol");
@@ -994,6 +1145,30 @@ mod tests {
 
         assert_eq!(dv.status, DeathVerificationStatus::Rejected);
         assert_eq!(dv.resolved_at, Some(timestamp(7_003)));
+    }
+
+    #[test]
+    fn rejection_timestamp_before_creation_rejected() {
+        let subject = did("alice");
+        let bob = did("bob");
+        let carol = did("carol");
+        let bob_key = keypair(1);
+        let carol_key = keypair(2);
+        let authorized = authorized_trustees(&[(&bob, &bob_key), (&carol, &carol_key)]);
+        let mut dv = signed_verification(
+            &subject,
+            &bob,
+            2,
+            authorized,
+            b"r6-reject-before-created".to_vec(),
+            &bob_key,
+        );
+
+        let result = dv.reject(rejection_metadata(999));
+
+        assert!(
+            matches!(result, Err(MessagingError::InvalidDeathVerification(reason)) if reason.contains("rejected_at"))
+        );
     }
 
     #[test]

--- a/crates/exochain-wasm/src/messaging_bindings.rs
+++ b/crates/exochain-wasm/src/messaging_bindings.rs
@@ -314,14 +314,18 @@ fn parse_authorized_trustees_json(
 /// Compute the canonical death-verification initial confirmation payload.
 ///
 /// Returns the CBOR bytes that `initiated_by_did` signs before calling
-/// [`wasm_death_verification_new`].
+/// [`wasm_death_verification_new`]. The HLC values must match the creation
+/// metadata supplied to `wasm_death_verification_new`.
 #[wasm_bindgen]
+#[allow(clippy::too_many_arguments)]
 pub fn wasm_death_verification_initial_signing_payload(
     subject_did: &str,
     initiated_by_did: &str,
     required_confirmations: u8,
     authorized_trustees_json: &str,
     claim_nonce_hex: &str,
+    created_physical_ms: u64,
+    created_logical: u32,
 ) -> Result<Vec<u8>, JsValue> {
     let subject = exo_core::Did::new(subject_did)
         .map_err(|e| JsValue::from_str(&format!("invalid subject DID: {e}")))?;
@@ -330,6 +334,10 @@ pub fn wasm_death_verification_initial_signing_payload(
     let authorized_trustees = parse_authorized_trustees_json(authorized_trustees_json)?;
     let claim_nonce = hex::decode(claim_nonce_hex)
         .map_err(|e| JsValue::from_str(&format!("invalid claim nonce hex: {e}")))?;
+    let metadata = exo_messaging::death_trigger::DeathVerificationCreationMetadata::new(
+        exo_core::Timestamp::new(created_physical_ms, created_logical),
+    )
+    .map_err(|e| JsValue::from_str(&format!("invalid death verification metadata: {e}")))?;
 
     exo_messaging::death_trigger::initial_confirmation_signing_payload(
         &subject,
@@ -337,6 +345,7 @@ pub fn wasm_death_verification_initial_signing_payload(
         required_confirmations,
         &authorized_trustees,
         &claim_nonce,
+        &metadata.created_at,
     )
     .map_err(|e| JsValue::from_str(&format!("death verification signing payload failed: {e}")))
 }
@@ -393,20 +402,28 @@ pub fn wasm_death_verification_new(
 /// Compute the canonical trustee confirmation payload for an existing claim.
 ///
 /// Returns the CBOR bytes that `trustee_did` signs before calling
-/// [`wasm_death_verification_confirm`].
+/// [`wasm_death_verification_confirm`]. The HLC values must match the
+/// confirmation metadata supplied to `wasm_death_verification_confirm`.
 #[wasm_bindgen]
 pub fn wasm_death_verification_confirmation_signing_payload(
     state_json: &str,
     trustee_did: &str,
+    confirmed_physical_ms: u64,
+    confirmed_logical: u32,
 ) -> Result<Vec<u8>, JsValue> {
     let dv: exo_messaging::death_trigger::DeathVerification = from_json_str(state_json)?;
     let trustee = exo_core::Did::new(trustee_did)
         .map_err(|e| JsValue::from_str(&format!("invalid trustee DID: {e}")))?;
-    dv.confirmation_signing_payload(&trustee).map_err(|e| {
-        JsValue::from_str(&format!(
-            "death verification confirmation payload failed: {e}"
-        ))
-    })
+    let metadata = exo_messaging::death_trigger::DeathConfirmationMetadata::new(
+        exo_core::Timestamp::new(confirmed_physical_ms, confirmed_logical),
+    )
+    .map_err(|e| JsValue::from_str(&format!("invalid death confirmation metadata: {e}")))?;
+    dv.confirmation_signing_payload(&trustee, &metadata)
+        .map_err(|e| {
+            JsValue::from_str(&format!(
+                "death verification confirmation payload failed: {e}"
+            ))
+        })
 }
 
 /// Add a trustee confirmation to a death verification.

--- a/demo/apps/vitallock/src/lib/crypto.ts
+++ b/demo/apps/vitallock/src/lib/crypto.ts
@@ -185,6 +185,8 @@ export function deathVerificationInitialSigningPayload(
   initiatedByDid: string,
   authorizedTrustees: AuthorizedDeathVerificationTrustee[],
   claimNonceHex: string,
+  createdPhysicalMs: bigint,
+  createdLogical: number,
   requiredConfirmations: number = 3,
 ): Uint8Array {
   return wasm_death_verification_initial_signing_payload(
@@ -193,6 +195,8 @@ export function deathVerificationInitialSigningPayload(
     requiredConfirmations,
     JSON.stringify(authorizedTrustees),
     claimNonceHex,
+    createdPhysicalMs,
+    createdLogical,
   );
 }
 
@@ -223,8 +227,15 @@ export function createDeathVerification(
 export function deathVerificationConfirmationSigningPayload(
   stateJson: string,
   trusteeDid: string,
+  confirmedPhysicalMs: bigint,
+  confirmedLogical: number,
 ): Uint8Array {
-  return wasm_death_verification_confirmation_signing_payload(stateJson, trusteeDid);
+  return wasm_death_verification_confirmation_signing_payload(
+    stateJson,
+    trusteeDid,
+    confirmedPhysicalMs,
+    confirmedLogical,
+  );
 }
 
 /** Add a trustee confirmation to a death verification. */

--- a/demo/services/vitallock-api/src/index.js
+++ b/demo/services/vitallock-api/src/index.js
@@ -24,6 +24,8 @@ import pg from 'pg';
 
 const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
 const PORT = process.env.PORT || 3010;
+const DEATH_VERIFICATION_INGRESS_SKEW_MS = 300_000n;
+const MAX_HLC_LOGICAL = 4_294_967_295;
 
 function json(res, status, data) {
   res.writeHead(status, {
@@ -43,6 +45,51 @@ function parseBody(req) {
 }
 
 function nowMs() { return Date.now(); }
+
+function parseUnsignedPhysicalMs(value, field) {
+  if (typeof value === 'number') {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+      return { error: `${field} must be a positive safe integer millisecond timestamp` };
+    }
+    return { value: BigInt(value) };
+  }
+  if (typeof value === 'string' && /^[1-9][0-9]*$/.test(value)) {
+    return { value: BigInt(value) };
+  }
+  return { error: `${field} must be a positive integer millisecond timestamp` };
+}
+
+function parseHlcLogical(value, field) {
+  if (!Number.isInteger(value) || value < 0 || value > MAX_HLC_LOGICAL) {
+    return { error: `${field} must be an unsigned 32-bit integer` };
+  }
+  return { value };
+}
+
+function parseTrustedDeathVerificationHlc(physicalMs, logical, physicalField, logicalField) {
+  const parsedPhysical = parseUnsignedPhysicalMs(physicalMs, physicalField);
+  if (parsedPhysical.error) return parsedPhysical;
+
+  const parsedLogical = parseHlcLogical(logical, logicalField);
+  if (parsedLogical.error) return parsedLogical;
+
+  const observedAtMs = nowMs();
+  const observedPhysical = BigInt(observedAtMs);
+  const delta = parsedPhysical.value > observedPhysical
+    ? parsedPhysical.value - observedPhysical
+    : observedPhysical - parsedPhysical.value;
+  if (delta > DEATH_VERIFICATION_INGRESS_SKEW_MS) {
+    return {
+      error: `${physicalField} must be within the trusted ingress clock window`,
+    };
+  }
+
+  return {
+    physicalMs: parsedPhysical.value,
+    logical: parsedLogical.value,
+    observedAtMs,
+  };
+}
 
 export const server = http.createServer(async (req, res) => {
   if (req.method === 'OPTIONS') {
@@ -320,6 +367,15 @@ export const server = http.createServer(async (req, res) => {
           error: 'created_physical_ms and created_logical are required',
         });
       }
+      const creationHlc = parseTrustedDeathVerificationHlc(
+        created_physical_ms,
+        created_logical,
+        'created_physical_ms',
+        'created_logical',
+      );
+      if (creationHlc.error) {
+        return json(res, 400, { error: creationHlc.error });
+      }
 
       const state = wasm.wasm_death_verification_new(
         subject_did,
@@ -328,8 +384,8 @@ export const server = http.createServer(async (req, res) => {
         JSON.stringify(authorized_trustees),
         claim_nonce_hex,
         initiator_signature_hex,
-        BigInt(created_physical_ms),
-        created_logical
+        creationHlc.physicalMs,
+        creationHlc.logical
       );
       const initialStatus = state.status === 'Verified' ? 'verified' : 'pending';
 
@@ -340,7 +396,7 @@ export const server = http.createServer(async (req, res) => {
           trustee_confirmations, verification_state, status, created_at_ms)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
         [id, subject_did, initiated_by_did, required_confirmations || 3,
-         JSON.stringify(state.confirmations || []), JSON.stringify(state), initialStatus, created_physical_ms]
+         JSON.stringify(state.confirmations || []), JSON.stringify(state), initialStatus, creationHlc.observedAtMs]
       );
 
       return json(res, 201, { id, status: initialStatus, state });
@@ -367,6 +423,15 @@ export const server = http.createServer(async (req, res) => {
           error: 'confirmed_physical_ms and confirmed_logical are required',
         });
       }
+      const confirmationHlc = parseTrustedDeathVerificationHlc(
+        confirmed_physical_ms,
+        confirmed_logical,
+        'confirmed_physical_ms',
+        'confirmed_logical',
+      );
+      if (confirmationHlc.error) {
+        return json(res, 400, { error: confirmationHlc.error });
+      }
 
       const { rows } = await pool.query(
         'SELECT * FROM death_verification WHERE id = $1',
@@ -387,8 +452,8 @@ export const server = http.createServer(async (req, res) => {
         trustee_did,
         trustee_public_key_hex,
         signature_hex,
-        BigInt(confirmed_physical_ms),
-        confirmed_logical
+        confirmationHlc.physicalMs,
+        confirmationHlc.logical
       );
 
       const verified = result.verified;
@@ -403,7 +468,7 @@ export const server = http.createServer(async (req, res) => {
           JSON.stringify(result.state.confirmations || []),
           JSON.stringify(result.state),
           newStatus,
-          verified ? confirmed_physical_ms : null,
+          verified ? confirmationHlc.observedAtMs : null,
           verification_id,
         ]
       );
@@ -628,6 +693,8 @@ export const server = http.createServer(async (req, res) => {
   }
 });
 
-server.listen(PORT, () => {
-  console.log(`✅ VitalLock API running on port ${PORT}`);
-});
+if (!process.env.VITEST) {
+  server.listen(PORT, () => {
+    console.log(`✅ VitalLock API running on port ${PORT}`);
+  });
+}

--- a/demo/services/vitallock-api/src/index.test.js
+++ b/demo/services/vitallock-api/src/index.test.js
@@ -1,0 +1,193 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import supertest from 'supertest';
+
+const mockWasm = vi.hoisted(() => ({
+  wasm_death_verification_new: vi.fn(() => ({
+    subject_did: 'did:exo:alice',
+    initiated_by: 'did:exo:bob',
+    required_confirmations: 2,
+    confirmations: [],
+    status: 'Pending',
+  })),
+  wasm_death_verification_confirm: vi.fn(() => ({
+    verified: true,
+    state: {
+      subject_did: 'did:exo:alice',
+      confirmations: [{ trustee_did: 'did:exo:carol' }],
+    },
+  })),
+}));
+
+vi.mock('module', async (importOriginal) => {
+  const original = await importOriginal();
+  return {
+    ...original,
+    createRequire: () => (id) => {
+      if (id === '@exochain/exochain-wasm') {
+        return mockWasm;
+      }
+      throw new Error(`unexpected require('${id}') in test`);
+    },
+  };
+});
+
+vi.mock('pg', () => {
+  const mockQuery = vi.fn();
+  const MockPool = vi.fn(() => ({ query: mockQuery }));
+  return { default: { Pool: MockPool } };
+});
+
+import pg from 'pg';
+import { server } from './index.js';
+
+const OBSERVED_AT_MS = 1_779_120_000_000;
+const TOO_OLD_MS = OBSERVED_AT_MS - 300_001;
+const TOO_FAR_FUTURE_MS = OBSERVED_AT_MS + 300_001;
+
+const request = supertest(server);
+
+afterAll(async () => {
+  vi.useRealTimers();
+  if (server.listening) {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(OBSERVED_AT_MS));
+  vi.clearAllMocks();
+  const pool = new pg.Pool();
+  pool.query.mockImplementation((sql) => {
+    if (typeof sql === 'string' && sql.includes('FROM death_verification')) {
+      return Promise.resolve({
+        rows: [{
+          id: 'death-claim-1',
+          subject_did: 'did:exo:alice',
+          required_confirmations: 2,
+          status: 'pending',
+          verification_state: { subject_did: 'did:exo:alice', confirmations: [] },
+        }],
+      });
+    }
+    return Promise.resolve({ rows: [] });
+  });
+});
+
+describe('death verification ingress timestamp boundary', () => {
+  it('accepts created_at metadata within the ingress window and stores observed audit time', async () => {
+    const createdPhysicalMs = OBSERVED_AT_MS - 10;
+    const res = await request.post('/api/death/initiate').send({
+      subject_did: 'did:exo:alice',
+      initiated_by_did: 'did:exo:bob',
+      required_confirmations: 2,
+      authorized_trustees: [
+        { did: 'did:exo:bob', public_key_hex: '11'.repeat(32) },
+        { did: 'did:exo:carol', public_key_hex: '22'.repeat(32) },
+      ],
+      claim_nonce_hex: 'aa'.repeat(16),
+      initiator_signature_hex: 'bb'.repeat(64),
+      created_physical_ms: createdPhysicalMs,
+      created_logical: 0,
+    });
+
+    expect(res.status).toBe(201);
+    expect(mockWasm.wasm_death_verification_new).toHaveBeenCalledWith(
+      'did:exo:alice',
+      'did:exo:bob',
+      2,
+      expect.any(String),
+      'aa'.repeat(16),
+      'bb'.repeat(64),
+      BigInt(createdPhysicalMs),
+      0,
+    );
+    const pool = new pg.Pool();
+    const insertCall = pool.query.mock.calls.find(([sql]) =>
+      typeof sql === 'string' && sql.includes('INSERT INTO death_verification'));
+    expect(insertCall[1][7]).toBe(OBSERVED_AT_MS);
+  });
+
+  it.each([
+    ['past', TOO_OLD_MS],
+    ['future', TOO_FAR_FUTURE_MS],
+  ])('rejects %s created_at metadata outside the trusted ingress window', async (_label, timestamp) => {
+    const res = await request.post('/api/death/initiate').send({
+      subject_did: 'did:exo:alice',
+      initiated_by_did: 'did:exo:bob',
+      required_confirmations: 2,
+      authorized_trustees: [
+        { did: 'did:exo:bob', public_key_hex: '11'.repeat(32) },
+        { did: 'did:exo:carol', public_key_hex: '22'.repeat(32) },
+      ],
+      claim_nonce_hex: 'aa'.repeat(16),
+      initiator_signature_hex: 'bb'.repeat(64),
+      created_physical_ms: timestamp,
+      created_logical: 0,
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('created_physical_ms');
+    expect(mockWasm.wasm_death_verification_new).not.toHaveBeenCalled();
+  });
+
+  it('accepts confirmed_at metadata within the ingress window and stores observed resolution time', async () => {
+    const confirmedPhysicalMs = OBSERVED_AT_MS + 10;
+    const res = await request.post('/api/death/confirm').send({
+      verification_id: 'death-claim-1',
+      trustee_did: 'did:exo:carol',
+      trustee_public_key_hex: '22'.repeat(32),
+      signature_hex: 'cc'.repeat(64),
+      confirmed_physical_ms: confirmedPhysicalMs,
+      confirmed_logical: 0,
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockWasm.wasm_death_verification_confirm).toHaveBeenCalledWith(
+      JSON.stringify({ subject_did: 'did:exo:alice', confirmations: [] }),
+      'did:exo:carol',
+      '22'.repeat(32),
+      'cc'.repeat(64),
+      BigInt(confirmedPhysicalMs),
+      0,
+    );
+    const pool = new pg.Pool();
+    const updateCall = pool.query.mock.calls.find(([sql]) =>
+      typeof sql === 'string' && sql.includes('UPDATE death_verification'));
+    expect(updateCall[1][3]).toBe(OBSERVED_AT_MS);
+  });
+
+  it.each([
+    ['past', TOO_OLD_MS],
+    ['future', TOO_FAR_FUTURE_MS],
+  ])('rejects %s confirmed_at metadata outside the trusted ingress window', async (_label, timestamp) => {
+    const res = await request.post('/api/death/confirm').send({
+      verification_id: 'death-claim-1',
+      trustee_did: 'did:exo:carol',
+      trustee_public_key_hex: '22'.repeat(32),
+      signature_hex: 'cc'.repeat(64),
+      confirmed_physical_ms: timestamp,
+      confirmed_logical: 0,
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('confirmed_physical_ms');
+    expect(mockWasm.wasm_death_verification_confirm).not.toHaveBeenCalled();
+  });
+});

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -447,7 +447,9 @@ test('wasm_death_verification_initial_signing_payload', () => {
     TEST_DID_2,
     2,
     deathTrusteesJson,
-    deathClaimNonceHex
+    deathClaimNonceHex,
+    NOW_MS,
+    0
   );
 });
 
@@ -457,7 +459,9 @@ const deathInitialPayload = setup(() =>
     TEST_DID_2,
     2,
     deathTrusteesJson,
-    deathClaimNonceHex
+    deathClaimNonceHex,
+    NOW_MS,
+    0
   ));
 const deathInitialSignatureHex = setup(() =>
   deathInitialPayload && signer2.signHex(deathInitialPayload));
@@ -477,12 +481,29 @@ test('wasm_death_verification_new', () => {
     0
   );
   if (state.created.physical_ms !== NOW_NUM || state.created.logical !== 0) {
-    throw new Error('death verification created timestamp must be caller-supplied HLC');
+    throw new Error('death verification created timestamp must be the signed creation HLC');
   }
   if (state.confirmations[0].confirmed_at.physical_ms !== NOW_NUM) {
-    throw new Error('initial confirmation timestamp must match caller-supplied creation HLC');
+    throw new Error('initial confirmation timestamp must match signed creation HLC');
   }
   return state;
+});
+
+test('wasm_death_verification_new rejects replayed created_at metadata', () => {
+  if (!deathTrusteesJson || !deathInitialSignatureHex) {
+    throw new Error('skipped -- no signed initial payload');
+  }
+  return expectErrorContains('wasm_death_verification_new replayed timestamp', () =>
+    wasm.wasm_death_verification_new(
+      TEST_DID,
+      TEST_DID_2,
+      2,
+      deathTrusteesJson,
+      deathClaimNonceHex,
+      deathInitialSignatureHex,
+      BigInt(NOW_NUM + 10_000),
+      0
+    ), 'signature');
 });
 
 const deathState = setup(() =>
@@ -501,14 +522,18 @@ test('wasm_death_verification_confirmation_signing_payload', () => {
   if (!deathState) throw new Error('skipped -- no death-verification state');
   return wasm.wasm_death_verification_confirmation_signing_payload(
     JSON.stringify(deathState),
-    TEST_DID_3
+    TEST_DID_3,
+    BigInt(NOW_NUM + 1),
+    0
   );
 });
 
 const deathConfirmationPayload = setup(() =>
   deathState && wasm.wasm_death_verification_confirmation_signing_payload(
     JSON.stringify(deathState),
-    TEST_DID_3
+    TEST_DID_3,
+    BigInt(NOW_NUM + 1),
+    0
   ));
 const deathConfirmationSignatureHex = setup(() =>
   deathConfirmationPayload && signer3.signHex(deathConfirmationPayload));
@@ -527,12 +552,27 @@ test('wasm_death_verification_confirm', () => {
   );
   const confirmation = result.state.confirmations[1];
   if (confirmation.confirmed_at.physical_ms !== NOW_NUM + 1 || confirmation.confirmed_at.logical !== 0) {
-    throw new Error('trustee confirmation timestamp must be caller-supplied HLC');
+    throw new Error('trustee confirmation timestamp must match signed confirmation HLC');
   }
   if (result.state.resolved_at.physical_ms !== NOW_NUM + 1) {
     throw new Error('verified death claim resolution timestamp must match confirmation HLC');
   }
   return result;
+});
+
+test('wasm_death_verification_confirm rejects replayed confirmed_at metadata', () => {
+  if (!deathState || !trusteePublicKey || !deathConfirmationSignatureHex) {
+    throw new Error('skipped -- no signed confirmation payload');
+  }
+  return expectErrorContains('wasm_death_verification_confirm replayed timestamp', () =>
+    wasm.wasm_death_verification_confirm(
+      JSON.stringify(deathState),
+      TEST_DID_3,
+      trusteePublicKey,
+      deathConfirmationSignatureHex,
+      BigInt(NOW_NUM + 10_000),
+      0
+    ), 'signature');
 });
 
 // =========================================================================


### PR DESCRIPTION
## Summary
- Bind death-verification creation and confirmation HLCs into the canonical CBOR payload that trustees sign.
- Reject replayed timestamp metadata and confirmations/rejections that predate claim creation.
- Update the WASM signing-payload API and bridge harness so timestamp metadata must match the later state mutation.
- Harden the adjacent VitaLock HTTP boundary to reject created_at/confirmed_at values outside a trusted ingress window and store server-observed audit times.

## Path Classification
- EXOCHAIN core: `crates/exo-messaging/src/death_trigger.rs`
- Core runtime adapter: `crates/exochain-wasm/src/messaging_bindings.rs`, `packages/exochain-wasm/test/bridge_verification.mjs`
- Adjacent surface: `demo/services/vitallock-api/src/index.js`, `demo/services/vitallock-api/src/index.test.js`, `demo/apps/vitallock/src/lib/crypto.ts`
- Documentation/repo-truth: `README.md`

## Verification
- RED before fix: `cargo test -p exo-messaging replayed_` failed on timestamp replay tests.
- RED before fix: `cargo test -p exo-messaging timestamp_before_creation_rejected` failed on chronological audit tests.
- RED before fix: `npm test -- --project services services/vitallock-api/src/index.test.js` failed 4 timestamp-ingress tests.
- PASS: `cargo test -p exo-messaging`
- PASS: `cargo test -p exochain-wasm`
- PASS: `cargo clippy -p exo-messaging --all-targets -- -D warnings`
- PASS: `cargo clippy -p exochain-wasm --all-targets -- -D warnings`
- PASS: `wasm-pack build crates/exochain-wasm --target nodejs --release --out-dir ../../packages/exochain-wasm/wasm`
- PASS: `node packages/exochain-wasm/test/bridge_verification.mjs`
- PASS: `npm test -- --project services`
- PASS: `cargo fmt --all -- --check`
- PASS: `git diff --check`
- PASS: `bash tools/test_repo_truth.sh`

## Notes
- `npm run build` in `demo/apps/vitallock` remains blocked by pre-existing adjacent app issues unrelated to this remediation: missing `@/wasm/exochain_wasm`, `Afterlife.tsx` referencing `created_at_ms` outside its declared type, and an unused `Plus` import in `Family.tsx`.
