### PR TITLE
fix(gateway): use trusted auth observation time

### DIFF
--- a/crates/exo-gateway/src/auth.rs
+++ b/crates/exo-gateway/src/auth.rs
@@ -21,7 +21,7 @@
 //! `authenticate` validates:
 //!   1. DID format (`did:exo:<id>`)
 //!   2. Non-empty / non-zero signature bytes
-//!   3. Timestamp freshness (±`FRESHNESS_WINDOW_MS`)
+//!   3. Timestamp freshness against trusted gateway observation time (±`FRESHNESS_WINDOW_MS`)
 //!   4. Ed25519 signature via `exo_identity::did_verification::verify_did_signature`
 //!      over a domain-separated canonical CBOR authentication envelope
 //!      against the first active verification method in the resolved DID document
@@ -59,32 +59,37 @@ pub struct Request {
     pub timestamp: Timestamp,
 }
 
-/// A successfully authenticated actor with their resolved DID and auth timestamp.
+/// A successfully authenticated actor with their resolved DID and trusted auth timestamp.
 #[derive(Debug, Clone)]
 pub struct AuthenticatedActor {
     pub did: Did,
     pub authenticated_at: Timestamp,
 }
 
-/// Caller-supplied metadata for an authentication attempt.
+/// Trusted gateway metadata for an authentication attempt.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AuthenticationMetadata {
-    pub observed_at: Timestamp,
+    observed_at: Timestamp,
 }
 
 impl AuthenticationMetadata {
-    /// Validate caller-supplied authentication metadata.
+    /// Validate trusted gateway authentication metadata.
     ///
     /// # Errors
     ///
     /// Returns `GatewayError::BadRequest` if `observed_at` is `Timestamp::ZERO`.
-    pub fn new(observed_at: Timestamp) -> Result<Self> {
+    pub(crate) fn new(observed_at: Timestamp) -> Result<Self> {
         if observed_at == Timestamp::ZERO {
             return Err(GatewayError::BadRequest(
-                "authentication observed_at must be caller-supplied and non-zero".into(),
+                "authentication observed_at must be trusted gateway metadata and non-zero".into(),
             ));
         }
         Ok(Self { observed_at })
+    }
+
+    #[must_use]
+    pub fn observed_at(&self) -> Timestamp {
+        self.observed_at
     }
 }
 
@@ -96,23 +101,20 @@ struct RequestSigningPayload<'a> {
     body_hash: Hash256,
     request_timestamp_physical_ms: u64,
     request_timestamp_logical: u32,
-    observed_at_physical_ms: u64,
-    observed_at_logical: u32,
 }
 
 /// Build the canonical bytes signed by DID-authenticated gateway requests.
 ///
 /// The signature binds both the signed body hash and security-sensitive request
 /// metadata consumed after authentication, so a signature for one action cannot
-/// be replayed as a different action with the same body.
+/// be replayed as a different action with the same body. Trusted gateway
+/// observation time is intentionally excluded because it is measured at ingress
+/// and must not be supplied or signed by the requester.
 ///
 /// # Errors
 ///
 /// Returns `GatewayError::Internal` if canonical CBOR serialization fails.
-pub fn request_signing_payload(
-    request: &Request,
-    metadata: AuthenticationMetadata,
-) -> Result<Vec<u8>> {
+pub fn request_signing_payload(request: &Request) -> Result<Vec<u8>> {
     let payload = RequestSigningPayload {
         domain: GATEWAY_AUTH_SIGNING_DOMAIN,
         actor_did: &request.actor_did,
@@ -120,8 +122,6 @@ pub fn request_signing_payload(
         body_hash: request.body_hash,
         request_timestamp_physical_ms: request.timestamp.physical_ms,
         request_timestamp_logical: request.timestamp.logical,
-        observed_at_physical_ms: metadata.observed_at.physical_ms,
-        observed_at_logical: metadata.observed_at.logical,
     };
     let mut encoded = Vec::new();
     ciborium::into_writer(&payload, &mut encoded)
@@ -383,7 +383,7 @@ pub fn authenticate(
 
     // 6. Cryptographically verify the Ed25519 signature over the full
     //    authentication envelope consumed by downstream authorization.
-    let signing_payload = request_signing_payload(request, metadata)?;
+    let signing_payload = request_signing_payload(request)?;
     verify_did_signature(doc, &method.id, &signing_payload, &request.signature).map_err(|e| {
         GatewayError::AuthenticationFailed {
             reason: format!("signature verification failed: {e}"),
@@ -604,10 +604,7 @@ mod tests {
     }
 
     fn signed_request(mut request: Request, secret_key: &exo_core::SecretKey) -> Request {
-        request.signature = sign(
-            &request_signing_payload(&request, auth_metadata()).unwrap(),
-            secret_key,
-        );
+        request.signature = sign(&request_signing_payload(&request).unwrap(), secret_key);
         request
     }
 
@@ -631,7 +628,7 @@ mod tests {
         );
         let a = authenticate(&r, &reg, auth_metadata()).unwrap();
         assert_eq!(a.did.as_str(), "did:exo:alice");
-        assert_eq!(a.authenticated_at, auth_metadata().observed_at);
+        assert_eq!(a.authenticated_at, auth_metadata().observed_at());
     }
 
     #[test]
@@ -654,9 +651,9 @@ mod tests {
     }
 
     #[test]
-    fn auth_rejects_observed_at_changed_after_signing() {
+    fn auth_accepts_same_signed_request_with_independent_trusted_observation_inside_freshness() {
         let (reg, sk) = registry_with_alice();
-        let body_hash = Hash256::digest(b"same body, different observed time");
+        let body_hash = Hash256::digest(b"same body, gateway observed one millisecond later");
         let request = signed_request(
             Request {
                 actor_did: "did:exo:alice".into(),
@@ -667,10 +664,42 @@ mod tests {
             },
             &sk,
         );
-        let tampered_metadata =
+        let later_trusted_metadata =
             AuthenticationMetadata::new(Timestamp::new(req_ts().physical_ms + 1, 0)).unwrap();
 
-        assert!(authenticate(&request, &reg, tampered_metadata).is_err());
+        let actor = authenticate(&request, &reg, later_trusted_metadata).unwrap();
+
+        assert_eq!(
+            actor.authenticated_at,
+            Timestamp::new(req_ts().physical_ms + 1, 0)
+        );
+    }
+
+    #[test]
+    fn auth_rejects_replayed_request_against_trusted_observation_time() {
+        let (reg, sk) = registry_with_alice();
+        let request = signed_request(
+            Request {
+                actor_did: "did:exo:alice".into(),
+                action: "read".into(),
+                body_hash: Hash256::digest(b"old signed request"),
+                signature: Signature::Empty,
+                timestamp: req_ts(),
+            },
+            &sk,
+        );
+        let trusted_later = AuthenticationMetadata::new(Timestamp::new(
+            req_ts().physical_ms + FRESHNESS_WINDOW_MS + 1,
+            0,
+        ))
+        .unwrap();
+
+        let error = authenticate(&request, &reg, trusted_later).unwrap_err();
+
+        assert!(
+            error.to_string().contains("freshness window"),
+            "replayed request must fail against trusted gateway observation time: {error}"
+        );
     }
 
     #[test]
@@ -720,8 +749,6 @@ mod tests {
             body_hash: Hash256,
             request_timestamp_physical_ms: u64,
             request_timestamp_logical: u32,
-            observed_at_physical_ms: u64,
-            observed_at_logical: u32,
         }
 
         let body_hash = Hash256::digest(b"canonical body hash");
@@ -732,7 +759,7 @@ mod tests {
             signature: Signature::Empty,
             timestamp: req_ts(),
         };
-        let payload = request_signing_payload(&request, auth_metadata()).unwrap();
+        let payload = request_signing_payload(&request).unwrap();
         let decoded: DecodedPayload = ciborium::from_reader(payload.as_slice()).unwrap();
 
         assert_eq!(decoded.domain, GATEWAY_AUTH_SIGNING_DOMAIN);
@@ -741,14 +768,6 @@ mod tests {
         assert_eq!(decoded.body_hash, body_hash);
         assert_eq!(decoded.request_timestamp_physical_ms, req_ts().physical_ms);
         assert_eq!(decoded.request_timestamp_logical, req_ts().logical);
-        assert_eq!(
-            decoded.observed_at_physical_ms,
-            auth_metadata().observed_at.physical_ms
-        );
-        assert_eq!(
-            decoded.observed_at_logical,
-            auth_metadata().observed_at.logical
-        );
     }
 
     #[test]
@@ -973,7 +992,7 @@ mod tests {
     }
 
     #[test]
-    fn authenticate_rejects_stale_against_supplied_metadata() {
+    fn authenticate_rejects_stale_against_trusted_metadata() {
         let (reg, sk) = registry_with_alice();
         let body_hash = Hash256::ZERO;
         let signature = sign(body_hash.as_bytes(), &sk);
@@ -1006,12 +1025,20 @@ mod tests {
         let forbidden_timestamp = ["Timestamp", "::now_utc"].concat();
         assert!(
             !production.contains(&forbidden_timestamp),
-            "gateway auth must use caller-supplied authentication timestamps"
+            "gateway auth must use trusted gateway authentication timestamps"
         );
         let forbidden_system_time = ["SystemTime", "::now"].concat();
         assert!(
             !production.contains(&forbidden_system_time),
             "gateway auth must not read wall-clock time"
+        );
+        assert!(
+            !production.contains("pub observed_at"),
+            "authentication observation time must not be a public caller-controlled field"
+        );
+        assert!(
+            !production.contains("observed_at_physical_ms"),
+            "DID request signatures must not bind caller-supplied observation time"
         );
     }
 
@@ -1028,7 +1055,7 @@ mod tests {
             "gateway auth must bind DID signatures to the canonical request envelope"
         );
         assert!(
-            production.contains("request_signing_payload(request, metadata)"),
+            production.contains("request_signing_payload(request)"),
             "gateway auth must route signature verification through the canonical payload helper"
         );
     }
@@ -1296,7 +1323,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_credential_uses_supplied_authentication_metadata() {
+    fn resolve_credential_uses_trusted_authentication_metadata() {
         let did_reg = LocalDidRegistry::new();
         let mut api_reg = ApiKeyRegistry::new();
         let did = Did::new("did:exo:alice").unwrap();

--- a/crates/exo-gateway/src/routes.rs
+++ b/crates/exo-gateway/src/routes.rs
@@ -48,21 +48,31 @@ pub struct RouteResult {
     pub correlation_id: Uuid,
 }
 
-/// Caller-supplied route metadata bound into the gateway audit trail.
+/// Route metadata bound into the gateway audit trail and authentication boundary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RouteMetadata {
-    pub correlation_id: Uuid,
-    pub audit_timestamp: exo_core::Timestamp,
+    correlation_id: Uuid,
+    audit_timestamp: exo_core::Timestamp,
+    trusted_auth_observed_at: exo_core::Timestamp,
 }
 
 impl RouteMetadata {
-    /// Validate caller-supplied route metadata.
+    /// Validate route metadata.
+    ///
+    /// `audit_timestamp` may describe the audited action time. `trusted_auth_observed_at`
+    /// must come from the gateway ingress clock or another trusted runtime adapter, never
+    /// from request JSON, route metadata, or caller-controlled audit fields.
     ///
     /// # Errors
     ///
-    /// Returns `GatewayError::BadRequest` if the correlation ID is nil or the
-    /// audit timestamp is `Timestamp::ZERO`.
-    pub fn new(correlation_id: Uuid, audit_timestamp: exo_core::Timestamp) -> Result<Self> {
+    /// Returns `GatewayError::BadRequest` if the correlation ID is nil, the
+    /// audit timestamp is `Timestamp::ZERO`, or the trusted auth observation
+    /// timestamp is `Timestamp::ZERO`.
+    pub fn new(
+        correlation_id: Uuid,
+        audit_timestamp: exo_core::Timestamp,
+        trusted_auth_observed_at: exo_core::Timestamp,
+    ) -> Result<Self> {
         if correlation_id.is_nil() {
             return Err(GatewayError::BadRequest(
                 "route correlation_id must be caller-supplied and non-nil".into(),
@@ -73,9 +83,15 @@ impl RouteMetadata {
                 "route audit timestamp must be caller-supplied and non-zero".into(),
             ));
         }
+        if trusted_auth_observed_at == exo_core::Timestamp::ZERO {
+            return Err(GatewayError::BadRequest(
+                "route trusted auth observed_at must be gateway-supplied and non-zero".into(),
+            ));
+        }
         Ok(Self {
             correlation_id,
             audit_timestamp,
+            trusted_auth_observed_at,
         })
     }
 }
@@ -90,7 +106,7 @@ pub fn process_request(
     metadata: RouteMetadata,
     log: &mut AuditLog,
 ) -> Result<RouteResult> {
-    let auth_metadata = AuthenticationMetadata::new(metadata.audit_timestamp)?;
+    let auth_metadata = AuthenticationMetadata::new(metadata.trusted_auth_observed_at)?;
     let actor = authenticate(request, registry, auth_metadata)?;
     consent_middleware(&actor.did, &request.action, consent)?;
     governance_middleware(&actor.did, &request.action, verdict)?;
@@ -129,7 +145,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::auth::request_signing_payload;
+    use crate::auth::{FRESHNESS_WINDOW_MS, request_signing_payload};
 
     /// Create a registry with `did:exo:alice` and return the registry +
     /// a signed request using alice's key.
@@ -168,15 +184,22 @@ mod tests {
             signature: exo_core::Signature::Empty,
             timestamp: Timestamp::new(7_000, 1),
         };
-        let auth_metadata = AuthenticationMetadata::new(Timestamp::new(7_000, 1)).unwrap();
-        req.signature = sign(&request_signing_payload(&req, auth_metadata).unwrap(), &sk);
+        req.signature = sign(&request_signing_payload(&req).unwrap(), &sk);
         (reg, req)
     }
 
     fn route_metadata() -> RouteMetadata {
+        route_metadata_with(Timestamp::new(7_000, 1), Timestamp::new(7_000, 1))
+    }
+
+    fn route_metadata_with(
+        audit_timestamp: Timestamp,
+        trusted_auth_observed_at: Timestamp,
+    ) -> RouteMetadata {
         RouteMetadata::new(
             Uuid::parse_str("018f7a96-8ad0-7c4f-8e0f-333333333333").unwrap(),
-            Timestamp::new(7_000, 1),
+            audit_timestamp,
+            trusted_auth_observed_at,
         )
         .expect("valid route metadata")
     }
@@ -205,8 +228,38 @@ mod tests {
     }
 
     #[test]
+    fn process_request_rejects_replayed_request_when_audit_timestamp_matches_old_request() {
+        let (reg, req) = alice_registry_and_req();
+        let mut log = AuditLog::new();
+        let metadata = route_metadata_with(
+            Timestamp::new(7_000, 1),
+            Timestamp::new(7_000 + FRESHNESS_WINDOW_MS + 2, 1),
+        );
+
+        let result = process_request(
+            &req,
+            &reg,
+            Route::CreateTransaction,
+            true,
+            &Verdict::Allow,
+            metadata,
+            &mut log,
+        );
+
+        assert!(
+            matches!(result, Err(GatewayError::AuthenticationFailed { reason }) if reason.contains("freshness window")),
+            "route auth must not treat caller/audit metadata as the trusted freshness clock"
+        );
+        assert_eq!(log.len(), 0);
+    }
+
+    #[test]
     fn route_metadata_rejects_nil_correlation_id() {
-        let result = RouteMetadata::new(Uuid::nil(), Timestamp::new(7_000, 0));
+        let result = RouteMetadata::new(
+            Uuid::nil(),
+            Timestamp::new(7_000, 0),
+            Timestamp::new(7_000, 0),
+        );
 
         assert!(
             matches!(result, Err(GatewayError::BadRequest(reason)) if reason.contains("correlation"))
@@ -218,10 +271,24 @@ mod tests {
         let result = RouteMetadata::new(
             Uuid::parse_str("018f7a96-8ad0-7c4f-8e0f-444444444444").unwrap(),
             Timestamp::ZERO,
+            Timestamp::new(7_000, 0),
         );
 
         assert!(
             matches!(result, Err(GatewayError::BadRequest(reason)) if reason.contains("timestamp"))
+        );
+    }
+
+    #[test]
+    fn route_metadata_rejects_zero_trusted_auth_observed_at() {
+        let result = RouteMetadata::new(
+            Uuid::parse_str("018f7a96-8ad0-7c4f-8e0f-555555555555").unwrap(),
+            Timestamp::new(7_000, 0),
+            Timestamp::ZERO,
+        );
+
+        assert!(
+            matches!(result, Err(GatewayError::BadRequest(reason)) if reason.contains("observed_at"))
         );
     }
 
@@ -242,6 +309,14 @@ mod tests {
         assert!(
             !production.contains(&forbidden_time),
             "route processing must not fabricate audit timestamps"
+        );
+        assert!(
+            production.contains("AuthenticationMetadata::new(metadata.trusted_auth_observed_at)"),
+            "route authentication must use a trusted auth observation timestamp"
+        );
+        assert!(
+            !production.contains("AuthenticationMetadata::new(metadata.audit_timestamp)"),
+            "route authentication must not treat caller/audit timestamps as freshness time"
         );
     }
 

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -1101,7 +1101,6 @@ fn validate_session_expires_at_within_gateway_ttl(
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct SessionLoginProof {
     timestamp: Timestamp,
-    observed_at: Timestamp,
     signature: Signature,
 }
 
@@ -1111,13 +1110,8 @@ impl SessionLoginProof {
             required_nonzero_u64(body, "authTimestampPhysicalMs")?,
             required_u32(body, "authTimestampLogical")?,
         );
-        let observed_at = Timestamp::new(
-            required_nonzero_u64(body, "observedAt")?,
-            required_u32(body, "observedAtLogical")?,
-        );
         Ok(Self {
             timestamp,
-            observed_at,
             signature: required_ed25519_signature_hex(body, "signature")?,
         })
     }
@@ -1786,11 +1780,9 @@ fn session_login_auth_signing_payload(
     did: &str,
     metadata: &SessionIssueMetadata,
     timestamp: Timestamp,
-    observed_at: Timestamp,
 ) -> Result<Vec<u8>> {
-    let auth_metadata = AuthenticationMetadata::new(observed_at)?;
     let request = session_login_auth_request(did, metadata, timestamp, Signature::Empty)?;
-    request_signing_payload(&request, auth_metadata)
+    request_signing_payload(&request)
 }
 
 fn authenticate_session_login(
@@ -1798,10 +1790,11 @@ fn authenticate_session_login(
     metadata: &SessionIssueMetadata,
     proof: &SessionLoginProof,
     registry: &dyn DidRegistry,
+    trusted_observed_at: Timestamp,
 ) -> Result<AuthenticatedActor> {
     let request =
         session_login_auth_request(did, metadata, proof.timestamp, proof.signature.clone())?;
-    let auth_metadata = AuthenticationMetadata::new(proof.observed_at)?;
+    let auth_metadata = AuthenticationMetadata::new(trusted_observed_at)?;
     authenticate(&request, registry, auth_metadata)
 }
 
@@ -1812,7 +1805,7 @@ fn authenticate_session_login_against_trusted_time(
     registry: &dyn DidRegistry,
     trusted_observed_at: Timestamp,
 ) -> Result<AuthenticatedActor> {
-    let actor = authenticate_session_login(did, metadata, proof, registry)?;
+    let actor = authenticate_session_login(did, metadata, proof, registry, trusted_observed_at)?;
     validate_session_login_freshness_against_trusted_time(proof, trusted_observed_at)?;
     Ok(actor)
 }
@@ -8206,9 +8199,9 @@ mod tests {
             expires_at: 20_000,
         };
         let timestamp = Timestamp::new(10_000, 0);
-        let observed_at = Timestamp::new(10_000, 0);
+        let trusted_gateway_time = Timestamp::new(10_000, 0);
         let signature = sign(
-            &session_login_auth_signing_payload(did, &metadata, timestamp, observed_at).unwrap(),
+            &session_login_auth_signing_payload(did, &metadata, timestamp).unwrap(),
             &sk,
         );
         let body = serde_json::json!({
@@ -8217,8 +8210,6 @@ mod tests {
             "expiresAt": metadata.expires_at,
             "authTimestampPhysicalMs": timestamp.physical_ms,
             "authTimestampLogical": timestamp.logical,
-            "observedAt": observed_at.physical_ms,
-            "observedAtLogical": observed_at.logical,
             "signature": hex::encode(signature.to_bytes())
         });
 
@@ -8226,7 +8217,7 @@ mod tests {
             State(db_state_at(
                 pool.clone(),
                 Arc::new(RwLock::new(LocalDidRegistry::new())),
-                observed_at.physical_ms,
+                trusted_gateway_time.physical_ms,
             )),
             Json(body),
         )
@@ -8298,7 +8289,7 @@ mod tests {
         };
         let timestamp = Timestamp::new(gateway_now_ms, 0);
         let signature = sign(
-            &session_login_auth_signing_payload(did, &metadata, timestamp, timestamp).unwrap(),
+            &session_login_auth_signing_payload(did, &metadata, timestamp).unwrap(),
             &sk,
         );
         let body = serde_json::json!({
@@ -8307,8 +8298,6 @@ mod tests {
             "expiresAt": metadata.expires_at,
             "authTimestampPhysicalMs": timestamp.physical_ms,
             "authTimestampLogical": timestamp.logical,
-            "observedAt": timestamp.physical_ms,
-            "observedAtLogical": timestamp.logical,
             "signature": hex::encode(signature.to_bytes())
         });
 
@@ -8343,9 +8332,7 @@ mod tests {
     fn session_login_proof_rejects_missing_signature() {
         let body = serde_json::json!({
             "authTimestampPhysicalMs": 10_000,
-            "authTimestampLogical": 0,
-            "observedAt": 10_000,
-            "observedAtLogical": 0
+            "authTimestampLogical": 0
         });
         let err = SessionLoginProof::from_body(&body).unwrap_err();
         assert!(
@@ -8359,8 +8346,6 @@ mod tests {
         let body = serde_json::json!({
             "authTimestampPhysicalMs": 10_000,
             "authTimestampLogical": 0,
-            "observedAt": 10_000,
-            "observedAtLogical": 0,
             "signature": ""
         });
         let err = SessionLoginProof::from_body(&body).unwrap_err();
@@ -8379,23 +8364,23 @@ mod tests {
         };
         let timestamp = Timestamp::new(10_000, 0);
         let signature = sign(
-            &session_login_auth_signing_payload(
-                "did:exo:login-alice",
-                &metadata,
-                timestamp,
-                timestamp,
-            )
-            .unwrap(),
+            &session_login_auth_signing_payload("did:exo:login-alice", &metadata, timestamp)
+                .unwrap(),
             &sk,
         );
         let proof = SessionLoginProof {
             timestamp,
-            observed_at: timestamp,
             signature,
         };
         let guard = registry.read().unwrap();
-        let actor =
-            authenticate_session_login("did:exo:login-alice", &metadata, &proof, &*guard).unwrap();
+        let actor = authenticate_session_login(
+            "did:exo:login-alice",
+            &metadata,
+            &proof,
+            &*guard,
+            timestamp,
+        )
+        .unwrap();
 
         assert_eq!(actor.did.as_str(), "did:exo:login-alice");
     }
@@ -8409,22 +8394,24 @@ mod tests {
             expires_at: 20_000,
         };
         let timestamp = Timestamp::new(10_000, 0);
-        let payload = session_login_auth_signing_payload(
-            "did:exo:login-alice",
-            &metadata,
-            timestamp,
-            timestamp,
-        )
-        .unwrap();
+        let payload =
+            session_login_auth_signing_payload("did:exo:login-alice", &metadata, timestamp)
+                .unwrap();
         let proof = SessionLoginProof {
             timestamp,
-            observed_at: timestamp,
             signature: sign(&payload, &wrong_sk),
         };
         let guard = registry.read().unwrap();
 
         assert!(
-            authenticate_session_login("did:exo:login-alice", &metadata, &proof, &*guard).is_err()
+            authenticate_session_login(
+                "did:exo:login-alice",
+                &metadata,
+                &proof,
+                &*guard,
+                timestamp
+            )
+            .is_err()
         );
     }
 
@@ -8440,23 +8427,24 @@ mod tests {
             expires_at: 30_000,
         };
         let timestamp = Timestamp::new(10_000, 0);
-        let payload = session_login_auth_signing_payload(
-            "did:exo:login-alice",
-            &signed_metadata,
-            timestamp,
-            timestamp,
-        )
-        .unwrap();
+        let payload =
+            session_login_auth_signing_payload("did:exo:login-alice", &signed_metadata, timestamp)
+                .unwrap();
         let proof = SessionLoginProof {
             timestamp,
-            observed_at: timestamp,
             signature: sign(&payload, &sk),
         };
         let guard = registry.read().unwrap();
 
         assert!(
-            authenticate_session_login("did:exo:login-alice", &tampered_metadata, &proof, &*guard)
-                .is_err()
+            authenticate_session_login(
+                "did:exo:login-alice",
+                &tampered_metadata,
+                &proof,
+                &*guard,
+                timestamp
+            )
+            .is_err()
         );
     }
 
@@ -8469,21 +8457,22 @@ mod tests {
         };
         let timestamp = Timestamp::new(1, 0);
         let observed_at = Timestamp::new(400_000, 0);
-        let payload = session_login_auth_signing_payload(
-            "did:exo:login-alice",
-            &metadata,
-            timestamp,
-            observed_at,
-        )
-        .unwrap();
+        let payload =
+            session_login_auth_signing_payload("did:exo:login-alice", &metadata, timestamp)
+                .unwrap();
         let proof = SessionLoginProof {
             timestamp,
-            observed_at,
             signature: sign(&payload, &sk),
         };
         let guard = registry.read().unwrap();
-        let err = authenticate_session_login("did:exo:login-alice", &metadata, &proof, &*guard)
-            .unwrap_err();
+        let err = authenticate_session_login(
+            "did:exo:login-alice",
+            &metadata,
+            &proof,
+            &*guard,
+            observed_at,
+        )
+        .unwrap_err();
 
         assert!(
             err.to_string().contains("freshness window"),
@@ -8499,17 +8488,11 @@ mod tests {
             expires_at: 500_000,
         };
         let timestamp = Timestamp::new(10_000, 0);
-        let caller_observed_at = Timestamp::new(10_000, 0);
-        let payload = session_login_auth_signing_payload(
-            "did:exo:login-alice",
-            &metadata,
-            timestamp,
-            caller_observed_at,
-        )
-        .unwrap();
+        let payload =
+            session_login_auth_signing_payload("did:exo:login-alice", &metadata, timestamp)
+                .unwrap();
         let proof = SessionLoginProof {
             timestamp,
-            observed_at: caller_observed_at,
             signature: sign(&payload, &sk),
         };
         let state =


### PR DESCRIPTION
## Summary

Remediates Codex Security CSV row 40: caller-controlled auth time could allow replayed DID credentials or expired tokens when route/auth wrappers treated request/audit metadata as freshness time.

Changes:
- DID auth signatures now bind actor DID, action, body hash, and request timestamp, but not gateway observation time.
- `AuthenticationMetadata` now represents trusted gateway auth metadata with a private observation field and crate-local constructor.
- `RouteMetadata` separates audit timestamp from `trusted_auth_observed_at`; route auth uses the trusted auth observation timestamp instead of audit metadata.
- Session-login proof bodies no longer carry `observedAt`; login verification uses the gateway trusted validation clock.
- Added regressions and source guards proving replay is rejected even when audit metadata matches the old signed request.

## Path Classification

- `crates/exo-gateway/src/auth.rs` - Core runtime adapter authentication boundary.
- `crates/exo-gateway/src/routes.rs` - Core runtime adapter route/middleware auth boundary.
- `crates/exo-gateway/src/server.rs` - Core runtime adapter HTTP/session login boundary.

## TDD Record

RED, verified live before fix:
- `cargo test -p exo-gateway process_request_rejects_replayed_request_when_caller_reuses_old_audit_timestamp -- --nocapture` failed because a request signed around the old audit timestamp was accepted.

GREEN:
- `cargo test -p exo-gateway process_request_rejects_replayed_request_when_audit_timestamp_matches_old_request -- --nocapture`
- `cargo test -p exo-gateway auth_accepts_same_signed_request_with_independent_trusted_observation_inside_freshness -- --nocapture`
- `cargo test -p exo-gateway auth_rejects_replayed_request_against_trusted_observation_time -- --nocapture`
- `cargo test -p exo-gateway session_login_authentication_accepts_valid_signature -- --nocapture`
- `cargo test -p exo-gateway session_login_authentication_rejects_stale_timestamp_against_gateway_clock -- --nocapture`
- `cargo test -p exo-gateway session_validation_uses_gateway_clock_not_caller_header_time -- --nocapture`
- `cargo test -p exo-gateway auth_production_does_not_verify_raw_body_hash_signatures -- --nocapture`
- `cargo test -p exo-gateway -- --nocapture` - 331 lib tests, 2 main tests, integration/doc tests passed
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `git diff --check`

## Notes

No adjacent surfaces were changed. Untracked `docs/heartfield/HEARTFIELD_AI_WHITEPAPER.md` was left untouched.
