### PR TITLE
fix(node): bind saved claims to signed DAG nodes

### DIFF
--- a/crates/exo-node/src/zerodentity/store.rs
+++ b/crates/exo-node/src/zerodentity/store.rs
@@ -276,6 +276,22 @@ impl ZerodentityStore {
             .map_or_else(Vec::new, |parent| vec![parent.hash])
     }
 
+    fn validate_next_dag_timestamp(
+        &self,
+        timestamp: Timestamp,
+        label: &'static str,
+    ) -> anyhow::Result<()> {
+        if timestamp.physical_ms == 0 {
+            anyhow::bail!("{label} timestamp must be greater than 0");
+        }
+        if let Some(parent) = self.dag_nodes.last() {
+            if timestamp <= parent.timestamp {
+                anyhow::bail!("{label} timestamp must strictly exceed latest DAG parent timestamp");
+            }
+        }
+        Ok(())
+    }
+
     /// Compute the next claim DAG node hash without mutating the store.
     pub fn next_claim_dag_node_hash(
         &self,
@@ -285,6 +301,7 @@ impl ZerodentityStore {
         let Some(context) = &self.receipt_signing else {
             anyhow::bail!("0dentity DAG node signer is not configured");
         };
+        self.validate_next_dag_timestamp(timestamp, "0dentity claim DAG")?;
         Ok(compute_node_hash(
             &self.next_dag_parents(),
             &payload_hash,
@@ -301,6 +318,7 @@ impl ZerodentityStore {
         let Some(context) = &self.receipt_signing else {
             anyhow::bail!("0dentity DAG node signer is not configured");
         };
+        self.validate_next_dag_timestamp(timestamp, "0dentity DAG node")?;
         let parents = self.next_dag_parents();
         let hash = compute_node_hash(&parents, &payload_hash, &context.actor_did, &timestamp)?;
         let signature = (context.signer)(hash.as_bytes());
@@ -692,8 +710,10 @@ impl ZerodentityStore {
             None
         };
 
-        self.insert_claim(claim_id, claim)?;
         let dag_node_hash = node.hash;
+        let mut stored_claim = claim.clone();
+        stored_claim.dag_node_hash = dag_node_hash;
+        self.insert_claim(claim_id, &stored_claim)?;
         self.dag_nodes.push(node);
 
         // Emit TrustReceipt for verified claims.
@@ -1128,6 +1148,24 @@ mod tests {
     }
 
     #[test]
+    fn save_claim_binds_stored_claim_to_signed_dag_node_hash() {
+        let (mut store, _, _) = signed_store(34);
+        let d = did("did:exo:dag-bound-claim");
+        let mut c = claim(&d, ClaimType::Email);
+        c.dag_node_hash = Hash256::digest(b"caller-controlled-dag-pointer");
+
+        let evidence = store
+            .save_claim_with_evidence("apg-dag-bound-001", &c)
+            .unwrap();
+
+        let claims = store.get_claims(&d).unwrap();
+        assert_eq!(claims.len(), 1);
+        assert_eq!(claims[0].1.dag_node_hash, evidence.dag_node_hash);
+        assert_eq!(claims[0].1.dag_node_hash, store.dag_nodes()[0].hash);
+        assert_ne!(claims[0].1.dag_node_hash, c.dag_node_hash);
+    }
+
+    #[test]
     fn save_claim_dag_node_is_signed_by_node_identity() {
         let (mut store, node_did, node_public_key) = signed_store(31);
         let d = did("did:exo:dag-signed-claim");
@@ -1165,7 +1203,9 @@ mod tests {
         let (mut store, _, node_public_key) = signed_store(32);
         let d = did("did:exo:dag-chain");
         let first = claim(&d, ClaimType::Email);
-        let second = claim(&d, ClaimType::Phone);
+        let mut second = claim(&d, ClaimType::Phone);
+        second.created_ms = first.created_ms + 1;
+        second.verified_ms = Some(first.created_ms + 2);
 
         store.save_claim("apg-dag-chain-001", &first).unwrap();
         store.save_claim("apg-dag-chain-002", &second).unwrap();
@@ -1184,6 +1224,29 @@ mod tests {
             &nodes[1].signature,
             &node_public_key
         ));
+    }
+
+    #[test]
+    fn save_claim_rejects_timestamp_not_after_latest_dag_node() {
+        let (mut store, _, _) = signed_store(35);
+        let d = did("did:exo:dag-causality-claim");
+        let first = claim(&d, ClaimType::Email);
+        let mut second = claim(&d, ClaimType::Phone);
+        second.claim_hash = Hash256::digest(b"same-time-second-claim");
+        second.created_ms = first.created_ms;
+
+        store.save_claim("apg-dag-causal-001", &first).unwrap();
+        let err = store.save_claim("apg-dag-causal-002", &second).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("strictly exceed latest DAG parent"),
+            "expected claim DAG causality refusal, got {err}"
+        );
+        assert_eq!(store.dag_nodes().len(), 1);
+        let claims = store.get_claims(&d).unwrap();
+        assert_eq!(claims.len(), 1);
+        assert_eq!(claims[0].0, "apg-dag-causal-001");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- validates Codex Security row 74 against current main
- persists saved claims with `dag_node_hash` set to the signed DAG node actually appended
- rejects claim DAG node timestamps that are zero or not strictly greater than the latest parent

## Path Classification
- `crates/exo-node/src/zerodentity/store.rs`: EXOCHAIN core 0dentity store and DAG evidence path

## Finding Validation
- `save_claim_binds_stored_claim_to_signed_dag_node_hash` failed before the fix because the stored claim kept a caller-controlled DAG pointer.
- `save_claim_rejects_timestamp_not_after_latest_dag_node` failed before the fix because same-timestamp child nodes were accepted.

## Tests
- `cargo test -p exo-node save_claim_ -- --nocapture`
- `cargo test -p exo-node zerodentity::store -- --nocapture`
- `cargo test -p exo-dag append -- --nocapture`
- `cargo test -p exo-node -- --nocapture`
- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p exo-node --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `git diff --check`

## Bypass Search
- `rg -n "validate_next_dag_timestamp|save_claim_binds_stored_claim|save_claim_rejects_timestamp_not_after_latest|insert_claim\(claim_id, claim\)" crates/exo-node/src/zerodentity/store.rs`
