### PR TITLE
fix(consensus): lower confidence without consensus

### DIFF
--- a/crates/exo-consensus/src/lib.rs
+++ b/crates/exo-consensus/src/lib.rs
@@ -176,6 +176,7 @@ mod tests {
         let inputs = PanelConfidenceInputs {
             models_agreeing: 3,
             total_models: 3,
+            converged: true,
             rounds_to_convergence: 1,
             max_rounds: 3,
             devil_found_serious_objection: false,
@@ -195,6 +196,7 @@ mod tests {
         let inputs = PanelConfidenceInputs {
             models_agreeing: 2,
             total_models: 3,
+            converged: true,
             rounds_to_convergence: 3,
             max_rounds: 3,
             devil_found_serious_objection: false,
@@ -214,6 +216,7 @@ mod tests {
         let inputs = PanelConfidenceInputs {
             models_agreeing: 3,
             total_models: 3,
+            converged: true,
             rounds_to_convergence: 1,
             max_rounds: 3,
             devil_found_serious_objection: true,

--- a/crates/exo-consensus/src/scoring.rs
+++ b/crates/exo-consensus/src/scoring.rs
@@ -20,6 +20,7 @@ use std::collections::BTreeSet;
 pub struct PanelConfidenceInputs {
     pub models_agreeing: u32,
     pub total_models: u32,
+    pub converged: bool,
     pub rounds_to_convergence: u32,
     pub max_rounds: u32,
     pub devil_found_serious_objection: bool,
@@ -144,7 +145,7 @@ pub fn calculate_panel_confidence(inputs: &PanelConfidenceInputs) -> u64 {
     }
 
     // 2. Speed of Convergence (30%)
-    if inputs.max_rounds > 0 {
+    if inputs.converged && inputs.max_rounds > 0 {
         // Original formula: (max - r + 1) / max * 3000.
         // When r = 1 and max = N, this gives the full 3000 (fastest observed convergence).
         // Guard against r = 0 (or any r < 1) which would push numerator above max
@@ -212,6 +213,7 @@ mod proptests {
             let inputs = PanelConfidenceInputs {
                 models_agreeing,
                 total_models,
+                converged: true,
                 rounds_to_convergence,
                 max_rounds,
                 devil_found_serious_objection: devil,
@@ -252,5 +254,26 @@ mod proptests {
             vec!["C".to_string()],
         ]);
         assert_eq!(score, 0);
+    }
+
+    #[test]
+    fn panel_confidence_does_not_award_speed_without_convergence() {
+        let converged = PanelConfidenceInputs {
+            models_agreeing: 3,
+            total_models: 3,
+            converged: true,
+            rounds_to_convergence: 1,
+            max_rounds: 3,
+            devil_found_serious_objection: false,
+            minority_reports_count: 0,
+        };
+        let converged_score = calculate_panel_confidence(&converged);
+        let not_converged = PanelConfidenceInputs {
+            converged: false,
+            ..converged
+        };
+
+        assert_eq!(converged_score, 10_000);
+        assert_eq!(calculate_panel_confidence(&not_converged), 7_000);
     }
 }

--- a/crates/exo-consensus/src/session.rs
+++ b/crates/exo-consensus/src/session.rs
@@ -264,18 +264,26 @@ impl DeliberationSession {
         let claim_sets = position_claim_sets(&last_round.positions);
         let consensus_claims =
             consensus_claims_at_threshold(&claim_sets, panel.convergence_threshold_bps);
+        let no_consensus_claims = consensus_claims.is_empty();
 
         for pos in last_round.positions.values() {
-            if is_minority_report(pos, &consensus_claims, panel.convergence_threshold_bps) {
-                let missing_claims = missing_consensus_claims(pos, &consensus_claims);
+            if no_consensus_claims
+                || is_minority_report(pos, &consensus_claims, panel.convergence_threshold_bps)
+            {
+                let reasons = if no_consensus_claims {
+                    vec!["No structured consensus claims met threshold.".to_string()]
+                } else {
+                    let missing_claims = missing_consensus_claims(pos, &consensus_claims);
+                    vec![format!(
+                        "Missing structured consensus claims: {}",
+                        missing_claims.join(", ")
+                    )]
+                };
                 minority_reports.push(MinorityReport {
                     model_id: pos.model_id.clone(),
                     round: pos.round,
                     dissenting_position: pos.position_text.clone(),
-                    reasons: vec![format!(
-                        "Missing structured consensus claims: {}",
-                        missing_claims.join(", ")
-                    )],
+                    reasons,
                     divergence_score_bps: 10_000u64
                         .saturating_sub(last_round.convergence_score_bps),
                 });
@@ -300,10 +308,17 @@ impl DeliberationSession {
         let minority_reports_count =
             usize_to_u32("minority_reports_count", minority_reports.len())?;
         let rounds_to_convergence = usize_to_u32("rounds_to_convergence", rounds.len())?;
+        let converged = last_round.convergence_score_bps >= panel.convergence_threshold_bps;
+        let models_agreeing = if no_consensus_claims {
+            0
+        } else {
+            panelists_count.saturating_sub(minority_reports_count)
+        };
 
         let inputs = PanelConfidenceInputs {
-            models_agreeing: panelists_count.saturating_sub(minority_reports_count),
+            models_agreeing,
             total_models: panelists_count,
+            converged,
             rounds_to_convergence,
             max_rounds: panel.max_rounds,
             devil_found_serious_objection: serious_objection,
@@ -532,6 +547,38 @@ mod tests {
         // Zero overlap across three distinct claims => 0 bps, clearly below the 7500 threshold.
         assert_eq!(round.convergence_score_bps, 0);
         assert!(!session.is_converged());
+    }
+
+    #[test]
+    fn finalize_no_consensus_does_not_award_full_panel_confidence() {
+        let panel = Panel::default_panel(DecisionClass::Routine);
+        let responses = BTreeMap::from([
+            (
+                "claude-3-haiku".to_string(),
+                response("alpha position", &["alpha"]),
+            ),
+            (
+                "gpt-4o-mini".to_string(),
+                response("beta position", &["beta"]),
+            ),
+            (
+                "gemini-1.5-flash".to_string(),
+                response("gamma position", &["gamma"]),
+            ),
+        ]);
+        let provider = DeterministicResponseProvider::with_positions(responses);
+        let mut session = DeliberationSession::new("s".into(), panel, "Q?".into(), provider);
+
+        let round = session.execute_round(timing(1)).unwrap();
+        assert_eq!(round.convergence_score_bps, 0);
+        let result = session.finalize(finalization_timing()).unwrap();
+
+        assert_eq!(result.minority_reports.len(), 3);
+        assert!(
+            result.panel_confidence_index_bps <= 2_000,
+            "no-consensus deliberation must not receive high confidence, got {}",
+            result.panel_confidence_index_bps
+        );
     }
 
     // Covers is_converged false branch when no rounds have been executed yet.


### PR DESCRIPTION
## Summary
- classify `crates/exo-consensus/*` as EXOCHAIN core deliberation/scoring logic
- treat empty consensus-claim sets as no model agreement during finalization
- emit minority reports for every panelist when no structured consensus claims meet threshold
- award the speed component in Panel Confidence only when the final round actually converged

## Verification
- RED: `cargo test -p exo-consensus finalize_no_consensus_does_not_award_full_panel_confidence -- --nocapture` failed because no minority reports were emitted and confidence stayed high
- GREEN: `cargo test -p exo-consensus finalize_no_consensus_does_not_award_full_panel_confidence -- --nocapture`
- `cargo test -p exo-consensus panel_confidence_does_not_award_speed_without_convergence -- --nocapture`
- `cargo test -p exo-consensus -- --nocapture`
- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p exo-consensus --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `git diff --check`

## Bypass Search
- `rg -n "converged|models_agreeing|no_consensus_claims|consensus_claims\.is_empty|PanelConfidenceInputs \{" crates/exo-consensus/src`
- Finalization now explicitly branches on `no_consensus_claims`; scoring no longer treats fast finalization as convergence unless `converged` is true.