### PR TITLE
fix(authority): preserve signed depths during chain lookup

### DIFF
--- a/crates/exo-authority/src/chain.rs
+++ b/crates/exo-authority/src/chain.rs
@@ -177,7 +177,7 @@ impl AuthorityChain {
 /// - Non-empty
 /// - Continuity: each link's delegate == next link's delegator
 /// - Depth limits
-/// - Depth values are correct (0, 1, 2, ...)
+/// - Depth values are contiguous and remain within `max_depth`
 ///
 /// # Errors
 /// Returns `AuthorityError` if validation fails.
@@ -212,12 +212,35 @@ fn validate_chain_topology(
         });
     }
 
-    // Validate continuity and depth values
+    let first_depth = links[0].depth;
+    let chain_end_depth =
+        first_depth
+            .checked_add(links.len())
+            .ok_or(AuthorityError::DepthExceeded {
+                depth: first_depth,
+                max_depth,
+            })?;
+    if chain_end_depth > max_depth {
+        return Err(AuthorityError::DepthExceeded {
+            depth: chain_end_depth,
+            max_depth,
+        });
+    }
+
+    // Validate continuity and signed depth values. Depth can start at a
+    // non-zero offset for verified subchains, but each stored link must keep
+    // its original signed depth.
     for (i, link) in links.iter().enumerate() {
-        if link.depth != i {
+        let expected_depth = first_depth
+            .checked_add(i)
+            .ok_or(AuthorityError::DepthExceeded {
+                depth: first_depth,
+                max_depth,
+            })?;
+        if link.depth != expected_depth {
             return Err(AuthorityError::ChainBroken {
                 index: i,
-                reason: format!("expected depth {i}, got {}", link.depth),
+                reason: format!("expected depth {expected_depth}, got {}", link.depth),
             });
         }
         if i > 0 {
@@ -468,6 +491,20 @@ mod tests {
         ];
         let chain = build_chain(&links).unwrap();
         assert_eq!(chain.depth(), 3);
+    }
+
+    #[test]
+    fn build_accepts_contiguous_depth_offset() {
+        let links = vec![
+            fake_link("alice", "bob", vec![Permission::Read], 1, None),
+            fake_link("bob", "charlie", vec![Permission::Read], 2, None),
+        ];
+
+        let chain = build_chain(&links).unwrap();
+
+        assert_eq!(chain.depth(), 2);
+        assert_eq!(chain.links[0].depth, 1);
+        assert_eq!(chain.links[1].depth, 2);
     }
 
     #[test]
@@ -751,7 +788,10 @@ mod tests {
 
         assert!(matches!(
             verify_chain(&chain, &now(), reg.resolver()),
-            Err(AuthorityError::ChainBroken { index: 0, .. })
+            Err(AuthorityError::DepthExceeded {
+                depth: 8,
+                max_depth: DEFAULT_MAX_DEPTH,
+            })
         ));
     }
 

--- a/crates/exo-authority/src/delegation.rs
+++ b/crates/exo-authority/src/delegation.rs
@@ -515,10 +515,6 @@ impl DelegationRegistry {
     pub fn find_chain(&self, from: &Did, to: &Did) -> Option<AuthorityChain> {
         let mut path = Vec::new();
         if self.find_path_dfs(from, to, &mut path, 0, DEFAULT_MAX_DEPTH) {
-            // Re-number depths
-            for (i, link) in path.iter_mut().enumerate() {
-                link.depth = i;
-            }
             chain::build_chain(&path).ok()
         } else {
             None
@@ -981,6 +977,52 @@ mod tests {
         ]);
 
         assert!(chain::verify_chain(&chain, &now(), |did| keys.get(did.as_str()).copied()).is_ok());
+    }
+
+    #[test]
+    fn find_chain_subchain_preserves_signed_depth_and_verifies() {
+        let mut reg = DelegationRegistry::new();
+        let root_key = KeyPair::generate();
+        let alice_key = KeyPair::generate();
+        signed_delegate(
+            &mut reg,
+            "root",
+            "alice",
+            &[Permission::Read, Permission::Write],
+            &root_key,
+        )
+        .unwrap();
+        let alice_to_bob =
+            signed_delegate(&mut reg, "alice", "bob", &[Permission::Read], &alice_key).unwrap();
+        assert_eq!(alice_to_bob.depth, 1);
+
+        let chain = reg
+            .find_chain(&did("alice"), &did("bob"))
+            .expect("subchain should resolve");
+        assert_eq!(chain.links[0].depth, 1);
+        let keys = std::collections::BTreeMap::from([(
+            did("alice").as_str().to_owned(),
+            public_key(&alice_key),
+        )]);
+
+        assert!(chain::verify_chain(&chain, &now(), |did| keys.get(did.as_str()).copied()).is_ok());
+    }
+
+    #[test]
+    fn find_chain_source_does_not_mutate_signed_link_depths() {
+        let source = include_str!("delegation.rs");
+        let find_chain_source = source
+            .split("pub fn find_chain")
+            .nth(1)
+            .expect("find_chain source present")
+            .split("/// Number of active delegations")
+            .next()
+            .expect("find_chain source end");
+
+        assert!(
+            !find_chain_source.contains(".depth ="),
+            "find_chain must not mutate signed depth values while assembling a chain"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Remediates Codex Security row 38: find_chain rewrote AuthorityLink.depth even though depth is part of the signed payload.
- Removes depth renumbering from DelegationRegistry::find_chain.
- Updates authority-chain topology validation to accept contiguous signed-depth offsets for subchains while still rejecting gaps and out-of-range forged depths.

## Path classification
- crates/exo-authority/src/delegation.rs: EXOCHAIN core authority registry and chain lookup logic.
- crates/exo-authority/src/chain.rs: EXOCHAIN core authority-chain topology validation.

## TDD and validation
- RED before fix: cargo test -p exo-authority find_chain_subchain_preserves_signed_depth_and_verifies -- --nocapture failed because find_chain rewrote depth 1 to 0.
- RED before fix: cargo test -p exo-authority build_accepts_contiguous_depth_offset -- --nocapture failed because build_chain rejected a valid contiguous signed-depth offset.
- GREEN: cargo test -p exo-authority find_chain_subchain_preserves_signed_depth_and_verifies -- --nocapture
- GREEN: cargo test -p exo-authority build_accepts_contiguous_depth_offset -- --nocapture
- GREEN: cargo test -p exo-authority find_chain_source_does_not_mutate_signed_link_depths -- --nocapture
- GREEN: cargo test -p exo-authority verify_rejects_prebuilt_chain_with_forged_depth -- --nocapture
- GREEN: cargo test -p exo-authority -- --nocapture
- GREEN: cargo clippy -p exo-authority --all-targets -- -D warnings
- GREEN: cargo fmt --all -- --check
- GREEN: cargo check --workspace --all-targets
- GREEN: git diff --check
- Guard after topology change: cargo test -p exo-legal verify_ai_delegation_grant -- --nocapture
- Guard after topology change: cargo test -p exo-legal verify_authority_clearance -- --nocapture
- Guard after topology change: cargo test -p exo-authority verify_rejects_prebuilt_chain_with_broken_topology -- --nocapture

## Bypass search
- Source guard proves find_chain no longer contains a signed-depth assignment.
- verify_chain still validates continuity and rejects broken topology before signature trust.
- Forged depth outside max_depth remains rejected as DepthExceeded.