### PR TITLE
Bind root signer metadata into signed root artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 313 | `find crates -name '*.rs'` |
-| Rust LOC | 212266 | `wc -l` |
-| Workspace tests | 4,696 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 212598 | `wc -l` |
+| Workspace tests | 4,698 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,696 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,698 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 212266 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 212598 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,696 listed workspace tests
+         cryptographic proofs, 4,698 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          171 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -62,8 +62,10 @@ use exo_avc::{
     AvcValidationResult, InMemoryAvcRegistry, avc_action_signature_payload, create_trust_receipt,
     validate_avc,
 };
-use exo_core::{Did, Hash256, PublicKey, Signature, Timestamp, crypto, hlc::HybridClock};
-use exo_root::{RootTrustBundle, verify_root_bundle};
+use exo_core::{
+    Did, Hash256, PublicKey, Signature, Timestamp, crypto, hash::hash_structured, hlc::HybridClock,
+};
+use exo_root::{RootSignature, RootTrustBundle, verify_root_bundle, verify_root_signature};
 use serde::{Deserialize, Serialize};
 use sqlx::{PgPool, Postgres, Row, Transaction};
 use tower::limit::ConcurrencyLimitLayer;
@@ -418,6 +420,112 @@ fn parse_expected_public_key(hex_value: &str, label: &str) -> anyhow::Result<Pub
     Ok(PublicKey::from_bytes(buf))
 }
 
+#[derive(Serialize)]
+struct LegacyRootArtifactPayload<'a> {
+    domain: &'static str,
+    config_hash: Hash256,
+    public_key_package_hash: Hash256,
+    transcript_hash: Hash256,
+    issuer_delegation_hash: Hash256,
+    issuer_did: &'a Did,
+}
+
+#[derive(Serialize)]
+struct LegacyRootBundleIdPayload<'a> {
+    domain: &'static str,
+    artifact_payload_hash: Hash256,
+    root_signature: &'a RootSignature,
+}
+
+fn avc_root_canonical_bytes<T: Serialize>(value: &T) -> anyhow::Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    ciborium::into_writer(value, &mut bytes)
+        .map_err(|error| anyhow::anyhow!("AVC root trust canonical encoding failed: {error}"))?;
+    Ok(bytes)
+}
+
+fn avc_root_structured_hash<T: Serialize>(value: &T) -> anyhow::Result<Hash256> {
+    hash_structured(value)
+        .map_err(|error| anyhow::anyhow!("AVC root trust structured hash failed: {error}"))
+}
+
+fn legacy_avc_root_artifact_payload(bundle: &RootTrustBundle) -> anyhow::Result<Vec<u8>> {
+    let payload = LegacyRootArtifactPayload {
+        domain: "EXOCHAIN_ROOT_ARTIFACT_V1",
+        config_hash: avc_root_structured_hash(&bundle.config)?,
+        public_key_package_hash: avc_root_structured_hash(&bundle.public_key_package)?,
+        transcript_hash: bundle.transcript_hash,
+        issuer_delegation_hash: avc_root_structured_hash(&bundle.issuer_delegation)?,
+        issuer_did: &bundle.issuer_delegation.issuer_did,
+    };
+    avc_root_canonical_bytes(&payload)
+}
+
+fn legacy_avc_root_bundle_id(bundle: &RootTrustBundle) -> anyhow::Result<Hash256> {
+    let artifact_payload = legacy_avc_root_artifact_payload(bundle)?;
+    let payload = LegacyRootBundleIdPayload {
+        domain: "EXOCHAIN_ROOT_BUNDLE_V1",
+        artifact_payload_hash: Hash256::digest(&artifact_payload),
+        root_signature: &bundle.root_signature,
+    };
+    avc_root_structured_hash(&payload)
+}
+
+fn verify_pinned_legacy_avc_root_bundle(
+    bundle: &RootTrustBundle,
+    expected_bundle_id: Hash256,
+) -> anyhow::Result<()> {
+    if bundle.bundle_id != expected_bundle_id {
+        anyhow::bail!(
+            "legacy AVC root trust bundle id mismatch: expected {}, got {}",
+            expected_bundle_id,
+            bundle.bundle_id
+        );
+    }
+    bundle
+        .config
+        .validate()
+        .map_err(|error| anyhow::anyhow!("legacy AVC root trust config invalid: {error}"))?;
+    if bundle.root_signature.signer_ids != bundle.config.signing_set {
+        anyhow::bail!(
+            "legacy AVC root trust signer metadata mismatch: root_signature.signer_ids must equal config.signing_set"
+        );
+    }
+    let recomputed_bundle_id = legacy_avc_root_bundle_id(bundle)?;
+    if recomputed_bundle_id != expected_bundle_id {
+        anyhow::bail!(
+            "legacy AVC root trust recomputed bundle id mismatch: expected {}, got {}",
+            expected_bundle_id,
+            recomputed_bundle_id
+        );
+    }
+    let payload = legacy_avc_root_artifact_payload(bundle)?;
+    verify_root_signature(
+        &bundle.public_key_package.root_public_key,
+        &payload,
+        bundle.root_signature.signature.as_slice(),
+    )
+    .map_err(|error| anyhow::anyhow!("legacy AVC root trust signature rejected: {error}"))
+}
+
+fn verify_current_or_pinned_legacy_avc_root_bundle(
+    bundle: &RootTrustBundle,
+    expected_bundle_id: Hash256,
+) -> anyhow::Result<()> {
+    match verify_root_bundle(bundle) {
+        Ok(()) => Ok(()),
+        Err(strict_error) => {
+            verify_pinned_legacy_avc_root_bundle(bundle, expected_bundle_id).map_err(
+                |legacy_error| {
+                    anyhow::anyhow!(
+                        "strict root trust verification failed: {strict_error}; pinned legacy AVC root trust verification failed: {legacy_error}"
+                    )
+                },
+            )
+        }
+    }
+}
+
 /// Load the configured AVC root trust bundle, verify it in-process, and
 /// register the delegated operational issuer public key.
 ///
@@ -460,12 +568,16 @@ pub fn load_root_trust_bundle_from_path(
             path.display()
         )
     })?;
-    verify_root_bundle(&bundle).map_err(|error| {
-        anyhow::anyhow!(
-            "AVC root trust bundle verification failed for {}: {error}",
-            path.display()
-        )
-    })?;
+    let expected_bundle_id =
+        parse_expected_hash(AVC_ROOT_TRUST_BUNDLE_ID_HEX, "AVC root trust bundle id")?;
+    verify_current_or_pinned_legacy_avc_root_bundle(&bundle, expected_bundle_id).map_err(
+        |error| {
+            anyhow::anyhow!(
+                "AVC root trust bundle verification failed for {}: {error}",
+                path.display()
+            )
+        },
+    )?;
 
     if bundle.config.ceremony_id != AVC_ROOT_TRUST_CEREMONY_ID {
         anyhow::bail!(
@@ -475,8 +587,6 @@ pub fn load_root_trust_bundle_from_path(
         );
     }
 
-    let expected_bundle_id =
-        parse_expected_hash(AVC_ROOT_TRUST_BUNDLE_ID_HEX, "AVC root trust bundle id")?;
     if bundle.bundle_id != expected_bundle_id {
         anyhow::bail!(
             "AVC root trust bundle id mismatch: expected {}, got {}",
@@ -3317,6 +3427,31 @@ mod avc_root_trust_tests {
         assert_eq!(registry.resolve_public_key(&expected_did), None);
         assert_eq!(
             registry.resolve_issuer_permission_grant(&expected_did),
+            None
+        );
+    }
+
+    #[test]
+    fn avc_root_trust_legacy_bundle_rejects_relabelled_signer_metadata() {
+        let mut bundle: RootTrustBundle =
+            serde_json::from_slice(&std::fs::read(installed_bundle_path()).expect("read bundle"))
+                .expect("parse bundle");
+        bundle.root_signature.signer_ids = vec![1, 2, 3, 4, 5, 6, 8];
+        let temp = tempfile::NamedTempFile::new().expect("temp file");
+        serde_json::to_writer(temp.as_file(), &bundle).expect("write relabelled bundle");
+
+        let state = avc_state_for_root_trust_test();
+        let error = load_root_trust_bundle_from_path(&state, temp.path())
+            .expect_err("legacy compatibility must not accept relabelled signer metadata");
+        assert!(
+            error.to_string().contains("signer metadata"),
+            "expected signer metadata rejection, got: {error}"
+        );
+
+        let registry = state.registry.lock().expect("registry lock");
+        assert_eq!(registry.resolve_public_key(&root_issuer_did()), None);
+        assert_eq!(
+            registry.resolve_issuer_permission_grant(&root_issuer_did()),
             None
         );
     }

--- a/crates/exo-root/src/bundle.rs
+++ b/crates/exo-root/src/bundle.rs
@@ -55,6 +55,7 @@ struct RootArtifactPayload<'a> {
     transcript_hash: Hash256,
     issuer_delegation_hash: Hash256,
     issuer_did: &'a Did,
+    signer_ids: &'a [u16],
 }
 
 #[derive(Serialize)]
@@ -81,14 +82,33 @@ fn canonical_encoding_error(error: impl Display) -> RootError {
 }
 
 impl RootIssuerDelegation {
-    /// Canonical payload signed by the root threshold authority.
+    /// Canonical payload signed by the root threshold authority for the
+    /// predeclared deterministic signing set.
     pub fn root_artifact_payload(
         &self,
         config: &GenesisCeremonyConfig,
         public_key_package: &RootPublicKeyPackage,
         transcript_hash: Hash256,
     ) -> Result<Vec<u8>> {
+        self.root_artifact_payload_for_signers(
+            config,
+            public_key_package,
+            transcript_hash,
+            config.signing_set.as_slice(),
+        )
+    }
+
+    /// Canonical payload signed by the root threshold authority for the exact
+    /// signer metadata carried by a root signature.
+    pub fn root_artifact_payload_for_signers(
+        &self,
+        config: &GenesisCeremonyConfig,
+        public_key_package: &RootPublicKeyPackage,
+        transcript_hash: Hash256,
+        signer_ids: &[u16],
+    ) -> Result<Vec<u8>> {
         config.validate()?;
+        validate_root_signer_ids(config, signer_ids)?;
         if self.purpose.trim().is_empty() {
             return Err(RootError::BundleRejected {
                 reason: "issuer delegation purpose must not be empty".to_owned(),
@@ -106,6 +126,7 @@ impl RootIssuerDelegation {
             transcript_hash,
             issuer_delegation_hash: structured_hash(self)?,
             issuer_did: &self.issuer_did,
+            signer_ids,
         };
         canonical_bytes(&payload)
     }
@@ -118,8 +139,12 @@ fn bundle_id(
     transcript_hash: Hash256,
     root_signature: &RootSignature,
 ) -> Result<Hash256> {
-    let artifact_payload =
-        delegation.root_artifact_payload(config, public_key_package, transcript_hash)?;
+    let artifact_payload = delegation.root_artifact_payload_for_signers(
+        config,
+        public_key_package,
+        transcript_hash,
+        root_signature.signer_ids.as_slice(),
+    )?;
     let id_payload = RootBundleIdPayload {
         domain: "EXOCHAIN_ROOT_BUNDLE_V1",
         artifact_payload_hash: Hash256::digest(&artifact_payload),
@@ -138,8 +163,12 @@ pub fn assemble_root_bundle(
 ) -> Result<RootTrustBundle> {
     validate_public_key_package(&config, &public_key_package)?;
     validate_root_signer_ids(&config, root_signature.signer_ids.as_slice())?;
-    let payload =
-        issuer_delegation.root_artifact_payload(&config, &public_key_package, transcript_hash)?;
+    let payload = issuer_delegation.root_artifact_payload_for_signers(
+        &config,
+        &public_key_package,
+        transcript_hash,
+        root_signature.signer_ids.as_slice(),
+    )?;
     verify_root_signature(
         &public_key_package.root_public_key,
         &payload,
@@ -167,10 +196,11 @@ pub fn verify_root_bundle(bundle: &RootTrustBundle) -> Result<()> {
     bundle.config.validate()?;
     validate_public_key_package(&bundle.config, &bundle.public_key_package)?;
     validate_root_signer_ids(&bundle.config, bundle.root_signature.signer_ids.as_slice())?;
-    let payload = bundle.issuer_delegation.root_artifact_payload(
+    let payload = bundle.issuer_delegation.root_artifact_payload_for_signers(
         &bundle.config,
         &bundle.public_key_package,
         bundle.transcript_hash,
+        bundle.root_signature.signer_ids.as_slice(),
     )?;
     verify_root_signature(
         &bundle.public_key_package.root_public_key,
@@ -194,11 +224,178 @@ pub fn verify_root_bundle(bundle: &RootTrustBundle) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
+    use exo_core::{Did, PublicKey};
+    use frost_ristretto255 as frost;
+    use rand::{SeedableRng, rngs::StdRng};
+
     use super::*;
+    use crate::{
+        CertifierContact, RootKeyPackage,
+        dkg::{deserialize_frost, serialize_frost},
+        run_complete_dkg,
+    };
+
+    #[derive(Serialize)]
+    struct LegacyRootArtifactPayload<'a> {
+        domain: &'static str,
+        config_hash: Hash256,
+        public_key_package_hash: Hash256,
+        transcript_hash: Hash256,
+        issuer_delegation_hash: Hash256,
+        issuer_did: &'a Did,
+    }
+
+    fn test_config() -> GenesisCeremonyConfig {
+        let certifiers = (1..=13)
+            .map(|identifier| {
+                let byte = u8::try_from(identifier).expect("identifier fits");
+                CertifierContact {
+                    did: Did::new(&format!("did:exo:bundle-unit-{identifier:02}"))
+                        .expect("valid did"),
+                    frost_identifier: identifier,
+                    signing_public_key: PublicKey::from_bytes([byte; 32]),
+                    transport_public_key: [byte; 32],
+                }
+            })
+            .collect();
+        GenesisCeremonyConfig {
+            ceremony_id: "bundle-root".into(),
+            network_id: "unit-net".into(),
+            repo_commit: "d8927686a34bdc28ba36d53938f665685d2c4c04".into(),
+            constitution_hash: Hash256::digest(b"constitution"),
+            threshold: 7,
+            max_signers: 13,
+            created_at: Timestamp::new(1, 0),
+            certifiers,
+            signing_set: (1..=7).collect(),
+        }
+    }
+
+    fn issuer_delegation() -> RootIssuerDelegation {
+        RootIssuerDelegation {
+            issuer_did: Did::new("did:exo:bundle-avc-issuer").expect("valid did"),
+            issuer_public_key: PublicKey::from_bytes([0x44; 32]),
+            granted_permissions: vec![Permission::Govern, Permission::Delegate],
+            effective_at: Timestamp::new(1_785_000_010_000, 0),
+            expires_at: None,
+            purpose: "Delegate operational AVC issuing authority".into(),
+        }
+    }
+
+    fn legacy_unbound_root_artifact_payload(
+        delegation: &RootIssuerDelegation,
+        config: &GenesisCeremonyConfig,
+        public_key_package: &RootPublicKeyPackage,
+        transcript_hash: Hash256,
+    ) -> Result<Vec<u8>> {
+        let payload = LegacyRootArtifactPayload {
+            domain: "EXOCHAIN_ROOT_ARTIFACT_V1",
+            config_hash: structured_hash(config)?,
+            public_key_package_hash: structured_hash(public_key_package)?,
+            transcript_hash,
+            issuer_delegation_hash: structured_hash(delegation)?,
+            issuer_did: &delegation.issuer_did,
+        };
+        canonical_bytes(&payload)
+    }
+
+    fn raw_threshold_signature_without_signer_policy<R>(
+        public_key_package: &RootPublicKeyPackage,
+        shares: BTreeMap<u16, RootKeyPackage>,
+        message: &[u8],
+        rng: &mut R,
+    ) -> RootSignature
+    where
+        R: frost::rand_core::RngCore + frost::rand_core::CryptoRng,
+    {
+        let public: frost::keys::PublicKeyPackage =
+            deserialize_frost(public_key_package.public_key_package.as_slice())
+                .expect("public key package");
+        let mut key_packages = BTreeMap::new();
+        let mut signing_nonces = BTreeMap::new();
+        let mut signing_commitments = BTreeMap::new();
+
+        for (identifier, share) in &shares {
+            let frost_identifier = frost::Identifier::try_from(*identifier).expect("frost id");
+            let key_package: frost::keys::KeyPackage =
+                deserialize_frost(share.key_package.as_slice()).expect("key package");
+            let (nonces, commitments) = frost::round1::commit(key_package.signing_share(), rng);
+            signing_nonces.insert(frost_identifier, nonces);
+            signing_commitments.insert(frost_identifier, commitments);
+            key_packages.insert(frost_identifier, key_package);
+        }
+
+        let signing_package = frost::SigningPackage::new(signing_commitments, message);
+        let mut signature_shares = BTreeMap::new();
+        for (identifier, key_package) in &key_packages {
+            let share =
+                frost::round2::sign(&signing_package, &signing_nonces[identifier], key_package)
+                    .expect("signature share");
+            signature_shares.insert(*identifier, share);
+        }
+        let aggregate =
+            frost::aggregate(&signing_package, &signature_shares, &public).expect("aggregate");
+        let signer_ids = shares.keys().copied().collect();
+        RootSignature {
+            signature: serialize_frost(&aggregate).expect("signature encoding"),
+            signer_ids,
+        }
+    }
 
     #[test]
     fn canonical_error_conversion_is_diagnostic() {
         let error = canonical_encoding_error("encoder failed");
         assert!(error.to_string().contains("encoder failed"));
+    }
+
+    #[test]
+    fn root_bundle_rejects_relabelled_signature_when_signer_metadata_was_unsigned() {
+        let config = test_config();
+        let mut rng = StdRng::seed_from_u64(700);
+        let dkg = run_complete_dkg(&config, &mut rng).expect("dkg");
+        let delegation = issuer_delegation();
+        let transcript_hash = Hash256::digest(b"transcript");
+        let legacy_payload = legacy_unbound_root_artifact_payload(
+            &delegation,
+            &config,
+            &dkg.public_key_package,
+            transcript_hash,
+        )
+        .expect("legacy payload");
+        let actual_signers = [1, 2, 3, 4, 5, 6, 8]
+            .into_iter()
+            .map(|identifier| {
+                (
+                    identifier,
+                    dkg.key_packages
+                        .get(&identifier)
+                        .expect("key package")
+                        .clone(),
+                )
+            })
+            .collect();
+        let mut root_signature = raw_threshold_signature_without_signer_policy(
+            &dkg.public_key_package,
+            actual_signers,
+            &legacy_payload,
+            &mut rng,
+        );
+        assert_eq!(root_signature.signer_ids, vec![1, 2, 3, 4, 5, 6, 8]);
+
+        root_signature.signer_ids = config.signing_set.clone();
+
+        assert!(
+            assemble_root_bundle(
+                config,
+                dkg.public_key_package,
+                delegation,
+                transcript_hash,
+                root_signature,
+            )
+            .is_err(),
+            "bundle assembly must reject a threshold signature whose claimed signer metadata was not covered by the signed artifact"
+        );
     }
 }

--- a/docs/avc/root-trust-authority.md
+++ b/docs/avc/root-trust-authority.md
@@ -24,10 +24,15 @@ A valid root trust bundle binds:
 - 7-of-13 threshold policy;
 - FROST public key package hash;
 - transcript hash;
+- exact predeclared root signer identifiers;
 - root signature;
 - AVC issuer delegation.
 
-Bundle verification recomputes the canonical CBOR payload and verifies the FROST root signature against the bundled root public key.
+Bundle verification recomputes the canonical CBOR payload with the signer
+identifiers carried by the root signature and verifies the FROST root signature
+against the bundled root public key. A signature over legacy payload bytes that
+omitted the signer identifiers is rejected even when the aggregate signature
+bytes verify against the root public key.
 
 ## Rejection Rules
 


### PR DESCRIPTION
## Summary
- Remediates Codex Security artifact 7: `Root signer set metadata is not signed`.
- Adds the root signature signer identifiers to the canonical root artifact payload.
- Recomputes bundle assembly, verification, and bundle ID payload hashes using `root_signature.signer_ids`, so a legacy aggregate signature over unsigned signer metadata cannot be relabeled after signing.
- Keeps `exo-root::verify_root_bundle` strict for new root bundles.
- Adds a narrow `exo-node` AVC loader compatibility verifier for the exact hard-pinned legacy production root-trust bundle ID, while rejecting relabelled legacy signer metadata.
- Updates the root-trust authority doc and README repo-truth counters.

## Path Classification
- Imported evidence: `/Users/bobstewart/Downloads/codex-security-findings-2026-06-04T02-42-46.883Z.csv` row 7, read-only, not committed.
- EXOCHAIN core: `crates/exo-root/src/bundle.rs`.
- Core runtime adapter: `crates/exo-node/src/avc.rs`.
- Constitutional governance/root-trust documentation: `docs/avc/root-trust-authority.md`.
- Repo-truth documentation: `README.md`.

## TDD Proof
- Red first: `cargo test -p exo-root bundle::tests::root_bundle_rejects_relabelled_signature_when_signer_metadata_was_unsigned -- --exact --nocapture` failed on current `origin/main` because `assemble_root_bundle` accepted a non-predeclared `[1,2,3,4,5,6,8]` aggregate signature relabeled as `[1,2,3,4,5,6,7]`.
- Green after fix: the same regression test passes because the verifier recomputes the signed payload with the claimed signer IDs and rejects the legacy unsigned-metadata signature.
- Compatibility regression: `cargo test -p exo-node legacy_bundle_rejects_relabelled -- --nocapture` passes and proves the pinned legacy AVC path rejects modified signer metadata without registering the issuer.

## Validation
- `cargo test -p exo-root bundle::tests::root_bundle_rejects_relabelled_signature_when_signer_metadata_was_unsigned -- --exact --nocapture` passed after fix.
- `cargo test -p exo-root` passed.
- `cargo clippy -p exo-root --all-targets -- -D warnings` passed.
- `cargo doc -p exo-root --no-deps` passed.
- `cargo tarpaulin --packages exo-root --include-files "crates/exo-root/src/**" --out xml --out stdout --output-dir coverage-exo-root --skip-clean --engine llvm --timeout 600 --fail-under 100` passed with `100.00% coverage, 984/984 lines covered`.
- `cargo test -p exo-node avc_root_trust -- --nocapture` passed.
- `cargo test --workspace` passed.
- `cargo clippy -p exo-node --all-targets -- -D warnings` passed.
- `cargo doc -p exo-node --no-deps` passed.
- `cargo +nightly fmt --all -- --check` passed.
- `git diff --check` passed.
- `bash tools/test_repo_truth.sh` passed.
- `cargo tarpaulin --packages exo-node --include-files "crates/exo-node/src/root_genesis.rs" --out xml --output-dir coverage-root-genesis-portal --skip-clean --engine llvm --timeout 300 --fail-under 100` passed with `100.00% coverage, 60/60 lines covered`.
- `cargo tarpaulin --packages exo-node --include-files "crates/exo-node/src/zerodentity/**" --out xml --output-dir coverage-zerodentity --skip-clean --engine llvm --timeout 300 --fail-under 80` passed with `91.72% coverage, 1662/1812 lines covered`.

## Bypass Search
- Checked root artifact payload/signature verification call sites with `rg -n "root_artifact_payload\\(|root_artifact_payload_for_signers|RootArtifactPayload|LegacyRootArtifactPayload|verify_root_signature\\(" crates/exo-root/src crates/exo-root/tests docs/avc/root-trust-authority.md -S`.
- Assembly, verification, and bundle ID computation now use `root_artifact_payload_for_signers(..., root_signature.signer_ids.as_slice())`.
- The only legacy acceptance path is scoped to the hardcoded AVC production bundle ID and requires `root_signature.signer_ids == config.signing_set`, legacy bundle-ID recomputation, and old signature verification before issuer registration.
