### PR TITLE
fix(messaging): bind death trigger timestamps to signatures

### DIFF
--- a/crates/exo-messaging/src/death_trigger.rs
+++ b/crates/exo-messaging/src/death_trigger.rs
@@ -140,20 +140,22 @@ struct ConfirmationSigningPayload<'a> {
     required_confirmations: u8,
     claim_nonce: &'a [u8],
     trustee_did: &'a str,
+    confirmed_at: &'a Timestamp,
     authorized_trustees: Vec<AuthorizedTrusteeSigningEntry<'a>>,
 }
 
 /// Canonical CBOR payload signed for the initiator's first confirmation.
 ///
 /// The payload binds the subject, initiator, threshold, authorized trustee set,
-/// caller-supplied claim nonce, and confirming trustee DID. The signature itself
-/// and HLC timestamps are excluded so callers can sign before the state exists.
+/// caller-supplied claim nonce, confirming trustee DID, and the HLC timestamp
+/// that will be stored for that confirmation. The signature itself is excluded.
 pub fn initial_confirmation_signing_payload(
     subject_did: &Did,
     initiated_by: &Did,
     required_confirmations: u8,
     authorized_trustees: &BTreeMap<Did, PublicKey>,
     claim_nonce: &[u8],
+    created_at: &Timestamp,
 ) -> Result<Vec<u8>, MessagingError> {
     confirmation_signing_payload_for(
         subject_did,
@@ -162,6 +164,7 @@ pub fn initial_confirmation_signing_payload(
         authorized_trustees,
         claim_nonce,
         initiated_by,
+        created_at,
     )
 }
 
@@ -172,6 +175,7 @@ fn confirmation_signing_payload_for(
     authorized_trustees: &BTreeMap<Did, PublicKey>,
     claim_nonce: &[u8],
     trustee_did: &Did,
+    confirmed_at: &Timestamp,
 ) -> Result<Vec<u8>, MessagingError> {
     let trustee_entries = authorized_trustees
         .iter()
@@ -187,6 +191,7 @@ fn confirmation_signing_payload_for(
         required_confirmations,
         claim_nonce,
         trustee_did: trustee_did.as_str(),
+        confirmed_at,
         authorized_trustees: trustee_entries,
     };
     let mut encoded = Vec::new();
@@ -221,6 +226,7 @@ impl DeathVerification {
             required_confirmations,
             &authorized_trustees,
             &claim_nonce,
+            &metadata.created_at,
         )?;
         if !exo_core::crypto::verify(
             &signing_payload,
@@ -252,6 +258,7 @@ impl DeathVerification {
     pub fn confirmation_signing_payload(
         &self,
         trustee_did: &Did,
+        confirmed_at: &Timestamp,
     ) -> Result<Vec<u8>, MessagingError> {
         confirmation_signing_payload_for(
             &self.subject_did,
@@ -260,6 +267,7 @@ impl DeathVerification {
             &self.authorized_trustees,
             &self.claim_nonce,
             trustee_did,
+            confirmed_at,
         )
     }
 
@@ -293,7 +301,8 @@ impl DeathVerification {
         if expected_public_key != trustee_public_key {
             return Err(MessagingError::SignatureVerificationFailed);
         }
-        let signing_payload = self.confirmation_signing_payload(&trustee_did)?;
+        let signing_payload =
+            self.confirmation_signing_payload(&trustee_did, &metadata.confirmed_at)?;
         if !exo_core::crypto::verify(&signing_payload, &signature, &expected_public_key) {
             return Err(MessagingError::SignatureVerificationFailed);
         }
@@ -426,12 +435,59 @@ mod tests {
             .collect()
     }
 
+    fn legacy_confirmation_payload_without_timestamp(
+        subject_did: &Did,
+        initiated_by: &Did,
+        required_confirmations: u8,
+        authorized_trustees: &BTreeMap<Did, PublicKey>,
+        claim_nonce: &[u8],
+        trustee_did: &Did,
+    ) -> Vec<u8> {
+        #[derive(serde::Serialize)]
+        struct LegacyAuthorizedTrusteeSigningEntry<'a> {
+            did: &'a str,
+            public_key: &'a [u8; 32],
+        }
+
+        #[derive(serde::Serialize)]
+        struct LegacyConfirmationSigningPayload<'a> {
+            domain: &'static str,
+            subject_did: &'a str,
+            initiated_by: &'a str,
+            required_confirmations: u8,
+            claim_nonce: &'a [u8],
+            trustee_did: &'a str,
+            authorized_trustees: Vec<LegacyAuthorizedTrusteeSigningEntry<'a>>,
+        }
+
+        let trustee_entries = authorized_trustees
+            .iter()
+            .map(|(did, public_key)| LegacyAuthorizedTrusteeSigningEntry {
+                did: did.as_str(),
+                public_key: public_key.as_bytes(),
+            })
+            .collect();
+        let payload = LegacyConfirmationSigningPayload {
+            domain: DEATH_CONFIRMATION_SIGNING_DOMAIN,
+            subject_did: subject_did.as_str(),
+            initiated_by: initiated_by.as_str(),
+            required_confirmations,
+            claim_nonce,
+            trustee_did: trustee_did.as_str(),
+            authorized_trustees: trustee_entries,
+        };
+        let mut encoded = Vec::new();
+        ciborium::into_writer(&payload, &mut encoded).unwrap();
+        encoded
+    }
+
     fn initial_signature(
         subject: &Did,
         initiated_by: &Did,
         required_confirmations: u8,
         authorized_trustees: &BTreeMap<Did, PublicKey>,
         claim_nonce: &[u8],
+        created_at: Timestamp,
         keypair: &KeyPair,
     ) -> Signature {
         let payload = initial_confirmation_signing_payload(
@@ -440,8 +496,28 @@ mod tests {
             required_confirmations,
             authorized_trustees,
             claim_nonce,
+            &created_at,
         )
         .unwrap();
+        sign(&payload, keypair.secret_key())
+    }
+
+    fn legacy_initial_signature_without_timestamp(
+        subject: &Did,
+        initiated_by: &Did,
+        required_confirmations: u8,
+        authorized_trustees: &BTreeMap<Did, PublicKey>,
+        claim_nonce: &[u8],
+        keypair: &KeyPair,
+    ) -> Signature {
+        let payload = legacy_confirmation_payload_without_timestamp(
+            subject,
+            initiated_by,
+            required_confirmations,
+            authorized_trustees,
+            claim_nonce,
+            initiated_by,
+        );
         sign(&payload, keypair.secret_key())
     }
 
@@ -459,6 +535,7 @@ mod tests {
             required_confirmations,
             &authorized_trustees,
             &claim_nonce,
+            timestamp(1_000),
             keypair,
         );
         DeathVerification::new(
@@ -476,11 +553,28 @@ mod tests {
     fn confirmation_signature(
         verification: &DeathVerification,
         trustee_did: &Did,
+        confirmed_at: Timestamp,
         keypair: &KeyPair,
     ) -> Signature {
         let payload = verification
-            .confirmation_signing_payload(trustee_did)
+            .confirmation_signing_payload(trustee_did, &confirmed_at)
             .unwrap();
+        sign(&payload, keypair.secret_key())
+    }
+
+    fn legacy_confirmation_signature_without_timestamp(
+        verification: &DeathVerification,
+        trustee_did: &Did,
+        keypair: &KeyPair,
+    ) -> Signature {
+        let payload = legacy_confirmation_payload_without_timestamp(
+            &verification.subject_did,
+            &verification.initiated_by,
+            verification.required_confirmations,
+            &verification.authorized_trustees,
+            &verification.claim_nonce,
+            trustee_did,
+        );
         sign(&payload, keypair.secret_key())
     }
 
@@ -508,7 +602,15 @@ mod tests {
             Err(MessagingError::SignatureVerificationFailed)
         ));
 
-        let signature = initial_signature(&subject, &bob, 2, &authorized, &nonce, &bob_key);
+        let signature = initial_signature(
+            &subject,
+            &bob,
+            2,
+            &authorized,
+            &nonce,
+            timestamp(1_002),
+            &bob_key,
+        );
         let dv = DeathVerification::new(
             subject,
             bob.clone(),
@@ -533,7 +635,15 @@ mod tests {
         let bob_key = keypair(1);
         let authorized = authorized_trustees(&[(&bob, &bob_key)]);
         let nonce = b"r6-claim-one-trustee".to_vec();
-        let signature = initial_signature(&subject, &bob, 1, &authorized, &nonce, &bob_key);
+        let signature = initial_signature(
+            &subject,
+            &bob,
+            1,
+            &authorized,
+            &nonce,
+            timestamp(1_003),
+            &bob_key,
+        );
 
         let result = DeathVerification::new(
             subject,
@@ -598,7 +708,7 @@ mod tests {
             b"r6-claim-3".to_vec(),
             &bob_key,
         );
-        let signature = confirmation_signature(&dv, &carol, &wrong_key);
+        let signature = confirmation_signature(&dv, &carol, timestamp(2_001), &wrong_key);
 
         let result = dv.confirm(
             carol,
@@ -636,7 +746,8 @@ mod tests {
             b"r6-claim-b".to_vec(),
             &bob_key,
         );
-        let replayed_signature = confirmation_signature(&dv_a, &carol, &carol_key);
+        let replayed_signature =
+            confirmation_signature(&dv_a, &carol, timestamp(2_002), &carol_key);
 
         let result = dv_b.confirm(
             carol,
@@ -666,7 +777,7 @@ mod tests {
             b"r6-claim-4".to_vec(),
             &bob_key,
         );
-        let signature = confirmation_signature(&dv, &carol, &carol_key);
+        let signature = confirmation_signature(&dv, &carol, timestamp(2_003), &carol_key);
         dv.subject_did = did("mallory");
 
         let result = dv.confirm(
@@ -701,7 +812,7 @@ mod tests {
             &bob_key,
         );
 
-        let carol_signature = confirmation_signature(&dv, &carol, &carol_key);
+        let carol_signature = confirmation_signature(&dv, &carol, timestamp(2_004), &carol_key);
         let met = dv
             .confirm(
                 carol.clone(),
@@ -713,7 +824,7 @@ mod tests {
         assert!(!met);
         assert_eq!(dv.confirmations_remaining(), 1);
 
-        let dave_signature = confirmation_signature(&dv, &dave, &dave_key);
+        let dave_signature = confirmation_signature(&dv, &dave, timestamp(2_005), &dave_key);
         let met = dv
             .confirm(
                 dave,
@@ -747,7 +858,7 @@ mod tests {
             b"r6-claim-6".to_vec(),
             &bob_key,
         );
-        let signature = confirmation_signature(&dv, &carol, &carol_key);
+        let signature = confirmation_signature(&dv, &carol, timestamp(2_006), &carol_key);
         dv.confirm(
             carol.clone(),
             *carol_key.public_key(),
@@ -787,7 +898,7 @@ mod tests {
             b"r6-claim-7".to_vec(),
             &bob_key,
         );
-        let carol_signature = confirmation_signature(&dv, &carol, &carol_key);
+        let carol_signature = confirmation_signature(&dv, &carol, timestamp(2_008), &carol_key);
         dv.confirm(
             carol,
             *carol_key.public_key(),
@@ -796,7 +907,7 @@ mod tests {
         )
         .unwrap();
 
-        let dave_signature = confirmation_signature(&dv, &dave, &dave_key);
+        let dave_signature = confirmation_signature(&dv, &dave, timestamp(2_009), &dave_key);
         let result = dv.confirm(
             dave,
             *dave_key.public_key(),
@@ -829,7 +940,7 @@ mod tests {
         assert_eq!(dv.status, DeathVerificationStatus::Rejected);
         assert!(!dv.should_release());
 
-        let carol_signature = confirmation_signature(&dv, &carol, &carol_key);
+        let carol_signature = confirmation_signature(&dv, &carol, timestamp(2_010), &carol_key);
         let result = dv.confirm(
             carol,
             *carol_key.public_key(),
@@ -869,7 +980,8 @@ mod tests {
         );
         assert_eq!(dv.confirmations_remaining(), 2);
 
-        let alternate_signature = confirmation_signature(&dv, &alternate, &alternate_key);
+        let alternate_signature =
+            confirmation_signature(&dv, &alternate, timestamp(2_011), &alternate_key);
         dv.confirm(
             alternate,
             *alternate_key.public_key(),
@@ -879,7 +991,8 @@ mod tests {
         .unwrap();
         assert_eq!(dv.confirmations_remaining(), 1);
 
-        let contingency_signature = confirmation_signature(&dv, &contingency, &contingency_key);
+        let contingency_signature =
+            confirmation_signature(&dv, &contingency, timestamp(2_012), &contingency_key);
         let verified = dv
             .confirm(
                 contingency,
@@ -911,7 +1024,15 @@ mod tests {
         let carol_key = keypair(2);
         let authorized = authorized_trustees(&[(&bob, &bob_key), (&carol, &carol_key)]);
         let nonce = b"r6-claim-created-at".to_vec();
-        let signature = initial_signature(&subject, &bob, 2, &authorized, &nonce, &bob_key);
+        let signature = initial_signature(
+            &subject,
+            &bob,
+            2,
+            &authorized,
+            &nonce,
+            timestamp(7_001),
+            &bob_key,
+        );
         let metadata = creation_metadata(7_001);
 
         let dv = DeathVerification::new(subject, bob, 2, authorized, nonce, signature, metadata)
@@ -921,6 +1042,40 @@ mod tests {
         assert_eq!(dv.confirmations[0].confirmed_at, timestamp(7_001));
         assert_eq!(dv.status, DeathVerificationStatus::Pending);
         assert_eq!(dv.resolved_at, None);
+    }
+
+    #[test]
+    fn creation_rejects_timestampless_signature_replayed_with_forged_created_at() {
+        let subject = did("alice");
+        let bob = did("bob");
+        let carol = did("carol");
+        let bob_key = keypair(1);
+        let carol_key = keypair(2);
+        let authorized = authorized_trustees(&[(&bob, &bob_key), (&carol, &carol_key)]);
+        let nonce = b"r6-claim-created-at-forgery".to_vec();
+        let signature = legacy_initial_signature_without_timestamp(
+            &subject,
+            &bob,
+            2,
+            &authorized,
+            &nonce,
+            &bob_key,
+        );
+
+        let result = DeathVerification::new(
+            subject,
+            bob,
+            2,
+            authorized,
+            nonce,
+            signature,
+            creation_metadata(99_999),
+        );
+
+        assert!(matches!(
+            result,
+            Err(MessagingError::SignatureVerificationFailed)
+        ));
     }
 
     #[test]
@@ -948,7 +1103,7 @@ mod tests {
             b"r6-claim-confirm-time".to_vec(),
             &bob_key,
         );
-        let signature = confirmation_signature(&dv, &carol, &carol_key);
+        let signature = confirmation_signature(&dv, &carol, timestamp(7_002), &carol_key);
 
         let verified = dv
             .confirm(
@@ -962,6 +1117,37 @@ mod tests {
         assert!(verified);
         assert_eq!(dv.confirmations[1].confirmed_at, timestamp(7_002));
         assert_eq!(dv.resolved_at, Some(timestamp(7_002)));
+    }
+
+    #[test]
+    fn confirm_rejects_timestampless_signature_replayed_with_forged_confirmed_at() {
+        let subject = did("alice");
+        let bob = did("bob");
+        let carol = did("carol");
+        let bob_key = keypair(1);
+        let carol_key = keypair(2);
+        let authorized = authorized_trustees(&[(&bob, &bob_key), (&carol, &carol_key)]);
+        let mut dv = signed_verification(
+            &subject,
+            &bob,
+            2,
+            authorized,
+            b"r6-claim-confirm-time-forgery".to_vec(),
+            &bob_key,
+        );
+        let signature = legacy_confirmation_signature_without_timestamp(&dv, &carol, &carol_key);
+
+        let result = dv.confirm(
+            carol,
+            *carol_key.public_key(),
+            signature,
+            confirmation_metadata(99_999),
+        );
+
+        assert!(matches!(
+            result,
+            Err(MessagingError::SignatureVerificationFailed)
+        ));
     }
 
     #[test]

--- a/crates/exochain-wasm/src/lib.rs
+++ b/crates/exochain-wasm/src/lib.rs
@@ -515,6 +515,30 @@ mod source_guard_tests {
                 && source.contains("DeathConfirmationMetadata::new"),
             "messaging WASM death verification must validate caller-supplied state metadata"
         );
+        let initial_payload = source
+            .split("pub fn wasm_death_verification_initial_signing_payload")
+            .nth(1)
+            .and_then(|section| {
+                section
+                    .split("/// Create a new death verification request")
+                    .next()
+            })
+            .expect("initial death-verification signing payload section");
+        assert!(
+            initial_payload.contains("created_physical_ms")
+                && initial_payload.contains("&metadata.created_at"),
+            "initial death-verification signatures must bind the submitted creation timestamp"
+        );
+        let confirmation_payload = source
+            .split("pub fn wasm_death_verification_confirmation_signing_payload")
+            .nth(1)
+            .and_then(|section| section.split("/// Add a trustee confirmation").next())
+            .expect("confirmation death-verification signing payload section");
+        assert!(
+            confirmation_payload.contains("confirmed_physical_ms")
+                && confirmation_payload.contains("&metadata.confirmed_at"),
+            "death-verification confirmation signatures must bind the submitted confirmation timestamp"
+        );
 
         let forbidden = [
             format!("{}{}", "Timestamp::", "now_utc()"),

--- a/crates/exochain-wasm/src/messaging_bindings.rs
+++ b/crates/exochain-wasm/src/messaging_bindings.rs
@@ -322,6 +322,8 @@ pub fn wasm_death_verification_initial_signing_payload(
     required_confirmations: u8,
     authorized_trustees_json: &str,
     claim_nonce_hex: &str,
+    created_physical_ms: u64,
+    created_logical: u32,
 ) -> Result<Vec<u8>, JsValue> {
     let subject = exo_core::Did::new(subject_did)
         .map_err(|e| JsValue::from_str(&format!("invalid subject DID: {e}")))?;
@@ -330,6 +332,10 @@ pub fn wasm_death_verification_initial_signing_payload(
     let authorized_trustees = parse_authorized_trustees_json(authorized_trustees_json)?;
     let claim_nonce = hex::decode(claim_nonce_hex)
         .map_err(|e| JsValue::from_str(&format!("invalid claim nonce hex: {e}")))?;
+    let metadata = exo_messaging::death_trigger::DeathVerificationCreationMetadata::new(
+        exo_core::Timestamp::new(created_physical_ms, created_logical),
+    )
+    .map_err(|e| JsValue::from_str(&format!("invalid death verification metadata: {e}")))?;
 
     exo_messaging::death_trigger::initial_confirmation_signing_payload(
         &subject,
@@ -337,6 +343,7 @@ pub fn wasm_death_verification_initial_signing_payload(
         required_confirmations,
         &authorized_trustees,
         &claim_nonce,
+        &metadata.created_at,
     )
     .map_err(|e| JsValue::from_str(&format!("death verification signing payload failed: {e}")))
 }
@@ -398,15 +405,22 @@ pub fn wasm_death_verification_new(
 pub fn wasm_death_verification_confirmation_signing_payload(
     state_json: &str,
     trustee_did: &str,
+    confirmed_physical_ms: u64,
+    confirmed_logical: u32,
 ) -> Result<Vec<u8>, JsValue> {
     let dv: exo_messaging::death_trigger::DeathVerification = from_json_str(state_json)?;
     let trustee = exo_core::Did::new(trustee_did)
         .map_err(|e| JsValue::from_str(&format!("invalid trustee DID: {e}")))?;
-    dv.confirmation_signing_payload(&trustee).map_err(|e| {
-        JsValue::from_str(&format!(
-            "death verification confirmation payload failed: {e}"
-        ))
-    })
+    let metadata = exo_messaging::death_trigger::DeathConfirmationMetadata::new(
+        exo_core::Timestamp::new(confirmed_physical_ms, confirmed_logical),
+    )
+    .map_err(|e| JsValue::from_str(&format!("invalid death confirmation metadata: {e}")))?;
+    dv.confirmation_signing_payload(&trustee, &metadata.confirmed_at)
+        .map_err(|e| {
+            JsValue::from_str(&format!(
+                "death verification confirmation payload failed: {e}"
+            ))
+        })
 }
 
 /// Add a trustee confirmation to a death verification.

--- a/demo/apps/vitallock/src/lib/crypto.ts
+++ b/demo/apps/vitallock/src/lib/crypto.ts
@@ -185,6 +185,8 @@ export function deathVerificationInitialSigningPayload(
   initiatedByDid: string,
   authorizedTrustees: AuthorizedDeathVerificationTrustee[],
   claimNonceHex: string,
+  createdPhysicalMs: bigint,
+  createdLogical: number,
   requiredConfirmations: number = 3,
 ): Uint8Array {
   return wasm_death_verification_initial_signing_payload(
@@ -193,6 +195,8 @@ export function deathVerificationInitialSigningPayload(
     requiredConfirmations,
     JSON.stringify(authorizedTrustees),
     claimNonceHex,
+    createdPhysicalMs,
+    createdLogical,
   );
 }
 
@@ -223,8 +227,15 @@ export function createDeathVerification(
 export function deathVerificationConfirmationSigningPayload(
   stateJson: string,
   trusteeDid: string,
+  confirmedPhysicalMs: bigint,
+  confirmedLogical: number,
 ): Uint8Array {
-  return wasm_death_verification_confirmation_signing_payload(stateJson, trusteeDid);
+  return wasm_death_verification_confirmation_signing_payload(
+    stateJson,
+    trusteeDid,
+    confirmedPhysicalMs,
+    confirmedLogical,
+  );
 }
 
 /** Add a trustee confirmation to a death verification. */

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -447,7 +447,9 @@ test('wasm_death_verification_initial_signing_payload', () => {
     TEST_DID_2,
     2,
     deathTrusteesJson,
-    deathClaimNonceHex
+    deathClaimNonceHex,
+    NOW_MS,
+    0
   );
 });
 
@@ -457,7 +459,9 @@ const deathInitialPayload = setup(() =>
     TEST_DID_2,
     2,
     deathTrusteesJson,
-    deathClaimNonceHex
+    deathClaimNonceHex,
+    NOW_MS,
+    0
   ));
 const deathInitialSignatureHex = setup(() =>
   deathInitialPayload && signer2.signHex(deathInitialPayload));
@@ -501,14 +505,18 @@ test('wasm_death_verification_confirmation_signing_payload', () => {
   if (!deathState) throw new Error('skipped -- no death-verification state');
   return wasm.wasm_death_verification_confirmation_signing_payload(
     JSON.stringify(deathState),
-    TEST_DID_3
+    TEST_DID_3,
+    BigInt(NOW_NUM + 1),
+    0
   );
 });
 
 const deathConfirmationPayload = setup(() =>
   deathState && wasm.wasm_death_verification_confirmation_signing_payload(
     JSON.stringify(deathState),
-    TEST_DID_3
+    TEST_DID_3,
+    BigInt(NOW_NUM + 1),
+    0
   ));
 const deathConfirmationSignatureHex = setup(() =>
   deathConfirmationPayload && signer3.signHex(deathConfirmationPayload));


### PR DESCRIPTION
## Summary

Remediates Codex Security CSV row 39: death verification timestamps were caller-forgeable because the signed confirmation payload did not bind the HLC timestamp that the state machine stored.

Changes:
- Bind initial death-verification signatures to `created_at`.
- Bind trustee confirmation signatures to `confirmed_at`.
- Reject legacy/timestamp-free replay signatures for both creation and confirmation.
- Update WASM signing payload helpers and the VitalLock wrapper to require the same timestamp fields used by `new`/`confirm`.
- Extend WASM source guards and bridge verification to cover the timestamp-bound payload helpers.

## Path Classification

- `crates/exo-messaging/src/death_trigger.rs` - EXOCHAIN core messaging death-verification state machine.
- `crates/exochain-wasm/src/messaging_bindings.rs` - Core runtime adapter/WASM boundary.
- `crates/exochain-wasm/src/lib.rs` - Core runtime adapter source guard.
- `packages/exochain-wasm/test/bridge_verification.mjs` - Core runtime adapter verification harness.
- `demo/apps/vitallock/src/lib/crypto.ts` - Adjacent demo wrapper around the WASM boundary.

## TDD Record

RED, verified live before fix:
- `cargo test -p exo-messaging creation_rejects_timestampless_signature_replayed_with_forged_created_at -- --nocapture` failed because a timestamp-free legacy signature was accepted with forged `created_at`.
- `cargo test -p exo-messaging confirm_rejects_timestampless_signature_replayed_with_forged_confirmed_at -- --nocapture` failed because a timestamp-free legacy signature was accepted with forged `confirmed_at`.

GREEN:
- `cargo test -p exo-messaging creation_rejects_timestampless_signature_replayed_with_forged_created_at -- --nocapture`
- `cargo test -p exo-messaging confirm_rejects_timestampless_signature_replayed_with_forged_confirmed_at -- --nocapture`
- `cargo test -p exochain-wasm wasm_messaging_bridge_requires_caller_supplied_envelope_metadata -- --nocapture`
- `cargo test -p exo-messaging -- --nocapture`
- `cargo test -p exochain-wasm -- --nocapture`
- `cargo clippy -p exo-messaging -p exochain-wasm --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `git diff --check`
- `wasm-pack build crates/exochain-wasm --target nodejs --out-dir /Users/bobstewart/dev/exochain/packages/exochain-wasm/wasm --release`
- `node packages/exochain-wasm/test/bridge_verification.mjs` - 160/160 passed

## Notes

The generated `packages/exochain-wasm/wasm/*` build outputs remain ignored and are not included in this PR. `demo/apps/vitallock` app build was not run because this checkout does not contain an app-local generated `@/wasm/exochain_wasm` module for that Vite app; the WASM package bridge verification was rebuilt and passed.
