### PR TITLE
genesis: client-side ceremony CLI (envelope sign, pairwise encrypt/decrypt, artifact bytes, distributed signing, portal pull) — consolidated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -622,7 +622,7 @@ jobs:
             --output-dir coverage-root-genesis-portal \
             --skip-clean \
             --engine llvm \
-            --timeout 120 \
+            --timeout 300 \
             --fail-under 100
       - name: Upload root genesis portal coverage report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,7 +555,7 @@ jobs:
             --output-dir coverage-zerodentity \
             --skip-clean \
             --engine llvm \
-            --timeout 120 \
+            --timeout 300 \
             --fail-under 80
       - name: Upload 0dentity coverage report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 207351 | `wc -l` |
+| Rust LOC | 207402 | `wc -l` |
 | Workspace tests | 4,602 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 206227 | `wc -l` |
-| Workspace tests | 4,596 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 207351 | `wc -l` |
+| Workspace tests | 4,602 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,566 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,602 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 203671 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 207351 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,566 listed workspace tests
+         cryptographic proofs, 4,602 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          159 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 207402 | `wc -l` |
-| Workspace tests | 4,602 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 207969 | `wc -l` |
+| Workspace tests | 4,610 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 312 | `find crates -name '*.rs'` |
-| Rust LOC | 203671 | `wc -l` |
-| Workspace tests | 4,566 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 206227 | `wc -l` |
+| Workspace tests | 4,596 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |

--- a/crates/exo-node/src/cli.rs
+++ b/crates/exo-node/src/cli.rs
@@ -354,6 +354,17 @@ pub struct GenesisCeremonyInitArgs {
     #[arg(long)]
     pub roster: PathBuf,
 
+    /// Predeclared signing set: exactly `threshold` (7) rostered FROST identifiers
+    /// that will sign root artifacts, comma-separated (e.g. `1,2,3,4,5,6,7`).
+    #[arg(long, value_delimiter = ',')]
+    pub signing_set: Vec<u16>,
+
+    /// Ordered alternate signers (rostered, disjoint from `--signing-set`),
+    /// comma-separated, used only to replace a primary unavailable before
+    /// commitments, taken in order (e.g. `8,9,10,11,12,13`).
+    #[arg(long, value_delimiter = ',')]
+    pub signing_alternates: Vec<u16>,
+
     /// Ceremony configuration output path.
     #[arg(long)]
     pub out: PathBuf,

--- a/crates/exo-node/src/cli.rs
+++ b/crates/exo-node/src/cli.rs
@@ -267,6 +267,34 @@ pub enum GenesisCommand {
     /// Submit a signed envelope to a running root genesis portal.
     #[command(name = "submit-envelope")]
     SubmitEnvelope(GenesisSubmitEnvelopeArgs),
+
+    /// Pull accepted envelopes back from a running portal (read half of the relay).
+    #[command(name = "pull-envelopes")]
+    PullEnvelopes(GenesisPullEnvelopesArgs),
+
+    /// CBOR-encode an encrypted round-two payload into envelope `payload_bytes`.
+    #[command(name = "encode-encrypted-payload")]
+    EncodeEncryptedPayload(GenesisIoArgs),
+
+    /// CBOR-decode envelope `payload_bytes` back into an encrypted round-two payload.
+    #[command(name = "decode-encrypted-payload")]
+    DecodeEncryptedPayload(GenesisIoArgs),
+
+    /// Distributed signing — produce one signer's commitment + secret nonces.
+    #[command(name = "sign-commit")]
+    SignCommit(GenesisIoArgs),
+
+    /// Distributed signing — coordinator builds the signing package from >=7 commitments.
+    #[command(name = "build-signing-package")]
+    BuildSigningPackage(GenesisIoArgs),
+
+    /// Distributed signing — produce one signer's signature share.
+    #[command(name = "sign-share")]
+    SignShare(GenesisIoArgs),
+
+    /// Distributed signing — coordinator aggregates >=7 shares into the root signature.
+    #[command(name = "aggregate-signature")]
+    AggregateSignature(GenesisIoArgs),
 }
 
 #[derive(Subcommand)]
@@ -379,6 +407,31 @@ pub struct GenesisSignEnvelopeArgs {
     /// 32-byte Ed25519 signing secret as hex (from `certifier-NN.private.json`).
     #[arg(long)]
     pub signing_key_hex: String,
+}
+
+#[derive(Args)]
+/// Pull accepted envelopes back from a running portal.
+pub struct GenesisPullEnvelopesArgs {
+    /// Portal base URL (for example `http://127.0.0.1:3017`). The
+    /// `/api/v1/root-genesis/portal/envelopes` path is appended automatically.
+    #[arg(long)]
+    pub portal_url: String,
+
+    /// Optional ceremony phase filter (Round1, Round2, Finalize, RootSigning, ...).
+    #[arg(long)]
+    pub phase: Option<String>,
+
+    /// Optional payload-kind filter (Round1Package, Round2EncryptedPackage, ...).
+    #[arg(long)]
+    pub payload_kind: Option<String>,
+
+    /// Optional recipient DID filter (for recipient-bound round-two packages).
+    #[arg(long)]
+    pub recipient_did: Option<String>,
+
+    /// Output path for the JSON array of matching envelopes.
+    #[arg(long)]
+    pub output: Option<PathBuf>,
 }
 
 #[derive(Args)]

--- a/crates/exo-node/src/cli.rs
+++ b/crates/exo-node/src/cli.rs
@@ -223,7 +223,11 @@ pub enum GenesisCommand {
     #[command(name = "finalize-dkg")]
     FinalizeDkg(GenesisIoArgs),
 
-    /// Sign a root-governance artifact with at least seven certifier shares.
+    /// Build CBOR payload bytes for this certifier's final key confirmation.
+    #[command(name = "build-final-key-confirmation")]
+    BuildFinalKeyConfirmation(GenesisIoArgs),
+
+    /// Sign a root-governance artifact with the exact predeclared signing set.
     #[command(name = "sign-root-artifact")]
     SignRootArtifact(GenesisIoArgs),
 
@@ -267,6 +271,14 @@ pub enum GenesisCommand {
     #[command(name = "pull-envelopes")]
     PullEnvelopes(GenesisPullEnvelopesArgs),
 
+    /// Replay accepted envelopes and emit the completed DKG transcript hash.
+    #[command(name = "compute-dkg-transcript-hash")]
+    ComputeDkgTranscriptHash(GenesisIoArgs),
+
+    /// Replay accepted envelopes and emit the final ceremony transcript hash.
+    #[command(name = "compute-final-transcript-hash")]
+    ComputeFinalTranscriptHash(GenesisIoArgs),
+
     /// CBOR-encode an encrypted round-two payload into envelope `payload_bytes`.
     #[command(name = "encode-encrypted-payload")]
     EncodeEncryptedPayload(GenesisIoArgs),
@@ -280,7 +292,7 @@ pub enum GenesisCommand {
     #[command(name = "sign-commit")]
     SignCommit(GenesisSignCommitArgs),
 
-    /// Distributed signing — coordinator builds the signing package from >=7 commitments.
+    /// Distributed signing — coordinator builds the signing package from the declared set.
     #[command(name = "build-signing-package")]
     BuildSigningPackage(GenesisIoArgs),
 
@@ -288,7 +300,7 @@ pub enum GenesisCommand {
     #[command(name = "sign-share")]
     SignShare(GenesisSignShareArgs),
 
-    /// Distributed signing — coordinator aggregates >=7 shares into the root signature.
+    /// Distributed signing — coordinator aggregates the declared set into the root signature.
     #[command(name = "aggregate-signature")]
     AggregateSignature(GenesisIoArgs),
 }
@@ -358,12 +370,6 @@ pub struct GenesisCeremonyInitArgs {
     /// that will sign root artifacts, comma-separated (e.g. `1,2,3,4,5,6,7`).
     #[arg(long, value_delimiter = ',')]
     pub signing_set: Vec<u16>,
-
-    /// Ordered alternate signers (rostered, disjoint from `--signing-set`),
-    /// comma-separated, used only to replace a primary unavailable before
-    /// commitments, taken in order (e.g. `8,9,10,11,12,13`).
-    #[arg(long, value_delimiter = ',')]
-    pub signing_alternates: Vec<u16>,
 
     /// Ceremony configuration output path.
     #[arg(long)]
@@ -531,6 +537,7 @@ mod tests {
             "round1",
             "round2",
             "finalize-dkg",
+            "build-final-key-confirmation",
             "sign-root-artifact",
             "assemble-bundle",
             "verify-bundle",
@@ -542,6 +549,8 @@ mod tests {
             "emit-artifact-bytes",
             "submit-envelope",
             "pull-envelopes",
+            "compute-dkg-transcript-hash",
+            "compute-final-transcript-hash",
             "encode-encrypted-payload",
             "decode-encrypted-payload",
             "sign-commit",

--- a/crates/exo-node/src/cli.rs
+++ b/crates/exo-node/src/cli.rs
@@ -242,6 +242,31 @@ pub enum GenesisCommand {
     /// Open a sealed certifier share artifact.
     #[command(name = "unseal-share")]
     UnsealShare(GenesisIoArgs),
+
+    /// Sign a ceremony portal envelope ready for submission.
+    #[command(name = "sign-envelope")]
+    SignEnvelope(GenesisSignEnvelopeArgs),
+
+    /// Encrypt a DKG round-two payload for exactly one recipient.
+    #[command(name = "encrypt-pairwise")]
+    EncryptPairwise(GenesisIoArgs),
+
+    /// Decrypt a recipient-bound DKG round-two payload.
+    #[command(name = "decrypt-pairwise")]
+    DecryptPairwise(GenesisIoArgs),
+
+    /// Emit the exact root-artifact bytes that `sign-root-artifact` must sign.
+    #[command(name = "emit-artifact-bytes")]
+    EmitArtifactBytes(GenesisIoArgs),
+
+    /// Build a PROVISIONAL round-one set attestation payload (shape pending
+    /// ratification — see command long help).
+    #[command(name = "build-round1-attestation")]
+    BuildRound1Attestation(GenesisIoArgs),
+
+    /// Submit a signed envelope to a running root genesis portal.
+    #[command(name = "submit-envelope")]
+    SubmitEnvelope(GenesisSubmitEnvelopeArgs),
 }
 
 #[derive(Subcommand)]
@@ -334,6 +359,42 @@ pub struct GenesisIoArgs {
     pub output: Option<PathBuf>,
 }
 
+#[derive(Args)]
+/// Sign a ceremony portal envelope.
+///
+/// The 32-byte Ed25519 signing secret is supplied as a hex flag rather than
+/// inside the envelope draft so the draft file never carries certifier key
+/// material. The secret is visible in the process table while the command
+/// runs; run certifier signing on an isolated, single-operator host.
+pub struct GenesisSignEnvelopeArgs {
+    /// Envelope draft JSON path (ceremony_id, phase, payload_kind, sender_did,
+    /// recipient_did, sequence, payload_bytes).
+    #[arg(long)]
+    pub input: Option<PathBuf>,
+
+    /// Signed envelope output path. Omit to print to stdout.
+    #[arg(long)]
+    pub output: Option<PathBuf>,
+
+    /// 32-byte Ed25519 signing secret as hex (from `certifier-NN.private.json`).
+    #[arg(long)]
+    pub signing_key_hex: String,
+}
+
+#[derive(Args)]
+/// Submit a signed envelope to a running portal.
+pub struct GenesisSubmitEnvelopeArgs {
+    /// Portal base URL (for example `http://127.0.0.1:3017`). The
+    /// `/api/v1/root-genesis/portal/envelopes` path is appended automatically
+    /// when it is not already present.
+    #[arg(long)]
+    pub portal_url: String,
+
+    /// Signed envelope JSON path to POST.
+    #[arg(long)]
+    pub input: Option<PathBuf>,
+}
+
 #[cfg(test)]
 mod tests {
     use clap::CommandFactory;
@@ -370,6 +431,12 @@ mod tests {
             "verify-bundle",
             "seal-share",
             "unseal-share",
+            "sign-envelope",
+            "encrypt-pairwise",
+            "decrypt-pairwise",
+            "emit-artifact-bytes",
+            "build-round1-attestation",
+            "submit-envelope",
         ] {
             assert!(help.contains(command), "missing genesis command {command}");
         }

--- a/crates/exo-node/src/cli.rs
+++ b/crates/exo-node/src/cli.rs
@@ -259,11 +259,6 @@ pub enum GenesisCommand {
     #[command(name = "emit-artifact-bytes")]
     EmitArtifactBytes(GenesisIoArgs),
 
-    /// Build a PROVISIONAL round-one set attestation payload (shape pending
-    /// ratification — see command long help).
-    #[command(name = "build-round1-attestation")]
-    BuildRound1Attestation(GenesisIoArgs),
-
     /// Submit a signed envelope to a running root genesis portal.
     #[command(name = "submit-envelope")]
     SubmitEnvelope(GenesisSubmitEnvelopeArgs),
@@ -280,9 +275,10 @@ pub enum GenesisCommand {
     #[command(name = "decode-encrypted-payload")]
     DecodeEncryptedPayload(GenesisIoArgs),
 
-    /// Distributed signing — produce one signer's commitment + secret nonces.
+    /// Distributed signing — produce one signer's public commitment (and a
+    /// separate local-only secret-nonces file).
     #[command(name = "sign-commit")]
-    SignCommit(GenesisIoArgs),
+    SignCommit(GenesisSignCommitArgs),
 
     /// Distributed signing — coordinator builds the signing package from >=7 commitments.
     #[command(name = "build-signing-package")]
@@ -290,7 +286,7 @@ pub enum GenesisCommand {
 
     /// Distributed signing — produce one signer's signature share.
     #[command(name = "sign-share")]
-    SignShare(GenesisIoArgs),
+    SignShare(GenesisSignShareArgs),
 
     /// Distributed signing — coordinator aggregates >=7 shares into the root signature.
     #[command(name = "aggregate-signature")]
@@ -390,10 +386,12 @@ pub struct GenesisIoArgs {
 #[derive(Args)]
 /// Sign a ceremony portal envelope.
 ///
-/// The 32-byte Ed25519 signing secret is supplied as a hex flag rather than
-/// inside the envelope draft so the draft file never carries certifier key
-/// material. The secret is visible in the process table while the command
-/// runs; run certifier signing on an isolated, single-operator host.
+/// The signing secret is read from the certifier's `0600` private-material file
+/// (`--private-input`, the file written by `certifier init --private-out`), never
+/// passed on the command line. Passing key material through argv would leak it
+/// through process listings, shell history, terminal capture, and operator
+/// transcripts — unacceptable for a ceremony artifact that may later be
+/// challenged by a third-party auditor.
 pub struct GenesisSignEnvelopeArgs {
     /// Envelope draft JSON path (ceremony_id, phase, payload_kind, sender_did,
     /// recipient_did, sequence, payload_bytes).
@@ -404,9 +402,11 @@ pub struct GenesisSignEnvelopeArgs {
     #[arg(long)]
     pub output: Option<PathBuf>,
 
-    /// 32-byte Ed25519 signing secret as hex (from `certifier-NN.private.json`).
+    /// Path to the certifier's private-material JSON (`certifier-NN.private.json`,
+    /// `0600`). The 32-byte Ed25519 signing secret is read from this file's
+    /// `signing_secret_hex` field; it is never accepted as a CLI argument.
     #[arg(long)]
-    pub signing_key_hex: String,
+    pub private_input: PathBuf,
 }
 
 #[derive(Args)]
@@ -446,6 +446,47 @@ pub struct GenesisSubmitEnvelopeArgs {
     /// Signed envelope JSON path to POST.
     #[arg(long)]
     pub input: Option<PathBuf>,
+}
+
+#[derive(Args)]
+/// Distributed signing round one — emit a public commitment and a separate
+/// local-only secret-nonces file.
+///
+/// The commitment is relay-safe and is broadcast to the coordinator; the nonces
+/// file is SECRET, written `0600`, and must stay on the signer's host until
+/// `sign-share`. They are written to two distinct paths so the secret nonces are
+/// never co-located with the artifact that leaves the signer.
+pub struct GenesisSignCommitArgs {
+    /// Input JSON path (`config`, `key_package`).
+    #[arg(long)]
+    pub input: Option<PathBuf>,
+
+    /// Output path for the PUBLIC `RootSigningCommitment` (safe to transmit to
+    /// the coordinator). Refused if it already exists.
+    #[arg(long)]
+    pub commitment_out: PathBuf,
+
+    /// Output path for the SECRET `RootSigningNonces` (`0600`, local-only, fed to
+    /// `sign-share`). Refused if it already exists.
+    #[arg(long)]
+    pub nonces_out: PathBuf,
+}
+
+#[derive(Args)]
+/// Distributed signing round two — produce one signer's signature share.
+pub struct GenesisSignShareArgs {
+    /// Input JSON path (`config`, `key_package`, `signing_package_hex`).
+    #[arg(long)]
+    pub input: Option<PathBuf>,
+
+    /// Path to this signer's local-only `RootSigningNonces` file produced by
+    /// `sign-commit --nonces-out`.
+    #[arg(long)]
+    pub nonces: PathBuf,
+
+    /// Signature-share output path. Omit to print to stdout (the share is public).
+    #[arg(long)]
+    pub output: Option<PathBuf>,
 }
 
 #[cfg(test)]
@@ -488,11 +529,64 @@ mod tests {
             "encrypt-pairwise",
             "decrypt-pairwise",
             "emit-artifact-bytes",
-            "build-round1-attestation",
             "submit-envelope",
+            "pull-envelopes",
+            "encode-encrypted-payload",
+            "decode-encrypted-payload",
+            "sign-commit",
+            "build-signing-package",
+            "sign-share",
+            "aggregate-signature",
         ] {
             assert!(help.contains(command), "missing genesis command {command}");
         }
+    }
+
+    #[test]
+    fn genesis_build_round1_attestation_command_is_absent_pending_ratification() {
+        // The unratified round-one set attestation command was removed; it must
+        // not reappear on the production ceremony CLI until a ratified payload
+        // shape lands and the portal validates it.
+        let help = long_help_for(&["genesis"]);
+        assert!(!help.contains("build-round1-attestation"));
+    }
+
+    #[test]
+    fn genesis_sign_envelope_takes_no_signing_secret_through_argv() {
+        use clap::Parser;
+
+        // The signing secret comes from a `0600` private-material file path.
+        let with_file = Cli::try_parse_from([
+            "exochain",
+            "genesis",
+            "sign-envelope",
+            "--input",
+            "draft.json",
+            "--private-input",
+            "certifier-01.private.json",
+            "--output",
+            "envelope.json",
+        ]);
+        assert!(
+            with_file.is_ok(),
+            "private-material file path must be accepted"
+        );
+
+        // A 32-byte hex secret cannot be passed as a CLI argument: the old flag
+        // is gone and any attempt to supply key material on argv is rejected.
+        let with_argv_secret = Cli::try_parse_from([
+            "exochain",
+            "genesis",
+            "sign-envelope",
+            "--input",
+            "draft.json",
+            "--signing-key-hex",
+            &"ab".repeat(32),
+        ]);
+        assert!(
+            with_argv_secret.is_err(),
+            "no CLI argument may carry 32-byte signing-secret material"
+        );
     }
 
     #[test]

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -1540,6 +1540,8 @@ mod root_genesis_adapter_tests {
                 max_signers: 13,
                 created_at: Timestamp::new(1_785_000_000_000, 0),
                 certifiers,
+                signing_set: (1..=7).collect(),
+                signing_alternates: (8..=13).collect(),
             },
             first_secret.expect("first certifier secret"),
         )

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -1541,7 +1541,6 @@ mod root_genesis_adapter_tests {
                 created_at: Timestamp::new(1_785_000_000_000, 0),
                 certifiers,
                 signing_set: (1..=7).collect(),
-                signing_alternates: (8..=13).collect(),
             },
             first_secret.expect("first certifier secret"),
         )

--- a/crates/exo-node/src/root_genesis.rs
+++ b/crates/exo-node/src/root_genesis.rs
@@ -236,7 +236,6 @@ mod tests {
                 created_at: Timestamp::new(1_785_000_000_000, 0),
                 certifiers,
                 signing_set: (1..=7).collect(),
-                signing_alternates: (8..=13).collect(),
             },
             first_secret.expect("first certifier secret"),
         )

--- a/crates/exo-node/src/root_genesis.rs
+++ b/crates/exo-node/src/root_genesis.rs
@@ -235,6 +235,8 @@ mod tests {
                 max_signers: exo_root::ROOT_GENESIS_SIGNERS,
                 created_at: Timestamp::new(1_785_000_000_000, 0),
                 certifiers,
+                signing_set: (1..=7).collect(),
+                signing_alternates: (8..=13).collect(),
             },
             first_secret.expect("first certifier secret"),
         )

--- a/crates/exo-node/src/root_genesis.rs
+++ b/crates/exo-node/src/root_genesis.rs
@@ -127,7 +127,10 @@ async fn handle_portal_envelopes_query(
         None => None,
     };
     let payload_kind = match &query.payload_kind {
-        Some(value) => Some(parse_query_enum::<CeremonyPayloadKind>(value, "payload_kind")?),
+        Some(value) => Some(parse_query_enum::<CeremonyPayloadKind>(
+            value,
+            "payload_kind",
+        )?),
         None => None,
     };
     let recipient = match &query.recipient_did {

--- a/crates/exo-node/src/root_genesis.rs
+++ b/crates/exo-node/src/root_genesis.rs
@@ -4,13 +4,16 @@ use std::sync::{Arc, Mutex};
 
 use axum::{
     Json, Router,
-    extract::State,
+    extract::{Query, State},
     http::StatusCode,
     routing::{get, post},
 };
-use exo_core::Hash256;
-use exo_root::{CeremonyEnvelope, GenesisCeremonyConfig, PortalStore, RootError};
-use serde::Serialize;
+use exo_core::{Did, Hash256};
+use exo_root::{
+    CeremonyEnvelope, CeremonyPayloadKind, CeremonyPhase, GenesisCeremonyConfig, PortalStore,
+    RootError,
+};
+use serde::{Deserialize, Serialize};
 
 /// Shared root genesis portal state.
 #[derive(Clone)]
@@ -54,7 +57,7 @@ pub fn root_genesis_router(state: RootGenesisApiState) -> Router {
         .route("/api/v1/root-genesis/portal", get(handle_portal_status))
         .route(
             "/api/v1/root-genesis/portal/envelopes",
-            post(handle_portal_envelope),
+            post(handle_portal_envelope).get(handle_portal_envelopes_query),
         )
         .with_state(state)
 }
@@ -93,6 +96,54 @@ async fn handle_portal_envelope(
         )),
         Err(error) => Err(root_error_to_response(error)),
     }
+}
+
+/// Filters for reading relay envelopes back from the portal. Each absent field
+/// matches any value (e.g. `?phase=Round1` collects the round-one broadcast set;
+/// `?phase=Round2&recipient_did=did:exo:...` pulls one recipient's round-two set).
+/// Enum filters are taken as plain strings and parsed explicitly so query
+/// decoding does not depend on enum support in the urlencoded deserializer.
+#[derive(Debug, Default, Deserialize)]
+struct EnvelopeQuery {
+    phase: Option<String>,
+    payload_kind: Option<String>,
+    recipient_did: Option<String>,
+}
+
+fn parse_query_enum<T: serde::de::DeserializeOwned>(
+    value: &str,
+    field: &str,
+) -> Result<T, (StatusCode, Json<ErrorResponse>)> {
+    serde_json::from_value(serde_json::Value::String(value.to_owned()))
+        .map_err(|_| portal_error(StatusCode::BAD_REQUEST, &format!("invalid {field}")))
+}
+
+async fn handle_portal_envelopes_query(
+    State(state): State<RootGenesisApiState>,
+    Query(query): Query<EnvelopeQuery>,
+) -> Result<Json<Vec<CeremonyEnvelope>>, (StatusCode, Json<ErrorResponse>)> {
+    let phase = match &query.phase {
+        Some(value) => Some(parse_query_enum::<CeremonyPhase>(value, "phase")?),
+        None => None,
+    };
+    let payload_kind = match &query.payload_kind {
+        Some(value) => Some(parse_query_enum::<CeremonyPayloadKind>(value, "payload_kind")?),
+        None => None,
+    };
+    let recipient = match &query.recipient_did {
+        Some(value) => Some(
+            Did::new(value)
+                .map_err(|_| portal_error(StatusCode::BAD_REQUEST, "invalid recipient_did"))?,
+        ),
+        None => None,
+    };
+    let portal = state.portal.lock().map_err(|_| {
+        portal_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "portal store lock failed",
+        )
+    })?;
+    Ok(Json(portal.query(phase, payload_kind, recipient.as_ref())))
 }
 
 fn portal_error(status: StatusCode, message: &str) -> (StatusCode, Json<ErrorResponse>) {
@@ -243,6 +294,52 @@ mod tests {
             )
             .await
             .expect("response")
+    }
+
+    async fn get_envelopes(router: axum::Router, query: &str) -> axum::response::Response {
+        router
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(format!("/api/v1/root-genesis/portal/envelopes?{query}"))
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response")
+    }
+
+    #[tokio::test]
+    async fn portal_query_returns_only_matching_envelopes() {
+        let (config, secret) = config();
+        let state = RootGenesisApiState::new(config.clone());
+        let router = root_genesis_router(state);
+        let accepted = post_envelope(
+            router.clone(),
+            &envelope(&config, &secret, 1, b"ct".to_vec()),
+        )
+        .await;
+        assert_eq!(accepted.status(), StatusCode::CREATED);
+
+        // The submitted envelope is a Round2 package; it matches a Round2 query.
+        let matched = get_envelopes(router.clone(), "phase=Round2").await;
+        assert_eq!(matched.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(matched.into_body(), 1 << 20)
+            .await
+            .expect("body bytes");
+        let envelopes: Vec<CeremonyEnvelope> =
+            serde_json::from_slice(&body).expect("envelopes json");
+        assert_eq!(envelopes.len(), 1);
+        assert_eq!(envelopes[0].phase, CeremonyPhase::Round2);
+
+        // A Round1 query matches nothing that was submitted.
+        let empty = get_envelopes(router, "phase=Round1").await;
+        let body = axum::body::to_bytes(empty.into_body(), 1 << 20)
+            .await
+            .expect("body bytes");
+        let envelopes: Vec<CeremonyEnvelope> =
+            serde_json::from_slice(&body).expect("envelopes json");
+        assert!(envelopes.is_empty());
     }
 
     fn poison_portal_lock(state: &RootGenesisApiState) {

--- a/crates/exo-node/src/root_genesis.rs
+++ b/crates/exo-node/src/root_genesis.rs
@@ -312,6 +312,16 @@ mod tests {
             .expect("response")
     }
 
+    async fn count_envelopes(response: axum::response::Response) -> usize {
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1 << 20)
+            .await
+            .expect("body bytes");
+        let envelopes: Vec<CeremonyEnvelope> =
+            serde_json::from_slice(&body).expect("envelopes json");
+        envelopes.len()
+    }
+
     #[tokio::test]
     async fn portal_query_returns_only_matching_envelopes() {
         let (config, secret) = config();
@@ -323,26 +333,60 @@ mod tests {
         )
         .await;
         assert_eq!(accepted.status(), StatusCode::CREATED);
+        let recipient = config.certifiers[1].did.to_string();
+        let other = config.certifiers[2].did.to_string();
 
-        // The submitted envelope is a Round2 package; it matches a Round2 query.
-        let matched = get_envelopes(router.clone(), "phase=Round2").await;
-        assert_eq!(matched.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(matched.into_body(), 1 << 20)
-            .await
-            .expect("body bytes");
-        let envelopes: Vec<CeremonyEnvelope> =
-            serde_json::from_slice(&body).expect("envelopes json");
-        assert_eq!(envelopes.len(), 1);
-        assert_eq!(envelopes[0].phase, CeremonyPhase::Round2);
+        // The submitted envelope is a Round2 package addressed to certifier 2.
+        assert_eq!(
+            count_envelopes(get_envelopes(router.clone(), "phase=Round2").await).await,
+            1
+        );
+        assert_eq!(
+            count_envelopes(get_envelopes(router.clone(), "phase=Round1").await).await,
+            0
+        );
+        assert_eq!(
+            count_envelopes(
+                get_envelopes(router.clone(), "payload_kind=Round2EncryptedPackage").await
+            )
+            .await,
+            1
+        );
+        assert_eq!(
+            count_envelopes(
+                get_envelopes(router.clone(), &format!("recipient_did={recipient}")).await
+            )
+            .await,
+            1
+        );
+        assert_eq!(
+            count_envelopes(get_envelopes(router, &format!("recipient_did={other}")).await).await,
+            0
+        );
+    }
 
-        // A Round1 query matches nothing that was submitted.
-        let empty = get_envelopes(router, "phase=Round1").await;
-        let body = axum::body::to_bytes(empty.into_body(), 1 << 20)
-            .await
-            .expect("body bytes");
-        let envelopes: Vec<CeremonyEnvelope> =
-            serde_json::from_slice(&body).expect("envelopes json");
-        assert!(envelopes.is_empty());
+    #[tokio::test]
+    async fn portal_query_rejects_invalid_filters() {
+        let (config, _secret) = config();
+        let router = root_genesis_router(RootGenesisApiState::new(config));
+        // Unknown enum values -> 400 (parse_query_enum error branch).
+        assert_eq!(
+            get_envelopes(router.clone(), "phase=Bogus").await.status(),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            get_envelopes(router.clone(), "payload_kind=Nope")
+                .await
+                .status(),
+            StatusCode::BAD_REQUEST
+        );
+        // Malformed DID -> 400 (Did::new error branch).
+        assert_eq!(
+            get_envelopes(router, "recipient_did=not-a-did")
+                .await
+                .status(),
+            StatusCode::BAD_REQUEST
+        );
     }
 
     fn poison_portal_lock(state: &RootGenesisApiState) {
@@ -387,6 +431,10 @@ mod tests {
 
         let status = get_status(router.clone()).await;
         assert_eq!(status.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        // Valid filters parse, then the poisoned store lock fails closed.
+        let queried = get_envelopes(router.clone(), "phase=Round1").await;
+        assert_eq!(queried.status(), StatusCode::INTERNAL_SERVER_ERROR);
 
         let submitted = post_envelope(router, &envelope(&config, &secret, 1, b"ct".to_vec())).await;
         assert_eq!(submitted.status(), StatusCode::INTERNAL_SERVER_ERROR);

--- a/crates/exo-node/src/root_genesis_cli.rs
+++ b/crates/exo-node/src/root_genesis_cli.rs
@@ -272,6 +272,8 @@ fn init_ceremony(args: GenesisCeremonyInitArgs) -> anyhow::Result<()> {
         max_signers: exo_root::ROOT_GENESIS_SIGNERS,
         created_at: Timestamp::new(args.created_physical_ms, 0),
         certifiers,
+        signing_set: args.signing_set,
+        signing_alternates: args.signing_alternates,
     };
     config.validate()?;
     write_json(&args.out, &config)?;
@@ -569,7 +571,18 @@ fn run_sign_share(args: GenesisSignShareArgs) -> anyhow::Result<()> {
         &nonces,
         decode_hex(&input.signing_package_hex)?.as_slice(),
     )?;
-    write_output(&io, &output)
+    write_output(&io, &output)?;
+    // Single-use: consume (delete) the nonces file after a successful share so
+    // the same nonces can never be reused. Fail loud if consumption fails — the
+    // signing session must then be aborted and fresh commitments/nonces produced.
+    fs::remove_file(&args.nonces).map_err(|error| {
+        anyhow::anyhow!(
+            "sign-share produced a share but failed to consume the single-use nonces file {}: \
+             {error}; delete it manually and abort this signing session",
+            args.nonces.display()
+        )
+    })?;
+    Ok(())
 }
 
 fn run_aggregate_signature(args: GenesisIoArgs) -> anyhow::Result<()> {
@@ -766,9 +779,19 @@ mod tests {
             max_signers: exo_root::ROOT_GENESIS_SIGNERS,
             created_at: Timestamp::new(1_785_000_000_000, 0),
             certifiers,
+            signing_set: (1..=7).collect(),
+            signing_alternates: (8..=13).collect(),
         };
         config.validate().expect("rostered config is valid");
         config
+    }
+
+    /// A schema-valid round-one package payload (the portal now decodes these to a
+    /// concrete FROST type, so placeholder bytes no longer pass).
+    fn valid_round1_package(config: &GenesisCeremonyConfig) -> Vec<u8> {
+        exo_root::dkg_round1(config, 1, &mut rand::rngs::OsRng)
+            .expect("round one")
+            .round1_package
     }
 
     fn round1_broadcast(
@@ -810,6 +833,8 @@ mod tests {
             constitution_hash: hex::encode([7u8; 32]),
             created_physical_ms: 42,
             roster: roster_path,
+            signing_set: (1..=7).collect(),
+            signing_alternates: (8..=13).collect(),
             out: config_path.clone(),
         })
         .expect("ceremony init");
@@ -943,7 +968,7 @@ mod tests {
                 sender_did: signer.did.clone(),
                 recipient_did: None,
                 sequence: 1,
-                payload_bytes: b"round1 package bytes".to_vec(),
+                payload_bytes: valid_round1_package(&config),
             },
         )
         .expect("write draft");
@@ -1238,6 +1263,11 @@ mod tests {
                 output: Some(out_path.clone()),
             })
             .expect("sign-share");
+            // Single-use: the nonces file is consumed (deleted) on success.
+            assert!(
+                !nonces_paths[id].exists(),
+                "sign-share must consume (delete) the single-use nonces file"
+            );
             let share: exo_root::RootSignatureShareOutput =
                 read_json(&out_path).expect("read share");
             shares_hex.insert(*id, hex::encode(share.signature_share.as_slice()));
@@ -1328,7 +1358,7 @@ mod tests {
     #[tokio::test]
     async fn submit_envelope_posts_signed_envelope_to_running_portal() {
         let config = rostered_config();
-        let envelope = round1_broadcast(&config, 0, 1, b"round1 package bytes".to_vec());
+        let envelope = round1_broadcast(&config, 0, 1, valid_round1_package(&config));
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await

--- a/crates/exo-node/src/root_genesis_cli.rs
+++ b/crates/exo-node/src/root_genesis_cli.rs
@@ -1164,6 +1164,38 @@ mod tests {
                 nonces_out: nonces_out.clone(),
             })
             .expect("sign-commit");
+            // sign-commit splits its output: the coordinator-facing commitment
+            // file must carry no nonces field, and the secret nonces must live
+            // only in the separate local-only file.
+            let commitment_value: serde_json::Value =
+                serde_json::from_slice(&fs::read(&commitment_out).expect("read commitment file"))
+                    .expect("commitment json");
+            let commitment_object = commitment_value
+                .as_object()
+                .expect("commitment is a JSON object");
+            assert!(
+                !commitment_object.contains_key("nonces"),
+                "coordinator-facing commitment file must not contain a nonces field"
+            );
+            for key in commitment_object.keys() {
+                let lowered = key.to_lowercase();
+                assert!(
+                    !(lowered.contains("nonce")
+                        || lowered.contains("secret")
+                        || lowered.contains("private")),
+                    "commitment file must not expose field `{key}`"
+                );
+            }
+            let nonces_value: serde_json::Value =
+                serde_json::from_slice(&fs::read(&nonces_out).expect("read nonces file"))
+                    .expect("nonces json");
+            assert!(
+                nonces_value
+                    .as_object()
+                    .expect("nonces is a JSON object")
+                    .contains_key("nonces"),
+                "the secret nonces file must carry the nonces"
+            );
             let commit: exo_root::RootSigningCommitment =
                 read_json(&commitment_out).expect("read commitment");
             commitments_hex.insert(*id, hex::encode(commit.commitments.as_slice()));
@@ -1238,12 +1270,12 @@ mod tests {
     #[test]
     fn root_signing_commitment_json_has_no_secret_named_field() {
         // The relay-safe RootSigningCommitment, round-tripped through JSON, must
-        // expose no field whose name suggests secret material.
-        let config = rostered_config();
-        let dkg = exo_root::run_complete_dkg(&config, &mut rand::rngs::OsRng).expect("dkg");
-        let (commitment, _nonces) =
-            exo_root::sign_commit(&config, &dkg.key_packages[&1], &mut rand::rngs::OsRng)
-                .expect("commit");
+        // expose no field whose name suggests secret material. Constructed
+        // directly (no DKG) to keep this off the slow coverage-instrumented path.
+        let commitment = exo_root::RootSigningCommitment {
+            frost_identifier: 1,
+            commitments: vec![1, 2, 3, 4],
+        };
         let json = serde_json::to_string(&commitment).expect("serialize commitment");
         let value: serde_json::Value = serde_json::from_str(&json).expect("parse commitment json");
         let object = value
@@ -1258,63 +1290,6 @@ mod tests {
                 "relay-safe RootSigningCommitment must not expose field `{key}`"
             );
         }
-    }
-
-    #[test]
-    fn sign_commit_writes_public_commitment_and_secret_nonces_to_separate_files() {
-        let config = rostered_config();
-        let dkg = exo_root::run_complete_dkg(&config, &mut rand::rngs::OsRng).expect("dkg");
-        let directory = tempdir().expect("temporary directory");
-        let in_path = directory.path().join("commit-in.json");
-        let commitment_out = directory.path().join("commitment.json");
-        let nonces_out = directory.path().join("nonces.json");
-        write_json(
-            &in_path,
-            &SignCommitCommandInput {
-                config: config.clone(),
-                key_package: dkg.key_packages[&1].clone(),
-            },
-        )
-        .expect("write commit input");
-        run_sign_commit(GenesisSignCommitArgs {
-            input: Some(in_path),
-            commitment_out: commitment_out.clone(),
-            nonces_out: nonces_out.clone(),
-        })
-        .expect("sign-commit");
-
-        // The coordinator-facing commitment file carries no nonces field.
-        let commitment_value: serde_json::Value =
-            serde_json::from_slice(&fs::read(&commitment_out).expect("read commitment"))
-                .expect("commitment json");
-        let commitment_object = commitment_value
-            .as_object()
-            .expect("commitment is a JSON object");
-        assert!(
-            !commitment_object.contains_key("nonces"),
-            "coordinator-facing commitment file must not contain a nonces field"
-        );
-        for key in commitment_object.keys() {
-            let lowered = key.to_lowercase();
-            assert!(
-                !(lowered.contains("nonce")
-                    || lowered.contains("secret")
-                    || lowered.contains("private")),
-                "commitment file must not expose field `{key}`"
-            );
-        }
-
-        // The secret nonces live only in the separate local-only file.
-        let nonces_value: serde_json::Value =
-            serde_json::from_slice(&fs::read(&nonces_out).expect("read nonces"))
-                .expect("nonces json");
-        assert!(
-            nonces_value
-                .as_object()
-                .expect("nonces is a JSON object")
-                .contains_key("nonces"),
-            "the secret nonces file must carry the nonces"
-        );
     }
 
     #[test]

--- a/crates/exo-node/src/root_genesis_cli.rs
+++ b/crates/exo-node/src/root_genesis_cli.rs
@@ -6,9 +6,10 @@ use exo_core::{Did, Hash256, SecretKey, Timestamp, crypto::KeyPair};
 use exo_root::{
     CeremonyEnvelope, CeremonyEnvelopeDraft, CeremonyPayloadKind, CeremonyPhase, CertifierContact,
     GenesisCeremonyConfig, PairwiseEncryptedPayload, RootIssuerDelegation, RootKeyPackage,
-    RootPublicKeyPackage, RootTrustBundle, assemble_root_bundle, decrypt_pairwise_payload,
-    dkg_finalize_participant, dkg_round1, dkg_round2, encrypt_pairwise_payload, seal_share,
-    threshold_sign, unseal_share, verify_root_bundle,
+    RootPublicKeyPackage, RootTrustBundle, aggregate_signature, assemble_root_bundle,
+    build_signing_package, decrypt_pairwise_payload, dkg_finalize_participant, dkg_round1,
+    dkg_round2, encrypt_pairwise_payload, seal_share, sign_commit, sign_share, threshold_sign,
+    unseal_share, verify_root_bundle,
 };
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -18,7 +19,7 @@ use crate::{
     cli::{
         GenesisCeremonyCommand, GenesisCeremonyInitArgs, GenesisCertifierCommand,
         GenesisCertifierInitArgs, GenesisCommand, GenesisIoArgs, GenesisPortalArgs,
-        GenesisSignEnvelopeArgs, GenesisSubmitEnvelopeArgs,
+        GenesisPullEnvelopesArgs, GenesisSignEnvelopeArgs, GenesisSubmitEnvelopeArgs,
     },
     root_genesis::{RootGenesisApiState, root_genesis_router},
 };
@@ -189,6 +190,51 @@ struct Round1SetAttestationStatement<'a> {
     entries: &'a [Round1SetAttestationEntry],
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct EncodeEncryptedPayloadCommandInput {
+    encrypted: PairwiseEncryptedPayload,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct DecodeEncryptedPayloadCommandInput {
+    payload_bytes: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct PayloadBytesOutput {
+    payload_bytes: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct SignCommitCommandInput {
+    config: GenesisCeremonyConfig,
+    key_package: RootKeyPackage,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct BuildSigningPackageCommandInput {
+    config: GenesisCeremonyConfig,
+    commitments_hex: BTreeMapStringBytes,
+    artifact_hex: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct SignShareCommandInput {
+    config: GenesisCeremonyConfig,
+    key_package: RootKeyPackage,
+    nonces_hex: String,
+    signing_package_hex: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct AggregateSignatureCommandInput {
+    config: GenesisCeremonyConfig,
+    public_key_package: RootPublicKeyPackage,
+    signing_package_hex: String,
+    shares_hex: BTreeMapStringBytes,
+    artifact_hex: String,
+}
+
 type BTreeMapStringBytes = BTreeMap<u16, String>;
 
 /// Execute a root genesis CLI command.
@@ -211,6 +257,13 @@ pub async fn run_genesis_command(command: GenesisCommand) -> anyhow::Result<()> 
         GenesisCommand::EmitArtifactBytes(args) => run_emit_artifact_bytes(args),
         GenesisCommand::BuildRound1Attestation(args) => run_build_round1_attestation(args),
         GenesisCommand::SubmitEnvelope(args) => run_submit_envelope(args).await,
+        GenesisCommand::PullEnvelopes(args) => run_pull_envelopes(args).await,
+        GenesisCommand::EncodeEncryptedPayload(args) => run_encode_encrypted_payload(args),
+        GenesisCommand::DecodeEncryptedPayload(args) => run_decode_encrypted_payload(args),
+        GenesisCommand::SignCommit(args) => run_sign_commit(args),
+        GenesisCommand::BuildSigningPackage(args) => run_build_signing_package(args),
+        GenesisCommand::SignShare(args) => run_sign_share(args),
+        GenesisCommand::AggregateSignature(args) => run_aggregate_signature(args),
     }
 }
 
@@ -521,6 +574,94 @@ async fn run_submit_envelope(args: GenesisSubmitEnvelopeArgs) -> anyhow::Result<
         anyhow::bail!("portal rejected envelope: HTTP {status}");
     }
     Ok(())
+}
+
+async fn run_pull_envelopes(args: GenesisPullEnvelopesArgs) -> anyhow::Result<()> {
+    let url = portal_envelopes_url(&args.portal_url);
+    let mut params: Vec<(&str, String)> = Vec::new();
+    if let Some(phase) = &args.phase {
+        params.push(("phase", phase.clone()));
+    }
+    if let Some(kind) = &args.payload_kind {
+        params.push(("payload_kind", kind.clone()));
+    }
+    if let Some(recipient) = &args.recipient_did {
+        params.push(("recipient_did", recipient.clone()));
+    }
+    let response = reqwest::Client::new()
+        .get(url)
+        .query(&params)
+        .send()
+        .await?;
+    let status = response.status();
+    let body = response.text().await?;
+    if !status.is_success() {
+        anyhow::bail!("portal pull failed: HTTP {status}: {body}");
+    }
+    let envelopes: Vec<CeremonyEnvelope> = serde_json::from_str(&body)?;
+    let io = GenesisIoArgs {
+        input: None,
+        output: args.output.clone(),
+    };
+    write_output(&io, &envelopes)
+}
+
+fn run_encode_encrypted_payload(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: EncodeEncryptedPayloadCommandInput = read_json(&required_input(&args)?)?;
+    let mut payload_bytes = Vec::new();
+    ciborium::into_writer(&input.encrypted, &mut payload_bytes)
+        .map_err(|error| anyhow::anyhow!("encrypted payload encoding failed: {error}"))?;
+    write_output(&args, &PayloadBytesOutput { payload_bytes })
+}
+
+fn run_decode_encrypted_payload(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: DecodeEncryptedPayloadCommandInput = read_json(&required_input(&args)?)?;
+    let encrypted: PairwiseEncryptedPayload = ciborium::from_reader(input.payload_bytes.as_slice())
+        .map_err(|error| anyhow::anyhow!("encrypted payload decoding failed: {error}"))?;
+    write_output(&args, &encrypted)
+}
+
+fn run_sign_commit(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: SignCommitCommandInput = read_json(&required_input(&args)?)?;
+    let mut rng = rand::rngs::OsRng;
+    let output = sign_commit(&input.config, &input.key_package, &mut rng)?;
+    // Contains secret signing nonces — never print to stdout.
+    write_secret_output(&args, &output)
+}
+
+fn run_build_signing_package(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: BuildSigningPackageCommandInput = read_json(&required_input(&args)?)?;
+    let message = decode_hex(&input.artifact_hex)?;
+    let output = build_signing_package(
+        &input.config,
+        decode_package_map(input.commitments_hex)?,
+        message.as_slice(),
+    )?;
+    write_output(&args, &output)
+}
+
+fn run_sign_share(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: SignShareCommandInput = read_json(&required_input(&args)?)?;
+    let output = sign_share(
+        &input.config,
+        &input.key_package,
+        decode_hex(&input.nonces_hex)?.as_slice(),
+        decode_hex(&input.signing_package_hex)?.as_slice(),
+    )?;
+    write_output(&args, &output)
+}
+
+fn run_aggregate_signature(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: AggregateSignatureCommandInput = read_json(&required_input(&args)?)?;
+    let message = decode_hex(&input.artifact_hex)?;
+    let output = aggregate_signature(
+        &input.config,
+        &input.public_key_package,
+        decode_hex(&input.signing_package_hex)?.as_slice(),
+        decode_package_map(input.shares_hex)?,
+        message.as_slice(),
+    )?;
+    write_output(&args, &output)
 }
 
 /// Append the portal envelopes path to a base URL unless it is already present.

--- a/crates/exo-node/src/root_genesis_cli.rs
+++ b/crates/exo-node/src/root_genesis_cli.rs
@@ -1233,6 +1233,127 @@ mod tests {
             .expect("portal accepts the attestation envelope");
     }
 
+    #[test]
+    fn distributed_signing_handlers_produce_a_verifiable_signature() {
+        let config = rostered_config();
+        let dkg = exo_root::run_complete_dkg(&config, &mut rand::rngs::OsRng).expect("dkg");
+        let message = b"distributed root artifact";
+        let artifact_hex = hex::encode(message);
+        let directory = tempdir().expect("temporary directory");
+        let signers: Vec<u16> = (1..=7).collect();
+
+        let mut commitments_hex = BTreeMap::new();
+        let mut nonces_hex = BTreeMap::new();
+        for id in &signers {
+            let in_path = directory.path().join(format!("commit-in-{id}.json"));
+            let out_path = directory.path().join(format!("commit-out-{id}.json"));
+            write_json(
+                &in_path,
+                &SignCommitCommandInput {
+                    config: config.clone(),
+                    key_package: dkg.key_packages[id].clone(),
+                },
+            )
+            .expect("write commit input");
+            run_sign_commit(io_args(in_path, out_path.clone())).expect("sign-commit");
+            let commit: exo_root::RootSigningCommitment =
+                read_json(&out_path).expect("read commitment");
+            commitments_hex.insert(*id, hex::encode(&commit.commitments));
+            nonces_hex.insert(*id, hex::encode(&commit.nonces));
+        }
+
+        let pkg_in = directory.path().join("pkg-in.json");
+        let pkg_out = directory.path().join("pkg-out.json");
+        write_json(
+            &pkg_in,
+            &BuildSigningPackageCommandInput {
+                config: config.clone(),
+                commitments_hex,
+                artifact_hex: artifact_hex.clone(),
+            },
+        )
+        .expect("write package input");
+        run_build_signing_package(io_args(pkg_in, pkg_out.clone())).expect("build-signing-package");
+        let package: exo_root::RootSigningPackage = read_json(&pkg_out).expect("read package");
+        let signing_package_hex = hex::encode(&package.signing_package);
+
+        let mut shares_hex = BTreeMap::new();
+        for id in &signers {
+            let in_path = directory.path().join(format!("share-in-{id}.json"));
+            let out_path = directory.path().join(format!("share-out-{id}.json"));
+            write_json(
+                &in_path,
+                &SignShareCommandInput {
+                    config: config.clone(),
+                    key_package: dkg.key_packages[id].clone(),
+                    nonces_hex: nonces_hex[id].clone(),
+                    signing_package_hex: signing_package_hex.clone(),
+                },
+            )
+            .expect("write share input");
+            run_sign_share(io_args(in_path, out_path.clone())).expect("sign-share");
+            let share: exo_root::RootSignatureShareOutput =
+                read_json(&out_path).expect("read share");
+            shares_hex.insert(*id, hex::encode(&share.signature_share));
+        }
+
+        let agg_in = directory.path().join("agg-in.json");
+        let agg_out = directory.path().join("agg-out.json");
+        write_json(
+            &agg_in,
+            &AggregateSignatureCommandInput {
+                config: config.clone(),
+                public_key_package: dkg.public_key_package.clone(),
+                signing_package_hex,
+                shares_hex,
+                artifact_hex,
+            },
+        )
+        .expect("write aggregate input");
+        run_aggregate_signature(io_args(agg_in, agg_out.clone())).expect("aggregate-signature");
+        let signature: exo_root::RootSignature = read_json(&agg_out).expect("read signature");
+        assert_eq!(signature.signer_ids.len(), 7);
+        exo_root::verify_root_signature(
+            &dkg.public_key_package.root_public_key,
+            message,
+            &signature.signature,
+        )
+        .expect("distributed signature verifies against the root key");
+    }
+
+    #[test]
+    fn encrypted_payload_codec_round_trips_through_the_cli() {
+        let payload = PairwiseEncryptedPayload {
+            nonce: [5u8; 24],
+            ciphertext: b"recipient-bound ciphertext".to_vec(),
+        };
+        let directory = tempdir().expect("temporary directory");
+        let enc_in = directory.path().join("encode-in.json");
+        let enc_out = directory.path().join("encode-out.json");
+        write_json(
+            &enc_in,
+            &EncodeEncryptedPayloadCommandInput {
+                encrypted: payload.clone(),
+            },
+        )
+        .expect("write encode input");
+        run_encode_encrypted_payload(io_args(enc_in, enc_out.clone())).expect("encode");
+        let encoded: PayloadBytesOutput = read_json(&enc_out).expect("read encoded");
+
+        let dec_in = directory.path().join("decode-in.json");
+        let dec_out = directory.path().join("decode-out.json");
+        write_json(
+            &dec_in,
+            &DecodeEncryptedPayloadCommandInput {
+                payload_bytes: encoded.payload_bytes,
+            },
+        )
+        .expect("write decode input");
+        run_decode_encrypted_payload(io_args(dec_in, dec_out.clone())).expect("decode");
+        let decoded: PairwiseEncryptedPayload = read_json(&dec_out).expect("read decoded");
+        assert_eq!(decoded, payload);
+    }
+
     #[tokio::test]
     async fn submit_envelope_posts_signed_envelope_to_running_portal() {
         let config = rostered_config();

--- a/crates/exo-node/src/root_genesis_cli.rs
+++ b/crates/exo-node/src/root_genesis_cli.rs
@@ -2,11 +2,13 @@
 
 use std::{collections::BTreeMap, fs, io::Write, net::SocketAddr};
 
-use exo_core::{Did, Hash256, Timestamp, crypto::KeyPair};
+use exo_core::{Did, Hash256, SecretKey, Timestamp, crypto::KeyPair};
 use exo_root::{
-    CertifierContact, GenesisCeremonyConfig, RootIssuerDelegation, RootKeyPackage,
-    RootPublicKeyPackage, RootTrustBundle, assemble_root_bundle, dkg_finalize_participant,
-    dkg_round1, dkg_round2, seal_share, threshold_sign, unseal_share, verify_root_bundle,
+    CeremonyEnvelope, CeremonyEnvelopeDraft, CeremonyPayloadKind, CeremonyPhase, CertifierContact,
+    GenesisCeremonyConfig, PairwiseEncryptedPayload, RootIssuerDelegation, RootKeyPackage,
+    RootPublicKeyPackage, RootTrustBundle, assemble_root_bundle, decrypt_pairwise_payload,
+    dkg_finalize_participant, dkg_round1, dkg_round2, encrypt_pairwise_payload, seal_share,
+    threshold_sign, unseal_share, verify_root_bundle,
 };
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -16,9 +18,22 @@ use crate::{
     cli::{
         GenesisCeremonyCommand, GenesisCeremonyInitArgs, GenesisCertifierCommand,
         GenesisCertifierInitArgs, GenesisCommand, GenesisIoArgs, GenesisPortalArgs,
+        GenesisSignEnvelopeArgs, GenesisSubmitEnvelopeArgs,
     },
     root_genesis::{RootGenesisApiState, root_genesis_router},
 };
+
+/// Portal HTTP path that accepts signed ceremony envelopes.
+const PORTAL_ENVELOPES_PATH: &str = "/api/v1/root-genesis/portal/envelopes";
+
+/// Domain separator for the PROVISIONAL round-one set attestation statement.
+///
+/// The canonical shape of a `Round1SetAttestation` payload is not defined or
+/// validated anywhere in `exo-root` (the portal treats the bytes as opaque).
+/// This encoding is a deterministic best-effort proposal and is NOT ratified;
+/// the `V0_UNRATIFIED` suffix must change once the exo-root maintainer confirms
+/// the intended shape. See `run_build_round1_attestation`.
+const ROUND1_SET_ATTESTATION_DOMAIN: &str = "EXOCHAIN_ROOT_ROUND1_SET_ATTESTATION_V0_UNRATIFIED";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct PrivateCertifierMaterial {
@@ -94,6 +109,86 @@ struct HexBytesOutput {
     bytes_hex: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct SignEnvelopeCommandInput {
+    ceremony_id: String,
+    phase: CeremonyPhase,
+    payload_kind: CeremonyPayloadKind,
+    sender_did: Did,
+    #[serde(default)]
+    recipient_did: Option<Did>,
+    sequence: u64,
+    payload_bytes: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct EncryptPairwiseCommandInput {
+    plaintext: Vec<u8>,
+    sender_transport_secret_hex: String,
+    recipient_transport_pubkey_hex: String,
+    associated_data_hex: String,
+    nonce_hex: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct DecryptPairwiseCommandInput {
+    encrypted: PairwiseEncryptedPayload,
+    recipient_transport_secret_hex: String,
+    sender_transport_pubkey_hex: String,
+    associated_data_hex: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct EmitArtifactBytesCommandInput {
+    config: GenesisCeremonyConfig,
+    public_key_package: RootPublicKeyPackage,
+    issuer_delegation: RootIssuerDelegation,
+    transcript_hash_hex: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct BuildRound1AttestationCommandInput {
+    round1_envelopes: Vec<CeremonyEnvelope>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct ArtifactBytesOutput {
+    artifact_hex: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct PlaintextOutput {
+    plaintext: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct Round1AttestationOutput {
+    /// Bytes to place in the `payload_bytes` field of a `Round1SetAttestation`
+    /// envelope (then sign with `sign-envelope`). PROVISIONAL encoding.
+    payload_hex: String,
+    /// blake3 of `payload_hex` — a convenience digest of the attested set.
+    attestation_hash_hex: String,
+    /// Number of round-one packages bound by this attestation.
+    entry_count: usize,
+}
+
+/// One `(sender, round1-package-hash)` binding inside the provisional
+/// round-one set attestation statement, canonicalised in sorted order.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct Round1SetAttestationEntry {
+    sender_did: Did,
+    round1_package_hash: Hash256,
+}
+
+/// Provisional canonical statement bound by a `Round1SetAttestation` envelope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct Round1SetAttestationStatement<'a> {
+    domain: &'static str,
+    ceremony_id: &'a str,
+    entry_count: usize,
+    entries: &'a [Round1SetAttestationEntry],
+}
+
 type BTreeMapStringBytes = BTreeMap<u16, String>;
 
 /// Execute a root genesis CLI command.
@@ -110,6 +205,12 @@ pub async fn run_genesis_command(command: GenesisCommand) -> anyhow::Result<()> 
         GenesisCommand::VerifyBundle(args) => run_verify_bundle(args),
         GenesisCommand::SealShare(args) => run_seal_share(args),
         GenesisCommand::UnsealShare(args) => run_unseal_share(args),
+        GenesisCommand::SignEnvelope(args) => run_sign_envelope(args),
+        GenesisCommand::EncryptPairwise(args) => run_encrypt_pairwise(args),
+        GenesisCommand::DecryptPairwise(args) => run_decrypt_pairwise(args),
+        GenesisCommand::EmitArtifactBytes(args) => run_emit_artifact_bytes(args),
+        GenesisCommand::BuildRound1Attestation(args) => run_build_round1_attestation(args),
+        GenesisCommand::SubmitEnvelope(args) => run_submit_envelope(args).await,
     }
 }
 
@@ -270,6 +371,168 @@ fn run_unseal_share(args: GenesisIoArgs) -> anyhow::Result<()> {
     )
 }
 
+fn run_sign_envelope(args: GenesisSignEnvelopeArgs) -> anyhow::Result<()> {
+    let io = GenesisIoArgs {
+        input: args.input.clone(),
+        output: args.output.clone(),
+    };
+    let input: SignEnvelopeCommandInput = read_json(&required_input(&io)?)?;
+    let signing_secret = SecretKey::from_bytes(decode_fixed_32(&args.signing_key_hex)?);
+    let draft = CeremonyEnvelopeDraft {
+        ceremony_id: input.ceremony_id,
+        phase: input.phase,
+        payload_kind: input.payload_kind,
+        sender_did: input.sender_did,
+        recipient_did: input.recipient_did,
+        sequence: input.sequence,
+        payload_bytes: input.payload_bytes,
+    };
+    let envelope = CeremonyEnvelope::sign(draft, &signing_secret)?;
+    write_output(&io, &envelope)
+}
+
+fn run_encrypt_pairwise(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: EncryptPairwiseCommandInput = read_json(&required_input(&args)?)?;
+    let sender_secret = decode_fixed_32(&input.sender_transport_secret_hex)?;
+    let recipient_public = decode_fixed_32(&input.recipient_transport_pubkey_hex)?;
+    let nonce = decode_fixed_24(&input.nonce_hex)?;
+    let associated_data = decode_hex(&input.associated_data_hex)?;
+    let encrypted = encrypt_pairwise_payload(
+        &sender_secret,
+        &recipient_public,
+        input.plaintext.as_slice(),
+        associated_data.as_slice(),
+        &nonce,
+    )?;
+    write_output(&args, &encrypted)
+}
+
+fn run_decrypt_pairwise(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: DecryptPairwiseCommandInput = read_json(&required_input(&args)?)?;
+    let recipient_secret = decode_fixed_32(&input.recipient_transport_secret_hex)?;
+    let sender_public = decode_fixed_32(&input.sender_transport_pubkey_hex)?;
+    let associated_data = decode_hex(&input.associated_data_hex)?;
+    let plaintext = decrypt_pairwise_payload(
+        &recipient_secret,
+        &sender_public,
+        &input.encrypted,
+        associated_data.as_slice(),
+    )?;
+    write_secret_output(&args, &PlaintextOutput { plaintext })
+}
+
+fn run_emit_artifact_bytes(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: EmitArtifactBytesCommandInput = read_json(&required_input(&args)?)?;
+    let transcript_hash = parse_hash_hex(&input.transcript_hash_hex)?;
+    let artifact = input.issuer_delegation.root_artifact_payload(
+        &input.config,
+        &input.public_key_package,
+        transcript_hash,
+    )?;
+    write_output(
+        &args,
+        &ArtifactBytesOutput {
+            artifact_hex: hex::encode(artifact),
+        },
+    )
+}
+
+/// Build a PROVISIONAL round-one set attestation payload.
+///
+/// `exo-root` defines no canonical shape for `Round1SetAttestation` payloads —
+/// the portal accepts the bytes opaquely (see `portal.rs::validate_phase_policy`,
+/// which only checks phase/kind/recipient, never content). This command emits a
+/// deterministic statement binding the sorted set of
+/// `(sender_did, round1_package_hash)` pairs taken from the round-one
+/// broadcast envelopes, domain-separated by [`ROUND1_SET_ATTESTATION_DOMAIN`]
+/// and CBOR-encoded with the same canonical encoder the library uses for its
+/// own signing payloads.
+///
+/// This encoding is UNRATIFIED. Do not rely on it for the production ceremony
+/// until the exo-root maintainer confirms the intended shape; if they choose a
+/// different one (for example a bare digest, or keying on `frost_identifier`
+/// instead of `sender_did`), only this function and the domain tag change.
+fn run_build_round1_attestation(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: BuildRound1AttestationCommandInput = read_json(&required_input(&args)?)?;
+    if input.round1_envelopes.is_empty() {
+        anyhow::bail!("round1 set must contain at least one envelope");
+    }
+    let ceremony_id = input.round1_envelopes[0].ceremony_id.clone();
+    let mut entries = Vec::with_capacity(input.round1_envelopes.len());
+    for envelope in &input.round1_envelopes {
+        if envelope.ceremony_id != ceremony_id {
+            anyhow::bail!("round1 set mixes ceremony identifiers");
+        }
+        if envelope.phase != CeremonyPhase::Round1
+            || envelope.payload_kind != CeremonyPayloadKind::Round1Package
+        {
+            anyhow::bail!("round1 set contains a non-Round1Package envelope");
+        }
+        entries.push(Round1SetAttestationEntry {
+            sender_did: envelope.sender_did.clone(),
+            round1_package_hash: envelope.payload_hash,
+        });
+    }
+    entries.sort_by(|left, right| left.sender_did.cmp(&right.sender_did));
+    for pair in entries.windows(2) {
+        if pair[0].sender_did == pair[1].sender_did {
+            anyhow::bail!(
+                "round1 set contains duplicate sender {}",
+                pair[0].sender_did
+            );
+        }
+    }
+    let statement = Round1SetAttestationStatement {
+        domain: ROUND1_SET_ATTESTATION_DOMAIN,
+        ceremony_id: &ceremony_id,
+        entry_count: entries.len(),
+        entries: entries.as_slice(),
+    };
+    let mut payload = Vec::new();
+    ciborium::into_writer(&statement, &mut payload)
+        .map_err(|error| anyhow::anyhow!("round1 attestation encoding failed: {error}"))?;
+    let attestation_hash = Hash256::digest(payload.as_slice());
+    write_output(
+        &args,
+        &Round1AttestationOutput {
+            payload_hex: hex::encode(payload.as_slice()),
+            attestation_hash_hex: hex::encode(attestation_hash.as_bytes()),
+            entry_count: entries.len(),
+        },
+    )
+}
+
+async fn run_submit_envelope(args: GenesisSubmitEnvelopeArgs) -> anyhow::Result<()> {
+    let io = GenesisIoArgs {
+        input: args.input.clone(),
+        output: None,
+    };
+    let envelope: CeremonyEnvelope = read_json(&required_input(&io)?)?;
+    let url = portal_envelopes_url(&args.portal_url);
+    let response = reqwest::Client::new()
+        .post(url)
+        .json(&envelope)
+        .send()
+        .await?;
+    let status = response.status();
+    let body = response.text().await?;
+    println!("{body}");
+    if !status.is_success() {
+        anyhow::bail!("portal rejected envelope: HTTP {status}");
+    }
+    Ok(())
+}
+
+/// Append the portal envelopes path to a base URL unless it is already present.
+fn portal_envelopes_url(base: &str) -> String {
+    let trimmed = base.trim_end_matches('/');
+    if trimmed.ends_with(PORTAL_ENVELOPES_PATH) {
+        trimmed.to_owned()
+    } else {
+        format!("{trimmed}{PORTAL_ENVELOPES_PATH}")
+    }
+}
+
 fn parse_hash_hex(value: &str) -> anyhow::Result<Hash256> {
     let bytes = hex::decode(value)?;
     if bytes.len() != 32 {
@@ -368,6 +631,16 @@ fn decode_fixed_24(value: &str) -> anyhow::Result<[u8; 24]> {
     Ok(result)
 }
 
+fn decode_fixed_32(value: &str) -> anyhow::Result<[u8; 32]> {
+    let bytes = decode_hex(value)?;
+    if bytes.len() != 32 {
+        anyhow::bail!("expected 32 bytes");
+    }
+    let mut result = [0u8; 32];
+    result.copy_from_slice(&bytes);
+    Ok(result)
+}
+
 fn decode_package_map(packages: BTreeMapStringBytes) -> anyhow::Result<BTreeMap<u16, Vec<u8>>> {
     let mut decoded = BTreeMap::new();
     for (identifier, package_hex) in packages {
@@ -380,7 +653,9 @@ fn decode_package_map(packages: BTreeMapStringBytes) -> anyhow::Result<BTreeMap<
 mod tests {
     use std::path::PathBuf;
 
+    use exo_authority::permission::Permission;
     use exo_core::PublicKey;
+    use exo_root::PortalStore;
     use tempfile::tempdir;
 
     use super::*;
@@ -400,6 +675,62 @@ mod tests {
             input: Some(input),
             output: Some(output),
         }
+    }
+
+    /// Build a fully valid 13-certifier config whose signing keys are derived
+    /// from `[index; 32]`, so envelopes signed with that secret verify against
+    /// the rostered public key (unlike the lighter `certifier` helper above).
+    fn rostered_config() -> GenesisCeremonyConfig {
+        let certifiers = (1..=13u16)
+            .map(|index| {
+                let seed = u8::try_from(index).expect("index fits u8");
+                let keypair = KeyPair::from_secret_bytes([seed; 32]).expect("valid keypair");
+                let transport_secret = [seed.wrapping_add(64); 32];
+                let transport_public = X25519PublicKey::from(&StaticSecret::from(transport_secret));
+                CertifierContact {
+                    did: Did::new(&format!("did:exo:root-cli-signed-{index:02}")).expect("did"),
+                    frost_identifier: index,
+                    signing_public_key: *keypair.public_key(),
+                    transport_public_key: *transport_public.as_bytes(),
+                }
+            })
+            .collect();
+        let config = GenesisCeremonyConfig {
+            ceremony_id: "root-cli-signed-ceremony".to_owned(),
+            network_id: "exo-mainnet".to_owned(),
+            repo_commit: "d8927686a34bdc28ba36d53938f665685d2c4c04".to_owned(),
+            constitution_hash: Hash256::digest(b"constitution"),
+            threshold: exo_root::ROOT_GENESIS_THRESHOLD,
+            max_signers: exo_root::ROOT_GENESIS_SIGNERS,
+            created_at: Timestamp::new(1_785_000_000_000, 0),
+            certifiers,
+        };
+        config.validate().expect("rostered config is valid");
+        config
+    }
+
+    fn round1_broadcast(
+        config: &GenesisCeremonyConfig,
+        certifier_index: usize,
+        sequence: u64,
+        payload_bytes: Vec<u8>,
+    ) -> CeremonyEnvelope {
+        let signer = &config.certifiers[certifier_index];
+        let seed = u8::try_from(certifier_index + 1).expect("index fits u8");
+        let secret = SecretKey::from_bytes([seed; 32]);
+        CeremonyEnvelope::sign(
+            CeremonyEnvelopeDraft {
+                ceremony_id: config.ceremony_id.clone(),
+                phase: CeremonyPhase::Round1,
+                payload_kind: CeremonyPayloadKind::Round1Package,
+                sender_did: signer.did.clone(),
+                recipient_did: None,
+                sequence,
+                payload_bytes,
+            },
+            &secret,
+        )
+        .expect("signed round1 envelope")
     }
 
     #[test]
@@ -531,6 +862,268 @@ mod tests {
         let mut packages = BTreeMap::new();
         packages.insert(7, "not-hex".to_owned());
         assert!(decode_package_map(packages).is_err());
+    }
+
+    #[test]
+    fn sign_envelope_output_is_accepted_by_the_portal() {
+        let config = rostered_config();
+        let signer = config.certifiers[0].clone();
+        let directory = tempdir().expect("temporary directory");
+        let input_path = directory.path().join("draft.json");
+        let output_path = directory.path().join("envelope.json");
+        write_json(
+            &input_path,
+            &SignEnvelopeCommandInput {
+                ceremony_id: config.ceremony_id.clone(),
+                phase: CeremonyPhase::Round1,
+                payload_kind: CeremonyPayloadKind::Round1Package,
+                sender_did: signer.did.clone(),
+                recipient_did: None,
+                sequence: 1,
+                payload_bytes: b"round1 package bytes".to_vec(),
+            },
+        )
+        .expect("write draft");
+
+        run_sign_envelope(GenesisSignEnvelopeArgs {
+            input: Some(input_path),
+            output: Some(output_path.clone()),
+            signing_key_hex: hex::encode([1u8; 32]),
+        })
+        .expect("sign envelope");
+
+        let envelope: CeremonyEnvelope = read_json(&output_path).expect("read envelope");
+        assert_eq!(envelope.sender_did, signer.did);
+        let mut store = PortalStore::new(config);
+        store
+            .submit(envelope)
+            .expect("portal accepts the signed envelope");
+    }
+
+    #[test]
+    fn encrypt_then_decrypt_pairwise_round_trips() {
+        let directory = tempdir().expect("temporary directory");
+        let sender_secret = [5u8; 32];
+        let recipient_secret = [6u8; 32];
+        let sender_public = *X25519PublicKey::from(&StaticSecret::from(sender_secret)).as_bytes();
+        let recipient_public =
+            *X25519PublicKey::from(&StaticSecret::from(recipient_secret)).as_bytes();
+        let associated_data = b"exo-root-round2";
+        let nonce = [7u8; 24];
+        let plaintext = b"round2 secret package".to_vec();
+
+        let encrypt_in = directory.path().join("encrypt-in.json");
+        let encrypt_out = directory.path().join("encrypt-out.json");
+        write_json(
+            &encrypt_in,
+            &EncryptPairwiseCommandInput {
+                plaintext: plaintext.clone(),
+                sender_transport_secret_hex: hex::encode(sender_secret),
+                recipient_transport_pubkey_hex: hex::encode(recipient_public),
+                associated_data_hex: hex::encode(associated_data),
+                nonce_hex: hex::encode(nonce),
+            },
+        )
+        .expect("write encrypt input");
+        run_encrypt_pairwise(io_args(encrypt_in, encrypt_out.clone())).expect("encrypt pairwise");
+        let encrypted: PairwiseEncryptedPayload =
+            read_json(&encrypt_out).expect("read encrypted payload");
+        assert_eq!(encrypted.nonce, nonce);
+
+        let decrypt_in = directory.path().join("decrypt-in.json");
+        let decrypt_out = directory.path().join("decrypt-out.json");
+        write_json(
+            &decrypt_in,
+            &DecryptPairwiseCommandInput {
+                encrypted,
+                recipient_transport_secret_hex: hex::encode(recipient_secret),
+                sender_transport_pubkey_hex: hex::encode(sender_public),
+                associated_data_hex: hex::encode(associated_data),
+            },
+        )
+        .expect("write decrypt input");
+        run_decrypt_pairwise(io_args(decrypt_in, decrypt_out.clone())).expect("decrypt pairwise");
+        let opened: PlaintextOutput = read_json(&decrypt_out).expect("read plaintext");
+        assert_eq!(opened.plaintext, plaintext);
+    }
+
+    #[test]
+    fn decrypt_pairwise_refuses_to_print_plaintext_to_stdout() {
+        let directory = tempdir().expect("temporary directory");
+        let sender_secret = [5u8; 32];
+        let recipient_secret = [6u8; 32];
+        let sender_public = *X25519PublicKey::from(&StaticSecret::from(sender_secret)).as_bytes();
+        let recipient_public =
+            *X25519PublicKey::from(&StaticSecret::from(recipient_secret)).as_bytes();
+        let encrypted = encrypt_pairwise_payload(
+            &sender_secret,
+            &recipient_public,
+            b"round2 secret package",
+            b"exo-root-round2",
+            &[7u8; 24],
+        )
+        .expect("encrypted");
+        let decrypt_in = directory.path().join("decrypt-in.json");
+        write_json(
+            &decrypt_in,
+            &DecryptPairwiseCommandInput {
+                encrypted,
+                recipient_transport_secret_hex: hex::encode(recipient_secret),
+                sender_transport_pubkey_hex: hex::encode(sender_public),
+                associated_data_hex: hex::encode(b"exo-root-round2"),
+            },
+        )
+        .expect("write decrypt input");
+
+        let error = run_decrypt_pairwise(GenesisIoArgs {
+            input: Some(decrypt_in),
+            output: None,
+        })
+        .expect_err("decrypted round-two material must require --output");
+        assert!(error.to_string().contains("--output is required"));
+    }
+
+    #[test]
+    fn emit_artifact_bytes_matches_the_library_signing_payload() {
+        let config = rostered_config();
+        let public_key_package = RootPublicKeyPackage {
+            public_key_package: b"public-key-package-bytes".to_vec(),
+            root_public_key: b"root-public-key".to_vec(),
+            verifying_shares: (1..=13u16)
+                .map(|id| (id, vec![u8::try_from(id).expect("id fits u8")]))
+                .collect(),
+        };
+        let delegation = RootIssuerDelegation {
+            issuer_did: Did::new("did:exo:avc-issuer").expect("valid did"),
+            issuer_public_key: PublicKey::from_bytes([0x44; 32]),
+            granted_permissions: vec![Permission::Govern, Permission::Delegate],
+            effective_at: Timestamp::new(1_785_000_010_000, 0),
+            expires_at: None,
+            purpose: "Delegate operational AVC issuing authority".to_owned(),
+        };
+        let transcript_hash = Hash256::digest(b"transcript");
+        let expected = delegation
+            .root_artifact_payload(&config, &public_key_package, transcript_hash)
+            .expect("library artifact payload");
+
+        let directory = tempdir().expect("temporary directory");
+        let input_path = directory.path().join("artifact-in.json");
+        let output_path = directory.path().join("artifact-out.json");
+        write_json(
+            &input_path,
+            &EmitArtifactBytesCommandInput {
+                config: config.clone(),
+                public_key_package: public_key_package.clone(),
+                issuer_delegation: delegation.clone(),
+                transcript_hash_hex: hex::encode(transcript_hash.as_bytes()),
+            },
+        )
+        .expect("write artifact input");
+        run_emit_artifact_bytes(io_args(input_path, output_path.clone()))
+            .expect("emit artifact bytes");
+        let output: ArtifactBytesOutput = read_json(&output_path).expect("read artifact output");
+        assert_eq!(output.artifact_hex, hex::encode(expected.as_slice()));
+    }
+
+    #[test]
+    fn build_round1_attestation_is_order_independent_and_portal_submittable() {
+        let config = rostered_config();
+        let envelopes = vec![
+            round1_broadcast(&config, 0, 1, b"round1-a".to_vec()),
+            round1_broadcast(&config, 1, 1, b"round1-b".to_vec()),
+            round1_broadcast(&config, 2, 1, b"round1-c".to_vec()),
+        ];
+
+        let directory = tempdir().expect("temporary directory");
+        let forward_in = directory.path().join("attest-forward-in.json");
+        let forward_out = directory.path().join("attest-forward-out.json");
+        write_json(
+            &forward_in,
+            &BuildRound1AttestationCommandInput {
+                round1_envelopes: envelopes.clone(),
+            },
+        )
+        .expect("write forward input");
+        run_build_round1_attestation(io_args(forward_in, forward_out.clone()))
+            .expect("build attestation (forward)");
+
+        let mut reversed = envelopes;
+        reversed.reverse();
+        let reversed_in = directory.path().join("attest-reversed-in.json");
+        let reversed_out = directory.path().join("attest-reversed-out.json");
+        write_json(
+            &reversed_in,
+            &BuildRound1AttestationCommandInput {
+                round1_envelopes: reversed,
+            },
+        )
+        .expect("write reversed input");
+        run_build_round1_attestation(io_args(reversed_in, reversed_out.clone()))
+            .expect("build attestation (reversed)");
+
+        let forward: Round1AttestationOutput =
+            read_json(&forward_out).expect("read forward output");
+        let reversed: Round1AttestationOutput =
+            read_json(&reversed_out).expect("read reversed output");
+        assert_eq!(
+            forward, reversed,
+            "attestation must be canonical regardless of input order"
+        );
+        assert_eq!(forward.entry_count, 3);
+
+        let payload_bytes = hex::decode(forward.payload_hex.as_str()).expect("hex payload");
+        let attestation_secret = SecretKey::from_bytes([1u8; 32]);
+        let attestation = CeremonyEnvelope::sign(
+            CeremonyEnvelopeDraft {
+                ceremony_id: config.ceremony_id.clone(),
+                phase: CeremonyPhase::Round1SetAttestation,
+                payload_kind: CeremonyPayloadKind::Round1SetAttestation,
+                sender_did: config.certifiers[0].did.clone(),
+                recipient_did: None,
+                sequence: 100,
+                payload_bytes,
+            },
+            &attestation_secret,
+        )
+        .expect("sign attestation envelope");
+        let mut store = PortalStore::new(config);
+        store
+            .submit(attestation)
+            .expect("portal accepts the attestation envelope");
+    }
+
+    #[tokio::test]
+    async fn submit_envelope_posts_signed_envelope_to_running_portal() {
+        let config = rostered_config();
+        let envelope = round1_broadcast(&config, 0, 1, b"round1 package bytes".to_vec());
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind portal listener");
+        let address = listener.local_addr().expect("portal address");
+        let router = root_genesis_router(RootGenesisApiState::new(config));
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.expect("serve portal");
+        });
+
+        let directory = tempdir().expect("temporary directory");
+        let input_path = directory.path().join("envelope.json");
+        write_json(&input_path, &envelope).expect("write envelope");
+
+        run_submit_envelope(GenesisSubmitEnvelopeArgs {
+            portal_url: format!("http://{address}"),
+            input: Some(input_path),
+        })
+        .await
+        .expect("portal accepts submitted envelope");
+    }
+
+    #[test]
+    fn portal_envelopes_url_appends_path_at_most_once() {
+        let expected = "http://127.0.0.1:3017/api/v1/root-genesis/portal/envelopes";
+        assert_eq!(portal_envelopes_url("http://127.0.0.1:3017"), expected);
+        assert_eq!(portal_envelopes_url("http://127.0.0.1:3017/"), expected);
+        assert_eq!(portal_envelopes_url(expected), expected);
     }
 
     #[cfg(unix)]

--- a/crates/exo-node/src/root_genesis_cli.rs
+++ b/crates/exo-node/src/root_genesis_cli.rs
@@ -5,11 +5,13 @@ use std::{collections::BTreeMap, fs, io::Write, net::SocketAddr};
 use exo_core::{Did, Hash256, SecretKey, Timestamp, crypto::KeyPair};
 use exo_root::{
     CeremonyEnvelope, CeremonyEnvelopeDraft, CeremonyPayloadKind, CeremonyPhase, CertifierContact,
-    GenesisCeremonyConfig, PairwiseEncryptedPayload, RootIssuerDelegation, RootKeyPackage,
-    RootPublicKeyPackage, RootSigningNonces, RootSigningPackage, RootTrustBundle,
-    aggregate_signature, assemble_root_bundle, build_signing_package, decrypt_pairwise_payload,
-    dkg_finalize_participant, dkg_round1, dkg_round2, encrypt_pairwise_payload, seal_share,
-    sign_commit, sign_share, threshold_sign, unseal_share, verify_root_bundle,
+    GenesisCeremonyConfig, PairwiseEncryptedPayload, PortalStore, RootIssuerDelegation,
+    RootKeyPackage, RootParticipantDkgOutput, RootPublicKeyPackage, RootSignature,
+    RootSigningNonces, RootSigningPackage, RootTrustBundle, aggregate_signature,
+    assemble_root_bundle, build_final_key_confirmation, build_signing_package,
+    decrypt_pairwise_payload, dkg_finalize_participant, dkg_round1, dkg_round2,
+    encode_final_key_confirmation_payload, encrypt_pairwise_payload, seal_share, sign_commit,
+    sign_share, threshold_sign, unseal_share, verify_root_bundle,
 };
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -60,6 +62,13 @@ struct FinalizeDkgCommandInput {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct BuildFinalKeyConfirmationCommandInput {
+    config: GenesisCeremonyConfig,
+    dkg_output: RootParticipantDkgOutput,
+    dkg_transcript_hash_hex: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct SignRootArtifactCommandInput {
     config: GenesisCeremonyConfig,
     public_key_package: RootPublicKeyPackage,
@@ -73,12 +82,18 @@ struct AssembleBundleCommandInput {
     public_key_package: RootPublicKeyPackage,
     issuer_delegation: RootIssuerDelegation,
     transcript_hash: Hash256,
-    root_signature_hex: String,
+    root_signature: RootSignature,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct VerifyBundleCommandInput {
     bundle: RootTrustBundle,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct TranscriptHashCommandInput {
+    config: GenesisCeremonyConfig,
+    envelopes: Vec<CeremonyEnvelope>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -100,6 +115,11 @@ struct UnsealShareCommandInput {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct HexBytesOutput {
     bytes_hex: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct HashHexOutput {
+    hash_hex: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -210,6 +230,7 @@ pub async fn run_genesis_command(command: GenesisCommand) -> anyhow::Result<()> 
         GenesisCommand::Round1(args) => run_round1(args),
         GenesisCommand::Round2(args) => run_round2(args),
         GenesisCommand::FinalizeDkg(args) => run_finalize_dkg(args),
+        GenesisCommand::BuildFinalKeyConfirmation(args) => run_build_final_key_confirmation(args),
         GenesisCommand::SignRootArtifact(args) => run_sign_root_artifact(args),
         GenesisCommand::AssembleBundle(args) => run_assemble_bundle(args),
         GenesisCommand::VerifyBundle(args) => run_verify_bundle(args),
@@ -221,6 +242,8 @@ pub async fn run_genesis_command(command: GenesisCommand) -> anyhow::Result<()> 
         GenesisCommand::EmitArtifactBytes(args) => run_emit_artifact_bytes(args),
         GenesisCommand::SubmitEnvelope(args) => run_submit_envelope(args).await,
         GenesisCommand::PullEnvelopes(args) => run_pull_envelopes(args).await,
+        GenesisCommand::ComputeDkgTranscriptHash(args) => run_compute_dkg_transcript_hash(args),
+        GenesisCommand::ComputeFinalTranscriptHash(args) => run_compute_final_transcript_hash(args),
         GenesisCommand::EncodeEncryptedPayload(args) => run_encode_encrypted_payload(args),
         GenesisCommand::DecodeEncryptedPayload(args) => run_decode_encrypted_payload(args),
         GenesisCommand::SignCommit(args) => run_sign_commit(args),
@@ -280,7 +303,6 @@ fn init_ceremony(args: GenesisCeremonyInitArgs) -> anyhow::Result<()> {
         created_at: Timestamp::new(args.created_physical_ms, 0),
         certifiers,
         signing_set: args.signing_set,
-        signing_alternates: args.signing_alternates,
     };
     config.validate()?;
     write_json(&args.out, &config)?;
@@ -328,6 +350,15 @@ fn run_finalize_dkg(args: GenesisIoArgs) -> anyhow::Result<()> {
     write_secret_output(&args, &output)
 }
 
+fn run_build_final_key_confirmation(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: BuildFinalKeyConfirmationCommandInput = read_json(&required_input(&args)?)?;
+    let dkg_transcript_hash = parse_hash_hex(&input.dkg_transcript_hash_hex)?;
+    let confirmation =
+        build_final_key_confirmation(&input.config, &input.dkg_output, dkg_transcript_hash)?;
+    let payload_bytes = encode_final_key_confirmation_payload(&confirmation)?;
+    write_output(&args, &PayloadBytesOutput { payload_bytes })
+}
+
 fn run_sign_root_artifact(args: GenesisIoArgs) -> anyhow::Result<()> {
     let input: SignRootArtifactCommandInput = read_json(&required_input(&args)?)?;
     let artifact = decode_hex(&input.artifact_hex)?;
@@ -349,7 +380,7 @@ fn run_assemble_bundle(args: GenesisIoArgs) -> anyhow::Result<()> {
         input.public_key_package,
         input.issuer_delegation,
         input.transcript_hash,
-        decode_hex(&input.root_signature_hex)?,
+        input.root_signature,
     )?;
     write_output(&args, &bundle)
 }
@@ -395,23 +426,20 @@ fn run_sign_envelope(args: GenesisSignEnvelopeArgs) -> anyhow::Result<()> {
         output: args.output.clone(),
     };
     let input: SignEnvelopeCommandInput = read_json(&required_input(&io)?)?;
-    // Fail closed on disabled / unratified payload kinds: the generic signer must
-    // not be usable to mint envelopes the portal rejects (round-one set
-    // attestation and final key confirmation have no ratified schema; raw
-    // round-two plaintext is never relayed). This keeps the signer aligned with
-    // the portal's accepted set rather than relying on the portal alone.
+    // Fail closed on disabled payload kinds: the generic signer must not be
+    // usable to mint envelopes the portal rejects. FinalKeyConfirmation is now
+    // ratified, but it must be produced by `build-final-key-confirmation` before
+    // signing.
     match input.payload_kind {
-        CeremonyPayloadKind::Round1SetAttestation
-        | CeremonyPayloadKind::FinalKeyConfirmation
-        | CeremonyPayloadKind::Round2PlaintextPackage => {
+        CeremonyPayloadKind::Round1SetAttestation | CeremonyPayloadKind::Round2PlaintextPackage => {
             anyhow::bail!(
-                "sign-envelope refuses payload kind {:?}: it is disabled/unratified and rejected \
-                 by the portal",
+                "sign-envelope refuses payload kind {:?}: it is disabled and rejected by the portal",
                 input.payload_kind
             );
         }
         CeremonyPayloadKind::Round1Package
         | CeremonyPayloadKind::Round2EncryptedPackage
+        | CeremonyPayloadKind::FinalKeyConfirmation
         | CeremonyPayloadKind::RootSigningCommitment
         | CeremonyPayloadKind::RootSignatureShare => {}
     }
@@ -487,6 +515,30 @@ fn run_emit_artifact_bytes(args: GenesisIoArgs) -> anyhow::Result<()> {
         &args,
         &ArtifactBytesOutput {
             artifact_hex: hex::encode(artifact),
+        },
+    )
+}
+
+fn run_compute_dkg_transcript_hash(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: TranscriptHashCommandInput = read_json(&required_input(&args)?)?;
+    let store = replay_portal_envelopes(input.config, input.envelopes)?;
+    let hash = store.dkg_transcript_hash()?;
+    write_output(
+        &args,
+        &HashHexOutput {
+            hash_hex: hex::encode(hash.as_bytes()),
+        },
+    )
+}
+
+fn run_compute_final_transcript_hash(args: GenesisIoArgs) -> anyhow::Result<()> {
+    let input: TranscriptHashCommandInput = read_json(&required_input(&args)?)?;
+    let store = replay_portal_envelopes(input.config, input.envelopes)?;
+    let hash = store.final_transcript_hash()?;
+    write_output(
+        &args,
+        &HashHexOutput {
+            hash_hex: hex::encode(hash.as_bytes()),
         },
     )
 }
@@ -633,6 +685,29 @@ fn run_aggregate_signature(args: GenesisIoArgs) -> anyhow::Result<()> {
     write_output(&args, &output)
 }
 
+fn replay_portal_envelopes(
+    config: GenesisCeremonyConfig,
+    mut envelopes: Vec<CeremonyEnvelope>,
+) -> anyhow::Result<PortalStore> {
+    sort_portal_envelopes(envelopes.as_mut_slice());
+    let mut store = PortalStore::new(config);
+    for envelope in envelopes {
+        store.submit(envelope)?;
+    }
+    Ok(store)
+}
+
+fn sort_portal_envelopes(envelopes: &mut [CeremonyEnvelope]) {
+    envelopes.sort_by(|left, right| {
+        left.phase
+            .cmp(&right.phase)
+            .then(left.payload_kind.cmp(&right.payload_kind))
+            .then(left.sender_did.cmp(&right.sender_did))
+            .then(left.recipient_did.cmp(&right.recipient_did))
+            .then(left.sequence.cmp(&right.sequence))
+    });
+}
+
 /// Append the portal envelopes path to a base URL unless it is already present.
 fn portal_envelopes_url(base: &str) -> String {
     let trimmed = base.trim_end_matches('/');
@@ -646,7 +721,7 @@ fn portal_envelopes_url(base: &str) -> String {
 fn parse_hash_hex(value: &str) -> anyhow::Result<Hash256> {
     let bytes = hex::decode(value)?;
     if bytes.len() != 32 {
-        anyhow::bail!("constitution hash must be 32 bytes");
+        anyhow::bail!("hash must be 32 bytes");
     }
     let mut hash = [0u8; 32];
     hash.copy_from_slice(&bytes);
@@ -765,7 +840,7 @@ mod tests {
 
     use exo_authority::permission::Permission;
     use exo_core::PublicKey;
-    use exo_root::PortalStore;
+    use rand::SeedableRng;
     use tempfile::tempdir;
 
     use super::*;
@@ -815,7 +890,6 @@ mod tests {
             created_at: Timestamp::new(1_785_000_000_000, 0),
             certifiers,
             signing_set: (1..=7).collect(),
-            signing_alternates: (8..=13).collect(),
         };
         config.validate().expect("rostered config is valid");
         config
@@ -827,6 +901,50 @@ mod tests {
         exo_root::dkg_round1(config, 1, &mut rand::rngs::OsRng)
             .expect("round one")
             .round1_package
+    }
+
+    fn signed_test_envelope(
+        config: &GenesisCeremonyConfig,
+        sender_identifier: u16,
+        phase: CeremonyPhase,
+        payload_kind: CeremonyPayloadKind,
+        recipient_identifier: Option<u16>,
+        sequence: u64,
+        payload_bytes: Vec<u8>,
+    ) -> CeremonyEnvelope {
+        let sender = config
+            .certifier_by_identifier(sender_identifier)
+            .expect("sender");
+        let recipient = recipient_identifier.map(|identifier| {
+            config
+                .certifier_by_identifier(identifier)
+                .expect("recipient")
+                .did
+                .clone()
+        });
+        CeremonyEnvelope::sign(
+            CeremonyEnvelopeDraft {
+                ceremony_id: config.ceremony_id.clone(),
+                phase,
+                payload_kind,
+                sender_did: sender.did.clone(),
+                recipient_did: recipient,
+                sequence,
+                payload_bytes,
+            },
+            &SecretKey::from_bytes([u8::try_from(sender_identifier).expect("id fits"); 32]),
+        )
+        .expect("signed envelope")
+    }
+
+    fn encoded_pairwise_payload(ciphertext: impl Into<Vec<u8>>) -> Vec<u8> {
+        let payload = PairwiseEncryptedPayload {
+            nonce: [9u8; 24],
+            ciphertext: ciphertext.into(),
+        };
+        let mut bytes = Vec::new();
+        ciborium::into_writer(&payload, &mut bytes).expect("encode encrypted payload");
+        bytes
     }
 
     fn round1_broadcast(
@@ -869,7 +987,6 @@ mod tests {
             created_physical_ms: 42,
             roster: roster_path,
             signing_set: (1..=7).collect(),
-            signing_alternates: (8..=13).collect(),
             out: config_path.clone(),
         })
         .expect("ceremony init");
@@ -967,7 +1084,7 @@ mod tests {
             parse_hash_hex("abcd")
                 .expect_err("short hash must fail")
                 .to_string()
-                .contains("constitution hash must be 32 bytes")
+                .contains("hash must be 32 bytes")
         );
         assert!(
             decode_fixed_16("abcd")
@@ -1035,9 +1152,156 @@ mod tests {
     }
 
     #[test]
+    fn build_final_key_confirmation_emits_only_public_payload_bytes() {
+        let config = rostered_config();
+        let mut rng = rand::rngs::OsRng;
+        let dkg = exo_root::run_complete_dkg(&config, &mut rng).expect("dkg");
+        let transcript_hash = Hash256::digest(b"accepted dkg transcript");
+        let participant = RootParticipantDkgOutput {
+            key_package: dkg.key_packages[&1].clone(),
+            public_key_package: dkg.public_key_package.clone(),
+        };
+        let directory = tempdir().expect("temporary directory");
+        let input_path = directory.path().join("final-key-confirmation-in.json");
+        let output_path = directory.path().join("final-key-confirmation-out.json");
+        write_json(
+            &input_path,
+            &BuildFinalKeyConfirmationCommandInput {
+                config: config.clone(),
+                dkg_output: participant,
+                dkg_transcript_hash_hex: hex::encode(transcript_hash.as_bytes()),
+            },
+        )
+        .expect("write confirmation input");
+
+        run_build_final_key_confirmation(io_args(input_path, output_path.clone()))
+            .expect("build final key confirmation");
+        let output: PayloadBytesOutput = read_json(&output_path).expect("read payload bytes");
+        let confirmation: exo_root::FinalKeyConfirmation =
+            ciborium::from_reader(output.payload_bytes.as_slice()).expect("decode confirmation");
+        assert_eq!(confirmation.certifier_did, config.certifiers[0].did);
+        assert_eq!(confirmation.frost_identifier, 1);
+        assert_eq!(confirmation.dkg_transcript_hash, transcript_hash);
+        assert_eq!(confirmation.public_key_package, dkg.public_key_package);
+
+        let confirmation_json =
+            serde_json::to_value(&confirmation).expect("confirmation json projection");
+        let object = confirmation_json
+            .as_object()
+            .expect("confirmation is a JSON object");
+        assert!(
+            !object.contains_key("key_package"),
+            "final confirmation payload must not expose the secret FROST key package"
+        );
+        let rendered = serde_json::to_string(&confirmation_json).expect("render confirmation");
+        assert!(
+            !rendered.to_lowercase().contains("secret"),
+            "final confirmation payload must not expose secret-labeled fields"
+        );
+    }
+
+    #[test]
+    fn transcript_hash_commands_replay_envelopes_in_ceremony_order() {
+        let config = rostered_config();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(5_151);
+        let mut envelopes = Vec::new();
+        let mut store = PortalStore::new(config.clone());
+        for certifier in &config.certifiers {
+            let round1 = dkg_round1(&config, certifier.frost_identifier, &mut rng)
+                .expect("round one")
+                .round1_package;
+            let envelope = signed_test_envelope(
+                &config,
+                certifier.frost_identifier,
+                CeremonyPhase::Round1,
+                CeremonyPayloadKind::Round1Package,
+                None,
+                10,
+                round1,
+            );
+            store.submit(envelope.clone()).expect("submit round one");
+            envelopes.push(envelope);
+        }
+        for sender in &config.certifiers {
+            for recipient in &config.certifiers {
+                if sender.frost_identifier == recipient.frost_identifier {
+                    continue;
+                }
+                let sequence = 1_000
+                    + u64::from(sender.frost_identifier) * 100
+                    + u64::from(recipient.frost_identifier);
+                let envelope = signed_test_envelope(
+                    &config,
+                    sender.frost_identifier,
+                    CeremonyPhase::Round2,
+                    CeremonyPayloadKind::Round2EncryptedPackage,
+                    Some(recipient.frost_identifier),
+                    sequence,
+                    encoded_pairwise_payload(format!(
+                        "round2-{}-{}",
+                        sender.frost_identifier, recipient.frost_identifier
+                    )),
+                );
+                store.submit(envelope.clone()).expect("submit round two");
+                envelopes.push(envelope);
+            }
+        }
+        let dkg_hash = store.dkg_transcript_hash().expect("dkg hash");
+
+        let directory = tempdir().expect("temporary directory");
+        let dkg_in = directory.path().join("dkg-hash-in.json");
+        let dkg_out = directory.path().join("dkg-hash-out.json");
+        let mut reversed = envelopes.clone();
+        reversed.reverse();
+        write_json(
+            &dkg_in,
+            &TranscriptHashCommandInput {
+                config: config.clone(),
+                envelopes: reversed,
+            },
+        )
+        .expect("write dkg hash input");
+        run_compute_dkg_transcript_hash(io_args(dkg_in, dkg_out.clone()))
+            .expect("compute dkg hash");
+        let dkg_output: HashHexOutput = read_json(&dkg_out).expect("read dkg hash");
+        assert_eq!(dkg_output.hash_hex, hex::encode(dkg_hash.as_bytes()));
+
+        let dkg = exo_root::run_complete_dkg(&config, &mut rng).expect("dkg");
+        for identifier in 1..=13u16 {
+            let participant = RootParticipantDkgOutput {
+                key_package: dkg.key_packages[&identifier].clone(),
+                public_key_package: dkg.public_key_package.clone(),
+            };
+            let confirmation =
+                build_final_key_confirmation(&config, &participant, dkg_hash).expect("confirm");
+            let envelope = signed_test_envelope(
+                &config,
+                identifier,
+                CeremonyPhase::Finalize,
+                CeremonyPayloadKind::FinalKeyConfirmation,
+                None,
+                5_000 + u64::from(identifier),
+                encode_final_key_confirmation_payload(&confirmation).expect("encode"),
+            );
+            store.submit(envelope.clone()).expect("submit confirmation");
+            envelopes.push(envelope);
+        }
+        let final_hash = store.final_transcript_hash().expect("final hash");
+        let final_in = directory.path().join("final-hash-in.json");
+        let final_out = directory.path().join("final-hash-out.json");
+        envelopes.reverse();
+        write_json(&final_in, &TranscriptHashCommandInput { config, envelopes })
+            .expect("write final hash input");
+        run_compute_final_transcript_hash(io_args(final_in, final_out.clone()))
+            .expect("compute final hash");
+        let final_output: HashHexOutput = read_json(&final_out).expect("read final hash");
+        assert_eq!(final_output.hash_hex, hex::encode(final_hash.as_bytes()));
+    }
+
+    #[test]
     fn sign_envelope_refuses_disabled_payload_kinds() {
         // Bob's blocker-3 regression: the generic signer must fail closed on
-        // disabled/unratified kinds so it cannot mint envelopes the portal rejects.
+        // disabled kinds so it cannot mint envelopes the portal rejects.
         let config = rostered_config();
         let signer = config.certifiers[0].clone();
         let directory = tempdir().expect("temporary directory");
@@ -1072,8 +1336,8 @@ mod tests {
             output: Some(directory.path().join("envelope.json")),
             private_input: private_path,
         })
-        .expect_err("sign-envelope must refuse a disabled/unratified payload kind");
-        assert!(error.to_string().contains("disabled/unratified"));
+        .expect_err("sign-envelope must refuse a disabled payload kind");
+        assert!(error.to_string().contains("disabled"));
     }
 
     #[test]

--- a/crates/exo-node/src/root_genesis_cli.rs
+++ b/crates/exo-node/src/root_genesis_cli.rs
@@ -6,8 +6,8 @@ use exo_core::{Did, Hash256, SecretKey, Timestamp, crypto::KeyPair};
 use exo_root::{
     CeremonyEnvelope, CeremonyEnvelopeDraft, CeremonyPayloadKind, CeremonyPhase, CertifierContact,
     GenesisCeremonyConfig, PairwiseEncryptedPayload, RootIssuerDelegation, RootKeyPackage,
-    RootPublicKeyPackage, RootSigningNonces, RootTrustBundle, aggregate_signature,
-    assemble_root_bundle, build_signing_package, decrypt_pairwise_payload,
+    RootPublicKeyPackage, RootSigningNonces, RootSigningPackage, RootTrustBundle,
+    aggregate_signature, assemble_root_bundle, build_signing_package, decrypt_pairwise_payload,
     dkg_finalize_participant, dkg_round1, dkg_round2, encrypt_pairwise_payload, seal_share,
     sign_commit, sign_share, threshold_sign, unseal_share, verify_root_bundle,
 };
@@ -167,6 +167,9 @@ struct PayloadBytesOutput {
 struct SignCommitCommandInput {
     config: GenesisCeremonyConfig,
     key_package: RootKeyPackage,
+    /// Hex of the exact root artifact to be signed (from `emit-artifact-bytes`).
+    /// The nonces are bound to this artifact and can sign no other message.
+    artifact_hex: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -180,7 +183,11 @@ struct BuildSigningPackageCommandInput {
 struct SignShareCommandInput {
     config: GenesisCeremonyConfig,
     key_package: RootKeyPackage,
-    signing_package_hex: String,
+    /// The coordinator's signing package (commitments + signer set).
+    signing_package: RootSigningPackage,
+    /// Hex of the root artifact this signer intends to sign; must equal the
+    /// artifact its nonces were bound to at `sign-commit`.
+    artifact_hex: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -388,6 +395,26 @@ fn run_sign_envelope(args: GenesisSignEnvelopeArgs) -> anyhow::Result<()> {
         output: args.output.clone(),
     };
     let input: SignEnvelopeCommandInput = read_json(&required_input(&io)?)?;
+    // Fail closed on disabled / unratified payload kinds: the generic signer must
+    // not be usable to mint envelopes the portal rejects (round-one set
+    // attestation and final key confirmation have no ratified schema; raw
+    // round-two plaintext is never relayed). This keeps the signer aligned with
+    // the portal's accepted set rather than relying on the portal alone.
+    match input.payload_kind {
+        CeremonyPayloadKind::Round1SetAttestation
+        | CeremonyPayloadKind::FinalKeyConfirmation
+        | CeremonyPayloadKind::Round2PlaintextPackage => {
+            anyhow::bail!(
+                "sign-envelope refuses payload kind {:?}: it is disabled/unratified and rejected \
+                 by the portal",
+                input.payload_kind
+            );
+        }
+        CeremonyPayloadKind::Round1Package
+        | CeremonyPayloadKind::Round2EncryptedPackage
+        | CeremonyPayloadKind::RootSigningCommitment
+        | CeremonyPayloadKind::RootSignatureShare => {}
+    }
     // The signing secret is read from the certifier's 0600 private-material file,
     // never from argv — see GenesisSignEnvelopeArgs.
     let private: PrivateCertifierMaterial = read_json(&args.private_input)?;
@@ -536,8 +563,14 @@ fn run_sign_commit(args: GenesisSignCommitArgs) -> anyhow::Result<()> {
         output: None,
     };
     let input: SignCommitCommandInput = read_json(&required_input(&io)?)?;
+    let artifact = decode_hex(&input.artifact_hex)?;
     let mut rng = rand::rngs::OsRng;
-    let (commitment, nonces) = sign_commit(&input.config, &input.key_package, &mut rng)?;
+    let (commitment, nonces) = sign_commit(
+        &input.config,
+        &input.key_package,
+        artifact.as_slice(),
+        &mut rng,
+    )?;
     // The public commitment goes to a file safe to transmit to the coordinator;
     // the SECRET nonces go to a SEPARATE local-only file. Both writes are
     // create-new + 0600 and refuse to overwrite an existing path.
@@ -565,11 +598,13 @@ fn run_sign_share(args: GenesisSignShareArgs) -> anyhow::Result<()> {
     let input: SignShareCommandInput = read_json(&required_input(&io)?)?;
     // The secret nonces are read from the signer's local-only file, never inline.
     let nonces: RootSigningNonces = read_json(&args.nonces)?;
+    let artifact = decode_hex(&input.artifact_hex)?;
     let output = sign_share(
         &input.config,
         &input.key_package,
         &nonces,
-        decode_hex(&input.signing_package_hex)?.as_slice(),
+        &input.signing_package,
+        artifact.as_slice(),
     )?;
     write_output(&io, &output)?;
     // Single-use: consume (delete) the nonces file after a successful share so
@@ -1000,6 +1035,48 @@ mod tests {
     }
 
     #[test]
+    fn sign_envelope_refuses_disabled_payload_kinds() {
+        // Bob's blocker-3 regression: the generic signer must fail closed on
+        // disabled/unratified kinds so it cannot mint envelopes the portal rejects.
+        let config = rostered_config();
+        let signer = config.certifiers[0].clone();
+        let directory = tempdir().expect("temporary directory");
+        let input_path = directory.path().join("attestation-draft.json");
+        let private_path = directory.path().join("certifier-01.private.json");
+        write_json(
+            &input_path,
+            &SignEnvelopeCommandInput {
+                ceremony_id: config.ceremony_id.clone(),
+                phase: CeremonyPhase::Round1SetAttestation,
+                payload_kind: CeremonyPayloadKind::Round1SetAttestation,
+                sender_did: signer.did.clone(),
+                recipient_did: None,
+                sequence: 1,
+                payload_bytes: b"unratified attestation payload".to_vec(),
+            },
+        )
+        .expect("write draft");
+        write_json(
+            &private_path,
+            &PrivateCertifierMaterial {
+                did: signer.did.clone(),
+                frost_identifier: signer.frost_identifier,
+                signing_secret_hex: hex::encode([1u8; 32]),
+                transport_secret_hex: hex::encode([65u8; 32]),
+            },
+        )
+        .expect("write private material");
+
+        let error = run_sign_envelope(GenesisSignEnvelopeArgs {
+            input: Some(input_path),
+            output: Some(directory.path().join("envelope.json")),
+            private_input: private_path,
+        })
+        .expect_err("sign-envelope must refuse a disabled/unratified payload kind");
+        assert!(error.to_string().contains("disabled/unratified"));
+    }
+
+    #[test]
     fn encrypt_then_decrypt_pairwise_round_trips() {
         let directory = tempdir().expect("temporary directory");
         let sender_secret = [5u8; 32];
@@ -1180,6 +1257,7 @@ mod tests {
                 &SignCommitCommandInput {
                     config: config.clone(),
                     key_package: dkg.key_packages[id].clone(),
+                    artifact_hex: artifact_hex.clone(),
                 },
             )
             .expect("write commit input");
@@ -1242,7 +1320,6 @@ mod tests {
         .expect("write package input");
         run_build_signing_package(io_args(pkg_in, pkg_out.clone())).expect("build-signing-package");
         let package: exo_root::RootSigningPackage = read_json(&pkg_out).expect("read package");
-        let signing_package_hex = hex::encode(&package.signing_package);
 
         let mut shares_hex = BTreeMap::new();
         for id in &signers {
@@ -1253,7 +1330,8 @@ mod tests {
                 &SignShareCommandInput {
                     config: config.clone(),
                     key_package: dkg.key_packages[id].clone(),
-                    signing_package_hex: signing_package_hex.clone(),
+                    signing_package: package.clone(),
+                    artifact_hex: artifact_hex.clone(),
                 },
             )
             .expect("write share input");
@@ -1280,7 +1358,7 @@ mod tests {
             &AggregateSignatureCommandInput {
                 config: config.clone(),
                 public_key_package: dkg.public_key_package.clone(),
-                signing_package_hex,
+                signing_package_hex: hex::encode(package.signing_package.as_slice()),
                 shares_hex,
                 artifact_hex,
             },

--- a/crates/exo-node/src/root_genesis_cli.rs
+++ b/crates/exo-node/src/root_genesis_cli.rs
@@ -6,10 +6,10 @@ use exo_core::{Did, Hash256, SecretKey, Timestamp, crypto::KeyPair};
 use exo_root::{
     CeremonyEnvelope, CeremonyEnvelopeDraft, CeremonyPayloadKind, CeremonyPhase, CertifierContact,
     GenesisCeremonyConfig, PairwiseEncryptedPayload, RootIssuerDelegation, RootKeyPackage,
-    RootPublicKeyPackage, RootTrustBundle, aggregate_signature, assemble_root_bundle,
-    build_signing_package, decrypt_pairwise_payload, dkg_finalize_participant, dkg_round1,
-    dkg_round2, encrypt_pairwise_payload, seal_share, sign_commit, sign_share, threshold_sign,
-    unseal_share, verify_root_bundle,
+    RootPublicKeyPackage, RootSigningNonces, RootTrustBundle, aggregate_signature,
+    assemble_root_bundle, build_signing_package, decrypt_pairwise_payload,
+    dkg_finalize_participant, dkg_round1, dkg_round2, encrypt_pairwise_payload, seal_share,
+    sign_commit, sign_share, threshold_sign, unseal_share, verify_root_bundle,
 };
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -19,22 +19,14 @@ use crate::{
     cli::{
         GenesisCeremonyCommand, GenesisCeremonyInitArgs, GenesisCertifierCommand,
         GenesisCertifierInitArgs, GenesisCommand, GenesisIoArgs, GenesisPortalArgs,
-        GenesisPullEnvelopesArgs, GenesisSignEnvelopeArgs, GenesisSubmitEnvelopeArgs,
+        GenesisPullEnvelopesArgs, GenesisSignCommitArgs, GenesisSignEnvelopeArgs,
+        GenesisSignShareArgs, GenesisSubmitEnvelopeArgs,
     },
     root_genesis::{RootGenesisApiState, root_genesis_router},
 };
 
 /// Portal HTTP path that accepts signed ceremony envelopes.
 const PORTAL_ENVELOPES_PATH: &str = "/api/v1/root-genesis/portal/envelopes";
-
-/// Domain separator for the PROVISIONAL round-one set attestation statement.
-///
-/// The canonical shape of a `Round1SetAttestation` payload is not defined or
-/// validated anywhere in `exo-root` (the portal treats the bytes as opaque).
-/// This encoding is a deterministic best-effort proposal and is NOT ratified;
-/// the `V0_UNRATIFIED` suffix must change once the exo-root maintainer confirms
-/// the intended shape. See `run_build_round1_attestation`.
-const ROUND1_SET_ATTESTATION_DOMAIN: &str = "EXOCHAIN_ROOT_ROUND1_SET_ATTESTATION_V0_UNRATIFIED";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct PrivateCertifierMaterial {
@@ -128,7 +120,6 @@ struct EncryptPairwiseCommandInput {
     sender_transport_secret_hex: String,
     recipient_transport_pubkey_hex: String,
     associated_data_hex: String,
-    nonce_hex: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -148,11 +139,6 @@ struct EmitArtifactBytesCommandInput {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-struct BuildRound1AttestationCommandInput {
-    round1_envelopes: Vec<CeremonyEnvelope>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct ArtifactBytesOutput {
     artifact_hex: String,
 }
@@ -160,34 +146,6 @@ struct ArtifactBytesOutput {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct PlaintextOutput {
     plaintext: Vec<u8>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-struct Round1AttestationOutput {
-    /// Bytes to place in the `payload_bytes` field of a `Round1SetAttestation`
-    /// envelope (then sign with `sign-envelope`). PROVISIONAL encoding.
-    payload_hex: String,
-    /// blake3 of `payload_hex` — a convenience digest of the attested set.
-    attestation_hash_hex: String,
-    /// Number of round-one packages bound by this attestation.
-    entry_count: usize,
-}
-
-/// One `(sender, round1-package-hash)` binding inside the provisional
-/// round-one set attestation statement, canonicalised in sorted order.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct Round1SetAttestationEntry {
-    sender_did: Did,
-    round1_package_hash: Hash256,
-}
-
-/// Provisional canonical statement bound by a `Round1SetAttestation` envelope.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct Round1SetAttestationStatement<'a> {
-    domain: &'static str,
-    ceremony_id: &'a str,
-    entry_count: usize,
-    entries: &'a [Round1SetAttestationEntry],
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -222,7 +180,6 @@ struct BuildSigningPackageCommandInput {
 struct SignShareCommandInput {
     config: GenesisCeremonyConfig,
     key_package: RootKeyPackage,
-    nonces_hex: String,
     signing_package_hex: String,
 }
 
@@ -255,7 +212,6 @@ pub async fn run_genesis_command(command: GenesisCommand) -> anyhow::Result<()> 
         GenesisCommand::EncryptPairwise(args) => run_encrypt_pairwise(args),
         GenesisCommand::DecryptPairwise(args) => run_decrypt_pairwise(args),
         GenesisCommand::EmitArtifactBytes(args) => run_emit_artifact_bytes(args),
-        GenesisCommand::BuildRound1Attestation(args) => run_build_round1_attestation(args),
         GenesisCommand::SubmitEnvelope(args) => run_submit_envelope(args).await,
         GenesisCommand::PullEnvelopes(args) => run_pull_envelopes(args).await,
         GenesisCommand::EncodeEncryptedPayload(args) => run_encode_encrypted_payload(args),
@@ -430,7 +386,17 @@ fn run_sign_envelope(args: GenesisSignEnvelopeArgs) -> anyhow::Result<()> {
         output: args.output.clone(),
     };
     let input: SignEnvelopeCommandInput = read_json(&required_input(&io)?)?;
-    let signing_secret = SecretKey::from_bytes(decode_fixed_32(&args.signing_key_hex)?);
+    // The signing secret is read from the certifier's 0600 private-material file,
+    // never from argv — see GenesisSignEnvelopeArgs.
+    let private: PrivateCertifierMaterial = read_json(&args.private_input)?;
+    if private.did != input.sender_did {
+        anyhow::bail!(
+            "private material DID {} does not match envelope sender_did {}",
+            private.did,
+            input.sender_did
+        );
+    }
+    let signing_secret = SecretKey::from_bytes(decode_fixed_32(&private.signing_secret_hex)?);
     let draft = CeremonyEnvelopeDraft {
         ceremony_id: input.ceremony_id,
         phase: input.phase,
@@ -448,7 +414,13 @@ fn run_encrypt_pairwise(args: GenesisIoArgs) -> anyhow::Result<()> {
     let input: EncryptPairwiseCommandInput = read_json(&required_input(&args)?)?;
     let sender_secret = decode_fixed_32(&input.sender_transport_secret_hex)?;
     let recipient_public = decode_fixed_32(&input.recipient_transport_pubkey_hex)?;
-    let nonce = decode_fixed_24(&input.nonce_hex)?;
+    // The 24-byte XChaCha20-Poly1305 nonce is generated internally with the OS
+    // CSPRNG, never taken from caller input: a repeated nonce under the same
+    // derived key would break round-two confidentiality, so the binary — not an
+    // operator script — owns nonce uniqueness. The nonce is returned inside the
+    // encrypted payload for the recipient to use during decryption.
+    let mut nonce = [0u8; 24];
+    rand::rngs::OsRng.fill_bytes(&mut nonce);
     let associated_data = decode_hex(&input.associated_data_hex)?;
     let encrypted = encrypt_pairwise_payload(
         &sender_secret,
@@ -486,71 +458,6 @@ fn run_emit_artifact_bytes(args: GenesisIoArgs) -> anyhow::Result<()> {
         &args,
         &ArtifactBytesOutput {
             artifact_hex: hex::encode(artifact),
-        },
-    )
-}
-
-/// Build a PROVISIONAL round-one set attestation payload.
-///
-/// `exo-root` defines no canonical shape for `Round1SetAttestation` payloads —
-/// the portal accepts the bytes opaquely (see `portal.rs::validate_phase_policy`,
-/// which only checks phase/kind/recipient, never content). This command emits a
-/// deterministic statement binding the sorted set of
-/// `(sender_did, round1_package_hash)` pairs taken from the round-one
-/// broadcast envelopes, domain-separated by [`ROUND1_SET_ATTESTATION_DOMAIN`]
-/// and CBOR-encoded with the same canonical encoder the library uses for its
-/// own signing payloads.
-///
-/// This encoding is UNRATIFIED. Do not rely on it for the production ceremony
-/// until the exo-root maintainer confirms the intended shape; if they choose a
-/// different one (for example a bare digest, or keying on `frost_identifier`
-/// instead of `sender_did`), only this function and the domain tag change.
-fn run_build_round1_attestation(args: GenesisIoArgs) -> anyhow::Result<()> {
-    let input: BuildRound1AttestationCommandInput = read_json(&required_input(&args)?)?;
-    if input.round1_envelopes.is_empty() {
-        anyhow::bail!("round1 set must contain at least one envelope");
-    }
-    let ceremony_id = input.round1_envelopes[0].ceremony_id.clone();
-    let mut entries = Vec::with_capacity(input.round1_envelopes.len());
-    for envelope in &input.round1_envelopes {
-        if envelope.ceremony_id != ceremony_id {
-            anyhow::bail!("round1 set mixes ceremony identifiers");
-        }
-        if envelope.phase != CeremonyPhase::Round1
-            || envelope.payload_kind != CeremonyPayloadKind::Round1Package
-        {
-            anyhow::bail!("round1 set contains a non-Round1Package envelope");
-        }
-        entries.push(Round1SetAttestationEntry {
-            sender_did: envelope.sender_did.clone(),
-            round1_package_hash: envelope.payload_hash,
-        });
-    }
-    entries.sort_by(|left, right| left.sender_did.cmp(&right.sender_did));
-    for pair in entries.windows(2) {
-        if pair[0].sender_did == pair[1].sender_did {
-            anyhow::bail!(
-                "round1 set contains duplicate sender {}",
-                pair[0].sender_did
-            );
-        }
-    }
-    let statement = Round1SetAttestationStatement {
-        domain: ROUND1_SET_ATTESTATION_DOMAIN,
-        ceremony_id: &ceremony_id,
-        entry_count: entries.len(),
-        entries: entries.as_slice(),
-    };
-    let mut payload = Vec::new();
-    ciborium::into_writer(&statement, &mut payload)
-        .map_err(|error| anyhow::anyhow!("round1 attestation encoding failed: {error}"))?;
-    let attestation_hash = Hash256::digest(payload.as_slice());
-    write_output(
-        &args,
-        &Round1AttestationOutput {
-            payload_hex: hex::encode(payload.as_slice()),
-            attestation_hash_hex: hex::encode(attestation_hash.as_bytes()),
-            entry_count: entries.len(),
         },
     )
 }
@@ -621,12 +528,20 @@ fn run_decode_encrypted_payload(args: GenesisIoArgs) -> anyhow::Result<()> {
     write_output(&args, &encrypted)
 }
 
-fn run_sign_commit(args: GenesisIoArgs) -> anyhow::Result<()> {
-    let input: SignCommitCommandInput = read_json(&required_input(&args)?)?;
+fn run_sign_commit(args: GenesisSignCommitArgs) -> anyhow::Result<()> {
+    let io = GenesisIoArgs {
+        input: args.input.clone(),
+        output: None,
+    };
+    let input: SignCommitCommandInput = read_json(&required_input(&io)?)?;
     let mut rng = rand::rngs::OsRng;
-    let output = sign_commit(&input.config, &input.key_package, &mut rng)?;
-    // Contains secret signing nonces — never print to stdout.
-    write_secret_output(&args, &output)
+    let (commitment, nonces) = sign_commit(&input.config, &input.key_package, &mut rng)?;
+    // The public commitment goes to a file safe to transmit to the coordinator;
+    // the SECRET nonces go to a SEPARATE local-only file. Both writes are
+    // create-new + 0600 and refuse to overwrite an existing path.
+    write_json(&args.commitment_out, &commitment)?;
+    write_json(&args.nonces_out, &nonces)?;
+    Ok(())
 }
 
 fn run_build_signing_package(args: GenesisIoArgs) -> anyhow::Result<()> {
@@ -640,15 +555,21 @@ fn run_build_signing_package(args: GenesisIoArgs) -> anyhow::Result<()> {
     write_output(&args, &output)
 }
 
-fn run_sign_share(args: GenesisIoArgs) -> anyhow::Result<()> {
-    let input: SignShareCommandInput = read_json(&required_input(&args)?)?;
+fn run_sign_share(args: GenesisSignShareArgs) -> anyhow::Result<()> {
+    let io = GenesisIoArgs {
+        input: args.input.clone(),
+        output: args.output.clone(),
+    };
+    let input: SignShareCommandInput = read_json(&required_input(&io)?)?;
+    // The secret nonces are read from the signer's local-only file, never inline.
+    let nonces: RootSigningNonces = read_json(&args.nonces)?;
     let output = sign_share(
         &input.config,
         &input.key_package,
-        decode_hex(&input.nonces_hex)?.as_slice(),
+        &nonces,
         decode_hex(&input.signing_package_hex)?.as_slice(),
     )?;
-    write_output(&args, &output)
+    write_output(&io, &output)
 }
 
 fn run_aggregate_signature(args: GenesisIoArgs) -> anyhow::Result<()> {
@@ -1011,6 +932,7 @@ mod tests {
         let signer = config.certifiers[0].clone();
         let directory = tempdir().expect("temporary directory");
         let input_path = directory.path().join("draft.json");
+        let private_path = directory.path().join("certifier-01.private.json");
         let output_path = directory.path().join("envelope.json");
         write_json(
             &input_path,
@@ -1025,11 +947,22 @@ mod tests {
             },
         )
         .expect("write draft");
+        // The signing secret lives only in the 0600 private-material file.
+        write_json(
+            &private_path,
+            &PrivateCertifierMaterial {
+                did: signer.did.clone(),
+                frost_identifier: signer.frost_identifier,
+                signing_secret_hex: hex::encode([1u8; 32]),
+                transport_secret_hex: hex::encode([65u8; 32]),
+            },
+        )
+        .expect("write private material");
 
         run_sign_envelope(GenesisSignEnvelopeArgs {
             input: Some(input_path),
             output: Some(output_path.clone()),
-            signing_key_hex: hex::encode([1u8; 32]),
+            private_input: private_path,
         })
         .expect("sign envelope");
 
@@ -1050,7 +983,6 @@ mod tests {
         let recipient_public =
             *X25519PublicKey::from(&StaticSecret::from(recipient_secret)).as_bytes();
         let associated_data = b"exo-root-round2";
-        let nonce = [7u8; 24];
         let plaintext = b"round2 secret package".to_vec();
 
         let encrypt_in = directory.path().join("encrypt-in.json");
@@ -1062,14 +994,14 @@ mod tests {
                 sender_transport_secret_hex: hex::encode(sender_secret),
                 recipient_transport_pubkey_hex: hex::encode(recipient_public),
                 associated_data_hex: hex::encode(associated_data),
-                nonce_hex: hex::encode(nonce),
             },
         )
         .expect("write encrypt input");
         run_encrypt_pairwise(io_args(encrypt_in, encrypt_out.clone())).expect("encrypt pairwise");
+        // The nonce is generated by the command and carried in the payload for
+        // the recipient; the caller never supplies it.
         let encrypted: PairwiseEncryptedPayload =
             read_json(&encrypt_out).expect("read encrypted payload");
-        assert_eq!(encrypted.nonce, nonce);
 
         let decrypt_in = directory.path().join("decrypt-in.json");
         let decrypt_out = directory.path().join("decrypt-out.json");
@@ -1086,6 +1018,43 @@ mod tests {
         run_decrypt_pairwise(io_args(decrypt_in, decrypt_out.clone())).expect("decrypt pairwise");
         let opened: PlaintextOutput = read_json(&decrypt_out).expect("read plaintext");
         assert_eq!(opened.plaintext, plaintext);
+    }
+
+    #[test]
+    fn encrypt_pairwise_cannot_be_forced_to_reuse_a_nonce() {
+        // Identical plaintext + AAD + keys across two invocations must still
+        // produce different nonces, because the caller cannot supply one and the
+        // command draws it from the OS CSPRNG each time.
+        let directory = tempdir().expect("temporary directory");
+        let sender_secret = [5u8; 32];
+        let recipient_public = *X25519PublicKey::from(&StaticSecret::from([6u8; 32])).as_bytes();
+        let make_input = || EncryptPairwiseCommandInput {
+            plaintext: b"identical round2 plaintext".to_vec(),
+            sender_transport_secret_hex: hex::encode(sender_secret),
+            recipient_transport_pubkey_hex: hex::encode(recipient_public),
+            associated_data_hex: hex::encode(b"exo-root-round2"),
+        };
+
+        let first_in = directory.path().join("reuse-in-1.json");
+        let first_out = directory.path().join("reuse-out-1.json");
+        write_json(&first_in, &make_input()).expect("write first input");
+        run_encrypt_pairwise(io_args(first_in, first_out.clone())).expect("first encrypt");
+        let first: PairwiseEncryptedPayload = read_json(&first_out).expect("read first");
+
+        let second_in = directory.path().join("reuse-in-2.json");
+        let second_out = directory.path().join("reuse-out-2.json");
+        write_json(&second_in, &make_input()).expect("write second input");
+        run_encrypt_pairwise(io_args(second_in, second_out.clone())).expect("second encrypt");
+        let second: PairwiseEncryptedPayload = read_json(&second_out).expect("read second");
+
+        assert_ne!(
+            first.nonce, second.nonce,
+            "internally generated nonces must differ across invocations"
+        );
+        assert_ne!(
+            first.ciphertext, second.ciphertext,
+            "distinct nonces must yield distinct ciphertext"
+        );
     }
 
     #[test]
@@ -1167,73 +1136,6 @@ mod tests {
     }
 
     #[test]
-    fn build_round1_attestation_is_order_independent_and_portal_submittable() {
-        let config = rostered_config();
-        let envelopes = vec![
-            round1_broadcast(&config, 0, 1, b"round1-a".to_vec()),
-            round1_broadcast(&config, 1, 1, b"round1-b".to_vec()),
-            round1_broadcast(&config, 2, 1, b"round1-c".to_vec()),
-        ];
-
-        let directory = tempdir().expect("temporary directory");
-        let forward_in = directory.path().join("attest-forward-in.json");
-        let forward_out = directory.path().join("attest-forward-out.json");
-        write_json(
-            &forward_in,
-            &BuildRound1AttestationCommandInput {
-                round1_envelopes: envelopes.clone(),
-            },
-        )
-        .expect("write forward input");
-        run_build_round1_attestation(io_args(forward_in, forward_out.clone()))
-            .expect("build attestation (forward)");
-
-        let mut reversed = envelopes;
-        reversed.reverse();
-        let reversed_in = directory.path().join("attest-reversed-in.json");
-        let reversed_out = directory.path().join("attest-reversed-out.json");
-        write_json(
-            &reversed_in,
-            &BuildRound1AttestationCommandInput {
-                round1_envelopes: reversed,
-            },
-        )
-        .expect("write reversed input");
-        run_build_round1_attestation(io_args(reversed_in, reversed_out.clone()))
-            .expect("build attestation (reversed)");
-
-        let forward: Round1AttestationOutput =
-            read_json(&forward_out).expect("read forward output");
-        let reversed: Round1AttestationOutput =
-            read_json(&reversed_out).expect("read reversed output");
-        assert_eq!(
-            forward, reversed,
-            "attestation must be canonical regardless of input order"
-        );
-        assert_eq!(forward.entry_count, 3);
-
-        let payload_bytes = hex::decode(forward.payload_hex.as_str()).expect("hex payload");
-        let attestation_secret = SecretKey::from_bytes([1u8; 32]);
-        let attestation = CeremonyEnvelope::sign(
-            CeremonyEnvelopeDraft {
-                ceremony_id: config.ceremony_id.clone(),
-                phase: CeremonyPhase::Round1SetAttestation,
-                payload_kind: CeremonyPayloadKind::Round1SetAttestation,
-                sender_did: config.certifiers[0].did.clone(),
-                recipient_did: None,
-                sequence: 100,
-                payload_bytes,
-            },
-            &attestation_secret,
-        )
-        .expect("sign attestation envelope");
-        let mut store = PortalStore::new(config);
-        store
-            .submit(attestation)
-            .expect("portal accepts the attestation envelope");
-    }
-
-    #[test]
     fn distributed_signing_handlers_produce_a_verifiable_signature() {
         let config = rostered_config();
         let dkg = exo_root::run_complete_dkg(&config, &mut rand::rngs::OsRng).expect("dkg");
@@ -1243,10 +1145,11 @@ mod tests {
         let signers: Vec<u16> = (1..=7).collect();
 
         let mut commitments_hex = BTreeMap::new();
-        let mut nonces_hex = BTreeMap::new();
+        let mut nonces_paths: BTreeMap<u16, PathBuf> = BTreeMap::new();
         for id in &signers {
             let in_path = directory.path().join(format!("commit-in-{id}.json"));
-            let out_path = directory.path().join(format!("commit-out-{id}.json"));
+            let commitment_out = directory.path().join(format!("commitment-{id}.json"));
+            let nonces_out = directory.path().join(format!("nonces-{id}.json"));
             write_json(
                 &in_path,
                 &SignCommitCommandInput {
@@ -1255,11 +1158,18 @@ mod tests {
                 },
             )
             .expect("write commit input");
-            run_sign_commit(io_args(in_path, out_path.clone())).expect("sign-commit");
+            run_sign_commit(GenesisSignCommitArgs {
+                input: Some(in_path),
+                commitment_out: commitment_out.clone(),
+                nonces_out: nonces_out.clone(),
+            })
+            .expect("sign-commit");
             let commit: exo_root::RootSigningCommitment =
-                read_json(&out_path).expect("read commitment");
-            commitments_hex.insert(*id, hex::encode(&commit.commitments));
-            nonces_hex.insert(*id, hex::encode(&commit.nonces));
+                read_json(&commitment_out).expect("read commitment");
+            commitments_hex.insert(*id, hex::encode(commit.commitments.as_slice()));
+            // The secret nonces stay in their own local-only file, referenced by
+            // path for round two — they never travel with the commitment.
+            nonces_paths.insert(*id, nonces_out);
         }
 
         let pkg_in = directory.path().join("pkg-in.json");
@@ -1286,15 +1196,19 @@ mod tests {
                 &SignShareCommandInput {
                     config: config.clone(),
                     key_package: dkg.key_packages[id].clone(),
-                    nonces_hex: nonces_hex[id].clone(),
                     signing_package_hex: signing_package_hex.clone(),
                 },
             )
             .expect("write share input");
-            run_sign_share(io_args(in_path, out_path.clone())).expect("sign-share");
+            run_sign_share(GenesisSignShareArgs {
+                input: Some(in_path),
+                nonces: nonces_paths[id].clone(),
+                output: Some(out_path.clone()),
+            })
+            .expect("sign-share");
             let share: exo_root::RootSignatureShareOutput =
                 read_json(&out_path).expect("read share");
-            shares_hex.insert(*id, hex::encode(&share.signature_share));
+            shares_hex.insert(*id, hex::encode(share.signature_share.as_slice()));
         }
 
         let agg_in = directory.path().join("agg-in.json");
@@ -1319,6 +1233,88 @@ mod tests {
             &signature.signature,
         )
         .expect("distributed signature verifies against the root key");
+    }
+
+    #[test]
+    fn root_signing_commitment_json_has_no_secret_named_field() {
+        // The relay-safe RootSigningCommitment, round-tripped through JSON, must
+        // expose no field whose name suggests secret material.
+        let config = rostered_config();
+        let dkg = exo_root::run_complete_dkg(&config, &mut rand::rngs::OsRng).expect("dkg");
+        let (commitment, _nonces) =
+            exo_root::sign_commit(&config, &dkg.key_packages[&1], &mut rand::rngs::OsRng)
+                .expect("commit");
+        let json = serde_json::to_string(&commitment).expect("serialize commitment");
+        let value: serde_json::Value = serde_json::from_str(&json).expect("parse commitment json");
+        let object = value
+            .as_object()
+            .expect("commitment serializes as a JSON object");
+        for key in object.keys() {
+            let lowered = key.to_lowercase();
+            assert!(
+                !(lowered.contains("nonce")
+                    || lowered.contains("secret")
+                    || lowered.contains("private")),
+                "relay-safe RootSigningCommitment must not expose field `{key}`"
+            );
+        }
+    }
+
+    #[test]
+    fn sign_commit_writes_public_commitment_and_secret_nonces_to_separate_files() {
+        let config = rostered_config();
+        let dkg = exo_root::run_complete_dkg(&config, &mut rand::rngs::OsRng).expect("dkg");
+        let directory = tempdir().expect("temporary directory");
+        let in_path = directory.path().join("commit-in.json");
+        let commitment_out = directory.path().join("commitment.json");
+        let nonces_out = directory.path().join("nonces.json");
+        write_json(
+            &in_path,
+            &SignCommitCommandInput {
+                config: config.clone(),
+                key_package: dkg.key_packages[&1].clone(),
+            },
+        )
+        .expect("write commit input");
+        run_sign_commit(GenesisSignCommitArgs {
+            input: Some(in_path),
+            commitment_out: commitment_out.clone(),
+            nonces_out: nonces_out.clone(),
+        })
+        .expect("sign-commit");
+
+        // The coordinator-facing commitment file carries no nonces field.
+        let commitment_value: serde_json::Value =
+            serde_json::from_slice(&fs::read(&commitment_out).expect("read commitment"))
+                .expect("commitment json");
+        let commitment_object = commitment_value
+            .as_object()
+            .expect("commitment is a JSON object");
+        assert!(
+            !commitment_object.contains_key("nonces"),
+            "coordinator-facing commitment file must not contain a nonces field"
+        );
+        for key in commitment_object.keys() {
+            let lowered = key.to_lowercase();
+            assert!(
+                !(lowered.contains("nonce")
+                    || lowered.contains("secret")
+                    || lowered.contains("private")),
+                "commitment file must not expose field `{key}`"
+            );
+        }
+
+        // The secret nonces live only in the separate local-only file.
+        let nonces_value: serde_json::Value =
+            serde_json::from_slice(&fs::read(&nonces_out).expect("read nonces"))
+                .expect("nonces json");
+        assert!(
+            nonces_value
+                .as_object()
+                .expect("nonces is a JSON object")
+                .contains_key("nonces"),
+            "the secret nonces file must carry the nonces"
+        );
     }
 
     #[test]

--- a/crates/exo-root/src/bundle.rs
+++ b/crates/exo-root/src/bundle.rs
@@ -8,7 +8,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     GenesisCeremonyConfig, Result, RootError, RootPublicKeyPackage,
-    dkg::validate_public_key_package, verify_root_signature,
+    dkg::validate_public_key_package,
+    signing::{RootSignature, validate_root_signer_ids},
+    verify_root_signature,
 };
 
 /// Operational AVC issuer authority delegated by the root.
@@ -40,7 +42,7 @@ pub struct RootTrustBundle {
     /// Canonical transcript hash.
     pub transcript_hash: Hash256,
     /// Root threshold signature over the trust artifact payload.
-    pub root_signature: Vec<u8>,
+    pub root_signature: RootSignature,
     /// Canonical bundle content identifier.
     pub bundle_id: Hash256,
 }
@@ -59,7 +61,7 @@ struct RootArtifactPayload<'a> {
 struct RootBundleIdPayload<'a> {
     domain: &'static str,
     artifact_payload_hash: Hash256,
-    root_signature: &'a [u8],
+    root_signature: &'a RootSignature,
 }
 
 fn canonical_bytes<T: Serialize>(value: &T) -> Result<Vec<u8>> {
@@ -114,7 +116,7 @@ fn bundle_id(
     config: &GenesisCeremonyConfig,
     public_key_package: &RootPublicKeyPackage,
     transcript_hash: Hash256,
-    root_signature: &[u8],
+    root_signature: &RootSignature,
 ) -> Result<Hash256> {
     let artifact_payload =
         delegation.root_artifact_payload(config, public_key_package, transcript_hash)?;
@@ -132,22 +134,23 @@ pub fn assemble_root_bundle(
     public_key_package: RootPublicKeyPackage,
     issuer_delegation: RootIssuerDelegation,
     transcript_hash: Hash256,
-    root_signature: Vec<u8>,
+    root_signature: RootSignature,
 ) -> Result<RootTrustBundle> {
     validate_public_key_package(&config, &public_key_package)?;
+    validate_root_signer_ids(&config, root_signature.signer_ids.as_slice())?;
     let payload =
         issuer_delegation.root_artifact_payload(&config, &public_key_package, transcript_hash)?;
     verify_root_signature(
         &public_key_package.root_public_key,
         &payload,
-        root_signature.as_slice(),
+        root_signature.signature.as_slice(),
     )?;
     let bundle_id = bundle_id(
         &issuer_delegation,
         &config,
         &public_key_package,
         transcript_hash,
-        root_signature.as_slice(),
+        &root_signature,
     )?;
     Ok(RootTrustBundle {
         config,
@@ -163,6 +166,7 @@ pub fn assemble_root_bundle(
 pub fn verify_root_bundle(bundle: &RootTrustBundle) -> Result<()> {
     bundle.config.validate()?;
     validate_public_key_package(&bundle.config, &bundle.public_key_package)?;
+    validate_root_signer_ids(&bundle.config, bundle.root_signature.signer_ids.as_slice())?;
     let payload = bundle.issuer_delegation.root_artifact_payload(
         &bundle.config,
         &bundle.public_key_package,
@@ -171,14 +175,14 @@ pub fn verify_root_bundle(bundle: &RootTrustBundle) -> Result<()> {
     verify_root_signature(
         &bundle.public_key_package.root_public_key,
         &payload,
-        bundle.root_signature.as_slice(),
+        bundle.root_signature.signature.as_slice(),
     )?;
     let expected_id = bundle_id(
         &bundle.issuer_delegation,
         &bundle.config,
         &bundle.public_key_package,
         bundle.transcript_hash,
-        bundle.root_signature.as_slice(),
+        &bundle.root_signature,
     )?;
     if expected_id != bundle.bundle_id {
         return Err(RootError::BundleRejected {

--- a/crates/exo-root/src/ceremony.rs
+++ b/crates/exo-root/src/ceremony.rs
@@ -47,14 +47,9 @@ pub struct GenesisCeremonyConfig {
     pub certifiers: Vec<CertifierContact>,
     /// Predeclared deterministic signing set: exactly `threshold` rostered FROST
     /// identifiers chosen before commitments are emitted. Root artifacts are
-    /// signed by this set unless a primary is unavailable before commitments, in
-    /// which case the next unused `signing_alternates` member substitutes, in
-    /// declared order. Fixing the set in the bound config removes coordinator
-    /// discretion over which signers participate.
+    /// signed only by this exact set. If any signer is unavailable, the ceremony
+    /// aborts and restarts with a new signed config and ceremony id.
     pub signing_set: Vec<u16>,
-    /// Ordered alternate signers (rostered, disjoint from `signing_set`) used only
-    /// to replace a primary that is unavailable before commitments, taken in order.
-    pub signing_alternates: Vec<u16>,
 }
 
 impl GenesisCeremonyConfig {
@@ -133,7 +128,7 @@ impl GenesisCeremonyConfig {
         Ok(())
     }
 
-    /// Validate the predeclared signing set and alternates.
+    /// Validate the predeclared signing set.
     fn validate_signing_set(&self) -> Result<()> {
         if self.signing_set.len() != usize::from(self.threshold) {
             return Err(RootError::InvalidConfig {
@@ -143,34 +138,16 @@ impl GenesisCeremonyConfig {
                 ),
             });
         }
-        let mut primaries = BTreeSet::new();
+        let mut declared = BTreeSet::new();
         for identifier in &self.signing_set {
             if self.certifier_by_identifier(*identifier).is_none() {
                 return Err(RootError::InvalidConfig {
                     reason: format!("signing_set member {identifier} is not rostered"),
                 });
             }
-            if !primaries.insert(*identifier) {
+            if !declared.insert(*identifier) {
                 return Err(RootError::InvalidConfig {
                     reason: format!("duplicate signing_set member {identifier}"),
-                });
-            }
-        }
-        let mut alternates = BTreeSet::new();
-        for identifier in &self.signing_alternates {
-            if self.certifier_by_identifier(*identifier).is_none() {
-                return Err(RootError::InvalidConfig {
-                    reason: format!("signing_alternate {identifier} is not rostered"),
-                });
-            }
-            if primaries.contains(identifier) {
-                return Err(RootError::InvalidConfig {
-                    reason: format!("signing_alternate {identifier} is also a primary signer"),
-                });
-            }
-            if !alternates.insert(*identifier) {
-                return Err(RootError::InvalidConfig {
-                    reason: format!("duplicate signing_alternate {identifier}"),
                 });
             }
         }
@@ -178,11 +155,9 @@ impl GenesisCeremonyConfig {
     }
 
     /// Validate that `submitted` is the canonical signing selection for this
-    /// ceremony: exactly `threshold` signers, every one a declared primary or
-    /// alternate, and any primary absent from the selection replaced by the
-    /// leading unused alternates in declared order. This removes coordinator
-    /// discretion — the only permitted deviation from the predeclared set is
-    /// ordered alternate substitution for a primary unavailable before commitments.
+    /// ceremony: exactly the predeclared `signing_set`. There is no in-ceremony
+    /// alternate substitution; an unavailable signer aborts the ceremony and forces
+    /// a new config/ceremony id.
     pub fn validate_signing_selection(&self, submitted: &BTreeSet<u16>) -> Result<()> {
         if submitted.len() != usize::from(self.threshold) {
             return Err(RootError::InvalidConfig {
@@ -192,39 +167,10 @@ impl GenesisCeremonyConfig {
                 ),
             });
         }
-        let primaries: BTreeSet<u16> = self.signing_set.iter().copied().collect();
-        let alternates: BTreeSet<u16> = self.signing_alternates.iter().copied().collect();
-        for identifier in submitted {
-            if !primaries.contains(identifier) && !alternates.contains(identifier) {
-                return Err(RootError::InvalidConfig {
-                    reason: format!(
-                        "signer {identifier} is not in the declared signing set or alternates"
-                    ),
-                });
-            }
-        }
-        let absent_primaries = self
-            .signing_set
-            .iter()
-            .filter(|primary| !submitted.contains(primary))
-            .count();
-        // The canonical selection keeps present primaries and substitutes the
-        // leading `absent_primaries` alternates, in declared order. If too few
-        // alternates are declared, the expected set is smaller than the selection
-        // and the equality check below rejects it.
-        let mut expected: BTreeSet<u16> = self
-            .signing_set
-            .iter()
-            .copied()
-            .filter(|primary| submitted.contains(primary))
-            .collect();
-        for alternate in self.signing_alternates.iter().take(absent_primaries) {
-            expected.insert(*alternate);
-        }
+        let expected: BTreeSet<u16> = self.signing_set.iter().copied().collect();
         if &expected != submitted {
             return Err(RootError::InvalidConfig {
-                reason: "signing selection must use declared alternates in order to replace \
-                         unavailable primaries"
+                reason: "signing selection must exactly match the predeclared signing_set"
                     .to_owned(),
             });
         }
@@ -278,7 +224,6 @@ mod tests {
             created_at: Timestamp::new(1, 0),
             certifiers,
             signing_set: (1..=7).collect(),
-            signing_alternates: (8..=13).collect(),
         }
     }
 
@@ -292,7 +237,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_rejects_malformed_signing_set_and_alternates() {
+    fn validate_rejects_malformed_signing_set() {
         let mut wrong_len = config();
         wrong_len.signing_set = (1..=6).collect();
         assert!(wrong_len.validate().is_err());
@@ -304,39 +249,18 @@ mod tests {
         let mut duplicate_primary = config();
         duplicate_primary.signing_set = vec![1, 2, 3, 4, 5, 6, 6];
         assert!(duplicate_primary.validate().is_err());
-
-        let mut unrostered_alternate = config();
-        unrostered_alternate.signing_alternates = vec![99];
-        assert!(unrostered_alternate.validate().is_err());
-
-        let mut alternate_is_primary = config();
-        alternate_is_primary.signing_alternates = vec![1];
-        assert!(alternate_is_primary.validate().is_err());
-
-        let mut duplicate_alternate = config();
-        duplicate_alternate.signing_alternates = vec![8, 8];
-        assert!(duplicate_alternate.validate().is_err());
     }
 
     #[test]
-    fn validate_signing_selection_accepts_declared_set_and_ordered_alternates() {
+    fn validate_signing_selection_accepts_only_declared_set() {
         let config = config();
-        // The full predeclared primary set.
         config
             .validate_signing_selection(&selection(&[1, 2, 3, 4, 5, 6, 7]))
             .expect("declared set accepted");
-        // Primary 1 unavailable → first alternate (8) substitutes.
-        config
-            .validate_signing_selection(&selection(&[2, 3, 4, 5, 6, 7, 8]))
-            .expect("ordered alternate substitution accepted");
-        // Primaries 1 and 2 unavailable → first two alternates (8, 9).
-        config
-            .validate_signing_selection(&selection(&[3, 4, 5, 6, 7, 8, 9]))
-            .expect("two ordered alternates accepted");
     }
 
     #[test]
-    fn validate_signing_selection_rejects_wrong_size_unknown_and_misordered() {
+    fn validate_signing_selection_rejects_wrong_size_unknown_and_substitution() {
         let config = config();
         // Wrong size.
         assert!(
@@ -350,10 +274,10 @@ mod tests {
                 .validate_signing_selection(&selection(&[1, 2, 3, 4, 5, 6, 99]))
                 .is_err()
         );
-        // Out-of-order alternate: primary 2 absent but alternate 9 used instead of 8.
+        // No alternate substitution: primary 7 absent and alternate 8 present.
         assert!(
             config
-                .validate_signing_selection(&selection(&[1, 3, 4, 5, 6, 7, 9]))
+                .validate_signing_selection(&selection(&[1, 2, 3, 4, 5, 6, 8]))
                 .is_err()
         );
     }

--- a/crates/exo-root/src/ceremony.rs
+++ b/crates/exo-root/src/ceremony.rs
@@ -45,6 +45,16 @@ pub struct GenesisCeremonyConfig {
     pub created_at: Timestamp,
     /// Full certifier roster.
     pub certifiers: Vec<CertifierContact>,
+    /// Predeclared deterministic signing set: exactly `threshold` rostered FROST
+    /// identifiers chosen before commitments are emitted. Root artifacts are
+    /// signed by this set unless a primary is unavailable before commitments, in
+    /// which case the next unused `signing_alternates` member substitutes, in
+    /// declared order. Fixing the set in the bound config removes coordinator
+    /// discretion over which signers participate.
+    pub signing_set: Vec<u16>,
+    /// Ordered alternate signers (rostered, disjoint from `signing_set`) used only
+    /// to replace a primary that is unavailable before commitments, taken in order.
+    pub signing_alternates: Vec<u16>,
 }
 
 impl GenesisCeremonyConfig {
@@ -118,6 +128,106 @@ impl GenesisCeremonyConfig {
             }
         }
 
+        self.validate_signing_set()?;
+
+        Ok(())
+    }
+
+    /// Validate the predeclared signing set and alternates.
+    fn validate_signing_set(&self) -> Result<()> {
+        if self.signing_set.len() != usize::from(self.threshold) {
+            return Err(RootError::InvalidConfig {
+                reason: format!(
+                    "signing_set must contain exactly {} signers",
+                    self.threshold
+                ),
+            });
+        }
+        let mut primaries = BTreeSet::new();
+        for identifier in &self.signing_set {
+            if self.certifier_by_identifier(*identifier).is_none() {
+                return Err(RootError::InvalidConfig {
+                    reason: format!("signing_set member {identifier} is not rostered"),
+                });
+            }
+            if !primaries.insert(*identifier) {
+                return Err(RootError::InvalidConfig {
+                    reason: format!("duplicate signing_set member {identifier}"),
+                });
+            }
+        }
+        let mut alternates = BTreeSet::new();
+        for identifier in &self.signing_alternates {
+            if self.certifier_by_identifier(*identifier).is_none() {
+                return Err(RootError::InvalidConfig {
+                    reason: format!("signing_alternate {identifier} is not rostered"),
+                });
+            }
+            if primaries.contains(identifier) {
+                return Err(RootError::InvalidConfig {
+                    reason: format!("signing_alternate {identifier} is also a primary signer"),
+                });
+            }
+            if !alternates.insert(*identifier) {
+                return Err(RootError::InvalidConfig {
+                    reason: format!("duplicate signing_alternate {identifier}"),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate that `submitted` is the canonical signing selection for this
+    /// ceremony: exactly `threshold` signers, every one a declared primary or
+    /// alternate, and any primary absent from the selection replaced by the
+    /// leading unused alternates in declared order. This removes coordinator
+    /// discretion — the only permitted deviation from the predeclared set is
+    /// ordered alternate substitution for a primary unavailable before commitments.
+    pub fn validate_signing_selection(&self, submitted: &BTreeSet<u16>) -> Result<()> {
+        if submitted.len() != usize::from(self.threshold) {
+            return Err(RootError::InvalidConfig {
+                reason: format!(
+                    "signing selection must contain exactly {} signers",
+                    self.threshold
+                ),
+            });
+        }
+        let primaries: BTreeSet<u16> = self.signing_set.iter().copied().collect();
+        let alternates: BTreeSet<u16> = self.signing_alternates.iter().copied().collect();
+        for identifier in submitted {
+            if !primaries.contains(identifier) && !alternates.contains(identifier) {
+                return Err(RootError::InvalidConfig {
+                    reason: format!(
+                        "signer {identifier} is not in the declared signing set or alternates"
+                    ),
+                });
+            }
+        }
+        let absent_primaries = self
+            .signing_set
+            .iter()
+            .filter(|primary| !submitted.contains(primary))
+            .count();
+        // The canonical selection keeps present primaries and substitutes the
+        // leading `absent_primaries` alternates, in declared order. If too few
+        // alternates are declared, the expected set is smaller than the selection
+        // and the equality check below rejects it.
+        let mut expected: BTreeSet<u16> = self
+            .signing_set
+            .iter()
+            .copied()
+            .filter(|primary| submitted.contains(primary))
+            .collect();
+        for alternate in self.signing_alternates.iter().take(absent_primaries) {
+            expected.insert(*alternate);
+        }
+        if &expected != submitted {
+            return Err(RootError::InvalidConfig {
+                reason: "signing selection must use declared alternates in order to replace \
+                         unavailable primaries"
+                    .to_owned(),
+            });
+        }
         Ok(())
     }
 
@@ -135,5 +245,116 @@ impl GenesisCeremonyConfig {
         self.certifiers
             .iter()
             .find(|certifier| certifier.frost_identifier == identifier)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use exo_core::{Did, Hash256, PublicKey, Timestamp};
+
+    use super::*;
+
+    fn config() -> GenesisCeremonyConfig {
+        let certifiers = (1..=ROOT_GENESIS_SIGNERS)
+            .map(|index| {
+                let byte = u8::try_from(index).expect("index fits");
+                CertifierContact {
+                    did: Did::new(&format!("did:exo:ceremony-unit-{index:02}")).expect("did"),
+                    frost_identifier: index,
+                    signing_public_key: PublicKey::from_bytes([byte; 32]),
+                    transport_public_key: [byte; 32],
+                }
+            })
+            .collect();
+        GenesisCeremonyConfig {
+            ceremony_id: "ceremony-unit".into(),
+            network_id: "exochain-test".into(),
+            repo_commit: "d8927686a34bdc28ba36d53938f665685d2c4c04".into(),
+            constitution_hash: Hash256::digest(b"constitution"),
+            threshold: ROOT_GENESIS_THRESHOLD,
+            max_signers: ROOT_GENESIS_SIGNERS,
+            created_at: Timestamp::new(1, 0),
+            certifiers,
+            signing_set: (1..=7).collect(),
+            signing_alternates: (8..=13).collect(),
+        }
+    }
+
+    fn selection(ids: &[u16]) -> BTreeSet<u16> {
+        ids.iter().copied().collect()
+    }
+
+    #[test]
+    fn valid_config_with_signing_set_validates() {
+        config().validate().expect("config validates");
+    }
+
+    #[test]
+    fn validate_rejects_malformed_signing_set_and_alternates() {
+        let mut wrong_len = config();
+        wrong_len.signing_set = (1..=6).collect();
+        assert!(wrong_len.validate().is_err());
+
+        let mut unrostered_primary = config();
+        unrostered_primary.signing_set = vec![1, 2, 3, 4, 5, 6, 99];
+        assert!(unrostered_primary.validate().is_err());
+
+        let mut duplicate_primary = config();
+        duplicate_primary.signing_set = vec![1, 2, 3, 4, 5, 6, 6];
+        assert!(duplicate_primary.validate().is_err());
+
+        let mut unrostered_alternate = config();
+        unrostered_alternate.signing_alternates = vec![99];
+        assert!(unrostered_alternate.validate().is_err());
+
+        let mut alternate_is_primary = config();
+        alternate_is_primary.signing_alternates = vec![1];
+        assert!(alternate_is_primary.validate().is_err());
+
+        let mut duplicate_alternate = config();
+        duplicate_alternate.signing_alternates = vec![8, 8];
+        assert!(duplicate_alternate.validate().is_err());
+    }
+
+    #[test]
+    fn validate_signing_selection_accepts_declared_set_and_ordered_alternates() {
+        let config = config();
+        // The full predeclared primary set.
+        config
+            .validate_signing_selection(&selection(&[1, 2, 3, 4, 5, 6, 7]))
+            .expect("declared set accepted");
+        // Primary 1 unavailable → first alternate (8) substitutes.
+        config
+            .validate_signing_selection(&selection(&[2, 3, 4, 5, 6, 7, 8]))
+            .expect("ordered alternate substitution accepted");
+        // Primaries 1 and 2 unavailable → first two alternates (8, 9).
+        config
+            .validate_signing_selection(&selection(&[3, 4, 5, 6, 7, 8, 9]))
+            .expect("two ordered alternates accepted");
+    }
+
+    #[test]
+    fn validate_signing_selection_rejects_wrong_size_unknown_and_misordered() {
+        let config = config();
+        // Wrong size.
+        assert!(
+            config
+                .validate_signing_selection(&selection(&[1, 2, 3, 4, 5, 6, 7, 8]))
+                .is_err()
+        );
+        // Signer outside the declared pool.
+        assert!(
+            config
+                .validate_signing_selection(&selection(&[1, 2, 3, 4, 5, 6, 99]))
+                .is_err()
+        );
+        // Out-of-order alternate: primary 2 absent but alternate 9 used instead of 8.
+        assert!(
+            config
+                .validate_signing_selection(&selection(&[1, 3, 4, 5, 6, 7, 9]))
+                .is_err()
+        );
     }
 }

--- a/crates/exo-root/src/dkg.rs
+++ b/crates/exo-root/src/dkg.rs
@@ -425,7 +425,6 @@ mod tests {
             created_at: Timestamp::new(1, 0),
             certifiers,
             signing_set: (1..=7).collect(),
-            signing_alternates: (8..=13).collect(),
         }
     }
 

--- a/crates/exo-root/src/dkg.rs
+++ b/crates/exo-root/src/dkg.rs
@@ -424,6 +424,8 @@ mod tests {
             max_signers: 13,
             created_at: Timestamp::new(1, 0),
             certifiers,
+            signing_set: (1..=7).collect(),
+            signing_alternates: (8..=13).collect(),
         }
     }
 

--- a/crates/exo-root/src/lib.rs
+++ b/crates/exo-root/src/lib.rs
@@ -28,7 +28,7 @@ pub use seal::{
     seal_share, unseal_share,
 };
 pub use signing::{
-    RootSignature, RootSignatureShareOutput, RootSigningCommitment, RootSigningPackage,
-    aggregate_signature, build_signing_package, sign_commit, sign_share, threshold_sign,
-    verify_root_signature,
+    RootSignature, RootSignatureShareOutput, RootSigningCommitment, RootSigningNonces,
+    RootSigningPackage, aggregate_signature, build_signing_package, sign_commit, sign_share,
+    threshold_sign, verify_root_signature,
 };

--- a/crates/exo-root/src/lib.rs
+++ b/crates/exo-root/src/lib.rs
@@ -21,7 +21,9 @@ pub use dkg::{
 };
 pub use error::{Result, RootError};
 pub use portal::{
-    CeremonyEnvelope, CeremonyEnvelopeDraft, CeremonyPayloadKind, CeremonyPhase, PortalStore,
+    CeremonyEnvelope, CeremonyEnvelopeDraft, CeremonyPayloadKind, CeremonyPhase,
+    FinalKeyConfirmation, PortalStore, build_final_key_confirmation, ceremony_config_hash,
+    encode_final_key_confirmation_payload,
 };
 pub use seal::{
     PairwiseEncryptedPayload, SealedShare, decrypt_pairwise_payload, encrypt_pairwise_payload,

--- a/crates/exo-root/src/lib.rs
+++ b/crates/exo-root/src/lib.rs
@@ -27,4 +27,8 @@ pub use seal::{
     PairwiseEncryptedPayload, SealedShare, decrypt_pairwise_payload, encrypt_pairwise_payload,
     seal_share, unseal_share,
 };
-pub use signing::{RootSignature, threshold_sign, verify_root_signature};
+pub use signing::{
+    RootSignature, RootSignatureShareOutput, RootSigningCommitment, RootSigningPackage,
+    aggregate_signature, build_signing_package, sign_commit, sign_share, threshold_sign,
+    verify_root_signature,
+};

--- a/crates/exo-root/src/lib.rs
+++ b/crates/exo-root/src/lib.rs
@@ -22,7 +22,8 @@ pub use dkg::{
 pub use error::{Result, RootError};
 pub use portal::{
     CeremonyEnvelope, CeremonyEnvelopeDraft, CeremonyPayloadKind, CeremonyPhase,
-    FinalKeyConfirmation, PortalStore, build_final_key_confirmation, ceremony_config_hash,
+    FINAL_KEY_CONFIRMATION_DOMAIN, FINAL_KEY_CONFIRMATION_SCHEMA_VERSION, FinalKeyConfirmation,
+    PortalStore, build_final_key_confirmation, ceremony_config_hash,
     encode_final_key_confirmation_payload,
 };
 pub use seal::{

--- a/crates/exo-root/src/portal.rs
+++ b/crates/exo-root/src/portal.rs
@@ -353,12 +353,140 @@ fn key_parts(key: &PortalEnvelopeKey) -> PortalEnvelopeKeyParts<'_> {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
+    use exo_core::{Timestamp, crypto::KeyPair};
+
     use super::*;
+    use crate::{CertifierContact, PairwiseEncryptedPayload};
+
+    fn certifier(index: u16) -> (CertifierContact, exo_core::SecretKey) {
+        let seed = [u8::try_from(index).expect("index fits"); 32];
+        let keypair = KeyPair::from_secret_bytes(seed).expect("keypair");
+        let transport_public =
+            x25519_dalek::PublicKey::from(&x25519_dalek::StaticSecret::from(seed));
+        (
+            CertifierContact {
+                did: Did::new(&format!("did:exo:portal-query-{index:02}")).expect("did"),
+                frost_identifier: index,
+                signing_public_key: *keypair.public_key(),
+                transport_public_key: *transport_public.as_bytes(),
+            },
+            keypair.secret_key().clone(),
+        )
+    }
+
+    fn config_with_secrets() -> (GenesisCeremonyConfig, Vec<SecretKey>) {
+        let mut certifiers = Vec::new();
+        let mut secrets = Vec::new();
+        for index in 1..=crate::ROOT_GENESIS_SIGNERS {
+            let (contact, secret) = certifier(index);
+            certifiers.push(contact);
+            secrets.push(secret);
+        }
+        (
+            GenesisCeremonyConfig {
+                ceremony_id: "portal-query".into(),
+                network_id: "exochain-test".into(),
+                repo_commit: "d8927686a34bdc28ba36d53938f665685d2c4c04".into(),
+                constitution_hash: Hash256::digest(b"constitution"),
+                threshold: crate::ROOT_GENESIS_THRESHOLD,
+                max_signers: crate::ROOT_GENESIS_SIGNERS,
+                created_at: Timestamp::new(1, 0),
+                certifiers,
+            },
+            secrets,
+        )
+    }
+
+    fn encrypted_payload_bytes() -> Vec<u8> {
+        let payload = PairwiseEncryptedPayload {
+            nonce: [9u8; 24],
+            ciphertext: b"ciphertext".to_vec(),
+        };
+        let mut bytes = Vec::new();
+        ciborium::into_writer(&payload, &mut bytes).expect("encode");
+        bytes
+    }
 
     #[test]
     fn canonical_error_conversion_is_diagnostic() {
         let error = canonical_encoding_error("portal encoding failed");
         assert!(error.to_string().contains("portal encoding failed"));
+    }
+
+    #[test]
+    fn query_filters_by_phase_kind_and_recipient() {
+        let (config, secrets) = config_with_secrets();
+        let mut store = PortalStore::new(config.clone());
+
+        // A round-one broadcast from certifier 1.
+        store
+            .submit(
+                CeremonyEnvelope::sign(
+                    CeremonyEnvelopeDraft {
+                        ceremony_id: config.ceremony_id.clone(),
+                        phase: CeremonyPhase::Round1,
+                        payload_kind: CeremonyPayloadKind::Round1Package,
+                        sender_did: config.certifiers[0].did.clone(),
+                        recipient_did: None,
+                        sequence: 0,
+                        payload_bytes: b"round1".to_vec(),
+                    },
+                    &secrets[0],
+                )
+                .expect("round1 envelope"),
+            )
+            .expect("submit round1");
+
+        // A round-two package from certifier 1 addressed to certifier 2.
+        store
+            .submit(
+                CeremonyEnvelope::sign(
+                    CeremonyEnvelopeDraft {
+                        ceremony_id: config.ceremony_id.clone(),
+                        phase: CeremonyPhase::Round2,
+                        payload_kind: CeremonyPayloadKind::Round2EncryptedPackage,
+                        sender_did: config.certifiers[0].did.clone(),
+                        recipient_did: Some(config.certifiers[1].did.clone()),
+                        sequence: 1,
+                        payload_bytes: encrypted_payload_bytes(),
+                    },
+                    &secrets[0],
+                )
+                .expect("round2 envelope"),
+            )
+            .expect("submit round2");
+
+        // No filters → both envelopes.
+        assert_eq!(store.query(None, None, None).len(), 2);
+        // Phase filter (match + non-match).
+        assert_eq!(store.query(Some(CeremonyPhase::Round1), None, None).len(), 1);
+        assert_eq!(
+            store
+                .query(Some(CeremonyPhase::Finalize), None, None)
+                .len(),
+            0
+        );
+        // Payload-kind filter.
+        assert_eq!(
+            store
+                .query(None, Some(CeremonyPayloadKind::Round2EncryptedPackage), None)
+                .len(),
+            1
+        );
+        // Recipient filter (match + non-match).
+        assert_eq!(
+            store
+                .query(Some(CeremonyPhase::Round2), None, Some(&config.certifiers[1].did))
+                .len(),
+            1
+        );
+        assert_eq!(
+            store
+                .query(None, None, Some(&config.certifiers[2].did))
+                .len(),
+            0
+        );
     }
 }

--- a/crates/exo-root/src/portal.rs
+++ b/crates/exo-root/src/portal.rs
@@ -189,6 +189,29 @@ impl PortalStore {
         self.envelopes.len()
     }
 
+    /// Return accepted envelopes matching all of the supplied filters; a `None`
+    /// filter matches any value. Envelopes are relay data — already signed and
+    /// (for round two) encrypted — so returning them to rostered participants is
+    /// the read half of the relay, used to collect round-one packages, pull
+    /// recipient-bound round-two packages, and gather signing commitments/shares.
+    #[must_use]
+    pub fn query(
+        &self,
+        phase: Option<CeremonyPhase>,
+        payload_kind: Option<CeremonyPayloadKind>,
+        recipient_did: Option<&Did>,
+    ) -> Vec<CeremonyEnvelope> {
+        self.envelopes
+            .values()
+            .filter(|envelope| phase.is_none_or(|value| envelope.phase == value))
+            .filter(|envelope| payload_kind.is_none_or(|value| envelope.payload_kind == value))
+            .filter(|envelope| {
+                recipient_did.is_none_or(|value| envelope.recipient_did.as_ref() == Some(value))
+            })
+            .cloned()
+            .collect()
+    }
+
     /// Submit a signed envelope to the relay.
     pub fn submit(&mut self, envelope: CeremonyEnvelope) -> Result<Hash256> {
         self.validate_envelope(&envelope)?;

--- a/crates/exo-root/src/portal.rs
+++ b/crates/exo-root/src/portal.rs
@@ -3,6 +3,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use exo_core::{Did, Hash256, SecretKey, Signature, crypto, hash::hash_structured};
+use frost_ristretto255 as frost;
 use serde::{Deserialize, Serialize};
 
 use crate::{GenesisCeremonyConfig, PairwiseEncryptedPayload, Result, RootError};
@@ -100,6 +101,9 @@ pub struct PortalStore {
     config: GenesisCeremonyConfig,
     envelopes: BTreeMap<PortalEnvelopeKey, CeremonyEnvelope>,
     seen_sequences: BTreeSet<(Did, u64)>,
+    /// Signers who have already submitted a root signature share this session.
+    /// Enforces one share per signer (single-use of the signer's nonces).
+    signature_share_senders: BTreeSet<Did>,
 }
 
 #[derive(Serialize)]
@@ -180,6 +184,7 @@ impl PortalStore {
             config,
             envelopes: BTreeMap::new(),
             seen_sequences: BTreeSet::new(),
+            signature_share_senders: BTreeSet::new(),
         }
     }
 
@@ -221,6 +226,15 @@ impl PortalStore {
                 reason: "sender sequence replay".to_owned(),
             });
         }
+        // One root signature share per signer per session: a second share from the
+        // same signer is rejected, enforcing single-use of that signer's nonces.
+        if envelope.payload_kind == CeremonyPayloadKind::RootSignatureShare
+            && self.signature_share_senders.contains(&envelope.sender_did)
+        {
+            return Err(RootError::PortalRejected {
+                reason: "signer has already submitted a signature share this session".to_owned(),
+            });
+        }
         let key = PortalEnvelopeKey {
             sender_did: envelope.sender_did.clone(),
             phase: envelope.phase,
@@ -230,6 +244,10 @@ impl PortalStore {
         };
         let envelope_id = hash_structured(&key_parts(&key)).map_err(canonical_encoding_error)?;
         self.seen_sequences.insert(sequence_key);
+        if envelope.payload_kind == CeremonyPayloadKind::RootSignatureShare {
+            self.signature_share_senders
+                .insert(envelope.sender_did.clone());
+        }
         self.envelopes.insert(key, envelope);
         Ok(envelope_id)
     }
@@ -288,18 +306,32 @@ impl PortalStore {
     }
 
     fn validate_phase_policy(&self, envelope: &CeremonyEnvelope) -> Result<()> {
+        // Every accepted payload kind is schema-validated by decoding it to its
+        // concrete type before storage — the portal never stores opaque bytes for
+        // a security-sensitive kind. Kinds without a ratified, decodable schema
+        // (round-one set attestation, final key confirmation) are disabled.
+        let bytes = envelope.payload_bytes.as_slice();
         match (envelope.phase, envelope.payload_kind) {
-            (CeremonyPhase::Round1, CeremonyPayloadKind::Round1Package)
-            | (CeremonyPhase::Round1SetAttestation, CeremonyPayloadKind::Round1SetAttestation)
-            | (CeremonyPhase::Finalize, CeremonyPayloadKind::FinalKeyConfirmation)
-            | (CeremonyPhase::RootSigning, CeremonyPayloadKind::RootSigningCommitment)
-            | (CeremonyPhase::RootSigning, CeremonyPayloadKind::RootSignatureShare) => {
-                if envelope.recipient_did.is_some() {
-                    return Err(RootError::PortalRejected {
-                        reason: "broadcast payload must not set recipient".to_owned(),
-                    });
-                }
-                Ok(())
+            (CeremonyPhase::Round1, CeremonyPayloadKind::Round1Package) => {
+                reject_recipient(envelope)?;
+                reject_unless_decodable::<frost::keys::dkg::round1::Package>(
+                    bytes,
+                    "round-one package",
+                )
+            }
+            (CeremonyPhase::RootSigning, CeremonyPayloadKind::RootSigningCommitment) => {
+                reject_recipient(envelope)?;
+                reject_unless_decodable::<frost::round1::SigningCommitments>(
+                    bytes,
+                    "root signing commitment",
+                )
+            }
+            (CeremonyPhase::RootSigning, CeremonyPayloadKind::RootSignatureShare) => {
+                reject_recipient(envelope)?;
+                reject_unless_decodable::<frost::round2::SignatureShare>(
+                    bytes,
+                    "root signature share",
+                )
             }
             (CeremonyPhase::Round2, CeremonyPayloadKind::Round2EncryptedPackage) => {
                 if envelope.recipient_did.is_none() {
@@ -307,8 +339,21 @@ impl PortalStore {
                         reason: "round-two encrypted package requires recipient".to_owned(),
                     });
                 }
-                validate_encrypted_round2_payload(envelope.payload_bytes.as_slice())?;
-                Ok(())
+                validate_encrypted_round2_payload(bytes)
+            }
+            (CeremonyPhase::Round1SetAttestation, CeremonyPayloadKind::Round1SetAttestation) => {
+                Err(RootError::PortalRejected {
+                    reason: "round-one set attestation is disabled pending a ratified, \
+                             portal-validated payload schema"
+                        .to_owned(),
+                })
+            }
+            (CeremonyPhase::Finalize, CeremonyPayloadKind::FinalKeyConfirmation) => {
+                Err(RootError::PortalRejected {
+                    reason: "final key confirmation is disabled pending a ratified, \
+                             portal-validated payload schema"
+                        .to_owned(),
+                })
             }
             (_, CeremonyPayloadKind::Round2PlaintextPackage) => Err(RootError::PortalRejected {
                 reason: "round-two raw package is rejected".to_owned(),
@@ -318,6 +363,26 @@ impl PortalStore {
             }),
         }
     }
+}
+
+/// Reject a broadcast payload that carries a recipient.
+fn reject_recipient(envelope: &CeremonyEnvelope) -> Result<()> {
+    if envelope.recipient_did.is_some() {
+        return Err(RootError::PortalRejected {
+            reason: "broadcast payload must not set recipient".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+/// Schema-validate a payload by decoding it to its concrete type `T`; a decode
+/// failure is a portal rejection (bad request), never silent storage.
+fn reject_unless_decodable<T: serde::de::DeserializeOwned>(bytes: &[u8], kind: &str) -> Result<()> {
+    ciborium::from_reader::<T, _>(bytes)
+        .map(|_decoded| ())
+        .map_err(|error| RootError::PortalRejected {
+            reason: format!("{kind} payload failed schema validation: {error}"),
+        })
 }
 
 fn validate_encrypted_round2_payload(payload_bytes: &[u8]) -> Result<()> {
@@ -356,9 +421,17 @@ fn key_parts(key: &PortalEnvelopeKey) -> PortalEnvelopeKeyParts<'_> {
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use exo_core::{Timestamp, crypto::KeyPair};
+    use rand::{SeedableRng, rngs::StdRng};
 
     use super::*;
     use crate::{CertifierContact, PairwiseEncryptedPayload};
+
+    fn round1_package_bytes(config: &GenesisCeremonyConfig, frost_identifier: u16) -> Vec<u8> {
+        let mut rng = StdRng::seed_from_u64(u64::from(frost_identifier));
+        crate::dkg_round1(config, frost_identifier, &mut rng)
+            .expect("round one")
+            .round1_package
+    }
 
     fn certifier(index: u16) -> (CertifierContact, exo_core::SecretKey) {
         let seed = [u8::try_from(index).expect("index fits"); 32];
@@ -394,6 +467,8 @@ mod tests {
                 max_signers: crate::ROOT_GENESIS_SIGNERS,
                 created_at: Timestamp::new(1, 0),
                 certifiers,
+                signing_set: (1..=7).collect(),
+                signing_alternates: (8..=13).collect(),
             },
             secrets,
         )
@@ -431,7 +506,7 @@ mod tests {
                         sender_did: config.certifiers[0].did.clone(),
                         recipient_did: None,
                         sequence: 0,
-                        payload_bytes: b"round1".to_vec(),
+                        payload_bytes: round1_package_bytes(&config, 1),
                     },
                     &secrets[0],
                 )

--- a/crates/exo-root/src/portal.rs
+++ b/crates/exo-root/src/portal.rs
@@ -6,9 +6,17 @@ use exo_core::{Did, Hash256, SecretKey, Signature, crypto, hash::hash_structured
 use frost_ristretto255 as frost;
 use serde::{Deserialize, Serialize};
 
-use crate::{GenesisCeremonyConfig, PairwiseEncryptedPayload, Result, RootError};
+use crate::{
+    GenesisCeremonyConfig, PairwiseEncryptedPayload, Result, RootError,
+    dkg::{
+        RootParticipantDkgOutput, RootPublicKeyPackage, deserialize_frost, frost_identifier,
+        validate_public_key_package,
+    },
+};
 
 const MAX_PORTAL_PAYLOAD_BYTES: usize = 64 * 1024;
+pub const FINAL_KEY_CONFIRMATION_DOMAIN: &str = "EXOCHAIN_ROOT_FINAL_KEY_CONFIRMATION_V1";
+pub const FINAL_KEY_CONFIRMATION_SCHEMA_VERSION: u16 = 1;
 
 /// Ceremony phase associated with a portal envelope.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -86,6 +94,33 @@ pub struct CeremonyEnvelopeDraft {
     pub payload_bytes: Vec<u8>,
 }
 
+/// Ratified final DKG key confirmation payload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FinalKeyConfirmation {
+    /// Domain separator; must equal [`FINAL_KEY_CONFIRMATION_DOMAIN`].
+    pub domain: String,
+    /// Schema version; must equal [`FINAL_KEY_CONFIRMATION_SCHEMA_VERSION`].
+    pub schema_version: u16,
+    /// Ceremony identifier.
+    pub ceremony_id: String,
+    /// Confirming certifier DID.
+    pub certifier_did: Did,
+    /// Confirming certifier FROST identifier.
+    pub frost_identifier: u16,
+    /// Canonical hash of the ceremony config.
+    pub config_hash: Hash256,
+    /// Canonical hash of the completed DKG relay transcript.
+    pub dkg_transcript_hash: Hash256,
+    /// Public key package independently derived by the certifier.
+    pub public_key_package: RootPublicKeyPackage,
+    /// Canonical hash of the full public key package.
+    pub root_public_key_package_hash: Hash256,
+    /// Hash of `public_key_package.root_public_key`.
+    pub root_public_key_hash: Hash256,
+    /// Hash of this certifier's verifying share in the public key package.
+    pub certifier_verifying_share_hash: Hash256,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct PortalEnvelopeKey {
     sender_did: Did,
@@ -101,6 +136,7 @@ pub struct PortalStore {
     config: GenesisCeremonyConfig,
     envelopes: BTreeMap<PortalEnvelopeKey, CeremonyEnvelope>,
     seen_sequences: BTreeSet<(Did, u64)>,
+    final_key_confirmations: BTreeMap<Did, FinalKeyConfirmation>,
     /// Signers who have already submitted a root signature share this session.
     /// Enforces one share per signer (single-use of the signer's nonces).
     signature_share_senders: BTreeSet<Did>,
@@ -125,6 +161,32 @@ struct EnvelopeSigningPayload<'a> {
     payload_hash: Hash256,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+struct TranscriptEnvelopeRecord {
+    phase: CeremonyPhase,
+    payload_kind: CeremonyPayloadKind,
+    sender_did: Did,
+    recipient_did: Option<Did>,
+    sequence: u64,
+    envelope_id: Hash256,
+    envelope_hash: Hash256,
+}
+
+#[derive(Serialize)]
+struct DkgTranscriptPayload<'a> {
+    domain: &'static str,
+    config_hash: Hash256,
+    envelopes: &'a [TranscriptEnvelopeRecord],
+}
+
+#[derive(Serialize)]
+struct FinalTranscriptPayload<'a> {
+    domain: &'static str,
+    config_hash: Hash256,
+    dkg_transcript_hash: Hash256,
+    final_key_confirmations: &'a [TranscriptEnvelopeRecord],
+}
+
 fn payload_hash(kind: CeremonyPayloadKind, payload_bytes: &[u8]) -> Result<Hash256> {
     hash_structured(&PayloadHashEnvelope {
         domain: "EXOCHAIN_ROOT_PORTAL_PAYLOAD_V1",
@@ -132,6 +194,79 @@ fn payload_hash(kind: CeremonyPayloadKind, payload_bytes: &[u8]) -> Result<Hash2
         payload_bytes,
     })
     .map_err(canonical_encoding_error)
+}
+
+/// Canonical hash of a root genesis ceremony config.
+pub fn ceremony_config_hash(config: &GenesisCeremonyConfig) -> Result<Hash256> {
+    hash_structured(config).map_err(canonical_encoding_error)
+}
+
+/// Encode a ratified final key confirmation as portal payload bytes.
+pub fn encode_final_key_confirmation_payload(
+    confirmation: &FinalKeyConfirmation,
+) -> Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    ciborium::into_writer(confirmation, &mut bytes).map_err(canonical_encoding_error)?;
+    Ok(bytes)
+}
+
+fn decode_final_key_confirmation_payload(bytes: &[u8]) -> Result<FinalKeyConfirmation> {
+    ciborium::from_reader(bytes).map_err(|error| RootError::PortalRejected {
+        reason: format!("final key confirmation payload failed schema validation: {error}"),
+    })
+}
+
+/// Build the ratified final key confirmation payload for one finalized
+/// certifier. This emits only public confirmation material; the secret FROST key
+/// package is parsed locally to bind the certifier identifier but is never copied
+/// into the payload.
+pub fn build_final_key_confirmation(
+    config: &GenesisCeremonyConfig,
+    dkg_output: &RootParticipantDkgOutput,
+    dkg_transcript_hash: Hash256,
+) -> Result<FinalKeyConfirmation> {
+    config.validate()?;
+    validate_public_key_package(config, &dkg_output.public_key_package)?;
+    let frost_identifier_value = dkg_output.key_package.frost_identifier;
+    let certifier = config
+        .certifier_by_identifier(frost_identifier_value)
+        .ok_or_else(|| RootError::InvalidConfig {
+            reason: format!(
+                "final key confirmation certifier {frost_identifier_value} is not rostered"
+            ),
+        })?;
+    let parsed_key_package: frost::keys::KeyPackage =
+        deserialize_frost(dkg_output.key_package.key_package.as_slice())?;
+    if *parsed_key_package.identifier() != frost_identifier(frost_identifier_value)? {
+        return Err(RootError::Frost {
+            detail: "final key confirmation key package identifier mismatch".to_owned(),
+        });
+    }
+    let verifying_share = dkg_output
+        .public_key_package
+        .verifying_shares
+        .get(&frost_identifier_value)
+        .ok_or_else(|| RootError::BundleRejected {
+            reason: format!(
+                "public key package missing verifying share for certifier {frost_identifier_value}"
+            ),
+        })?;
+    Ok(FinalKeyConfirmation {
+        domain: FINAL_KEY_CONFIRMATION_DOMAIN.to_owned(),
+        schema_version: FINAL_KEY_CONFIRMATION_SCHEMA_VERSION,
+        ceremony_id: config.ceremony_id.clone(),
+        certifier_did: certifier.did.clone(),
+        frost_identifier: frost_identifier_value,
+        config_hash: ceremony_config_hash(config)?,
+        dkg_transcript_hash,
+        public_key_package: dkg_output.public_key_package.clone(),
+        root_public_key_package_hash: hash_structured(&dkg_output.public_key_package)
+            .map_err(canonical_encoding_error)?,
+        root_public_key_hash: Hash256::digest(
+            dkg_output.public_key_package.root_public_key.as_slice(),
+        ),
+        certifier_verifying_share_hash: Hash256::digest(verifying_share.as_slice()),
+    })
 }
 
 fn signing_payload(envelope: &CeremonyEnvelope) -> Result<Vec<u8>> {
@@ -184,6 +319,7 @@ impl PortalStore {
             config,
             envelopes: BTreeMap::new(),
             seen_sequences: BTreeSet::new(),
+            final_key_confirmations: BTreeMap::new(),
             signature_share_senders: BTreeSet::new(),
         }
     }
@@ -220,6 +356,12 @@ impl PortalStore {
     /// Submit a signed envelope to the relay.
     pub fn submit(&mut self, envelope: CeremonyEnvelope) -> Result<Hash256> {
         self.validate_envelope(&envelope)?;
+        let final_key_confirmation =
+            if envelope.payload_kind == CeremonyPayloadKind::FinalKeyConfirmation {
+                Some(self.validate_final_key_confirmation(&envelope)?)
+            } else {
+                None
+            };
         let sequence_key = (envelope.sender_did.clone(), envelope.sequence);
         if self.seen_sequences.contains(&sequence_key) {
             return Err(RootError::PortalRejected {
@@ -248,8 +390,39 @@ impl PortalStore {
             self.signature_share_senders
                 .insert(envelope.sender_did.clone());
         }
+        if let Some(confirmation) = final_key_confirmation {
+            self.final_key_confirmations
+                .insert(envelope.sender_did.clone(), confirmation);
+        }
         self.envelopes.insert(key, envelope);
         Ok(envelope_id)
+    }
+
+    /// Canonical hash over the complete accepted DKG relay transcript.
+    pub fn dkg_transcript_hash(&self) -> Result<Hash256> {
+        let records = self.dkg_transcript_records()?;
+        self.ensure_dkg_transcript_complete(records.as_slice())?;
+        let payload = DkgTranscriptPayload {
+            domain: "EXOCHAIN_ROOT_DKG_TRANSCRIPT_V1",
+            config_hash: ceremony_config_hash(&self.config)?,
+            envelopes: records.as_slice(),
+        };
+        hash_structured(&payload).map_err(canonical_encoding_error)
+    }
+
+    /// Canonical final ceremony transcript hash, including all accepted final
+    /// key confirmation envelopes. This is the transcript hash root artifacts
+    /// must bind before root signing begins.
+    pub fn final_transcript_hash(&self) -> Result<Hash256> {
+        self.ensure_final_key_confirmations_complete()?;
+        let records = self.final_key_confirmation_records()?;
+        let payload = FinalTranscriptPayload {
+            domain: "EXOCHAIN_ROOT_FINAL_TRANSCRIPT_V1",
+            config_hash: ceremony_config_hash(&self.config)?,
+            dkg_transcript_hash: self.dkg_transcript_hash()?,
+            final_key_confirmations: records.as_slice(),
+        };
+        hash_structured(&payload).map_err(canonical_encoding_error)
     }
 
     fn validate_envelope(&self, envelope: &CeremonyEnvelope) -> Result<()> {
@@ -309,11 +482,18 @@ impl PortalStore {
         // Every accepted payload kind is schema-validated by decoding it to its
         // concrete type before storage — the portal never stores opaque bytes for
         // a security-sensitive kind. Kinds without a ratified, decodable schema
-        // (round-one set attestation, final key confirmation) are disabled.
+        // (round-one set attestation) are disabled.
         let bytes = envelope.payload_bytes.as_slice();
         match (envelope.phase, envelope.payload_kind) {
             (CeremonyPhase::Round1, CeremonyPayloadKind::Round1Package) => {
                 reject_recipient(envelope)?;
+                self.reject_dkg_mutation_after_final_confirmation()?;
+                self.reject_duplicate_broadcast_sender(
+                    envelope,
+                    CeremonyPhase::Round1,
+                    CeremonyPayloadKind::Round1Package,
+                    "round-one package already submitted by sender",
+                )?;
                 reject_unless_decodable::<frost::keys::dkg::round1::Package>(
                     bytes,
                     "round-one package",
@@ -321,6 +501,13 @@ impl PortalStore {
             }
             (CeremonyPhase::RootSigning, CeremonyPayloadKind::RootSigningCommitment) => {
                 reject_recipient(envelope)?;
+                self.ensure_final_key_confirmations_complete()?;
+                self.reject_duplicate_broadcast_sender(
+                    envelope,
+                    CeremonyPhase::RootSigning,
+                    CeremonyPayloadKind::RootSigningCommitment,
+                    "root signing commitment already submitted by sender",
+                )?;
                 reject_unless_decodable::<frost::round1::SigningCommitments>(
                     bytes,
                     "root signing commitment",
@@ -328,6 +515,7 @@ impl PortalStore {
             }
             (CeremonyPhase::RootSigning, CeremonyPayloadKind::RootSignatureShare) => {
                 reject_recipient(envelope)?;
+                self.ensure_final_key_confirmations_complete()?;
                 reject_unless_decodable::<frost::round2::SignatureShare>(
                     bytes,
                     "root signature share",
@@ -339,6 +527,13 @@ impl PortalStore {
                         reason: "round-two encrypted package requires recipient".to_owned(),
                     });
                 }
+                self.reject_dkg_mutation_after_final_confirmation()?;
+                self.reject_duplicate_pairwise_sender_recipient(
+                    envelope,
+                    CeremonyPhase::Round2,
+                    CeremonyPayloadKind::Round2EncryptedPackage,
+                    "round-two encrypted package already submitted for sender and recipient",
+                )?;
                 validate_encrypted_round2_payload(bytes)
             }
             (CeremonyPhase::Round1SetAttestation, CeremonyPayloadKind::Round1SetAttestation) => {
@@ -349,11 +544,8 @@ impl PortalStore {
                 })
             }
             (CeremonyPhase::Finalize, CeremonyPayloadKind::FinalKeyConfirmation) => {
-                Err(RootError::PortalRejected {
-                    reason: "final key confirmation is disabled pending a ratified, \
-                             portal-validated payload schema"
-                        .to_owned(),
-                })
+                reject_recipient(envelope)?;
+                self.validate_final_key_confirmation(envelope).map(|_| ())
             }
             (_, CeremonyPayloadKind::Round2PlaintextPackage) => Err(RootError::PortalRejected {
                 reason: "round-two raw package is rejected".to_owned(),
@@ -362,6 +554,315 @@ impl PortalStore {
                 reason: "payload kind is not valid for phase".to_owned(),
             }),
         }
+    }
+
+    fn reject_dkg_mutation_after_final_confirmation(&self) -> Result<()> {
+        if !self.final_key_confirmations.is_empty() {
+            return Err(RootError::PortalRejected {
+                reason: "dkg transcript is frozen after final key confirmation".to_owned(),
+            });
+        }
+        Ok(())
+    }
+
+    fn reject_duplicate_broadcast_sender(
+        &self,
+        envelope: &CeremonyEnvelope,
+        phase: CeremonyPhase,
+        payload_kind: CeremonyPayloadKind,
+        reason: &str,
+    ) -> Result<()> {
+        if self.envelopes.values().any(|accepted| {
+            accepted.sender_did == envelope.sender_did
+                && accepted.phase == phase
+                && accepted.payload_kind == payload_kind
+                && accepted.recipient_did.is_none()
+                && accepted.sequence != envelope.sequence
+        }) {
+            return Err(RootError::PortalRejected {
+                reason: reason.to_owned(),
+            });
+        }
+        Ok(())
+    }
+
+    fn reject_duplicate_pairwise_sender_recipient(
+        &self,
+        envelope: &CeremonyEnvelope,
+        phase: CeremonyPhase,
+        payload_kind: CeremonyPayloadKind,
+        reason: &str,
+    ) -> Result<()> {
+        if self.envelopes.values().any(|accepted| {
+            accepted.sender_did == envelope.sender_did
+                && accepted.recipient_did == envelope.recipient_did
+                && accepted.phase == phase
+                && accepted.payload_kind == payload_kind
+                && accepted.sequence != envelope.sequence
+        }) {
+            return Err(RootError::PortalRejected {
+                reason: reason.to_owned(),
+            });
+        }
+        Ok(())
+    }
+
+    fn validate_final_key_confirmation(
+        &self,
+        envelope: &CeremonyEnvelope,
+    ) -> Result<FinalKeyConfirmation> {
+        if self
+            .final_key_confirmations
+            .contains_key(&envelope.sender_did)
+        {
+            return Err(RootError::PortalRejected {
+                reason: "final key confirmation already submitted by sender".to_owned(),
+            });
+        }
+        let confirmation =
+            decode_final_key_confirmation_payload(envelope.payload_bytes.as_slice())?;
+        self.validate_final_key_confirmation_semantics(envelope, &confirmation)?;
+        for accepted in self.final_key_confirmations.values() {
+            if accepted.config_hash != confirmation.config_hash {
+                return Err(RootError::PortalRejected {
+                    reason: "final key confirmation config hash disagrees with accepted set"
+                        .to_owned(),
+                });
+            }
+            if accepted.dkg_transcript_hash != confirmation.dkg_transcript_hash {
+                return Err(RootError::PortalRejected {
+                    reason:
+                        "final key confirmation DKG transcript hash disagrees with accepted set"
+                            .to_owned(),
+                });
+            }
+            if accepted.public_key_package != confirmation.public_key_package {
+                return Err(RootError::PortalRejected {
+                    reason: "final key confirmation public key package disagrees with accepted set"
+                        .to_owned(),
+                });
+            }
+            if accepted.root_public_key_package_hash != confirmation.root_public_key_package_hash {
+                return Err(RootError::PortalRejected {
+                    reason:
+                        "final key confirmation public key package hash disagrees with accepted set"
+                            .to_owned(),
+                });
+            }
+            if accepted.root_public_key_hash != confirmation.root_public_key_hash {
+                return Err(RootError::PortalRejected {
+                    reason: "final key confirmation root key hash disagrees with accepted set"
+                        .to_owned(),
+                });
+            }
+        }
+        Ok(confirmation)
+    }
+
+    fn validate_final_key_confirmation_semantics(
+        &self,
+        envelope: &CeremonyEnvelope,
+        confirmation: &FinalKeyConfirmation,
+    ) -> Result<()> {
+        if confirmation.domain != FINAL_KEY_CONFIRMATION_DOMAIN {
+            return Err(RootError::PortalRejected {
+                reason: "final key confirmation domain mismatch".to_owned(),
+            });
+        }
+        if confirmation.schema_version != FINAL_KEY_CONFIRMATION_SCHEMA_VERSION {
+            return Err(RootError::PortalRejected {
+                reason: "final key confirmation schema version mismatch".to_owned(),
+            });
+        }
+        if confirmation.ceremony_id != self.config.ceremony_id {
+            return Err(RootError::PortalRejected {
+                reason: "final key confirmation ceremony_id mismatch".to_owned(),
+            });
+        }
+        if confirmation.certifier_did != envelope.sender_did {
+            return Err(RootError::PortalRejected {
+                reason: "final key confirmation certifier_did must match envelope sender"
+                    .to_owned(),
+            });
+        }
+        let certifier = self
+            .config
+            .certifier_by_did(&confirmation.certifier_did)
+            .ok_or_else(|| RootError::PortalRejected {
+                reason: "final key confirmation certifier is not rostered".to_owned(),
+            })?;
+        if certifier.frost_identifier != confirmation.frost_identifier {
+            return Err(RootError::PortalRejected {
+                reason: "final key confirmation DID and FROST identifier mismatch".to_owned(),
+            });
+        }
+        let expected_config_hash = ceremony_config_hash(&self.config)?;
+        if confirmation.config_hash != expected_config_hash {
+            return Err(RootError::PortalRejected {
+                reason: "final key confirmation config hash mismatch".to_owned(),
+            });
+        }
+        let expected_dkg_transcript_hash = self.dkg_transcript_hash()?;
+        if confirmation.dkg_transcript_hash != expected_dkg_transcript_hash {
+            return Err(RootError::PortalRejected {
+                reason: "final key confirmation DKG transcript hash mismatch".to_owned(),
+            });
+        }
+        validate_public_key_package(&self.config, &confirmation.public_key_package)?;
+        let expected_package_hash =
+            hash_structured(&confirmation.public_key_package).map_err(canonical_encoding_error)?;
+        if confirmation.root_public_key_package_hash != expected_package_hash {
+            return Err(RootError::PortalRejected {
+                reason: "final key confirmation public key package hash mismatch".to_owned(),
+            });
+        }
+        let expected_root_public_key_hash =
+            Hash256::digest(confirmation.public_key_package.root_public_key.as_slice());
+        if confirmation.root_public_key_hash != expected_root_public_key_hash {
+            return Err(RootError::PortalRejected {
+                reason: "final key confirmation root public key hash mismatch".to_owned(),
+            });
+        }
+        let verifying_share = confirmation
+            .public_key_package
+            .verifying_shares
+            .get(&confirmation.frost_identifier)
+            .ok_or_else(|| RootError::PortalRejected {
+                reason: "final key confirmation verifying share is missing".to_owned(),
+            })?;
+        if confirmation.certifier_verifying_share_hash
+            != Hash256::digest(verifying_share.as_slice())
+        {
+            return Err(RootError::PortalRejected {
+                reason: "final key confirmation verifying share hash mismatch".to_owned(),
+            });
+        }
+        Ok(())
+    }
+
+    fn dkg_transcript_records(&self) -> Result<Vec<TranscriptEnvelopeRecord>> {
+        let mut records = Vec::new();
+        for (key, envelope) in &self.envelopes {
+            if matches!(
+                (envelope.phase, envelope.payload_kind),
+                (CeremonyPhase::Round1, CeremonyPayloadKind::Round1Package)
+                    | (
+                        CeremonyPhase::Round2,
+                        CeremonyPayloadKind::Round2EncryptedPackage
+                    )
+            ) {
+                records.push(transcript_record(key, envelope)?);
+            }
+        }
+        records.sort();
+        Ok(records)
+    }
+
+    fn final_key_confirmation_records(&self) -> Result<Vec<TranscriptEnvelopeRecord>> {
+        let mut records = Vec::new();
+        for (key, envelope) in &self.envelopes {
+            if envelope.phase == CeremonyPhase::Finalize
+                && envelope.payload_kind == CeremonyPayloadKind::FinalKeyConfirmation
+            {
+                records.push(transcript_record(key, envelope)?);
+            }
+        }
+        records.sort();
+        Ok(records)
+    }
+
+    fn ensure_dkg_transcript_complete(&self, records: &[TranscriptEnvelopeRecord]) -> Result<()> {
+        let expected_certifiers: BTreeSet<Did> = self
+            .config
+            .certifiers
+            .iter()
+            .map(|certifier| certifier.did.clone())
+            .collect();
+        let mut round1_senders = BTreeSet::new();
+        let mut round2_pairs = BTreeSet::new();
+        for record in records {
+            match (record.phase, record.payload_kind) {
+                (CeremonyPhase::Round1, CeremonyPayloadKind::Round1Package) => {
+                    if record.recipient_did.is_some() {
+                        return Err(RootError::PortalRejected {
+                            reason: "dkg transcript round-one record has a recipient".to_owned(),
+                        });
+                    }
+                    if !round1_senders.insert(record.sender_did.clone()) {
+                        return Err(RootError::PortalRejected {
+                            reason: "dkg transcript contains duplicate round-one sender".to_owned(),
+                        });
+                    }
+                }
+                (CeremonyPhase::Round2, CeremonyPayloadKind::Round2EncryptedPackage) => {
+                    let recipient =
+                        record
+                            .recipient_did
+                            .clone()
+                            .ok_or_else(|| RootError::PortalRejected {
+                                reason: "dkg transcript round-two record missing recipient"
+                                    .to_owned(),
+                            })?;
+                    if !round2_pairs.insert((record.sender_did.clone(), recipient)) {
+                        return Err(RootError::PortalRejected {
+                            reason:
+                                "dkg transcript contains duplicate round-two sender-recipient pair"
+                                    .to_owned(),
+                        });
+                    }
+                }
+                _ => {
+                    return Err(RootError::PortalRejected {
+                        reason: "dkg transcript contains non-DKG envelope".to_owned(),
+                    });
+                }
+            }
+        }
+        if round1_senders != expected_certifiers {
+            return Err(RootError::PortalRejected {
+                reason: "dkg transcript requires one round-one package from every certifier"
+                    .to_owned(),
+            });
+        }
+        let expected_round2 = usize::from(self.config.max_signers)
+            * usize::from(self.config.max_signers.saturating_sub(1));
+        if round2_pairs.len() != expected_round2 {
+            return Err(RootError::PortalRejected {
+                reason: "dkg transcript requires every ordered round-two sender-recipient package"
+                    .to_owned(),
+            });
+        }
+        for sender in &expected_certifiers {
+            for recipient in &expected_certifiers {
+                if sender == recipient {
+                    continue;
+                }
+                if !round2_pairs.contains(&(sender.clone(), recipient.clone())) {
+                    return Err(RootError::PortalRejected {
+                        reason: "dkg transcript missing round-two sender-recipient package"
+                            .to_owned(),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn ensure_final_key_confirmations_complete(&self) -> Result<()> {
+        if self.final_key_confirmations.len() != usize::from(self.config.max_signers) {
+            return Err(RootError::PortalRejected {
+                reason: "root signing requires final key confirmations from all certifiers"
+                    .to_owned(),
+            });
+        }
+        for certifier in &self.config.certifiers {
+            if !self.final_key_confirmations.contains_key(&certifier.did) {
+                return Err(RootError::PortalRejected {
+                    reason: "root signing missing a certifier final key confirmation".to_owned(),
+                });
+            }
+        }
+        Ok(())
     }
 }
 
@@ -417,6 +918,21 @@ fn key_parts(key: &PortalEnvelopeKey) -> PortalEnvelopeKeyParts<'_> {
     }
 }
 
+fn transcript_record(
+    key: &PortalEnvelopeKey,
+    envelope: &CeremonyEnvelope,
+) -> Result<TranscriptEnvelopeRecord> {
+    Ok(TranscriptEnvelopeRecord {
+        phase: envelope.phase,
+        payload_kind: envelope.payload_kind,
+        sender_did: envelope.sender_did.clone(),
+        recipient_did: envelope.recipient_did.clone(),
+        sequence: envelope.sequence,
+        envelope_id: hash_structured(&key_parts(key)).map_err(canonical_encoding_error)?,
+        envelope_hash: hash_structured(envelope).map_err(canonical_encoding_error)?,
+    })
+}
+
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
@@ -468,7 +984,6 @@ mod tests {
                 created_at: Timestamp::new(1, 0),
                 certifiers,
                 signing_set: (1..=7).collect(),
-                signing_alternates: (8..=13).collect(),
             },
             secrets,
         )

--- a/crates/exo-root/src/portal.rs
+++ b/crates/exo-root/src/portal.rs
@@ -97,9 +97,9 @@ pub struct CeremonyEnvelopeDraft {
 /// Ratified final DKG key confirmation payload.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FinalKeyConfirmation {
-    /// Domain separator; must equal [`FINAL_KEY_CONFIRMATION_DOMAIN`].
+    /// Domain separator; must equal [`crate::FINAL_KEY_CONFIRMATION_DOMAIN`].
     pub domain: String,
-    /// Schema version; must equal [`FINAL_KEY_CONFIRMATION_SCHEMA_VERSION`].
+    /// Schema version; must equal [`crate::FINAL_KEY_CONFIRMATION_SCHEMA_VERSION`].
     pub schema_version: u16,
     /// Ceremony identifier.
     pub ceremony_id: String,

--- a/crates/exo-root/src/portal.rs
+++ b/crates/exo-root/src/portal.rs
@@ -461,24 +461,33 @@ mod tests {
         // No filters → both envelopes.
         assert_eq!(store.query(None, None, None).len(), 2);
         // Phase filter (match + non-match).
-        assert_eq!(store.query(Some(CeremonyPhase::Round1), None, None).len(), 1);
         assert_eq!(
-            store
-                .query(Some(CeremonyPhase::Finalize), None, None)
-                .len(),
+            store.query(Some(CeremonyPhase::Round1), None, None).len(),
+            1
+        );
+        assert_eq!(
+            store.query(Some(CeremonyPhase::Finalize), None, None).len(),
             0
         );
         // Payload-kind filter.
         assert_eq!(
             store
-                .query(None, Some(CeremonyPayloadKind::Round2EncryptedPackage), None)
+                .query(
+                    None,
+                    Some(CeremonyPayloadKind::Round2EncryptedPackage),
+                    None
+                )
                 .len(),
             1
         );
         // Recipient filter (match + non-match).
         assert_eq!(
             store
-                .query(Some(CeremonyPhase::Round2), None, Some(&config.certifiers[1].did))
+                .query(
+                    Some(CeremonyPhase::Round2),
+                    None,
+                    Some(&config.certifiers[1].did)
+                )
                 .len(),
             1
         );

--- a/crates/exo-root/src/portal.rs
+++ b/crates/exo-root/src/portal.rs
@@ -216,6 +216,18 @@ fn decode_final_key_confirmation_payload(bytes: &[u8]) -> Result<FinalKeyConfirm
     })
 }
 
+fn certifier_verifying_share_hash(
+    public_key_package: &RootPublicKeyPackage,
+    frost_identifier_value: u16,
+    missing_error: RootError,
+) -> Result<Hash256> {
+    let verifying_share = public_key_package
+        .verifying_shares
+        .get(&frost_identifier_value)
+        .ok_or(missing_error)?;
+    Ok(Hash256::digest(verifying_share.as_slice()))
+}
+
 /// Build the ratified final key confirmation payload for one finalized
 /// certifier. This emits only public confirmation material; the secret FROST key
 /// package is parsed locally to bind the certifier identifier but is never copied
@@ -242,15 +254,15 @@ pub fn build_final_key_confirmation(
             detail: "final key confirmation key package identifier mismatch".to_owned(),
         });
     }
-    let verifying_share = dkg_output
-        .public_key_package
-        .verifying_shares
-        .get(&frost_identifier_value)
-        .ok_or_else(|| RootError::BundleRejected {
+    let certifier_verifying_share_hash = certifier_verifying_share_hash(
+        &dkg_output.public_key_package,
+        frost_identifier_value,
+        RootError::BundleRejected {
             reason: format!(
                 "public key package missing verifying share for certifier {frost_identifier_value}"
             ),
-        })?;
+        },
+    )?;
     Ok(FinalKeyConfirmation {
         domain: FINAL_KEY_CONFIRMATION_DOMAIN.to_owned(),
         schema_version: FINAL_KEY_CONFIRMATION_SCHEMA_VERSION,
@@ -265,7 +277,7 @@ pub fn build_final_key_confirmation(
         root_public_key_hash: Hash256::digest(
             dkg_output.public_key_package.root_public_key.as_slice(),
         ),
-        certifier_verifying_share_hash: Hash256::digest(verifying_share.as_slice()),
+        certifier_verifying_share_hash,
     })
 }
 
@@ -723,16 +735,14 @@ impl PortalStore {
                 reason: "final key confirmation root public key hash mismatch".to_owned(),
             });
         }
-        let verifying_share = confirmation
-            .public_key_package
-            .verifying_shares
-            .get(&confirmation.frost_identifier)
-            .ok_or_else(|| RootError::PortalRejected {
+        let certifier_verifying_share_hash = certifier_verifying_share_hash(
+            &confirmation.public_key_package,
+            confirmation.frost_identifier,
+            RootError::PortalRejected {
                 reason: "final key confirmation verifying share is missing".to_owned(),
-            })?;
-        if confirmation.certifier_verifying_share_hash
-            != Hash256::digest(verifying_share.as_slice())
-        {
+            },
+        )?;
+        if confirmation.certifier_verifying_share_hash != certifier_verifying_share_hash {
             return Err(RootError::PortalRejected {
                 reason: "final key confirmation verifying share hash mismatch".to_owned(),
             });
@@ -999,6 +1009,201 @@ mod tests {
         bytes
     }
 
+    fn encrypted_payload_with(ciphertext: impl Into<Vec<u8>>) -> Vec<u8> {
+        let payload = PairwiseEncryptedPayload {
+            nonce: [9u8; 24],
+            ciphertext: ciphertext.into(),
+        };
+        let mut bytes = Vec::new();
+        ciborium::into_writer(&payload, &mut bytes).expect("encode");
+        bytes
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn sign_envelope(
+        config: &GenesisCeremonyConfig,
+        secrets: &[SecretKey],
+        sender_identifier: u16,
+        phase: CeremonyPhase,
+        payload_kind: CeremonyPayloadKind,
+        recipient_identifier: Option<u16>,
+        sequence: u64,
+        payload_bytes: Vec<u8>,
+    ) -> CeremonyEnvelope {
+        let sender_index = usize::from(sender_identifier - 1);
+        let recipient_did = recipient_identifier
+            .map(|identifier| config.certifiers[usize::from(identifier - 1)].did.clone());
+        CeremonyEnvelope::sign(
+            CeremonyEnvelopeDraft {
+                ceremony_id: config.ceremony_id.clone(),
+                phase,
+                payload_kind,
+                sender_did: config.certifiers[sender_index].did.clone(),
+                recipient_did,
+                sequence,
+                payload_bytes,
+            },
+            &secrets[sender_index],
+        )
+        .expect("signed envelope")
+    }
+
+    fn participant_output(
+        dkg: &crate::RootDkgOutput,
+        identifier: u16,
+    ) -> crate::RootParticipantDkgOutput {
+        crate::RootParticipantDkgOutput {
+            key_package: dkg.key_packages[&identifier].clone(),
+            public_key_package: dkg.public_key_package.clone(),
+        }
+    }
+
+    fn submit_complete_dkg_transcript(
+        store: &mut PortalStore,
+        config: &GenesisCeremonyConfig,
+        secrets: &[SecretKey],
+    ) -> Hash256 {
+        for certifier in &config.certifiers {
+            store
+                .submit(sign_envelope(
+                    config,
+                    secrets,
+                    certifier.frost_identifier,
+                    CeremonyPhase::Round1,
+                    CeremonyPayloadKind::Round1Package,
+                    None,
+                    10,
+                    round1_package_bytes(config, certifier.frost_identifier),
+                ))
+                .expect("round one submit");
+        }
+        for sender in &config.certifiers {
+            for recipient in &config.certifiers {
+                if sender.frost_identifier == recipient.frost_identifier {
+                    continue;
+                }
+                store
+                    .submit(sign_envelope(
+                        config,
+                        secrets,
+                        sender.frost_identifier,
+                        CeremonyPhase::Round2,
+                        CeremonyPayloadKind::Round2EncryptedPackage,
+                        Some(recipient.frost_identifier),
+                        1_000
+                            + u64::from(sender.frost_identifier) * 100
+                            + u64::from(recipient.frost_identifier),
+                        encrypted_payload_with(format!(
+                            "round2-{}-{}",
+                            sender.frost_identifier, recipient.frost_identifier
+                        )),
+                    ))
+                    .expect("round two submit");
+            }
+        }
+        store.dkg_transcript_hash().expect("dkg transcript hash")
+    }
+
+    fn final_key_confirmation(
+        config: &GenesisCeremonyConfig,
+        dkg: &crate::RootDkgOutput,
+        identifier: u16,
+        dkg_transcript_hash: Hash256,
+    ) -> FinalKeyConfirmation {
+        build_final_key_confirmation(
+            config,
+            &participant_output(dkg, identifier),
+            dkg_transcript_hash,
+        )
+        .expect("final key confirmation")
+    }
+
+    fn final_key_confirmation_envelope(
+        config: &GenesisCeremonyConfig,
+        secrets: &[SecretKey],
+        identifier: u16,
+        confirmation: &FinalKeyConfirmation,
+    ) -> CeremonyEnvelope {
+        sign_envelope(
+            config,
+            secrets,
+            identifier,
+            CeremonyPhase::Finalize,
+            CeremonyPayloadKind::FinalKeyConfirmation,
+            None,
+            5_000 + u64::from(identifier),
+            encode_final_key_confirmation_payload(confirmation).expect("confirmation payload"),
+        )
+    }
+
+    fn transcript_record_for(
+        config: &GenesisCeremonyConfig,
+        phase: CeremonyPhase,
+        payload_kind: CeremonyPayloadKind,
+        sender_identifier: u16,
+        recipient_identifier: Option<u16>,
+        sequence: u64,
+    ) -> TranscriptEnvelopeRecord {
+        let sender_did = if sender_identifier == 0 {
+            Did::new("did:exo:transcript-outside").expect("outside did")
+        } else {
+            config.certifiers[usize::from(sender_identifier - 1)]
+                .did
+                .clone()
+        };
+        let recipient_did = recipient_identifier.map(|identifier| {
+            if identifier == 0 {
+                Did::new("did:exo:transcript-outside-recipient").expect("outside recipient")
+            } else {
+                config.certifiers[usize::from(identifier - 1)].did.clone()
+            }
+        });
+        let material = format!("{phase:?}:{payload_kind:?}:{sender_identifier}:{sequence}");
+        TranscriptEnvelopeRecord {
+            phase,
+            payload_kind,
+            sender_did,
+            recipient_did,
+            sequence,
+            envelope_id: Hash256::digest(material.as_bytes()),
+            envelope_hash: Hash256::digest(format!("hash:{material}").as_bytes()),
+        }
+    }
+
+    fn complete_transcript_records(
+        config: &GenesisCeremonyConfig,
+    ) -> Vec<TranscriptEnvelopeRecord> {
+        let mut records = Vec::new();
+        for certifier in &config.certifiers {
+            records.push(transcript_record_for(
+                config,
+                CeremonyPhase::Round1,
+                CeremonyPayloadKind::Round1Package,
+                certifier.frost_identifier,
+                None,
+                10,
+            ));
+        }
+        for sender in &config.certifiers {
+            for recipient in &config.certifiers {
+                if sender.frost_identifier == recipient.frost_identifier {
+                    continue;
+                }
+                records.push(transcript_record_for(
+                    config,
+                    CeremonyPhase::Round2,
+                    CeremonyPayloadKind::Round2EncryptedPackage,
+                    sender.frost_identifier,
+                    Some(recipient.frost_identifier),
+                    1_000
+                        + u64::from(sender.frost_identifier) * 100
+                        + u64::from(recipient.frost_identifier),
+                ));
+            }
+        }
+        records
+    }
+
     #[test]
     fn canonical_error_conversion_is_diagnostic() {
         let error = canonical_encoding_error("portal encoding failed");
@@ -1087,5 +1292,361 @@ mod tests {
                 .len(),
             0
         );
+    }
+
+    #[test]
+    fn final_key_confirmation_builder_rejects_misbound_key_material() {
+        let (config, _) = config_with_secrets();
+        let mut rng = StdRng::seed_from_u64(7_001);
+        let dkg = crate::run_complete_dkg(&config, &mut rng).expect("dkg");
+        let dkg_transcript_hash = Hash256::digest(b"dkg transcript");
+
+        let mut unrostered = participant_output(&dkg, 1);
+        unrostered.key_package.frost_identifier = 99;
+        assert!(
+            build_final_key_confirmation(&config, &unrostered, dkg_transcript_hash).is_err(),
+            "builder must reject a certifier id outside the ratified roster"
+        );
+
+        let mut mismatched = participant_output(&dkg, 1);
+        mismatched.key_package.key_package = dkg.key_packages[&2].key_package.clone();
+        assert!(
+            build_final_key_confirmation(&config, &mismatched, dkg_transcript_hash).is_err(),
+            "builder must bind the public confirmation to the certifier key package"
+        );
+
+        let mut missing_share = participant_output(&dkg, 1);
+        missing_share.public_key_package.verifying_shares.remove(&1);
+        assert!(
+            build_final_key_confirmation(&config, &missing_share, dkg_transcript_hash).is_err(),
+            "builder must reject public key package metadata that omits a rostered share"
+        );
+        let missing_share_error = certifier_verifying_share_hash(
+            &missing_share.public_key_package,
+            1,
+            RootError::PortalRejected {
+                reason: "unit missing share".to_owned(),
+            },
+        )
+        .expect_err("missing share helper must fail closed");
+        assert!(
+            missing_share_error
+                .to_string()
+                .contains("unit missing share")
+        );
+    }
+
+    #[test]
+    fn duplicate_dkg_replacements_are_rejected() {
+        let (config, secrets) = config_with_secrets();
+        let mut store = PortalStore::new(config.clone());
+        store
+            .submit(sign_envelope(
+                &config,
+                &secrets,
+                1,
+                CeremonyPhase::Round1,
+                CeremonyPayloadKind::Round1Package,
+                None,
+                1,
+                round1_package_bytes(&config, 1),
+            ))
+            .expect("first round-one");
+        assert!(
+            store
+                .submit(sign_envelope(
+                    &config,
+                    &secrets,
+                    1,
+                    CeremonyPhase::Round1,
+                    CeremonyPayloadKind::Round1Package,
+                    None,
+                    2,
+                    round1_package_bytes(&config, 1),
+                ))
+                .is_err(),
+            "a sender cannot replace a broadcast DKG package after acceptance"
+        );
+
+        store
+            .submit(sign_envelope(
+                &config,
+                &secrets,
+                1,
+                CeremonyPhase::Round2,
+                CeremonyPayloadKind::Round2EncryptedPackage,
+                Some(2),
+                101,
+                encrypted_payload_with(b"one"),
+            ))
+            .expect("first round-two");
+        assert!(
+            store
+                .submit(sign_envelope(
+                    &config,
+                    &secrets,
+                    1,
+                    CeremonyPhase::Round2,
+                    CeremonyPayloadKind::Round2EncryptedPackage,
+                    Some(2),
+                    102,
+                    encrypted_payload_with(b"two"),
+                ))
+                .is_err(),
+            "a sender cannot replace a pairwise DKG package after acceptance"
+        );
+    }
+
+    #[test]
+    fn final_key_confirmation_semantics_reject_every_bound_field() {
+        let (config, secrets) = config_with_secrets();
+        let mut rng = StdRng::seed_from_u64(7_002);
+        let dkg = crate::run_complete_dkg(&config, &mut rng).expect("dkg");
+        let mut store = PortalStore::new(config.clone());
+        let dkg_transcript_hash = submit_complete_dkg_transcript(&mut store, &config, &secrets);
+        let valid = final_key_confirmation(&config, &dkg, 1, dkg_transcript_hash);
+        let envelope = final_key_confirmation_envelope(&config, &secrets, 1, &valid);
+
+        let mut bad = valid.clone();
+        bad.domain = "wrong-domain".to_owned();
+        assert!(
+            store
+                .validate_final_key_confirmation_semantics(&envelope, &bad)
+                .is_err()
+        );
+
+        let mut bad = valid.clone();
+        bad.schema_version = FINAL_KEY_CONFIRMATION_SCHEMA_VERSION + 1;
+        assert!(
+            store
+                .validate_final_key_confirmation_semantics(&envelope, &bad)
+                .is_err()
+        );
+
+        let mut bad = valid.clone();
+        bad.ceremony_id = "wrong-ceremony".to_owned();
+        assert!(
+            store
+                .validate_final_key_confirmation_semantics(&envelope, &bad)
+                .is_err()
+        );
+
+        let mut bad_envelope = envelope.clone();
+        bad_envelope.sender_did = Did::new("did:exo:not-rostered").expect("outside did");
+        let mut bad = valid.clone();
+        bad.certifier_did = bad_envelope.sender_did.clone();
+        assert!(
+            store
+                .validate_final_key_confirmation_semantics(&bad_envelope, &bad)
+                .is_err()
+        );
+
+        let mut bad = valid.clone();
+        bad.frost_identifier = 2;
+        assert!(
+            store
+                .validate_final_key_confirmation_semantics(&envelope, &bad)
+                .is_err()
+        );
+
+        let mut bad = valid.clone();
+        bad.config_hash = Hash256::digest(b"wrong config hash");
+        assert!(
+            store
+                .validate_final_key_confirmation_semantics(&envelope, &bad)
+                .is_err()
+        );
+
+        let mut bad = valid.clone();
+        bad.dkg_transcript_hash = Hash256::digest(b"wrong dkg transcript");
+        assert!(
+            store
+                .validate_final_key_confirmation_semantics(&envelope, &bad)
+                .is_err()
+        );
+
+        let mut bad = valid.clone();
+        bad.root_public_key_package_hash = Hash256::digest(b"wrong public package");
+        assert!(
+            store
+                .validate_final_key_confirmation_semantics(&envelope, &bad)
+                .is_err()
+        );
+
+        let mut bad = valid.clone();
+        bad.root_public_key_hash = Hash256::digest(b"wrong root key");
+        assert!(
+            store
+                .validate_final_key_confirmation_semantics(&envelope, &bad)
+                .is_err()
+        );
+
+        let mut bad = valid;
+        bad.certifier_verifying_share_hash = Hash256::digest(b"wrong verifying share");
+        assert!(
+            store
+                .validate_final_key_confirmation_semantics(&envelope, &bad)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn final_key_confirmation_rejects_accepted_set_drift() {
+        let (config, secrets) = config_with_secrets();
+        let mut rng = StdRng::seed_from_u64(7_003);
+        let dkg = crate::run_complete_dkg(&config, &mut rng).expect("dkg");
+        let mut store = PortalStore::new(config.clone());
+        let dkg_transcript_hash = submit_complete_dkg_transcript(&mut store, &config, &secrets);
+        let valid_one = final_key_confirmation(&config, &dkg, 1, dkg_transcript_hash);
+        let valid_two = final_key_confirmation(&config, &dkg, 2, dkg_transcript_hash);
+        let envelope_two = final_key_confirmation_envelope(&config, &secrets, 2, &valid_two);
+        let transcript_store = store.clone();
+
+        for mutation in 0..5 {
+            let mut store = transcript_store.clone();
+            let mut accepted = valid_one.clone();
+            if mutation == 0 {
+                accepted.config_hash = Hash256::digest(b"accepted config drift");
+            } else if mutation == 1 {
+                accepted.dkg_transcript_hash = Hash256::digest(b"accepted transcript drift");
+            } else if mutation == 2 {
+                accepted.public_key_package.root_public_key = b"accepted package drift".to_vec();
+            } else if mutation == 3 {
+                accepted.root_public_key_package_hash =
+                    Hash256::digest(b"accepted package hash drift");
+            } else {
+                accepted.root_public_key_hash = Hash256::digest(b"accepted root drift");
+            }
+            store
+                .final_key_confirmations
+                .insert(valid_one.certifier_did.clone(), accepted);
+            assert!(
+                store
+                    .validate_final_key_confirmation(&envelope_two)
+                    .is_err(),
+                "accepted-set drift case {mutation} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn dkg_transcript_completion_reports_malformed_shapes() {
+        let (config, _) = config_with_secrets();
+        let store = PortalStore::new(config.clone());
+        let complete = complete_transcript_records(&config);
+
+        let mut round1_with_recipient = complete.clone();
+        round1_with_recipient[0].recipient_did = Some(config.certifiers[1].did.clone());
+        assert!(
+            store
+                .ensure_dkg_transcript_complete(&round1_with_recipient)
+                .is_err()
+        );
+
+        let mut duplicate_round1 = complete.clone();
+        duplicate_round1[1].sender_did = duplicate_round1[0].sender_did.clone();
+        assert!(
+            store
+                .ensure_dkg_transcript_complete(&duplicate_round1)
+                .is_err()
+        );
+
+        let round2_start = usize::from(config.max_signers);
+        let mut round2_missing_recipient = complete.clone();
+        round2_missing_recipient[round2_start].recipient_did = None;
+        assert!(
+            store
+                .ensure_dkg_transcript_complete(&round2_missing_recipient)
+                .is_err()
+        );
+
+        let mut duplicate_round2 = complete.clone();
+        duplicate_round2[round2_start + 1].sender_did =
+            duplicate_round2[round2_start].sender_did.clone();
+        duplicate_round2[round2_start + 1].recipient_did =
+            duplicate_round2[round2_start].recipient_did.clone();
+        assert!(
+            store
+                .ensure_dkg_transcript_complete(&duplicate_round2)
+                .is_err()
+        );
+
+        let mut non_dkg = complete.clone();
+        non_dkg[0].phase = CeremonyPhase::Finalize;
+        assert!(store.ensure_dkg_transcript_complete(&non_dkg).is_err());
+
+        let mut missing_round1 = complete.clone();
+        missing_round1.remove(0);
+        assert!(
+            store
+                .ensure_dkg_transcript_complete(&missing_round1)
+                .is_err()
+        );
+
+        let round1_only = complete[..round2_start].to_vec();
+        assert!(store.ensure_dkg_transcript_complete(&round1_only).is_err());
+
+        let mut missing_specific_pair = complete;
+        let removed = missing_specific_pair.remove(round2_start);
+        assert_eq!(removed.sender_did, config.certifiers[0].did);
+        missing_specific_pair.push(transcript_record_for(
+            &config,
+            CeremonyPhase::Round2,
+            CeremonyPayloadKind::Round2EncryptedPackage,
+            0,
+            Some(2),
+            9_999,
+        ));
+        assert!(
+            store
+                .ensure_dkg_transcript_complete(&missing_specific_pair)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn root_signing_completion_rejects_missing_rostered_confirmation() {
+        let (config, _) = config_with_secrets();
+        let mut store = PortalStore::new(config.clone());
+        for certifier in &config.certifiers[1..] {
+            let confirmation = FinalKeyConfirmation {
+                domain: FINAL_KEY_CONFIRMATION_DOMAIN.to_owned(),
+                schema_version: FINAL_KEY_CONFIRMATION_SCHEMA_VERSION,
+                ceremony_id: config.ceremony_id.clone(),
+                certifier_did: certifier.did.clone(),
+                frost_identifier: certifier.frost_identifier,
+                config_hash: Hash256::digest(b"config"),
+                dkg_transcript_hash: Hash256::digest(b"dkg"),
+                public_key_package: RootPublicKeyPackage {
+                    public_key_package: Vec::new(),
+                    root_public_key: Vec::new(),
+                    verifying_shares: BTreeMap::new(),
+                },
+                root_public_key_package_hash: Hash256::digest(b"package"),
+                root_public_key_hash: Hash256::digest(b"root"),
+                certifier_verifying_share_hash: Hash256::digest(b"share"),
+            };
+            store
+                .final_key_confirmations
+                .insert(certifier.did.clone(), confirmation);
+        }
+        let outside = Did::new("did:exo:outside-confirmation").expect("outside did");
+        let mut outside_confirmation = store
+            .final_key_confirmations
+            .values()
+            .next()
+            .expect("seed confirmation")
+            .clone();
+        outside_confirmation.certifier_did = outside.clone();
+        store
+            .final_key_confirmations
+            .insert(outside, outside_confirmation);
+        assert!(store.ensure_final_key_confirmations_complete().is_err());
+    }
+
+    #[test]
+    fn encrypted_round2_payload_validation_rejects_bad_shapes() {
+        assert!(validate_encrypted_round2_payload(b"not cbor").is_err());
+        assert!(validate_encrypted_round2_payload(&encrypted_payload_with(Vec::new())).is_err());
     }
 }

--- a/crates/exo-root/src/signing.rs
+++ b/crates/exo-root/src/signing.rs
@@ -696,4 +696,33 @@ mod tests {
                 .contains("not bound to this signing package")
         );
     }
+
+    #[test]
+    fn sign_share_rejects_signer_absent_from_signing_package() {
+        // A rostered signer that did not contribute a commitment to the package
+        // (here an alternate, id 8) has no commitment to bind its nonces to.
+        let config = test_config();
+        let mut rng = StdRng::seed_from_u64(606);
+        let dkg = crate::run_complete_dkg(&config, &mut rng).expect("dkg");
+        let mut commitments = BTreeMap::new();
+        for (id, kp) in dkg.key_packages.iter().take(7) {
+            let (commitment, _nonces) = sign_commit(&config, kp, &mut rng).expect("commit");
+            commitments.insert(*id, commitment.commitments);
+        }
+        let package = build_signing_package(&config, commitments, b"artifact").expect("package");
+        let (_commitment8, nonces8) =
+            sign_commit(&config, &dkg.key_packages[&8], &mut rng).expect("commit 8");
+        let error = sign_share(
+            &config,
+            &dkg.key_packages[&8],
+            &nonces8,
+            &package.signing_package,
+        )
+        .expect_err("a signer absent from the package must be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("has no commitment for this signer")
+        );
+    }
 }

--- a/crates/exo-root/src/signing.rs
+++ b/crates/exo-root/src/signing.rs
@@ -1,7 +1,8 @@
 //! Threshold root signing helpers.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
+use exo_core::Hash256;
 use frost_ristretto255 as frost;
 use serde::{Deserialize, Serialize};
 
@@ -170,8 +171,23 @@ pub struct RootSigningCommitment {
 pub struct RootSigningNonces {
     /// Owner's FROST identifier.
     pub frost_identifier: u16,
+    /// Ceremony these nonces were generated for; `sign_share` rejects reuse in a
+    /// different ceremony.
+    pub ceremony_id: String,
+    /// blake3 of the public commitment these nonces pair with. `sign_share`
+    /// requires this to equal the hash of the commitment bound for this signer in
+    /// the supplied signing package — which transitively binds the nonces to that
+    /// package's artifact (message) and full signer set, so they can only be
+    /// consumed for the one signing instance they were committed to.
+    pub commitment_hash: Hash256,
     /// Serialized secret signing nonces (retained by the signer; never shared).
     pub nonces: Vec<u8>,
+}
+
+/// blake3 of a signer's serialized public commitment, used to bind nonces to the
+/// signing instance.
+fn commitment_hash(commitment_bytes: &[u8]) -> Hash256 {
+    Hash256::digest(commitment_bytes)
 }
 
 /// Public signing package built by the coordinator from `>= threshold`
@@ -220,13 +236,16 @@ where
     ensure_rostered(config, key_package.frost_identifier, "signer")?;
     let parsed: frost::keys::KeyPackage = deserialize_frost(key_package.key_package.as_slice())?;
     let (nonces, commitments) = frost::round1::commit(parsed.signing_share(), rng);
+    let commitment_bytes = serialize_frost(&commitments)?;
     Ok((
         RootSigningCommitment {
             frost_identifier: key_package.frost_identifier,
-            commitments: serialize_frost(&commitments)?,
+            commitments: commitment_bytes.clone(),
         },
         RootSigningNonces {
             frost_identifier: key_package.frost_identifier,
+            ceremony_id: config.ceremony_id.clone(),
+            commitment_hash: commitment_hash(commitment_bytes.as_slice()),
             nonces: serialize_frost(&nonces)?,
         },
     ))
@@ -246,6 +265,10 @@ pub fn build_signing_package(
             supplied: u16::try_from(commitments.len()).unwrap_or(u16::MAX),
         });
     }
+    // The participating signers must be the predeclared signing set, allowing only
+    // ordered alternate substitution for primaries unavailable before commitments.
+    let selection: BTreeSet<u16> = commitments.keys().copied().collect();
+    config.validate_signing_selection(&selection)?;
     let mut parsed = BTreeMap::new();
     let mut signer_ids = Vec::new();
     for (identifier, bytes) in commitments {
@@ -280,10 +303,32 @@ pub fn sign_share(
             detail: format!("nonces id {nonce_id} mismatches key {key_id}"),
         });
     }
+    if nonces.ceremony_id != config.ceremony_id {
+        return Err(RootError::Frost {
+            detail: "nonces were generated for a different ceremony".to_owned(),
+        });
+    }
     let parsed_key: frost::keys::KeyPackage =
         deserialize_frost(key_package.key_package.as_slice())?;
     let parsed_nonces: frost::round1::SigningNonces = deserialize_frost(nonces.nonces.as_slice())?;
     let parsed_package: frost::SigningPackage = deserialize_frost(signing_package)?;
+    // Bind the nonces to this exact signing instance: the commitment they pair
+    // with must be the one this signer contributed to the signing package. Because
+    // the package fixes the message (artifact) and every signer's commitment (the
+    // signer set), matching the commitment hash binds the nonces to that artifact
+    // and signer set. Combined with single-use consumption by the caller, a set of
+    // nonces can never be replayed against a different artifact, set, or session.
+    let frost_id = crate::dkg::frost_identifier(key_package.frost_identifier)?;
+    let package_commitment = parsed_package
+        .signing_commitment(&frost_id)
+        .ok_or_else(|| RootError::Frost {
+            detail: "signing package has no commitment for this signer".to_owned(),
+        })?;
+    if commitment_hash(serialize_frost(&package_commitment)?.as_slice()) != nonces.commitment_hash {
+        return Err(RootError::Frost {
+            detail: "nonces are not bound to this signing package's commitment".to_owned(),
+        });
+    }
     let share =
         frost::round2::sign(&parsed_package, &parsed_nonces, &parsed_key).map_err(frost_error)?;
     Ok(RootSignatureShareOutput {
@@ -359,6 +404,8 @@ mod tests {
             max_signers: 13,
             created_at: Timestamp::new(1, 0),
             certifiers,
+            signing_set: (1..=7).collect(),
+            signing_alternates: (8..=13).collect(),
         }
     }
 
@@ -589,10 +636,64 @@ mod tests {
         };
         let foreign_nonces = RootSigningNonces {
             frost_identifier: 2,
+            ceremony_id: config.ceremony_id.clone(),
+            commitment_hash: Hash256::digest(b"unrelated commitment"),
             nonces: Vec::new(),
         };
         let error = sign_share(&config, &key_package, &foreign_nonces, &[])
             .expect_err("nonces bound to a different signer must be rejected");
         assert!(error.to_string().contains("mismatches key 1"));
+    }
+
+    #[test]
+    fn sign_share_rejects_nonces_from_a_different_ceremony() {
+        // The ceremony-id check runs before any deserialization, so empty byte
+        // fields suffice and no DKG is needed.
+        let config = test_config();
+        let key_package = RootKeyPackage {
+            frost_identifier: 1,
+            key_package: Vec::new(),
+        };
+        let foreign_nonces = RootSigningNonces {
+            frost_identifier: 1,
+            ceremony_id: "some-other-ceremony".to_owned(),
+            commitment_hash: Hash256::digest(b"unrelated commitment"),
+            nonces: Vec::new(),
+        };
+        let error = sign_share(&config, &key_package, &foreign_nonces, &[])
+            .expect_err("nonces from a different ceremony must be rejected");
+        assert!(error.to_string().contains("different ceremony"));
+    }
+
+    #[test]
+    fn sign_share_rejects_nonces_bound_to_a_different_signing_instance() {
+        // A signer's nonces whose commitment hash does not match the commitment
+        // bound for that signer in the signing package are rejected — this is what
+        // ties a nonce to one artifact + signer set and prevents cross-instance reuse.
+        let config = test_config();
+        let mut rng = StdRng::seed_from_u64(404);
+        let dkg = crate::run_complete_dkg(&config, &mut rng).expect("dkg");
+        let mut commitments = BTreeMap::new();
+        for (id, kp) in dkg.key_packages.iter().take(7) {
+            let (commitment, _nonces) = sign_commit(&config, kp, &mut rng).expect("commit");
+            commitments.insert(*id, commitment.commitments);
+        }
+        let package = build_signing_package(&config, commitments, b"artifact").expect("package");
+        // Fresh nonces for signer 1 from a *different* commitment than the one in
+        // the package (a second sign_commit produces a different commitment).
+        let (_other_commitment, stale_nonces) =
+            sign_commit(&config, &dkg.key_packages[&1], &mut rng).expect("commit");
+        let error = sign_share(
+            &config,
+            &dkg.key_packages[&1],
+            &stale_nonces,
+            &package.signing_package,
+        )
+        .expect_err("nonces not bound to the package commitment must be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("not bound to this signing package")
+        );
     }
 }

--- a/crates/exo-root/src/signing.rs
+++ b/crates/exo-root/src/signing.rs
@@ -147,14 +147,29 @@ fn signature_rejected(error: frost::Error) -> RootError {
 // and `RootSignatureShare` payload kinds.
 // ---------------------------------------------------------------------------
 
-/// One signer's round-one signing material. `commitments` is public and is
-/// broadcast; `nonces` is SECRET and must be retained locally until `sign_share`.
+/// One signer's round-one PUBLIC commitment. Relay-safe: carries no secret
+/// material and is the only round-one artifact broadcast to the coordinator.
+/// Kept deliberately separate from [`RootSigningNonces`] so the secret nonces
+/// can never be co-serialized with, or mistaken for, relay-safe data.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RootSigningCommitment {
     /// Owner's FROST identifier.
     pub frost_identifier: u16,
     /// Serialized public signing commitments (broadcast to the coordinator).
     pub commitments: Vec<u8>,
+}
+
+/// One signer's round-one SECRET signing nonces. **LOCAL-ONLY** — this artifact
+/// must never be broadcast, archived off the signer, copied to the coordinator,
+/// or submitted through the portal. In FROST, disclosure of these nonces
+/// together with the signer's later signature share can compromise the signer's
+/// secret key share. It derives `Serialize`/`Deserialize` only so a signer can
+/// persist it to a `0600` local file between `sign_commit` and `sign_share`; the
+/// distinct type name keeps it from being confused with relay-safe data.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RootSigningNonces {
+    /// Owner's FROST identifier.
+    pub frost_identifier: u16,
     /// Serialized secret signing nonces (retained by the signer; never shared).
     pub nonces: Vec<u8>,
 }
@@ -188,13 +203,16 @@ fn ensure_rostered(config: &GenesisCeremonyConfig, identifier: u16, role: &str) 
     Ok(())
 }
 
-/// Distributed signing — round one. Produce one signer's public commitments and
-/// secret nonces. Run by each participating certifier against its own share.
+/// Distributed signing — round one. Produce one signer's PUBLIC commitment and
+/// SECRET nonces as two distinct artifacts. Run by each participating certifier
+/// against its own share. The caller MUST broadcast only the
+/// [`RootSigningCommitment`] and retain the [`RootSigningNonces`] locally (never
+/// share, archive off-host, or submit it) until [`sign_share`].
 pub fn sign_commit<R>(
     config: &GenesisCeremonyConfig,
     key_package: &RootKeyPackage,
     rng: &mut R,
-) -> Result<RootSigningCommitment>
+) -> Result<(RootSigningCommitment, RootSigningNonces)>
 where
     R: frost::rand_core::RngCore + frost::rand_core::CryptoRng,
 {
@@ -202,11 +220,16 @@ where
     ensure_rostered(config, key_package.frost_identifier, "signer")?;
     let parsed: frost::keys::KeyPackage = deserialize_frost(key_package.key_package.as_slice())?;
     let (nonces, commitments) = frost::round1::commit(parsed.signing_share(), rng);
-    Ok(RootSigningCommitment {
-        frost_identifier: key_package.frost_identifier,
-        commitments: serialize_frost(&commitments)?,
-        nonces: serialize_frost(&nonces)?,
-    })
+    Ok((
+        RootSigningCommitment {
+            frost_identifier: key_package.frost_identifier,
+            commitments: serialize_frost(&commitments)?,
+        },
+        RootSigningNonces {
+            frost_identifier: key_package.frost_identifier,
+            nonces: serialize_frost(&nonces)?,
+        },
+    ))
 }
 
 /// Distributed signing — coordinator assembles the signing package from at
@@ -240,18 +263,26 @@ pub fn build_signing_package(
 }
 
 /// Distributed signing — round two. One signer produces its signature share
-/// from its key package, its retained nonces, and the coordinator's package.
+/// from its key package, its retained local-only [`RootSigningNonces`], and the
+/// coordinator's package.
 pub fn sign_share(
     config: &GenesisCeremonyConfig,
     key_package: &RootKeyPackage,
-    nonces: &[u8],
+    nonces: &RootSigningNonces,
     signing_package: &[u8],
 ) -> Result<RootSignatureShareOutput> {
     config.validate()?;
     ensure_rostered(config, key_package.frost_identifier, "signer")?;
+    if nonces.frost_identifier != key_package.frost_identifier {
+        let nonce_id = nonces.frost_identifier;
+        let key_id = key_package.frost_identifier;
+        return Err(RootError::Frost {
+            detail: format!("nonces id {nonce_id} mismatches key {key_id}"),
+        });
+    }
     let parsed_key: frost::keys::KeyPackage =
         deserialize_frost(key_package.key_package.as_slice())?;
-    let parsed_nonces: frost::round1::SigningNonces = deserialize_frost(nonces)?;
+    let parsed_nonces: frost::round1::SigningNonces = deserialize_frost(nonces.nonces.as_slice())?;
     let parsed_package: frost::SigningPackage = deserialize_frost(signing_package)?;
     let share =
         frost::round2::sign(&parsed_package, &parsed_nonces, &parsed_key).map_err(frost_error)?;
@@ -437,9 +468,9 @@ mod tests {
         let mut commitments = BTreeMap::new();
         let mut nonces = BTreeMap::new();
         for (id, kp) in &signers {
-            let commitment = sign_commit(&config, kp, &mut rng).expect("commit");
-            nonces.insert(*id, commitment.nonces.clone());
-            commitments.insert(*id, commitment.commitments.clone());
+            let (commitment, signer_nonces) = sign_commit(&config, kp, &mut rng).expect("commit");
+            nonces.insert(*id, signer_nonces);
+            commitments.insert(*id, commitment.commitments);
         }
 
         // Coordinator builds the signing package from the commitments.
@@ -480,7 +511,7 @@ mod tests {
         let dkg = crate::run_complete_dkg(&config, &mut rng).expect("dkg");
         let mut commitments = BTreeMap::new();
         for (id, kp) in dkg.key_packages.iter().take(3) {
-            let commitment = sign_commit(&config, kp, &mut rng).expect("commit");
+            let (commitment, _nonces) = sign_commit(&config, kp, &mut rng).expect("commit");
             commitments.insert(*id, commitment.commitments);
         }
         let error = build_signing_package(&config, commitments, b"msg")
@@ -511,12 +542,8 @@ mod tests {
         // build_signing_package rejects a commitment from an unrostered signer.
         let mut commitments = BTreeMap::new();
         for (id, kp) in dkg.key_packages.iter().take(7) {
-            commitments.insert(
-                *id,
-                sign_commit(&config, kp, &mut rng)
-                    .expect("commit")
-                    .commitments,
-            );
+            let (commitment, _nonces) = sign_commit(&config, kp, &mut rng).expect("commit");
+            commitments.insert(*id, commitment.commitments);
         }
         let mut unrostered = commitments.clone();
         let stolen = unrostered.remove(&1).expect("commitment one");
@@ -528,9 +555,10 @@ mod tests {
 
         // sign_share rejects an unrostered key package.
         let package = build_signing_package(&config, commitments, b"msg").expect("package");
-        let commit = sign_commit(&config, &dkg.key_packages[&1], &mut rng).expect("commit");
+        let (_commitment, commit_nonces) =
+            sign_commit(&config, &dkg.key_packages[&1], &mut rng).expect("commit");
         assert!(matches!(
-            sign_share(&config, &stranger, &commit.nonces, &package.signing_package)
+            sign_share(&config, &stranger, &commit_nonces, &package.signing_package)
                 .expect_err("unrostered share"),
             RootError::InvalidConfig { .. }
         ));

--- a/crates/exo-root/src/signing.rs
+++ b/crates/exo-root/src/signing.rs
@@ -333,23 +333,17 @@ pub fn sign_share(
             detail: "nonces are bound to a different artifact than the message".to_owned(),
         });
     }
+    // Enforce the ratified deterministic signer-selection policy signer-side too:
+    // a signer must refuse a signing package whose signer set is not the canonical
+    // selection (predeclared primaries with ordered alternate substitution), even
+    // when a coordinator builds the package outside `build_signing_package`.
+    let selection: BTreeSet<u16> = signing_package.signer_ids.iter().copied().collect();
+    config.validate_signing_selection(&selection)?;
     let parsed_key: frost::keys::KeyPackage =
         deserialize_frost(key_package.key_package.as_slice())?;
     let parsed_nonces: frost::round1::SigningNonces = deserialize_frost(nonces.nonces.as_slice())?;
     let parsed_package: frost::SigningPackage =
         deserialize_frost(signing_package.signing_package.as_slice())?;
-    // The nonces must pair with this signer's commitment in the package.
-    let frost_id = crate::dkg::frost_identifier(key_package.frost_identifier)?;
-    let package_commitment = parsed_package
-        .signing_commitment(&frost_id)
-        .ok_or_else(|| RootError::Frost {
-            detail: "signing package has no commitment for this signer".to_owned(),
-        })?;
-    if commitment_hash(serialize_frost(&package_commitment)?.as_slice()) != nonces.commitment_hash {
-        return Err(RootError::Frost {
-            detail: "nonces are not bound to this signing package's commitment".to_owned(),
-        });
-    }
     // Rebuild the signing package from the supplied commitments and the caller's
     // message, so the share is provably over `message` regardless of what message
     // the coordinator embedded in the distributed package.
@@ -362,6 +356,16 @@ pub fn sign_share(
                 detail: format!("signing package is missing commitment for signer {identifier}"),
             })?;
         commitments.insert(signer_frost_id, commitment);
+    }
+    // The nonces must pair with this signer's commitment in the bound set.
+    let frost_id = crate::dkg::frost_identifier(key_package.frost_identifier)?;
+    let package_commitment = commitments.get(&frost_id).ok_or_else(|| RootError::Frost {
+        detail: "signer is not in the signing package's signer set".to_owned(),
+    })?;
+    if commitment_hash(serialize_frost(package_commitment)?.as_slice()) != nonces.commitment_hash {
+        return Err(RootError::Frost {
+            detail: "nonces are not bound to this signing package's commitment".to_owned(),
+        });
     }
     let rebuilt_package = frost::SigningPackage::new(commitments, message);
     let share =
@@ -759,8 +763,8 @@ mod tests {
 
     #[test]
     fn sign_share_rejects_signer_absent_from_signing_package() {
-        // A rostered signer that did not contribute a commitment to the package
-        // (here an alternate, id 8) has no commitment to bind its nonces to.
+        // Signers 1..7 are the canonical set; an alternate (id 8) that is not in
+        // that set cannot sign against it.
         let config = test_config();
         let mut rng = StdRng::seed_from_u64(606);
         let dkg = crate::run_complete_dkg(&config, &mut rng).expect("dkg");
@@ -780,11 +784,49 @@ mod tests {
             &package,
             b"artifact",
         )
-        .expect_err("a signer absent from the package must be rejected");
+        .expect_err("a signer absent from the set must be rejected");
         assert!(
             error
                 .to_string()
-                .contains("has no commitment for this signer")
+                .contains("signer is not in the signing package's signer set")
+        );
+    }
+
+    #[test]
+    fn sign_share_rejects_non_canonical_signer_set() {
+        // Bob's regression: a coordinator must not bypass the ratified
+        // signer-selection policy by hand-crafting a RootSigningPackage with a
+        // non-canonical signer set. Set [1,2,3,4,5,6,9] skips the required first
+        // alternate (8) for the absent primary (7); sign_share must reject it even
+        // though build_signing_package was never used.
+        let config = test_config();
+        let mut rng = StdRng::seed_from_u64(909);
+        let dkg = crate::run_complete_dkg(&config, &mut rng).expect("dkg");
+        let mut commitments = BTreeMap::new();
+        let mut signer_one_nonces = None;
+        for (id, kp) in dkg.key_packages.iter().take(7) {
+            let (commitment, nonces) =
+                sign_commit(&config, kp, b"artifact", &mut rng).expect("commit");
+            if *id == 1 {
+                signer_one_nonces = Some(nonces);
+            }
+            commitments.insert(*id, commitment.commitments);
+        }
+        let mut package =
+            build_signing_package(&config, commitments, b"artifact").expect("package");
+        // Hand-craft a non-canonical signer set (skips required alternate 8).
+        package.signer_ids = vec![1, 2, 3, 4, 5, 6, 9];
+        let error = sign_share(
+            &config,
+            &dkg.key_packages[&1],
+            &signer_one_nonces.expect("signer one nonces"),
+            &package,
+            b"artifact",
+        )
+        .expect_err("a non-canonical signer set must be rejected");
+        assert!(
+            error.to_string().contains("alternates in order"),
+            "expected a signing-selection-policy rejection, got: {error}"
         );
     }
 
@@ -849,8 +891,11 @@ mod tests {
         }
         let mut package =
             build_signing_package(&config, commitments, b"artifact").expect("package");
-        // Tamper: claim signer 8 participated, though its commitment is not present.
-        package.signer_ids.push(8);
+        // Tamper: replace primary 7 with alternate 8 in signer_ids. This set
+        // [1,2,3,4,5,6,8] IS canonical (passes the selection policy), but the
+        // embedded package still only contains commitments for 1..7, so the
+        // rebuild fails closed when it can't find signer 8's commitment.
+        package.signer_ids = vec![1, 2, 3, 4, 5, 6, 8];
         let error = sign_share(
             &config,
             &dkg.key_packages[&1],

--- a/crates/exo-root/src/signing.rs
+++ b/crates/exo-root/src/signing.rs
@@ -135,6 +135,168 @@ fn signature_rejected(error: frost::Error) -> RootError {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Distributed (online) threshold signing.
+//
+// `threshold_sign` above performs the whole protocol in one process and so
+// requires every key package in one place. The functions below run the same
+// FROST protocol as a two-round distributed exchange: each signer keeps its
+// own `RootKeyPackage` and only ever emits PUBLIC commitments and signature
+// shares. A coordinator (holding no secrets) assembles the signing package and
+// aggregates the shares. These map onto the portal's `RootSigningCommitment`
+// and `RootSignatureShare` payload kinds.
+// ---------------------------------------------------------------------------
+
+/// One signer's round-one signing material. `commitments` is public and is
+/// broadcast; `nonces` is SECRET and must be retained locally until `sign_share`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RootSigningCommitment {
+    /// Owner's FROST identifier.
+    pub frost_identifier: u16,
+    /// Serialized public signing commitments (broadcast to the coordinator).
+    pub commitments: Vec<u8>,
+    /// Serialized secret signing nonces (retained by the signer; never shared).
+    pub nonces: Vec<u8>,
+}
+
+/// Public signing package built by the coordinator from `>= threshold`
+/// commitments. Distributed to the participating signers for round two.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RootSigningPackage {
+    /// Serialized FROST signing package (binds the commitments and message).
+    pub signing_package: Vec<u8>,
+    /// Identifiers whose commitments are bound into this package.
+    pub signer_ids: Vec<u16>,
+}
+
+/// One signer's round-two signature share. Public; reveals nothing about the
+/// signer's secret key share.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RootSignatureShareOutput {
+    /// Owner's FROST identifier.
+    pub frost_identifier: u16,
+    /// Serialized FROST signature share.
+    pub signature_share: Vec<u8>,
+}
+
+fn ensure_rostered(config: &GenesisCeremonyConfig, identifier: u16, role: &str) -> Result<()> {
+    if config.certifier_by_identifier(identifier).is_none() {
+        return Err(RootError::InvalidConfig {
+            reason: format!("{role} {identifier} is not rostered"),
+        });
+    }
+    Ok(())
+}
+
+/// Distributed signing — round one. Produce one signer's public commitments and
+/// secret nonces. Run by each participating certifier against its own share.
+pub fn sign_commit<R>(
+    config: &GenesisCeremonyConfig,
+    key_package: &RootKeyPackage,
+    rng: &mut R,
+) -> Result<RootSigningCommitment>
+where
+    R: frost::rand_core::RngCore + frost::rand_core::CryptoRng,
+{
+    config.validate()?;
+    ensure_rostered(config, key_package.frost_identifier, "signer")?;
+    let parsed: frost::keys::KeyPackage = deserialize_frost(key_package.key_package.as_slice())?;
+    let (nonces, commitments) = frost::round1::commit(parsed.signing_share(), rng);
+    Ok(RootSigningCommitment {
+        frost_identifier: key_package.frost_identifier,
+        commitments: serialize_frost(&commitments)?,
+        nonces: serialize_frost(&nonces)?,
+    })
+}
+
+/// Distributed signing — coordinator assembles the signing package from at
+/// least `threshold` public commitments bound to `message` (the root artifact).
+pub fn build_signing_package(
+    config: &GenesisCeremonyConfig,
+    commitments: BTreeMap<u16, Vec<u8>>,
+    message: &[u8],
+) -> Result<RootSigningPackage> {
+    config.validate()?;
+    if commitments.len() < usize::from(config.threshold) {
+        return Err(RootError::ThresholdNotMet {
+            required: config.threshold,
+            supplied: u16::try_from(commitments.len()).unwrap_or(u16::MAX),
+        });
+    }
+    let mut parsed = BTreeMap::new();
+    let mut signer_ids = Vec::new();
+    for (identifier, bytes) in commitments {
+        ensure_rostered(config, identifier, "signer")?;
+        let frost_id = crate::dkg::frost_identifier(identifier)?;
+        let commitment: frost::round1::SigningCommitments = deserialize_frost(bytes.as_slice())?;
+        parsed.insert(frost_id, commitment);
+        signer_ids.push(identifier);
+    }
+    let signing_package = frost::SigningPackage::new(parsed, message);
+    Ok(RootSigningPackage {
+        signing_package: serialize_frost(&signing_package)?,
+        signer_ids,
+    })
+}
+
+/// Distributed signing — round two. One signer produces its signature share
+/// from its key package, its retained nonces, and the coordinator's package.
+pub fn sign_share(
+    config: &GenesisCeremonyConfig,
+    key_package: &RootKeyPackage,
+    nonces: &[u8],
+    signing_package: &[u8],
+) -> Result<RootSignatureShareOutput> {
+    config.validate()?;
+    ensure_rostered(config, key_package.frost_identifier, "signer")?;
+    let parsed_key: frost::keys::KeyPackage = deserialize_frost(key_package.key_package.as_slice())?;
+    let parsed_nonces: frost::round1::SigningNonces = deserialize_frost(nonces)?;
+    let parsed_package: frost::SigningPackage = deserialize_frost(signing_package)?;
+    let share =
+        frost::round2::sign(&parsed_package, &parsed_nonces, &parsed_key).map_err(frost_error)?;
+    Ok(RootSignatureShareOutput {
+        frost_identifier: key_package.frost_identifier,
+        signature_share: serialize_frost(&share)?,
+    })
+}
+
+/// Distributed signing — coordinator aggregates `>= threshold` signature shares
+/// into the final root signature and verifies it against the root public key.
+pub fn aggregate_signature(
+    config: &GenesisCeremonyConfig,
+    public_key_package: &RootPublicKeyPackage,
+    signing_package: &[u8],
+    shares: BTreeMap<u16, Vec<u8>>,
+    message: &[u8],
+) -> Result<RootSignature> {
+    config.validate()?;
+    if shares.len() < usize::from(config.threshold) {
+        return Err(RootError::ThresholdNotMet {
+            required: config.threshold,
+            supplied: u16::try_from(shares.len()).unwrap_or(u16::MAX),
+        });
+    }
+    let public = deserialize_frost(public_key_package.public_key_package.as_slice())?;
+    let parsed_package: frost::SigningPackage = deserialize_frost(signing_package)?;
+    let mut parsed_shares = BTreeMap::new();
+    let mut signer_ids = Vec::new();
+    for (identifier, bytes) in shares {
+        ensure_rostered(config, identifier, "signer")?;
+        let frost_id = crate::dkg::frost_identifier(identifier)?;
+        let share: frost::round2::SignatureShare = deserialize_frost(bytes.as_slice())?;
+        parsed_shares.insert(frost_id, share);
+        signer_ids.push(identifier);
+    }
+    let aggregated =
+        frost::aggregate(&parsed_package, &parsed_shares, &public).map_err(frost_error)?;
+    let signature = serialize_frost(&aggregated)?;
+    verify_root_signature(&public_key_package.root_public_key, message, &signature)?;
+    Ok(RootSignature {
+        signature,
+        signer_ids,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use exo_core::{Did, Hash256, PublicKey, Timestamp};
@@ -253,5 +415,75 @@ mod tests {
         )
         .expect_err("share identifier mismatch");
         assert!(error.to_string().contains("mismatches key 1"));
+    }
+
+    #[test]
+    fn distributed_signing_matches_one_shot_and_verifies() {
+        let config = test_config();
+        let mut rng = StdRng::seed_from_u64(99);
+        let dkg = crate::run_complete_dkg(&config, &mut rng).expect("dkg");
+        let message = b"distributed root signing artifact";
+
+        // Seven signers, each keeping its own key package.
+        let signers: Vec<(u16, _)> = dkg
+            .key_packages
+            .iter()
+            .take(7)
+            .map(|(id, kp)| (*id, kp.clone()))
+            .collect();
+
+        // Round one: each signer commits locally; only commitments are shared.
+        let mut commitments = BTreeMap::new();
+        let mut nonces = BTreeMap::new();
+        for (id, kp) in &signers {
+            let commitment = sign_commit(&config, kp, &mut rng).expect("commit");
+            nonces.insert(*id, commitment.nonces.clone());
+            commitments.insert(*id, commitment.commitments.clone());
+        }
+
+        // Coordinator builds the signing package from the commitments.
+        let package = build_signing_package(&config, commitments, message).expect("package");
+        assert_eq!(package.signer_ids.len(), 7);
+
+        // Round two: each signer produces its share from its own nonces.
+        let mut shares = BTreeMap::new();
+        for (id, kp) in &signers {
+            let share = sign_share(&config, kp, &nonces[id], &package.signing_package)
+                .expect("share");
+            shares.insert(*id, share.signature_share);
+        }
+
+        // Coordinator aggregates; result verifies against the root key and
+        // matches the threshold the one-shot path would accept.
+        let signature = aggregate_signature(
+            &config,
+            &dkg.public_key_package,
+            &package.signing_package,
+            shares,
+            message,
+        )
+        .expect("aggregate");
+        verify_root_signature(
+            &dkg.public_key_package.root_public_key,
+            message,
+            &signature.signature,
+        )
+        .expect("distributed signature verifies");
+        assert_eq!(signature.signer_ids.len(), 7);
+    }
+
+    #[test]
+    fn build_signing_package_rejects_sub_threshold_commitment_set() {
+        let config = test_config();
+        let mut rng = StdRng::seed_from_u64(100);
+        let dkg = crate::run_complete_dkg(&config, &mut rng).expect("dkg");
+        let mut commitments = BTreeMap::new();
+        for (id, kp) in dkg.key_packages.iter().take(3) {
+            let commitment = sign_commit(&config, kp, &mut rng).expect("commit");
+            commitments.insert(*id, commitment.commitments);
+        }
+        let error = build_signing_package(&config, commitments, b"msg")
+            .expect_err("sub-threshold commitments");
+        assert!(matches!(error, RootError::ThresholdNotMet { required: 7, supplied: 3 }));
     }
 }

--- a/crates/exo-root/src/signing.rs
+++ b/crates/exo-root/src/signing.rs
@@ -42,7 +42,7 @@ fn frost_aggregate_signature(
     frost::aggregate(signing_package, signature_shares, public).map_err(frost_error)
 }
 
-/// Create a FROST threshold signature from at least seven rostered shares.
+/// Create a FROST threshold signature from the exact predeclared signing set.
 pub fn threshold_sign<R>(
     config: &GenesisCeremonyConfig,
     public_key_package: &RootPublicKeyPackage,
@@ -65,13 +65,14 @@ where
         };
         return Err(error);
     }
+    let signer_ids: Vec<u16> = shares.keys().copied().collect();
+    validate_root_signer_ids(config, signer_ids.as_slice())?;
 
     let public = deserialize_frost(public_key_package.public_key_package.as_slice())?;
 
     let mut key_packages = BTreeMap::new();
     let mut signing_nonces = BTreeMap::new();
     let mut signing_commitments = BTreeMap::new();
-    let mut signer_ids = Vec::new();
 
     for (identifier, share) in shares {
         if config.certifier_by_identifier(identifier).is_none() {
@@ -95,7 +96,6 @@ where
         signing_nonces.insert(frost_identifier, nonces);
         signing_commitments.insert(frost_identifier, commitments);
         key_packages.insert(frost_identifier, key_package);
-        signer_ids.push(identifier);
     }
 
     let signing_package = frost::SigningPackage::new(signing_commitments, message);
@@ -223,6 +223,34 @@ fn ensure_rostered(config: &GenesisCeremonyConfig, identifier: u16, role: &str) 
     Ok(())
 }
 
+pub(crate) fn validate_root_signer_ids(
+    config: &GenesisCeremonyConfig,
+    signer_ids: &[u16],
+) -> Result<()> {
+    if signer_ids.len() != usize::from(config.threshold) {
+        return Err(RootError::InvalidConfig {
+            reason: format!(
+                "signing selection must contain exactly {} signers",
+                config.threshold
+            ),
+        });
+    }
+    let mut selection = BTreeSet::new();
+    for identifier in signer_ids {
+        if config.certifier_by_identifier(*identifier).is_none() {
+            return Err(RootError::InvalidConfig {
+                reason: format!("signer {identifier} is not rostered"),
+            });
+        }
+        if !selection.insert(*identifier) {
+            return Err(RootError::InvalidConfig {
+                reason: format!("duplicate signer {identifier}"),
+            });
+        }
+    }
+    config.validate_signing_selection(&selection)
+}
+
 /// Distributed signing — round one. Produce one signer's PUBLIC commitment and
 /// SECRET nonces as two distinct artifacts, **bound to the exact root `artifact`
 /// being signed**. Run by each participating certifier against its own share.
@@ -260,7 +288,7 @@ where
 }
 
 /// Distributed signing — coordinator assembles the signing package from at
-/// least `threshold` public commitments bound to `message` (the root artifact).
+/// the exact predeclared public commitments bound to `message` (the root artifact).
 pub fn build_signing_package(
     config: &GenesisCeremonyConfig,
     commitments: BTreeMap<u16, Vec<u8>>,
@@ -273,18 +301,17 @@ pub fn build_signing_package(
             supplied: u16::try_from(commitments.len()).unwrap_or(u16::MAX),
         });
     }
-    // The participating signers must be the predeclared signing set, allowing only
-    // ordered alternate substitution for primaries unavailable before commitments.
-    let selection: BTreeSet<u16> = commitments.keys().copied().collect();
-    config.validate_signing_selection(&selection)?;
+    // The participating signers must be exactly the predeclared signing set. Any
+    // unavailability aborts the ceremony before commitments and requires a new
+    // config/ceremony id.
+    let signer_ids: Vec<u16> = commitments.keys().copied().collect();
+    validate_root_signer_ids(config, signer_ids.as_slice())?;
     let mut parsed = BTreeMap::new();
-    let mut signer_ids = Vec::new();
     for (identifier, bytes) in commitments {
         ensure_rostered(config, identifier, "signer")?;
         let frost_id = crate::dkg::frost_identifier(identifier)?;
         let commitment: frost::round1::SigningCommitments = deserialize_frost(bytes.as_slice())?;
         parsed.insert(frost_id, commitment);
-        signer_ids.push(identifier);
     }
     let signing_package = frost::SigningPackage::new(parsed, message);
     Ok(RootSigningPackage {
@@ -334,11 +361,10 @@ pub fn sign_share(
         });
     }
     // Enforce the ratified deterministic signer-selection policy signer-side too:
-    // a signer must refuse a signing package whose signer set is not the canonical
-    // selection (predeclared primaries with ordered alternate substitution), even
-    // when a coordinator builds the package outside `build_signing_package`.
-    let selection: BTreeSet<u16> = signing_package.signer_ids.iter().copied().collect();
-    config.validate_signing_selection(&selection)?;
+    // a signer must refuse a signing package whose signer set is not exactly the
+    // predeclared set, even when a coordinator builds the package outside
+    // `build_signing_package`.
+    validate_root_signer_ids(config, signing_package.signer_ids.as_slice())?;
     let parsed_key: frost::keys::KeyPackage =
         deserialize_frost(key_package.key_package.as_slice())?;
     let parsed_nonces: frost::round1::SigningNonces = deserialize_frost(nonces.nonces.as_slice())?;
@@ -376,8 +402,8 @@ pub fn sign_share(
     })
 }
 
-/// Distributed signing — coordinator aggregates `>= threshold` signature shares
-/// into the final root signature and verifies it against the root public key.
+/// Distributed signing — coordinator aggregates the exact predeclared signature
+/// shares into the final root signature and verifies it against the root public key.
 pub fn aggregate_signature(
     config: &GenesisCeremonyConfig,
     public_key_package: &RootPublicKeyPackage,
@@ -392,16 +418,16 @@ pub fn aggregate_signature(
             supplied: u16::try_from(shares.len()).unwrap_or(u16::MAX),
         });
     }
+    let signer_ids: Vec<u16> = shares.keys().copied().collect();
+    validate_root_signer_ids(config, signer_ids.as_slice())?;
     let public = deserialize_frost(public_key_package.public_key_package.as_slice())?;
     let parsed_package: frost::SigningPackage = deserialize_frost(signing_package)?;
     let mut parsed_shares = BTreeMap::new();
-    let mut signer_ids = Vec::new();
     for (identifier, bytes) in shares {
         ensure_rostered(config, identifier, "signer")?;
         let frost_id = crate::dkg::frost_identifier(identifier)?;
         let share: frost::round2::SignatureShare = deserialize_frost(bytes.as_slice())?;
         parsed_shares.insert(frost_id, share);
-        signer_ids.push(identifier);
     }
     let aggregated =
         frost::aggregate(&parsed_package, &parsed_shares, &public).map_err(frost_error)?;
@@ -444,7 +470,6 @@ mod tests {
             created_at: Timestamp::new(1, 0),
             certifiers,
             signing_set: (1..=7).collect(),
-            signing_alternates: (8..=13).collect(),
         }
     }
 
@@ -533,6 +558,35 @@ mod tests {
         )
         .expect_err("share identifier mismatch");
         assert!(error.to_string().contains("mismatches key 1"));
+    }
+
+    #[test]
+    fn threshold_sign_rejects_non_declared_signer_set_before_public_deserialization() {
+        let config = test_config();
+        let public_key_package = RootPublicKeyPackage {
+            public_key_package: b"not a public package".to_vec(),
+            root_public_key: b"not a verifying key".to_vec(),
+            verifying_shares: BTreeMap::new(),
+        };
+        let shares = [1, 2, 3, 4, 5, 6, 9]
+            .into_iter()
+            .map(|identifier| {
+                (
+                    identifier,
+                    RootKeyPackage {
+                        frost_identifier: identifier,
+                        key_package: Vec::new(),
+                    },
+                )
+            })
+            .collect();
+        let mut rng = StdRng::seed_from_u64(72);
+        let error = threshold_sign(&config, &public_key_package, shares, b"artifact", &mut rng)
+            .expect_err("non-declared signer set");
+        assert!(
+            error.to_string().contains("predeclared signing_set"),
+            "expected signer-set rejection before public package decoding, got: {error}"
+        );
     }
 
     #[test]
@@ -662,6 +716,32 @@ mod tests {
             .expect_err("sub-threshold aggregate"),
             RootError::ThresholdNotMet { required: 7, .. }
         ));
+    }
+
+    #[test]
+    fn aggregate_signature_rejects_non_declared_signer_set_before_deserialization() {
+        let config = test_config();
+        let public_key_package = RootPublicKeyPackage {
+            public_key_package: b"not a public package".to_vec(),
+            root_public_key: b"not a verifying key".to_vec(),
+            verifying_shares: BTreeMap::new(),
+        };
+        let shares = [1, 2, 3, 4, 5, 6, 9]
+            .into_iter()
+            .map(|identifier| (identifier, vec![u8::try_from(identifier).expect("id fits")]))
+            .collect();
+        let error = aggregate_signature(
+            &config,
+            &public_key_package,
+            b"not a signing package",
+            shares,
+            b"artifact",
+        )
+        .expect_err("non-declared aggregate signer set");
+        assert!(
+            error.to_string().contains("predeclared signing_set"),
+            "expected signer-set rejection before signature artifacts decode, got: {error}"
+        );
     }
 
     #[test]
@@ -796,9 +876,9 @@ mod tests {
     fn sign_share_rejects_non_canonical_signer_set() {
         // Bob's regression: a coordinator must not bypass the ratified
         // signer-selection policy by hand-crafting a RootSigningPackage with a
-        // non-canonical signer set. Set [1,2,3,4,5,6,9] skips the required first
-        // alternate (8) for the absent primary (7); sign_share must reject it even
-        // though build_signing_package was never used.
+        // non-declared signer set. Set [1,2,3,4,5,6,9] replaces signer 7 with
+        // signer 9; sign_share must reject it even though build_signing_package
+        // was never used.
         let config = test_config();
         let mut rng = StdRng::seed_from_u64(909);
         let dkg = crate::run_complete_dkg(&config, &mut rng).expect("dkg");
@@ -825,7 +905,7 @@ mod tests {
         )
         .expect_err("a non-canonical signer set must be rejected");
         assert!(
-            error.to_string().contains("alternates in order"),
+            error.to_string().contains("predeclared signing_set"),
             "expected a signing-selection-policy rejection, got: {error}"
         );
     }
@@ -891,11 +971,25 @@ mod tests {
         }
         let mut package =
             build_signing_package(&config, commitments, b"artifact").expect("package");
-        // Tamper: replace primary 7 with alternate 8 in signer_ids. This set
-        // [1,2,3,4,5,6,8] IS canonical (passes the selection policy), but the
-        // embedded package still only contains commitments for 1..7, so the
-        // rebuild fails closed when it can't find signer 8's commitment.
-        package.signer_ids = vec![1, 2, 3, 4, 5, 6, 8];
+        let parsed_package: frost::SigningPackage =
+            deserialize_frost(package.signing_package.as_slice()).expect("parsed package");
+        let mut embedded_commitments = BTreeMap::new();
+        for id in 1..=6u16 {
+            let signer_frost_id = crate::dkg::frost_identifier(id).expect("frost id");
+            let commitment = parsed_package
+                .signing_commitment(&signer_frost_id)
+                .expect("commitment");
+            embedded_commitments.insert(signer_frost_id, commitment);
+        }
+        let (commitment8, _nonces8) =
+            sign_commit(&config, &dkg.key_packages[&8], b"artifact", &mut rng).expect("commit 8");
+        embedded_commitments.insert(
+            crate::dkg::frost_identifier(8).expect("frost id 8"),
+            deserialize_frost(commitment8.commitments.as_slice()).expect("commitment 8"),
+        );
+        let malformed_package = frost::SigningPackage::new(embedded_commitments, b"artifact");
+        package.signing_package = serialize_frost(&malformed_package).expect("serialize package");
+        package.signer_ids = vec![1, 2, 3, 4, 5, 6, 7];
         let error = sign_share(
             &config,
             &dkg.key_packages[&1],
@@ -907,7 +1001,7 @@ mod tests {
         assert!(
             error
                 .to_string()
-                .contains("missing commitment for signer 8")
+                .contains("missing commitment for signer 7")
         );
     }
 }

--- a/crates/exo-root/src/signing.rs
+++ b/crates/exo-root/src/signing.rs
@@ -174,11 +174,15 @@ pub struct RootSigningNonces {
     /// Ceremony these nonces were generated for; `sign_share` rejects reuse in a
     /// different ceremony.
     pub ceremony_id: String,
+    /// blake3 of the exact root artifact (message) these nonces commit to.
+    /// `sign_share` requires the message it signs to hash to this value, so a
+    /// given nonce set can only ever sign its one bound artifact — this is what
+    /// prevents a coordinator from getting the same nonces to sign two different
+    /// messages (FROST nonce reuse exposes the signer's key share).
+    pub artifact_hash: Hash256,
     /// blake3 of the public commitment these nonces pair with. `sign_share`
     /// requires this to equal the hash of the commitment bound for this signer in
-    /// the supplied signing package — which transitively binds the nonces to that
-    /// package's artifact (message) and full signer set, so they can only be
-    /// consumed for the one signing instance they were committed to.
+    /// the signing package.
     pub commitment_hash: Hash256,
     /// Serialized secret signing nonces (retained by the signer; never shared).
     pub nonces: Vec<u8>,
@@ -220,13 +224,16 @@ fn ensure_rostered(config: &GenesisCeremonyConfig, identifier: u16, role: &str) 
 }
 
 /// Distributed signing — round one. Produce one signer's PUBLIC commitment and
-/// SECRET nonces as two distinct artifacts. Run by each participating certifier
-/// against its own share. The caller MUST broadcast only the
-/// [`RootSigningCommitment`] and retain the [`RootSigningNonces`] locally (never
-/// share, archive off-host, or submit it) until [`sign_share`].
+/// SECRET nonces as two distinct artifacts, **bound to the exact root `artifact`
+/// being signed**. Run by each participating certifier against its own share.
+/// The caller MUST broadcast only the [`RootSigningCommitment`] and retain the
+/// [`RootSigningNonces`] locally (never share, archive off-host, or submit it)
+/// until [`sign_share`]. The artifact must be the bytes emitted by
+/// `root_artifact_payload` and is known before commitments are produced.
 pub fn sign_commit<R>(
     config: &GenesisCeremonyConfig,
     key_package: &RootKeyPackage,
+    artifact: &[u8],
     rng: &mut R,
 ) -> Result<(RootSigningCommitment, RootSigningNonces)>
 where
@@ -245,6 +252,7 @@ where
         RootSigningNonces {
             frost_identifier: key_package.frost_identifier,
             ceremony_id: config.ceremony_id.clone(),
+            artifact_hash: Hash256::digest(artifact),
             commitment_hash: commitment_hash(commitment_bytes.as_slice()),
             nonces: serialize_frost(&nonces)?,
         },
@@ -285,14 +293,24 @@ pub fn build_signing_package(
     })
 }
 
-/// Distributed signing — round two. One signer produces its signature share
-/// from its key package, its retained local-only [`RootSigningNonces`], and the
-/// coordinator's package.
+/// Distributed signing — round two. One signer produces its signature share from
+/// its key package, its retained local-only [`RootSigningNonces`], the
+/// coordinator's [`RootSigningPackage`], and the `message` (root artifact) it
+/// intends to sign.
+///
+/// The share is produced over a signing package **rebuilt from the supplied
+/// commitments and the caller's `message`**, never over a coordinator-controlled
+/// message. Combined with the nonce's `artifact_hash` binding, this means a given
+/// nonce set can only ever sign the one artifact it committed to: a coordinator
+/// cannot present two packages built from the same commitments but different
+/// messages to obtain two shares under one nonce (which would expose the signer's
+/// key share). The caller must additionally retire the nonces after one share.
 pub fn sign_share(
     config: &GenesisCeremonyConfig,
     key_package: &RootKeyPackage,
     nonces: &RootSigningNonces,
-    signing_package: &[u8],
+    signing_package: &RootSigningPackage,
+    message: &[u8],
 ) -> Result<RootSignatureShareOutput> {
     config.validate()?;
     ensure_rostered(config, key_package.frost_identifier, "signer")?;
@@ -308,16 +326,19 @@ pub fn sign_share(
             detail: "nonces were generated for a different ceremony".to_owned(),
         });
     }
+    // Bind the nonces to the exact artifact being signed. A nonce committed to one
+    // artifact can never be used to sign a different message.
+    if Hash256::digest(message) != nonces.artifact_hash {
+        return Err(RootError::Frost {
+            detail: "nonces are bound to a different artifact than the message".to_owned(),
+        });
+    }
     let parsed_key: frost::keys::KeyPackage =
         deserialize_frost(key_package.key_package.as_slice())?;
     let parsed_nonces: frost::round1::SigningNonces = deserialize_frost(nonces.nonces.as_slice())?;
-    let parsed_package: frost::SigningPackage = deserialize_frost(signing_package)?;
-    // Bind the nonces to this exact signing instance: the commitment they pair
-    // with must be the one this signer contributed to the signing package. Because
-    // the package fixes the message (artifact) and every signer's commitment (the
-    // signer set), matching the commitment hash binds the nonces to that artifact
-    // and signer set. Combined with single-use consumption by the caller, a set of
-    // nonces can never be replayed against a different artifact, set, or session.
+    let parsed_package: frost::SigningPackage =
+        deserialize_frost(signing_package.signing_package.as_slice())?;
+    // The nonces must pair with this signer's commitment in the package.
     let frost_id = crate::dkg::frost_identifier(key_package.frost_identifier)?;
     let package_commitment = parsed_package
         .signing_commitment(&frost_id)
@@ -329,8 +350,22 @@ pub fn sign_share(
             detail: "nonces are not bound to this signing package's commitment".to_owned(),
         });
     }
+    // Rebuild the signing package from the supplied commitments and the caller's
+    // message, so the share is provably over `message` regardless of what message
+    // the coordinator embedded in the distributed package.
+    let mut commitments = BTreeMap::new();
+    for identifier in &signing_package.signer_ids {
+        let signer_frost_id = crate::dkg::frost_identifier(*identifier)?;
+        let commitment = parsed_package
+            .signing_commitment(&signer_frost_id)
+            .ok_or_else(|| RootError::Frost {
+                detail: format!("signing package is missing commitment for signer {identifier}"),
+            })?;
+        commitments.insert(signer_frost_id, commitment);
+    }
+    let rebuilt_package = frost::SigningPackage::new(commitments, message);
     let share =
-        frost::round2::sign(&parsed_package, &parsed_nonces, &parsed_key).map_err(frost_error)?;
+        frost::round2::sign(&rebuilt_package, &parsed_nonces, &parsed_key).map_err(frost_error)?;
     Ok(RootSignatureShareOutput {
         frost_identifier: key_package.frost_identifier,
         signature_share: serialize_frost(&share)?,
@@ -515,7 +550,8 @@ mod tests {
         let mut commitments = BTreeMap::new();
         let mut nonces = BTreeMap::new();
         for (id, kp) in &signers {
-            let (commitment, signer_nonces) = sign_commit(&config, kp, &mut rng).expect("commit");
+            let (commitment, signer_nonces) =
+                sign_commit(&config, kp, message, &mut rng).expect("commit");
             nonces.insert(*id, signer_nonces);
             commitments.insert(*id, commitment.commitments);
         }
@@ -524,11 +560,11 @@ mod tests {
         let package = build_signing_package(&config, commitments, message).expect("package");
         assert_eq!(package.signer_ids.len(), 7);
 
-        // Round two: each signer produces its share from its own nonces.
+        // Round two: each signer produces its share from its own nonces, signing
+        // the artifact its nonces are bound to.
         let mut shares = BTreeMap::new();
         for (id, kp) in &signers {
-            let share =
-                sign_share(&config, kp, &nonces[id], &package.signing_package).expect("share");
+            let share = sign_share(&config, kp, &nonces[id], &package, message).expect("share");
             shares.insert(*id, share.signature_share);
         }
 
@@ -558,7 +594,7 @@ mod tests {
         let dkg = crate::run_complete_dkg(&config, &mut rng).expect("dkg");
         let mut commitments = BTreeMap::new();
         for (id, kp) in dkg.key_packages.iter().take(3) {
-            let (commitment, _nonces) = sign_commit(&config, kp, &mut rng).expect("commit");
+            let (commitment, _nonces) = sign_commit(&config, kp, b"msg", &mut rng).expect("commit");
             commitments.insert(*id, commitment.commitments);
         }
         let error = build_signing_package(&config, commitments, b"msg")
@@ -582,14 +618,14 @@ mod tests {
         let mut stranger = dkg.key_packages[&1].clone();
         stranger.frost_identifier = 99;
         assert!(matches!(
-            sign_commit(&config, &stranger, &mut rng).expect_err("unrostered commit"),
+            sign_commit(&config, &stranger, b"msg", &mut rng).expect_err("unrostered commit"),
             RootError::InvalidConfig { .. }
         ));
 
         // build_signing_package rejects a commitment from an unrostered signer.
         let mut commitments = BTreeMap::new();
         for (id, kp) in dkg.key_packages.iter().take(7) {
-            let (commitment, _nonces) = sign_commit(&config, kp, &mut rng).expect("commit");
+            let (commitment, _nonces) = sign_commit(&config, kp, b"msg", &mut rng).expect("commit");
             commitments.insert(*id, commitment.commitments);
         }
         let mut unrostered = commitments.clone();
@@ -603,9 +639,9 @@ mod tests {
         // sign_share rejects an unrostered key package.
         let package = build_signing_package(&config, commitments, b"msg").expect("package");
         let (_commitment, commit_nonces) =
-            sign_commit(&config, &dkg.key_packages[&1], &mut rng).expect("commit");
+            sign_commit(&config, &dkg.key_packages[&1], b"msg", &mut rng).expect("commit");
         assert!(matches!(
-            sign_share(&config, &stranger, &commit_nonces, &package.signing_package)
+            sign_share(&config, &stranger, &commit_nonces, &package, b"msg")
                 .expect_err("unrostered share"),
             RootError::InvalidConfig { .. }
         ));
@@ -637,11 +673,22 @@ mod tests {
         let foreign_nonces = RootSigningNonces {
             frost_identifier: 2,
             ceremony_id: config.ceremony_id.clone(),
+            artifact_hash: Hash256::digest(b"artifact"),
             commitment_hash: Hash256::digest(b"unrelated commitment"),
             nonces: Vec::new(),
         };
-        let error = sign_share(&config, &key_package, &foreign_nonces, &[])
-            .expect_err("nonces bound to a different signer must be rejected");
+        let empty_package = RootSigningPackage {
+            signing_package: Vec::new(),
+            signer_ids: Vec::new(),
+        };
+        let error = sign_share(
+            &config,
+            &key_package,
+            &foreign_nonces,
+            &empty_package,
+            b"artifact",
+        )
+        .expect_err("nonces bound to a different signer must be rejected");
         assert!(error.to_string().contains("mismatches key 1"));
     }
 
@@ -657,11 +704,22 @@ mod tests {
         let foreign_nonces = RootSigningNonces {
             frost_identifier: 1,
             ceremony_id: "some-other-ceremony".to_owned(),
+            artifact_hash: Hash256::digest(b"artifact"),
             commitment_hash: Hash256::digest(b"unrelated commitment"),
             nonces: Vec::new(),
         };
-        let error = sign_share(&config, &key_package, &foreign_nonces, &[])
-            .expect_err("nonces from a different ceremony must be rejected");
+        let empty_package = RootSigningPackage {
+            signing_package: Vec::new(),
+            signer_ids: Vec::new(),
+        };
+        let error = sign_share(
+            &config,
+            &key_package,
+            &foreign_nonces,
+            &empty_package,
+            b"artifact",
+        )
+        .expect_err("nonces from a different ceremony must be rejected");
         assert!(error.to_string().contains("different ceremony"));
     }
 
@@ -675,19 +733,21 @@ mod tests {
         let dkg = crate::run_complete_dkg(&config, &mut rng).expect("dkg");
         let mut commitments = BTreeMap::new();
         for (id, kp) in dkg.key_packages.iter().take(7) {
-            let (commitment, _nonces) = sign_commit(&config, kp, &mut rng).expect("commit");
+            let (commitment, _nonces) =
+                sign_commit(&config, kp, b"artifact", &mut rng).expect("commit");
             commitments.insert(*id, commitment.commitments);
         }
         let package = build_signing_package(&config, commitments, b"artifact").expect("package");
-        // Fresh nonces for signer 1 from a *different* commitment than the one in
-        // the package (a second sign_commit produces a different commitment).
+        // Fresh nonces for signer 1 (same artifact) from a *different* commitment
+        // than the one in the package (a second sign_commit produces a new commitment).
         let (_other_commitment, stale_nonces) =
-            sign_commit(&config, &dkg.key_packages[&1], &mut rng).expect("commit");
+            sign_commit(&config, &dkg.key_packages[&1], b"artifact", &mut rng).expect("commit");
         let error = sign_share(
             &config,
             &dkg.key_packages[&1],
             &stale_nonces,
-            &package.signing_package,
+            &package,
+            b"artifact",
         )
         .expect_err("nonces not bound to the package commitment must be rejected");
         assert!(
@@ -706,17 +766,19 @@ mod tests {
         let dkg = crate::run_complete_dkg(&config, &mut rng).expect("dkg");
         let mut commitments = BTreeMap::new();
         for (id, kp) in dkg.key_packages.iter().take(7) {
-            let (commitment, _nonces) = sign_commit(&config, kp, &mut rng).expect("commit");
+            let (commitment, _nonces) =
+                sign_commit(&config, kp, b"artifact", &mut rng).expect("commit");
             commitments.insert(*id, commitment.commitments);
         }
         let package = build_signing_package(&config, commitments, b"artifact").expect("package");
         let (_commitment8, nonces8) =
-            sign_commit(&config, &dkg.key_packages[&8], &mut rng).expect("commit 8");
+            sign_commit(&config, &dkg.key_packages[&8], b"artifact", &mut rng).expect("commit 8");
         let error = sign_share(
             &config,
             &dkg.key_packages[&8],
             &nonces8,
-            &package.signing_package,
+            &package,
+            b"artifact",
         )
         .expect_err("a signer absent from the package must be rejected");
         assert!(
@@ -724,5 +786,47 @@ mod tests {
                 .to_string()
                 .contains("has no commitment for this signer")
         );
+    }
+
+    #[test]
+    fn sign_share_refuses_to_sign_a_second_different_message_with_one_nonce_set() {
+        // Bob's blocker-2 regression: a coordinator must not be able to get one
+        // RootSigningNonces object to sign two different messages (FROST nonce
+        // reuse exposes the signer key share). The first share over the bound
+        // artifact succeeds; a second share over a *different* message is rejected.
+        let config = test_config();
+        let mut rng = StdRng::seed_from_u64(707);
+        let dkg = crate::run_complete_dkg(&config, &mut rng).expect("dkg");
+        let artifact = b"the one true root artifact";
+        let mut commitments = BTreeMap::new();
+        let mut nonces = BTreeMap::new();
+        for (id, kp) in dkg.key_packages.iter().take(7) {
+            let (commitment, signer_nonces) =
+                sign_commit(&config, kp, artifact, &mut rng).expect("commit");
+            commitments.insert(*id, commitment.commitments);
+            nonces.insert(*id, signer_nonces);
+        }
+        let package = build_signing_package(&config, commitments, artifact).expect("package");
+
+        // First use over the bound artifact succeeds.
+        sign_share(
+            &config,
+            &dkg.key_packages[&1],
+            &nonces[&1],
+            &package,
+            artifact,
+        )
+        .expect("first share over the bound artifact");
+
+        // Second use of the SAME nonces over a different message is refused.
+        let error = sign_share(
+            &config,
+            &dkg.key_packages[&1],
+            &nonces[&1],
+            &package,
+            b"a different message the coordinator wants signed",
+        )
+        .expect_err("a second, different message under the same nonces must be rejected");
+        assert!(error.to_string().contains("bound to a different artifact"));
     }
 }

--- a/crates/exo-root/src/signing.rs
+++ b/crates/exo-root/src/signing.rs
@@ -576,4 +576,23 @@ mod tests {
             RootError::ThresholdNotMet { required: 7, .. }
         ));
     }
+
+    #[test]
+    fn sign_share_rejects_nonces_bound_to_a_different_signer() {
+        // Nonces must belong to the same signer as the key package. The identifier
+        // check runs before any deserialization, so empty byte fields suffice and
+        // no DKG is needed.
+        let config = test_config();
+        let key_package = RootKeyPackage {
+            frost_identifier: 1,
+            key_package: Vec::new(),
+        };
+        let foreign_nonces = RootSigningNonces {
+            frost_identifier: 2,
+            nonces: Vec::new(),
+        };
+        let error = sign_share(&config, &key_package, &foreign_nonces, &[])
+            .expect_err("nonces bound to a different signer must be rejected");
+        assert!(error.to_string().contains("mismatches key 1"));
+    }
 }

--- a/crates/exo-root/src/signing.rs
+++ b/crates/exo-root/src/signing.rs
@@ -75,11 +75,6 @@ where
     let mut signing_commitments = BTreeMap::new();
 
     for (identifier, share) in shares {
-        if config.certifier_by_identifier(identifier).is_none() {
-            return Err(RootError::InvalidConfig {
-                reason: format!("signer {identifier} is not rostered"),
-            });
-        }
         if share.frost_identifier != identifier {
             let share_id = share.frost_identifier;
             let detail = format!("share id {share_id} mismatches key {identifier}");
@@ -272,19 +267,18 @@ where
     let parsed: frost::keys::KeyPackage = deserialize_frost(key_package.key_package.as_slice())?;
     let (nonces, commitments) = frost::round1::commit(parsed.signing_share(), rng);
     let commitment_bytes = serialize_frost(&commitments)?;
-    Ok((
-        RootSigningCommitment {
-            frost_identifier: key_package.frost_identifier,
-            commitments: commitment_bytes.clone(),
-        },
-        RootSigningNonces {
-            frost_identifier: key_package.frost_identifier,
-            ceremony_id: config.ceremony_id.clone(),
-            artifact_hash: Hash256::digest(artifact),
-            commitment_hash: commitment_hash(commitment_bytes.as_slice()),
-            nonces: serialize_frost(&nonces)?,
-        },
-    ))
+    let commitment = RootSigningCommitment {
+        frost_identifier: key_package.frost_identifier,
+        commitments: commitment_bytes.clone(),
+    };
+    let signing_nonces = RootSigningNonces {
+        frost_identifier: key_package.frost_identifier,
+        ceremony_id: config.ceremony_id.clone(),
+        artifact_hash: Hash256::digest(artifact),
+        commitment_hash: commitment_hash(commitment_bytes.as_slice()),
+        nonces: serialize_frost(&nonces)?,
+    };
+    Ok((commitment, signing_nonces))
 }
 
 /// Distributed signing — coordinator assembles the signing package from at
@@ -515,6 +509,18 @@ mod tests {
                 supplied: 0
             }
         );
+    }
+
+    #[test]
+    fn signer_id_validation_rejects_wrong_count_and_duplicates() {
+        let config = test_config();
+        let wrong_count = validate_root_signer_ids(&config, &[1, 2, 3, 4, 5, 6])
+            .expect_err("signer set must match threshold count");
+        assert!(wrong_count.to_string().contains("exactly 7 signers"));
+
+        let duplicate = validate_root_signer_ids(&config, &[1, 2, 3, 4, 5, 6, 6])
+            .expect_err("signer set must reject duplicates");
+        assert!(duplicate.to_string().contains("duplicate signer 6"));
     }
 
     #[test]

--- a/crates/exo-root/src/signing.rs
+++ b/crates/exo-root/src/signing.rs
@@ -829,4 +829,40 @@ mod tests {
         .expect_err("a second, different message under the same nonces must be rejected");
         assert!(error.to_string().contains("bound to a different artifact"));
     }
+
+    #[test]
+    fn sign_share_rejects_a_signing_package_missing_a_declared_signer() {
+        // A RootSigningPackage whose signer_ids claim a signer whose commitment is
+        // absent from the embedded package is malformed; the rebuild fails closed.
+        let config = test_config();
+        let mut rng = StdRng::seed_from_u64(808);
+        let dkg = crate::run_complete_dkg(&config, &mut rng).expect("dkg");
+        let mut commitments = BTreeMap::new();
+        let mut signer_one_nonces = None;
+        for (id, kp) in dkg.key_packages.iter().take(7) {
+            let (commitment, nonces) =
+                sign_commit(&config, kp, b"artifact", &mut rng).expect("commit");
+            if *id == 1 {
+                signer_one_nonces = Some(nonces);
+            }
+            commitments.insert(*id, commitment.commitments);
+        }
+        let mut package =
+            build_signing_package(&config, commitments, b"artifact").expect("package");
+        // Tamper: claim signer 8 participated, though its commitment is not present.
+        package.signer_ids.push(8);
+        let error = sign_share(
+            &config,
+            &dkg.key_packages[&1],
+            &signer_one_nonces.expect("signer one nonces"),
+            &package,
+            b"artifact",
+        )
+        .expect_err("a signing package missing a declared signer must be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("missing commitment for signer 8")
+        );
+    }
 }

--- a/crates/exo-root/src/signing.rs
+++ b/crates/exo-root/src/signing.rs
@@ -511,7 +511,12 @@ mod tests {
         // build_signing_package rejects a commitment from an unrostered signer.
         let mut commitments = BTreeMap::new();
         for (id, kp) in dkg.key_packages.iter().take(7) {
-            commitments.insert(*id, sign_commit(&config, kp, &mut rng).expect("commit").commitments);
+            commitments.insert(
+                *id,
+                sign_commit(&config, kp, &mut rng)
+                    .expect("commit")
+                    .commitments,
+            );
         }
         let mut unrostered = commitments.clone();
         let stolen = unrostered.remove(&1).expect("commitment one");

--- a/crates/exo-root/src/signing.rs
+++ b/crates/exo-root/src/signing.rs
@@ -249,7 +249,8 @@ pub fn sign_share(
 ) -> Result<RootSignatureShareOutput> {
     config.validate()?;
     ensure_rostered(config, key_package.frost_identifier, "signer")?;
-    let parsed_key: frost::keys::KeyPackage = deserialize_frost(key_package.key_package.as_slice())?;
+    let parsed_key: frost::keys::KeyPackage =
+        deserialize_frost(key_package.key_package.as_slice())?;
     let parsed_nonces: frost::round1::SigningNonces = deserialize_frost(nonces)?;
     let parsed_package: frost::SigningPackage = deserialize_frost(signing_package)?;
     let share =
@@ -448,8 +449,8 @@ mod tests {
         // Round two: each signer produces its share from its own nonces.
         let mut shares = BTreeMap::new();
         for (id, kp) in &signers {
-            let share = sign_share(&config, kp, &nonces[id], &package.signing_package)
-                .expect("share");
+            let share =
+                sign_share(&config, kp, &nonces[id], &package.signing_package).expect("share");
             shares.insert(*id, share.signature_share);
         }
 
@@ -484,6 +485,62 @@ mod tests {
         }
         let error = build_signing_package(&config, commitments, b"msg")
             .expect_err("sub-threshold commitments");
-        assert!(matches!(error, RootError::ThresholdNotMet { required: 7, supplied: 3 }));
+        assert!(matches!(
+            error,
+            RootError::ThresholdNotMet {
+                required: 7,
+                supplied: 3
+            }
+        ));
+    }
+
+    #[test]
+    fn distributed_signing_rejects_unrostered_and_sub_threshold() {
+        let config = test_config();
+        let mut rng = StdRng::seed_from_u64(123);
+        let dkg = crate::run_complete_dkg(&config, &mut rng).expect("dkg");
+
+        // sign_commit rejects an unrostered key package.
+        let mut stranger = dkg.key_packages[&1].clone();
+        stranger.frost_identifier = 99;
+        assert!(matches!(
+            sign_commit(&config, &stranger, &mut rng).expect_err("unrostered commit"),
+            RootError::InvalidConfig { .. }
+        ));
+
+        // build_signing_package rejects a commitment from an unrostered signer.
+        let mut commitments = BTreeMap::new();
+        for (id, kp) in dkg.key_packages.iter().take(7) {
+            commitments.insert(*id, sign_commit(&config, kp, &mut rng).expect("commit").commitments);
+        }
+        let mut unrostered = commitments.clone();
+        let stolen = unrostered.remove(&1).expect("commitment one");
+        unrostered.insert(99, stolen);
+        assert!(matches!(
+            build_signing_package(&config, unrostered, b"msg").expect_err("unrostered commitment"),
+            RootError::InvalidConfig { .. }
+        ));
+
+        // sign_share rejects an unrostered key package.
+        let package = build_signing_package(&config, commitments, b"msg").expect("package");
+        let commit = sign_commit(&config, &dkg.key_packages[&1], &mut rng).expect("commit");
+        assert!(matches!(
+            sign_share(&config, &stranger, &commit.nonces, &package.signing_package)
+                .expect_err("unrostered share"),
+            RootError::InvalidConfig { .. }
+        ));
+
+        // aggregate_signature enforces the threshold and rosters every share.
+        assert!(matches!(
+            aggregate_signature(
+                &config,
+                &dkg.public_key_package,
+                &package.signing_package,
+                BTreeMap::new(),
+                b"msg",
+            )
+            .expect_err("sub-threshold aggregate"),
+            RootError::ThresholdNotMet { required: 7, .. }
+        ));
     }
 }

--- a/crates/exo-root/tests/root_genesis.rs
+++ b/crates/exo-root/tests/root_genesis.rs
@@ -6,11 +6,12 @@ use exo_authority::permission::Permission;
 use exo_core::{Did, Hash256, PublicKey, SecretKey, Signature, Timestamp, crypto::KeyPair};
 use exo_root::{
     CeremonyEnvelope, CeremonyEnvelopeDraft, CeremonyPayloadKind, CeremonyPhase, CertifierContact,
-    GenesisCeremonyConfig, PairwiseEncryptedPayload, PortalStore, RootIssuerDelegation,
-    SealedShare, assemble_root_bundle, build_signing_package, decrypt_pairwise_payload,
-    dkg_finalize_participant, dkg_round1, dkg_round2, encrypt_pairwise_payload, run_complete_dkg,
-    seal_share, sign_commit, sign_share, threshold_sign, unseal_share, verify_root_bundle,
-    verify_root_signature,
+    GenesisCeremonyConfig, PairwiseEncryptedPayload, PortalStore, RootDkgOutput,
+    RootIssuerDelegation, RootParticipantDkgOutput, SealedShare, assemble_root_bundle,
+    build_final_key_confirmation, build_signing_package, decrypt_pairwise_payload,
+    dkg_finalize_participant, dkg_round1, dkg_round2, encode_final_key_confirmation_payload,
+    encrypt_pairwise_payload, run_complete_dkg, seal_share, sign_commit, sign_share,
+    threshold_sign, unseal_share, verify_root_bundle, verify_root_signature,
 };
 use rand::{SeedableRng, rngs::StdRng};
 
@@ -70,6 +71,158 @@ fn encrypted_payload_bytes(ciphertext: impl Into<Vec<u8>>) -> Vec<u8> {
     bytes
 }
 
+#[allow(clippy::too_many_arguments)]
+fn sign_envelope(
+    config: &GenesisCeremonyConfig,
+    signing_secrets: &BTreeMap<Did, SecretKey>,
+    sender_identifier: u16,
+    phase: CeremonyPhase,
+    payload_kind: CeremonyPayloadKind,
+    recipient_identifier: Option<u16>,
+    sequence: u64,
+    payload_bytes: Vec<u8>,
+) -> CeremonyEnvelope {
+    let sender = config
+        .certifier_by_identifier(sender_identifier)
+        .expect("sender");
+    let recipient = recipient_identifier.map(|identifier| {
+        config
+            .certifier_by_identifier(identifier)
+            .expect("recipient")
+            .did
+            .clone()
+    });
+    let signing_secret = signing_secrets.get(&sender.did).expect("secret");
+    CeremonyEnvelope::sign(
+        envelope_draft(
+            &config.ceremony_id,
+            phase,
+            payload_kind,
+            sender.did.clone(),
+            recipient,
+            sequence,
+            payload_bytes,
+        ),
+        signing_secret,
+    )
+    .expect("signed envelope")
+}
+
+fn submit_complete_dkg_transcript(
+    store: &mut PortalStore,
+    config: &GenesisCeremonyConfig,
+    signing_secrets: &BTreeMap<Did, SecretKey>,
+    rng: &mut StdRng,
+) -> Hash256 {
+    for certifier in &config.certifiers {
+        let round1 = dkg_round1(config, certifier.frost_identifier, rng)
+            .expect("round one")
+            .round1_package;
+        store
+            .submit(sign_envelope(
+                config,
+                signing_secrets,
+                certifier.frost_identifier,
+                CeremonyPhase::Round1,
+                CeremonyPayloadKind::Round1Package,
+                None,
+                10,
+                round1,
+            ))
+            .expect("submit round one");
+    }
+    for sender in &config.certifiers {
+        for recipient in &config.certifiers {
+            if sender.frost_identifier == recipient.frost_identifier {
+                continue;
+            }
+            let sequence = 1_000
+                + u64::from(sender.frost_identifier) * 100
+                + u64::from(recipient.frost_identifier);
+            store
+                .submit(sign_envelope(
+                    config,
+                    signing_secrets,
+                    sender.frost_identifier,
+                    CeremonyPhase::Round2,
+                    CeremonyPayloadKind::Round2EncryptedPackage,
+                    Some(recipient.frost_identifier),
+                    sequence,
+                    encrypted_payload_bytes(format!(
+                        "round2-{}-{}",
+                        sender.frost_identifier, recipient.frost_identifier
+                    )),
+                ))
+                .expect("submit round two");
+        }
+    }
+    store.dkg_transcript_hash().expect("dkg transcript hash")
+}
+
+fn participant_output(dkg: &RootDkgOutput, identifier: u16) -> RootParticipantDkgOutput {
+    RootParticipantDkgOutput {
+        key_package: dkg.key_packages[&identifier].clone(),
+        public_key_package: dkg.public_key_package.clone(),
+    }
+}
+
+fn final_key_confirmation_payload(
+    config: &GenesisCeremonyConfig,
+    dkg: &RootDkgOutput,
+    identifier: u16,
+    dkg_transcript_hash: Hash256,
+) -> Vec<u8> {
+    let confirmation = build_final_key_confirmation(
+        config,
+        &participant_output(dkg, identifier),
+        dkg_transcript_hash,
+    )
+    .expect("final key confirmation");
+    encode_final_key_confirmation_payload(&confirmation).expect("confirmation payload")
+}
+
+fn submit_final_key_confirmations(
+    store: &mut PortalStore,
+    config: &GenesisCeremonyConfig,
+    signing_secrets: &BTreeMap<Did, SecretKey>,
+    dkg: &RootDkgOutput,
+    dkg_transcript_hash: Hash256,
+    count: u16,
+) {
+    for identifier in 1..=count {
+        submit_final_key_confirmation(
+            store,
+            config,
+            signing_secrets,
+            dkg,
+            dkg_transcript_hash,
+            identifier,
+        );
+    }
+}
+
+fn submit_final_key_confirmation(
+    store: &mut PortalStore,
+    config: &GenesisCeremonyConfig,
+    signing_secrets: &BTreeMap<Did, SecretKey>,
+    dkg: &RootDkgOutput,
+    dkg_transcript_hash: Hash256,
+    identifier: u16,
+) {
+    store
+        .submit(sign_envelope(
+            config,
+            signing_secrets,
+            identifier,
+            CeremonyPhase::Finalize,
+            CeremonyPayloadKind::FinalKeyConfirmation,
+            None,
+            5_000 + u64::from(identifier),
+            final_key_confirmation_payload(config, dkg, identifier, dkg_transcript_hash),
+        ))
+        .expect("submit final key confirmation");
+}
+
 fn config() -> (
     GenesisCeremonyConfig,
     BTreeMap<Did, SecretKey>,
@@ -95,7 +248,6 @@ fn config() -> (
             created_at: Timestamp::new(1_785_000_000_000, 0),
             certifiers,
             signing_set: (1..=7).collect(),
-            signing_alternates: (8..=13).collect(),
         },
         signing_secrets,
         transport_secrets,
@@ -660,7 +812,7 @@ fn root_bundle_verification_rejects_tampered_delegation() {
         dkg.public_key_package.clone(),
         delegation.clone(),
         transcript_hash,
-        root_signature.signature,
+        root_signature,
     )
     .expect("bundle");
     verify_root_bundle(&bundle).expect("bundle verifies");
@@ -712,7 +864,7 @@ fn root_bundle_rejects_public_key_package_metadata_mismatch() {
             mixed_public,
             delegation,
             transcript_hash,
-            root_signature.signature,
+            root_signature,
         )
         .is_err(),
         "bundle must reject root key metadata that does not derive from the serialized FROST public package"
@@ -783,7 +935,7 @@ fn root_bundle_verification_rejects_tampered_config_transcript_signature_and_id(
         dkg.public_key_package,
         delegation,
         transcript_hash,
-        root_signature.signature,
+        root_signature,
     )
     .expect("bundle");
 
@@ -796,8 +948,12 @@ fn root_bundle_verification_rejects_tampered_config_transcript_signature_and_id(
     assert!(verify_root_bundle(&tampered_transcript).is_err());
 
     let mut tampered_signature = bundle.clone();
-    tampered_signature.root_signature[0] ^= 0x01;
+    tampered_signature.root_signature.signature[0] ^= 0x01;
     assert!(verify_root_bundle(&tampered_signature).is_err());
+
+    let mut tampered_signer_set = bundle.clone();
+    tampered_signer_set.root_signature.signer_ids = vec![1, 2, 3, 4, 5, 6, 9];
+    assert!(verify_root_bundle(&tampered_signer_set).is_err());
 
     let mut tampered_id = bundle;
     tampered_id.bundle_id = Hash256::digest(b"wrong bundle id");
@@ -1051,19 +1207,204 @@ fn portal_rejects_wrong_ceremony_bad_recipient_self_target_and_bad_broadcasts() 
 }
 
 #[test]
-fn portal_schema_validates_accepted_kinds_and_disables_unratified_ones() {
+fn portal_schema_validates_dkg_kinds_and_keeps_unratified_kinds_disabled() {
     let (config, signing_secrets, _) = config();
-    let sender = config.certifiers[0].did.clone();
-    let signing_secret = signing_secrets.get(&sender).expect("secret").clone();
     let mut rng = StdRng::seed_from_u64(2026);
-    let dkg = run_complete_dkg(&config, &mut rng).expect("dkg");
-
-    // Mint real, schema-valid payloads for the three accepted broadcast kinds.
     let round1_package = dkg_round1(&config, 1, &mut rng)
         .expect("round one")
         .round1_package;
-    let mut commitments = std::collections::BTreeMap::new();
-    let mut nonces = std::collections::BTreeMap::new();
+    let mut store = PortalStore::new(config.clone());
+
+    store
+        .submit(sign_envelope(
+            &config,
+            &signing_secrets,
+            1,
+            CeremonyPhase::Round1,
+            CeremonyPayloadKind::Round1Package,
+            None,
+            30,
+            round1_package.clone(),
+        ))
+        .expect("round-one package accepted");
+    store
+        .submit(sign_envelope(
+            &config,
+            &signing_secrets,
+            1,
+            CeremonyPhase::Round2,
+            CeremonyPayloadKind::Round2EncryptedPackage,
+            Some(2),
+            31,
+            encrypted_payload_bytes(b"ciphertext"),
+        ))
+        .expect("round-two encrypted package accepted");
+    assert_eq!(store.envelope_count(), 2);
+
+    // FinalKeyConfirmation is ratified, but it still fails closed until the
+    // complete DKG transcript exists and the typed payload verifies.
+    assert!(
+        store
+            .submit(sign_envelope(
+                &config,
+                &signing_secrets,
+                1,
+                CeremonyPhase::Finalize,
+                CeremonyPayloadKind::FinalKeyConfirmation,
+                None,
+                32,
+                vec![1, 2, 3],
+            ))
+            .is_err()
+    );
+
+    // Round-one set attestation remains disabled because it still has no
+    // ratified producer/schema/verifier.
+    assert!(
+        store
+            .submit(sign_envelope(
+                &config,
+                &signing_secrets,
+                1,
+                CeremonyPhase::Round1SetAttestation,
+                CeremonyPayloadKind::Round1SetAttestation,
+                None,
+                33,
+                vec![1, 2, 3],
+            ))
+            .is_err()
+    );
+
+    // A structurally invalid round-one package fails schema validation.
+    assert!(
+        store
+            .submit(sign_envelope(
+                &config,
+                &signing_secrets,
+                2,
+                CeremonyPhase::Round1,
+                CeremonyPayloadKind::Round1Package,
+                None,
+                35,
+                b"not a round-one package".to_vec(),
+            ))
+            .is_err()
+    );
+
+    // A broadcast kind may not carry a recipient.
+    assert!(
+        store
+            .submit(sign_envelope(
+                &config,
+                &signing_secrets,
+                3,
+                CeremonyPhase::Round1,
+                CeremonyPayloadKind::Round1Package,
+                Some(2),
+                36,
+                round1_package,
+            ))
+            .is_err()
+    );
+}
+
+#[test]
+fn final_key_confirmation_gates_root_signing_and_final_transcript_hash() {
+    let (config, signing_secrets, _) = config();
+    let mut rng = StdRng::seed_from_u64(2126);
+    let dkg = run_complete_dkg(&config, &mut rng).expect("dkg");
+    let mut store = PortalStore::new(config.clone());
+    let dkg_transcript_hash =
+        submit_complete_dkg_transcript(&mut store, &config, &signing_secrets, &mut rng);
+
+    let (commitment, signer_nonces) =
+        sign_commit(&config, &dkg.key_packages[&1], b"artifact", &mut rng).expect("commit");
+    assert!(
+        store
+            .submit(sign_envelope(
+                &config,
+                &signing_secrets,
+                1,
+                CeremonyPhase::RootSigning,
+                CeremonyPayloadKind::RootSigningCommitment,
+                None,
+                6_001,
+                commitment.commitments.clone(),
+            ))
+            .is_err(),
+        "root signing must be blocked before final key confirmations"
+    );
+
+    submit_final_key_confirmations(
+        &mut store,
+        &config,
+        &signing_secrets,
+        &dkg,
+        dkg_transcript_hash,
+        12,
+    );
+    assert!(
+        store
+            .submit(sign_envelope(
+                &config,
+                &signing_secrets,
+                1,
+                CeremonyPhase::RootSigning,
+                CeremonyPayloadKind::RootSigningCommitment,
+                None,
+                6_002,
+                commitment.commitments.clone(),
+            ))
+            .is_err(),
+        "root signing must wait for all thirteen confirmations"
+    );
+
+    submit_final_key_confirmation(
+        &mut store,
+        &config,
+        &signing_secrets,
+        &dkg,
+        dkg_transcript_hash,
+        13,
+    );
+    let final_transcript_hash = store
+        .final_transcript_hash()
+        .expect("final transcript hash");
+    assert_ne!(final_transcript_hash, dkg_transcript_hash);
+
+    store
+        .submit(sign_envelope(
+            &config,
+            &signing_secrets,
+            1,
+            CeremonyPhase::RootSigning,
+            CeremonyPayloadKind::RootSigningCommitment,
+            None,
+            6_003,
+            commitment.commitments,
+        ))
+        .expect("root signing commitment accepted after all confirmations");
+
+    let mut nonces_shaped_payload = Vec::new();
+    ciborium::into_writer(&signer_nonces, &mut nonces_shaped_payload).expect("encode nonces");
+    assert!(
+        store
+            .submit(sign_envelope(
+                &config,
+                &signing_secrets,
+                2,
+                CeremonyPhase::RootSigning,
+                CeremonyPayloadKind::RootSigningCommitment,
+                None,
+                6_004,
+                nonces_shaped_payload,
+            ))
+            .is_err(),
+        "RootSigningNonces bytes must not be accepted as a public commitment"
+    );
+
+    let mut commitments = BTreeMap::new();
+    let mut nonces = BTreeMap::new();
     for identifier in 1..=7u16 {
         let (commitment, signer_nonces) = sign_commit(
             &config,
@@ -1072,17 +1413,9 @@ fn portal_schema_validates_accepted_kinds_and_disables_unratified_ones() {
             &mut rng,
         )
         .expect("commit");
-        commitments.insert(identifier, commitment.commitments.clone());
+        commitments.insert(identifier, commitment.commitments);
         nonces.insert(identifier, signer_nonces);
     }
-    let commitment_payload = commitments[&1].clone();
-    // A serialized RootSigningNonces blob (Bob's blocker-1 probe): it must NOT be
-    // accepted as a public RootSigningCommitment payload.
-    let nonces_shaped_payload = {
-        let mut bytes = Vec::new();
-        ciborium::into_writer(&nonces[&1], &mut bytes).expect("encode nonces");
-        bytes
-    };
     let package = build_signing_package(&config, commitments, b"artifact").expect("package");
     let share_payload = sign_share(
         &config,
@@ -1093,137 +1426,119 @@ fn portal_schema_validates_accepted_kinds_and_disables_unratified_ones() {
     )
     .expect("share")
     .signature_share;
-
-    let submit = |store: &mut PortalStore,
-                  sequence: u64,
-                  phase: CeremonyPhase,
-                  kind: CeremonyPayloadKind,
-                  recipient: Option<Did>,
-                  payload: Vec<u8>| {
-        let envelope = CeremonyEnvelope::sign(
-            envelope_draft(
-                &config.ceremony_id,
-                phase,
-                kind,
-                sender.clone(),
-                recipient,
-                sequence,
-                payload,
-            ),
-            &signing_secret,
-        )
-        .expect("envelope");
-        store.submit(envelope)
-    };
-
-    let mut store = PortalStore::new(config.clone());
-
-    // Schema-valid broadcasts are accepted.
-    submit(
-        &mut store,
-        30,
-        CeremonyPhase::Round1,
-        CeremonyPayloadKind::Round1Package,
-        None,
-        round1_package.clone(),
-    )
-    .expect("round-one package accepted");
-    submit(
-        &mut store,
-        31,
-        CeremonyPhase::RootSigning,
-        CeremonyPayloadKind::RootSigningCommitment,
-        None,
-        commitment_payload,
-    )
-    .expect("signing commitment accepted");
-    submit(
-        &mut store,
-        32,
-        CeremonyPhase::RootSigning,
-        CeremonyPayloadKind::RootSignatureShare,
-        None,
-        share_payload.clone(),
-    )
-    .expect("signature share accepted");
-    assert_eq!(store.envelope_count(), 3);
-
-    // Disabled kinds (no ratified, portal-validated schema) are rejected.
-    assert!(
-        submit(
-            &mut store,
-            33,
-            CeremonyPhase::Round1SetAttestation,
-            CeremonyPayloadKind::Round1SetAttestation,
-            None,
-            vec![1, 2, 3],
-        )
-        .is_err()
-    );
-    assert!(
-        submit(
-            &mut store,
-            34,
-            CeremonyPhase::Finalize,
-            CeremonyPayloadKind::FinalKeyConfirmation,
-            None,
-            vec![1, 2, 3],
-        )
-        .is_err()
-    );
-
-    // A structurally invalid round-one package fails schema validation.
-    assert!(
-        submit(
-            &mut store,
-            35,
-            CeremonyPhase::Round1,
-            CeremonyPayloadKind::Round1Package,
-            None,
-            b"not a round-one package".to_vec(),
-        )
-        .is_err()
-    );
-
-    // Bob's blocker-1 probe: serialized secret nonces must NOT be relayable under
-    // the public RootSigningCommitment kind — schema validation rejects them.
-    assert!(
-        submit(
-            &mut store,
-            38,
-            CeremonyPhase::RootSigning,
-            CeremonyPayloadKind::RootSigningCommitment,
-            None,
-            nonces_shaped_payload,
-        )
-        .is_err(),
-        "RootSigningNonces bytes must not be accepted as a public commitment"
-    );
-
-    // A broadcast kind may not carry a recipient.
-    assert!(
-        submit(
-            &mut store,
-            36,
-            CeremonyPhase::Round1,
-            CeremonyPayloadKind::Round1Package,
-            Some(config.certifiers[1].did.clone()),
-            round1_package,
-        )
-        .is_err()
-    );
-
-    // A second signature share from the same signer is rejected (single-use).
-    assert!(
-        submit(
-            &mut store,
-            37,
+    store
+        .submit(sign_envelope(
+            &config,
+            &signing_secrets,
+            1,
             CeremonyPhase::RootSigning,
             CeremonyPayloadKind::RootSignatureShare,
             None,
-            share_payload,
-        )
-        .is_err()
+            6_005,
+            share_payload.clone(),
+        ))
+        .expect("signature share accepted after all confirmations");
+    assert!(
+        store
+            .submit(sign_envelope(
+                &config,
+                &signing_secrets,
+                1,
+                CeremonyPhase::RootSigning,
+                CeremonyPayloadKind::RootSignatureShare,
+                None,
+                6_006,
+                share_payload,
+            ))
+            .is_err(),
+        "a second signature share from one signer is rejected"
+    );
+
+    assert!(
+        store
+            .submit(sign_envelope(
+                &config,
+                &signing_secrets,
+                1,
+                CeremonyPhase::Round2,
+                CeremonyPayloadKind::Round2EncryptedPackage,
+                Some(2),
+                6_007,
+                encrypted_payload_bytes(b"late dkg mutation"),
+            ))
+            .is_err(),
+        "the DKG transcript is frozen after final confirmations begin"
+    );
+}
+
+#[test]
+fn final_key_confirmation_rejects_sender_hash_and_duplicate_mismatches() {
+    let (config, signing_secrets, _) = config();
+    let mut rng = StdRng::seed_from_u64(2226);
+    let dkg = run_complete_dkg(&config, &mut rng).expect("dkg");
+    let mut store = PortalStore::new(config.clone());
+    let dkg_transcript_hash =
+        submit_complete_dkg_transcript(&mut store, &config, &signing_secrets, &mut rng);
+
+    // Payload certifier DID/FROST id must match the signed envelope sender.
+    let id1_payload = final_key_confirmation_payload(&config, &dkg, 1, dkg_transcript_hash);
+    assert!(
+        store
+            .submit(sign_envelope(
+                &config,
+                &signing_secrets,
+                2,
+                CeremonyPhase::Finalize,
+                CeremonyPayloadKind::FinalKeyConfirmation,
+                None,
+                5_002,
+                id1_payload,
+            ))
+            .is_err()
+    );
+
+    submit_final_key_confirmation(
+        &mut store,
+        &config,
+        &signing_secrets,
+        &dkg,
+        dkg_transcript_hash,
+        1,
+    );
+    assert!(
+        store
+            .submit(sign_envelope(
+                &config,
+                &signing_secrets,
+                1,
+                CeremonyPhase::Finalize,
+                CeremonyPayloadKind::FinalKeyConfirmation,
+                None,
+                5_101,
+                final_key_confirmation_payload(&config, &dkg, 1, dkg_transcript_hash),
+            ))
+            .is_err(),
+        "at most one final key confirmation is accepted per certifier"
+    );
+
+    let mut tampered =
+        build_final_key_confirmation(&config, &participant_output(&dkg, 2), dkg_transcript_hash)
+            .expect("confirmation");
+    tampered.root_public_key_hash = Hash256::digest(b"wrong root key hash");
+    assert!(
+        store
+            .submit(sign_envelope(
+                &config,
+                &signing_secrets,
+                2,
+                CeremonyPhase::Finalize,
+                CeremonyPayloadKind::FinalKeyConfirmation,
+                None,
+                5_102,
+                encode_final_key_confirmation_payload(&tampered).expect("tampered payload"),
+            ))
+            .is_err(),
+        "semantic hash mismatches must fail closed"
     );
 }
 

--- a/crates/exo-root/tests/root_genesis.rs
+++ b/crates/exo-root/tests/root_genesis.rs
@@ -7,9 +7,10 @@ use exo_core::{Did, Hash256, PublicKey, SecretKey, Signature, Timestamp, crypto:
 use exo_root::{
     CeremonyEnvelope, CeremonyEnvelopeDraft, CeremonyPayloadKind, CeremonyPhase, CertifierContact,
     GenesisCeremonyConfig, PairwiseEncryptedPayload, PortalStore, RootIssuerDelegation,
-    SealedShare, assemble_root_bundle, decrypt_pairwise_payload, dkg_finalize_participant,
-    dkg_round1, dkg_round2, encrypt_pairwise_payload, run_complete_dkg, seal_share, threshold_sign,
-    unseal_share, verify_root_bundle, verify_root_signature,
+    SealedShare, assemble_root_bundle, build_signing_package, decrypt_pairwise_payload,
+    dkg_finalize_participant, dkg_round1, dkg_round2, encrypt_pairwise_payload, run_complete_dkg,
+    seal_share, sign_commit, sign_share, threshold_sign, unseal_share, verify_root_bundle,
+    verify_root_signature,
 };
 use rand::{SeedableRng, rngs::StdRng};
 
@@ -93,6 +94,8 @@ fn config() -> (
             max_signers: 13,
             created_at: Timestamp::new(1_785_000_000_000, 0),
             certifiers,
+            signing_set: (1..=7).collect(),
+            signing_alternates: (8..=13).collect(),
         },
         signing_secrets,
         transport_secrets,
@@ -1048,56 +1051,152 @@ fn portal_rejects_wrong_ceremony_bad_recipient_self_target_and_bad_broadcasts() 
 }
 
 #[test]
-fn portal_accepts_all_valid_broadcast_phase_kinds() {
+fn portal_schema_validates_accepted_kinds_and_disables_unratified_ones() {
     let (config, signing_secrets, _) = config();
     let sender = config.certifiers[0].did.clone();
-    let signing_secret = signing_secrets.get(&sender).expect("secret");
-    let mut store = PortalStore::new(config.clone());
+    let signing_secret = signing_secrets.get(&sender).expect("secret").clone();
+    let mut rng = StdRng::seed_from_u64(2026);
+    let dkg = run_complete_dkg(&config, &mut rng).expect("dkg");
 
-    for (sequence, phase, kind) in [
-        (
-            30,
-            CeremonyPhase::Round1,
-            CeremonyPayloadKind::Round1Package,
-        ),
-        (
-            31,
-            CeremonyPhase::Round1SetAttestation,
-            CeremonyPayloadKind::Round1SetAttestation,
-        ),
-        (
-            32,
-            CeremonyPhase::Finalize,
-            CeremonyPayloadKind::FinalKeyConfirmation,
-        ),
-        (
-            33,
-            CeremonyPhase::RootSigning,
-            CeremonyPayloadKind::RootSigningCommitment,
-        ),
-        (
-            34,
-            CeremonyPhase::RootSigning,
-            CeremonyPayloadKind::RootSignatureShare,
-        ),
-    ] {
+    // Mint real, schema-valid payloads for the three accepted broadcast kinds.
+    let round1_package = dkg_round1(&config, 1, &mut rng)
+        .expect("round one")
+        .round1_package;
+    let mut commitments = std::collections::BTreeMap::new();
+    let mut nonces = std::collections::BTreeMap::new();
+    for identifier in 1..=7u16 {
+        let (commitment, signer_nonces) =
+            sign_commit(&config, &dkg.key_packages[&identifier], &mut rng).expect("commit");
+        commitments.insert(identifier, commitment.commitments.clone());
+        nonces.insert(identifier, signer_nonces);
+    }
+    let commitment_payload = commitments[&1].clone();
+    let package = build_signing_package(&config, commitments, b"artifact").expect("package");
+    let share_payload = sign_share(
+        &config,
+        &dkg.key_packages[&1],
+        &nonces[&1],
+        &package.signing_package,
+    )
+    .expect("share")
+    .signature_share;
+
+    let submit = |store: &mut PortalStore,
+                  sequence: u64,
+                  phase: CeremonyPhase,
+                  kind: CeremonyPayloadKind,
+                  recipient: Option<Did>,
+                  payload: Vec<u8>| {
         let envelope = CeremonyEnvelope::sign(
             envelope_draft(
                 &config.ceremony_id,
                 phase,
                 kind,
                 sender.clone(),
-                None,
+                recipient,
                 sequence,
-                b"payload".to_vec(),
+                payload,
             ),
-            signing_secret,
+            &signing_secret,
         )
         .expect("envelope");
-        store.submit(envelope).expect("accepted broadcast");
-    }
+        store.submit(envelope)
+    };
 
-    assert_eq!(store.envelope_count(), 5);
+    let mut store = PortalStore::new(config.clone());
+
+    // Schema-valid broadcasts are accepted.
+    submit(
+        &mut store,
+        30,
+        CeremonyPhase::Round1,
+        CeremonyPayloadKind::Round1Package,
+        None,
+        round1_package.clone(),
+    )
+    .expect("round-one package accepted");
+    submit(
+        &mut store,
+        31,
+        CeremonyPhase::RootSigning,
+        CeremonyPayloadKind::RootSigningCommitment,
+        None,
+        commitment_payload,
+    )
+    .expect("signing commitment accepted");
+    submit(
+        &mut store,
+        32,
+        CeremonyPhase::RootSigning,
+        CeremonyPayloadKind::RootSignatureShare,
+        None,
+        share_payload.clone(),
+    )
+    .expect("signature share accepted");
+    assert_eq!(store.envelope_count(), 3);
+
+    // Disabled kinds (no ratified, portal-validated schema) are rejected.
+    assert!(
+        submit(
+            &mut store,
+            33,
+            CeremonyPhase::Round1SetAttestation,
+            CeremonyPayloadKind::Round1SetAttestation,
+            None,
+            vec![1, 2, 3],
+        )
+        .is_err()
+    );
+    assert!(
+        submit(
+            &mut store,
+            34,
+            CeremonyPhase::Finalize,
+            CeremonyPayloadKind::FinalKeyConfirmation,
+            None,
+            vec![1, 2, 3],
+        )
+        .is_err()
+    );
+
+    // A structurally invalid round-one package fails schema validation.
+    assert!(
+        submit(
+            &mut store,
+            35,
+            CeremonyPhase::Round1,
+            CeremonyPayloadKind::Round1Package,
+            None,
+            b"not a round-one package".to_vec(),
+        )
+        .is_err()
+    );
+
+    // A broadcast kind may not carry a recipient.
+    assert!(
+        submit(
+            &mut store,
+            36,
+            CeremonyPhase::Round1,
+            CeremonyPayloadKind::Round1Package,
+            Some(config.certifiers[1].did.clone()),
+            round1_package,
+        )
+        .is_err()
+    );
+
+    // A second signature share from the same signer is rejected (single-use).
+    assert!(
+        submit(
+            &mut store,
+            37,
+            CeremonyPhase::RootSigning,
+            CeremonyPayloadKind::RootSignatureShare,
+            None,
+            share_payload,
+        )
+        .is_err()
+    );
 }
 
 #[test]

--- a/crates/exo-root/tests/root_genesis.rs
+++ b/crates/exo-root/tests/root_genesis.rs
@@ -1065,18 +1065,31 @@ fn portal_schema_validates_accepted_kinds_and_disables_unratified_ones() {
     let mut commitments = std::collections::BTreeMap::new();
     let mut nonces = std::collections::BTreeMap::new();
     for identifier in 1..=7u16 {
-        let (commitment, signer_nonces) =
-            sign_commit(&config, &dkg.key_packages[&identifier], &mut rng).expect("commit");
+        let (commitment, signer_nonces) = sign_commit(
+            &config,
+            &dkg.key_packages[&identifier],
+            b"artifact",
+            &mut rng,
+        )
+        .expect("commit");
         commitments.insert(identifier, commitment.commitments.clone());
         nonces.insert(identifier, signer_nonces);
     }
     let commitment_payload = commitments[&1].clone();
+    // A serialized RootSigningNonces blob (Bob's blocker-1 probe): it must NOT be
+    // accepted as a public RootSigningCommitment payload.
+    let nonces_shaped_payload = {
+        let mut bytes = Vec::new();
+        ciborium::into_writer(&nonces[&1], &mut bytes).expect("encode nonces");
+        bytes
+    };
     let package = build_signing_package(&config, commitments, b"artifact").expect("package");
     let share_payload = sign_share(
         &config,
         &dkg.key_packages[&1],
         &nonces[&1],
-        &package.signing_package,
+        &package,
+        b"artifact",
     )
     .expect("share")
     .signature_share;
@@ -1170,6 +1183,21 @@ fn portal_schema_validates_accepted_kinds_and_disables_unratified_ones() {
             b"not a round-one package".to_vec(),
         )
         .is_err()
+    );
+
+    // Bob's blocker-1 probe: serialized secret nonces must NOT be relayable under
+    // the public RootSigningCommitment kind — schema validation rejects them.
+    assert!(
+        submit(
+            &mut store,
+            38,
+            CeremonyPhase::RootSigning,
+            CeremonyPayloadKind::RootSigningCommitment,
+            None,
+            nonces_shaped_payload,
+        )
+        .is_err(),
+        "RootSigningNonces bytes must not be accepted as a public commitment"
     );
 
     // A broadcast kind may not carry a recipient.


### PR DESCRIPTION
## Summary

Consolidates **#666** (client-side ceremony commands) and **#667** (distributed
threshold signing + portal read API + round-2 codec) into one PR and applies all
five of @bob-stewart's requested changes. #667 was branched on top of #666, so its
tree already contained #666's commands; this branch is built off `origin/main`
with both PRs' content plus the fixes.

Supersedes and closes:
- #666 — cli(genesis): client-side ceremony commands
- #667 — genesis: distributed threshold signing + portal read API + round-2 codec

**Update (2026-05-26):** following @bob-stewart's ratification of the open
ceremony-policy decisions (comment below), this PR now also lands those
protocol-level changes in `exo-root` (portal payload policy, the
`RootSigningNonces` binding, and a config-declared signing set). These are
deliberate, Bob-authorized library changes — see "Ratified protocol decisions".
No workspace-dependency changes.

## Ratified protocol decisions (@bob-stewart, 2026-05-26)

Bob ratified the five open decisions; implemented as his stated secure defaults:

1. **Round-1 attestation disabled.** The portal now **rejects**
   `Round1SetAttestation`. (`build-round1-attestation` was already removed.)
2. **Deterministic predeclared signer set.** `GenesisCeremonyConfig` gains
   `signing_set` (exactly `threshold` rostered primaries) and ordered
   `signing_alternates`; `config.validate()` enforces them; `build_signing_package`
   accepts only the declared set, allowing solely **ordered alternate
   substitution** for a primary unavailable before commitments. `genesis ceremony
   init` gains `--signing-set` / `--signing-alternates`.
3. **Abort after commitments.** Enforced via single-use nonces (below) + portal
   one-share-per-signer dedup; the operational abort/retry rule is documented in
   the command help and PR.
4. **Nonce binding + single use.** `RootSigningNonces` is now bound to
   `{ceremony_id, signer_id, commitment_hash}`; `sign_share` verifies the
   ceremony, the signer, and that the nonces' commitment is the one bound for that
   signer **in the supplied signing package** — which fixes the artifact (message)
   and the full signer set, so a nonce can only be consumed for the one instance
   it was committed to. The `sign-share` CLI **deletes the nonces file on success**
   (single use), and the portal **rejects a second `RootSignatureShare` from the
   same signer** in a session.
5. **No opaque payloads.** The portal **schema-validates every accepted payload
   kind** by decoding it to its concrete type before storage: `Round1Package` →
   FROST round-1 package, `Round2EncryptedPackage` → `PairwiseEncryptedPayload`,
   `RootSigningCommitment` → FROST signing commitments, `RootSignatureShare` →
   FROST signature share.

**⚠️ One extension flagged for ratification:** `FinalKeyConfirmation` has **no
defined/producer schema** anywhere in `exo-root` (only a test referenced it). Per
the "no opaque payloads / schema-validate every accepted kind" rule, it cannot be
validated, so — consistent with the attestation decision — the portal now
**rejects `FinalKeyConfirmation`** too, pending a ratified schema. Re-enabling it
is a one-arm change once its payload type is defined. Please confirm.

Tests added per decision: `ceremony` signing-set validation + ordered-substitution
selection tests; `signing` nonce ceremony/instance-binding tests; `portal`
schema-valid-accept + disabled-reject + recipient + share-dedup test;
`root_genesis_cli` single-use nonce-file consumption assertion.

## Bob's review comments — each addressed (original five fixes)

### [P0] sign-envelope must not take signing secrets via argv
`#666` cli.rs:367 — https://github.com/exochain/exochain/pull/666#discussion_r3305777222

`--signing-key-hex` is **removed**. `sign-envelope` now reads the 32-byte Ed25519
secret from `--private-input <path>`, the `0600` `certifier-NN.private.json` file
written by `certifier init --private-out` (field `signing_secret_hex`). No CLI
argument carries key material, so it cannot leak through process listings, shell
history, terminal capture, or operator transcripts. The handler also binds the
file's DID to the envelope `sender_did` and fails closed on mismatch.
- **Test:** `cli::tests::genesis_sign_envelope_takes_no_signing_secret_through_argv`
  (asserts `--private-input` parses and `--signing-key-hex` is rejected) and
  `root_genesis_cli::tests::sign_envelope_output_is_accepted_by_the_portal`
  (signs from the private-material file; the portal accepts the result).

### [P0] build-round1-attestation cannot ship unratified
`#666` root_genesis_cli.rs:451 — https://github.com/exochain/exochain/pull/666#discussion_r3305777229

The command, its handler, input/output structs, the
`EXOCHAIN_ROOT_ROUND1_SET_ATTESTATION_V0_UNRATIFIED` domain constant, and its test
are **removed entirely**. The portal accepted those bytes opaquely, so it could
never bind ratified semantics. The **ceremony playbook will skip the round-one
set-attestation phase** until a ratified payload shape lands in `exo-root` (with
portal validation) in a separate PR.
- **Test:** `cli::tests::genesis_build_round1_attestation_command_is_absent_pending_ratification`
  (asserts the command is not present in `genesis --help`).

### [P1] encrypt-pairwise must not accept the AEAD nonce from caller input
`#666` root_genesis_cli.rs:398 — https://github.com/exochain/exochain/pull/666#discussion_r3305777238

The `nonce_hex` input field is **dropped**. `encrypt-pairwise` now draws the
24-byte XChaCha20-Poly1305 nonce from `OsRng` internally and returns it inside the
encrypted payload, so the binary — not an operator script — owns nonce uniqueness.
- **Test:** `root_genesis_cli::tests::encrypt_pairwise_cannot_be_forced_to_reuse_a_nonce`
  (two invocations with identical plaintext + AAD + keys yield different nonces and
  ciphertext).

### [P0] RootSigningCommitment mixes public commitment with secret nonces
`#667` signing.rs:159 — https://github.com/exochain/exochain/pull/667#discussion_r3305778687

`signing.rs` is split into two types: `RootSigningCommitment { frost_identifier,
commitments }` (public, relay-safe) and `RootSigningNonces { frost_identifier,
nonces }` (local-only, doc-commented as secret-bearing). `sign_commit()` now
returns `(RootSigningCommitment, RootSigningNonces)`; `sign_share()` takes
`&RootSigningNonces` (and binds its identifier to the key package). `RootSigningNonces`
is re-exported from `lib.rs`.
- **Test:** `root_genesis_cli::tests::root_signing_commitment_json_has_no_secret_named_field`
  (round-trips `RootSigningCommitment` through JSON; asserts no field name matches
  `nonce|secret|private`).

### [P0] sign-commit must write public commitment and secret nonces separately
`#667` root_genesis_cli.rs:629 — https://github.com/exochain/exochain/pull/667#discussion_r3305778693

`sign-commit` now writes `--commitment-out <path>` (public, safe to transmit) and
`--nonces-out <path>` (`0600`, refused if it exists) as two files. `sign-share`
reads the local-only nonces from `--nonces <path>`.
- **Test:** `root_genesis_cli::tests::distributed_signing_handlers_produce_a_verifiable_signature`
  asserts, for each signer, that the `--commitment-out` JSON has no
  `nonces`/secret-named field and that the nonces live only in the separate
  `--nonces-out` file.

## Consolidated command surface

`certifier`, `ceremony`, `portal`, `round1`, `round2`, `finalize-dkg`,
`sign-root-artifact`, `assemble-bundle`, `verify-bundle`, `seal-share`,
`unseal-share`, `sign-envelope`, `encrypt-pairwise`, `decrypt-pairwise`,
`emit-artifact-bytes`, `submit-envelope`, `pull-envelopes`,
`encode-encrypted-payload`, `decode-encrypted-payload`, `sign-commit`,
`build-signing-package`, `sign-share`, `aggregate-signature`.
(`build-round1-attestation` intentionally absent — see above.)

## Validation

- `cargo fmt --all -- --check` — **pass**
- `cargo clippy --workspace --all-targets -- -D warnings` — **pass** <!-- R -->
- `cargo test -p exo-root --test root_genesis` — **pass** <!-- R -->
- `cargo test -p exo-node genesis` — **pass** <!-- R -->

Matrix build (`apexvelocitycatalyst/avc-root-genesis-ceremony → build-exochain.yml`)
green on Linux/macOS/Windows against this branch SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
