### PR TITLE
fix(exoforge): monitor wasm fail-closed boundaries

### DIFF
--- a/exoforge/bin/exoforge-monitor.js
+++ b/exoforge/bin/exoforge-monitor.js
@@ -44,7 +44,10 @@ import {
   buildValidationDecision,
   buildValidationTncFlags,
   buildValidationInvariantRequest,
-  validationReportTimestampIso
+  validationReportTimestampIso,
+  isExpectedPublicWasmTncBoundaryRejection,
+  isExpectedPublicWasmTncViolationSet,
+  isExpectedPublicWasmInvariantBoundaryRejection
 } from '../lib/constitutional.js';
 
 // ── Parse CLI arguments ─────────────────────────────────────────────────────
@@ -140,9 +143,9 @@ function checkTncEnforcement() {
       ? violations.violations.length
       : Array.isArray(violations) ? violations.length : 0;
 
-    const score = allPass.ok && violationCount === 0 ? 1.0
-      : allPass.ok ? 0.8
-      : 0.0;
+    const boundaryRejected = isExpectedPublicWasmTncBoundaryRejection(allPass) &&
+      isExpectedPublicWasmTncViolationSet(violations);
+    const score = boundaryRejected ? 1.0 : 0.0;
 
     return {
       check: 'tnc_enforcement',
@@ -150,9 +153,11 @@ function checkTncEnforcement() {
       score,
       all_pass: allPass.ok,
       violation_count: violationCount,
-      details: allPass.ok
-        ? `All 10 TNCs enforcing correctly (${violationCount} violations in exhaustive scan)`
-        : `TNC enforcement failure: ${allPass.violation}`
+      details: boundaryRejected
+        ? `Public WASM TNC boundary rejected caller-supplied proof flags as expected (${violationCount} violations)`
+        : allPass.ok
+          ? 'Public WASM TNC boundary accepted caller-supplied proof flags unexpectedly'
+          : `Unexpected TNC enforcement failure: ${allPass.violation}`
     };
   } catch (err) {
     return {
@@ -174,8 +179,8 @@ function checkInvariants() {
   try {
     const result = verifyInvariants(ctx);
     const violationCount = result.violations ? result.violations.length : 0;
-    const score = result.ok && result.passed && violationCount === 0 ? 1.0
-      : 0.0;
+    const boundaryRejected = isExpectedPublicWasmInvariantBoundaryRejection(result);
+    const score = boundaryRejected ? 1.0 : 0.0;
 
     return {
       check: 'invariant_enforcement',
@@ -184,9 +189,11 @@ function checkInvariants() {
       passed: result.passed,
       violation_count: violationCount,
       violations: violationCount > 0 ? result.violations : undefined,
-      details: result.ok
-        ? `Invariant enforcement active (${violationCount} violations)`
-        : 'Invariant enforcement failed'
+      details: boundaryRejected
+        ? `Public WASM invariant boundary rejected caller-supplied trust roots as expected (${violationCount} violations)`
+        : result.ok && result.passed
+          ? 'Public WASM invariant boundary accepted caller-supplied trust roots unexpectedly'
+          : 'Unexpected invariant enforcement failure'
     };
   } catch (err) {
     return {

--- a/exoforge/bin/exoforge-validate.js
+++ b/exoforge/bin/exoforge-validate.js
@@ -40,7 +40,10 @@ import {
   buildValidationDecision,
   buildValidationTncFlags,
   buildValidationInvariantRequest,
-  validationReportTimestampIso
+  validationReportTimestampIso,
+  isExpectedPublicWasmTncBoundaryRejection,
+  isExpectedPublicWasmTncViolationSet,
+  isExpectedPublicWasmInvariantBoundaryRejection
 } from '../lib/constitutional.js';
 
 // ── Parse CLI arguments ─────────────────────────────────────────────────────
@@ -164,16 +167,19 @@ function runValidation(args, validatedAt = validationReportTimestampIso()) {
 
     // Test enforceAllTnc (short-circuit mode)
     const tncResult = enforceAllTnc(ctx);
+    const tncBoundaryRejected = isExpectedPublicWasmTncBoundaryRejection(tncResult);
     results.checks.push({
       name: 'tnc_enforce_all',
       category: 'tnc',
-      status: tncResult.ok ? 'pass' : 'fail',
-      details: tncResult.ok
-        ? 'All 10 TNCs passed enforcement check'
-        : `TNC enforcement failed: ${tncResult.violation}`
+      status: tncBoundaryRejected ? 'pass' : 'fail',
+      details: tncBoundaryRejected
+        ? `Public WASM TNC boundary rejected caller-supplied proof flags as expected: ${tncResult.violation}`
+        : tncResult.ok
+          ? 'Public WASM TNC boundary accepted caller-supplied proof flags unexpectedly'
+          : `Unexpected TNC enforcement failure: ${tncResult.violation}`
     });
     results.summary.total++;
-    if (tncResult.ok) results.summary.passed++;
+    if (tncBoundaryRejected) results.summary.passed++;
     else results.summary.failed++;
 
     // Test collectTncViolations (exhaustive mode)
@@ -181,17 +187,18 @@ function runValidation(args, validatedAt = validationReportTimestampIso()) {
       const violations = collectTncViolations(ctx);
       const violationList = violations.violations || violations;
       const count = Array.isArray(violationList) ? violationList.length : 0;
+      const tncViolationBoundaryRejected = isExpectedPublicWasmTncViolationSet(violations);
       results.checks.push({
         name: 'tnc_collect_violations',
         category: 'tnc',
-        status: count === 0 ? 'pass' : 'fail',
-        details: count === 0
-          ? 'Zero TNC violations detected (exhaustive scan)'
-          : `${count} TNC violation(s) detected`,
+        status: tncViolationBoundaryRejected ? 'pass' : 'fail',
+        details: tncViolationBoundaryRejected
+          ? `${count} fail-closed TNC boundary violation(s) detected as expected`
+          : `${count} unexpected TNC violation(s) detected`,
         violations: count > 0 ? violationList : undefined
       });
       results.summary.total++;
-      if (count === 0) results.summary.passed++;
+      if (tncViolationBoundaryRejected) results.summary.passed++;
       else results.summary.failed++;
     } catch (err) {
       results.checks.push({
@@ -237,16 +244,19 @@ function runValidation(args, validatedAt = validationReportTimestampIso()) {
     const invCtx = buildInvariantContext();
     const invResult = verifyInvariants(invCtx);
     const violationCount = invResult.violations ? invResult.violations.length : 0;
+    const invariantBoundaryRejected = isExpectedPublicWasmInvariantBoundaryRejection(invResult);
     results.checks.push({
       name: 'invariant_enforcement',
       category: 'invariants',
-      status: invResult.ok && violationCount === 0 && invResult.passed ? 'pass' : 'fail',
-      details: invResult.ok
-        ? `Invariant enforcement passed (${violationCount} violations)`
-        : `Invariant enforcement failed: ${invResult.violations.join(', ')}`
+      status: invariantBoundaryRejected ? 'pass' : 'fail',
+      details: invariantBoundaryRejected
+        ? `Public WASM invariant boundary rejected caller-supplied trust roots as expected (${violationCount} violations)`
+        : invResult.ok && invResult.passed
+          ? 'Public WASM invariant boundary accepted caller-supplied trust roots unexpectedly'
+          : `Unexpected invariant enforcement failure: ${invResult.violations.join(', ')}`
     });
     results.summary.total++;
-    if (invResult.ok && violationCount === 0 && invResult.passed) results.summary.passed++;
+    if (invariantBoundaryRejected) results.summary.passed++;
     else results.summary.failed++;
   }
 

--- a/exoforge/lib/constitutional.js
+++ b/exoforge/lib/constitutional.js
@@ -113,6 +113,31 @@ export function enforceAllTnc(state) {
   }
 }
 
+export function isExpectedPublicWasmTncBoundaryRejection(tncResult) {
+  return !tncResult.ok &&
+    typeof tncResult.violation === 'string' &&
+    tncResult.violation.includes('authority chain not verified');
+}
+
+export function isExpectedPublicWasmTncViolationSet(violations) {
+  const violationList = violations.violations || violations;
+  if (!Array.isArray(violationList)) return false;
+
+  const requiredFragments = [
+    'authority chain not verified',
+    'human gate not satisfied',
+    'consent not verified',
+    'identity not verified',
+    'decision not bound to valid constitution',
+    'quorum not met',
+    'evidence bundle incomplete'
+  ];
+
+  return requiredFragments.every(fragment =>
+    violationList.some(violation => String(violation).includes(fragment))
+  );
+}
+
 /**
  * Collect all TNC violations without short-circuiting.
  *
@@ -149,6 +174,18 @@ export function verifyInvariants(state) {
   } catch (err) {
     return { ok: false, passed: false, violations: [err.message || String(err)] };
   }
+}
+
+export function isExpectedPublicWasmInvariantBoundaryRejection(invResult) {
+  if (!invResult.ok || invResult.passed) return false;
+  const violations = Array.isArray(invResult.violations) ? invResult.violations : [];
+
+  const descriptions = violations.map(violation =>
+    typeof violation === 'string' ? violation : violation.description || ''
+  );
+
+  return descriptions.some(description => description.includes('trusted_authority_keys')) &&
+    descriptions.some(description => description.includes('trusted_provenance_keys'));
 }
 
 /**

--- a/exoforge/test/validation-contracts.test.js
+++ b/exoforge/test/validation-contracts.test.js
@@ -34,8 +34,16 @@ test('exoforge-validate passes against the live WASM validation contract', async
 
   equal(report.kernel_loaded, true);
   equal(report.summary.failed, 0);
-  ok(report.checks.some(check => check.name === 'tnc_enforce_all' && check.status === 'pass'));
-  ok(report.checks.some(check => check.name === 'invariant_enforcement' && check.status === 'pass'));
+  ok(report.checks.some(check =>
+    check.name === 'tnc_enforce_all' &&
+    check.status === 'pass' &&
+    check.details.includes('rejected caller-supplied proof flags')
+  ));
+  ok(report.checks.some(check =>
+    check.name === 'invariant_enforcement' &&
+    check.status === 'pass' &&
+    check.details.includes('rejected caller-supplied trust roots')
+  ));
 });
 
 test('exoforge-monitor --once reports healthy against the live WASM validation contract', async () => {
@@ -43,6 +51,14 @@ test('exoforge-monitor --once reports healthy against the live WASM validation c
 
   equal(report.status, 'healthy');
   equal(report.checks_critical, 0);
-  ok(report.checks.some(check => check.check === 'tnc_enforcement' && check.status === 'healthy'));
-  ok(report.checks.some(check => check.check === 'invariant_enforcement' && check.status === 'healthy'));
+  ok(report.checks.some(check =>
+    check.check === 'tnc_enforcement' &&
+    check.status === 'healthy' &&
+    check.details.includes('rejected caller-supplied proof flags')
+  ));
+  ok(report.checks.some(check =>
+    check.check === 'invariant_enforcement' &&
+    check.status === 'healthy' &&
+    check.details.includes('rejected caller-supplied trust roots')
+  ));
 });


### PR DESCRIPTION
## Summary
- Update ExoForge validate/monitor to treat public WASM fail-closed rejections as healthy boundary validation.
- Add shared helpers for expected TNC and invariant public-WASM boundary rejections.
- Tighten validation-contract tests so ExoForge cannot claim caller-supplied proof flags or trust roots are accepted.

## Path classification
- Adjacent surface: `exoforge/bin/exoforge-validate.js`, `exoforge/bin/exoforge-monitor.js`, `exoforge/lib/constitutional.js`, `exoforge/test/validation-contracts.test.js`.
- Core runtime adapter: no Rust adapter source changed; focused `exochain-wasm` contract tests were run to verify the boundary behavior this adjacent surface depends on.
- EXOCHAIN core: no core source changes.

## Adjacent surface intake
- Owner/accountable maintainer: EXOCHAIN maintainers; Bob Stewart accountable until a dedicated ExoForge owner is assigned.
- Deployment status: internal tooling / planning and monitoring surface.
- Constitutional trust claims: may describe non-binding validation/monitoring results only; it must not claim caller-supplied WASM flags or trust roots prove constitutional enforcement.
- Core state access: calls public `@exochain/exochain-wasm` validation helpers; no writes to EXOCHAIN core state, signatures, credentials, governance outcomes, consent records, or provenance records.
- Trust boundary: public WASM rejects caller-supplied proof flags and trust roots; trusted authority/provenance resolution remains in core runtime adapters.
- Test command / CI gate: `npm --prefix exoforge test`.
- Secrets inventory: none for this surface.
- Rollback path: revert this PR; the core WASM fail-closed behavior remains unchanged.

## Validation
- RED: `node --test exoforge/test/validation-contracts.test.js` failed before implementation.
- `node --test exoforge/test/validation-contracts.test.js`
- `node --test exoforge/test/product-contracts.test.js`
- `npm --prefix exoforge test`
- `cargo test -p exochain-wasm wasm_tnc_adapter_does_not_trust_caller_supplied_flags -- --nocapture`
- `cargo test -p exochain-wasm wasm_enforce_invariants_rejects_caller_supplied_trusted_key_maps -- --nocapture`
- `cargo test -p exochain-wasm validation_invariant_request_includes_trusted -- --nocapture`
- `cargo clippy -p exochain-wasm --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`