### PR TITLE
fix(vitallock): stop exposing derived signing seed

### DIFF
--- a/demo/apps/vitallock/package.json
+++ b/demo/apps/vitallock/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:security": "node tests/security-guards.mjs"
   },
   "dependencies": {
     "react": "^19.1.0",

--- a/demo/apps/vitallock/src/hooks/useAuth.ts
+++ b/demo/apps/vitallock/src/hooks/useAuth.ts
@@ -20,8 +20,6 @@ import React from 'react';
 export interface AuthState {
   did: string;
   displayName: string;
-  ed25519PublicHex: string;
-  ed25519SecretHex: string;
   x25519PublicHex: string;
   x25519SecretHex: string;
 }

--- a/demo/apps/vitallock/src/lib/crypto.ts
+++ b/demo/apps/vitallock/src/lib/crypto.ts
@@ -23,7 +23,6 @@
 
 import init, {
   wasm_generate_x25519_keypair,
-  wasm_ed25519_public_from_secret,
   wasm_encrypt_message,
   wasm_decrypt_message,
   wasm_verify_message_signature,
@@ -41,11 +40,6 @@ export async function initCrypto(): Promise<void> {
   if (initialized) return;
   await init();
   initialized = true;
-}
-
-/** Derive an Ed25519 public key hex string from a caller-held secret key. */
-export function ed25519PublicFromSecret(secretKeyHex: string): string {
-  return wasm_ed25519_public_from_secret(secretKeyHex);
 }
 
 /** Check if WASM is initialized. */
@@ -90,7 +84,6 @@ export function encryptMessage(
   contentType: string,
   senderDid: string,
   recipientDid: string,
-  senderSigningKeyHex: string,
   recipientX25519PublicHex: string,
   messageId: string,
   createdPhysicalMs: bigint,
@@ -103,7 +96,7 @@ export function encryptMessage(
     JSON.stringify(contentType),
     senderDid,
     recipientDid,
-    senderSigningKeyHex,
+    '',
     recipientX25519PublicHex,
     messageId,
     createdPhysicalMs,

--- a/demo/apps/vitallock/src/pages/Compose.tsx
+++ b/demo/apps/vitallock/src/pages/Compose.tsx
@@ -62,7 +62,6 @@ export default function Compose() {
         contentType,
         auth!.did,
         recipientDid,
-        auth!.ed25519SecretHex,
         recipientX25519,
         messageId,
         createdPhysicalMs,

--- a/demo/apps/vitallock/src/pages/Login.tsx
+++ b/demo/apps/vitallock/src/pages/Login.tsx
@@ -43,18 +43,10 @@ export default function Login() {
       // Ensure WASM is ready
       if (!isCryptoReady()) await initCrypto();
 
-      // Derive Ed25519 signing key deterministically from passphrase via WebCrypto
-      // (passphrase never leaves the device — zero-knowledge)
       const encoder = new TextEncoder();
       const hashBuffer = await crypto.subtle.digest('SHA-256', encoder.encode(passphrase));
       const hashArray = new Uint8Array(hashBuffer);
-      const ed25519SecretHex = Array.from(hashArray).map(b => b.toString(16).padStart(2, '0')).join('');
-
-      // The Ed25519 secret stays client-side for signing via wasm_sign.
-      // The "public" hex here is used as a display identifier only.
-      // In production, derive the real Ed25519 public via wasm_sign_with_ephemeral
-      // or a dedicated WASM binding.
-      const ed25519PublicHex = ed25519SecretHex;
+      const identityDigestHex = Array.from(hashArray).map(b => b.toString(16).padStart(2, '0')).join('');
 
       // Generate X25519 keypair via WASM (real Diffie-Hellman crypto)
       const x25519Kp = genX25519Wasm();
@@ -62,8 +54,8 @@ export default function Login() {
       const x25519Secret = x25519Kp.secret_key_hex;
 
       // Derive DID from passphrase hash (deterministic across sessions)
-      const did = `did:exo:${ed25519SecretHex.slice(0, 16)}`;
-      const name = displayName || `User-${ed25519SecretHex.slice(0, 8)}`;
+      const did = `did:exo:${identityDigestHex.slice(0, 16)}`;
+      const name = displayName || `User-${identityDigestHex.slice(0, 8)}`;
 
       setStatus('Initializing sharded keystore...');
 
@@ -85,8 +77,6 @@ export default function Login() {
       const authState: AuthState = {
         did,
         displayName: name,
-        ed25519PublicHex: ed25519PublicHex,
-        ed25519SecretHex: ed25519SecretHex,
         x25519PublicHex: x25519Public,
         x25519SecretHex: x25519Secret,
       };

--- a/demo/apps/vitallock/src/pages/Settings.tsx
+++ b/demo/apps/vitallock/src/pages/Settings.tsx
@@ -75,22 +75,9 @@ export default function Settings() {
               </button>
             </div>
           </div>
-          <div>
-            <label className="block text-[10px] text-zinc-500 mb-1">
-              Ed25519 Public Key (for signature verification)
-            </label>
-            <div className="flex items-center gap-2">
-              <code className="flex-1 text-[10px] text-emerald-400 bg-zinc-800 rounded px-3 py-2 font-mono truncate">
-                {auth?.ed25519PublicHex}
-              </code>
-              <button onClick={() => copyToClipboard(auth?.ed25519PublicHex || '')} className="text-zinc-500 hover:text-white shrink-0">
-                <Copy size={14} />
-              </button>
-            </div>
-          </div>
         </div>
         <p className="text-[10px] text-zinc-600 mt-3">
-          Secret keys are derived from your passphrase and never leave this device.
+          Signing keys are not exported or displayed by this adjacent demo.
         </p>
       </div>
 

--- a/demo/apps/vitallock/tests/security-guards.mjs
+++ b/demo/apps/vitallock/tests/security-guards.mjs
@@ -1,0 +1,56 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const root = resolve(import.meta.dirname, '..');
+
+function readSource(path) {
+  return readFileSync(resolve(root, path), 'utf8');
+}
+
+const login = readSource('src/pages/Login.tsx');
+const settings = readSource('src/pages/Settings.tsx');
+const compose = readSource('src/pages/Compose.tsx');
+const auth = readSource('src/hooks/useAuth.ts');
+const crypto = readSource('src/lib/crypto.ts');
+
+assert(
+  !login.includes('ed25519PublicHex = ed25519SecretHex'),
+  'VitalLock login must not publish the passphrase-derived signing seed as an Ed25519 public key',
+);
+
+assert(
+  !settings.includes('auth?.ed25519SecretHex') && !settings.includes('auth?.ed25519PublicHex'),
+  'VitalLock settings must not display or copy passphrase-derived Ed25519 key material',
+);
+
+assert(
+  !compose.includes('auth!.ed25519SecretHex') && !compose.includes('auth.ed25519SecretHex'),
+  'VitalLock compose must not pass a session-stored passphrase hash as a signing secret',
+);
+
+assert(
+  !auth.includes('ed25519SecretHex: string;') && !auth.includes('ed25519PublicHex: string;'),
+  'VitalLock auth state must not persist passphrase-derived Ed25519 key material',
+);
+
+assert(
+  !crypto.includes('wasm_ed25519_public_from_secret') && !crypto.includes('senderSigningKeyHex'),
+  'VitalLock crypto wrapper must not expose raw-secret public derivation or raw signing-key parameters',
+);


### PR DESCRIPTION
## Summary
- Remediates Codex Security CSV row 67 for the remaining adjacent VitalLock surface.
- Removes `ed25519SecretHex` and `ed25519PublicHex` from VitalLock session auth state.
- Stops deriving `ed25519PublicHex = ed25519SecretHex`, stops displaying/copying that value in settings, and stops passing the session-stored passphrase hash as a signing secret from compose.
- Adds a local `npm run test:security` source guard for the adjacent app.

## Classification
- Adjacent surface: `demo/apps/vitallock/**`.
- Core runtime adapter checked but not changed: `crates/exochain-wasm/src/messaging_bindings.rs`, `crates/exochain-wasm/src/core_bindings.rs`.
- Imported evidence: Codex Security CSV row 67.

## Adjacent Surface Intake
- Owner/accountable maintainer: EXOCHAIN maintainers pending a named VitalLock surface owner.
- Deployment status: demo / adjacent surface.
- Constitutional trust claims: not allowed to claim EXOCHAIN constitutional enforcement unless a tested core adapter path is used.
- Core state access: this patch does not add access to EXOCHAIN core state, signatures, credentials, governance outcomes, consent records, or provenance records.
- Trust boundary: browser demo may call WASM bindings, but raw Ed25519 secret signing and raw-secret public derivation are fail-closed in the WASM adapter.
- Surface test command: `npm run test:security` from `demo/apps/vitallock`.
- Secrets inventory: passphrase-derived signing material is no longer persisted in `AuthState`, displayed, copied, or passed to compose.
- Rollback/disablement: keep the security guard in CI or disable the adjacent app route if it attempts to reintroduce raw signing-key exposure.

## Verification Against Current Main
- Reproduced on current `main` before the fix:
  - `npm run test:security` failed because `Login.tsx` assigned `ed25519PublicHex = ed25519SecretHex`.
- Core adapter sanity check: the reported WASM raw-secret path is stale for current Rust source because raw Ed25519 sender signing and raw-secret public derivation fail closed.

## Tests
- `npm run test:security` from `demo/apps/vitallock`
- `cargo test -p exochain-wasm wasm_messaging -- --nocapture`
- `cargo test -p exochain-wasm wasm_core_legacy_raw_secret_entrypoints_fail_closed -- --nocapture`
- `cargo check --workspace --all-targets`
- `git diff --check`

## Build Note
- `npm run build` from `demo/apps/vitallock` could not run in this checkout because the adjacent app dependencies are not installed locally (`tsc: command not found`). I did not add generated dependency artifacts in this security PR.

## Bypass Search
- `rg -n "ed25519SecretHex|ed25519PublicHex|ed25519PublicHex = ed25519SecretHex|senderSigningKeyHex|wasm_ed25519_public_from_secret" demo/apps/vitallock/src demo/apps/vitallock/tests -g '*.ts' -g '*.tsx' -g '*.mjs'`
- Result: matches remain only in the security guard assertions, not production VitalLock source.
