### PR TITLE
fix(identity): bind hybrid DID keys to multibase

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 198209 | `wc -l` |
-| Workspace tests | 4,452 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 198399 | `wc -l` |
+| Workspace tests | 4,455 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,452 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,455 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 198209 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 198399 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,452 listed workspace tests
+         cryptographic proofs, 4,455 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          160 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-identity/src/did.rs
+++ b/crates/exo-identity/src/did.rs
@@ -27,6 +27,8 @@
 use exo_core::{Did, PqPublicKey, PublicKey, Signature, Timestamp, crypto};
 use serde::{Deserialize, Serialize};
 
+pub const HYBRID_VERIFICATION_METHOD_KEY_TYPE: &str = "HybridKeyEd25519MlDsa652020";
+
 /// Derive the self-certifying EXOCHAIN DID bound to an Ed25519 public key.
 ///
 /// The canonical node/participant DID format is
@@ -118,13 +120,34 @@ pub struct HybridVerificationMethod {
 }
 
 impl HybridVerificationMethod {
+    #[must_use]
+    pub(crate) fn key_material_matches_multibase(&self) -> bool {
+        multibase_matches_raw_key(
+            &self.classical_public_key_multibase,
+            self.classical_public_key.as_bytes(),
+        ) && multibase_matches_raw_key(&self.pq_public_key_multibase, self.pq_public_key.as_bytes())
+    }
+
+    #[must_use]
+    pub(crate) fn is_internally_consistent(&self) -> bool {
+        let controller_prefix = format!("{}#", self.controller.as_str());
+        self.key_type == HYBRID_VERIFICATION_METHOD_KEY_TYPE
+            && self.id.starts_with(&controller_prefix)
+            && self.id.len() > controller_prefix.len()
+            && matches!(
+                (self.active, self.revoked_at),
+                (true, None) | (false, Some(_))
+            )
+            && self.key_material_matches_multibase()
+    }
+
     /// Verify a `Signature::Hybrid` against this method's key bundle.
     ///
     /// Delegates to `crypto::verify_hybrid`, which requires **both** the
     /// Ed25519 and ML-DSA-65 components to pass with no short-circuit.
     #[must_use]
     pub fn verify(&self, message: &[u8], signature: &Signature) -> bool {
-        if !self.active {
+        if !self.active || !self.is_internally_consistent() {
             return false;
         }
         crypto::verify_hybrid(
@@ -133,6 +156,16 @@ impl HybridVerificationMethod {
             &self.classical_public_key,
             &self.pq_public_key,
         )
+    }
+}
+
+fn multibase_matches_raw_key(public_key_multibase: &str, raw_key: &[u8]) -> bool {
+    let Some(encoded) = public_key_multibase.strip_prefix('z') else {
+        return false;
+    };
+    match bs58::decode(encoded).into_vec() {
+        Ok(decoded) => decoded.as_slice() == raw_key,
+        Err(_) => false,
     }
 }
 
@@ -448,7 +481,7 @@ mod tests {
         let pq_mb = format!("z{}", bs58::encode(pq_pk.as_bytes()).into_string());
         HybridVerificationMethod {
             id: format!("{}#hybrid-key-1", did.as_str()),
-            key_type: "HybridKeyEd25519MlDsa652020".into(),
+            key_type: HYBRID_VERIFICATION_METHOD_KEY_TYPE.into(),
             controller: did.clone(),
             classical_public_key_multibase: classical_mb,
             pq_public_key_multibase: pq_mb,
@@ -475,6 +508,52 @@ mod tests {
         assert!(
             method.verify(message, &sig),
             "HybridVerificationMethod::verify must accept valid Hybrid signature"
+        );
+    }
+
+    #[test]
+    fn hybrid_method_verify_rejects_classical_raw_key_multibase_mismatch() {
+        use exo_core::crypto::{generate_pq_keypair, sign_hybrid};
+
+        let (advertised_classical_pk, _advertised_classical_sk) = generate_keypair();
+        let (raw_classical_pk, raw_classical_sk) = generate_keypair();
+        let (pq_pk, pq_sk) = generate_pq_keypair();
+        let did = make_did("hybrid-classical-mismatch");
+
+        let mut method = make_hybrid_method(&did, raw_classical_pk, pq_pk);
+        method.classical_public_key_multibase = format!(
+            "z{}",
+            bs58::encode(advertised_classical_pk.as_bytes()).into_string()
+        );
+        let message = b"hybrid DID verification must bind advertised classical key";
+        let sig = sign_hybrid(message, &raw_classical_sk, &pq_sk).expect("sign_hybrid");
+
+        assert!(
+            !method.verify(message, &sig),
+            "hybrid verification must reject raw Ed25519 key material that disagrees with multibase"
+        );
+    }
+
+    #[test]
+    fn hybrid_method_verify_rejects_pq_raw_key_multibase_mismatch() {
+        use exo_core::crypto::{generate_pq_keypair, sign_hybrid};
+
+        let (classical_pk, classical_sk) = generate_keypair();
+        let (advertised_pq_pk, _advertised_pq_sk) = generate_pq_keypair();
+        let (raw_pq_pk, raw_pq_sk) = generate_pq_keypair();
+        let did = make_did("hybrid-pq-mismatch");
+
+        let mut method = make_hybrid_method(&did, classical_pk, raw_pq_pk);
+        method.pq_public_key_multibase = format!(
+            "z{}",
+            bs58::encode(advertised_pq_pk.as_bytes()).into_string()
+        );
+        let message = b"hybrid DID verification must bind advertised PQ key";
+        let sig = sign_hybrid(message, &classical_sk, &raw_pq_sk).expect("sign_hybrid");
+
+        assert!(
+            !method.verify(message, &sig),
+            "hybrid verification must reject raw ML-DSA key material that disagrees with multibase"
         );
     }
 

--- a/crates/exo-identity/src/registry.rs
+++ b/crates/exo-identity/src/registry.rs
@@ -20,7 +20,10 @@ use exo_core::{Did, PublicKey, Signature, Timestamp, crypto};
 use serde::Serialize;
 
 use crate::{
-    did::{DidDocument, DidRegistrationProof, RevocationProof, did_from_public_key},
+    did::{
+        DidDocument, DidRegistrationProof, HYBRID_VERIFICATION_METHOD_KEY_TYPE, RevocationProof,
+        did_from_public_key,
+    },
     did_verification::validate_verification_method_document_binding,
     error::IdentityError,
 };
@@ -495,7 +498,15 @@ fn validate_registered_did_document(doc: &DidDocument) -> Result<(), IdentityErr
             })?;
         }
     }
+    let mut hybrid_verification_method_ids = BTreeSet::new();
     for method in &doc.hybrid_verification_methods {
+        if !hybrid_verification_method_ids.insert(method.id.as_str()) {
+            return Err(invalid_did_document_field(
+                did,
+                "hybrid_verification_methods.id",
+                format!("duplicate hybrid verification method id '{}'", method.id),
+            ));
+        }
         ensure_byte_bound(
             did,
             "hybrid_verification_methods.id",
@@ -514,6 +525,38 @@ fn validate_registered_did_document(doc: &DidDocument) -> Result<(), IdentityErr
             method.controller.as_str(),
             MAX_DID_DOCUMENT_ID_BYTES,
         )?;
+        if !method.id.starts_with(&verification_method_id_prefix)
+            || method.id.len() <= verification_method_id_prefix.len()
+        {
+            return Err(invalid_did_document_field(
+                did,
+                "hybrid_verification_methods.id",
+                format!(
+                    "hybrid verification method id '{}' must be scoped to DID subject '{}'",
+                    method.id, did
+                ),
+            ));
+        }
+        if method.controller != doc.id {
+            return Err(invalid_did_document_field(
+                did,
+                "hybrid_verification_methods.controller",
+                format!(
+                    "hybrid verification method '{}' controller '{}' must equal DID subject '{}'",
+                    method.id, method.controller, did
+                ),
+            ));
+        }
+        if method.key_type != HYBRID_VERIFICATION_METHOD_KEY_TYPE {
+            return Err(invalid_did_document_field(
+                did,
+                "hybrid_verification_methods.key_type",
+                format!(
+                    "hybrid verification method '{}' key_type '{}' is unsupported; expected '{}'",
+                    method.id, method.key_type, HYBRID_VERIFICATION_METHOD_KEY_TYPE
+                ),
+            ));
+        }
         ensure_byte_bound(
             did,
             "hybrid_verification_methods.classical_public_key_multibase",
@@ -526,6 +569,23 @@ fn validate_registered_did_document(doc: &DidDocument) -> Result<(), IdentityErr
             &method.pq_public_key_multibase,
             MAX_DID_DOCUMENT_PQ_MULTIBASE_BYTES,
         )?;
+        ensure_verification_method_lifecycle(
+            did,
+            "hybrid_verification_methods.revoked_at",
+            &method.id,
+            method.active,
+            method.revoked_at,
+        )?;
+        if !method.key_material_matches_multibase() {
+            return Err(invalid_did_document_field(
+                did,
+                "hybrid_verification_methods.key_material",
+                format!(
+                    "hybrid verification method '{}' key material must match its multibase fields",
+                    method.id
+                ),
+            ));
+        }
     }
     for endpoint in &doc.service_endpoints {
         ensure_byte_bound(
@@ -636,11 +696,11 @@ impl DidRegistry for LocalDidRegistry {
 mod tests {
     use exo_core::{
         SecretKey,
-        crypto::{generate_keypair, sign},
+        crypto::{generate_keypair, generate_pq_keypair, sign},
     };
 
     use super::*;
-    use crate::did::{DidDocument, VerificationMethod};
+    use crate::did::{DidDocument, HybridVerificationMethod, VerificationMethod};
 
     fn make_did(label: &str) -> Did {
         Did::new(&format!("did:exo:{label}")).expect("valid did")
@@ -670,6 +730,30 @@ mod tests {
             key_type: "Ed25519VerificationKey2020".to_owned(),
             controller: did.clone(),
             public_key_multibase: format!("z{}", bs58::encode(pk.as_bytes()).into_string()),
+            version,
+            active: true,
+            valid_from: 1000,
+            revoked_at: None,
+        }
+    }
+
+    fn hybrid_verification_method(
+        did: &Did,
+        pk: PublicKey,
+        pq_pk: exo_core::PqPublicKey,
+        version: u64,
+    ) -> HybridVerificationMethod {
+        HybridVerificationMethod {
+            id: format!("{did}#hybrid-key-{version}"),
+            key_type: HYBRID_VERIFICATION_METHOD_KEY_TYPE.to_owned(),
+            controller: did.clone(),
+            classical_public_key_multibase: format!(
+                "z{}",
+                bs58::encode(pk.as_bytes()).into_string()
+            ),
+            pq_public_key_multibase: format!("z{}", bs58::encode(pq_pk.as_bytes()).into_string()),
+            pq_public_key: pq_pk,
+            classical_public_key: pk,
             version,
             active: true,
             valid_from: 1000,
@@ -933,6 +1017,33 @@ mod tests {
         assert!(
             err.to_string().contains("revoked_at"),
             "error should identify inactive revoked_at inconsistency: {err}"
+        );
+        assert_eq!(reg.len(), 0);
+    }
+
+    #[test]
+    fn register_rejects_hybrid_method_with_mismatched_key_material() {
+        let (document_pk, _) = generate_keypair();
+        let (raw_classical_pk, _) = generate_keypair();
+        let (advertised_classical_pk, _) = generate_keypair();
+        let (pq_pk, _) = generate_pq_keypair();
+        let did = make_did("hybrid-registry-mismatch");
+        let mut doc = make_doc(did.clone(), document_pk);
+        let mut method = hybrid_verification_method(&did, raw_classical_pk, pq_pk, 1);
+        method.classical_public_key_multibase = format!(
+            "z{}",
+            bs58::encode(advertised_classical_pk.as_bytes()).into_string()
+        );
+        doc.hybrid_verification_methods = vec![method];
+
+        let mut reg = LocalDidRegistry::new();
+        let err = reg
+            .register(doc)
+            .expect_err("hybrid DID methods must bind raw key material to multibase fields");
+
+        assert!(
+            err.to_string().contains("key material"),
+            "error should identify hybrid key material inconsistency: {err}"
         );
         assert_eq!(reg.len(), 0);
     }


### PR DESCRIPTION
## Summary
- Remediates Codex Security row 47: Hybrid DID verification trusts duplicate raw keys.
- Classification: EXOCHAIN core (`crates/exo-identity/src/did.rs`, `crates/exo-identity/src/registry.rs`).
- Verifies `HybridVerificationMethod` raw Ed25519 and ML-DSA key material matches the advertised `z` base58btc multibase fields before accepting signatures.
- Rejects malformed hybrid DID methods during registry ingestion when method IDs, controllers, key type, lifecycle, or raw/multibase key material are inconsistent.

## TDD Evidence
- RED: `cargo test -p exo-identity hybrid_method_verify_rejects_classical_raw_key_multibase_mismatch` failed on current vulnerable behavior.
- RED: `cargo test -p exo-identity hybrid_method_verify_rejects_pq_raw_key_multibase_mismatch` failed on current vulnerable behavior.
- RED: `cargo test -p exo-identity register_rejects_hybrid_method_with_mismatched_key_material` failed on current vulnerable behavior.

## Verification
- `cargo test -p exo-identity` passed: 190 unit tests, 12 integration tests.
- `cargo clippy -p exo-identity --all-targets -- -D warnings` passed.
- `cargo test -p exo-node` passed: 1106 tests.
- `cargo clippy -p exo-node --all-targets -- -D warnings` passed.
- `cargo fmt --all -- --check` passed.
- `git diff --check` passed.
- Production source guards passed for `crates/exo-identity/src/did.rs` and `crates/exo-identity/src/registry.rs` against `HashMap`, `HashSet`, wall-clock time, unsafe, and production `unwrap`/`expect`.
