### PR TITLE
fix(livesafe): authenticate medical data access

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -197,5 +197,6 @@ See [docs/guides/ARCHON-INTEGRATION.md](../docs/guides/ARCHON-INTEGRATION.md) fo
 | `PORT` | Service listen port | Varies per service (see table above) |
 | `NODE_ENV` | Runtime environment | `development` |
 | `CROSSCHECKED_API_TOKENS` | CrossChecked API bearer principal map as JSON: `{"token":{"actor_did":"did:exo:...","role":"steward"}}`. Missing or malformed values make `/api` routes fail closed with `401`. | None |
+| `LIVESAFE_API_TOKENS` | LiveSafe API bearer principal map as JSON: `{"token":{"actor_did":"did:exo:...","role":"owner"}}`. Roles are `owner`, `trustee`, `responder`, or `admin`; missing or malformed values make `/api` routes fail closed with `401`. | None |
 
 Each service reads its own `PORT` from the environment. In Docker Compose, these are pre-configured in the compose file.

--- a/demo/apps/livesafe/src/hooks/useAuth.ts
+++ b/demo/apps/livesafe/src/hooks/useAuth.ts
@@ -24,6 +24,7 @@ export interface AuthState {
   x25519PublicHex: string;
   x25519SecretHex: string;
   passphraseHash: string;
+  apiToken: string;
 }
 
 interface AuthContextType {

--- a/demo/apps/livesafe/src/lib/api.ts
+++ b/demo/apps/livesafe/src/lib/api.ts
@@ -15,11 +15,36 @@
 // SPDX-License-Identifier: Apache-2.0
 
 const API_BASE = '/api';
+const AUTH_STORAGE_KEY = 'livesafe_auth';
+
+function authToken() {
+  try {
+    const raw = sessionStorage.getItem(AUTH_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed.apiToken === 'string' && parsed.apiToken.length > 0) {
+      return parsed.apiToken;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function apiHeaders(headersInit?: HeadersInit) {
+  const headers = new Headers(headersInit);
+  if (!headers.has('Content-Type')) headers.set('Content-Type', 'application/json');
+  if (!headers.has('Authorization')) {
+    const token = authToken();
+    if (token) headers.set('Authorization', `Bearer ${token}`);
+  }
+  return headers;
+}
 
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`, {
-    headers: { 'Content-Type': 'application/json' },
     ...options,
+    headers: apiHeaders(options?.headers),
   });
   if (!res.ok) {
     const err = await res.json().catch(() => ({ error: res.statusText }));

--- a/demo/apps/livesafe/src/pages/EmergencyPlans.tsx
+++ b/demo/apps/livesafe/src/pages/EmergencyPlans.tsx
@@ -15,7 +15,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useState } from 'react';
-import { useAuth } from '@/hooks/useAuth';
 import { SCENARIO_TYPES } from '@/lib/utils';
 import {
   FileText, Plus, X, CloudLightning, Heart, AlertTriangle,
@@ -44,23 +43,19 @@ const EMPTY_PLAN: PlanDraft = {
 };
 
 export default function EmergencyPlans() {
-  const { auth } = useAuth();
   const [plans, setPlans] = useState<Array<PlanDraft & { id: string }>>([]);
   const [showCreate, setShowCreate] = useState(false);
-  const [selectedScenario, setSelectedScenario] = useState<string | null>(null);
   const [draft, setDraft] = useState<PlanDraft>(EMPTY_PLAN);
 
   const startPlan = (scenarioId: string) => {
     const scenario = SCENARIO_TYPES.find(s => s.id === scenarioId);
     setDraft({ ...EMPTY_PLAN, scenario_type: scenarioId, name: `${scenario?.label || ''} Response Plan` });
-    setSelectedScenario(scenarioId);
     setShowCreate(true);
   };
 
   const savePlan = () => {
     setPlans(prev => [...prev, { ...draft, id: crypto.randomUUID() }]);
     setShowCreate(false);
-    setSelectedScenario(null);
     setDraft(EMPTY_PLAN);
   };
 
@@ -146,7 +141,7 @@ export default function EmergencyPlans() {
         <div className="max-w-2xl">
           <div className="flex items-center justify-between mb-6">
             <h3 className="text-lg font-heading font-semibold text-white">{draft.name}</h3>
-            <button onClick={() => { setShowCreate(false); setSelectedScenario(null); }}>
+            <button onClick={() => setShowCreate(false)}>
               <X size={18} className="text-white/30" />
             </button>
           </div>

--- a/demo/apps/livesafe/src/pages/GoldenHour.tsx
+++ b/demo/apps/livesafe/src/pages/GoldenHour.tsx
@@ -25,11 +25,6 @@ const ICON_MAP: Record<string, React.ElementType> = {
   CloudLightning, Heart, AlertTriangle, Flame, ShieldAlert, Zap, Bug, Navigation,
 };
 
-interface GoldenHourProtocol {
-  scenarioId: string;
-  steps: Array<{ text: string; timeframe: string; critical: boolean }>;
-}
-
 const DEFAULT_PROTOCOLS: Record<string, Array<{ text: string; timeframe: string; critical: boolean }>> = {
   'natural-disaster': [
     { text: 'Drop, Cover, Hold On (earthquake) / Shelter in place (tornado)', timeframe: '0-2 min', critical: true },

--- a/demo/apps/livesafe/src/pages/IceCard.tsx
+++ b/demo/apps/livesafe/src/pages/IceCard.tsx
@@ -54,7 +54,6 @@ export default function IceCard() {
   });
   const [newAllergy, setNewAllergy] = useState('');
   const [newMed, setNewMed] = useState('');
-  const [newCondition, setNewCondition] = useState('');
   const [newContact, setNewContact] = useState({ name: '', phone: '', relationship: '' });
   const [saved, setSaved] = useState(false);
 

--- a/demo/apps/livesafe/src/pages/Landing.tsx
+++ b/demo/apps/livesafe/src/pages/Landing.tsx
@@ -157,7 +157,7 @@ export default function Landing() {
         </p>
 
         <div className="grid grid-cols-4 gap-4 max-w-lg mx-auto">
-          {['P', 'A', 'C', 'E'].map((letter, i) => (
+          {['P', 'A', 'C', 'E'].map((letter) => (
             <div
               key={letter}
               className="aspect-square rounded-2xl border-2 border-dashed border-white/20 flex items-center justify-center text-2xl font-heading font-bold text-white/40 hover:border-blue-400/50 hover:text-blue-400 transition-all cursor-default"

--- a/demo/apps/livesafe/src/pages/Login.tsx
+++ b/demo/apps/livesafe/src/pages/Login.tsx
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth, type AuthState } from '@/hooks/useAuth';
 import { Shield } from 'lucide-react';
@@ -30,20 +30,12 @@ export default function Login({ mode: initialMode = 'login' }: Props) {
   const [displayName, setDisplayName] = useState('');
   const [email, setEmail] = useState('');
   const [passphrase, setPassphrase] = useState('');
+  const [apiToken, setApiToken] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [status, setStatus] = useState('');
-  const [wasmReady, setWasmReady] = useState(false);
-
-  useEffect(() => {
-    import('@/wasm/exochain_wasm').then(async (wasm) => {
-      await wasm.default();
-      setWasmReady(true);
-      setStatus('Secure kernel ready');
-    }).catch(() => setStatus(''));
-  }, []);
 
   const handleSubmit = async () => {
-    if (!passphrase) return;
+    if (!passphrase || !apiToken.trim()) return;
     setIsLoading(true);
     setStatus('Deriving secure identity...');
 
@@ -54,19 +46,14 @@ export default function Login({ mode: initialMode = 'login' }: Props) {
       const hashArray = new Uint8Array(hashBuffer);
       const passphraseHash = Array.from(hashArray).map(b => b.toString(16).padStart(2, '0')).join('');
 
-      // Generate X25519 keypair via WASM
-      let x25519Public = '', x25519Secret = '';
-      if (wasmReady) {
-        const wasm = await import('@/wasm/exochain_wasm');
-        const kp = wasm.wasm_generate_x25519_keypair();
-        x25519Public = kp.public_key_hex;
-        x25519Secret = kp.secret_key_hex;
-      } else {
-        const bytes = new Uint8Array(32);
-        crypto.getRandomValues(bytes);
-        x25519Public = Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
-        x25519Secret = x25519Public;
-      }
+      const keyResponse = await fetch('/api/keys/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiToken.trim()}` },
+      });
+      if (!keyResponse.ok) throw new Error('key generation failed');
+      const keypair = await keyResponse.json() as { public_key_hex: string; secret_key_hex: string };
+      const x25519Public = keypair.public_key_hex;
+      const x25519Secret = keypair.secret_key_hex;
 
       const did = `did:exo:${passphraseHash.slice(0, 16)}`;
       const name = displayName || `User-${passphraseHash.slice(0, 8)}`;
@@ -77,7 +64,7 @@ export default function Login({ mode: initialMode = 'login' }: Props) {
         setTimeout(() => ctrl.abort(), 1500);
         await fetch('/api/profile', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiToken.trim()}` },
           body: JSON.stringify({ did, display_name: name, email, x25519_public_key_hex: x25519Public }),
           signal: ctrl.signal,
         });
@@ -90,6 +77,7 @@ export default function Login({ mode: initialMode = 'login' }: Props) {
         x25519PublicHex: x25519Public,
         x25519SecretHex: x25519Secret,
         passphraseHash,
+        apiToken: apiToken.trim(),
       };
 
       login(authState);
@@ -163,9 +151,18 @@ export default function Login({ mode: initialMode = 'login' }: Props) {
           className="w-full bg-white/5 border border-white/10 rounded-xl px-5 py-4 mb-8 text-white placeholder-white/30 focus:outline-none focus:border-blue-400"
         />
 
+        <input
+          type="password"
+          placeholder="API token"
+          value={apiToken}
+          onChange={(e) => setApiToken(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
+          className="w-full bg-white/5 border border-white/10 rounded-xl px-5 py-4 mb-8 text-white placeholder-white/30 focus:outline-none focus:border-blue-400"
+        />
+
         <button
           onClick={handleSubmit}
-          disabled={isLoading || !passphrase}
+          disabled={isLoading || !passphrase || !apiToken.trim()}
           className="w-full bg-blue-500 hover:bg-blue-600 disabled:bg-white/10 disabled:cursor-not-allowed text-white font-semibold py-4 rounded-xl text-lg transition-all"
         >
           {isLoading ? 'Securing...' : mode === 'register' ? 'CREATE SAFETY NET' : 'ENTER LIVESAFE'}

--- a/demo/apps/livesafe/src/pages/PaceNetwork.tsx
+++ b/demo/apps/livesafe/src/pages/PaceNetwork.tsx
@@ -15,11 +15,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useState } from 'react';
-import { useAuth } from '@/hooks/useAuth';
 import { PACE_ROLES } from '@/lib/utils';
 import { cn } from '@/lib/utils';
 import {
-  Users, Plus, X, Shield, CheckCircle, Clock, UserPlus, Key,
+  Users, X, Shield, CheckCircle, Clock, UserPlus, Key,
 } from 'lucide-react';
 
 interface PaceMember {
@@ -37,7 +36,6 @@ const RELATIONSHIPS = [
 ];
 
 export default function PaceNetwork() {
-  const { auth } = useAuth();
   const [members, setMembers] = useState<PaceMember[]>([]);
   const [showInvite, setShowInvite] = useState(false);
   const [inviteRole, setInviteRole] = useState('');

--- a/demo/services/livesafe-api/src/index.js
+++ b/demo/services/livesafe-api/src/index.js
@@ -29,7 +29,7 @@ function json(res, status, data) {
   res.writeHead(status, {
     'Content-Type': 'application/json',
     'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
   });
   res.end(JSON.stringify(data, null, 2));
 }
@@ -44,22 +44,80 @@ function parseBody(req) {
 
 function nowMs() { return Date.now(); }
 
+const ALLOWED_ROLES = ['owner', 'trustee', 'responder', 'admin'];
+
+function parseApiTokens(raw) {
+  if (!raw) return new Map();
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return new Map();
+    const tokens = new Map();
+    for (const [token, principal] of Object.entries(parsed)) {
+      if (!token || typeof token !== 'string') return new Map();
+      if (!principal || typeof principal !== 'object' || Array.isArray(principal)) return new Map();
+      const did = principal.actor_did;
+      const role = principal.role;
+      if (typeof did !== 'string' || did.length === 0) return new Map();
+      if (typeof role !== 'string' || !ALLOWED_ROLES.includes(role)) return new Map();
+      tokens.set(token, { did, role });
+    }
+    return tokens;
+  } catch {
+    return new Map();
+  }
+}
+
+const apiTokens = parseApiTokens(process.env.LIVESAFE_API_TOKENS);
+
+function authenticatedActor(req) {
+  const header = req.headers.authorization || '';
+  const match = /^Bearer\s+(.+)$/.exec(header);
+  if (!match) return null;
+  return apiTokens.get(match[1]) || null;
+}
+
+function requireAuthenticatedActor(req, res) {
+  const actor = authenticatedActor(req);
+  if (!actor) {
+    json(res, 401, { error: 'authentication required' });
+    return null;
+  }
+  return actor;
+}
+
+function requireRole(actor, roles, res) {
+  if (!roles.includes(actor.role)) {
+    json(res, 403, { error: 'insufficient role for action' });
+    return false;
+  }
+  return true;
+}
+
+function requireOwnerAccess(actor, did, res) {
+  if (actor.role === 'admin' || actor.did === did) return true;
+  json(res, 403, { error: 'owner access required' });
+  return false;
+}
+
 export const server = http.createServer(async (req, res) => {
   if (req.method === 'OPTIONS') {
-    res.writeHead(204, { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': '*', 'Access-Control-Allow-Headers': 'Content-Type' });
+    res.writeHead(204, { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': '*', 'Access-Control-Allow-Headers': 'Content-Type, Authorization' });
     return res.end();
   }
   const url = new URL(req.url, `http://${req.headers.host}`);
 
   try {
     if (url.pathname === '/health') return json(res, 200, { status: 'ok', service: 'livesafe-api' });
+    const authActor = url.pathname.startsWith('/api/') ? requireAuthenticatedActor(req, res) : null;
+    if (url.pathname.startsWith('/api/') && !authActor) return;
 
     // ══════════════════════════════════════════════════════════════════
     // PROFILE
     // ══════════════════════════════════════════════════════════════════
 
     if (url.pathname === '/api/profile' && req.method === 'POST') {
-      const { did, display_name, email, x25519_public_key_hex } = await parseBody(req);
+      if (!requireRole(authActor, ['owner', 'admin'], res)) return;
+      const { display_name, email, x25519_public_key_hex } = await parseBody(req);
       await pool.query(
         `INSERT INTO livesafe_profiles (did, display_name, email, x25519_public_key_hex, created_at_ms)
          VALUES ($1, $2, $3, $4, $5)
@@ -67,13 +125,14 @@ export const server = http.createServer(async (req, res) => {
            display_name = COALESCE(EXCLUDED.display_name, livesafe_profiles.display_name),
            email = COALESCE(EXCLUDED.email, livesafe_profiles.email),
            x25519_public_key_hex = COALESCE(EXCLUDED.x25519_public_key_hex, livesafe_profiles.x25519_public_key_hex)`,
-        [did, display_name, email, x25519_public_key_hex, nowMs()]
+        [authActor.did, display_name, email, x25519_public_key_hex, nowMs()]
       );
-      return json(res, 200, { did, status: 'profile_updated' });
+      return json(res, 200, { did: authActor.did, status: 'profile_updated' });
     }
 
     if (url.pathname.startsWith('/api/profile/') && req.method === 'GET') {
       const did = url.pathname.split('/api/profile/')[1];
+      if (!requireOwnerAccess(authActor, did, res)) return;
       const { rows } = await pool.query('SELECT * FROM livesafe_profiles WHERE did = $1', [did]);
       if (rows.length === 0) return json(res, 404, { error: 'profile not found' });
       return json(res, 200, rows[0]);
@@ -84,19 +143,21 @@ export const server = http.createServer(async (req, res) => {
     // ══════════════════════════════════════════════════════════════════
 
     if (url.pathname === '/api/plans' && req.method === 'POST') {
-      const { owner_did, scenario_type, name, rally_point, go_bag_checklist, communication_plan, evacuation_routes, special_instructions, golden_hour_steps } = await parseBody(req);
+      if (!requireRole(authActor, ['owner', 'admin'], res)) return;
+      const { scenario_type, name, rally_point, go_bag_checklist, communication_plan, evacuation_routes, special_instructions, golden_hour_steps } = await parseBody(req);
       const id = crypto.randomUUID();
       const now = nowMs();
       await pool.query(
         `INSERT INTO emergency_plans (id, owner_did, scenario_type, name, rally_point, go_bag_checklist, communication_plan, evacuation_routes, special_instructions, golden_hour_steps, created_at_ms, updated_at_ms)
          VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
-        [id, owner_did, scenario_type, name, rally_point, JSON.stringify(go_bag_checklist || []), communication_plan, JSON.stringify(evacuation_routes || []), special_instructions, JSON.stringify(golden_hour_steps || []), now, now]
+        [id, authActor.did, scenario_type, name, rally_point, JSON.stringify(go_bag_checklist || []), communication_plan, JSON.stringify(evacuation_routes || []), special_instructions, JSON.stringify(golden_hour_steps || []), now, now]
       );
       return json(res, 201, { id });
     }
 
     if (url.pathname.startsWith('/api/plans/') && req.method === 'GET') {
       const did = url.pathname.split('/api/plans/')[1];
+      if (!requireOwnerAccess(authActor, did, res)) return;
       const { rows } = await pool.query('SELECT * FROM emergency_plans WHERE owner_did = $1 ORDER BY created_at_ms DESC', [did]);
       return json(res, 200, rows);
     }
@@ -106,20 +167,22 @@ export const server = http.createServer(async (req, res) => {
     // ══════════════════════════════════════════════════════════════════
 
     if (url.pathname === '/api/ice-card' && req.method === 'POST') {
+      if (!requireRole(authActor, ['owner', 'admin'], res)) return;
       const body = await parseBody(req);
       const id = crypto.randomUUID();
       const qr_token = crypto.randomUUID().replace(/-/g, '');
       await pool.query(
         `INSERT INTO ice_cards (id, owner_did, full_name, date_of_birth, blood_type, allergies, medications, medical_conditions, emergency_contacts, insurance_info, organ_donor, dnr, special_instructions, qr_token, created_at_ms)
          VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
-        [id, body.owner_did, body.full_name, body.date_of_birth, body.blood_type, JSON.stringify(body.allergies || []), JSON.stringify(body.medications || []), JSON.stringify(body.medical_conditions || []), JSON.stringify(body.emergency_contacts || []), body.insurance_info, body.organ_donor || false, body.dnr || false, body.special_instructions, qr_token, nowMs()]
+        [id, authActor.did, body.full_name, body.date_of_birth, body.blood_type, JSON.stringify(body.allergies || []), JSON.stringify(body.medications || []), JSON.stringify(body.medical_conditions || []), JSON.stringify(body.emergency_contacts || []), body.insurance_info, body.organ_donor || false, body.dnr || false, body.special_instructions, qr_token, nowMs()]
       );
       return json(res, 201, { id, qr_token });
     }
 
     if (url.pathname.startsWith('/api/ice-card/scan/') && req.method === 'POST') {
+      if (!requireRole(authActor, ['responder', 'admin'], res)) return;
       const token = url.pathname.split('/api/ice-card/scan/')[1];
-      const { responder_did } = await parseBody(req);
+      await parseBody(req);
       const { rows } = await pool.query('SELECT * FROM ice_cards WHERE qr_token = $1 AND card_status = $2', [token, 'active']);
       if (rows.length === 0) return json(res, 404, { error: 'card not found or revoked' });
 
@@ -130,7 +193,7 @@ export const server = http.createServer(async (req, res) => {
       await pool.query(
         `INSERT INTO ice_scan_receipts (id, card_id, subscriber_did, responder_did, scanned_at_ms, consent_expires_at_ms)
          VALUES ($1,$2,$3,$4,$5,$6)`,
-        [crypto.randomUUID(), card.id, card.owner_did, responder_did, nowMs(), consentExpires]
+        [crypto.randomUUID(), card.id, card.owner_did, authActor.did, nowMs(), consentExpires]
       );
 
       return json(res, 200, { card, consent_expires_at_ms: consentExpires });
@@ -138,6 +201,7 @@ export const server = http.createServer(async (req, res) => {
 
     if (url.pathname.startsWith('/api/ice-card/') && req.method === 'GET') {
       const did = url.pathname.split('/api/ice-card/')[1];
+      if (!requireOwnerAccess(authActor, did, res)) return;
       const { rows } = await pool.query('SELECT * FROM ice_cards WHERE owner_did = $1 ORDER BY created_at_ms DESC LIMIT 1', [did]);
       if (rows.length === 0) return json(res, 404, { error: 'no ICE card found' });
       return json(res, 200, rows[0]);
@@ -148,20 +212,22 @@ export const server = http.createServer(async (req, res) => {
     // ══════════════════════════════════════════════════════════════════
 
     if (url.pathname === '/api/pace/invite' && req.method === 'POST') {
-      const { owner_did, trustee_email, trustee_name, role, relationship } = await parseBody(req);
+      if (!requireRole(authActor, ['owner', 'admin'], res)) return;
+      const { trustee_email, trustee_name, role, relationship } = await parseBody(req);
       const token = crypto.randomUUID();
       await pool.query(
         `INSERT INTO livesafe_pace_network (owner_did, trustee_email, trustee_name, role, relationship, invitation_token, created_at_ms) VALUES ($1,$2,$3,$4,$5,$6,$7)`,
-        [owner_did, trustee_email, trustee_name, role, relationship, token, nowMs()]
+        [authActor.did, trustee_email, trustee_name, role, relationship, token, nowMs()]
       );
       return json(res, 201, { invitation_token: token, role });
     }
 
     if (url.pathname === '/api/pace/accept' && req.method === 'POST') {
-      const { invitation_token, trustee_did } = await parseBody(req);
+      if (!requireRole(authActor, ['owner', 'trustee', 'admin'], res)) return;
+      const { invitation_token } = await parseBody(req);
       const result = await pool.query(
         `UPDATE livesafe_pace_network SET trustee_did = $1, invitation_status = 'accepted', accepted_at_ms = $2 WHERE invitation_token = $3 AND invitation_status = 'pending' RETURNING *`,
-        [trustee_did, nowMs(), invitation_token]
+        [authActor.did, nowMs(), invitation_token]
       );
       if (result.rows.length === 0) return json(res, 404, { error: 'invitation not found' });
       return json(res, 200, { accepted: true, member: result.rows[0] });
@@ -169,6 +235,7 @@ export const server = http.createServer(async (req, res) => {
 
     if (url.pathname.startsWith('/api/pace/network/') && req.method === 'GET') {
       const did = url.pathname.split('/api/pace/network/')[1];
+      if (!requireOwnerAccess(authActor, did, res)) return;
       const { rows } = await pool.query(
         `SELECT * FROM livesafe_pace_network WHERE owner_did = $1 ORDER BY CASE role WHEN 'Primary' THEN 1 WHEN 'Alternate' THEN 2 WHEN 'Contingency' THEN 3 WHEN 'Emergency' THEN 4 END`, [did]
       );
@@ -177,6 +244,7 @@ export const server = http.createServer(async (req, res) => {
 
     if (url.pathname.startsWith('/api/pace/responsibilities/') && req.method === 'GET') {
       const did = url.pathname.split('/api/pace/responsibilities/')[1];
+      if (!requireOwnerAccess(authActor, did, res)) return;
       const { rows } = await pool.query(
         `SELECT owner_did, role FROM livesafe_pace_network WHERE trustee_did = $1 AND invitation_status = 'accepted'`, [did]
       );
@@ -188,17 +256,19 @@ export const server = http.createServer(async (req, res) => {
     // ══════════════════════════════════════════════════════════════════
 
     if (url.pathname === '/api/wellness/check-in' && req.method === 'POST') {
-      const { did } = await parseBody(req);
+      if (!requireRole(authActor, ['owner', 'admin'], res)) return;
+      await parseBody(req);
       const id = crypto.randomUUID();
       await pool.query(
         `INSERT INTO wellness_checks (id, owner_did, status, responded_at_ms, created_at_ms) VALUES ($1,$2,'ok',$3,$4)`,
-        [id, did, nowMs(), nowMs()]
+        [id, authActor.did, nowMs(), nowMs()]
       );
       return json(res, 201, { sent: true, id });
     }
 
     if (url.pathname.startsWith('/api/wellness/') && req.method === 'GET') {
       const did = url.pathname.split('/api/wellness/')[1];
+      if (!requireOwnerAccess(authActor, did, res)) return;
       const { rows } = await pool.query(
         'SELECT * FROM wellness_checks WHERE owner_did = $1 ORDER BY created_at_ms DESC LIMIT 50', [did]
       );
@@ -221,6 +291,8 @@ export const server = http.createServer(async (req, res) => {
   }
 });
 
-server.listen(PORT, () => {
-  console.log(`✅ LiveSafe API running on port ${PORT}`);
-});
+if (process.env.NODE_ENV !== 'test') {
+  server.listen(PORT, () => {
+    console.log(`✅ LiveSafe API running on port ${PORT}`);
+  });
+}

--- a/demo/services/livesafe-api/src/index.test.js
+++ b/demo/services/livesafe-api/src/index.test.js
@@ -1,0 +1,159 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import supertest from 'supertest';
+
+const mockWasm = vi.hoisted(() => ({
+  wasm_generate_x25519_keypair: vi.fn(() => ({
+    public_key_hex: 'a'.repeat(64),
+    secret_key_hex: 'b'.repeat(64),
+  })),
+}));
+
+vi.hoisted(() => {
+  process.env.LIVESAFE_API_TOKENS = JSON.stringify({
+    'owner-token': { actor_did: 'did:exo:owner1', role: 'owner' },
+    'responder-token': { actor_did: 'did:exo:responder1', role: 'responder' },
+    'admin-token': { actor_did: 'did:exo:admin1', role: 'admin' },
+  });
+});
+
+vi.mock('module', async (importOriginal) => {
+  const original = await importOriginal();
+  return {
+    ...original,
+    createRequire: () => (id) => {
+      if (id === '@exochain/exochain-wasm') return mockWasm;
+      throw new Error(`Unexpected require('${id}')`);
+    },
+  };
+});
+
+const mockQuery = vi.hoisted(() => vi.fn());
+vi.mock('pg', () => {
+  const Pool = vi.fn(() => ({ query: mockQuery }));
+  return { default: { Pool } };
+});
+
+import { server } from './index.js';
+
+const request = supertest(server);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterAll(async () => {
+  if (server.listening) {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+function withAuth(req, token = 'owner-token') {
+  return req.set('Authorization', `Bearer ${token}`);
+}
+
+function iceCard(ownerDid = 'did:exo:owner1') {
+  return {
+    id: 'card-1',
+    owner_did: ownerDid,
+    full_name: 'Alice Owner',
+    date_of_birth: '1970-01-01',
+    blood_type: 'O+',
+    allergies: ['penicillin'],
+    medications: ['insulin'],
+    medical_conditions: ['diabetes'],
+    emergency_contacts: [{ name: 'Bob', phone: '+15551234567', relationship: 'spouse' }],
+    insurance_info: 'policy-123',
+    organ_donor: true,
+    dnr: false,
+    special_instructions: 'Use blue kit',
+    qr_token: 'qr-token',
+    card_status: 'active',
+    created_at_ms: 1_000,
+  };
+}
+
+describe('LiveSafe API authentication boundary', () => {
+  it('rejects unauthenticated ICE-card lookup before database access', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [iceCard()] });
+
+    const res = await request.get('/api/ice-card/did:exo:owner1');
+
+    expect(res.status).toBe(401);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('rejects authenticated lookup of another owner before database access', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [iceCard('did:exo:victim')] });
+
+    const res = await withAuth(request.get('/api/ice-card/did:exo:victim'));
+
+    expect(res.status).toBe(403);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('rejects unauthenticated QR scans before database access', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [iceCard()] });
+
+    const res = await request
+      .post('/api/ice-card/scan/qr-token')
+      .send({ responder_did: 'did:exo:attacker' });
+
+    expect(res.status).toBe(401);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('binds QR scan receipts to the authenticated responder instead of the body DID', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [iceCard()] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await withAuth(
+      request.post('/api/ice-card/scan/qr-token'),
+      'responder-token',
+    ).send({ responder_did: 'did:exo:attacker' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.card.owner_did).toBe('did:exo:owner1');
+    expect(mockQuery.mock.calls[1][1][3]).toBe('did:exo:responder1');
+  });
+
+  it('binds profile updates to the authenticated owner instead of the body DID', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await withAuth(request.post('/api/profile')).send({
+      did: 'did:exo:attacker',
+      display_name: 'Alice',
+      email: 'alice@example.test',
+      x25519_public_key_hex: 'a'.repeat(64),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.did).toBe('did:exo:owner1');
+    expect(mockQuery.mock.calls[0][1][0]).toBe('did:exo:owner1');
+  });
+
+  it('rejects authenticated emergency plan lookup for another owner before database access', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ owner_did: 'did:exo:victim' }] });
+
+    const res = await withAuth(request.get('/api/plans/did:exo:victim'));
+
+    expect(res.status).toBe(403);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Remediates Codex Security finding from `codex-security-findings-2026-05-19T15-37-10.140Z.csv`: "Unauthenticated LiveSafe API exposes medical and emergency data".
- Verified against current `main` before fixing: LiveSafe accepted URL/body DIDs as authorization boundaries, unauthenticated ICE card reads returned full medical cards, QR scans trusted caller-supplied `responder_did`, and cross-owner emergency plan reads were allowed.
- Adds fail-closed bearer-principal auth for LiveSafe `/api` routes, derives owner/responder/trustee identity from `LIVESAFE_API_TOKENS`, enforces owner/admin reads for sensitive owner data, and requires authenticated responder/admin access for QR card scans.
- Updates the LiveSafe frontend to require and send the API token, moves key generation through the authenticated API path, and fixes pre-existing TypeScript build blockers in the adjacent app.

## Path Classification
- `demo/services/livesafe-api/src/index.js` - Adjacent surface / core runtime adapter boundary for LiveSafe API.
- `demo/services/livesafe-api/src/index.test.js` - Adjacent surface / adapter regression tests.
- `demo/apps/livesafe/src/hooks/useAuth.ts` - Adjacent surface auth state.
- `demo/apps/livesafe/src/lib/api.ts` - Adjacent surface API client.
- `demo/apps/livesafe/src/pages/Login.tsx` - Adjacent surface login and authenticated key/profile bootstrap.
- `demo/apps/livesafe/src/pages/EmergencyPlans.tsx`, `GoldenHour.tsx`, `IceCard.tsx`, `Landing.tsx`, `PaceNetwork.tsx` - Adjacent surface TypeScript build hygiene needed for the touched app gate.
- `demo/README.md` - Adjacent surface operator documentation.

## Validation
- RED first: `npx vitest run --workspace vitest.workspace.js --project services services/livesafe-api/src/index.test.js` failed 6/6 before the production fix.
- `npx vitest run --workspace vitest.workspace.js --project services services/livesafe-api/src/index.test.js`
- `npm run test:services`
- `npm test`
- `node --check demo/services/livesafe-api/src/index.js`
- `node --check demo/services/livesafe-api/src/index.test.js`
- `npx tsc --noEmit` in `demo/apps/livesafe`
- `npm run build` in `demo/apps/livesafe`
- `git diff --check`

## Notes
- EXOCHAIN core Rust crates were not modified.
- Missing or malformed `LIVESAFE_API_TOKENS` now makes LiveSafe `/api` routes fail closed with `401`.
- Railway CLI deployment inspection remains blocked locally by Railway OAuth refresh errors; public `https://exochain-production.up.railway.app/` currently returns Railway edge `404 Application not found`.
