### PR TITLE
fix(authority): bind delegation depth to selected parent

### DIFF
--- a/crates/exo-authority/src/delegation.rs
+++ b/crates/exo-authority/src/delegation.rs
@@ -85,6 +85,8 @@ pub struct DelegationGrant<'a> {
     pub scope: &'a [Permission],
     pub expires: Timestamp,
     pub now: &'a Timestamp,
+    /// Selected parent link for delegated authority, or `None` for a self-root grant.
+    pub parent_link_id: Option<&'a Hash256>,
     pub delegatee_kind: DelegateeKind,
     pub delegator_public_key: &'a PublicKey,
 }
@@ -360,6 +362,7 @@ impl DelegationRegistry {
             scope,
             expires,
             now,
+            parent_link_id,
             delegatee_kind,
             delegator_public_key,
         } = grant;
@@ -399,17 +402,7 @@ impl DelegationRegistry {
         }
 
         let scope = canonical_scope(scope)?;
-        let depth = self.compute_depth(from)?;
-        let chain_depth = depth.checked_add(1).ok_or(AuthorityError::DepthExceeded {
-            depth,
-            max_depth: DEFAULT_MAX_DEPTH,
-        })?;
-        if chain_depth > DEFAULT_MAX_DEPTH {
-            return Err(AuthorityError::DepthExceeded {
-                depth: chain_depth,
-                max_depth: DEFAULT_MAX_DEPTH,
-            });
-        }
+        let depth = self.compute_depth(from, parent_link_id, &scope, now)?;
 
         let mut link = AuthorityLink {
             delegator_did: from.clone(),
@@ -595,28 +588,63 @@ impl DelegationRegistry {
         false
     }
 
-    fn compute_depth(&self, did: &Did) -> Result<usize, AuthorityError> {
-        let mut max_depth = 0usize;
-        if let Some(ids) = self.by_delegate.get(did.as_str()) {
-            for id in ids {
-                if let Some(link) = self.links.get(id) {
-                    let candidate =
-                        link.depth
-                            .checked_add(1)
-                            .ok_or(AuthorityError::DepthExceeded {
-                                depth: link.depth,
-                                max_depth: DEFAULT_MAX_DEPTH,
-                            })?;
-                    if candidate > max_depth {
-                        max_depth = candidate;
-                    }
-                    if max_depth >= DEFAULT_MAX_DEPTH {
-                        return Ok(max_depth);
-                    }
-                }
+    fn compute_depth(
+        &self,
+        did: &Did,
+        parent_link_id: Option<&Hash256>,
+        scope: &[Permission],
+        now: &Timestamp,
+    ) -> Result<usize, AuthorityError> {
+        let Some(parent_link_id) = parent_link_id else {
+            return Ok(0);
+        };
+
+        let parent = self
+            .links
+            .get(parent_link_id)
+            .ok_or_else(|| AuthorityError::NotFound(parent_link_id.to_string()))?;
+        if parent.delegate_did != *did {
+            return Err(AuthorityError::PermissionDenied(format!(
+                "parent link {} delegates to {}, not {}",
+                parent_link_id,
+                parent.delegate_did.as_str(),
+                did.as_str()
+            )));
+        }
+        if let Some(expires) = &parent.expires {
+            if expires.is_expired(now) {
+                return Err(AuthorityError::ExpiredLink {
+                    index: parent.depth,
+                });
             }
         }
-        Ok(max_depth)
+
+        let parent_scope = parent.scope.iter().copied().collect::<BTreeSet<_>>();
+        let child_scope = scope.iter().copied().collect::<BTreeSet<_>>();
+        if !child_scope.is_subset(&parent_scope) {
+            return Err(AuthorityError::InvalidDelegation {
+                reason: "delegation scope must not exceed selected parent link scope".into(),
+            });
+        }
+
+        let depth = parent
+            .depth
+            .checked_add(1)
+            .ok_or(AuthorityError::DepthExceeded {
+                depth: parent.depth,
+                max_depth: DEFAULT_MAX_DEPTH,
+            })?;
+        let chain_depth = depth.checked_add(1).ok_or(AuthorityError::DepthExceeded {
+            depth,
+            max_depth: DEFAULT_MAX_DEPTH,
+        })?;
+        if chain_depth > DEFAULT_MAX_DEPTH {
+            return Err(AuthorityError::DepthExceeded {
+                depth: chain_depth,
+                max_depth: DEFAULT_MAX_DEPTH,
+            });
+        }
+        Ok(depth)
     }
 }
 
@@ -679,6 +707,16 @@ mod tests {
         scope: &[Permission],
         signer: &KeyPair,
     ) -> Result<AuthorityLink, AuthorityError> {
+        signed_delegate_with_parent(reg, from, to, scope, None, signer)
+    }
+    fn signed_delegate_with_parent(
+        reg: &mut DelegationRegistry,
+        from: &str,
+        to: &str,
+        scope: &[Permission],
+        parent_link_id: Option<&Hash256>,
+        signer: &KeyPair,
+    ) -> Result<AuthorityLink, AuthorityError> {
         let public_key = public_key(signer);
         let from = did(from);
         let to = did(to);
@@ -689,6 +727,7 @@ mod tests {
                 scope,
                 expires: ts(10000),
                 now: &now(),
+                parent_link_id,
                 delegatee_kind: DelegateeKind::Human,
                 delegator_public_key: &public_key,
             },
@@ -816,6 +855,7 @@ mod tests {
                 scope: &[Permission::Read],
                 expires: ts(10000),
                 now: &now(),
+                parent_link_id: None,
                 delegatee_kind: DelegateeKind::Human,
                 delegator_public_key: &wrong_public_key,
             },
@@ -843,6 +883,7 @@ mod tests {
                 scope: &[Permission::Read],
                 expires: ts(10000),
                 now: &now(),
+                parent_link_id: None,
                 delegatee_kind: DelegateeKind::Human,
                 delegator_public_key: &public_key,
             },
@@ -870,6 +911,7 @@ mod tests {
                 scope: &[Permission::Read],
                 expires: ts(10000),
                 now: &now(),
+                parent_link_id: None,
                 delegatee_kind: DelegateeKind::Unknown,
                 delegator_public_key: &public_key,
             },
@@ -899,6 +941,7 @@ mod tests {
                     scope: &[Permission::Read],
                     expires: ts(10000),
                     now: &now(),
+                    parent_link_id: None,
                     delegatee_kind: DelegateeKind::AiAgent {
                         model_id: "exo-agent-v1".to_owned(),
                     },
@@ -931,6 +974,7 @@ mod tests {
                 scope: &[Permission::Read],
                 expires: ts(10000),
                 now: &now(),
+                parent_link_id: None,
                 delegatee_kind: DelegateeKind::Human,
                 delegator_public_key: &public_key,
             },
@@ -962,7 +1006,7 @@ mod tests {
         let mut reg = DelegationRegistry::new();
         let alice_key = KeyPair::generate();
         let bob_key = KeyPair::generate();
-        signed_delegate(
+        let alice_to_bob = signed_delegate(
             &mut reg,
             "alice",
             "bob",
@@ -970,7 +1014,16 @@ mod tests {
             &alice_key,
         )
         .unwrap();
-        signed_delegate(&mut reg, "bob", "charlie", &[Permission::Read], &bob_key).unwrap();
+        let alice_to_bob_id = alice_to_bob.id().unwrap();
+        signed_delegate_with_parent(
+            &mut reg,
+            "bob",
+            "charlie",
+            &[Permission::Read],
+            Some(&alice_to_bob_id),
+            &bob_key,
+        )
+        .unwrap();
 
         let chain = reg
             .find_chain(&did("alice"), &did("charlie"))
@@ -1056,18 +1109,152 @@ mod tests {
     }
 
     #[test]
-    fn delegate_uses_max_parent_depth_for_multi_parent_delegator() {
+    fn delegate_uses_selected_parent_depth_for_multi_parent_delegator() {
         let mut reg = DelegationRegistry::new();
         let key = KeyPair::generate();
 
-        signed_delegate(&mut reg, "root-a", "shared", &[Permission::Read], &key).unwrap();
-        signed_delegate(&mut reg, "root-b", "mid", &[Permission::Read], &key).unwrap();
-        signed_delegate(&mut reg, "mid", "deep", &[Permission::Read], &key).unwrap();
-        signed_delegate(&mut reg, "deep", "shared", &[Permission::Read], &key).unwrap();
+        let shallow_parent =
+            signed_delegate(&mut reg, "root-a", "shared", &[Permission::Read], &key).unwrap();
+        let shallow_parent_id = shallow_parent.id().unwrap();
+        let root_to_mid =
+            signed_delegate(&mut reg, "root-b", "mid", &[Permission::Read], &key).unwrap();
+        let root_to_mid_id = root_to_mid.id().unwrap();
+        let mid_to_deep = signed_delegate_with_parent(
+            &mut reg,
+            "mid",
+            "deep",
+            &[Permission::Read],
+            Some(&root_to_mid_id),
+            &key,
+        )
+        .unwrap();
+        let mid_to_deep_id = mid_to_deep.id().unwrap();
+        let deep_parent = signed_delegate_with_parent(
+            &mut reg,
+            "deep",
+            "shared",
+            &[Permission::Read],
+            Some(&mid_to_deep_id),
+            &key,
+        )
+        .unwrap();
+        let deep_parent_id = deep_parent.id().unwrap();
 
-        let link = signed_delegate(&mut reg, "shared", "leaf", &[Permission::Read], &key).unwrap();
+        let shallow_link = signed_delegate_with_parent(
+            &mut reg,
+            "shared",
+            "leaf-shallow",
+            &[Permission::Read],
+            Some(&shallow_parent_id),
+            &key,
+        )
+        .unwrap();
+        let deep_link = signed_delegate_with_parent(
+            &mut reg,
+            "shared",
+            "leaf-deep",
+            &[Permission::Read],
+            Some(&deep_parent_id),
+            &key,
+        )
+        .unwrap();
 
-        assert_eq!(link.depth, 3);
+        assert_eq!(shallow_link.depth, 1);
+        assert_eq!(deep_link.depth, 3);
+    }
+
+    #[test]
+    fn delegate_rejects_parent_link_that_does_not_delegate_to_grantor() {
+        let mut reg = DelegationRegistry::new();
+        let key = KeyPair::generate();
+        let parent = signed_delegate(&mut reg, "root", "alice", &[Permission::Read], &key)
+            .expect("parent delegation");
+        let parent_id = parent.id().unwrap();
+
+        let result = signed_delegate_with_parent(
+            &mut reg,
+            "bob",
+            "charlie",
+            &[Permission::Read],
+            Some(&parent_id),
+            &key,
+        );
+
+        assert!(matches!(result, Err(AuthorityError::PermissionDenied(_))));
+    }
+
+    #[test]
+    fn delegate_rejects_missing_parent_link() {
+        let mut reg = DelegationRegistry::new();
+        let key = KeyPair::generate();
+        let missing_parent_id = Hash256::digest(b"missing-parent-link");
+
+        let result = signed_delegate_with_parent(
+            &mut reg,
+            "bob",
+            "charlie",
+            &[Permission::Read],
+            Some(&missing_parent_id),
+            &key,
+        );
+
+        assert!(matches!(result, Err(AuthorityError::NotFound(_))));
+    }
+
+    #[test]
+    fn delegate_rejects_scope_widening_under_selected_parent() {
+        let mut reg = DelegationRegistry::new();
+        let key = KeyPair::generate();
+        let parent = signed_delegate(&mut reg, "root", "bob", &[Permission::Read], &key)
+            .expect("parent delegation");
+        let parent_id = parent.id().unwrap();
+
+        let result = signed_delegate_with_parent(
+            &mut reg,
+            "bob",
+            "charlie",
+            &[Permission::Write],
+            Some(&parent_id),
+            &key,
+        );
+
+        assert!(matches!(
+            result,
+            Err(AuthorityError::InvalidDelegation { reason }) if reason.contains("scope")
+        ));
+    }
+
+    #[test]
+    fn unilateral_incoming_depth_cannot_squat_self_root_delegation() {
+        let mut reg = DelegationRegistry::new();
+        let key = KeyPair::generate();
+
+        let mut parent_link_id = None;
+        for i in 0..DEFAULT_MAX_DEPTH {
+            let next = if i + 1 == DEFAULT_MAX_DEPTH {
+                "victim".to_owned()
+            } else {
+                format!("attacker-{}", i + 1)
+            };
+            let link = signed_delegate_with_parent(
+                &mut reg,
+                &format!("attacker-{i}"),
+                next.as_str(),
+                &[Permission::Read],
+                parent_link_id.as_ref(),
+                &key,
+            )
+            .unwrap();
+            parent_link_id = Some(link.id().unwrap());
+        }
+
+        let link = signed_delegate(&mut reg, "victim", "leaf", &[Permission::Read], &key)
+            .expect("unaccepted incoming delegations must not block self-root grants");
+
+        assert_eq!(
+            link.depth, 0,
+            "self-root grants must not inherit unilateral incoming depth"
+        );
     }
 
     #[test]
@@ -1075,22 +1262,26 @@ mod tests {
         let mut reg = DelegationRegistry::new();
         let key = KeyPair::generate();
 
+        let mut parent_link_id = None;
         for i in 0..DEFAULT_MAX_DEPTH {
-            signed_delegate(
+            let link = signed_delegate_with_parent(
                 &mut reg,
                 &format!("node-{i}"),
                 &format!("node-{}", i + 1),
                 &[Permission::Read],
+                parent_link_id.as_ref(),
                 &key,
             )
             .unwrap();
+            parent_link_id = Some(link.id().unwrap());
         }
 
-        let result = signed_delegate(
+        let result = signed_delegate_with_parent(
             &mut reg,
             &format!("node-{DEFAULT_MAX_DEPTH}"),
             "too-deep",
             &[Permission::Read],
+            parent_link_id.as_ref(),
             &key,
         );
 
@@ -1317,7 +1508,7 @@ mod tests {
         let mut reg = DelegationRegistry::new();
         let alice_key = KeyPair::generate();
         let bob_key = KeyPair::generate();
-        signed_delegate(
+        let alice_to_bob = signed_delegate(
             &mut reg,
             "alice",
             "bob",
@@ -1325,7 +1516,16 @@ mod tests {
             &alice_key,
         )
         .ok();
-        signed_delegate(&mut reg, "bob", "charlie", &[Permission::Read], &bob_key).ok();
+        let alice_to_bob_id = alice_to_bob.unwrap().id().unwrap();
+        signed_delegate_with_parent(
+            &mut reg,
+            "bob",
+            "charlie",
+            &[Permission::Read],
+            Some(&alice_to_bob_id),
+            &bob_key,
+        )
+        .ok();
         let chain = reg.find_chain(&did("alice"), &did("charlie"));
         assert!(chain.is_some());
         assert_eq!(chain.unwrap().depth(), 2);


### PR DESCRIPTION
## Summary
- Remediates Codex Security row 33: unsolicited high-depth incoming delegations can no longer consume a target DID's delegation-depth budget.
- Adds explicit `parent_link_id` selection to `DelegationGrant`; `None` creates a self-root grant at depth 0, while subdelegation depth is derived only from the selected parent link.
- Fails closed when the selected parent link is missing, delegates to a different DID, is expired, exceeds max depth, or would allow scope widening.

## Path Classification
- `crates/exo-authority/src/delegation.rs` — EXOCHAIN core authority delegation registry and depth enforcement.

## TDD / Verification
RED before production fix:
- `cargo test -p exo-authority unilateral_incoming_depth_cannot_squat_self_root_delegation -- --nocapture` failed with `DepthExceeded { depth: 6, max_depth: 5 }` after a hostile chain ended at `victim`.

GREEN after production fix:
- `cargo test -p exo-authority unilateral_incoming_depth_cannot_squat_self_root_delegation -- --nocapture`
- `cargo test -p exo-authority delegate_uses_selected_parent_depth_for_multi_parent_delegator -- --nocapture`
- `cargo test -p exo-authority delegate_rejects_parent_link_that_does_not_delegate_to_grantor -- --nocapture`
- `cargo test -p exo-authority delegate_rejects_missing_parent_link -- --nocapture`
- `cargo test -p exo-authority delegate_rejects_scope_widening_under_selected_parent -- --nocapture`
- `cargo test -p exo-authority delegate_rejects_chain_beyond_default_max_depth -- --nocapture`
- `cargo test -p exo-authority find_chain_transitive -- --nocapture`
- `cargo test -p exo-authority find_chain_returns_cryptographically_valid_chain -- --nocapture`
- `cargo test -p exo-authority -- --nocapture`
- `cargo clippy -p exo-authority --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `git diff --check`

## Bypass Search
- Confirmed delegation depth is no longer derived from the reverse `by_delegate` incoming-link index.
- Confirmed subdelegations must choose a parent link that actually delegates to the grantor DID.
- Confirmed self-root grants ignore unsolicited incoming depth and remain depth 0.
