### PR TITLE
fix(gatekeeper): bind governance attestations to findings

### DIFF
--- a/crates/exo-gatekeeper/src/governance_monitor.rs
+++ b/crates/exo-gatekeeper/src/governance_monitor.rs
@@ -21,7 +21,8 @@
 //! monitoring output. Implements three sub-mitigations:
 //!
 //! 1. **Signed attestation verification** — rejects payloads without a valid
-//!    Ed25519 signature over the findings digest (sub-threat T-14a).
+//!    Ed25519 signature over the canonical findings payload digest
+//!    (sub-threat T-14a).
 //! 2. **Circuit breaker** — auto-pauses self-improvement when >3 Critical
 //!    findings are recorded within a 24-hour window (sub-threat T-14c).
 //! 3. **Human approval gate** — requires human-DID (`SignerType 0x01`)
@@ -32,7 +33,8 @@
 
 use std::collections::BTreeMap;
 
-use exo_core::{Did, Hash256, PublicKey, Signature, Timestamp, crypto};
+use exo_core::{Did, Hash256, PublicKey, Signature, Timestamp, crypto, hash::hash_structured};
+use serde::Serialize;
 
 // ---------------------------------------------------------------------------
 // Signed attestation envelope (T-14a)
@@ -40,9 +42,9 @@ use exo_core::{Did, Hash256, PublicKey, Signature, Timestamp, crypto};
 
 /// A signed governance health attestation.
 ///
-/// The signature covers the `findings_digest` — a BLAKE3 hash of the
-/// serialized findings array. The signer must be identifiable by their
-/// public key for verification.
+/// The signature covers `findings_digest`, which must match the canonical
+/// BLAKE3/CBOR digest of the findings payload passed to [`verify_attestation`].
+/// The signer must be identifiable by their public key for verification.
 #[derive(Debug, Clone)]
 pub struct GovernanceAttestation {
     /// DID of the entity that produced this attestation.
@@ -63,6 +65,22 @@ pub enum GovernanceMonitorError {
     /// Attestation signature is invalid.
     #[error("attestation signature verification failed for signer {signer_did}")]
     InvalidAttestation {
+        /// DID of the claimed signer.
+        signer_did: Did,
+    },
+
+    /// Findings payload could not be canonically encoded for digesting.
+    #[error("findings payload digest encoding failed: {reason}")]
+    FindingsDigestEncodingFailed {
+        /// Encoding failure reason.
+        reason: String,
+    },
+
+    /// Attested digest does not match the actual findings payload.
+    #[error(
+        "attestation findings digest does not match canonical findings payload for signer {signer_did}"
+    )]
+    FindingsDigestMismatch {
         /// DID of the claimed signer.
         signer_did: Did,
     },
@@ -90,6 +108,22 @@ pub enum GovernanceMonitorError {
     ApproverNotHuman,
 }
 
+/// Compute the canonical digest for a governance findings payload.
+///
+/// # Errors
+///
+/// Returns [`GovernanceMonitorError::FindingsDigestEncodingFailed`] if the
+/// payload cannot be encoded with the canonical structured hash format.
+pub fn governance_findings_digest<T: Serialize>(
+    findings_payload: &T,
+) -> Result<Hash256, GovernanceMonitorError> {
+    hash_structured(findings_payload).map_err(|err| {
+        GovernanceMonitorError::FindingsDigestEncodingFailed {
+            reason: err.to_string(),
+        }
+    })
+}
+
 /// Verify the cryptographic attestation on a governance health payload.
 ///
 /// **Security: This MUST be called BEFORE any data is stored or circuit
@@ -101,10 +135,21 @@ pub enum GovernanceMonitorError {
 /// Returns [`GovernanceMonitorError::MissingAttestation`] if no attestation
 /// is provided, or [`GovernanceMonitorError::InvalidAttestation`] if the
 /// signature does not verify against the signer's public key.
-pub fn verify_attestation(
+///
+/// Returns [`GovernanceMonitorError::FindingsDigestMismatch`] if the digest
+/// in the attestation is not the canonical digest of `findings_payload`.
+pub fn verify_attestation<T: Serialize>(
     attestation: &GovernanceAttestation,
     signer_public_key: &PublicKey,
+    findings_payload: &T,
 ) -> Result<(), GovernanceMonitorError> {
+    let computed_digest = governance_findings_digest(findings_payload)?;
+    if computed_digest != attestation.findings_digest {
+        return Err(GovernanceMonitorError::FindingsDigestMismatch {
+            signer_did: attestation.signer_did.clone(),
+        });
+    }
+
     let message = attestation.findings_digest.as_bytes();
     if crypto::verify(message, &attestation.signature, signer_public_key) {
         Ok(())
@@ -351,25 +396,53 @@ mod tests {
         }
     }
 
+    fn findings_payload(label: &str, severity: &str) -> serde_json::Value {
+        serde_json::json!([
+            {
+                "id": label,
+                "severity": severity,
+                "title": "governance monitor finding"
+            }
+        ])
+    }
+
     // ── Attestation verification tests ──────────────────────────────────
 
     #[test]
     fn valid_attestation_passes() {
         let (pk, sk) = generate_keypair();
-        let digest = Hash256::digest(b"findings-payload");
+        let findings = findings_payload("F-001", "critical");
+        let digest = exo_core::hash::hash_structured(&findings).expect("findings digest");
         let attestation = make_attestation(digest, test_did("scanner"), &sk);
 
-        assert!(verify_attestation(&attestation, &pk).is_ok());
+        assert!(verify_attestation(&attestation, &pk, &findings).is_ok());
+    }
+
+    #[test]
+    fn attestation_rejects_signature_replayed_for_different_findings_payload() {
+        let (pk, sk) = generate_keypair();
+        let signed_findings = findings_payload("F-001", "low");
+        let substituted_findings = findings_payload("F-999", "critical");
+        let signed_digest =
+            exo_core::hash::hash_structured(&signed_findings).expect("findings digest");
+        let attestation = make_attestation(signed_digest, test_did("scanner"), &sk);
+
+        let err = verify_attestation(&attestation, &pk, &substituted_findings).unwrap_err();
+        assert!(matches!(
+            err,
+            GovernanceMonitorError::FindingsDigestMismatch { .. }
+        ));
     }
 
     #[test]
     fn wrong_key_attestation_fails() {
         let (_pk, sk) = generate_keypair();
         let (wrong_pk, _) = generate_keypair();
-        let digest = Hash256::digest(b"findings-payload");
+        let findings = findings_payload("F-001", "critical");
+        let digest = exo_core::hash::hash_structured(&findings).expect("findings digest");
         let attestation = make_attestation(digest, test_did("scanner"), &sk);
 
-        let err = verify_attestation(&attestation, &wrong_pk).unwrap_err();
+        let err = verify_attestation(&attestation, &wrong_pk, &findings).unwrap_err();
         assert!(matches!(
             err,
             GovernanceMonitorError::InvalidAttestation { .. }
@@ -379,16 +452,17 @@ mod tests {
     #[test]
     fn tampered_digest_fails() {
         let (pk, sk) = generate_keypair();
-        let digest = Hash256::digest(b"findings-payload");
+        let findings = findings_payload("F-001", "critical");
+        let digest = exo_core::hash::hash_structured(&findings).expect("findings digest");
         let mut attestation = make_attestation(digest, test_did("scanner"), &sk);
 
         // Tamper with the digest after signing
         attestation.findings_digest = Hash256::digest(b"tampered");
 
-        let err = verify_attestation(&attestation, &pk).unwrap_err();
+        let err = verify_attestation(&attestation, &pk, &findings).unwrap_err();
         assert!(matches!(
             err,
-            GovernanceMonitorError::InvalidAttestation { .. }
+            GovernanceMonitorError::FindingsDigestMismatch { .. }
         ));
     }
 

--- a/crates/exochain-wasm/src/gatekeeper_bindings.rs
+++ b/crates/exochain-wasm/src/gatekeeper_bindings.rs
@@ -172,7 +172,7 @@ fn caller_supplied_trusted_key_violations(
 #[wasm_bindgen]
 pub fn wasm_governance_findings_digest(findings_json: &str) -> Result<String, JsValue> {
     let findings: serde_json::Value = from_json_str(findings_json)?;
-    let digest = exo_core::hash::hash_structured(&findings)
+    let digest = exo_gatekeeper::governance_monitor::governance_findings_digest(&findings)
         .map_err(|_| gatekeeper_boundary_error("governance findings digest failed"))?;
     Ok(hex::encode(digest.as_bytes()))
 }
@@ -187,8 +187,9 @@ pub fn wasm_verify_governance_attestation(
 ) -> Result<bool, JsValue> {
     let signer_did = exo_core::Did::new(signer_did)
         .map_err(|_| gatekeeper_boundary_error("invalid governance attestation signer DID"))?;
-    let digest_hex = wasm_governance_findings_digest(findings_json)?;
-    let digest = exo_core::Hash256::from_bytes(decode_fixed_hex(&digest_hex, "findings digest")?);
+    let findings: serde_json::Value = from_json_str(findings_json)?;
+    let digest = exo_gatekeeper::governance_monitor::governance_findings_digest(&findings)
+        .map_err(|_| gatekeeper_boundary_error("governance findings digest failed"))?;
     let signature: exo_core::Signature = from_json_str(signature_json)?;
     let signer_public_key = exo_core::PublicKey::from_bytes(decode_fixed_hex(
         signer_public_key_hex,
@@ -200,9 +201,13 @@ pub fn wasm_verify_governance_attestation(
         signature,
     };
 
-    exo_gatekeeper::governance_monitor::verify_attestation(&attestation, &signer_public_key)
-        .map(|()| true)
-        .map_err(|_| gatekeeper_boundary_error("governance attestation rejected"))
+    exo_gatekeeper::governance_monitor::verify_attestation(
+        &attestation,
+        &signer_public_key,
+        &findings,
+    )
+    .map(|()| true)
+    .map_err(|_| gatekeeper_boundary_error("governance attestation rejected"))
 }
 
 /// Build a deterministic valid invariant request fixture for external

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -1471,6 +1471,28 @@ test('wasm_verify_governance_attestation accepts valid signatures', () => {
   );
 });
 
+test('wasm_verify_governance_attestation rejects signatures replayed for substituted findings', () => {
+  const signedFindingsJson = JSON.stringify([
+    { id: 'F-001', severity: 'low', title: 'Benign finding' },
+  ]);
+  const substitutedFindingsJson = JSON.stringify([
+    { id: 'F-999', severity: 'critical', title: 'Substituted critical finding' },
+  ]);
+  const digestHex = wasm.wasm_governance_findings_digest(signedFindingsJson);
+  const signature = signatureJsonFromHex(signer1.signHex(Buffer.from(digestHex, 'hex')));
+
+  return expectErrorContains(
+    'wasm_verify_governance_attestation',
+    () => wasm.wasm_verify_governance_attestation(
+      'did:exo:monitor',
+      substitutedFindingsJson,
+      JSON.stringify(signature),
+      signer1.publicKeyHex,
+    ),
+    'governance attestation rejected',
+  );
+});
+
 test('wasm_verify_governance_attestation rejects invalid signatures', () =>
   expectErrorContains(
     'wasm_verify_governance_attestation',


### PR DESCRIPTION
## Summary
- binds governance attestation verification to the actual canonical findings payload instead of accepting a caller-supplied signed digest alone
- exposes the same canonical digest helper through the WASM adapter
- adds bridge coverage proving a signature over one findings payload cannot be replayed for substituted findings

## Path Classification
- `crates/exo-gatekeeper/src/governance_monitor.rs`: EXOCHAIN core governance monitor
- `crates/exochain-wasm/src/gatekeeper_bindings.rs`: core runtime adapter
- `packages/exochain-wasm/test/bridge_verification.mjs`: core runtime adapter test harness

## Verification
- RED before fix: `cargo test -p exo-gatekeeper attestation -- --nocapture` failed to compile because `verify_attestation` did not accept a findings payload and `FindingsDigestMismatch` did not exist.
- `cargo test -p exo-gatekeeper governance_monitor::tests -- --nocapture`
- `cargo test -p exochain-wasm -- --nocapture`
- `node --check packages/exochain-wasm/test/bridge_verification.mjs`
- `wasm-pack build crates/exochain-wasm --target nodejs --out-dir /Users/bobstewart/dev/exochain/packages/exochain-wasm/wasm --release`
- `node packages/exochain-wasm/test/bridge_verification.mjs` passed 161/161
- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p exo-gatekeeper -p exochain-wasm --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `git diff --check`

## Bypass Search
- `rg -n "governance_findings_digest|verify_attestation\\(" crates/exo-gatekeeper/src/governance_monitor.rs crates/exochain-wasm/src/gatekeeper_bindings.rs packages/exochain-wasm/test/bridge_verification.mjs -S`
