### PR TITLE
genesis: distributed threshold signing + portal read API + round-2 codec

### DIFF
--- a/crates/exo-node/src/cli.rs
+++ b/crates/exo-node/src/cli.rs
@@ -267,6 +267,34 @@ pub enum GenesisCommand {
     /// Submit a signed envelope to a running root genesis portal.
     #[command(name = "submit-envelope")]
     SubmitEnvelope(GenesisSubmitEnvelopeArgs),
+
+    /// Pull accepted envelopes back from a running portal (read half of the relay).
+    #[command(name = "pull-envelopes")]
+    PullEnvelopes(GenesisPullEnvelopesArgs),
+
+    /// CBOR-encode an encrypted round-two payload into envelope `payload_bytes`.
+    #[command(name = "encode-encrypted-payload")]
+    EncodeEncryptedPayload(GenesisIoArgs),
+
+    /// CBOR-decode envelope `payload_bytes` back into an encrypted round-two payload.
+    #[command(name = "decode-encrypted-payload")]
+    DecodeEncryptedPayload(GenesisIoArgs),
+
+    /// Distributed signing — produce one signer's commitment + secret nonces.
+    #[command(name = "sign-commit")]
+    SignCommit(GenesisIoArgs),
+
+    /// Distributed signing — coordinator builds the signing package from >=7 commitments.
+    #[command(name = "build-signing-package")]
+    BuildSigningPackage(GenesisIoArgs),
+
+    /// Distributed signing — produce one signer's signature share.
+    #[command(name = "sign-share")]
+    SignShare(GenesisIoArgs),
+
+    /// Distributed signing — coordinator aggregates >=7 shares into the root signature.
+    #[command(name = "aggregate-signature")]
+    AggregateSignature(GenesisIoArgs),
 }
 
 #[derive(Subcommand)]
@@ -379,6 +407,31 @@ pub struct GenesisSignEnvelopeArgs {
     /// 32-byte Ed25519 signing secret as hex (from `certifier-NN.private.json`).
     #[arg(long)]
     pub signing_key_hex: String,
+}
+
+#[derive(Args)]
+/// Pull accepted envelopes back from a running portal.
+pub struct GenesisPullEnvelopesArgs {
+    /// Portal base URL (for example `http://127.0.0.1:3017`). The
+    /// `/api/v1/root-genesis/portal/envelopes` path is appended automatically.
+    #[arg(long)]
+    pub portal_url: String,
+
+    /// Optional ceremony phase filter (Round1, Round2, Finalize, RootSigning, ...).
+    #[arg(long)]
+    pub phase: Option<String>,
+
+    /// Optional payload-kind filter (Round1Package, Round2EncryptedPackage, ...).
+    #[arg(long)]
+    pub payload_kind: Option<String>,
+
+    /// Optional recipient DID filter (for recipient-bound round-two packages).
+    #[arg(long)]
+    pub recipient_did: Option<String>,
+
+    /// Output path for the JSON array of matching envelopes.
+    #[arg(long)]
+    pub output: Option<PathBuf>,
 }
 
 #[derive(Args)]

--- a/crates/exo-node/src/root_genesis.rs
+++ b/crates/exo-node/src/root_genesis.rs
@@ -127,7 +127,10 @@ async fn handle_portal_envelopes_query(
         None => None,
     };
     let payload_kind = match &query.payload_kind {
-        Some(value) => Some(parse_query_enum::<CeremonyPayloadKind>(value, "payload_kind")?),
+        Some(value) => Some(parse_query_enum::<CeremonyPayloadKind>(
+            value,
+            "payload_kind",
+        )?),
         None => None,
     };
     let recipient = match &query.recipient_did {

--- a/crates/exo-node/src/root_genesis.rs
+++ b/crates/exo-node/src/root_genesis.rs
@@ -4,13 +4,16 @@ use std::sync::{Arc, Mutex};
 
 use axum::{
     Json, Router,
-    extract::State,
+    extract::{Query, State},
     http::StatusCode,
     routing::{get, post},
 };
-use exo_core::Hash256;
-use exo_root::{CeremonyEnvelope, GenesisCeremonyConfig, PortalStore, RootError};
-use serde::Serialize;
+use exo_core::{Did, Hash256};
+use exo_root::{
+    CeremonyEnvelope, CeremonyPayloadKind, CeremonyPhase, GenesisCeremonyConfig, PortalStore,
+    RootError,
+};
+use serde::{Deserialize, Serialize};
 
 /// Shared root genesis portal state.
 #[derive(Clone)]
@@ -54,7 +57,7 @@ pub fn root_genesis_router(state: RootGenesisApiState) -> Router {
         .route("/api/v1/root-genesis/portal", get(handle_portal_status))
         .route(
             "/api/v1/root-genesis/portal/envelopes",
-            post(handle_portal_envelope),
+            post(handle_portal_envelope).get(handle_portal_envelopes_query),
         )
         .with_state(state)
 }
@@ -93,6 +96,54 @@ async fn handle_portal_envelope(
         )),
         Err(error) => Err(root_error_to_response(error)),
     }
+}
+
+/// Filters for reading relay envelopes back from the portal. Each absent field
+/// matches any value (e.g. `?phase=Round1` collects the round-one broadcast set;
+/// `?phase=Round2&recipient_did=did:exo:...` pulls one recipient's round-two set).
+/// Enum filters are taken as plain strings and parsed explicitly so query
+/// decoding does not depend on enum support in the urlencoded deserializer.
+#[derive(Debug, Default, Deserialize)]
+struct EnvelopeQuery {
+    phase: Option<String>,
+    payload_kind: Option<String>,
+    recipient_did: Option<String>,
+}
+
+fn parse_query_enum<T: serde::de::DeserializeOwned>(
+    value: &str,
+    field: &str,
+) -> Result<T, (StatusCode, Json<ErrorResponse>)> {
+    serde_json::from_value(serde_json::Value::String(value.to_owned()))
+        .map_err(|_| portal_error(StatusCode::BAD_REQUEST, &format!("invalid {field}")))
+}
+
+async fn handle_portal_envelopes_query(
+    State(state): State<RootGenesisApiState>,
+    Query(query): Query<EnvelopeQuery>,
+) -> Result<Json<Vec<CeremonyEnvelope>>, (StatusCode, Json<ErrorResponse>)> {
+    let phase = match &query.phase {
+        Some(value) => Some(parse_query_enum::<CeremonyPhase>(value, "phase")?),
+        None => None,
+    };
+    let payload_kind = match &query.payload_kind {
+        Some(value) => Some(parse_query_enum::<CeremonyPayloadKind>(value, "payload_kind")?),
+        None => None,
+    };
+    let recipient = match &query.recipient_did {
+        Some(value) => Some(
+            Did::new(value)
+                .map_err(|_| portal_error(StatusCode::BAD_REQUEST, "invalid recipient_did"))?,
+        ),
+        None => None,
+    };
+    let portal = state.portal.lock().map_err(|_| {
+        portal_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "portal store lock failed",
+        )
+    })?;
+    Ok(Json(portal.query(phase, payload_kind, recipient.as_ref())))
 }
 
 fn portal_error(status: StatusCode, message: &str) -> (StatusCode, Json<ErrorResponse>) {
@@ -243,6 +294,52 @@ mod tests {
             )
             .await
             .expect("response")
+    }
+
+    async fn get_envelopes(router: axum::Router, query: &str) -> axum::response::Response {
+        router
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(format!("/api/v1/root-genesis/portal/envelopes?{query}"))
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response")
+    }
+
+    #[tokio::test]
+    async fn portal_query_returns_only_matching_envelopes() {
+        let (config, secret) = config();
+        let state = RootGenesisApiState::new(config.clone());
+        let router = root_genesis_router(state);
+        let accepted = post_envelope(
+            router.clone(),
+            &envelope(&config, &secret, 1, b"ct".to_vec()),
+        )
+        .await;
+        assert_eq!(accepted.status(), StatusCode::CREATED);
+
+        // The submitted envelope is a Round2 package; it matches a Round2 query.
+        let matched = get_envelopes(router.clone(), "phase=Round2").await;
+        assert_eq!(matched.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(matched.into_body(), 1 << 20)
+            .await
+            .expect("body bytes");
+        let envelopes: Vec<CeremonyEnvelope> =
+            serde_json::from_slice(&body).expect("envelopes json");
+        assert_eq!(envelopes.len(), 1);
+        assert_eq!(envelopes[0].phase, CeremonyPhase::Round2);
+
+        // A Round1 query matches nothing that was submitted.
+        let empty = get_envelopes(router, "phase=Round1").await;
+        let body = axum::body::to_bytes(empty.into_body(), 1 << 20)
+            .await
+            .expect("body bytes");
+        let envelopes: Vec<CeremonyEnvelope> =
+            serde_json::from_slice(&body).expect("envelopes json");
+        assert!(envelopes.is_empty());
     }
 
     fn poison_portal_lock(state: &RootGenesisApiState) {

--- a/crates/exo-node/src/root_genesis.rs
+++ b/crates/exo-node/src/root_genesis.rs
@@ -312,6 +312,16 @@ mod tests {
             .expect("response")
     }
 
+    async fn count_envelopes(response: axum::response::Response) -> usize {
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1 << 20)
+            .await
+            .expect("body bytes");
+        let envelopes: Vec<CeremonyEnvelope> =
+            serde_json::from_slice(&body).expect("envelopes json");
+        envelopes.len()
+    }
+
     #[tokio::test]
     async fn portal_query_returns_only_matching_envelopes() {
         let (config, secret) = config();
@@ -323,26 +333,60 @@ mod tests {
         )
         .await;
         assert_eq!(accepted.status(), StatusCode::CREATED);
+        let recipient = config.certifiers[1].did.to_string();
+        let other = config.certifiers[2].did.to_string();
 
-        // The submitted envelope is a Round2 package; it matches a Round2 query.
-        let matched = get_envelopes(router.clone(), "phase=Round2").await;
-        assert_eq!(matched.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(matched.into_body(), 1 << 20)
-            .await
-            .expect("body bytes");
-        let envelopes: Vec<CeremonyEnvelope> =
-            serde_json::from_slice(&body).expect("envelopes json");
-        assert_eq!(envelopes.len(), 1);
-        assert_eq!(envelopes[0].phase, CeremonyPhase::Round2);
+        // The submitted envelope is a Round2 package addressed to certifier 2.
+        assert_eq!(
+            count_envelopes(get_envelopes(router.clone(), "phase=Round2").await).await,
+            1
+        );
+        assert_eq!(
+            count_envelopes(get_envelopes(router.clone(), "phase=Round1").await).await,
+            0
+        );
+        assert_eq!(
+            count_envelopes(
+                get_envelopes(router.clone(), "payload_kind=Round2EncryptedPackage").await
+            )
+            .await,
+            1
+        );
+        assert_eq!(
+            count_envelopes(
+                get_envelopes(router.clone(), &format!("recipient_did={recipient}")).await
+            )
+            .await,
+            1
+        );
+        assert_eq!(
+            count_envelopes(get_envelopes(router, &format!("recipient_did={other}")).await).await,
+            0
+        );
+    }
 
-        // A Round1 query matches nothing that was submitted.
-        let empty = get_envelopes(router, "phase=Round1").await;
-        let body = axum::body::to_bytes(empty.into_body(), 1 << 20)
-            .await
-            .expect("body bytes");
-        let envelopes: Vec<CeremonyEnvelope> =
-            serde_json::from_slice(&body).expect("envelopes json");
-        assert!(envelopes.is_empty());
+    #[tokio::test]
+    async fn portal_query_rejects_invalid_filters() {
+        let (config, _secret) = config();
+        let router = root_genesis_router(RootGenesisApiState::new(config));
+        // Unknown enum values -> 400 (parse_query_enum error branch).
+        assert_eq!(
+            get_envelopes(router.clone(), "phase=Bogus").await.status(),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            get_envelopes(router.clone(), "payload_kind=Nope")
+                .await
+                .status(),
+            StatusCode::BAD_REQUEST
+        );
+        // Malformed DID -> 400 (Did::new error branch).
+        assert_eq!(
+            get_envelopes(router, "recipient_did=not-a-did")
+                .await
+                .status(),
+            StatusCode::BAD_REQUEST
+        );
     }
 
     fn poison_portal_lock(state: &RootGenesisApiState) {
@@ -387,6 +431,10 @@ mod tests {
 
         let status = get_status(router.clone()).await;
         assert_eq!(status.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        // Valid filters parse, then the poisoned store lock fails closed.
+        let queried = get_envelopes(router.clone(), "phase=Round1").await;
+        assert_eq!(queried.status(), StatusCode::INTERNAL_SERVER_ERROR);
 
         let submitted = post_envelope(router, &envelope(&config, &secret, 1, b"ct".to_vec())).await;
         assert_eq!(submitted.status(), StatusCode::INTERNAL_SERVER_ERROR);

--- a/crates/exo-node/src/root_genesis_cli.rs
+++ b/crates/exo-node/src/root_genesis_cli.rs
@@ -6,9 +6,10 @@ use exo_core::{Did, Hash256, SecretKey, Timestamp, crypto::KeyPair};
 use exo_root::{
     CeremonyEnvelope, CeremonyEnvelopeDraft, CeremonyPayloadKind, CeremonyPhase, CertifierContact,
     GenesisCeremonyConfig, PairwiseEncryptedPayload, RootIssuerDelegation, RootKeyPackage,
-    RootPublicKeyPackage, RootTrustBundle, assemble_root_bundle, decrypt_pairwise_payload,
-    dkg_finalize_participant, dkg_round1, dkg_round2, encrypt_pairwise_payload, seal_share,
-    threshold_sign, unseal_share, verify_root_bundle,
+    RootPublicKeyPackage, RootTrustBundle, aggregate_signature, assemble_root_bundle,
+    build_signing_package, decrypt_pairwise_payload, dkg_finalize_participant, dkg_round1,
+    dkg_round2, encrypt_pairwise_payload, seal_share, sign_commit, sign_share, threshold_sign,
+    unseal_share, verify_root_bundle,
 };
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -18,7 +19,7 @@ use crate::{
     cli::{
         GenesisCeremonyCommand, GenesisCeremonyInitArgs, GenesisCertifierCommand,
         GenesisCertifierInitArgs, GenesisCommand, GenesisIoArgs, GenesisPortalArgs,
-        GenesisSignEnvelopeArgs, GenesisSubmitEnvelopeArgs,
+        GenesisPullEnvelopesArgs, GenesisSignEnvelopeArgs, GenesisSubmitEnvelopeArgs,
     },
     root_genesis::{RootGenesisApiState, root_genesis_router},
 };
@@ -189,6 +190,51 @@ struct Round1SetAttestationStatement<'a> {
     entries: &'a [Round1SetAttestationEntry],
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct EncodeEncryptedPayloadCommandInput {
+    encrypted: PairwiseEncryptedPayload,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct DecodeEncryptedPayloadCommandInput {
+    payload_bytes: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct PayloadBytesOutput {
+    payload_bytes: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct SignCommitCommandInput {
+    config: GenesisCeremonyConfig,
+    key_package: RootKeyPackage,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct BuildSigningPackageCommandInput {
+    config: GenesisCeremonyConfig,
+    commitments_hex: BTreeMapStringBytes,
+    artifact_hex: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct SignShareCommandInput {
+    config: GenesisCeremonyConfig,
+    key_package: RootKeyPackage,
+    nonces_hex: String,
+    signing_package_hex: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct AggregateSignatureCommandInput {
+    config: GenesisCeremonyConfig,
+    public_key_package: RootPublicKeyPackage,
+    signing_package_hex: String,
+    shares_hex: BTreeMapStringBytes,
+    artifact_hex: String,
+}
+
 type BTreeMapStringBytes = BTreeMap<u16, String>;
 
 /// Execute a root genesis CLI command.
@@ -211,6 +257,13 @@ pub async fn run_genesis_command(command: GenesisCommand) -> anyhow::Result<()> 
         GenesisCommand::EmitArtifactBytes(args) => run_emit_artifact_bytes(args),
         GenesisCommand::BuildRound1Attestation(args) => run_build_round1_attestation(args),
         GenesisCommand::SubmitEnvelope(args) => run_submit_envelope(args).await,
+        GenesisCommand::PullEnvelopes(args) => run_pull_envelopes(args).await,
+        GenesisCommand::EncodeEncryptedPayload(args) => run_encode_encrypted_payload(args),
+        GenesisCommand::DecodeEncryptedPayload(args) => run_decode_encrypted_payload(args),
+        GenesisCommand::SignCommit(args) => run_sign_commit(args),
+        GenesisCommand::BuildSigningPackage(args) => run_build_signing_package(args),
+        GenesisCommand::SignShare(args) => run_sign_share(args),
+        GenesisCommand::AggregateSignature(args) => run_aggregate_signature(args),
     }
 }
 
@@ -521,6 +574,94 @@ async fn run_submit_envelope(args: GenesisSubmitEnvelopeArgs) -> anyhow::Result<
         anyhow::bail!("portal rejected envelope: HTTP {status}");
     }
     Ok(())
+}
+
+async fn run_pull_envelopes(args: GenesisPullEnvelopesArgs) -> anyhow::Result<()> {
+    let url = portal_envelopes_url(&args.portal_url);
+    let mut params: Vec<(&str, String)> = Vec::new();
+    if let Some(phase) = &args.phase {
+        params.push(("phase", phase.clone()));
+    }
+    if let Some(kind) = &args.payload_kind {
+        params.push(("payload_kind", kind.clone()));
+    }
+    if let Some(recipient) = &args.recipient_did {
+        params.push(("recipient_did", recipient.clone()));
+    }
+    let response = reqwest::Client::new()
+        .get(url)
+        .query(&params)
+        .send()
+        .await?;
+    let status = response.status();
+    let body = response.text().await?;
+    if !status.is_success() {
+        anyhow::bail!("portal pull failed: HTTP {status}: {body}");
+    }
+    let envelopes: Vec<CeremonyEnvelope> = serde_json::from_str(&body)?;
+    let io = GenesisIoArgs {
+        input: None,
+        output: args.output.clone(),
+    };
+    write_output(&io, &envelopes)
+}
+
+fn run_encode_encrypted_payload(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: EncodeEncryptedPayloadCommandInput = read_json(&required_input(&args)?)?;
+    let mut payload_bytes = Vec::new();
+    ciborium::into_writer(&input.encrypted, &mut payload_bytes)
+        .map_err(|error| anyhow::anyhow!("encrypted payload encoding failed: {error}"))?;
+    write_output(&args, &PayloadBytesOutput { payload_bytes })
+}
+
+fn run_decode_encrypted_payload(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: DecodeEncryptedPayloadCommandInput = read_json(&required_input(&args)?)?;
+    let encrypted: PairwiseEncryptedPayload = ciborium::from_reader(input.payload_bytes.as_slice())
+        .map_err(|error| anyhow::anyhow!("encrypted payload decoding failed: {error}"))?;
+    write_output(&args, &encrypted)
+}
+
+fn run_sign_commit(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: SignCommitCommandInput = read_json(&required_input(&args)?)?;
+    let mut rng = rand::rngs::OsRng;
+    let output = sign_commit(&input.config, &input.key_package, &mut rng)?;
+    // Contains secret signing nonces — never print to stdout.
+    write_secret_output(&args, &output)
+}
+
+fn run_build_signing_package(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: BuildSigningPackageCommandInput = read_json(&required_input(&args)?)?;
+    let message = decode_hex(&input.artifact_hex)?;
+    let output = build_signing_package(
+        &input.config,
+        decode_package_map(input.commitments_hex)?,
+        message.as_slice(),
+    )?;
+    write_output(&args, &output)
+}
+
+fn run_sign_share(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: SignShareCommandInput = read_json(&required_input(&args)?)?;
+    let output = sign_share(
+        &input.config,
+        &input.key_package,
+        decode_hex(&input.nonces_hex)?.as_slice(),
+        decode_hex(&input.signing_package_hex)?.as_slice(),
+    )?;
+    write_output(&args, &output)
+}
+
+fn run_aggregate_signature(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: AggregateSignatureCommandInput = read_json(&required_input(&args)?)?;
+    let message = decode_hex(&input.artifact_hex)?;
+    let output = aggregate_signature(
+        &input.config,
+        &input.public_key_package,
+        decode_hex(&input.signing_package_hex)?.as_slice(),
+        decode_package_map(input.shares_hex)?,
+        message.as_slice(),
+    )?;
+    write_output(&args, &output)
 }
 
 /// Append the portal envelopes path to a base URL unless it is already present.

--- a/crates/exo-node/src/root_genesis_cli.rs
+++ b/crates/exo-node/src/root_genesis_cli.rs
@@ -1233,6 +1233,127 @@ mod tests {
             .expect("portal accepts the attestation envelope");
     }
 
+    #[test]
+    fn distributed_signing_handlers_produce_a_verifiable_signature() {
+        let config = rostered_config();
+        let dkg = exo_root::run_complete_dkg(&config, &mut rand::rngs::OsRng).expect("dkg");
+        let message = b"distributed root artifact";
+        let artifact_hex = hex::encode(message);
+        let directory = tempdir().expect("temporary directory");
+        let signers: Vec<u16> = (1..=7).collect();
+
+        let mut commitments_hex = BTreeMap::new();
+        let mut nonces_hex = BTreeMap::new();
+        for id in &signers {
+            let in_path = directory.path().join(format!("commit-in-{id}.json"));
+            let out_path = directory.path().join(format!("commit-out-{id}.json"));
+            write_json(
+                &in_path,
+                &SignCommitCommandInput {
+                    config: config.clone(),
+                    key_package: dkg.key_packages[id].clone(),
+                },
+            )
+            .expect("write commit input");
+            run_sign_commit(io_args(in_path, out_path.clone())).expect("sign-commit");
+            let commit: exo_root::RootSigningCommitment =
+                read_json(&out_path).expect("read commitment");
+            commitments_hex.insert(*id, hex::encode(&commit.commitments));
+            nonces_hex.insert(*id, hex::encode(&commit.nonces));
+        }
+
+        let pkg_in = directory.path().join("pkg-in.json");
+        let pkg_out = directory.path().join("pkg-out.json");
+        write_json(
+            &pkg_in,
+            &BuildSigningPackageCommandInput {
+                config: config.clone(),
+                commitments_hex,
+                artifact_hex: artifact_hex.clone(),
+            },
+        )
+        .expect("write package input");
+        run_build_signing_package(io_args(pkg_in, pkg_out.clone())).expect("build-signing-package");
+        let package: exo_root::RootSigningPackage = read_json(&pkg_out).expect("read package");
+        let signing_package_hex = hex::encode(&package.signing_package);
+
+        let mut shares_hex = BTreeMap::new();
+        for id in &signers {
+            let in_path = directory.path().join(format!("share-in-{id}.json"));
+            let out_path = directory.path().join(format!("share-out-{id}.json"));
+            write_json(
+                &in_path,
+                &SignShareCommandInput {
+                    config: config.clone(),
+                    key_package: dkg.key_packages[id].clone(),
+                    nonces_hex: nonces_hex[id].clone(),
+                    signing_package_hex: signing_package_hex.clone(),
+                },
+            )
+            .expect("write share input");
+            run_sign_share(io_args(in_path, out_path.clone())).expect("sign-share");
+            let share: exo_root::RootSignatureShareOutput =
+                read_json(&out_path).expect("read share");
+            shares_hex.insert(*id, hex::encode(&share.signature_share));
+        }
+
+        let agg_in = directory.path().join("agg-in.json");
+        let agg_out = directory.path().join("agg-out.json");
+        write_json(
+            &agg_in,
+            &AggregateSignatureCommandInput {
+                config: config.clone(),
+                public_key_package: dkg.public_key_package.clone(),
+                signing_package_hex,
+                shares_hex,
+                artifact_hex,
+            },
+        )
+        .expect("write aggregate input");
+        run_aggregate_signature(io_args(agg_in, agg_out.clone())).expect("aggregate-signature");
+        let signature: exo_root::RootSignature = read_json(&agg_out).expect("read signature");
+        assert_eq!(signature.signer_ids.len(), 7);
+        exo_root::verify_root_signature(
+            &dkg.public_key_package.root_public_key,
+            message,
+            &signature.signature,
+        )
+        .expect("distributed signature verifies against the root key");
+    }
+
+    #[test]
+    fn encrypted_payload_codec_round_trips_through_the_cli() {
+        let payload = PairwiseEncryptedPayload {
+            nonce: [5u8; 24],
+            ciphertext: b"recipient-bound ciphertext".to_vec(),
+        };
+        let directory = tempdir().expect("temporary directory");
+        let enc_in = directory.path().join("encode-in.json");
+        let enc_out = directory.path().join("encode-out.json");
+        write_json(
+            &enc_in,
+            &EncodeEncryptedPayloadCommandInput {
+                encrypted: payload.clone(),
+            },
+        )
+        .expect("write encode input");
+        run_encode_encrypted_payload(io_args(enc_in, enc_out.clone())).expect("encode");
+        let encoded: PayloadBytesOutput = read_json(&enc_out).expect("read encoded");
+
+        let dec_in = directory.path().join("decode-in.json");
+        let dec_out = directory.path().join("decode-out.json");
+        write_json(
+            &dec_in,
+            &DecodeEncryptedPayloadCommandInput {
+                payload_bytes: encoded.payload_bytes,
+            },
+        )
+        .expect("write decode input");
+        run_decode_encrypted_payload(io_args(dec_in, dec_out.clone())).expect("decode");
+        let decoded: PairwiseEncryptedPayload = read_json(&dec_out).expect("read decoded");
+        assert_eq!(decoded, payload);
+    }
+
     #[tokio::test]
     async fn submit_envelope_posts_signed_envelope_to_running_portal() {
         let config = rostered_config();

--- a/crates/exo-root/src/lib.rs
+++ b/crates/exo-root/src/lib.rs
@@ -27,4 +27,8 @@ pub use seal::{
     PairwiseEncryptedPayload, SealedShare, decrypt_pairwise_payload, encrypt_pairwise_payload,
     seal_share, unseal_share,
 };
-pub use signing::{RootSignature, threshold_sign, verify_root_signature};
+pub use signing::{
+    RootSignature, RootSignatureShareOutput, RootSigningCommitment, RootSigningPackage,
+    aggregate_signature, build_signing_package, sign_commit, sign_share, threshold_sign,
+    verify_root_signature,
+};

--- a/crates/exo-root/src/portal.rs
+++ b/crates/exo-root/src/portal.rs
@@ -353,12 +353,140 @@ fn key_parts(key: &PortalEnvelopeKey) -> PortalEnvelopeKeyParts<'_> {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
+    use exo_core::{Timestamp, crypto::KeyPair};
+
     use super::*;
+    use crate::{CertifierContact, PairwiseEncryptedPayload};
+
+    fn certifier(index: u16) -> (CertifierContact, exo_core::SecretKey) {
+        let seed = [u8::try_from(index).expect("index fits"); 32];
+        let keypair = KeyPair::from_secret_bytes(seed).expect("keypair");
+        let transport_public =
+            x25519_dalek::PublicKey::from(&x25519_dalek::StaticSecret::from(seed));
+        (
+            CertifierContact {
+                did: Did::new(&format!("did:exo:portal-query-{index:02}")).expect("did"),
+                frost_identifier: index,
+                signing_public_key: *keypair.public_key(),
+                transport_public_key: *transport_public.as_bytes(),
+            },
+            keypair.secret_key().clone(),
+        )
+    }
+
+    fn config_with_secrets() -> (GenesisCeremonyConfig, Vec<SecretKey>) {
+        let mut certifiers = Vec::new();
+        let mut secrets = Vec::new();
+        for index in 1..=crate::ROOT_GENESIS_SIGNERS {
+            let (contact, secret) = certifier(index);
+            certifiers.push(contact);
+            secrets.push(secret);
+        }
+        (
+            GenesisCeremonyConfig {
+                ceremony_id: "portal-query".into(),
+                network_id: "exochain-test".into(),
+                repo_commit: "d8927686a34bdc28ba36d53938f665685d2c4c04".into(),
+                constitution_hash: Hash256::digest(b"constitution"),
+                threshold: crate::ROOT_GENESIS_THRESHOLD,
+                max_signers: crate::ROOT_GENESIS_SIGNERS,
+                created_at: Timestamp::new(1, 0),
+                certifiers,
+            },
+            secrets,
+        )
+    }
+
+    fn encrypted_payload_bytes() -> Vec<u8> {
+        let payload = PairwiseEncryptedPayload {
+            nonce: [9u8; 24],
+            ciphertext: b"ciphertext".to_vec(),
+        };
+        let mut bytes = Vec::new();
+        ciborium::into_writer(&payload, &mut bytes).expect("encode");
+        bytes
+    }
 
     #[test]
     fn canonical_error_conversion_is_diagnostic() {
         let error = canonical_encoding_error("portal encoding failed");
         assert!(error.to_string().contains("portal encoding failed"));
+    }
+
+    #[test]
+    fn query_filters_by_phase_kind_and_recipient() {
+        let (config, secrets) = config_with_secrets();
+        let mut store = PortalStore::new(config.clone());
+
+        // A round-one broadcast from certifier 1.
+        store
+            .submit(
+                CeremonyEnvelope::sign(
+                    CeremonyEnvelopeDraft {
+                        ceremony_id: config.ceremony_id.clone(),
+                        phase: CeremonyPhase::Round1,
+                        payload_kind: CeremonyPayloadKind::Round1Package,
+                        sender_did: config.certifiers[0].did.clone(),
+                        recipient_did: None,
+                        sequence: 0,
+                        payload_bytes: b"round1".to_vec(),
+                    },
+                    &secrets[0],
+                )
+                .expect("round1 envelope"),
+            )
+            .expect("submit round1");
+
+        // A round-two package from certifier 1 addressed to certifier 2.
+        store
+            .submit(
+                CeremonyEnvelope::sign(
+                    CeremonyEnvelopeDraft {
+                        ceremony_id: config.ceremony_id.clone(),
+                        phase: CeremonyPhase::Round2,
+                        payload_kind: CeremonyPayloadKind::Round2EncryptedPackage,
+                        sender_did: config.certifiers[0].did.clone(),
+                        recipient_did: Some(config.certifiers[1].did.clone()),
+                        sequence: 1,
+                        payload_bytes: encrypted_payload_bytes(),
+                    },
+                    &secrets[0],
+                )
+                .expect("round2 envelope"),
+            )
+            .expect("submit round2");
+
+        // No filters → both envelopes.
+        assert_eq!(store.query(None, None, None).len(), 2);
+        // Phase filter (match + non-match).
+        assert_eq!(store.query(Some(CeremonyPhase::Round1), None, None).len(), 1);
+        assert_eq!(
+            store
+                .query(Some(CeremonyPhase::Finalize), None, None)
+                .len(),
+            0
+        );
+        // Payload-kind filter.
+        assert_eq!(
+            store
+                .query(None, Some(CeremonyPayloadKind::Round2EncryptedPackage), None)
+                .len(),
+            1
+        );
+        // Recipient filter (match + non-match).
+        assert_eq!(
+            store
+                .query(Some(CeremonyPhase::Round2), None, Some(&config.certifiers[1].did))
+                .len(),
+            1
+        );
+        assert_eq!(
+            store
+                .query(None, None, Some(&config.certifiers[2].did))
+                .len(),
+            0
+        );
     }
 }

--- a/crates/exo-root/src/portal.rs
+++ b/crates/exo-root/src/portal.rs
@@ -189,6 +189,29 @@ impl PortalStore {
         self.envelopes.len()
     }
 
+    /// Return accepted envelopes matching all of the supplied filters; a `None`
+    /// filter matches any value. Envelopes are relay data — already signed and
+    /// (for round two) encrypted — so returning them to rostered participants is
+    /// the read half of the relay, used to collect round-one packages, pull
+    /// recipient-bound round-two packages, and gather signing commitments/shares.
+    #[must_use]
+    pub fn query(
+        &self,
+        phase: Option<CeremonyPhase>,
+        payload_kind: Option<CeremonyPayloadKind>,
+        recipient_did: Option<&Did>,
+    ) -> Vec<CeremonyEnvelope> {
+        self.envelopes
+            .values()
+            .filter(|envelope| phase.is_none_or(|value| envelope.phase == value))
+            .filter(|envelope| payload_kind.is_none_or(|value| envelope.payload_kind == value))
+            .filter(|envelope| {
+                recipient_did.is_none_or(|value| envelope.recipient_did.as_ref() == Some(value))
+            })
+            .cloned()
+            .collect()
+    }
+
     /// Submit a signed envelope to the relay.
     pub fn submit(&mut self, envelope: CeremonyEnvelope) -> Result<Hash256> {
         self.validate_envelope(&envelope)?;

--- a/crates/exo-root/src/portal.rs
+++ b/crates/exo-root/src/portal.rs
@@ -461,24 +461,33 @@ mod tests {
         // No filters → both envelopes.
         assert_eq!(store.query(None, None, None).len(), 2);
         // Phase filter (match + non-match).
-        assert_eq!(store.query(Some(CeremonyPhase::Round1), None, None).len(), 1);
         assert_eq!(
-            store
-                .query(Some(CeremonyPhase::Finalize), None, None)
-                .len(),
+            store.query(Some(CeremonyPhase::Round1), None, None).len(),
+            1
+        );
+        assert_eq!(
+            store.query(Some(CeremonyPhase::Finalize), None, None).len(),
             0
         );
         // Payload-kind filter.
         assert_eq!(
             store
-                .query(None, Some(CeremonyPayloadKind::Round2EncryptedPackage), None)
+                .query(
+                    None,
+                    Some(CeremonyPayloadKind::Round2EncryptedPackage),
+                    None
+                )
                 .len(),
             1
         );
         // Recipient filter (match + non-match).
         assert_eq!(
             store
-                .query(Some(CeremonyPhase::Round2), None, Some(&config.certifiers[1].did))
+                .query(
+                    Some(CeremonyPhase::Round2),
+                    None,
+                    Some(&config.certifiers[1].did)
+                )
                 .len(),
             1
         );

--- a/crates/exo-root/src/signing.rs
+++ b/crates/exo-root/src/signing.rs
@@ -135,6 +135,168 @@ fn signature_rejected(error: frost::Error) -> RootError {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Distributed (online) threshold signing.
+//
+// `threshold_sign` above performs the whole protocol in one process and so
+// requires every key package in one place. The functions below run the same
+// FROST protocol as a two-round distributed exchange: each signer keeps its
+// own `RootKeyPackage` and only ever emits PUBLIC commitments and signature
+// shares. A coordinator (holding no secrets) assembles the signing package and
+// aggregates the shares. These map onto the portal's `RootSigningCommitment`
+// and `RootSignatureShare` payload kinds.
+// ---------------------------------------------------------------------------
+
+/// One signer's round-one signing material. `commitments` is public and is
+/// broadcast; `nonces` is SECRET and must be retained locally until `sign_share`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RootSigningCommitment {
+    /// Owner's FROST identifier.
+    pub frost_identifier: u16,
+    /// Serialized public signing commitments (broadcast to the coordinator).
+    pub commitments: Vec<u8>,
+    /// Serialized secret signing nonces (retained by the signer; never shared).
+    pub nonces: Vec<u8>,
+}
+
+/// Public signing package built by the coordinator from `>= threshold`
+/// commitments. Distributed to the participating signers for round two.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RootSigningPackage {
+    /// Serialized FROST signing package (binds the commitments and message).
+    pub signing_package: Vec<u8>,
+    /// Identifiers whose commitments are bound into this package.
+    pub signer_ids: Vec<u16>,
+}
+
+/// One signer's round-two signature share. Public; reveals nothing about the
+/// signer's secret key share.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RootSignatureShareOutput {
+    /// Owner's FROST identifier.
+    pub frost_identifier: u16,
+    /// Serialized FROST signature share.
+    pub signature_share: Vec<u8>,
+}
+
+fn ensure_rostered(config: &GenesisCeremonyConfig, identifier: u16, role: &str) -> Result<()> {
+    if config.certifier_by_identifier(identifier).is_none() {
+        return Err(RootError::InvalidConfig {
+            reason: format!("{role} {identifier} is not rostered"),
+        });
+    }
+    Ok(())
+}
+
+/// Distributed signing — round one. Produce one signer's public commitments and
+/// secret nonces. Run by each participating certifier against its own share.
+pub fn sign_commit<R>(
+    config: &GenesisCeremonyConfig,
+    key_package: &RootKeyPackage,
+    rng: &mut R,
+) -> Result<RootSigningCommitment>
+where
+    R: frost::rand_core::RngCore + frost::rand_core::CryptoRng,
+{
+    config.validate()?;
+    ensure_rostered(config, key_package.frost_identifier, "signer")?;
+    let parsed: frost::keys::KeyPackage = deserialize_frost(key_package.key_package.as_slice())?;
+    let (nonces, commitments) = frost::round1::commit(parsed.signing_share(), rng);
+    Ok(RootSigningCommitment {
+        frost_identifier: key_package.frost_identifier,
+        commitments: serialize_frost(&commitments)?,
+        nonces: serialize_frost(&nonces)?,
+    })
+}
+
+/// Distributed signing — coordinator assembles the signing package from at
+/// least `threshold` public commitments bound to `message` (the root artifact).
+pub fn build_signing_package(
+    config: &GenesisCeremonyConfig,
+    commitments: BTreeMap<u16, Vec<u8>>,
+    message: &[u8],
+) -> Result<RootSigningPackage> {
+    config.validate()?;
+    if commitments.len() < usize::from(config.threshold) {
+        return Err(RootError::ThresholdNotMet {
+            required: config.threshold,
+            supplied: u16::try_from(commitments.len()).unwrap_or(u16::MAX),
+        });
+    }
+    let mut parsed = BTreeMap::new();
+    let mut signer_ids = Vec::new();
+    for (identifier, bytes) in commitments {
+        ensure_rostered(config, identifier, "signer")?;
+        let frost_id = crate::dkg::frost_identifier(identifier)?;
+        let commitment: frost::round1::SigningCommitments = deserialize_frost(bytes.as_slice())?;
+        parsed.insert(frost_id, commitment);
+        signer_ids.push(identifier);
+    }
+    let signing_package = frost::SigningPackage::new(parsed, message);
+    Ok(RootSigningPackage {
+        signing_package: serialize_frost(&signing_package)?,
+        signer_ids,
+    })
+}
+
+/// Distributed signing — round two. One signer produces its signature share
+/// from its key package, its retained nonces, and the coordinator's package.
+pub fn sign_share(
+    config: &GenesisCeremonyConfig,
+    key_package: &RootKeyPackage,
+    nonces: &[u8],
+    signing_package: &[u8],
+) -> Result<RootSignatureShareOutput> {
+    config.validate()?;
+    ensure_rostered(config, key_package.frost_identifier, "signer")?;
+    let parsed_key: frost::keys::KeyPackage = deserialize_frost(key_package.key_package.as_slice())?;
+    let parsed_nonces: frost::round1::SigningNonces = deserialize_frost(nonces)?;
+    let parsed_package: frost::SigningPackage = deserialize_frost(signing_package)?;
+    let share =
+        frost::round2::sign(&parsed_package, &parsed_nonces, &parsed_key).map_err(frost_error)?;
+    Ok(RootSignatureShareOutput {
+        frost_identifier: key_package.frost_identifier,
+        signature_share: serialize_frost(&share)?,
+    })
+}
+
+/// Distributed signing — coordinator aggregates `>= threshold` signature shares
+/// into the final root signature and verifies it against the root public key.
+pub fn aggregate_signature(
+    config: &GenesisCeremonyConfig,
+    public_key_package: &RootPublicKeyPackage,
+    signing_package: &[u8],
+    shares: BTreeMap<u16, Vec<u8>>,
+    message: &[u8],
+) -> Result<RootSignature> {
+    config.validate()?;
+    if shares.len() < usize::from(config.threshold) {
+        return Err(RootError::ThresholdNotMet {
+            required: config.threshold,
+            supplied: u16::try_from(shares.len()).unwrap_or(u16::MAX),
+        });
+    }
+    let public = deserialize_frost(public_key_package.public_key_package.as_slice())?;
+    let parsed_package: frost::SigningPackage = deserialize_frost(signing_package)?;
+    let mut parsed_shares = BTreeMap::new();
+    let mut signer_ids = Vec::new();
+    for (identifier, bytes) in shares {
+        ensure_rostered(config, identifier, "signer")?;
+        let frost_id = crate::dkg::frost_identifier(identifier)?;
+        let share: frost::round2::SignatureShare = deserialize_frost(bytes.as_slice())?;
+        parsed_shares.insert(frost_id, share);
+        signer_ids.push(identifier);
+    }
+    let aggregated =
+        frost::aggregate(&parsed_package, &parsed_shares, &public).map_err(frost_error)?;
+    let signature = serialize_frost(&aggregated)?;
+    verify_root_signature(&public_key_package.root_public_key, message, &signature)?;
+    Ok(RootSignature {
+        signature,
+        signer_ids,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use exo_core::{Did, Hash256, PublicKey, Timestamp};
@@ -253,5 +415,75 @@ mod tests {
         )
         .expect_err("share identifier mismatch");
         assert!(error.to_string().contains("mismatches key 1"));
+    }
+
+    #[test]
+    fn distributed_signing_matches_one_shot_and_verifies() {
+        let config = test_config();
+        let mut rng = StdRng::seed_from_u64(99);
+        let dkg = crate::run_complete_dkg(&config, &mut rng).expect("dkg");
+        let message = b"distributed root signing artifact";
+
+        // Seven signers, each keeping its own key package.
+        let signers: Vec<(u16, _)> = dkg
+            .key_packages
+            .iter()
+            .take(7)
+            .map(|(id, kp)| (*id, kp.clone()))
+            .collect();
+
+        // Round one: each signer commits locally; only commitments are shared.
+        let mut commitments = BTreeMap::new();
+        let mut nonces = BTreeMap::new();
+        for (id, kp) in &signers {
+            let commitment = sign_commit(&config, kp, &mut rng).expect("commit");
+            nonces.insert(*id, commitment.nonces.clone());
+            commitments.insert(*id, commitment.commitments.clone());
+        }
+
+        // Coordinator builds the signing package from the commitments.
+        let package = build_signing_package(&config, commitments, message).expect("package");
+        assert_eq!(package.signer_ids.len(), 7);
+
+        // Round two: each signer produces its share from its own nonces.
+        let mut shares = BTreeMap::new();
+        for (id, kp) in &signers {
+            let share = sign_share(&config, kp, &nonces[id], &package.signing_package)
+                .expect("share");
+            shares.insert(*id, share.signature_share);
+        }
+
+        // Coordinator aggregates; result verifies against the root key and
+        // matches the threshold the one-shot path would accept.
+        let signature = aggregate_signature(
+            &config,
+            &dkg.public_key_package,
+            &package.signing_package,
+            shares,
+            message,
+        )
+        .expect("aggregate");
+        verify_root_signature(
+            &dkg.public_key_package.root_public_key,
+            message,
+            &signature.signature,
+        )
+        .expect("distributed signature verifies");
+        assert_eq!(signature.signer_ids.len(), 7);
+    }
+
+    #[test]
+    fn build_signing_package_rejects_sub_threshold_commitment_set() {
+        let config = test_config();
+        let mut rng = StdRng::seed_from_u64(100);
+        let dkg = crate::run_complete_dkg(&config, &mut rng).expect("dkg");
+        let mut commitments = BTreeMap::new();
+        for (id, kp) in dkg.key_packages.iter().take(3) {
+            let commitment = sign_commit(&config, kp, &mut rng).expect("commit");
+            commitments.insert(*id, commitment.commitments);
+        }
+        let error = build_signing_package(&config, commitments, b"msg")
+            .expect_err("sub-threshold commitments");
+        assert!(matches!(error, RootError::ThresholdNotMet { required: 7, supplied: 3 }));
     }
 }

--- a/crates/exo-root/src/signing.rs
+++ b/crates/exo-root/src/signing.rs
@@ -511,7 +511,12 @@ mod tests {
         // build_signing_package rejects a commitment from an unrostered signer.
         let mut commitments = BTreeMap::new();
         for (id, kp) in dkg.key_packages.iter().take(7) {
-            commitments.insert(*id, sign_commit(&config, kp, &mut rng).expect("commit").commitments);
+            commitments.insert(
+                *id,
+                sign_commit(&config, kp, &mut rng)
+                    .expect("commit")
+                    .commitments,
+            );
         }
         let mut unrostered = commitments.clone();
         let stolen = unrostered.remove(&1).expect("commitment one");

--- a/crates/exo-root/src/signing.rs
+++ b/crates/exo-root/src/signing.rs
@@ -249,7 +249,8 @@ pub fn sign_share(
 ) -> Result<RootSignatureShareOutput> {
     config.validate()?;
     ensure_rostered(config, key_package.frost_identifier, "signer")?;
-    let parsed_key: frost::keys::KeyPackage = deserialize_frost(key_package.key_package.as_slice())?;
+    let parsed_key: frost::keys::KeyPackage =
+        deserialize_frost(key_package.key_package.as_slice())?;
     let parsed_nonces: frost::round1::SigningNonces = deserialize_frost(nonces)?;
     let parsed_package: frost::SigningPackage = deserialize_frost(signing_package)?;
     let share =
@@ -448,8 +449,8 @@ mod tests {
         // Round two: each signer produces its share from its own nonces.
         let mut shares = BTreeMap::new();
         for (id, kp) in &signers {
-            let share = sign_share(&config, kp, &nonces[id], &package.signing_package)
-                .expect("share");
+            let share =
+                sign_share(&config, kp, &nonces[id], &package.signing_package).expect("share");
             shares.insert(*id, share.signature_share);
         }
 
@@ -484,6 +485,62 @@ mod tests {
         }
         let error = build_signing_package(&config, commitments, b"msg")
             .expect_err("sub-threshold commitments");
-        assert!(matches!(error, RootError::ThresholdNotMet { required: 7, supplied: 3 }));
+        assert!(matches!(
+            error,
+            RootError::ThresholdNotMet {
+                required: 7,
+                supplied: 3
+            }
+        ));
+    }
+
+    #[test]
+    fn distributed_signing_rejects_unrostered_and_sub_threshold() {
+        let config = test_config();
+        let mut rng = StdRng::seed_from_u64(123);
+        let dkg = crate::run_complete_dkg(&config, &mut rng).expect("dkg");
+
+        // sign_commit rejects an unrostered key package.
+        let mut stranger = dkg.key_packages[&1].clone();
+        stranger.frost_identifier = 99;
+        assert!(matches!(
+            sign_commit(&config, &stranger, &mut rng).expect_err("unrostered commit"),
+            RootError::InvalidConfig { .. }
+        ));
+
+        // build_signing_package rejects a commitment from an unrostered signer.
+        let mut commitments = BTreeMap::new();
+        for (id, kp) in dkg.key_packages.iter().take(7) {
+            commitments.insert(*id, sign_commit(&config, kp, &mut rng).expect("commit").commitments);
+        }
+        let mut unrostered = commitments.clone();
+        let stolen = unrostered.remove(&1).expect("commitment one");
+        unrostered.insert(99, stolen);
+        assert!(matches!(
+            build_signing_package(&config, unrostered, b"msg").expect_err("unrostered commitment"),
+            RootError::InvalidConfig { .. }
+        ));
+
+        // sign_share rejects an unrostered key package.
+        let package = build_signing_package(&config, commitments, b"msg").expect("package");
+        let commit = sign_commit(&config, &dkg.key_packages[&1], &mut rng).expect("commit");
+        assert!(matches!(
+            sign_share(&config, &stranger, &commit.nonces, &package.signing_package)
+                .expect_err("unrostered share"),
+            RootError::InvalidConfig { .. }
+        ));
+
+        // aggregate_signature enforces the threshold and rosters every share.
+        assert!(matches!(
+            aggregate_signature(
+                &config,
+                &dkg.public_key_package,
+                &package.signing_package,
+                BTreeMap::new(),
+                b"msg",
+            )
+            .expect_err("sub-threshold aggregate"),
+            RootError::ThresholdNotMet { required: 7, .. }
+        ));
     }
 }


### PR DESCRIPTION
## What & why

The released genesis CLI can produce/submit envelopes (PR #666) but cannot run the
ceremony **distributed**: there was no way to read envelopes back from the portal,
and the only signing command (`sign-root-artifact`) requires loading ≥7 secret
`key_package`s into one process. A 2026-05-25 single-host rehearsal surfaced this
as a blocker for the real 7-of-13 ceremony. This PR adds the missing pieces so
**secret key shares never leave their holders**.

> ⚠️ **Root-key crypto — do not use for the real ceremony until the exo-root
> maintainer reviews.** This is a proposal validated by rehearsal, not a sign-off.
> Stacks on `#666` (base = `john/genesis-cli-client-helpers-20260525`).

## Changes

**#0 — portal read API** (`exo-root/portal.rs`, `exo-node/root_genesis.rs`)
- `PortalStore::query(phase, payload_kind, recipient_did)` — the read half of the relay.
- `GET /api/v1/root-genesis/portal/envelopes` with those filters. (Envelopes are
  signed, and round-two payloads are encrypted, so returning relay data is safe.)

**#1 — distributed FROST signing** (`exo-root/signing.rs`, `exo-node` CLI)
- `sign_commit` / `build_signing_package` / `sign_share` / `aggregate_signature` —
  the same protocol `threshold_sign` runs internally, split into two distributed
  rounds. Each signer keeps its `key_package` and secret nonces; only public
  commitments and signature shares are exchanged. Maps onto the existing
  `RootSigningCommitment` / `RootSignatureShare` payload kinds.
- CLI: `sign-commit`, `build-signing-package`, `sign-share`, `aggregate-signature`.

**#2 — round-two over the portal** (`exo-node` CLI)
- `pull-envelopes` (built on #0) + `encode-encrypted-payload` / `decode-encrypted-payload`
  (CBOR codec bridging `encrypt-pairwise` output ↔ `Round2EncryptedPackage`
  `payload_bytes`).

Not included: round-1 set attestation (shape still unratified — deferred).

## Tests

- `exo-root` unit: distributed signing round-trip produces a signature that
  `verify_root_signature` accepts; `build_signing_package` rejects sub-threshold sets.
- `exo-node` unit: `GET …/envelopes` returns only matching envelopes.
- Both CI gates (`cargo test -p exo-root --test root_genesis`, `cargo test -p exo-node genesis`) pass.

## Rehearsal evidence (single-host, 13 simulated certifiers)

Full ceremony runs end-to-end with everything flowing through the portal;
`verify-bundle` OK on the operator and all 13 certifiers. Verified that the
coordinator's signing inputs (`commit-set`, `share-set`, `signing_package`, `sig`,
`public_key_package`) contain **no `key_package`** — shares stayed in each
certifier's own context; the coordinator pulled only `RootSigningCommitment` /
`RootSignatureShare`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
