### PR TITLE
Harden AVC receipt trusted time source

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ pricing or settlement state, and the economy layer never gates trust on
 payment availability. Future governance amendments can switch nonzero
 pricing on by policy without modifying AVC validation.
 
+Production `exo-node` receipt emission requires a trusted HLC physical
+source. Set `EXO_AVC_RECEIPT_HLC_PHYSICAL_MS_FILE` to a file maintained
+by the deployment's trusted clock boundary; the file must contain a
+nonzero integer physical millisecond value. Receipt validation fails
+closed instead of falling back to the deterministic default HLC when this
+operator source is absent or malformed.
+
 HonorGood and Apex Velocity Catalyst Mission Economics now live in
 `exo-economy` as core provenance and settlement primitives: Missions,
 Contribution Receipts, Legacy Receipts, Value Contribution Nodes,

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -61,7 +61,7 @@ use exo_avc::{
     AvcValidationResult, InMemoryAvcRegistry, avc_action_signature_payload, create_trust_receipt,
     validate_avc,
 };
-use exo_core::{Did, Hash256, PublicKey, Signature, Timestamp, crypto, hlc::HybridClock};
+use exo_core::{Did, ExoError, Hash256, PublicKey, Signature, Timestamp, crypto, hlc::HybridClock};
 use exo_root::{RootTrustBundle, verify_root_bundle};
 use serde::{Deserialize, Serialize};
 use sqlx::{PgPool, Postgres, Row, Transaction};
@@ -76,6 +76,7 @@ pub const AVC_ROOT_TRUST_BUNDLE_ID_HEX: &str =
 pub const AVC_ROOT_TRUST_ISSUER_DID: &str = "did:exo:8EVGmqLo15JEnrbcrLo9r84qX1mtrVeBdPjHLUtb1sXX";
 pub const AVC_ROOT_TRUST_ISSUER_PUBLIC_KEY_HEX: &str =
     "6b765381964de7f74e77e4f9d265105f415e58722d19ff71603f62c31d5aff32";
+pub const AVC_RECEIPT_HLC_PHYSICAL_MS_FILE_ENV: &str = "EXO_AVC_RECEIPT_HLC_PHYSICAL_MS_FILE";
 const AVC_REGISTRY_DURABLE_STATE_FILE: &str = "avc-registry.cbor";
 const AVC_REGISTRY_POSTGRES_TABLE: &str = "avc_registry_state";
 const AVC_REGISTRY_POSTGRES_KEY: &str = "default";
@@ -154,14 +155,91 @@ impl AvcApiState {
                 AvcRegistryDurability::File(Arc::new(durable_state_path)),
             ),
         };
+        Self::with_durable_registry_and_receipt_timestamp_source(
+            registry,
+            durability,
+            validator_did,
+            receipt_signer,
+            configured_receipt_timestamp_source()?,
+        )
+    }
+
+    fn with_durable_registry_and_receipt_timestamp_source(
+        registry: InMemoryAvcRegistry,
+        durability: AvcRegistryDurability,
+        validator_did: Did,
+        receipt_signer: AvcReceiptSigner,
+        receipt_timestamp_source: AvcReceiptTimestampSource,
+    ) -> anyhow::Result<Self> {
         Ok(Self {
             registry: Arc::new(Mutex::new(registry)),
             validator_did,
             receipt_signer,
-            receipt_timestamp_source: receipt_timestamp_source_from_clock(HybridClock::new()),
+            receipt_timestamp_source,
             durability,
         })
     }
+}
+
+fn configured_receipt_timestamp_source() -> anyhow::Result<AvcReceiptTimestampSource> {
+    match std::env::var(AVC_RECEIPT_HLC_PHYSICAL_MS_FILE_ENV) {
+        Ok(raw_path) => {
+            let trimmed_path = raw_path.trim();
+            if trimmed_path.is_empty() {
+                anyhow::bail!(
+                    "{AVC_RECEIPT_HLC_PHYSICAL_MS_FILE_ENV} must name a trusted HLC physical-ms file"
+                );
+            }
+            Ok(receipt_timestamp_source_from_physical_ms_file(
+                PathBuf::from(trimmed_path),
+            ))
+        }
+        Err(std::env::VarError::NotPresent) => {
+            #[cfg(test)]
+            {
+                Ok(receipt_timestamp_source_from_clock(HybridClock::new()))
+            }
+            #[cfg(not(test))]
+            {
+                anyhow::bail!(
+                    "trusted AVC receipt HLC source unavailable; set \
+                    {AVC_RECEIPT_HLC_PHYSICAL_MS_FILE_ENV} to a file containing current trusted HLC physical milliseconds"
+                );
+            }
+        }
+        Err(std::env::VarError::NotUnicode(_)) => {
+            anyhow::bail!("{AVC_RECEIPT_HLC_PHYSICAL_MS_FILE_ENV} is not valid Unicode");
+        }
+    }
+}
+
+fn receipt_timestamp_source_from_physical_ms_file(path: PathBuf) -> AvcReceiptTimestampSource {
+    receipt_timestamp_source_from_clock(HybridClock::with_fallible_wall_clock(move || {
+        let raw = fs::read_to_string(&path).map_err(|error| ExoError::ClockUnavailable {
+            reason: format!(
+                "failed to read AVC receipt HLC physical-ms file at {}: {error}",
+                path.display()
+            ),
+        })?;
+        let physical_ms =
+            raw.trim()
+                .parse::<u64>()
+                .map_err(|error| ExoError::ClockUnavailable {
+                    reason: format!(
+                        "failed to parse AVC receipt HLC physical milliseconds from {}: {error}",
+                        path.display()
+                    ),
+                })?;
+        if physical_ms == 0 {
+            return Err(ExoError::ClockUnavailable {
+                reason: format!(
+                    "AVC receipt HLC physical-ms file at {} must contain a nonzero value",
+                    path.display()
+                ),
+            });
+        }
+        Ok(physical_ms)
+    }))
 }
 
 fn receipt_timestamp_source_from_clock(clock: HybridClock) -> AvcReceiptTimestampSource {
@@ -1111,6 +1189,23 @@ mod tests {
         let state = AvcApiState::with_durable_registry(data_dir, validator_did(), signer, None)
             .await
             .expect("durable AVC state");
+        seed_avc_trust_keys(&state);
+        Arc::new(state)
+    }
+
+    fn fresh_durable_state_with_receipt_timestamp_source(
+        data_dir: &FsPath,
+        receipt_timestamp_source: AvcReceiptTimestampSource,
+    ) -> Arc<AvcApiState> {
+        let signer: AvcReceiptSigner = Arc::new(|payload: &[u8]| validator_keypair().sign(payload));
+        let state = AvcApiState::with_durable_registry_and_receipt_timestamp_source(
+            InMemoryAvcRegistry::new(),
+            AvcRegistryDurability::File(Arc::new(data_dir.join(AVC_REGISTRY_DURABLE_STATE_FILE))),
+            validator_did(),
+            signer,
+            receipt_timestamp_source,
+        )
+        .expect("durable AVC state with trusted receipt timestamp source");
         seed_avc_trust_keys(&state);
         Arc::new(state)
     }
@@ -2098,6 +2193,68 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
         assert_eq!(state.registry.lock().unwrap().receipt_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn durable_receipt_emit_rejects_backdated_request_with_configured_hlc_file_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let clock_path = dir.path().join("trusted-avc-receipt-hlc-ms");
+        std::fs::write(&clock_path, "1600000\n").unwrap();
+        let state = fresh_durable_state_with_receipt_timestamp_source(
+            dir.path(),
+            receipt_timestamp_source_from_physical_ms_file(clock_path),
+        );
+        let credential = credential_expiring_at(Timestamp::new(1_550_000, 0));
+        state
+            .registry
+            .lock()
+            .unwrap()
+            .put_credential(credential.clone())
+            .unwrap();
+        let backdated_now = Timestamp::new(1_500_000, 0);
+        let request = AvcValidationRequest {
+            credential,
+            action: Some(baseline_action(Did::new("did:exo:agent").unwrap())),
+            now: backdated_now,
+        };
+        let body = serde_json::to_vec(&EmitReceiptRequest {
+            validation: request.clone(),
+            subject_signature: sign_action(&request, &subject_keypair()),
+            subject_public_key: None,
+        })
+        .unwrap();
+
+        let app = avc_router(Arc::clone(&state));
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/avc/receipts/emit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(state.registry.lock().unwrap().receipt_count(), 0);
+    }
+
+    #[test]
+    fn receipt_timestamp_source_reads_operator_hlc_physical_ms_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let clock_path = dir.path().join("trusted-avc-receipt-hlc-ms");
+        std::fs::write(&clock_path, "1600000\n").unwrap();
+        let source = receipt_timestamp_source_from_physical_ms_file(clock_path.clone());
+
+        assert_eq!(source().unwrap(), Timestamp::new(1_600_000, 0));
+        std::fs::write(&clock_path, "1700000\n").unwrap();
+        assert_eq!(source().unwrap(), Timestamp::new(1_700_000, 0));
+        std::fs::write(&clock_path, "0\n").unwrap();
+        let error = source().unwrap_err().to_string();
+        assert!(error.contains("AVC receipt HLC unavailable"));
+        assert!(error.contains("must contain a nonzero value"));
     }
 
     #[tokio::test]
@@ -3130,6 +3287,20 @@ mod tests {
         assert!(
             production.contains("AvcRegistryDurability::File"),
             "AVC durable registry must keep a no-DATABASE_URL file fallback for local nodes"
+        );
+        assert!(
+            production.contains("configured_receipt_timestamp_source()"),
+            "AVC durable registry must use an explicit trusted receipt HLC source"
+        );
+        assert!(
+            production.contains("AVC_RECEIPT_HLC_PHYSICAL_MS_FILE_ENV"),
+            "AVC durable registry must expose operator configuration for trusted receipt HLC physical time"
+        );
+        assert!(
+            !production.contains(
+                "receipt_timestamp_source: receipt_timestamp_source_from_clock(HybridClock::new())"
+            ),
+            "AVC durable registry must not use the deterministic default HLC as trusted receipt time"
         );
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent node-signed AVC receipts from being validated against the workspace's deterministic default HLC (fixed epoch) which could allow expired credentials to receive `Allow` receipts. 
- Ensure production nodes source a trusted physical HLC from an operator-provided boundary and fail closed when that source is absent or malformed.

### Description
- Add `AVC_RECEIPT_HLC_PHYSICAL_MS_FILE_ENV` and an operator-configured receipt HLC physical-ms file source that reads a nonzero integer physical millisecond value and produces a trusted `Timestamp` for receipt emission. 
- Replace the durable `AvcApiState` construction path that previously used `HybridClock::new()` with a flow that requires a configured trusted receipt timestamp source in production (`with_durable_registry_and_receipt_timestamp_source` + `configured_receipt_timestamp_source`).
- Implement `receipt_timestamp_source_from_physical_ms_file` which wraps a fallible physical source and maps parse/read errors to `ExoError::ClockUnavailable`, causing fail-closed behavior. 
- Add regression tests exercising the new file-backed HLC source and durable receipt emission behavior, and document the `EXO_AVC_RECEIPT_HLC_PHYSICAL_MS_FILE` operator configuration in `README.md`.

### Testing
- Ran `cargo test -p exo-node avc::tests::durable_receipt_emit_rejects_backdated_request_with_configured_hlc_file_source -- --nocapture` which passed. 
- Ran `cargo test -p exo-node avc::tests::receipt_timestamp_source_reads_operator_hlc_physical_ms_file -- --nocapture` which passed. 
- Ran `cargo test -p exo-node avc::tests::durable_registry_prefers_postgres_and_keeps_file_fallback -- --nocapture` which passed. 
- Ran `cargo test -p exo-node avc::tests::receipt_emit_rejects_credential_expired_at_trusted_node_time -- --nocapture` which passed. 
- Ran `cargo clippy -p exo-node --all-targets -- -D warnings` which completed cleanly, and ran `cargo fmt --all -- --check` which succeeded (format warnings for nightly rustfmt options are informational).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a210ec808a8832fb0a01ed5cea886a8)