### PR TITLE
fix(command-base): report failed ExoForge TNC verdicts

### DIFF
--- a/command-base/app/routes/exoforge.js
+++ b/command-base/app/routes/exoforge.js
@@ -443,12 +443,17 @@ module.exports = function(app, db, helpers) {
         checks.push({ check: 'kernel_availability', status: 'healthy', score: 1.0 });
 
         // Check 2: TNC enforcement
-        // Use wasm_create_decision to build a valid DecisionObject, then enforce all TNCs.
-        // A health-check decision won't pass all TNCs (e.g. empty authority chain), but the
-        // check validates that the TNC enforcement engine is functional — not that a synthetic
-        // decision passes all rules. We mark healthy if the engine responds without crashing.
+        // Failed TNC verdicts are constitutional health failures, not healthy adapter responses.
+        // Adapter crashes are tracked separately as degraded runtime availability.
         try {
-          const healthDecision = kernel.wasm_create_decision('Health Check', '"Routine"', '2'.repeat(64));
+          const healthDecision = kernel.wasm_create_decision(
+            '00000000-0000-0000-0000-0000000000ef',
+            'Health Check',
+            '"Routine"',
+            '2'.repeat(64),
+            1n,
+            0
+          );
           const decisionStr = typeof healthDecision === 'string' ? healthDecision : JSON.stringify(healthDecision);
           const tncResult = kernel.wasm_enforce_all_tnc(
             decisionStr,
@@ -463,9 +468,15 @@ module.exports = function(app, db, helpers) {
               ai_ceilings_externally_verified: true
             })
           );
-          // The engine responded (ok:true or ok:false with violation detail) — it's functional.
           const parsed = typeof tncResult === 'string' ? JSON.parse(tncResult) : tncResult;
-          checks.push({ check: 'tnc_enforcement', status: 'healthy', score: 1.0, engine_ok: true, tnc_result: parsed });
+          const tncPassed = parsed && parsed.ok === true;
+          checks.push({
+            check: 'tnc_enforcement',
+            status: tncPassed ? 'healthy' : 'critical',
+            score: tncPassed ? 1.0 : 0.0,
+            engine_ok: true,
+            tnc_result: parsed
+          });
         } catch (err) {
           checks.push({ check: 'tnc_enforcement', status: 'degraded', score: 0.5, error: err.message });
         }

--- a/command-base/app/routes/exoforge.test.js
+++ b/command-base/app/routes/exoforge.test.js
@@ -1,0 +1,226 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const test = require('node:test');
+
+function installWasmKernelStub(t, kernel) {
+  const originalLoad = Module._load;
+  Module._load = function(request, parent, isMain) {
+    if (request === '@exochain/exochain-wasm') {
+      return kernel;
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  t.after(() => {
+    Module._load = originalLoad;
+  });
+}
+
+function createAppHarness() {
+  const routes = new Map();
+  return {
+    routes,
+    app: {
+      get(path, handler) {
+        routes.set(`GET ${path}`, handler);
+      },
+      post(path, handler) {
+        routes.set(`POST ${path}`, handler);
+      },
+    },
+  };
+}
+
+class ExoForgeHealthDatabase {
+  constructor() {
+    this.receipts = [];
+    this.nextReceiptId = 1;
+  }
+
+  prepare(sql) {
+    const db = this;
+    return {
+      get(...params) {
+        if (sql.includes('SELECT id, receipt_hash FROM governance_receipts')) {
+          return db.receipts[db.receipts.length - 1] || null;
+        }
+        if (sql.includes('SELECT COUNT(*) as c FROM governance_receipts')) {
+          return { c: db.receipts.length };
+        }
+        if (sql.includes('SELECT') && sql.includes('FROM constitutional_invariants')) {
+          return { total: 10, enforced: 10 };
+        }
+        if (sql.includes('FROM exoforge_cycles WHERE status = ?')) {
+          assert.equal(params[0], 'active');
+          return null;
+        }
+        if (sql.includes('FROM exoforge_queue WHERE status = ?')) {
+          assert.equal(params[0], 'triaged');
+          return { c: 0 };
+        }
+        throw new Error(`unexpected get SQL: ${sql}`);
+      },
+      all() {
+        if (sql.includes('SELECT receipt_hash, previous_hash FROM governance_receipts')) {
+          return db.receipts.slice(-2).reverse();
+        }
+        throw new Error(`unexpected all SQL: ${sql}`);
+      },
+      run(...params) {
+        if (sql.includes('CREATE TABLE IF NOT EXISTS')) {
+          return { changes: 0 };
+        }
+        if (sql.includes('INSERT INTO governance_receipts')) {
+          const receipt = {
+            id: db.nextReceiptId,
+            receipt_hash: params[8],
+            previous_hash: params[7],
+          };
+          db.nextReceiptId += 1;
+          db.receipts.push(receipt);
+          return { lastInsertRowid: receipt.id };
+        }
+        if (sql.includes('INSERT INTO governance_audit_trail')) {
+          return { lastInsertRowid: db.nextReceiptId };
+        }
+        throw new Error(`unexpected run SQL: ${sql}`);
+      },
+    };
+  }
+}
+
+function invokeJson(handler) {
+  return new Promise((resolve, reject) => {
+    const req = {};
+    const res = {
+      statusCode: 200,
+      status(code) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload) {
+        resolve({ statusCode: this.statusCode, payload });
+      },
+    };
+    try {
+      handler(req, res);
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+function registerExoForgeRoutes() {
+  const { app, routes } = createAppHarness();
+  const db = new ExoForgeHealthDatabase();
+  require('./exoforge.js')(app, db, {
+    localNow: () => '2026-05-19T09:50:00.000-04:00',
+    broadcast: () => {},
+  });
+  const handler = routes.get('GET /api/exoforge/health');
+  assert.equal(typeof handler, 'function', 'health route should be registered');
+  return handler;
+}
+
+test('ExoForge health reports failed TNC verdicts as unhealthy', async (t) => {
+  installWasmKernelStub(t, {
+    wasm_create_decision(decisionId, title, decisionClass, constitutionHash, createdAtMs, createdAtLogical) {
+      assert.equal(decisionId, '00000000-0000-0000-0000-0000000000ef');
+      assert.equal(title, 'Health Check');
+      assert.equal(decisionClass, '"Routine"');
+      assert.equal(constitutionHash, '2'.repeat(64));
+      assert.equal(createdAtMs, 1n);
+      assert.equal(createdAtLogical, 0);
+      return JSON.stringify({
+        id: '00000000-0000-0000-0000-000000000123',
+        title: 'Health Check',
+        class: 'Routine',
+        authority_chain: [],
+        evidence_bundle: [],
+      });
+    },
+    wasm_enforce_all_tnc() {
+      return {
+        ok: false,
+        error: 'TNC violation: TNC-01: empty authority chain',
+      };
+    },
+    wasm_workflow_stages() {
+      return ['Draft', 'Submitted', 'Approved', 'Closed'];
+    },
+    wasm_audit_verify() {
+      return { ok: true };
+    },
+  });
+
+  const { statusCode, payload } = await invokeJson(registerExoForgeRoutes());
+
+  assert.equal(statusCode, 200);
+  assert.equal(payload.success, true);
+  const tncCheck = payload.data.checks.find((check) => check.check === 'tnc_enforcement');
+  assert.ok(tncCheck, 'TNC health check should be present');
+  assert.equal(tncCheck.status, 'critical');
+  assert.equal(tncCheck.score, 0);
+  assert.equal(tncCheck.tnc_result.ok, false);
+  assert.equal(payload.data.status, 'degraded');
+});
+
+test('ExoForge health preserves healthy status for passing TNC verdicts', async (t) => {
+  installWasmKernelStub(t, {
+    wasm_create_decision(decisionId, title, decisionClass, constitutionHash, createdAtMs, createdAtLogical) {
+      assert.equal(decisionId, '00000000-0000-0000-0000-0000000000ef');
+      assert.equal(title, 'Health Check');
+      assert.equal(decisionClass, '"Routine"');
+      assert.equal(constitutionHash, '2'.repeat(64));
+      assert.equal(createdAtMs, 1n);
+      assert.equal(createdAtLogical, 0);
+      return JSON.stringify({
+        id: '00000000-0000-0000-0000-000000000123',
+        title: 'Health Check',
+        class: 'Routine',
+        authority_chain: [{ actor_did: 'did:exo:root' }],
+        evidence_bundle: [{ hash: '2'.repeat(64) }],
+      });
+    },
+    wasm_enforce_all_tnc() {
+      return {
+        ok: true,
+        violations: [],
+      };
+    },
+    wasm_workflow_stages() {
+      return ['Draft', 'Submitted', 'Approved', 'Closed'];
+    },
+    wasm_audit_verify() {
+      return { ok: true };
+    },
+  });
+
+  const { statusCode, payload } = await invokeJson(registerExoForgeRoutes());
+
+  assert.equal(statusCode, 200);
+  assert.equal(payload.success, true);
+  const tncCheck = payload.data.checks.find((check) => check.check === 'tnc_enforcement');
+  assert.ok(tncCheck, 'TNC health check should be present');
+  assert.equal(tncCheck.status, 'healthy');
+  assert.equal(tncCheck.score, 1);
+  assert.equal(tncCheck.tnc_result.ok, true);
+  assert.equal(payload.data.status, 'healthy');
+});


### PR DESCRIPTION
## Summary
- classify row 46 as adjacent CommandBase health surface exercising the EXOCHAIN WASM/decision-forum TNC boundary
- update /api/exoforge/health to call the current wasm_create_decision signature with deterministic synthetic metadata
- report returned `{ ok: false }` TNC verdicts as `critical` with score `0` instead of healthy adapter responses
- preserve healthy reporting for genuine `{ ok: true }` verdicts and keep adapter crashes as degraded availability failures

## Path Classification
- `command-base/app/routes/exoforge.js`: adjacent surface, health/status route that relays core adapter verdicts
- `command-base/app/routes/exoforge.test.js`: adjacent surface regression coverage

## Verification
- RED: `node --test command-base/app/routes/exoforge.test.js` failed because a failed TNC verdict was reported as healthy
- GREEN: `node --test command-base/app/routes/exoforge.test.js`
- `node --check command-base/app/routes/exoforge.js && node --check command-base/app/routes/exoforge.test.js`
- real-WASM route harness confirmed `tnc_enforcement.status === critical` for actual TNC-01 failure
- `node --test command-base/app/auth-bootstrap.test.js command-base/app/lib/auth.security.test.js command-base/app/services/governance.test.js command-base/app/services/cqi-orchestrator.test.js command-base/app/services/honorgood-economy.test.js command-base/app/routes/exoforge.test.js`
- `cargo test -p decision-forum tnc_ -- --nocapture`
- `cargo test -p exochain-wasm wasm_tnc_adapter_does_not_trust_caller_supplied_flags -- --nocapture`
- `cargo clippy -p decision-forum -p exochain-wasm --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `git diff --check`