### PR TITLE
fix(ci): set channel for pinned rust toolchains

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
+          toolchain: stable
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Build workspace (release)
@@ -61,6 +62,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Run all workspace tests
         run: cargo test --workspace
@@ -79,6 +82,8 @@ jobs:
       - name: Coverage policy guard
         run: bash tools/test_coverage_policy.sh
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin --version 0.35.4 --locked
@@ -119,6 +124,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
+          toolchain: stable
           components: clippy
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Clippy (all workspace targets, deny all warnings)
@@ -134,6 +140,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2
         with:
+          toolchain: nightly
           components: rustfmt
       - name: Check formatting
         run: cargo +nightly fmt --all -- --check
@@ -167,6 +174,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
       - uses: EmbarkStudios/cargo-deny-action@5bb39ff5d5a0e94dc9e2dc94eced0c6129743a57
         with:
           command: check
@@ -184,6 +193,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Build documentation
         run: cargo doc --workspace --no-deps
@@ -305,6 +316,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Install cargo-cyclonedx
         run: cargo install cargo-cyclonedx --version 0.5.9 --locked
@@ -338,6 +351,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Install cargo-machete
         run: cargo install cargo-machete --version 0.9.2 --locked
@@ -365,6 +380,8 @@ jobs:
               - 'crates/exo-gateway/**'
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         if: steps.filter.outputs.gateway == 'true'
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
         if: steps.filter.outputs.gateway == 'true'
       - name: Run workspace integration tests
@@ -383,6 +400,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: DB-backed gateway CI guard
         run: bash tools/test_gateway_db_ci.sh
@@ -429,6 +448,8 @@ jobs:
               - 'crates/exo-dag/**'
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         if: steps.filter.outputs.node == 'true'
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
         if: steps.filter.outputs.node == 'true'
       - name: Run exo-node unit and integration tests
@@ -458,6 +479,8 @@ jobs:
               - 'crates/exo-node/**'
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         if: steps.filter.outputs.sync == 'true'
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
         if: steps.filter.outputs.sync == 'true'
       - name: Run sync engine tests
@@ -497,6 +520,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
         with:
@@ -524,6 +548,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin --version 0.35.4 --locked
@@ -555,6 +581,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin --version 0.35.4 --locked
@@ -587,6 +615,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin --version 0.35.4 --locked
@@ -618,6 +648,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
+          toolchain: stable
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - name: Install wasm-pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,7 @@ jobs:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
 
@@ -211,6 +212,8 @@ jobs:
           ref: ${{ steps.release-ref.outputs.ref }}
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
 
       - name: Download all build artifacts
@@ -280,6 +283,8 @@ jobs:
           ref: ${{ steps.release-ref.outputs.ref }}
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
 
       - name: Publish crates in dependency order
         env:

--- a/tools/test_github_actions_pinned.sh
+++ b/tools/test_github_actions_pinned.sh
@@ -48,4 +48,36 @@ if ((${#violations[@]} > 0)); then
   fail "external actions must be pinned to immutable commit SHAs"
 fi
 
+rust_toolchain_violations=()
+for workflow in .github/workflows/*.yml .github/workflows/*.yaml; do
+  while IFS= read -r match; do
+    line_no=${match%%:*}
+    step_block=$(
+      awk -v start="$line_no" '
+        NR < start { next }
+        NR == start {
+          step_indent = match($0, /[^ ]/) - 1
+          print
+          next
+        }
+        {
+          current_indent = match($0, /[^ ]/) - 1
+          if ($0 ~ /^[[:space:]]*-[[:space:]]+(name|uses|run):/ && current_indent <= step_indent) {
+            exit
+          }
+          print
+        }
+      ' "$workflow"
+    )
+    if ! grep -Eq '^[[:space:]]+toolchain:[[:space:]]+(stable|nightly)[[:space:]]*$' <<<"$step_block"; then
+      rust_toolchain_violations+=("${workflow}:${line_no}: dtolnay/rust-toolchain requires explicit with.toolchain when pinned")
+    fi
+  done < <(grep -nE 'uses:[[:space:]]+dtolnay/rust-toolchain@[0-9a-f]{40}' "$workflow" || true)
+done
+
+if ((${#rust_toolchain_violations[@]} > 0)); then
+  printf '%s\n' "${rust_toolchain_violations[@]}" >&2
+  fail "pinned dtolnay/rust-toolchain actions must set stable or nightly explicitly"
+fi
+
 printf 'github actions pinning test passed\n'


### PR DESCRIPTION
## Summary
- validates Codex Security row 72 against current main
- adds explicit `toolchain: stable` or `toolchain: nightly` to every pinned `dtolnay/rust-toolchain` step
- extends the GitHub Actions pinning guard so pinned dtolnay steps must declare a channel

## Path Classification
- `.github/workflows/ci.yml`: EXOCHAIN core CI gate
- `.github/workflows/release.yml`: EXOCHAIN release CI gate
- `tools/test_github_actions_pinned.sh`: EXOCHAIN CI guard

## Finding Validation
- Current main used pinned dtolnay action SHAs without `with.toolchain`; the new guard failed on all affected steps before workflow remediation.

## Tests
- `bash tools/test_github_actions_pinned.sh`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f}: ok" }' .github/workflows/ci.yml .github/workflows/release.yml`\n- `git diff --check`\n