### PR TITLE
fix(node): require auth for challenge reads

### DIFF
--- a/crates/exo-node/src/auth.rs
+++ b/crates/exo-node/src/auth.rs
@@ -154,6 +154,8 @@ fn is_sensitive_read_path(path: &str) -> bool {
         || path.starts_with("/api/v1/receipts/")
         || path.starts_with("/api/v1/provenance/")
         || path.starts_with("/api/v1/avc/")
+        || path == "/api/v1/challenges"
+        || path.starts_with("/api/v1/challenges/")
         || (path.starts_with("/api/v1/economy/") && path != "/api/v1/economy/policy/active")
         || (path.starts_with("/api/v1/agents/") && path.ends_with("/avcs"))
 }
@@ -187,8 +189,8 @@ fn is_zerodentity_local_signed_write(method: &axum::http::Method, path: &str) ->
 /// trust-object reads.
 ///
 /// Public `GET` and `HEAD` requests pass through without authentication unless
-/// they target receipts, provenance, AVCs, economy trust objects, or agent
-/// credential listings. The active economy policy remains public. All
+/// they target receipts, provenance, AVCs, challenge holds, economy trust
+/// objects, or agent credential listings. The active economy policy remains public. All
 /// other methods (`POST`, `PUT`, `DELETE`, `PATCH`) require
 /// `Authorization: Bearer <token>` unless they are exact 0dentity signed-write
 /// routes whose handlers perform identity-session and request-signature checks.
@@ -266,6 +268,8 @@ mod tests {
             .route("/api/v1/provenance/:hash", get(|| async { "provenance" }))
             .route("/api/v1/avc/:id", get(|| async { "credential" }))
             .route("/api/v1/agents/:did/avcs", get(|| async { "credentials" }))
+            .route("/api/v1/challenges", get(|| async { "challenges" }))
+            .route("/api/v1/challenges/:id", get(|| async { "challenge" }))
             .route(
                 "/api/v1/economy/bailment-terms/:id",
                 get(|| async { "bailment terms" }),
@@ -424,6 +428,38 @@ mod tests {
                 Request::builder()
                     .method("GET")
                     .uri("/api/v1/agents/did:exo:alice/avcs")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn challenge_list_get_without_token_rejected() {
+        let app = test_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/challenges")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn challenge_get_without_token_rejected() {
+        let app = test_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/challenges/00000000-0000-0000-0000-000000000000")
                     .body(Body::empty())
                     .unwrap(),
             )


### PR DESCRIPTION
## Summary
- classifies `/api/v1/challenges` and `/api/v1/challenges/*` as sensitive read paths in the node auth middleware
- adds regression coverage proving unauthenticated challenge collection and challenge item reads are rejected
- keeps public GET/HEAD behavior unchanged for non-sensitive reads and the active economy policy exception

## Classification
- Core runtime adapter: `crates/exo-node/src/auth.rs`
- No adjacent surfaces, imported evidence, docs metrics, or third-party code changed

## Validation
- RED: `cargo test -p exo-node challenge_list_get_without_token_rejected -- --nocapture` failed with 200 vs 401 before implementation
- RED: `cargo test -p exo-node challenge_get_without_token_rejected -- --nocapture` failed with 200 vs 401 before implementation
- GREEN: `cargo test -p exo-node challenge_list_get_without_token_rejected -- --nocapture`
- GREEN: `cargo test -p exo-node challenge_get_without_token_rejected -- --nocapture`
- `cargo test -p exo-node auth::tests:: -- --nocapture`
- `cargo test -p exo-node`
- `cargo clippy -p exo-node --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Supersedes stale PR #432 with a current-main implementation and without README metric churn.