### PR TITLE
fix(crosschecked): authenticate clearance actions

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -196,5 +196,6 @@ See [docs/guides/ARCHON-INTEGRATION.md](../docs/guides/ARCHON-INTEGRATION.md) fo
 | `DATABASE_URL` | PostgreSQL connection string | `postgres://exochain:exochain@localhost:5432/exochain` |
 | `PORT` | Service listen port | Varies per service (see table above) |
 | `NODE_ENV` | Runtime environment | `development` |
+| `CROSSCHECKED_API_TOKENS` | CrossChecked API bearer principal map as JSON: `{"token":{"actor_did":"did:exo:...","role":"steward"}}`. Missing or malformed values make `/api` routes fail closed with `401`. | None |
 
 Each service reads its own `PORT` from the environment. In Docker Compose, these are pre-configured in the compose file.

--- a/demo/apps/crosschecked/src/hooks/useAuth.ts
+++ b/demo/apps/crosschecked/src/hooks/useAuth.ts
@@ -21,6 +21,7 @@ export interface AuthState {
   did: string;
   displayName: string;
   role: string;
+  apiToken: string;
 }
 
 interface AuthContextType {

--- a/demo/apps/crosschecked/src/lib/api.ts
+++ b/demo/apps/crosschecked/src/lib/api.ts
@@ -15,9 +15,34 @@
 // SPDX-License-Identifier: Apache-2.0
 
 const API = '/api';
+const AUTH_STORAGE_KEY = 'crosschecked_auth';
+
+function authToken() {
+  try {
+    const raw = sessionStorage.getItem(AUTH_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed.apiToken === 'string' && parsed.apiToken.length > 0) {
+      return parsed.apiToken;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function apiHeaders(headersInit?: HeadersInit) {
+  const headers = new Headers(headersInit);
+  if (!headers.has('Content-Type')) headers.set('Content-Type', 'application/json');
+  if (!headers.has('Authorization')) {
+    const token = authToken();
+    if (token) headers.set('Authorization', `Bearer ${token}`);
+  }
+  return headers;
+}
 
 async function req<T>(path: string, opts?: RequestInit): Promise<T> {
-  const res = await fetch(`${API}${path}`, { headers: { 'Content-Type': 'application/json' }, ...opts });
+  const res = await fetch(`${API}${path}`, { ...opts, headers: apiHeaders(opts?.headers) });
   if (!res.ok) { const e = await res.json().catch(() => ({ error: res.statusText })); throw new Error(e.error || `API ${res.status}`); }
   return res.json();
 }

--- a/demo/apps/crosschecked/src/pages/Login.tsx
+++ b/demo/apps/crosschecked/src/pages/Login.tsx
@@ -37,6 +37,7 @@ export default function Login({ mode }: LoginProps) {
   const [activeTab, setActiveTab] = useState<'login' | 'register'>(mode);
   const [displayName, setDisplayName] = useState('');
   const [passphrase, setPassphrase] = useState('');
+  const [apiToken, setApiToken] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const { login } = useAuth();
@@ -48,9 +49,12 @@ export default function Login({ mode }: LoginProps) {
     setLoading(true);
 
     try {
+      if (apiToken.trim().length === 0) {
+        throw new Error('missing API token');
+      }
       const did = await deriveDidFromPassphrase(passphrase);
       const name = activeTab === 'register' ? displayName : `User ${did.slice(-6)}`;
-      login({ did, displayName: name, role: 'steward' });
+      login({ did, displayName: name, role: 'steward', apiToken: apiToken.trim() });
       navigate('/dashboard');
     } catch {
       setError('Authentication failed. Please try again.');
@@ -128,6 +132,21 @@ export default function Login({ mode }: LoginProps) {
                   onChange={(e) => setPassphrase(e.target.value)}
                   className="w-full pl-10 pr-4 py-2.5 rounded-lg bg-xc-navy border border-white/10 text-white text-sm placeholder:text-gray-500 focus:outline-none focus:border-xc-indigo-500 transition-colors"
                   placeholder="Enter your passphrase"
+                  required
+                />
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-xs text-gray-400 mb-1.5">API Token</label>
+              <div className="relative">
+                <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500" />
+                <input
+                  type="password"
+                  value={apiToken}
+                  onChange={(e) => setApiToken(e.target.value)}
+                  className="w-full pl-10 pr-4 py-2.5 rounded-lg bg-xc-navy border border-white/10 text-white text-sm placeholder:text-gray-500 focus:outline-none focus:border-xc-indigo-500 transition-colors"
+                  placeholder="Enter your API token"
                   required
                 />
               </div>

--- a/demo/infra/postgres/init/006_crosschecked.sql
+++ b/demo/infra/postgres/init/006_crosschecked.sql
@@ -26,14 +26,14 @@ CREATE TABLE IF NOT EXISTS crosscheck_policy (
         CHECK (mode IN ('single', 'quorum')),
     quorum_count INTEGER NOT NULL DEFAULT 2,
     allowed_roles JSONB DEFAULT '["reviewer", "steward"]',
-    require_valid_signatures BOOLEAN DEFAULT FALSE,
+    require_valid_signatures BOOLEAN DEFAULT TRUE,
     reject_veto BOOLEAN DEFAULT TRUE,
     created_at_ms BIGINT NOT NULL
 );
 
 -- Default clearance policy (matching upk.yaml)
 INSERT INTO crosscheck_policy (id, name, mode, quorum_count, allowed_roles, require_valid_signatures, reject_veto, created_at_ms)
-VALUES ('default', 'Default Clearance Policy', 'quorum', 2, '["reviewer", "steward"]', false, true, 0)
+VALUES ('default', 'Default Clearance Policy', 'quorum', 2, '["reviewer", "steward"]', true, true, 0)
 ON CONFLICT (id) DO NOTHING;
 
 -- Public key registry for actors

--- a/demo/services/crosschecked-api/src/index.js
+++ b/demo/services/crosschecked-api/src/index.js
@@ -30,7 +30,7 @@ function json(res, status, data) {
   res.writeHead(status, {
     'Content-Type': 'application/json',
     'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
   });
   res.end(JSON.stringify(data, null, 2));
 }
@@ -45,6 +45,134 @@ function parseBody(req) {
 
 function nowMs() { return Date.now(); }
 function genId(prefix = 'CR') { return `${prefix}-${crypto.randomUUID().replace(/-/g, '').slice(0, 10)}`; }
+
+const ALLOWED_ROLES = ['proposer', 'reviewer', 'steward', 'participant'];
+
+function parseApiTokens(raw) {
+  if (!raw) return new Map();
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return new Map();
+    const tokens = new Map();
+    for (const [token, principal] of Object.entries(parsed)) {
+      if (!token || typeof token !== 'string') return new Map();
+      if (!principal || typeof principal !== 'object' || Array.isArray(principal)) return new Map();
+      const did = principal.actor_did;
+      const role = principal.role;
+      if (typeof did !== 'string' || did.length === 0) return new Map();
+      if (typeof role !== 'string' || !ALLOWED_ROLES.includes(role)) return new Map();
+      tokens.set(token, { did, role });
+    }
+    return tokens;
+  } catch {
+    return new Map();
+  }
+}
+
+const apiTokens = parseApiTokens(process.env.CROSSCHECKED_API_TOKENS);
+
+function authenticatedActor(req) {
+  const header = req.headers.authorization || '';
+  const match = /^Bearer\s+(.+)$/.exec(header);
+  if (!match) return null;
+  return apiTokens.get(match[1]) || null;
+}
+
+function requireAuthenticatedActor(req, res) {
+  const actor = authenticatedActor(req);
+  if (!actor) {
+    json(res, 401, { error: 'authentication required' });
+    return null;
+  }
+  return actor;
+}
+
+function requireRole(actor, roles, res) {
+  if (!roles.includes(actor.role)) {
+    json(res, 403, { error: 'insufficient role for action' });
+    return false;
+  }
+  return true;
+}
+
+function custodyMetadata(actor) {
+  return {
+    authenticated: true,
+    auth_actor_did: actor.did,
+    auth_role: actor.role,
+    auth_method: 'bearer-token-principal',
+  };
+}
+
+function metadataJson(actor) {
+  return JSON.stringify(custodyMetadata(actor));
+}
+
+function eventMetadata(event) {
+  const metadata = event.metadata;
+  if (!metadata) return {};
+  if (typeof metadata === 'string') {
+    try {
+      const parsed = JSON.parse(metadata);
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+  return typeof metadata === 'object' && !Array.isArray(metadata) ? metadata : {};
+}
+
+function isAuthenticatedCustodyEvent(event) {
+  const metadata = eventMetadata(event);
+  return metadata.authenticated === true
+    && metadata.auth_actor_did === event.actor_did
+    && metadata.auth_role === event.role
+    && metadata.auth_method === 'bearer-token-principal';
+}
+
+function allowedRolesFromPolicy(policy) {
+  if (typeof policy.allowed_roles === 'string') return JSON.parse(policy.allowed_roles);
+  return policy.allowed_roles || [];
+}
+
+function clearanceSnapshot(policy, events) {
+  const latest = new Map();
+  for (const event of events) {
+    if (!isAuthenticatedCustodyEvent(event)) continue;
+    latest.set(`${event.actor_did}:${event.attestation}`, event);
+  }
+
+  const attestations = Array.from(latest.values());
+  const allowedRoles = allowedRolesFromPolicy(policy);
+  const filtered = attestations.filter(a => allowedRoles.includes(a.role));
+
+  const approvals = filtered.filter(a => a.attestation === 'approve');
+  const rejections = filtered.filter(a => a.attestation === 'reject');
+  const abstentions = filtered.filter(a => a.attestation === 'abstain');
+
+  let quorum_met = approvals.length >= policy.quorum_count;
+  if (policy.reject_veto && rejections.length > 0) quorum_met = false;
+
+  return { quorum_met, approvals, rejections, abstentions };
+}
+
+function governanceRole(role) {
+  if (role === 'steward') return 'Steward';
+  if (role === 'reviewer') return 'Reviewer';
+  return 'Contributor';
+}
+
+function votePosition(choice) {
+  const normalized = String(choice).toLowerCase();
+  if (normalized === 'approve' || normalized === 'for') return 'For';
+  if (normalized === 'reject' || normalized === 'against') return 'Against';
+  if (normalized === 'abstain') return 'Abstain';
+  return choice;
+}
+
+function reasoningHash(rationale) {
+  return Array.from(crypto.createHash('sha256').update(rationale || '').digest());
+}
 
 /** Compute canonical hash matching sybil-cli: sorted keys, excludes custody/anchors/timestamps/status */
 function canonicalHash(proposal) {
@@ -63,13 +191,15 @@ function canonicalHash(proposal) {
 
 export const server = http.createServer(async (req, res) => {
   if (req.method === 'OPTIONS') {
-    res.writeHead(204, { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': '*', 'Access-Control-Allow-Headers': 'Content-Type' });
+    res.writeHead(204, { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': '*', 'Access-Control-Allow-Headers': 'Content-Type, Authorization' });
     return res.end();
   }
   const url = new URL(req.url, `http://${req.headers.host}`);
 
   try {
     if (url.pathname === '/health') return json(res, 200, { status: 'ok', service: 'crosschecked-api' });
+    const authActor = url.pathname.startsWith('/api/') ? requireAuthenticatedActor(req, res) : null;
+    if (url.pathname.startsWith('/api/') && !authActor) return;
 
     // ══════════════════════════════════════════════════════════════════
     // PROPOSAL LIFECYCLE
@@ -78,7 +208,7 @@ export const server = http.createServer(async (req, res) => {
     // ── Create proposal ──
     if (url.pathname === '/api/proposals' && req.method === 'POST') {
       const { author_did, title, context, decision, consequences, method, decision_class, full_5x5, assumptions, options_considered, tags } = await parseBody(req);
-      if (!author_did || !title || !context) return json(res, 400, { error: 'author_did, title, and context are required' });
+      if (!title || !context) return json(res, 400, { error: 'title and context are required' });
 
       const id = genId('CR');
       const now = nowMs();
@@ -87,7 +217,7 @@ export const server = http.createServer(async (req, res) => {
       await pool.query(
         `INSERT INTO crosscheck_proposals (id, author_did, title, context, decision, consequences, method, status, decision_class, full_5x5, assumptions, options_considered, tags, record_hash, created_at_ms, updated_at_ms)
          VALUES ($1,$2,$3,$4,$5,$6,$7,'draft',$8,$9,$10,$11,$12,$13,$14,$15)`,
-        [id, author_did, title, context, decision || null, consequences || null,
+        [id, authActor.did, title, context, decision || null, consequences || null,
          method || 'mosaic', decision_class || 'Operational', full_5x5 || false,
          JSON.stringify(assumptions || []), JSON.stringify(options_considered || []),
          JSON.stringify(tags || []), record_hash, now, now]
@@ -95,9 +225,9 @@ export const server = http.createServer(async (req, res) => {
 
       // Record custody event
       await pool.query(
-        `INSERT INTO crosscheck_custody_events (proposal_id, actor_did, role, action, record_hash, created_at_ms)
-         VALUES ($1, $2, 'proposer', 'create', $3, $4)`,
-        [id, author_did, record_hash, now]
+        `INSERT INTO crosscheck_custody_events (proposal_id, actor_did, role, action, record_hash, metadata, created_at_ms)
+         VALUES ($1, $2, $3, 'create', $4, $5, $6)`,
+        [id, authActor.did, authActor.role, record_hash, metadataJson(authActor), now]
       );
 
       return json(res, 201, { id, status: 'draft', record_hash });
@@ -145,8 +275,9 @@ export const server = http.createServer(async (req, res) => {
     // ── Transition status ──
     if (url.pathname.match(/^\/api\/proposals\/[^/]+\/status$/) && req.method === 'PUT') {
       const id = url.pathname.split('/')[3];
-      const { status: newStatus, actor_did } = await parseBody(req);
-      if (!newStatus || !actor_did) return json(res, 400, { error: 'status and actor_did required' });
+      if (!requireRole(authActor, ['steward'], res)) return;
+      const { status: newStatus } = await parseBody(req);
+      if (!newStatus) return json(res, 400, { error: 'status required' });
 
       const result = await pool.query(
         'UPDATE crosscheck_proposals SET status = $1, updated_at_ms = $2 WHERE id = $3 RETURNING *',
@@ -155,9 +286,9 @@ export const server = http.createServer(async (req, res) => {
       if (result.rows.length === 0) return json(res, 404, { error: 'proposal not found' });
 
       await pool.query(
-        `INSERT INTO crosscheck_custody_events (proposal_id, actor_did, role, action, created_at_ms)
-         VALUES ($1, $2, 'steward', $3, $4)`,
-        [id, actor_did, `status:${newStatus}`, nowMs()]
+        `INSERT INTO crosscheck_custody_events (proposal_id, actor_did, role, action, metadata, created_at_ms)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [id, authActor.did, authActor.role, `status:${newStatus}`, metadataJson(authActor), nowMs()]
       );
 
       return json(res, 200, result.rows[0]);
@@ -247,13 +378,14 @@ export const server = http.createServer(async (req, res) => {
     // ── Trigger crosscheck ──
     if (url.pathname.match(/^\/api\/proposals\/[^/]+\/crosscheck$/) && req.method === 'POST') {
       const proposalId = url.pathname.split('/')[3];
-      const { actor_did } = await parseBody(req);
+      if (!requireRole(authActor, ['steward'], res)) return;
+      await parseBody(req);
 
       await pool.query('UPDATE crosscheck_proposals SET status = $1, updated_at_ms = $2 WHERE id = $3', ['crosschecking', nowMs(), proposalId]);
       await pool.query(
-        `INSERT INTO crosscheck_custody_events (proposal_id, actor_did, role, action, created_at_ms)
-         VALUES ($1, $2, 'steward', 'crosscheck:start', $3)`,
-        [proposalId, actor_did || 'system', nowMs()]
+        `INSERT INTO crosscheck_custody_events (proposal_id, actor_did, role, action, metadata, created_at_ms)
+         VALUES ($1, $2, $3, 'crosscheck:start', $4, $5)`,
+        [proposalId, authActor.did, authActor.role, metadataJson(authActor), nowMs()]
       );
 
       return json(res, 200, { proposal_id: proposalId, status: 'crosschecking' });
@@ -273,9 +405,9 @@ export const server = http.createServer(async (req, res) => {
       );
 
       await pool.query(
-        `INSERT INTO crosscheck_custody_events (proposal_id, actor_did, role, action, created_at_ms)
-         VALUES ($1, $2, 'participant', 'add_crosscheck', $3)`,
-        [proposalId, agent_did, nowMs()]
+        `INSERT INTO crosscheck_custody_events (proposal_id, actor_did, role, action, metadata, created_at_ms)
+         VALUES ($1, $2, $3, 'add_crosscheck', $4, $5)`,
+        [proposalId, authActor.did, authActor.role, metadataJson(authActor), nowMs()]
       );
 
       return json(res, 201, { id, proposal_id: proposalId, stance });
@@ -284,7 +416,8 @@ export const server = http.createServer(async (req, res) => {
     // ── Synthesize report ──
     if (url.pathname.match(/^\/api\/proposals\/[^/]+\/synthesize$/) && req.method === 'POST') {
       const proposalId = url.pathname.split('/')[3];
-      const { actor_did, synthesis, dissent } = await parseBody(req);
+      if (!requireRole(authActor, ['steward'], res)) return;
+      const { synthesis, dissent } = await parseBody(req);
 
       // Fetch all opinions
       const { rows: opinions } = await pool.query('SELECT * FROM crosscheck_opinions WHERE proposal_id = $1', [proposalId]);
@@ -325,7 +458,7 @@ export const server = http.createServer(async (req, res) => {
       await pool.query(
         `INSERT INTO crosscheck_reports (id, proposal_id, schema_version, created_by, question, method, synthesis, dissent, dissenters, independence_result, coordination_signals, report_hash, created_at_ms)
          VALUES ($1,$2,'0.2',$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
-        [reportId, proposalId, actor_did || null, null, proposals[0]?.method || 'mosaic',
+        [reportId, proposalId, authActor.did, null, proposals[0]?.method || 'mosaic',
          synthesis || null, dissent || null, JSON.stringify(dissenters),
          JSON.stringify(independenceResult), JSON.stringify(coordinationSignals),
          reportHash, nowMs()]
@@ -334,9 +467,9 @@ export const server = http.createServer(async (req, res) => {
       await pool.query('UPDATE crosscheck_proposals SET status = $1, updated_at_ms = $2 WHERE id = $3', ['verified', nowMs(), proposalId]);
 
       await pool.query(
-        `INSERT INTO crosscheck_custody_events (proposal_id, actor_did, role, action, record_hash, created_at_ms)
-         VALUES ($1, $2, 'steward', 'synthesize', $3, $4)`,
-        [proposalId, actor_did || 'system', reportHash, nowMs()]
+        `INSERT INTO crosscheck_custody_events (proposal_id, actor_did, role, action, record_hash, metadata, created_at_ms)
+         VALUES ($1, $2, $3, 'synthesize', $4, $5, $6)`,
+        [proposalId, authActor.did, authActor.role, reportHash, metadataJson(authActor), nowMs()]
       );
 
       return json(res, 201, {
@@ -357,21 +490,22 @@ export const server = http.createServer(async (req, res) => {
     // ── Attest ──
     if (url.pathname.match(/^\/api\/proposals\/[^/]+\/attest$/) && req.method === 'POST') {
       const proposalId = url.pathname.split('/')[3];
-      const { actor_did, role, attestation, notes, signature, public_key_b64 } = await parseBody(req);
-      if (!actor_did || !attestation) return json(res, 400, { error: 'actor_did and attestation required' });
+      if (!requireRole(authActor, ['reviewer', 'steward'], res)) return;
+      const { attestation, notes } = await parseBody(req);
+      if (!attestation) return json(res, 400, { error: 'attestation required' });
 
       // Get current record hash
       const { rows } = await pool.query('SELECT record_hash FROM crosscheck_proposals WHERE id = $1', [proposalId]);
       if (rows.length === 0) return json(res, 404, { error: 'proposal not found' });
 
       await pool.query(
-        `INSERT INTO crosscheck_custody_events (proposal_id, actor_did, role, action, attestation, record_hash, signature, public_key_b64, notes, created_at_ms)
-         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
-        [proposalId, actor_did, role || 'reviewer', `attest:${attestation}`, attestation,
-         rows[0].record_hash, signature || null, public_key_b64 || null, notes || null, nowMs()]
+        `INSERT INTO crosscheck_custody_events (proposal_id, actor_did, role, action, attestation, record_hash, signature, public_key_b64, metadata, notes, created_at_ms)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+        [proposalId, authActor.did, authActor.role, `attest:${attestation}`, attestation,
+         rows[0].record_hash, null, null, metadataJson(authActor), notes || null, nowMs()]
       );
 
-      return json(res, 201, { proposal_id: proposalId, attestation, actor_did });
+      return json(res, 201, { proposal_id: proposalId, attestation, actor_did: authActor.did });
     }
 
     // ── Evaluate clearance ──
@@ -388,22 +522,7 @@ export const server = http.createServer(async (req, res) => {
         [proposalId]
       );
 
-      // De-duplicate by (actor_did, attestation kind) — latest wins
-      const latest = new Map();
-      for (const e of events) {
-        latest.set(`${e.actor_did}:${e.attestation}`, e);
-      }
-
-      const attestations = Array.from(latest.values());
-      const allowedRoles = typeof policy.allowed_roles === 'string' ? JSON.parse(policy.allowed_roles) : (policy.allowed_roles || []);
-      const filtered = attestations.filter(a => allowedRoles.includes(a.role));
-
-      const approvals = filtered.filter(a => a.attestation === 'approve');
-      const rejections = filtered.filter(a => a.attestation === 'reject');
-      const abstentions = filtered.filter(a => a.attestation === 'abstain');
-
-      let quorum_met = approvals.length >= policy.quorum_count;
-      if (policy.reject_veto && rejections.length > 0) quorum_met = false;
+      const { quorum_met, approvals, rejections, abstentions } = clearanceSnapshot(policy, events);
 
       return json(res, 200, {
         proposal_id: proposalId,
@@ -418,7 +537,8 @@ export const server = http.createServer(async (req, res) => {
     // ── Issue clearance certificate ──
     if (url.pathname.match(/^\/api\/proposals\/[^/]+\/clear$/) && req.method === 'POST') {
       const proposalId = url.pathname.split('/')[3];
-      const { actor_did } = await parseBody(req);
+      if (!requireRole(authActor, ['steward'], res)) return;
+      await parseBody(req);
 
       // Evaluate clearance first
       const { rows: policies } = await pool.query('SELECT * FROM crosscheck_policy WHERE id = $1', ['default']);
@@ -429,18 +549,7 @@ export const server = http.createServer(async (req, res) => {
         [proposalId]
       );
 
-      const latest = new Map();
-      for (const e of events) latest.set(`${e.actor_did}:${e.attestation}`, e);
-      const attestations = Array.from(latest.values());
-      const allowedRoles = typeof policy.allowed_roles === 'string' ? JSON.parse(policy.allowed_roles) : (policy.allowed_roles || []);
-      const filtered = attestations.filter(a => allowedRoles.includes(a.role));
-
-      const approvals = filtered.filter(a => a.attestation === 'approve');
-      const rejections = filtered.filter(a => a.attestation === 'reject');
-      const abstentions = filtered.filter(a => a.attestation === 'abstain');
-
-      let quorum_met = approvals.length >= policy.quorum_count;
-      if (policy.reject_veto && rejections.length > 0) quorum_met = false;
+      const { quorum_met, approvals, rejections, abstentions } = clearanceSnapshot(policy, events);
 
       if (!quorum_met) return json(res, 400, { error: 'clearance requirements not met' });
 
@@ -456,9 +565,9 @@ export const server = http.createServer(async (req, res) => {
       await pool.query('UPDATE crosscheck_proposals SET status = $1, updated_at_ms = $2 WHERE id = $3', ['verified', nowMs(), proposalId]);
 
       await pool.query(
-        `INSERT INTO crosscheck_custody_events (proposal_id, actor_did, role, action, created_at_ms)
-         VALUES ($1, $2, 'steward', 'clear', $3)`,
-        [proposalId, actor_did || 'system', nowMs()]
+        `INSERT INTO crosscheck_custody_events (proposal_id, actor_did, role, action, metadata, created_at_ms)
+         VALUES ($1, $2, $3, 'clear', $4, $5)`,
+        [proposalId, authActor.did, authActor.role, metadataJson(authActor), nowMs()]
       );
 
       return json(res, 201, { certificate_id: certId, quorum_met: true });
@@ -470,7 +579,8 @@ export const server = http.createServer(async (req, res) => {
 
     if (url.pathname.match(/^\/api\/proposals\/[^/]+\/anchor$/) && req.method === 'POST') {
       const proposalId = url.pathname.split('/')[3];
-      const { actor_did } = await parseBody(req);
+      if (!requireRole(authActor, ['steward'], res)) return;
+      await parseBody(req);
 
       // Get latest report
       const { rows: reports } = await pool.query(
@@ -483,7 +593,7 @@ export const server = http.createServer(async (req, res) => {
 
       // Anchor to EXOCHAIN audit chain
       const auditResult = wasm.wasm_audit_append(
-        actor_did || 'did:exo:crosschecked',
+        authActor.did,
         'crosscheck_anchor',
         'success',
         evidenceHash.padEnd(64, '0').slice(0, 64)
@@ -499,9 +609,9 @@ export const server = http.createServer(async (req, res) => {
       await pool.query('UPDATE crosscheck_proposals SET status = $1, updated_at_ms = $2 WHERE id = $3', ['anchored', nowMs(), proposalId]);
 
       await pool.query(
-        `INSERT INTO crosscheck_custody_events (proposal_id, actor_did, role, action, record_hash, created_at_ms)
-         VALUES ($1, $2, 'steward', 'anchor', $3, $4)`,
-        [proposalId, actor_did || 'system', evidenceHash, nowMs()]
+        `INSERT INTO crosscheck_custody_events (proposal_id, actor_did, role, action, record_hash, metadata, created_at_ms)
+         VALUES ($1, $2, $3, 'anchor', $4, $5, $6)`,
+        [proposalId, authActor.did, authActor.role, evidenceHash, metadataJson(authActor), nowMs()]
       );
 
       return json(res, 201, {
@@ -520,7 +630,8 @@ export const server = http.createServer(async (req, res) => {
     // ── Open deliberation ──
     if (url.pathname.match(/^\/api\/proposals\/[^/]+\/deliberate$/) && req.method === 'POST') {
       const proposalId = url.pathname.split('/')[3];
-      const { participants, quorum_policy, actor_did } = await parseBody(req);
+      if (!requireRole(authActor, ['steward'], res)) return;
+      const { participants, quorum_policy } = await parseBody(req);
       if (!participants || participants.length === 0) return json(res, 400, { error: 'participants required' });
 
       const { rows } = await pool.query('SELECT record_hash FROM crosscheck_proposals WHERE id = $1', [proposalId]);
@@ -541,9 +652,9 @@ export const server = http.createServer(async (req, res) => {
       await pool.query('UPDATE crosscheck_proposals SET status = $1, updated_at_ms = $2 WHERE id = $3', ['deliberating', nowMs(), proposalId]);
 
       await pool.query(
-        `INSERT INTO crosscheck_custody_events (proposal_id, actor_did, role, action, created_at_ms)
-         VALUES ($1, $2, 'steward', 'deliberate:open', $3)`,
-        [proposalId, actor_did || 'system', nowMs()]
+        `INSERT INTO crosscheck_custody_events (proposal_id, actor_did, role, action, metadata, created_at_ms)
+         VALUES ($1, $2, $3, 'deliberate:open', $4, $5)`,
+        [proposalId, authActor.did, authActor.role, metadataJson(authActor), nowMs()]
       );
 
       return json(res, 201, { deliberation_id: delibId, status: 'deliberating', participants });
@@ -552,14 +663,15 @@ export const server = http.createServer(async (req, res) => {
     // ── Cast vote ──
     if (url.pathname.match(/^\/api\/proposals\/[^/]+\/vote$/) && req.method === 'POST') {
       const proposalId = url.pathname.split('/')[3];
-      const { voter_did, choice, rationale } = await parseBody(req);
-      if (!voter_did || !choice) return json(res, 400, { error: 'voter_did and choice required' });
+      const { choice, rationale } = await parseBody(req);
+      if (!choice) return json(res, 400, { error: 'choice required' });
+      const voterDid = authActor.did;
 
       // Check for conflicts
       try {
         wasm.wasm_conflict_enforce(
-          voter_did,
-          JSON.stringify({ action_id: proposalId, actor_did: voter_did, description: 'Vote' }),
+          voterDid,
+          JSON.stringify({ action_id: proposalId, actor_did: voterDid, description: 'Vote' }),
           '[]'
         );
       } catch (e) {
@@ -574,7 +686,14 @@ export const server = http.createServer(async (req, res) => {
       if (delibs.length === 0) return json(res, 400, { error: 'no active deliberation' });
 
       const delib = delibs[0];
-      const vote = { voter: voter_did, choice, rationale: rationale || '', signature: { Ed25519: Array(64).fill(0) }, timestamp_ms: Date.now() };
+      const vote = {
+        voter_did: voterDid,
+        position: votePosition(choice),
+        role: governanceRole(authActor.role),
+        reasoning_hash: reasoningHash(rationale),
+        signature: 'Empty',
+        independence_attestation: null,
+      };
 
       const updated = wasm.wasm_cast_vote(JSON.stringify(delib.deliberation_json), JSON.stringify(vote));
 
@@ -584,18 +703,19 @@ export const server = http.createServer(async (req, res) => {
       );
 
       await pool.query(
-        `INSERT INTO crosscheck_custody_events (proposal_id, actor_did, role, action, attestation, created_at_ms)
-         VALUES ($1, $2, 'reviewer', 'vote', $3, $4)`,
-        [proposalId, voter_did, choice.toLowerCase(), nowMs()]
+        `INSERT INTO crosscheck_custody_events (proposal_id, actor_did, role, action, attestation, metadata, created_at_ms)
+         VALUES ($1, $2, $3, 'vote', $4, $5, $6)`,
+        [proposalId, voterDid, authActor.role, choice.toLowerCase(), metadataJson(authActor), nowMs()]
       );
 
-      return json(res, 200, { voted: true, voter_did, choice, deliberation_id: delib.id });
+      return json(res, 200, { voted: true, voter_did: voterDid, choice, deliberation_id: delib.id });
     }
 
     // ── Resolve deliberation ──
     if (url.pathname.match(/^\/api\/proposals\/[^/]+\/resolve$/) && req.method === 'POST') {
       const proposalId = url.pathname.split('/')[3];
-      const { actor_did } = await parseBody(req);
+      if (!requireRole(authActor, ['steward'], res)) return;
+      await parseBody(req);
 
       const { rows: delibs } = await pool.query(
         'SELECT * FROM crosscheck_deliberations WHERE proposal_id = $1 AND result IS NULL ORDER BY opened_at_ms DESC LIMIT 1',
@@ -620,9 +740,9 @@ export const server = http.createServer(async (req, res) => {
       await pool.query('UPDATE crosscheck_proposals SET status = $1, updated_at_ms = $2 WHERE id = $3', [newStatus, nowMs(), proposalId]);
 
       await pool.query(
-        `INSERT INTO crosscheck_custody_events (proposal_id, actor_did, role, action, created_at_ms)
-         VALUES ($1, $2, 'steward', $3, $4)`,
-        [proposalId, actor_did || 'system', `deliberate:${outcome.toLowerCase()}`, nowMs()]
+        `INSERT INTO crosscheck_custody_events (proposal_id, actor_did, role, action, metadata, created_at_ms)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [proposalId, authActor.did, authActor.role, `deliberate:${outcome.toLowerCase()}`, metadataJson(authActor), nowMs()]
       );
 
       return json(res, 200, { result: outcome, votes_for: result.votes_for, votes_against: result.votes_against, abstentions: result.abstentions, proposal_status: newStatus });
@@ -646,14 +766,14 @@ export const server = http.createServer(async (req, res) => {
     // ══════════════════════════════════════════════════════════════════
 
     if (url.pathname === '/api/keys' && req.method === 'POST') {
-      const { actor_did, public_key_b64 } = await parseBody(req);
-      if (!actor_did || !public_key_b64) return json(res, 400, { error: 'actor_did and public_key_b64 required' });
+      const { public_key_b64 } = await parseBody(req);
+      if (!public_key_b64) return json(res, 400, { error: 'public_key_b64 required' });
       await pool.query(
         `INSERT INTO crosscheck_keys (actor_did, public_key_b64, registered_at_ms)
          VALUES ($1, $2, $3) ON CONFLICT (actor_did) DO UPDATE SET public_key_b64 = $2`,
-        [actor_did, public_key_b64, nowMs()]
+        [authActor.did, public_key_b64, nowMs()]
       );
-      return json(res, 201, { actor_did, registered: true });
+      return json(res, 201, { actor_did: authActor.did, registered: true });
     }
 
     if (url.pathname.match(/^\/api\/keys\//) && req.method === 'GET') {

--- a/demo/services/crosschecked-api/src/index.test.js
+++ b/demo/services/crosschecked-api/src/index.test.js
@@ -33,6 +33,13 @@ const mockWasm = vi.hoisted(() => ({
   wasm_check_conflicts: vi.fn(() => ({ must_recuse: false, conflicts: [] })),
 }));
 
+vi.hoisted(() => {
+  process.env.CROSSCHECKED_API_TOKENS = JSON.stringify({
+    'reviewer-token': { actor_did: 'did:exo:reviewer1', role: 'reviewer' },
+    'steward-token': { actor_did: 'did:exo:steward1', role: 'steward' },
+  });
+});
+
 vi.mock('module', async (importOriginal) => {
   const orig = await importOriginal();
   return { ...orig, createRequire: () => (id) => { if (id === '@exochain/exochain-wasm') return mockWasm; throw new Error(`Unexpected require('${id}')`); } };
@@ -48,6 +55,24 @@ let request;
 beforeAll(async () => { await new Promise(r => server.listen(0, r)); request = supertest(server); });
 beforeEach(() => { vi.clearAllMocks(); });
 afterAll(async () => { await new Promise(r => server.close(r)); });
+
+function withAuth(req, token = 'reviewer-token') {
+  return req.set('Authorization', `Bearer ${token}`);
+}
+
+function authenticatedEvent(actor_did, role, attestation) {
+  return {
+    actor_did,
+    role,
+    attestation,
+    metadata: {
+      authenticated: true,
+      auth_actor_did: actor_did,
+      auth_role: role,
+      auth_method: 'bearer-token-principal',
+    },
+  };
+}
 
 // ══════════════════════════════════════════════════════════════════
 // HEALTH
@@ -68,7 +93,7 @@ describe('GET /health', () => {
 describe('POST /api/proposals', () => {
   it('creates a proposal with custody event', async () => {
     mockQuery.mockResolvedValue({ rows: [] });
-    const res = await request.post('/api/proposals').send({
+    const res = await withAuth(request.post('/api/proposals')).send({
       author_did: 'did:exo:alice', title: 'Test Proposal', context: 'Should we adopt X?',
     });
     expect(res.status).toBe(201);
@@ -79,23 +104,31 @@ describe('POST /api/proposals', () => {
   });
 
   it('returns 400 when missing required fields', async () => {
-    const res = await request.post('/api/proposals').send({ title: 'No author' });
+    const res = await withAuth(request.post('/api/proposals')).send({ title: 'No context' });
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('required');
+  });
+
+  it('rejects unauthenticated API access before database access', async () => {
+    const res = await request.post('/api/proposals').send({
+      author_did: 'did:exo:attacker', title: 'Test Proposal', context: 'Should we adopt X?',
+    });
+    expect(res.status).toBe(401);
+    expect(mockQuery).not.toHaveBeenCalled();
   });
 });
 
 describe('GET /api/proposals', () => {
   it('lists proposals', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [{ id: 'CR-001', title: 'Test', status: 'draft' }] });
-    const res = await request.get('/api/proposals');
+    const res = await withAuth(request.get('/api/proposals'));
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(1);
   });
 
   it('filters by status', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [] });
-    const res = await request.get('/api/proposals?status=ratified');
+    const res = await withAuth(request.get('/api/proposals?status=ratified'));
     expect(res.status).toBe(200);
     expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('WHERE status'), ['ratified']);
   });
@@ -108,7 +141,7 @@ describe('GET /api/proposals/:id', () => {
       { rows: [] }, { rows: [] }, { rows: [] }, { rows: [] }, { rows: [] }, { rows: [] }, { rows: [] }, // relations
     ];
     resolves.forEach(r => mockQuery.mockResolvedValueOnce(r));
-    const res = await request.get('/api/proposals/CR-001');
+    const res = await withAuth(request.get('/api/proposals/CR-001'));
     expect(res.status).toBe(200);
     expect(res.body.id).toBe('CR-001');
     expect(res.body).toHaveProperty('opinions');
@@ -118,7 +151,7 @@ describe('GET /api/proposals/:id', () => {
 
   it('returns 404 for missing proposal', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [] });
-    const res = await request.get('/api/proposals/CR-missing');
+    const res = await withAuth(request.get('/api/proposals/CR-missing'));
     expect(res.status).toBe(404);
   });
 });
@@ -127,12 +160,12 @@ describe('PUT /api/proposals/:id/status', () => {
   it('transitions status with custody event', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [{ id: 'CR-001', status: 'submitted' }] })
              .mockResolvedValueOnce({ rows: [] });
-    const res = await request.put('/api/proposals/CR-001/status').send({ status: 'crosschecking', actor_did: 'did:exo:alice' });
+    const res = await withAuth(request.put('/api/proposals/CR-001/status'), 'steward-token').send({ status: 'crosschecking', actor_did: 'did:exo:alice' });
     expect(res.status).toBe(200);
   });
 
   it('returns 400 without required fields', async () => {
-    const res = await request.put('/api/proposals/CR-001/status').send({});
+    const res = await withAuth(request.put('/api/proposals/CR-001/status'), 'steward-token').send({});
     expect(res.status).toBe(400);
   });
 });
@@ -140,14 +173,14 @@ describe('PUT /api/proposals/:id/status', () => {
 describe('GET /api/proposals/:id/hash', () => {
   it('computes canonical hash', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [{ title: 'Test', context: 'Context', decision: 'Decision' }] });
-    const res = await request.get('/api/proposals/CR-001/hash');
+    const res = await withAuth(request.get('/api/proposals/CR-001/hash'));
     expect(res.status).toBe(200);
     expect(res.body.hash).toMatch(/^[a-f0-9]{64}$/);
   });
 
   it('returns 404 for missing proposal', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [] });
-    const res = await request.get('/api/proposals/CR-missing/hash');
+    const res = await withAuth(request.get('/api/proposals/CR-missing/hash'));
     expect(res.status).toBe(404);
   });
 });
@@ -161,13 +194,13 @@ describe('POST /api/proposals/:id/evidence', () => {
     mockQuery.mockResolvedValueOnce({ rows: [] }) // insert
              .mockResolvedValueOnce({ rows: [{ title: 'T', context: 'C' }] }) // select for rehash
              .mockResolvedValueOnce({ rows: [] }); // update hash
-    const res = await request.post('/api/proposals/CR-001/evidence').send({ description: 'Test doc', kind: 'doc', uri: 'https://example.com' });
+    const res = await withAuth(request.post('/api/proposals/CR-001/evidence')).send({ description: 'Test doc', kind: 'doc', uri: 'https://example.com' });
     expect(res.status).toBe(201);
     expect(res.body.id).toMatch(/^EV-/);
   });
 
   it('returns 400 without description', async () => {
-    const res = await request.post('/api/proposals/CR-001/evidence').send({});
+    const res = await withAuth(request.post('/api/proposals/CR-001/evidence')).send({});
     expect(res.status).toBe(400);
   });
 });
@@ -175,7 +208,7 @@ describe('POST /api/proposals/:id/evidence', () => {
 describe('GET /api/proposals/:id/evidence', () => {
   it('lists evidence', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [{ id: 'EV-001', kind: 'link' }] });
-    const res = await request.get('/api/proposals/CR-001/evidence');
+    const res = await withAuth(request.get('/api/proposals/CR-001/evidence'));
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(1);
   });
@@ -188,7 +221,7 @@ describe('GET /api/proposals/:id/evidence', () => {
 describe('GET /api/proposals/:id/crosscheck/template', () => {
   it('generates template for standard crosscheck', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [{ id: 'CR-001', title: 'Test', method: 'mosaic', full_5x5: false }] });
-    const res = await request.get('/api/proposals/CR-001/crosscheck/template');
+    const res = await withAuth(request.get('/api/proposals/CR-001/crosscheck/template'));
     expect(res.status).toBe(200);
     expect(res.body.opinions_needed).toBe(5); // 5 panels × 1 null property
     expect(res.body.template_opinions).toHaveLength(5);
@@ -196,7 +229,7 @@ describe('GET /api/proposals/:id/crosscheck/template', () => {
 
   it('generates 5x5 template with 25 opinions', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [{ id: 'CR-001', title: 'Test', method: 'mosaic', full_5x5: true }] });
-    const res = await request.get('/api/proposals/CR-001/crosscheck/template');
+    const res = await withAuth(request.get('/api/proposals/CR-001/crosscheck/template'));
     expect(res.status).toBe(200);
     expect(res.body.opinions_needed).toBe(25); // 5 panels × 5 properties
     expect(res.body.template_opinions).toHaveLength(25);
@@ -207,7 +240,7 @@ describe('GET /api/proposals/:id/crosscheck/template', () => {
 describe('POST /api/proposals/:id/crosscheck', () => {
   it('sets status to crosschecking', async () => {
     mockQuery.mockResolvedValue({ rows: [] });
-    const res = await request.post('/api/proposals/CR-001/crosscheck').send({ actor_did: 'did:exo:alice' });
+    const res = await withAuth(request.post('/api/proposals/CR-001/crosscheck'), 'steward-token').send({ actor_did: 'did:exo:alice' });
     expect(res.status).toBe(200);
     expect(res.body.status).toBe('crosschecking');
   });
@@ -216,7 +249,7 @@ describe('POST /api/proposals/:id/crosscheck', () => {
 describe('POST /api/proposals/:id/opinions', () => {
   it('submits opinion with panel tag', async () => {
     mockQuery.mockResolvedValue({ rows: [] });
-    const res = await request.post('/api/proposals/CR-001/opinions').send({
+    const res = await withAuth(request.post('/api/proposals/CR-001/opinions')).send({
       agent_did: 'did:exo:agent-gov', agent_kind: 'ai', agent_label: 'Governance Panel',
       stance: 'support', summary: 'Constitutional alignment confirmed',
       panel: 'Governance', confidence: 0.85, risks: ['delegation ambiguity'],
@@ -226,7 +259,7 @@ describe('POST /api/proposals/:id/opinions', () => {
   });
 
   it('returns 400 without required fields', async () => {
-    const res = await request.post('/api/proposals/CR-001/opinions').send({ stance: 'support' });
+    const res = await withAuth(request.post('/api/proposals/CR-001/opinions')).send({ stance: 'support' });
     expect(res.status).toBe(400);
   });
 });
@@ -242,7 +275,7 @@ describe('POST /api/proposals/:id/synthesize', () => {
       .mockResolvedValueOnce({ rows: [{ method: 'mosaic' }] }) // proposal method
       .mockResolvedValue({ rows: [] }); // inserts
 
-    const res = await request.post('/api/proposals/CR-001/synthesize').send({
+    const res = await withAuth(request.post('/api/proposals/CR-001/synthesize'), 'steward-token').send({
       actor_did: 'did:exo:steward', synthesis: 'Consensus with amendments', dissent: 'Agent a2 opposes',
     });
     expect(res.status).toBe(201);
@@ -256,7 +289,7 @@ describe('POST /api/proposals/:id/synthesize', () => {
 
   it('returns 400 with no opinions', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [] });
-    const res = await request.post('/api/proposals/CR-001/synthesize').send({});
+    const res = await withAuth(request.post('/api/proposals/CR-001/synthesize'), 'steward-token').send({});
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('no opinions');
   });
@@ -273,7 +306,7 @@ describe('POST /api/proposals/:id/synthesize', () => {
       .mockResolvedValueOnce({ rows: [{ method: 'mosaic' }] })
       .mockResolvedValue({ rows: [] });
 
-    const res = await request.post('/api/proposals/CR-001/synthesize').send({ actor_did: 'did:exo:steward' });
+    const res = await withAuth(request.post('/api/proposals/CR-001/synthesize'), 'steward-token').send({ actor_did: 'did:exo:steward' });
     expect(res.status).toBe(201);
     expect(res.body.independence.independent_count).toBe(1);
     expect(res.body.independence.clusters).toHaveLength(1);
@@ -285,10 +318,44 @@ describe('POST /api/proposals/:id/synthesize', () => {
 // ══════════════════════════════════════════════════════════════════
 
 describe('POST /api/proposals/:id/attest', () => {
+  it('rejects unauthenticated attestations before database access', async () => {
+    mockQuery.mockResolvedValue({ rows: [{ record_hash: 'abc123' }] });
+    const res = await request.post('/api/proposals/CR-001/attest').send({
+      actor_did: 'did:exo:attacker',
+      role: 'reviewer',
+      attestation: 'approve',
+    });
+
+    expect(res.status).toBe(401);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('binds attestations to the authenticated actor and role instead of body fields', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ record_hash: 'abc123' }] })
+             .mockResolvedValueOnce({ rows: [] });
+
+    const res = await withAuth(request.post('/api/proposals/CR-001/attest')).send({
+      actor_did: 'did:exo:attacker',
+      role: 'steward',
+      attestation: 'approve',
+      notes: 'LGTM',
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.actor_did).toBe('did:exo:reviewer1');
+    expect(mockQuery.mock.calls[1][1][1]).toBe('did:exo:reviewer1');
+    expect(mockQuery.mock.calls[1][1][2]).toBe('reviewer');
+    expect(JSON.parse(mockQuery.mock.calls[1][1][8])).toMatchObject({
+      authenticated: true,
+      auth_actor_did: 'did:exo:reviewer1',
+      auth_role: 'reviewer',
+    });
+  });
+
   it('records attestation with custody event', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [{ record_hash: 'abc123' }] }) // proposal hash
              .mockResolvedValueOnce({ rows: [] }); // insert custody
-    const res = await request.post('/api/proposals/CR-001/attest').send({
+    const res = await withAuth(request.post('/api/proposals/CR-001/attest')).send({
       actor_did: 'did:exo:reviewer1', role: 'reviewer', attestation: 'approve', notes: 'LGTM',
     });
     expect(res.status).toBe(201);
@@ -296,13 +363,13 @@ describe('POST /api/proposals/:id/attest', () => {
   });
 
   it('returns 400 without required fields', async () => {
-    const res = await request.post('/api/proposals/CR-001/attest').send({});
+    const res = await withAuth(request.post('/api/proposals/CR-001/attest')).send({});
     expect(res.status).toBe(400);
   });
 
   it('returns 404 for missing proposal', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [] });
-    const res = await request.post('/api/proposals/CR-missing/attest').send({
+    const res = await withAuth(request.post('/api/proposals/CR-missing/attest')).send({
       actor_did: 'did:exo:reviewer', attestation: 'approve',
     });
     expect(res.status).toBe(404);
@@ -314,10 +381,10 @@ describe('GET /api/proposals/:id/clearance', () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [{ mode: 'quorum', quorum_count: 2, allowed_roles: '["reviewer","steward"]', reject_veto: true }] })
       .mockResolvedValueOnce({ rows: [
-        { actor_did: 'did:exo:r1', role: 'reviewer', attestation: 'approve' },
-        { actor_did: 'did:exo:r2', role: 'reviewer', attestation: 'approve' },
+        authenticatedEvent('did:exo:r1', 'reviewer', 'approve'),
+        authenticatedEvent('did:exo:r2', 'reviewer', 'approve'),
       ]});
-    const res = await request.get('/api/proposals/CR-001/clearance');
+    const res = await withAuth(request.get('/api/proposals/CR-001/clearance'));
     expect(res.status).toBe(200);
     expect(res.body.quorum_met).toBe(true);
     expect(res.body.approvals).toHaveLength(2);
@@ -327,11 +394,11 @@ describe('GET /api/proposals/:id/clearance', () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [{ mode: 'quorum', quorum_count: 2, allowed_roles: '["reviewer","steward"]', reject_veto: true }] })
       .mockResolvedValueOnce({ rows: [
-        { actor_did: 'did:exo:r1', role: 'reviewer', attestation: 'approve' },
-        { actor_did: 'did:exo:r2', role: 'reviewer', attestation: 'approve' },
-        { actor_did: 'did:exo:r3', role: 'reviewer', attestation: 'reject' },
+        authenticatedEvent('did:exo:r1', 'reviewer', 'approve'),
+        authenticatedEvent('did:exo:r2', 'reviewer', 'approve'),
+        authenticatedEvent('did:exo:r3', 'reviewer', 'reject'),
       ]});
-    const res = await request.get('/api/proposals/CR-001/clearance');
+    const res = await withAuth(request.get('/api/proposals/CR-001/clearance'));
     expect(res.status).toBe(200);
     expect(res.body.quorum_met).toBe(false);
     expect(res.body.rejections).toHaveLength(1);
@@ -339,15 +406,31 @@ describe('GET /api/proposals/:id/clearance', () => {
 });
 
 describe('POST /api/proposals/:id/clear', () => {
+  it('does not issue clearance from unauthenticated legacy custody rows', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ mode: 'quorum', quorum_count: 2, allowed_roles: '["reviewer","steward"]', reject_veto: true }] })
+      .mockResolvedValueOnce({ rows: [
+        { actor_did: 'did:exo:r1', role: 'reviewer', attestation: 'approve', metadata: {} },
+        { actor_did: 'did:exo:r2', role: 'steward', attestation: 'approve', metadata: {} },
+      ]});
+
+    const res = await withAuth(request.post('/api/proposals/CR-001/clear'), 'steward-token')
+      .send({ actor_did: 'did:exo:attacker' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('not met');
+  });
+
   it('issues clearance certificate when quorum met', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [{ mode: 'quorum', quorum_count: 2, allowed_roles: '["reviewer","steward"]', reject_veto: true }] })
       .mockResolvedValueOnce({ rows: [
-        { actor_did: 'did:exo:r1', role: 'reviewer', attestation: 'approve' },
-        { actor_did: 'did:exo:r2', role: 'steward', attestation: 'approve' },
+        authenticatedEvent('did:exo:r1', 'reviewer', 'approve'),
+        authenticatedEvent('did:exo:r2', 'steward', 'approve'),
       ]})
       .mockResolvedValue({ rows: [] }); // inserts
-    const res = await request.post('/api/proposals/CR-001/clear').send({ actor_did: 'did:exo:steward' });
+    const res = await withAuth(request.post('/api/proposals/CR-001/clear'), 'steward-token')
+      .send({ actor_did: 'did:exo:attacker' });
     expect(res.status).toBe(201);
     expect(res.body.certificate_id).toMatch(/^CLR-/);
     expect(res.body.quorum_met).toBe(true);
@@ -359,7 +442,7 @@ describe('POST /api/proposals/:id/clear', () => {
       .mockResolvedValueOnce({ rows: [
         { actor_did: 'did:exo:r1', role: 'reviewer', attestation: 'approve' },
       ]});
-    const res = await request.post('/api/proposals/CR-001/clear').send({ actor_did: 'did:exo:steward' });
+    const res = await withAuth(request.post('/api/proposals/CR-001/clear'), 'steward-token').send({ actor_did: 'did:exo:steward' });
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('not met');
   });
@@ -374,18 +457,18 @@ describe('POST /api/proposals/:id/anchor', () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [{ id: 'RPT-001', report_hash: 'd'.repeat(64) }] }) // report
       .mockResolvedValue({ rows: [] }); // inserts
-    const res = await request.post('/api/proposals/CR-001/anchor').send({ actor_did: 'did:exo:steward' });
+    const res = await withAuth(request.post('/api/proposals/CR-001/anchor'), 'steward-token').send({ actor_did: 'did:exo:steward' });
     expect(res.status).toBe(201);
     expect(res.body.anchor_id).toMatch(/^ANC-/);
     expect(res.body.chain).toBe('exochain');
     expect(mockWasm.wasm_audit_append).toHaveBeenCalledWith(
-      'did:exo:steward', 'crosscheck_anchor', 'success', expect.any(String)
+      'did:exo:steward1', 'crosscheck_anchor', 'success', expect.any(String)
     );
   });
 
   it('returns 400 without report', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [] });
-    const res = await request.post('/api/proposals/CR-001/anchor').send({ actor_did: 'did:exo:steward' });
+    const res = await withAuth(request.post('/api/proposals/CR-001/anchor'), 'steward-token').send({ actor_did: 'did:exo:steward' });
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('synthesize first');
   });
@@ -400,7 +483,7 @@ describe('POST /api/proposals/:id/deliberate', () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [{ record_hash: 'e'.repeat(64) }] }) // proposal
       .mockResolvedValue({ rows: [] }); // inserts
-    const res = await request.post('/api/proposals/CR-001/deliberate').send({
+    const res = await withAuth(request.post('/api/proposals/CR-001/deliberate'), 'steward-token').send({
       participants: ['did:exo:alice', 'did:exo:bob', 'did:exo:carol'],
       actor_did: 'did:exo:steward',
     });
@@ -410,16 +493,39 @@ describe('POST /api/proposals/:id/deliberate', () => {
   });
 
   it('returns 400 without participants', async () => {
-    const res = await request.post('/api/proposals/CR-001/deliberate').send({});
+    const res = await withAuth(request.post('/api/proposals/CR-001/deliberate'), 'steward-token').send({});
     expect(res.status).toBe(400);
   });
 });
 
 describe('POST /api/proposals/:id/vote', () => {
+  it('casts votes as the authenticated actor instead of request body voter_did', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 'DLB-001', deliberation_json: { id: 'delib', votes: [] }, result: null }] })
+             .mockResolvedValue({ rows: [] });
+
+    const res = await withAuth(request.post('/api/proposals/CR-001/vote')).send({
+      voter_did: 'did:exo:attacker',
+      choice: 'Approve',
+      rationale: 'Good proposal',
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.voter_did).toBe('did:exo:reviewer1');
+    expect(mockWasm.wasm_conflict_enforce).toHaveBeenCalledWith(
+      'did:exo:reviewer1',
+      expect.any(String),
+      '[]',
+    );
+    const vote = JSON.parse(mockWasm.wasm_cast_vote.mock.calls[0][1]);
+    expect(vote.voter_did).toBe('did:exo:reviewer1');
+    expect(vote.signature).toBe('Empty');
+    expect(vote).not.toHaveProperty('voter');
+  });
+
   it('casts vote with conflict check', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [{ id: 'DLB-001', deliberation_json: { id: 'delib', votes: [] }, result: null }] })
              .mockResolvedValue({ rows: [] });
-    const res = await request.post('/api/proposals/CR-001/vote').send({
+    const res = await withAuth(request.post('/api/proposals/CR-001/vote')).send({
       voter_did: 'did:exo:alice', choice: 'Approve', rationale: 'Good proposal',
     });
     expect(res.status).toBe(200);
@@ -430,7 +536,7 @@ describe('POST /api/proposals/:id/vote', () => {
 
   it('blocks vote on conflict', async () => {
     mockWasm.wasm_conflict_enforce.mockImplementationOnce(() => { throw new Error('ConflictBlocked: financial interest'); });
-    const res = await request.post('/api/proposals/CR-001/vote').send({
+    const res = await withAuth(request.post('/api/proposals/CR-001/vote')).send({
       voter_did: 'did:exo:conflicted', choice: 'Approve',
     });
     expect(res.status).toBe(403);
@@ -438,14 +544,14 @@ describe('POST /api/proposals/:id/vote', () => {
   });
 
   it('returns 400 without required fields', async () => {
-    const res = await request.post('/api/proposals/CR-001/vote').send({});
+    const res = await withAuth(request.post('/api/proposals/CR-001/vote')).send({});
     expect(res.status).toBe(400);
   });
 
   it('returns 400 without active deliberation', async () => {
     mockWasm.wasm_conflict_enforce.mockReturnValueOnce({ allowed: true });
     mockQuery.mockResolvedValueOnce({ rows: [] }); // no active deliberation
-    const res = await request.post('/api/proposals/CR-001/vote').send({ voter_did: 'did:exo:alice', choice: 'Approve' });
+    const res = await withAuth(request.post('/api/proposals/CR-001/vote')).send({ voter_did: 'did:exo:alice', choice: 'Approve' });
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('no active deliberation');
   });
@@ -455,7 +561,7 @@ describe('POST /api/proposals/:id/resolve', () => {
   it('resolves deliberation as Approved', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [{ id: 'DLB-001', deliberation_json: { votes: [1,2,3] }, quorum_policy: {}, result: null }] })
              .mockResolvedValue({ rows: [] });
-    const res = await request.post('/api/proposals/CR-001/resolve').send({ actor_did: 'did:exo:steward' });
+    const res = await withAuth(request.post('/api/proposals/CR-001/resolve'), 'steward-token').send({ actor_did: 'did:exo:steward' });
     expect(res.status).toBe(200);
     expect(res.body.result).toBe('Approved');
     expect(res.body.proposal_status).toBe('ratified');
@@ -465,7 +571,7 @@ describe('POST /api/proposals/:id/resolve', () => {
     mockWasm.wasm_close_deliberation.mockReturnValueOnce({ result: 'Rejected', votes_for: 1, votes_against: 2, abstentions: 0 });
     mockQuery.mockResolvedValueOnce({ rows: [{ id: 'DLB-001', deliberation_json: {}, quorum_policy: {}, result: null }] })
              .mockResolvedValue({ rows: [] });
-    const res = await request.post('/api/proposals/CR-001/resolve').send({});
+    const res = await withAuth(request.post('/api/proposals/CR-001/resolve'), 'steward-token').send({});
     expect(res.status).toBe(200);
     expect(res.body.result).toBe('Rejected');
     expect(res.body.proposal_status).toBe('rejected');
@@ -475,7 +581,7 @@ describe('POST /api/proposals/:id/resolve', () => {
     mockWasm.wasm_close_deliberation.mockReturnValueOnce({ result: 'NoQuorum', reason: 'Insufficient votes' });
     mockQuery.mockResolvedValueOnce({ rows: [{ id: 'DLB-001', deliberation_json: {}, quorum_policy: {}, result: null }] })
              .mockResolvedValue({ rows: [] });
-    const res = await request.post('/api/proposals/CR-001/resolve').send({});
+    const res = await withAuth(request.post('/api/proposals/CR-001/resolve'), 'steward-token').send({});
     expect(res.status).toBe(200);
     expect(res.body.result).toBe('NoQuorum');
     expect(res.body.proposal_status).toBe('verified');
@@ -483,7 +589,7 @@ describe('POST /api/proposals/:id/resolve', () => {
 
   it('returns 400 without active deliberation', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [] });
-    const res = await request.post('/api/proposals/CR-001/resolve').send({});
+    const res = await withAuth(request.post('/api/proposals/CR-001/resolve'), 'steward-token').send({});
     expect(res.status).toBe(400);
   });
 });
@@ -498,7 +604,7 @@ describe('GET /api/proposals/:id/custody', () => {
       { id: 1, action: 'create', actor_did: 'did:exo:alice', created_at_ms: 1000 },
       { id: 2, action: 'add_crosscheck', actor_did: 'did:exo:agent', created_at_ms: 2000 },
     ]});
-    const res = await request.get('/api/proposals/CR-001/custody');
+    const res = await withAuth(request.get('/api/proposals/CR-001/custody'));
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(2);
     expect(res.body[0].action).toBe('create');
@@ -508,13 +614,14 @@ describe('GET /api/proposals/:id/custody', () => {
 describe('POST /api/keys', () => {
   it('registers a public key', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [] });
-    const res = await request.post('/api/keys').send({ actor_did: 'did:exo:alice', public_key_b64: 'base64encodedkey==' });
+    const res = await withAuth(request.post('/api/keys')).send({ actor_did: 'did:exo:alice', public_key_b64: 'base64encodedkey==' });
     expect(res.status).toBe(201);
     expect(res.body.registered).toBe(true);
+    expect(res.body.actor_did).toBe('did:exo:reviewer1');
   });
 
   it('returns 400 without required fields', async () => {
-    const res = await request.post('/api/keys').send({});
+    const res = await withAuth(request.post('/api/keys')).send({});
     expect(res.status).toBe(400);
   });
 });
@@ -522,14 +629,14 @@ describe('POST /api/keys', () => {
 describe('GET /api/keys/:did', () => {
   it('returns key for known actor', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [{ actor_did: 'did:exo:alice', public_key_b64: 'key==' }] });
-    const res = await request.get('/api/keys/did:exo:alice');
+    const res = await withAuth(request.get('/api/keys/did:exo:alice'));
     expect(res.status).toBe(200);
     expect(res.body.public_key_b64).toBe('key==');
   });
 
   it('returns 404 for unknown actor', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [] });
-    const res = await request.get('/api/keys/did:exo:unknown');
+    const res = await withAuth(request.get('/api/keys/did:exo:unknown'));
     expect(res.status).toBe(404);
   });
 });
@@ -547,7 +654,7 @@ describe('OPTIONS preflight', () => {
 
 describe('404 handling', () => {
   it('returns 404 for unknown routes', async () => {
-    const res = await request.get('/api/nonexistent');
+    const res = await withAuth(request.get('/api/nonexistent'));
     expect(res.status).toBe(404);
   });
 });


### PR DESCRIPTION
## Summary
- Remediates Codex Security finding from `codex-security-findings-2026-05-19T15-37-10.140Z.csv`: "Unauthenticated API can forge CrossChecked clearance".
- Verifies the current branch still had the exploit class before fixing: unauthenticated `/api` requests could write attestations, body `actor_did`/`role`/`voter_did` were trusted, and legacy unauthenticated custody rows counted toward clearance.
- Adds fail-closed bearer-principal authentication for CrossChecked `/api` routes, derives custody/vote/clearance actors from server-side token config, ignores caller-supplied trust fields for privileged actions, and filters clearance to authenticated custody events only.
- Updates the CrossChecked frontend to send an API token from session auth state and documents `CROSSCHECKED_API_TOKENS`.

## Path Classification
- `demo/services/crosschecked-api/src/index.js` - Adjacent surface / core runtime adapter boundary for CrossChecked API.
- `demo/services/crosschecked-api/src/index.test.js` - Adjacent surface / adapter regression tests.
- `demo/apps/crosschecked/src/hooks/useAuth.ts` - Adjacent surface auth state.
- `demo/apps/crosschecked/src/lib/api.ts` - Adjacent surface API client.
- `demo/apps/crosschecked/src/pages/Login.tsx` - Adjacent surface login UI.
- `demo/infra/postgres/init/006_crosschecked.sql` - Adjacent surface persistence schema.
- `demo/README.md` - Adjacent surface operator documentation.

## Validation
- `npx vitest run --workspace vitest.workspace.js --project services services/crosschecked-api/src/index.test.js`
- `npm run test:services`
- `npm test`
- `node --check demo/services/crosschecked-api/src/index.js`
- `node --check demo/services/crosschecked-api/src/index.test.js`
- `npm run build` in `demo/apps/crosschecked`
- `git diff --check`

## Notes
- EXOCHAIN core Rust crates were not modified.
- Missing or malformed `CROSSCHECKED_API_TOKENS` now makes CrossChecked `/api` routes fail closed with `401`.
- Existing unauthenticated custody rows no longer satisfy clearance quorum because clearance evaluation requires authenticated custody metadata bound to the stored actor DID and role.
