### PR TITLE
fix(tools): trust registry keys for sybil clearance

### DIFF
--- a/tools/sybil-cli/README.md
+++ b/tools/sybil-cli/README.md
@@ -141,6 +141,11 @@ python sybil-cli.py forum attest DR-... \
   --secret-key-b64 <BASE64_SECRET_KEY>
 ```
 
+When `require_valid_signatures` is enabled, clearance verifies signatures only
+against the trusted key registry populated by `forum keys register`.
+`public_key_b64` on a custody event is retained as metadata and is not
+authoritative for clearance.
+
 ---
 
 ## Clearance (gravity)

--- a/tools/sybil-cli/codex/clearance.py
+++ b/tools/sybil-cli/codex/clearance.py
@@ -124,6 +124,13 @@ def _attestation_kind(ev: CustodyEvent) -> Optional[str]:
     return None
 
 
+def _trusted_public_key_for_actor(actor_id: str, key_registry: KeyRegistry) -> Optional[str]:
+    public_key = key_registry.get(actor_id)
+    if not public_key or not public_key.strip():
+        return None
+    return public_key
+
+
 def evaluate_clearance(
     record: DecisionRecord,
     *,
@@ -165,7 +172,7 @@ def evaluate_clearance(
             if not ev.signature:
                 sig_valid = False
             else:
-                pub = ev.public_key_b64 or key_registry.get(ev.actor_id)
+                pub = _trusted_public_key_for_actor(ev.actor_id, key_registry)
                 if not pub:
                     sig_valid = False
                 else:

--- a/tools/sybil-cli/sybil-cli.py
+++ b/tools/sybil-cli/sybil-cli.py
@@ -280,7 +280,8 @@ def forum_attest(
         None, help="If provided, signs the record_hash (Ed25519 base64 secret key)"
     ),
     public_key_b64: Optional[str] = typer.Option(
-        None, help="Optional public key (base64) to store with the attestation"
+        None,
+        help="Optional public key (base64) stored as metadata; clearance verifies registry keys",
     ),
     path: str = typer.Option(".decision_forum", help="Store path"),
 ):
@@ -369,7 +370,10 @@ def forum_clear(
     actor: str = typer.Option("local", help="Actor id performing clearance"),
     role: str = typer.Option("steward", help="Role of clearing actor"),
     secret_key_b64: Optional[str] = typer.Option(None, help="Optional signing key (base64)"),
-    public_key_b64: Optional[str] = typer.Option(None, help="Optional public key (base64)"),
+    public_key_b64: Optional[str] = typer.Option(
+        None,
+        help="Optional public key (base64) stored as metadata; clearance verifies registry keys",
+    ),
     path: str = typer.Option(".decision_forum", help="Store path"),
 ):
     """Clear a record (if it meets policy), issue a certificate, and set status=accepted."""

--- a/tools/sybil-cli/tests/test_clearance.py
+++ b/tools/sybil-cli/tests/test_clearance.py
@@ -1,0 +1,149 @@
+# Copyright 2026 Exochain Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from codex.clearance import ClearanceMode, ClearancePolicy, evaluate_clearance
+from codex.schemas import CustodyEvent, DecisionRecord
+from codex.store import compute_record_hash
+
+
+class MemoryKeyRegistry:
+    def __init__(self, keys: dict[str, str]) -> None:
+        self._keys = keys
+
+    def get(self, actor_id: str) -> str | None:
+        return self._keys.get(actor_id)
+
+
+def strict_signature_verifier(
+    message_hex: str, *, signature_b64: str, public_key_b64: str
+) -> bool:
+    del message_hex
+    return signature_b64 == f"signed-by:{public_key_b64}"
+
+
+def clearance_policy() -> ClearancePolicy:
+    return ClearancePolicy(
+        mode=ClearanceMode.single,
+        quorum=1,
+        allowed_roles=["reviewer"],
+        require_valid_signatures=True,
+    )
+
+
+def decision_record_with_attestation(
+    *, actor_id: str, signature: str, event_public_key: str | None
+) -> DecisionRecord:
+    record = DecisionRecord(
+        id="DR-test-clearance",
+        title="Registry-bound clearance",
+        context="Current decision context",
+        decision="Use trusted registry keys",
+        consequences="Event-supplied verifier keys do not authorize clearance",
+    )
+    record_hash = compute_record_hash(record)
+    record.record_hash = record_hash
+    record.custody.append(
+        CustodyEvent(
+            actor_id=actor_id,
+            role="reviewer",
+            action="attest:approve",
+            attestation="approve",
+            record_hash=record_hash,
+            signature=signature,
+            public_key_b64=event_public_key,
+        )
+    )
+    return record
+
+
+class ClearanceKeyRegistryTests(unittest.TestCase):
+    def test_clearance_source_does_not_use_event_public_key_for_verification(self) -> None:
+        source = (Path(__file__).resolve().parents[1] / "codex" / "clearance.py").read_text(
+            encoding="utf-8"
+        )
+        verifier_block = source.split("if policy.require_valid_signatures:", 1)[1].split(
+            "if sig_valid is False:", 1
+        )[0]
+
+        self.assertIn("_trusted_public_key_for_actor(ev.actor_id, key_registry)", verifier_block)
+        self.assertNotIn("ev.public_key_b64 or", verifier_block)
+        self.assertNotIn("public_key_b64=ev.public_key_b64", verifier_block)
+
+    def test_event_supplied_public_key_cannot_authorize_clearance(self) -> None:
+        record = decision_record_with_attestation(
+            actor_id="did:exo:reviewer",
+            signature="signed-by:attacker-key",
+            event_public_key="attacker-key",
+        )
+        registry = MemoryKeyRegistry({"did:exo:reviewer": "trusted-registry-key"})
+
+        with patch("codex.clearance.verify_detached", strict_signature_verifier):
+            result = evaluate_clearance(
+                record, policy=clearance_policy(), key_registry=registry
+            )
+
+        self.assertFalse(result.cleared)
+        self.assertEqual([], result.approvals)
+        self.assertIn("quorum_not_met", result.reason or "")
+
+    def test_registered_public_key_authorizes_clearance_even_when_event_carries_key(
+        self,
+    ) -> None:
+        record = decision_record_with_attestation(
+            actor_id="did:exo:reviewer",
+            signature="signed-by:trusted-registry-key",
+            event_public_key="attacker-key",
+        )
+        registry = MemoryKeyRegistry({"did:exo:reviewer": "trusted-registry-key"})
+
+        with patch("codex.clearance.verify_detached", strict_signature_verifier):
+            result = evaluate_clearance(
+                record, policy=clearance_policy(), key_registry=registry
+            )
+
+        self.assertTrue(result.cleared)
+        self.assertEqual(["did:exo:reviewer"], [a.actor_id for a in result.approvals])
+        self.assertTrue(result.approvals[0].signature_valid)
+
+    def test_missing_registered_key_fails_closed_even_with_event_public_key(self) -> None:
+        record = decision_record_with_attestation(
+            actor_id="did:exo:reviewer",
+            signature="signed-by:attacker-key",
+            event_public_key="attacker-key",
+        )
+        registry = MemoryKeyRegistry({})
+
+        with patch("codex.clearance.verify_detached", strict_signature_verifier):
+            result = evaluate_clearance(
+                record, policy=clearance_policy(), key_registry=registry
+            )
+
+        self.assertFalse(result.cleared)
+        self.assertEqual([], result.approvals)
+        self.assertIn("quorum_not_met", result.reason or "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Classifies row 49 as an owned adjacent governance-tool adapter: `tools/sybil-cli` can issue clearance certificates and mark records accepted, but it is not canonical Rust core.
- Verifies the reported flaw against current main: signed clearance used `ev.public_key_b64` before the trusted key registry.
- Changes clearance signature verification to use only the trusted `KeyRegistry` entry for the event actor; event `public_key_b64` remains metadata.
- Updates CLI help and sybil-cli docs so certifier/reviewer workflows do not mistake event-supplied keys for authority.

## Path Classification
- Adjacent governance-tool adapter: `tools/sybil-cli/codex/clearance.py`, `tools/sybil-cli/sybil-cli.py`, `tools/sybil-cli/tests/test_clearance.py`, `tools/sybil-cli/README.md`.
- No EXOCHAIN core Rust crate, WASM, CI, governance, deployment, or production runtime files changed.

## Validation
- RED: `python3 -m unittest discover -s tools/sybil-cli/tests` failed because attacker-supplied event keys authorized clearance and trusted registry keys were ignored when an event key was present.
- GREEN: `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tools/sybil-cli/tests`
- `python3 -m compileall tools/sybil-cli`
- `bash tools/test_repo_truth.sh`
- `git diff --check`
