### PR TITLE
fix(gap): expand council rationale inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,6 +280,8 @@ jobs:
         run: bash tools/test_cr001_status.sh
       - name: GAP registry truth
         run: bash tools/test_gap_registry_truth.sh
+      - name: GAP Syntaxis YAML parse contract
+        run: bash tools/test_gap_syntaxis_yaml_parse.sh
       - name: No orphan Rust modules
         run: bash tools/test_no_orphan_rust_modules.sh
       - name: Railway entrypoint ingress contract

--- a/gap/syntaxis/protocols/council-review.yaml
+++ b/gap/syntaxis/protocols/council-review.yaml
@@ -83,6 +83,13 @@ nodes:
   - id: resolution-generation
     type: ledger_anchor
     description: "Draft formal resolution document and anchor the deliberation state to the DAG."
-    inputs: [constitutional_receipt, aggregate_result, *rationale]
+    inputs:
+      - constitutional_receipt
+      - aggregate_result
+      - gov_rationale
+      - legal_rationale
+      - arch_rationale
+      - sec_rationale
+      - ops_rationale
     outputs: [council_resolution, dag_receipt]
     bcts_transition: Governed

--- a/tools/test_gap_syntaxis_yaml_parse.sh
+++ b/tools/test_gap_syntaxis_yaml_parse.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Copyright 2026 Exochain Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+fail() {
+  printf 'GAP Syntaxis YAML parse test failed: %s\n' "$1" >&2
+  exit 1
+}
+
+protocols=(gap/syntaxis/protocols/*.yaml)
+
+if grep -nE '(^|[[:space:],[])\*[A-Za-z0-9_-]+' "${protocols[@]}"; then
+  fail "Syntaxis protocols must not use unquoted YAML alias tokens as wildcard inputs"
+fi
+
+if command -v ruby >/dev/null 2>&1; then
+  ruby -ryaml -e 'ARGV.each { |path| YAML.load_file(path) }' "${protocols[@]}"
+else
+  printf 'ruby unavailable; alias-token source guard completed\n'
+fi
+
+printf 'GAP Syntaxis YAML parse test passed\n'


### PR DESCRIPTION
## Summary
- Classifies CSV row 83 as adjacent GAP Syntaxis YAML configuration, not EXOCHAIN core.
- Confirms current main fails YAML parsing because council-review.yaml uses an unquoted *rationale alias token with no anchor.
- Replaces the pseudo-wildcard with explicit panel rationale inputs.
- Adds a CI hygiene guard that rejects unquoted alias-like Syntaxis inputs and parses all GAP protocol YAML files when Ruby/Psych is available.

## Validation
- RED: bash tools/test_gap_syntaxis_yaml_parse.sh failed on gap/syntaxis/protocols/council-review.yaml:86.
- RED: ruby -ryaml -e 'YAML.load_file(...)' failed with Psych::BadAlias Unknown alias: rationale.
- GREEN: bash tools/test_gap_syntaxis_yaml_parse.sh
- ruby -ryaml -e 'ARGV.each { |path| data = YAML.load_file(path); raise "missing nodes" unless data.fetch("nodes").is_a?(Array) }' gap/syntaxis/protocols/*.yaml
- bash tools/test_github_actions_pinned.sh
- bash tools/test_gap_registry_truth.sh
- bash tools/test_syntaxis_workflow_input_boundary.sh
- git diff --check
