### PR TITLE
fix(wasm): require trusted governance attestation keys

### DIFF
--- a/crates/exochain-wasm/src/gatekeeper_bindings.rs
+++ b/crates/exochain-wasm/src/gatekeeper_bindings.rs
@@ -16,6 +16,8 @@
 
 //! Gatekeeper bindings: CGR combinator algebra, kernel adjudication, invariants
 
+use std::collections::BTreeMap;
+
 use wasm_bindgen::prelude::*;
 
 use crate::serde_bridge::*;
@@ -179,31 +181,70 @@ pub fn wasm_governance_findings_digest(findings_json: &str) -> Result<String, Js
 
 /// Verify a governance monitor attestation before persistence.
 #[wasm_bindgen]
-pub fn wasm_verify_governance_attestation(
+pub fn wasm_verify_governance_attestation_with_trusted_keys(
     signer_did: &str,
     findings_json: &str,
     signature_json: &str,
-    signer_public_key_hex: &str,
+    trusted_signer_keys_json: &str,
 ) -> Result<bool, JsValue> {
     let signer_did = exo_core::Did::new(signer_did)
         .map_err(|_| gatekeeper_boundary_error("invalid governance attestation signer DID"))?;
+    let trusted_signer_keys = parse_trusted_governance_attestation_keys(trusted_signer_keys_json)?;
+    let signer_public_key = trusted_signer_keys
+        .get(&signer_did)
+        .ok_or_else(|| gatekeeper_boundary_error("governance attestation signer is not trusted"))?;
+    verify_governance_attestation_with_key(
+        &signer_did,
+        findings_json,
+        signature_json,
+        signer_public_key,
+    )
+}
+
+fn parse_trusted_governance_attestation_keys(
+    trusted_signer_keys_json: &str,
+) -> Result<BTreeMap<exo_core::Did, exo_core::PublicKey>, JsValue> {
+    let raw_keys: BTreeMap<String, String> = from_json_str(trusted_signer_keys_json)?;
+    if raw_keys.is_empty() {
+        return Err(gatekeeper_boundary_error(
+            "governance attestation trusted signer registry is empty",
+        ));
+    }
+
+    let mut trusted_signer_keys = BTreeMap::new();
+    for (signer_did, public_key_hex) in raw_keys {
+        let signer_did = exo_core::Did::new(&signer_did).map_err(|_| {
+            gatekeeper_boundary_error("invalid governance attestation trusted signer DID")
+        })?;
+        let public_key = exo_core::PublicKey::from_bytes(decode_fixed_hex(
+            &public_key_hex,
+            "governance attestation trusted signer public key",
+        )?);
+        trusted_signer_keys.insert(signer_did, public_key);
+    }
+
+    Ok(trusted_signer_keys)
+}
+
+fn verify_governance_attestation_with_key(
+    signer_did: &exo_core::Did,
+    findings_json: &str,
+    signature_json: &str,
+    signer_public_key: &exo_core::PublicKey,
+) -> Result<bool, JsValue> {
     let findings: serde_json::Value = from_json_str(findings_json)?;
     let digest = exo_gatekeeper::governance_monitor::governance_findings_digest(&findings)
         .map_err(|_| gatekeeper_boundary_error("governance findings digest failed"))?;
     let signature: exo_core::Signature = from_json_str(signature_json)?;
-    let signer_public_key = exo_core::PublicKey::from_bytes(decode_fixed_hex(
-        signer_public_key_hex,
-        "governance attestation public key",
-    )?);
     let attestation = exo_gatekeeper::governance_monitor::GovernanceAttestation {
-        signer_did,
+        signer_did: signer_did.clone(),
         findings_digest: digest,
         signature,
     };
 
     exo_gatekeeper::governance_monitor::verify_attestation(
         &attestation,
-        &signer_public_key,
+        signer_public_key,
         &findings,
     )
     .map(|()| true)
@@ -696,6 +737,32 @@ mod tests {
 
         assert!(!production.contains("format!(\"{r:?}\")"));
         assert!(production.contains("\"rule\": r.id()"));
+    }
+
+    #[test]
+    fn governance_attestation_wasm_boundary_requires_trusted_signer_registry() {
+        let source = include_str!("gatekeeper_bindings.rs");
+        let production = source
+            .split("// ===========================================================================\n// Tests")
+            .next()
+            .expect("production section");
+
+        assert!(
+            production.contains("wasm_verify_governance_attestation_with_trusted_keys"),
+            "WASM governance attestation verification must expose a trusted-registry boundary"
+        );
+        assert!(
+            production.contains("trusted_signer_keys_json"),
+            "trusted signer keys must be passed as an explicit registry, not as a raw peer key"
+        );
+        assert!(
+            !production.contains("pub fn wasm_verify_governance_attestation("),
+            "WASM governance attestations must not expose a raw caller-supplied public-key verifier"
+        );
+        assert!(
+            !production.contains("signer_public_key_hex"),
+            "WASM governance attestation verification must not accept a raw signer_public_key_hex parameter"
+        );
     }
 
     #[test]

--- a/demo/services/audit-api/src/index.js
+++ b/demo/services/audit-api/src/index.js
@@ -30,6 +30,9 @@ const GOVERNANCE_API_TOKEN = process.env.GOVERNANCE_API_TOKEN || null;
 const GOVERNANCE_ATTESTATION_KEYS = parseGovernanceAttestationKeys(
   process.env.GOVERNANCE_ATTESTATION_KEYS || null,
 );
+const GOVERNANCE_ATTESTATION_KEYS_JSON = JSON.stringify(
+  Object.fromEntries(GOVERNANCE_ATTESTATION_KEYS),
+);
 
 function parseGovernanceAttestationKeys(value) {
   const trustedKeys = new Map();
@@ -201,11 +204,11 @@ export const server = http.createServer(async (req, res) => {
           return json(res, 400, { error: 'findings_digest does not match canonical findings payload' });
         }
 
-        wasm.wasm_verify_governance_attestation(
+        wasm.wasm_verify_governance_attestation_with_trusted_keys(
           attestation_signer_did,
           JSON.stringify(findings),
           JSON.stringify(attestation_signature),
-          trustedAttestationPublicKey,
+          GOVERNANCE_ATTESTATION_KEYS_JSON,
         );
       } catch (e) {
         return json(res, 400, { error: `invalid governance attestation: ${e.message || e}` });

--- a/demo/services/audit-api/src/index.test.js
+++ b/demo/services/audit-api/src/index.test.js
@@ -28,7 +28,7 @@ const mockWasm = vi.hoisted(() => ({
   wasm_audit_append: vi.fn(() => ({ entries: 1, head_hash: 'f'.repeat(64) })),
   wasm_hash_bytes: vi.fn(() => 'a'.repeat(64)),
   wasm_governance_findings_digest: vi.fn(() => 'b'.repeat(64)),
-  wasm_verify_governance_attestation: vi.fn(() => true),
+  wasm_verify_governance_attestation_with_trusted_keys: vi.fn(() => true),
 }));
 
 const mockPg = vi.hoisted(() => {
@@ -171,7 +171,7 @@ describe('POST /governance/health attestation gate', () => {
   });
 
   it('rejects invalid attestation before persistence', async () => {
-    mockWasm.wasm_verify_governance_attestation.mockImplementationOnce(() => {
+    mockWasm.wasm_verify_governance_attestation_with_trusted_keys.mockImplementationOnce(() => {
       throw new Error('governance attestation rejected');
     });
     mockPg.query.mockResolvedValue({ rows: [] });
@@ -196,7 +196,7 @@ describe('POST /governance/health attestation gate', () => {
 
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/not configured/);
-    expect(mockWasm.wasm_verify_governance_attestation).not.toHaveBeenCalled();
+    expect(mockWasm.wasm_verify_governance_attestation_with_trusted_keys).not.toHaveBeenCalled();
     expect(mockPg.query).not.toHaveBeenCalled();
   });
 
@@ -210,7 +210,7 @@ describe('POST /governance/health attestation gate', () => {
 
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/does not match configured signer key/);
-    expect(mockWasm.wasm_verify_governance_attestation).not.toHaveBeenCalled();
+    expect(mockWasm.wasm_verify_governance_attestation_with_trusted_keys).not.toHaveBeenCalled();
     expect(mockPg.query).not.toHaveBeenCalled();
   });
 
@@ -230,11 +230,11 @@ describe('POST /governance/health attestation gate', () => {
       .send(snapshotWithoutCallerKey);
 
     expect(res.status).toBe(201);
-    expect(mockWasm.wasm_verify_governance_attestation).toHaveBeenCalledWith(
+    expect(mockWasm.wasm_verify_governance_attestation_with_trusted_keys).toHaveBeenCalledWith(
       validSnapshot.attestation_signer_did,
       JSON.stringify(validSnapshot.findings),
       JSON.stringify(validSnapshot.attestation_signature),
-      '11'.repeat(32),
+      JSON.stringify({ 'did:exo:monitor': '11'.repeat(32) }),
     );
     expect(mockPg.query).toHaveBeenCalled();
   });
@@ -254,11 +254,11 @@ describe('POST /governance/health attestation gate', () => {
       .send(validSnapshot);
 
     expect(res.status).toBe(201);
-    expect(mockWasm.wasm_verify_governance_attestation).toHaveBeenCalledWith(
+    expect(mockWasm.wasm_verify_governance_attestation_with_trusted_keys).toHaveBeenCalledWith(
       validSnapshot.attestation_signer_did,
       JSON.stringify(validSnapshot.findings),
       JSON.stringify(validSnapshot.attestation_signature),
-      '11'.repeat(32),
+      JSON.stringify({ 'did:exo:monitor': '11'.repeat(32) }),
     );
     expect(mockPg.query).toHaveBeenCalled();
   });

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -1471,18 +1471,18 @@ test('wasm_governance_findings_digest is deterministic', () => {
   return a;
 });
 
-test('wasm_verify_governance_attestation accepts valid signatures', () => {
+test('wasm_verify_governance_attestation_with_trusted_keys accepts valid signatures', () => {
   const digestHex = wasm.wasm_governance_findings_digest(governanceFindingsJson);
   const signature = signatureJsonFromHex(signer1.signHex(Buffer.from(digestHex, 'hex')));
-  return wasm.wasm_verify_governance_attestation(
+  return wasm.wasm_verify_governance_attestation_with_trusted_keys(
     'did:exo:monitor',
     governanceFindingsJson,
     JSON.stringify(signature),
-    signer1.publicKeyHex,
+    JSON.stringify({ 'did:exo:monitor': signer1.publicKeyHex }),
   );
 });
 
-test('wasm_verify_governance_attestation rejects signatures replayed for substituted findings', () => {
+test('wasm_verify_governance_attestation_with_trusted_keys rejects signatures replayed for substituted findings', () => {
   const signedFindingsJson = JSON.stringify([
     { id: 'F-001', severity: 'low', title: 'Benign finding' },
   ]);
@@ -1493,28 +1493,43 @@ test('wasm_verify_governance_attestation rejects signatures replayed for substit
   const signature = signatureJsonFromHex(signer1.signHex(Buffer.from(digestHex, 'hex')));
 
   return expectErrorContains(
-    'wasm_verify_governance_attestation',
-    () => wasm.wasm_verify_governance_attestation(
+    'wasm_verify_governance_attestation_with_trusted_keys',
+    () => wasm.wasm_verify_governance_attestation_with_trusted_keys(
       'did:exo:monitor',
       substitutedFindingsJson,
       JSON.stringify(signature),
-      signer1.publicKeyHex,
+      JSON.stringify({ 'did:exo:monitor': signer1.publicKeyHex }),
     ),
     'governance attestation rejected',
   );
 });
 
-test('wasm_verify_governance_attestation rejects invalid signatures', () =>
+test('wasm_verify_governance_attestation_with_trusted_keys rejects invalid signatures', () =>
   expectErrorContains(
-    'wasm_verify_governance_attestation',
-    () => wasm.wasm_verify_governance_attestation(
+    'wasm_verify_governance_attestation_with_trusted_keys',
+    () => wasm.wasm_verify_governance_attestation_with_trusted_keys(
       'did:exo:monitor',
       governanceFindingsJson,
       JSON.stringify({ Ed25519: Array.from({ length: 64 }, () => 0) }),
-      signer1.publicKeyHex,
+      JSON.stringify({ 'did:exo:monitor': signer1.publicKeyHex }),
     ),
     'governance attestation rejected',
   ));
+
+test('wasm_verify_governance_attestation_with_trusted_keys rejects untrusted signers', () => {
+  const digestHex = wasm.wasm_governance_findings_digest(governanceFindingsJson);
+  const signature = signatureJsonFromHex(signer1.signHex(Buffer.from(digestHex, 'hex')));
+  return expectErrorContains(
+    'wasm_verify_governance_attestation_with_trusted_keys',
+    () => wasm.wasm_verify_governance_attestation_with_trusted_keys(
+      'did:exo:monitor',
+      governanceFindingsJson,
+      JSON.stringify(signature),
+      JSON.stringify({ 'did:exo:other-monitor': signer1.publicKeyHex }),
+    ),
+    'governance attestation signer is not trusted',
+  );
+});
 
 // Identity combinator is a unit variant — just a string, no fields
 test('wasm_reduce_combinator', () =>


### PR DESCRIPTION
## Summary
- Replaces stale/conflicting PR #589 from current `main` without README metric churn.
- Remediates Codex Security row 2: `Governance attestations trust caller-supplied keys`.
- Classification:
  - `crates/exochain-wasm/src/gatekeeper_bindings.rs` - **Core runtime adapter**.
  - `packages/exochain-wasm/test/bridge_verification.mjs` - **Core runtime adapter verification**.
  - `demo/services/audit-api/src/index.js` and `index.test.js` - **Adjacent surface** consuming the adapter boundary.
- Verified current `main` first: the audit API already resolves its configured attestation key, but the public WASM export still accepted a raw `signer_public_key_hex` parameter.
- Replaces that raw-key export with `wasm_verify_governance_attestation_with_trusted_keys`, which requires a trusted signer DID -> public key registry and rejects untrusted signer DIDs.
- Preserves existing findings-payload binding by verifying against the canonical findings digest and the supplied findings JSON.

## TDD / validation
- RED first: `cargo test -p exochain-wasm governance_attestation_wasm_boundary_requires_trusted_signer_registry` failed against current `main` because the raw-key export was still present.
- GREEN: `cargo test -p exochain-wasm governance_attestation_wasm_boundary_requires_trusted_signer_registry`
- GREEN: `cargo test -p exochain-wasm`
- GREEN: `cargo clippy -p exochain-wasm --all-targets -- -D warnings`
- GREEN: `/Users/bobstewart/dev/exochain/demo/node_modules/.bin/vitest run src/index.test.js` from `demo/services/audit-api` (17/17)
- GREEN: `wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm`
- GREEN: `node packages/exochain-wasm/test/bridge_verification.mjs` (163/163)
- GREEN: `cargo fmt --all -- --check`
- GREEN: `git diff --check`
- GREEN: `cargo test --workspace`
- GREEN: `cargo clippy --workspace --all-targets -- -D warnings`

## Already-remediated disposition
- CSV row 1, `Root genesis secrets written with unsafe file permissions`, was also rechecked before this PR.
- Current `main` already uses `create_new(true)`, Unix mode `0600`, permission resets, `sync_all`, symlink refusal, existing-file refusal, and stdout refusal for secret output.
- Evidence: `cargo test -p exo-node root_genesis_cli::tests::` passed, so no code change was needed for row 1.
