### PR TITLE
fix(identity): bind hybrid DID keys to multibase material

### DIFF
--- a/crates/exo-identity/src/did.rs
+++ b/crates/exo-identity/src/did.rs
@@ -117,7 +117,30 @@ pub struct HybridVerificationMethod {
     pub revoked_at: Option<u64>,
 }
 
+fn decode_base58btc_multibase_key(public_key_multibase: &str) -> Option<Vec<u8>> {
+    let encoded = public_key_multibase.strip_prefix('z')?;
+    bs58::decode(encoded).into_vec().ok()
+}
+
 impl HybridVerificationMethod {
+    /// Return true only when both raw verification keys match the advertised
+    /// multibase key material.
+    #[must_use]
+    pub fn key_material_matches_multibase(&self) -> bool {
+        let Some(classical_public_key) =
+            decode_base58btc_multibase_key(&self.classical_public_key_multibase)
+        else {
+            return false;
+        };
+        let Some(pq_public_key) = decode_base58btc_multibase_key(&self.pq_public_key_multibase)
+        else {
+            return false;
+        };
+
+        classical_public_key.as_slice() == self.classical_public_key.as_bytes()
+            && pq_public_key.as_slice() == self.pq_public_key.as_bytes()
+    }
+
     /// Verify a `Signature::Hybrid` against this method's key bundle.
     ///
     /// Delegates to `crypto::verify_hybrid`, which requires **both** the
@@ -125,6 +148,9 @@ impl HybridVerificationMethod {
     #[must_use]
     pub fn verify(&self, message: &[u8], signature: &Signature) -> bool {
         if !self.active {
+            return false;
+        }
+        if !self.key_material_matches_multibase() {
             return false;
         }
         crypto::verify_hybrid(
@@ -475,6 +501,33 @@ mod tests {
         assert!(
             method.verify(message, &sig),
             "HybridVerificationMethod::verify must accept valid Hybrid signature"
+        );
+    }
+
+    #[test]
+    fn hybrid_method_verify_rejects_mismatched_multibase_key_material() {
+        use exo_core::crypto::{generate_pq_keypair, sign_hybrid};
+
+        let (classical_pk, classical_sk) = generate_keypair();
+        let (declared_classical_pk, _declared_classical_sk) = generate_keypair();
+        let (pq_pk, pq_sk) = generate_pq_keypair();
+        let (declared_pq_pk, _declared_pq_sk) = generate_pq_keypair();
+        let did = make_did("hybrid-key-alias");
+
+        let mut method = make_hybrid_method(&did, classical_pk, pq_pk);
+        method.classical_public_key_multibase = format!(
+            "z{}",
+            bs58::encode(declared_classical_pk.as_bytes()).into_string()
+        );
+        method.pq_public_key_multibase =
+            format!("z{}", bs58::encode(declared_pq_pk.as_bytes()).into_string());
+
+        let message = b"hybrid DID verification key alias";
+        let sig = sign_hybrid(message, &classical_sk, &pq_sk).expect("sign_hybrid");
+
+        assert!(
+            !method.verify(message, &sig),
+            "hybrid verification must reject raw keys that do not match the advertised multibase keys"
         );
     }
 

--- a/crates/exo-identity/src/registry.rs
+++ b/crates/exo-identity/src/registry.rs
@@ -526,6 +526,16 @@ fn validate_registered_did_document(doc: &DidDocument) -> Result<(), IdentityErr
             &method.pq_public_key_multibase,
             MAX_DID_DOCUMENT_PQ_MULTIBASE_BYTES,
         )?;
+        if !method.key_material_matches_multibase() {
+            return Err(invalid_did_document_field(
+                did,
+                "hybrid_verification_methods",
+                format!(
+                    "hybrid verification method '{}' raw key material must match multibase encodings",
+                    method.id
+                ),
+            ));
+        }
     }
     for endpoint in &doc.service_endpoints {
         ensure_byte_bound(
@@ -635,12 +645,12 @@ impl DidRegistry for LocalDidRegistry {
 #[cfg(test)]
 mod tests {
     use exo_core::{
-        SecretKey,
-        crypto::{generate_keypair, sign},
+        PqPublicKey, SecretKey,
+        crypto::{generate_keypair, generate_pq_keypair, sign},
     };
 
     use super::*;
-    use crate::did::{DidDocument, VerificationMethod};
+    use crate::did::{DidDocument, HybridVerificationMethod, VerificationMethod};
 
     fn make_did(label: &str) -> Did {
         Did::new(&format!("did:exo:{label}")).expect("valid did")
@@ -670,6 +680,30 @@ mod tests {
             key_type: "Ed25519VerificationKey2020".to_owned(),
             controller: did.clone(),
             public_key_multibase: format!("z{}", bs58::encode(pk.as_bytes()).into_string()),
+            version,
+            active: true,
+            valid_from: 1000,
+            revoked_at: None,
+        }
+    }
+
+    fn hybrid_verification_method(
+        did: &Did,
+        classical_pk: PublicKey,
+        pq_pk: PqPublicKey,
+        version: u64,
+    ) -> HybridVerificationMethod {
+        HybridVerificationMethod {
+            id: format!("{did}#hybrid-key-{version}"),
+            key_type: "HybridKeyEd25519MlDsa652020".to_owned(),
+            controller: did.clone(),
+            classical_public_key_multibase: format!(
+                "z{}",
+                bs58::encode(classical_pk.as_bytes()).into_string()
+            ),
+            pq_public_key_multibase: format!("z{}", bs58::encode(pq_pk.as_bytes()).into_string()),
+            pq_public_key: pq_pk,
+            classical_public_key: classical_pk,
             version,
             active: true,
             valid_from: 1000,
@@ -933,6 +967,36 @@ mod tests {
         assert!(
             err.to_string().contains("revoked_at"),
             "error should identify inactive revoked_at inconsistency: {err}"
+        );
+        assert_eq!(reg.len(), 0);
+    }
+
+    #[test]
+    fn register_rejects_hybrid_method_with_mismatched_multibase_key_material() {
+        let (document_pk, _) = generate_keypair();
+        let (classical_pk, _) = generate_keypair();
+        let (declared_classical_pk, _) = generate_keypair();
+        let (pq_pk, _) = generate_pq_keypair();
+        let (declared_pq_pk, _) = generate_pq_keypair();
+        let did = make_did("hybrid-mismatched-key-material");
+        let mut doc = make_doc(did.clone(), document_pk);
+        let mut method = hybrid_verification_method(&did, classical_pk, pq_pk, 1);
+        method.classical_public_key_multibase = format!(
+            "z{}",
+            bs58::encode(declared_classical_pk.as_bytes()).into_string()
+        );
+        method.pq_public_key_multibase =
+            format!("z{}", bs58::encode(declared_pq_pk.as_bytes()).into_string());
+        doc.hybrid_verification_methods = vec![method];
+
+        let mut reg = LocalDidRegistry::new();
+        let err = reg
+            .register(doc)
+            .expect_err("hybrid methods must bind raw keys to advertised multibase keys");
+
+        assert!(
+            err.to_string().contains("hybrid_verification_methods"),
+            "error should identify hybrid method key binding failure: {err}"
         );
         assert_eq!(reg.len(), 0);
     }


### PR DESCRIPTION
## Summary
- classify row 48 as EXOCHAIN core identity/DID verification
- make `HybridVerificationMethod::verify` fail closed unless raw Ed25519/PQ keys match their advertised base58btc multibase fields
- make DID registry registration reject hybrid verification methods whose raw key material aliases different multibase keys
- preserve valid hybrid signature roundtrips and registered hybrid DID document behavior

## Path Classification
- `crates/exo-identity/src/did.rs`: EXOCHAIN core identity verification
- `crates/exo-identity/src/registry.rs`: EXOCHAIN core DID registry validation

## Verification
- RED: `cargo test -p exo-identity mismatched_multibase_key_material -- --nocapture` failed on direct verification and registry acceptance
- GREEN: `cargo test -p exo-identity mismatched_multibase_key_material -- --nocapture`
- `cargo test -p exo-identity hybrid_method -- --nocapture`
- `cargo test -p exo-identity did_document_with_hybrid_method_roundtrip -- --nocapture`
- `cargo test -p exo-identity -- --nocapture`
- bypass search: `rg -n "HybridVerificationMethod|key_material_matches_multibase|verify_hybrid\(" crates/exo-identity/src crates/exo-core/src crates/exo-node/src crates/exo-api/src -S`
- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p exo-identity --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `git diff --check`