### PR TITLE
fix(node): redact invalid passport DID logs

### DIFF
--- a/crates/exo-node/src/passport.rs
+++ b/crates/exo-node/src/passport.rs
@@ -54,8 +54,8 @@ type PassportResult<T> = Result<T, PassportError>;
 const PASSPORT_CONCURRENCY_LIMIT: usize = 32;
 
 fn parse_passport_did(did: &str) -> PassportResult<exo_core::types::Did> {
-    exo_core::types::Did::new(did).map_err(|error| {
-        tracing::warn!(%error, "invalid passport DID path parameter");
+    exo_core::types::Did::new(did).map_err(|_| {
+        tracing::warn!("invalid passport DID path parameter");
         (StatusCode::BAD_REQUEST, "Invalid DID".to_string())
     })
 }
@@ -622,6 +622,29 @@ mod tests {
         assert!(
             !handlers.contains(".lock()"),
             "passport async handlers must not lock std::sync::Mutex values directly"
+        );
+    }
+
+    #[test]
+    fn passport_invalid_did_log_does_not_render_raw_parser_error() {
+        let source = include_str!("passport.rs");
+        let production = source
+            .split("// ---------------------------------------------------------------------------\n// Tests")
+            .next()
+            .unwrap();
+        let parse_helper = production
+            .split("fn parse_passport_did")
+            .nth(1)
+            .and_then(|section| section.split("// ---------------------------------------------------------------------------\n// Shared state").next())
+            .unwrap();
+
+        assert!(
+            !parse_helper.contains("%error") && !parse_helper.contains("error = %"),
+            "passport invalid-DID logging must not render ExoError::InvalidDid because it contains attacker-controlled DID text"
+        );
+        assert!(
+            parse_helper.contains("tracing::warn!(\"invalid passport DID path parameter\")"),
+            "passport invalid-DID logging must emit only a constant diagnostic"
         );
     }
 


### PR DESCRIPTION
## Summary
- classify `crates/exo-node/src/passport.rs` as a core runtime adapter for passport HTTP handlers
- stop rendering `ExoError::InvalidDid` in the invalid passport DID warning because it contains caller-controlled path text
- add a regression guard that keeps the passport invalid-DID log path constant-only while preserving redacted HTTP responses

## Verification
- RED: `cargo test -p exo-node passport_invalid_did_log_does_not_render_raw_parser_error -- --nocapture` failed on `%error` logging
- GREEN: `cargo test -p exo-node passport_invalid_did -- --nocapture`
- `cargo test -p exo-node passport -- --nocapture`
- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p exo-node --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `git diff --check`

## Bypass Search
- `rg -n "parse_passport_did|invalid passport DID|%error|error = %|Invalid DID: \{e\}|InvalidDid" crates/exo-node/src/passport.rs crates/exo-node/src/api.rs crates/exo-node/src/zerodentity/dashboard.rs`
- passport path now emits only `invalid passport DID path parameter`; the other hits are non-passport response text, not this server-side log sink.