### PR TITLE
fix(gateway): count vote quorum inside transaction

### DIFF
--- a/crates/exo-gateway/src/db.rs
+++ b/crates/exo-gateway/src/db.rs
@@ -26,7 +26,7 @@ use decision_forum::decision_object::DecisionClass;
 use exo_identity::{did::DidDocument, registry::MAX_LOCAL_DID_REGISTRY_DOCUMENTS};
 use serde_json::Value as JsonValue;
 use sqlx::{
-    Row,
+    Executor, Postgres, Row, Transaction,
     postgres::{PgPool, PgPoolOptions},
 };
 use thiserror::Error;
@@ -669,41 +669,51 @@ fn count_result_to_usize(label: &'static str, value: i64) -> Result<usize, sqlx:
 }
 
 /// Count quorum-eligible voters for a tenant and decision class.
-pub async fn count_quorum_eligible_voters(
-    pool: &PgPool,
+async fn count_quorum_eligible_voters_with_executor<'e, E>(
+    executor: E,
     tenant_id: &str,
     decision_class: DecisionClass,
-) -> Result<QuorumEligibilityCounts, sqlx::Error> {
+) -> Result<QuorumEligibilityCounts, sqlx::Error>
+where
+    E: Executor<'e, Database = Postgres>,
+{
+    let row = sqlx::query(
+        r#"
+        SELECT
+            (
+                SELECT COUNT(*)
+                FROM users
+                WHERE tenant_id = $1
+                  AND status = 'Active'
+            ) AS active_human_users,
+            (
+                SELECT COUNT(*)
+                FROM agents
+                WHERE tenant_id = $1
+                  AND status = 'Active'
+                  AND delegation_id IS NOT NULL
+                  AND CASE max_decision_class
+                      WHEN 'Routine' THEN 0
+                      WHEN 'Operational' THEN 1
+                      WHEN 'Strategic' THEN 2
+                      WHEN 'Constitutional' THEN 3
+                      ELSE -1
+                  END >= $2
+            ) AS active_delegated_agents
+        "#,
+    )
+    .bind(tenant_id)
+    .bind(decision_class_rank(decision_class))
+    .fetch_one(executor)
+    .await?;
+
     let active_human_users = count_result_to_usize(
         "active_human_users",
-        sqlx::query_scalar::<_, i64>(
-            "SELECT COUNT(*) FROM users WHERE tenant_id = $1 AND status = 'Active'",
-        )
-        .bind(tenant_id)
-        .fetch_one(pool)
-        .await?,
+        row.try_get::<i64, _>("active_human_users")?,
     )?;
     let active_delegated_agents = count_result_to_usize(
         "active_delegated_agents",
-        sqlx::query_scalar::<_, i64>(
-            r#"
-            SELECT COUNT(*) FROM agents
-            WHERE tenant_id = $1
-              AND status = 'Active'
-              AND delegation_id IS NOT NULL
-              AND CASE max_decision_class
-                  WHEN 'Routine' THEN 0
-                  WHEN 'Operational' THEN 1
-                  WHEN 'Strategic' THEN 2
-                  WHEN 'Constitutional' THEN 3
-                  ELSE -1
-              END >= $2
-            "#,
-        )
-        .bind(tenant_id)
-        .bind(decision_class_rank(decision_class))
-        .fetch_one(pool)
-        .await?,
+        row.try_get::<i64, _>("active_delegated_agents")?,
     )?;
     let eligible_voters = active_human_users
         .checked_add(active_delegated_agents)
@@ -713,6 +723,24 @@ pub async fn count_quorum_eligible_voters(
         eligible_voters,
         eligible_human_voters: active_human_users,
     })
+}
+
+/// Count quorum-eligible voters for a tenant and decision class.
+pub async fn count_quorum_eligible_voters(
+    pool: &PgPool,
+    tenant_id: &str,
+    decision_class: DecisionClass,
+) -> Result<QuorumEligibilityCounts, sqlx::Error> {
+    count_quorum_eligible_voters_with_executor(pool, tenant_id, decision_class).await
+}
+
+/// Count quorum-eligible voters using the caller's open transaction.
+pub async fn count_quorum_eligible_voters_in_transaction(
+    tx: &mut Transaction<'_, Postgres>,
+    tenant_id: &str,
+    decision_class: DecisionClass,
+) -> Result<QuorumEligibilityCounts, sqlx::Error> {
+    count_quorum_eligible_voters_with_executor(&mut **tx, tenant_id, decision_class).await
 }
 
 // ---------------------------------------------------------------------------
@@ -1979,9 +2007,11 @@ mod tests {
     }
 
     fn function_source<'a>(source: &'a str, name: &str) -> &'a str {
-        let signature = format!("pub async fn {name}");
+        let public_signature = format!("pub async fn {name}");
+        let private_signature = format!("async fn {name}");
         let start = source
-            .find(&signature)
+            .find(&public_signature)
+            .or_else(|| source.find(&private_signature))
             .unwrap_or_else(|| panic!("{name} source must be present"));
         let after_start = &source[start..];
         let end = after_start.find("\n/// ").unwrap_or(after_start.len());
@@ -3053,7 +3083,7 @@ mod tests {
     #[test]
     fn quorum_eligibility_counts_are_tenant_scoped_and_human_bounded() {
         let source = production_source();
-        let count = function_source(source, "count_quorum_eligible_voters");
+        let count = function_source(source, "count_quorum_eligible_voters_with_executor");
 
         assert!(
             count.contains("tenant_id: &str"),

--- a/crates/exo-gateway/src/handlers.rs
+++ b/crates/exo-gateway/src/handlers.rs
@@ -723,9 +723,12 @@ pub async fn vote_handler(
     // Verify quorum precondition (TNC-07): enough tenant-scoped eligible
     // voters must exist before accepting the vote.
     let registry = QuorumRegistry::with_defaults();
-    let eligible = match state
-        .quorum_eligible_voter_counts(&actor.tenant_id, decision.class)
-        .await
+    let eligible = match crate::db::count_quorum_eligible_voters_in_transaction(
+        &mut tx,
+        &actor.tenant_id,
+        decision.class,
+    )
+    .await
     {
         Ok(counts) => counts,
         Err(e) => {
@@ -1857,9 +1860,12 @@ mod tests {
             .split("// Build the typed Vote")
             .next()
             .expect("vote handler quorum block present");
+        let compact_vote_handler = vote_handler.split_whitespace().collect::<String>();
 
         assert!(
-            vote_handler.contains("quorum_eligible_voter_counts(&actor.tenant_id, decision.class)"),
+            compact_vote_handler.contains(
+                "count_quorum_eligible_voters_in_transaction(&muttx,&actor.tenant_id,decision.class,)"
+            ),
             "vote handler must derive quorum eligibility from the authenticated tenant and decision class"
         );
         assert!(
@@ -1877,6 +1883,34 @@ mod tests {
         assert!(
             !vote_handler.contains("let eligible_human_voters = eligible_voters"),
             "vote handler must not assume every registered DID is a human eligible voter"
+        );
+    }
+
+    #[test]
+    fn vote_handler_quorum_precondition_reuses_vote_transaction_connection() {
+        let source = include_str!("handlers.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("test module marker present");
+        let vote_handler = production
+            .split("pub async fn vote_handler")
+            .nth(1)
+            .expect("vote handler source present")
+            .split("// Build the typed Vote")
+            .next()
+            .expect("vote handler quorum block present");
+        let compact_vote_handler = vote_handler.split_whitespace().collect::<String>();
+
+        assert!(
+            compact_vote_handler.contains(
+                "crate::db::count_quorum_eligible_voters_in_transaction(&muttx,&actor.tenant_id,decision.class,)"
+            ),
+            "vote handler must count quorum eligibility on the already-held vote transaction connection"
+        );
+        assert!(
+            !vote_handler.contains(".quorum_eligible_voter_counts("),
+            "vote handler must not acquire a second pooled connection while holding the vote transaction"
         );
     }
 


### PR DESCRIPTION
## Summary
- validates Codex Security row 71 against current main
- moves vote quorum eligibility counting onto the already-held vote transaction connection
- keeps the pool-backed helper for non-transaction callers while sharing the same tenant-scoped count query

## Path Classification
- `crates/exo-gateway/src/db.rs`: EXOCHAIN core runtime adapter / gateway persistence
- `crates/exo-gateway/src/handlers.rs`: EXOCHAIN core runtime adapter / vote ingress

## Finding Validation
- Current main held a vote transaction and then called `state.quorum_eligible_voter_counts`, which acquires from `PgPool` separately.
- Added `vote_handler_quorum_precondition_reuses_vote_transaction_connection`; it failed before the fix because the handler did not call the transaction-backed helper.

## Tests
- `cargo test -p exo-gateway vote_handler_quorum_precondition_reuses_vote_transaction_connection -- --nocapture`
- `cargo test -p exo-gateway vote_handler_quorum_precondition -- --nocapture`
- `cargo test -p exo-gateway quorum_eligibility -- --nocapture`
- `cargo test -p exo-gateway -- --nocapture`
- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p exo-gateway --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `git diff --check`

## Bypass Search
- `rg -n "quorum_eligible_voter_counts\(|count_quorum_eligible_voters_in_transaction\(" crates/exo-gateway/src`
