### PR TITLE
fix(demo): route web proxy to gateway port

### DIFF
--- a/demo/web/src/vite-config.test.js
+++ b/demo/web/src/vite-config.test.js
@@ -1,0 +1,61 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const webSrcDir = path.dirname(fileURLToPath(import.meta.url));
+const demoRoot = path.resolve(webSrcDir, '..', '..');
+
+function readDemoFile(relativePath) {
+  return fs.readFileSync(path.join(demoRoot, relativePath), 'utf8');
+}
+
+function gatewayDefaultPort() {
+  const source = readDemoFile('services/gateway-api/src/index.js');
+  const match = source.match(/const PORT = process\.env\.PORT \|\| (\d+);/);
+
+  expect(match).not.toBeNull();
+
+  return Number(match[1]);
+}
+
+function viteApiProxyPort() {
+  const source = readDemoFile('web/vite.config.js');
+  const match = source.match(/['"]\/api['"]:\s*['"]http:\/\/localhost:(\d+)['"]/);
+
+  expect(match).not.toBeNull();
+
+  return Number(match[1]);
+}
+
+describe('Vite API proxy', () => {
+  it('routes /api to the gateway-api port used by local demo entrypoints', () => {
+    const gatewayPort = gatewayDefaultPort();
+    const devScript = readDemoFile('scripts/dev.sh');
+    const compose = readDemoFile('infra/docker-compose.yml');
+    const readme = readDemoFile('README.md');
+
+    expect(viteApiProxyPort()).toBe(gatewayPort);
+    expect(devScript).toContain(`PORT=${gatewayPort} node services/gateway-api/src/index.js`);
+    expect(devScript).toContain(`gateway-api:       http://localhost:${gatewayPort}`);
+    expect(compose).toContain(`ports: ["${gatewayPort}:${gatewayPort}"]`);
+    expect(compose).toContain(`PORT: ${gatewayPort}`);
+    expect(readme).toContain(`| gateway-api | ${gatewayPort} |`);
+  });
+});

--- a/demo/web/vite.config.js
+++ b/demo/web/vite.config.js
@@ -23,7 +23,7 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      '/api': 'http://localhost:3010',
+      '/api': 'http://localhost:3000',
     },
   },
 })


### PR DESCRIPTION
## Summary
- Classifies CSV row 80 as adjacent demo surface availability/configuration, not EXOCHAIN core.
- Confirms current main still had Vite proxying /api to localhost:3010 while gateway-api defaults, dev script, Docker Compose, and README all use port 3000.
- Routes the demo web /api proxy to localhost:3000 and adds a regression guard tying Vite, gateway-api, dev script, Compose, and README together.

## Validation
- RED: npx vitest run --workspace vitest.workspace.js --project web web/src/vite-config.test.js failed with expected 3010 to be 3000.
- GREEN: npx vitest run --workspace vitest.workspace.js --project web web/src/vite-config.test.js
- node --check web/src/vite-config.test.js
- node --check web/vite.config.js
- npm run test:react
- npm test
- npm run build (demo/web)
- npx eslint src/vite-config.test.js vite.config.js (demo/web)
- git diff --check

## Notes
- npm run lint in demo/web still fails on pre-existing App.jsx/App.test.jsx/test-setup.js lint issues unrelated to this change; focused lint for touched files passes.