### PR TITLE
fix(avc): receipt emit always returns NotYetValid (validated against the 1_000_000 stub clock, not wall time)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 313 | `find crates -name '*.rs'` |
-| Rust LOC | 212650 | `wc -l` |
-| Workspace tests | 4,699 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 212716 | `wc -l` |
+| Workspace tests | 4,700 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **4,699 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **4,700 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 212650 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 212716 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,699 listed workspace tests
+         cryptographic proofs, 4,700 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          171 verified bridge exports — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -144,6 +144,27 @@ impl AvcApiState {
         receipt_signer: AvcReceiptSigner,
         database_pool: Option<PgPool>,
     ) -> anyhow::Result<Self> {
+        // Production stamps receipts with real wall-clock time (the receipt's
+        // `now` must fall inside the credential's validity window). Tests inject
+        // a fixed source via `with_durable_registry_and_timestamp_source` so their
+        // fixtures stay deterministic.
+        Self::with_durable_registry_and_timestamp_source(
+            data_dir,
+            validator_did,
+            receipt_signer,
+            database_pool,
+            receipt_timestamp_source_from_clock(HybridClock::with_wall_clock(wall_clock_ms)),
+        )
+        .await
+    }
+
+    async fn with_durable_registry_and_timestamp_source(
+        data_dir: &FsPath,
+        validator_did: Did,
+        receipt_signer: AvcReceiptSigner,
+        database_pool: Option<PgPool>,
+        receipt_timestamp_source: AvcReceiptTimestampSource,
+    ) -> anyhow::Result<Self> {
         let durable_state_path = data_dir.join(AVC_REGISTRY_DURABLE_STATE_FILE);
         let (registry, durability) = match database_pool {
             Some(pool) => {
@@ -161,10 +182,27 @@ impl AvcApiState {
             registry: Arc::new(Mutex::new(registry)),
             validator_did,
             receipt_signer,
-            receipt_timestamp_source: receipt_timestamp_source_from_clock(HybridClock::new()),
+            receipt_timestamp_source,
             durability,
         })
     }
+}
+
+/// Real wall-clock millisecond source for receipt timestamps.
+///
+/// The HLC physical component MUST track real time so a minted receipt's `now`
+/// falls inside the credential's validity window. The deterministic
+/// `HybridClock::new()` stub (physical = `DEFAULT_DETERMINISTIC_PHYSICAL_MS`
+/// = 1_000_000 ms ≈ 1970-01-01) made every receipt emit fail `[NotYetValid]`,
+/// because `credential.created_at` (~1.78e12) is always greater than 1_000_000.
+fn wall_clock_ms() -> u64 {
+    // No expect/unwrap and no `as` cast (the crate denies clippy::expect_used /
+    // unwrap_used and warns on as_conversions). The error arm is unreachable
+    // unless the system clock predates 1970.
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
 }
 
 fn receipt_timestamp_source_from_clock(clock: HybridClock) -> AvcReceiptTimestampSource {
@@ -1240,9 +1278,15 @@ mod tests {
 
     async fn fresh_durable_state(data_dir: &FsPath) -> Arc<AvcApiState> {
         let signer: AvcReceiptSigner = Arc::new(|payload: &[u8]| validator_keypair().sign(payload));
-        let state = AvcApiState::with_durable_registry(data_dir, validator_did(), signer, None)
-            .await
-            .expect("durable AVC state");
+        let state = AvcApiState::with_durable_registry_and_timestamp_source(
+            data_dir,
+            validator_did(),
+            signer,
+            None,
+            fixed_receipt_timestamp_source(Timestamp::new(1_000_000, 0)),
+        )
+        .await
+        .expect("durable AVC state");
         seed_avc_trust_keys(&state);
         Arc::new(state)
     }
@@ -1507,6 +1551,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn with_durable_registry_stamps_receipts_with_wall_clock_not_stub() {
+        // Regression: the prod (`with_durable_registry`) constructor wired the
+        // receipt timestamp to the deterministic `HybridClock::new()` stub
+        // (physical = 1_000_000 ms ≈ 1970), so `created_at > trusted_now` was
+        // always true and EVERY receipt emit failed `[NotYetValid]`. The source
+        // must return a real current-epoch timestamp.
+        let dir = tempfile::tempdir().unwrap();
+        let signer: AvcReceiptSigner = Arc::new(|payload: &[u8]| validator_keypair().sign(payload));
+        let state = AvcApiState::with_durable_registry(dir.path(), validator_did(), signer, None)
+            .await
+            .expect("durable AVC state");
+        let ts = (state.receipt_timestamp_source)().expect("receipt timestamp source");
+        assert!(
+            ts.physical_ms >= 1_700_000_000_000,
+            "receipt timestamp must track the wall clock (>= 2023-11), got physical_ms={} \
+             (the 1_000_000 stub is the NotYetValid bug)",
+            ts.physical_ms
+        );
+    }
+
+    #[tokio::test]
     async fn durable_registry_restores_issued_credentials_for_receipt_emit_after_restart() {
         let dir = tempfile::tempdir().unwrap();
         let state = fresh_durable_state(dir.path()).await;
@@ -1693,11 +1758,12 @@ mod tests {
         };
         let dir = tempfile::tempdir().unwrap();
         let signer: AvcReceiptSigner = Arc::new(|payload: &[u8]| validator_keypair().sign(payload));
-        let state = AvcApiState::with_durable_registry(
+        let state = AvcApiState::with_durable_registry_and_timestamp_source(
             dir.path(),
             validator_did(),
             Arc::clone(&signer),
             Some(pool.clone()),
+            fixed_receipt_timestamp_source(Timestamp::new(1_000_000, 0)),
         )
         .await
         .expect("Postgres AVC state");


### PR DESCRIPTION
Fixes #690. Receipt emission is currently **100% broken in production** — every `POST /api/v1/avc/receipts/emit` returns `403 [NotYetValid]`.

## Root cause
Commit `41c78f98` made the emit handler override the caller's `request.now` with a server `trusted_now` (`avc.rs:1044-1056`) — good design — but wired the timestamp source to the **deterministic stub clock**:
- `AvcApiState::with_durable_registry` (the prod path, `avc.rs:164`) used `receipt_timestamp_source_from_clock(HybridClock::new())`.
- `HybridClock::new()` (`hlc.rs:59-68`) sets `physical_source = || Ok(DEFAULT_DETERMINISTIC_PHYSICAL_MS)` where that constant = `1_000_000` (`hlc.rs:38`).
- So `trusted_now.physical_ms == 1_000_000` (≈1970) forever, and `validation.rs:194` `if credential.created_at (~1.78e12) > request.now (1_000_000) { NotYetValid }` always fires.

This is why `/api/v1/avc/validate` (no override) honors `request.now` perfectly while `/emit` rejects every `now` up to year 2099. Proven against prod with signed bodies at multiple `now` values — all `[NotYetValid]`.

## Fix
Wire the prod constructor to a real wall-clock source (`wall_clock_ms`). The `#[cfg(test)]` `new()` constructor keeps the deterministic clock so existing tests stay deterministic. With the fix `trusted_now ≈ now()` ⇒ in-window ⇒ `Allow` ⇒ receipt mints.

## Verification (local)
- `cargo clippy -p exo-node --bins` → clean (the fix avoids `expect`/`unwrap`/`as`-cast per the crate's denies).
- New regression test `with_durable_registry_stamps_receipts_with_wall_clock_not_stub` → **pass** (asserts the source returns a current-epoch ts, not `1_000_000`). It fails against the old stub by construction (`1_000_000 < 1_700_000_000_000`); I couldn't run the negative case end-to-end here only due to a local disk-space limit, but it's mechanical.
- The per-file `SystemTime::now` guards (metrics/sentinels/exoforge/types) don't cover `avc.rs`; sentinel suite still green.
- **Please let CI run the full `exo-node` suite** — I verified the targeted test + clippy + guards locally, not the whole suite.

## Design note for review
`wall_clock_ms` uses `SystemTime::now()` directly at the construction site. `avc.rs` isn't guarded against that (unlike metrics/sentinels/exoforge/types), but the codebase elsewhere prefers trusted/injected time (e.g. `exo-gateway::trusted_database_epoch_ms` pulls epoch from Postgres). If you'd rather source the receipt clock from the DB or inject it from node setup, `wall_clock_ms` is the single swap point — happy to redo it that way.

**Requires a prod redeploy of exochain-production** (compiled binary).