### PR TITLE
fix(node): protect ExoForge read surfaces

### DIFF
--- a/crates/exo-node/src/auth.rs
+++ b/crates/exo-node/src/auth.rs
@@ -156,6 +156,8 @@ fn is_sensitive_read_path(path: &str) -> bool {
         || path.starts_with("/api/v1/avc/")
         || path == "/api/v1/challenges"
         || path.starts_with("/api/v1/challenges/")
+        || path == "/exoforge"
+        || path.starts_with("/api/v1/forge/")
         || (path.starts_with("/api/v1/economy/") && path != "/api/v1/economy/policy/active")
         || (path.starts_with("/api/v1/agents/") && path.ends_with("/avcs"))
 }
@@ -190,8 +192,9 @@ fn is_zerodentity_local_signed_write(method: &axum::http::Method, path: &str) ->
 ///
 /// Public `GET` and `HEAD` requests pass through without authentication unless
 /// they target receipts, provenance, AVCs, challenge holds, economy trust
-/// objects, or agent credential listings. The active economy policy remains public. All
-/// other methods (`POST`, `PUT`, `DELETE`, `PATCH`) require
+/// objects, ExoForge build-orchestration state, or agent credential listings.
+/// The active economy policy remains public. All other methods (`POST`, `PUT`,
+/// `DELETE`, `PATCH`) require
 /// `Authorization: Bearer <token>` unless they are exact 0dentity signed-write
 /// routes whose handlers perform identity-session and request-signature checks.
 pub async fn require_bearer_on_writes(
@@ -270,6 +273,10 @@ mod tests {
             .route("/api/v1/agents/:did/avcs", get(|| async { "credentials" }))
             .route("/api/v1/challenges", get(|| async { "challenges" }))
             .route("/api/v1/challenges/:id", get(|| async { "challenge" }))
+            .route("/exoforge", get(|| async { "forge dashboard" }))
+            .route("/api/v1/forge/tasks", get(|| async { "forge tasks" }))
+            .route("/api/v1/forge/stats", get(|| async { "forge stats" }))
+            .route("/api/v1/forge/activity", get(|| async { "forge activity" }))
             .route(
                 "/api/v1/economy/bailment-terms/:id",
                 get(|| async { "bailment terms" }),
@@ -466,6 +473,95 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn exoforge_dashboard_get_without_token_rejected() {
+        let app = test_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/exoforge")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn exoforge_tasks_get_without_token_rejected() {
+        let app = test_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/forge/tasks")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn exoforge_stats_get_without_token_rejected() {
+        let app = test_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/forge/stats")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn exoforge_activity_get_without_token_rejected() {
+        let app = test_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/forge/activity")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn exoforge_read_get_with_correct_token_passes() {
+        let app = test_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/forge/tasks")
+                    .header("authorization", "Bearer test-token-abc123")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn sensitive_read_paths_include_exoforge_surfaces() {
+        assert!(is_sensitive_read_path("/exoforge"));
+        assert!(is_sensitive_read_path("/api/v1/forge/tasks"));
+        assert!(is_sensitive_read_path("/api/v1/forge/stats"));
+        assert!(is_sensitive_read_path("/api/v1/forge/activity"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Protect ExoForge dashboard and `/api/v1/forge/*` read surfaces behind the existing bearer-auth middleware.
- Add regression coverage proving unauthenticated ExoForge reads fail closed and authenticated reads still pass.
- Supersedes stale finding branch/PR #435 after verifying the issue was still live on current `main`.

## Classification
- `crates/exo-node/src/auth.rs`: core runtime adapter.

## Verification
- Verified current `origin/main` (`b5c62afc9983b2bc6ace1fd21222bef724a1e86c`) still mounted ExoForge routes while `is_sensitive_read_path` omitted `/exoforge` and `/api/v1/forge/`.
- RED: `cargo test -p exo-node exoforge_ -- --nocapture` failed with unauthenticated ExoForge GETs returning `200`.
- GREEN: `cargo test -p exo-node exoforge_ -- --nocapture` passed.
- `cargo test -p exo-node auth::tests -- --nocapture`
- `cargo test -p exo-node`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --release`
- `cargo fmt --all -- --check`
- `cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check` (existing duplicate-version warnings only; advisories/bans/licenses/sources ok)
- `git diff --check`
- Production source guard over `crates/exo-node/src/auth.rs` before tests: no `HashMap`, `HashSet`, wall-clock calls, `unsafe`, production `unwrap`, or production `expect`.

## Notes
- During validation, the first full workspace test attempt failed with `No space left on device`; build artifacts in old remediation worktrees were cleaned, and the full workspace test was rerun successfully from a clean target state.
