### PR TITLE
fix(wasm): require trusted governance attestation keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 198209 | `wc -l` |
-| Workspace tests | 4,452 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 198276 | `wc -l` |
+| Workspace tests | 4,453 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,452 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,453 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 198209 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 198276 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,452 listed workspace tests
+         cryptographic proofs, 4,453 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          160 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exochain-wasm/src/gatekeeper_bindings.rs
+++ b/crates/exochain-wasm/src/gatekeeper_bindings.rs
@@ -16,6 +16,8 @@
 
 //! Gatekeeper bindings: CGR combinator algebra, kernel adjudication, invariants
 
+use std::collections::BTreeMap;
+
 use wasm_bindgen::prelude::*;
 
 use crate::serde_bridge::*;
@@ -179,28 +181,67 @@ pub fn wasm_governance_findings_digest(findings_json: &str) -> Result<String, Js
 
 /// Verify a governance monitor attestation before persistence.
 #[wasm_bindgen]
-pub fn wasm_verify_governance_attestation(
+pub fn wasm_verify_governance_attestation_with_trusted_keys(
     signer_did: &str,
     findings_json: &str,
     signature_json: &str,
-    signer_public_key_hex: &str,
+    trusted_signer_keys_json: &str,
 ) -> Result<bool, JsValue> {
     let signer_did = exo_core::Did::new(signer_did)
         .map_err(|_| gatekeeper_boundary_error("invalid governance attestation signer DID"))?;
+    let trusted_signer_keys = parse_trusted_governance_attestation_keys(trusted_signer_keys_json)?;
+    let signer_public_key = trusted_signer_keys
+        .get(&signer_did)
+        .ok_or_else(|| gatekeeper_boundary_error("governance attestation signer is not trusted"))?;
+    verify_governance_attestation_with_key(
+        &signer_did,
+        findings_json,
+        signature_json,
+        signer_public_key,
+    )
+}
+
+fn parse_trusted_governance_attestation_keys(
+    trusted_signer_keys_json: &str,
+) -> Result<BTreeMap<exo_core::Did, exo_core::PublicKey>, JsValue> {
+    let raw_keys: BTreeMap<String, String> = from_json_str(trusted_signer_keys_json)?;
+    if raw_keys.is_empty() {
+        return Err(gatekeeper_boundary_error(
+            "governance attestation trusted signer registry is empty",
+        ));
+    }
+
+    let mut trusted_signer_keys = BTreeMap::new();
+    for (signer_did, public_key_hex) in raw_keys {
+        let signer_did = exo_core::Did::new(&signer_did).map_err(|_| {
+            gatekeeper_boundary_error("invalid governance attestation trusted signer DID")
+        })?;
+        let public_key = exo_core::PublicKey::from_bytes(decode_fixed_hex(
+            &public_key_hex,
+            "governance attestation trusted signer public key",
+        )?);
+        trusted_signer_keys.insert(signer_did, public_key);
+    }
+
+    Ok(trusted_signer_keys)
+}
+
+fn verify_governance_attestation_with_key(
+    signer_did: &exo_core::Did,
+    findings_json: &str,
+    signature_json: &str,
+    signer_public_key: &exo_core::PublicKey,
+) -> Result<bool, JsValue> {
     let digest_hex = wasm_governance_findings_digest(findings_json)?;
     let digest = exo_core::Hash256::from_bytes(decode_fixed_hex(&digest_hex, "findings digest")?);
     let signature: exo_core::Signature = from_json_str(signature_json)?;
-    let signer_public_key = exo_core::PublicKey::from_bytes(decode_fixed_hex(
-        signer_public_key_hex,
-        "governance attestation public key",
-    )?);
     let attestation = exo_gatekeeper::governance_monitor::GovernanceAttestation {
-        signer_did,
+        signer_did: signer_did.clone(),
         findings_digest: digest,
         signature,
     };
 
-    exo_gatekeeper::governance_monitor::verify_attestation(&attestation, &signer_public_key)
+    exo_gatekeeper::governance_monitor::verify_attestation(&attestation, signer_public_key)
         .map(|()| true)
         .map_err(|_| gatekeeper_boundary_error("governance attestation rejected"))
 }
@@ -691,6 +732,32 @@ mod tests {
 
         assert!(!production.contains("format!(\"{r:?}\")"));
         assert!(production.contains("\"rule\": r.id()"));
+    }
+
+    #[test]
+    fn governance_attestation_wasm_boundary_requires_trusted_signer_registry() {
+        let source = include_str!("gatekeeper_bindings.rs");
+        let production = source
+            .split("// ===========================================================================\n// Tests")
+            .next()
+            .expect("production section");
+
+        assert!(
+            production.contains("wasm_verify_governance_attestation_with_trusted_keys"),
+            "WASM governance attestation verification must expose a trusted-registry boundary"
+        );
+        assert!(
+            production.contains("trusted_signer_keys_json"),
+            "trusted signer keys must be passed as an explicit registry, not as a raw signature peer key"
+        );
+        assert!(
+            !production.contains("pub fn wasm_verify_governance_attestation("),
+            "WASM governance attestations must not expose a raw caller-supplied public-key verifier"
+        );
+        assert!(
+            !production.contains("signer_public_key_hex"),
+            "WASM governance attestation verification must not accept a raw signer_public_key_hex parameter"
+        );
     }
 
     #[test]

--- a/demo/services/audit-api/src/index.js
+++ b/demo/services/audit-api/src/index.js
@@ -30,6 +30,9 @@ const GOVERNANCE_API_TOKEN = process.env.GOVERNANCE_API_TOKEN || null;
 const GOVERNANCE_ATTESTATION_KEYS = parseGovernanceAttestationKeys(
   process.env.GOVERNANCE_ATTESTATION_KEYS || null,
 );
+const GOVERNANCE_ATTESTATION_KEYS_JSON = JSON.stringify(
+  Object.fromEntries(GOVERNANCE_ATTESTATION_KEYS),
+);
 
 function parseGovernanceAttestationKeys(value) {
   const trustedKeys = new Map();
@@ -201,11 +204,11 @@ export const server = http.createServer(async (req, res) => {
           return json(res, 400, { error: 'findings_digest does not match canonical findings payload' });
         }
 
-        wasm.wasm_verify_governance_attestation(
+        wasm.wasm_verify_governance_attestation_with_trusted_keys(
           attestation_signer_did,
           JSON.stringify(findings),
           JSON.stringify(attestation_signature),
-          trustedAttestationPublicKey,
+          GOVERNANCE_ATTESTATION_KEYS_JSON,
         );
       } catch (e) {
         return json(res, 400, { error: `invalid governance attestation: ${e.message || e}` });

--- a/demo/services/audit-api/src/index.test.js
+++ b/demo/services/audit-api/src/index.test.js
@@ -28,7 +28,7 @@ const mockWasm = vi.hoisted(() => ({
   wasm_audit_append: vi.fn(() => ({ entries: 1, head_hash: 'f'.repeat(64) })),
   wasm_hash_bytes: vi.fn(() => 'a'.repeat(64)),
   wasm_governance_findings_digest: vi.fn(() => 'b'.repeat(64)),
-  wasm_verify_governance_attestation: vi.fn(() => true),
+  wasm_verify_governance_attestation_with_trusted_keys: vi.fn(() => true),
 }));
 
 const mockPg = vi.hoisted(() => {
@@ -171,7 +171,7 @@ describe('POST /governance/health attestation gate', () => {
   });
 
   it('rejects invalid attestation before persistence', async () => {
-    mockWasm.wasm_verify_governance_attestation.mockImplementationOnce(() => {
+    mockWasm.wasm_verify_governance_attestation_with_trusted_keys.mockImplementationOnce(() => {
       throw new Error('governance attestation rejected');
     });
     mockPg.query.mockResolvedValue({ rows: [] });
@@ -196,7 +196,7 @@ describe('POST /governance/health attestation gate', () => {
 
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/not configured/);
-    expect(mockWasm.wasm_verify_governance_attestation).not.toHaveBeenCalled();
+    expect(mockWasm.wasm_verify_governance_attestation_with_trusted_keys).not.toHaveBeenCalled();
     expect(mockPg.query).not.toHaveBeenCalled();
   });
 
@@ -210,7 +210,7 @@ describe('POST /governance/health attestation gate', () => {
 
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/does not match configured signer key/);
-    expect(mockWasm.wasm_verify_governance_attestation).not.toHaveBeenCalled();
+    expect(mockWasm.wasm_verify_governance_attestation_with_trusted_keys).not.toHaveBeenCalled();
     expect(mockPg.query).not.toHaveBeenCalled();
   });
 
@@ -230,11 +230,11 @@ describe('POST /governance/health attestation gate', () => {
       .send(snapshotWithoutCallerKey);
 
     expect(res.status).toBe(201);
-    expect(mockWasm.wasm_verify_governance_attestation).toHaveBeenCalledWith(
+    expect(mockWasm.wasm_verify_governance_attestation_with_trusted_keys).toHaveBeenCalledWith(
       validSnapshot.attestation_signer_did,
       JSON.stringify(validSnapshot.findings),
       JSON.stringify(validSnapshot.attestation_signature),
-      '11'.repeat(32),
+      JSON.stringify({ 'did:exo:monitor': '11'.repeat(32) }),
     );
     expect(mockPg.query).toHaveBeenCalled();
   });
@@ -254,11 +254,11 @@ describe('POST /governance/health attestation gate', () => {
       .send(validSnapshot);
 
     expect(res.status).toBe(201);
-    expect(mockWasm.wasm_verify_governance_attestation).toHaveBeenCalledWith(
+    expect(mockWasm.wasm_verify_governance_attestation_with_trusted_keys).toHaveBeenCalledWith(
       validSnapshot.attestation_signer_did,
       JSON.stringify(validSnapshot.findings),
       JSON.stringify(validSnapshot.attestation_signature),
-      '11'.repeat(32),
+      JSON.stringify({ 'did:exo:monitor': '11'.repeat(32) }),
     );
     expect(mockPg.query).toHaveBeenCalled();
   });

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -1460,28 +1460,43 @@ test('wasm_governance_findings_digest is deterministic', () => {
   return a;
 });
 
-test('wasm_verify_governance_attestation accepts valid signatures', () => {
+test('wasm_verify_governance_attestation_with_trusted_keys accepts valid signatures', () => {
   const digestHex = wasm.wasm_governance_findings_digest(governanceFindingsJson);
   const signature = signatureJsonFromHex(signer1.signHex(Buffer.from(digestHex, 'hex')));
-  return wasm.wasm_verify_governance_attestation(
+  return wasm.wasm_verify_governance_attestation_with_trusted_keys(
     'did:exo:monitor',
     governanceFindingsJson,
     JSON.stringify(signature),
-    signer1.publicKeyHex,
+    JSON.stringify({ 'did:exo:monitor': signer1.publicKeyHex }),
   );
 });
 
-test('wasm_verify_governance_attestation rejects invalid signatures', () =>
+test('wasm_verify_governance_attestation_with_trusted_keys rejects invalid signatures', () =>
   expectErrorContains(
-    'wasm_verify_governance_attestation',
-    () => wasm.wasm_verify_governance_attestation(
+    'wasm_verify_governance_attestation_with_trusted_keys',
+    () => wasm.wasm_verify_governance_attestation_with_trusted_keys(
       'did:exo:monitor',
       governanceFindingsJson,
       JSON.stringify({ Ed25519: Array.from({ length: 64 }, () => 0) }),
-      signer1.publicKeyHex,
+      JSON.stringify({ 'did:exo:monitor': signer1.publicKeyHex }),
     ),
     'governance attestation rejected',
   ));
+
+test('wasm_verify_governance_attestation_with_trusted_keys rejects untrusted signers', () => {
+  const digestHex = wasm.wasm_governance_findings_digest(governanceFindingsJson);
+  const signature = signatureJsonFromHex(signer1.signHex(Buffer.from(digestHex, 'hex')));
+  return expectErrorContains(
+    'wasm_verify_governance_attestation_with_trusted_keys',
+    () => wasm.wasm_verify_governance_attestation_with_trusted_keys(
+      'did:exo:monitor',
+      governanceFindingsJson,
+      JSON.stringify(signature),
+      JSON.stringify({ 'did:exo:other-monitor': signer1.publicKeyHex }),
+    ),
+    'governance attestation signer is not trusted',
+  );
+});
 
 // Identity combinator is a unit variant — just a string, no fields
 test('wasm_reduce_combinator', () =>


### PR DESCRIPTION
## Summary
- Remediates Codex Security row 2: `Governance attestations trust caller-supplied keys`.
- Classification:
  - `crates/exochain-wasm/src/gatekeeper_bindings.rs` - EXOCHAIN core runtime adapter.
  - `packages/exochain-wasm/test/bridge_verification.mjs` - core WASM adapter verification.
  - `demo/services/audit-api/src/index.js` / `index.test.js` - adjacent audit-api call site consuming the adapter boundary.
  - `README.md` - repo-truth metrics only.
- Verified current main before editing: the audit API already loaded signer keys from `GOVERNANCE_ATTESTATION_KEYS`, but the public WASM export still accepted a raw `signer_public_key_hex` parameter.
- Replaces the raw public-key verifier with `wasm_verify_governance_attestation_with_trusted_keys`, which requires an explicit trusted signer registry and rejects untrusted signer DIDs.
- Updates the audit API to pass its configured registry JSON into the WASM verifier, not a request-provided key.

## Already-remediated disposition
- Row 1, `Root genesis secrets written with unsafe file permissions`, was checked against current main before this PR.
- Current Unix CLI writes already use `create_new(true)`, `mode(0o600)`, permission resets, `sync_all`, and tests for owner-only mode, symlink refusal, and existing-file refusal.
- Focused row 1 validation passed, so no code change was made for that stale finding.

## TDD / validation
- RED: `cargo test -p exochain-wasm governance_attestation_wasm_boundary_requires_trusted_signer_registry` failed on the old raw-key WASM export.
- RED: focused audit-api Vitest file was updated first to expect `wasm_verify_governance_attestation_with_trusted_keys`.
- GREEN: `cargo test -p exochain-wasm`
- GREEN: `cargo clippy -p exochain-wasm --all-targets -- -D warnings`
- GREEN: `wasm-pack test --node crates/exochain-wasm`
- GREEN: `wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm`
- GREEN: `node packages/exochain-wasm/test/bridge_verification.mjs` (161/161)
- GREEN: `./node_modules/.bin/vitest run src/index.test.js` from `demo/services/audit-api` using temporary local test deps (17/17)
- GREEN: `bash tools/repo_truth.sh --json --list-tests`
- GREEN: `bash tools/test_repo_truth.sh`
- GREEN: `cargo fmt --all -- --check`
- GREEN: `git diff --check`
- GREEN: source guard: no raw `wasm_verify_governance_attestation(` export, no `signer_public_key_hex` parameter, audit-api uses registry verifier, and production `gatekeeper_bindings.rs` contains no `HashMap`, `HashSet`, `SystemTime`, `Instant::now`, `unsafe`, `unwrap(`, or `expect(`.
