### PR TITLE
fix(gateway): commit votes and audit atomically

### DIFF
--- a/crates/exo-gateway/src/handlers.rs
+++ b/crates/exo-gateway/src/handlers.rs
@@ -49,7 +49,7 @@ use exo_governance::conflict::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use sqlx::Row;
+use sqlx::{Postgres, Row, Transaction};
 
 use crate::server::{AppState, AuthenticatedSessionUser, auth_boundary_error_response};
 
@@ -317,8 +317,8 @@ fn build_audit_entry(
 }
 
 /// Write an audit entry using CBOR-hashed event payload.
-async fn write_audit(
-    state: &AppState,
+async fn write_audit_in_transaction(
+    tx: &mut Transaction<'_, Postgres>,
     event_type: &str,
     actor: &str,
     tenant_id: &str,
@@ -326,17 +326,15 @@ async fn write_audit(
     timestamp: Timestamp,
     payload: &Value,
 ) -> Result<(), String> {
-    let db = state.require_db().map_err(|e| e.to_string())?;
-    let mut tx = db.begin().await.map_err(|e| e.to_string())?;
     sqlx::query("LOCK TABLE audit_entries IN EXCLUSIVE MODE")
-        .execute(&mut *tx)
+        .execute(&mut **tx)
         .await
         .map_err(|e| e.to_string())?;
     let last = sqlx::query_as::<_, crate::db::AuditRow>(
         "SELECT sequence, prev_hash, event_hash, event_type, actor, tenant_id, decision_id, timestamp_physical_ms, timestamp_logical, entry_hash
          FROM audit_entries ORDER BY sequence DESC LIMIT 1",
     )
-    .fetch_optional(&mut *tx)
+    .fetch_optional(&mut **tx)
     .await
     .map_err(|e| e.to_string())?;
     let entry = build_audit_entry(
@@ -362,10 +360,9 @@ async fn write_audit(
     .bind(entry.timestamp_physical_ms)
     .bind(entry.timestamp_logical)
     .bind(&entry.entry_hash)
-    .execute(&mut *tx)
+    .execute(&mut **tx)
     .await
     .map_err(|e| e.to_string())?;
-    tx.commit().await.map_err(|e| e.to_string())?;
     Ok(())
 }
 
@@ -818,6 +815,35 @@ pub async fn vote_handler(
         }
     };
 
+    // ── VIOLATION 3 FIX: CBOR canonical audit hash ──────────────────────
+    let audit_payload = serde_json::json!({
+        "event": "VoteCast",
+        "decision_id": body.decision_id.as_str(),
+        "tenant_id": tenant_id.as_str(),
+        "voter": body.voter_did.as_str(),
+        "choice": body.choice,
+        "timestamp_physical_ms": timestamp.physical_ms,
+        "timestamp_logical": timestamp.logical,
+    });
+    if let Err(e) = write_audit_in_transaction(
+        &mut tx,
+        "VoteCast",
+        &body.voter_did,
+        &tenant_id,
+        &body.decision_id,
+        timestamp,
+        &audit_payload,
+    )
+    .await
+    {
+        tracing::error!(error = %e, "audit write failed");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "audit write failed"})),
+        )
+            .into_response();
+    }
+
     // Persist updated decision.
     if let Err(e) =
         sqlx::query("UPDATE decisions SET payload = $1 WHERE id_hash = $2 AND tenant_id = $3")
@@ -839,35 +865,6 @@ pub async fn vote_handler(
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({"error": "decision persistence failed"})),
-        )
-            .into_response();
-    }
-
-    // ── VIOLATION 3 FIX: CBOR canonical audit hash ──────────────────────
-    let audit_payload = serde_json::json!({
-        "event": "VoteCast",
-        "decision_id": body.decision_id.as_str(),
-        "tenant_id": tenant_id.as_str(),
-        "voter": body.voter_did.as_str(),
-        "choice": body.choice,
-        "timestamp_physical_ms": timestamp.physical_ms,
-        "timestamp_logical": timestamp.logical,
-    });
-    if let Err(e) = write_audit(
-        &state,
-        "VoteCast",
-        &body.voter_did,
-        &tenant_id,
-        &body.decision_id,
-        timestamp,
-        &audit_payload,
-    )
-    .await
-    {
-        tracing::error!(error = %e, "audit write failed");
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": "audit write failed"})),
         )
             .into_response();
     }
@@ -1743,6 +1740,41 @@ mod tests {
     }
 
     #[test]
+    fn vote_handler_writes_audit_in_decision_transaction_before_commit() {
+        let source = include_str!("handlers.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("test module marker present");
+        let vote_handler = production
+            .split("pub async fn vote_handler")
+            .nth(1)
+            .expect("vote handler source present")
+            .split("// ── Health handler")
+            .next()
+            .expect("vote handler source end");
+
+        let audit_index = vote_handler
+            .find("write_audit_in_transaction(")
+            .expect("vote handler must write audit entries through the decision transaction");
+        let update_index = vote_handler
+            .find("UPDATE decisions SET payload")
+            .expect("vote handler must persist the updated decision");
+        let commit_index = vote_handler
+            .find("tx.commit().await")
+            .expect("vote handler must commit the decision transaction");
+
+        assert!(
+            audit_index < update_index && update_index < commit_index,
+            "audit hash and insert must succeed before the decision update commits"
+        );
+        assert!(
+            !vote_handler.contains("write_audit(\n        &state"),
+            "vote handler must not write vote audit entries in a separate post-commit transaction"
+        );
+    }
+
+    #[test]
     fn vote_handler_scopes_decision_mutation_to_authenticated_actor_tenant() {
         let source = include_str!("handlers.rs");
         let production = source
@@ -2038,8 +2070,9 @@ mod tests {
             "choice": "Approve",
         });
 
-        write_audit(
-            &state,
+        let mut audit_tx = pool.begin().await.expect("start audit transaction");
+        write_audit_in_transaction(
+            &mut audit_tx,
             "VoteCast",
             voter,
             "tenant-r4",
@@ -2049,8 +2082,8 @@ mod tests {
         )
         .await
         .expect("first audit write");
-        write_audit(
-            &state,
+        write_audit_in_transaction(
+            &mut audit_tx,
             "VoteCast",
             voter,
             "tenant-r4",
@@ -2060,6 +2093,7 @@ mod tests {
         )
         .await
         .expect("second audit write");
+        audit_tx.commit().await.expect("commit audit transaction");
 
         let app = crate::server::build_router(state);
         let resp = app


### PR DESCRIPTION
## Summary
- Remediates Codex Security row 32: vote audit hash/insert failures can no longer occur after the decision vote has committed.
- Moves vote audit insertion into the same database transaction as the locked decision-row update.
- Writes and hashes the audit entry before `UPDATE decisions`, then commits both together; any audit hash-budget, timestamp conversion, insert, update, or commit failure rolls back the whole vote transaction.

## Path Classification
- `crates/exo-gateway/src/handlers.rs` — Core runtime adapter / gateway governance vote handler and audit writer.

## TDD / Verification
RED before production fix:
- `cargo test -p exo-gateway vote_handler_writes_audit_in_decision_transaction_before_commit -- --nocapture` failed because `vote_handler` wrote audit entries in a separate post-commit transaction.

GREEN after production fix:
- `cargo test -p exo-gateway vote_handler_writes_audit_in_decision_transaction_before_commit -- --nocapture`
- `cargo test -p exo-gateway vote_handler_updates_decision_under_row_lock_transaction -- --nocapture`
- `cargo test -p exo-gateway audit_entry -- --nocapture`
- `cargo test -p exo-gateway canonical_hash_rejects_payloads_above_hash_budget -- --nocapture`
- `cargo test -p exo-gateway vote_ -- --nocapture`
- `cargo test -p exo-gateway handlers -- --nocapture`
- `cargo test -p exo-gateway -- --nocapture`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Bypass Search
- Confirmed `vote_handler` calls `write_audit_in_transaction(&mut tx, ...)` before `UPDATE decisions` and before `tx.commit().await`.
- Confirmed the vote handler no longer calls the audit writer with `&state` after commit.
- Confirmed `audit_entries` locking and last-entry selection now use the caller's transaction for the vote path.
