### PR TITLE
Validate durable AVC revocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 313 | `find crates -name '*.rs'` |
-| Rust LOC | 211415 | `wc -l` |
-| Workspace tests | 4,677 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 211604 | `wc -l` |
+| Workspace tests | 4,680 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,677 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,680 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 211415 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 211604 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,677 listed workspace tests
+         cryptographic proofs, 4,680 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          171 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-avc/src/registry.rs
+++ b/crates/exo-avc/src/registry.rs
@@ -149,6 +149,12 @@ impl InMemoryAvcRegistry {
                     ),
                 });
             }
+            if revocation.schema_version != crate::credential::AVC_SCHEMA_VERSION {
+                return Err(AvcError::UnsupportedSchema {
+                    got: revocation.schema_version,
+                    supported: crate::credential::AVC_SCHEMA_VERSION,
+                });
+            }
             if revocation.signature.is_empty() {
                 return Err(AvcError::InvalidInput {
                     reason: format!(
@@ -199,10 +205,34 @@ impl InMemoryAvcRegistry {
     /// verified startup configuration or live runtime registration.
     pub fn apply_durable_state(&mut self, state: AvcRegistryDurableState) -> Result<(), AvcError> {
         let durable = Self::from_durable_state(state)?;
-        self.credentials = durable.credentials;
-        self.by_subject = durable.by_subject;
-        self.revocations = durable.revocations;
-        self.receipts = durable.receipts;
+        let mut candidate = self.clone();
+        candidate.credentials = durable.credentials;
+        candidate.by_subject = durable.by_subject;
+        candidate.revocations.clear();
+        candidate.receipts = durable.receipts;
+
+        for revocation in durable.revocations.into_values() {
+            candidate.validate_revocation(&revocation)?;
+            candidate
+                .revocations
+                .insert(revocation.credential_id, revocation);
+        }
+
+        self.credentials = candidate.credentials;
+        self.by_subject = candidate.by_subject;
+        self.revocations = candidate.revocations;
+        self.receipts = candidate.receipts;
+        Ok(())
+    }
+
+    /// Revalidate durable revocations after startup trust anchors have been
+    /// registered. This lets runtime adapters load durable records before
+    /// verified configuration is available while still failing closed before
+    /// those revocations are trusted for validation.
+    pub fn validate_loaded_revocations(&self) -> Result<(), AvcError> {
+        for revocation in self.revocations.values() {
+            self.validate_revocation(revocation)?;
+        }
         Ok(())
     }
 
@@ -896,6 +926,28 @@ mod tests {
     }
 
     #[test]
+    fn durable_state_rejects_revocation_with_unsupported_schema() {
+        let mut reg = fresh_registry();
+        let (id, issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
+        let mut unsupported_schema = sample_issuer_revocation(id, &issuer_keypair);
+        unsupported_schema.schema_version = crate::credential::AVC_SCHEMA_VERSION + 1;
+
+        let mut state = reg.durable_state();
+        state.revocations.insert(id, unsupported_schema);
+
+        let err = InMemoryAvcRegistry::from_durable_state(state).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                AvcError::UnsupportedSchema { got, supported }
+                    if got == crate::credential::AVC_SCHEMA_VERSION + 1
+                        && supported == crate::credential::AVC_SCHEMA_VERSION
+            ),
+            "durable revocation schema must be validated before tombstone import"
+        );
+    }
+
+    #[test]
     fn durable_state_rejects_invalid_receipt_records() {
         let mut reg = fresh_registry();
         let (id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
@@ -975,6 +1027,30 @@ mod tests {
         assert!(live.consent_ref_exists(&consent_ref));
         assert!(live.policy_ref_exists(&policy_ref, 7));
         assert!(live.authority_chain_valid(&authority_chain, &ts(9)));
+    }
+
+    #[test]
+    fn apply_durable_state_rejects_forged_revocation_signature_with_live_trust_anchor() {
+        let mut durable_source = fresh_registry();
+        let (id, issuer_keypair) = register_sample_credential_and_issuer_key(&mut durable_source);
+        let attacker_keypair = keypair(0x44);
+        let forged_revocation = signed_revocation(id, did("issuer"), &attacker_keypair);
+        let mut state = durable_source.durable_state();
+        state.revocations.insert(id, forged_revocation);
+
+        let mut live = fresh_registry();
+        live.put_public_key(did("issuer"), issuer_keypair.public);
+
+        let err = live.apply_durable_state(state).unwrap_err();
+        assert!(
+            matches!(err, AvcError::InvalidInput { reason } if reason.contains("signature") && reason.contains("invalid")),
+            "durable revocation signatures must be verified with live startup trust anchors"
+        );
+        assert_eq!(live.credential_count(), 0);
+        assert!(
+            !live.is_revoked(&id),
+            "forged durable revocation must not create a tombstone"
+        );
     }
 
     #[test]

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -426,6 +426,14 @@ pub fn load_configured_root_trust_bundle(
     state: &AvcApiState,
 ) -> anyhow::Result<Option<RootTrustIssuerRegistration>> {
     let Some(path) = std::env::var_os(AVC_ROOT_TRUST_BUNDLE_ENV) else {
+        let registry = state.registry.lock().map_err(|_| {
+            anyhow::anyhow!("AVC registry unavailable while checking durable revocations")
+        })?;
+        if registry.revocation_count() > 0 {
+            anyhow::bail!(
+                "AVC durable registry contains revocations but {AVC_ROOT_TRUST_BUNDLE_ENV} is not configured; durable revocation signatures cannot be verified"
+            );
+        }
         return Ok(None);
     };
     if path.is_empty() {
@@ -506,10 +514,17 @@ pub fn load_root_trust_bundle_from_path(
     let mut registry = state.registry.lock().map_err(|_| {
         anyhow::anyhow!("AVC registry unavailable while registering root trust issuer")
     })?;
-    registry.put_public_key(
+    let mut candidate = registry.clone();
+    candidate.put_public_key(
         registration.issuer_did.clone(),
         registration.issuer_public_key,
     );
+    candidate.validate_loaded_revocations().map_err(|error| {
+        anyhow::anyhow!(
+            "AVC durable revocation validation failed after root trust issuer registration: {error}"
+        )
+    })?;
+    *registry = candidate;
 
     Ok(registration)
 }
@@ -3136,7 +3151,12 @@ mod tests {
 
 #[cfg(test)]
 mod avc_root_trust_tests {
-    use exo_avc::AvcRegistryRead;
+    use exo_authority::permission::Permission;
+    use exo_avc::{
+        AVC_SCHEMA_VERSION, AuthorityScope, AutonomyLevel, AvcConstraints, AvcDraft,
+        AvcRegistryDurableState, AvcRegistryRead, AvcRevocationReason, AvcSubjectKind,
+        DelegatedIntent, issue_avc, revoke_avc,
+    };
 
     use super::*;
 
@@ -3146,6 +3166,17 @@ mod avc_root_trust_tests {
             Did::new("did:exo:test-validator").expect("test DID"),
             signer,
         )
+    }
+
+    fn avc_state_with_registry(registry: InMemoryAvcRegistry) -> AvcApiState {
+        let signer: AvcReceiptSigner = Arc::new(|_| Signature::empty());
+        AvcApiState {
+            registry: Arc::new(Mutex::new(registry)),
+            validator_did: Did::new("did:exo:test-validator").expect("test DID"),
+            receipt_signer: signer,
+            receipt_timestamp_source: Arc::new(|| Ok(Timestamp::new(1_700_000, 0))),
+            durability: AvcRegistryDurability::None,
+        }
     }
 
     fn repo_root() -> std::path::PathBuf {
@@ -3158,6 +3189,70 @@ mod avc_root_trust_tests {
 
     fn installed_bundle_path() -> std::path::PathBuf {
         repo_root().join("artifacts/trust/avc-exo-ceremony-2026/root-trust-bundle.canonical.json")
+    }
+
+    fn root_issuer_did() -> Did {
+        Did::new(AVC_ROOT_TRUST_ISSUER_DID).expect("expected issuer DID")
+    }
+
+    fn forged_root_issuer_revocation_registry() -> InMemoryAvcRegistry {
+        let issuer_did = root_issuer_did();
+        let credential = issue_avc(
+            AvcDraft {
+                schema_version: AVC_SCHEMA_VERSION,
+                issuer_did: issuer_did.clone(),
+                principal_did: issuer_did.clone(),
+                subject_did: Did::new("did:exo:agent").expect("agent DID"),
+                holder_did: None,
+                subject_kind: AvcSubjectKind::AiAgent {
+                    model_id: "alpha".into(),
+                    agent_version: None,
+                },
+                created_at: Timestamp::new(1_000_000, 0),
+                expires_at: Some(Timestamp::new(2_000_000, 0)),
+                delegated_intent: DelegatedIntent {
+                    intent_id: Hash256::from_bytes([0xAA; 32]),
+                    purpose: "research".into(),
+                    allowed_objectives: vec!["primary".into()],
+                    prohibited_objectives: vec![],
+                    autonomy_level: AutonomyLevel::Draft,
+                    delegation_allowed: false,
+                },
+                authority_scope: AuthorityScope {
+                    permissions: vec![Permission::Read],
+                    tools: vec![],
+                    data_classes: vec![],
+                    counterparties: vec![],
+                    jurisdictions: vec!["US".into()],
+                },
+                constraints: AvcConstraints::permissive(),
+                authority_chain: None,
+                consent_refs: vec![],
+                policy_refs: vec![],
+                parent_avc_id: None,
+            },
+            |_| Signature::from_bytes([0x41; 64]),
+        )
+        .expect("test credential");
+        let credential_id = credential.id().expect("credential id");
+        let forged_revocation = revoke_avc(
+            credential_id,
+            issuer_did,
+            AvcRevocationReason::IssuerRevoked,
+            Timestamp::new(1_100_000, 0),
+            |_| Signature::from_bytes([0x42; 64]),
+        )
+        .expect("forged revocation");
+
+        let mut durable_state = AvcRegistryDurableState::default();
+        durable_state
+            .credentials
+            .insert(credential_id, credential.clone());
+        durable_state
+            .revocations
+            .insert(credential_id, forged_revocation);
+        InMemoryAvcRegistry::from_durable_state(durable_state)
+            .expect("current durable structural checks accept forged signature")
     }
 
     #[test]
@@ -3202,6 +3297,24 @@ mod avc_root_trust_tests {
         let expected_did = Did::new(AVC_ROOT_TRUST_ISSUER_DID).expect("expected issuer DID");
         let registry = state.registry.lock().expect("registry lock");
         assert_eq!(registry.resolve_public_key(&expected_did), None);
+    }
+
+    #[test]
+    fn avc_root_trust_bundle_loader_revalidates_loaded_durable_revocations() {
+        let state = avc_state_with_registry(forged_root_issuer_revocation_registry());
+        let error = load_root_trust_bundle_from_path(&state, &installed_bundle_path())
+            .expect_err("forged durable revocation must fail closed after issuer key registration");
+        assert!(
+            error.to_string().contains("revocation signature"),
+            "root trust startup must surface durable revocation signature validation failure: {error}"
+        );
+
+        let registry = state.registry.lock().expect("registry lock");
+        assert_eq!(
+            registry.resolve_public_key(&root_issuer_did()),
+            None,
+            "root trust issuer key registration must roll back when durable revocation validation fails"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Codex Security artifact

CSV row 3: Durable AVC revocations trusted without signature checks.

## Path classification

- EXOCHAIN core: crates/exo-avc/src/registry.rs
- Core runtime adapter: crates/exo-node/src/avc.rs
- Imported evidence/status metadata only: README.md repo-truth counters derived from this branch

## Remediation

- Reject unsupported durable revocation schema versions during structural import.
- Revalidate durable revocation signatures through live startup trust anchors before trusting tombstones in apply_durable_state.
- Revalidate already-loaded durable revocations after root trust issuer registration, and roll back issuer key registration if validation fails.
- Fail closed when durable revocations exist but EXO_AVC_ROOT_TRUST_BUNDLE is not configured.

## TDD and verification

Red tests first:
- cargo test -p exo-avc registry::tests::durable_state_rejects_revocation_with_unsupported_schema -- --exact
- cargo test -p exo-avc registry::tests::apply_durable_state_rejects_forged_revocation_signature_with_live_trust_anchor -- --exact
- cargo test -p exo-node avc_root_trust_bundle_loader_revalidates_loaded_durable_revocations

Green verification:
- cargo test -p exo-avc registry::tests::durable_state
- cargo test -p exo-avc registry::tests::apply_durable_state
- cargo test -p exo-node durable_registry -- --skip postgres_durable_registry_preserves_trust_anchors_across_multiple_mutations
- cargo test -p exo-node root_trust
- cargo test -p exo-avc
- cargo test -p exo-node avc::tests
- cargo test -p exo-node avc::avc_root_trust_tests
- cargo test -p exo-node
- cargo clippy -p exo-avc --all-targets -- -D warnings
- cargo clippy -p exo-node --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- bash tools/test_repo_truth.sh
- cargo build -p exo-node