### PR TITLE
fix(gateway): use trusted auth observed time

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 198113 | `wc -l` |
-| Workspace tests | 4,450 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 198254 | `wc -l` |
+| Workspace tests | 4,455 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |

--- a/crates/exo-gateway/src/auth.rs
+++ b/crates/exo-gateway/src/auth.rs
@@ -66,25 +66,48 @@ pub struct AuthenticatedActor {
     pub authenticated_at: Timestamp,
 }
 
-/// Caller-supplied metadata for an authentication attempt.
+/// Authentication metadata supplied by a trusted ingress adapter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AuthenticationMetadata {
+    /// Timestamp that is bound into signed DID authentication payloads.
     pub observed_at: Timestamp,
+    /// Trusted ingress timestamp used for freshness and expiration decisions.
+    pub trusted_observed_at: Timestamp,
 }
 
 impl AuthenticationMetadata {
-    /// Validate caller-supplied authentication metadata.
+    /// Validate trusted authentication metadata.
     ///
     /// # Errors
     ///
     /// Returns `GatewayError::BadRequest` if `observed_at` is `Timestamp::ZERO`.
     pub fn new(observed_at: Timestamp) -> Result<Self> {
+        Self::from_signed_and_trusted(observed_at, observed_at)
+    }
+
+    /// Validate authentication metadata with distinct signed and trusted clocks.
+    ///
+    /// `observed_at` remains part of the signed request envelope for wire
+    /// compatibility. `trusted_observed_at` is the ingress adapter's trusted
+    /// clock and is the only timestamp used for freshness and token expiry.
+    pub fn from_signed_and_trusted(
+        observed_at: Timestamp,
+        trusted_observed_at: Timestamp,
+    ) -> Result<Self> {
         if observed_at == Timestamp::ZERO {
             return Err(GatewayError::BadRequest(
-                "authentication observed_at must be caller-supplied and non-zero".into(),
+                "authentication observed_at must be non-zero".into(),
             ));
         }
-        Ok(Self { observed_at })
+        if trusted_observed_at == Timestamp::ZERO {
+            return Err(GatewayError::BadRequest(
+                "authentication trusted_observed_at must be non-zero".into(),
+            ));
+        }
+        Ok(Self {
+            observed_at,
+            trusted_observed_at,
+        })
     }
 }
 
@@ -363,7 +386,7 @@ pub fn authenticate(
     }
 
     // 3. Timestamp freshness — guard against replay attacks.
-    check_freshness(&request.timestamp, &metadata.observed_at)?;
+    check_freshness(&request.timestamp, &metadata.trusted_observed_at)?;
 
     // 4. Resolve DID document from the registry.
     let doc = registry
@@ -392,7 +415,7 @@ pub fn authenticate(
 
     Ok(AuthenticatedActor {
         did,
-        authenticated_at: metadata.observed_at,
+        authenticated_at: metadata.trusted_observed_at,
     })
 }
 
@@ -460,7 +483,7 @@ fn resolve_token(
     }
 
     if let Some(expires_at) = record.expires_at {
-        if metadata.observed_at > expires_at {
+        if metadata.trusted_observed_at > expires_at {
             return Err(GatewayError::AuthenticationFailed {
                 reason: format!("{kind} has expired"),
             });
@@ -469,7 +492,7 @@ fn resolve_token(
 
     Ok(AuthenticatedActor {
         did: record.did.clone(),
-        authenticated_at: metadata.observed_at,
+        authenticated_at: metadata.trusted_observed_at,
     })
 }
 
@@ -525,6 +548,14 @@ mod tests {
 
     fn auth_metadata() -> AuthenticationMetadata {
         AuthenticationMetadata::new(Timestamp::new(10_000, 0)).unwrap()
+    }
+
+    fn replayed_auth_metadata(trusted_observed_at: Timestamp) -> AuthenticationMetadata {
+        AuthenticationMetadata::from_signed_and_trusted(
+            Timestamp::new(10_000, 0),
+            trusted_observed_at,
+        )
+        .unwrap()
     }
 
     fn api_key_metadata() -> ApiKeyMetadata {
@@ -671,6 +702,34 @@ mod tests {
             AuthenticationMetadata::new(Timestamp::new(req_ts().physical_ms + 1, 0)).unwrap();
 
         assert!(authenticate(&request, &reg, tampered_metadata).is_err());
+    }
+
+    #[test]
+    fn auth_rejects_replayed_signed_observed_at_against_trusted_time() {
+        let (reg, sk) = registry_with_alice();
+        let body_hash = Hash256::digest(b"replayed request with old signed observed time");
+        let request = signed_request(
+            Request {
+                actor_did: "did:exo:alice".into(),
+                action: "read".into(),
+                body_hash,
+                signature: Signature::Empty,
+                timestamp: req_ts(),
+            },
+            &sk,
+        );
+
+        let err = authenticate(
+            &request,
+            &reg,
+            replayed_auth_metadata(Timestamp::new(400_000, 0)),
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("freshness window"),
+            "expected trusted freshness rejection, got {err}"
+        );
     }
 
     #[test]
@@ -973,6 +1032,18 @@ mod tests {
     }
 
     #[test]
+    fn authentication_metadata_rejects_zero_trusted_observed_at() {
+        let metadata = AuthenticationMetadata::from_signed_and_trusted(
+            Timestamp::new(10_000, 0),
+            Timestamp::ZERO,
+        );
+
+        assert!(
+            matches!(metadata, Err(GatewayError::BadRequest(reason)) if reason.contains("trusted_observed_at"))
+        );
+    }
+
+    #[test]
     fn authenticate_rejects_stale_against_supplied_metadata() {
         let (reg, sk) = registry_with_alice();
         let body_hash = Hash256::ZERO;
@@ -1006,7 +1077,7 @@ mod tests {
         let forbidden_timestamp = ["Timestamp", "::now_utc"].concat();
         assert!(
             !production.contains(&forbidden_timestamp),
-            "gateway auth must use caller-supplied authentication timestamps"
+            "gateway auth must receive authentication timestamps from the ingress adapter"
         );
         let forbidden_system_time = ["SystemTime", "::now"].concat();
         assert!(
@@ -1169,6 +1240,32 @@ mod tests {
     }
 
     #[test]
+    fn credential_api_key_expiration_uses_trusted_observed_at() {
+        let did_reg = LocalDidRegistry::new();
+        let mut api_reg = ApiKeyRegistry::new();
+        let did = Did::new("did:exo:alice").unwrap();
+        let (plaintext, record) = api_reg
+            .register(did, "test key".into(), api_key_metadata())
+            .expect("api key registration");
+        api_reg.keys.get_mut(&record.key_hash).unwrap().expires_at =
+            Some(Timestamp::new(15_000, 0));
+
+        let metadata = AuthenticationMetadata::from_signed_and_trusted(
+            Timestamp::new(10_000, 0),
+            Timestamp::new(20_000, 0),
+        )
+        .unwrap();
+        let cred = Credential::ApiKey(plaintext);
+        let err = resolve_credential(&cred, &did_reg, &api_reg, metadata).unwrap_err();
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains("expired"),
+            "expected trusted-time expiry in: {msg}"
+        );
+    }
+
+    #[test]
     fn credential_api_key_unknown() {
         let did_reg = LocalDidRegistry::new();
         let api_reg = ApiKeyRegistry::new();
@@ -1296,7 +1393,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_credential_uses_supplied_authentication_metadata() {
+    fn resolve_credential_uses_trusted_authentication_metadata() {
         let did_reg = LocalDidRegistry::new();
         let mut api_reg = ApiKeyRegistry::new();
         let did = Did::new("did:exo:alice").unwrap();

--- a/crates/exo-gateway/src/routes.rs
+++ b/crates/exo-gateway/src/routes.rs
@@ -53,16 +53,21 @@ pub struct RouteResult {
 pub struct RouteMetadata {
     pub correlation_id: Uuid,
     pub audit_timestamp: exo_core::Timestamp,
+    pub trusted_auth_observed_at: exo_core::Timestamp,
 }
 
 impl RouteMetadata {
-    /// Validate caller-supplied route metadata.
+    /// Validate route metadata and trusted authentication clock metadata.
     ///
     /// # Errors
     ///
     /// Returns `GatewayError::BadRequest` if the correlation ID is nil or the
     /// audit timestamp is `Timestamp::ZERO`.
-    pub fn new(correlation_id: Uuid, audit_timestamp: exo_core::Timestamp) -> Result<Self> {
+    pub fn new(
+        correlation_id: Uuid,
+        audit_timestamp: exo_core::Timestamp,
+        trusted_auth_observed_at: exo_core::Timestamp,
+    ) -> Result<Self> {
         if correlation_id.is_nil() {
             return Err(GatewayError::BadRequest(
                 "route correlation_id must be caller-supplied and non-nil".into(),
@@ -73,9 +78,15 @@ impl RouteMetadata {
                 "route audit timestamp must be caller-supplied and non-zero".into(),
             ));
         }
+        if trusted_auth_observed_at == exo_core::Timestamp::ZERO {
+            return Err(GatewayError::BadRequest(
+                "route trusted authentication timestamp must be non-zero".into(),
+            ));
+        }
         Ok(Self {
             correlation_id,
             audit_timestamp,
+            trusted_auth_observed_at,
         })
     }
 }
@@ -90,7 +101,10 @@ pub fn process_request(
     metadata: RouteMetadata,
     log: &mut AuditLog,
 ) -> Result<RouteResult> {
-    let auth_metadata = AuthenticationMetadata::new(metadata.audit_timestamp)?;
+    let auth_metadata = AuthenticationMetadata::from_signed_and_trusted(
+        metadata.audit_timestamp,
+        metadata.trusted_auth_observed_at,
+    )?;
     let actor = authenticate(request, registry, auth_metadata)?;
     consent_middleware(&actor.did, &request.action, consent)?;
     governance_middleware(&actor.did, &request.action, verdict)?;
@@ -177,6 +191,7 @@ mod tests {
         RouteMetadata::new(
             Uuid::parse_str("018f7a96-8ad0-7c4f-8e0f-333333333333").unwrap(),
             Timestamp::new(7_000, 1),
+            Timestamp::new(7_000, 1),
         )
         .expect("valid route metadata")
     }
@@ -206,7 +221,11 @@ mod tests {
 
     #[test]
     fn route_metadata_rejects_nil_correlation_id() {
-        let result = RouteMetadata::new(Uuid::nil(), Timestamp::new(7_000, 0));
+        let result = RouteMetadata::new(
+            Uuid::nil(),
+            Timestamp::new(7_000, 0),
+            Timestamp::new(7_000, 0),
+        );
 
         assert!(
             matches!(result, Err(GatewayError::BadRequest(reason)) if reason.contains("correlation"))
@@ -218,10 +237,52 @@ mod tests {
         let result = RouteMetadata::new(
             Uuid::parse_str("018f7a96-8ad0-7c4f-8e0f-444444444444").unwrap(),
             Timestamp::ZERO,
+            Timestamp::new(7_000, 0),
         );
 
         assert!(
             matches!(result, Err(GatewayError::BadRequest(reason)) if reason.contains("timestamp"))
+        );
+    }
+
+    #[test]
+    fn route_metadata_rejects_zero_trusted_auth_timestamp() {
+        let result = RouteMetadata::new(
+            Uuid::parse_str("018f7a96-8ad0-7c4f-8e0f-555555555555").unwrap(),
+            Timestamp::new(7_000, 0),
+            Timestamp::ZERO,
+        );
+
+        assert!(
+            matches!(result, Err(GatewayError::BadRequest(reason)) if reason.contains("trusted"))
+        );
+    }
+
+    #[test]
+    fn process_request_uses_trusted_auth_time_not_audit_timestamp() {
+        let (reg, req) = alice_registry_and_req();
+        let mut log = AuditLog::new();
+        let metadata = RouteMetadata::new(
+            Uuid::parse_str("018f7a96-8ad0-7c4f-8e0f-666666666666").unwrap(),
+            Timestamp::new(7_000, 1),
+            Timestamp::new(400_000, 0),
+        )
+        .expect("route metadata with replayed audit timestamp");
+
+        let err = process_request(
+            &req,
+            &reg,
+            Route::CreateTransaction,
+            true,
+            &Verdict::Allow,
+            metadata,
+            &mut log,
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("freshness window"),
+            "expected trusted auth timestamp to reject replayed route audit timestamp: {err}"
         );
     }
 

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -70,10 +70,7 @@ const MAX_DID_DOCUMENT_BODY_BYTES: usize = 64 * 1024;
 #[cfg(test)]
 use crate::auth::request_signing_payload;
 use crate::{
-    auth::{
-        AuthenticatedActor, AuthenticationMetadata, FRESHNESS_WINDOW_MS, Request as AuthRequest,
-        authenticate,
-    },
+    auth::{AuthenticatedActor, AuthenticationMetadata, Request as AuthRequest, authenticate},
     db,
     error::{GatewayError, Result},
     graphql,
@@ -1793,6 +1790,7 @@ fn session_login_auth_signing_payload(
     request_signing_payload(&request, auth_metadata)
 }
 
+#[cfg(test)]
 fn authenticate_session_login(
     did: &str,
     metadata: &SessionIssueMetadata,
@@ -1812,26 +1810,11 @@ fn authenticate_session_login_against_trusted_time(
     registry: &dyn DidRegistry,
     trusted_observed_at: Timestamp,
 ) -> Result<AuthenticatedActor> {
-    let actor = authenticate_session_login(did, metadata, proof, registry)?;
-    validate_session_login_freshness_against_trusted_time(proof, trusted_observed_at)?;
-    Ok(actor)
-}
-
-fn validate_session_login_freshness_against_trusted_time(
-    proof: &SessionLoginProof,
-    trusted_observed_at: Timestamp,
-) -> Result<()> {
-    let skew_ms = trusted_observed_at
-        .physical_ms
-        .abs_diff(proof.timestamp.physical_ms);
-    if skew_ms > FRESHNESS_WINDOW_MS {
-        return Err(GatewayError::AuthenticationFailed {
-            reason: format!(
-                "request timestamp outside freshness window: skew {skew_ms}ms (max {FRESHNESS_WINDOW_MS}ms)"
-            ),
-        });
-    }
-    Ok(())
+    let request =
+        session_login_auth_request(did, metadata, proof.timestamp, proof.signature.clone())?;
+    let auth_metadata =
+        AuthenticationMetadata::from_signed_and_trusted(proof.observed_at, trusted_observed_at)?;
+    authenticate(&request, registry, auth_metadata)
 }
 
 fn metadata_error(reason: impl Into<String>) -> GatewayError {


### PR DESCRIPTION
## Summary
- remediates Codex Security row 40: caller-controlled auth time replay for gateway DID/API/bearer credentials
- splits signed request observed_at from trusted ingress observed time used for freshness and token expiry decisions
- updates route/session login paths so caller audit metadata cannot refresh stale signed requests or expired tokens

## Path classification
- Core runtime adapter: crates/exo-gateway/src/auth.rs
- Core runtime adapter: crates/exo-gateway/src/routes.rs
- Core runtime adapter: crates/exo-gateway/src/server.rs
- Documentation/repo truth: README.md

## TDD / reproduction
- RED: cargo test -p exo-gateway trusted initially failed because AuthenticationMetadata::from_signed_and_trusted and the trusted RouteMetadata constructor path did not exist
- GREEN: added regression tests for replayed signed observed_at, zero trusted auth time, trusted token expiry, and route audit timestamp replay

## Validation
- cargo test -p exo-gateway
- cargo clippy -p exo-gateway --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- bash tools/test_repo_truth.sh

## Bypass search
- rg "AuthenticationMetadata::|RouteMetadata::new|trusted_auth_observed_at|trusted_observed_at" -n crates/exo-gateway/src crates/exo-gateway/tests
