### PR TITLE
fix(core): keep default HLC physical epoch fixed

### DIFF
--- a/crates/exo-core/src/hlc.rs
+++ b/crates/exo-core/src/hlc.rs
@@ -59,23 +59,11 @@ impl HybridClock {
     /// Create a new clock driven by EXOCHAIN's deterministic default source.
     #[must_use]
     pub fn new() -> Self {
-        let next_physical_ms = std::sync::atomic::AtomicU64::new(DEFAULT_DETERMINISTIC_PHYSICAL_MS);
         Self {
             physical: 0,
             logical: 0,
             max_drift_ms: MAX_DRIFT_MS,
-            physical_source: Box::new(move || {
-                next_physical_ms
-                    .fetch_update(
-                        std::sync::atomic::Ordering::Relaxed,
-                        std::sync::atomic::Ordering::Relaxed,
-                        |current| current.checked_add(1),
-                    )
-                    .map_err(|current| ExoError::ClockOverflow {
-                        physical_ms: current,
-                        logical: u32::MAX,
-                    })
-            }),
+            physical_source: Box::new(|| Ok(DEFAULT_DETERMINISTIC_PHYSICAL_MS)),
         }
     }
 
@@ -423,7 +411,7 @@ mod tests {
     }
 
     #[test]
-    fn default_clock_advances_physical_time_deterministically() {
+    fn default_clock_advances_logical_time_at_fixed_physical_epoch() {
         let mut clock = HybridClock::default();
 
         let first = clock.now().expect("first HLC timestamp");
@@ -431,14 +419,8 @@ mod tests {
         let third = clock.now().expect("third HLC timestamp");
 
         assert_eq!(first, Timestamp::new(DEFAULT_DETERMINISTIC_PHYSICAL_MS, 0));
-        assert_eq!(
-            second,
-            Timestamp::new(DEFAULT_DETERMINISTIC_PHYSICAL_MS + 1, 0)
-        );
-        assert_eq!(
-            third,
-            Timestamp::new(DEFAULT_DETERMINISTIC_PHYSICAL_MS + 2, 0)
-        );
+        assert_eq!(second, Timestamp::new(DEFAULT_DETERMINISTIC_PHYSICAL_MS, 1));
+        assert_eq!(third, Timestamp::new(DEFAULT_DETERMINISTIC_PHYSICAL_MS, 2));
     }
 
     #[test]
@@ -465,6 +447,10 @@ mod tests {
         assert!(
             !production.contains("js_sys::Date"),
             "production HLC must not import browser wall-clock APIs"
+        );
+        assert!(
+            !production.contains("fetch_update"),
+            "default HLC must not fabricate elapsed physical milliseconds from call count"
         );
     }
 

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -4841,6 +4841,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gateway_default_hlc_rate_limit_window_does_not_reset_by_request_count() {
+        let mut state = state();
+        state.rate_limiter = Arc::new(Mutex::new(GatewayRateLimiter::with_limits(1, 2, 8)));
+        let app = apply_gateway_layers(
+            Router::new().route("/probe", get(probe)),
+            state,
+            GLOBAL_CONCURRENCY_LIMIT,
+        );
+
+        let first = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/probe")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+
+        let second = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/probe")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        let third = app
+            .oneshot(
+                Request::builder()
+                    .uri("/probe")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(third.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[tokio::test]
     async fn gateway_rate_limit_resets_after_hlc_window() {
         let wall = Arc::new(AtomicU64::new(10_000));
         let state = rate_limited_state(1, 60_000, Arc::clone(&wall));


### PR DESCRIPTION
## Summary
- Remediates Codex Security row 28: deterministic default HLC no longer fabricates elapsed physical milliseconds from request count.
- Keeps `HybridClock::new()` deterministic and constitutional by using a fixed physical epoch with logical-counter advancement.
- Adds a gateway regression proving default rate-limit windows cannot reset simply by making more requests; injected HLC sources still drive real window resets when explicitly configured.

## Path Classification
- `crates/exo-core/src/hlc.rs` — EXOCHAIN core HLC primitive.
- `crates/exo-gateway/src/server.rs` — Core runtime adapter / gateway rate-limit middleware.

## TDD / Verification
RED before production fix:
- `cargo test -p exo-gateway gateway_default_hlc_rate_limit_window_does_not_reset_by_request_count -- --nocapture` failed with the third request returning `200 OK` instead of `429 Too Many Requests`.

GREEN after production fix:
- `cargo test -p exo-gateway gateway_default_hlc_rate_limit_window_does_not_reset_by_request_count -- --nocapture`
- `cargo test -p exo-core default_clock -- --nocapture`
- `cargo test -p exo-core hlc -- --nocapture`
- `cargo test -p exo-gateway gateway_rate_limit -- --nocapture`
- `cargo test -p exo-gateway gateway_rejects_requests_over_default_per_client_rate_budget -- --nocapture`
- `cargo test -p exo-core -- --nocapture`
- `cargo test -p exo-gateway -- --nocapture`
- `cargo clippy -p exo-core --all-targets -- -D warnings`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Bypass Search
- Confirmed production HLC no longer uses `fetch_update` to synthesize elapsed physical time.
- Confirmed no `SystemTime::now()` or `Instant::now()` was introduced.
- Confirmed gateway rate limiting still obtains time from the configured gateway HLC source, preserving deterministic default behavior and explicit injected clock behavior.
