### PR TITLE
fix(commandbase): align bootstrap schema with routes

### DIFF
--- a/command-base/app/lib/bootstrap-schema.js
+++ b/command-base/app/lib/bootstrap-schema.js
@@ -23,6 +23,71 @@
  */
 'use strict';
 
+function existingColumns(db, tableName) {
+  return new Set(db.prepare(`PRAGMA table_info(${tableName})`).all().map((row) => row.name));
+}
+
+function ensureColumn(db, tableName, columnName, definition) {
+  const columns = existingColumns(db, tableName);
+
+  if (!columns.has(columnName)) {
+    db.exec(`ALTER TABLE ${tableName} ADD COLUMN ${columnName} ${definition}`);
+  }
+}
+
+function ensureRouteSchemaCompatibility(db) {
+  const migrations = {
+    llm_providers: [
+      ['type', "TEXT NOT NULL DEFAULT 'custom'"],
+      ['base_url', 'TEXT'],
+      ['api_key', 'TEXT'],
+      ['default_model', 'TEXT'],
+      ['enabled', 'INTEGER NOT NULL DEFAULT 0'],
+      ['updated_at', 'TEXT'],
+    ],
+    model_sources: [
+      ['type', "TEXT NOT NULL DEFAULT 'ollama'"],
+      ['endpoint', "TEXT NOT NULL DEFAULT 'http://localhost:11434'"],
+      ['label', 'TEXT'],
+      ['device', 'TEXT'],
+      ['ssh_host', 'TEXT'],
+      ['ssh_tunnel_port', 'INTEGER'],
+      ['updated_at', 'TEXT'],
+    ],
+    credential_vault: [
+      ['name', "TEXT NOT NULL DEFAULT 'Unnamed Credential'"],
+      ['credential_type', "TEXT NOT NULL DEFAULT 'api_key'"],
+      ['metadata', "TEXT NOT NULL DEFAULT '{}'"],
+    ],
+    idea_board: [
+      ['reference_material', 'TEXT'],
+      ['structure', 'TEXT'],
+      ['market_notes', 'TEXT'],
+      ['related_project_id', 'INTEGER REFERENCES projects(id)'],
+    ],
+    research_sessions: [
+      ['research_brief', 'TEXT'],
+      ['assigned_to', 'TEXT'],
+      ['project_id', 'INTEGER REFERENCES projects(id)'],
+      ['started_at', 'TEXT'],
+      ['completed_at', 'TEXT'],
+      ['summary', 'TEXT'],
+      ['updated_at', 'TEXT'],
+    ],
+  };
+
+  for (const [tableName, columns] of Object.entries(migrations)) {
+    for (const [columnName, definition] of columns) {
+      ensureColumn(db, tableName, columnName, definition);
+    }
+  }
+
+  db.exec(`UPDATE llm_providers SET updated_at = COALESCE(updated_at, created_at, datetime('now','localtime'))`);
+  db.exec(`UPDATE model_sources SET updated_at = COALESCE(updated_at, created_at, datetime('now','localtime'))`);
+  db.exec(`UPDATE research_sessions SET updated_at = COALESCE(updated_at, created_at, datetime('now','localtime'))`);
+  db.exec(`UPDATE model_sources SET label = COALESCE(label, name)`);
+}
+
 module.exports = function bootstrapSchema(db) {
 
   db.exec(`CREATE TABLE IF NOT EXISTS system_settings (
@@ -34,10 +99,14 @@ module.exports = function bootstrapSchema(db) {
   db.exec(`CREATE TABLE IF NOT EXISTS llm_providers (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL UNIQUE,
-    provider_type TEXT NOT NULL DEFAULT 'api',
+    type TEXT NOT NULL DEFAULT 'custom',
+    base_url TEXT,
+    api_key TEXT,
+    default_model TEXT,
+    enabled INTEGER NOT NULL DEFAULT 0,
     config TEXT DEFAULT '{}',
-    status TEXT NOT NULL DEFAULT 'active',
-    created_at TEXT NOT NULL DEFAULT (datetime('now','localtime'))
+    created_at TEXT NOT NULL DEFAULT (datetime('now','localtime')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now','localtime'))
   )`);
 
   db.exec(`CREATE TABLE IF NOT EXISTS team_members (
@@ -463,12 +532,19 @@ module.exports = function bootstrapSchema(db) {
     title TEXT NOT NULL,
     goal TEXT,
     success_criteria TEXT,
+    research_brief TEXT,
     max_cycles INTEGER DEFAULT 50,
     model TEXT DEFAULT 'sonnet',
+    assigned_to TEXT,
+    project_id INTEGER REFERENCES projects(id),
     current_cycle INTEGER DEFAULT 0,
     status TEXT DEFAULT 'pending',
     program_id INTEGER,
-    created_at TEXT NOT NULL DEFAULT (datetime('now','localtime'))
+    started_at TEXT,
+    completed_at TEXT,
+    summary TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now','localtime')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now','localtime'))
   )`);
 
   db.exec(`CREATE TABLE IF NOT EXISTS research_cycles (
@@ -516,16 +592,23 @@ module.exports = function bootstrapSchema(db) {
     tagline TEXT,
     description TEXT,
     category TEXT,
+    reference_material TEXT,
+    structure TEXT,
+    market_notes TEXT,
     status TEXT DEFAULT 'fresh',
     generated_by TEXT,
+    related_project_id INTEGER REFERENCES projects(id),
     created_at TEXT NOT NULL DEFAULT (datetime('now','localtime')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now','localtime'))
   )`);
 
   db.exec(`CREATE TABLE IF NOT EXISTS credential_vault (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL DEFAULT 'Unnamed Credential',
     provider TEXT NOT NULL,
+    credential_type TEXT NOT NULL DEFAULT 'api_key',
     encrypted_value TEXT,
+    metadata TEXT NOT NULL DEFAULT '{}',
     created_at TEXT NOT NULL DEFAULT (datetime('now','localtime')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now','localtime'))
   )`);
@@ -549,10 +632,17 @@ module.exports = function bootstrapSchema(db) {
   db.exec(`CREATE TABLE IF NOT EXISTS model_sources (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL,
+    type TEXT NOT NULL DEFAULT 'ollama',
+    endpoint TEXT NOT NULL DEFAULT 'http://localhost:11434',
+    label TEXT,
+    device TEXT,
     is_active INTEGER DEFAULT 1,
     is_local INTEGER DEFAULT 0,
+    ssh_host TEXT,
+    ssh_tunnel_port INTEGER,
     max_concurrent INTEGER DEFAULT 3,
-    created_at TEXT NOT NULL DEFAULT (datetime('now','localtime'))
+    created_at TEXT NOT NULL DEFAULT (datetime('now','localtime')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now','localtime'))
   )`);
 
   // ── Catapult: franchise incubator tables ─────────────────────────────────
@@ -586,4 +676,6 @@ module.exports = function bootstrapSchema(db) {
     hired_at TEXT,
     PRIMARY KEY (newco_id, slot)
   )`);
+
+  ensureRouteSchemaCompatibility(db);
 };

--- a/command-base/app/lib/bootstrap-schema.test.js
+++ b/command-base/app/lib/bootstrap-schema.test.js
@@ -1,0 +1,192 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const Database = require('better-sqlite3');
+const bootstrapSchema = require('./bootstrap-schema');
+
+const REQUIRED_COLUMNS = {
+  llm_providers: [
+    'id', 'name', 'type', 'base_url', 'api_key', 'default_model', 'enabled',
+    'config', 'created_at', 'updated_at',
+  ],
+  model_sources: [
+    'id', 'name', 'type', 'endpoint', 'label', 'device', 'is_active',
+    'is_local', 'ssh_host', 'ssh_tunnel_port', 'max_concurrent',
+    'created_at', 'updated_at',
+  ],
+  credential_vault: [
+    'id', 'name', 'provider', 'credential_type', 'encrypted_value', 'metadata',
+    'created_at', 'updated_at',
+  ],
+  idea_board: [
+    'id', 'title', 'tagline', 'description', 'category', 'reference_material',
+    'structure', 'market_notes', 'status', 'generated_by',
+    'related_project_id', 'created_at', 'updated_at',
+  ],
+  research_sessions: [
+    'id', 'title', 'goal', 'success_criteria', 'research_brief', 'max_cycles',
+    'model', 'assigned_to', 'project_id', 'current_cycle', 'status',
+    'program_id', 'started_at', 'completed_at', 'summary',
+    'created_at', 'updated_at',
+  ],
+};
+
+function bootstrappedDatabase() {
+  const db = new Database(':memory:');
+  bootstrapSchema(db);
+  return db;
+}
+
+function staleBootstrappedDatabase() {
+  const db = new Database(':memory:');
+
+  db.exec(`CREATE TABLE llm_providers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE,
+    provider_type TEXT NOT NULL DEFAULT 'api',
+    config TEXT DEFAULT '{}',
+    status TEXT NOT NULL DEFAULT 'active',
+    created_at TEXT NOT NULL DEFAULT (datetime('now','localtime'))
+  )`);
+
+  db.exec(`CREATE TABLE model_sources (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    is_active INTEGER DEFAULT 1,
+    is_local INTEGER DEFAULT 0,
+    max_concurrent INTEGER DEFAULT 3,
+    created_at TEXT NOT NULL DEFAULT (datetime('now','localtime'))
+  )`);
+
+  db.exec(`CREATE TABLE credential_vault (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    provider TEXT NOT NULL,
+    encrypted_value TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now','localtime')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now','localtime'))
+  )`);
+
+  db.exec(`CREATE TABLE idea_board (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    tagline TEXT,
+    description TEXT,
+    category TEXT,
+    status TEXT DEFAULT 'fresh',
+    generated_by TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now','localtime')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now','localtime'))
+  )`);
+
+  db.exec(`CREATE TABLE research_sessions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    goal TEXT,
+    success_criteria TEXT,
+    max_cycles INTEGER DEFAULT 50,
+    model TEXT DEFAULT 'sonnet',
+    current_cycle INTEGER DEFAULT 0,
+    status TEXT DEFAULT 'pending',
+    program_id INTEGER,
+    created_at TEXT NOT NULL DEFAULT (datetime('now','localtime'))
+  )`);
+
+  bootstrapSchema(db);
+  return db;
+}
+
+function columnsFor(db, table) {
+  return new Set(db.prepare(`PRAGMA table_info(${table})`).all().map((row) => row.name));
+}
+
+function assertRouteRequiredColumns(db) {
+  for (const [table, expectedColumns] of Object.entries(REQUIRED_COLUMNS)) {
+    const actualColumns = columnsFor(db, table);
+    const missing = expectedColumns.filter((column) => !actualColumns.has(column));
+
+    assert.deepEqual(missing, [], `${table} bootstrap schema is missing route-required columns`);
+  }
+}
+
+function assertRouteCompatibleWrites(db) {
+  const now = '2026-05-19T20:00:00.000-04:00';
+
+  db.prepare(`
+    INSERT INTO llm_providers (name, type, base_url, api_key, default_model, enabled, config, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?)
+  `).run('Anthropic', 'claude', 'https://api.anthropic.com', 'sk-test', 'claude-sonnet', '{}', now, now);
+
+  db.prepare(`
+    INSERT INTO model_sources (name, type, endpoint, label, device, is_local, ssh_host, ssh_tunnel_port, max_concurrent, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run('Local Ollama', 'ollama', 'http://localhost:11434', 'Local', 'Mac', 1, null, null, 3, now, now);
+
+  db.prepare(`
+    INSERT INTO credential_vault (name, provider, credential_type, encrypted_value, metadata, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run('Anthropic key', 'anthropic', 'api_key', 'sk-test', '{}', now, now);
+
+  db.prepare(`
+    INSERT INTO idea_board (title, tagline, description, category, reference_material, structure, market_notes, generated_by, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run('Receipt explorer', 'Traceable decisions', 'Show receipts', 'product', 'notes', 'app', 'market', 'Max', now, now);
+
+  db.prepare(`
+    INSERT INTO research_sessions (title, goal, success_criteria, research_brief, max_cycles, model, assigned_to, project_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run('Root receipts', 'Validate receipts', 'no gaps', 'inspect DAG', 50, 'sonnet', 'Briar', null);
+
+  assert.equal(db.prepare('SELECT COUNT(*) AS c FROM llm_providers').get().c, 1);
+  assert.equal(db.prepare('SELECT COUNT(*) AS c FROM model_sources').get().c, 1);
+  assert.equal(db.prepare('SELECT COUNT(*) AS c FROM credential_vault').get().c, 1);
+  assert.equal(db.prepare('SELECT COUNT(*) AS c FROM idea_board').get().c, 1);
+  assert.equal(db.prepare('SELECT COUNT(*) AS c FROM research_sessions').get().c, 1);
+}
+
+test('bootstrap schema includes every column used by clean-install routes', () => {
+  const db = bootstrappedDatabase();
+
+  try {
+    assertRouteRequiredColumns(db);
+  } finally {
+    db.close();
+  }
+});
+
+test('bootstrap schema supports fresh-install writes used by settings, ideas, and research routes', () => {
+  const db = bootstrappedDatabase();
+
+  try {
+    assertRouteCompatibleWrites(db);
+  } finally {
+    db.close();
+  }
+});
+
+test('bootstrap schema upgrades tables created by the stale bootstrap', () => {
+  const db = staleBootstrappedDatabase();
+
+  try {
+    assertRouteRequiredColumns(db);
+    assertRouteCompatibleWrites(db);
+  } finally {
+    db.close();
+  }
+});

--- a/command-base/app/routes/research.js
+++ b/command-base/app/routes/research.js
@@ -16,7 +16,16 @@
 
 'use strict';
 module.exports = function(app, db, helpers) {
-  const { broadcast, localNow, createNotification, authRateLimiter, apiRateLimiter, spawnMemberTerminal } = helpers;
+  const {
+    broadcast,
+    localNow,
+    createNotification,
+    authRateLimiter,
+    apiRateLimiter,
+    spawnMemberTerminal,
+    badRequest,
+    notFound,
+  } = helpers;
   const stmt = helpers.stmt || ((sql) => db.prepare(sql));
 
 // GET /api/research-sessions — alias endpoint for the Auto-Research page

--- a/command-base/app/routes/settings.js
+++ b/command-base/app/routes/settings.js
@@ -16,7 +16,18 @@
 
 'use strict';
 module.exports = function(app, db, helpers) {
-  const { broadcast, localNow, createNotification, authRateLimiter, apiRateLimiter, spawnMemberTerminal } = helpers;
+  const {
+    broadcast,
+    localNow,
+    createNotification,
+    authRateLimiter,
+    apiRateLimiter,
+    spawnMemberTerminal,
+    maskApiKey,
+    maskCredential,
+    badRequest,
+    notFound,
+  } = helpers;
   const stmt = helpers.stmt || ((sql) => db.prepare(sql));
 
 // GET /api/model-sources — list all configured model sources with live status

--- a/command-base/app/schema-bootstrap.routes.test.js
+++ b/command-base/app/schema-bootstrap.routes.test.js
@@ -1,0 +1,188 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const { mkdtempSync, rmSync, mkdirSync } = require('node:fs');
+const { join } = require('node:path');
+const { spawn } = require('node:child_process');
+const os = require('node:os');
+const net = require('node:net');
+const test = require('node:test');
+
+function pickFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.unref();
+    srv.on('error', reject);
+    srv.listen(0, () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitForHttpReady(url, stderr) {
+  const timeoutAt = Date.now() + 12_000;
+  while (Date.now() < timeoutAt) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch (_err) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+  throw new Error(`server failed to become ready at ${url}; stderr: ${stderr.join('')}`);
+}
+
+function spawnCommandBaseServer(port, dbPath, tmpDir) {
+  const env = { ...process.env };
+  env.PORT = String(port);
+  env.NODE_ENV = 'test';
+  env.DB_PATH = dbPath;
+  env.INBOX_PATH = join(tmpDir, 'inbox');
+  env.OUTBOX_PATH = join(tmpDir, 'outbox');
+  env.TRUST_PROXY = 'loopback';
+
+  mkdirSync(env.INBOX_PATH, { recursive: true });
+  mkdirSync(env.OUTBOX_PATH, { recursive: true });
+
+  const proc = spawn(process.execPath, ['server.js'], {
+    cwd: __dirname,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  const stderr = [];
+  proc.stderr.setEncoding('utf8');
+  proc.stderr.on('data', (chunk) => stderr.push(chunk.toString()));
+
+  return { proc, stderr };
+}
+
+function stopCommandBaseServer(proc) {
+  return new Promise((resolve) => {
+    if (!proc || proc.killed || proc.exitCode !== null) {
+      resolve();
+      return;
+    }
+
+    proc.once('exit', () => resolve());
+    proc.kill('SIGTERM');
+
+    setTimeout(() => {
+      if (!proc.killed && proc.exitCode === null) {
+        proc.kill('SIGKILL');
+      }
+    }, 2000);
+  });
+}
+
+function cookieHeader(setCookie) {
+  return (setCookie || '').split(';')[0];
+}
+
+async function postJson(baseUrl, cookie, path, body) {
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: 'POST',
+    headers: {
+      Cookie: cookie,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+
+  assert.equal(res.ok, true, `${path} returned ${res.status}: ${text}`);
+
+  return JSON.parse(text);
+}
+
+test('clean CommandBase bootstrap supports affected authenticated create routes', { timeout: 60_000 }, async (t) => {
+  const tmpDir = mkdtempSync(join(os.tmpdir(), 'cb-schema-routes-'));
+  const dbPath = join(tmpDir, 'command-base.db');
+  const port = await pickFreePort();
+
+  const { proc, stderr } = spawnCommandBaseServer(port, dbPath, tmpDir);
+  t.after(() => {
+    return stopCommandBaseServer(proc).finally(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+  });
+
+  let exitCode;
+  proc.once('exit', (code) => {
+    exitCode = code;
+  });
+
+  const baseUrl = `http://127.0.0.1:${port}`;
+  await waitForHttpReady(`${baseUrl}/health`, stderr);
+
+  const authRes = await fetch(`${baseUrl}/api/auth/status`);
+  assert.equal(authRes.status, 200, 'loopback auth status should set the bootstrap cookie');
+  const cookie = cookieHeader(authRes.headers.get('set-cookie'));
+  assert.match(cookie, /^cb_auth=/, 'bootstrap response should include cb_auth cookie');
+
+  await postJson(baseUrl, cookie, '/api/llm/providers', {
+    name: 'Anthropic',
+    type: 'claude',
+    base_url: 'https://api.anthropic.com',
+    api_key: 'sk-test',
+    default_model: 'claude-sonnet',
+    config: {},
+  });
+  await postJson(baseUrl, cookie, '/api/model-sources', {
+    name: 'Local Ollama',
+    type: 'ollama',
+    endpoint: 'http://localhost:11434',
+    label: 'Local',
+    device: 'Mac',
+    is_local: true,
+    max_concurrent: 3,
+  });
+  await postJson(baseUrl, cookie, '/api/vault', {
+    name: 'Anthropic key',
+    provider: 'anthropic',
+    credential_type: 'api_key',
+    value: 'sk-test',
+    metadata: { source: 'test' },
+  });
+  await postJson(baseUrl, cookie, '/api/ideas', {
+    title: 'Receipt explorer',
+    tagline: 'Traceable decisions',
+    description: 'Show receipts',
+    category: 'product',
+    reference_material: 'notes',
+    structure: 'app',
+    market_notes: 'market',
+    generated_by: 'Max',
+  });
+  await postJson(baseUrl, cookie, '/api/research-sessions', {
+    title: 'Root receipts',
+    goal: 'Validate receipts',
+    success_criteria: 'no gaps',
+    research_brief: 'inspect DAG',
+    max_cycles: 50,
+    model: 'sonnet',
+    assigned_to: 'Briar',
+    project_id: null,
+  });
+
+  if (exitCode !== undefined) {
+    assert.equal(exitCode, 0, `server exited unexpectedly; stderr: ${stderr.join('')}`);
+  }
+});

--- a/command-base/app/server.js
+++ b/command-base/app/server.js
@@ -22429,7 +22429,18 @@ app.get('/system-map', (req, res) => {
 require('./routes/governance.js')(app, db, { broadcast, localNow, createNotification, stmt, getCachedSetting, authRateLimiter, apiRateLimiter, spawnMemberTerminal });
 require('./routes/honorgood-economy.js')(app, db, { broadcast, localNow, createNotification, stmt, getCachedSetting, authRateLimiter, apiRateLimiter, spawnMemberTerminal });
 require('./routes/companies.js')(app, db, { broadcast, localNow, createNotification, stmt, getCachedSetting, authRateLimiter, apiRateLimiter, spawnMemberTerminal });
-require('./routes/research.js')(app, db, { broadcast, localNow, createNotification, stmt, getCachedSetting, authRateLimiter, apiRateLimiter, spawnMemberTerminal });
+require('./routes/research.js')(app, db, {
+  broadcast,
+  localNow,
+  createNotification,
+  stmt,
+  getCachedSetting,
+  authRateLimiter,
+  apiRateLimiter,
+  spawnMemberTerminal,
+  badRequest,
+  notFound,
+});
 require('./routes/projects.js')(app, db, { broadcast, localNow, createNotification, stmt, getCachedSetting, authRateLimiter, apiRateLimiter, spawnMemberTerminal });
 require('./routes/members.js')(app, db, { broadcast, localNow, createNotification, stmt, getCachedSetting, authRateLimiter, apiRateLimiter, spawnMemberTerminal });
 require('./routes/analytics.js')(app, db, { broadcast, localNow, createNotification, stmt, getCachedSetting, authRateLimiter, apiRateLimiter, spawnMemberTerminal });
@@ -22438,7 +22449,20 @@ require('./routes/context.js')(app, db, { broadcast, localNow, createNotificatio
 require('./routes/refinement.js')(app, db, { broadcast, localNow, createNotification, stmt, getCachedSetting, authRateLimiter, apiRateLimiter, spawnMemberTerminal });
 require('./routes/calendar.js')(app, db, { broadcast, localNow, createNotification, stmt, getCachedSetting, authRateLimiter, apiRateLimiter, spawnMemberTerminal });
 require('./routes/notes.js')(app, db, { broadcast, localNow, createNotification, stmt, getCachedSetting, authRateLimiter, apiRateLimiter, spawnMemberTerminal });
-require('./routes/settings.js')(app, db, { broadcast, localNow, createNotification, stmt, getCachedSetting, authRateLimiter, apiRateLimiter, spawnMemberTerminal });
+require('./routes/settings.js')(app, db, {
+  broadcast,
+  localNow,
+  createNotification,
+  stmt,
+  getCachedSetting,
+  authRateLimiter,
+  apiRateLimiter,
+  spawnMemberTerminal,
+  maskApiKey,
+  maskCredential,
+  badRequest,
+  notFound,
+});
 require('./routes/goals.js')(app, db, { broadcast, localNow, createNotification, stmt, getCachedSetting, authRateLimiter, apiRateLimiter, spawnMemberTerminal });
 require('./routes/system.js')(app, db, { broadcast, localNow, createNotification, stmt, getCachedSetting, authRateLimiter, apiRateLimiter, spawnMemberTerminal });
 require('./routes/plugins.js')(app, db, { broadcast, localNow, createNotification, stmt, getCachedSetting, authRateLimiter, apiRateLimiter, spawnMemberTerminal });


### PR DESCRIPTION
## Summary
- Classifies CSV row 82 as adjacent CommandBase reliability/schema compatibility, not EXOCHAIN core.
- Confirms current main still creates stale clean-install schemas for llm_providers, model_sources, credential_vault, idea_board, and research_sessions.
- Updates fresh bootstrap schemas and adds idempotent column backfills for databases already created by the stale bootstrap.
- Wires existing server helpers into modular settings/research routes so the affected authenticated create routes can complete after schema compatibility is restored.

## Validation
- RED: node --test lib/bootstrap-schema.test.js failed on missing route-required columns and route-style inserts.
- RED: node --test schema-bootstrap.routes.test.js failed on /api/llm/providers with maskApiKey helper not wired into route module.
- GREEN: node --test lib/bootstrap-schema.test.js schema-bootstrap.routes.test.js
- node --test auth-bootstrap.test.js schema-bootstrap.routes.test.js lib/*.test.js services/*.test.js (42 tests passing)
- node --check lib/bootstrap-schema.js && node --check lib/bootstrap-schema.test.js
- node --check routes/settings.js && node --check routes/ideas.js && node --check routes/research.js && node --check server.js
- authenticated clean-server GET smoke passed for /api/llm/providers, /api/model-sources, /api/vault, /api/ideas, /api/research
- authenticated clean-server POST smoke is now captured by schema-bootstrap.routes.test.js
- git diff --check