### PR TITLE
fix(gatekeeper): enforce final denials before challenge holds

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 198209 | `wc -l` |
+| Rust LOC | 198255 | `wc -l` |
 | Workspace tests | 4,452 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
@@ -113,7 +113,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 198209 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 198255 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 4,452 listed workspace tests
 

--- a/crates/exo-escalation/src/challenge.rs
+++ b/crates/exo-escalation/src/challenge.rs
@@ -75,7 +75,8 @@ impl std::fmt::Display for SybilChallengeGround {
 pub enum ContestStatus {
     /// Challenge admitted; action is paused pending review.  Callers MUST
     /// propagate this into `AdjudicationContext::active_challenge_reason` so
-    /// the CGR Kernel returns `Verdict::Escalated`.
+    /// the CGR Kernel returns `Verdict::Escalated` for otherwise-valid actions.
+    /// Final-denial invariants still return `Verdict::Denied`.
     PauseEligible,
     /// Evidentiary review is in progress.
     UnderReview,
@@ -297,8 +298,8 @@ fn validate_challenge_admission_metadata(
 /// 1. Storing the `ContestHold` in a durable audit store.
 /// 2. Passing `hold.escalation_reason()` into the kernel's
 ///    `AdjudicationContext::active_challenge_reason` so the CGR Kernel
-///    returns `Verdict::Escalated` (not `Verdict::Denied`) while review is
-///    pending.
+///    returns `Verdict::Escalated` for otherwise-valid actions while review is
+///    pending. Final-denial invariants still return `Verdict::Denied`.
 ///
 /// The hold id and `admitted_at` are supplied by the caller to avoid internal
 /// randomness or clock calls.

--- a/crates/exo-escalation/tests/sybil_adjudication.rs
+++ b/crates/exo-escalation/tests/sybil_adjudication.rs
@@ -310,8 +310,9 @@ fn full_detection_to_reinstatement_flow() {
 // ---------------------------------------------------------------------------
 
 /// While a ContestHold is PauseEligible, the kernel returns Verdict::Escalated
-/// rather than Permitted or Denied, so the action is paused (not blocked).
-/// Once the hold is cleared the action may proceed normally.
+/// rather than Permitted for otherwise-valid actions, so the action is paused.
+/// Final-denial invariants still deny. Once the hold is cleared the action may
+/// proceed normally.
 #[test]
 fn quarantine_pauses_contested_actions_via_kernel() {
     let kernel = Kernel::new(b"We the people of EXOCHAIN...", InvariantSet::all());
@@ -336,7 +337,8 @@ fn quarantine_pauses_contested_actions_via_kernel() {
     let reason = hold.escalation_reason();
     assert!(reason.contains("SybilChallenge"));
 
-    // With active challenge → Verdict::Escalated (action is paused)
+    // With active challenge and valid invariant evidence → Verdict::Escalated
+    // (action is paused)
     let ctx_challenged = valid_kernel_context(&actor, Some(reason));
     match kernel.adjudicate(&action, &ctx_challenged) {
         Verdict::Escalated { reason } => {

--- a/crates/exo-gatekeeper/src/kernel.rs
+++ b/crates/exo-gatekeeper/src/kernel.rs
@@ -89,8 +89,8 @@ pub struct AdjudicationContext {
     pub provenance: Option<Provenance>,
     pub quorum_evidence: Option<QuorumEvidence>,
     /// When set, the action is under an active Sybil challenge hold.
-    /// The kernel short-circuits to `Verdict::Escalated` before running
-    /// invariant checks — the action is paused (not denied) pending review.
+    /// The kernel returns `Verdict::Escalated` only after all invariants pass,
+    /// so final-denial invariants are never converted into review holds.
     /// Populate from `ContestHold::escalation_reason()` in exo-escalation.
     pub active_challenge_reason: Option<String>,
 }
@@ -117,14 +117,6 @@ impl Kernel {
     }
 
     pub fn adjudicate(&self, action: &ActionRequest, context: &AdjudicationContext) -> Verdict {
-        // Short-circuit: an active Sybil challenge hold pauses the action
-        // (Escalated, not Denied) so it can be reviewed rather than blocked.
-        if let Some(ref reason) = context.active_challenge_reason {
-            return Verdict::Escalated {
-                reason: reason.clone(),
-            };
-        }
-
         let inv_ctx = InvariantContext {
             actor: action.actor.clone(),
             actor_roles: context.actor_roles.clone(),
@@ -143,7 +135,15 @@ impl Kernel {
         };
 
         match enforce_all(&self.invariant_engine, &inv_ctx) {
-            Ok(()) => Verdict::Permitted,
+            Ok(()) => {
+                if let Some(ref reason) = context.active_challenge_reason {
+                    Verdict::Escalated {
+                        reason: reason.clone(),
+                    }
+                } else {
+                    Verdict::Permitted
+                }
+            }
             Err(violations) => {
                 let needs_escalation = violations.iter().any(|v| {
                     v.invariant == ConstitutionalInvariant::QuorumLegitimate
@@ -688,14 +688,15 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // WO-005: Challenge paths — contested actions return Escalated, not Denied
-    // CR-001 §8.5 — any active Sybil challenge hold pauses the action.
+    // WO-005: Challenge paths — otherwise-valid contested actions return
+    // Escalated, not Denied. Final-denial invariants still deny.
+    // CR-001 §8.5 — active Sybil challenge holds pause valid actions only.
     // -----------------------------------------------------------------------
     mod challenge_paths {
         use super::*;
 
-        /// WO-005: An action under an active Sybil challenge returns
-        /// Verdict::Escalated so it is paused (not denied) pending review.
+        /// WO-005: An otherwise-valid action under an active Sybil challenge
+        /// returns Verdict::Escalated so it is paused pending review.
         #[test]
         fn active_challenge_escalates_not_denies() {
             let kernel = test_kernel();
@@ -731,21 +732,63 @@ mod tests {
             );
         }
 
-        /// WO-005: Challenge escalation takes priority over invariant checks —
-        /// even an otherwise-denied action is escalated (not denied) while
-        /// the challenge is pending.
+        /// WO-005/F-048: Challenge escalation must not suppress final-denial
+        /// invariants. A hold can pause an otherwise-valid action, but it
+        /// cannot convert forbidden kernel mutations, self-grants, missing
+        /// consent, or suppressed human override into reviewable work.
         #[test]
-        fn challenge_takes_priority_over_denial() {
+        fn challenge_hold_does_not_suppress_final_denials() {
             let kernel = test_kernel();
             let actor = did("did:exo:actor1");
+
             let mut ctx = valid_context(&actor);
-            // Would normally be denied (ConsentRequired: BailmentState::None)
             ctx.bailment_state = BailmentState::None;
             ctx.active_challenge_reason =
-                Some("SybilChallenge/QuorumContamination: pause-eligible".into());
-            match kernel.adjudicate(&valid_action(&actor), &ctx) {
-                Verdict::Escalated { .. } => {}
-                other => panic!("WO-005: challenge must pre-empt denial, got {:?}", other),
+                Some("SybilChallenge/QuorumContamination: action under review".into());
+            assert_denied_by(
+                kernel.adjudicate(&valid_action(&actor), &ctx),
+                ConstitutionalInvariant::ConsentRequired,
+            );
+
+            let mut action = valid_action(&actor);
+            action.is_self_grant = true;
+            let mut ctx = valid_context(&actor);
+            ctx.active_challenge_reason =
+                Some("SybilChallenge/SelfGrant: action under review".into());
+            assert_denied_by(
+                kernel.adjudicate(&action, &ctx),
+                ConstitutionalInvariant::NoSelfGrant,
+            );
+
+            let mut ctx = valid_context(&actor);
+            ctx.human_override_preserved = false;
+            ctx.active_challenge_reason =
+                Some("SybilChallenge/HumanOverride: action under review".into());
+            assert_denied_by(
+                kernel.adjudicate(&valid_action(&actor), &ctx),
+                ConstitutionalInvariant::HumanOverride,
+            );
+
+            let mut action = valid_action(&actor);
+            action.modifies_kernel = true;
+            let mut ctx = valid_context(&actor);
+            ctx.active_challenge_reason =
+                Some("SybilChallenge/KernelMutation: action under review".into());
+            assert_denied_by(
+                kernel.adjudicate(&action, &ctx),
+                ConstitutionalInvariant::KernelImmutability,
+            );
+        }
+
+        fn assert_denied_by(verdict: Verdict, invariant: ConstitutionalInvariant) {
+            match verdict {
+                Verdict::Denied { violations } => assert!(
+                    violations
+                        .iter()
+                        .any(|violation| violation.invariant == invariant),
+                    "expected denial by {invariant:?}, got {violations:?}"
+                ),
+                other => panic!("expected Denied by {invariant:?}, got {other:?}"),
             }
         }
     }


### PR DESCRIPTION
## Summary
- Remediates Codex Security row 48: `Challenge hold suppresses final kernel denials`.
- Classification: EXOCHAIN core (`crates/exo-gatekeeper/src/kernel.rs`) plus core escalation contract docs/tests (`crates/exo-escalation/...`) and repo-truth README metrics.
- Confirms the finding against current `origin/main`: `Kernel::adjudicate` returned `Verdict::Escalated` before `enforce_all`, suppressing final-denial invariants.

## Fix
- Runs kernel invariant enforcement before challenge-hold escalation.
- Allows active challenge holds to pause only otherwise-valid actions.
- Preserves existing narrow single `AuthorityChainValid` / `QuorumLegitimate` escalation behavior for invariant failures.
- Adds regression coverage for `ConsentRequired`, `NoSelfGrant`, `HumanOverride`, and `KernelImmutability` under active challenge holds.
- Updates challenge contract wording so `ContestHold` callers do not treat holds as denial bypasses.

## TDD Evidence
- RED first: `cargo test -p exo-gatekeeper challenge_hold_does_not_suppress_final_denials` failed because `ConsentRequired` returned `Escalated`.
- GREEN after fix: same focused regression passed.

## Validation
- `cargo test -p exo-gatekeeper`
- `cargo test -p exo-escalation`
- `cargo clippy -p exo-gatekeeper -p exo-escalation --all-targets -- -D warnings`
- `bash tools/test_repo_truth.sh`
- `cargo fmt --all -- --check`
- `git diff --check`
- Production source guard over modified kernel/challenge source for `HashMap`, `HashSet`, `SystemTime`, `Instant::now`, `unsafe`, `unwrap(`, and `expect(`
