### PR TITLE
[codex] Harden AVC trust receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 23 | `ls -d crates/*/` |
 | Rust source files | 313 | `find crates -name '*.rs'` |
-| Rust LOC | 213277 | `wc -l` |
-| Workspace tests | 4,706 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 214750 | `wc -l` |
+| Workspace tests | 4,740 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates, plus required aggregator |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |

--- a/crates/exo-avc/src/lib.rs
+++ b/crates/exo-avc/src/lib.rs
@@ -123,7 +123,7 @@ pub use delegation::{delegate_avc, parent_id_of};
 pub use error::AvcError;
 pub use receipt::{
     AVC_RECEIPT_SIGNING_DOMAIN, AvcReceiptTimestampProvenance, AvcTrustReceipt,
-    create_trust_receipt, create_trust_receipt_with_evidence,
+    AvcTrustReceiptEvidence, create_trust_receipt, create_trust_receipt_with_evidence,
 };
 pub use registry::{
     AvcRegistryDurableState, AvcRegistryRead, AvcRegistryWrite, InMemoryAvcRegistry,

--- a/crates/exo-avc/src/lib.rs
+++ b/crates/exo-avc/src/lib.rs
@@ -121,7 +121,10 @@ pub use credential::{
 };
 pub use delegation::{delegate_avc, parent_id_of};
 pub use error::AvcError;
-pub use receipt::{AVC_RECEIPT_SIGNING_DOMAIN, AvcTrustReceipt, create_trust_receipt};
+pub use receipt::{
+    AVC_RECEIPT_SIGNING_DOMAIN, AvcReceiptTimestampProvenance, AvcTrustReceipt,
+    create_trust_receipt, create_trust_receipt_with_evidence,
+};
 pub use registry::{
     AvcRegistryDurableState, AvcRegistryRead, AvcRegistryWrite, InMemoryAvcRegistry,
 };
@@ -129,14 +132,16 @@ pub use revocation::{
     AVC_REVOCATION_SIGNING_DOMAIN, AvcRevocation, AvcRevocationReason, revoke_avc,
 };
 pub use validation::{
-    AVC_ACTION_SIGNING_DOMAIN, AVC_HUMAN_APPROVAL_SIGNING_DOMAIN, AvcActionRequest, AvcDecision,
-    AvcHumanApproval, AvcReasonCode, AvcValidationRequest, AvcValidationResult,
-    avc_action_signature_payload, human_approval_signature_payload, validate_avc,
+    AVC_ACTION_COMMITMENT_DOMAIN, AVC_ACTION_SIGNING_DOMAIN, AVC_HUMAN_APPROVAL_SIGNING_DOMAIN,
+    AvcActionRequest, AvcDecision, AvcHumanApproval, AvcReasonCode, AvcValidationRequest,
+    AvcValidationResult, avc_action_commitment_hash, avc_action_signature_payload,
+    human_approval_signature_payload, validate_avc,
 };
 
 /// All AVC signing domains as a sorted slice — used by hygiene tests
 /// and external auditors who need to ensure no domain collisions.
 pub const AVC_SIGNING_DOMAINS: &[&str] = &[
+    AVC_ACTION_COMMITMENT_DOMAIN,
     AVC_ACTION_SIGNING_DOMAIN,
     AVC_CREDENTIAL_SIGNING_DOMAIN,
     AVC_HUMAN_APPROVAL_SIGNING_DOMAIN,

--- a/crates/exo-avc/src/receipt.rs
+++ b/crates/exo-avc/src/receipt.rs
@@ -39,12 +39,25 @@ pub struct AvcTrustReceipt {
     pub receipt_id: Hash256,
     pub credential_id: Hash256,
     pub action_id: Option<Hash256>,
+    #[serde(default)]
+    pub action_commitment_hash: Option<Hash256>,
+    #[serde(default)]
+    pub previous_receipt_hash: Option<Hash256>,
+    #[serde(default)]
+    pub timestamp_provenance: Option<AvcReceiptTimestampProvenance>,
     pub validator_did: Did,
     pub decision: AvcDecision,
     pub reason_codes: Vec<AvcReasonCode>,
     pub created_at: Timestamp,
     pub validation_hash: Hash256,
     pub signature: Signature,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AvcReceiptTimestampProvenance {
+    PostgresClockTimestamp,
+    LocalHybridLogicalClock,
+    FixedTestTimestamp,
 }
 
 #[derive(Serialize)]
@@ -60,25 +73,66 @@ struct ReceiptSigningPayload<'a> {
     validation_hash: &'a Hash256,
 }
 
+#[derive(Serialize)]
+struct ExtendedReceiptSigningPayload<'a> {
+    domain: &'static str,
+    schema_version: u16,
+    credential_id: &'a Hash256,
+    action_id: Option<&'a Hash256>,
+    action_commitment_hash: Option<&'a Hash256>,
+    previous_receipt_hash: Option<&'a Hash256>,
+    timestamp_provenance: Option<&'a AvcReceiptTimestampProvenance>,
+    validator_did: &'a Did,
+    decision: &'a AvcDecision,
+    reason_codes: &'a [AvcReasonCode],
+    created_at: &'a Timestamp,
+    validation_hash: &'a Hash256,
+}
+
 impl AvcTrustReceipt {
+    #[must_use]
+    pub fn has_extended_evidence(&self) -> bool {
+        self.action_commitment_hash.is_some()
+            || self.previous_receipt_hash.is_some()
+            || self.timestamp_provenance.is_some()
+    }
+
     /// Compute the canonical signing payload bytes for this receipt.
     ///
     /// # Errors
     /// Returns [`AvcError::Serialization`] when CBOR encoding fails.
     pub fn signing_payload(&self) -> Result<Vec<u8>, AvcError> {
-        let payload = ReceiptSigningPayload {
-            domain: AVC_RECEIPT_SIGNING_DOMAIN,
-            schema_version: self.schema_version,
-            credential_id: &self.credential_id,
-            action_id: self.action_id.as_ref(),
-            validator_did: &self.validator_did,
-            decision: &self.decision,
-            reason_codes: &self.reason_codes,
-            created_at: &self.created_at,
-            validation_hash: &self.validation_hash,
-        };
         let mut buf = Vec::new();
-        ciborium::ser::into_writer(&payload, &mut buf)?;
+        if self.has_extended_evidence() {
+            let payload = ExtendedReceiptSigningPayload {
+                domain: AVC_RECEIPT_SIGNING_DOMAIN,
+                schema_version: self.schema_version,
+                credential_id: &self.credential_id,
+                action_id: self.action_id.as_ref(),
+                action_commitment_hash: self.action_commitment_hash.as_ref(),
+                previous_receipt_hash: self.previous_receipt_hash.as_ref(),
+                timestamp_provenance: self.timestamp_provenance.as_ref(),
+                validator_did: &self.validator_did,
+                decision: &self.decision,
+                reason_codes: &self.reason_codes,
+                created_at: &self.created_at,
+                validation_hash: &self.validation_hash,
+            };
+            ciborium::ser::into_writer(&payload, &mut buf)?;
+        } else {
+            let payload = ReceiptSigningPayload {
+                domain: AVC_RECEIPT_SIGNING_DOMAIN,
+                schema_version: self.schema_version,
+                credential_id: &self.credential_id,
+                action_id: self.action_id.as_ref(),
+                validator_did: &self.validator_did,
+                decision: &self.decision,
+                reason_codes: &self.reason_codes,
+                created_at: &self.created_at,
+                validation_hash: &self.validation_hash,
+            };
+            ciborium::ser::into_writer(&payload, &mut buf)?;
+        }
         Ok(buf)
     }
 
@@ -119,6 +173,39 @@ pub fn create_trust_receipt<F>(
 where
     F: FnOnce(&[u8]) -> Signature,
 {
+    create_trust_receipt_with_evidence(
+        validation,
+        action_id,
+        None,
+        None,
+        None,
+        validator_did,
+        now,
+        sign,
+    )
+}
+
+/// Build and sign a trust receipt with local evidence fields.
+///
+/// When all evidence fields are absent, this preserves the legacy v1
+/// signing payload exactly. When any evidence field is present, all
+/// evidence fields are included in the signed payload and receipt ID.
+///
+/// # Errors
+/// Returns [`AvcError::Serialization`] when CBOR encoding fails.
+pub fn create_trust_receipt_with_evidence<F>(
+    validation: &AvcValidationResult,
+    action_id: Option<Hash256>,
+    action_commitment_hash: Option<Hash256>,
+    previous_receipt_hash: Option<Hash256>,
+    timestamp_provenance: Option<AvcReceiptTimestampProvenance>,
+    validator_did: Did,
+    now: Timestamp,
+    sign: F,
+) -> Result<AvcTrustReceipt, AvcError>
+where
+    F: FnOnce(&[u8]) -> Signature,
+{
     let validation_hash = hash_structured(validation).map_err(AvcError::from)?;
 
     // Build the receipt with an empty signature first so we can compute
@@ -128,6 +215,9 @@ where
         receipt_id: Hash256::ZERO,
         credential_id: validation.credential_id,
         action_id,
+        action_commitment_hash,
+        previous_receipt_hash,
+        timestamp_provenance,
         validator_did,
         decision: validation.decision,
         reason_codes: validation.reason_codes.clone(),
@@ -270,5 +360,113 @@ mod tests {
         )
         .unwrap();
         assert_eq!(r1.action_id, Some(action_id));
+    }
+
+    #[test]
+    fn legacy_receipt_payload_stays_v1_when_evidence_absent() {
+        let (validation, _id) = sample_validation();
+        let receipt = create_trust_receipt(&validation, None, did("validator"), ts(2_000), |_| {
+            fixed_signature()
+        })
+        .unwrap();
+        assert!(!receipt.has_extended_evidence());
+
+        let legacy_payload = ReceiptSigningPayload {
+            domain: AVC_RECEIPT_SIGNING_DOMAIN,
+            schema_version: receipt.schema_version,
+            credential_id: &receipt.credential_id,
+            action_id: receipt.action_id.as_ref(),
+            validator_did: &receipt.validator_did,
+            decision: &receipt.decision,
+            reason_codes: &receipt.reason_codes,
+            created_at: &receipt.created_at,
+            validation_hash: &receipt.validation_hash,
+        };
+        let mut expected = Vec::new();
+        ciborium::ser::into_writer(&legacy_payload, &mut expected).unwrap();
+
+        assert_eq!(receipt.signing_payload().unwrap(), expected);
+        assert!(receipt.verify_id().unwrap());
+    }
+
+    #[test]
+    fn legacy_receipt_deserializes_with_absent_evidence_fields() {
+        #[derive(Serialize)]
+        struct LegacyReceiptWire<'a> {
+            schema_version: u16,
+            receipt_id: &'a Hash256,
+            credential_id: &'a Hash256,
+            action_id: Option<&'a Hash256>,
+            validator_did: &'a Did,
+            decision: &'a AvcDecision,
+            reason_codes: &'a [AvcReasonCode],
+            created_at: &'a Timestamp,
+            validation_hash: &'a Hash256,
+            signature: &'a Signature,
+        }
+
+        let (validation, _id) = sample_validation();
+        let receipt = create_trust_receipt(&validation, None, did("validator"), ts(2_000), |_| {
+            fixed_signature()
+        })
+        .unwrap();
+        let legacy_wire = LegacyReceiptWire {
+            schema_version: receipt.schema_version,
+            receipt_id: &receipt.receipt_id,
+            credential_id: &receipt.credential_id,
+            action_id: receipt.action_id.as_ref(),
+            validator_did: &receipt.validator_did,
+            decision: &receipt.decision,
+            reason_codes: &receipt.reason_codes,
+            created_at: &receipt.created_at,
+            validation_hash: &receipt.validation_hash,
+            signature: &receipt.signature,
+        };
+        let mut bytes = Vec::new();
+        ciborium::ser::into_writer(&legacy_wire, &mut bytes).unwrap();
+
+        let decoded: AvcTrustReceipt = ciborium::de::from_reader(bytes.as_slice()).unwrap();
+
+        assert_eq!(decoded.action_commitment_hash, None);
+        assert_eq!(decoded.previous_receipt_hash, None);
+        assert_eq!(decoded.timestamp_provenance, None);
+        assert_eq!(
+            decoded.signing_payload().unwrap(),
+            receipt.signing_payload().unwrap()
+        );
+        assert!(decoded.verify_id().unwrap());
+    }
+
+    #[test]
+    fn extended_evidence_changes_signed_receipt_payload_and_id() {
+        let (validation, _id) = sample_validation();
+        let action_id = Hash256::from_bytes([0x42; 32]);
+        let legacy = create_trust_receipt(
+            &validation,
+            Some(action_id),
+            did("validator"),
+            ts(2_000),
+            |_| fixed_signature(),
+        )
+        .unwrap();
+        let extended = create_trust_receipt_with_evidence(
+            &validation,
+            Some(action_id),
+            Some(Hash256::from_bytes([0xA1; 32])),
+            None,
+            Some(AvcReceiptTimestampProvenance::LocalHybridLogicalClock),
+            did("validator"),
+            ts(2_000),
+            |_| fixed_signature(),
+        )
+        .unwrap();
+
+        assert!(extended.has_extended_evidence());
+        assert_ne!(
+            legacy.signing_payload().unwrap(),
+            extended.signing_payload().unwrap()
+        );
+        assert_ne!(legacy.receipt_id, extended.receipt_id);
+        assert!(extended.verify_id().unwrap());
     }
 }

--- a/crates/exo-avc/src/receipt.rs
+++ b/crates/exo-avc/src/receipt.rs
@@ -60,6 +60,17 @@ pub enum AvcReceiptTimestampProvenance {
     FixedTestTimestamp,
 }
 
+/// Optional local evidence included in extended trust receipt payloads.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct AvcTrustReceiptEvidence {
+    /// Hash committing to the credential action being receipted.
+    pub action_commitment_hash: Option<Hash256>,
+    /// Previous receipt hash used to link extended receipts in order.
+    pub previous_receipt_hash: Option<Hash256>,
+    /// Source of the trusted timestamp used for this receipt.
+    pub timestamp_provenance: Option<AvcReceiptTimestampProvenance>,
+}
+
 #[derive(Serialize)]
 struct ReceiptSigningPayload<'a> {
     domain: &'static str,
@@ -176,9 +187,7 @@ where
     create_trust_receipt_with_evidence(
         validation,
         action_id,
-        None,
-        None,
-        None,
+        AvcTrustReceiptEvidence::default(),
         validator_did,
         now,
         sign,
@@ -196,9 +205,7 @@ where
 pub fn create_trust_receipt_with_evidence<F>(
     validation: &AvcValidationResult,
     action_id: Option<Hash256>,
-    action_commitment_hash: Option<Hash256>,
-    previous_receipt_hash: Option<Hash256>,
-    timestamp_provenance: Option<AvcReceiptTimestampProvenance>,
+    evidence: AvcTrustReceiptEvidence,
     validator_did: Did,
     now: Timestamp,
     sign: F,
@@ -215,9 +222,9 @@ where
         receipt_id: Hash256::ZERO,
         credential_id: validation.credential_id,
         action_id,
-        action_commitment_hash,
-        previous_receipt_hash,
-        timestamp_provenance,
+        action_commitment_hash: evidence.action_commitment_hash,
+        previous_receipt_hash: evidence.previous_receipt_hash,
+        timestamp_provenance: evidence.timestamp_provenance,
         validator_did,
         decision: validation.decision,
         reason_codes: validation.reason_codes.clone(),
@@ -452,9 +459,11 @@ mod tests {
         let extended = create_trust_receipt_with_evidence(
             &validation,
             Some(action_id),
-            Some(Hash256::from_bytes([0xA1; 32])),
-            None,
-            Some(AvcReceiptTimestampProvenance::LocalHybridLogicalClock),
+            AvcTrustReceiptEvidence {
+                action_commitment_hash: Some(Hash256::from_bytes([0xA1; 32])),
+                previous_receipt_hash: None,
+                timestamp_provenance: Some(AvcReceiptTimestampProvenance::LocalHybridLogicalClock),
+            },
             did("validator"),
             ts(2_000),
             |_| fixed_signature(),

--- a/crates/exo-avc/src/registry.rs
+++ b/crates/exo-avc/src/registry.rs
@@ -63,6 +63,7 @@ pub trait AvcRegistryWrite: AvcRegistryRead {
     fn put_revocation(&mut self, revocation: AvcRevocation) -> Result<(), AvcError>;
     fn put_receipt(&mut self, receipt: AvcTrustReceipt) -> Result<(), AvcError>;
     fn put_public_key(&mut self, did: Did, public_key: PublicKey);
+    fn put_receipt_validator_public_key(&mut self, did: Did, public_key: PublicKey);
     fn put_issuer_permission_grant(&mut self, did: Did, granted_permissions: Vec<Permission>);
     fn put_human_approval_key(&mut self, did: Did, public_key: PublicKey);
     fn add_consent_ref(&mut self, consent_id: Hash256);
@@ -81,6 +82,8 @@ pub struct AvcRegistryDurableState {
     pub credentials: BTreeMap<Hash256, AutonomousVolitionCredential>,
     pub revocations: BTreeMap<Hash256, AvcRevocation>,
     pub receipts: BTreeMap<Hash256, AvcTrustReceipt>,
+    #[serde(default)]
+    pub receipt_chain_head: Option<Hash256>,
 }
 
 /// Deterministic in-memory implementation of the registry traits.
@@ -90,7 +93,9 @@ pub struct InMemoryAvcRegistry {
     by_subject: BTreeMap<Did, BTreeSet<Hash256>>,
     revocations: BTreeMap<Hash256, AvcRevocation>,
     receipts: BTreeMap<Hash256, AvcTrustReceipt>,
+    receipt_chain_head: Option<Hash256>,
     public_keys: BTreeMap<Did, PublicKey>,
+    receipt_validator_public_keys: BTreeMap<Did, PublicKey>,
     issuer_permission_grants: BTreeMap<Did, BTreeSet<Permission>>,
     human_approval_keys: BTreeMap<Did, PublicKey>,
     consent_refs: BTreeSet<Hash256>,
@@ -111,6 +116,7 @@ impl InMemoryAvcRegistry {
             credentials: self.credentials.clone(),
             revocations: self.revocations.clone(),
             receipts: self.receipts.clone(),
+            receipt_chain_head: self.receipt_chain_head,
         }
     }
 
@@ -193,9 +199,11 @@ impl InMemoryAvcRegistry {
                     ),
                 });
             }
-            registry.validate_receipt(&receipt)?;
+            registry.validate_receipt_structural(&receipt)?;
             registry.receipts.insert(stored_id, receipt);
         }
+        registry.validate_durable_receipt_evidence(state.receipt_chain_head)?;
+        registry.receipt_chain_head = state.receipt_chain_head;
 
         Ok(registry)
     }
@@ -214,6 +222,7 @@ impl InMemoryAvcRegistry {
         candidate.by_subject = durable.by_subject;
         candidate.revocations.clear();
         candidate.receipts = durable.receipts;
+        candidate.receipt_chain_head = durable.receipt_chain_head;
 
         for revocation in durable.revocations.into_values() {
             candidate.validate_revocation(&revocation)?;
@@ -221,11 +230,13 @@ impl InMemoryAvcRegistry {
                 .revocations
                 .insert(revocation.credential_id, revocation);
         }
+        candidate.validate_loaded_receipts()?;
 
         self.credentials = candidate.credentials;
         self.by_subject = candidate.by_subject;
         self.revocations = candidate.revocations;
         self.receipts = candidate.receipts;
+        self.receipt_chain_head = candidate.receipt_chain_head;
         Ok(())
     }
 
@@ -236,6 +247,16 @@ impl InMemoryAvcRegistry {
     pub fn validate_loaded_revocations(&self) -> Result<(), AvcError> {
         for revocation in self.revocations.values() {
             self.validate_revocation(revocation)?;
+        }
+        Ok(())
+    }
+
+    /// Revalidate durable receipts after validator trust anchors have been
+    /// registered. Durable import only performs structural checks because
+    /// startup trust anchors are intentionally restored out-of-band.
+    pub fn validate_loaded_receipts(&self) -> Result<(), AvcError> {
+        for receipt in self.receipts.values() {
+            self.validate_receipt(receipt)?;
         }
         Ok(())
     }
@@ -258,7 +279,140 @@ impl InMemoryAvcRegistry {
         self.receipts.len()
     }
 
-    fn validate_receipt(&self, receipt: &AvcTrustReceipt) -> Result<(), AvcError> {
+    #[must_use]
+    pub fn receipt_chain_head(&self) -> Option<Hash256> {
+        self.receipt_chain_head
+    }
+
+    fn validate_unique_action_commitment(&self, receipt: &AvcTrustReceipt) -> Result<(), AvcError> {
+        let Some(action_commitment_hash) = receipt.action_commitment_hash else {
+            return Ok(());
+        };
+        if let Some(existing) = self
+            .get_receipt_by_action_commitment_excluding(&action_commitment_hash, receipt.receipt_id)
+        {
+            return Err(AvcError::Registry {
+                reason: format!(
+                    "duplicate AVC receipt action commitment {action_commitment_hash} claimed by receipts {} and {}",
+                    existing.receipt_id, receipt.receipt_id
+                ),
+            });
+        }
+        Ok(())
+    }
+
+    fn validate_durable_receipt_evidence(
+        &self,
+        stored_chain_head: Option<Hash256>,
+    ) -> Result<(), AvcError> {
+        let mut commitments = BTreeMap::new();
+        let mut extended = BTreeMap::new();
+        for (receipt_id, receipt) in &self.receipts {
+            if let Some(action_commitment_hash) = receipt.action_commitment_hash {
+                if let Some(previous_receipt_id) =
+                    commitments.insert(action_commitment_hash, *receipt_id)
+                {
+                    return Err(AvcError::Registry {
+                        reason: format!(
+                            "duplicate durable AVC receipt action commitment {action_commitment_hash} claimed by receipts {previous_receipt_id} and {receipt_id}"
+                        ),
+                    });
+                }
+            }
+            if receipt.has_extended_evidence() {
+                extended.insert(*receipt_id, receipt);
+            }
+        }
+
+        if extended.is_empty() {
+            if let Some(head) = stored_chain_head {
+                return Err(AvcError::Registry {
+                    reason: format!(
+                        "durable receipt chain head {head} is set but no extended receipts are stored"
+                    ),
+                });
+            }
+            return Ok(());
+        }
+
+        let mut child_by_previous: BTreeMap<Option<Hash256>, Hash256> = BTreeMap::new();
+        for (receipt_id, receipt) in &extended {
+            if let Some(previous) = receipt.previous_receipt_hash {
+                if !extended.contains_key(&previous) {
+                    return Err(AvcError::Registry {
+                        reason: format!(
+                            "durable receipt {} references missing previous extended receipt {previous}",
+                            receipt.receipt_id
+                        ),
+                    });
+                }
+            }
+            if let Some(existing_child) =
+                child_by_previous.insert(receipt.previous_receipt_hash, *receipt_id)
+            {
+                return Err(AvcError::Registry {
+                    reason: format!(
+                        "durable receipt chain branches after previous head {:?}: receipts {existing_child} and {receipt_id}",
+                        receipt.previous_receipt_hash
+                    ),
+                });
+            }
+        }
+
+        let Some(mut current) = child_by_previous.get(&None).copied() else {
+            return Err(AvcError::Registry {
+                reason: "durable receipt chain has no genesis receipt".into(),
+            });
+        };
+        let mut visited = BTreeSet::new();
+        let terminal = loop {
+            if !visited.insert(current) {
+                return Err(AvcError::Registry {
+                    reason: format!("durable receipt chain contains a cycle at receipt {current}"),
+                });
+            }
+            let Some(next) = child_by_previous.get(&Some(current)).copied() else {
+                break current;
+            };
+            current = next;
+        };
+
+        if visited.len() != extended.len() {
+            return Err(AvcError::Registry {
+                reason: format!(
+                    "durable receipt chain is disconnected: visited {} of {} extended receipts",
+                    visited.len(),
+                    extended.len()
+                ),
+            });
+        }
+        if stored_chain_head != Some(terminal) {
+            return Err(AvcError::Registry {
+                reason: format!(
+                    "durable receipt chain head {:?} does not match computed terminal receipt {terminal}",
+                    stored_chain_head
+                ),
+            });
+        }
+        Ok(())
+    }
+
+    fn validate_receipt_chain_link(&self, receipt: &AvcTrustReceipt) -> Result<(), AvcError> {
+        if !receipt.has_extended_evidence() {
+            return Ok(());
+        }
+        if receipt.previous_receipt_hash != self.receipt_chain_head {
+            return Err(AvcError::InvalidInput {
+                reason: format!(
+                    "receipt {} previous_receipt_hash {:?} does not match current AVC receipt chain head {:?}",
+                    receipt.receipt_id, receipt.previous_receipt_hash, self.receipt_chain_head
+                ),
+            });
+        }
+        Ok(())
+    }
+
+    fn validate_receipt_structural(&self, receipt: &AvcTrustReceipt) -> Result<(), AvcError> {
         if !receipt.verify_id()? {
             return Err(AvcError::InvalidInput {
                 reason: format!(
@@ -278,6 +432,26 @@ impl InMemoryAvcRegistry {
                     "receipt {} references unknown credential {}",
                     receipt.receipt_id, receipt.credential_id
                 ),
+            });
+        }
+        Ok(())
+    }
+
+    fn validate_receipt(&self, receipt: &AvcTrustReceipt) -> Result<(), AvcError> {
+        self.validate_receipt_structural(receipt)?;
+        let public_key = self
+            .receipt_validator_public_keys
+            .get(&receipt.validator_did)
+            .ok_or_else(|| AvcError::InvalidInput {
+                reason: format!(
+                    "receipt validator public key for {} is unresolved",
+                    receipt.validator_did
+                ),
+            })?;
+        let payload = receipt.signing_payload()?;
+        if !crypto::verify(&payload, &receipt.signature, public_key) {
+            return Err(AvcError::InvalidInput {
+                reason: format!("receipt signature for {} is invalid", receipt.receipt_id),
             });
         }
         Ok(())
@@ -404,6 +578,26 @@ impl InMemoryAvcRegistry {
         self.receipts.get(receipt_hash).cloned()
     }
 
+    #[must_use]
+    pub fn get_receipt_by_action_commitment(
+        &self,
+        action_commitment_hash: &Hash256,
+    ) -> Option<AvcTrustReceipt> {
+        self.get_receipt_by_action_commitment_excluding(action_commitment_hash, Hash256::ZERO)
+    }
+
+    fn get_receipt_by_action_commitment_excluding(
+        &self,
+        action_commitment_hash: &Hash256,
+        excluded_receipt_id: Hash256,
+    ) -> Option<AvcTrustReceipt> {
+        self.receipts
+            .values()
+            .filter(|receipt| receipt.receipt_id != excluded_receipt_id)
+            .find(|receipt| receipt.action_commitment_hash.as_ref() == Some(action_commitment_hash))
+            .cloned()
+    }
+
     /// List receipts whose referenced credential belongs to `subject_did`.
     ///
     /// Receipts are stored in a `BTreeMap`, so iteration order is the
@@ -512,12 +706,22 @@ impl AvcRegistryWrite for InMemoryAvcRegistry {
             });
         }
         self.validate_receipt(&receipt)?;
+        self.validate_unique_action_commitment(&receipt)?;
+        self.validate_receipt_chain_link(&receipt)?;
+        let advances_chain = receipt.has_extended_evidence();
         self.receipts.insert(key, receipt);
+        if advances_chain {
+            self.receipt_chain_head = Some(key);
+        }
         Ok(())
     }
 
     fn put_public_key(&mut self, did: Did, public_key: PublicKey) {
         self.public_keys.insert(did, public_key);
+    }
+
+    fn put_receipt_validator_public_key(&mut self, did: Did, public_key: PublicKey) {
+        self.receipt_validator_public_keys.insert(did, public_key);
     }
 
     fn put_issuer_permission_grant(&mut self, did: Did, granted_permissions: Vec<Permission>) {
@@ -560,10 +764,6 @@ mod tests {
         revocation::{AvcRevocation, AvcRevocationReason, revoke_avc},
     };
 
-    fn fixed_signature() -> Signature {
-        Signature::from_bytes([7u8; 64])
-    }
-
     fn keypair(seed: u8) -> KeyPair {
         KeyPair::from_secret_bytes([seed; 32]).unwrap()
     }
@@ -598,6 +798,12 @@ mod tests {
         issuer
     }
 
+    fn put_validator_key(reg: &mut InMemoryAvcRegistry) -> KeyPair {
+        let validator = keypair(0x33);
+        reg.put_receipt_validator_public_key(did("validator"), validator.public);
+        validator
+    }
+
     fn register_sample_credential_and_issuer_key(
         reg: &mut InMemoryAvcRegistry,
     ) -> (Hash256, KeyPair) {
@@ -612,21 +818,66 @@ mod tests {
         signed_revocation(id, did("issuer"), issuer_keypair)
     }
 
-    fn receipt_for_credential(credential_id: Hash256) -> AvcTrustReceipt {
+    fn receipt_for_credential(
+        credential_id: Hash256,
+        validator_keypair: &KeyPair,
+    ) -> AvcTrustReceipt {
         let mut receipt = AvcTrustReceipt {
             schema_version: crate::credential::AVC_SCHEMA_VERSION,
             receipt_id: Hash256::ZERO,
             credential_id,
             action_id: None,
+            action_commitment_hash: None,
+            previous_receipt_hash: None,
+            timestamp_provenance: None,
             validator_did: did("validator"),
             decision: crate::validation::AvcDecision::Allow,
             reason_codes: vec![crate::validation::AvcReasonCode::Valid],
             created_at: ts(3),
             validation_hash: h256(0xBB),
-            signature: fixed_signature(),
+            signature: Signature::empty(),
         };
-        receipt.receipt_id = receipt.recompute_id().unwrap();
+        let payload = receipt.signing_payload().unwrap();
+        receipt.receipt_id = Hash256::digest(&payload);
+        receipt.signature = validator_keypair.sign(&payload);
         receipt
+    }
+
+    fn chained_receipt_for_credential(
+        credential_id: Hash256,
+        validator_keypair: &KeyPair,
+        previous_receipt_hash: Option<Hash256>,
+        action_byte: u8,
+    ) -> AvcTrustReceipt {
+        let mut receipt = AvcTrustReceipt {
+            schema_version: crate::credential::AVC_SCHEMA_VERSION,
+            receipt_id: Hash256::ZERO,
+            credential_id,
+            action_id: Some(h256(action_byte)),
+            action_commitment_hash: Some(h256(action_byte.wrapping_add(1))),
+            previous_receipt_hash,
+            timestamp_provenance: Some(
+                crate::receipt::AvcReceiptTimestampProvenance::LocalHybridLogicalClock,
+            ),
+            validator_did: did("validator"),
+            decision: crate::validation::AvcDecision::Allow,
+            reason_codes: vec![crate::validation::AvcReasonCode::Valid],
+            created_at: ts(u64::from(action_byte) + 3),
+            validation_hash: h256(0xBB),
+            signature: Signature::empty(),
+        };
+        let payload = receipt.signing_payload().unwrap();
+        receipt.receipt_id = Hash256::digest(&payload);
+        receipt.signature = validator_keypair.sign(&payload);
+        receipt
+    }
+
+    fn resign_receipt(receipt: &mut AvcTrustReceipt, validator_keypair: &KeyPair) {
+        receipt.receipt_id = Hash256::ZERO;
+        receipt.signature = Signature::empty();
+        let payload = receipt.signing_payload().unwrap();
+        receipt.receipt_id = Hash256::digest(&payload);
+        receipt.signature = validator_keypair.sign(&payload);
     }
 
     #[test]
@@ -861,6 +1112,26 @@ mod tests {
     }
 
     #[test]
+    fn put_revocation_accepts_principal_revoker() {
+        let mut reg = fresh_registry();
+        let mut draft = baseline_draft();
+        draft.principal_did = did("principal");
+        let issuer_keypair = keypair(0x11);
+        let principal_keypair = keypair(0x22);
+        let credential = issue_avc(draft, |bytes| issuer_keypair.sign(bytes)).unwrap();
+        let id = credential.id().unwrap();
+        reg.put_public_key(did("issuer"), issuer_keypair.public);
+        reg.put_public_key(did("principal"), principal_keypair.public);
+        reg.put_credential(credential).unwrap();
+        let revocation = signed_revocation(id, did("principal"), &principal_keypair);
+
+        reg.put_revocation(revocation.clone()).unwrap();
+
+        assert!(reg.is_revoked(&id));
+        assert_eq!(reg.get_revocation(&id).unwrap(), revocation);
+    }
+
+    #[test]
     fn put_revocation_rejects_revoker_that_is_not_issuer_or_principal() {
         let mut reg = fresh_registry();
         let cred = sample_credential();
@@ -971,7 +1242,8 @@ mod tests {
     fn put_receipt_rejects_duplicates() {
         let mut reg = fresh_registry();
         let (id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
-        let receipt = receipt_for_credential(id);
+        let validator_keypair = put_validator_key(&mut reg);
+        let receipt = receipt_for_credential(id, &validator_keypair);
         reg.put_receipt(receipt.clone()).unwrap();
         let err = reg.put_receipt(receipt.clone()).unwrap_err();
         assert!(matches!(err, AvcError::Registry { .. }));
@@ -980,9 +1252,207 @@ mod tests {
     }
 
     #[test]
+    fn put_receipt_accepts_validator_signed_receipt_with_registered_key() {
+        let mut reg = fresh_registry();
+        let (id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
+        let validator_keypair = put_validator_key(&mut reg);
+        let receipt = receipt_for_credential(id, &validator_keypair);
+
+        reg.put_receipt(receipt.clone()).unwrap();
+
+        assert_eq!(reg.receipt_count(), 1);
+        assert_eq!(reg.get_receipt(&receipt.receipt_id).unwrap(), receipt);
+    }
+
+    #[test]
+    fn put_receipt_accepts_scoped_validator_key_without_generic_issuer_trust() {
+        let mut reg = fresh_registry();
+        let (id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
+        let validator_keypair = keypair(0x33);
+        reg.put_receipt_validator_public_key(did("validator"), validator_keypair.public);
+        let receipt = receipt_for_credential(id, &validator_keypair);
+
+        reg.put_receipt(receipt.clone()).unwrap();
+
+        assert_eq!(reg.receipt_count(), 1);
+        assert_eq!(reg.get_receipt(&receipt.receipt_id).unwrap(), receipt);
+        assert_eq!(reg.resolve_public_key(&did("validator")), None);
+    }
+
+    #[test]
+    fn generic_public_key_does_not_validate_receipt_signature() {
+        let mut reg = fresh_registry();
+        let (id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
+        let validator_keypair = keypair(0x33);
+        reg.put_public_key(did("validator"), validator_keypair.public);
+        let receipt = receipt_for_credential(id, &validator_keypair);
+
+        let err = reg.put_receipt(receipt.clone()).unwrap_err();
+
+        assert!(
+            matches!(err, AvcError::InvalidInput { reason } if reason.contains("receipt validator public key") && reason.contains("unresolved"))
+        );
+        assert_eq!(
+            reg.resolve_public_key(&did("validator")),
+            Some(validator_keypair.public)
+        );
+        assert_eq!(reg.receipt_count(), 0);
+        assert!(reg.get_receipt(&receipt.receipt_id).is_none());
+    }
+
+    #[test]
+    fn receipt_validator_key_does_not_grant_credential_issuer_trust() {
+        let mut reg = fresh_registry();
+        let issuer_keypair = keypair(0x11);
+        reg.put_receipt_validator_public_key(did("issuer"), issuer_keypair.public);
+        let credential = sample_credential();
+
+        let err = reg.put_credential(credential).unwrap_err();
+
+        assert_eq!(reg.resolve_public_key(&did("issuer")), None);
+        assert!(
+            matches!(err, AvcError::InvalidInput { reason } if reason.contains("credential issuer key") && reason.contains("unresolved"))
+        );
+        assert_eq!(reg.credential_count(), 0);
+    }
+
+    #[test]
+    fn receipt_chain_advances_for_extended_receipts() {
+        let mut reg = fresh_registry();
+        let (id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
+        let validator_keypair = put_validator_key(&mut reg);
+        let first = chained_receipt_for_credential(id, &validator_keypair, None, 0x21);
+        let second =
+            chained_receipt_for_credential(id, &validator_keypair, Some(first.receipt_id), 0x22);
+
+        reg.put_receipt(first.clone()).unwrap();
+        assert_eq!(reg.receipt_chain_head(), Some(first.receipt_id));
+
+        reg.put_receipt(second.clone()).unwrap();
+        assert_eq!(reg.receipt_chain_head(), Some(second.receipt_id));
+        assert_eq!(reg.receipt_count(), 2);
+        assert_eq!(reg.get_receipt(&second.receipt_id).unwrap(), second);
+    }
+
+    #[test]
+    fn receipt_chain_rejects_wrong_previous_hash_without_advancing() {
+        let mut reg = fresh_registry();
+        let (id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
+        let validator_keypair = put_validator_key(&mut reg);
+        let first = chained_receipt_for_credential(id, &validator_keypair, None, 0x21);
+        reg.put_receipt(first.clone()).unwrap();
+        let wrong_link =
+            chained_receipt_for_credential(id, &validator_keypair, Some(h256(0xFE)), 0x22);
+
+        let err = reg.put_receipt(wrong_link.clone()).unwrap_err();
+
+        assert!(
+            matches!(err, AvcError::InvalidInput { reason } if reason.contains("previous_receipt_hash"))
+        );
+        assert_eq!(reg.receipt_chain_head(), Some(first.receipt_id));
+        assert_eq!(reg.receipt_count(), 1);
+        assert!(reg.get_receipt(&wrong_link.receipt_id).is_none());
+    }
+
+    #[test]
+    fn put_receipt_rejects_duplicate_action_commitment_without_advancing() {
+        let mut reg = fresh_registry();
+        let (id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
+        let validator_keypair = put_validator_key(&mut reg);
+        let first = chained_receipt_for_credential(id, &validator_keypair, None, 0x21);
+        let mut duplicate_commitment =
+            chained_receipt_for_credential(id, &validator_keypair, Some(first.receipt_id), 0x22);
+        duplicate_commitment.action_commitment_hash = first.action_commitment_hash;
+        resign_receipt(&mut duplicate_commitment, &validator_keypair);
+
+        reg.put_receipt(first.clone()).unwrap();
+        let err = reg.put_receipt(duplicate_commitment.clone()).unwrap_err();
+
+        assert!(
+            matches!(err, AvcError::Registry { reason } if reason.contains("duplicate AVC receipt action commitment"))
+        );
+        assert_eq!(reg.receipt_chain_head(), Some(first.receipt_id));
+        assert_eq!(reg.receipt_count(), 1);
+        assert!(reg.get_receipt(&duplicate_commitment.receipt_id).is_none());
+    }
+
+    #[test]
+    fn get_receipt_by_action_commitment_finds_extended_receipts() {
+        let mut reg = fresh_registry();
+        let (id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
+        let validator_keypair = put_validator_key(&mut reg);
+        let legacy = receipt_for_credential(id, &validator_keypair);
+        let extended = chained_receipt_for_credential(id, &validator_keypair, None, 0x21);
+        let action_commitment_hash = extended.action_commitment_hash.unwrap();
+        reg.put_receipt(legacy).unwrap();
+        reg.put_receipt(extended.clone()).unwrap();
+
+        assert_eq!(
+            reg.get_receipt_by_action_commitment(&action_commitment_hash),
+            Some(extended)
+        );
+        assert!(reg.get_receipt_by_action_commitment(&h256(0xFE)).is_none());
+    }
+
+    #[test]
+    fn legacy_receipts_do_not_advance_receipt_chain_head() {
+        let mut reg = fresh_registry();
+        let (id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
+        let validator_keypair = put_validator_key(&mut reg);
+        let receipt = receipt_for_credential(id, &validator_keypair);
+
+        reg.put_receipt(receipt.clone()).unwrap();
+
+        assert_eq!(reg.receipt_count(), 1);
+        assert_eq!(reg.receipt_chain_head(), None);
+        assert_eq!(reg.get_receipt(&receipt.receipt_id).unwrap(), receipt);
+    }
+
+    #[test]
+    fn put_receipt_rejects_forged_signature_without_storing() {
+        let mut reg = fresh_registry();
+        let (id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
+        let validator_keypair = put_validator_key(&mut reg);
+        let attacker_keypair = keypair(0x44);
+        let receipt = receipt_for_credential(id, &attacker_keypair);
+
+        let err = reg.put_receipt(receipt.clone()).unwrap_err();
+        match err {
+            AvcError::InvalidInput { reason } => {
+                assert!(reason.contains("signature"));
+                assert!(reason.contains("invalid"));
+            }
+            other => panic!("expected invalid input for forged receipt, got {other:?}"),
+        }
+        assert_eq!(reg.receipt_count(), 0);
+        assert!(reg.get_receipt(&receipt.receipt_id).is_none());
+        assert_ne!(validator_keypair.public, attacker_keypair.public);
+    }
+
+    #[test]
+    fn put_receipt_rejects_unresolved_validator_key_without_storing() {
+        let mut reg = fresh_registry();
+        let (id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
+        let validator_keypair = keypair(0x33);
+        let receipt = receipt_for_credential(id, &validator_keypair);
+
+        let err = reg.put_receipt(receipt.clone()).unwrap_err();
+        match err {
+            AvcError::InvalidInput { reason } => {
+                assert!(reason.contains("validator public key"));
+                assert!(reason.contains("unresolved"));
+            }
+            other => panic!("expected invalid input for unresolved validator, got {other:?}"),
+        }
+        assert_eq!(reg.receipt_count(), 0);
+        assert!(reg.get_receipt(&receipt.receipt_id).is_none());
+    }
+
+    #[test]
     fn put_receipt_rejects_unknown_credential_without_storing() {
         let mut reg = fresh_registry();
-        let receipt = receipt_for_credential(h256(0xAA));
+        let validator_keypair = put_validator_key(&mut reg);
+        let receipt = receipt_for_credential(h256(0xAA), &validator_keypair);
         let err = reg.put_receipt(receipt).unwrap_err();
         match err {
             AvcError::InvalidInput { reason } => {
@@ -997,6 +1467,7 @@ mod tests {
     fn list_receipts_for_subject_filters_by_credential_subject_and_limit() {
         let mut reg = fresh_registry();
         let issuer_keypair = put_issuer_key(&mut reg);
+        let validator_keypair = put_validator_key(&mut reg);
 
         let mut first_draft = baseline_draft();
         first_draft.subject_did = did("agent-one");
@@ -1016,9 +1487,9 @@ mod tests {
         let other = issue_avc(other_draft, |bytes| issuer_keypair.sign(bytes)).unwrap();
         let other_id = reg.put_credential(other).unwrap();
 
-        let first_receipt = receipt_for_credential(first_id);
-        let second_receipt = receipt_for_credential(second_id);
-        let other_receipt = receipt_for_credential(other_id);
+        let first_receipt = receipt_for_credential(first_id, &validator_keypair);
+        let second_receipt = receipt_for_credential(second_id, &validator_keypair);
+        let other_receipt = receipt_for_credential(other_id, &validator_keypair);
         reg.put_receipt(first_receipt.clone()).unwrap();
         reg.put_receipt(other_receipt).unwrap();
         reg.put_receipt(second_receipt.clone()).unwrap();
@@ -1042,7 +1513,8 @@ mod tests {
         let (id, issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
         let revocation = sample_issuer_revocation(id, &issuer_keypair);
         reg.put_revocation(revocation.clone()).unwrap();
-        let receipt = receipt_for_credential(id);
+        let validator_keypair = put_validator_key(&mut reg);
+        let receipt = receipt_for_credential(id, &validator_keypair);
         reg.put_receipt(receipt.clone()).unwrap();
 
         let restored = InMemoryAvcRegistry::from_durable_state(reg.durable_state()).unwrap();
@@ -1052,9 +1524,210 @@ mod tests {
         assert_eq!(restored.receipt_count(), 1);
         assert_eq!(restored.get_revocation(&id).unwrap(), revocation);
         assert_eq!(restored.get_receipt(&receipt.receipt_id).unwrap(), receipt);
+        assert_eq!(restored.receipt_chain_head(), None);
         assert!(
             restored.resolve_public_key(&did("issuer")).is_none(),
             "key trust anchors must be reloaded from verified startup config"
+        );
+        assert!(
+            restored.resolve_public_key(&did("validator")).is_none(),
+            "validator trust anchors must be reloaded from verified startup config"
+        );
+    }
+
+    #[test]
+    fn durable_state_receipt_chain_head_round_trips() {
+        let mut reg = fresh_registry();
+        let (id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
+        let validator_keypair = put_validator_key(&mut reg);
+        let first = chained_receipt_for_credential(id, &validator_keypair, None, 0x21);
+        let second =
+            chained_receipt_for_credential(id, &validator_keypair, Some(first.receipt_id), 0x22);
+        reg.put_receipt(first).unwrap();
+        reg.put_receipt(second.clone()).unwrap();
+
+        let state = reg.durable_state();
+        assert_eq!(state.receipt_chain_head, Some(second.receipt_id));
+        let restored = InMemoryAvcRegistry::from_durable_state(state).unwrap();
+
+        assert_eq!(restored.receipt_count(), 2);
+        assert_eq!(restored.receipt_chain_head(), Some(second.receipt_id));
+        assert_eq!(restored.get_receipt(&second.receipt_id).unwrap(), second);
+    }
+
+    #[test]
+    fn durable_state_accepts_legacy_only_receipts_with_no_chain_head() {
+        let mut reg = fresh_registry();
+        let (id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
+        let validator_keypair = keypair(0x33);
+        let receipt = receipt_for_credential(id, &validator_keypair);
+        let mut state = reg.durable_state();
+        state.receipts.insert(receipt.receipt_id, receipt.clone());
+        state.receipt_chain_head = None;
+
+        let restored = InMemoryAvcRegistry::from_durable_state(state).unwrap();
+
+        assert_eq!(restored.receipt_count(), 1);
+        assert_eq!(restored.receipt_chain_head(), None);
+        assert_eq!(restored.get_receipt(&receipt.receipt_id).unwrap(), receipt);
+    }
+
+    #[test]
+    fn durable_state_rejects_legacy_receipt_chain_head_without_extended_receipts() {
+        let mut reg = fresh_registry();
+        let (id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
+        let validator_keypair = keypair(0x33);
+        let receipt = receipt_for_credential(id, &validator_keypair);
+        let mut state = reg.durable_state();
+        state.receipts.insert(receipt.receipt_id, receipt.clone());
+        state.receipt_chain_head = Some(receipt.receipt_id);
+
+        let err = InMemoryAvcRegistry::from_durable_state(state).unwrap_err();
+
+        match err {
+            AvcError::Registry { reason } => {
+                assert!(reason.contains("no extended receipts are stored"));
+            }
+            other => panic!("expected durable receipt chain head error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn durable_state_rejects_receipt_chain_missing_intermediate_prior() {
+        let mut reg = fresh_registry();
+        let (id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
+        let validator_keypair = keypair(0x33);
+        let receipt =
+            chained_receipt_for_credential(id, &validator_keypair, Some(h256(0xEE)), 0x21);
+        let mut state = reg.durable_state();
+        state.receipts.insert(receipt.receipt_id, receipt.clone());
+        state.receipt_chain_head = Some(receipt.receipt_id);
+
+        let err = InMemoryAvcRegistry::from_durable_state(state).unwrap_err();
+
+        match err {
+            AvcError::Registry { reason } => {
+                assert!(reason.contains("missing previous extended receipt"));
+            }
+            other => panic!("expected missing previous receipt error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn durable_state_rejects_receipt_chain_branch() {
+        let mut reg = fresh_registry();
+        let (id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
+        let validator_keypair = keypair(0x33);
+        let first = chained_receipt_for_credential(id, &validator_keypair, None, 0x21);
+        let second =
+            chained_receipt_for_credential(id, &validator_keypair, Some(first.receipt_id), 0x22);
+        let third =
+            chained_receipt_for_credential(id, &validator_keypair, Some(first.receipt_id), 0x23);
+        let mut state = reg.durable_state();
+        state.receipts.insert(first.receipt_id, first);
+        state.receipts.insert(second.receipt_id, second.clone());
+        state.receipts.insert(third.receipt_id, third);
+        state.receipt_chain_head = Some(second.receipt_id);
+
+        let err = InMemoryAvcRegistry::from_durable_state(state).unwrap_err();
+
+        assert!(
+            matches!(err, AvcError::Registry { reason } if reason.contains("branches after previous head"))
+        );
+    }
+
+    #[test]
+    fn durable_receipt_evidence_rejects_extended_chain_with_no_genesis() {
+        let mut reg = fresh_registry();
+        let (id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
+        let validator_keypair = keypair(0x33);
+        let mut first = chained_receipt_for_credential(id, &validator_keypair, None, 0x21);
+        let second =
+            chained_receipt_for_credential(id, &validator_keypair, Some(first.receipt_id), 0x22);
+        first.previous_receipt_hash = Some(second.receipt_id);
+        reg.receipts.insert(first.receipt_id, first);
+        reg.receipts.insert(second.receipt_id, second.clone());
+
+        let err = reg
+            .validate_durable_receipt_evidence(Some(second.receipt_id))
+            .unwrap_err();
+
+        match err {
+            AvcError::Registry { reason } => {
+                assert!(reason.contains("no genesis receipt"));
+            }
+            other => panic!("expected durable receipt chain genesis error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn durable_receipt_evidence_rejects_disconnected_chain() {
+        let mut reg = fresh_registry();
+        let (id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
+        let validator_keypair = keypair(0x33);
+        let first = chained_receipt_for_credential(id, &validator_keypair, None, 0x21);
+        let second =
+            chained_receipt_for_credential(id, &validator_keypair, Some(first.receipt_id), 0x22);
+        let mut third = chained_receipt_for_credential(id, &validator_keypair, None, 0x23);
+        let fourth =
+            chained_receipt_for_credential(id, &validator_keypair, Some(third.receipt_id), 0x24);
+        third.previous_receipt_hash = Some(fourth.receipt_id);
+        reg.receipts.insert(first.receipt_id, first);
+        reg.receipts.insert(second.receipt_id, second.clone());
+        reg.receipts.insert(third.receipt_id, third);
+        reg.receipts.insert(fourth.receipt_id, fourth);
+
+        let err = reg
+            .validate_durable_receipt_evidence(Some(second.receipt_id))
+            .unwrap_err();
+
+        match err {
+            AvcError::Registry { reason } => {
+                assert!(reason.contains("chain is disconnected"));
+            }
+            other => panic!("expected disconnected durable receipt chain error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn durable_state_rejects_receipt_chain_head_that_is_not_terminal() {
+        let mut reg = fresh_registry();
+        let (id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
+        let validator_keypair = keypair(0x33);
+        let first = chained_receipt_for_credential(id, &validator_keypair, None, 0x21);
+        let second =
+            chained_receipt_for_credential(id, &validator_keypair, Some(first.receipt_id), 0x22);
+        let mut state = reg.durable_state();
+        state.receipts.insert(first.receipt_id, first.clone());
+        state.receipts.insert(second.receipt_id, second);
+        state.receipt_chain_head = Some(first.receipt_id);
+
+        let err = InMemoryAvcRegistry::from_durable_state(state).unwrap_err();
+
+        assert!(
+            matches!(err, AvcError::Registry { reason } if reason.contains("computed terminal receipt"))
+        );
+    }
+
+    #[test]
+    fn durable_state_rejects_duplicate_action_commitments() {
+        let mut reg = fresh_registry();
+        let (id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
+        let validator_keypair = keypair(0x33);
+        let first = chained_receipt_for_credential(id, &validator_keypair, None, 0x21);
+        let mut second =
+            chained_receipt_for_credential(id, &validator_keypair, Some(first.receipt_id), 0x22);
+        second.action_commitment_hash = first.action_commitment_hash;
+        resign_receipt(&mut second, &validator_keypair);
+        let mut state = reg.durable_state();
+        state.receipts.insert(first.receipt_id, first);
+        state.receipts.insert(second.receipt_id, second.clone());
+        state.receipt_chain_head = Some(second.receipt_id);
+
+        let err = InMemoryAvcRegistry::from_durable_state(state).unwrap_err();
+
+        assert!(
+            matches!(err, AvcError::Registry { reason } if reason.contains("duplicate durable AVC receipt action commitment"))
         );
     }
 
@@ -1120,6 +1793,27 @@ mod tests {
     }
 
     #[test]
+    fn durable_state_accepts_principal_revocation() {
+        let mut reg = fresh_registry();
+        let mut draft = baseline_draft();
+        draft.principal_did = did("principal");
+        let issuer_keypair = keypair(0x11);
+        let principal_keypair = keypair(0x22);
+        let credential = issue_avc(draft, |bytes| issuer_keypair.sign(bytes)).unwrap();
+        let id = credential.id().unwrap();
+        reg.put_public_key(did("issuer"), issuer_keypair.public);
+        reg.put_credential(credential).unwrap();
+        let revocation = signed_revocation(id, did("principal"), &principal_keypair);
+        let mut state = reg.durable_state();
+        state.revocations.insert(id, revocation.clone());
+
+        let restored = InMemoryAvcRegistry::from_durable_state(state).unwrap();
+
+        assert_eq!(restored.revocation_count(), 1);
+        assert_eq!(restored.get_revocation(&id).unwrap(), revocation);
+    }
+
+    #[test]
     fn durable_state_rejects_revocation_with_unsupported_schema() {
         let mut reg = fresh_registry();
         let (id, issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
@@ -1145,7 +1839,8 @@ mod tests {
     fn durable_state_rejects_invalid_receipt_records() {
         let mut reg = fresh_registry();
         let (id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
-        let receipt = receipt_for_credential(id);
+        let validator_keypair = keypair(0x33);
+        let receipt = receipt_for_credential(id, &validator_keypair);
 
         let mut mismatched_key = reg.durable_state();
         mismatched_key.receipts.insert(h256(0x77), receipt.clone());
@@ -1165,7 +1860,7 @@ mod tests {
             matches!(err, AvcError::InvalidInput { reason } if reason.contains("empty signature"))
         );
 
-        let unknown_receipt = receipt_for_credential(h256(0xAA));
+        let unknown_receipt = receipt_for_credential(h256(0xAA), &validator_keypair);
         let mut unknown_state = AvcRegistryDurableState::default();
         unknown_state
             .receipts
@@ -1182,7 +1877,8 @@ mod tests {
         let (id, issuer_keypair) = register_sample_credential_and_issuer_key(&mut durable_source);
         let revocation = sample_issuer_revocation(id, &issuer_keypair);
         durable_source.put_revocation(revocation.clone()).unwrap();
-        let receipt = receipt_for_credential(id);
+        let validator_keypair = put_validator_key(&mut durable_source);
+        let receipt = receipt_for_credential(id, &validator_keypair);
         durable_source.put_receipt(receipt.clone()).unwrap();
 
         let subject_keypair = keypair(0x22);
@@ -1192,6 +1888,7 @@ mod tests {
         let authority_chain = h256(0xCC);
         let mut live = fresh_registry();
         live.put_public_key(did("issuer"), issuer_keypair.public);
+        live.put_receipt_validator_public_key(did("validator"), validator_keypair.public);
         live.put_public_key(did("subject"), subject_keypair.public);
         live.put_human_approval_key(did("human"), human_keypair.public);
         live.add_consent_ref(consent_ref);
@@ -1214,6 +1911,7 @@ mod tests {
             live.resolve_public_key(&did("subject")).unwrap(),
             subject_keypair.public
         );
+        assert_eq!(live.resolve_public_key(&did("validator")), None);
         assert_eq!(
             live.resolve_human_approval_key(&did("human")).unwrap(),
             human_keypair.public
@@ -1248,10 +1946,36 @@ mod tests {
     }
 
     #[test]
+    fn apply_durable_state_rejects_forged_receipt_signature_with_live_trust_anchor() {
+        let mut durable_source = fresh_registry();
+        let (id, issuer_keypair) = register_sample_credential_and_issuer_key(&mut durable_source);
+        let validator_keypair = keypair(0x33);
+        let attacker_keypair = keypair(0x44);
+        let forged_receipt = receipt_for_credential(id, &attacker_keypair);
+        let mut state = durable_source.durable_state();
+        state
+            .receipts
+            .insert(forged_receipt.receipt_id, forged_receipt);
+
+        let mut live = fresh_registry();
+        live.put_public_key(did("issuer"), issuer_keypair.public);
+        live.put_receipt_validator_public_key(did("validator"), validator_keypair.public);
+
+        let err = live.apply_durable_state(state).unwrap_err();
+        assert!(
+            matches!(err, AvcError::InvalidInput { reason } if reason.contains("signature") && reason.contains("invalid")),
+            "durable receipt signatures must be verified with live startup trust anchors"
+        );
+        assert_eq!(live.credential_count(), 0);
+        assert_eq!(live.receipt_count(), 0);
+    }
+
+    #[test]
     fn durable_state_rejects_receipt_with_invalid_content_id() {
         let mut reg = fresh_registry();
         let (id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
-        let mut receipt = receipt_for_credential(id);
+        let validator_keypair = keypair(0x33);
+        let mut receipt = receipt_for_credential(id, &validator_keypair);
         let stored_id = receipt.receipt_id;
         receipt.validation_hash = h256(0xCC);
 

--- a/crates/exo-avc/src/validation.rs
+++ b/crates/exo-avc/src/validation.rs
@@ -32,7 +32,7 @@
 use std::collections::BTreeSet;
 
 use exo_authority::permission::Permission;
-use exo_core::{Did, Hash256, PublicKey, Signature, Timestamp, crypto};
+use exo_core::{Did, Hash256, PublicKey, Signature, Timestamp, crypto, hash::hash_structured};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -48,6 +48,8 @@ use crate::{
 pub const AVC_HUMAN_APPROVAL_SIGNING_DOMAIN: &str = "exo.avc.human-approval.v1";
 /// Signing domain tag for AVC subject action proofs.
 pub const AVC_ACTION_SIGNING_DOMAIN: &str = "exo.avc.action.v1";
+/// Signing domain tag for AVC receipt action commitments.
+pub const AVC_ACTION_COMMITMENT_DOMAIN: &str = "exo.avc.action.commitment.v1";
 
 // ---------------------------------------------------------------------------
 // Decision / Reason
@@ -160,6 +162,15 @@ struct HumanApprovalSigningPayload<'a> {
 
 #[derive(Serialize)]
 struct AvcActionSigningPayload<'a> {
+    domain: &'static str,
+    schema_version: u16,
+    credential_id: &'a Hash256,
+    action: &'a AvcActionRequest,
+    validation_now: &'a Timestamp,
+}
+
+#[derive(Serialize)]
+struct AvcActionCommitmentPayload<'a> {
     domain: &'static str,
     schema_version: u16,
     credential_id: &'a Hash256,
@@ -388,6 +399,30 @@ pub fn avc_action_signature_payload(
     let mut buf = Vec::new();
     ciborium::ser::into_writer(&payload, &mut buf)?;
     Ok(buf)
+}
+
+/// Compute a deterministic commitment over the subject-signed action content.
+///
+/// The commitment binds the full action request to the content-addressed AVC
+/// credential ID and the validation timestamp used by the subject action
+/// signature. It does not claim external anchoring.
+///
+/// # Errors
+/// Returns [`AvcError::Serialization`] if canonical CBOR encoding fails.
+pub fn avc_action_commitment_hash(
+    credential: &AutonomousVolitionCredential,
+    action: &AvcActionRequest,
+    validation_now: &Timestamp,
+) -> Result<Hash256, AvcError> {
+    let credential_id = credential.id()?;
+    let payload = AvcActionCommitmentPayload {
+        domain: AVC_ACTION_COMMITMENT_DOMAIN,
+        schema_version: AVC_SCHEMA_VERSION,
+        credential_id: &credential_id,
+        action,
+        validation_now,
+    };
+    hash_structured(&payload).map_err(AvcError::from)
 }
 
 fn evaluate_action<R: AvcRegistryRead>(

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -64,8 +64,8 @@ use exo_avc::{
     AVC_PROTOCOL_DEPRECATION_WINDOW_DAYS, AVC_PROTOCOL_VERSION, AVC_SCHEMA_VERSION,
     AutonomousVolitionCredential, AvcActionRequest, AvcDecision, AvcReceiptTimestampProvenance,
     AvcRegistryDurableState, AvcRegistryRead, AvcRegistryWrite, AvcRevocation, AvcTrustReceipt,
-    AvcValidationRequest, AvcValidationResult, InMemoryAvcRegistry, avc_action_commitment_hash,
-    avc_action_signature_payload, create_trust_receipt, create_trust_receipt_with_evidence,
+    AvcTrustReceiptEvidence, AvcValidationRequest, AvcValidationResult, InMemoryAvcRegistry,
+    avc_action_commitment_hash, avc_action_signature_payload, create_trust_receipt_with_evidence,
     require_supported_avc_protocol_version, validate_avc,
 };
 use exo_core::{
@@ -1267,9 +1267,11 @@ async fn handle_emit_receipt(
         let receipt = create_trust_receipt_with_evidence(
             &validation,
             Some(action_id),
-            Some(action_commitment_hash),
-            previous_receipt_hash,
-            Some(timestamp_provenance),
+            AvcTrustReceiptEvidence {
+                action_commitment_hash: Some(action_commitment_hash),
+                previous_receipt_hash,
+                timestamp_provenance: Some(timestamp_provenance),
+            },
             validator_did,
             trusted_now,
             |bytes| (receipt_signer)(bytes),
@@ -1445,7 +1447,7 @@ mod tests {
     use exo_avc::{
         AVC_SCHEMA_VERSION, AuthorityScope, AutonomyLevel, AvcActionRequest, AvcConstraints,
         AvcDecision, AvcDraft, AvcReasonCode, AvcRevocationReason, AvcSubjectKind, DelegatedIntent,
-        issue_avc, revoke_avc,
+        create_trust_receipt, issue_avc, revoke_avc,
     };
     use exo_core::{Hash256, Signature, Timestamp, crypto, crypto::KeyPair};
     use tower::ServiceExt;
@@ -2935,9 +2937,11 @@ mod tests {
             let conflicting_receipt = create_trust_receipt_with_evidence(
                 &validation,
                 Some(Hash256::from_bytes([0x99; 32])),
-                Some(action_commitment_hash),
-                None,
-                Some(AvcReceiptTimestampProvenance::FixedTestTimestamp),
+                AvcTrustReceiptEvidence {
+                    action_commitment_hash: Some(action_commitment_hash),
+                    previous_receipt_hash: None,
+                    timestamp_provenance: Some(AvcReceiptTimestampProvenance::FixedTestTimestamp),
+                },
                 validator_did(),
                 Timestamp::new(1_600_000, 0),
                 |bytes| validator_keypair().sign(bytes),

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -62,9 +62,10 @@ use exo_authority::permission::Permission;
 use exo_avc::{
     AVC_MAX_SUPPORTED_PROTOCOL_VERSION, AVC_MIN_SUPPORTED_PROTOCOL_VERSION,
     AVC_PROTOCOL_DEPRECATION_WINDOW_DAYS, AVC_PROTOCOL_VERSION, AVC_SCHEMA_VERSION,
-    AutonomousVolitionCredential, AvcActionRequest, AvcDecision, AvcRegistryDurableState,
-    AvcRegistryRead, AvcRegistryWrite, AvcRevocation, AvcTrustReceipt, AvcValidationRequest,
-    AvcValidationResult, InMemoryAvcRegistry, avc_action_signature_payload, create_trust_receipt,
+    AutonomousVolitionCredential, AvcActionRequest, AvcDecision, AvcReceiptTimestampProvenance,
+    AvcRegistryDurableState, AvcRegistryRead, AvcRegistryWrite, AvcRevocation, AvcTrustReceipt,
+    AvcValidationRequest, AvcValidationResult, InMemoryAvcRegistry, avc_action_commitment_hash,
+    avc_action_signature_payload, create_trust_receipt, create_trust_receipt_with_evidence,
     require_supported_avc_protocol_version, validate_avc,
 };
 use exo_core::{
@@ -78,6 +79,7 @@ use tower::limit::ConcurrencyLimitLayer;
 const MAX_AVC_API_BODY_BYTES: usize = 64 * 1024;
 const MAX_AVC_API_CONCURRENT_REQUESTS: usize = 64;
 pub const AVC_ROOT_TRUST_BUNDLE_ENV: &str = "EXO_AVC_ROOT_TRUST_BUNDLE";
+pub const AVC_REQUIRE_POSTGRES_DURABILITY_ENV: &str = "EXO_AVC_REQUIRE_POSTGRES_DURABILITY";
 pub const AVC_ROOT_TRUST_CEREMONY_ID: &str = "avc-exo-ceremony-2026";
 pub const AVC_ROOT_TRUST_BUNDLE_ID_HEX: &str =
     "7d9954a797ef244c15ad1b733cf77598125ccef0f812a404137e827c192d6a58";
@@ -104,19 +106,33 @@ enum AvcReceiptTimestampSource {
 }
 
 impl AvcReceiptTimestampSource {
-    async fn now(&self) -> anyhow::Result<Timestamp> {
+    async fn now(&self) -> anyhow::Result<(Timestamp, AvcReceiptTimestampProvenance)> {
         match self {
             Self::HybridLogicalClock(clock) => {
                 let mut clock = clock
                     .lock()
                     .map_err(|_| anyhow::anyhow!("AVC receipt HLC mutex poisoned"))?;
-                clock
+                let timestamp = clock
                     .now()
-                    .map_err(|error| anyhow::anyhow!("AVC receipt HLC unavailable: {error}"))
+                    .map_err(|error| anyhow::anyhow!("AVC receipt HLC unavailable: {error}"))?;
+                Ok((
+                    timestamp,
+                    AvcReceiptTimestampProvenance::LocalHybridLogicalClock,
+                ))
             }
-            Self::Postgres(pool) => trusted_postgres_receipt_timestamp(pool).await,
+            Self::Postgres(pool) => {
+                trusted_postgres_receipt_timestamp(pool)
+                    .await
+                    .map(|timestamp| {
+                        (
+                            timestamp,
+                            AvcReceiptTimestampProvenance::PostgresClockTimestamp,
+                        )
+                    })
+            }
             #[cfg(test)]
-            Self::Fixed(source) => source(),
+            Self::Fixed(source) => source()
+                .map(|timestamp| (timestamp, AvcReceiptTimestampProvenance::FixedTestTimestamp)),
         }
     }
 }
@@ -190,11 +206,17 @@ impl AvcApiState {
                     AvcReceiptTimestampSource::Postgres(pool),
                 )
             }
-            None => (
-                load_file_durable_registry(&durable_state_path)?,
-                AvcRegistryDurability::File(Arc::new(durable_state_path)),
-                receipt_timestamp_source_from_clock(HybridClock::new()),
-            ),
+            None => {
+                tracing::warn!(
+                    path = %durable_state_path.display(),
+                    "AVC registry using local file fallback without Postgres-backed durability; set DATABASE_URL for production AVC registry durability"
+                );
+                (
+                    load_file_durable_registry(&durable_state_path)?,
+                    AvcRegistryDurability::File(Arc::new(durable_state_path)),
+                    receipt_timestamp_source_from_clock(HybridClock::new()),
+                )
+            }
         };
         Ok(Self {
             registry: Arc::new(Mutex::new(registry)),
@@ -203,6 +225,26 @@ impl AvcApiState {
             receipt_timestamp_source,
             durability,
         })
+    }
+
+    pub fn register_validator_public_keys<I>(&self, public_keys: I) -> anyhow::Result<()>
+    where
+        I: IntoIterator<Item = (Did, PublicKey)>,
+    {
+        let mut registry = self.registry.lock().map_err(|_| {
+            anyhow::anyhow!("AVC registry unavailable while registering validator public key")
+        })?;
+        let mut candidate = registry.clone();
+        for (did, public_key) in public_keys {
+            candidate.put_receipt_validator_public_key(did, public_key);
+        }
+        candidate.validate_loaded_receipts().map_err(|error| {
+            anyhow::anyhow!(
+                "AVC durable receipt validation failed after validator public key registration: {error}"
+            )
+        })?;
+        *registry = candidate;
+        Ok(())
     }
 }
 
@@ -848,7 +890,9 @@ fn receipt_timestamp_error(err: anyhow::Error) -> ApiError {
     )
 }
 
-async fn trusted_receipt_timestamp(state: &AvcApiState) -> ApiResult<Timestamp> {
+async fn trusted_receipt_timestamp(
+    state: &AvcApiState,
+) -> ApiResult<(Timestamp, AvcReceiptTimestampProvenance)> {
     state
         .receipt_timestamp_source
         .now()
@@ -1107,6 +1151,41 @@ fn store_receipt_idempotent(
     }
 }
 
+fn validate_idempotent_receipt_hit(
+    receipt: &AvcTrustReceipt,
+    credential_id: Hash256,
+    action_id: Hash256,
+    action_commitment_hash: Hash256,
+    validation: &AvcValidationResult,
+) -> ApiResult<()> {
+    let validation_hash = hash_structured(validation)
+        .map_err(exo_avc::AvcError::from)
+        .map_err(map_avc_error)?;
+    if receipt.credential_id == credential_id
+        && receipt.action_id == Some(action_id)
+        && receipt.action_commitment_hash == Some(action_commitment_hash)
+        && receipt.validation_hash == validation_hash
+        && receipt.decision == validation.decision
+        && receipt.reason_codes == validation.reason_codes
+    {
+        return Ok(());
+    }
+
+    tracing::error!(
+        receipt_id = %receipt.receipt_id,
+        stored_credential_id = %receipt.credential_id,
+        expected_credential_id = %credential_id,
+        stored_action_id = ?receipt.action_id,
+        expected_action_id = %action_id,
+        action_commitment_hash = %action_commitment_hash,
+        "AVC receipt action commitment conflict"
+    );
+    Err((
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "AVC receipt action commitment conflict".into(),
+    ))
+}
+
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
@@ -1143,11 +1222,18 @@ async fn handle_emit_receipt(
 ) -> ApiResult<Json<EmitReceiptResponse>> {
     let validator_did = state.validator_did.clone();
     let receipt_signer = Arc::clone(&state.receipt_signer);
-    let trusted_now = trusted_receipt_timestamp(&state).await?;
+    let (trusted_now, timestamp_provenance) = trusted_receipt_timestamp(&state).await?;
     let response = with_registry_blocking(state, true, move |registry| {
         let submitted_request = payload.validation;
-        let action_id = require_action(&submitted_request)?.action_id;
-        require_registered_credential(registry, &submitted_request)?;
+        let action = require_action(&submitted_request)?;
+        let action_id = action.action_id;
+        let action_commitment_hash = avc_action_commitment_hash(
+            &submitted_request.credential,
+            action,
+            &submitted_request.now,
+        )
+        .map_err(map_avc_error)?;
+        let credential_id = require_registered_credential(registry, &submitted_request)?;
         verify_subject_action_signature(
             registry,
             &submitted_request,
@@ -1163,9 +1249,27 @@ async fn handle_emit_receipt(
                 format!("AVC validation denied: {:?}", validation.reason_codes),
             ));
         }
-        let receipt = create_trust_receipt(
+        if let Some(receipt) = registry.get_receipt_by_action_commitment(&action_commitment_hash) {
+            validate_idempotent_receipt_hit(
+                &receipt,
+                credential_id,
+                action_id,
+                action_commitment_hash,
+                &validation,
+            )?;
+            return Ok(EmitReceiptResponse {
+                receipt_hash: format!("{}", receipt.receipt_id),
+                receipt,
+                validation,
+            });
+        }
+        let previous_receipt_hash = registry.receipt_chain_head();
+        let receipt = create_trust_receipt_with_evidence(
             &validation,
             Some(action_id),
+            Some(action_commitment_hash),
+            previous_receipt_hash,
+            Some(timestamp_provenance),
             validator_did,
             trusted_now,
             |bytes| (receipt_signer)(bytes),
@@ -1374,6 +1478,7 @@ mod tests {
         let mut registry = state.registry.lock().unwrap();
         registry.put_public_key(did, kp.public);
         registry.put_public_key(Did::new("did:exo:agent").unwrap(), subject_keypair().public);
+        registry.put_receipt_validator_public_key(validator_did(), validator_keypair().public);
     }
 
     fn fixed_receipt_timestamp_source(timestamp: Timestamp) -> AvcReceiptTimestampSource {
@@ -1859,9 +1964,13 @@ mod tests {
         let state = Arc::new(state);
         let app = avc_router(Arc::clone(&state));
 
-        let trusted_now = trusted_receipt_timestamp(&state)
+        let (trusted_now, provenance) = trusted_receipt_timestamp(&state)
             .await
             .expect("trusted Postgres receipt timestamp");
+        assert_eq!(
+            provenance,
+            AvcReceiptTimestampProvenance::PostgresClockTimestamp
+        );
         let mut first_draft = baseline_draft();
         first_draft.delegated_intent.purpose = "postgres anchor persistence one".into();
         first_draft.expires_at = Some(Timestamp::new(trusted_now.physical_ms + 1_000_000, 0));
@@ -2274,6 +2383,12 @@ mod tests {
             now: Timestamp::new(1_500_000, 0),
         };
         let action_id = request.action.as_ref().unwrap().action_id;
+        let action_commitment_hash = avc_action_commitment_hash(
+            &request.credential,
+            request.action.as_ref().unwrap(),
+            &request.now,
+        )
+        .unwrap();
         let subject_signature = sign_action(&request, &subject_keypair());
         let body = serde_json::to_vec(&EmitReceiptRequest {
             validation: request,
@@ -2304,6 +2419,15 @@ mod tests {
         );
         assert_eq!(parsed.receipt.credential_id, credential_id);
         assert_eq!(parsed.receipt.action_id, Some(action_id));
+        assert_eq!(
+            parsed.receipt.action_commitment_hash,
+            Some(action_commitment_hash)
+        );
+        assert_eq!(parsed.receipt.previous_receipt_hash, None);
+        assert_eq!(
+            parsed.receipt.timestamp_provenance,
+            Some(AvcReceiptTimestampProvenance::FixedTestTimestamp)
+        );
         assert_eq!(parsed.receipt.validator_did, validator_did());
         assert_eq!(parsed.validation.decision, AvcDecision::Allow);
         assert!(parsed.receipt.verify_id().unwrap());
@@ -2314,6 +2438,89 @@ mod tests {
             validator_keypair().public_key()
         ));
         assert_eq!(state.registry.lock().unwrap().receipt_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn receipt_emit_links_sequential_receipts_to_previous_avc_receipt_hash() {
+        let state = fresh_state();
+        let first_credential = credential_with_purpose("first linked receipt");
+        let second_credential = credential_with_purpose("second linked receipt");
+        {
+            let mut registry = state.registry.lock().unwrap();
+            registry.put_credential(first_credential.clone()).unwrap();
+            registry.put_credential(second_credential.clone()).unwrap();
+        }
+
+        let first_request = AvcValidationRequest {
+            credential: first_credential,
+            action: Some(baseline_action(Did::new("did:exo:agent").unwrap())),
+            now: Timestamp::new(1_500_000, 0),
+        };
+        let mut second_action = baseline_action(Did::new("did:exo:agent").unwrap());
+        second_action.action_id = Hash256::from_bytes([0x56; 32]);
+        let second_request = AvcValidationRequest {
+            credential: second_credential,
+            action: Some(second_action),
+            now: Timestamp::new(1_500_000, 0),
+        };
+        let first_body = serde_json::to_vec(&EmitReceiptRequest {
+            validation: first_request.clone(),
+            subject_signature: sign_action(&first_request, &subject_keypair()),
+            subject_public_key: None,
+        })
+        .unwrap();
+        let second_body = serde_json::to_vec(&EmitReceiptRequest {
+            validation: second_request.clone(),
+            subject_signature: sign_action(&second_request, &subject_keypair()),
+            subject_public_key: None,
+        })
+        .unwrap();
+
+        let app = avc_router(Arc::clone(&state));
+        let first_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/avc/receipts/emit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(first_body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let second_response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/avc/receipts/emit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(second_body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(first_response.status(), StatusCode::OK);
+        assert_eq!(second_response.status(), StatusCode::OK);
+        let first: EmitReceiptResponse =
+            serde_json::from_slice(&read_body(first_response).await).unwrap();
+        let second: EmitReceiptResponse =
+            serde_json::from_slice(&read_body(second_response).await).unwrap();
+
+        assert_eq!(first.receipt.previous_receipt_hash, None);
+        assert_eq!(
+            second.receipt.previous_receipt_hash,
+            Some(first.receipt.receipt_id)
+        );
+        assert_ne!(
+            first.receipt.action_commitment_hash,
+            second.receipt.action_commitment_hash
+        );
+        assert_eq!(
+            state.registry.lock().unwrap().receipt_chain_head(),
+            Some(second.receipt.receipt_id)
+        );
     }
 
     #[tokio::test]
@@ -2705,6 +2912,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn receipt_emit_rejects_conflicting_stored_action_commitment() {
+        let state = fresh_state();
+        let credential = baseline_credential();
+        let request = AvcValidationRequest {
+            credential: credential.clone(),
+            action: Some(baseline_action(Did::new("did:exo:agent").unwrap())),
+            now: Timestamp::new(1_500_000, 0),
+        };
+        let action_commitment_hash = avc_action_commitment_hash(
+            &request.credential,
+            request.action.as_ref().unwrap(),
+            &request.now,
+        )
+        .unwrap();
+        {
+            let mut registry = state.registry.lock().unwrap();
+            registry.put_credential(credential).unwrap();
+            let mut trusted_request = request.clone();
+            trusted_request.now = Timestamp::new(1_600_000, 0);
+            let validation = validate_avc(&trusted_request, &*registry).unwrap();
+            let conflicting_receipt = create_trust_receipt_with_evidence(
+                &validation,
+                Some(Hash256::from_bytes([0x99; 32])),
+                Some(action_commitment_hash),
+                None,
+                Some(AvcReceiptTimestampProvenance::FixedTestTimestamp),
+                validator_did(),
+                Timestamp::new(1_600_000, 0),
+                |bytes| validator_keypair().sign(bytes),
+            )
+            .unwrap();
+            registry.put_receipt(conflicting_receipt).unwrap();
+        }
+        let body = serde_json::to_vec(&EmitReceiptRequest {
+            validation: request.clone(),
+            subject_signature: sign_action(&request, &subject_keypair()),
+            subject_public_key: None,
+        })
+        .unwrap();
+
+        let app = avc_router(Arc::clone(&state));
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/avc/receipts/emit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(state.registry.lock().unwrap().receipt_count(), 1);
+    }
+
+    #[tokio::test]
     async fn receipt_emit_accepts_derived_subject_public_key_when_registry_key_absent() {
         let state = fresh_state();
         let subject = crate::identity::did_from_public_key(subject_keypair().public_key()).unwrap();
@@ -2749,6 +3014,7 @@ mod tests {
     fn duplicate_same_receipt_is_idempotent() {
         let mut registry = InMemoryAvcRegistry::new();
         registry.put_public_key(Did::new("did:exo:issuer").unwrap(), issuer_keypair().public);
+        registry.put_receipt_validator_public_key(validator_did(), validator_keypair().public);
         let credential = baseline_credential();
         let credential_id = registry.put_credential(credential).unwrap();
         let validation = AvcValidationResult {
@@ -2771,6 +3037,125 @@ mod tests {
         store_receipt_idempotent(&mut registry, receipt.clone()).unwrap();
         store_receipt_idempotent(&mut registry, receipt).unwrap();
         assert_eq!(registry.receipt_count(), 1);
+    }
+
+    #[test]
+    fn avc_registry_validator_key_registration_does_not_create_issuer_trust() {
+        let signer: AvcReceiptSigner = Arc::new(|payload: &[u8]| validator_keypair().sign(payload));
+        let state = AvcApiState::new_with_receipt_timestamp_source(
+            validator_did(),
+            signer,
+            fixed_receipt_timestamp_source(Timestamp::new(1_600_000, 0)),
+        );
+
+        state
+            .register_validator_public_keys([(validator_did(), validator_keypair().public)])
+            .unwrap();
+
+        assert_eq!(
+            state
+                .registry
+                .lock()
+                .unwrap()
+                .resolve_public_key(&validator_did()),
+            None
+        );
+    }
+
+    #[test]
+    fn avc_registry_validator_key_registration_errors_when_mutex_is_poisoned() {
+        let signer: AvcReceiptSigner = Arc::new(|payload: &[u8]| validator_keypair().sign(payload));
+        let state = AvcApiState::new(validator_did(), signer);
+        let registry = Arc::clone(&state.registry);
+        let _ = std::panic::catch_unwind(move || {
+            let _guard = registry.lock().unwrap();
+            panic!("poison AVC registry mutex for validator key registration test");
+        });
+
+        let error = state
+            .register_validator_public_keys([(validator_did(), validator_keypair().public)])
+            .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "AVC registry unavailable while registering validator public key"
+        );
+    }
+
+    #[test]
+    fn avc_registry_validator_key_registration_rejects_loaded_receipt_without_swapping_state() {
+        let other_validator_keypair = KeyPair::from_secret_bytes([0x44; 32]).unwrap();
+        let credential = baseline_credential();
+        let credential_id = credential.id().unwrap();
+        let validation = AvcValidationResult {
+            credential_id,
+            decision: AvcDecision::Allow,
+            reason_codes: Vec::new(),
+            normalized_holder_did: Did::new("did:exo:agent").unwrap(),
+            valid_until: Some(Timestamp::new(2_000_000, 0)),
+            receipt: None,
+        };
+        let receipt = create_trust_receipt(
+            &validation,
+            None,
+            validator_did(),
+            Timestamp::new(1_500_000, 0),
+            |bytes| other_validator_keypair.sign(bytes),
+        )
+        .unwrap();
+        let mut durable_state = AvcRegistryDurableState::default();
+        durable_state.credentials.insert(credential_id, credential);
+        durable_state.receipts.insert(receipt.receipt_id, receipt);
+        let loaded_registry = InMemoryAvcRegistry::from_durable_state(durable_state).unwrap();
+
+        let signer: AvcReceiptSigner = Arc::new(|payload: &[u8]| validator_keypair().sign(payload));
+        let state = AvcApiState::new(validator_did(), signer);
+        *state.registry.lock().unwrap() = loaded_registry;
+
+        let error = state
+            .register_validator_public_keys([(validator_did(), validator_keypair().public)])
+            .unwrap_err();
+        let error = error.to_string();
+        assert!(error.contains("AVC durable receipt validation failed"));
+        assert!(error.contains("signature"));
+
+        let post_failure_error = {
+            let registry = state.registry.lock().unwrap();
+            registry.validate_loaded_receipts().unwrap_err()
+        };
+        assert_eq!(
+            post_failure_error.to_string(),
+            "AVC invalid input: receipt validator public key for did:exo:validator is unresolved",
+            "failed validator key registration must not replace the live registry with the candidate"
+        );
+    }
+
+    #[test]
+    fn avc_registry_registered_credential_mismatch_is_rejected() {
+        let credential = baseline_credential();
+        let credential_id = credential.id().unwrap();
+        let mut submitted_credential = credential.clone();
+        submitted_credential.signature = Signature::from_bytes([0x44; 64]);
+        assert_eq!(submitted_credential.id().unwrap(), credential_id);
+
+        let mut registry = InMemoryAvcRegistry::new();
+        registry.put_public_key(Did::new("did:exo:issuer").unwrap(), issuer_keypair().public);
+        registry.put_credential(credential).unwrap();
+        let request = AvcValidationRequest {
+            credential: submitted_credential,
+            action: None,
+            now: Timestamp::new(1_500_000, 0),
+        };
+
+        let error = require_registered_credential(&registry, &request).unwrap_err();
+
+        assert_eq!(
+            error,
+            (
+                StatusCode::BAD_REQUEST,
+                "credential does not match registered AVC".into()
+            )
+        );
     }
 
     #[test]
@@ -3692,6 +4077,15 @@ mod tests {
         assert!(
             production.contains("load_postgres_durable_registry_or_import_file"),
             "AVC startup must import any existing file-backed state into Postgres"
+        );
+        let file_fallback = production
+            .split("None => {")
+            .nth(1)
+            .and_then(|section| section.split("Ok(Self").next())
+            .expect("AVC file fallback branch present");
+        assert!(
+            file_fallback.contains("tracing::warn!"),
+            "AVC file fallback startup must warn operators that Postgres durability is unavailable"
         );
         assert!(
             production.contains("AvcRegistryDurability::File"),

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -340,6 +340,38 @@ fn spawn_event_fanout(
     });
 }
 
+fn avc_require_postgres_durability_from_env() -> anyhow::Result<bool> {
+    let value = match std::env::var(avc::AVC_REQUIRE_POSTGRES_DURABILITY_ENV) {
+        Ok(value) => value,
+        Err(std::env::VarError::NotPresent) => return Ok(false),
+        Err(std::env::VarError::NotUnicode(_)) => {
+            anyhow::bail!(
+                "{} is not valid Unicode",
+                avc::AVC_REQUIRE_POSTGRES_DURABILITY_ENV
+            );
+        }
+    };
+    let value = value.trim();
+    if value == "1" || value.eq_ignore_ascii_case("true") {
+        Ok(true)
+    } else if value.is_empty() || value == "0" || value.eq_ignore_ascii_case("false") {
+        Ok(false)
+    } else {
+        anyhow::bail!(
+            "{} must be true, false, 1, or 0",
+            avc::AVC_REQUIRE_POSTGRES_DURABILITY_ENV
+        );
+    }
+}
+
+fn warn_avc_non_postgres_durability(data_dir: &std::path::Path) {
+    tracing::warn!(
+        data_dir = %data_dir.display(),
+        required_env = avc::AVC_REQUIRE_POSTGRES_DURABILITY_ENV,
+        "PRODUCTION AVC DURABILITY WARNING: DATABASE_URL not configured; AVC registry runtime credentials, revocations, and trust receipts will use local file fallback in the node data directory, not Postgres"
+    );
+}
+
 /// Start all subsystems for a running node.
 #[allow(clippy::too_many_arguments)]
 // 10 args is the minimum for a node bootstrap entry point:
@@ -893,6 +925,7 @@ async fn start_node(
         drop(alert_rx);
     }
 
+    let require_avc_postgres_durability = avc_require_postgres_durability_from_env()?;
     let gateway_pool = match std::env::var("DATABASE_URL") {
         Ok(database_url) => {
             tracing::info!("DATABASE_URL configured - initializing gateway readiness pool");
@@ -905,6 +938,13 @@ async fn start_node(
             )
         }
         Err(std::env::VarError::NotPresent) => {
+            if require_avc_postgres_durability {
+                anyhow::bail!(
+                    "{} is enabled but DATABASE_URL is not configured; AVC registry would use the local file fallback, which does not meet production Postgres durability requirements",
+                    avc::AVC_REQUIRE_POSTGRES_DURABILITY_ENV
+                );
+            }
+            warn_avc_non_postgres_durability(data_dir);
             tracing::warn!(
                 "DATABASE_URL not configured - /ready will remain unavailable until a database is configured"
             );
@@ -925,6 +965,7 @@ async fn start_node(
         )
         .await?,
     );
+    avc_state.register_validator_public_keys(sync_validator_public_keys.clone())?;
     match avc::load_configured_root_trust_bundle(avc_state.as_ref())? {
         Some(registration) => {
             tracing::info!(
@@ -1521,6 +1562,69 @@ mod tests {
         assert!(
             production[avc_index..].contains("gateway_pool.clone()"),
             "AVC durable registry must reuse the gateway database pool instead of requiring a separate /data-backed store"
+        );
+    }
+
+    #[test]
+    fn avc_registry_startup_registers_all_resolved_validator_public_keys() {
+        let source = include_str!("main.rs");
+        let production = source.split("#[cfg(test)]").next().unwrap();
+        let avc_startup = production
+            .split("let avc_state = Arc::new(")
+            .nth(1)
+            .and_then(|section| {
+                section
+                    .split("match avc::load_configured_root_trust_bundle")
+                    .next()
+            })
+            .expect("AVC startup section present");
+
+        assert!(
+            avc_startup.contains(
+                "avc_state.register_validator_public_keys(sync_validator_public_keys.clone())"
+            ),
+            "AVC startup must register the full configured validator key set before durable receipt revalidation"
+        );
+        assert!(
+            !avc_startup.contains("register_validator_public_key(node_identity.public_key)"),
+            "AVC startup must not revalidate durable receipts against only the local node key"
+        );
+    }
+
+    #[test]
+    fn avc_registry_missing_database_url_warns_and_can_fail_closed() {
+        let source = include_str!("main.rs");
+        let production = source.split("#[cfg(test)]").next().unwrap();
+        let gateway_section = production
+            .split("let gateway_pool = match std::env::var(\"DATABASE_URL\")")
+            .nth(1)
+            .and_then(|section| section.split("let avc_state = Arc::new").next())
+            .unwrap();
+        let missing_database_url_branch = gateway_section
+            .split("Err(std::env::VarError::NotPresent)")
+            .nth(1)
+            .and_then(|section| section.split("Err(std::env::VarError::NotUnicode").next())
+            .unwrap();
+
+        assert!(
+            production.contains("fn avc_require_postgres_durability_from_env"),
+            "node startup must expose an explicit AVC Postgres durability guard"
+        );
+        assert!(
+            production.contains("avc::AVC_REQUIRE_POSTGRES_DURABILITY_ENV"),
+            "AVC Postgres durability guard must use the AVC-owned env constant"
+        );
+        assert!(
+            missing_database_url_branch.contains("if require_avc_postgres_durability"),
+            "missing DATABASE_URL branch must check the fail-closed AVC durability guard"
+        );
+        assert!(
+            missing_database_url_branch.contains("anyhow::bail!"),
+            "enabled AVC Postgres durability guard must fail closed without DATABASE_URL"
+        );
+        assert!(
+            missing_database_url_branch.contains("warn_avc_non_postgres_durability(data_dir)"),
+            "missing DATABASE_URL branch must warn operators before using local AVC file fallback"
         );
     }
 

--- a/deploy/NODE-ZERO.md
+++ b/deploy/NODE-ZERO.md
@@ -55,7 +55,7 @@ This creates the Railway project and links it to the repo. Pushes to `main` will
 railway add --database postgres
 ```
 
-Railway provisions a Postgres 16 instance and automatically injects `DATABASE_URL` into your service environment over the private network. No manual connection string needed.
+Railway provisions a Postgres 16 instance and automatically injects `DATABASE_URL` into your service environment over the private network. No manual connection string needed. This is required for production AVC registry durability; without it, the node uses the local AVC file fallback and logs a production durability warning.
 
 ---
 
@@ -81,13 +81,17 @@ railway variables --set "JWT_SECRET=$(openssl rand -hex 32)"
 railway variables --set "EXOCHAIN_DATA_DIR=/data"
 railway variables --set "RUST_LOG=info"
 railway variables --set "IS_VALIDATOR=true"   # Genesis validator mode
+railway variables --set "EXO_AVC_REQUIRE_POSTGRES_DURABILITY=true"
 # DATABASE_URL is injected automatically by the Postgres plugin
 # PORT is auto-injected by Railway and consumed by entrypoint.sh
+# EXO_AVC_ROOT_TRUST_BUNDLE is set by the root Dockerfile to the bundled verified root trust bundle
 ```
 
 | Variable | Required | Description |
 |---|---|---|
-| `DATABASE_URL` | Yes (auto) | Set by Railway Postgres plugin — private network URL |
+| `DATABASE_URL` | Yes (auto) | Set by Railway Postgres plugin — private network URL; required for production AVC registry durability |
+| `EXO_AVC_REQUIRE_POSTGRES_DURABILITY` | Yes | `true` — fail startup if `DATABASE_URL` is missing |
+| `EXO_AVC_ROOT_TRUST_BUNDLE` | Yes for production AVC root trust | Verified bundle path; public-key trust anchors are reloaded from this startup config, not from AVC durable state |
 | `JWT_SECRET` | Yes | 32+ byte random hex — JWT signing secret |
 | `EXOCHAIN_DATA_DIR` | Yes | `/data` — persistent volume mount path |
 | `IS_VALIDATOR` | Yes for Node 0 | `true` — entrypoint.sh adds `--validator` flag |
@@ -255,9 +259,10 @@ railway shell                   # open a shell in the running container
 This is the genesis deployment. Once running:
 
 - **DAG is live** — persisting to SQLite at `/data/dag.db`
-- **Postgres connected** — governance artifacts stored via `PostgresStore`
+- **Postgres connected** — governance artifacts and production AVC registry runtime records are stored through Postgres-backed durability
 - **BFT consensus bootstrapped** — standalone validator mode, ready for quorum expansion
 - **Identity key generated** — node DID is committed and stored at `/data/identity.key`
+- **AVC root trust restored** — verified startup bundle registers public-key trust anchors; they are not recovered from AVC durable state
 - **Chain of custody is mathematically provable** — regardless of Railway's availability, the DAG hashes are the truth
 
 When Node 1 joins and quorum reaches 4 validators (3f+1 BFT safety), the network becomes fully fault-tolerant.

--- a/deploy/RAILWAY-HANDOFF.md
+++ b/deploy/RAILWAY-HANDOFF.md
@@ -63,7 +63,7 @@ Choose `production` environment when prompted.
 railway add --database postgres
 ```
 
-Railway provisions a Postgres 16 instance and auto-injects `DATABASE_URL` over the private network.
+Railway provisions a Postgres 16 instance and auto-injects `DATABASE_URL` over the private network. `DATABASE_URL` is required for production AVC registry durability; without it the node only has the local AVC file fallback and logs a production durability warning.
 
 ### 4. Add a service (the exochain node)
 
@@ -83,10 +83,11 @@ railway variables --service exochain \
   --set "JWT_SECRET=$(openssl rand -hex 32)" \
   --set "EXOCHAIN_DATA_DIR=/data" \
   --set "RUST_LOG=info" \
-  --set "IS_VALIDATOR=true"
+  --set "IS_VALIDATOR=true" \
+  --set "EXO_AVC_REQUIRE_POSTGRES_DURABILITY=true"
 ```
 
-(`PORT` is auto-injected by Railway. `DATABASE_URL` is auto-injected by the Postgres plugin.)
+(`PORT` is auto-injected by Railway. `DATABASE_URL` is auto-injected by the Postgres plugin. The root Dockerfile sets `EXO_AVC_ROOT_TRUST_BUNDLE` to the bundled verified root trust bundle; keep that startup configuration in place because AVC public-key trust anchors are reloaded from it, not from AVC durable state.)
 
 ### 6. Mount persistent volume at /data
 
@@ -187,6 +188,7 @@ Each environment gets its own Postgres + volume + URL. Promotion flow: branch `d
 |-------|-----------|----------|
 | `GET /health` | Every 30s (Railway healthcheck) | 200 OK |
 | `GET /api/v1/governance/status` | Manual | `is_validator: true`, `consensus_round` increments slowly |
+| AVC durability logs | Every deploy | No `PRODUCTION AVC DURABILITY WARNING`; `DATABASE_URL` must be present |
 | Memory usage | Dashboard | <500 MB at idle, grows with DAG size |
 | CPU | Dashboard | <5% at idle |
 | Volume usage | Dashboard | DAG grows ~10 KB per event |

--- a/docs/audit/AVC-TRUST-RECEIPT-ISSUES-696-700-PLAN.md
+++ b/docs/audit/AVC-TRUST-RECEIPT-ISSUES-696-700-PLAN.md
@@ -1,0 +1,262 @@
+# Summary
+
+This plan remediates GitHub issues #696 through #700 for the AVC trust-receipt path by fixing receipt signature verification, adding truthful durability guardrails, binding receipts to action content commitments, adding hash-linkage for receipt ordering, and documenting the remaining external timestamp/anchor boundary. The plan preserves the existing `/api/v1/avc/*` API surface, existing credential and revocation semantics, and backward compatibility for previously serialized receipts.
+
+Exit criterion: The remediation objective, user outcome, and preserved compatibility boundaries are stated in this section.
+
+# Locked Decisions
+
+1. Execution branch: `codex/avc-trust-receipt-issues-696-700`.
+2. Base branch: `exochain/main`.
+3. Canonical plan file: `docs/audit/AVC-TRUST-RECEIPT-ISSUES-696-700-PLAN.md`.
+4. Issue #696 writes are scoped to `crates/exo-avc/src/registry.rs` unless node startup revalidation is required.
+5. Issue #700 writes are scoped to `crates/exo-node/src/avc.rs`, `crates/exo-node/src/main.rs`, `deploy/NODE-ZERO.md`, `deploy/RAILWAY-HANDOFF.md`, and `docs/guides/production-deployment.md`.
+6. Issues #697, #698, and #699 share receipt schema and emit-path ownership and execute after the architecture scout returns a non-overlapping implementation map.
+7. No fake RFC-3161, blockchain, DAG, BCTS, or external anchor provider will be added.
+8. If no real external timestamp or anchor provider exists in the current repository, the fix will record truthful timestamp provenance and defer external anchoring with an activation trigger.
+9. Existing signed receipts remain deserializable by using optional new fields with `serde(default)` when receipt schema fields are added.
+10. Receipt signing payload changes must be deterministic, canonical-CBOR encoded, and covered by regression tests.
+11. The open DAG DB PR #695 remains untouched by this issue set.
+12. GitHub issues #696 through #700 remain the external tracker until a maintainer closes or supersedes them.
+
+Exit criterion: Every ambiguous execution, path, compatibility, and scope decision is pinned to a literal value.
+
+# Deferred Phases
+
+1. RFC-3161 TSA integration is deferred until maintainers provide approved TSA endpoint configuration, trust policy, timeout budget, retry budget, and acceptance-test credentials.
+2. Public blockchain anchoring is deferred until maintainers select a chain, transaction format, key custody model, confirmation policy, fee policy, and replay-safe testnet validation path.
+3. Full BCTS lifecycle integration for every AVC receipt is deferred until maintainers decide whether AVC receipt emission creates a BCTS transaction or attaches to a caller-supplied BCTS correlation ID.
+4. Persisting public-key trust anchors is deferred until maintainers decide whether startup configuration remains the sole trust-anchor source or durable state becomes an authenticated trust-anchor store.
+
+Exit criterion: Every deferred item has a concrete activation trigger and no deferred item is required for the in-scope code to be truthful.
+
+# Requirements Specification
+
+## Functional
+
+1. `InMemoryAvcRegistry::put_receipt` verifies receipt signatures against `receipt.validator_did` when a validator public key is registered.
+2. Durable receipt import rejects malformed receipt IDs, empty signatures, unknown credentials, and duplicate durable keys.
+3. Live durable-state application rejects forged receipt signatures when startup trust anchors are available.
+4. AVC receipt emission binds the receipt to an action content commitment derived from the submitted `AvcActionRequest`.
+5. AVC receipt storage records enough linkage to detect deletion or reordering within the implemented receipt-chain scope.
+6. AVC startup emits an operator-visible warning when Postgres-backed registry durability is unavailable.
+7. Deployment documentation states that `DATABASE_URL` is required for production AVC registry durability.
+8. Documentation states that public-key trust anchors are restored from verified startup configuration, not from ordinary durable registry state.
+
+## Non-Functional
+
+1. Receipt validation fails closed on unresolved validator keys in live storage paths.
+2. Receipt schema changes are backward-compatible with legacy receipts.
+3. Hashes are deterministic across platforms by using existing canonical structured hashing or canonical CBOR patterns.
+4. The implementation introduces no new network dependency for timestamping or anchoring.
+5. Tests run without real external services except existing optional Postgres tests that already skip when the configured database URL is absent.
+6. Logging avoids secrets, signatures, raw private payloads, and database URLs.
+
+## Compatibility
+
+1. Existing `/api/v1/avc/issue`, `/api/v1/avc/validate`, `/api/v1/avc/receipts/emit`, `/api/v1/avc/receipts/:hash`, `/api/v1/avc/receipts`, `/api/v1/avc/protocol`, `/api/v1/avc/delegate`, `/api/v1/avc/revoke`, `/api/v1/avc/:id`, and `/api/v1/agents/:did/avcs` routes remain present.
+2. Existing credential, delegation, revocation, policy reference, consent reference, and authority-chain validation semantics remain unchanged.
+3. Existing legacy `AvcTrustReceipt` records without new optional fields remain deserializable.
+4. Existing root trust bundle verification constants remain unchanged.
+5. Existing file-based durable registry fallback remains available for non-production use.
+
+## Observability
+
+1. Startup logs identify AVC durability mode as Postgres-backed or non-Postgres-backed without printing secret values.
+2. Signature verification failures surface through existing `AvcError::InvalidInput` reason text.
+3. Tests prove forged receipt signatures do not increment `receipt_count`.
+4. Tests prove action content commitment and receipt-chain fields are included in receipt ID/signing behavior when implemented.
+5. Documentation identifies external timestamp and anchoring gaps without claiming fake capability.
+
+Exit criterion: Functional, non-functional, compatibility, and observability requirements are explicit and testable.
+
+# AVC Remediation Contract
+
+| claim | scope | proof command or check |
+| --- | --- | --- |
+| Receipt signatures are verified on live storage. | `crates/exo-avc/src/registry.rs` | `cargo test -p exo-avc receipt -- --nocapture` |
+| Forged receipt signatures are rejected without storage. | `crates/exo-avc/src/registry.rs` | Test named for forged receipt signature rejection. |
+| Durable receipt records remain structurally validated before trust anchors load. | `crates/exo-avc/src/registry.rs` | Existing durable-state receipt tests plus new live-signature test. |
+| AVC production durability requires Postgres configuration. | `crates/exo-node/src/main.rs`, deployment docs | Source assertion test or `rg -n "DATABASE_URL.*AVC|AVC.*DATABASE_URL" crates/exo-node deploy docs/guides`. |
+| Trust anchors are not falsely claimed to be ordinary durable records. | `crates/exo-avc/src/registry.rs`, docs | `rg -n "trust anchors" crates/exo-avc/src/registry.rs deploy docs/guides`. |
+| Action content commitment binds receipts to submitted action details. | `crates/exo-avc/src/receipt.rs`, `crates/exo-node/src/avc.rs` | Test proves changing action content changes receipt ID or action commitment. |
+| Receipt ordering is tamper-evident within the implemented scope. | `crates/exo-avc/src/receipt.rs`, `crates/exo-avc/src/registry.rs` | Test proves second receipt records previous receipt hash and tampering breaks verification. |
+| External timestamp and external anchor providers are not stubbed. | Repository-wide | `rg -n "RFC-3161|TimestampService|ExternalChain|TODO|stub|fake" crates docs` review finds no false implementation claim. |
+
+Definitions: `AvcTrustReceipt` is the signed receipt struct in `crates/exo-avc/src/receipt.rs`; `AvcActionRequest` is the submitted action payload in `crates/exo-avc/src/validation.rs`; `AvcRegistryDurableState` is the persisted AVC runtime state in `crates/exo-avc/src/registry.rs`; `DATABASE_URL` is the existing Postgres configuration environment variable consumed by `crates/exo-node/src/main.rs`.
+
+Exit criterion: Every claim used later has a scope and proof command or observable check.
+
+# Implementation Slices
+
+Sub-Agent Delegation Protocol: Each sub-agent receives an SOP-adapted brief with objective, allowed write scope, forbidden write scope, reuse check, no-stub rule, tests, acceptance criteria, and reporting format. The main orchestrator reviews all outputs before integration. Work that violates write boundaries, duplicates an existing system, fabricates capability, or lacks test evidence is rejected or returned for correction. Sub-agent standards are equivalent to local standards.
+
+## Slice 1: Issue #696 Receipt Signature Verification
+
+Goal: Verify AVC receipt signatures in live receipt storage and live durable-state application.
+
+Allowed write scope: `crates/exo-avc/src/registry.rs`.
+
+Requirements: Use `exo_core::crypto::verify`, `AvcTrustReceipt::signing_payload`, and existing registry public-key resolution.
+
+Specification: Add signature verification to live receipt validation; preserve structural durable import checks before trust anchors load; add focused valid and forged receipt tests.
+
+Test plan: Run `cargo test -p exo-avc receipt -- --nocapture`.
+
+Exit criterion: A forged receipt signature fails closed and no receipt is stored.
+
+## Slice 2: Issue #700 Durability Guardrails
+
+Goal: Make non-Postgres AVC durability visible to operators and documented as non-production.
+
+Allowed write scope: `crates/exo-node/src/avc.rs`, `crates/exo-node/src/main.rs`, `deploy/NODE-ZERO.md`, `deploy/RAILWAY-HANDOFF.md`, `docs/guides/production-deployment.md`.
+
+Requirements: Reuse existing `DATABASE_URL`, `AvcRegistryDurability`, and deployment documentation patterns.
+
+Specification: Add startup warning or existing-pattern guard for non-Postgres AVC durability; document production requirement and trust-anchor reload design.
+
+Test plan: Run targeted node AVC startup/durability tests or source assertion tests discovered in `crates/exo-node/src/avc.rs` and `crates/exo-node/src/main.rs`.
+
+Exit criterion: Production operators can discover that `DATABASE_URL` is required for durable AVC registry operation before deployment.
+
+## Slice 3: Issues #697, #698, and #699 Architecture Map
+
+Goal: Prevent schema/time/anchor implementation from guessing or overlapping with earlier slices.
+
+Allowed write scope: none.
+
+Requirements: Inspect existing receipt schema, BCTS chain, economy anchor pattern, DAG append path, timestamp source, and deployment docs.
+
+Specification: Return exact implementation slices for content commitment, hash-linkage, and truthful timestamp provenance.
+
+Test plan: Read-only file:line report reviewed by main orchestrator.
+
+Exit criterion: The next write slices have exact non-overlapping file scopes and no fake provider dependency.
+
+## Slice 4: Issue #699 Action Content Commitment
+
+Goal: Bind emitted AVC receipts to the submitted action content without storing raw payloads.
+
+Allowed write scope: To be finalized by Slice 3.
+
+Requirements: Preserve legacy receipt deserialization and canonical signing.
+
+Specification: Add optional content commitment derived from `AvcActionRequest` or a caller-supplied content hash if existing API shape supports it.
+
+Test plan: Add tests proving action-field changes alter the signed receipt commitment and legacy receipts remain valid.
+
+Exit criterion: A receipt can be cryptographically tied to the action details that produced it.
+
+## Slice 5: Issue #697 Receipt Hash Linkage
+
+Goal: Add tamper-evident ordering within an explicit receipt-chain scope.
+
+Allowed write scope: To be finalized by Slice 3.
+
+Requirements: Reuse existing hash-chain or anchor patterns where possible.
+
+Specification: Add previous-receipt linkage or existing anchor commitment without claiming full external anchoring.
+
+Test plan: Add tests proving chain linkage is recorded and tampering is detected.
+
+Exit criterion: Receipts have an implemented ordering proof within the selected chain scope.
+
+## Slice 6: Issue #698 Timestamp Provenance Boundary
+
+Goal: Make timestamp trust level explicit and avoid legal-admissibility overclaiming.
+
+Allowed write scope: To be finalized by Slice 3.
+
+Requirements: Reuse `AvcReceiptTimestampSource` and existing Postgres clock path.
+
+Specification: Record or document whether a receipt timestamp came from Postgres-backed runtime time or local HLC, and defer RFC-3161/blockchain anchoring until real provider configuration exists.
+
+Test plan: Add tests proving emitted receipts use trusted node timestamp source rather than caller-supplied `validation.now`, and documentation grep proves no false external timestamp claim.
+
+Exit criterion: The system no longer hides timestamp trust source or claims an unimplemented external timestamp provider.
+
+Exit criterion: Every implementation slice has goal, write scope, requirements, specification, test plan, and observable completion condition.
+
+# Test Plan
+
+## Baseline Commands
+
+1. `git status --short --branch`
+2. `cargo test -p exo-avc receipt -- --nocapture`
+3. `cargo test -p exo-node avc -- --nocapture`
+
+## Per-Slice Commands
+
+1. Slice 1: `cargo test -p exo-avc receipt -- --nocapture`
+2. Slice 2: `cargo test -p exo-node avc -- --nocapture`
+3. Slice 3: `rg -n "AvcTrustReceipt|AvcActionRequest|BctsTransition|EconomyRecordAnchor|AvcReceiptTimestampSource" crates/exo-avc crates/exo-node crates/exo-core`
+4. Slice 4: Commands to be finalized after Slice 3.
+5. Slice 5: Commands to be finalized after Slice 3.
+6. Slice 6: Commands to be finalized after Slice 3.
+
+## Final Agent-Runnable Sequence
+
+1. `git status --short --branch`
+2. `cargo fmt --check`
+3. `cargo test -p exo-avc receipt -- --nocapture`
+4. `cargo test -p exo-node avc -- --nocapture`
+5. `rg -n "RFC-3161|TimestampService|ExternalChain|fake|stub|placeholder" crates/exo-avc crates/exo-node docs deploy`
+6. `git diff --stat`
+
+## Operator-Only Steps
+
+1. Configure `DATABASE_URL` in production deployment.
+2. Select real RFC-3161 and blockchain anchoring providers if external legal timestamping is required.
+3. Close or comment on GitHub issues #696 through #700 after maintainer review.
+
+Exit criterion: Baseline, per-slice, final, and operator-only checks are listed as runnable commands or explicit operator actions.
+
+# Definition of Done
+
+1. Issue #696 has a code path that verifies receipt signatures against validator public keys.
+2. Issue #696 has a forged-signature regression test.
+3. Valid receipts store successfully with registered validator keys.
+4. Forged receipts do not increment registry receipt count.
+5. Durable receipt structural checks still reject invalid IDs.
+6. Durable receipt structural checks still reject empty signatures.
+7. Durable receipt structural checks still reject unknown credentials.
+8. Live durable-state application rejects forged receipt signatures when trust anchors are present.
+9. Issue #700 startup warning or guard exists for non-Postgres AVC durability.
+10. Deployment docs require `DATABASE_URL` for production AVC registry durability.
+11. Deployment docs state trust anchors reload from verified startup configuration.
+12. No documentation claims trust anchors are ordinary durable registry records.
+13. Issue #699 receipt output contains an action content commitment or equivalent signed content binding.
+14. Issue #699 tests prove action content affects the receipt binding.
+15. Legacy receipts without new optional fields remain deserializable.
+16. Issue #697 receipts contain implemented hash linkage or documented existing anchor commitment.
+17. Issue #697 tests prove linkage detects tampering or ordering changes within scope.
+18. Issue #698 does not add fake external timestamp providers.
+19. Issue #698 records or documents the timestamp trust source for emitted receipts.
+20. Existing AVC routes remain present.
+21. `cargo fmt --check` passes.
+22. Targeted `exo-avc` tests pass.
+23. Targeted `exo-node` AVC tests pass or an external dependency blocker is documented with exact command output.
+24. Git status contains only issue-scoped files.
+25. The PR/commit message references GitHub issues #696 through #700.
+
+Exit criterion: All listed Definition of Done items are independently checkable.
+
+# Post-Implementation Review
+
+When the Definition of Done is met and the checkpoint commit is created, a post-implementation review pass runs before push or deployment. The pass walks code review, test coverage, hardening, end-to-end verification, and documentation. Blockers found in the review are fixed and the relevant layers re-run before ship.
+
+Review scope: Slices 1 through 6 and files under `crates/exo-avc/src/registry.rs`, `crates/exo-avc/src/receipt.rs`, `crates/exo-node/src/avc.rs`, `crates/exo-node/src/main.rs`, `deploy/NODE-ZERO.md`, `deploy/RAILWAY-HANDOFF.md`, `docs/guides/production-deployment.md`, and this plan file.
+Review trigger: Definition of Done met and checkpoint commit created.
+Review verdict gate: Ship | Fix blockers and re-run | Hand back to planning.
+
+Completed review evidence recorded before PR:
+
+- Code Review: Two reviewer passes and one silent-failure pass reported no remaining high-confidence blockers after scoped receipt-validator keys replaced generic public-key receipt verification.
+- Test Coverage: `cargo +nightly llvm-cov -p exo-avc -p exo-node --branch --summary-only --json --output-path /tmp/exochain-avc-coverage-branch-final5.json --no-fail-fast` passed with `exo-avc` 194/194 and `exo-node` 1219/1219 tests passing. Compared with base coverage from `/tmp/exochain-avc-coverage-base.json`, total line coverage moved from 89.9613% to 90.0238%, total branch coverage moved from 67.6080% to 67.9745%, `crates/exo-avc/src/registry.rs` moved from 98.3535%/81.4286% to 98.3871%/81.5385%, `crates/exo-node/src/avc.rs` moved from 89.3953%/67.1053% to 90.0774%/67.7778%, and `crates/exo-node/src/main.rs` moved from 41.6981%/70.0000% to 43.1616%/70.0000%.
+- Hardening: Receipt signatures verify with scoped validator keys only, durable receipt import rejects malformed chains and duplicate action commitments, idempotency conflicts fail closed, and `EXO_AVC_REQUIRE_POSTGRES_DURABILITY` can fail startup without `DATABASE_URL`.
+- End-to-End Verification: Targeted `cargo test -p exo-avc registry -- --nocapture` passed 56 tests and targeted `cargo test -p exo-node avc -- --nocapture` passed 79 tests after final coverage tests.
+- Documentation and Handoff: Production deployment docs and deploy handoffs now require Postgres-backed AVC durability for production and state that key trust anchors reload from verified startup configuration, not durable state.
+
+Review verdict: Ship.
+
+Exit criterion: The post-implementation review scope, trigger, and verdict gate are explicit and require review before push or deployment.

--- a/docs/guides/production-deployment.md
+++ b/docs/guides/production-deployment.md
@@ -88,7 +88,9 @@ POSTGRES_PASSWORD=<your-secret> docker compose -f docker-compose.prod.yml up -d
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `DATABASE_URL` | Yes (production) | — | `postgres://<user>:<pass>@<host>:<port>/<db>` |
+| `DATABASE_URL` | Yes (production) | — | PostgreSQL URL; required for production AVC registry durability and `/ready` |
+| `EXO_AVC_REQUIRE_POSTGRES_DURABILITY` | Recommended (production) | `false` | Set to `true` or `1` to abort startup when `DATABASE_URL` is missing |
+| `EXO_AVC_ROOT_TRUST_BUNDLE` | Yes (production AVC root trust) | Docker image default | Verified root trust bundle path used to restore AVC public-key trust anchors at startup |
 | `BIND_ADDRESS` | No | `127.0.0.1:8443` | Host and port the gateway listens on |
 | `LOG_LEVEL` | No | `info` | Tracing filter: `trace`, `debug`, `info`, `warn`, `error` |
 
@@ -97,6 +99,18 @@ POSTGRES_PASSWORD=<your-secret> docker compose -f docker-compose.prod.yml up -d
 ```
 postgres://exochain:secret@localhost:5432/exochain
 ```
+
+For production AVC registry durability, `DATABASE_URL` must point to a reachable
+PostgreSQL instance. Without it, the node uses the local AVC file fallback under
+the node data directory and emits a production durability warning; that fallback
+is not a substitute for Postgres-backed production durability. Set
+`EXO_AVC_REQUIRE_POSTGRES_DURABILITY=true` in production to fail startup instead
+of accepting the fallback.
+
+AVC public-key trust anchors are not persisted in the AVC registry durable state.
+They are restored on every boot from the verified
+`EXO_AVC_ROOT_TRUST_BUNDLE` startup configuration, then durable revocations are
+revalidated against those live trust anchors.
 
 ---
 


### PR DESCRIPTION
## Amendment Summary

This PR remediates the AVC trust-receipt issues filed as #696 through #700.

- Re-verifies AVC trust receipt signatures on live storage and loaded durable state using scoped receipt-validator keys.
- Separates receipt-validator trust anchors from credential issuer public keys so validator keys do not become issuer trust, and issuer keys do not validate receipts.
- Adds signed action content commitments to receipts and enforces idempotency conflicts fail closed.
- Adds local receipt-chain linkage and durable import validation for missing links, branches, disconnected chains, duplicate commitments, and invalid terminal heads.
- Records truthful timestamp provenance for emitted receipts without fabricating RFC-3161, blockchain, or external timestamp providers.
- Adds production durability guardrails and docs requiring `DATABASE_URL` / Postgres-backed AVC durability for production, while keeping file fallback explicit for non-production/local use.
- Updates the extended receipt API shape to satisfy strict clippy without weakening lint policy, and refreshes README repo-truth counts required by the hygiene gate.

## Legislative Basis

* **Fixes Issue**: #696, #697, #698, #699, #700
* **Spec Section**: AVC trust receipt integrity, receipt provenance, and production durability requirements tracked by issues #696-#700 and `docs/audit/AVC-TRUST-RECEIPT-ISSUES-696-700-PLAN.md`; CR-001 Section 8.8 coverage gate applies to verification.
* **Traceability ID**: AVC-TRUST-RECEIPT-ISSUES-696-700

## Judicial Impact

* [x] **Invariants**: Preserves identity adjudication and deterministic receipt verification by validating scoped issuer and receipt-validator trust anchors separately.
* [x] **Security**: Fails closed for invalid receipt signatures, disconnected chains, duplicate commitments, idempotency conflicts, and required production durability without adding fake trust providers.
* [x] **Performance**: No BFT finality path changes; added checks are limited to AVC receipt storage, loading, import, and emission paths.
* [x] **Post-Quantum**: Uses the existing signature abstraction and does not add direct signature construction outside the AVC signing/verification surfaces.

## Verification Evidence

Local checks run against PR head `a7388838`:

* `cargo +nightly fmt --all -- --check`
* `git diff --check`
* `bash tools/test_repo_truth.sh`
* `bash tools/test_coverage_policy.sh`
* `RUSTFLAGS='-D warnings' cargo build --workspace --all-targets`
* `RUSTFLAGS='-D warnings' cargo test --workspace --lib`
* `cargo clippy --workspace --all-targets -- -D warnings`
* `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
* `cargo deny check`
* `cargo audit --deny unsound --deny unmaintained`
* `cargo tarpaulin --workspace --exclude exochain-wasm --exclude exo-proofs --out xml --output-dir coverage --engine llvm --timeout 300 --fail-under 90` -> 90.75% line coverage, 22176/24437 lines covered

Targeted regression checks also passed during review:

* `cargo fmt -p exo-avc -p exo-node --check`
* `cargo clippy -p exo-avc -p exo-node --all-targets -- -D warnings`
* `cargo test -p exo-avc receipt -- --nocapture` -> 35 passed
* `cargo test -p exo-node avc -- --nocapture` -> 79 passed
* `cargo +nightly llvm-cov -p exo-avc -p exo-node --branch --summary-only --json --output-path /tmp/exochain-avc-coverage-branch-final5.json --no-fail-fast` -> passed before the final clippy/doc-shape cleanup, with `exo-avc` 194/194 and `exo-node` 1219/1219 tests passing

Post-push status: `gh pr checks 701 --repo exochain/exochain --watch=false` previously reported no checks on this branch; GitHub CI/check status should be treated as pending until Actions are allowed to run and report on the new head.

## Scope and Non-Claims

This PR intentionally does not add fake external timestamp or public-chain anchoring providers. Receipt timestamps expose provenance (`PostgresClockTimestamp`, `LocalHybridLogicalClock`, or `FixedTestTimestamp`), and real RFC-3161/blockchain anchoring remains deferred until maintainers select provider configuration, trust policy, timeout/retry budgets, and acceptance-test credentials.
