### PR TITLE
fix(avc): surface TSA error class in 503 + fix leading-zero RFC 3161 nonce

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 31 | `ls -d crates/*/` |
 | Rust source files | 456 | `find crates -name '*.rs'` |
-| Rust LOC | 366837 | `wc -l` |
+| Rust LOC | 366865 | `wc -l` |
 | Workspace tests | 6,027 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
@@ -113,7 +113,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 31 crates, 366837 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 31 crates, 366865 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 6,027 listed workspace tests
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 31 | `ls -d crates/*/` |
 | Rust source files | 456 | `find crates -name '*.rs'` |
-| Rust LOC | 366757 | `wc -l` |
-| Workspace tests | 6,024 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 366834 | `wc -l` |
+| Workspace tests | 6,027 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **6,024 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **6,027 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 31 crates, 366757 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 31 crates, 366834 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 6,024 listed workspace tests
+         cryptographic proofs, 6,027 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          165 verified WASM exports covered by 172 bridge checks — Rust -> WebAssembly -> JavaScript

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 31 | `ls -d crates/*/` |
 | Rust source files | 456 | `find crates -name '*.rs'` |
-| Rust LOC | 366834 | `wc -l` |
+| Rust LOC | 366837 | `wc -l` |
 | Workspace tests | 6,027 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
@@ -113,7 +113,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 31 crates, 366834 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 31 crates, 366837 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          cryptographic proofs, 6,027 listed workspace tests
 

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -1708,11 +1708,18 @@ fn external_timestamp_error(err: anyhow::Error) -> ApiError {
     tracing::error!(
         err = %err,
         error_class = error_class,
-        "AVC external timestamp authority unavailable"
+        "AVC external timestamp proof could not be obtained"
     );
+    // Surface the stable operator class in the PUBLIC message too. Callers (the
+    // emit smoke, operators) often see only the response, not the node logs, and
+    // a blanket "authority unavailable" misreads a signer-SPKI pin rejection
+    // (class=invalid_proof) or a TSA-returned error status (class=rejected) as
+    // upstream downtime (class=unreachable) — exactly the misdiagnosis we hit in
+    // production. The class tokens are already the sanctioned operator-facing
+    // classification, so this leaks no response detail.
     (
         StatusCode::SERVICE_UNAVAILABLE,
-        "AVC external timestamp authority unavailable".into(),
+        format!("AVC external timestamp proof could not be obtained (class: {error_class})"),
     )
 }
 
@@ -4603,6 +4610,24 @@ mod tests {
         assert!(
             production.contains("external_timestamp_error_class"),
             "the 503 path must attach a stable operator-facing TSA error class before returning the generic public error"
+        );
+    }
+
+    #[test]
+    fn external_timestamp_error_surfaces_operator_class_in_public_message() {
+        // A signer-SPKI pin rejection (the production misdiagnosis) must not read
+        // as a generic "authority unavailable": the public 503 message carries the
+        // stable operator class so callers seeing only the response — not the node
+        // logs — can tell a verification/config failure from upstream downtime.
+        let err: anyhow::Error = AvcExternalTimestampFailure::InvalidProof {
+            reason: "RFC 3161 TSA signer public key did not match any pinned SPKI DER".to_owned(),
+        }
+        .into();
+        let (status, message) = external_timestamp_error(err);
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(
+            message.contains("invalid_proof"),
+            "public TSA error must carry the operator class, got: {message}"
         );
     }
 

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -4619,16 +4619,44 @@ mod tests {
         // as a generic "authority unavailable": the public 503 message carries the
         // stable operator class so callers seeing only the response — not the node
         // logs — can tell a verification/config failure from upstream downtime.
-        let err: anyhow::Error = AvcExternalTimestampFailure::InvalidProof {
-            reason: "RFC 3161 TSA signer public key did not match any pinned SPKI DER".to_owned(),
+        // Cover every failure class so each operator_class arm is exercised.
+        let cases = [
+            (AvcExternalTimestampFailure::Unconfigured, "unconfigured"),
+            (
+                AvcExternalTimestampFailure::Unreachable {
+                    reason: "connection refused".to_owned(),
+                },
+                "unreachable",
+            ),
+            (
+                AvcExternalTimestampFailure::Rejected {
+                    status: "503 Service Unavailable".to_owned(),
+                },
+                "rejected",
+            ),
+            (
+                AvcExternalTimestampFailure::InvalidResponse {
+                    reason: "malformed DER".to_owned(),
+                },
+                "invalid_response",
+            ),
+            (
+                AvcExternalTimestampFailure::InvalidProof {
+                    reason: "RFC 3161 TSA signer public key did not match any pinned SPKI DER"
+                        .to_owned(),
+                },
+                "invalid_proof",
+            ),
+        ];
+        for (failure, expected_class) in cases {
+            let err: anyhow::Error = failure.into();
+            let (status, message) = external_timestamp_error(err);
+            assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+            assert!(
+                message.contains(expected_class),
+                "public TSA error must carry operator class '{expected_class}', got: {message}"
+            );
         }
-        .into();
-        let (status, message) = external_timestamp_error(err);
-        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
-        assert!(
-            message.contains("invalid_proof"),
-            "public TSA error must carry the operator class, got: {message}"
-        );
     }
 
     #[tokio::test]

--- a/crates/exo-node/src/avc_rfc3161.rs
+++ b/crates/exo-node/src/avc_rfc3161.rs
@@ -976,7 +976,10 @@ mod tests {
             minimal_unsigned_integer_bytes(&[0x80u8, 0x01]).to_vec(),
             vec![0x80u8, 0x01]
         );
-        assert_eq!(minimal_unsigned_integer_bytes(&[0u8, 0, 0]).to_vec(), vec![0u8]);
+        assert_eq!(
+            minimal_unsigned_integer_bytes(&[0u8, 0, 0]).to_vec(),
+            vec![0u8]
+        );
     }
 
     #[test]

--- a/crates/exo-node/src/avc_rfc3161.rs
+++ b/crates/exo-node/src/avc_rfc3161.rs
@@ -204,6 +204,20 @@ fn der_integer_from_positive_bytes(bytes: &[u8]) -> Vec<u8> {
     der_tlv(DER_INTEGER, &positive_integer_value_bytes(bytes))
 }
 
+/// Minimal unsigned big-endian representation of an integer: leading zero bytes
+/// removed (keeping at least one byte). This is the canonical value the TSA
+/// echoes back and that `parse_positive_integer_bytes` reconstructs from the
+/// response — so the request-side `nonce_hex` must use the SAME canonicalization,
+/// otherwise a nonce whose first byte is `0x00` fails the nonce-equality check
+/// (`canonical_hex` does not strip leading zeros) and the whole emit fails closed.
+fn minimal_unsigned_integer_bytes(bytes: &[u8]) -> &[u8] {
+    let first_non_zero = bytes
+        .iter()
+        .position(|byte| *byte != 0)
+        .unwrap_or(bytes.len().saturating_sub(1));
+    &bytes[first_non_zero..]
+}
+
 fn encode_oid_arc(mut arc: u32, out: &mut Vec<u8>) {
     let mut stack = [0u8; 5];
     let mut len = 1usize;
@@ -286,7 +300,9 @@ pub(crate) fn build_timestamp_request(
 
     Ok(Rfc3161TimestampRequest {
         der: der_sequence(&request),
-        nonce_hex: hex::encode(nonce),
+        // Canonical (leading-zero-stripped) nonce value, matching what the TSA
+        // echoes and what `parse_positive_integer_bytes` yields from the response.
+        nonce_hex: hex::encode(minimal_unsigned_integer_bytes(&nonce)),
         message_imprint_sha256,
     })
 }
@@ -949,6 +965,42 @@ mod tests {
     use exo_core::{Hash256, Timestamp};
 
     use super::*;
+
+    #[test]
+    fn minimal_unsigned_integer_bytes_strips_leading_zeros() {
+        assert_eq!(
+            minimal_unsigned_integer_bytes(&[0u8, 0, 0x12, 0x34]).to_vec(),
+            vec![0x12u8, 0x34]
+        );
+        assert_eq!(
+            minimal_unsigned_integer_bytes(&[0x80u8, 0x01]).to_vec(),
+            vec![0x80u8, 0x01]
+        );
+        assert_eq!(minimal_unsigned_integer_bytes(&[0u8, 0, 0]).to_vec(), vec![0u8]);
+    }
+
+    #[test]
+    fn nonce_hex_matches_der_roundtrip_for_leading_zero_nonce() {
+        // Regression: a nonce whose first byte is 0x00. The DER INTEGER encoding
+        // strips the leading zero, so the request-side nonce_hex must use the same
+        // canonical (leading-zero-stripped) form that parse_positive_integer_bytes
+        // reconstructs from the TSA's echoed response. Before the fix the request
+        // stored hex of the full 32 bytes (with the 0x00), so the nonce-equality
+        // check failed and the whole emit fell through to a fail-closed 503.
+        let mut nonce = [0u8; 32];
+        nonce[1] = 0x12;
+        nonce[31] = 0x34;
+        let request_nonce_hex = hex::encode(minimal_unsigned_integer_bytes(&nonce));
+        let der = der_integer_from_positive_bytes(&nonce);
+        let mut reader = DerReader::new(&der);
+        let tlv = reader.read_tlv().expect("nonce DER integer");
+        let parsed = parse_positive_integer_bytes(tlv).expect("parse nonce integer");
+        assert_eq!(
+            request_nonce_hex,
+            hex::encode(parsed),
+            "request nonce_hex must equal the canonical value parsed back from the echoed DER integer"
+        );
+    }
 
     const MICROSOFT_FIXTURE_RESPONSE_DER_BASE64: &str =
         include_str!("fixtures/microsoft_rfc3161_timestamp_response.b64");


### PR DESCRIPTION
## Context

While diagnosing why most live emits to `exochain-production` fail-closed with `503: AVC external timestamp authority unavailable` (even though the receipt store + Microsoft RFC 3161 TSA are healthy and successful receipts read back fine), I found that the **real cause is a config issue masked by a misleading error**, plus a latent nonce-encoding bug. This PR fixes the two code issues; the config fix (incomplete pinned-SPKI set) is tracked separately in #713.

## 1. Misleading 503 — surface the operator class in the public message

`external_timestamp_error` mapped **every** `AvcExternalTimestampFailure` variant to the blanket public message `"AVC external timestamp authority unavailable"`. The stable `operator_class` (`unreachable` / `rejected` / `invalid_proof` / …) was attached only to the **log**. Callers that see the response but not the node logs — the `avc-emit` smoke, operators — therefore read a **signer-SPKI pin rejection** (`invalid_proof`) or a **TSA-returned error status** (`rejected`) as upstream downtime (`unreachable`). That is exactly how an incomplete pinned-SPKI set got misdiagnosed in prod as "Microsoft is down."

- Carry the `operator_class` token in the public 503 message: `"... (class: invalid_proof)"`.
- **Status stays `503`** (still fail-closed) → no status-assertion test changes.
- No leaked detail: the class tokens are already the sanctioned operator-facing classification (per the `operator diagnostics …` regression test).

## 2. Leading-zero RFC 3161 nonce fails verification

The nonce-equality check is `tst_info.nonce_hex != canonical_hex(expected_nonce_hex)`. The parsed response nonce has leading zeros stripped (`parse_positive_integer_bytes`), but `canonical_hex` only re-encodes — it does **not** strip leading zeros — and the request stored `nonce_hex = hex(full 32-byte nonce)`. So a nonce whose first byte is `0x00` (~0.4% of SHA-256-derived nonces) **mismatches and the whole emit fails closed**.

- Store the canonical (leading-zero-stripped) nonce value on the request side (`minimal_unsigned_integer_bytes`), matching what the TSA echoes and what the response parse reconstructs.

## Tests
- `external_timestamp_error_surfaces_operator_class_in_public_message`
- `nonce_hex_matches_der_roundtrip_for_leading_zero_nonce`, `minimal_unsigned_integer_bytes_strips_leading_zeros`
- README repo-truth counts updated (LOC + workspace test count).

## Verification note
I could not run `cargo`/`clippy` locally (no Rust toolchain in my environment), so I'm relying on CI to verify build + tests + the `unwrap_used`/`as_conversions` lints. Flagging explicitly rather than claiming local green. The helper uses `unwrap_or` (allowed), no `unwrap`/`expect`/`as` in production code.

Refs #713.
