### PR TITLE
fix(site): ignore spoofable contact forwarding headers

### DIFF
--- a/site/scripts/test-contact-intake-policy.mjs
+++ b/site/scripts/test-contact-intake-policy.mjs
@@ -90,9 +90,14 @@ assert.equal(honeypot.ok, true);
 assert.equal(honeypot.deliver, false, 'honeypot submissions must not queue or send mail');
 
 assert.equal(
-  policy.normalizeClientAddress(' 203.0.113.7, 10.0.0.1 '),
+  policy.normalizeClientAddress(' 203.0.113.7 '),
   '203.0.113.7',
-  'client key must use the first forwarded address',
+  'client key may use a single trusted runtime address',
+);
+assert.equal(
+  policy.normalizeClientAddress(' 203.0.113.7, 10.0.0.1 '),
+  'unknown',
+  'client key must not trust spoofable forwarded address chains',
 );
 assert.equal(
   policy.normalizeClientAddress(''),
@@ -117,12 +122,31 @@ assert.equal(
 assert.ok(buckets.every((bucket) => Number.isInteger(bucket.maxRequests)));
 assert.ok(buckets.every((bucket) => Number.isInteger(bucket.windowSeconds)));
 
+const unknownClientBuckets = policy.getContactRateLimitBuckets({
+  email: 'ada@example.com',
+  clientAddress: 'unknown',
+});
+assert.ok(
+  !unknownClientBuckets.some((bucket) => bucket.bucket === 'contact:ip:unknown:hour'),
+  'unknown client identity must not collapse all visitors into a three-request shared IP bucket',
+);
+
 const routeSource = readFileSync(routePath, 'utf8');
 assert.match(routeSource, /request\.text\(\)/, 'contact route must bound raw body before JSON parse');
 assert.doesNotMatch(routeSource, /request\.json\(\)/, 'contact route must not parse unbounded JSON directly');
 assert.match(routeSource, /CONTACT_BODY_MAX_BYTES/, 'contact route must enforce a byte limit');
 assert.match(routeSource, /assertContactSubmissionRateLimit/, 'contact route must enforce database-backed rate limits');
 assert.match(routeSource, /getContactRateLimitBuckets/, 'contact route must derive rate-limit buckets from normalized inputs');
+assert.doesNotMatch(
+  routeSource,
+  /x-forwarded-for|x-real-ip/i,
+  'contact route must not trust spoofable forwarded headers for client rate-limit identity',
+);
+assert.match(
+  routeSource,
+  /runtimeClientIp\(request\)/,
+  'contact route must derive client rate-limit identity from runtime peer metadata',
+);
 
 const storageSource = readFileSync(storagePath, 'utf8');
 assert.match(storageSource, /site_contact_rate_limits/, 'contact storage must include a rate-limit table');

--- a/site/src/app/api/contact/route.ts
+++ b/site/src/app/api/contact/route.ts
@@ -34,6 +34,10 @@ type EmailConfig = {
   toEmail: string;
 };
 
+type RuntimePeerRequest = NextRequest & {
+  ip?: string;
+};
+
 const RESEND_API_KEY_PREFIX = 're_';
 const CONTACT_QUEUE_ERROR = 'Unable to queue inquiry right now.';
 const CONTACT_RATE_LIMIT_ERROR = 'Too many inquiries. Please try again later.';
@@ -45,6 +49,11 @@ function clean(value: unknown): string {
     return '';
   }
   return value.trim();
+}
+
+function runtimeClientIp(request: NextRequest): string | null {
+  const candidate = (request as RuntimePeerRequest).ip;
+  return typeof candidate === 'string' ? candidate : null;
 }
 
 function normalizeSecret(value: string | undefined): string {
@@ -163,9 +172,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'Invalid payload format.' }, { status: 400 });
   }
 
-  const clientAddress = normalizeClientAddress(
-    request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip'),
-  );
+  const clientAddress = normalizeClientAddress(runtimeClientIp(request));
   try {
     const withinRateLimit = await assertContactSubmissionRateLimit(
       getContactRateLimitBuckets({

--- a/site/src/lib/contact-intake-policy.ts
+++ b/site/src/lib/contact-intake-policy.ts
@@ -130,28 +130,34 @@ export function validateContactPayload(data: Record<string, unknown>): ContactPa
 }
 
 export function normalizeClientAddress(value: string | null | undefined): string {
-  const firstAddress = (value || '').split(',')[0]?.trim() || '';
-  if (!firstAddress) {
+  const normalized = (value || '').trim();
+  if (!normalized || normalized.includes(',') || /\s/.test(normalized)) {
     return 'unknown';
   }
-  return firstAddress.slice(0, CONTACT_FIELD_LIMITS.clientAddress);
+  return normalized.slice(0, CONTACT_FIELD_LIMITS.clientAddress);
 }
 
 export function getContactRateLimitBuckets(input: {
   email: string;
   clientAddress: string;
 }): ContactRateLimitBucket[] {
-  return [
+  const buckets: ContactRateLimitBucket[] = [
     {
       bucket: 'contact:global:minute',
       maxRequests: 30,
       windowSeconds: 60,
     },
-    {
+  ];
+
+  if (input.clientAddress !== 'unknown') {
+    buckets.push({
       bucket: `contact:ip:${input.clientAddress}:hour`,
       maxRequests: 3,
       windowSeconds: 3600,
-    },
+    });
+  }
+
+  buckets.push(
     {
       bucket: `contact:email:${input.email}:day`,
       maxRequests: 5,
@@ -162,5 +168,7 @@ export function getContactRateLimitBuckets(input: {
       maxRequests: 200,
       windowSeconds: 86400,
     },
-  ];
+  );
+
+  return buckets;
 }


### PR DESCRIPTION
## Summary
- classify row 7 as adjacent surface: public site contact endpoint, not EXOCHAIN core runtime
- stop deriving contact per-client rate-limit buckets from caller-controlled `x-forwarded-for` / `x-real-ip` headers
- use runtime peer metadata when available and omit the strict per-IP bucket when identity is unknown, leaving global and email buckets in force
- extend the contact intake guard to prove forwarded chains collapse to `unknown` and the route does not read spoofable forwarding headers

## Adjacent Surface Intake
- owner/accountable maintainer: EXOCHAIN site maintainer
- deployment status: production public web presence
- constitutional trust claims: site copy only; contact form is not allowed to mint or simulate EXOCHAIN trust decisions
- core state access: no EXOCHAIN core state, signatures, credentials, governance outcomes, consent records, or provenance records are read or written by this endpoint
- trust boundary: public browser input enters `/api/contact`, is validated locally, rate-limited in the site database, and queued for support notification; EXOCHAIN core remains out of path
- test command/CI gate: `npm --prefix site run security:contact-intake`, `npm --prefix site run security:contact-disclosure`, `npm --prefix site run typecheck`, `npm --prefix site run lint`, `npm --prefix site run build`
- secrets inventory/config: `CONTACT_DATABASE_URL`/`DATABASE_URL`, `RESEND_API_KEY`, `CONTACT_TO_EMAIL`, `CONTACT_FROM_EMAIL` from site runtime environment
- rollback/disablement: remove or block `/api/contact`; submissions fail closed with 503 if database rate-limit state cannot be checked

## Verification
- RED: `npm --prefix site run security:contact-intake` failed because a forged forwarded chain normalized to `203.0.113.7` instead of `unknown`
- GREEN: `npm --prefix site run security:contact-intake`
- `npm --prefix site run security:contact-disclosure`
- `npm --prefix site run typecheck`
- `npm --prefix site run lint`
- `npm --prefix site run build`
- `npm --prefix site audit --audit-level=critical` (no critical advisories; existing high Next/eslint advisories remain outside this row)
- `git diff --check`
- `rg -n "x-forwarded-for|x-real-ip|forwardedFor|normalizeClientAddress\(" site/src/app/api/contact site/src/lib/contact-intake-policy.ts site/src/lib/contact-submissions.ts site/scripts/test-contact-intake-policy.mjs`