### PR TITLE
fix(node): bind MCP Merkle roots to leaf count

### DIFF
--- a/crates/exo-core/src/hash.rs
+++ b/crates/exo-core/src/hash.rs
@@ -30,6 +30,8 @@ use crate::{
 
 const MERKLE_LEAF_DOMAIN: u8 = 0x00;
 const MERKLE_PARENT_DOMAIN: u8 = 0x01;
+const MERKLE_COUNTED_ROOT_DOMAIN: u8 = 0x02;
+const MERKLE_LEAF_COUNT_BYTES: usize = 16;
 
 /// Compute the blake3 hash of raw bytes.
 #[must_use]
@@ -79,6 +81,27 @@ pub fn merkle_root(leaves: &[Hash256]) -> Hash256 {
         current = next;
     }
     current[0]
+}
+
+/// Compute a Merkle root commitment that binds both the tree root and the
+/// number of leaves represented by that tree.
+#[must_use]
+pub fn merkle_root_with_leaf_count(leaves: &[Hash256]) -> Hash256 {
+    bind_merkle_root_to_leaf_count(&merkle_root(leaves), leaves.len())
+}
+
+/// Bind an existing Merkle tree root to a fixed-width leaf-count commitment.
+#[must_use]
+pub fn bind_merkle_root_to_leaf_count(root: &Hash256, leaf_count: usize) -> Hash256 {
+    let mut combined = [0u8; 1 + MERKLE_LEAF_COUNT_BYTES + 32];
+    let leaf_count_bytes = leaf_count.to_be_bytes();
+    let count_end = 1 + MERKLE_LEAF_COUNT_BYTES;
+    let count_start = count_end - leaf_count_bytes.len();
+
+    combined[0] = MERKLE_COUNTED_ROOT_DOMAIN;
+    combined[count_start..count_end].copy_from_slice(&leaf_count_bytes);
+    combined[count_end..].copy_from_slice(root.as_bytes());
+    canonical_hash(&combined)
 }
 
 /// Generate a Merkle proof for the leaf at `index`.
@@ -157,6 +180,95 @@ pub fn merkle_root_from_proof(leaf: &Hash256, proof: &[Hash256], index: usize) -
     }
 
     current
+}
+
+/// Verify a Merkle proof against a root commitment that binds the claimed leaf
+/// count.
+///
+/// The `root` parameter must be produced by [`merkle_root_with_leaf_count`] or
+/// [`bind_merkle_root_to_leaf_count`]. The compact proof path alone cannot
+/// prove the size of opaque sibling subtrees, so count binding is enforced at
+/// the root-commitment layer.
+#[must_use]
+pub fn verify_merkle_proof_with_leaf_count(
+    root: &Hash256,
+    leaf: &Hash256,
+    proof: &[Hash256],
+    index: usize,
+    leaf_count: usize,
+) -> bool {
+    let Ok((current, duplicate_siblings_match)) =
+        fold_merkle_proof_with_leaf_count(leaf, proof, index, leaf_count)
+    else {
+        return false;
+    };
+    let count_bound_root = bind_merkle_root_to_leaf_count(&current, leaf_count);
+    duplicate_siblings_match && hash256_eq_constant_time(&count_bound_root, root)
+}
+
+/// Reconstruct the leaf-count-bound Merkle root implied by a leaf, proof path,
+/// leaf index, and claimed leaf count.
+///
+/// # Errors
+///
+/// Returns `ExoError::InvalidMerkleProof` when `leaf_count` is zero, when
+/// `index` is outside the claimed tree, or when the proof path length is not
+/// the path length required by `leaf_count`, or when an odd duplicated sibling
+/// does not match the duplicated current node.
+pub fn merkle_root_from_proof_with_leaf_count(
+    leaf: &Hash256,
+    proof: &[Hash256],
+    index: usize,
+    leaf_count: usize,
+) -> Result<Hash256> {
+    let (root, duplicate_siblings_match) =
+        fold_merkle_proof_with_leaf_count(leaf, proof, index, leaf_count)?;
+    if duplicate_siblings_match {
+        Ok(bind_merkle_root_to_leaf_count(&root, leaf_count))
+    } else {
+        Err(ExoError::InvalidMerkleProof)
+    }
+}
+
+fn fold_merkle_proof_with_leaf_count(
+    leaf: &Hash256,
+    proof: &[Hash256],
+    index: usize,
+    leaf_count: usize,
+) -> Result<(Hash256, bool)> {
+    if leaf_count == 0 || index >= leaf_count {
+        return Err(ExoError::InvalidMerkleProof);
+    }
+
+    let mut current = hash_leaf(leaf);
+    let mut idx = index;
+    let mut level_count = leaf_count;
+    let mut duplicate_siblings_match = true;
+
+    for sibling in proof {
+        if level_count == 1 || idx >= level_count {
+            return Err(ExoError::InvalidMerkleProof);
+        }
+
+        let is_duplicated_odd_leaf = level_count % 2 != 0 && idx == level_count - 1;
+        if is_duplicated_odd_leaf {
+            duplicate_siblings_match &= hash256_eq_constant_time(&current, sibling);
+            current = hash_pair(&current, &current);
+        } else if idx % 2 == 0 {
+            current = hash_pair(&current, sibling);
+        } else {
+            current = hash_pair(sibling, &current);
+        }
+
+        idx /= 2;
+        level_count = level_count.div_ceil(2);
+    }
+
+    if level_count == 1 {
+        Ok((current, duplicate_siblings_match))
+    } else {
+        Err(ExoError::InvalidMerkleProof)
+    }
 }
 
 /// Compare two `Hash256` values without data-dependent early exit.
@@ -308,6 +420,32 @@ mod tests {
     }
 
     #[test]
+    fn merkle_root_with_leaf_count_binds_count_and_inner_root() {
+        let leaves = [
+            Hash256::digest(b"count-bound-a"),
+            Hash256::digest(b"count-bound-b"),
+            Hash256::digest(b"count-bound-c"),
+            Hash256::digest(b"count-bound-d"),
+        ];
+        let inner_root = merkle_root(&leaves);
+        let bound_root = merkle_root_with_leaf_count(&leaves);
+
+        assert_eq!(
+            bound_root,
+            bind_merkle_root_to_leaf_count(&inner_root, leaves.len())
+        );
+        assert_ne!(
+            bound_root,
+            bind_merkle_root_to_leaf_count(&inner_root, 3),
+            "same inner root must not verify under a different leaf count"
+        );
+        assert_ne!(
+            bound_root, inner_root,
+            "count-bound root must not be interchangeable with the raw Merkle root"
+        );
+    }
+
+    #[test]
     fn merkle_root_deterministic() {
         let leaves: Vec<Hash256> = (0..7u8).map(|i| Hash256::digest(&[i])).collect();
         let r1 = merkle_root(&leaves);
@@ -431,6 +569,96 @@ mod tests {
             let proof = merkle_proof(&leaves, index).expect("proof");
             assert_eq!(merkle_root_from_proof(leaf, &proof, index), root);
         }
+    }
+
+    #[test]
+    fn merkle_root_from_proof_with_leaf_count_matches_canonical_root() {
+        let leaves = vec![
+            Hash256::digest(b"count-proof-a"),
+            Hash256::digest(b"count-proof-b"),
+            Hash256::digest(b"count-proof-c"),
+            Hash256::digest(b"count-proof-d"),
+            Hash256::digest(b"count-proof-e"),
+        ];
+        let root = merkle_root_with_leaf_count(&leaves);
+
+        for (index, leaf) in leaves.iter().enumerate() {
+            let proof = merkle_proof(&leaves, index).expect("proof");
+            let computed =
+                merkle_root_from_proof_with_leaf_count(leaf, &proof, index, leaves.len())
+                    .expect("leaf-count-bound proof root");
+            assert_eq!(computed, root);
+            assert!(verify_merkle_proof_with_leaf_count(
+                &root,
+                leaf,
+                &proof,
+                index,
+                leaves.len()
+            ));
+        }
+    }
+
+    #[test]
+    fn verify_merkle_proof_with_leaf_count_rejects_false_leaf_count() {
+        let leaves = [
+            Hash256::digest(b"false-count-a"),
+            Hash256::digest(b"false-count-b"),
+            Hash256::digest(b"false-count-c"),
+            Hash256::digest(b"false-count-d"),
+        ];
+        let root = merkle_root_with_leaf_count(&leaves);
+        let target_index = 2;
+        let proof = merkle_proof(&leaves, target_index).expect("proof");
+
+        assert!(!verify_merkle_proof_with_leaf_count(
+            &root,
+            &leaves[target_index],
+            &proof,
+            target_index,
+            3
+        ));
+    }
+
+    #[test]
+    fn verify_merkle_proof_with_leaf_count_rejects_false_prefix_leaf_count() {
+        let leaves = [
+            Hash256::digest(b"false-prefix-count-a"),
+            Hash256::digest(b"false-prefix-count-b"),
+            Hash256::digest(b"false-prefix-count-c"),
+            Hash256::digest(b"false-prefix-count-d"),
+        ];
+        let root = merkle_root_with_leaf_count(&leaves);
+        let target_index = 1;
+        let proof = merkle_proof(&leaves, target_index).expect("proof");
+
+        assert!(!verify_merkle_proof_with_leaf_count(
+            &root,
+            &leaves[target_index],
+            &proof,
+            target_index,
+            3
+        ));
+    }
+
+    #[test]
+    fn verify_merkle_proof_with_leaf_count_rejects_bad_odd_duplicate_sibling() {
+        let leaves = [
+            Hash256::digest(b"odd-count-a"),
+            Hash256::digest(b"odd-count-b"),
+            Hash256::digest(b"odd-count-c"),
+        ];
+        let root = merkle_root_with_leaf_count(&leaves);
+        let target_index = 2;
+        let mut proof = merkle_proof(&leaves, target_index).expect("proof");
+        proof[0] = Hash256::digest(b"attacker-supplied-non-duplicate");
+
+        assert!(!verify_merkle_proof_with_leaf_count(
+            &root,
+            &leaves[target_index],
+            &proof,
+            target_index,
+            leaves.len()
+        ));
     }
 
     #[test]

--- a/crates/exo-node/src/mcp/resources/readme.rs
+++ b/crates/exo-node/src/mcp/resources/readme.rs
@@ -68,9 +68,9 @@ MCP rules and 8 kernel invariants on every action. Read this document first.
   fetch checkpoints.
 - **proofs (4)** — Construct non-attested draft legal evidence envelopes from
   caller-supplied metadata, verify caller-supplied custody-chain metadata and
-  continuity, generate verifier-compatible Merkle proofs from 32-byte event
-  hashes, and refuse CGR proof verification until a production verifier is
-  wired.
+  continuity, generate verifier-compatible leaf-count-bound Merkle proofs from
+  32-byte event hashes, and refuse CGR proof verification until a production
+  verifier is wired.
 - **legal (4)** — eDiscovery search, privilege assertion, safe-harbor
   initiation, fiduciary-duty checks. These tools refuse by default unless
   `unaudited-mcp-simulation-tools` is enabled, because they are not wired to

--- a/crates/exo-node/src/mcp/tools/ledger.rs
+++ b/crates/exo-node/src/mcp/tools/ledger.rs
@@ -21,7 +21,7 @@ use std::fmt::Display;
 
 use exo_core::{
     Did, Hash256,
-    hash::{merkle_root_from_proof, verify_merkle_proof},
+    hash::{merkle_root_from_proof_with_leaf_count, verify_merkle_proof_with_leaf_count},
 };
 use serde_json::{Value, json};
 
@@ -281,8 +281,9 @@ pub fn execute_get_event(params: &Value, context: &NodeContext) -> ToolResult {
 pub fn verify_inclusion_definition() -> ToolDefinition {
     ToolDefinition {
         name: "exochain_verify_inclusion".to_owned(),
-        description: "Verify a Merkle inclusion proof for a given event hash against a root hash."
-            .to_owned(),
+        description:
+            "Verify a Merkle inclusion proof for a given event hash against a leaf-count-bound root hash."
+                .to_owned(),
         input_schema: json!({
             "type": "object",
             "properties": {
@@ -298,7 +299,7 @@ pub fn verify_inclusion_definition() -> ToolDefinition {
                 },
                 "root_hash": {
                     "type": "string",
-                    "description": "Hex-encoded expected Merkle root hash."
+                    "description": "Hex-encoded expected leaf-count-bound Merkle root hash."
                 },
                 "target_index": {
                     "type": "integer",
@@ -464,8 +465,19 @@ pub fn execute_verify_inclusion(params: &Value, _context: &NodeContext) -> ToolR
         }
     }
 
-    let computed_root = merkle_root_from_proof(&event_hash, &proof, target_index);
-    let verified = verify_merkle_proof(&root_hash, &event_hash, &proof, target_index);
+    let computed_root =
+        match merkle_root_from_proof_with_leaf_count(&event_hash, &proof, target_index, leaf_count)
+        {
+            Ok(root) => root,
+            Err(_) => Hash256::ZERO,
+        };
+    let verified = verify_merkle_proof_with_leaf_count(
+        &root_hash,
+        &event_hash,
+        &proof,
+        target_index,
+        leaf_count,
+    );
 
     let response = json!({
         "event_hash": event_hash.to_string(),
@@ -573,7 +585,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use exo_core::{
-        hash::{merkle_proof, merkle_root},
+        hash::{merkle_proof, merkle_root_with_leaf_count},
         types::{Did, Signature},
     };
     use exo_dag::dag::{Dag, DeterministicDagClock, append};
@@ -883,7 +895,7 @@ mod tests {
             Hash256::digest(b"event-right"),
         ];
         let target_index = 0;
-        let expected_root = merkle_root(&leaves);
+        let expected_root = merkle_root_with_leaf_count(&leaves);
         let proof = merkle_proof(&leaves, target_index).expect("core proof");
         let proof_hashes: Vec<String> = proof.iter().map(ToString::to_string).collect();
 
@@ -908,7 +920,7 @@ mod tests {
             Hash256::digest(b"event-right"),
         ];
         let target_index = 1;
-        let expected_root = merkle_root(&leaves);
+        let expected_root = merkle_root_with_leaf_count(&leaves);
         let proof = merkle_proof(&leaves, target_index).expect("core proof");
         let proof_hashes: Vec<String> = proof.iter().map(ToString::to_string).collect();
 
@@ -934,7 +946,7 @@ mod tests {
             Hash256::digest(b"event-2"),
         ];
         let target_index = 2;
-        let root = merkle_root(&leaves);
+        let root = merkle_root_with_leaf_count(&leaves);
         let proof = merkle_proof(&leaves, target_index).expect("core proof");
         let proof_hashes: Vec<String> = proof.iter().map(ToString::to_string).collect();
 
@@ -968,8 +980,8 @@ mod tests {
             .expect("execute_verify_inclusion section");
 
         assert!(
-            verifier.contains("verify_merkle_proof("),
-            "MCP inclusion verification must delegate to exo_core's canonical Merkle verifier"
+            verifier.contains("verify_merkle_proof_with_leaf_count("),
+            "MCP inclusion verification must delegate to exo_core's leaf-count-bound Merkle verifier"
         );
         assert!(
             !production.contains("fn hash_merkle_pair"),
@@ -1004,7 +1016,7 @@ mod tests {
             Hash256::digest(b"event-left"),
             Hash256::digest(b"event-right"),
         ];
-        let expected_root = merkle_root(&leaves);
+        let expected_root = merkle_root_with_leaf_count(&leaves);
         let proof = merkle_proof(&leaves, 0).expect("core proof");
         let proof_hashes: Vec<String> = proof.iter().map(ToString::to_string).collect();
 
@@ -1022,6 +1034,66 @@ mod tests {
             result.content[0]
                 .text()
                 .contains("target_index 2 out of range for leaf_count 2")
+        );
+    }
+
+    #[test]
+    fn execute_verify_inclusion_rejects_false_leaf_count_with_matching_depth() {
+        let leaves = [
+            Hash256::digest(b"event-0"),
+            Hash256::digest(b"event-1"),
+            Hash256::digest(b"event-2"),
+            Hash256::digest(b"event-3"),
+        ];
+        let target_index = 2;
+        let expected_root = merkle_root_with_leaf_count(&leaves);
+        let proof = merkle_proof(&leaves, target_index).expect("core proof");
+        let proof_hashes: Vec<String> = proof.iter().map(ToString::to_string).collect();
+
+        let params = json!({
+            "event_hash": leaves[target_index].to_string(),
+            "proof_hashes": proof_hashes,
+            "root_hash": expected_root.to_string(),
+            "target_index": target_index,
+            "leaf_count": 3,
+        });
+        let result = execute_verify_inclusion(&params, &NodeContext::empty());
+
+        assert!(!result.is_error);
+        let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
+        assert_eq!(
+            v["verified"], false,
+            "proof verification must bind leaf_count, not just proof depth"
+        );
+    }
+
+    #[test]
+    fn execute_verify_inclusion_rejects_false_prefix_leaf_count_with_matching_depth() {
+        let leaves = [
+            Hash256::digest(b"event-0"),
+            Hash256::digest(b"event-1"),
+            Hash256::digest(b"event-2"),
+            Hash256::digest(b"event-3"),
+        ];
+        let target_index = 1;
+        let expected_root = merkle_root_with_leaf_count(&leaves);
+        let proof = merkle_proof(&leaves, target_index).expect("core proof");
+        let proof_hashes: Vec<String> = proof.iter().map(ToString::to_string).collect();
+
+        let params = json!({
+            "event_hash": leaves[target_index].to_string(),
+            "proof_hashes": proof_hashes,
+            "root_hash": expected_root.to_string(),
+            "target_index": target_index,
+            "leaf_count": 3,
+        });
+        let result = execute_verify_inclusion(&params, &NodeContext::empty());
+
+        assert!(!result.is_error);
+        let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
+        assert_eq!(
+            v["verified"], false,
+            "root_hash must bind leaf_count even when the target is in a prefix subtree"
         );
     }
 

--- a/crates/exo-node/src/mcp/tools/proofs.rs
+++ b/crates/exo-node/src/mcp/tools/proofs.rs
@@ -19,7 +19,7 @@
 
 use exo_core::{
     Did, Hash256, Timestamp,
-    hash::{merkle_proof, merkle_root},
+    hash::{merkle_proof, merkle_root, merkle_root_with_leaf_count},
 };
 use exo_legal::evidence::{
     create_evidence_from_hash, custody_chain_digest, transfer_custody, verify_chain_of_custody,
@@ -694,7 +694,8 @@ pub fn execute_generate_merkle_proof(params: &Value, _context: &NodeContext) -> 
         }
     }
 
-    let root_hash = merkle_root(&hashes);
+    let tree_root = merkle_root(&hashes);
+    let root_hash = merkle_root_with_leaf_count(&hashes);
     let proof_hashes = match merkle_proof(&hashes, target_index) {
         Ok(proof) => proof.iter().map(ToString::to_string).collect::<Vec<_>>(),
         Err(err) => return ToolResult::error(json!({"error": err.to_string()}).to_string()),
@@ -704,6 +705,8 @@ pub fn execute_generate_merkle_proof(params: &Value, _context: &NodeContext) -> 
     let response = json!({
         "root": root_hash.to_string(),
         "root_hash": root_hash.to_string(),
+        "tree_root": tree_root.to_string(),
+        "leaf_count_bound_root": root_hash.to_string(),
         "target_leaf": target_hash,
         "target_hash": target_hash,
         "event_hash": target_hash,
@@ -1080,6 +1083,8 @@ mod tests {
         let v: Value = serde_json::from_str(result.content[0].text()).expect("valid JSON");
         assert!(v["root_hash"].as_str().is_some());
         assert_eq!(v["root"], v["root_hash"]);
+        assert_eq!(v["leaf_count_bound_root"], v["root_hash"]);
+        assert_ne!(v["tree_root"], v["root_hash"]);
         assert_eq!(v["event_hash"], leaves[1]);
         assert_eq!(v["target_hash"], leaves[1]);
         assert_eq!(v["target_index"], 1);

--- a/docs/guides/mcp-integration.md
+++ b/docs/guides/mcp-integration.md
@@ -315,7 +315,7 @@ Use these at session start to let the agent self-orient.
 |---|---|
 | `exochain_create_evidence` | Construct a verifier-compatible draft legal evidence envelope from caller-supplied UUID, content hash, creator DID, and creation HLC. The result is marked `not_attested`, is not persisted, does not bind trusted server HLC time, and does not check uniqueness. |
 | `exochain_verify_chain_of_custody` | Verify caller-supplied evidence UUID/DID/hash metadata, transfer continuity, transfer reasons, and monotonic HLC timestamps. The result is scoped to the supplied payload only and is not a legal-store attestation. |
-| `exochain_generate_merkle_proof` | Produce a verifier-compatible Merkle inclusion proof for a 32-byte event hash, returning `event_hash`, `root_hash`, and `proof_hashes`. |
+| `exochain_generate_merkle_proof` | Produce a verifier-compatible Merkle inclusion proof for a 32-byte event hash, returning `event_hash`, leaf-count-bound `root_hash`, raw `tree_root`, `leaf_count`, and `proof_hashes`. |
 | `exochain_verify_cgr_proof` | Refuses CGR proof verification until proof bytes, public inputs, checkpoint roots, validator signatures, and a production verifier are wired. |
 
 ### Legal (4)


### PR DESCRIPTION
## Summary
- Remediates Codex Security CSV row 4 as a live core runtime adapter issue: `exochain_verify_inclusion` accepted a Merkle proof whose proof depth matched the claimed `leaf_count` even when the root did not cryptographically commit to that count.
- Adds leaf-count-bound Merkle root commitments in `exo-core` and switches MCP proof generation/verification to that commitment.
- Keeps the raw tree root available as `tree_root` while making `root_hash` the verifier-compatible leaf-count-bound root.

## Path Classification
- `crates/exo-core/src/hash.rs` — EXOCHAIN core
- `crates/exo-node/src/mcp/tools/ledger.rs` — Core runtime adapter
- `crates/exo-node/src/mcp/tools/proofs.rs` — Core runtime adapter
- `crates/exo-node/src/mcp/resources/readme.rs` — Core runtime adapter documentation/resource text
- `docs/guides/mcp-integration.md` — Core runtime adapter documentation

## Verification Against Current Main
- Confirmed the stale/partial depth-only behavior with a failing red test before implementation: a 4-leaf proof for a prefix leaf could verify while falsely claiming `leaf_count = 3`.
- Sanity check: compact Merkle paths cannot prove the shape of opaque sibling subtrees by proof-depth alone; the fix binds `leaf_count` at the root commitment boundary.
- Updated the sibling ingress path `exochain_generate_merkle_proof` so generated proofs produce the hardened `root_hash` consumed by `exochain_verify_inclusion`.

## Local Gates
- `cargo test -p exo-core verify_merkle_proof_with_leaf_count_rejects_false_prefix_leaf_count -- --nocapture`
- `cargo test -p exo-node execute_verify_inclusion_rejects_false_prefix_leaf_count_with_matching_depth -- --nocapture`
- `cargo test -p exo-node execute_generate_merkle_proof_output_verifies_with_verify_inclusion -- --nocapture`
- `cargo test -p exo-core merkle -- --nocapture`
- `cargo test -p exo-node execute_verify_inclusion -- --nocapture`
- `cargo test -p exo-node execute_generate_merkle_proof -- --nocapture`
- `cargo test -p exo-node verify_inclusion_uses_core_merkle_verifier_not_local_hashing -- --nocapture`
- `cargo clippy -p exo-core -p exo-node --all-targets -- -D warnings`
- `cargo test -p exo-core`
- `cargo test -p exo-node`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
