### PR TITLE
fix(audit-api): require signed governance approvals

### DIFF
--- a/demo/services/audit-api/src/index.js
+++ b/demo/services/audit-api/src/index.js
@@ -26,6 +26,7 @@ const PORT = process.env.PORT || 3007;
 // Governance health endpoint requires a bearer token (Security panel condition — CR-001 amendment).
 // Set GOVERNANCE_API_TOKEN in the secrets manager; never in env files or Compose.
 // Set GOVERNANCE_ATTESTATION_KEYS as a JSON object mapping trusted signer DID to Ed25519 public key hex.
+// Set GOVERNANCE_APPROVAL_KEYS separately for human approval signers.
 const GOVERNANCE_API_TOKEN = process.env.GOVERNANCE_API_TOKEN || null;
 const GOVERNANCE_ATTESTATION_KEYS = parseGovernanceAttestationKeys(
   process.env.GOVERNANCE_ATTESTATION_KEYS || null,
@@ -33,8 +34,15 @@ const GOVERNANCE_ATTESTATION_KEYS = parseGovernanceAttestationKeys(
 const GOVERNANCE_ATTESTATION_KEYS_JSON = JSON.stringify(
   Object.fromEntries(GOVERNANCE_ATTESTATION_KEYS),
 );
+const GOVERNANCE_APPROVAL_KEYS = parseGovernanceAttestationKeys(
+  process.env.GOVERNANCE_APPROVAL_KEYS || null,
+  'GOVERNANCE_APPROVAL_KEYS',
+);
+const GOVERNANCE_APPROVAL_KEYS_JSON = JSON.stringify(
+  Object.fromEntries(GOVERNANCE_APPROVAL_KEYS),
+);
 
-function parseGovernanceAttestationKeys(value) {
+function parseGovernanceAttestationKeys(value, envName = 'GOVERNANCE_ATTESTATION_KEYS') {
   const trustedKeys = new Map();
   if (!value) return trustedKeys;
 
@@ -42,19 +50,19 @@ function parseGovernanceAttestationKeys(value) {
   try {
     parsed = JSON.parse(value);
   } catch (e) {
-    throw new Error('GOVERNANCE_ATTESTATION_KEYS must be a JSON object mapping signer DID to Ed25519 public key hex');
+    throw new Error(`${envName} must be a JSON object mapping signer DID to Ed25519 public key hex`);
   }
 
   if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') {
-    throw new Error('GOVERNANCE_ATTESTATION_KEYS must be a JSON object mapping signer DID to Ed25519 public key hex');
+    throw new Error(`${envName} must be a JSON object mapping signer DID to Ed25519 public key hex`);
   }
 
   for (const [signerDid, publicKeyHex] of Object.entries(parsed)) {
     if (typeof signerDid !== 'string' || !signerDid.startsWith('did:exo:')) {
-      throw new Error('GOVERNANCE_ATTESTATION_KEYS contains an invalid signer DID');
+      throw new Error(`${envName} contains an invalid signer DID`);
     }
     if (typeof publicKeyHex !== 'string' || !/^[0-9a-fA-F]{64}$/.test(publicKeyHex)) {
-      throw new Error(`GOVERNANCE_ATTESTATION_KEYS contains an invalid Ed25519 public key for ${signerDid}`);
+      throw new Error(`${envName} contains an invalid Ed25519 public key for ${signerDid}`);
     }
     trustedKeys.set(signerDid, publicKeyHex.toLowerCase());
   }
@@ -304,10 +312,51 @@ export const server = http.createServer(async (req, res) => {
       }
 
       const approvalId = url.pathname.replace('/governance/approve/', '');
-      const { approved_by_did, notes } = await parseBody(req);
+      const {
+        approved_by_did,
+        approval_signer_did,
+        approval_signature,
+        approval_public_key,
+        notes,
+      } = await parseBody(req);
 
       if (!approved_by_did) {
         return json(res, 400, { error: 'approved_by_did is required (must be a human DID)' });
+      }
+      if (!approval_signature || !approval_signer_did) {
+        return json(res, 400, { error: 'approval_signature and approval_signer_did are required' });
+      }
+      if (approval_signer_did !== approved_by_did) {
+        return json(res, 400, { error: 'approval_signer_did must match approved_by_did' });
+      }
+
+      const trustedApprovalPublicKey = GOVERNANCE_APPROVAL_KEYS.get(approval_signer_did);
+      if (!trustedApprovalPublicKey) {
+        return json(res, 400, { error: `approval signer ${approval_signer_did} is not configured` });
+      }
+      if (
+        approval_public_key !== undefined
+        && approval_public_key !== null
+        && String(approval_public_key).toLowerCase() !== trustedApprovalPublicKey
+      ) {
+        return json(res, 400, { error: 'approval_public_key does not match configured signer key' });
+      }
+
+      const approvalPayload = {
+        approval_id: approvalId,
+        approved_by_did,
+        decision: 'Approved',
+        notes: notes || null,
+      };
+      try {
+        wasm.wasm_verify_governance_attestation_with_trusted_keys(
+          approval_signer_did,
+          JSON.stringify(approvalPayload),
+          JSON.stringify(approval_signature),
+          GOVERNANCE_APPROVAL_KEYS_JSON,
+        );
+      } catch (e) {
+        return json(res, 400, { error: `invalid governance approval: ${e.message || e}` });
       }
 
       const { rowCount } = await pool.query(
@@ -321,7 +370,12 @@ export const server = http.createServer(async (req, res) => {
         return json(res, 404, { error: 'Approval gate not found or already resolved' });
       }
 
-      return json(res, 200, { approval_id: approvalId, status: 'Approved', approved_by_did });
+      return json(res, 200, {
+        approval_id: approvalId,
+        status: 'Approved',
+        approved_by_did,
+        approval_signer_did,
+      });
     }
 
     // ── Verify Chain Integrity ──

--- a/demo/services/audit-api/src/index.test.js
+++ b/demo/services/audit-api/src/index.test.js
@@ -22,6 +22,9 @@ vi.hoisted(() => {
   process.env.GOVERNANCE_ATTESTATION_KEYS = JSON.stringify({
     'did:exo:monitor': '11'.repeat(32),
   });
+  process.env.GOVERNANCE_APPROVAL_KEYS = JSON.stringify({
+    'did:exo:human': '22'.repeat(32),
+  });
 });
 
 const mockWasm = vi.hoisted(() => ({
@@ -259,6 +262,96 @@ describe('POST /governance/health attestation gate', () => {
       JSON.stringify(validSnapshot.findings),
       JSON.stringify(validSnapshot.attestation_signature),
       JSON.stringify({ 'did:exo:monitor': '11'.repeat(32) }),
+    );
+    expect(mockPg.query).toHaveBeenCalled();
+  });
+});
+
+describe('POST /governance/approve/:approvalId human approval signature gate', () => {
+  const approvalId = 'approval-run-1';
+  const validApproval = {
+    approved_by_did: 'did:exo:human',
+    approval_signer_did: 'did:exo:human',
+    approval_signature: { Ed25519: Array.from({ length: 64 }, () => 2) },
+    notes: 'ship after human review',
+  };
+  const expectedApprovalPayload = JSON.stringify({
+    approval_id: approvalId,
+    approved_by_did: 'did:exo:human',
+    decision: 'Approved',
+    notes: 'ship after human review',
+  });
+
+  it('rejects missing human approval signature before any database write', async () => {
+    const res = await request
+      .post(`/governance/approve/${approvalId}`)
+      .set('Authorization', 'Bearer test-token')
+      .send({ approved_by_did: 'did:exo:human' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/approval_signature/);
+    expect(mockPg.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects approval signer DID mismatch before verification', async () => {
+    const res = await request
+      .post(`/governance/approve/${approvalId}`)
+      .set('Authorization', 'Bearer test-token')
+      .send({ ...validApproval, approval_signer_did: 'did:exo:other-human' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/match approved_by_did/);
+    expect(mockWasm.wasm_verify_governance_attestation_with_trusted_keys).not.toHaveBeenCalled();
+    expect(mockPg.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects unconfigured human approval signers before persistence', async () => {
+    const res = await request
+      .post(`/governance/approve/${approvalId}`)
+      .set('Authorization', 'Bearer test-token')
+      .send({
+        ...validApproval,
+        approved_by_did: 'did:exo:rogue-human',
+        approval_signer_did: 'did:exo:rogue-human',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/not configured/);
+    expect(mockWasm.wasm_verify_governance_attestation_with_trusted_keys).not.toHaveBeenCalled();
+    expect(mockPg.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid human approval signatures before persistence', async () => {
+    mockWasm.wasm_verify_governance_attestation_with_trusted_keys.mockImplementationOnce(() => {
+      throw new Error('approval signature rejected');
+    });
+
+    const res = await request
+      .post(`/governance/approve/${approvalId}`)
+      .set('Authorization', 'Bearer test-token')
+      .send(validApproval);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/invalid governance approval/);
+    expect(mockPg.query).not.toHaveBeenCalled();
+  });
+
+  it('persists approved gates only after trusted human signature verification', async () => {
+    mockPg.query.mockResolvedValueOnce({ rowCount: 1 });
+
+    const res = await request
+      .post(`/governance/approve/${approvalId}`)
+      .set('Authorization', 'Bearer test-token')
+      .send(validApproval);
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('Approved');
+    expect(res.body.approved_by_did).toBe('did:exo:human');
+    expect(mockWasm.wasm_verify_governance_attestation_with_trusted_keys).toHaveBeenCalledWith(
+      'did:exo:human',
+      expectedApprovalPayload,
+      JSON.stringify(validApproval.approval_signature),
+      JSON.stringify({ 'did:exo:human': '22'.repeat(32) }),
     );
     expect(mockPg.query).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- classify Codex Security row52 approval endpoint as adjacent demo surface under demo/services/audit-api
- require governance approval requests to include an approval signer DID and human approval signature
- verify approval signatures with configured GOVERNANCE_APPROVAL_KEYS before updating governance_trigger_approvals
- fail closed for missing, mismatched, unconfigured, caller-key-mismatched, and invalid approval signatures

## Path classification
- demo/services/audit-api/src/index.js — adjacent surface
- demo/services/audit-api/src/index.test.js — adjacent surface test

## Verification
- TDD red: npm --prefix demo exec -- vitest run services/audit-api/src/index.test.js failed 5 governance approval signature tests before the production fix
- npm --prefix demo exec -- vitest run services/audit-api/src/index.test.js
- npm --prefix demo test -- --project services
- git diff --check

## Security notes
- imported scanner CSV remains read-only evidence; this PR remediates the verified owned route only
- approval signing keys are separate from governance health attestation keys so API bearer auth cannot forge human approval