### PR TITLE
fix(gateway): validate recusal conflict candidates

### DIFF
--- a/crates/exo-gateway/src/db.rs
+++ b/crates/exo-gateway/src/db.rs
@@ -952,8 +952,8 @@ pub async fn update_decision(
 ///
 /// This is a bounded list helper for administrative display and export
 /// surfaces. Vote recusal enforcement must use
-/// `list_blocking_conflict_declaration_payloads_for_recusal_db` so a generic
-/// UI row cap cannot hide a later blocking declaration.
+/// `list_blocking_conflict_declaration_recusal_candidates_db` so a generic UI
+/// row cap cannot hide a later blocking declaration.
 pub async fn list_conflict_declaration_payloads_db(
     pool: &PgPool,
     declarant_did: &str,
@@ -974,12 +974,26 @@ pub async fn list_conflict_declaration_payloads_db(
         .collect()
 }
 
-/// Load at most one blocking conflict declaration for vote recusal enforcement.
-pub async fn list_blocking_conflict_declaration_payloads_for_recusal_db(
+/// Scalar-indexed conflict declaration candidate for recusal enforcement.
+///
+/// The server must validate these scalar columns against `payload` before
+/// using the decoded declaration for vote recusal. A mismatch means the row is
+/// inconsistent and must fail closed.
+#[derive(Debug, Clone)]
+pub struct ConflictDeclarationRecusalCandidate {
+    pub declarant_did: String,
+    pub nature: String,
+    pub related_dids: JsonValue,
+    pub payload: JsonValue,
+}
+
+/// Load at most one scalar-blocking conflict declaration candidate for vote
+/// recusal enforcement.
+pub async fn list_blocking_conflict_declaration_recusal_candidates_db(
     pool: &PgPool,
     declarant_did: &str,
     affected_dids: &[String],
-) -> Result<Vec<JsonValue>, sqlx::Error> {
+) -> Result<Vec<ConflictDeclarationRecusalCandidate>, sqlx::Error> {
     if affected_dids.is_empty() {
         return Ok(Vec::new());
     }
@@ -989,7 +1003,7 @@ pub async fn list_blocking_conflict_declaration_payloads_for_recusal_db(
         .map(ToOwned::to_owned)
         .collect::<Vec<String>>();
     let row = sqlx::query(
-        "SELECT payload FROM conflict_declarations
+        "SELECT declarant_did, nature, related_dids, payload FROM conflict_declarations
          WHERE declarant_did = $1
            AND related_dids ?| $2
            AND nature LIKE ANY($3)
@@ -1003,7 +1017,12 @@ pub async fn list_blocking_conflict_declaration_payloads_for_recusal_db(
     .await?;
 
     match row {
-        Some(row) => Ok(vec![row.try_get::<JsonValue, _>("payload")?]),
+        Some(row) => Ok(vec![ConflictDeclarationRecusalCandidate {
+            declarant_did: row.try_get::<String, _>("declarant_did")?,
+            nature: row.try_get::<String, _>("nature")?,
+            related_dids: row.try_get::<JsonValue, _>("related_dids")?,
+            payload: row.try_get::<JsonValue, _>("payload")?,
+        }]),
         None => Ok(Vec::new()),
     }
 }
@@ -2166,9 +2185,13 @@ mod tests {
         let source = production_source();
         let recusal_lookup = function_source(
             source,
-            "list_blocking_conflict_declaration_payloads_for_recusal_db",
+            "list_blocking_conflict_declaration_recusal_candidates_db",
         );
 
+        assert!(
+            recusal_lookup.contains("SELECT declarant_did, nature, related_dids, payload"),
+            "recusal enforcement must return scalar fields with the payload so the server can verify canonical consistency"
+        );
         assert!(
             recusal_lookup.contains("related_dids ?|"),
             "recusal enforcement must scope the DB lookup to affected DIDs"
@@ -2252,15 +2275,16 @@ mod tests {
         .expect("insert blocking conflict declaration after capped rows");
 
         let affected_did_strings = vec![affected.as_str().to_owned()];
-        let payloads = list_blocking_conflict_declaration_payloads_for_recusal_db(
+        let candidates = list_blocking_conflict_declaration_recusal_candidates_db(
             &pool,
             actor.as_str(),
             &affected_did_strings,
         )
         .await
         .expect("load conflict declarations");
-        let declarations = payloads
+        let declarations = candidates
             .into_iter()
+            .map(|candidate| candidate.payload)
             .map(serde_json::from_value)
             .collect::<Result<Vec<_>, _>>()
             .expect("decode conflict declarations");

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -656,7 +656,7 @@ impl AppState {
             .iter()
             .map(|did| did.as_str().to_owned())
             .collect::<Vec<String>>();
-        let payloads = db::list_blocking_conflict_declaration_payloads_for_recusal_db(
+        let candidates = db::list_blocking_conflict_declaration_recusal_candidates_db(
             pool,
             actor.as_str(),
             &affected_did_strings,
@@ -666,9 +666,11 @@ impl AppState {
             GatewayError::Internal(format!("failed to load conflict declarations: {e}"))
         })?;
 
-        payloads
+        candidates
             .into_iter()
-            .map(|payload| decode_conflict_declaration_payload(actor, payload))
+            .map(|candidate| {
+                decode_conflict_declaration_recusal_candidate(actor, affected_dids, candidate)
+            })
             .collect()
     }
 
@@ -1014,6 +1016,72 @@ fn decode_conflict_declaration_payload(
         GatewayError::Internal(format!("invalid stored conflict declaration payload: {e}"))
     })?;
     validate_conflict_declaration(actor, declaration)
+}
+
+fn decode_conflict_declaration_recusal_candidate(
+    actor: &Did,
+    affected_dids: &[Did],
+    candidate: db::ConflictDeclarationRecusalCandidate,
+) -> std::result::Result<ConflictDeclaration, GatewayError> {
+    if candidate.declarant_did != actor.as_str() {
+        return Err(GatewayError::Internal(
+            "stored conflict declaration scalar declarant does not match requested actor".into(),
+        ));
+    }
+
+    let scalar_related_dids = parse_conflict_related_dids(&candidate.related_dids)?;
+    if !affected_dids
+        .iter()
+        .any(|affected| scalar_related_dids.contains(affected.as_str()))
+    {
+        return Err(GatewayError::Internal(
+            "stored conflict declaration scalar related DIDs do not match affected DIDs".into(),
+        ));
+    }
+
+    let declaration = decode_conflict_declaration_payload(actor, candidate.payload)?;
+    if declaration.nature != candidate.nature {
+        return Err(GatewayError::Internal(
+            "stored conflict declaration scalar nature does not match payload".into(),
+        ));
+    }
+
+    let payload_related_dids = declaration
+        .related_dids
+        .iter()
+        .map(|did| did.as_str().to_owned())
+        .collect::<BTreeSet<String>>();
+    if payload_related_dids != scalar_related_dids {
+        return Err(GatewayError::Internal(
+            "stored conflict declaration scalar related DIDs do not match payload".into(),
+        ));
+    }
+    if !affected_dids
+        .iter()
+        .any(|affected| declaration.related_dids.contains(affected))
+    {
+        return Err(GatewayError::Internal(
+            "stored conflict declaration payload does not match affected DIDs".into(),
+        ));
+    }
+
+    Ok(declaration)
+}
+
+fn parse_conflict_related_dids(
+    related_dids: &serde_json::Value,
+) -> std::result::Result<BTreeSet<String>, GatewayError> {
+    let values = serde_json::from_value::<Vec<String>>(related_dids.clone()).map_err(|e| {
+        GatewayError::Internal(format!(
+            "invalid stored conflict declaration scalar related DIDs: {e}"
+        ))
+    })?;
+    if values.is_empty() {
+        return Err(GatewayError::Internal(
+            "stored conflict declaration scalar related DIDs are empty".into(),
+        ));
+    }
+    Ok(values.into_iter().collect())
 }
 
 fn validate_conflict_declaration(
@@ -4733,6 +4801,51 @@ mod tests {
             "timestamp": { "physical_ms": 0, "logical": 0 }
         });
         assert!(decode_conflict_declaration_payload(&actor, zero_timestamp).is_err());
+    }
+
+    #[test]
+    fn conflict_recusal_candidate_validation_rejects_scalar_payload_shadowing() {
+        let actor = Did::new("did:exo:alice").expect("valid DID");
+        let affected = Did::new("did:exo:tenant-a").expect("valid DID");
+        let unrelated = Did::new("did:exo:tenant-b").expect("valid DID");
+
+        let nature_shadow = db::ConflictDeclarationRecusalCandidate {
+            declarant_did: actor.as_str().to_owned(),
+            nature: "financial ownership".to_owned(),
+            related_dids: serde_json::json!([affected.as_str()]),
+            payload: serde_json::json!({
+                "declarant_did": actor.as_str(),
+                "nature": "advisory",
+                "related_dids": [affected.as_str()],
+                "timestamp": { "physical_ms": 7000, "logical": 0 }
+            }),
+        };
+        assert!(
+            decode_conflict_declaration_recusal_candidate(
+                &actor,
+                std::slice::from_ref(&affected),
+                nature_shadow
+            )
+            .is_err(),
+            "scalar-blocking rows must fail closed when the canonical payload is advisory"
+        );
+
+        let related_shadow = db::ConflictDeclarationRecusalCandidate {
+            declarant_did: actor.as_str().to_owned(),
+            nature: "financial ownership".to_owned(),
+            related_dids: serde_json::json!([affected.as_str()]),
+            payload: serde_json::json!({
+                "declarant_did": actor.as_str(),
+                "nature": "financial ownership",
+                "related_dids": [unrelated.as_str()],
+                "timestamp": { "physical_ms": 7000, "logical": 0 }
+            }),
+        };
+        assert!(
+            decode_conflict_declaration_recusal_candidate(&actor, &[affected], related_shadow)
+                .is_err(),
+            "scalar-blocking rows must fail closed when the canonical payload does not name the affected DID"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- changes the recusal DB lookup to return scalar columns alongside the canonical payload
- validates scalar declarant, nature, and related DIDs against the decoded canonical payload before recusal enforcement
- fails closed when a scalar-blocking row is inconsistent, preventing it from shadowing a later genuine blocking declaration

## Path Classification
- `crates/exo-gateway/src/db.rs`: core runtime adapter persistence path
- `crates/exo-gateway/src/server.rs`: core runtime adapter vote-recusal loader

## RED Evidence
- `cargo test -p exo-gateway conflict_recusal_candidate_validation_rejects_scalar_payload_shadowing -- --nocapture` failed to compile before the fix because the DB returned payload-only rows and no recusal-candidate validator existed.
- `cargo test -p exo-gateway conflict_recusal_enforcement_uses_scoped_blocking_lookup_not_ui_list_cap -- --nocapture` failed before the fix after the source guard required scalar columns to be returned with the payload.

## Verification
- `cargo test -p exo-gateway conflict_recusal -- --nocapture`
- `cargo test -p exo-gateway -- --nocapture`
- `cargo test -p exo-governance conflict -- --nocapture`
- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p exo-gateway -p exo-governance --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `git diff --check`

## Bypass Search
- `rg -n "list_blocking_conflict_declaration_payloads_for_recusal_db|SELECT payload FROM conflict_declarations|decode_conflict_declaration_payload\\(actor, payload\\)|LIMIT 1" crates/exo-gateway/src/db.rs crates/exo-gateway/src/server.rs crates/exo-gateway/src/handlers.rs crates/exo-governance/src/conflict.rs -S`
- Remaining `SELECT payload FROM conflict_declarations` and `decode_conflict_declaration_payload(actor, payload)` hits are the generic admin/list loader, not the vote-recusal enforcement path.
