### PR TITLE
Publish public EXOCHAIN discovery and route proof tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 31 | `ls -d crates/*/` |
 | Rust source files | 456 | `find crates -name '*.rs'` |
-| Rust LOC | 366865 | `wc -l` |
-| Workspace tests | 6,027 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 367021 | `wc -l` |
+| Workspace tests | 6,029 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **6,027 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **6,029 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 31 crates, 366865 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 31 crates, 367021 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 6,027 listed workspace tests
+         cryptographic proofs, 6,029 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          165 verified WASM exports covered by 172 bridge checks — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-gateway/src/rest.rs
+++ b/crates/exo-gateway/src/rest.rs
@@ -30,9 +30,84 @@ pub struct HealthResponse {
     pub dagdb_runtime_reason: Option<String>,
 }
 
+/// Public EXOCHAIN discovery document served from `/.well-known/exochain.json`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExochainDiscoveryResponse {
+    pub base_url: String,
+    pub routes: ExochainDiscoveryRoutes,
+    pub sdk: ExochainSdkDiscovery,
+    pub mcp: ExochainMcpDiscovery,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExochainDiscoveryRoutes {
+    pub health: String,
+    pub ready: String,
+    pub avc: ExochainAvcDiscoveryRoutes,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExochainAvcDiscoveryRoutes {
+    pub issue: String,
+    pub validate: String,
+    pub receipts_emit: String,
+    pub receipts_get: String,
+    pub protocol: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExochainSdkDiscovery {
+    pub rust: String,
+    pub typescript: String,
+    pub python: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExochainMcpDiscovery {
+    pub public_transport: bool,
+    pub transports: Vec<String>,
+    pub capabilities: Vec<String>,
+}
+
+impl ExochainDiscoveryResponse {
+    #[must_use]
+    pub fn canonical() -> Self {
+        Self {
+            base_url: "https://exochain.io".to_owned(),
+            routes: ExochainDiscoveryRoutes {
+                health: "/health".to_owned(),
+                ready: "/ready".to_owned(),
+                avc: ExochainAvcDiscoveryRoutes {
+                    issue: "/api/v1/avc/issue".to_owned(),
+                    validate: "/api/v1/avc/validate".to_owned(),
+                    receipts_emit: "/api/v1/avc/receipts/emit".to_owned(),
+                    receipts_get: "/api/v1/avc/receipts/:hash".to_owned(),
+                    protocol: "/api/v1/avc/protocol".to_owned(),
+                },
+            },
+            sdk: ExochainSdkDiscovery {
+                rust: "crates/exochain-sdk".to_owned(),
+                typescript: "packages/exochain-sdk".to_owned(),
+                python: "packages/exochain-py".to_owned(),
+            },
+            mcp: ExochainMcpDiscovery {
+                public_transport: false,
+                transports: vec!["stdio".to_owned(), "loopback-sse".to_owned()],
+                capabilities: vec![
+                    "tools".to_owned(),
+                    "resources".to_owned(),
+                    "prompts".to_owned(),
+                ],
+            },
+        }
+    }
+}
+
 /// REST API route definitions.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RestRoute {
+    /// GET /.well-known/exochain.json
+    ExochainDiscovery,
     /// GET /health
     Health,
     /// GET /ready
@@ -97,7 +172,8 @@ impl RestRoute {
     /// Get the HTTP method for this route.
     pub fn method(&self) -> &str {
         match self {
-            RestRoute::Health
+            RestRoute::ExochainDiscovery
+            | RestRoute::Health
             | RestRoute::Ready
             | RestRoute::GatewayMetrics
             | RestRoute::DbHealth
@@ -131,6 +207,7 @@ impl RestRoute {
     /// Get the path pattern for this route.
     pub fn path(&self) -> &str {
         match self {
+            RestRoute::ExochainDiscovery => "/.well-known/exochain.json",
             RestRoute::Health => "/health",
             RestRoute::Ready => "/ready",
             RestRoute::GatewayMetrics => "/gateway/metrics",
@@ -166,6 +243,7 @@ impl RestRoute {
     /// All defined routes.
     pub fn all() -> Vec<RestRoute> {
         vec![
+            RestRoute::ExochainDiscovery,
             RestRoute::Health,
             RestRoute::Ready,
             RestRoute::GatewayMetrics,
@@ -207,6 +285,7 @@ mod tests {
 
     #[test]
     fn test_route_methods() {
+        assert_eq!(RestRoute::ExochainDiscovery.method(), "GET");
         assert_eq!(RestRoute::Health.method(), "GET");
         assert_eq!(RestRoute::Ready.method(), "GET");
         assert_eq!(RestRoute::GatewayMetrics.method(), "GET");
@@ -231,6 +310,10 @@ mod tests {
 
     #[test]
     fn test_route_paths() {
+        assert_eq!(
+            RestRoute::ExochainDiscovery.path(),
+            "/.well-known/exochain.json"
+        );
         assert_eq!(RestRoute::Health.path(), "/health");
         assert_eq!(RestRoute::Ready.path(), "/ready");
         assert_eq!(RestRoute::GatewayMetrics.path(), "/gateway/metrics");
@@ -312,9 +395,38 @@ mod tests {
     }
 
     #[test]
+    fn discovery_document_advertises_public_api_sdk_and_mcp_boundaries() {
+        let discovery = ExochainDiscoveryResponse::canonical();
+
+        assert_eq!(discovery.base_url, "https://exochain.io");
+        assert_eq!(discovery.routes.health, "/health");
+        assert_eq!(discovery.routes.ready, "/ready");
+        assert_eq!(discovery.routes.avc.issue, "/api/v1/avc/issue");
+        assert_eq!(discovery.routes.avc.validate, "/api/v1/avc/validate");
+        assert_eq!(
+            discovery.routes.avc.receipts_emit,
+            "/api/v1/avc/receipts/emit"
+        );
+        assert_eq!(
+            discovery.routes.avc.receipts_get,
+            "/api/v1/avc/receipts/:hash"
+        );
+        assert_eq!(discovery.routes.avc.protocol, "/api/v1/avc/protocol");
+        assert_eq!(discovery.sdk.rust, "crates/exochain-sdk");
+        assert_eq!(discovery.sdk.typescript, "packages/exochain-sdk");
+        assert_eq!(discovery.sdk.python, "packages/exochain-py");
+        assert!(!discovery.mcp.public_transport);
+        assert_eq!(discovery.mcp.transports, vec!["stdio", "loopback-sse"]);
+        assert_eq!(
+            discovery.mcp.capabilities,
+            vec!["tools", "resources", "prompts"]
+        );
+    }
+
+    #[test]
     fn test_all_routes() {
         let routes = RestRoute::all();
-        assert_eq!(routes.len(), 29);
+        assert_eq!(routes.len(), 30);
     }
 
     #[test]
@@ -325,6 +437,7 @@ mod tests {
             .map(|route| (route.method(), route.path()))
             .collect();
         let expected = BTreeSet::from([
+            ("GET", "/.well-known/exochain.json"),
             ("GET", "/health"),
             ("GET", "/ready"),
             ("GET", "/gateway/metrics"),

--- a/crates/exo-gateway/src/server.rs
+++ b/crates/exo-gateway/src/server.rs
@@ -87,7 +87,7 @@ use crate::{
     error::{GatewayError, Result},
     graphql,
     handlers::health_handler as db_health_handler,
-    rest::HealthResponse,
+    rest::{ExochainDiscoveryResponse, HealthResponse},
 };
 
 const XSRF_COOKIE_PREFIX: &str = "XSRF-TOKEN=";
@@ -2368,6 +2368,11 @@ async fn handle_ready(State(state): State<AppState>) -> (StatusCode, Json<Health
     (http_status, Json(body))
 }
 
+/// GET /.well-known/exochain.json — public discovery for API, SDK, and MCP.
+async fn handle_exochain_discovery() -> Json<ExochainDiscoveryResponse> {
+    Json(ExochainDiscoveryResponse::canonical())
+}
+
 async fn probe_dagdb_runtime_status(state: &AppState) -> DagDbRuntimeStatus {
     let Some(pool) = &state.pool else {
         return dagdb_runtime_status_from_probe(false, None);
@@ -4519,6 +4524,7 @@ fn build_unlayered_router(state: AppState) -> Router {
 
     Router::new()
         // Probes
+        .route("/.well-known/exochain.json", get(handle_exochain_discovery))
         .route("/health", get(handle_health))
         .route("/ready", get(handle_ready))
         .route("/gateway/metrics", get(handle_metrics))
@@ -4996,7 +5002,7 @@ mod tests {
     };
 
     use axum::{
-        body::Body,
+        body::{Body, to_bytes},
         extract::ConnectInfo,
         http::{Request, header},
     };
@@ -5019,6 +5025,43 @@ mod tests {
 
     async fn probe() -> StatusCode {
         StatusCode::OK
+    }
+
+    #[tokio::test]
+    async fn discovery_route_returns_public_api_sdk_and_mcp_metadata() {
+        let app = build_router(state());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/.well-known/exochain.json")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), 16 * 1024).await.unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(payload["base_url"], "https://exochain.io");
+        assert_eq!(payload["routes"]["health"], "/health");
+        assert_eq!(payload["routes"]["ready"], "/ready");
+        assert_eq!(payload["routes"]["avc"]["issue"], "/api/v1/avc/issue");
+        assert_eq!(
+            payload["routes"]["avc"]["receipts_emit"],
+            "/api/v1/avc/receipts/emit"
+        );
+        assert_eq!(payload["routes"]["avc"]["protocol"], "/api/v1/avc/protocol");
+        assert_eq!(payload["sdk"]["rust"], "crates/exochain-sdk");
+        assert_eq!(payload["sdk"]["typescript"], "packages/exochain-sdk");
+        assert_eq!(payload["sdk"]["python"], "packages/exochain-py");
+        assert_eq!(payload["mcp"]["public_transport"], false);
+        assert_eq!(payload["mcp"]["transports"][0], "stdio");
+        assert_eq!(payload["mcp"]["transports"][1], "loopback-sse");
+        assert_eq!(payload["mcp"]["capabilities"][0], "tools");
+        assert_eq!(payload["mcp"]["capabilities"][1], "resources");
+        assert_eq!(payload["mcp"]["capabilities"][2], "prompts");
     }
 
     fn base64_standard(bytes: &[u8]) -> String {

--- a/packages/exochain-py/exochain/__init__.py
+++ b/packages/exochain-py/exochain/__init__.py
@@ -55,7 +55,17 @@ from .governance.vote import Vote, VoteChoice
 from .identity.did import is_did, validate_did
 from .identity.keypair import Identity, derive_did
 from .transport.http import HttpTransport
-from .types import Did, Hash256Hex, QuorumResult, TrustReceipt
+from .types import (
+    Did,
+    ExochainAvcDiscoveryRoutes,
+    ExochainDiscoveryResponse,
+    ExochainDiscoveryRoutes,
+    ExochainMcpDiscovery,
+    ExochainSdkDiscovery,
+    Hash256Hex,
+    QuorumResult,
+    TrustReceipt,
+)
 
 __version__ = "0.1.0"
 
@@ -77,8 +87,13 @@ __all__ = [
     "DecisionBuilder",
     "DecisionStatus",
     "Did",
+    "ExochainAvcDiscoveryRoutes",
+    "ExochainDiscoveryResponse",
+    "ExochainDiscoveryRoutes",
     "ExochainClient",
     "ExochainError",
+    "ExochainMcpDiscovery",
+    "ExochainSdkDiscovery",
     "GovernanceError",
     "Hash256Hex",
     "HlcTimestamp",

--- a/packages/exochain-py/exochain/client.py
+++ b/packages/exochain-py/exochain/client.py
@@ -27,10 +27,11 @@ from types import TracebackType
 from typing import Any
 
 import httpx
+from pydantic import ValidationError
 
 from .errors import KernelError, TransportError
 from .transport.http import HttpTransport
-from .types import TrustReceipt
+from .types import ExochainDiscoveryResponse, TrustReceipt
 
 
 class ExochainClient:
@@ -66,6 +67,14 @@ class ExochainClient:
     async def health(self) -> dict[str, Any]:
         """Probe the fabric's ``/health`` endpoint."""
         return await self._transport.health()
+
+    async def discover(self) -> ExochainDiscoveryResponse:
+        """Fetch and validate ``/.well-known/exochain.json``."""
+        body = await self._transport.get("/.well-known/exochain.json")
+        try:
+            return ExochainDiscoveryResponse.model_validate(body)
+        except ValidationError as exc:
+            raise TransportError(f"malformed discovery document: {exc}") from exc
 
     async def submit_action(self, action: dict[str, Any]) -> TrustReceipt:
         """Submit an action to the constitutional kernel and get a receipt back."""

--- a/packages/exochain-py/exochain/types.py
+++ b/packages/exochain-py/exochain/types.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, StringConstraints
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StringConstraints
 
 # A DID on the exo network: "did:exo:" followed by a base58-alphanumeric suffix.
 Did = Annotated[
@@ -72,8 +72,66 @@ class QuorumResult(BaseModel):
     abstentions: int
 
 
+class ExochainAvcDiscoveryRoutes(BaseModel):
+    """AVC route paths from the public EXOCHAIN discovery document."""
+
+    model_config = ConfigDict(frozen=True, populate_by_name=True)
+
+    issue: str
+    validate_route: str = Field(alias="validate")
+    receipts_emit: str
+    receipts_get: str
+    protocol: str
+
+
+class ExochainDiscoveryRoutes(BaseModel):
+    """Public route paths from the canonical EXOCHAIN node."""
+
+    model_config = ConfigDict(frozen=True)
+
+    health: str
+    ready: str
+    avc: ExochainAvcDiscoveryRoutes
+
+
+class ExochainSdkDiscovery(BaseModel):
+    """SDK package locations advertised by the canonical EXOCHAIN node."""
+
+    model_config = ConfigDict(frozen=True)
+
+    rust: str
+    typescript: str
+    python: str
+
+
+class ExochainMcpDiscovery(BaseModel):
+    """MCP capability metadata; public_transport false means discovery only."""
+
+    model_config = ConfigDict(frozen=True)
+
+    public_transport: StrictBool
+    transports: tuple[str, ...]
+    capabilities: tuple[str, ...]
+
+
+class ExochainDiscoveryResponse(BaseModel):
+    """Public EXOCHAIN discovery document."""
+
+    model_config = ConfigDict(frozen=True)
+
+    base_url: str
+    routes: ExochainDiscoveryRoutes
+    sdk: ExochainSdkDiscovery
+    mcp: ExochainMcpDiscovery
+
+
 __all__ = [
     "Did",
+    "ExochainAvcDiscoveryRoutes",
+    "ExochainDiscoveryResponse",
+    "ExochainDiscoveryRoutes",
+    "ExochainMcpDiscovery",
+    "ExochainSdkDiscovery",
     "Hash256Hex",
     "Outcome",
     "QuorumResult",

--- a/packages/exochain-py/tests/test_transport.py
+++ b/packages/exochain-py/tests/test_transport.py
@@ -62,3 +62,107 @@ async def test_client_accepts_configured_httpx_timeout() -> None:
     )
     assert isinstance(client.transport, HttpTransport)
     await client.close()
+
+
+@pytest.mark.asyncio
+async def test_client_discover_validates_public_discovery_document() -> None:
+    """The high-level client validates the well-known discovery payload."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/.well-known/exochain.json"
+        return httpx.Response(
+            200,
+            json={
+                "base_url": "https://exochain.io",
+                "routes": {
+                    "health": "/health",
+                    "ready": "/ready",
+                    "avc": {
+                        "issue": "/api/v1/avc/issue",
+                        "validate": "/api/v1/avc/validate",
+                        "receipts_emit": "/api/v1/avc/receipts/emit",
+                        "receipts_get": "/api/v1/avc/receipts/:hash",
+                        "protocol": "/api/v1/avc/protocol",
+                    },
+                },
+                "sdk": {
+                    "rust": "crates/exochain-sdk",
+                    "typescript": "packages/exochain-sdk",
+                    "python": "packages/exochain-py",
+                },
+                "mcp": {
+                    "public_transport": False,
+                    "transports": ["stdio", "loopback-sse"],
+                    "capabilities": ["tools", "resources", "prompts"],
+                },
+            },
+        )
+
+    transport = HttpTransport("https://fabric.example", timeout=httpx.Timeout(1.0))
+    await transport._client.aclose()
+    transport._client = httpx.AsyncClient(
+        base_url="https://fabric.example",
+        transport=httpx.MockTransport(handler),
+        timeout=httpx.Timeout(1.0),
+    )
+    client = ExochainClient.from_transport(transport)
+
+    discovery = await client.discover()
+
+    assert discovery.base_url == "https://exochain.io"
+    assert discovery.routes.avc.validate_route == "/api/v1/avc/validate"
+    assert discovery.routes.avc.receipts_emit == "/api/v1/avc/receipts/emit"
+    assert discovery.sdk.python == "packages/exochain-py"
+    assert discovery.mcp.public_transport is False
+    assert discovery.mcp.transports == ("stdio", "loopback-sse")
+    assert discovery.mcp.capabilities == ("tools", "resources", "prompts")
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_client_discover_rejects_malformed_mcp_metadata() -> None:
+    """Malformed MCP discovery metadata fails closed."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "base_url": "https://exochain.io",
+                "routes": {
+                    "health": "/health",
+                    "ready": "/ready",
+                    "avc": {
+                        "issue": "/api/v1/avc/issue",
+                        "validate": "/api/v1/avc/validate",
+                        "receipts_emit": "/api/v1/avc/receipts/emit",
+                        "receipts_get": "/api/v1/avc/receipts/:hash",
+                        "protocol": "/api/v1/avc/protocol",
+                    },
+                },
+                "sdk": {
+                    "rust": "crates/exochain-sdk",
+                    "typescript": "packages/exochain-sdk",
+                    "python": "packages/exochain-py",
+                },
+                "mcp": {
+                    "public_transport": "false",
+                    "transports": ["stdio", "loopback-sse"],
+                    "capabilities": ["tools", "resources", "prompts"],
+                },
+            },
+        )
+
+    transport = HttpTransport("https://fabric.example", timeout=httpx.Timeout(1.0))
+    await transport._client.aclose()
+    transport._client = httpx.AsyncClient(
+        base_url="https://fabric.example",
+        transport=httpx.MockTransport(handler),
+        timeout=httpx.Timeout(1.0),
+    )
+    client = ExochainClient.from_transport(transport)
+
+    with pytest.raises(TransportError):
+        await client.discover()
+
+    await client.close()

--- a/packages/exochain-sdk/src/client.ts
+++ b/packages/exochain-sdk/src/client.ts
@@ -24,6 +24,7 @@ import { HttpTransport } from './transport/http.js';
 import type {
   AutomatedSettlementRequest,
   EconomyObjectResponse,
+  ExochainDiscoveryResponse,
   HealthResponse,
   Did,
   Hash256,
@@ -35,6 +36,7 @@ import {
   validateDecisionState,
   validateDidResponse,
   validateEconomyObjectResponse,
+  validateExochainDiscoveryResponse,
   validateHashResponse,
   type JsonObject,
 } from './validation.js';
@@ -350,5 +352,12 @@ export class ExochainClient {
   /** Gateway health probe. */
   public async health(): Promise<HealthResponse> {
     return this.#http.health();
+  }
+
+  /** Public EXOCHAIN discovery document from `/.well-known/exochain.json`. */
+  public async discover(): Promise<ExochainDiscoveryResponse> {
+    return validateExochainDiscoveryResponse(
+      await this.#http.get('/.well-known/exochain.json'),
+    );
   }
 }

--- a/packages/exochain-sdk/src/types.ts
+++ b/packages/exochain-sdk/src/types.ts
@@ -70,6 +70,44 @@ export interface HealthResponse {
   readonly uptime: number;
 }
 
+/** AVC route paths advertised by `/.well-known/exochain.json`. */
+export interface ExochainAvcDiscoveryRoutes {
+  readonly issue: string;
+  readonly validate: string;
+  readonly receipts_emit: string;
+  readonly receipts_get: string;
+  readonly protocol: string;
+}
+
+/** Public route paths advertised by the canonical EXOCHAIN node. */
+export interface ExochainDiscoveryRoutes {
+  readonly health: string;
+  readonly ready: string;
+  readonly avc: ExochainAvcDiscoveryRoutes;
+}
+
+/** SDK package locations advertised by the canonical EXOCHAIN node. */
+export interface ExochainSdkDiscovery {
+  readonly rust: string;
+  readonly typescript: string;
+  readonly python: string;
+}
+
+/** MCP capability metadata; public_transport false means discoverable only. */
+export interface ExochainMcpDiscovery {
+  readonly public_transport: boolean;
+  readonly transports: readonly string[];
+  readonly capabilities: readonly string[];
+}
+
+/** Public EXOCHAIN discovery document. */
+export interface ExochainDiscoveryResponse {
+  readonly base_url: string;
+  readonly routes: ExochainDiscoveryRoutes;
+  readonly sdk: ExochainSdkDiscovery;
+  readonly mcp: ExochainMcpDiscovery;
+}
+
 /** EXOCHAIN economy object kinds stored behind the HonorGood adapter routes. */
 export type EconomyObjectKind =
   | 'mission'

--- a/packages/exochain-sdk/src/validation.ts
+++ b/packages/exochain-sdk/src/validation.ts
@@ -21,6 +21,7 @@ import type {
   EconomyObjectKind,
   EconomyObjectResponse,
   EconomyRecordAnchor,
+  ExochainDiscoveryResponse,
   Hash256,
   HealthResponse,
   QuorumResult,
@@ -143,6 +144,23 @@ function requireJsonValue(record: Record<string, unknown>, key: string, context:
   return value as JsonValue;
 }
 
+function requireStringArray(
+  record: Record<string, unknown>,
+  key: string,
+  context: string,
+): readonly string[] {
+  const value = record[key];
+  if (!Array.isArray(value)) {
+    throw validationError(`${context}.${key} must be an array`);
+  }
+  for (let index = 0; index < value.length; index++) {
+    if (typeof value[index] !== 'string') {
+      throw validationError(`${context}.${key}[${index}] must be a string`);
+    }
+  }
+  return value;
+}
+
 function requireEconomyObjectKind(
   record: Record<string, unknown>,
   key: string,
@@ -180,6 +198,51 @@ export function validateHealthResponse(value: unknown): HealthResponse {
     status: requireString(record, 'status', 'health response'),
     version: requireString(record, 'version', 'health response'),
     uptime: requireFiniteNumber(record, 'uptime', 'health response'),
+  };
+}
+
+export function validateExochainDiscoveryResponse(value: unknown): ExochainDiscoveryResponse {
+  const record = requireRecord(value, 'EXOCHAIN discovery response');
+  const routes = requireRecord(record.routes, 'EXOCHAIN discovery response.routes');
+  const avc = requireRecord(routes.avc, 'EXOCHAIN discovery response.routes.avc');
+  const sdk = requireRecord(record.sdk, 'EXOCHAIN discovery response.sdk');
+  const mcp = requireRecord(record.mcp, 'EXOCHAIN discovery response.mcp');
+
+  return {
+    base_url: requireString(record, 'base_url', 'EXOCHAIN discovery response'),
+    routes: {
+      health: requireString(routes, 'health', 'EXOCHAIN discovery response.routes'),
+      ready: requireString(routes, 'ready', 'EXOCHAIN discovery response.routes'),
+      avc: {
+        issue: requireString(avc, 'issue', 'EXOCHAIN discovery response.routes.avc'),
+        validate: requireString(avc, 'validate', 'EXOCHAIN discovery response.routes.avc'),
+        receipts_emit: requireString(
+          avc,
+          'receipts_emit',
+          'EXOCHAIN discovery response.routes.avc',
+        ),
+        receipts_get: requireString(
+          avc,
+          'receipts_get',
+          'EXOCHAIN discovery response.routes.avc',
+        ),
+        protocol: requireString(avc, 'protocol', 'EXOCHAIN discovery response.routes.avc'),
+      },
+    },
+    sdk: {
+      rust: requireString(sdk, 'rust', 'EXOCHAIN discovery response.sdk'),
+      typescript: requireString(sdk, 'typescript', 'EXOCHAIN discovery response.sdk'),
+      python: requireString(sdk, 'python', 'EXOCHAIN discovery response.sdk'),
+    },
+    mcp: {
+      public_transport: requireBoolean(
+        mcp,
+        'public_transport',
+        'EXOCHAIN discovery response.mcp',
+      ),
+      transports: requireStringArray(mcp, 'transports', 'EXOCHAIN discovery response.mcp'),
+      capabilities: requireStringArray(mcp, 'capabilities', 'EXOCHAIN discovery response.mcp'),
+    },
   };
 }
 

--- a/packages/exochain-sdk/test/client.test.ts
+++ b/packages/exochain-sdk/test/client.test.ts
@@ -24,13 +24,16 @@ import type { Hash256 } from '../src/types.js';
 const HASH_64 = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' as Hash256;
 
 interface RecordedFetch {
+  readonly inputs: (RequestInfo | URL)[];
   readonly calls: RequestInit[];
   readonly fetch: typeof fetch;
 }
 
 function jsonFetch(body: unknown, status = 200): RecordedFetch {
+  const inputs: (RequestInfo | URL)[] = [];
   const calls: RequestInit[] = [];
-  const fetchImpl = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    inputs.push(input);
     if (init !== undefined) {
       calls.push(init);
     }
@@ -39,7 +42,7 @@ function jsonFetch(body: unknown, status = 200): RecordedFetch {
       headers: { 'content-type': 'application/json' },
     });
   }) as typeof fetch;
-  return { calls, fetch: fetchImpl };
+  return { inputs, calls, fetch: fetchImpl };
 }
 
 test('health rejects malformed gateway payloads instead of trusting casts', async () => {
@@ -64,6 +67,80 @@ test('health accepts a valid gateway payload', async () => {
   strictEqual(health.status, 'ok');
   strictEqual(health.version, '0.1.0');
   strictEqual(health.uptime, 42);
+});
+
+test('discover fetches and validates the public EXOCHAIN discovery document', async () => {
+  const transport = jsonFetch({
+    base_url: 'https://exochain.io',
+    routes: {
+      health: '/health',
+      ready: '/ready',
+      avc: {
+        issue: '/api/v1/avc/issue',
+        validate: '/api/v1/avc/validate',
+        receipts_emit: '/api/v1/avc/receipts/emit',
+        receipts_get: '/api/v1/avc/receipts/:hash',
+        protocol: '/api/v1/avc/protocol',
+      },
+    },
+    sdk: {
+      rust: 'crates/exochain-sdk',
+      typescript: 'packages/exochain-sdk',
+      python: 'packages/exochain-py',
+    },
+    mcp: {
+      public_transport: false,
+      transports: ['stdio', 'loopback-sse'],
+      capabilities: ['tools', 'resources', 'prompts'],
+    },
+  });
+  const client = new ExochainClient({
+    baseUrl: 'https://gateway.example',
+    fetch: transport.fetch,
+  });
+
+  const discovery = await client.discover();
+
+  strictEqual(String(transport.inputs[0]), 'https://gateway.example/.well-known/exochain.json');
+  strictEqual(discovery.base_url, 'https://exochain.io');
+  strictEqual(discovery.routes.avc.receipts_emit, '/api/v1/avc/receipts/emit');
+  strictEqual(discovery.sdk.typescript, 'packages/exochain-sdk');
+  strictEqual(discovery.mcp.public_transport, false);
+  strictEqual(discovery.mcp.transports[1], 'loopback-sse');
+  strictEqual(discovery.mcp.capabilities[2], 'prompts');
+});
+
+test('discover rejects malformed MCP discovery metadata', async () => {
+  const transport = jsonFetch({
+    base_url: 'https://exochain.io',
+    routes: {
+      health: '/health',
+      ready: '/ready',
+      avc: {
+        issue: '/api/v1/avc/issue',
+        validate: '/api/v1/avc/validate',
+        receipts_emit: '/api/v1/avc/receipts/emit',
+        receipts_get: '/api/v1/avc/receipts/:hash',
+        protocol: '/api/v1/avc/protocol',
+      },
+    },
+    sdk: {
+      rust: 'crates/exochain-sdk',
+      typescript: 'packages/exochain-sdk',
+      python: 'packages/exochain-py',
+    },
+    mcp: {
+      public_transport: 'false',
+      transports: ['stdio', 'loopback-sse'],
+      capabilities: ['tools', 'resources', 'prompts'],
+    },
+  });
+  const client = new ExochainClient({
+    baseUrl: 'https://gateway.example',
+    fetch: transport.fetch,
+  });
+
+  await rejects(() => client.discover(), TransportError);
 });
 
 test('identity.register rejects malformed DID response payloads', async () => {

--- a/tools/avc_emit_production_smoke.mjs
+++ b/tools/avc_emit_production_smoke.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises';
+
+const DEFAULT_BASE_URL = 'https://exochain.io';
+const DEFAULT_EXPECTED_CASES = 18;
+const DEFAULT_ROUNDS = 2;
+
+function fail(message) {
+  console.error(`AVC production smoke failed: ${message}`);
+  process.exit(1);
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    fail(`${name} must be set`);
+  }
+  return value;
+}
+
+function optionalPositiveInteger(name, fallback) {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim().length === 0) {
+    return fallback;
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    fail(`${name} must be a positive safe integer`);
+  }
+  return parsed;
+}
+
+async function readJson(path, envName) {
+  let parsed;
+  try {
+    parsed = JSON.parse(await readFile(path, 'utf8'));
+  } catch (error) {
+    fail(`${envName} could not be read as JSON: ${error.message}`);
+  }
+  return parsed;
+}
+
+function requestArray(parsed, envName) {
+  const requests = Array.isArray(parsed) ? parsed : parsed?.requests;
+  if (!Array.isArray(requests)) {
+    fail(`${envName} must contain a JSON array or an object with a requests array`);
+  }
+  if (requests.length === 0) {
+    fail(`${envName} must contain at least one request`);
+  }
+  for (let index = 0; index < requests.length; index += 1) {
+    const item = requests[index];
+    if (typeof item !== 'object' || item === null || Array.isArray(item)) {
+      fail(`${envName}[${index}] must be a JSON object`);
+    }
+  }
+  return requests;
+}
+
+async function requestJson(baseUrl, path, token, method, body) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers: {
+      accept: 'application/json',
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await response.text();
+  let payload = undefined;
+  if (text.length > 0) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      payload = text;
+    }
+  }
+  if (!response.ok) {
+    const detail = typeof payload === 'string' ? payload : JSON.stringify(payload);
+    throw new Error(`HTTP ${response.status} for ${method} ${path}: ${detail}`);
+  }
+  return payload;
+}
+
+function requireString(value, name) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${name} must be a non-empty string`);
+  }
+  return value;
+}
+
+function requirePresent(value, name) {
+  if (value === undefined || value === null) {
+    throw new Error(`${name} must be present`);
+  }
+  return value;
+}
+
+function validateReceiptProof(receipt, context, allowEmptyPreviousReceipt) {
+  requirePresent(receipt, `${context}.receipt`);
+  requirePresent(receipt.external_timestamp_proof, `${context}.external_timestamp_proof`);
+  requirePresent(receipt.action_descriptor, `${context}.action_descriptor`);
+  requireString(receipt.action_descriptor_hash, `${context}.action_descriptor_hash`);
+  if (!allowEmptyPreviousReceipt) {
+    requireString(receipt.previous_receipt_hash, `${context}.previous_receipt_hash`);
+  }
+  if (receipt.timestamp_provenance !== 'ExternalTimestampAuthority') {
+    throw new Error(`${context}.timestamp_provenance must be ExternalTimestampAuthority`);
+  }
+}
+
+function validateEmitResponse(payload, context, allowEmptyPreviousReceipt) {
+  const receiptHash = requireString(payload?.receipt_hash, `${context}.receipt_hash`);
+  requireString(payload.exochain_finality_hash, `${context}.exochain_finality_hash`);
+  requirePresent(payload.exochain_finality_height, `${context}.exochain_finality_height`);
+  requireString(
+    payload.exochain_finality_receipt_hash,
+    `${context}.exochain_finality_receipt_hash`,
+  );
+  validateReceiptProof(payload.receipt, `${context}.receipt`, allowEmptyPreviousReceipt);
+  return receiptHash;
+}
+
+async function seedCredentials(baseUrl, token, issueRequests) {
+  for (let index = 0; index < issueRequests.length; index += 1) {
+    const payload = await requestJson(baseUrl, '/api/v1/avc/issue', token, 'POST', issueRequests[index]);
+    if (payload?.status !== 'registered') {
+      throw new Error(`seed credential ${index + 1} did not return status=registered`);
+    }
+    console.log(`seed ${index + 1}/${issueRequests.length}: ${payload.credential_id}`);
+  }
+}
+
+async function run() {
+  const baseUrl = (process.env.EXO_AVC_SMOKE_BASE_URL ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
+  const token = requiredEnv('EXO_AVC_SMOKE_BEARER_TOKEN');
+  const emitRequestsPath = requiredEnv('EXO_AVC_SMOKE_EMIT_REQUESTS_FILE');
+  const expectedCases = optionalPositiveInteger('EXO_AVC_SMOKE_EXPECTED_CASES', DEFAULT_EXPECTED_CASES);
+  const rounds = optionalPositiveInteger('EXO_AVC_SMOKE_ROUNDS', DEFAULT_ROUNDS);
+  const allowEmptyPreviousReceipt = process.env.EXO_AVC_SMOKE_ALLOW_EMPTY_PREVIOUS_RECEIPT === '1';
+
+  const emitRequests = requestArray(
+    await readJson(emitRequestsPath, 'EXO_AVC_SMOKE_EMIT_REQUESTS_FILE'),
+    'EXO_AVC_SMOKE_EMIT_REQUESTS_FILE',
+  );
+  if (emitRequests.length !== expectedCases) {
+    fail(`expected ${expectedCases} emit requests, got ${emitRequests.length}`);
+  }
+
+  const issueRequestsPath = process.env.EXO_AVC_SMOKE_ISSUE_REQUESTS_FILE;
+  if (issueRequestsPath !== undefined && issueRequestsPath.trim().length > 0) {
+    const issueRequests = requestArray(
+      await readJson(issueRequestsPath, 'EXO_AVC_SMOKE_ISSUE_REQUESTS_FILE'),
+      'EXO_AVC_SMOKE_ISSUE_REQUESTS_FILE',
+    );
+    await seedCredentials(baseUrl, token, issueRequests);
+  }
+
+  let successCount = 0;
+  for (let round = 1; round <= rounds; round += 1) {
+    for (let index = 0; index < emitRequests.length; index += 1) {
+      const context = `round ${round} case ${index + 1}`;
+      const emitResponse = await requestJson(
+        baseUrl,
+        '/api/v1/avc/receipts/emit',
+        token,
+        'POST',
+        emitRequests[index],
+      );
+      const receiptHash = validateEmitResponse(emitResponse, context, allowEmptyPreviousReceipt);
+      const fetched = await requestJson(
+        baseUrl,
+        `/api/v1/avc/receipts/${encodeURIComponent(receiptHash)}`,
+        token,
+        'GET',
+      );
+      validateReceiptProof(fetched, `${context} fetched receipt`, allowEmptyPreviousReceipt);
+      successCount += 1;
+      console.log(`${context}: OK receipt_hash=${receiptHash}`);
+    }
+  }
+
+  console.log(`AVC production smoke passed: ${successCount}/${rounds * emitRequests.length} emits`);
+}
+
+run().catch((error) => {
+  fail(error instanceof Error ? error.message : String(error));
+});

--- a/tools/verify_public_exochain_route.sh
+++ b/tools/verify_public_exochain_route.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${EXOCHAIN_PUBLIC_ROUTE_BASE_URL:-https://exochain.io}"
+DOH_URL="${EXOCHAIN_PUBLIC_ROUTE_DOH_URL:-}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+fail() {
+  echo "public route verification failed: $*" >&2
+  exit 1
+}
+
+fetch() {
+  local name="$1"
+  local path="$2"
+  local method="${3:-GET}"
+  local headers="${TMP_DIR}/${name}.headers"
+  local body="${TMP_DIR}/${name}.body"
+  local status
+
+  if ! status="$(
+    curl -sS \
+      --max-time 20 \
+      "${CURL_DNS_ARGS[@]}" \
+      -X "${method}" \
+      -D "${headers}" \
+      -o "${body}" \
+      -w '%{http_code}' \
+      "${BASE_URL}${path}"
+  )"; then
+    fail "${path} request failed before an HTTP response was accepted"
+  fi
+  printf '%s\t%s\t%s\n' "${name}" "${status}" "${path}"
+  if rg -i '(^server:.*fly|^via:.*fly\.io|fly-request-id:)' "${headers}" >/dev/null; then
+    sed -n '1,40p' "${headers}" >&2
+    fail "${path} still traverses deprecated Fly infrastructure"
+  fi
+  FETCH_STATUS="${status}"
+  FETCH_HEADERS="${headers}"
+  FETCH_BODY="${body}"
+}
+
+require_status() {
+  local got="$1"
+  local want="$2"
+  local path="$3"
+  if [ "${got}" != "${want}" ]; then
+    sed -n '1,80p' "${FETCH_HEADERS}" >&2
+    sed -n '1,80p' "${FETCH_BODY}" >&2
+    fail "${path} returned HTTP ${got}, expected ${want}"
+  fi
+}
+
+command -v curl >/dev/null || fail "curl is required"
+command -v jq >/dev/null || fail "jq is required"
+command -v rg >/dev/null || fail "rg is required"
+
+CURL_DNS_ARGS=()
+if [ -n "${DOH_URL}" ]; then
+  CURL_DNS_ARGS=(--doh-url "${DOH_URL}")
+fi
+
+fetch health /health
+require_status "${FETCH_STATUS}" 200 /health
+jq -e '.status == "ok" and (.version | type == "string")' "${FETCH_BODY}" >/dev/null \
+  || fail "/health did not return the expected JSON health body"
+
+fetch ready /ready
+require_status "${FETCH_STATUS}" 200 /ready
+jq -e '.status == "ok" and .dagdb_runtime_status == "dagdb_active"' "${FETCH_BODY}" >/dev/null \
+  || fail "/ready did not prove dagdb_active readiness"
+
+fetch discovery /.well-known/exochain.json
+require_status "${FETCH_STATUS}" 200 /.well-known/exochain.json
+jq -e '
+  .base_url == "https://exochain.io"
+  and .routes.health == "/health"
+  and .routes.ready == "/ready"
+  and .routes.avc.receipts_emit == "/api/v1/avc/receipts/emit"
+  and .mcp.public_transport == false
+  and (.mcp.capabilities | index("tools") != null)
+  and (.mcp.capabilities | index("resources") != null)
+  and (.mcp.capabilities | index("prompts") != null)
+' "${FETCH_BODY}" >/dev/null || fail "discovery document is missing required public metadata"
+
+fetch avc_issue_auth_boundary /api/v1/avc/issue POST
+require_status "${FETCH_STATUS}" 401 /api/v1/avc/issue
+
+echo "public route verification passed for ${BASE_URL}"


### PR DESCRIPTION
## Summary

- Adds `GET /.well-known/exochain.json` to `exo-gateway` for the canonical public EXOCHAIN API, SDK, and MCP discovery contract.
- Adds TypeScript and Python SDK `discover()` helpers that validate the same well-known document.
- Adds route/AVC proof tooling:
  - `tools/verify_public_exochain_route.sh`
  - `tools/avc_emit_production_smoke.mjs`

## Path Classification

- `crates/exo-gateway/src/rest.rs` — core runtime adapter
- `crates/exo-gateway/src/server.rs` — core runtime adapter
- `packages/exochain-sdk/**` — core runtime adapter SDK surface
- `packages/exochain-py/**` — core runtime adapter SDK surface
- `tools/verify_public_exochain_route.sh` — production route proof tooling
- `tools/avc_emit_production_smoke.mjs` — production AVC proof tooling

## Core/Adapter Boundary

No `exo-gatekeeper`, `exo-avc`, `exo-core`, governance invariant, consent, authority, DAG finality, or receipt-emission logic is reimplemented here. This branch is based on PR #714 and intentionally reuses its TSA error-class and nonce changes.

MCP is advertised as discoverable metadata only: `public_transport: false`, transports `stdio` and `loopback-sse`, capabilities `tools`, `resources`, and `prompts`. No public `/mcp/message` transport is exposed by this PR.

## Local Verification

- `cargo test -p exo-gateway discovery -- --nocapture`
- `cargo test -p exo-node mcp -- --nocapture`
- `cargo test -p exo-node avc_rfc3161 -- --nocapture`
- `npm test --prefix packages/exochain-sdk`
- `python3 -m pytest packages/exochain-py`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `EXO_AVC_RFC3161_LIVE_PREFLIGHT=1 ./tools/avc_rfc3161_microsoft_preflight.sh`
- `node --check tools/avc_emit_production_smoke.mjs`
- `bash -n tools/verify_public_exochain_route.sh`

## Runtime / DNS Truth At Creation

Cloudflare DNS cleanup has been applied outside this repo:

- Removed deprecated apex Fly `A 137.66.5.218`.
- Removed deprecated apex Fly `AAAA 2a09:8280:1::f2:8261:0`.
- Removed deprecated Fly ACME challenge CNAME `_acme-challenge.exochain.io -> exochain.io.53m9e83.flydns.net`.
- Added apex CNAME `exochain.io -> exochain-production.up.railway.app`.
- Set that CNAME proxied per Railway/Cloudflare custom-domain behavior.

Current public route proof is not yet accepted: public DoH reaches Cloudflare/Railway, but Railway returns `x-railway-fallback: true` / 404 for Host `exochain.io`, so Railway custom-domain association still needs activation/repair before `/health`, `/ready`, and discovery can pass on the canonical domain.

Direct Railway service domain is healthy:

- `https://exochain-production.up.railway.app/health` returns 200.
- `https://exochain-production.up.railway.app/ready` returns 200 with `dagdb_runtime_status: dagdb_active`.
- unauthenticated AVC protocol path reaches the node auth boundary with 401.

## AVC Smoke Boundary

`tools/avc_emit_production_smoke.mjs` requires approved smoke env and request fixtures:

- `EXO_AVC_SMOKE_BEARER_TOKEN`
- `EXO_AVC_SMOKE_EMIT_REQUESTS_FILE`
- optional `EXO_AVC_SMOKE_ISSUE_REQUESTS_FILE`

It refuses to derive or fabricate production issuer/subject material. Running without approved smoke env fails closed before any request.
