### PR TITLE
fix(decision-forum): enforce emergency actor caps

### DIFF
--- a/crates/decision-forum/src/emergency.rs
+++ b/crates/decision-forum/src/emergency.rs
@@ -129,10 +129,15 @@ pub struct EmergencyActionInput {
     pub created_at: Timestamp,
 }
 
-/// Create an emergency action, validating against the policy.
+/// Create an emergency action, validating against the policy and current-quarter history.
+///
+/// `prior_actions` must contain the actor's relevant emergency history for the
+/// current quarter. Ratification expiry does not remove an invocation from the
+/// quarterly cap.
 pub fn create_emergency_action(
     input: EmergencyActionInput,
     policy: &EmergencyPolicy,
+    prior_actions: &[EmergencyAction],
 ) -> Result<EmergencyAction> {
     validate_uuid(input.id, "emergency action id")?;
     validate_timestamp(input.created_at, "emergency created_at")?;
@@ -155,6 +160,7 @@ pub fn create_emergency_action(
             ),
         });
     }
+    check_per_actor_limit(prior_actions, &input.actor, policy)?;
 
     let deadline_ms = input
         .created_at
@@ -183,10 +189,11 @@ pub fn create_emergency_action(
 
 /// Enforce the per-actor emergency invocation limit (hard gate).
 ///
-/// Call this **before** [`create_emergency_action`] to enforce the constitutional
-/// limit (`policy.max_per_quarter_per_actor`).  Returns `Ok(())` if the actor
-/// is permitted to invoke another emergency action given the slice of existing
-/// actions in the current quarter.
+/// Called by [`create_emergency_action`] to enforce the constitutional limit
+/// (`policy.max_per_quarter_per_actor`). Returns `Ok(())` if the actor is
+/// permitted to invoke another emergency action given the slice of existing
+/// actions in the current quarter. Ratification expiry does not reset this
+/// quarterly count.
 ///
 /// # Errors
 ///
@@ -203,7 +210,7 @@ pub fn check_per_actor_limit(
     }
     let actor_count = prior_actions
         .iter()
-        .filter(|a| &a.actor_did == actor && a.ratification_status != RatificationStatus::Expired)
+        .filter(|a| &a.actor_did == actor)
         .count();
     if actor_count >= policy.max_per_quarter_per_actor {
         return Err(ForumError::EmergencyInvalid {
@@ -318,8 +325,12 @@ mod tests {
     }
 
     fn make_action(action_type: EmergencyActionType) -> EmergencyAction {
-        create_emergency_action(emergency_input(Uuid::from_u128(31), action_type), &policy())
-            .expect("valid emergency")
+        create_emergency_action(
+            emergency_input(Uuid::from_u128(31), action_type),
+            &policy(),
+            &[],
+        )
+        .expect("valid emergency")
     }
 
     fn production_source() -> &'static str {
@@ -335,6 +346,7 @@ mod tests {
         let action = create_emergency_action(
             emergency_input(Uuid::from_u128(32), EmergencyActionType::SystemHalt),
             &policy(),
+            &[],
         )
         .expect("valid");
         assert_eq!(action.id, Uuid::from_u128(32));
@@ -343,6 +355,7 @@ mod tests {
         let nil = create_emergency_action(
             emergency_input(Uuid::nil(), EmergencyActionType::SystemHalt),
             &policy(),
+            &[],
         )
         .unwrap_err();
         assert!(matches!(nil, ForumError::InvalidProvenance { .. }));
@@ -353,6 +366,7 @@ mod tests {
                 ..emergency_input(Uuid::from_u128(33), EmergencyActionType::SystemHalt)
             },
             &policy(),
+            &[],
         )
         .unwrap_err();
         assert!(matches!(zero_time, ForumError::InvalidProvenance { .. }));
@@ -363,6 +377,7 @@ mod tests {
                 ..emergency_input(Uuid::from_u128(34), EmergencyActionType::SystemHalt)
             },
             &policy(),
+            &[],
         )
         .unwrap_err();
         assert!(matches!(
@@ -379,6 +394,7 @@ mod tests {
                 ..emergency_input(Uuid::from_u128(35), EmergencyActionType::SystemHalt)
             },
             &policy(),
+            &[],
         )
         .unwrap_err();
 
@@ -394,6 +410,29 @@ mod tests {
     }
 
     #[test]
+    fn create_action_enforces_per_actor_limit_with_prior_history() {
+        let p = policy();
+        let first = create_emergency_action(
+            emergency_input(Uuid::from_u128(37), EmergencyActionType::SystemHalt),
+            &p,
+            &[],
+        )
+        .expect("first emergency action is within per-actor cap");
+
+        let err = create_emergency_action(
+            emergency_input(Uuid::from_u128(38), EmergencyActionType::RoleEscalation),
+            &p,
+            std::slice::from_ref(&first),
+        )
+        .expect_err("second same-actor emergency must be blocked by hard cap");
+
+        assert!(
+            matches!(err, ForumError::EmergencyInvalid { .. }),
+            "expected EmergencyInvalid after prior action {first:?}, got {err:?}"
+        );
+    }
+
+    #[test]
     fn cap_exceeded() {
         let err = create_emergency_action(
             EmergencyActionInput {
@@ -401,6 +440,7 @@ mod tests {
                 ..emergency_input(Uuid::from_u128(35), EmergencyActionType::SystemHalt)
             },
             &policy(),
+            &[],
         )
         .unwrap_err();
         assert!(matches!(err, ForumError::EmergencyCapExceeded { .. }));
@@ -415,6 +455,7 @@ mod tests {
         let err = create_emergency_action(
             emergency_input(Uuid::from_u128(36), EmergencyActionType::RoleEscalation),
             &p,
+            &[],
         )
         .unwrap_err();
         assert!(matches!(err, ForumError::EmergencyInvalid { .. }));
@@ -450,7 +491,10 @@ mod tests {
 
     #[test]
     fn frequency_monitoring() {
-        let p = policy();
+        let p = EmergencyPolicy {
+            max_per_quarter_per_actor: 0,
+            ..policy()
+        };
         let actions: Vec<EmergencyAction> = (0..4)
             .map(|i| {
                 create_emergency_action(
@@ -459,6 +503,7 @@ mod tests {
                         ..emergency_input(Uuid::from_u128(40 + i), EmergencyActionType::SystemHalt)
                     },
                     &p,
+                    &[],
                 )
                 .expect("ok")
             })
@@ -481,6 +526,7 @@ mod tests {
         let first = create_emergency_action(
             emergency_input(Uuid::from_u128(50), EmergencyActionType::SystemHalt),
             &p,
+            &[],
         )
         .expect("ok");
         let err = check_per_actor_limit(&[first], &did(), &p).unwrap_err();
@@ -501,6 +547,7 @@ mod tests {
                 ..emergency_input(Uuid::from_u128(51), EmergencyActionType::SystemHalt)
             },
             &p,
+            &[],
         )
         .expect("ok");
         // actor_b is unaffected by actor_a's invocation
@@ -508,19 +555,21 @@ mod tests {
     }
 
     #[test]
-    fn per_actor_limit_excludes_expired_actions() {
+    fn per_actor_limit_counts_expired_actions_for_full_quarter() {
         let p = policy(); // max_per_quarter_per_actor = 1
         let mut expired = create_emergency_action(
             emergency_input(Uuid::from_u128(52), EmergencyActionType::SystemHalt),
             &p,
+            &[],
         )
         .expect("ok");
         // Mark as expired (missed ratification window)
         let now_past = Timestamp::new(expired.ratification_deadline.physical_ms + 1000, 0);
         check_expiry(&mut expired, &now_past);
         assert_eq!(expired.ratification_status, RatificationStatus::Expired);
-        // Expired action does not count toward the per-actor limit
-        assert!(check_per_actor_limit(&[expired], &did(), &p).is_ok());
+        let err = check_per_actor_limit(&[expired], &did(), &p)
+            .expect_err("ratification expiry must not reset the quarterly actor cap");
+        assert!(matches!(err, ForumError::EmergencyInvalid { .. }));
     }
 
     #[test]
@@ -535,6 +584,7 @@ mod tests {
                 create_emergency_action(
                     emergency_input(Uuid::from_u128(60 + i), EmergencyActionType::SystemHalt),
                     &p,
+                    &[],
                 )
                 .expect("ok")
             })
@@ -570,6 +620,7 @@ mod tests {
         let disallowed = create_emergency_action(
             emergency_input(Uuid::from_u128(70), EmergencyActionType::RoleEscalation),
             &p,
+            &[],
         )
         .expect_err("role escalation is not allowed by policy");
         assert_eq!(
@@ -608,5 +659,37 @@ mod tests {
                 "emergency errors must use explicit stable labels: {forbidden}"
             );
         }
+    }
+
+    #[test]
+    fn per_actor_limit_is_not_optional_at_creation_boundary() {
+        let production = production_source();
+        let create_body = production
+            .split("pub fn create_emergency_action")
+            .nth(1)
+            .expect("create_emergency_action exists")
+            .split("/// Enforce the per-actor emergency invocation limit")
+            .next()
+            .expect("create_emergency_action body is bounded by helper docs");
+
+        assert!(
+            create_body.contains("prior_actions: &[EmergencyAction]"),
+            "emergency creation must require current-quarter prior action history"
+        );
+        assert!(
+            create_body.contains("check_per_actor_limit(prior_actions, &input.actor, policy)?"),
+            "emergency creation must enforce the per-actor cap directly"
+        );
+        let per_actor_body = production
+            .split("pub fn check_per_actor_limit")
+            .nth(1)
+            .expect("check_per_actor_limit exists")
+            .split("/// Ratify an emergency action")
+            .next()
+            .expect("per-actor helper body is bounded by ratify docs");
+        assert!(
+            !per_actor_body.contains("ratification_status != RatificationStatus::Expired"),
+            "ratification expiry must not reset the per-quarter actor cap"
+        );
     }
 }

--- a/crates/exochain-wasm/src/decision_forum_bindings.rs
+++ b/crates/exochain-wasm/src/decision_forum_bindings.rs
@@ -656,7 +656,8 @@ pub fn wasm_verify_quorum_precondition(
 #[wasm_bindgen]
 #[allow(clippy::too_many_arguments)]
 // Mirrors the emergency action provenance contract across the JS/Rust
-// boundary without rebuilding IDs or HLC timestamps inside the bridge.
+// boundary without rebuilding IDs, HLC timestamps, or quarterly action history
+// inside the bridge.
 pub fn wasm_create_emergency_action(
     action_id: &str,
     action_type_json: &str,
@@ -667,6 +668,7 @@ pub fn wasm_create_emergency_action(
     policy_json: &str,
     timestamp_ms: u64,
     timestamp_logical: u32,
+    prior_actions_json: &str,
 ) -> Result<JsValue, JsValue> {
     let action_id = parse_uuid(action_id)?;
     let action_type: decision_forum::emergency::EmergencyActionType =
@@ -676,6 +678,11 @@ pub fn wasm_create_emergency_action(
     let evidence_hash = parse_hash(evidence_hash_hex, "evidence hash")?;
     let policy: decision_forum::emergency::EmergencyPolicy = from_json_str(policy_json)?;
     let ts = exo_core::types::Timestamp::new(timestamp_ms, timestamp_logical);
+    let prior_actions: Vec<decision_forum::emergency::EmergencyAction> = from_json_bounded_vec(
+        prior_actions_json,
+        "forum emergency actions",
+        MAX_WASM_FORUM_EMERGENCY_ACTIONS,
+    )?;
 
     let action = decision_forum::emergency::create_emergency_action(
         decision_forum::emergency::EmergencyActionInput {
@@ -688,6 +695,7 @@ pub fn wasm_create_emergency_action(
             created_at: ts,
         },
         &policy,
+        &prior_actions,
     )
     .map_err(|e| JsValue::from_str(&format!("Emergency error: {e}")))?;
     to_js_value(&action)
@@ -996,5 +1004,36 @@ mod tests {
                 "{export_name} must not derive eligible signers from caller-supplied keys"
             );
         }
+    }
+
+    #[test]
+    fn wasm_emergency_create_requires_bounded_prior_action_history() {
+        let source = include_str!("decision_forum_bindings.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production section");
+        let body = production
+            .split("pub fn wasm_create_emergency_action")
+            .nth(1)
+            .expect("emergency create export exists")
+            .split("/// Ratify an emergency action")
+            .next()
+            .expect("emergency create export body is bounded by ratify docs");
+
+        assert!(
+            body.contains("prior_actions_json: &str"),
+            "WASM emergency creation must require caller-supplied prior action history"
+        );
+        assert!(
+            body.contains("from_json_bounded_vec(")
+                && body.contains("prior_actions_json")
+                && body.contains("MAX_WASM_FORUM_EMERGENCY_ACTIONS"),
+            "WASM emergency creation must parse bounded prior action history"
+        );
+        assert!(
+            body.contains("&prior_actions"),
+            "WASM emergency creation must pass prior action history into the core constructor"
+        );
     }
 }

--- a/crates/exochain-wasm/tests/wasm_bindings_test.rs
+++ b/crates/exochain-wasm/tests/wasm_bindings_test.rs
@@ -533,6 +533,7 @@ fn test_create_emergency_action_round_trip() {
         policy,
         1_700_000_000_000,
         0,
+        r#"[]"#,
     )
     .expect("create_emergency_action");
     let json = js_to_json(result);

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -2255,7 +2255,8 @@ test('wasm_create_emergency_action', () =>
     NONZERO_32_HEX,
     JSON.stringify(emergencyPolicy),
     NOW_MS,
-    0
+    0,
+    JSON.stringify([])
   ));
 
 const emergencyAction = setup(() =>
@@ -2268,8 +2269,45 @@ const emergencyAction = setup(() =>
     NONZERO_32_HEX,
     JSON.stringify(emergencyPolicy),
     NOW_MS,
-    0
+    0,
+    JSON.stringify([])
   ));
+
+test('wasm_create_emergency_action rejects repeated same-actor emergency history', () => {
+  const onePerActorPolicy = {
+    ...emergencyPolicy,
+    max_per_quarter_per_actor: 1
+  };
+  const first = wasm.wasm_create_emergency_action(
+    UUID_1,
+    JSON.stringify('SystemHalt'),
+    TEST_DID,
+    'Critical security breach',
+    BigInt(50000),
+    NONZERO_32_HEX,
+    JSON.stringify(onePerActorPolicy),
+    NOW_MS,
+    0,
+    JSON.stringify([])
+  );
+
+  return expectErrorContains(
+    'wasm_create_emergency_action',
+    () => wasm.wasm_create_emergency_action(
+      UUID_2,
+      JSON.stringify('RoleEscalation'),
+      TEST_DID,
+      'Second same-actor emergency',
+      BigInt(50000),
+      NONZERO_32_HEX,
+      JSON.stringify(onePerActorPolicy),
+      NOW_MS + 1n,
+      0,
+      JSON.stringify([first])
+    ),
+    'Emergency error',
+  );
+});
 
 test('wasm_check_expiry', () => {
   if (!emergencyAction) throw new Error('skipped -- no emergency action from setup');


### PR DESCRIPTION
## Summary
- makes emergency creation require current-quarter prior action history and enforces `max_per_quarter_per_actor` inside the constructor
- counts expired ratification records toward the actor's quarterly emergency cap
- requires bounded prior-action history at the WASM boundary and adds bridge coverage for repeated same-actor attempts

## Path Classification
- `crates/decision-forum/src/emergency.rs`: EXOCHAIN core emergency governance protocol
- `crates/exochain-wasm/src/decision_forum_bindings.rs`: core runtime adapter
- `crates/exochain-wasm/tests/wasm_bindings_test.rs`: core runtime adapter test
- `packages/exochain-wasm/test/bridge_verification.mjs`: core runtime adapter bridge verification

## RED Evidence
- `cargo test -p decision-forum create_action_enforces_per_actor_limit_with_prior_history -- --nocapture` failed because a second same-actor emergency was created successfully.
- `cargo test -p decision-forum per_actor_limit_counts_expired_actions_for_full_quarter -- --nocapture` failed because expired actions reset the cap.
- `node packages/exochain-wasm/test/bridge_verification.mjs` failed on `wasm_create_emergency_action rejects repeated same-actor emergency history` before the WASM export accepted history.

## Verification
- `cargo test -p decision-forum emergency::tests -- --nocapture`
- `cargo test -p decision-forum -- --nocapture`
- `cargo test -p exochain-wasm -- --nocapture`
- `node --check packages/exochain-wasm/test/bridge_verification.mjs`
- `wasm-pack build crates/exochain-wasm --target nodejs --out-dir /Users/bobstewart/dev/exochain/packages/exochain-wasm/wasm --release`
- `node packages/exochain-wasm/test/bridge_verification.mjs` passed 161/161
- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p decision-forum -p exochain-wasm --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `git diff --check`

## Bypass Search
- `rg -n "decision_forum::emergency::create_emergency_action|\\bcreate_emergency_action\\(" crates --glob '*.rs' -S`
- `rg -n "wasm_create_emergency_action\\(" packages/exochain-wasm/test/bridge_verification.mjs crates -S`
