### PR TITLE
fix(archon): require approval before issue remediation

### DIFF
--- a/.archon/workflows/exochain-fix-issue-dag.yaml
+++ b/.archon/workflows/exochain-fix-issue-dag.yaml
@@ -46,7 +46,7 @@ nodes:
   - id: fix
     command: exochain-fix-bug
     depends_on: [council_review]
-    when: "$council_review.output.aggregate_disposition != 'Rejected'"
+    when: "$council_review.output.aggregate_disposition == 'Approved'"
     description: Implement the fix
 
   - id: validate

--- a/tools/test_agent_workflow_bounds.sh
+++ b/tools/test_agent_workflow_bounds.sh
@@ -77,4 +77,11 @@ require_file ".github/workflows/ci.yml"
 require_pattern ".github/workflows/ci.yml" 'bash tools/test_agent_prompt_boundaries\.sh' "agent prompt boundary CI gate"
 require_pattern ".github/workflows/ci.yml" 'bash tools/test_agent_workflow_bounds\.sh' "agent workflow bound CI gate"
 
+fix_issue_workflow=".archon/workflows/exochain-fix-issue-dag.yaml"
+require_file "$fix_issue_workflow"
+require_pattern "$fix_issue_workflow" "when: \"\\\$council_review\\.output\\.aggregate_disposition == 'Approved'\"" "approved-only council gate before fix node"
+if grep -Fq "aggregate_disposition != 'Rejected'" "$fix_issue_workflow"; then
+  fail "$fix_issue_workflow must not route Deferred or Requires-Amendment council outputs to code-writing nodes"
+fi
+
 printf 'agent workflow bound test passed\n'


### PR DESCRIPTION
## Summary
- classify row 19 as adjacent automation / agent workflow hardening around EXOCHAIN remediation
- require `exochain-fix-issue-dag` to route code-writing fixes only when council disposition is exactly `Approved`
- add a workflow guard that rejects the previous `!= Rejected` policy because it allowed `Deferred` and `Requires-Amendment` to write code

## Path Classification
- `.archon/workflows/exochain-fix-issue-dag.yaml` - adjacent automation / ExoForge agent workflow
- `tools/test_agent_workflow_bounds.sh` - CI source guard for adjacent automation loop and approval boundaries

## Security Validation
- RED: `bash tools/test_agent_workflow_bounds.sh` failed before the workflow change because the approved-only gate was missing
- GREEN: `bash tools/test_agent_workflow_bounds.sh`
- `bash tools/test_agent_prompt_boundaries.sh`
- `bash tools/test_github_issue_workflow_boundaries.sh`
- `git diff --check`

## Notes
- This does not modify EXOCHAIN core crates.
- `Deferred` and `Requires-Amendment` now skip the code-writing fix node and fall through to the existing escalation path.