### PR TITLE
fix(web): harden dev bypass onboarding parsing

### DIFF
--- a/web/src/lib/auth.test.tsx
+++ b/web/src/lib/auth.test.tsx
@@ -1,0 +1,104 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AuthProvider, useAuth } from './auth'
+
+function renderedValue(value: unknown): string {
+  return typeof value === 'string' ? value : `non-string:${typeof value}`
+}
+
+function AuthProbe() {
+  const auth = useAuth()
+
+  return (
+    <dl>
+      <dt>Loading</dt>
+      <dd data-testid="loading">{auth.isLoading ? 'loading' : 'ready'}</dd>
+      <dt>Display Name</dt>
+      <dd data-testid="display-name">{renderedValue(auth.user?.displayName ?? 'none')}</dd>
+      <dt>Email</dt>
+      <dd data-testid="email">{renderedValue(auth.user?.email ?? 'none')}</dd>
+      <dt>Token</dt>
+      <dd data-testid="token">{auth.token ?? 'none'}</dd>
+    </dl>
+  )
+}
+
+function renderAuthProvider() {
+  return render(
+    <AuthProvider>
+      <AuthProbe />
+    </AuthProvider>
+  )
+}
+
+describe('AuthProvider dev bypass onboarding storage', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_ALLOW_DEV_BYPASS', 'true')
+    localStorage.setItem('df_dev_bypass', '1')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('falls back to the dev preview user when onboarding storage is malformed JSON', async () => {
+    localStorage.setItem('ape_onboarding', '{not-json')
+
+    renderAuthProvider()
+
+    await waitFor(() => expect(screen.getByTestId('loading')).toHaveTextContent('ready'))
+    expect(screen.getByTestId('display-name')).toHaveTextContent('Dev Preview')
+    expect(screen.getByTestId('email')).toHaveTextContent('dev@exochain.io')
+    expect(screen.getByTestId('token')).toHaveTextContent('dev-preview-token')
+  })
+
+  it('falls back to typed defaults when onboarding fields are not strings', async () => {
+    localStorage.setItem(
+      'ape_onboarding',
+      JSON.stringify({
+        displayName: { text: 'not a string' },
+        email: ['dev@example.invalid'],
+      })
+    )
+
+    renderAuthProvider()
+
+    await waitFor(() => expect(screen.getByTestId('loading')).toHaveTextContent('ready'))
+    expect(screen.getByTestId('display-name')).toHaveTextContent('Dev Preview')
+    expect(screen.getByTestId('email')).toHaveTextContent('dev@exochain.io')
+    expect(screen.getByTestId('token')).toHaveTextContent('dev-preview-token')
+  })
+
+  it('uses valid onboarding strings for the dev preview user', async () => {
+    localStorage.setItem(
+      'ape_onboarding',
+      JSON.stringify({
+        displayName: 'Ada Lovelace',
+        email: 'ada@example.invalid',
+      })
+    )
+
+    renderAuthProvider()
+
+    await waitFor(() => expect(screen.getByTestId('loading')).toHaveTextContent('ready'))
+    expect(screen.getByTestId('display-name')).toHaveTextContent('Ada Lovelace')
+    expect(screen.getByTestId('email')).toHaveTextContent('ada@example.invalid')
+    expect(screen.getByTestId('token')).toHaveTextContent('dev-preview-token')
+  })
+})

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -43,6 +43,40 @@ const AuthContext = createContext<AuthContextType | null>(null)
 
 const TOKEN_KEY = 'df_token'
 const REFRESH_KEY = 'df_refresh_token'
+const DEV_PREVIEW_DISPLAY_NAME = 'Dev Preview'
+const DEV_PREVIEW_EMAIL = 'dev@exochain.io'
+
+function nonEmptyString(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim().length > 0 ? value : fallback
+}
+
+function readDevPreviewOnboarding(): { displayName: string; email: string } {
+  const fallback = {
+    displayName: DEV_PREVIEW_DISPLAY_NAME,
+    email: DEV_PREVIEW_EMAIL,
+  }
+  const stored = localStorage.getItem('ape_onboarding')
+
+  if (!stored) {
+    return fallback
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(stored)
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return fallback
+    }
+
+    const onboarding = parsed as Record<string, unknown>
+    return {
+      displayName: nonEmptyString(onboarding.displayName, fallback.displayName),
+      email: nonEmptyString(onboarding.email, fallback.email),
+    }
+  } catch {
+    return fallback
+  }
+}
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(null)
@@ -96,12 +130,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       import.meta.env.VITE_ALLOW_DEV_BYPASS === 'true' &&
       localStorage.getItem('df_dev_bypass') === '1'
     ) {
-      const onb = localStorage.getItem('ape_onboarding')
-      const parsed = onb ? JSON.parse(onb) : null
+      const preview = readDevPreviewOnboarding()
       setUser({
         did: 'did:exo:dev-preview',
-        displayName: parsed?.displayName || 'Dev Preview',
-        email: parsed?.email || 'dev@exochain.io',
+        displayName: preview.displayName,
+        email: preview.email,
         roles: ['admin'],
         paceStatus: 'verified' as PaceStatus,
         trustTier: 'Gold',


### PR DESCRIPTION
## Summary
- Classifies CSV row 81 as adjacent web dev-mode robustness, not EXOCHAIN core.
- Confirms current main still parsed ape_onboarding directly inside AuthProvider when df_dev_bypass was enabled.
- Adds a typed, fail-closed dev preview onboarding parser so malformed JSON and non-string display/email fields fall back to deterministic defaults.

## Validation
- RED: npm test -- src/lib/auth.test.tsx failed on malformed JSON escaping AuthProvider and non-string displayName reaching auth state.
- GREEN: npm test -- src/lib/auth.test.tsx
- npm test (web): 9 files, 375 tests passing
- npm run build (web): tsc and Vite production build passing
- git diff --check

## Lint/tooling note
- npm run lint is not currently a usable web gate on main: local node_modules does not contain eslint for this package, and an ephemeral ESLint 9 invocation fails because web has no eslint.config.* file. This remediation does not broaden into that unrelated tooling repair.