### PR TITLE
fix(command-base): block ssh host shell injection

### DIFF
--- a/command-base/app/routes/settings.js
+++ b/command-base/app/routes/settings.js
@@ -15,6 +15,42 @@
 // SPDX-License-Identifier: Apache-2.0
 
 'use strict';
+
+function normalizeSshHost(value) {
+  if (value === undefined || value === null || value === '') return null;
+  if (typeof value !== 'string') {
+    throw new Error('ssh_host must be a string');
+  }
+
+  const trimmed = value.trim();
+  if (trimmed === '') return null;
+  if (trimmed.length > 253) {
+    throw new Error('ssh_host is too long');
+  }
+  if (trimmed.startsWith('-')) {
+    throw new Error('ssh_host must be a host token, not an SSH option');
+  }
+
+  const hostToken = '(?:[A-Za-z0-9._%+-]+@)?[A-Za-z0-9._-]+';
+  if (!new RegExp(`^${hostToken}$`).test(trimmed)) {
+    throw new Error('ssh_host contains unsupported characters');
+  }
+
+  return trimmed;
+}
+
+function rejectInvalidSshHost(res, error) {
+  return res.status(400).json({ error: error.message });
+}
+
+function runRemoteHardwareProbe(sshHost, command) {
+  const { execFileSync } = require('child_process');
+  return execFileSync('ssh', ['-o', 'ConnectTimeout=5', sshHost, command], {
+    timeout: 10000,
+    encoding: 'utf8',
+  }).trim();
+}
+
 module.exports = function(app, db, helpers) {
   const {
     broadcast,
@@ -80,12 +116,14 @@ app.post('/api/model-sources', (req, res) => {
   try {
     const { name, type, endpoint, label, device, is_local, ssh_host, ssh_tunnel_port, max_concurrent } = req.body;
     if (!name || !endpoint) return res.status(400).json({ error: 'name and endpoint are required' });
+    const normalizedSshHost = normalizeSshHost(ssh_host);
     const now = localNow();
     const result = db.prepare(`INSERT INTO model_sources (name, type, endpoint, label, device, is_local, ssh_host, ssh_tunnel_port, max_concurrent, created_at, updated_at)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
-      .run(name, type || 'ollama', endpoint, label || name, device || null, is_local ? 1 : 0, ssh_host || null, ssh_tunnel_port || null, max_concurrent || 3, now, now);
+      .run(name, type || 'ollama', endpoint, label || name, device || null, is_local ? 1 : 0, normalizedSshHost, ssh_tunnel_port || null, max_concurrent || 3, now, now);
     res.json({ id: Number(result.lastInsertRowid), success: true });
   } catch (err) {
+    if (err.message && err.message.startsWith('ssh_host')) return rejectInvalidSshHost(res, err);
     res.status(500).json({ error: err.message });
   }
 });
@@ -102,7 +140,7 @@ app.put('/api/model-sources/:id', (req, res) => {
     if (label !== undefined) { sets.push('label = ?'); vals.push(label); }
     if (device !== undefined) { sets.push('device = ?'); vals.push(device); }
     if (is_active !== undefined) { sets.push('is_active = ?'); vals.push(is_active ? 1 : 0); }
-    if (ssh_host !== undefined) { sets.push('ssh_host = ?'); vals.push(ssh_host); }
+    if (ssh_host !== undefined) { sets.push('ssh_host = ?'); vals.push(normalizeSshHost(ssh_host)); }
     if (ssh_tunnel_port !== undefined) { sets.push('ssh_tunnel_port = ?'); vals.push(ssh_tunnel_port); }
     if (max_concurrent !== undefined) { sets.push('max_concurrent = ?'); vals.push(max_concurrent); }
     sets.push('updated_at = ?'); vals.push(now);
@@ -110,6 +148,7 @@ app.put('/api/model-sources/:id', (req, res) => {
     db.prepare(`UPDATE model_sources SET ${sets.join(', ')} WHERE id = ?`).run(...vals);
     res.json({ success: true });
   } catch (err) {
+    if (err.message && err.message.startsWith('ssh_host')) return rejectInvalidSshHost(res, err);
     res.status(500).json({ error: err.message });
   }
 });
@@ -209,13 +248,15 @@ app.post('/api/model-sources/:id/scan', async (req, res) => {
     // 2. Get device hardware info via SSH (for remote) or local commands
     if (source.ssh_host) {
       try {
-        const { execSync } = require('child_process');
-        const sshCmd = `ssh -o ConnectTimeout=5 ${source.ssh_host}`;
-        const ramGB = parseInt(execSync(`${sshCmd} "free -g 2>/dev/null | awk '/Mem:/{print \\$7}'"`, { timeout: 10000 }).toString().trim()) || 0;
-        const cpus = parseInt(execSync(`${sshCmd} "nproc 2>/dev/null"`, { timeout: 10000 }).toString().trim()) || 0;
-        const gpuInfo = execSync(`${sshCmd} "nvidia-smi --query-gpu=name,memory.total --format=csv,noheader 2>/dev/null || echo 'none'"`, { timeout: 10000 }).toString().trim();
+        const sshHost = normalizeSshHost(source.ssh_host);
+        const ramGB = parseInt(runRemoteHardwareProbe(sshHost, "free -g 2>/dev/null | awk '/Mem:/{print $7}'"), 10) || 0;
+        const cpus = parseInt(runRemoteHardwareProbe(sshHost, 'nproc 2>/dev/null'), 10) || 0;
+        const gpuInfo = runRemoteHardwareProbe(sshHost, "nvidia-smi --query-gpu=name,memory.total --format=csv,noheader 2>/dev/null || echo 'none'");
         scan.capabilities = { ram_gb: ramGB, cpus, gpu: gpuInfo !== 'none' ? gpuInfo : null, is_remote: true };
-      } catch (e) { scan.capabilities = { error: e.message, is_remote: true }; }
+      } catch (e) {
+        if (e.message && e.message.startsWith('ssh_host')) return rejectInvalidSshHost(res, e);
+        scan.capabilities = { error: e.message, is_remote: true };
+      }
     } else {
       // Local device
       try {

--- a/command-base/app/schema-bootstrap.routes.test.js
+++ b/command-base/app/schema-bootstrap.routes.test.js
@@ -17,12 +17,13 @@
 'use strict';
 
 const assert = require('node:assert/strict');
-const { mkdtempSync, rmSync, mkdirSync } = require('node:fs');
+const { existsSync, mkdtempSync, rmSync, mkdirSync } = require('node:fs');
 const { join } = require('node:path');
 const { spawn } = require('node:child_process');
 const os = require('node:os');
 const net = require('node:net');
 const test = require('node:test');
+const Database = require('better-sqlite3');
 
 function pickFreePort() {
   return new Promise((resolve, reject) => {
@@ -112,6 +113,32 @@ async function postJson(baseUrl, cookie, path, body) {
   return JSON.parse(text);
 }
 
+async function postJsonRaw(baseUrl, cookie, path, body) {
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: 'POST',
+    headers: {
+      Cookie: cookie,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  return { status: res.status, body: text ? JSON.parse(text) : null };
+}
+
+async function putJsonRaw(baseUrl, cookie, path, body) {
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: 'PUT',
+    headers: {
+      Cookie: cookie,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  return { status: res.status, body: text ? JSON.parse(text) : null };
+}
+
 test('clean CommandBase bootstrap supports affected authenticated create routes', { timeout: 60_000 }, async (t) => {
   const tmpDir = mkdtempSync(join(os.tmpdir(), 'cb-schema-routes-'));
   const dbPath = join(tmpDir, 'command-base.db');
@@ -185,4 +212,105 @@ test('clean CommandBase bootstrap supports affected authenticated create routes'
   if (exitCode !== undefined) {
     assert.equal(exitCode, 0, `server exited unexpectedly; stderr: ${stderr.join('')}`);
   }
+});
+
+test('model-source scan rejects unsafe ssh_host from existing rows before shell execution', { timeout: 60_000 }, async (t) => {
+  const tmpDir = mkdtempSync(join(os.tmpdir(), 'cb-ssh-host-'));
+  const dbPath = join(tmpDir, 'command-base.db');
+  const markerPath = join(tmpDir, 'shell-executed');
+  const port = await pickFreePort();
+
+  const { proc, stderr } = spawnCommandBaseServer(port, dbPath, tmpDir);
+  t.after(() => {
+    return stopCommandBaseServer(proc).finally(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+  });
+
+  const baseUrl = `http://127.0.0.1:${port}`;
+  await waitForHttpReady(`${baseUrl}/health`, stderr);
+
+  const authRes = await fetch(`${baseUrl}/api/auth/status`);
+  assert.equal(authRes.status, 200, 'loopback auth status should set the bootstrap cookie');
+  const cookie = cookieHeader(authRes.headers.get('set-cookie'));
+  assert.match(cookie, /^cb_auth=/, 'bootstrap response should include cb_auth cookie');
+
+  const db = new Database(dbPath);
+  try {
+    const now = '2026-05-20T01:32:00.000-04:00';
+    db.prepare(`
+      INSERT INTO model_sources (name, type, endpoint, label, device, is_local, ssh_host, ssh_tunnel_port, max_concurrent, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      'Injected Remote',
+      'ollama',
+      'http://127.0.0.1:9',
+      'Injected',
+      'GPU',
+      0,
+      `127.0.0.1; touch ${markerPath}; true #`,
+      null,
+      1,
+      now,
+      now
+    );
+  } finally {
+    db.close();
+  }
+
+  const response = await postJsonRaw(baseUrl, cookie, '/api/model-sources/1/scan', {});
+
+  assert.equal(response.status, 400, 'unsafe ssh_host must be rejected before scan execution');
+  assert.match(response.body.error, /ssh_host/i);
+  assert.equal(existsSync(markerPath), false, 'scan must not execute shell metacharacters from ssh_host');
+});
+
+test('model-source create and update reject unsafe ssh_host tokens', { timeout: 60_000 }, async (t) => {
+  const tmpDir = mkdtempSync(join(os.tmpdir(), 'cb-ssh-host-write-'));
+  const dbPath = join(tmpDir, 'command-base.db');
+  const port = await pickFreePort();
+
+  const { proc, stderr } = spawnCommandBaseServer(port, dbPath, tmpDir);
+  t.after(() => {
+    return stopCommandBaseServer(proc).finally(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+  });
+
+  const baseUrl = `http://127.0.0.1:${port}`;
+  await waitForHttpReady(`${baseUrl}/health`, stderr);
+
+  const authRes = await fetch(`${baseUrl}/api/auth/status`);
+  assert.equal(authRes.status, 200, 'loopback auth status should set the bootstrap cookie');
+  const cookie = cookieHeader(authRes.headers.get('set-cookie'));
+
+  const createResponse = await postJsonRaw(baseUrl, cookie, '/api/model-sources', {
+    name: 'Injected Remote',
+    type: 'ollama',
+    endpoint: 'http://127.0.0.1:9',
+    label: 'Injected',
+    device: 'GPU',
+    is_local: false,
+    ssh_host: '127.0.0.1; touch /tmp/commandbase-pwned',
+    max_concurrent: 1,
+  });
+  assert.equal(createResponse.status, 400);
+  assert.match(createResponse.body.error, /ssh_host/i);
+
+  const validSource = await postJson(baseUrl, cookie, '/api/model-sources', {
+    name: 'Safe Remote',
+    type: 'ollama',
+    endpoint: 'http://127.0.0.1:9',
+    label: 'Safe',
+    device: 'GPU',
+    is_local: false,
+    ssh_host: 'operator@127.0.0.1',
+    max_concurrent: 1,
+  });
+
+  const updateResponse = await putJsonRaw(baseUrl, cookie, `/api/model-sources/${validSource.id}`, {
+    ssh_host: 'operator@127.0.0.1 && touch /tmp/commandbase-pwned',
+  });
+  assert.equal(updateResponse.status, 400);
+  assert.match(updateResponse.body.error, /ssh_host/i);
 });


### PR DESCRIPTION
## Summary
- Reject unsafe `ssh_host` tokens on model-source create/update and before scanning stale stored rows.
- Replace shell-string SSH probes with `execFileSync` argument-vector execution.
- Add regression coverage proving shell metacharacters in stored `ssh_host` values do not execute during scan.

## Finding Disposition
- Source: Codex Security CSV 2026-05-20 row 2, `Schema enables ssh_host command injection path`.
- Classification: adjacent surface (`command-base/app`).
- Current-main verification: live on `origin/main` before this branch; `ssh_host` was interpolated into an `execSync` shell command in `/api/model-sources/:id/scan`.
- RED: `node --test command-base/app/schema-bootstrap.routes.test.js` returned 200 for an injected stored `ssh_host` before implementation.

## Path classification
- Adjacent surface: `command-base/app/routes/settings.js`, `command-base/app/schema-bootstrap.routes.test.js`.
- EXOCHAIN core / core runtime adapter: no changes.
- Imported evidence / third-party: no changes.

## Adjacent surface intake
- Owner/accountable maintainer: EXOCHAIN maintainers; Bob Stewart accountable until a dedicated CommandBase owner is assigned.
- Deployment status: adjacent product surface.
- Constitutional trust claims: this PR makes no EXOCHAIN constitutional enforcement claim for CommandBase.
- Core state access: no EXOCHAIN core state, signatures, credentials, governance outcomes, consent records, or provenance records are read or written by this change.
- Trust boundary: CommandBase model-source SSH scanning is an OS-command boundary; untrusted HTTP/body/database `ssh_host` values must be validated and passed as argv, never interpolated into a shell.
- Test command / CI gate: `node --test command-base/app/lib/bootstrap-schema.test.js command-base/app/schema-bootstrap.routes.test.js`.
- Secrets inventory: no new secrets; SSH credentials remain external operator configuration.
- Rollback path: revert this PR or disable the model-source scan route if unexpected operational impact occurs.

## Validation
- `node --test command-base/app/schema-bootstrap.routes.test.js`
- `node --test command-base/app/lib/bootstrap-schema.test.js command-base/app/schema-bootstrap.routes.test.js`
- `node --check command-base/app/routes/settings.js`
- `node --check command-base/app/schema-bootstrap.routes.test.js`
- `npm --prefix command-base/app run audit:check` (passes high-severity gate; existing moderate `ws` advisory remains separate triage)
- `git diff --check`