### PR TITLE
fix(exoforge): emit fresh report timestamps

### DIFF
--- a/exoforge/bin/exoforge-council-review.js
+++ b/exoforge/bin/exoforge-council-review.js
@@ -34,6 +34,7 @@
 import {
   REVIEW_BINDING,
   REVIEW_METHOD,
+  reviewTimestampIso,
   getPanels,
   conductReview,
   tallyVotes
@@ -241,8 +242,9 @@ async function main() {
   }
 
   // Conduct review
-  const assessments = conductReview(panels, proposal);
-  const tally = tallyVotes(assessments);
+  const reviewedAt = reviewTimestampIso();
+  const assessments = conductReview(panels, proposal, reviewedAt);
+  const tally = tallyVotes(assessments, reviewedAt);
 
   if (args.json) {
     console.log(JSON.stringify({

--- a/exoforge/bin/exoforge-implement.js
+++ b/exoforge/bin/exoforge-implement.js
@@ -31,7 +31,7 @@
 import { getIssue } from '../lib/github.js';
 import {
   REVIEW_BINDING,
-  REVIEW_TIMESTAMP_ISO,
+  reviewTimestampIso,
   getPanels,
   conductReview,
   tallyVotes
@@ -287,8 +287,9 @@ async function main() {
       affectedSystems: (issue.labels || []).map(l => l.name || l),
       author: issue.author ? (issue.author.login || issue.author) : 'unknown'
     };
-    const assessments = conductReview(panels, proposal);
-    const tally = tallyVotes(assessments);
+    const reviewedAt = reviewTimestampIso();
+    const assessments = conductReview(panels, proposal, reviewedAt);
+    const tally = tallyVotes(assessments, reviewedAt);
 
     // Analyze file impact
     const affectedFiles = analyzeFileImpact(issue);
@@ -322,7 +323,7 @@ async function main() {
         : tally.total_findings > 2 ? 'medium' : 'low',
       requires_wasm_rebuild: affectedFiles.some(f => f.includes('crates/') || f.includes('wasm')),
       requires_council_review: tally.verdict !== 'APPROVED',
-      generated_at: REVIEW_TIMESTAMP_ISO,
+      generated_at: reviewedAt,
       execution_mode: 'planning_only',
       binding_review: REVIEW_BINDING,
       planning_note: 'This command generates an implementation readiness plan; it does not modify files.'

--- a/exoforge/bin/exoforge-monitor.js
+++ b/exoforge/bin/exoforge-monitor.js
@@ -44,7 +44,7 @@ import {
   buildValidationDecision,
   buildValidationTncFlags,
   buildValidationInvariantRequest,
-  VALIDATION_TIMESTAMP_ISO
+  validationReportTimestampIso
 } from '../lib/constitutional.js';
 
 // ── Parse CLI arguments ─────────────────────────────────────────────────────
@@ -262,7 +262,7 @@ function checkWorkflowStages() {
 /**
  * Run all health checks and produce an aggregate report.
  */
-function runHealthCheck(verbose) {
+function runHealthCheck(verbose, checkedAt = validationReportTimestampIso()) {
   const checks = [
     checkKernel(),
     checkTncEnforcement(),
@@ -295,7 +295,7 @@ function runHealthCheck(verbose) {
     })),
     exochain_version: '2.2',
     monitor_version: '0.1.0-beta',
-    checked_at: VALIDATION_TIMESTAMP_ISO
+    checked_at: checkedAt
   };
 
   return report;

--- a/exoforge/bin/exoforge-validate.js
+++ b/exoforge/bin/exoforge-validate.js
@@ -40,7 +40,7 @@ import {
   buildValidationDecision,
   buildValidationTncFlags,
   buildValidationInvariantRequest,
-  VALIDATION_TIMESTAMP_ISO
+  validationReportTimestampIso
 } from '../lib/constitutional.js';
 
 // ── Parse CLI arguments ─────────────────────────────────────────────────────
@@ -101,12 +101,12 @@ function buildInvariantContext() {
 /**
  * Run all validation checks and collect results.
  */
-function runValidation(args) {
+function runValidation(args, validatedAt = validationReportTimestampIso()) {
   const results = {
     kernel_loaded: false,
     checks: [],
     summary: { total: 0, passed: 0, failed: 0, skipped: 0 },
-    validated_at: VALIDATION_TIMESTAMP_ISO
+    validated_at: validatedAt
   };
 
   // Step 0: Load kernel

--- a/exoforge/lib/constitutional.js
+++ b/exoforge/lib/constitutional.js
@@ -27,7 +27,6 @@ const require = createRequire(import.meta.url);
 
 let wasm = null;
 
-export const VALIDATION_TIMESTAMP_ISO = '2023-11-14T22:13:20.000Z';
 const VALIDATION_TIMESTAMP_MS = 1_700_000_000_000;
 const VALIDATION_TIMESTAMP_MS_BIGINT = 1_700_000_000_000n;
 const VALIDATION_DECISION_ID = '00000000-0000-0000-0000-0000000005f0';
@@ -39,6 +38,14 @@ function repeatedByte(byte) {
 
 function validationTimestamp() {
   return { physical_ms: VALIDATION_TIMESTAMP_MS, logical: 0 };
+}
+
+function validationFixtureTimestampIso() {
+  return new Date(VALIDATION_TIMESTAMP_MS).toISOString();
+}
+
+export function validationReportTimestampIso() {
+  return new Date().toISOString();
 }
 
 /**
@@ -307,7 +314,7 @@ export function buildValidationInvariantRequest() {
     },
     provenance: {
       actor: 'did:exo:alice',
-      timestamp: VALIDATION_TIMESTAMP_ISO,
+      timestamp: validationFixtureTimestampIso(),
       action_hash: repeatedByte(4),
       signature: [1, 2, 3],
       voice_kind: 'Human',

--- a/exoforge/lib/panels.js
+++ b/exoforge/lib/panels.js
@@ -23,7 +23,10 @@
 
 export const REVIEW_METHOD = 'heuristic_triage';
 export const REVIEW_BINDING = false;
-export const REVIEW_TIMESTAMP_ISO = '2023-11-14T22:13:20.000Z';
+
+export function reviewTimestampIso() {
+  return new Date().toISOString();
+}
 
 /**
  * The 5 standing council panels.
@@ -128,11 +131,11 @@ export function getPanel(name) {
  * @returns {Array} Array of panel assessments:
  *   { panel, vote, confidence, findings, criteria_met, criteria_failed }
  */
-export function conductReview(panels, proposal) {
+export function conductReview(panels, proposal, reviewedAt = reviewTimestampIso()) {
   const assessments = [];
 
   for (const panel of panels) {
-    const assessment = evaluatePanel(panel, proposal);
+    const assessment = evaluatePanel(panel, proposal, reviewedAt);
     assessments.push(assessment);
   }
 
@@ -149,7 +152,7 @@ export function conductReview(panels, proposal) {
  * @param {object} proposal - Proposal to evaluate
  * @returns {object} Panel assessment
  */
-function evaluatePanel(panel, proposal) {
+function evaluatePanel(panel, proposal, reviewedAt) {
   const desc = (proposal.description || '').toLowerCase();
   const title = (proposal.title || '').toLowerCase();
   const combined = `${title} ${desc}`;
@@ -292,7 +295,7 @@ function evaluatePanel(panel, proposal) {
     findings,
     criteria_met: criteriaMet,
     criteria_failed: criteriaFailed,
-    reviewed_at: REVIEW_TIMESTAMP_ISO
+    reviewed_at: reviewedAt
   };
 }
 
@@ -314,7 +317,7 @@ function evaluatePanel(panel, proposal) {
  * @param {Array} votes - Array of panel assessments (from conductReview)
  * @returns {object} { verdict, score, breakdown, vetoed_by, total_findings }
  */
-export function tallyVotes(votes) {
+export function tallyVotes(votes, reviewedAt = votes[0]?.reviewed_at || reviewTimestampIso()) {
   const voteValues = {
     approve: 1.0,
     approve_with_conditions: 0.5,
@@ -374,6 +377,6 @@ export function tallyVotes(votes) {
     vetoed_by: vetoedBy,
     total_findings: totalFindings,
     panels_reviewed: votes.length,
-    reviewed_at: REVIEW_TIMESTAMP_ISO
+    reviewed_at: reviewedAt
   };
 }

--- a/exoforge/test/product-contracts.test.js
+++ b/exoforge/test/product-contracts.test.js
@@ -15,16 +15,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
 import { test } from 'node:test';
 import { promisify } from 'node:util';
 import { equal, ok } from 'node:assert/strict';
 
 const execFileAsync = promisify(execFile);
+const repoRoot = new URL('../..', import.meta.url);
 
 async function runJsonCli(script, args = []) {
   try {
     const { stdout } = await execFileAsync(process.execPath, [script, ...args], {
-      cwd: new URL('../..', import.meta.url),
+      cwd: repoRoot,
       maxBuffer: 1024 * 1024,
     });
     return JSON.parse(stdout);
@@ -60,4 +62,25 @@ test('exoforge-council-review labels heuristic output as non-binding triage', as
   equal(review.binding_review, false);
   equal(review.verdict.review_method, 'heuristic_triage');
   equal(review.verdict.binding_review, false);
+});
+
+test('exoforge report timestamps are not hard-coded', async () => {
+  const sourceFiles = [
+    '../lib/panels.js',
+    '../lib/constitutional.js',
+    '../bin/exoforge-implement.js',
+    '../bin/exoforge-council-review.js',
+    '../bin/exoforge-validate.js',
+    '../bin/exoforge-monitor.js',
+  ];
+
+  const sources = await Promise.all(
+    sourceFiles.map(async path => [path, await readFile(new URL(path, import.meta.url), 'utf8')])
+  );
+
+  for (const [path, source] of sources) {
+    ok(!source.includes('2023-11-14T22:13:20.000Z'), `${path} must not emit stale report timestamps`);
+    ok(!source.includes('REVIEW_TIMESTAMP_ISO'), `${path} must not depend on a fixed review timestamp`);
+    ok(!source.includes('VALIDATION_TIMESTAMP_ISO'), `${path} must not depend on a fixed validation timestamp`);
+  }
 });


### PR DESCRIPTION
Classification: adjacent surface/tooling (ExoForge implementation/review/validation reports).

Verification against current main: Codex Security row 75 was still valid; ExoForge report paths used fixed 2023-11-14T22:13:20.000Z metadata via REVIEW_TIMESTAMP_ISO and VALIDATION_TIMESTAMP_ISO.

Remediation: added fresh report timestamp helpers, threaded one timestamp through each report run, and kept deterministic validation fixture timestamps separate from output metadata.

Tests:
- node --test exoforge/test/product-contracts.test.js
- CLI timestamp checks for exoforge-implement, exoforge-council-review, exoforge-validate, and exoforge-monitor
- git diff --check

Known separate failure not fixed in this adjacent timestamp PR:
- node --test exoforge/test/*.test.js still fails exoforge/test/validation-contracts.test.js because live WASM TNC/invariant validation currently rejects the existing validation fixture. That was observed before this timestamp patch and is not mixed into this commit.