### PR TITLE
test(authority): align subchain depth regression

### DIFF
--- a/crates/exo-authority/src/delegation.rs
+++ b/crates/exo-authority/src/delegation.rs
@@ -1043,7 +1043,7 @@ mod tests {
         let mut reg = DelegationRegistry::new();
         let root_key = KeyPair::generate();
         let alice_key = KeyPair::generate();
-        signed_delegate(
+        let root_to_alice = signed_delegate(
             &mut reg,
             "root",
             "alice",
@@ -1051,8 +1051,16 @@ mod tests {
             &root_key,
         )
         .unwrap();
-        let alice_to_bob =
-            signed_delegate(&mut reg, "alice", "bob", &[Permission::Read], &alice_key).unwrap();
+        let root_to_alice_id = root_to_alice.id().unwrap();
+        let alice_to_bob = signed_delegate_with_parent(
+            &mut reg,
+            "alice",
+            "bob",
+            &[Permission::Read],
+            Some(&root_to_alice_id),
+            &alice_key,
+        )
+        .unwrap();
         assert_eq!(alice_to_bob.depth, 1);
 
         let chain = reg


### PR DESCRIPTION
## Classification

- EXOCHAIN core: `crates/exo-authority/src/delegation.rs`

## Summary

- Aligns the signed-depth preservation regression test with the selected-parent delegation model merged by the depth-squatting remediation.
- Keeps self-root grants at depth 0 and tests subchain preservation via an explicit parent link.

## Validation

- `cargo test -p exo-authority delegation::tests::find_chain_subchain_preserves_signed_depth_and_verifies`
- `cargo test -p exo-authority`
- `cargo test --workspace`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`