### PR TITLE
fix(avc): seed receipt HLC from wall clock — fixes #710 NotYetValid regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 31 | `ls -d crates/*/` |
 | Rust source files | 455 | `find crates -name '*.rs'` |
-| Rust LOC | 364275 | `wc -l` |
-| Workspace tests | 6,011 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 364322 | `wc -l` |
+| Workspace tests | 6,012 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -2230,9 +2230,10 @@ mod tests {
         // from the wall clock.
         let dir = tempfile::tempdir().unwrap();
         let signer: AvcReceiptSigner = Arc::new(|payload: &[u8]| validator_keypair().sign(payload));
-        let state = AvcApiState::with_durable_registry(dir.path(), validator_did(), signer, None, None)
-            .await
-            .expect("durable AVC state");
+        let state =
+            AvcApiState::with_durable_registry(dir.path(), validator_did(), signer, None, None)
+                .await
+                .expect("durable AVC state");
         let ts = trusted_local_hlc_timestamp(&state).expect("local HLC timestamp");
         assert!(
             ts.physical_ms >= 1_700_000_000_000,

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -532,7 +532,11 @@ impl AvcApiState {
             validator_did,
             receipt_signer,
             external_timestamp_source: configured_external_timestamp_source_from_env()?,
-            receipt_clock: Arc::new(Mutex::new(HybridClock::new())),
+            // Seed the receipt HLC from the real wall clock. `HybridClock::new()` is the
+            // deterministic 1_000_000 ms (≈1970) stub; on the local-HLC path it makes the
+            // validation `now` predate every credential's `created_at` → every emit
+            // `[NotYetValid]` (regression after the external-timestamp split).
+            receipt_clock: Arc::new(Mutex::new(HybridClock::with_wall_clock(wall_clock_ms))),
             require_external_timestamp: configured_require_external_timestamp_from_env()?,
             finality_store,
             durability,
@@ -558,6 +562,24 @@ impl AvcApiState {
         *registry = candidate;
         Ok(())
     }
+}
+
+/// Real wall-clock millisecond source for the receipt HLC.
+///
+/// `HybridClock::new()` uses the deterministic stub (`DEFAULT_DETERMINISTIC_PHYSICAL_MS`
+/// = 1_000_000 ms ≈ 1970). On the local-HLC timestamp path (no external TSA configured
+/// and `EXO_AVC_REQUIRE_EXTERNAL_TIMESTAMP_AUTHORITY` not required), the validation
+/// `now` is read from the receipt HLC, so a stubbed clock makes
+/// `credential.created_at > trusted_now` always true and EVERY receipt emit fails
+/// `[NotYetValid]`. Production must seed the receipt clock from the real wall clock.
+fn wall_clock_ms() -> u64 {
+    // No expect/unwrap and no `as` cast (the crate denies clippy::expect_used /
+    // unwrap_used and warns on as_conversions). The error arm is unreachable
+    // unless the system clock predates 1970.
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
 }
 
 fn configured_external_timestamp_source_from_env()
@@ -2194,6 +2216,30 @@ mod tests {
             fixed_external_timestamp_source(Timestamp::new(1_600_000, 0));
         seed_avc_trust_keys(&state);
         Arc::new(state)
+    }
+
+    #[tokio::test]
+    async fn with_durable_registry_seeds_receipt_clock_with_wall_clock_not_stub() {
+        // Regression for the local-HLC `[NotYetValid]` bug: with no external TSA and
+        // `EXO_AVC_REQUIRE_EXTERNAL_TIMESTAMP_AUTHORITY` not required, receipt emission
+        // resolves the validation `now` from `receipt_clock` via
+        // `trusted_local_hlc_timestamp`. If that clock is the deterministic
+        // `HybridClock::new()` stub (physical = 1_000_000 ms ≈ 1970), then
+        // `credential.created_at > trusted_now` is always true and EVERY emit fails
+        // `[NotYetValid]`. The production `with_durable_registry` constructor must seed it
+        // from the wall clock.
+        let dir = tempfile::tempdir().unwrap();
+        let signer: AvcReceiptSigner = Arc::new(|payload: &[u8]| validator_keypair().sign(payload));
+        let state = AvcApiState::with_durable_registry(dir.path(), validator_did(), signer, None, None)
+            .await
+            .expect("durable AVC state");
+        let ts = trusted_local_hlc_timestamp(&state).expect("local HLC timestamp");
+        assert!(
+            ts.physical_ms >= 1_700_000_000_000,
+            "receipt HLC must track the wall clock (>= 2023-11), got physical_ms={} \
+             (the 1_000_000 stub is the NotYetValid bug)",
+            ts.physical_ms
+        );
     }
 
     async fn clear_postgres_avc_registry_state(pool: &PgPool) -> Result<(), sqlx::Error> {


### PR DESCRIPTION
## Problem

Receipt emission on `exochain-production` fails **`403: AVC validation denied: [NotYetValid]`** for currently-valid credentials. Verified live (runner emit smoke, 2026-06-26): **18/18** emits return `[NotYetValid]`, even though the credential is valid (`created_at ≈ 2026-05-31`, `expires ≈ 2026-08-29`, now 06-26) and emitted fine on 06-17/18.

## Root cause (regression from #709)

`validation.rs` raises `NotYetValid` iff `credential.created_at > request.now`. The `now` comes from the node, not the client.

#709 introduced `receipt_clock` and seeded it with `HybridClock::new()` — the deterministic `DEFAULT_DETERMINISTIC_PHYSICAL_MS = 1_000_000` ms (≈1970) **stub**. With `external_timestamp_source == Unconfigured && !require_external_timestamp` (exactly prod's config: `EXO_AVC_REQUIRE_EXTERNAL_TIMESTAMP_AUTHORITY=false`), `trusted_receipt_timestamp_evidence` resolves `now` via `trusted_local_hlc_timestamp(state)`, which reads that stub clock. So `now ≈ 1970`, every credential's `created_at` is in the future, and **every emit fails `[NotYetValid]`**.

This is the same failure mode as the earlier fix `1b6a407c` ("receipt emit validated against deterministic stub clock -> always NotYetValid"), which fixed the then-current `receipt_timestamp_source` path. #709 replaced that field with `receipt_clock` and reintroduced the stub seed — and removed the regression test that would have caught it.

## Fix

- Restore the `wall_clock_ms()` helper (removed with `receipt_timestamp_source`) and seed `receipt_clock` from it in the production `with_durable_registry` constructor: `HybridClock::with_wall_clock(wall_clock_ms)`. `#[cfg(test)]` constructors keep the deterministic stub.
- Add regression test `with_durable_registry_seeds_receipt_clock_with_wall_clock_not_stub` asserting `trusted_local_hlc_timestamp` returns `physical_ms >= 1_700_000_000_000` (≥ 2023-11), mirroring the guard #709 dropped.

## Scope / safety

- One production constructor line + one helper + one test. No wire/schema change; client emitters (CommandBase, Archon runner) need zero change.
- Aligns with #709's intent (local HLC provenance with **real** time), not a behavior reversal.
- Once merged + redeployed, re-running the runner emit smoke should return `200` with `exochain_finality_*` populated.

## Verification note

I could not run `cargo test`/`clippy` in my environment (no Rust toolchain), so I'm relying on CI (the constitutional gate) to verify build + tests + the `unwrap_used`/`as_conversions` lints — the helper is written to satisfy those. Flagging this explicitly rather than claiming local green.

Closes #710. Refs #709, #706.
