### PR TITLE
Pin root trust verifier policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 313 | `find crates -name '*.rs'` |
-| Rust LOC | 212210 | `wc -l` |
-| Workspace tests | 4,695 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 212266 | `wc -l` |
+| Workspace tests | 4,696 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,695 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,696 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 212210 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 212266 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,695 listed workspace tests
+         cryptographic proofs, 4,696 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          171 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-node/src/root_genesis_cli.rs
+++ b/crates/exo-node/src/root_genesis_cli.rs
@@ -895,6 +895,44 @@ mod tests {
         config
     }
 
+    fn valid_root_trust_bundle() -> RootTrustBundle {
+        let config = rostered_config();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(9683);
+        let dkg = exo_root::run_complete_dkg(&config, &mut rng).expect("dkg");
+        let delegation = RootIssuerDelegation {
+            issuer_did: Did::new("did:exo:root-cli-avc-issuer").expect("issuer DID"),
+            issuer_public_key: PublicKey::from_bytes([0x44; 32]),
+            granted_permissions: vec![Permission::Read, Permission::Write, Permission::Delegate],
+            effective_at: Timestamp::new(1_785_000_010_000, 0),
+            expires_at: None,
+            purpose: "Delegate operational AVC issuing authority".to_owned(),
+        };
+        let transcript_hash = Hash256::digest(b"root-cli-verifier-policy-transcript");
+        let payload = delegation
+            .root_artifact_payload(&config, &dkg.public_key_package, transcript_hash)
+            .expect("payload");
+        let root_signature = threshold_sign(
+            &config,
+            &dkg.public_key_package,
+            dkg.key_packages
+                .iter()
+                .take(7)
+                .map(|(identifier, key_package)| (*identifier, key_package.clone()))
+                .collect(),
+            &payload,
+            &mut rng,
+        )
+        .expect("signature");
+        assemble_root_bundle(
+            config,
+            dkg.public_key_package,
+            delegation,
+            transcript_hash,
+            root_signature,
+        )
+        .expect("bundle")
+    }
+
     /// A schema-valid round-one package payload (the portal now decodes these to a
     /// concrete FROST type, so placeholder bytes no longer pass).
     fn valid_round1_package(config: &GenesisCeremonyConfig) -> Vec<u8> {
@@ -1101,6 +1139,24 @@ mod tests {
         let mut packages = BTreeMap::new();
         packages.insert(7, "not-hex".to_owned());
         assert!(decode_package_map(packages).is_err());
+    }
+
+    #[test]
+    fn verify_bundle_command_outputs_success_record() {
+        let directory = tempdir().expect("temporary directory");
+        let input_path = directory.path().join("verify-bundle-in.json");
+        let output_path = directory.path().join("verify-bundle-out.json");
+        write_json(
+            &input_path,
+            &VerifyBundleCommandInput {
+                bundle: valid_root_trust_bundle(),
+            },
+        )
+        .expect("write verify input");
+
+        run_verify_bundle(io_args(input_path, output_path.clone())).expect("verify bundle");
+        let output: serde_json::Value = read_json(&output_path).expect("read verify output");
+        assert_eq!(output, serde_json::json!({ "verified": true }));
     }
 
     #[test]

--- a/docs/avc/root-trust-authority.md
+++ b/docs/avc/root-trust-authority.md
@@ -53,5 +53,9 @@ adjacent-surface install flow in this repository:
 
 Do not treat imported ceremony artifacts as live EXOCHAIN trust signals.
 The artifact is considered active only when a consuming path validates:
-- `exo-node genesis verify-bundle` succeeds for the bundle exactly as emitted, using the ceremony `repo_commit` recorded in the bundle, and
-- the adjacent manifest/pointer record reports `verification_status = verified` and the recorded checksum matches the stored canonical bundle.
+- `exo-node genesis verify-bundle` succeeds for the bundle exactly as emitted,
+  using an operator-trusted verifier commit rather than code selected by the
+  imported bundle, and
+- the adjacent manifest/pointer record reports `verification_status = verified`,
+  `trusted_verifier_commit`, `source_bundle_repo_commit`, and a checksum that
+  matches the stored canonical bundle.

--- a/docs/avc/root-trust-install-intake.md
+++ b/docs/avc/root-trust-install-intake.md
@@ -5,8 +5,8 @@
 - **Path class**: Adjacent surface artifact installation
 - **Adjacent surface owner**: EXOCHAIN Operations (Bob Stewart / Exochain Foundation)
 - **Deployment status**: Internal rollout only until a downstream runtime adapter is wired.
-- **Allowed EXOCHAIN trust claims**: None by default. Root trust claims are only valid in a downstream runtime that re-verifies the same canonical bundle with `exo-node genesis verify-bundle` at the bundle's declared `config.repo_commit`.
-- **Trust boundary**: Imported evidence artifact (`/Users/bobstewart/exo-ceremony/bundle.json`) -> emitted bundle preserved exactly -> manifest/pointer -> runtime consumer.
+- **Allowed EXOCHAIN trust claims**: None by default. Root trust claims are only valid in a downstream runtime that re-verifies the same canonical bundle with `exo-node genesis verify-bundle` from an operator-trusted verifier commit.
+- **Trust boundary**: Imported evidence artifact (`/Users/bobstewart/exo-ceremony/bundle.json`) -> emitted bundle preserved exactly -> operator-selected verifier commit -> manifest/pointer -> runtime consumer.
   - **No direct read/write access** to EXOCHAIN core state, private keys, consent records, authority chain, or governance outcomes.
 - **Required runtime reads**: Bundle JSON, manifest JSON, pointer JSON.
 
@@ -30,7 +30,10 @@ Manifest/pointer must include:
 - Signer set (`[1,2,3,4,5,6,7]`)
 - Bundle ID
 - Verification timestamp
-- Verifier command/version (`cargo run -p exo-node -- genesis verify-bundle` + ceremony `repo_commit` and `cargo --version`)
+- Source bundle repo commit (`config.repo_commit`)
+- Trusted verifier commit and source (`--trusted-verifier-commit`,
+  `EXO_ROOT_TRUST_VERIFIER_COMMIT`, or current repository `HEAD`)
+- Verifier command/version (`cargo run -p exo-node -- genesis verify-bundle` + trusted verifier commit and `cargo --version`)
 - Result status `verified`
 
 ## Secrets and failure behavior

--- a/docs/avc/root-trust-installation.md
+++ b/docs/avc/root-trust-installation.md
@@ -8,7 +8,7 @@ This runbook installs the imported ceremony artifact at `/Users/bobstewart/exo-c
 The installer performs:
 
 1. preservation of the bundle exactly as `assemble-bundle` emitted it,
-2. strict EXOCHAIN verification via `exo-node` at the bundle's declared `config.repo_commit`,
+2. strict EXOCHAIN verification via `exo-node` from an operator-trusted verifier commit,
 3. immutable publish of the verified emitted artifact,
 4. manifest/pointer write for audit and fail-closed consumption.
 
@@ -17,6 +17,10 @@ The installer performs:
 - `cargo` available on PATH.
 - `python3` and Python module `blake3`.
 - Source artifact at `/Users/bobstewart/exo-ceremony/bundle.json`.
+- A trusted verifier commit selected by the operator. If omitted, the installer
+  uses the current repository `HEAD`. To pin it explicitly, pass
+  `--trusted-verifier-commit <40-char-commit>` or set
+  `EXO_ROOT_TRUST_VERIFIER_COMMIT`.
 
 ## Installation command
 
@@ -30,8 +34,13 @@ Equivalent with explicit arguments:
 tools/root-trust-install.sh \
   --source /Users/bobstewart/exo-ceremony/bundle.json \
   --artifact-id avc-exo-ceremony-2026 \
-  --publish-root artifacts/trust/avc-exo-ceremony-2026
+  --publish-root artifacts/trust/avc-exo-ceremony-2026 \
+  --trusted-verifier-commit "$(git rev-parse HEAD)"
 ```
+
+The imported bundle's `config.repo_commit` is signed source-bundle data. It is
+recorded and compared as policy evidence, but it never selects which verifier
+code the installer executes.
 
 ## Verification summary
 
@@ -40,7 +49,9 @@ On success, verify:
 - `install-manifest.json` exists and is writable only after install.
 - verified emitted bundle appears at `root-trust-bundle.canonical.json`.
 - bundle pointer appears at `root-trust-pointer.<record-id>.json`.
-- manifest record and pointer report `verification_status = "verified"` and the ceremony `repo_commit` used as the verifier commit.
+- manifest record and pointer report `verification_status = "verified"`,
+  `source_bundle_repo_commit`, and the operator-selected
+  `trusted_verifier_commit`.
 
 ## Fail-closed consumer rule
 
@@ -64,8 +75,9 @@ tools/test_root_trust_install_plan.sh
 
 Scenarios covered:
 
-1. Happy-path install validation.
-2. Missing field failure for `transcript_hash`.
-3. Signature tamper failure.
-4. Identity/certificate tamper failure (`signer_ids`, `config.threshold`, or `config.ceremony_id`).
-5. Deployment fail-closed check when published bundle is missing.
+1. Verifier executable policy source guard.
+2. Happy-path install validation.
+3. Missing field failure for `transcript_hash`.
+4. Signature tamper failure.
+5. Identity/certificate tamper failure (`signer_ids`, `config.threshold`, or `config.ceremony_id`).
+6. Deployment fail-closed check when published bundle is missing.

--- a/tools/root-trust-install.sh
+++ b/tools/root-trust-install.sh
@@ -35,7 +35,7 @@ usage() {
 Usage: tools/root-trust-install.sh [options]
 
 Install and publish a ceremony-root trust bundle only after strict exo-node
-verification at the bundle's declared ceremony repo commit.
+verification by a trusted operator-selected verifier commit.
 
 Options:
   --source <path>      Source ceremony artifact path
@@ -44,12 +44,18 @@ Options:
                        (default: avc-exo-ceremony-2026)
   --publish-root <dir> Directory for immutable published artifact
                        (default: <repo>/artifacts/trust/<artifact-id>)
+  --trusted-verifier-commit <commit>
+                       Trusted 40-character verifier commit to execute.
+                       Defaults to EXO_ROOT_TRUST_VERIFIER_COMMIT when set,
+                       otherwise the current repository HEAD.
   --help               Show this help text
 
 This adjacent-surface process:
 - treats the source bundle as imported evidence
 - preserves the bundle exactly as emitted by assemble-bundle
-- verifies with the exo-node version named by config.repo_commit
+- verifies with an operator-trusted exo-node commit, not with code selected by
+  imported bundle contents
+- records the bundle's config.repo_commit only as signed source-bundle data
 - publishes a read-only canonical artifact only on verification success
 - writes append-only installation metadata and pointer records
 EOF_USAGE
@@ -59,6 +65,11 @@ source_path="$DEFAULT_SOURCE"
 publish_root="$DEFAULT_PUBLISH_ROOT"
 artifact_id="$ARTIFACT_ID"
 publish_root_set=0
+trusted_verifier_commit="${EXO_ROOT_TRUST_VERIFIER_COMMIT:-}"
+trusted_verifier_commit_source="current repository HEAD"
+if [[ -n "$trusted_verifier_commit" ]]; then
+  trusted_verifier_commit_source="EXO_ROOT_TRUST_VERIFIER_COMMIT"
+fi
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -78,6 +89,11 @@ while [[ $# -gt 0 ]]; do
       publish_root_set=1
       shift 2
       ;;
+    --trusted-verifier-commit)
+      trusted_verifier_commit="$2"
+      trusted_verifier_commit_source="--trusted-verifier-commit"
+      shift 2
+      ;;
     --help)
       usage
       exit 0
@@ -93,6 +109,14 @@ done
 command -v cargo >/dev/null 2>&1 || fail "Required command missing: cargo"
 command -v git >/dev/null 2>&1 || fail "Required command missing: git"
 command -v python3 >/dev/null 2>&1 || fail "Required command missing: python3"
+
+if [[ -z "$trusted_verifier_commit" ]]; then
+  trusted_verifier_commit="$(git -C "$REPO_ROOT" rev-parse HEAD)" \
+    || fail "Failed to resolve trusted verifier commit from current HEAD"
+fi
+if [[ ! "$trusted_verifier_commit" =~ ^[0-9a-f]{40}$ ]]; then
+  fail "trusted verifier commit must be a 40-character lowercase hex commit"
+fi
 
 if ! python3 - <<'PY_CHECK'
 import importlib.util
@@ -117,7 +141,7 @@ verifier_source="$tmp_dir/verifier-source"
 publish_bundle="$publish_root/root-trust-bundle.canonical.json"
 manifest_path="$publish_root/install-manifest.json"
 
-python3 - "$source_path" "$canonical_bundle" "$verify_input" "$metadata_path" "$artifact_id" <<'PY'
+python3 - "$source_path" "$canonical_bundle" "$verify_input" "$metadata_path" "$artifact_id" "$trusted_verifier_commit" "$trusted_verifier_commit_source" <<'PY'
 import json
 import re
 import sys
@@ -129,6 +153,8 @@ canonical_bundle_path = Path(sys.argv[2])
 verify_input_path = Path(sys.argv[3])
 metadata_path = Path(sys.argv[4])
 artifact_id = sys.argv[5]
+trusted_verifier_commit = sys.argv[6]
+trusted_verifier_commit_source = sys.argv[7]
 
 source_bundle = json.loads(source_path.read_text(encoding="utf-8"))
 
@@ -152,6 +178,10 @@ for key in ("ceremony_id", "network_id", "repo_commit", "threshold", "max_signer
 repo_commit = config["repo_commit"]
 if not isinstance(repo_commit, str) or not re.fullmatch(r"[0-9a-f]{40}", repo_commit):
     raise SystemExit("config.repo_commit must be a 40-character lowercase hex commit")
+source_bundle_repo_commit = repo_commit
+
+if not re.fullmatch(r"[0-9a-f]{40}", trusted_verifier_commit):
+    raise SystemExit("trusted verifier commit must be a 40-character lowercase hex commit")
 
 if config["threshold"] != 7 or config["max_signers"] != 13:
     raise SystemExit("expected 7-of-13 configuration")
@@ -190,7 +220,10 @@ metadata = {
     "artifact_id": artifact_id,
     "source_path": str(source_path),
     "bundle_format": "emitted_root_signature_object",
-    "verifier_commit": repo_commit,
+    "source_bundle_repo_commit": source_bundle_repo_commit,
+    "trusted_verifier_commit": trusted_verifier_commit,
+    "trusted_verifier_commit_source": trusted_verifier_commit_source,
+    "verifier_commit": trusted_verifier_commit,
     "source_checksum": {
         "algorithm": "BLAKE3",
         "value": blake3(source_path.read_bytes()).hexdigest(),
@@ -205,7 +238,7 @@ metadata = {
         "bundle_id_hex": "".join(f"{value:02x}" for value in bundle_id),
         "ceremony_id": config["ceremony_id"],
         "network_id": config["network_id"],
-        "repo_commit": repo_commit,
+        "repo_commit": source_bundle_repo_commit,
         "constitution_hash": config.get("constitution_hash"),
         "threshold": config["threshold"],
         "max_signers": config["max_signers"],
@@ -221,7 +254,14 @@ verifier_commit="$(python3 - "$metadata_path" <<'PY'
 import json
 import sys
 from pathlib import Path
-print(json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))["verifier_commit"])
+print(json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))["trusted_verifier_commit"])
+PY
+)"
+source_bundle_repo_commit="$(python3 - "$metadata_path" <<'PY'
+import json
+import sys
+from pathlib import Path
+print(json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))["source_bundle_repo_commit"])
 PY
 )"
 verifier_short="${verifier_commit:0:12}"
@@ -325,6 +365,9 @@ pointer = {
     "verification_status": "verified",
     "verification_command": verification_command,
     "verifier_commit": verifier_commit,
+    "trusted_verifier_commit": verifier_commit,
+    "trusted_verifier_commit_source": metadata["trusted_verifier_commit_source"],
+    "source_bundle_repo_commit": metadata["source_bundle_repo_commit"],
     "verifier_version": cargo_version,
     "artifact_uri": bundle_uri,
     "bundle_checksum": {
@@ -379,11 +422,17 @@ record = {
         "command_toolchain": cargo_version,
         "result": "verified",
         "pointer_file": pointer_path.name,
+        "source_bundle_repo_commit": metadata["source_bundle_repo_commit"],
+        "trusted_verifier_commit": verifier_commit,
+        "trusted_verifier_commit_source": metadata["trusted_verifier_commit_source"],
     },
     "policy": {
         "source_type": "imported evidence",
         "fail_closed": True,
-        "allowed_exochain_trust_claims": ["only after downstream equivalent verification at verifier_commit"],
+        "verifier_commit_authority": "operator trusted policy, never imported bundle contents",
+        "allowed_exochain_trust_claims": [
+            "only after downstream equivalent verification by a trusted verifier commit"
+        ],
         "rollback_path": "delete artifact/pointer and re-run install with replacement manifest",
     },
 }
@@ -403,7 +452,8 @@ else:
             "append_only": True,
             "trust_source": "imported evidence",
             "allowed_exochain_claims": "none until downstream runtime verifier re-checks",
-            "required_runtime_check": "exo-node verify-bundle at verifier_commit",
+            "required_runtime_check": "exo-node verify-bundle with trusted verifier commit",
+            "verifier_commit_authority": "operator trusted policy, never imported bundle contents",
         },
     }
 
@@ -455,6 +505,7 @@ record-id: $record_id
 bundle-id: $bundle_id_hex
 bundle-blake3: $bundle_checksum
 verifier-commit: $verifier_commit
+source-bundle-repo-commit: $source_bundle_repo_commit
 published-at: $install_timestamp
 artifact-uri: file://$publish_bundle
 publish-root: $publish_root

--- a/tools/test_root_trust_install_plan.sh
+++ b/tools/test_root_trust_install_plan.sh
@@ -75,6 +75,45 @@ print(manifest['latest_record_id'])
 PY
 }
 
+assert_verifier_policy_recorded() {
+  local source="$1"
+  local publish_root="$2"
+
+  python3 - "$source" "$publish_root/install-manifest.json" "$REPO_ROOT" <<'PY'
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+source = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+manifest = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+repo_root = sys.argv[3]
+trusted_head = subprocess.check_output(
+    ["git", "-C", repo_root, "rev-parse", "HEAD"],
+    text=True,
+).strip()
+source_bundle_repo_commit = source["config"]["repo_commit"]
+
+record = manifest["records"][-1]
+verification = record["verification"]
+policy = record["policy"]
+
+if verification["trusted_verifier_commit"] != trusted_head:
+    raise SystemExit("trusted verifier commit was not current HEAD")
+if verification["source_bundle_repo_commit"] != source_bundle_repo_commit:
+    raise SystemExit("source bundle repo commit was not preserved")
+if policy["verifier_commit_authority"] != "operator trusted policy, never imported bundle contents":
+    raise SystemExit("verifier commit authority policy missing")
+
+pointer_path = Path(sys.argv[2]).parent / verification["pointer_file"]
+pointer = json.loads(pointer_path.read_text(encoding="utf-8"))
+if pointer["trusted_verifier_commit"] != trusted_head:
+    raise SystemExit("pointer trusted verifier commit mismatch")
+if pointer["source_bundle_repo_commit"] != source_bundle_repo_commit:
+    raise SystemExit("pointer source bundle repo commit mismatch")
+PY
+}
+
 consumer_must_fail_if_missing_bundle() {
   local publish_root="$1"
   local record_id
@@ -119,6 +158,46 @@ PY
 
 tmp_root="$(mktemp -d -t exo-root-trust-plan.XXXXXX)"
 
+# 0) Verifier executable policy guard
+python3 - "$INSTALL_SCRIPT" <<'PY'
+import sys
+from pathlib import Path
+
+script = Path(sys.argv[1]).read_text(encoding="utf-8")
+
+required_fragments = [
+    "--trusted-verifier-commit",
+    "EXO_ROOT_TRUST_VERIFIER_COMMIT",
+    "trusted_verifier_commit",
+    "source_bundle_repo_commit",
+]
+missing = [fragment for fragment in required_fragments if fragment not in script]
+if missing:
+    raise SystemExit(
+        "installer is missing trusted verifier policy fragments: "
+        + ", ".join(missing)
+    )
+
+forbidden_fragments = [
+    '"verifier_commit": repo_commit',
+    '["verifier_commit"])',
+    "verifier_commit = metadata[\"verifier_commit\"]",
+]
+present = [fragment for fragment in forbidden_fragments if fragment in script]
+if present:
+    raise SystemExit(
+        "installer still derives executable verifier commit from imported bundle metadata: "
+        + ", ".join(present)
+    )
+PY
+
+# Invalid verifier policy must fail before install or publication.
+if EXO_ROOT_TRUST_VERIFIER_COMMIT=not-a-commit \
+  "$INSTALL_SCRIPT" --source "$SOURCE_ARTIFACT" --publish-root "$tmp_root/fail-verifier-policy" \
+  >/tmp/root-trust-install.out.txt 2>/tmp/root-trust-install.err.txt; then
+  fail "expected invalid trusted verifier commit to fail closed"
+fi
+
 # 1) Happy-path install validation
 install_root="$tmp_root/happy"
 expect_success "$SOURCE_ARTIFACT" "$install_root"
@@ -129,6 +208,7 @@ record_id="$(latest_record_id "$install_root/install-manifest.json")"
 bundle_hex="$(bundle_id_hex "$install_root/root-trust-bundle.canonical.json")"
 expected_hex="$(bundle_id_hex "$SOURCE_ARTIFACT")"
 [ "$bundle_hex" = "$expected_hex" ] || fail "bundle-id mismatch"
+assert_verifier_policy_recorded "$SOURCE_ARTIFACT" "$install_root"
 
 # 2) Missing field failure
 missing_field_artifact="$tmp_root/missing-field.json"


### PR DESCRIPTION
## Summary
- fixes Codex Security artifact #6: installer verifier code is no longer selected by imported bundle `config.repo_commit`
- adds operator-controlled verifier policy via `--trusted-verifier-commit`, `EXO_ROOT_TRUST_VERIFIER_COMMIT`, or current repository `HEAD`
- records `source_bundle_repo_commit` and `trusted_verifier_commit` separately in metadata, pointer, manifest, and docs

## Path Classification
- `tools/root-trust-install.sh`: core runtime-adjacent root-trust install tooling; executes verifier code and publishes imported evidence
- `tools/test_root_trust_install_plan.sh`: deterministic source/behavior guard for the installer policy
- `docs/avc/root-trust-installation.md`: root-trust operator runbook
- `docs/avc/root-trust-install-intake.md`: adjacent-surface intake/trust-boundary record
- `docs/avc/root-trust-authority.md`: root-trust authority documentation
- CSV finding row: imported evidence, read-only, not committed

## TDD
Red first:
- `bash tools/test_root_trust_install_plan.sh` failed immediately with missing trusted verifier policy fragments

Green:
- installer now rejects invalid trusted verifier policy before publication
- successful installer records preserve both source bundle repo commit and trusted verifier commit
- source guard rejects any regression that derives executable verifier commit from imported bundle metadata

## Validation
- `bash -n tools/root-trust-install.sh && bash -n tools/test_root_trust_install_plan.sh`
- `bash tools/test_root_trust_install_plan.sh`
- `cargo test -p exo-root`
- `cargo test -p exo-node root_genesis -- --nocapture`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `bash tools/test_repo_truth.sh`
- stale-pattern search over production installer/docs excluding the guard file
