### PR TITLE
fix: harden Archon workflow gates to require explicit approval

### DIFF
--- a/.archon/workflows/exochain-fix-issue-dag.yaml
+++ b/.archon/workflows/exochain-fix-issue-dag.yaml
@@ -46,7 +46,7 @@ nodes:
   - id: fix
     command: exochain-fix-bug
     depends_on: [council_review]
-    when: "$council_review.output.aggregate_disposition != 'Rejected'"
+    when: "$council_review.output.aggregate_disposition == 'Approved'"
     description: Implement the fix
 
   - id: validate
@@ -67,7 +67,7 @@ nodes:
   - id: create_pr
     command: archon-finalize-pr
     depends_on: [validate]
-    when: "$validate.output.passed == 'true'"
+    when: "$validate.output.passed == 'true' and $validate.output.governance_disposition == 'APPROVE'"
     trigger_rule: all_success
     description: Create governance-approved PR
 

--- a/.archon/workflows/exochain-self-improvement-cycle.yaml
+++ b/.archon/workflows/exochain-self-improvement-cycle.yaml
@@ -117,14 +117,14 @@ nodes:
   - id: create_pr
     command: archon-finalize-pr
     depends_on: [validate_constitution]
-    when: "$validate_constitution.output.passed == 'true'"
+    when: "$validate_constitution.output.passed == 'true' and $validate_constitution.output.governance_disposition == 'APPROVE'"
     description: Create governance-approved PR with full audit trail
     trigger_rule: all_success
 
   - id: remediate
     command: exochain-fix-bug
     depends_on: [validate_constitution]
-    when: "$validate_constitution.output.passed == 'false'"
+    when: "$validate_constitution.output.passed == 'false' or $validate_constitution.output.governance_disposition != 'APPROVE'"
     description: Fix constitutional violations and re-validate
 
   # ── Escalation: auto-report blocking issues to council ──


### PR DESCRIPTION
### Motivation
- Close an automation logic gap where untrusted backlog/issue text could lead LLM-driven council outputs to trigger repository-modifying agents without an explicit approval gate. 
- Ensure the pipeline fails closed so only an explicit `Approved` council disposition plus a positive constitutional validation allow implementation and PR finalization. 
- Maintain adjacent-surface classification by making a minimal workflow-only hardening rather than changing command implementations.

### Description
- Change `.archon/workflows/exochain-fix-issue-dag.yaml` so the `fix` node runs only when `$council_review.output.aggregate_disposition == 'Approved'` instead of `!= 'Rejected'`.
- Tighten `.archon/workflows/exochain-fix-issue-dag.yaml` `create_pr` node to require both `$validate.output.passed == 'true'` and `$validate.output.governance_disposition == 'APPROVE'`.
- Update `.archon/workflows/exochain-self-improvement-cycle.yaml` so `create_pr` requires both `$validate_constitution.output.passed == 'true'` and `$validate_constitution.output.governance_disposition == 'APPROVE'`, and make `remediate` run when validation fails or the governance disposition is not `APPROVE`.
- Commit message: `fix(workflows): require explicit approval before implementation and PR` and PR title: `fix: harden Archon workflow gates to require explicit approval`.

### Testing
- Verified file contents and diffs with `sed`/`nl` and `git diff` to confirm the `when:` expressions were updated as intended, and the `git commit` succeeded.
- Ran repository inspections (`rg`, file reads) to confirm only the two workflow files were modified; these checks all succeeded.
- No unit/integration tests were modified or run by this patch; changes are scoped to Archon workflow YAMLs (adjacent surface) and do not alter core crates or CI gates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0819fef9ac832fb803c16b4d6e7a9b)