### PR TITLE
fix(node): bound zerodentity erasure DAG timestamps

### DIFF
--- a/crates/exo-node/src/zerodentity/api.rs
+++ b/crates/exo-node/src/zerodentity/api.rs
@@ -54,7 +54,7 @@ use super::{
     device_behavioral_axes_enabled,
     session_auth::{public_key_from_session_bytes, request_signing_payload, signature_from_hex},
     session_clock::{SessionClock, SessionClockError, TRUSTED_SESSION_CLOCK_UNAVAILABLE},
-    store::ZerodentityStore,
+    store::{ZERODENTITY_ERASURE_MAX_FUTURE_SKEW_MS, ZerodentityStore},
     types::{
         AttestationType, BehavioralSample, DeviceFingerprint, IdentityClaim, ZerodentityScore,
     },
@@ -277,6 +277,14 @@ fn store_error(error: impl std::fmt::Display) -> (StatusCode, Json<serde_json::V
 fn store_operation_failed(operation: &'static str) -> (StatusCode, Json<serde_json::Value>) {
     tracing::error!(operation, "0dentity API store operation failed");
     json_error(StatusCode::INTERNAL_SERVER_ERROR, "Store operation failed")
+}
+
+fn erasure_store_error(error: impl std::fmt::Display) -> (StatusCode, Json<serde_json::Value>) {
+    let reason = error.to_string();
+    if reason.contains("erasure timestamp") {
+        return bad_request(&reason);
+    }
+    store_error(reason)
 }
 
 async fn with_store_blocking<T, F>(state: ApiState, operation: F) -> ApiResult<T>
@@ -1010,12 +1018,22 @@ pub async fn delete_identity(
     if erased_ms == 0 {
         return Err(bad_request("erased_ms must be greater than 0"));
     }
+    let validation_ms = state.now_ms()?;
+    if erased_ms > validation_ms.saturating_add(ZERODENTITY_ERASURE_MAX_FUTURE_SKEW_MS) {
+        return Err(bad_request(
+            "erased_ms exceeds trusted erasure clock tolerance",
+        ));
+    }
 
     let subject_did = did.to_string();
     let erasure_evidence = with_store_blocking(state, move |store| {
         store
-            .erase_did_with_evidence(&did, Timestamp::new(erased_ms, 0))
-            .map_err(store_error)
+            .erase_did_with_evidence(
+                &did,
+                Timestamp::new(erased_ms, 0),
+                Timestamp::new(validation_ms, 0),
+            )
+            .map_err(erasure_store_error)
     })
     .await?;
 
@@ -1307,7 +1325,7 @@ mod tests {
     }
 
     #[test]
-    fn erasure_write_path_does_not_fabricate_runtime_time() {
+    fn erasure_write_path_uses_trusted_session_clock_for_validation_time() {
         let source = include_str!("api.rs");
         let erasure_section = source
             .split("// DELETE /api/v1/0dentity/:did")
@@ -1315,7 +1333,10 @@ mod tests {
             .and_then(|section| section.split("// ---------------------------------------------------------------------------\n// Router").next())
             .unwrap();
 
-        assert!(!erasure_section.contains("now_ms()"));
+        assert!(erasure_section.contains("state.now_ms()?"));
+        assert!(erasure_section.contains("ZERODENTITY_ERASURE_MAX_FUTURE_SKEW_MS"));
+        assert!(!erasure_section.contains("SystemTime"));
+        assert!(!erasure_section.contains("Instant::now"));
     }
 
     fn test_keypair(seed: u8) -> KeyPair {
@@ -2198,6 +2219,30 @@ mod tests {
         assert_eq!(
             result["error"].as_str().unwrap(),
             "erased_ms must be greater than 0"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_identity_rejects_far_future_erasure_timestamp() {
+        let keypair = test_keypair(46);
+        let state =
+            make_state_with_signed_session_and_claim("tok-alice", "did:exo:alice", &keypair);
+        let app = zerodentity_api_router(state);
+        let resp = signed_delete(
+            app,
+            "/api/v1/0dentity/did%3Aexo%3Aalice",
+            "tok-alice",
+            "nonce-api-delete-future-time",
+            serde_json::json!({ "erased_ms": u64::MAX }),
+            &keypair,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            result["error"].as_str().unwrap(),
+            "erased_ms exceeds trusted erasure clock tolerance"
         );
     }
 

--- a/crates/exo-node/src/zerodentity/store.rs
+++ b/crates/exo-node/src/zerodentity/store.rs
@@ -48,6 +48,9 @@ pub type ReceiptSigner = Arc<dyn Fn(&[u8]) -> Signature + Send + Sync>;
 
 /// The current 0dentity store is intentionally volatile process memory.
 pub const ZERODENTITY_STORE_PERSISTENCE_READY: bool = false;
+/// Maximum future skew allowed between a caller-signed erasure timestamp and
+/// the trusted validation timestamp supplied by the runtime.
+pub const ZERODENTITY_ERASURE_MAX_FUTURE_SKEW_MS: u64 = 500;
 
 /// Startup warning emitted while 0dentity data is not durable.
 pub const ZERODENTITY_STORE_PERSISTENCE_WARNING: &str = "0dentity store is memory only; claims, sessions, OTPs, scores, and receipts are not durable across process restarts";
@@ -312,6 +315,34 @@ impl ZerodentityStore {
             timestamp,
             signature,
         })
+    }
+
+    fn validate_erasure_timestamp(
+        &self,
+        timestamp: Timestamp,
+        validation_time: Timestamp,
+    ) -> anyhow::Result<()> {
+        if timestamp.physical_ms == 0 {
+            anyhow::bail!("0dentity erasure timestamp must be greater than 0");
+        }
+        if validation_time.physical_ms == 0 {
+            anyhow::bail!("0dentity erasure validation timestamp must be greater than 0");
+        }
+        if timestamp.physical_ms
+            > validation_time
+                .physical_ms
+                .saturating_add(ZERODENTITY_ERASURE_MAX_FUTURE_SKEW_MS)
+        {
+            anyhow::bail!("0dentity erasure timestamp exceeds trusted erasure clock tolerance");
+        }
+        if let Some(parent) = self.dag_nodes.last() {
+            if timestamp <= parent.timestamp {
+                anyhow::bail!(
+                    "0dentity erasure timestamp must strictly exceed latest DAG parent timestamp"
+                );
+            }
+        }
+        Ok(())
     }
 
     // -----------------------------------------------------------------------
@@ -728,13 +759,12 @@ impl ZerodentityStore {
         &mut self,
         did: &Did,
         timestamp: Timestamp,
+        validation_time: Timestamp,
     ) -> anyhow::Result<ErasureEvidence> {
         if self.receipt_signing.is_none() {
             anyhow::bail!("0dentity trust receipt signer is not configured");
         }
-        if timestamp.physical_ms == 0 {
-            anyhow::bail!("0dentity erasure timestamp must be greater than 0");
-        }
+        self.validate_erasure_timestamp(timestamp, validation_time)?;
 
         let key = did.as_str().to_owned();
         let mut revoked_count = 0u32;
@@ -1165,7 +1195,7 @@ mod tests {
         let claim_node = store.dag_nodes()[0].clone();
 
         store
-            .erase_did_with_evidence(&d, Timestamp::new(6_000, 0))
+            .erase_did_with_evidence(&d, Timestamp::new(6_000, 0), Timestamp::new(6_000, 0))
             .unwrap();
 
         let nodes = store.dag_nodes();
@@ -1288,7 +1318,7 @@ mod tests {
 
         // Erase
         let evidence = store
-            .erase_did_with_evidence(&d, Timestamp::new(7_000, 0))
+            .erase_did_with_evidence(&d, Timestamp::new(7_000, 0), Timestamp::new(7_000, 0))
             .unwrap();
         assert_eq!(evidence.claims_revoked, 2);
 
@@ -1323,7 +1353,7 @@ mod tests {
         store.put_claim(claim(&d, ClaimType::Email));
 
         let evidence = store
-            .erase_did_with_evidence(&d, Timestamp::new(8_000, 0))
+            .erase_did_with_evidence(&d, Timestamp::new(8_000, 0), Timestamp::new(8_000, 0))
             .unwrap();
         assert_eq!(evidence.claims_revoked, 1);
 
@@ -1349,12 +1379,55 @@ mod tests {
         store.put_claim(claim(&d, ClaimType::Email));
 
         let err = store
-            .erase_did_with_evidence(&d, Timestamp::new(0, 0))
+            .erase_did_with_evidence(&d, Timestamp::new(0, 0), Timestamp::new(8_000, 0))
             .unwrap_err();
         assert!(
             err.to_string()
                 .contains("erasure timestamp must be greater than 0")
         );
+    }
+
+    #[test]
+    fn erase_did_rejects_timestamp_not_after_latest_dag_node() {
+        let (mut store, _, _) = signed_store(34);
+        let d = did("did:exo:old-erase");
+        let c = claim(&d, ClaimType::Email);
+        store.save_claim("old-erase-claim", &c).unwrap();
+
+        let err = store
+            .erase_did_with_evidence(
+                &d,
+                Timestamp::new(c.created_ms, 0),
+                Timestamp::new(c.created_ms, 0),
+            )
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("strictly exceed"),
+            "expected parent-causality rejection, got {err}"
+        );
+        assert_eq!(store.dag_nodes().len(), 1);
+    }
+
+    #[test]
+    fn erase_did_rejects_timestamp_beyond_validation_clock_tolerance() {
+        let (mut store, _, _) = signed_store(35);
+        let d = did("did:exo:future-erase");
+        store.put_claim(claim(&d, ClaimType::Email));
+
+        let err = store
+            .erase_did_with_evidence(
+                &d,
+                Timestamp::new(10_000, 0),
+                Timestamp::new(10_000 - ZERODENTITY_ERASURE_MAX_FUTURE_SKEW_MS - 1, 0),
+            )
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("clock tolerance"),
+            "expected future-skew rejection, got {err}"
+        );
+        assert!(store.dag_nodes().is_empty());
     }
 
     #[test]
@@ -1403,7 +1476,7 @@ mod tests {
         assert!(!store.get_behavioral_samples(&d).unwrap().is_empty());
 
         store
-            .erase_did_with_evidence(&d, Timestamp::new(9_000, 0))
+            .erase_did_with_evidence(&d, Timestamp::new(9_000, 0), Timestamp::new(9_000, 0))
             .unwrap();
 
         assert!(store.get_fingerprints(&d).unwrap().is_empty());
@@ -1419,7 +1492,7 @@ mod tests {
 
         let claim_node = store.dag_nodes()[0].clone();
         store
-            .erase_did_with_evidence(&d, Timestamp::new(10_000, 0))
+            .erase_did_with_evidence(&d, Timestamp::new(10_000, 0), Timestamp::new(10_000, 0))
             .unwrap();
         assert_eq!(store.dag_nodes().len(), 2);
         assert_eq!(store.dag_nodes()[0], claim_node);


### PR DESCRIPTION
## Summary
- Remediates Codex Security row 63: Signed erasure timestamp can poison the 0dentity DAG.
- Validates signed erasure timestamps against the trusted API HLC before creating the erasure tombstone.
- Requires store erasure timestamps to strictly exceed the current 0dentity DAG parent and stay within the trusted validation-time tolerance.

## Classification
- `crates/exo-node/src/zerodentity/api.rs`: Core runtime adapter for signed 0dentity erasure.
- `crates/exo-node/src/zerodentity/store.rs`: EXOCHAIN core 0dentity DAG/trust receipt evidence boundary.

## Verification
- RED: `cargo test -p exo-node erase_did_rejects_timestamp_not_after_latest_dag_node -- --nocapture` failed on current main with `called Result::unwrap_err() on an Ok value`.
- RED: `cargo test -p exo-node delete_identity_rejects_far_future_erasure_timestamp -- --nocapture` failed on current main with `left: 200 right: 400`.
- GREEN: `cargo test -p exo-node erase_did_rejects_timestamp_not_after_latest_dag_node -- --nocapture`
- GREEN: `cargo test -p exo-node delete_identity_rejects_far_future_erasure_timestamp -- --nocapture`
- GREEN: `cargo test -p exo-node erase_did_rejects_timestamp_beyond_validation_clock_tolerance -- --nocapture`
- GREEN: `cargo test -p exo-node erase_did -- --nocapture`
- GREEN: `cargo test -p exo-node delete_identity -- --nocapture`
- GREEN: `cargo test -p exo-node zerodentity::api -- --nocapture`
- GREEN: `cargo test -p exo-node zerodentity::store -- --nocapture`
- GREEN: `cargo test -p exo-node -- --nocapture`
- GREEN: `cargo +nightly fmt --all -- --check`
- GREEN: `cargo clippy -p exo-node --all-targets -- -D warnings`
- GREEN: `cargo check --workspace --all-targets`
- GREEN: `cargo test -p exo-dag append -- --nocapture`
- GREEN: `cargo test -p exo-dag -- --nocapture`
- GREEN: `git diff --check`

## Bypass Search
- `rg -n "erased_ms|erase_did_with_evidence\(|ZERODENTITY_ERASURE_MAX_FUTURE_SKEW_MS|validate_erasure_timestamp|state\.now_ms\(\)" crates/exo-node/src/zerodentity crates/exo-dag/src -g "*.rs"` shows DELETE now validates against trusted HLC and every erasure store call supplies a validation timestamp.
