### PR TITLE
fix(ci): deny external wildcard dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
 repository = "https://github.com/exochain/exochain"
+publish = false
 
 [workspace.dependencies]
 # Deterministic serialization

--- a/crates/decision-forum/Cargo.toml
+++ b/crates/decision-forum/Cargo.toml
@@ -23,6 +23,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/exo-api/Cargo.toml
+++ b/crates/exo-api/Cargo.toml
@@ -23,6 +23,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/exo-authority/Cargo.toml
+++ b/crates/exo-authority/Cargo.toml
@@ -23,6 +23,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/exo-avc/Cargo.toml
+++ b/crates/exo-avc/Cargo.toml
@@ -23,6 +23,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/exo-catapult/Cargo.toml
+++ b/crates/exo-catapult/Cargo.toml
@@ -23,6 +23,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/exo-consensus/Cargo.toml
+++ b/crates/exo-consensus/Cargo.toml
@@ -21,6 +21,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+publish.workspace = true
 
 [features]
 default = []

--- a/crates/exo-consent/Cargo.toml
+++ b/crates/exo-consent/Cargo.toml
@@ -23,6 +23,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/exo-core/Cargo.toml
+++ b/crates/exo-core/Cargo.toml
@@ -23,6 +23,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/exo-dag/Cargo.toml
+++ b/crates/exo-dag/Cargo.toml
@@ -23,6 +23,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/exo-economy/Cargo.toml
+++ b/crates/exo-economy/Cargo.toml
@@ -23,6 +23,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/exo-escalation/Cargo.toml
+++ b/crates/exo-escalation/Cargo.toml
@@ -23,6 +23,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/exo-gatekeeper/Cargo.toml
+++ b/crates/exo-gatekeeper/Cargo.toml
@@ -23,6 +23,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/exo-gateway/Cargo.toml
+++ b/crates/exo-gateway/Cargo.toml
@@ -23,6 +23,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/exo-governance/Cargo.toml
+++ b/crates/exo-governance/Cargo.toml
@@ -23,6 +23,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/exo-identity/Cargo.toml
+++ b/crates/exo-identity/Cargo.toml
@@ -23,6 +23,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/exo-legal/Cargo.toml
+++ b/crates/exo-legal/Cargo.toml
@@ -23,6 +23,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/exo-messaging/Cargo.toml
+++ b/crates/exo-messaging/Cargo.toml
@@ -23,6 +23,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/exo-node/Cargo.toml
+++ b/crates/exo-node/Cargo.toml
@@ -23,6 +23,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+publish.workspace = true
 
 [[bin]]
 name = "exochain"

--- a/crates/exo-proofs/Cargo.toml
+++ b/crates/exo-proofs/Cargo.toml
@@ -23,6 +23,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/exo-root/Cargo.toml
+++ b/crates/exo-root/Cargo.toml
@@ -23,6 +23,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/exo-tenant/Cargo.toml
+++ b/crates/exo-tenant/Cargo.toml
@@ -23,6 +23,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/exochain-sdk/Cargo.toml
+++ b/crates/exochain-sdk/Cargo.toml
@@ -23,6 +23,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/exochain-wasm/Cargo.toml
+++ b/crates/exochain-wasm/Cargo.toml
@@ -22,6 +22,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+publish.workspace = true
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/deny.toml
+++ b/deny.toml
@@ -107,8 +107,10 @@ license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 # ---------------------------------------------------------------------------
 [bans]
 multiple-versions = "warn"
-# Workspace-internal crates use path dependencies (wildcard version)
-wildcards = "allow"
+# External wildcard dependency requirements weaken the supply-chain gate.
+# Private workspace path dependencies are the only allowed wildcard form.
+wildcards = "deny"
+allow-wildcard-paths = true
 highlight = "all"
 
 deny = [

--- a/tools/test_security_critical_dependencies_pinned.sh
+++ b/tools/test_security_critical_dependencies_pinned.sh
@@ -26,7 +26,25 @@ import sys
 import tomllib
 
 with open("Cargo.toml", "rb") as manifest:
-    dependencies = tomllib.load(manifest)["workspace"]["dependencies"]
+    cargo = tomllib.load(manifest)
+
+with open("deny.toml", "rb") as deny_manifest:
+    deny = tomllib.load(deny_manifest)
+
+bans = deny["bans"]
+if bans.get("wildcards") != "deny":
+    print('cargo-deny must reject wildcard dependency requirements: set [bans].wildcards = "deny"', file=sys.stderr)
+    sys.exit(1)
+if bans.get("allow-wildcard-paths") is not True:
+    print("cargo-deny must allow only private path dependency wildcards: set [bans].allow-wildcard-paths = true", file=sys.stderr)
+    sys.exit(1)
+
+workspace_package = cargo["workspace"].get("package", {})
+if workspace_package.get("publish") is not False:
+    print("workspace packages must inherit publish = false so cargo-deny can allow private path dependency wildcards only", file=sys.stderr)
+    sys.exit(1)
+
+dependencies = cargo["workspace"]["dependencies"]
 
 unpinned = []
 for name, spec in sorted(dependencies.items()):


### PR DESCRIPTION
## Summary
- Remediates Codex Security CSV row 68: Cargo-deny wildcard dependency ban disabled globally.
- Changes `[bans].wildcards` from `allow` to `deny`.
- Enables `allow-wildcard-paths = true` so private workspace path dependencies remain allowed while external registry wildcard requirements fail.
- Marks workspace packages private via `[workspace.package] publish = false` plus member `publish.workspace = true` inheritance.
- Extends the existing CI dependency pin guard to fail if the wildcard policy is relaxed again.

## Classification
- EXOCHAIN core CI/supply-chain gate: `deny.toml`, `Cargo.toml`, `crates/*/Cargo.toml`, `tools/test_security_critical_dependencies_pinned.sh`.
- Imported evidence: Codex Security CSV row 68.

## Verification Against Current Main
- Reproduced on current `main` before the fix:
  - After adding the guard, `bash tools/test_security_critical_dependencies_pinned.sh` failed with: `cargo-deny must reject wildcard dependency requirements`.
- Sanity-checked cargo-deny 0.19.4 local source: `allow-wildcard-paths` applies only to private path/git deps or dev-deps; external registry wildcard requirements remain denied.

## Tests
- `bash tools/test_security_critical_dependencies_pinned.sh`
- `cargo deny check`
- `cargo check --workspace --all-targets`
- `git diff --check`

## Bypass Search
- `rg -n "wildcards|allow-wildcard-paths|publish\\.workspace|publish = false" Cargo.toml deny.toml crates -g 'Cargo.toml' -g 'deny.toml'`
- `rg -n "\\*=|= \\\"\\*\\\"|version = \\\"\\*\\\"" Cargo.toml crates packages tools .github deny.toml -g 'Cargo.toml' -g '*.toml' -g '*.yml' -g '*.yaml'`
- Result: cargo-deny now denies wildcard requirements; workspace members inherit private publish status; no external wildcard dependency requirements are present.
