### PR TITLE
fix(economy): bind settlement receipts to store chain

### DIFF
--- a/crates/exo-economy/src/store.rs
+++ b/crates/exo-economy/src/store.rs
@@ -398,6 +398,14 @@ impl EconomyStore for InMemoryEconomyStore {
                 reason: format!("duplicate settlement receipt {}", receipt.id),
             });
         }
+        if receipt.prev_settlement_receipt != self.latest_receipt_hash {
+            return Err(EconomyError::InvalidInput {
+                reason: format!(
+                    "settlement receipt prev_settlement_receipt {} does not match latest receipt hash {}",
+                    receipt.prev_settlement_receipt, self.latest_receipt_hash
+                ),
+            });
+        }
         self.receipt_by_hash
             .insert(receipt.content_hash, receipt.id.clone());
         self.latest_receipt_hash = receipt.content_hash;
@@ -711,6 +719,41 @@ mod tests {
         let receipt = settle(&q, &ctx, |_| fixed_signature()).unwrap();
         store.put_receipt(receipt.clone()).unwrap();
         assert!(store.put_receipt(receipt).is_err());
+    }
+
+    #[test]
+    fn put_receipt_rejects_receipt_not_chained_to_latest_hash() {
+        let mut store = InMemoryEconomyStore::new();
+        let policy = PricingPolicy::zero_launch_default();
+        let q = quote(&policy, &baseline_inputs(), "q-1".into()).unwrap();
+        let first_context = SettlementContext {
+            receipt_id: "rec-1".into(),
+            custody_transaction_hash: Hash256::from_bytes([0x33; 32]),
+            prev_settlement_receipt: store.latest_receipt_hash(),
+            now: Timestamp::new(1_010_000, 0),
+        };
+        let first_receipt = settle(&q, &first_context, |_| fixed_signature()).unwrap();
+        store.put_receipt(first_receipt.clone()).unwrap();
+
+        let mut inputs2 = baseline_inputs();
+        inputs2.compute_units = 200;
+        let q2 = quote(&policy, &inputs2, "q-2".into()).unwrap();
+        let fork_context = SettlementContext {
+            receipt_id: "rec-2".into(),
+            custody_transaction_hash: Hash256::from_bytes([0x44; 32]),
+            prev_settlement_receipt: Hash256::from_bytes([0xFA; 32]),
+            now: Timestamp::new(1_020_000, 0),
+        };
+        let forked_receipt = settle(&q2, &fork_context, |_| fixed_signature()).unwrap();
+
+        let err = store.put_receipt(forked_receipt).unwrap_err();
+        assert!(matches!(
+            err,
+            EconomyError::InvalidInput { reason }
+                if reason.contains("prev_settlement_receipt")
+                    && reason.contains("latest receipt hash")
+        ));
+        assert_eq!(store.latest_receipt_hash(), first_receipt.content_hash);
     }
 
     #[test]
@@ -1038,5 +1081,21 @@ mod tests {
         assert_ne!(r1.content_hash, r2.content_hash);
         assert_eq!(r2.prev_settlement_receipt, r1.content_hash);
         assert_eq!(store.latest_receipt_hash(), r2.content_hash);
+    }
+
+    #[test]
+    fn receipt_store_checks_chain_head_before_advancing_latest_hash() {
+        let source = include_str!("store.rs");
+        let production = source.split("#[cfg(test)]").next().unwrap();
+        let guard_index = production
+            .find("receipt.prev_settlement_receipt != self.latest_receipt_hash")
+            .expect("receipt store must compare receipt chain head to latest hash");
+        let update_index = production
+            .find("self.latest_receipt_hash = receipt.content_hash")
+            .expect("receipt store must advance latest receipt hash after validation");
+        assert!(
+            guard_index < update_index,
+            "receipt store must reject forked receipts before advancing the latest hash"
+        );
     }
 }

--- a/crates/exo-node/src/economy.rs
+++ b/crates/exo-node/src/economy.rs
@@ -448,13 +448,14 @@ async fn handle_settle(
     Json(payload): Json<SettleRequest>,
 ) -> ApiResult<Json<SettlementReceipt>> {
     let quote_hash = parse_hash(&payload.quote_hash_hex)?;
-    let context = payload.context;
+    let mut context = payload.context;
     let settlement_signer = Arc::clone(&state.settlement_signer);
     let receipt = with_store_blocking(state, move |store| {
         let stored = store
             .get_quote(&quote_hash)
             .map_err(map_economy_error)?
             .ok_or_else(|| map_economy_error(EconomyError::QuoteNotFound))?;
+        context.prev_settlement_receipt = store.latest_receipt_hash();
         let receipt = settle(&stored, &context, |payload| (settlement_signer)(payload))
             .map_err(map_economy_error)?;
         store
@@ -1873,6 +1874,110 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn settle_derives_previous_receipt_from_store_not_payload() {
+        let (state, _) = fresh_signed_state();
+        let app = economy_router(Arc::clone(&state));
+
+        let first_quote_request = QuoteRequest {
+            quote_id: "q-1".into(),
+            inputs: baseline_inputs(),
+        };
+        let first_quote_body = serde_json::to_vec(&first_quote_request).unwrap();
+        let first_quote_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/economy/quote")
+                    .header("content-type", "application/json")
+                    .body(Body::from(first_quote_body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let first_quote: SettlementQuote =
+            serde_json::from_slice(&read_body(first_quote_response).await).unwrap();
+
+        let first_settle_request = SettleRequest {
+            quote_hash_hex: format!("{}", first_quote.quote_hash),
+            context: SettlementContext {
+                receipt_id: "rec-1".into(),
+                custody_transaction_hash: Hash256::from_bytes([0x33; 32]),
+                prev_settlement_receipt: Hash256::from_bytes([0xAA; 32]),
+                now: Timestamp::new(1_010_000, 0),
+            },
+        };
+        let first_settle_body = serde_json::to_vec(&first_settle_request).unwrap();
+        let first_settle_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/economy/settle")
+                    .header("content-type", "application/json")
+                    .body(Body::from(first_settle_body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first_settle_response.status(), StatusCode::OK);
+        let first_receipt: SettlementReceipt =
+            serde_json::from_slice(&read_body(first_settle_response).await).unwrap();
+        assert_eq!(first_receipt.prev_settlement_receipt, Hash256::ZERO);
+
+        let mut second_inputs = baseline_inputs();
+        second_inputs.compute_units = 200;
+        let second_quote_request = QuoteRequest {
+            quote_id: "q-2".into(),
+            inputs: second_inputs,
+        };
+        let second_quote_body = serde_json::to_vec(&second_quote_request).unwrap();
+        let second_quote_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/economy/quote")
+                    .header("content-type", "application/json")
+                    .body(Body::from(second_quote_body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let second_quote: SettlementQuote =
+            serde_json::from_slice(&read_body(second_quote_response).await).unwrap();
+
+        let second_settle_request = SettleRequest {
+            quote_hash_hex: format!("{}", second_quote.quote_hash),
+            context: SettlementContext {
+                receipt_id: "rec-2".into(),
+                custody_transaction_hash: Hash256::from_bytes([0x44; 32]),
+                prev_settlement_receipt: Hash256::from_bytes([0xBB; 32]),
+                now: Timestamp::new(1_020_000, 0),
+            },
+        };
+        let second_settle_body = serde_json::to_vec(&second_settle_request).unwrap();
+        let second_settle_response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/economy/settle")
+                    .header("content-type", "application/json")
+                    .body(Body::from(second_settle_body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(second_settle_response.status(), StatusCode::OK);
+        let second_receipt: SettlementReceipt =
+            serde_json::from_slice(&read_body(second_settle_response).await).unwrap();
+        assert_eq!(
+            second_receipt.prev_settlement_receipt,
+            first_receipt.content_hash
+        );
+    }
+
+    #[tokio::test]
     async fn settle_returns_404_for_unknown_quote() {
         let state = fresh_state();
         let app = economy_router(Arc::clone(&state));
@@ -2523,6 +2628,22 @@ mod tests {
         assert!(
             !production.contains("Signature::empty()"),
             "production economy settlement must not fabricate empty receipt signatures"
+        );
+    }
+
+    #[test]
+    fn settle_handler_derives_chain_head_from_store_before_signing_receipt() {
+        let source = include_str!("economy.rs");
+        let production = source.split("#[cfg(test)]").next().unwrap();
+        let derivation_index = production
+            .find("context.prev_settlement_receipt = store.latest_receipt_hash()")
+            .expect("settlement handler must derive prev_settlement_receipt from the store");
+        let settle_index = production
+            .find("let receipt = settle(&stored, &context")
+            .expect("settlement handler must call settle with the derived context");
+        assert!(
+            derivation_index < settle_index,
+            "settlement handler must derive the chain head before signing the receipt"
         );
     }
 }


### PR DESCRIPTION
## Summary
- rejects settlement receipts whose prev_settlement_receipt does not match the persisted store head before advancing latest_receipt_hash
- derives /api/v1/economy/settle receipt chain heads from the store, ignoring caller-supplied previous receipt hashes before signing
- adds regression/source-guard coverage for both the core store boundary and node adapter boundary

## Path Classification
- EXOCHAIN core: crates/exo-economy/src/store.rs
- Core runtime adapter: crates/exo-node/src/economy.rs

## Verification
- RED: cargo test -p exo-economy put_receipt_rejects_receipt_not_chained_to_latest_hash -- --nocapture
- RED: cargo test -p exo-node settle_derives_previous_receipt_from_store_not_payload -- --nocapture
- RED: cargo test -p exo-economy receipt_store_checks_chain_head_before_advancing_latest_hash -- --nocapture
- RED: cargo test -p exo-node settle_handler_derives_chain_head_from_store_before_signing_receipt -- --nocapture
- GREEN: cargo test -p exo-economy put_receipt_rejects_receipt_not_chained_to_latest_hash -- --nocapture
- GREEN: cargo test -p exo-economy receipt_store_checks_chain_head_before_advancing_latest_hash -- --nocapture
- GREEN: cargo test -p exo-node settle_derives_previous_receipt_from_store_not_payload -- --nocapture
- GREEN: cargo test -p exo-node settle_handler_derives_chain_head_from_store_before_signing_receipt -- --nocapture
- cargo test -p exo-economy
- cargo test -p exo-node
- cargo clippy -p exo-economy -p exo-node --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- production-source guard search for HashMap/HashSet/wall-clock/unsafe/unwrap/expect in touched production slices
- bypass search: rg -n "put_receipt\(" crates --glob "*.rs"
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo deny check (existing duplicate-version warnings only; advisories/bans/licenses/sources ok)
- cargo audit
- cargo doc --workspace --no-deps
- cargo build --workspace --release

Supersedes stale PR #434 after verification against current main.
