### PR TITLE
fix(vitallock): bind death trustees to accepted PACE keys

### DIFF
--- a/demo/apps/vitallock/src/lib/api.ts
+++ b/demo/apps/vitallock/src/lib/api.ts
@@ -87,6 +87,7 @@ export const inviteTrustee = (data: {
 export const acceptInvitation = (data: {
   invitation_token: string;
   trustee_did: string;
+  trustee_ed25519_public_key_hex: string;
 }) => request<{ accepted: boolean }>('/pace/accept', {
   method: 'POST',
   body: JSON.stringify(data),
@@ -94,7 +95,7 @@ export const acceptInvitation = (data: {
 
 export const getPaceNetwork = (did: string) =>
   request<Array<{
-    id: number; trustee_did: string | null; trustee_email: string;
+    id: number; trustee_did: string | null; trustee_ed25519_public_key_hex: string | null; trustee_email: string;
     trustee_name: string; role: string; relationship: string | null;
     invitation_status: string;
   }>>(`/pace/network/${did}`);
@@ -109,6 +110,10 @@ export const initiateDeath = (data: {
   subject_did: string;
   initiated_by_did: string;
   required_confirmations?: number;
+  claim_nonce_hex: string;
+  initiator_signature_hex: string;
+  created_physical_ms: number;
+  created_logical: number;
 }) => request<{ id: string; status: string }>('/death/initiate', {
   method: 'POST',
   body: JSON.stringify(data),
@@ -117,6 +122,9 @@ export const initiateDeath = (data: {
 export const confirmDeath = (data: {
   verification_id: string;
   trustee_did: string;
+  signature_hex: string;
+  confirmed_physical_ms: number;
+  confirmed_logical: number;
 }) => request<{ verified: boolean; confirmations: number }>('/death/confirm', {
   method: 'POST',
   body: JSON.stringify(data),

--- a/demo/infra/postgres/init/004_vitallock.sql
+++ b/demo/infra/postgres/init/004_vitallock.sql
@@ -35,6 +35,10 @@ CREATE TABLE IF NOT EXISTS pace_network (
     id BIGSERIAL PRIMARY KEY,
     owner_did TEXT NOT NULL REFERENCES users(did),
     trustee_did TEXT,
+    trustee_ed25519_public_key_hex TEXT CHECK (
+        trustee_ed25519_public_key_hex IS NULL
+        OR trustee_ed25519_public_key_hex ~ '^[0-9a-fA-F]{64}$'
+    ),
     trustee_email TEXT NOT NULL,
     trustee_name TEXT NOT NULL,
     role TEXT NOT NULL CHECK (role IN ('Primary','Alternate','Contingency','Emergency')),
@@ -47,6 +51,8 @@ CREATE TABLE IF NOT EXISTS pace_network (
     accepted_at_ms BIGINT,
     UNIQUE(owner_did, trustee_email)
 );
+ALTER TABLE pace_network
+    ADD COLUMN IF NOT EXISTS trustee_ed25519_public_key_hex TEXT;
 CREATE INDEX IF NOT EXISTS idx_pace_owner ON pace_network(owner_did);
 CREATE INDEX IF NOT EXISTS idx_pace_trustee ON pace_network(trustee_did);
 CREATE INDEX IF NOT EXISTS idx_pace_token ON pace_network(invitation_token);

--- a/demo/services/vitallock-api/src/index.js
+++ b/demo/services/vitallock-api/src/index.js
@@ -44,6 +44,76 @@ function parseBody(req) {
 
 function nowMs() { return Date.now(); }
 
+const DEFAULT_DEATH_CONFIRMATIONS = 3;
+const ED25519_PUBLIC_KEY_HEX = /^[0-9a-fA-F]{64}$/;
+
+function normalizeDeathConfirmationThreshold(value) {
+  if (value === undefined || value === null) return DEFAULT_DEATH_CONFIRMATIONS;
+  if (!Number.isInteger(value) || value < 1 || value > 255) return null;
+  return value;
+}
+
+function normalizeEd25519PublicKeyHex(value) {
+  if (typeof value !== 'string' || !ED25519_PUBLIC_KEY_HEX.test(value)) return null;
+  return value.toLowerCase();
+}
+
+function publicKeyValueToHex(value) {
+  if (typeof value === 'string') return normalizeEd25519PublicKeyHex(value);
+  if (Array.isArray(value) && value.length === 32) {
+    return Buffer.from(value).toString('hex');
+  }
+  if (value && typeof value === 'object') {
+    return publicKeyValueToHex(value.public_key_hex)
+      || publicKeyValueToHex(value.public_key)
+      || publicKeyValueToHex(value.Ed25519);
+  }
+  return null;
+}
+
+function parseStoredJson(value) {
+  if (typeof value !== 'string') return value;
+  return JSON.parse(value);
+}
+
+function trustedTrusteesFromPaceRows(rows) {
+  return rows
+    .map(row => ({
+      did: row.trustee_did,
+      public_key_hex: normalizeEd25519PublicKeyHex(row.trustee_ed25519_public_key_hex),
+    }))
+    .filter(trustee => trustee.did && trustee.public_key_hex);
+}
+
+function trusteePublicKeyFromState(state, trusteeDid) {
+  const authorized = state?.authorized_trustees;
+  if (Array.isArray(authorized)) {
+    const entry = authorized.find(trustee => trustee.did === trusteeDid || trustee.trustee_did === trusteeDid);
+    return entry ? publicKeyValueToHex(entry.public_key_hex ?? entry.public_key) : null;
+  }
+  if (authorized && typeof authorized === 'object') {
+    return publicKeyValueToHex(authorized[trusteeDid]);
+  }
+  return null;
+}
+
+async function acceptedDeathVerificationTrustees(subjectDid) {
+  const { rows } = await pool.query(
+    `SELECT trustee_did, trustee_ed25519_public_key_hex
+     FROM pace_network
+     WHERE owner_did = $1
+       AND invitation_status = 'accepted'
+       AND trustee_did IS NOT NULL
+       AND trustee_ed25519_public_key_hex IS NOT NULL
+     ORDER BY CASE role
+       WHEN 'Primary' THEN 1 WHEN 'Alternate' THEN 2
+       WHEN 'Contingency' THEN 3 WHEN 'Emergency' THEN 4 ELSE 5
+     END, trustee_did`,
+    [subjectDid]
+  );
+  return trustedTrusteesFromPaceRows(rows);
+}
+
 export const server = http.createServer(async (req, res) => {
   if (req.method === 'OPTIONS') {
     res.writeHead(204, {
@@ -247,13 +317,26 @@ export const server = http.createServer(async (req, res) => {
 
     // ── Accept invitation ──
     if (url.pathname === '/api/pace/accept' && req.method === 'POST') {
-      const { invitation_token, trustee_did } = await parseBody(req);
+      const {
+        invitation_token,
+        trustee_did,
+        trustee_ed25519_public_key_hex,
+      } = await parseBody(req);
+      const normalizedTrusteeKey = normalizeEd25519PublicKeyHex(trustee_ed25519_public_key_hex);
+      if (!normalizedTrusteeKey) {
+        return json(res, 400, {
+          error: 'trustee_ed25519_public_key_hex must be a 32-byte Ed25519 public key hex string',
+        });
+      }
       const result = await pool.query(
         `UPDATE pace_network
-         SET trustee_did = $1, invitation_status = 'accepted', accepted_at_ms = $2
-         WHERE invitation_token = $3 AND invitation_status = 'pending'
+         SET trustee_did = $1,
+             trustee_ed25519_public_key_hex = $2,
+             invitation_status = 'accepted',
+             accepted_at_ms = $3
+         WHERE invitation_token = $4 AND invitation_status = 'pending'
          RETURNING *`,
-        [trustee_did, nowMs(), invitation_token]
+        [trustee_did, normalizedTrusteeKey, nowMs(), invitation_token]
       );
       if (result.rows.length === 0) {
         return json(res, 404, { error: 'invitation not found or already accepted' });
@@ -265,7 +348,8 @@ export const server = http.createServer(async (req, res) => {
     if (url.pathname.startsWith('/api/pace/network/') && req.method === 'GET') {
       const did = url.pathname.split('/api/pace/network/')[1];
       const { rows } = await pool.query(
-        `SELECT id, trustee_did, trustee_email, trustee_name, role,
+        `SELECT id, trustee_did, trustee_ed25519_public_key_hex,
+                trustee_email, trustee_name, role,
                 relationship, invitation_status, created_at_ms, accepted_at_ms
          FROM pace_network WHERE owner_did = $1
          ORDER BY CASE role
@@ -300,16 +384,12 @@ export const server = http.createServer(async (req, res) => {
         subject_did,
         initiated_by_did,
         required_confirmations,
-        authorized_trustees,
         claim_nonce_hex,
         initiator_signature_hex,
         created_physical_ms,
         created_logical,
       } = await parseBody(req);
 
-      if (!Array.isArray(authorized_trustees)) {
-        return json(res, 400, { error: 'authorized_trustees must be an array' });
-      }
       if (!claim_nonce_hex || !initiator_signature_hex) {
         return json(res, 400, {
           error: 'claim_nonce_hex and initiator_signature_hex are required',
@@ -320,12 +400,30 @@ export const server = http.createServer(async (req, res) => {
           error: 'created_physical_ms and created_logical are required',
         });
       }
+      const confirmationThreshold = normalizeDeathConfirmationThreshold(required_confirmations);
+      if (confirmationThreshold === null) {
+        return json(res, 400, {
+          error: 'required_confirmations must be an integer from 1 to 255',
+        });
+      }
+
+      const authorizedTrustees = await acceptedDeathVerificationTrustees(subject_did);
+      if (authorizedTrustees.length < confirmationThreshold) {
+        return json(res, 400, {
+          error: `subject has ${authorizedTrustees.length} accepted PACE trustees with registered signing keys; ${confirmationThreshold} required`,
+        });
+      }
+      if (!authorizedTrustees.some(trustee => trustee.did === initiated_by_did)) {
+        return json(res, 403, {
+          error: 'initiated_by_did must be an accepted PACE trustee with a registered signing key',
+        });
+      }
 
       const state = wasm.wasm_death_verification_new(
         subject_did,
         initiated_by_did,
-        required_confirmations || 3,
-        JSON.stringify(authorized_trustees),
+        confirmationThreshold,
+        JSON.stringify(authorizedTrustees),
         claim_nonce_hex,
         initiator_signature_hex,
         BigInt(created_physical_ms),
@@ -339,7 +437,7 @@ export const server = http.createServer(async (req, res) => {
          (id, subject_did, initiated_by, required_confirmations,
           trustee_confirmations, verification_state, status, created_at_ms)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-        [id, subject_did, initiated_by_did, required_confirmations || 3,
+        [id, subject_did, initiated_by_did, confirmationThreshold,
          JSON.stringify(state.confirmations || []), JSON.stringify(state), initialStatus, created_physical_ms]
       );
 
@@ -351,15 +449,14 @@ export const server = http.createServer(async (req, res) => {
       const {
         verification_id,
         trustee_did,
-        trustee_public_key_hex,
         signature_hex,
         confirmed_physical_ms,
         confirmed_logical,
       } = await parseBody(req);
 
-      if (!trustee_public_key_hex || !signature_hex) {
+      if (!trustee_did || !signature_hex) {
         return json(res, 400, {
-          error: 'trustee_public_key_hex and signature_hex are required',
+          error: 'trustee_did and signature_hex are required',
         });
       }
       if (confirmed_physical_ms === undefined || confirmed_logical === undefined) {
@@ -378,14 +475,19 @@ export const server = http.createServer(async (req, res) => {
       if (dv.status !== 'pending') {
         return json(res, 400, { error: 'verification already resolved' });
       }
-      if (!dv.verification_state || !dv.verification_state.subject_did) {
+      const verificationState = parseStoredJson(dv.verification_state);
+      if (!verificationState || !verificationState.subject_did) {
         return json(res, 500, { error: 'stored verification_state is invalid' });
+      }
+      const trusteePublicKeyHex = trusteePublicKeyFromState(verificationState, trustee_did);
+      if (!trusteePublicKeyHex) {
+        return json(res, 403, { error: 'trustee is not authorized for this death verification' });
       }
 
       const result = wasm.wasm_death_verification_confirm(
-        JSON.stringify(dv.verification_state),
+        JSON.stringify(verificationState),
         trustee_did,
-        trustee_public_key_hex,
+        trusteePublicKeyHex,
         signature_hex,
         BigInt(confirmed_physical_ms),
         confirmed_logical
@@ -628,6 +730,8 @@ export const server = http.createServer(async (req, res) => {
   }
 });
 
-server.listen(PORT, () => {
-  console.log(`✅ VitalLock API running on port ${PORT}`);
-});
+if (process.env.NODE_ENV !== 'test') {
+  server.listen(PORT, () => {
+    console.log(`✅ VitalLock API running on port ${PORT}`);
+  });
+}

--- a/demo/services/vitallock-api/src/index.test.js
+++ b/demo/services/vitallock-api/src/index.test.js
@@ -1,0 +1,192 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import supertest from 'supertest';
+
+const mockWasm = vi.hoisted(() => ({
+  wasm_death_verification_new: vi.fn((
+    subjectDid,
+    initiatedByDid,
+    requiredConfirmations,
+    authorizedTrusteesJson,
+  ) => ({
+    subject_did: subjectDid,
+    initiated_by: initiatedByDid,
+    required_confirmations: requiredConfirmations,
+    authorized_trustees: JSON.parse(authorizedTrusteesJson),
+    confirmations: [],
+    status: 'Pending',
+  })),
+  wasm_death_verification_confirm: vi.fn((stateJson, trusteeDid) => ({
+    verified: false,
+    confirmations_remaining: 1,
+    state: {
+      ...JSON.parse(stateJson),
+      confirmations: [{ trustee_did: trusteeDid }],
+      status: 'Pending',
+    },
+  })),
+}));
+
+const mockPg = vi.hoisted(() => {
+  const query = vi.fn();
+  const Pool = vi.fn(() => ({ query }));
+  return { Pool, query };
+});
+
+vi.mock('module', async (importOriginal) => {
+  const orig = await importOriginal();
+  return {
+    ...orig,
+    createRequire: () => (id) => {
+      if (id === '@exochain/exochain-wasm') return mockWasm;
+      throw new Error(`Unexpected require('${id}') in test`);
+    },
+  };
+});
+
+vi.mock('pg', () => ({ default: { Pool: mockPg.Pool } }));
+
+import { server } from './index.js';
+
+const request = supertest(server);
+
+const trustedRows = [
+  {
+    trustee_did: 'did:exo:trusted-primary',
+    trustee_ed25519_public_key_hex: '11'.repeat(32),
+  },
+  {
+    trustee_did: 'did:exo:trusted-alternate',
+    trustee_ed25519_public_key_hex: '22'.repeat(32),
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPg.query.mockReset();
+  mockPg.query.mockResolvedValue({ rows: [] });
+});
+
+afterAll(async () => {
+  if (server.listening) {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+describe('POST /api/death/initiate trustee boundary', () => {
+  it('derives authorized death trustees from accepted PACE rows instead of request body trust anchors', async () => {
+    mockPg.query.mockImplementation((sql) => {
+      if (String(sql).includes('FROM pace_network')) {
+        return Promise.resolve({ rows: trustedRows });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const res = await request.post('/api/death/initiate').send({
+      subject_did: 'did:exo:victim',
+      initiated_by_did: 'did:exo:trusted-primary',
+      required_confirmations: 2,
+      authorized_trustees: [
+        { did: 'did:exo:attacker-one', public_key_hex: 'aa'.repeat(32) },
+        { did: 'did:exo:attacker-two', public_key_hex: 'bb'.repeat(32) },
+      ],
+      claim_nonce_hex: 'cafe',
+      initiator_signature_hex: 'dd'.repeat(64),
+      created_physical_ms: 1000,
+      created_logical: 0,
+    });
+
+    expect(res.status).toBe(201);
+    const authorizedTrusteesJson = mockWasm.wasm_death_verification_new.mock.calls[0][3];
+    expect(JSON.parse(authorizedTrusteesJson)).toEqual([
+      { did: 'did:exo:trusted-primary', public_key_hex: '11'.repeat(32) },
+      { did: 'did:exo:trusted-alternate', public_key_hex: '22'.repeat(32) },
+    ]);
+  });
+
+  it('fails closed when accepted PACE trustees do not have enough registered signing keys', async () => {
+    mockPg.query.mockImplementation((sql) => {
+      if (String(sql).includes('FROM pace_network')) {
+        return Promise.resolve({ rows: [trustedRows[0]] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const res = await request.post('/api/death/initiate').send({
+      subject_did: 'did:exo:victim',
+      initiated_by_did: 'did:exo:trusted-primary',
+      required_confirmations: 2,
+      authorized_trustees: [
+        { did: 'did:exo:attacker-one', public_key_hex: 'aa'.repeat(32) },
+        { did: 'did:exo:attacker-two', public_key_hex: 'bb'.repeat(32) },
+      ],
+      claim_nonce_hex: 'cafe',
+      initiator_signature_hex: 'dd'.repeat(64),
+      created_physical_ms: 1000,
+      created_logical: 0,
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/accepted PACE trustees/);
+    expect(mockWasm.wasm_death_verification_new).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/death/confirm trustee boundary', () => {
+  it('uses the public key bound into stored verification state instead of request body key material', async () => {
+    const storedState = {
+      subject_did: 'did:exo:victim',
+      authorized_trustees: [
+        { did: 'did:exo:trusted-alternate', public_key_hex: '22'.repeat(32) },
+      ],
+      confirmations: [],
+      status: 'Pending',
+    };
+
+    mockPg.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'death-1',
+          subject_did: 'did:exo:victim',
+          status: 'pending',
+          required_confirmations: 2,
+          verification_state: storedState,
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await request.post('/api/death/confirm').send({
+      verification_id: 'death-1',
+      trustee_did: 'did:exo:trusted-alternate',
+      trustee_public_key_hex: 'aa'.repeat(32),
+      signature_hex: 'bb'.repeat(64),
+      confirmed_physical_ms: 2000,
+      confirmed_logical: 0,
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockWasm.wasm_death_verification_confirm).toHaveBeenCalledWith(
+      JSON.stringify(storedState),
+      'did:exo:trusted-alternate',
+      '22'.repeat(32),
+      'bb'.repeat(64),
+      2000n,
+      0,
+    );
+  });
+});


### PR DESCRIPTION
Classification:
- Adjacent surface/core runtime adapter: demo/services/vitallock-api/src/index.js, demo/services/vitallock-api/src/index.test.js, demo/apps/vitallock/src/lib/api.ts, demo/infra/postgres/init/004_vitallock.sql.
- Core verification references checked but not changed: crates/exo-messaging and crates/exochain-wasm death verification.

Verification against current main: Codex Security finding was still valid. /api/death/initiate accepted request-body authorized_trustees and passed them directly to WASM; /api/death/confirm accepted trustee_public_key_hex from the request body.

Remediation:
- PACE acceptance now requires and stores trustee_ed25519_public_key_hex.
- Death initiation derives authorized trustees from accepted pace_network rows for subject_did and ignores caller-supplied trust anchors.
- Death initiation fails closed if accepted PACE trustees with registered signing keys are below threshold or initiator is not one of them.
- Death confirmation derives trustee public key material from the stored verification state instead of the request body.
- Added VitalLock service tests for forged trustee maps, insufficient trusted PACE keys, and forged confirmation public keys.

Adjacent surface intake record:
- Owner/accountable maintainer: Exochain Foundation VitalLock maintainers.
- Deployment status: adjacent demo/customer-zero service, not canonical EXOCHAIN core.
- Constitutional trust claims: not allowed to claim EXOCHAIN protection by proximity; death release may claim only that this adapter derives trustee keys from persisted accepted PACE rows before calling WASM.
- Core state access: does not write canonical EXOCHAIN core state; it persists adjacent vitallock profiles, pace_network, death_verification, encrypted_messages, and related demo rows in DATABASE_URL.
- Trust boundary: public request bodies are untrusted; PACE accepted rows plus registered Ed25519 trustee keys are the local trust anchor for death verification; WASM/core validates signatures against that derived set.
- Surface-specific test/CI gate: npx vitest run --workspace vitest.workspace.js --project services services/vitallock-api/src/index.test.js and npm test from demo/.
- Secrets/runtime configuration: DATABASE_URL; no signing keys or bootstrap secrets are stored in process env by this change. Trustee public keys are public verification keys stored in pace_network.
- Rollback/disablement: disable /api/death/initiate and /api/death/confirm at the gateway/service route layer or remove accepted trustee signing keys to fail closed before message release.

Validation:
- npx vitest run --workspace vitest.workspace.js --project services services/vitallock-api/src/index.test.js
- npx vitest run --workspace vitest.workspace.js --project services
- npm test (demo workspace)
- npm run test:security (demo/apps/vitallock)
- node --check demo/services/vitallock-api/src/index.js
- node --check demo/services/vitallock-api/src/index.test.js
- cargo test -p exo-messaging -- --nocapture
- cargo test -p exochain-wasm death_verification -- --nocapture
- node packages/exochain-wasm/test/bridge_verification.mjs
- cargo +nightly fmt --all -- --check
- cargo check --workspace --all-targets
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- git diff --check

Validation note: npm run build in demo/apps/vitallock could not run because that standalone package has no local install and tsc is not present; no callers currently reference the changed API helper signatures.