### PR TITLE
Fix AVC receipt readback and WASM release package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,8 @@ jobs:
         run: bash tools/test_release_dry_run_boundaries.sh
       - name: Release publish completion boundary
         run: bash tools/test_release_publish_boundaries.sh
+      - name: WASM npm package boundary
+        run: bash tools/test_wasm_npm_package_boundary.sh
       - name: Repo truth and public claims
         run: bash tools/test_repo_truth.sh
       - name: Sybil CLI secret boundary
@@ -646,12 +648,22 @@ jobs:
           toolchain: stable
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 20
       - name: Install wasm-pack
         run: bash tools/ci_cargo_retry.sh cargo install wasm-pack --version 0.14.0 --locked
       - name: Build WASM
-        run: bash tools/ci_cargo_retry.sh wasm-pack build crates/exochain-wasm --target nodejs --out-dir ../../packages/exochain-wasm/wasm
+        run: bash tools/ci_cargo_retry.sh wasm-pack build crates/exochain-wasm --target nodejs --scope exochain --out-dir ../../packages/exochain-wasm/wasm
+      - name: Prepare scoped WASM npm package
+        run: |
+          cp LICENSE packages/exochain-wasm/wasm/LICENSE
+          node tools/prepare_wasm_npm_package.mjs packages/exochain-wasm/wasm
+      - name: Dry-pack WASM npm package
+        run: npm pack --dry-run
+        working-directory: packages/exochain-wasm/wasm
       - name: Verify WASM exports
-        # Expected export count = 164. Baseline was 110 before
+        # Expected export count = 165. Baseline was 110 before
         # decision-forum, messaging, death-trigger, and franchise/NewCo
         # scaffold were added; the adjudicated decision transition bridge
         # adds the current security boundary, and the HonorGood economy bridge
@@ -660,11 +672,12 @@ jobs:
         # the forum authority bridge adds trusted-root-key verification,
         # messaging adds caller-managed X25519 public-key derivation, and the
         # AVC bridge keeps legacy raw-subject-key entrypoints fail-closed and
-        # adds external-signature payload/request builders for trust receipts.
+        # adds external-signature payload/request builders plus explicit AVC
+        # protocol/package metadata for trust receipts.
         run: |
           COUNT=$(grep -c "module.exports.wasm_" packages/exochain-wasm/wasm/exochain_wasm.js)
           echo "Found $COUNT WASM exports"
-          [ "$COUNT" -eq 164 ] || (echo "Expected 164 exports, got $COUNT" && exit 1)
+          [ "$COUNT" -eq 165 ] || (echo "Expected 165 exports, got $COUNT" && exit 1)
       - name: Upload WASM artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
@@ -699,7 +712,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Verify Rust exports match JS expectations
-        # Expected #[wasm_bindgen] count = 164. Baseline was 110 before the
+        # Expected #[wasm_bindgen] count = 165. Baseline was 110 before the
         # Sprint-4 additions (decision-forum, messaging, death-trigger,
         # franchise/NewCo scaffold); the adjudicated decision transition bridge
         # adds the current security boundary, the HonorGood economy bridge
@@ -709,11 +722,12 @@ jobs:
         # messaging bridge adds a caller-managed X25519 public-key derivation
         # path, and the AVC bridge keeps legacy raw-subject-key entrypoints
         # fail-closed while adding external-signature payload/request builders
-        # for trust-receipt emission.
+        # plus explicit AVC protocol/package metadata for trust-receipt
+        # emission.
         run: |
           RUST_COUNT=$(grep -r '#\[wasm_bindgen\]' crates/exochain-wasm/src/ | wc -l | tr -d ' ')
           echo "Rust #[wasm_bindgen] exports: $RUST_COUNT"
-          [ "$RUST_COUNT" -eq 164 ] || (echo "WASM export count changed from 164 to $RUST_COUNT — update bridge tests" && exit 1)
+          [ "$RUST_COUNT" -eq 165 ] || (echo "WASM export count changed from 165 to $RUST_COUNT — update bridge tests" && exit 1)
 
   # -----------------------------------------------------------------------
   # Constitutional gate: all must pass

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,12 +319,89 @@ jobs:
           done
 
   # -----------------------------------------------------------------------
+  # Publish versioned WASM package to npm (unless dry run)
+  # -----------------------------------------------------------------------
+  publish-wasm-npm:
+    name: "Package and publish WASM npm package"
+    runs-on: ubuntu-latest
+    needs: [approve, verify-signed-tag, validate-release-inputs]
+    permissions:
+      id-token: write
+    steps:
+      - name: Resolve release source ref
+        id: release-ref
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          RELEASE_TAG: ${{ needs.validate-release-inputs.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ "$DRY_RUN" = "true" ]; then
+            printf 'ref=%s\n' "${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          else
+            printf 'ref=refs/tags/%s\n' "$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ steps.release-ref.outputs.ref }}
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Install wasm-pack
+        run: bash tools/ci_cargo_retry.sh cargo install wasm-pack --version 0.14.0 --locked
+
+      - name: Build scoped WASM npm package
+        run: bash tools/ci_cargo_retry.sh wasm-pack build crates/exochain-wasm --target nodejs --scope exochain --out-dir ../../packages/exochain-wasm/wasm
+
+      - name: Prepare scoped WASM npm package
+        run: |
+          cp LICENSE packages/exochain-wasm/wasm/LICENSE
+          node tools/prepare_wasm_npm_package.mjs packages/exochain-wasm/wasm
+
+      - name: Verify WASM npm package release metadata
+        env:
+          RELEASE_VERSION: ${{ needs.validate-release-inputs.outputs.version }}
+        run: |
+          set -euo pipefail
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const manifest = JSON.parse(fs.readFileSync('packages/exochain-wasm/wasm/package.json', 'utf8'));
+          if (manifest.name !== '@exochain/exochain-wasm') {
+            throw new Error(`unexpected WASM package name ${manifest.name}`);
+          }
+          if (manifest.version !== process.env.RELEASE_VERSION) {
+            throw new Error(`WASM package version ${manifest.version} must match release ${process.env.RELEASE_VERSION}`);
+          }
+          if (!manifest.files.includes('LICENSE')) {
+            throw new Error('WASM package must include LICENSE in npm files');
+          }
+          NODE
+
+      - name: Dry-pack WASM npm package
+        run: npm pack --dry-run
+        working-directory: packages/exochain-wasm/wasm
+
+      - name: Publish WASM npm package
+        if: ${{ !inputs.dry_run }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance
+        working-directory: packages/exochain-wasm/wasm
+
+  # -----------------------------------------------------------------------
   # Create GitHub Release
   # -----------------------------------------------------------------------
   github-release:
     name: "Create GitHub Release"
     runs-on: ubuntu-latest
-    needs: [release-build, sbom-and-attest, publish, validate-release-inputs]
+    needs: [release-build, sbom-and-attest, publish, publish-wasm-npm, validate-release-inputs]
     if: ${{ !inputs.dry_run }}
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 313 | `find crates -name '*.rs'` |
-| Rust LOC | 212650 | `wc -l` |
-| Workspace tests | 4,699 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 213277 | `wc -l` |
+| Workspace tests | 4,706 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -113,12 +113,12 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 23 crates, 212650 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 23 crates, 213277 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 4,699 listed workspace tests
+         cryptographic proofs, 4,706 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
-         171 verified bridge exports — Rust -> WebAssembly -> JavaScript
+         165 verified WASM exports covered by 172 bridge checks — Rust -> WebAssembly -> JavaScript
 
 Layer 3: CommandBase.ai     (command-base/)
          Adjacent cockpit adapter for cognitiveplane.ai

--- a/crates/exo-avc/src/credential.rs
+++ b/crates/exo-avc/src/credential.rs
@@ -32,8 +32,35 @@ use crate::error::AvcError;
 pub const AVC_CREDENTIAL_SIGNING_DOMAIN: &str = "exo.avc.credential.v1";
 /// Schema version supported by this binary.
 pub const AVC_SCHEMA_VERSION: u16 = 1;
+/// Current AVC wire protocol version exposed by node and WASM adapters.
+pub const AVC_PROTOCOL_VERSION: u16 = 1;
+/// Oldest AVC wire protocol version this binary accepts.
+pub const AVC_MIN_SUPPORTED_PROTOCOL_VERSION: u16 = 1;
+/// Newest AVC wire protocol version this binary accepts.
+pub const AVC_MAX_SUPPORTED_PROTOCOL_VERSION: u16 = AVC_PROTOCOL_VERSION;
+/// Compatibility runway advertised to clients before an AVC protocol removal.
+pub const AVC_PROTOCOL_DEPRECATION_WINDOW_DAYS: u16 = 180;
 /// Maximum value (in basis points) that any AVC bp field may hold.
 pub const MAX_BASIS_POINTS: u32 = 10_000;
+
+/// Normalize an optional caller protocol version and reject unsupported ranges.
+///
+/// Missing protocol metadata is treated as legacy current-v1 traffic so
+/// existing AVC callers remain compatible while new clients can probe the
+/// explicit supported range through node/WASM discovery.
+pub fn require_supported_avc_protocol_version(
+    requested_protocol_version: Option<u16>,
+) -> Result<u16, AvcError> {
+    let got = requested_protocol_version.unwrap_or(AVC_PROTOCOL_VERSION);
+    if !(AVC_MIN_SUPPORTED_PROTOCOL_VERSION..=AVC_MAX_SUPPORTED_PROTOCOL_VERSION).contains(&got) {
+        return Err(AvcError::UnsupportedProtocol {
+            got,
+            min_supported: AVC_MIN_SUPPORTED_PROTOCOL_VERSION,
+            max_supported: AVC_MAX_SUPPORTED_PROTOCOL_VERSION,
+        });
+    }
+    Ok(got)
+}
 
 // ---------------------------------------------------------------------------
 // Subject kind
@@ -687,6 +714,28 @@ mod tests {
         draft.schema_version = 99;
         let err = issue_avc(draft, |_| fixed_signature()).unwrap_err();
         assert!(matches!(err, AvcError::UnsupportedSchema { got: 99, .. }));
+    }
+
+    #[test]
+    fn protocol_version_support_accepts_legacy_and_current_rejects_future() {
+        assert_eq!(
+            require_supported_avc_protocol_version(None).unwrap(),
+            AVC_PROTOCOL_VERSION
+        );
+        assert_eq!(
+            require_supported_avc_protocol_version(Some(AVC_PROTOCOL_VERSION)).unwrap(),
+            AVC_PROTOCOL_VERSION
+        );
+        let err = require_supported_avc_protocol_version(Some(AVC_PROTOCOL_VERSION + 1))
+            .expect_err("future AVC protocol version must fail closed");
+        assert!(matches!(
+            err,
+            AvcError::UnsupportedProtocol {
+                got,
+                min_supported: AVC_MIN_SUPPORTED_PROTOCOL_VERSION,
+                max_supported: AVC_MAX_SUPPORTED_PROTOCOL_VERSION,
+            } if got == AVC_PROTOCOL_VERSION + 1
+        ));
     }
 
     #[test]

--- a/crates/exo-avc/src/error.rs
+++ b/crates/exo-avc/src/error.rs
@@ -38,6 +38,16 @@ pub enum AvcError {
     #[error("AVC schema version {got} is unsupported (supported: {supported})")]
     UnsupportedSchema { got: u16, supported: u16 },
 
+    /// Protocol version is outside the supported compatibility range.
+    #[error(
+        "AVC protocol version {got} is unsupported (supported: {min_supported}..={max_supported})"
+    )]
+    UnsupportedProtocol {
+        got: u16,
+        min_supported: u16,
+        max_supported: u16,
+    },
+
     /// A basis point value was outside the legal `0..=10_000` range.
     #[error("AVC basis point field `{field}` value {value} exceeds 10_000")]
     BasisPointOutOfRange { field: &'static str, value: u32 },
@@ -104,6 +114,11 @@ mod tests {
             AvcError::UnsupportedSchema {
                 got: 99,
                 supported: 1,
+            },
+            AvcError::UnsupportedProtocol {
+                got: 99,
+                min_supported: 1,
+                max_supported: 1,
             },
             AvcError::BasisPointOutOfRange {
                 field: "risk",

--- a/crates/exo-avc/src/lib.rs
+++ b/crates/exo-avc/src/lib.rs
@@ -112,9 +112,12 @@ pub mod revocation;
 pub mod validation;
 
 pub use credential::{
-    AVC_CREDENTIAL_SIGNING_DOMAIN, AVC_SCHEMA_VERSION, AuthorityChainRef, AuthorityScope,
-    AutonomousVolitionCredential, AutonomyLevel, AvcConstraints, AvcDraft, AvcSubjectKind,
-    ConsentRef, DataClass, DelegatedIntent, MAX_BASIS_POINTS, PolicyRef, TimeWindow, issue_avc,
+    AVC_CREDENTIAL_SIGNING_DOMAIN, AVC_MAX_SUPPORTED_PROTOCOL_VERSION,
+    AVC_MIN_SUPPORTED_PROTOCOL_VERSION, AVC_PROTOCOL_DEPRECATION_WINDOW_DAYS, AVC_PROTOCOL_VERSION,
+    AVC_SCHEMA_VERSION, AuthorityChainRef, AuthorityScope, AutonomousVolitionCredential,
+    AutonomyLevel, AvcConstraints, AvcDraft, AvcSubjectKind, ConsentRef, DataClass,
+    DelegatedIntent, MAX_BASIS_POINTS, PolicyRef, TimeWindow, issue_avc,
+    require_supported_avc_protocol_version,
 };
 pub use delegation::{delegate_avc, parent_id_of};
 pub use error::AvcError;

--- a/crates/exo-avc/src/registry.rs
+++ b/crates/exo-avc/src/registry.rs
@@ -403,6 +403,29 @@ impl InMemoryAvcRegistry {
     pub fn get_receipt(&self, receipt_hash: &Hash256) -> Option<AvcTrustReceipt> {
         self.receipts.get(receipt_hash).cloned()
     }
+
+    /// List receipts whose referenced credential belongs to `subject_did`.
+    ///
+    /// Receipts are stored in a `BTreeMap`, so iteration order is the
+    /// canonical receipt hash order. Missing or deleted credentials are not
+    /// surfaced as actor-owned receipts because the subject cannot be proven.
+    #[must_use]
+    pub fn list_receipts_for_subject(
+        &self,
+        subject_did: &Did,
+        limit: usize,
+    ) -> Vec<AvcTrustReceipt> {
+        self.receipts
+            .values()
+            .filter(|receipt| {
+                self.credentials
+                    .get(&receipt.credential_id)
+                    .is_some_and(|credential| credential.subject_did == *subject_did)
+            })
+            .take(limit)
+            .cloned()
+            .collect()
+    }
 }
 
 impl AvcRegistryRead for InMemoryAvcRegistry {
@@ -968,6 +991,49 @@ mod tests {
             other => panic!("expected invalid receipt credential reference, got {other:?}"),
         }
         assert_eq!(reg.receipt_count(), 0);
+    }
+
+    #[test]
+    fn list_receipts_for_subject_filters_by_credential_subject_and_limit() {
+        let mut reg = fresh_registry();
+        let issuer_keypair = put_issuer_key(&mut reg);
+
+        let mut first_draft = baseline_draft();
+        first_draft.subject_did = did("agent-one");
+        first_draft.delegated_intent.intent_id = h256(0x31);
+        let first = issue_avc(first_draft, |bytes| issuer_keypair.sign(bytes)).unwrap();
+        let first_id = reg.put_credential(first).unwrap();
+
+        let mut second_draft = baseline_draft();
+        second_draft.subject_did = did("agent-one");
+        second_draft.delegated_intent.intent_id = h256(0x32);
+        let second = issue_avc(second_draft, |bytes| issuer_keypair.sign(bytes)).unwrap();
+        let second_id = reg.put_credential(second).unwrap();
+
+        let mut other_draft = baseline_draft();
+        other_draft.subject_did = did("agent-two");
+        other_draft.delegated_intent.intent_id = h256(0x33);
+        let other = issue_avc(other_draft, |bytes| issuer_keypair.sign(bytes)).unwrap();
+        let other_id = reg.put_credential(other).unwrap();
+
+        let first_receipt = receipt_for_credential(first_id);
+        let second_receipt = receipt_for_credential(second_id);
+        let other_receipt = receipt_for_credential(other_id);
+        reg.put_receipt(first_receipt.clone()).unwrap();
+        reg.put_receipt(other_receipt).unwrap();
+        reg.put_receipt(second_receipt.clone()).unwrap();
+
+        let mut expected = [first_receipt.clone(), second_receipt.clone()];
+        expected.sort_by_key(|receipt| receipt.receipt_id);
+
+        let listed = reg.list_receipts_for_subject(&did("agent-one"), 10);
+        assert_eq!(listed, expected);
+
+        let limited = reg.list_receipts_for_subject(&did("agent-one"), 1);
+        assert_eq!(limited.len(), 1);
+        assert_eq!(limited[0], expected[0]);
+
+        assert!(reg.list_receipts_for_subject(&did("nobody"), 10).is_empty());
     }
 
     #[test]

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -30,6 +30,9 @@
 //! | `POST` | `/api/v1/avc/issue` | Register a signed credential. |
 //! | `POST` | `/api/v1/avc/validate` | Validate a credential and optional action. |
 //! | `POST` | `/api/v1/avc/receipts/emit` | Validate a subject-signed action and mint a node-signed receipt. |
+//! | `GET`  | `/api/v1/avc/receipts/:hash` | Fetch a stored AVC trust receipt by hash. |
+//! | `GET`  | `/api/v1/avc/receipts?actor=<did>&limit=N` | List stored AVC trust receipts for a subject DID. |
+//! | `GET`  | `/api/v1/avc/protocol` | Discover node AVC protocol compatibility metadata. |
 //! | `POST` | `/api/v1/avc/delegate` | Register a signed child credential. |
 //! | `POST` | `/api/v1/avc/revoke` | Register a signed revocation. |
 //! | `GET`  | `/api/v1/avc/:id` | Fetch a registered credential by hex ID. |
@@ -51,16 +54,18 @@ use std::{
 
 use axum::{
     Json, Router,
-    extract::{DefaultBodyLimit, Path, State},
+    extract::{DefaultBodyLimit, Path, Query, State},
     http::StatusCode,
     routing::{get, post},
 };
 use exo_authority::permission::Permission;
 use exo_avc::{
+    AVC_MAX_SUPPORTED_PROTOCOL_VERSION, AVC_MIN_SUPPORTED_PROTOCOL_VERSION,
+    AVC_PROTOCOL_DEPRECATION_WINDOW_DAYS, AVC_PROTOCOL_VERSION, AVC_SCHEMA_VERSION,
     AutonomousVolitionCredential, AvcActionRequest, AvcDecision, AvcRegistryDurableState,
     AvcRegistryRead, AvcRegistryWrite, AvcRevocation, AvcTrustReceipt, AvcValidationRequest,
     AvcValidationResult, InMemoryAvcRegistry, avc_action_signature_payload, create_trust_receipt,
-    validate_avc,
+    require_supported_avc_protocol_version, validate_avc,
 };
 use exo_core::{
     Did, Hash256, PublicKey, Signature, Timestamp, crypto, hash::hash_structured, hlc::HybridClock,
@@ -83,9 +88,38 @@ const AVC_REGISTRY_DURABLE_STATE_FILE: &str = "avc-registry.cbor";
 const AVC_REGISTRY_POSTGRES_TABLE: &str = "avc_registry_state";
 const AVC_REGISTRY_POSTGRES_KEY: &str = "default";
 const AVC_REGISTRY_POSTGRES_LOCK_KEY: i64 = 0x4156_435F_5245_4749;
+const DEFAULT_AVC_RECEIPT_LIST_LIMIT: u32 = 50;
+const MAX_AVC_RECEIPT_LIST_LIMIT: u32 = 500;
+const WASM_PACKAGE_NAME: &str = "@exochain/exochain-wasm";
+const WASM_PACKAGE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub type AvcReceiptSigner = Arc<dyn Fn(&[u8]) -> Signature + Send + Sync>;
-type AvcReceiptTimestampSource = Arc<dyn Fn() -> anyhow::Result<Timestamp> + Send + Sync>;
+
+#[derive(Clone)]
+enum AvcReceiptTimestampSource {
+    HybridLogicalClock(Arc<Mutex<HybridClock>>),
+    Postgres(PgPool),
+    #[cfg(test)]
+    Fixed(Arc<dyn Fn() -> anyhow::Result<Timestamp> + Send + Sync>),
+}
+
+impl AvcReceiptTimestampSource {
+    async fn now(&self) -> anyhow::Result<Timestamp> {
+        match self {
+            Self::HybridLogicalClock(clock) => {
+                let mut clock = clock
+                    .lock()
+                    .map_err(|_| anyhow::anyhow!("AVC receipt HLC mutex poisoned"))?;
+                clock
+                    .now()
+                    .map_err(|error| anyhow::anyhow!("AVC receipt HLC unavailable: {error}"))
+            }
+            Self::Postgres(pool) => trusted_postgres_receipt_timestamp(pool).await,
+            #[cfg(test)]
+            Self::Fixed(source) => source(),
+        }
+    }
+}
 
 #[derive(Clone)]
 enum AvcRegistryDurability {
@@ -145,38 +179,51 @@ impl AvcApiState {
         database_pool: Option<PgPool>,
     ) -> anyhow::Result<Self> {
         let durable_state_path = data_dir.join(AVC_REGISTRY_DURABLE_STATE_FILE);
-        let (registry, durability) = match database_pool {
+        let (registry, durability, receipt_timestamp_source) = match database_pool {
             Some(pool) => {
                 let registry =
                     load_postgres_durable_registry_or_import_file(&pool, &durable_state_path)
                         .await?;
-                (registry, AvcRegistryDurability::Postgres(pool))
+                (
+                    registry,
+                    AvcRegistryDurability::Postgres(pool.clone()),
+                    AvcReceiptTimestampSource::Postgres(pool),
+                )
             }
             None => (
                 load_file_durable_registry(&durable_state_path)?,
                 AvcRegistryDurability::File(Arc::new(durable_state_path)),
+                receipt_timestamp_source_from_clock(HybridClock::new()),
             ),
         };
         Ok(Self {
             registry: Arc::new(Mutex::new(registry)),
             validator_did,
             receipt_signer,
-            receipt_timestamp_source: receipt_timestamp_source_from_clock(HybridClock::new()),
+            receipt_timestamp_source,
             durability,
         })
     }
 }
 
 fn receipt_timestamp_source_from_clock(clock: HybridClock) -> AvcReceiptTimestampSource {
-    let clock = Arc::new(Mutex::new(clock));
-    Arc::new(move || {
-        let mut clock = clock
-            .lock()
-            .map_err(|_| anyhow::anyhow!("AVC receipt HLC mutex poisoned"))?;
-        clock
-            .now()
-            .map_err(|error| anyhow::anyhow!("AVC receipt HLC unavailable: {error}"))
-    })
+    AvcReceiptTimestampSource::HybridLogicalClock(Arc::new(Mutex::new(clock)))
+}
+
+async fn trusted_postgres_receipt_timestamp(pool: &PgPool) -> anyhow::Result<Timestamp> {
+    let physical_ms: i64 =
+        sqlx::query_scalar("SELECT FLOOR(EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::BIGINT")
+            .fetch_one(pool)
+            .await
+            .map_err(|error| {
+                anyhow::anyhow!(
+                    "failed to read trusted AVC receipt timestamp from Postgres: {error}"
+                )
+            })?;
+    let physical_ms = u64::try_from(physical_ms).map_err(|_| {
+        anyhow::anyhow!("Postgres returned a negative AVC receipt timestamp: {physical_ms}")
+    })?;
+    Ok(Timestamp::new(physical_ms, 0))
 }
 
 fn load_file_durable_registry(path: &FsPath) -> anyhow::Result<InMemoryAvcRegistry> {
@@ -702,6 +749,34 @@ pub struct EmitReceiptResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct ListAvcReceiptsResponse {
+    pub did: String,
+    pub receipts: Vec<AvcTrustReceipt>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ListAvcReceiptsQuery {
+    actor: Option<String>,
+    limit: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AvcProtocolQuery {
+    protocol_version: Option<u16>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AvcProtocolInfo {
+    pub protocol_version: u16,
+    pub min_supported_protocol_version: u16,
+    pub max_supported_protocol_version: u16,
+    pub schema_version: u16,
+    pub wasm_package_name: String,
+    pub wasm_package_version: String,
+    pub deprecation_window_days: u16,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct AvcSummary {
     pub credential_id: String,
     pub subject_did: String,
@@ -773,8 +848,34 @@ fn receipt_timestamp_error(err: anyhow::Error) -> ApiError {
     )
 }
 
-fn trusted_receipt_timestamp(state: &AvcApiState) -> ApiResult<Timestamp> {
-    (state.receipt_timestamp_source)().map_err(receipt_timestamp_error)
+async fn trusted_receipt_timestamp(state: &AvcApiState) -> ApiResult<Timestamp> {
+    state
+        .receipt_timestamp_source
+        .now()
+        .await
+        .map_err(receipt_timestamp_error)
+}
+
+fn avc_receipt_list_limit(limit: Option<u32>) -> usize {
+    let capped = limit
+        .unwrap_or(DEFAULT_AVC_RECEIPT_LIST_LIMIT)
+        .min(MAX_AVC_RECEIPT_LIST_LIMIT);
+    match usize::try_from(capped) {
+        Ok(value) => value,
+        Err(_) => usize::from(u16::MAX),
+    }
+}
+
+fn avc_protocol_info() -> AvcProtocolInfo {
+    AvcProtocolInfo {
+        protocol_version: AVC_PROTOCOL_VERSION,
+        min_supported_protocol_version: AVC_MIN_SUPPORTED_PROTOCOL_VERSION,
+        max_supported_protocol_version: AVC_MAX_SUPPORTED_PROTOCOL_VERSION,
+        schema_version: AVC_SCHEMA_VERSION,
+        wasm_package_name: WASM_PACKAGE_NAME.into(),
+        wasm_package_version: WASM_PACKAGE_VERSION.into(),
+        deprecation_window_days: AVC_PROTOCOL_DEPRECATION_WINDOW_DAYS,
+    }
 }
 
 fn mutate_postgres_registry_blocking<T, F>(
@@ -888,6 +989,7 @@ fn map_avc_error(err: exo_avc::AvcError) -> ApiError {
     match err {
         exo_avc::AvcError::EmptyField { .. }
         | exo_avc::AvcError::UnsupportedSchema { .. }
+        | exo_avc::AvcError::UnsupportedProtocol { .. }
         | exo_avc::AvcError::BasisPointOutOfRange { .. }
         | exo_avc::AvcError::InvalidTimestamp { .. }
         | exo_avc::AvcError::DelegationWidens { .. }
@@ -1041,7 +1143,7 @@ async fn handle_emit_receipt(
 ) -> ApiResult<Json<EmitReceiptResponse>> {
     let validator_did = state.validator_did.clone();
     let receipt_signer = Arc::clone(&state.receipt_signer);
-    let trusted_now = trusted_receipt_timestamp(&state)?;
+    let trusted_now = trusted_receipt_timestamp(&state).await?;
     let response = with_registry_blocking(state, true, move |registry| {
         let submitted_request = payload.validation;
         let action_id = require_action(&submitted_request)?.action_id;
@@ -1078,6 +1180,55 @@ async fn handle_emit_receipt(
     })
     .await?;
     Ok(Json(response))
+}
+
+async fn handle_get_receipt(
+    State(state): State<Arc<AvcApiState>>,
+    Path(id): Path<String>,
+) -> ApiResult<Json<AvcTrustReceipt>> {
+    let hash = parse_hash(&id)?;
+    let receipt = with_registry_blocking(state, false, move |registry| {
+        registry
+            .get_receipt(&hash)
+            .ok_or((StatusCode::NOT_FOUND, "receipt not found".into()))
+    })
+    .await?;
+    Ok(Json(receipt))
+}
+
+async fn handle_list_receipts(
+    State(state): State<Arc<AvcApiState>>,
+    Query(query): Query<ListAvcReceiptsQuery>,
+) -> ApiResult<Json<ListAvcReceiptsResponse>> {
+    let actor = query.actor.ok_or((
+        StatusCode::BAD_REQUEST,
+        "actor query parameter is required".into(),
+    ))?;
+    let did = parse_did(&actor)?;
+    let did_for_response = did.to_string();
+    let did_for_lookup = did.clone();
+    let limit = avc_receipt_list_limit(query.limit);
+    let receipts = with_registry_blocking(state, false, move |registry| {
+        Ok(registry.list_receipts_for_subject(&did_for_lookup, limit))
+    })
+    .await?;
+    Ok(Json(ListAvcReceiptsResponse {
+        did: did_for_response,
+        receipts,
+    }))
+}
+
+async fn handle_protocol_info(
+    Query(query): Query<AvcProtocolQuery>,
+) -> ApiResult<Json<AvcProtocolInfo>> {
+    if query.protocol_version.is_none() {
+        tracing::info!(
+            protocol_version = AVC_PROTOCOL_VERSION,
+            "served legacy AVC protocol discovery without explicit requested version"
+        );
+    }
+    require_supported_avc_protocol_version(query.protocol_version).map_err(map_avc_error)?;
+    Ok(Json(avc_protocol_info()))
 }
 
 async fn handle_delegate(
@@ -1164,6 +1315,9 @@ pub fn avc_router(state: Arc<AvcApiState>) -> Router {
         .route("/api/v1/avc/issue", post(handle_issue))
         .route("/api/v1/avc/validate", post(handle_validate))
         .route("/api/v1/avc/receipts/emit", post(handle_emit_receipt))
+        .route("/api/v1/avc/receipts", get(handle_list_receipts))
+        .route("/api/v1/avc/receipts/:hash", get(handle_get_receipt))
+        .route("/api/v1/avc/protocol", get(handle_protocol_info))
         .route("/api/v1/avc/delegate", post(handle_delegate))
         .route("/api/v1/avc/revoke", post(handle_revoke))
         .route("/api/v1/avc/:id", get(handle_get))
@@ -1223,7 +1377,7 @@ mod tests {
     }
 
     fn fixed_receipt_timestamp_source(timestamp: Timestamp) -> AvcReceiptTimestampSource {
-        Arc::new(move || Ok(timestamp))
+        AvcReceiptTimestampSource::Fixed(Arc::new(move || Ok(timestamp)))
     }
 
     fn fresh_state() -> Arc<AvcApiState> {
@@ -1705,8 +1859,23 @@ mod tests {
         let state = Arc::new(state);
         let app = avc_router(Arc::clone(&state));
 
-        let first = credential_with_purpose("postgres anchor persistence one");
-        let second = credential_with_purpose("postgres anchor persistence two");
+        let trusted_now = trusted_receipt_timestamp(&state)
+            .await
+            .expect("trusted Postgres receipt timestamp");
+        let mut first_draft = baseline_draft();
+        first_draft.delegated_intent.purpose = "postgres anchor persistence one".into();
+        first_draft.expires_at = Some(Timestamp::new(trusted_now.physical_ms + 1_000_000, 0));
+        let first = {
+            let kp = issuer_keypair();
+            issue_avc(first_draft, |bytes| kp.sign(bytes)).unwrap()
+        };
+        let mut second_draft = baseline_draft();
+        second_draft.delegated_intent.purpose = "postgres anchor persistence two".into();
+        second_draft.expires_at = Some(Timestamp::new(trusted_now.physical_ms + 1_000_000, 0));
+        let second = {
+            let kp = issuer_keypair();
+            issue_avc(second_draft, |bytes| kp.sign(bytes)).unwrap()
+        };
         assert_eq!(
             issue_credential(app.clone(), first).await,
             StatusCode::OK,
@@ -2148,6 +2317,253 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn receipt_readback_returns_stored_avc_receipt_by_hash() {
+        let state = fresh_state();
+        let credential = baseline_credential();
+        state
+            .registry
+            .lock()
+            .unwrap()
+            .put_credential(credential.clone())
+            .unwrap();
+        let request = AvcValidationRequest {
+            credential,
+            action: Some(baseline_action(Did::new("did:exo:agent").unwrap())),
+            now: Timestamp::new(1_500_000, 0),
+        };
+        let body = serde_json::to_vec(&EmitReceiptRequest {
+            validation: request.clone(),
+            subject_signature: sign_action(&request, &subject_keypair()),
+            subject_public_key: None,
+        })
+        .unwrap();
+
+        let app = avc_router(Arc::clone(&state));
+        let emitted = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/avc/receipts/emit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(emitted.status(), StatusCode::OK);
+        let emitted: EmitReceiptResponse =
+            serde_json::from_slice(&read_body(emitted).await).unwrap();
+
+        let read_back = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri(format!("/api/v1/avc/receipts/{}", emitted.receipt_hash))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(read_back.status(), StatusCode::OK);
+        let parsed: AvcTrustReceipt = serde_json::from_slice(&read_body(read_back).await).unwrap();
+        assert_eq!(parsed, emitted.receipt);
+
+        let non_avc_receipt_route = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri(format!("/api/v1/receipts/{}", emitted.receipt_hash))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            non_avc_receipt_route.status(),
+            StatusCode::NOT_FOUND,
+            "AVC receipt read-back must not fall through to the DAG receipt store route"
+        );
+    }
+
+    #[tokio::test]
+    async fn receipt_readback_rejects_invalid_and_unknown_hashes() {
+        let state = fresh_state();
+        let app = avc_router(state);
+
+        let invalid = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/api/v1/avc/receipts/not-hex")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(invalid.status(), StatusCode::BAD_REQUEST);
+
+        let uppercase = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri(format!("/api/v1/avc/receipts/{}", "AA".repeat(32)))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(uppercase.status(), StatusCode::BAD_REQUEST);
+
+        let unknown = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri(format!("/api/v1/avc/receipts/{}", "11".repeat(32)))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(unknown.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn receipt_list_filters_by_actor_caps_limit_and_orders_deterministically() {
+        let state = fresh_state();
+        let first = credential_with_purpose("receipt list first");
+        let second = credential_with_purpose("receipt list second");
+        let other = credential_for_subject(Did::new("did:exo:other-agent").unwrap());
+        let first_id = first.id().unwrap();
+        let second_id = second.id().unwrap();
+        let other_id = other.id().unwrap();
+
+        let make_receipt = |credential_id: Hash256, action_byte: u8| {
+            let validation = AvcValidationResult {
+                credential_id,
+                decision: AvcDecision::Allow,
+                reason_codes: Vec::new(),
+                normalized_holder_did: Did::new("did:exo:agent").unwrap(),
+                valid_until: Some(Timestamp::new(2_000_000, 0)),
+                receipt: None,
+            };
+            create_trust_receipt(
+                &validation,
+                Some(Hash256::from_bytes([action_byte; 32])),
+                validator_did(),
+                Timestamp::new(1_600_000, 0),
+                |bytes| validator_keypair().sign(bytes),
+            )
+            .unwrap()
+        };
+        let first_receipt = make_receipt(first_id, 0x21);
+        let second_receipt = make_receipt(second_id, 0x22);
+        let other_receipt = make_receipt(other_id, 0x23);
+        {
+            let mut registry = state.registry.lock().unwrap();
+            registry.put_credential(second).unwrap();
+            registry.put_credential(other).unwrap();
+            registry.put_credential(first).unwrap();
+            registry.put_receipt(second_receipt.clone()).unwrap();
+            registry.put_receipt(other_receipt).unwrap();
+            registry.put_receipt(first_receipt.clone()).unwrap();
+        }
+
+        let app = avc_router(Arc::clone(&state));
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/api/v1/avc/receipts?actor=did:exo:agent&limit=1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let parsed: ListAvcReceiptsResponse =
+            serde_json::from_slice(&read_body(response).await).unwrap();
+        assert_eq!(parsed.did, "did:exo:agent");
+        assert_eq!(parsed.receipts.len(), 1);
+        let mut expected = [first_receipt, second_receipt];
+        expected.sort_by_key(|receipt| receipt.receipt_id);
+        assert_eq!(parsed.receipts[0], expected[0]);
+
+        let missing_actor = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/api/v1/avc/receipts")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(missing_actor.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn protocol_discovery_accepts_legacy_and_current_rejects_future_version() {
+        let state = fresh_state();
+        let app = avc_router(state);
+
+        let legacy = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/api/v1/avc/protocol")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(legacy.status(), StatusCode::OK);
+        let legacy_info: AvcProtocolInfo =
+            serde_json::from_slice(&read_body(legacy).await).unwrap();
+        assert_eq!(legacy_info.protocol_version, AVC_PROTOCOL_VERSION);
+        assert_eq!(
+            legacy_info.min_supported_protocol_version,
+            AVC_MIN_SUPPORTED_PROTOCOL_VERSION
+        );
+        assert_eq!(legacy_info.wasm_package_name, WASM_PACKAGE_NAME);
+
+        let current = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri(format!(
+                        "/api/v1/avc/protocol?protocol_version={AVC_PROTOCOL_VERSION}"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(current.status(), StatusCode::OK);
+
+        let future = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri(format!(
+                        "/api/v1/avc/protocol?protocol_version={}",
+                        AVC_MAX_SUPPORTED_PROTOCOL_VERSION + 1
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(future.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
     async fn receipt_emit_does_not_stamp_receipt_with_caller_validation_time() {
         let state = fresh_state();
         let credential = baseline_credential();
@@ -2408,6 +2824,11 @@ mod tests {
             exo_avc::AvcError::UnsupportedSchema {
                 got: 99,
                 supported: 1,
+            },
+            exo_avc::AvcError::UnsupportedProtocol {
+                got: 99,
+                min_supported: 1,
+                max_supported: 1,
             },
             exo_avc::AvcError::BasisPointOutOfRange {
                 field: "risk",
@@ -3236,8 +3657,21 @@ mod tests {
             "AVC durable registry must accept the existing gateway Postgres pool"
         );
         assert!(
-            production.contains("AvcRegistryDurability::Postgres(pool)"),
+            production.contains("AvcRegistryDurability::Postgres(pool.clone())"),
             "AVC durable registry must persist to Postgres when DATABASE_URL is configured"
+        );
+        assert!(
+            production.contains("AvcReceiptTimestampSource::Postgres(pool)"),
+            "Postgres-backed AVC runtime receipts must use the trusted database timestamp source"
+        );
+        assert!(
+            production
+                .contains("SELECT FLOOR(EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::BIGINT"),
+            "AVC production receipt timestamps must come from trusted Postgres clock_timestamp()"
+        );
+        assert!(
+            !production.contains("SystemTime::now") && !production.contains("Instant::now"),
+            "AVC production receipt emission must not read Rust system time directly"
         );
         assert!(
             production.contains("pg_advisory_xact_lock"),
@@ -3291,7 +3725,9 @@ mod avc_root_trust_tests {
             registry: Arc::new(Mutex::new(registry)),
             validator_did: Did::new("did:exo:test-validator").expect("test DID"),
             receipt_signer: signer,
-            receipt_timestamp_source: Arc::new(|| Ok(Timestamp::new(1_700_000, 0))),
+            receipt_timestamp_source: AvcReceiptTimestampSource::Fixed(Arc::new(|| {
+                Ok(Timestamp::new(1_700_000, 0))
+            })),
             durability: AvcRegistryDurability::None,
         }
     }

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -943,7 +943,7 @@ async fn start_node(
     }
     let avc_router = avc::avc_router(Arc::clone(&avc_state));
     tracing::info!(
-        "AVC router ready — /api/v1/avc/{{issue,validate,receipts/emit,delegate,revoke,:id}}, /api/v1/agents/:did/avcs"
+        "AVC router ready — /api/v1/avc/{{issue,validate,receipts,receipts/emit,protocol,delegate,revoke,:id}}, /api/v1/agents/:did/avcs"
     );
 
     // Build the economy API router (zero-priced launch settlement).

--- a/crates/exochain-wasm/src/avc_bindings.rs
+++ b/crates/exochain-wasm/src/avc_bindings.rs
@@ -34,10 +34,13 @@
 //! verification path ([`exo_core::crypto::verify`] over the same payload).
 
 use exo_avc::{
+    AVC_MAX_SUPPORTED_PROTOCOL_VERSION, AVC_MIN_SUPPORTED_PROTOCOL_VERSION,
+    AVC_PROTOCOL_DEPRECATION_WINDOW_DAYS, AVC_PROTOCOL_VERSION, AVC_SCHEMA_VERSION,
     AutonomousVolitionCredential, AvcActionRequest, AvcSubjectKind, AvcValidationRequest,
     DataClass, avc_action_signature_payload,
 };
 use exo_core::{PublicKey, Signature, Timestamp};
+use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
 use crate::serde_bridge::{MAX_JSON_INPUT_BYTES, from_json_str};
@@ -54,6 +57,19 @@ const SUBJECT_PUBLIC_KEY_HEX_LEN: usize = 64;
 const MAX_WASM_AVC_COLLECTION_ITEMS: usize = 256;
 const MAX_WASM_AVC_STRING_BYTES: usize = 4_096;
 const MAX_WASM_AVC_DID_BYTES: usize = 512;
+const WASM_PACKAGE_NAME: &str = "@exochain/exochain-wasm";
+const WASM_PACKAGE_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[derive(Serialize)]
+struct WasmAvcProtocolInfo {
+    protocol_version: u16,
+    min_supported_protocol_version: u16,
+    max_supported_protocol_version: u16,
+    schema_version: u16,
+    wasm_package_name: &'static str,
+    wasm_package_version: &'static str,
+    deprecation_window_days: u16,
+}
 
 fn ensure_json_input_at_most(value: &str, label: &str) -> Result<(), String> {
     if value.len() > MAX_JSON_INPUT_BYTES {
@@ -66,6 +82,19 @@ fn parse_credential_json(value: &str) -> Result<AutonomousVolitionCredential, St
     ensure_json_input_at_most(value, "credential")?;
     from_json_str::<AutonomousVolitionCredential>(value)
         .map_err(|_| "credential json: JSON parse error".to_string())
+}
+
+fn avc_protocol_info_json_core() -> Result<String, String> {
+    let info = WasmAvcProtocolInfo {
+        protocol_version: AVC_PROTOCOL_VERSION,
+        min_supported_protocol_version: AVC_MIN_SUPPORTED_PROTOCOL_VERSION,
+        max_supported_protocol_version: AVC_MAX_SUPPORTED_PROTOCOL_VERSION,
+        schema_version: AVC_SCHEMA_VERSION,
+        wasm_package_name: WASM_PACKAGE_NAME,
+        wasm_package_version: WASM_PACKAGE_VERSION,
+        deprecation_window_days: AVC_PROTOCOL_DEPRECATION_WINDOW_DAYS,
+    };
+    serde_json::to_string(&info).map_err(|e| format!("avc protocol info json: {e}"))
 }
 
 fn parse_action_json(value: &str) -> Result<AvcActionRequest, String> {
@@ -385,6 +414,12 @@ pub fn wasm_avc_action_signing_payload(
         .map_err(|e| JsValue::from_str(&e))
 }
 
+/// Return explicit AVC protocol/package compatibility metadata for clients.
+#[wasm_bindgen]
+pub fn wasm_avc_protocol_info() -> Result<String, JsValue> {
+    avc_protocol_info_json_core().map_err(|e| JsValue::from_str(&e))
+}
+
 /// Legacy raw subject-secret request builder.
 ///
 /// This fails closed for the same reason as [`wasm_avc_sign_action`].
@@ -562,6 +597,29 @@ mod tests {
         assert!(
             crypto::verify(&payload, &signature, &subject_pk),
             "externally signed wasm_avc_action_signing_payload output must verify"
+        );
+    }
+
+    #[test]
+    fn avc_protocol_info_exposes_supported_range_and_package_name() {
+        let info: serde_json::Value =
+            serde_json::from_str(&avc_protocol_info_json_core().expect("protocol info json"))
+                .expect("protocol info parses");
+        assert_eq!(info["protocol_version"], AVC_PROTOCOL_VERSION);
+        assert_eq!(
+            info["min_supported_protocol_version"],
+            AVC_MIN_SUPPORTED_PROTOCOL_VERSION
+        );
+        assert_eq!(
+            info["max_supported_protocol_version"],
+            AVC_MAX_SUPPORTED_PROTOCOL_VERSION
+        );
+        assert_eq!(info["schema_version"], AVC_SCHEMA_VERSION);
+        assert_eq!(info["wasm_package_name"], WASM_PACKAGE_NAME);
+        assert_eq!(info["wasm_package_version"], WASM_PACKAGE_VERSION);
+        assert_eq!(
+            info["deprecation_window_days"],
+            AVC_PROTOCOL_DEPRECATION_WINDOW_DAYS
         );
     }
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -30,7 +30,7 @@ environments.
 | ----------------------------------------- | ------------------------ | ----------------------------------------- | ----------------------------------------------------------------------- |
 | [`exochain-sdk`](./exochain-sdk/)         | TypeScript / JavaScript  | `npm install @exochain/sdk`               | Pure-JS client SDK for browsers and Node 20+; HTTP transport to gateway. |
 | [`exochain-py`](./exochain-py/)           | Python 3.11+             | `pip install exochain`                    | Python client SDK with `httpx` async transport and pydantic v2 models. |
-| [`exochain-wasm`](./exochain-wasm/)       | WebAssembly + TS shim    | `npm install exochain-wasm`               | Precompiled WASM build of the Rust governance engine for embedding.     |
+| [`exochain-wasm`](./exochain-wasm/)       | WebAssembly + TS shim    | `npm install @exochain/exochain-wasm`     | Precompiled WASM build of the Rust governance engine for embedding.     |
 
 The canonical Rust SDK lives at
 [`../crates/exochain-sdk`](../crates/exochain-sdk/). All three client SDKs
@@ -54,7 +54,7 @@ Pick by deployment target first, then by language preference:
   [`../crates/exochain-sdk`](../crates/exochain-sdk/) directly. It is the
   reference implementation.
 - **Browser or Node app that wants the full kernel in-process** —
-  `exochain-wasm`. Runs the Rust governance engine as WebAssembly.
+  `@exochain/exochain-wasm`. Runs the Rust governance engine as WebAssembly.
 
 ## Cross-language compatibility notes
 

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -2676,6 +2676,29 @@ test('wasm_avc_action_signing_payload supports the checked-in byte-parity vector
   return { payloadBytes: payload.length, payloadHex };
 });
 
+test('wasm_avc_protocol_info exposes AVC protocol and package metadata', () => {
+  const info = JSON.parse(wasm.wasm_avc_protocol_info());
+  if (info.protocol_version !== 1) {
+    throw new Error('AVC protocol_version must be current v1');
+  }
+  if (info.min_supported_protocol_version !== 1 || info.max_supported_protocol_version !== 1) {
+    throw new Error('AVC supported protocol range must be explicit and bounded to v1');
+  }
+  if (info.schema_version !== 1) {
+    throw new Error('AVC schema_version must be exposed as v1');
+  }
+  if (info.wasm_package_name !== '@exochain/exochain-wasm') {
+    throw new Error('WASM package name must be the scoped public npm package name');
+  }
+  if (typeof info.wasm_package_version !== 'string' || info.wasm_package_version.length === 0) {
+    throw new Error('WASM package version must be explicit');
+  }
+  if (!Number.isInteger(info.deprecation_window_days) || info.deprecation_window_days <= 0) {
+    throw new Error('AVC deprecation window must be a positive integer day count');
+  }
+  return info;
+});
+
 test('wasm_avc_action_signing_payload rejects a zero (non-caller-supplied) timestamp', () =>
   expectErrorContains(
     'wasm_avc_action_signing_payload zero-ts',

--- a/packages/exochain-wasm/wasm/LICENSE
+++ b/packages/exochain-wasm/wasm/LICENSE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms and conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/packages/exochain-wasm/wasm/package.json
+++ b/packages/exochain-wasm/wasm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "exochain-wasm",
+  "name": "@exochain/exochain-wasm",
   "description": "ExoChain governance engine — WebAssembly bindings for Node.js",
   "version": "0.1.0-beta",
   "license": "Apache-2.0",
@@ -8,9 +8,10 @@
     "url": "https://github.com/exochain/exochain"
   },
   "files": [
-    "exochain_wasm_bg.wasm",
+    "LICENSE",
+    "exochain_wasm.d.ts",
     "exochain_wasm.js",
-    "exochain_wasm.d.ts"
+    "exochain_wasm_bg.wasm"
   ],
   "main": "exochain_wasm.js",
   "types": "exochain_wasm.d.ts"

--- a/tools/prepare_wasm_npm_package.mjs
+++ b/tools/prepare_wasm_npm_package.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const packageDir = process.argv[2];
+if (!packageDir) {
+  console.error('usage: prepare_wasm_npm_package.mjs <wasm-package-dir>');
+  process.exit(1);
+}
+
+const packageJsonPath = path.join(packageDir, 'package.json');
+const licensePath = path.join(packageDir, 'LICENSE');
+if (!fs.existsSync(packageJsonPath)) {
+  console.error(`${packageJsonPath} is missing`);
+  process.exit(1);
+}
+if (!fs.existsSync(licensePath)) {
+  console.error(`${licensePath} is missing`);
+  process.exit(1);
+}
+
+const manifest = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+if (manifest.name !== '@exochain/exochain-wasm') {
+  console.error(`WASM package name must be @exochain/exochain-wasm, got ${manifest.name}`);
+  process.exit(1);
+}
+if (manifest.license !== 'Apache-2.0') {
+  console.error(`WASM package license must be Apache-2.0, got ${manifest.license}`);
+  process.exit(1);
+}
+if (manifest.private === true) {
+  console.error('WASM npm package must not be private');
+  process.exit(1);
+}
+
+const requiredFiles = [
+  'LICENSE',
+  'exochain_wasm.d.ts',
+  'exochain_wasm.js',
+  'exochain_wasm_bg.wasm',
+];
+const files = Array.isArray(manifest.files) ? manifest.files : [];
+manifest.files = requiredFiles;
+for (const required of requiredFiles) {
+  if (!files.includes(required) && required !== 'LICENSE') {
+    console.error(`WASM package files list is missing ${required}`);
+    process.exit(1);
+  }
+}
+if (manifest.main !== 'exochain_wasm.js') {
+  console.error(`WASM package main must be exochain_wasm.js, got ${manifest.main}`);
+  process.exit(1);
+}
+if (manifest.types !== 'exochain_wasm.d.ts') {
+  console.error(`WASM package types must be exochain_wasm.d.ts, got ${manifest.types}`);
+  process.exit(1);
+}
+
+fs.writeFileSync(packageJsonPath, `${JSON.stringify(manifest, null, 2)}\n`);

--- a/tools/test_release_dry_run_boundaries.sh
+++ b/tools/test_release_dry_run_boundaries.sh
@@ -49,6 +49,7 @@ done
 
 sbom_block=$(job_block "sbom-and-attest")
 github_release_block=$(job_block "github-release")
+wasm_publish_block=$(job_block "publish-wasm-npm")
 
 grep -F 'attestations: write' <<<"$sbom_block" >/dev/null \
   || fail "sbom-and-attest must remain the only attestation-writing job"
@@ -58,6 +59,10 @@ grep -F 'contents: write' <<<"$github_release_block" >/dev/null \
   || fail "github-release must retain release publishing permission for real releases"
 grep -F 'softprops/action-gh-release@' <<<"$github_release_block" >/dev/null \
   || fail "github-release must remain the GitHub Release job for real releases"
+grep -F 'npm pack --dry-run' <<<"$wasm_publish_block" >/dev/null \
+  || fail "publish-wasm-npm must dry-pack the WASM package"
+grep -F 'if: ${{ !inputs.dry_run }}' <<<"$wasm_publish_block" >/dev/null \
+  || fail "publish-wasm-npm must guard npm publish for dry-run releases"
 
 if grep -F 'draft: ${{ inputs.dry_run }}' "$workflow" >/dev/null; then
   fail "dry-run releases must not create draft GitHub Releases"

--- a/tools/test_release_publish_boundaries.sh
+++ b/tools/test_release_publish_boundaries.sh
@@ -35,20 +35,32 @@ job_block() {
 }
 
 publish_block=$(job_block "publish")
+wasm_publish_block=$(job_block "publish-wasm-npm")
 github_release_block=$(job_block "github-release")
 
 [[ -n "$publish_block" ]] || fail "publish job is missing"
+[[ -n "$wasm_publish_block" ]] || fail "publish-wasm-npm job is missing"
 [[ -n "$github_release_block" ]] || fail "github-release job is missing"
 
 grep -F 'if: ${{ !inputs.dry_run }}' <<<"$publish_block" >/dev/null \
   || fail "publish job must be skipped for dry-run releases"
 grep -F 'if: ${{ !inputs.dry_run }}' <<<"$github_release_block" >/dev/null \
   || fail "github-release job must be skipped for dry-run releases"
+grep -F 'if: ${{ !inputs.dry_run }}' <<<"$wasm_publish_block" >/dev/null \
+  || fail "publish-wasm-npm must guard the npm publish step for dry-run releases"
 
 grep -F 'CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}' <<<"$publish_block" >/dev/null \
   || fail "publish job must use the crates.io registry token"
 grep -F 'cargo publish -p "$crate" --allow-dirty' <<<"$publish_block" >/dev/null \
   || fail "publish job must publish every crate in the dependency-ordered loop"
+grep -F 'NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}' <<<"$wasm_publish_block" >/dev/null \
+  || fail "publish-wasm-npm job must use the npm automation token"
+grep -F 'npm publish --access public --provenance' <<<"$wasm_publish_block" >/dev/null \
+  || fail "publish-wasm-npm must publish the public package with npm provenance"
+grep -F 'npm pack --dry-run' <<<"$wasm_publish_block" >/dev/null \
+  || fail "publish-wasm-npm must dry-pack before publish"
+grep -F 'manifest.version !== process.env.RELEASE_VERSION' <<<"$wasm_publish_block" >/dev/null \
+  || fail "publish-wasm-npm must bind package version to the validated release version"
 
 if grep -E 'cargo publish.*\|\|' <<<"$publish_block" >/dev/null; then
   fail "cargo publish failures must fail the publish job"
@@ -56,5 +68,7 @@ fi
 
 grep -E 'needs:.*publish' <<<"$github_release_block" >/dev/null \
   || fail "github-release must depend on successful crates.io publication"
+grep -E 'needs:.*publish-wasm-npm' <<<"$github_release_block" >/dev/null \
+  || fail "github-release must depend on successful WASM npm package verification/publication"
 
 printf 'release publish boundary test passed\n'

--- a/tools/test_release_version_input_boundary.sh
+++ b/tools/test_release_version_input_boundary.sh
@@ -71,7 +71,7 @@ grep -F '${{ needs.validate-release-inputs.outputs.version }}' "$workflow" >/dev
 grep -F '${{ needs.validate-release-inputs.outputs.tag }}' "$workflow" >/dev/null \
   || fail "release jobs must consume the sanitized tag output"
 
-for job in approve verify-signed-tag release-build sbom-and-attest publish github-release; do
+for job in approve verify-signed-tag release-build sbom-and-attest publish publish-wasm-npm github-release; do
   block=$(job_block "$job")
   [[ -n "$block" ]] || fail "job $job is missing"
   grep -F 'validate-release-inputs' <<<"$block" >/dev/null \

--- a/tools/test_release_workflow_ref_binding.sh
+++ b/tools/test_release_workflow_ref_binding.sh
@@ -34,7 +34,7 @@ job_block() {
   ' "$workflow"
 }
 
-for job in release-build sbom-and-attest publish; do
+for job in release-build sbom-and-attest publish publish-wasm-npm; do
   block=$(job_block "$job")
   [[ -n "$block" ]] || fail "job $job is missing"
   grep -F 'id: release-ref' <<<"$block" >/dev/null \

--- a/tools/test_wasm_npm_package_boundary.sh
+++ b/tools/test_wasm_npm_package_boundary.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Copyright 2026 Exochain Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+fail() {
+  printf 'WASM npm package boundary test failed: %s\n' "$1" >&2
+  exit 1
+}
+
+ci_workflow=".github/workflows/ci.yml"
+release_workflow=".github/workflows/release.yml"
+package_json="packages/exochain-wasm/wasm/package.json"
+package_license="packages/exochain-wasm/wasm/LICENSE"
+prep_script="tools/prepare_wasm_npm_package.mjs"
+
+for file in "$ci_workflow" "$release_workflow" "$package_json" "$package_license" "$prep_script"; do
+  [[ -f "$file" ]] || fail "$file is missing"
+done
+
+grep -F 'wasm-pack build crates/exochain-wasm --target nodejs --scope exochain' "$ci_workflow" >/dev/null \
+  || fail "CI WASM build must generate the scoped @exochain package"
+grep -F 'node tools/prepare_wasm_npm_package.mjs packages/exochain-wasm/wasm' "$ci_workflow" >/dev/null \
+  || fail "CI WASM build must normalize npm package metadata"
+grep -F 'npm pack --dry-run' "$ci_workflow" >/dev/null \
+  || fail "CI WASM build must dry-pack the npm package"
+
+grep -F 'wasm-pack build crates/exochain-wasm --target nodejs --scope exochain' "$release_workflow" >/dev/null \
+  || fail "release workflow must generate the scoped @exochain package"
+grep -F 'npm publish --access public --provenance' "$release_workflow" >/dev/null \
+  || fail "release workflow must publish npm package with provenance"
+grep -F 'NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}' "$release_workflow" >/dev/null \
+  || fail "release workflow must use the npm token only at publish step"
+grep -F 'id-token: write' "$release_workflow" >/dev/null \
+  || fail "release workflow must grant OIDC for npm provenance"
+
+node - "$package_json" <<'NODE'
+const fs = require('node:fs');
+const manifest = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+const fail = (message) => {
+  console.error(message);
+  process.exit(1);
+};
+if (manifest.name !== '@exochain/exochain-wasm') {
+  fail(`expected scoped package name, got ${manifest.name}`);
+}
+if (manifest.license !== 'Apache-2.0') {
+  fail(`expected Apache-2.0 license, got ${manifest.license}`);
+}
+for (const required of ['LICENSE', 'exochain_wasm_bg.wasm', 'exochain_wasm.js', 'exochain_wasm.d.ts']) {
+  if (!manifest.files.includes(required)) {
+    fail(`package files must include ${required}`);
+  }
+}
+NODE
+
+printf 'WASM npm package boundary test passed\n'


### PR DESCRIPTION
## Summary

Fixes #690, fixes #685, fixes #688, and fixes #689.

- Replaces the AVC durable-registry receipt timestamp stub path with an explicit timestamp source boundary. Postgres-backed production state now uses trusted database `clock_timestamp()`; deterministic HLC/fixed sources remain for local/test paths.
- Adds AVC-native receipt read-back routes: `GET /api/v1/avc/receipts/:hash` and `GET /api/v1/avc/receipts?actor=<did>&limit=N`.
- Adds explicit AVC protocol metadata in core, node discovery, and WASM export, including supported range and future-version rejection.
- Makes the WASM package publishable as `@exochain/exochain-wasm`, includes package-local Apache-2.0 license, adds `npm pack --dry-run`, and adds release workflow npm publish with provenance.

## Path Classification

- EXOCHAIN core: `crates/exo-avc/src/{credential,error,lib,registry}.rs`.
- Core runtime adapter: `crates/exo-node/src/{avc,main}.rs`, `crates/exochain-wasm/src/avc_bindings.rs`, `packages/exochain-wasm/**`.
- CI/release contract: `.github/workflows/{ci,release}.yml`, `tools/prepare_wasm_npm_package.mjs`, `tools/test_*release*`, `tools/test_wasm_npm_package_boundary.sh`.
- Adjacent surface: none.
- Imported evidence / third-party/vendor: none.

## Core Regression Firewall

This changes AVC core metadata/registry behavior, AVC node routes, WASM package metadata, and CI/release workflow boundaries. It does not modify unrelated adjacent products.

The Postgres receipt timestamp boundary intentionally avoids direct Rust `SystemTime::now()` / `Instant::now()` in `crates/exo-node/src/avc.rs`; a source guard now checks that.

## Verification

- `cargo test -p exo-avc -- --nocapture`
- `cargo test -p exo-node avc::tests -- --nocapture`
- `cargo test -p exochain-wasm avc_bindings -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy -p exo-node --bins --tests -- -D warnings`
- `bash tools/test_release_workflow_ref_binding.sh`
- `bash tools/test_release_version_input_boundary.sh`
- `bash tools/test_release_dry_run_boundaries.sh`
- `bash tools/test_release_publish_boundaries.sh`
- `bash tools/test_wasm_npm_package_boundary.sh`
- `bash tools/test_ci_supply_chain_hardening.sh`
- `bash tools/ci_cargo_retry.sh wasm-pack build crates/exochain-wasm --target nodejs --scope exochain --out-dir ../../packages/exochain-wasm/wasm`
- `cp LICENSE packages/exochain-wasm/wasm/LICENSE && node tools/prepare_wasm_npm_package.mjs packages/exochain-wasm/wasm`
- `npm pack --dry-run` from `packages/exochain-wasm/wasm`
- `node packages/exochain-wasm/test/bridge_verification.mjs` (`172/172 passed`)
- `git diff --check`

## Notes

PR #691's root cause was credible, but this implementation does not take its direct `SystemTime::now()` approach. The runtime source is explicit and fails through the existing AVC timestamp-unavailable path if the trusted source cannot be read.
