### PR TITLE
fix(messaging): version encrypted envelope KDF

### DIFF
--- a/crates/exo-messaging/src/compose.rs
+++ b/crates/exo-messaging/src/compose.rs
@@ -28,7 +28,7 @@ use sha2::Sha256;
 use uuid::Uuid;
 
 use crate::{
-    envelope::{ContentType, EncryptedEnvelope},
+    envelope::{ContentType, EncryptedEnvelope, KDF_VERSION_TRANSCRIPT_SALTED},
     error::MessagingError,
     kex::{self, X25519KeyPair, X25519PublicKey},
 };
@@ -219,6 +219,7 @@ pub fn prepare_envelope_for_signing_with_ephemeral(
         sender_did: sender_did.clone(),
         recipient_did: recipient_did.clone(),
         ephemeral_public_key: *ephemeral_x25519_keypair.public.as_bytes(),
+        kdf_version: Some(KDF_VERSION_TRANSCRIPT_SALTED),
         ciphertext,
         content_type,
         signature: exo_core::Signature::empty(),

--- a/crates/exo-messaging/src/envelope.rs
+++ b/crates/exo-messaging/src/envelope.rs
@@ -32,17 +32,38 @@ use crate::error::MessagingError;
 
 /// Domain tag for encrypted-envelope signatures.
 pub const ENVELOPE_SIGNING_DOMAIN: &str = "exo.messaging.envelope.v1";
-const ENVELOPE_SIGNING_SCHEMA_VERSION: u16 = 1;
+const ENVELOPE_SIGNING_SCHEMA_VERSION_LEGACY: u16 = 1;
+const ENVELOPE_SIGNING_SCHEMA_VERSION_KDF_VERSIONED: u16 = 2;
+/// Pre-versioned unversioned KDF: X25519 ECDH expanded with unsalted HKDF.
+pub const KDF_VERSION_LEGACY_UNSALTED: u16 = 1;
+/// Current KDF: X25519 ECDH expanded with transcript-salted HKDF.
+pub const KDF_VERSION_TRANSCRIPT_SALTED: u16 = 2;
 pub const MAX_ENVELOPE_CIPHERTEXT_LEN: usize = 16 * 1024 * 1024;
 
 #[derive(Serialize)]
-struct EnvelopeSigningPayload<'a> {
+struct EnvelopeSigningPayloadV1<'a> {
     domain: &'static str,
     schema_version: u16,
     id: &'a str,
     sender_did: &'a Did,
     recipient_did: &'a Did,
     ephemeral_public_key: &'a [u8; 32],
+    ciphertext: &'a [u8],
+    content_type: u8,
+    release_on_death: bool,
+    release_delay_hours: u32,
+    created: &'a Timestamp,
+}
+
+#[derive(Serialize)]
+struct EnvelopeSigningPayloadV2<'a> {
+    domain: &'static str,
+    schema_version: u16,
+    id: &'a str,
+    sender_did: &'a Did,
+    recipient_did: &'a Did,
+    ephemeral_public_key: &'a [u8; 32],
+    kdf_version: u16,
     ciphertext: &'a [u8],
     content_type: u8,
     release_on_death: bool,
@@ -102,6 +123,12 @@ pub struct EncryptedEnvelope {
     pub recipient_did: Did,
     /// Ephemeral X25519 public key used for this message's ECDH.
     pub ephemeral_public_key: [u8; 32],
+    /// KDF version used to derive the symmetric key.
+    ///
+    /// `None` means the envelope was created before KDF versioning existed.
+    /// New envelopes must set [`KDF_VERSION_TRANSCRIPT_SALTED`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kdf_version: Option<u16>,
     /// Encrypted payload: `[nonce][ciphertext][tag]`.
     #[serde(deserialize_with = "deserialize_bounded_ciphertext")]
     pub ciphertext: Vec<u8>,
@@ -124,6 +151,7 @@ impl fmt::Debug for EncryptedEnvelope {
             .field("sender_did", &self.sender_did)
             .field("recipient_did", &self.recipient_did)
             .field("ephemeral_public_key", &"<redacted>")
+            .field("kdf_version", &self.kdf_version)
             .field("ciphertext_len", &self.ciphertext.len())
             .field("content_type", &self.content_type)
             .field("release_on_death", &self.release_on_death)
@@ -212,23 +240,65 @@ impl EncryptedEnvelope {
     /// Returns [`MessagingError::EnvelopeSigningPayloadEncoding`] if the CBOR
     /// encoder rejects the payload.
     pub fn signing_payload(&self) -> Result<Vec<u8>, MessagingError> {
-        let payload = EnvelopeSigningPayload {
-            domain: ENVELOPE_SIGNING_DOMAIN,
-            schema_version: ENVELOPE_SIGNING_SCHEMA_VERSION,
-            id: &self.id,
-            sender_did: &self.sender_did,
-            recipient_did: &self.recipient_did,
-            ephemeral_public_key: &self.ephemeral_public_key,
-            ciphertext: &self.ciphertext,
-            content_type: u8::from(self.content_type),
-            release_on_death: self.release_on_death,
-            release_delay_hours: self.release_delay_hours,
-            created: &self.created,
-        };
         let mut buf = Vec::new();
-        ciborium::ser::into_writer(&payload, &mut buf)
-            .map_err(|e| MessagingError::EnvelopeSigningPayloadEncoding(e.to_string()))?;
+        match self.kdf_version {
+            Some(kdf_version) => {
+                validate_kdf_version(kdf_version)?;
+                let payload = EnvelopeSigningPayloadV2 {
+                    domain: ENVELOPE_SIGNING_DOMAIN,
+                    schema_version: ENVELOPE_SIGNING_SCHEMA_VERSION_KDF_VERSIONED,
+                    id: &self.id,
+                    sender_did: &self.sender_did,
+                    recipient_did: &self.recipient_did,
+                    ephemeral_public_key: &self.ephemeral_public_key,
+                    kdf_version,
+                    ciphertext: &self.ciphertext,
+                    content_type: u8::from(self.content_type),
+                    release_on_death: self.release_on_death,
+                    release_delay_hours: self.release_delay_hours,
+                    created: &self.created,
+                };
+                ciborium::ser::into_writer(&payload, &mut buf)
+                    .map_err(|e| MessagingError::EnvelopeSigningPayloadEncoding(e.to_string()))?;
+            }
+            None => {
+                let payload = EnvelopeSigningPayloadV1 {
+                    domain: ENVELOPE_SIGNING_DOMAIN,
+                    schema_version: ENVELOPE_SIGNING_SCHEMA_VERSION_LEGACY,
+                    id: &self.id,
+                    sender_did: &self.sender_did,
+                    recipient_did: &self.recipient_did,
+                    ephemeral_public_key: &self.ephemeral_public_key,
+                    ciphertext: &self.ciphertext,
+                    content_type: u8::from(self.content_type),
+                    release_on_death: self.release_on_death,
+                    release_delay_hours: self.release_delay_hours,
+                    created: &self.created,
+                };
+                ciborium::ser::into_writer(&payload, &mut buf)
+                    .map_err(|e| MessagingError::EnvelopeSigningPayloadEncoding(e.to_string()))?;
+            }
+        }
         Ok(buf)
+    }
+}
+
+pub fn validate_kdf_version(kdf_version: u16) -> Result<(), MessagingError> {
+    match kdf_version {
+        KDF_VERSION_LEGACY_UNSALTED | KDF_VERSION_TRANSCRIPT_SALTED => Ok(()),
+        other => Err(MessagingError::InvalidEnvelope(format!(
+            "unsupported envelope KDF version {other}"
+        ))),
+    }
+}
+
+pub fn explicit_kdf_version(envelope: &EncryptedEnvelope) -> Result<Option<u16>, MessagingError> {
+    match envelope.kdf_version {
+        Some(kdf_version) => {
+            validate_kdf_version(kdf_version)?;
+            Ok(Some(kdf_version))
+        }
+        None => Ok(None),
     }
 }
 
@@ -292,6 +362,8 @@ mod tests {
         sender_did: Did,
         recipient_did: Did,
         ephemeral_public_key: [u8; 32],
+        #[serde(default)]
+        kdf_version: Option<u16>,
         ciphertext: Vec<u8>,
         content_type: u8,
         release_on_death: bool,
@@ -305,6 +377,7 @@ mod tests {
             sender_did: Did::new("did:exo:alice").unwrap(),
             recipient_did: Did::new("did:exo:bob").unwrap(),
             ephemeral_public_key: [7; 32],
+            kdf_version: None,
             ciphertext: vec![1, 1, 2, 3, 5, 8],
             content_type: ContentType::Secret,
             signature: Signature::empty(),
@@ -329,11 +402,49 @@ mod tests {
         assert_eq!(decoded.sender_did, envelope.sender_did);
         assert_eq!(decoded.recipient_did, envelope.recipient_did);
         assert_eq!(decoded.ephemeral_public_key, envelope.ephemeral_public_key);
+        assert_eq!(decoded.kdf_version, None);
         assert_eq!(decoded.ciphertext, envelope.ciphertext);
         assert_eq!(decoded.content_type, u8::from(envelope.content_type));
         assert_eq!(decoded.release_on_death, envelope.release_on_death);
         assert_eq!(decoded.release_delay_hours, envelope.release_delay_hours);
         assert_eq!(decoded.created, envelope.created);
+    }
+
+    #[test]
+    fn versioned_envelope_signing_payload_binds_kdf_version() {
+        let mut envelope = sample_envelope();
+        envelope.kdf_version = Some(KDF_VERSION_TRANSCRIPT_SALTED);
+
+        let payload = envelope
+            .signing_payload()
+            .expect("versioned envelope signing payload");
+        let decoded: DecodedEnvelopeSigningPayload =
+            ciborium::from_reader(&payload[..]).expect("decode versioned payload");
+
+        assert_eq!(decoded.schema_version, 2);
+        assert_eq!(decoded.kdf_version, Some(KDF_VERSION_TRANSCRIPT_SALTED));
+
+        let mut tampered = envelope.clone();
+        tampered.kdf_version = Some(KDF_VERSION_LEGACY_UNSALTED);
+        let tampered_payload = tampered
+            .signing_payload()
+            .expect("tampered KDF version is still supported");
+
+        assert_ne!(payload, tampered_payload);
+    }
+
+    #[test]
+    fn envelope_signing_payload_rejects_unknown_kdf_version() {
+        let mut envelope = sample_envelope();
+        envelope.kdf_version = Some(99);
+
+        let err = envelope
+            .signing_payload()
+            .expect_err("unknown KDF version must fail closed");
+
+        assert!(
+            matches!(err, MessagingError::InvalidEnvelope(reason) if reason.contains("unsupported envelope KDF version 99"))
+        );
     }
 
     #[test]

--- a/crates/exo-messaging/src/kex.rs
+++ b/crates/exo-messaging/src/kex.rs
@@ -183,6 +183,41 @@ pub fn derive_shared_key(
     their_public: &X25519PublicKey,
     context: &[u8],
 ) -> Result<[u8; 32], MessagingError> {
+    let (shared_secret, our_public) = x25519_shared_secret(our_secret, their_public)?;
+    let salt = hkdf_salt(&our_public, their_public);
+
+    // HKDF-SHA256: extract from shared secret with a deterministic transcript
+    // salt, then expand with caller-supplied context.
+    let hk = Hkdf::<Sha256>::new(Some(&salt), &shared_secret);
+    let mut okm = [0u8; 32];
+    hk.expand(context, &mut okm)
+        .map_err(|e| MessagingError::KeyExchangeFailed(e.to_string()))?;
+    Ok(okm)
+}
+
+/// Derive the pre-versioned legacy symmetric key via unsalted HKDF-SHA256.
+///
+/// This is retained only so unversioned envelopes created before the transcript
+/// salt was introduced can still be opened. New envelopes must use
+/// [`derive_shared_key`], which binds the HKDF extract step to both X25519
+/// public keys.
+pub fn derive_shared_key_legacy_unsalted(
+    our_secret: &X25519SecretKey,
+    their_public: &X25519PublicKey,
+    context: &[u8],
+) -> Result<[u8; 32], MessagingError> {
+    let (shared_secret, _) = x25519_shared_secret(our_secret, their_public)?;
+    let hk = Hkdf::<Sha256>::new(None, &shared_secret);
+    let mut okm = [0u8; 32];
+    hk.expand(context, &mut okm)
+        .map_err(|e| MessagingError::KeyExchangeFailed(e.to_string()))?;
+    Ok(okm)
+}
+
+fn x25519_shared_secret(
+    our_secret: &X25519SecretKey,
+    their_public: &X25519PublicKey,
+) -> Result<([u8; 32], X25519PublicKey), MessagingError> {
     let secret = our_secret.static_secret();
     let public = PublicKey::from(*their_public.as_bytes());
     let shared_secret = secret.diffie_hellman(&public);
@@ -192,15 +227,7 @@ pub fn derive_shared_key(
         ));
     }
     let our_public = X25519PublicKey::from_trusted_bytes(PublicKey::from(&secret).to_bytes());
-    let salt = hkdf_salt(&our_public, their_public);
-
-    // HKDF-SHA256: extract from shared secret with a deterministic transcript
-    // salt, then expand with caller-supplied context.
-    let hk = Hkdf::<Sha256>::new(Some(&salt), shared_secret.as_bytes());
-    let mut okm = [0u8; 32];
-    hk.expand(context, &mut okm)
-        .map_err(|e| MessagingError::KeyExchangeFailed(e.to_string()))?;
-    Ok(okm)
+    Ok((*shared_secret.as_bytes(), our_public))
 }
 
 fn hkdf_salt(our_public: &X25519PublicKey, their_public: &X25519PublicKey) -> [u8; 32] {
@@ -446,9 +473,32 @@ mod tests {
     #[test]
     fn derive_shared_key_uses_protocol_bound_hkdf_salt() {
         let source = include_str!("kex.rs");
+        let derive_shared_key = source
+            .split("pub fn derive_shared_key(")
+            .nth(1)
+            .and_then(|section| section.split("/// Derive the pre-versioned legacy").next())
+            .expect("current derive_shared_key must be present");
+
         assert!(
-            !source.contains(&["Hkdf::<Sha256>::new", "(None"].concat()),
-            "X25519 shared-secret HKDF extraction must use a protocol-bound salt"
+            derive_shared_key.contains("hkdf_salt(&our_public, their_public)")
+                && derive_shared_key.contains("Hkdf::<Sha256>::new(Some(&salt), &shared_secret)")
+                && !derive_shared_key.contains("Hkdf::<Sha256>::new(None"),
+            "current X25519 shared-secret HKDF extraction must use a protocol-bound salt"
+        );
+    }
+
+    #[test]
+    fn legacy_unsalted_kdf_is_quarantined_for_unversioned_compatibility() {
+        let source = include_str!("kex.rs");
+        let legacy = source
+            .split("pub fn derive_shared_key_legacy_unsalted(")
+            .nth(1)
+            .and_then(|section| section.split("fn x25519_shared_secret").next())
+            .expect("legacy compatibility derive must be present");
+
+        assert!(
+            legacy.contains("Hkdf::<Sha256>::new(None, &shared_secret)"),
+            "legacy unsalted HKDF must be isolated to the explicitly named compatibility helper"
         );
     }
 }

--- a/crates/exo-messaging/src/open.rs
+++ b/crates/exo-messaging/src/open.rs
@@ -24,7 +24,10 @@ use exo_core::{PublicKey, crypto};
 use exo_identity::vault::VaultEncryptor;
 
 use crate::{
-    envelope::EncryptedEnvelope,
+    envelope::{
+        EncryptedEnvelope, KDF_VERSION_LEGACY_UNSALTED, KDF_VERSION_TRANSCRIPT_SALTED,
+        explicit_kdf_version,
+    },
     error::MessagingError,
     kex::{self, X25519PublicKey, X25519SecretKey},
 };
@@ -56,20 +59,67 @@ pub fn unlock(
 
     // 2. ECDH: derive shared symmetric key from ephemeral public + our secret
     let ephemeral_pub = X25519PublicKey::from_bytes(envelope.ephemeral_public_key)?;
-    let shared_key =
-        kex::derive_shared_key(recipient_x25519_secret, &ephemeral_pub, MESSAGE_KEX_CONTEXT)?;
+    let explicit_kdf_version = explicit_kdf_version(envelope)?;
 
-    // 3. Decrypt with XChaCha20-Poly1305
-    //    Associated data = recipient DID (must match what was used during encryption)
+    match explicit_kdf_version {
+        Some(KDF_VERSION_TRANSCRIPT_SALTED) => {
+            let shared_key = kex::derive_shared_key(
+                recipient_x25519_secret,
+                &ephemeral_pub,
+                MESSAGE_KEX_CONTEXT,
+            )?;
+            decrypt_with_key(envelope, shared_key)
+        }
+        Some(KDF_VERSION_LEGACY_UNSALTED) => {
+            let shared_key = kex::derive_shared_key_legacy_unsalted(
+                recipient_x25519_secret,
+                &ephemeral_pub,
+                MESSAGE_KEX_CONTEXT,
+            )?;
+            decrypt_with_key(envelope, shared_key)
+        }
+        None => unlock_unversioned_envelope(envelope, recipient_x25519_secret, &ephemeral_pub),
+        Some(_) => Err(MessagingError::InvalidEnvelope(
+            "unsupported envelope KDF version".to_owned(),
+        )),
+    }
+}
+
+fn unlock_unversioned_envelope(
+    envelope: &EncryptedEnvelope,
+    recipient_x25519_secret: &X25519SecretKey,
+    ephemeral_pub: &X25519PublicKey,
+) -> Result<Vec<u8>, MessagingError> {
+    let legacy_key = kex::derive_shared_key_legacy_unsalted(
+        recipient_x25519_secret,
+        ephemeral_pub,
+        MESSAGE_KEX_CONTEXT,
+    )?;
+    match decrypt_with_key(envelope, legacy_key) {
+        Ok(plaintext) => Ok(plaintext),
+        Err(MessagingError::DecryptionFailed) => {
+            let salted_key = kex::derive_shared_key(
+                recipient_x25519_secret,
+                ephemeral_pub,
+                MESSAGE_KEX_CONTEXT,
+            )?;
+            decrypt_with_key(envelope, salted_key)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn decrypt_with_key(
+    envelope: &EncryptedEnvelope,
+    shared_key: [u8; 32],
+) -> Result<Vec<u8>, MessagingError> {
     let encryptor = VaultEncryptor::from_key(shared_key);
-    let plaintext = encryptor
+    encryptor
         .decrypt(
             &envelope.ciphertext,
             envelope.recipient_did.as_str().as_bytes(),
         )
-        .map_err(|_| MessagingError::DecryptionFailed)?;
-
-    Ok(plaintext)
+        .map_err(|_| MessagingError::DecryptionFailed)
 }
 
 // ===========================================================================
@@ -78,8 +128,11 @@ pub fn unlock(
 
 #[cfg(test)]
 mod tests {
-    use exo_core::{Did, Timestamp, crypto::generate_keypair};
+    use exo_core::{Did, Signature, Timestamp, crypto::generate_keypair};
+    use hkdf::Hkdf;
+    use sha2::Sha256;
     use uuid::Uuid;
+    use x25519_dalek::{PublicKey as DalekX25519PublicKey, StaticSecret};
 
     use super::*;
     use crate::{
@@ -95,6 +148,20 @@ mod tests {
 
     fn x25519_keypair(seed: u8) -> X25519KeyPair {
         X25519KeyPair::from_secret_bytes([seed; 32]).expect("valid deterministic X25519 keypair")
+    }
+
+    fn legacy_unsalted_shared_key(
+        ephemeral_secret_seed: u8,
+        recipient_public: &X25519PublicKey,
+    ) -> [u8; 32] {
+        let secret = StaticSecret::from([ephemeral_secret_seed; 32]);
+        let public = DalekX25519PublicKey::from(*recipient_public.as_bytes());
+        let shared_secret = secret.diffie_hellman(&public);
+        let hk = Hkdf::<Sha256>::new(None, shared_secret.as_bytes());
+        let mut okm = [0u8; 32];
+        hk.expand(MESSAGE_KEX_CONTEXT, &mut okm)
+            .expect("legacy HKDF expands");
+        okm
     }
 
     fn legacy_signable_bytes(envelope: &EncryptedEnvelope) -> Vec<u8> {
@@ -136,9 +203,139 @@ mod tests {
         )
         .expect("lock_and_send");
 
+        assert_eq!(envelope.kdf_version, Some(KDF_VERSION_TRANSCRIPT_SALTED));
+
         let decrypted = unlock(&envelope, &recipient_kp.secret, &sender_pk).expect("unlock");
 
         assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn unlock_accepts_legacy_unsalted_unversioned_envelope() {
+        let sender_did = Did::new("did:exo:alice").unwrap();
+        let recipient_did = Did::new("did:exo:bob").unwrap();
+        let (sender_pk, sender_sk) = generate_keypair();
+        let recipient_kp = x25519_keypair(0x48);
+        let ephemeral_kp = x25519_keypair(0x58);
+        let plaintext = b"legacy encrypted message";
+
+        let legacy_key = legacy_unsalted_shared_key(0x58, &recipient_kp.public);
+        let encryptor = VaultEncryptor::from_key(legacy_key);
+        let ciphertext = encryptor
+            .encrypt_with_nonce(plaintext, recipient_did.as_str().as_bytes(), &[0x7c_u8; 24])
+            .expect("legacy encrypt");
+
+        let mut envelope = EncryptedEnvelope {
+            id: "018f7a96-8ad0-7c4f-8e0f-111111111131".to_owned(),
+            sender_did,
+            recipient_did,
+            ephemeral_public_key: *ephemeral_kp.public.as_bytes(),
+            kdf_version: None,
+            ciphertext,
+            content_type: ContentType::Secret,
+            signature: Signature::empty(),
+            release_on_death: false,
+            release_delay_hours: 0,
+            created: Timestamp::new(8_000, 0),
+        };
+        envelope.signature =
+            exo_core::crypto::sign(&envelope.signing_payload().unwrap(), &sender_sk);
+
+        let decrypted = unlock(&envelope, &recipient_kp.secret, &sender_pk).expect("unlock");
+
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn unlock_accepts_unversioned_transcript_salted_transition_envelope() {
+        let sender_did = Did::new("did:exo:alice").unwrap();
+        let recipient_did = Did::new("did:exo:bob").unwrap();
+        let (sender_pk, sender_sk) = generate_keypair();
+        let recipient_kp = x25519_keypair(0x49);
+        let ephemeral_kp = x25519_keypair(0x59);
+        let plaintext = b"transition encrypted message";
+
+        let mut envelope = lock_and_send_with_ephemeral(
+            plaintext,
+            ContentType::Secret,
+            &sender_did,
+            &recipient_did,
+            &sender_sk,
+            &recipient_kp.public,
+            &ephemeral_kp,
+            metadata(0x018f_7a96_8ad0_7c4f_8e0f_1111_1111_1132),
+            false,
+            0,
+        )
+        .expect("lock_and_send");
+        envelope.kdf_version = None;
+        envelope.signature =
+            exo_core::crypto::sign(&envelope.signing_payload().unwrap(), &sender_sk);
+
+        let decrypted = unlock(&envelope, &recipient_kp.secret, &sender_pk).expect("unlock");
+
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn unlock_rejects_explicit_kdf_version_tampering() {
+        let sender_did = Did::new("did:exo:alice").unwrap();
+        let recipient_did = Did::new("did:exo:bob").unwrap();
+        let (sender_pk, sender_sk) = generate_keypair();
+        let recipient_kp = x25519_keypair(0x4a);
+        let ephemeral_kp = x25519_keypair(0x5a);
+
+        let mut envelope = lock_and_send_with_ephemeral(
+            b"kdf tamper",
+            ContentType::Secret,
+            &sender_did,
+            &recipient_did,
+            &sender_sk,
+            &recipient_kp.public,
+            &ephemeral_kp,
+            metadata(0x018f_7a96_8ad0_7c4f_8e0f_1111_1111_1133),
+            false,
+            0,
+        )
+        .expect("lock_and_send");
+        envelope.kdf_version = Some(KDF_VERSION_LEGACY_UNSALTED);
+
+        let result = unlock(&envelope, &recipient_kp.secret, &sender_pk);
+
+        assert!(matches!(
+            result,
+            Err(MessagingError::SignatureVerificationFailed)
+        ));
+    }
+
+    #[test]
+    fn unlock_rejects_unknown_explicit_kdf_version() {
+        let sender_did = Did::new("did:exo:alice").unwrap();
+        let recipient_did = Did::new("did:exo:bob").unwrap();
+        let (sender_pk, sender_sk) = generate_keypair();
+        let recipient_kp = x25519_keypair(0x4b);
+        let ephemeral_kp = x25519_keypair(0x5b);
+
+        let mut envelope = lock_and_send_with_ephemeral(
+            b"kdf unknown",
+            ContentType::Secret,
+            &sender_did,
+            &recipient_did,
+            &sender_sk,
+            &recipient_kp.public,
+            &ephemeral_kp,
+            metadata(0x018f_7a96_8ad0_7c4f_8e0f_1111_1111_1134),
+            false,
+            0,
+        )
+        .expect("lock_and_send");
+        envelope.kdf_version = Some(99);
+
+        let result = unlock(&envelope, &recipient_kp.secret, &sender_pk);
+
+        assert!(
+            matches!(result, Err(MessagingError::InvalidEnvelope(reason)) if reason.contains("unsupported envelope KDF version 99"))
+        );
     }
 
     #[test]

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -379,6 +379,9 @@ test('wasm_prepare_encrypted_message', () => {
   if (!preparedEnvelope.signing_payload_hex) {
     throw new Error('prepared envelope must expose signing payload');
   }
+  if (preparedEnvelope.envelope.kdf_version !== 2) {
+    throw new Error('prepared envelope must expose explicit transcript-salted KDF version');
+  }
   return preparedEnvelope;
 });
 


### PR DESCRIPTION
## Summary
- classify `crates/exo-messaging/*` as EXOCHAIN core messaging and `packages/exochain-wasm/test/bridge_verification.mjs` as the WASM runtime adapter test surface
- add explicit signed `kdf_version` support to encrypted envelopes; new messages use transcript-salted KDF version 2
- preserve unversioned legacy signing payloads and decrypt both pre-salt legacy envelopes and the interim unversioned transcript-salted envelopes
- keep unsalted HKDF quarantined in a named compatibility helper only

## Verification
- RED: `cargo test -p exo-messaging unlock_accepts_legacy_unsalted_unversioned_envelope -- --nocapture` failed with `DecryptionFailed` after signature verification
- GREEN: `cargo test -p exo-messaging -- --nocapture`
- `cargo test -p exochain-wasm messaging -- --nocapture`
- `cargo test -p exochain-wasm -- --nocapture`
- `node --check packages/exochain-wasm/test/bridge_verification.mjs`
- `wasm-pack build crates/exochain-wasm --target nodejs --out-dir /Users/bobstewart/dev/exochain/packages/exochain-wasm/wasm --release`
- `node packages/exochain-wasm/test/bridge_verification.mjs`
- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p exo-messaging --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `git diff --check`

## Bypass Search
- `rg -n "kdf_version|KDF_VERSION|derive_shared_key_legacy_unsalted|Hkdf::<Sha256>::new\(None|derive_shared_key\(" crates/exo-messaging/src/kex.rs crates/exo-messaging/src/open.rs crates/exo-messaging/src/envelope.rs crates/exo-messaging/src/compose.rs`
- `rg -n "EncryptedEnvelope \{|kdf_version|wasm_encrypt_message|unlock\(" crates/exochain-wasm/src packages/exochain-wasm/test crates/exo-messaging/src -g "*.rs" -g "*.mjs"`

## Compatibility
- explicit version 2 envelopes bind KDF version into the canonical signing payload
- missing `kdf_version` remains a legacy wire shape: unlock first tries legacy unsalted HKDF, then the interim unversioned transcript-salted KDF, both only after signature verification.