### PR TITLE
Enforce AVC root issuer scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 313 | `find crates -name '*.rs'` |
-| Rust LOC | 212087 | `wc -l` |
-| Workspace tests | 4,687 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 212124 | `wc -l` |
+| Workspace tests | 4,689 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,687 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,689 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 212087 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 212124 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,687 listed workspace tests
+         cryptographic proofs, 4,689 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          171 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 313 | `find crates -name '*.rs'` |
-| Rust LOC | 211941 | `wc -l` |
-| Workspace tests | 4,685 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 212087 | `wc -l` |
+| Workspace tests | 4,687 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,685 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,687 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 211941 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 212087 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,685 listed workspace tests
+         cryptographic proofs, 4,687 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          171 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 313 | `find crates -name '*.rs'` |
-| Rust LOC | 212124 | `wc -l` |
-| Workspace tests | 4,689 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 212210 | `wc -l` |
+| Workspace tests | 4,695 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,689 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,695 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 212124 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 212210 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,689 listed workspace tests
+         cryptographic proofs, 4,695 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          171 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-avc/src/registry.rs
+++ b/crates/exo-avc/src/registry.rs
@@ -617,6 +617,28 @@ mod tests {
     }
 
     #[test]
+    fn put_credential_accepts_scope_within_registered_issuer_grant() {
+        let mut reg = fresh_registry();
+        let issuer = put_issuer_key(&mut reg);
+        reg.put_issuer_permission_grant(did("issuer"), vec![Permission::Read]);
+        let mut draft = baseline_draft();
+        draft.authority_scope.permissions = vec![Permission::Read];
+        let cred = issue_avc(draft, |bytes| issuer.sign(bytes)).unwrap();
+        let id = cred.id().unwrap();
+
+        let stored_id = reg
+            .put_credential(cred)
+            .expect("credential inside root issuer grant must store");
+
+        assert_eq!(stored_id, id);
+        assert_eq!(
+            reg.resolve_issuer_permission_grant(&did("issuer")),
+            Some(vec![Permission::Read])
+        );
+        assert_eq!(reg.credential_count(), 1);
+    }
+
+    #[test]
     fn put_credential_rejects_scope_wider_than_registered_issuer_grant() {
         let mut reg = fresh_registry();
         let issuer = put_issuer_key(&mut reg);

--- a/crates/exo-avc/src/registry.rs
+++ b/crates/exo-avc/src/registry.rs
@@ -617,6 +617,44 @@ mod tests {
     }
 
     #[test]
+    fn resolve_issuer_permission_grant_returns_none_for_unregistered_issuer() {
+        let reg = fresh_registry();
+
+        assert_eq!(reg.resolve_issuer_permission_grant(&did("issuer")), None);
+    }
+
+    #[test]
+    fn put_issuer_permission_grant_deduplicates_and_sorts_permissions() {
+        let mut reg = fresh_registry();
+
+        reg.put_issuer_permission_grant(
+            did("issuer"),
+            vec![Permission::Write, Permission::Read, Permission::Write],
+        );
+
+        assert_eq!(
+            reg.resolve_issuer_permission_grant(&did("issuer")),
+            Some(vec![Permission::Read, Permission::Write])
+        );
+    }
+
+    #[test]
+    fn put_credential_accepts_without_registered_issuer_grant() {
+        let mut reg = fresh_registry();
+        put_issuer_key(&mut reg);
+        let cred = sample_credential();
+        let id = cred.id().unwrap();
+
+        let stored_id = reg
+            .put_credential(cred)
+            .expect("credential must store when no issuer grant is registered");
+
+        assert_eq!(stored_id, id);
+        assert_eq!(reg.resolve_issuer_permission_grant(&did("issuer")), None);
+        assert_eq!(reg.credential_count(), 1);
+    }
+
+    #[test]
     fn put_credential_accepts_scope_within_registered_issuer_grant() {
         let mut reg = fresh_registry();
         let issuer = put_issuer_key(&mut reg);

--- a/crates/exo-avc/src/registry.rs
+++ b/crates/exo-avc/src/registry.rs
@@ -25,6 +25,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use exo_authority::permission::Permission;
 use exo_core::{Did, Hash256, PublicKey, Timestamp, crypto};
 use serde::{Deserialize, Serialize};
 
@@ -36,6 +37,7 @@ use crate::{
 /// Read-only registry interface used by validation.
 pub trait AvcRegistryRead {
     fn resolve_public_key(&self, did: &Did) -> Option<PublicKey>;
+    fn resolve_issuer_permission_grant(&self, did: &Did) -> Option<Vec<Permission>>;
     fn resolve_human_approval_key(&self, did: &Did) -> Option<PublicKey>;
     fn is_revoked(&self, credential_id: &Hash256) -> bool;
     fn get_revocation(&self, credential_id: &Hash256) -> Option<AvcRevocation>;
@@ -61,6 +63,7 @@ pub trait AvcRegistryWrite: AvcRegistryRead {
     fn put_revocation(&mut self, revocation: AvcRevocation) -> Result<(), AvcError>;
     fn put_receipt(&mut self, receipt: AvcTrustReceipt) -> Result<(), AvcError>;
     fn put_public_key(&mut self, did: Did, public_key: PublicKey);
+    fn put_issuer_permission_grant(&mut self, did: Did, granted_permissions: Vec<Permission>);
     fn put_human_approval_key(&mut self, did: Did, public_key: PublicKey);
     fn add_consent_ref(&mut self, consent_id: Hash256);
     fn add_policy_ref(&mut self, policy_id: Hash256, policy_version: u16);
@@ -88,6 +91,7 @@ pub struct InMemoryAvcRegistry {
     revocations: BTreeMap<Hash256, AvcRevocation>,
     receipts: BTreeMap<Hash256, AvcTrustReceipt>,
     public_keys: BTreeMap<Did, PublicKey>,
+    issuer_permission_grants: BTreeMap<Did, BTreeSet<Permission>>,
     human_approval_keys: BTreeMap<Did, PublicKey>,
     consent_refs: BTreeSet<Hash256>,
     policy_refs: BTreeSet<(Hash256, u16)>,
@@ -337,6 +341,27 @@ impl InMemoryAvcRegistry {
         Ok(())
     }
 
+    fn validate_issuer_permission_grant(
+        &self,
+        credential: &AutonomousVolitionCredential,
+    ) -> Result<(), AvcError> {
+        let Some(granted_permissions) = self.issuer_permission_grants.get(&credential.issuer_did)
+        else {
+            return Ok(());
+        };
+        for permission in &credential.authority_scope.permissions {
+            if !granted_permissions.contains(permission) {
+                return Err(AvcError::InvalidInput {
+                    reason: format!(
+                        "credential issuer {} declares permission {permission:?} outside issuer permission grant",
+                        credential.issuer_did
+                    ),
+                });
+            }
+        }
+        Ok(())
+    }
+
     fn validate_credential(
         &self,
         credential: &AutonomousVolitionCredential,
@@ -368,6 +393,7 @@ impl InMemoryAvcRegistry {
                 ),
             });
         }
+        self.validate_issuer_permission_grant(credential)?;
 
         Ok(())
     }
@@ -382,6 +408,12 @@ impl InMemoryAvcRegistry {
 impl AvcRegistryRead for InMemoryAvcRegistry {
     fn resolve_public_key(&self, did: &Did) -> Option<PublicKey> {
         self.public_keys.get(did).copied()
+    }
+
+    fn resolve_issuer_permission_grant(&self, did: &Did) -> Option<Vec<Permission>> {
+        self.issuer_permission_grants
+            .get(did)
+            .map(|permissions| permissions.iter().copied().collect())
     }
 
     fn resolve_human_approval_key(&self, did: &Did) -> Option<PublicKey> {
@@ -465,6 +497,11 @@ impl AvcRegistryWrite for InMemoryAvcRegistry {
         self.public_keys.insert(did, public_key);
     }
 
+    fn put_issuer_permission_grant(&mut self, did: Did, granted_permissions: Vec<Permission>) {
+        self.issuer_permission_grants
+            .insert(did, granted_permissions.into_iter().collect());
+    }
+
     fn put_human_approval_key(&mut self, did: Did, public_key: PublicKey) {
         self.human_approval_keys.insert(did, public_key);
     }
@@ -488,6 +525,7 @@ impl AvcRegistryWrite for InMemoryAvcRegistry {
 
 #[cfg(test)]
 mod tests {
+    use exo_authority::permission::Permission;
     use exo_core::{Signature, crypto::KeyPair};
 
     use super::*;
@@ -576,6 +614,36 @@ mod tests {
         let id = reg.put_credential(cred.clone()).unwrap();
         assert_eq!(reg.get_credential(&id).unwrap(), cred);
         assert_eq!(reg.credential_count(), 1);
+    }
+
+    #[test]
+    fn put_credential_rejects_scope_wider_than_registered_issuer_grant() {
+        let mut reg = fresh_registry();
+        let issuer = put_issuer_key(&mut reg);
+        reg.put_issuer_permission_grant(
+            did("issuer"),
+            vec![
+                Permission::Read,
+                Permission::Write,
+                Permission::Execute,
+                Permission::Delegate,
+            ],
+        );
+        let mut draft = baseline_draft();
+        draft.authority_scope.permissions = vec![Permission::Govern];
+        let cred = issue_avc(draft, |bytes| issuer.sign(bytes)).unwrap();
+        let id = cred.id().unwrap();
+
+        let error = reg
+            .put_credential(cred)
+            .expect_err("credential widening beyond root issuer grant must fail closed");
+
+        assert!(
+            error.to_string().contains("issuer permission grant"),
+            "error must identify issuer grant boundary: {error}"
+        );
+        assert_eq!(reg.credential_count(), 0);
+        assert!(reg.get_credential(&id).is_none());
     }
 
     #[test]

--- a/crates/exo-avc/src/validation.rs
+++ b/crates/exo-avc/src/validation.rs
@@ -675,6 +675,21 @@ mod tests {
     }
 
     #[test]
+    fn allows_credential_scope_within_registered_issuer_grant() {
+        let mut h = Harness::new();
+        h.registry
+            .put_issuer_permission_grant(did("issuer"), vec![Permission::Read]);
+        let mut draft = baseline_draft();
+        draft.authority_scope.permissions = vec![Permission::Read];
+        let cred = h.issue(draft);
+
+        let result = validate_avc(&baseline_request(cred, ts(1_500_000)), &h.registry).unwrap();
+
+        assert_eq!(result.decision, AvcDecision::Allow);
+        assert_eq!(result.reason_codes, vec![AvcReasonCode::Valid]);
+    }
+
+    #[test]
     fn action_signature_payload_is_domain_separated_and_context_bound() {
         let h = Harness::new();
         let cred = h.issue(baseline_draft());

--- a/crates/exo-avc/src/validation.rs
+++ b/crates/exo-avc/src/validation.rs
@@ -234,6 +234,7 @@ pub fn validate_avc<R: AvcRegistryRead>(
             }
         }
     }
+    enforce_registered_issuer_grant(credential, registry, &mut reasons);
 
     // Revocation.
     if registry.is_revoked(&credential_id) {
@@ -303,6 +304,26 @@ fn verify_signature(
     // simply rejected rather than producing a false positive.
     let payload = credential.signing_payload()?;
     Ok(crypto::verify(&payload, &credential.signature, pubkey))
+}
+
+fn enforce_registered_issuer_grant<R: AvcRegistryRead>(
+    credential: &AutonomousVolitionCredential,
+    registry: &R,
+    reasons: &mut BTreeSet<AvcReasonCode>,
+) {
+    let Some(granted_permissions) =
+        registry.resolve_issuer_permission_grant(&credential.issuer_did)
+    else {
+        return;
+    };
+    if credential
+        .authority_scope
+        .permissions
+        .iter()
+        .any(|permission| !granted_permissions.contains(permission))
+    {
+        reasons.insert(AvcReasonCode::ScopeWidening);
+    }
 }
 
 /// Compute the canonical signing payload for a human approval over a
@@ -889,6 +910,36 @@ mod tests {
             result
                 .reason_codes
                 .contains(&AvcReasonCode::PermissionDenied)
+        );
+    }
+
+    #[test]
+    fn denies_credential_scope_wider_than_registered_issuer_grant() {
+        let mut h = Harness::new();
+        h.registry.put_issuer_permission_grant(
+            did("issuer"),
+            vec![
+                Permission::Read,
+                Permission::Write,
+                Permission::Execute,
+                Permission::Delegate,
+            ],
+        );
+        let mut draft = baseline_draft();
+        draft.authority_scope.permissions = vec![Permission::Govern];
+        let cred = h.issue(draft);
+        let actor = cred.subject_did.clone();
+        let mut action = baseline_action(actor);
+        action.requested_permission = Permission::Govern;
+        let mut request = baseline_request(cred, ts(1_500_000));
+        request.action = Some(action);
+
+        let result = validate_avc(&request, &h.registry).unwrap();
+
+        assert_eq!(result.decision, AvcDecision::Deny);
+        assert!(
+            result.reason_codes.contains(&AvcReasonCode::ScopeWidening),
+            "root issuer grants must cap credential-declared permissions"
         );
     }
 

--- a/crates/exo-avc/src/validation.rs
+++ b/crates/exo-avc/src/validation.rs
@@ -675,12 +675,42 @@ mod tests {
     }
 
     #[test]
+    fn allows_credential_when_issuer_has_no_registered_grant() {
+        let h = Harness::new();
+        let mut draft = baseline_draft();
+        draft.authority_scope.permissions = vec![Permission::Read, Permission::Write];
+        let cred = h.issue(draft);
+
+        let result = validate_avc(&baseline_request(cred, ts(1_500_000)), &h.registry).unwrap();
+
+        assert_eq!(result.decision, AvcDecision::Allow);
+        assert_eq!(result.reason_codes, vec![AvcReasonCode::Valid]);
+    }
+
+    #[test]
     fn allows_credential_scope_within_registered_issuer_grant() {
         let mut h = Harness::new();
         h.registry
             .put_issuer_permission_grant(did("issuer"), vec![Permission::Read]);
         let mut draft = baseline_draft();
         draft.authority_scope.permissions = vec![Permission::Read];
+        let cred = h.issue(draft);
+
+        let result = validate_avc(&baseline_request(cred, ts(1_500_000)), &h.registry).unwrap();
+
+        assert_eq!(result.decision, AvcDecision::Allow);
+        assert_eq!(result.reason_codes, vec![AvcReasonCode::Valid]);
+    }
+
+    #[test]
+    fn allows_credential_scope_with_duplicate_registered_grant_entries() {
+        let mut h = Harness::new();
+        h.registry.put_issuer_permission_grant(
+            did("issuer"),
+            vec![Permission::Write, Permission::Read, Permission::Write],
+        );
+        let mut draft = baseline_draft();
+        draft.authority_scope.permissions = vec![Permission::Read, Permission::Write];
         let cred = h.issue(draft);
 
         let result = validate_avc(&baseline_request(cred, ts(1_500_000)), &h.registry).unwrap();
@@ -955,6 +985,24 @@ mod tests {
         assert!(
             result.reason_codes.contains(&AvcReasonCode::ScopeWidening),
             "root issuer grants must cap credential-declared permissions"
+        );
+    }
+
+    #[test]
+    fn denies_any_credential_permission_outside_registered_issuer_grant() {
+        let mut h = Harness::new();
+        h.registry
+            .put_issuer_permission_grant(did("issuer"), vec![Permission::Read]);
+        let mut draft = baseline_draft();
+        draft.authority_scope.permissions = vec![Permission::Read, Permission::Write];
+        let cred = h.issue(draft);
+
+        let result = validate_avc(&baseline_request(cred, ts(1_500_000)), &h.registry).unwrap();
+
+        assert_eq!(result.decision, AvcDecision::Deny);
+        assert!(
+            result.reason_codes.contains(&AvcReasonCode::ScopeWidening),
+            "any credential permission outside the issuer grant must fail closed"
         );
     }
 

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -55,6 +55,7 @@ use axum::{
     http::StatusCode,
     routing::{get, post},
 };
+use exo_authority::permission::Permission;
 use exo_avc::{
     AutonomousVolitionCredential, AvcActionRequest, AvcDecision, AvcRegistryDurableState,
     AvcRegistryRead, AvcRegistryWrite, AvcRevocation, AvcTrustReceipt, AvcValidationRequest,
@@ -386,6 +387,7 @@ pub struct RootTrustIssuerRegistration {
     pub ceremony_id: String,
     pub issuer_did: Did,
     pub issuer_public_key: PublicKey,
+    pub granted_permissions: Vec<Permission>,
 }
 
 fn parse_expected_hash(hex_value: &str, label: &str) -> anyhow::Result<Hash256> {
@@ -509,6 +511,7 @@ pub fn load_root_trust_bundle_from_path(
         ceremony_id: bundle.config.ceremony_id.clone(),
         issuer_did: bundle.issuer_delegation.issuer_did.clone(),
         issuer_public_key: bundle.issuer_delegation.issuer_public_key,
+        granted_permissions: bundle.issuer_delegation.granted_permissions.clone(),
     };
 
     let mut registry = state.registry.lock().map_err(|_| {
@@ -518,6 +521,10 @@ pub fn load_root_trust_bundle_from_path(
     candidate.put_public_key(
         registration.issuer_did.clone(),
         registration.issuer_public_key,
+    );
+    candidate.put_issuer_permission_grant(
+        registration.issuer_did.clone(),
+        registration.granted_permissions.clone(),
     );
     candidate.validate_loaded_revocations().map_err(|error| {
         anyhow::anyhow!(
@@ -3264,15 +3271,26 @@ mod avc_root_trust_tests {
         let expected_public_key =
             parse_expected_public_key(AVC_ROOT_TRUST_ISSUER_PUBLIC_KEY_HEX, "expected issuer key")
                 .expect("expected issuer key");
+        let expected_permissions = vec![
+            Permission::Read,
+            Permission::Write,
+            Permission::Execute,
+            Permission::Delegate,
+        ];
 
         assert_eq!(registration.ceremony_id, AVC_ROOT_TRUST_CEREMONY_ID);
         assert_eq!(registration.issuer_did, expected_did);
         assert_eq!(registration.issuer_public_key, expected_public_key);
+        assert_eq!(registration.granted_permissions, expected_permissions);
 
         let registry = state.registry.lock().expect("registry lock");
         assert_eq!(
             registry.resolve_public_key(&expected_did),
             Some(expected_public_key)
+        );
+        assert_eq!(
+            registry.resolve_issuer_permission_grant(&expected_did),
+            Some(expected_permissions)
         );
     }
 
@@ -3297,6 +3315,10 @@ mod avc_root_trust_tests {
         let expected_did = Did::new(AVC_ROOT_TRUST_ISSUER_DID).expect("expected issuer DID");
         let registry = state.registry.lock().expect("registry lock");
         assert_eq!(registry.resolve_public_key(&expected_did), None);
+        assert_eq!(
+            registry.resolve_issuer_permission_grant(&expected_did),
+            None
+        );
     }
 
     #[test]
@@ -3314,6 +3336,11 @@ mod avc_root_trust_tests {
             registry.resolve_public_key(&root_issuer_did()),
             None,
             "root trust issuer key registration must roll back when durable revocation validation fails"
+        );
+        assert_eq!(
+            registry.resolve_issuer_permission_grant(&root_issuer_did()),
+            None,
+            "root trust issuer permission grant must roll back when durable revocation validation fails"
         );
     }
 


### PR DESCRIPTION
## Summary
- enforce root-delegated AVC issuer permissions as a cap on credential-declared authority scope
- register the signed `issuer_delegation.granted_permissions` from the root trust bundle at node startup
- fail closed both when storing credentials and when validating actions if a root issuer attempts to self-assert permissions outside its root delegation

## Finding
Codex Security artifact: `AVC root issuer scope is not enforced`.

The root trust bundle delegates `Read`, `Write`, `Execute`, and `Delegate` to the operational AVC issuer. Before this change, the node retained the issuer DID/key but not the delegated permission scope, so a compromised or misused issuer key could sign a credential self-asserting `Govern`, `Escalate`, or `Challenge`.

## Path Classification
- `artifacts/trust/avc-exo-ceremony-2026/root-trust-bundle.canonical.json`: imported evidence / signed trust artifact; read-only, not modified
- `crates/exo-avc/src/registry.rs`: EXOCHAIN core AVC registry and storage validation
- `crates/exo-avc/src/validation.rs`: EXOCHAIN core AVC validation
- `crates/exo-node/src/avc.rs`: core runtime adapter for root trust bundle startup registration
- `README.md`: repo-truth counters only

## TDD Evidence
Red tests were added before implementation:
- `cargo test -p exo-avc validation::tests::denies_credential_scope_wider_than_registered_issuer_grant -- --exact` initially failed because the registry exposed no issuer grant boundary
- `cargo test -p exo-avc registry::tests::put_credential_rejects_scope_wider_than_registered_issuer_grant -- --exact` initially failed for the same missing write/read boundary
- `cargo test -p exo-node avc::avc_root_trust_tests::avc_root_trust_bundle_loader_registers_expected_issuer -- --exact` initially failed because the loader did not retain granted permissions

## Validation
- `cargo test -p exo-avc validation::tests::denies_credential_scope_wider_than_registered_issuer_grant -- --exact`
- `cargo test -p exo-avc registry::tests::put_credential_rejects_scope_wider_than_registered_issuer_grant -- --exact`
- `cargo test -p exo-node avc::avc_root_trust_tests::avc_root_trust_bundle_loader_registers_expected_issuer -- --exact`
- `cargo test -p exo-node avc::avc_root_trust_tests`
- `cargo test -p exo-avc`
- `cargo test -p exo-node`
- `cargo clippy -p exo-avc --all-targets -- -D warnings`
- `cargo clippy -p exo-node --all-targets -- -D warnings`
- `cargo build -p exo-node`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`

## Runtime / Trust Boundary
No new secrets or config were added. The root bundle remains a signed, read-only artifact. The permission grant is a startup trust anchor registered alongside the issuer key and rolls back if durable revocation revalidation fails.
