### PR TITLE
fix(ci): scan tsx gap stub markers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,16 +251,7 @@ jobs:
         # Fails if any `STUB` marker referencing a GAP-NNN identifier
         # remains in a code file. Prevents a GAP from being marked closed
         # in GAP-REGISTRY.md while a stub still lives in the tree.
-        run: |
-          MATCHES=$(grep -rEn "STUB[^\n]*GAP-0[0-9][0-9]" \
-            --include='*.rs' --include='*.ts' --include='*.py' \
-            crates/ packages/ web/src/ 2>/dev/null || true)
-          if [ -n "$MATCHES" ]; then
-            echo "::error::GAP stubs remain in code:"
-            echo "$MATCHES"
-            exit 1
-          fi
-          echo "✓ No GAP stubs remaining in code"
+        run: bash tools/test_gap_stub_ci_guard.sh
       - name: GitHub Actions pinned to immutable SHAs
         run: bash tools/test_github_actions_pinned.sh
       - name: GitHub issue workflow trust boundary

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 198274 | `wc -l` |
-| Workspace tests | 4,453 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 198924 | `wc -l` |
+| Workspace tests | 4,467 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |

--- a/tools/test_gap_stub_ci_guard.sh
+++ b/tools/test_gap_stub_ci_guard.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "GAP stub CI guard test failed: $*" >&2
+  exit 1
+}
+
+workflow=".github/workflows/ci.yml"
+
+scan_gap_stubs() {
+  grep -rEn \
+    "(STUB.*GAP-0[0-9][0-9]|GAP-0[0-9][0-9].*STUB)" \
+    --include='*.rs' \
+    --include='*.ts' \
+    --include='*.tsx' \
+    --include='*.js' \
+    --include='*.jsx' \
+    --include='*.mjs' \
+    --include='*.py' \
+    "$@" 2>/dev/null || true
+}
+
+grep -F "bash tools/test_gap_stub_ci_guard.sh" "$workflow" >/dev/null \
+  || fail "CI must run tools/test_gap_stub_ci_guard.sh"
+
+if grep -F "[^\\n]" "$workflow" >/dev/null; then
+  fail "CI GAP stub scan must not use grep ERE [^\\n]; it excludes literal n characters"
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/crates" "$tmp_dir/packages" "$tmp_dir/web/src"
+printf '%s\n' '// STUB pending GAP-001' > "$tmp_dir/web/src/StubFixture.tsx"
+printf '%s\n' '// GAP-002 temporary STUB' > "$tmp_dir/crates/lib.rs"
+printf '%s\n' '// STUB remediation GAP-003' > "$tmp_dir/packages/index.js"
+
+fixture_matches="$(scan_gap_stubs "$tmp_dir/crates" "$tmp_dir/packages" "$tmp_dir/web/src")"
+for expected in "StubFixture.tsx" "lib.rs" "index.js"; do
+  if ! grep -F "$expected" <<<"$fixture_matches" >/dev/null; then
+    fail "scan did not catch fixture $expected"
+  fi
+done
+
+matches="$(scan_gap_stubs crates packages web/src)"
+if [ -n "$matches" ]; then
+  echo "::error::GAP stubs remain in code:"
+  echo "$matches"
+  exit 1
+fi
+
+echo "GAP stub CI guard test passed"


### PR DESCRIPTION
Classification:
- EXOCHAIN CI hygiene: .github/workflows/ci.yml and tools/test_gap_stub_ci_guard.sh.
- Documentation/repo-truth support: README.md derived Rust LOC and workspace-test counts updated to satisfy the existing repo-truth CI gate.

Verification against current main: Codex Security finding was still valid. The A-102 CI step used grep ERE STUB[^\n]*GAP-0[0-9][0-9], which misses lines containing literal n characters, and scanned *.rs, *.ts, and *.py but not TSX React sources.

Remediation:
- Replaced the fragile inline grep with tools/test_gap_stub_ci_guard.sh.
- The guard self-tests fixtures for STUB pending GAP-001 in TSX, GAP-002 temporary STUB in Rust, and JS stub markers.
- The actual repo scan now covers rs, ts, tsx, js, jsx, mjs, and py under crates, packages, and web/src.
- Refreshed README repo-truth numbers exposed by the existing CI gate.

Validation:
- bash tools/test_gap_stub_ci_guard.sh
- bash tools/test_repo_truth.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci yaml ok"'\n- bash tools/test_github_actions_pinned.sh\n- bash tools/test_ci_supply_chain_hardening.sh\n- git diff --check