### PR TITLE
fix(site): sign and gate development sessions

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -55,6 +55,7 @@ Useful scripts:
 npm run typecheck    # tsc --noEmit
 npm run lint         # next lint
 npm run build        # production build
+npm run security:auth-boundary
 npm start            # serve the production build
 ```
 
@@ -63,16 +64,18 @@ npm start            # serve the production build
 | Surface | Route prefix | Auth | Login |
 |---|---|---|---|
 | Internet | `/` (and named pages) | none | — |
-| Extranet | `/app/*` | mock cookie session | `/app/login` |
-| Intranet | `/internal/*` | mock cookie session | `/internal/login` |
+| Extranet | `/app/*` | signed cookie session | `/app/login` |
+| Intranet | `/internal/*` | signed cookie session | `/internal/login` |
 
-Hard surface separation is enforced by `middleware.ts`. Unauthenticated
-requests to `/app/*` and `/internal/*` are redirected to the corresponding
-login page.
+Hard surface separation is enforced by `middleware.ts`. Unauthenticated or
+unsigned-cookie requests to `/app/*` and `/internal/*` are redirected to the
+corresponding login page.
 
-The dev login pages let you pick any role from the role enum to preview
-that surface under that capability set. **No real credentials are involved
-in v0.** Real OIDC + WebAuthn arrives in v0.5.
+Development login is disabled by default and is not available in production.
+To use it locally, set `EXO_SITE_ENABLE_DEV_LOGIN=1`,
+`NODE_ENV=development`, and `EXO_SITE_SESSION_SECRET` to a 32-byte-or-longer
+secret. Session cookies are HMAC signed; raw JSON `exo-session` cookies are
+rejected by middleware and server-side session loading.
 
 ### Public sitemap (excerpt)
 
@@ -117,8 +120,9 @@ in v0.** Real OIDC + WebAuthn arrives in v0.5.
 
 - **No live network calls.** All data renders from typed mocks in
   `src/lib/mock-data.ts`. Numeric metrics are visibly labeled `mock`.
-- **No real auth.** The `exo-session` cookie is a JSON blob. Replace with
-  OIDC + signed JWT in v0.5 (see `src/lib/auth.ts`).
+- **Local-only development auth.** The `exo-session` cookie is signed with
+  `EXO_SITE_SESSION_SECRET`; development login fails closed unless explicitly
+  enabled outside production.
 - **No real settlement.** All settlement-related views show the
   `ZeroPriceBanner` and amount = `0 EXO`.
 - **No fake claims.** The Trust Center, Security page, and copy generally
@@ -148,13 +152,12 @@ Diagrams (SVG):
 
 ## Roadmap (excerpt)
 
-- **v0.5** — real OIDC + WebAuthn, MDX docs, OG images, status feed wired,
-  webhook signing, OpenAPI mounted at `/api`.
-- **v1.0** — production gating, live AVC issuance against `exo-node` /
-  `exo-gateway`, audit packets backed by the real settlement chain, public
-  bug bounty.
-- **v1.5+** — validator dashboard, holon registry, governance proposal
-  authoring, multi-region status, public sandbox.
+- Real OIDC + WebAuthn, MDX docs, OG images, status feed wiring, webhook
+  signing, and OpenAPI mounted at `/api`.
+- Production gating, live AVC issuance against `exo-node` / `exo-gateway`,
+  audit packets backed by the real settlement chain, and public bug bounty.
+- Validator dashboard, holon registry, governance proposal authoring,
+  multi-region status, and public sandbox.
 
 See `SPEC.md` §11 for the full breakdown and `SPEC.md` §13 for v0
 acceptance criteria.
@@ -202,7 +205,7 @@ site/
     └── lib/
         ├── types.ts               # frontend view types
         ├── roles.ts               # role + capability matrix
-        ├── auth.ts                # mock session
+        ├── auth.ts                # signed development session
         ├── mock-data.ts           # typed mocks
         └── format.ts              # date/number helpers
 ```

--- a/site/SPEC.md
+++ b/site/SPEC.md
@@ -588,7 +588,7 @@ All data fields shown to end users must be sourced from typed mocks in `/web/src
 - Design system primitives, five SVG diagrams, full nav and footer.
 - Zero-pricing language and banners wired throughout settlement views.
 - Status page with explicit `mock` labels until the live `exo-gateway` status feed is wired.
-- Mock auth (server-side cookie + role) with a clearly-labeled dev login at `/app/login` and `/internal/login`. Replace with real OIDC before any external user is invited.
+- Local-only development auth with HMAC-signed server-side cookies. Development login at `/app/login` and `/internal/login` is disabled unless `EXO_SITE_ENABLE_DEV_LOGIN=1`, `NODE_ENV=development`, and `EXO_SITE_SESSION_SECRET` is configured.
 
 ### 11.2 v0.5 — short follow-up
 
@@ -622,7 +622,7 @@ All data fields shown to end users must be sourced from typed mocks in `/web/src
 
 - **Stack:** Next.js 14 (App Router) + React 18 + TypeScript + Tailwind CSS. No external UI kit dependency in v0; primitives are hand-authored to keep the brand precise.
 - **Routing:** route groups `(internet)`, with `app/` and `internal/` as top-level segments. Middleware enforces auth and role on the `app` and `internal` trees.
-- **Auth (MVP):** server-set HTTP-only cookie `exo-session` with `{ userId, role, surface }`. Replaced by OIDC in v0.5.
+- **Auth (MVP):** server-set HTTP-only cookie `exo-session` containing a canonical session payload and HMAC signature. Raw JSON cookies and unsigned session payloads are rejected.
 - **State:** server components by default. Client components only where interactivity is required (forms, drawers, toggles).
 - **Styling:** dark and light themes. Restrained palette: ink, slate, vellum, signal-amber, custody-cyan, alert-red. No neon. No glow.
 - **Diagrams:** hand-authored SVG so they remain accessible, themeable, and copy-exact. No third-party diagram runtime in v0.

--- a/site/package.json
+++ b/site/package.json
@@ -9,6 +9,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
+    "security:auth-boundary": "node scripts/test-auth-boundary-policy.mjs",
     "security:contact-intake": "node scripts/test-contact-intake-policy.mjs",
     "security:contact-disclosure": "node scripts/assert-no-contact-submission-disclosure.mjs"
   },

--- a/site/scripts/test-auth-boundary-policy.mjs
+++ b/site/scripts/test-auth-boundary-policy.mjs
@@ -1,0 +1,89 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+
+function read(relativePath) {
+  return readFileSync(join(root, relativePath), 'utf8');
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const auth = read('src/lib/auth.ts');
+const middleware = read('src/middleware.ts');
+const intranetLogin = read('src/app/internal-login/page.tsx');
+const extranetLogin = read('src/app/login/page.tsx');
+
+assert(
+  auth.includes('createSessionCookieValue') && auth.includes('verifySessionCookieValue'),
+  'auth library must seal and verify signed session cookie values',
+);
+assert(
+  auth.includes('EXO_SITE_SESSION_SECRET') && auth.includes('timingSafeEqual'),
+  'server session verification must use a configured HMAC secret and constant-time comparison',
+);
+assert(
+  !auth.includes('JSON.parse(raw) as Partial<Session>'),
+  'server session reads must not trust raw JSON cookies',
+);
+
+assert(
+  middleware.includes('async function verifySessionCookieValue') && middleware.includes('EXO_SITE_SESSION_SECRET'),
+  'middleware must verify signed session cookies before granting protected surface access',
+);
+assert(
+  !middleware.includes('return JSON.parse(raw) as SessionShape'),
+  'middleware must not trust raw JSON cookies',
+);
+assert(
+  middleware.includes("matcher: ['/app/:path*', '/login', '/internal/:path*', '/internal-login']"),
+  'middleware matcher must include direct login endpoints as protected dev-login boundaries',
+);
+const directLoginBypass = middleware.indexOf("pathname === '/login' || pathname === '/internal-login'");
+const internalPrefixCheck = middleware.indexOf("pathname.startsWith('/internal')");
+assert(
+  directLoginBypass !== -1 && internalPrefixCheck !== -1 && directLoginBypass < internalPrefixCheck,
+  'middleware must handle direct login endpoints before the /internal prefix check',
+);
+
+for (const [name, source] of [
+  ['extranet login', extranetLogin],
+  ['intranet login', intranetLogin],
+]) {
+  assert(
+    source.includes('isDevLoginEnabled') && source.includes('notFound()'),
+    `${name} must fail closed unless local development login is explicitly enabled`,
+  );
+  assert(
+    source.includes('createSessionCookieValue') && !source.includes('JSON.stringify(session)'),
+    `${name} must write only signed session cookies`,
+  );
+}
+
+assert(
+  !intranetLogin.includes("?? 'super_admin'") && !intranetLogin.includes('defaultValue="super_admin"'),
+  'intranet development login must not default to super_admin',
+);
+
+console.log('Auth boundary guard passed.');

--- a/site/src/app/internal-login/page.tsx
+++ b/site/src/app/internal-login/page.tsx
@@ -14,11 +14,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { redirect } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import { cookies } from 'next/headers';
 import Link from 'next/link';
-import { SESSION_COOKIE } from '@/lib/auth';
-import { INTRANET_ROLES, ROLE_LABEL, type IntranetRole } from '@/lib/roles';
+import { createSessionCookieValue, isDevLoginEnabled, SESSION_COOKIE } from '@/lib/auth';
+import { INTRANET_ROLES, ROLE_LABEL, isIntranetRole, type IntranetRole } from '@/lib/roles';
 import { Section, Eyebrow, H1, Lede } from '@/components/ui/Section';
 import { Pill } from '@/components/ui/Pill';
 import { Disclaimer } from '@/components/ui/Disclaimer';
@@ -27,18 +27,26 @@ export const metadata = { title: 'Sign in · Intranet' };
 
 async function signIn(formData: FormData) {
   'use server';
-  const role = String(formData.get('role') ?? 'super_admin') as IntranetRole;
+  if (!isDevLoginEnabled()) {
+    throw new Error('development login is disabled');
+  }
+  const roleValue = String(formData.get('role') ?? 'auditor_internal');
+  if (!isIntranetRole(roleValue)) {
+    throw new Error('invalid intranet role');
+  }
+  const role: IntranetRole = roleValue;
   const next = String(formData.get('next') ?? '/internal');
   const session = {
     userId: 'op_user_001',
     email: 'ops@exochain.io',
     role,
-    surface: 'intranet'
+    surface: 'intranet' as const
   };
-  cookies().set(SESSION_COOKIE, JSON.stringify(session), {
+  cookies().set(SESSION_COOKIE, createSessionCookieValue(session), {
     httpOnly: true,
     sameSite: 'lax',
     path: '/',
+    secure: process.env.NODE_ENV === 'production',
     maxAge: 60 * 60 * 4
   });
   redirect(next);
@@ -55,6 +63,10 @@ export default function Page({
 }: {
   searchParams: { next?: string };
 }) {
+  if (!isDevLoginEnabled()) {
+    notFound();
+  }
+
   const next = searchParams.next ?? '/internal';
   return (
     <div className="min-h-dvh grid place-items-center px-6 bg-ink text-vellum-soft">
@@ -62,9 +74,8 @@ export default function Page({
         <Eyebrow>Intranet · internal use only</Eyebrow>
         <H1 className="mt-3 text-vellum-soft">EXOCHAIN operations</H1>
         <Lede className="mt-4 text-vellum-soft/80">
-          v0 uses a dev login. Real OIDC + WebAuthn + step-up MFA arrive in
-          v0.5. Choose a role to preview the intranet with that capability
-          set.
+          Local development login is explicitly enabled for this environment.
+          Choose a role to preview the intranet with that capability set.
         </Lede>
         <div className="mt-3 flex gap-2">
           <Pill tone="signal">dev login</Pill>
@@ -76,7 +87,7 @@ export default function Page({
             <div className="text-eyebrow text-vellum-soft/60">Role</div>
             <select
               name="role"
-              defaultValue="super_admin"
+              defaultValue="auditor_internal"
               className="mt-1 w-full border border-vellum-soft/20 rounded-sm px-3 py-2 bg-transparent"
             >
               {INTRANET_ROLES.map((r) => (

--- a/site/src/app/login/page.tsx
+++ b/site/src/app/login/page.tsx
@@ -14,11 +14,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { redirect } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import { cookies } from 'next/headers';
 import Link from 'next/link';
-import { SESSION_COOKIE } from '@/lib/auth';
-import { EXTRANET_ROLES, ROLE_LABEL, type ExtranetRole } from '@/lib/roles';
+import { createSessionCookieValue, isDevLoginEnabled, SESSION_COOKIE } from '@/lib/auth';
+import { EXTRANET_ROLES, ROLE_LABEL, isExtranetRole, type ExtranetRole } from '@/lib/roles';
 import { Section, Eyebrow, H1, Lede } from '@/components/ui/Section';
 import { Pill } from '@/components/ui/Pill';
 
@@ -26,19 +26,27 @@ export const metadata = { title: 'Sign in · Extranet' };
 
 async function signIn(formData: FormData) {
   'use server';
-  const role = String(formData.get('role') ?? 'developer') as ExtranetRole;
+  if (!isDevLoginEnabled()) {
+    throw new Error('development login is disabled');
+  }
+  const roleValue = String(formData.get('role') ?? 'developer');
+  if (!isExtranetRole(roleValue)) {
+    throw new Error('invalid extranet role');
+  }
+  const role: ExtranetRole = roleValue;
   const next = String(formData.get('next') ?? '/app');
   const session = {
     userId: 'dev_user_001',
     email: 'dev@aperture.example',
     role,
-    surface: 'extranet',
+    surface: 'extranet' as const,
     org: 'Aperture Holdings'
   };
-  cookies().set(SESSION_COOKIE, JSON.stringify(session), {
+  cookies().set(SESSION_COOKIE, createSessionCookieValue(session), {
     httpOnly: true,
     sameSite: 'lax',
     path: '/',
+    secure: process.env.NODE_ENV === 'production',
     maxAge: 60 * 60 * 8
   });
   redirect(next);
@@ -55,6 +63,10 @@ export default function Page({
 }: {
   searchParams: { next?: string };
 }) {
+  if (!isDevLoginEnabled()) {
+    notFound();
+  }
+
   const next = searchParams.next ?? '/app';
   return (
     <div className="min-h-dvh grid place-items-center px-6">
@@ -62,8 +74,8 @@ export default function Page({
         <Eyebrow>Extranet · alpha</Eyebrow>
         <H1 className="mt-3">Sign in to EXOCHAIN.</H1>
         <Lede className="mt-4">
-          v0 uses a dev login. Choose a role to preview the extranet under
-          that capability set. Real OIDC + WebAuthn arrives in v0.5.
+          Local development login is explicitly enabled for this environment.
+          Choose a role to preview the extranet under that capability set.
         </Lede>
         <div className="mt-3 flex gap-2">
           <Pill tone="signal">dev login</Pill>

--- a/site/src/lib/auth.ts
+++ b/site/src/lib/auth.ts
@@ -14,12 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Mock auth for v0. Replace with OIDC + WebAuthn in v0.5+.
-// All session reads happen server-side; the cookie is HTTP-only and not exposed
-// to client JS. There are no real credentials here — the dev login pages
-// at /app/login and /internal/login simply set the chosen role.
-
 import { cookies } from 'next/headers';
+import { createHmac, timingSafeEqual } from 'node:crypto';
 import {
   EXTRANET_ROLES,
   INTRANET_ROLES,
@@ -31,6 +27,8 @@ import {
 } from './roles';
 
 export const SESSION_COOKIE = 'exo-session';
+const SESSION_SECRET_ENV = 'EXO_SITE_SESSION_SECRET';
+const DEV_LOGIN_ENV = 'EXO_SITE_ENABLE_DEV_LOGIN';
 
 export interface Session {
   userId: string;
@@ -40,33 +38,111 @@ export interface Session {
   org?: string;
 }
 
-export function getSession(): Session | null {
-  const raw = cookies().get(SESSION_COOKIE)?.value;
+function getSessionSecret(): string | null {
+  const secret = process.env[SESSION_SECRET_ENV];
+  if (typeof secret !== 'string' || Buffer.byteLength(secret, 'utf8') < 32) {
+    return null;
+  }
+  return secret;
+}
+
+export function isDevLoginEnabled(): boolean {
+  return process.env[DEV_LOGIN_ENV] === '1' && process.env.NODE_ENV !== 'production';
+}
+
+function normalizeSession(input: unknown): Session | null {
+  if (!input || typeof input !== 'object') return null;
+
+  const parsed = input as Record<string, unknown>;
+  if (
+    typeof parsed.userId !== 'string' ||
+    typeof parsed.email !== 'string' ||
+    typeof parsed.role !== 'string' ||
+    (parsed.surface !== 'extranet' && parsed.surface !== 'intranet')
+  ) {
+    return null;
+  }
+
+  const role = parsed.role as Role;
+  const surface = parsed.surface;
+  if (surface === 'extranet' && !isExtranetRole(role)) return null;
+  if (surface === 'intranet' && !isIntranetRole(role)) return null;
+
+  const session: Session = {
+    userId: parsed.userId,
+    email: parsed.email,
+    role,
+    surface
+  };
+  if (typeof parsed.org === 'string' && parsed.org.length > 0) {
+    session.org = parsed.org;
+  }
+  return session;
+}
+
+function canonicalSessionPayload(session: Session): string {
+  return JSON.stringify({
+    email: session.email,
+    org: session.org ?? null,
+    role: session.role,
+    surface: session.surface,
+    userId: session.userId
+  });
+}
+
+function signPayload(payload: string, secret: string): string {
+  return createHmac('sha256', secret).update(payload).digest('base64url');
+}
+
+function signaturesEqual(expected: string, actual: string): boolean {
+  const expectedBytes = Buffer.from(expected, 'utf8');
+  const actualBytes = Buffer.from(actual, 'utf8');
+  if (expectedBytes.length !== actualBytes.length) return false;
+  return timingSafeEqual(expectedBytes, actualBytes);
+}
+
+export function createSessionCookieValue(session: Session): string {
+  const normalized = normalizeSession(session);
+  const secret = getSessionSecret();
+  if (!normalized || !secret) {
+    throw new Error('signed session cookie cannot be created without a valid session secret');
+  }
+
+  const payload = canonicalSessionPayload(normalized);
+  const encodedPayload = Buffer.from(payload, 'utf8').toString('base64url');
+  const signature = signPayload(payload, secret);
+  return `${encodedPayload}.${signature}`;
+}
+
+export function verifySessionCookieValue(raw: string | undefined): Session | null {
   if (!raw) return null;
+  const secret = getSessionSecret();
+  if (!secret) return null;
+
+  const parts = raw.split('.');
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+
   try {
-    const parsed = JSON.parse(raw) as Partial<Session>;
-    if (
-      typeof parsed.userId === 'string' &&
-      typeof parsed.email === 'string' &&
-      typeof parsed.role === 'string' &&
-      (parsed.surface === 'extranet' || parsed.surface === 'intranet')
-    ) {
-      const role = parsed.role as Role;
-      const surface = parsed.surface;
-      if (surface === 'extranet' && !isExtranetRole(role)) return null;
-      if (surface === 'intranet' && !isIntranetRole(role)) return null;
-      return {
-        userId: parsed.userId,
-        email: parsed.email,
-        role,
-        surface,
-        org: parsed.org
-      };
-    }
+    const payload = Buffer.from(parts[0], 'base64url').toString('utf8');
+    const parsed = JSON.parse(payload);
+    const normalized = normalizeSession(parsed);
+    if (!normalized) return null;
+
+    const canonicalPayload = canonicalSessionPayload(normalized);
+    if (payload !== canonicalPayload) return null;
+
+    const expectedSignature = signPayload(canonicalPayload, secret);
+    if (!signaturesEqual(expectedSignature, parts[1])) return null;
+
+    return normalized;
   } catch {
     return null;
   }
-  return null;
+}
+
+export function getSession(): Session | null {
+  const raw = cookies().get(SESSION_COOKIE)?.value;
+  return verifySessionCookieValue(raw);
 }
 
 export function requireExtranet(): Session {

--- a/site/src/middleware.ts
+++ b/site/src/middleware.ts
@@ -16,33 +16,143 @@
 
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { isExtranetRole, isIntranetRole, type Role } from './lib/roles';
 
 // Hard surface separation: /app/* requires extranet session, /internal/*
 // requires intranet session. Login pages are served outside these protected
-// app shells so they do not run the layout redirect checks.
-//
-// In v0 the cookie payload is a JSON string. In v0.5+ this becomes a JWT
-// with audience claims and signature verification.
+// app shells and are only usable when local development login is enabled.
 
 const EXO_SESSION = 'exo-session';
+const SESSION_SECRET_ENV = 'EXO_SITE_SESSION_SECRET';
 
 interface SessionShape {
+  userId: string;
+  email: string;
   surface?: 'extranet' | 'intranet';
   role?: string;
+  org?: string;
 }
 
-function readSession(req: NextRequest): SessionShape | null {
-  const raw = req.cookies.get(EXO_SESSION)?.value;
+function getSessionSecret(): string | null {
+  const secret = process.env[SESSION_SECRET_ENV];
+  if (typeof secret !== 'string' || new TextEncoder().encode(secret).length < 32) {
+    return null;
+  }
+  return secret;
+}
+
+function base64UrlToBytes(value: string): Uint8Array {
+  const base64 = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function normalizeSession(input: unknown): SessionShape | null {
+  if (!input || typeof input !== 'object') return null;
+
+  const parsed = input as Record<string, unknown>;
+  if (
+    typeof parsed.userId !== 'string' ||
+    typeof parsed.email !== 'string' ||
+    typeof parsed.role !== 'string' ||
+    (parsed.surface !== 'extranet' && parsed.surface !== 'intranet')
+  ) {
+    return null;
+  }
+
+  const role = parsed.role as Role;
+  const surface = parsed.surface;
+  if (surface === 'extranet' && !isExtranetRole(role)) return null;
+  if (surface === 'intranet' && !isIntranetRole(role)) return null;
+
+  const session: SessionShape = {
+    userId: parsed.userId,
+    email: parsed.email,
+    role,
+    surface
+  };
+  if (typeof parsed.org === 'string' && parsed.org.length > 0) {
+    session.org = parsed.org;
+  }
+  return session;
+}
+
+function canonicalSessionPayload(session: SessionShape): string {
+  return JSON.stringify({
+    email: session.email,
+    org: session.org ?? null,
+    role: session.role,
+    surface: session.surface,
+    userId: session.userId
+  });
+}
+
+function constantTimeEqual(expected: string, actual: string): boolean {
+  if (expected.length !== actual.length) return false;
+  let diff = 0;
+  for (let i = 0; i < expected.length; i += 1) {
+    diff |= expected.charCodeAt(i) ^ actual.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+async function signPayload(payload: string, secret: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(payload));
+  return bytesToBase64Url(new Uint8Array(signature));
+}
+
+async function verifySessionCookieValue(raw: string | undefined): Promise<SessionShape | null> {
   if (!raw) return null;
+  const secret = getSessionSecret();
+  if (!secret) return null;
+
+  const parts = raw.split('.');
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+
   try {
-    return JSON.parse(raw) as SessionShape;
+    const payload = new TextDecoder().decode(base64UrlToBytes(parts[0]));
+    const normalized = normalizeSession(JSON.parse(payload));
+    if (!normalized) return null;
+
+    const canonicalPayload = canonicalSessionPayload(normalized);
+    if (payload !== canonicalPayload) return null;
+
+    const expectedSignature = await signPayload(canonicalPayload, secret);
+    if (!constantTimeEqual(expectedSignature, parts[1])) return null;
+
+    return normalized;
   } catch {
     return null;
   }
 }
 
-export function middleware(req: NextRequest) {
+export async function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
+
+  if (pathname === '/login' || pathname === '/internal-login') {
+    return NextResponse.next();
+  }
 
   if (pathname.startsWith('/app')) {
     if (pathname === '/app/login') {
@@ -50,7 +160,7 @@ export function middleware(req: NextRequest) {
       loginUrl.pathname = '/login';
       return NextResponse.rewrite(loginUrl);
     }
-    const sess = readSession(req);
+    const sess = await verifySessionCookieValue(req.cookies.get(EXO_SESSION)?.value);
     if (!sess || sess.surface !== 'extranet') {
       const url = req.nextUrl.clone();
       url.pathname = '/app/login';
@@ -66,7 +176,7 @@ export function middleware(req: NextRequest) {
       loginUrl.pathname = '/internal-login';
       return NextResponse.rewrite(loginUrl);
     }
-    const sess = readSession(req);
+    const sess = await verifySessionCookieValue(req.cookies.get(EXO_SESSION)?.value);
     if (!sess || sess.surface !== 'intranet') {
       const url = req.nextUrl.clone();
       url.pathname = '/internal/login';
@@ -80,5 +190,5 @@ export function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/app/:path*', '/internal/:path*']
+  matcher: ['/app/:path*', '/login', '/internal/:path*', '/internal-login']
 };


### PR DESCRIPTION
## Summary
- classify Codex Security rows 55/56 as adjacent surface issues in the Next.js site
- replace raw JSON exo-session trust with HMAC-signed canonical session cookies
- fail closed unless EXO_SITE_SESSION_SECRET is configured; reject unsigned or tampered sessions in middleware and server-side session loading
- disable public development login by default and in production; require EXO_SITE_ENABLE_DEV_LOGIN=1 plus development mode
- stop intranet development login from defaulting to super_admin
- add auth-boundary source guard and update site operator docs/spec

## Path classification
- site/src/lib/auth.ts — adjacent surface auth boundary
- site/src/middleware.ts — adjacent surface runtime adapter for site route protection
- site/src/app/login/page.tsx — adjacent surface
- site/src/app/internal-login/page.tsx — adjacent surface
- site/scripts/test-auth-boundary-policy.mjs — adjacent surface security guard
- site/package.json — adjacent surface test script
- site/README.md — adjacent surface docs
- site/SPEC.md — adjacent surface docs

## Verification
- TDD red: npm --prefix site run security:auth-boundary failed against current main with: auth library must seal and verify signed session cookie values
- npm --prefix site run security:auth-boundary
- npm --prefix site run typecheck
- npm --prefix site run lint
- npm --prefix site run build
- npm --prefix site run security:contact-intake
- npm --prefix site run security:contact-disclosure
- git diff --check
- runtime: next start -p 3205; /internal-login and /login returned 404 with production defaults
- runtime: raw JSON intranet super_admin exo-session cookie redirected to /internal/login instead of granting access

## Security notes
- imported scanner CSV remains read-only evidence
- this does not claim production IdP integration; absent a real IdP and explicit local dev flags, protected site surfaces fail closed