### PR TITLE
fix(api): enforce ASN peer cap in diversity check

### DIFF
--- a/crates/exo-api/src/p2p.rs
+++ b/crates/exo-api/src/p2p.rs
@@ -390,7 +390,15 @@ impl Default for AsnPolicy {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DiversityResult {
     Sufficient,
-    Insufficient { unique_asns: usize, required: usize },
+    Insufficient {
+        unique_asns: usize,
+        required: usize,
+    },
+    OverrepresentedAsn {
+        asn: Asn,
+        peers: usize,
+        maximum: usize,
+    },
 }
 
 /// Sentinel ASN value used to group peers with no known ASN.
@@ -405,12 +413,26 @@ fn effective_asn(peer: &PeerMetadata) -> Asn {
 /// Check whether the peer set meets the ASN diversity threshold.
 #[must_use]
 pub fn check_asn_diversity(peers: &[PeerMetadata], policy: &AsnPolicy) -> DiversityResult {
-    let unique: BTreeSet<Asn> = peers.iter().map(effective_asn).collect();
-    if unique.len() >= policy.min_unique_asns {
+    let mut by_asn: BTreeMap<Asn, usize> = BTreeMap::new();
+    for peer in peers {
+        *by_asn.entry(effective_asn(peer)).or_default() += 1;
+    }
+
+    for (asn, peer_count) in &by_asn {
+        if *peer_count > policy.max_peers_per_asn {
+            return DiversityResult::OverrepresentedAsn {
+                asn: *asn,
+                peers: *peer_count,
+                maximum: policy.max_peers_per_asn,
+            };
+        }
+    }
+
+    if by_asn.len() >= policy.min_unique_asns {
         DiversityResult::Sufficient
     } else {
         DiversityResult::Insufficient {
-            unique_asns: unique.len(),
+            unique_asns: by_asn.len(),
             required: policy.min_unique_asns,
         }
     }
@@ -924,6 +946,25 @@ mod tests {
         assert_eq!(
             check_asn_diversity(&peers, &policy),
             DiversityResult::Sufficient
+        );
+    }
+
+    #[test]
+    fn reject_peer_set_exceeding_max_peers_per_asn_even_when_unique_asns_sufficient() {
+        let mut peers: Vec<PeerMetadata> = (0..6)
+            .map(|i| peer_meta(&format!("attacker-{i}"), Some(64512), 1000))
+            .collect();
+        peers.push(peer_meta("honest-a", Some(64513), 1000));
+        peers.push(peer_meta("honest-b", Some(64514), 1000));
+        let policy = AsnPolicy::default();
+
+        assert_eq!(
+            check_asn_diversity(&peers, &policy),
+            DiversityResult::OverrepresentedAsn {
+                asn: Asn(64512),
+                peers: 6,
+                maximum: 5
+            }
         );
     }
 


### PR DESCRIPTION
## Summary
- Remediates Codex Security CSV row 69: ASN diversity check ignores per-ASN peer cap.
- Classifies the touched path as EXOCHAIN core runtime/API P2P logic: `crates/exo-api/src/p2p.rs`.
- Adds `DiversityResult::OverrepresentedAsn` and makes `check_asn_diversity` reject peer sets that exceed `policy.max_peers_per_asn` even when `min_unique_asns` is satisfied.

## Verification Against Current Main
- Reproduced on current `main` before the fix:
  - `cargo test -p exo-api reject_peer_set_exceeding_max_peers_per_asn_even_when_unique_asns_sufficient -- --nocapture` failed because the result enum had no overrepresented-ASN state and the current check would have returned `Sufficient` for the eclipse-shaped peer set.

## Tests
- `cargo test -p exo-api reject_peer_set_exceeding_max_peers_per_asn_even_when_unique_asns_sufficient -- --nocapture`
- `cargo test -p exo-api -- --nocapture`
- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p exo-api --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `git diff --check`

## Bypass Search
- `rg -n "check_asn_diversity|DiversityResult|OverrepresentedAsn|max_peers_per_asn|select_diverse_peers" crates/exo-api/src crates/exo-node/src crates/exo-gateway/src -g '*.rs'`
- Result: `check_asn_diversity` is centralized in `exo-api`; `select_diverse_peers` already enforces `max_peers_per_asn`; the health/admission check now enforces the same cap deterministically.
