### PR TITLE
fix(gateway): remove operational counts from metrics

### DIFF
--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -2188,17 +2188,6 @@ async fn handle_ready(State(state): State<AppState>) -> (StatusCode, Json<Health
 }
 
 fn render_gateway_metrics(state: &AppState) -> std::result::Result<String, &'static str> {
-    let did_registry_documents = state
-        .registry
-        .read()
-        .map_err(|_| "gateway DID registry lock poisoned while rendering metrics")?
-        .len();
-    let rate_limit_tracked_clients = state
-        .rate_limiter
-        .lock()
-        .map_err(|_| "gateway rate limiter lock poisoned while rendering metrics")?
-        .clients
-        .len();
     let db_configured = usize::from(state.pool.is_some());
     let uptime_seconds = state.uptime_seconds();
 
@@ -2213,17 +2202,9 @@ fn render_gateway_metrics(state: &AppState) -> std::result::Result<String, &'sta
             "# HELP exo_gateway_db_configured Whether durable storage is configured.\n",
             "# TYPE exo_gateway_db_configured gauge\n",
             "exo_gateway_db_configured {db_configured}\n",
-            "# HELP exo_gateway_did_registry_documents Local DID documents cached in memory.\n",
-            "# TYPE exo_gateway_did_registry_documents gauge\n",
-            "exo_gateway_did_registry_documents {did_registry_documents}\n",
-            "# HELP exo_gateway_rate_limit_tracked_clients Clients currently tracked by the rate limiter.\n",
-            "# TYPE exo_gateway_rate_limit_tracked_clients gauge\n",
-            "exo_gateway_rate_limit_tracked_clients {rate_limit_tracked_clients}\n",
         ),
         uptime_seconds = uptime_seconds,
         db_configured = db_configured,
-        did_registry_documents = did_registry_documents,
-        rate_limit_tracked_clients = rate_limit_tracked_clients,
     ))
 }
 
@@ -5750,6 +5731,15 @@ mod tests {
         assert!(body.contains("exo_gateway_up 1"));
         assert!(body.contains("exo_gateway_db_configured 0"));
         assert!(body.contains("exo_gateway_uptime_seconds"));
+        for forbidden_metric in [
+            "exo_gateway_did_registry_documents",
+            "exo_gateway_rate_limit_tracked_clients",
+        ] {
+            assert!(
+                !body.contains(forbidden_metric),
+                "unauthenticated gateway metrics must not expose operational counts: {forbidden_metric}"
+            );
+        }
         for forbidden in ["DATABASE_URL", "POSTGRES", "password", "secret", "token"] {
             assert!(
                 !body


### PR DESCRIPTION
## Summary
- classify row 24 as a core runtime adapter hardening issue on the gateway metrics endpoint
- remove unauthenticated DID registry document count and rate-limiter client occupancy metrics
- keep coarse Prometheus health/config gauges that do not expose identity-population or traffic occupancy counts

## Path Classification
- `crates/exo-gateway/src/server.rs` - core runtime adapter; gateway HTTP metrics surface

## Security Validation
- RED: `cargo test -p exo-gateway gateway_metrics_endpoint_returns_prometheus_text_without_secrets -- --nocapture` failed before the renderer change because `exo_gateway_did_registry_documents` was present
- GREEN: `cargo test -p exo-gateway gateway_metrics_endpoint_returns_prometheus_text_without_secrets -- --nocapture`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- source guard confirmed `render_gateway_metrics` no longer locks the DID registry or rate limiter and does not emit `exo_gateway_did_registry_documents` or `exo_gateway_rate_limit_tracked_clients`

## Notes
- `/health` and `/ready` behavior is unchanged.
- The unauthenticated metrics endpoint now avoids leaking identity-population/cache size and tracked-client/rate-limit occupancy.