### PR TITLE
fix(gatekeeper): bind governance attestations to findings payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 198209 | `wc -l` |
-| Workspace tests | 4,452 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 198328 | `wc -l` |
+| Workspace tests | 4,453 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,452 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,453 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 198209 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 198328 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,452 listed workspace tests
+         cryptographic proofs, 4,453 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          160 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-gatekeeper/src/governance_monitor.rs
+++ b/crates/exo-gatekeeper/src/governance_monitor.rs
@@ -21,7 +21,8 @@
 //! monitoring output. Implements three sub-mitigations:
 //!
 //! 1. **Signed attestation verification** — rejects payloads without a valid
-//!    Ed25519 signature over the findings digest (sub-threat T-14a).
+//!    Ed25519 signature over the canonical findings payload digest
+//!    (sub-threat T-14a).
 //! 2. **Circuit breaker** — auto-pauses self-improvement when >3 Critical
 //!    findings are recorded within a 24-hour window (sub-threat T-14c).
 //! 3. **Human approval gate** — requires human-DID (`SignerType 0x01`)
@@ -32,7 +33,11 @@
 
 use std::collections::BTreeMap;
 
-use exo_core::{Did, Hash256, PublicKey, Signature, Timestamp, crypto};
+use exo_core::{
+    Did, Hash256, PublicKey, Signature, Timestamp, crypto,
+    hash::{hash_structured, hash256_eq_constant_time},
+};
+use serde::Serialize;
 
 // ---------------------------------------------------------------------------
 // Signed attestation envelope (T-14a)
@@ -40,16 +45,16 @@ use exo_core::{Did, Hash256, PublicKey, Signature, Timestamp, crypto};
 
 /// A signed governance health attestation.
 ///
-/// The signature covers the `findings_digest` — a BLAKE3 hash of the
-/// serialized findings array. The signer must be identifiable by their
-/// public key for verification.
+/// The signature covers the `findings_digest`, which must equal the BLAKE3
+/// hash of the canonical findings payload supplied to [`verify_attestation`].
+/// The signer must be identifiable by their public key for verification.
 #[derive(Debug, Clone)]
 pub struct GovernanceAttestation {
     /// DID of the entity that produced this attestation.
     pub signer_did: Did,
     /// BLAKE3 hash of the canonical findings payload.
     pub findings_digest: Hash256,
-    /// Ed25519 signature over `findings_digest.as_bytes()`.
+    /// Ed25519 signature over the canonical findings payload digest.
     pub signature: Signature,
 }
 
@@ -65,6 +70,20 @@ pub enum GovernanceMonitorError {
     InvalidAttestation {
         /// DID of the claimed signer.
         signer_did: Did,
+    },
+
+    /// Attestation digest does not match the supplied findings payload.
+    #[error("attestation findings digest does not match supplied payload for signer {signer_did}")]
+    FindingsDigestMismatch {
+        /// DID of the claimed signer.
+        signer_did: Did,
+    },
+
+    /// Canonical findings payload hashing failed.
+    #[error("governance findings payload hashing failed: {reason}")]
+    FindingsDigestHashFailed {
+        /// Hashing failure reason.
+        reason: String,
     },
 
     /// Circuit breaker has been tripped — too many Critical findings.
@@ -90,6 +109,22 @@ pub enum GovernanceMonitorError {
     ApproverNotHuman,
 }
 
+/// Compute the canonical digest for a governance findings payload.
+///
+/// # Errors
+///
+/// Returns [`GovernanceMonitorError::FindingsDigestHashFailed`] if canonical
+/// CBOR hashing fails.
+pub fn governance_findings_digest<T: Serialize>(
+    findings_payload: &T,
+) -> Result<Hash256, GovernanceMonitorError> {
+    hash_structured(findings_payload).map_err(|err| {
+        GovernanceMonitorError::FindingsDigestHashFailed {
+            reason: err.to_string(),
+        }
+    })
+}
+
 /// Verify the cryptographic attestation on a governance health payload.
 ///
 /// **Security: This MUST be called BEFORE any data is stored or circuit
@@ -100,13 +135,26 @@ pub enum GovernanceMonitorError {
 ///
 /// Returns [`GovernanceMonitorError::MissingAttestation`] if no attestation
 /// is provided, or [`GovernanceMonitorError::InvalidAttestation`] if the
-/// signature does not verify against the signer's public key.
-pub fn verify_attestation(
+/// signature does not verify against the signer's public key. Returns
+/// [`GovernanceMonitorError::FindingsDigestMismatch`] if the attestation was
+/// replayed against a different findings payload.
+pub fn verify_attestation<T: Serialize>(
     attestation: &GovernanceAttestation,
+    findings_payload: &T,
     signer_public_key: &PublicKey,
 ) -> Result<(), GovernanceMonitorError> {
-    let message = attestation.findings_digest.as_bytes();
-    if crypto::verify(message, &attestation.signature, signer_public_key) {
+    let computed_digest = governance_findings_digest(findings_payload)?;
+    if !hash256_eq_constant_time(&attestation.findings_digest, &computed_digest) {
+        return Err(GovernanceMonitorError::FindingsDigestMismatch {
+            signer_did: attestation.signer_did.clone(),
+        });
+    }
+
+    if crypto::verify(
+        computed_digest.as_bytes(),
+        &attestation.signature,
+        signer_public_key,
+    ) {
         Ok(())
     } else {
         Err(GovernanceMonitorError::InvalidAttestation {
@@ -351,25 +399,46 @@ mod tests {
         }
     }
 
+    fn make_attestation_for_findings<T: Serialize>(
+        findings_payload: &T,
+        signer_did: Did,
+        secret: &exo_core::SecretKey,
+    ) -> GovernanceAttestation {
+        let digest = governance_findings_digest(findings_payload).expect("hash findings");
+        make_attestation(digest, signer_did, secret)
+    }
+
     // ── Attestation verification tests ──────────────────────────────────
 
     #[test]
     fn valid_attestation_passes() {
         let (pk, sk) = generate_keypair();
-        let digest = Hash256::digest(b"findings-payload");
-        let attestation = make_attestation(digest, test_did("scanner"), &sk);
+        let findings = serde_json::json!([
+            {
+                "finding_id": "F-1",
+                "severity": "critical",
+                "title": "real finding"
+            }
+        ]);
+        let attestation = make_attestation_for_findings(&findings, test_did("scanner"), &sk);
 
-        assert!(verify_attestation(&attestation, &pk).is_ok());
+        assert!(verify_attestation(&attestation, &findings, &pk).is_ok());
     }
 
     #[test]
     fn wrong_key_attestation_fails() {
         let (_pk, sk) = generate_keypair();
         let (wrong_pk, _) = generate_keypair();
-        let digest = Hash256::digest(b"findings-payload");
-        let attestation = make_attestation(digest, test_did("scanner"), &sk);
+        let findings = serde_json::json!([
+            {
+                "finding_id": "F-1",
+                "severity": "critical",
+                "title": "real finding"
+            }
+        ]);
+        let attestation = make_attestation_for_findings(&findings, test_did("scanner"), &sk);
 
-        let err = verify_attestation(&attestation, &wrong_pk).unwrap_err();
+        let err = verify_attestation(&attestation, &findings, &wrong_pk).unwrap_err();
         assert!(matches!(
             err,
             GovernanceMonitorError::InvalidAttestation { .. }
@@ -379,16 +448,61 @@ mod tests {
     #[test]
     fn tampered_digest_fails() {
         let (pk, sk) = generate_keypair();
-        let digest = Hash256::digest(b"findings-payload");
-        let mut attestation = make_attestation(digest, test_did("scanner"), &sk);
+        let findings = serde_json::json!([
+            {
+                "finding_id": "F-1",
+                "severity": "critical",
+                "title": "real finding"
+            }
+        ]);
+        let mut attestation = make_attestation_for_findings(&findings, test_did("scanner"), &sk);
 
         // Tamper with the digest after signing
-        attestation.findings_digest = Hash256::digest(b"tampered");
+        attestation.findings_digest = governance_findings_digest(&serde_json::json!([
+            {
+                "finding_id": "F-2",
+                "severity": "low",
+                "title": "tampered"
+            }
+        ]))
+        .expect("hash tampered findings");
 
-        let err = verify_attestation(&attestation, &pk).unwrap_err();
+        let err = verify_attestation(&attestation, &findings, &pk).unwrap_err();
         assert!(matches!(
             err,
-            GovernanceMonitorError::InvalidAttestation { .. }
+            GovernanceMonitorError::FindingsDigestMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn replayed_attestation_for_different_findings_payload_fails() {
+        let (pk, sk) = generate_keypair();
+        let signed_findings = serde_json::json!([
+            {
+                "finding_id": "F-1",
+                "severity": "critical",
+                "title": "real finding"
+            }
+        ]);
+        let stored_findings = serde_json::json!([
+            {
+                "finding_id": "F-2",
+                "severity": "low",
+                "title": "replayed payload"
+            }
+        ]);
+        let signed_digest =
+            exo_core::hash::hash_structured(&signed_findings).expect("hash signed findings");
+        let stored_digest =
+            exo_core::hash::hash_structured(&stored_findings).expect("hash stored findings");
+        assert_ne!(signed_digest, stored_digest);
+
+        let attestation = make_attestation(signed_digest, test_did("scanner"), &sk);
+
+        let err = verify_attestation(&attestation, &stored_findings, &pk).unwrap_err();
+        assert!(matches!(
+            err,
+            GovernanceMonitorError::FindingsDigestMismatch { .. }
         ));
     }
 

--- a/crates/exochain-wasm/src/gatekeeper_bindings.rs
+++ b/crates/exochain-wasm/src/gatekeeper_bindings.rs
@@ -172,7 +172,7 @@ fn caller_supplied_trusted_key_violations(
 #[wasm_bindgen]
 pub fn wasm_governance_findings_digest(findings_json: &str) -> Result<String, JsValue> {
     let findings: serde_json::Value = from_json_str(findings_json)?;
-    let digest = exo_core::hash::hash_structured(&findings)
+    let digest = exo_gatekeeper::governance_monitor::governance_findings_digest(&findings)
         .map_err(|_| gatekeeper_boundary_error("governance findings digest failed"))?;
     Ok(hex::encode(digest.as_bytes()))
 }
@@ -187,8 +187,9 @@ pub fn wasm_verify_governance_attestation(
 ) -> Result<bool, JsValue> {
     let signer_did = exo_core::Did::new(signer_did)
         .map_err(|_| gatekeeper_boundary_error("invalid governance attestation signer DID"))?;
-    let digest_hex = wasm_governance_findings_digest(findings_json)?;
-    let digest = exo_core::Hash256::from_bytes(decode_fixed_hex(&digest_hex, "findings digest")?);
+    let findings: serde_json::Value = from_json_str(findings_json)?;
+    let digest = exo_gatekeeper::governance_monitor::governance_findings_digest(&findings)
+        .map_err(|_| gatekeeper_boundary_error("governance findings digest failed"))?;
     let signature: exo_core::Signature = from_json_str(signature_json)?;
     let signer_public_key = exo_core::PublicKey::from_bytes(decode_fixed_hex(
         signer_public_key_hex,
@@ -200,9 +201,13 @@ pub fn wasm_verify_governance_attestation(
         signature,
     };
 
-    exo_gatekeeper::governance_monitor::verify_attestation(&attestation, &signer_public_key)
-        .map(|()| true)
-        .map_err(|_| gatekeeper_boundary_error("governance attestation rejected"))
+    exo_gatekeeper::governance_monitor::verify_attestation(
+        &attestation,
+        &findings,
+        &signer_public_key,
+    )
+    .map(|()| true)
+    .map_err(|_| gatekeeper_boundary_error("governance attestation rejected"))
 }
 
 /// Build a deterministic valid invariant request fixture for external


### PR DESCRIPTION
## Summary
- Remediates Codex Security row 50: `Attestation is not bound to findings payload`.
- Classification: EXOCHAIN core (`crates/exo-gatekeeper/src/governance_monitor.rs`) and core runtime adapter (`crates/exochain-wasm/src/gatekeeper_bindings.rs`).
- Confirms the issue against current `origin/main`: the core verifier accepted a valid `(findings_digest, signature)` without receiving or hashing the findings payload being stored/acted on.

## Fix
- Changes `verify_attestation` to accept the findings payload, compute its canonical CBOR/BLAKE3 digest inside core, compare it to `attestation.findings_digest`, and only then verify the Ed25519 signature.
- Adds `governance_findings_digest` as the shared core helper for canonical findings hashing.
- Updates the WASM governance attestation adapter to pass the parsed findings payload into the core verifier.
- Adds replay regression coverage proving a signature over one findings payload cannot validate a different payload.

## TDD Evidence
- RED first: `cargo test -p exo-gatekeeper replayed_attestation_for_different_findings_payload_fails` failed because the verifier had no findings-payload argument and no digest-mismatch error.
- GREEN after fix: same focused regression passed.

## Validation
- `cargo test -p exo-gatekeeper`
- `cargo test -p exochain-wasm`
- `cargo clippy -p exo-gatekeeper -p exochain-wasm --all-targets -- -D warnings`
- `bash tools/test_repo_truth.sh`
- `cargo fmt --all -- --check`
- `git diff --check`
- Production source guard over modified core/adapter files for `HashMap`, `HashSet`, `SystemTime`, `Instant::now`, `unsafe`, `unwrap(`, and `expect(`
