### PR TITLE
fix(avc): trust RFC3161 issuing CA anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 31 | `ls -d crates/*/` |
 | Rust source files | 456 | `find crates -name '*.rs'` |
-| Rust LOC | 367021 | `wc -l` |
-| Workspace tests | 6,029 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 367848 | `wc -l` |
+| Workspace tests | 6,042 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |

--- a/crates/exo-avc/src/lib.rs
+++ b/crates/exo-avc/src/lib.rs
@@ -125,8 +125,8 @@ pub use receipt::{
     AVC_RECEIPT_EVIDENCE_SUBJECT_DOMAIN, AVC_RECEIPT_EXTERNAL_TIMESTAMP_DOMAIN,
     AVC_RECEIPT_SIGNING_DOMAIN, AvcReceiptEvidenceSubject, AvcReceiptExternalTimestampProof,
     AvcReceiptExternalTimestampProofKind, AvcReceiptRfc3161TimestampProof,
-    AvcReceiptTimestampProvenance, AvcTrustReceipt, AvcTrustReceiptEvidence, create_trust_receipt,
-    create_trust_receipt_with_evidence,
+    AvcReceiptRfc3161TrustAnchorKind, AvcReceiptTimestampProvenance, AvcTrustReceipt,
+    AvcTrustReceiptEvidence, create_trust_receipt, create_trust_receipt_with_evidence,
 };
 pub use registry::{
     AvcRegistryDurableState, AvcRegistryRead, AvcRegistryWrite, InMemoryAvcRegistry,

--- a/crates/exo-avc/src/receipt.rs
+++ b/crates/exo-avc/src/receipt.rs
@@ -170,6 +170,13 @@ impl AvcReceiptExternalTimestampProofKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AvcReceiptRfc3161TrustAnchorKind {
+    SignerSpki,
+    IssuingCaSpki,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AvcReceiptRfc3161TimestampProof {
     pub message_imprint_sha256_hex: String,
     pub token_der_base64: String,
@@ -178,6 +185,12 @@ pub struct AvcReceiptRfc3161TimestampProof {
     pub nonce_hex: String,
     pub tsa_subject: String,
     pub tsa_public_key_spki_der_hex: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tsa_trust_anchor_kind: Option<AvcReceiptRfc3161TrustAnchorKind>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tsa_trust_anchor_spki_der_hex: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tsa_issuer_subject: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -613,6 +626,14 @@ mod tests {
                         .to_owned(),
                 tsa_public_key_spki_der_hex: "30820122300d06092a864886f70d01010105000382010f"
                     .to_owned(),
+                tsa_trust_anchor_kind: Some(AvcReceiptRfc3161TrustAnchorKind::IssuingCaSpki),
+                tsa_trust_anchor_spki_der_hex: Some(
+                    "30820222300d06092a864886f70d01010105000382020f".to_owned(),
+                ),
+                tsa_issuer_subject: Some(
+                    "CN=Microsoft Public RSA Timestamping CA 2020,O=Microsoft Corporation,C=US"
+                        .to_owned(),
+                ),
             },
         );
         let mut rfc3161_bytes = Vec::new();

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -66,9 +66,9 @@ use exo_avc::{
     AVC_PROTOCOL_DEPRECATION_WINDOW_DAYS, AVC_PROTOCOL_VERSION, AVC_SCHEMA_VERSION,
     AutonomousVolitionCredential, AvcActionDescriptor, AvcActionRequest, AvcDecision,
     AvcReceiptEvidenceSubject, AvcReceiptExternalTimestampProof, AvcReceiptRfc3161TimestampProof,
-    AvcReceiptTimestampProvenance, AvcRegistryDurableState, AvcRegistryRead, AvcRegistryWrite,
-    AvcRevocation, AvcTrustReceipt, AvcTrustReceiptEvidence, AvcValidationRequest,
-    AvcValidationResult, InMemoryAvcRegistry, avc_action_commitment_hash,
+    AvcReceiptRfc3161TrustAnchorKind, AvcReceiptTimestampProvenance, AvcRegistryDurableState,
+    AvcRegistryRead, AvcRegistryWrite, AvcRevocation, AvcTrustReceipt, AvcTrustReceiptEvidence,
+    AvcValidationRequest, AvcValidationResult, InMemoryAvcRegistry, avc_action_commitment_hash,
     avc_action_descriptor_hash, avc_action_signature_payload, create_trust_receipt_with_evidence,
     require_supported_avc_protocol_version, validate_avc,
 };
@@ -107,6 +107,7 @@ pub const AVC_EXTERNAL_TIMESTAMP_AUTHORITY_DID_ENV: &str =
     "EXO_AVC_EXTERNAL_TIMESTAMP_AUTHORITY_DID";
 pub const AVC_EXTERNAL_TIMESTAMP_AUTHORITY_PUBLIC_KEY_HEX_ENV: &str =
     "EXO_AVC_EXTERNAL_TIMESTAMP_AUTHORITY_PUBLIC_KEY_HEX";
+pub const AVC_RFC3161_TIMESTAMP_CA_SPKI_HEX_ENV: &str = "EXO_AVC_RFC3161_TIMESTAMP_CA_SPKI_HEX";
 pub const AVC_RFC3161_TIMESTAMP_POLICY_OID_ENV: &str = "EXO_AVC_RFC3161_TIMESTAMP_POLICY_OID";
 const AVC_REGISTRY_DURABLE_STATE_FILE: &str = "avc-registry.cbor";
 const AVC_REGISTRY_POSTGRES_TABLE: &str = "avc_registry_state";
@@ -136,6 +137,7 @@ enum AvcReceiptExternalTimestampSource {
         endpoint: Arc<String>,
         authority_did: Did,
         authority_public_key_spki_der_hexes: Arc<Vec<String>>,
+        issuing_ca_spki_der_hexes: Arc<Vec<String>>,
         policy_oid: Arc<String>,
         client: reqwest::Client,
     },
@@ -320,6 +322,7 @@ impl AvcReceiptExternalTimestampSource {
                 endpoint,
                 authority_did,
                 authority_public_key_spki_der_hexes,
+                issuing_ca_spki_der_hexes,
                 policy_oid,
                 client,
             } => {
@@ -352,17 +355,33 @@ impl AvcReceiptExternalTimestampSource {
                         reason: error.to_string(),
                     }
                 })?;
-                let verified = crate::avc_rfc3161::verify_timestamp_response_with_spki_pins(
+                let trust_anchors = crate::avc_rfc3161::Rfc3161TrustAnchors::new(
+                    authority_public_key_spki_der_hexes.as_ref().clone(),
+                    issuing_ca_spki_der_hexes.as_ref().clone(),
+                )
+                .map_err(|error| AvcExternalTimestampFailure::InvalidProof {
+                    reason: error.to_string(),
+                })?;
+                let verified = crate::avc_rfc3161::verify_timestamp_response_with_trust_anchors(
                     &response_der,
                     subject_hash,
                     request.message_imprint_sha256,
                     &request.nonce_hex,
                     policy_oid.as_str(),
-                    authority_public_key_spki_der_hexes.as_slice(),
+                    &trust_anchors,
                 )
                 .map_err(|error| AvcExternalTimestampFailure::InvalidProof {
                     reason: error.to_string(),
                 })?;
+                let (tsa_trust_anchor_kind, tsa_issuer_subject) = match verified.trust_anchor.kind {
+                    crate::avc_rfc3161::Rfc3161TrustAnchorKind::SignerSpki => {
+                        (AvcReceiptRfc3161TrustAnchorKind::SignerSpki, None)
+                    }
+                    crate::avc_rfc3161::Rfc3161TrustAnchorKind::IssuingCaSpki => (
+                        AvcReceiptRfc3161TrustAnchorKind::IssuingCaSpki,
+                        Some(verified.trust_anchor.subject.clone()),
+                    ),
+                };
                 Ok(AvcReceiptExternalTimestampProof::rfc3161(
                     authority_did.clone(),
                     verified.subject_hash,
@@ -375,6 +394,9 @@ impl AvcReceiptExternalTimestampSource {
                         nonce_hex: verified.nonce_hex,
                         tsa_subject: verified.tsa_subject,
                         tsa_public_key_spki_der_hex: verified.tsa_public_key_spki_der_hex,
+                        tsa_trust_anchor_kind: Some(tsa_trust_anchor_kind),
+                        tsa_trust_anchor_spki_der_hex: Some(verified.trust_anchor.spki_der_hex),
+                        tsa_issuer_subject,
                     },
                 ))
             }
@@ -433,6 +455,9 @@ impl AvcReceiptExternalTimestampSource {
                     nonce_hex: nonce_hex.clone(),
                     tsa_subject: tsa_subject.clone(),
                     tsa_public_key_spki_der_hex: tsa_public_key_spki_der_hex.clone(),
+                    tsa_trust_anchor_kind: Some(AvcReceiptRfc3161TrustAnchorKind::SignerSpki),
+                    tsa_trust_anchor_spki_der_hex: Some(tsa_public_key_spki_der_hex.clone()),
+                    tsa_issuer_subject: None,
                 },
             )),
         }
@@ -827,6 +852,10 @@ where
         read(AVC_EXTERNAL_TIMESTAMP_AUTHORITY_PUBLIC_KEY_HEX_ENV)?,
         AVC_EXTERNAL_TIMESTAMP_AUTHORITY_PUBLIC_KEY_HEX_ENV,
     )?;
+    let issuing_ca_spki = clean_optional_env_value(
+        read(AVC_RFC3161_TIMESTAMP_CA_SPKI_HEX_ENV)?,
+        AVC_RFC3161_TIMESTAMP_CA_SPKI_HEX_ENV,
+    )?;
     let policy_oid = clean_optional_env_value(
         read(AVC_RFC3161_TIMESTAMP_POLICY_OID_ENV)?,
         AVC_RFC3161_TIMESTAMP_POLICY_OID_ENV,
@@ -836,6 +865,7 @@ where
         && endpoint.is_none()
         && authority_did.is_none()
         && authority_public_key.is_none()
+        && issuing_ca_spki.is_none()
         && policy_oid.is_none()
     {
         tracing::warn!(
@@ -843,6 +873,7 @@ where
             url_env = AVC_EXTERNAL_TIMESTAMP_AUTHORITY_URL_ENV,
             did_env = AVC_EXTERNAL_TIMESTAMP_AUTHORITY_DID_ENV,
             key_env = AVC_EXTERNAL_TIMESTAMP_AUTHORITY_PUBLIC_KEY_HEX_ENV,
+            ca_env = AVC_RFC3161_TIMESTAMP_CA_SPKI_HEX_ENV,
             policy_env = AVC_RFC3161_TIMESTAMP_POLICY_OID_ENV,
             require_env = AVC_REQUIRE_EXTERNAL_TIMESTAMP_AUTHORITY_ENV,
             "AVC external timestamp authority is not configured; receipt emission will use local EXOCHAIN HLC finality unless external timestamp proof is explicitly required"
@@ -862,6 +893,11 @@ where
             if policy_oid.is_some() {
                 anyhow::bail!(
                     "{AVC_RFC3161_TIMESTAMP_POLICY_OID_ENV} is only valid with {AVC_EXTERNAL_TIMESTAMP_AUTHORITY_KIND_ENV}={AVC_EXTERNAL_TIMESTAMP_AUTHORITY_KIND_RFC3161}"
+                );
+            }
+            if issuing_ca_spki.is_some() {
+                anyhow::bail!(
+                    "{AVC_RFC3161_TIMESTAMP_CA_SPKI_HEX_ENV} is only valid with {AVC_EXTERNAL_TIMESTAMP_AUTHORITY_KIND_ENV}={AVC_EXTERNAL_TIMESTAMP_AUTHORITY_KIND_RFC3161}"
                 );
             }
             let endpoint = endpoint.unwrap_or_default();
@@ -889,12 +925,28 @@ where
                 authority_did,
                 AVC_EXTERNAL_TIMESTAMP_AUTHORITY_DID_ENV,
             )?;
-            let authority_public_key_spki_der_hexes = parse_non_empty_hex_string_set(
-                &require_optional_env_value(
-                    authority_public_key,
+            if authority_public_key.is_none() && issuing_ca_spki.is_none() {
+                anyhow::bail!(
+                    "RFC 3161 AVC timestamp authority requires at least one trust anchor; set either {AVC_EXTERNAL_TIMESTAMP_AUTHORITY_PUBLIC_KEY_HEX_ENV} for signer leaf SPKI pins or {AVC_RFC3161_TIMESTAMP_CA_SPKI_HEX_ENV} for issuing CA SPKI pins"
+                );
+            }
+            let authority_public_key_spki_der_hexes = match authority_public_key {
+                Some(authority_public_key) => parse_non_empty_hex_string_set(
+                    &authority_public_key,
                     AVC_EXTERNAL_TIMESTAMP_AUTHORITY_PUBLIC_KEY_HEX_ENV,
                 )?,
-                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_PUBLIC_KEY_HEX_ENV,
+                None => Vec::new(),
+            };
+            let issuing_ca_spki_der_hexes = match issuing_ca_spki {
+                Some(issuing_ca_spki) => parse_non_empty_hex_string_set(
+                    &issuing_ca_spki,
+                    AVC_RFC3161_TIMESTAMP_CA_SPKI_HEX_ENV,
+                )?,
+                None => Vec::new(),
+            };
+            crate::avc_rfc3161::Rfc3161TrustAnchors::new(
+                authority_public_key_spki_der_hexes.clone(),
+                issuing_ca_spki_der_hexes.clone(),
             )?;
             let policy_oid =
                 require_optional_env_value(policy_oid, AVC_RFC3161_TIMESTAMP_POLICY_OID_ENV)?;
@@ -907,6 +959,7 @@ where
                 endpoint: Arc::new(endpoint),
                 authority_did,
                 authority_public_key_spki_der_hexes: Arc::new(authority_public_key_spki_der_hexes),
+                issuing_ca_spki_der_hexes: Arc::new(issuing_ca_spki_der_hexes),
                 policy_oid: Arc::new(policy_oid),
                 client: external_timestamp_http_client()?,
             })
@@ -2416,6 +2469,7 @@ mod tests {
     const MICROSOFT_PUBLIC_RSA_TSA_DID: &str = "did:exo:microsoft-public-rsa-tsa";
     const MICROSOFT_FIXTURE_SIGNER_SPKI_HEX: &str = "30820222300d06092a864886f70d01010105000382020f003082020a0282020100b4a59f9bfba5d36eff77c4656fc327fe0d1052fbcba98d95b32ded23c536b454aca53668999383dc11d3f0b911f91ae130981bd558c0285372b1a2bd70b49789f3c648806b3c282cf4fe32db896b2449ab57a439cf8066a8c8483eb66112f6675a9092e073bb8d849e8bf9f1982effd44afe9792e0dcf992c5bf1dd8855c011c52c350789b107a5c8d2791e97dc1ad5d61bdb07c6a687eb6859b164ec53f5e361b782c7d1105256e79b6ba64da634bfd20b5f9bbaa2222c8fea9e8f4734d36cc9d5aac1e757f77fad6d331f1f90f90359e7052a2a64d9241f6153ce77fb6a57e6b0df2b7dae358f7f5813809b36ea82911d4246e231abd43325034a19b2708be01dd4274b6d3bb138fc33e9092f7b4e75a84fb8fa8cc2c6820a075fc30431d0ef5329eec54af6c0118b3502795d0a5fca1c6642395bd436a8f22f5d092ded3ff860fdff29ea5c6585a573a36ae9ef67f70a44e8633783397bac71d1bda68aa70f8a2e3f8a2d9985e29a9652444fb08a96915286cdf0ca0e85fdfa2343142f3e76d60f8372c7a9618d68f09a82dcc7ac351520ad6af2c2972df704b452953538a8a53169af1ded837b12aa67f573b4498d2e98ebca157ad61fbaf197ef626a2722b5d9d34e4b009d18ef7a474a4f7960ee544c7e67d953cbd73623745182734fd123aa3466d2e37f874a17c4f84d7cf62a7856f23d7186c73698533eb3c77a9370203010001";
     const MICROSOFT_LIVE_SIGNER_SPKI_HEX_20260627: &str = "30820222300d06092a864886f70d01010105000382020f003082020a02820201009d7834a47690ecf5409659fe1d966b24570ba0a6de9215b5c8bf9034152014552c8d920a6aaa8de28209b09337a6cd2b24d48eee7742351b990d7d9682eaf7024efb797ae5a015ea6663ba6555de0cd4422e5756e00d3f35f8f327b5d791d1218ebf358215c4a51ef30bec1b68d37eb0f4b1ccb01905e89b0c53fb5f0b39c17d19b48b0dd5adbe5eae5bbd6a77911332b70b244e3ba746078b64bfed069db7ec955d44f14043d8d844aa42a94068fefd718c12d1095dcf6a52a39c67dbdcc37853b8d5caa89f1474a17275b9084451a019946bab32803cc54abf1ede0f774cf34b1548af504d0698b7db5f971e0f51add45719eb1fc92d5013ce4e7e0561db331c092159153d3a9248c8d0e8a4ca75c9eade91f4738005269fe096f729ab453d7f36488c9186bdda62b2195197bed142d5214a3c47bc29f72c2ff1a904303874900ec1a1e8d5f60f445fb12c84b53001c8069efb6c351c1c930d372695334b12e40b7828f580d05d2168f458e6320ed8e343ff224d663a7b2d6f6fda87963223e478089dd4f93fd318936560d9eee129464d04d6c0fe1b2006cba867e217f3d5af8c437d69b17dd52e0e255ba29e62ac2cefcc2db9e5ee292e0f474dea803461ec320d09dcb35dac33d1ceb6eef6400fd366579fbd6f2bf71b4c5c06284257068ec93c5b851cedc7ea56a6c83e376873c6710732dc5dc5723f8a797322f0be430203010001";
+    const MICROSOFT_FIXTURE_CA_SPKI_HEX: &str = "30820222300d06092a864886f70d01010105000382020f003082020a02820201009e7ce75263fde0c59f057d63b50622a31c1ed7e79733d11305bd6546477791c15d706f7fb2ab43970c4aa1521c6aa0dbfa89858a8e431c2e1105c6f24078d70b0324fe5dd3398b60a018f19c6fde5624b8b0ec7ccb8812abc660e3d44401fe61b9784891044a7b7431b3c4a0a74d8a1c0ce711afd2b1a87c9d6a39849335c739e446c14fbbaadf0c7799786d566b5c084af964a4e428a1350b166f34f59d1962543c2e9ee2e45f58722165c802b09faca337f911e1f92ab9459f1a6328a4dabf07c53fa5da199196506f1365a893a20468025a9c7af6e2aa2a14cf562de0544ae773faa2f9d47c036322033d243749e1ed2a883466e6c39388442d04b19df5585dd4c69dc6819c1eb442b12e6b3bdca1bf67e3247ae6950d042179a9e0384306278a50647e799e02344ddcb56e2ebd20d055e4a9f61d5268f57c51611fc93c601a33ac46979ec48bde47530f4d57fb82df2163ae1734f3ba8b2506b0482df1cd8fc45f3b13e08eec0dbc4e98cdab978b8a2ba784a6ead176e390da14e4986d614ae59806e9c518dbf6d4ab78376d002a66deb929c69ec04277672344a1bbf7e4d7fac4de85ac0ea317de38efe347bc28de58b09067733c9607827279e14c5b72417dd7802a1ce88457bc539c3d5aebdc3f513c708c4ba0a483cc20813aed2159d8f328dbbc6394b007596de5d421001632cd1dddc443bf4f52bf055177ad5ebd0203010001";
     const MICROSOFT_FIXTURE_TSA_SUBJECT: &str = "C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, OU=Microsoft America Operations, OU=nShield TSS ESN:A500-05E0-D947, CN=Microsoft Public RSA Time Stamping Authority";
 
     #[derive(Clone, Copy)]
@@ -2488,6 +2542,7 @@ mod tests {
             authority_public_key_spki_der_hexes: Arc::new(vec![
                 MICROSOFT_FIXTURE_SIGNER_SPKI_HEX.to_owned(),
             ]),
+            issuing_ca_spki_der_hexes: Arc::new(Vec::new()),
             policy_oid: Arc::new(
                 crate::avc_rfc3161::MICROSOFT_ARTIFACT_SIGNING_POLICY_OID.to_owned(),
             ),
@@ -6051,6 +6106,250 @@ mod tests {
         .unwrap_err()
         .to_string();
         assert!(empty_pin_err.contains("member 2 is empty"));
+    }
+
+    #[test]
+    fn rfc3161_env_config_accepts_explicit_pinned_issuing_ca_without_leaf_pin() {
+        let source = external_timestamp_source_from_pairs(vec![
+            (
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_KIND_ENV,
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_KIND_RFC3161,
+            ),
+            (
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_URL_ENV,
+                "http://timestamp.acs.microsoft.com",
+            ),
+            (
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_DID_ENV,
+                "did:exo:microsoft-public-rsa-tsa",
+            ),
+            (
+                AVC_RFC3161_TIMESTAMP_CA_SPKI_HEX_ENV,
+                MICROSOFT_FIXTURE_CA_SPKI_HEX,
+            ),
+            (
+                AVC_RFC3161_TIMESTAMP_POLICY_OID_ENV,
+                crate::avc_rfc3161::MICROSOFT_ARTIFACT_SIGNING_POLICY_OID,
+            ),
+        ])
+        .unwrap();
+
+        match source {
+            AvcReceiptExternalTimestampSource::Rfc3161 {
+                authority_public_key_spki_der_hexes,
+                issuing_ca_spki_der_hexes,
+                ..
+            } => {
+                assert!(authority_public_key_spki_der_hexes.is_empty());
+                assert_eq!(
+                    issuing_ca_spki_der_hexes.as_slice(),
+                    &[MICROSOFT_FIXTURE_CA_SPKI_HEX.to_owned()]
+                );
+            }
+            _ => panic!("rfc3161 kind must construct the RFC 3161 timestamp source"),
+        }
+    }
+
+    #[test]
+    fn external_timestamp_source_debug_redacts_transport_clients_and_pin_material() {
+        let rfc3161 = external_timestamp_source_from_pairs(vec![
+            (
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_KIND_ENV,
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_KIND_RFC3161,
+            ),
+            (
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_URL_ENV,
+                "http://timestamp.acs.microsoft.com",
+            ),
+            (
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_DID_ENV,
+                "did:exo:microsoft-public-rsa-tsa",
+            ),
+            (
+                AVC_RFC3161_TIMESTAMP_CA_SPKI_HEX_ENV,
+                MICROSOFT_FIXTURE_CA_SPKI_HEX,
+            ),
+            (
+                AVC_RFC3161_TIMESTAMP_POLICY_OID_ENV,
+                crate::avc_rfc3161::MICROSOFT_ARTIFACT_SIGNING_POLICY_OID,
+            ),
+        ])
+        .unwrap();
+        let rfc3161_debug = format!("{rfc3161:?}");
+        assert!(rfc3161_debug.contains("AvcReceiptExternalTimestampSource::Rfc3161"));
+        assert!(rfc3161_debug.contains("http://timestamp.acs.microsoft.com"));
+        assert!(rfc3161_debug.contains("did:exo:microsoft-public-rsa-tsa"));
+        assert!(rfc3161_debug.contains(crate::avc_rfc3161::MICROSOFT_ARTIFACT_SIGNING_POLICY_OID));
+        assert!(!rfc3161_debug.contains(MICROSOFT_FIXTURE_CA_SPKI_HEX));
+        assert!(!rfc3161_debug.contains("client"));
+
+        let http = external_timestamp_source_from_pairs(vec![
+            (
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_URL_ENV,
+                "http://127.0.0.1:3000",
+            ),
+            (
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_DID_ENV,
+                "did:exo:timestamp-authority",
+            ),
+            (
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_PUBLIC_KEY_HEX_ENV,
+                &timestamp_authority_keypair().public.to_string(),
+            ),
+        ])
+        .unwrap();
+        let http_debug = format!("{http:?}");
+        assert!(http_debug.contains("AvcReceiptExternalTimestampSource::HttpJson"));
+        assert!(http_debug.contains("http://127.0.0.1:3000"));
+        assert!(http_debug.contains("did:exo:timestamp-authority"));
+        assert!(!http_debug.contains(&timestamp_authority_keypair().public.to_string()));
+        assert!(!http_debug.contains("client"));
+
+        assert_eq!(
+            format!("{:?}", AvcReceiptExternalTimestampSource::Unconfigured),
+            "AvcReceiptExternalTimestampSource::Unconfigured"
+        );
+
+        let fixed = fixed_external_timestamp_source(Timestamp::new(1_600_000, 0));
+        let fixed_debug = format!("{fixed:?}");
+        assert!(fixed_debug.contains("AvcReceiptExternalTimestampSource::Fixed"));
+        assert!(fixed_debug.contains("did:exo:timestamp-authority"));
+        assert!(fixed_debug.contains("issued_at"));
+
+        let fixed_rfc3161 = fixed_rfc3161_external_timestamp_source();
+        let fixed_rfc3161_debug = format!("{fixed_rfc3161:?}");
+        assert!(fixed_rfc3161_debug.contains("AvcReceiptExternalTimestampSource::FixedRfc3161"));
+        assert!(fixed_rfc3161_debug.contains("did:exo:microsoft-public-rsa-tsa"));
+        assert!(
+            fixed_rfc3161_debug.contains(crate::avc_rfc3161::MICROSOFT_ARTIFACT_SIGNING_POLICY_OID)
+        );
+        assert!(!fixed_rfc3161_debug.contains(MICROSOFT_FIXTURE_SIGNER_SPKI_HEX));
+    }
+
+    #[test]
+    fn rfc3161_env_config_rejects_missing_leaf_and_ca_trust_anchors() {
+        let err = external_timestamp_source_from_pairs(vec![
+            (
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_KIND_ENV,
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_KIND_RFC3161,
+            ),
+            (
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_URL_ENV,
+                "http://timestamp.acs.microsoft.com",
+            ),
+            (
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_DID_ENV,
+                "did:exo:microsoft-public-rsa-tsa",
+            ),
+            (
+                AVC_RFC3161_TIMESTAMP_POLICY_OID_ENV,
+                crate::avc_rfc3161::MICROSOFT_ARTIFACT_SIGNING_POLICY_OID,
+            ),
+        ])
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains(AVC_EXTERNAL_TIMESTAMP_AUTHORITY_PUBLIC_KEY_HEX_ENV));
+        assert!(err.contains(AVC_RFC3161_TIMESTAMP_CA_SPKI_HEX_ENV));
+    }
+
+    #[test]
+    fn external_timestamp_env_config_rejects_cross_protocol_and_malformed_values() {
+        let json_ca_err = external_timestamp_source_from_pairs(vec![
+            (
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_KIND_ENV,
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_KIND_JSON_ED25519,
+            ),
+            (
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_URL_ENV,
+                "http://127.0.0.1:3000",
+            ),
+            (
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_DID_ENV,
+                "did:exo:timestamp-authority",
+            ),
+            (
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_PUBLIC_KEY_HEX_ENV,
+                &timestamp_authority_keypair().public.to_string(),
+            ),
+            (
+                AVC_RFC3161_TIMESTAMP_CA_SPKI_HEX_ENV,
+                MICROSOFT_FIXTURE_CA_SPKI_HEX,
+            ),
+        ])
+        .unwrap_err()
+        .to_string();
+        assert!(json_ca_err.contains(AVC_RFC3161_TIMESTAMP_CA_SPKI_HEX_ENV));
+        assert!(json_ca_err.contains(AVC_EXTERNAL_TIMESTAMP_AUTHORITY_KIND_RFC3161));
+
+        let json_did_err = external_timestamp_source_from_pairs(vec![
+            (
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_URL_ENV,
+                "http://127.0.0.1:3000",
+            ),
+            (AVC_EXTERNAL_TIMESTAMP_AUTHORITY_DID_ENV, "not-a-did"),
+            (
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_PUBLIC_KEY_HEX_ENV,
+                &timestamp_authority_keypair().public.to_string(),
+            ),
+        ])
+        .unwrap_err()
+        .to_string();
+        assert!(json_did_err.contains(AVC_EXTERNAL_TIMESTAMP_AUTHORITY_DID_ENV));
+
+        let rfc3161_missing_endpoint_err = external_timestamp_source_from_pairs(vec![
+            (
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_KIND_ENV,
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_KIND_RFC3161,
+            ),
+            (
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_DID_ENV,
+                "did:exo:microsoft-public-rsa-tsa",
+            ),
+            (
+                AVC_RFC3161_TIMESTAMP_CA_SPKI_HEX_ENV,
+                MICROSOFT_FIXTURE_CA_SPKI_HEX,
+            ),
+            (
+                AVC_RFC3161_TIMESTAMP_POLICY_OID_ENV,
+                crate::avc_rfc3161::MICROSOFT_ARTIFACT_SIGNING_POLICY_OID,
+            ),
+        ])
+        .unwrap_err()
+        .to_string();
+        assert!(rfc3161_missing_endpoint_err.contains(AVC_EXTERNAL_TIMESTAMP_AUTHORITY_URL_ENV));
+
+        let rfc3161_did_err = external_timestamp_source_from_pairs(vec![
+            (
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_KIND_ENV,
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_KIND_RFC3161,
+            ),
+            (
+                AVC_EXTERNAL_TIMESTAMP_AUTHORITY_URL_ENV,
+                "http://timestamp.acs.microsoft.com",
+            ),
+            (AVC_EXTERNAL_TIMESTAMP_AUTHORITY_DID_ENV, "not-a-did"),
+            (
+                AVC_RFC3161_TIMESTAMP_CA_SPKI_HEX_ENV,
+                MICROSOFT_FIXTURE_CA_SPKI_HEX,
+            ),
+            (
+                AVC_RFC3161_TIMESTAMP_POLICY_OID_ENV,
+                crate::avc_rfc3161::MICROSOFT_ARTIFACT_SIGNING_POLICY_OID,
+            ),
+        ])
+        .unwrap_err()
+        .to_string();
+        assert!(rfc3161_did_err.contains(AVC_EXTERNAL_TIMESTAMP_AUTHORITY_DID_ENV));
+
+        let unknown_kind_err = external_timestamp_source_from_pairs(vec![(
+            AVC_EXTERNAL_TIMESTAMP_AUTHORITY_KIND_ENV,
+            "not-a-supported-kind",
+        )])
+        .unwrap_err()
+        .to_string();
+        assert!(unknown_kind_err.contains(AVC_EXTERNAL_TIMESTAMP_AUTHORITY_KIND_JSON_ED25519));
+        assert!(unknown_kind_err.contains(AVC_EXTERNAL_TIMESTAMP_AUTHORITY_KIND_RFC3161));
     }
 
     #[test]

--- a/crates/exo-node/src/avc_rfc3161.rs
+++ b/crates/exo-node/src/avc_rfc3161.rs
@@ -16,6 +16,8 @@
 
 //! RFC 3161 timestamp request and response verification for AVC receipts.
 
+use std::collections::BTreeSet;
+
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use cms::{
     cert::CertificateChoices,
@@ -28,7 +30,10 @@ use exo_avc::AvcReceiptEvidenceSubject;
 use exo_core::{Hash256, Timestamp};
 use ring::signature;
 use sha2::{Digest as _, Sha256};
-use x509_cert::{Certificate, ext::pkix::SubjectKeyIdentifier};
+use x509_cert::{
+    Certificate,
+    ext::pkix::{BasicConstraints, ExtendedKeyUsage, KeyUsage, SubjectKeyIdentifier},
+};
 
 #[cfg(test)]
 pub(crate) const MICROSOFT_ARTIFACT_SIGNING_POLICY_OID: &str = "1.3.6.1.4.1.601.10.3.1";
@@ -42,6 +47,9 @@ const CMS_MESSAGE_DIGEST_ATTRIBUTE_OID: &str = "1.2.840.113549.1.9.4";
 const CMS_CONTENT_TYPE_ATTRIBUTE_OID: &str = "1.2.840.113549.1.9.3";
 const RSA_ENCRYPTION_OID: &str = "1.2.840.113549.1.1.1";
 const SHA256_WITH_RSA_ENCRYPTION_OID: &str = "1.2.840.113549.1.1.11";
+const SHA384_WITH_RSA_ENCRYPTION_OID: &str = "1.2.840.113549.1.1.12";
+const SHA512_WITH_RSA_ENCRYPTION_OID: &str = "1.2.840.113549.1.1.13";
+const ID_KP_TIME_STAMPING_OID: &str = "1.3.6.1.5.5.7.3.8";
 const RFC3161_NONCE_DOMAIN: &[u8] = b"exo.avc.rfc3161.nonce.v1";
 const DER_BOOLEAN: u8 = 0x01;
 const DER_INTEGER: u8 = 0x02;
@@ -69,6 +77,80 @@ pub(crate) struct Rfc3161VerifiedTimestamp {
     pub nonce_hex: String,
     pub tsa_subject: String,
     pub tsa_public_key_spki_der_hex: String,
+    pub trust_anchor: Rfc3161VerifiedTrustAnchor,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Rfc3161TrustAnchorKind {
+    SignerSpki,
+    IssuingCaSpki,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Rfc3161VerifiedTrustAnchor {
+    pub kind: Rfc3161TrustAnchorKind,
+    pub spki_der_hex: String,
+    pub subject: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Rfc3161TrustAnchors {
+    signer_spki_der_hexes: Vec<String>,
+    issuing_ca_spki_der_hexes: Vec<String>,
+}
+
+impl Rfc3161TrustAnchors {
+    pub(crate) fn new(
+        signer_spki_der_hexes: Vec<String>,
+        issuing_ca_spki_der_hexes: Vec<String>,
+    ) -> anyhow::Result<Self> {
+        let mut seen = BTreeSet::new();
+        let signer_spki_der_hexes = canonicalize_trust_anchor_set(
+            signer_spki_der_hexes,
+            "RFC 3161 signer SPKI trust anchor",
+            &mut seen,
+        )?;
+        let issuing_ca_spki_der_hexes = canonicalize_trust_anchor_set(
+            issuing_ca_spki_der_hexes,
+            "RFC 3161 issuing CA SPKI trust anchor",
+            &mut seen,
+        )?;
+        if signer_spki_der_hexes.is_empty() && issuing_ca_spki_der_hexes.is_empty() {
+            anyhow::bail!("at least one RFC 3161 trust anchor is required");
+        }
+        Ok(Self {
+            signer_spki_der_hexes,
+            issuing_ca_spki_der_hexes,
+        })
+    }
+
+    fn signer_spki_der_hexes(&self) -> &[String] {
+        self.signer_spki_der_hexes.as_slice()
+    }
+
+    fn issuing_ca_spki_der_hexes(&self) -> &[String] {
+        self.issuing_ca_spki_der_hexes.as_slice()
+    }
+}
+
+fn canonicalize_trust_anchor_set(
+    raw_pins: Vec<String>,
+    label: &str,
+    seen: &mut BTreeSet<String>,
+) -> anyhow::Result<Vec<String>> {
+    let mut pins = Vec::with_capacity(raw_pins.len());
+    for (index, raw_pin) in raw_pins.into_iter().enumerate() {
+        let pin = canonical_hex(&raw_pin, label)
+            .map_err(|error| anyhow::anyhow!("{label} member {} is invalid: {error}", index + 1))?;
+        if !seen.insert(pin.clone()) {
+            anyhow::bail!(
+                "{label} member {} duplicates an existing trust anchor",
+                index + 1
+            );
+        }
+        pins.push(pin);
+    }
+    Ok(pins)
 }
 
 #[derive(Clone, Copy)]
@@ -735,13 +817,190 @@ fn verify_cms_signature(
     Ok(spki_der_hex)
 }
 
-fn verify_timestamp_response_with_optional_spki_pin(
+fn timestamp_ms_within_certificate_validity(
+    cert: &Certificate,
+    timestamp: Timestamp,
+    role: &str,
+) -> anyhow::Result<()> {
+    let validity = cert.tbs_certificate().validity();
+    let issued_at_ms = u128::from(timestamp.physical_ms);
+    let not_before_ms = validity.not_before.to_unix_duration().as_millis();
+    let not_after_ms = validity.not_after.to_unix_duration().as_millis();
+    if issued_at_ms < not_before_ms {
+        anyhow::bail!("TSA {role} certificate was not valid at RFC 3161 genTime");
+    }
+    if issued_at_ms > not_after_ms {
+        anyhow::bail!("TSA {role} certificate expired before RFC 3161 genTime");
+    }
+    Ok(())
+}
+
+fn validate_tsa_signer_certificate(cert: &Certificate, issued_at: Timestamp) -> anyhow::Result<()> {
+    timestamp_ms_within_certificate_validity(cert, issued_at, "signer")?;
+    let eku = cert
+        .tbs_certificate()
+        .get_extension::<ExtendedKeyUsage>()
+        .map_err(|error| anyhow::anyhow!("TSA signer EKU extension parse failed: {error}"))?
+        .ok_or_else(|| {
+            anyhow::anyhow!("TSA signer certificate has no Extended Key Usage extension")
+        })?;
+    if !eku
+        .1
+        .0
+        .iter()
+        .any(|oid| oid.to_string() == ID_KP_TIME_STAMPING_OID)
+    {
+        anyhow::bail!("TSA signer certificate EKU does not assert id-kp-timeStamping");
+    }
+    if let Some((_critical, basic_constraints)) = cert
+        .tbs_certificate()
+        .get_extension::<BasicConstraints>()
+        .map_err(|error| {
+            anyhow::anyhow!("TSA signer basicConstraints extension parse failed: {error}")
+        })?
+        && basic_constraints.ca
+    {
+        anyhow::bail!("TSA signer certificate must not assert CA:TRUE");
+    }
+    if let Some((_critical, key_usage)) = cert
+        .tbs_certificate()
+        .get_extension::<KeyUsage>()
+        .map_err(|error| anyhow::anyhow!("TSA signer keyUsage extension parse failed: {error}"))?
+        && !key_usage.digital_signature()
+        && !key_usage.non_repudiation()
+    {
+        anyhow::bail!("TSA signer keyUsage does not permit timestamp signing");
+    }
+    Ok(())
+}
+
+fn validate_tsa_issuing_ca_certificate(
+    cert: &Certificate,
+    issued_at: Timestamp,
+) -> anyhow::Result<()> {
+    timestamp_ms_within_certificate_validity(cert, issued_at, "issuing CA")?;
+    let basic_constraints = cert
+        .tbs_certificate()
+        .get_extension::<BasicConstraints>()
+        .map_err(|error| {
+            anyhow::anyhow!("TSA issuing CA basicConstraints extension parse failed: {error}")
+        })?
+        .ok_or_else(|| {
+            anyhow::anyhow!("TSA issuing CA certificate has no basicConstraints extension")
+        })?;
+    if !basic_constraints.1.ca {
+        anyhow::bail!("TSA issuing CA certificate does not assert CA:TRUE");
+    }
+    let key_usage = cert
+        .tbs_certificate()
+        .get_extension::<KeyUsage>()
+        .map_err(|error| {
+            anyhow::anyhow!("TSA issuing CA keyUsage extension parse failed: {error}")
+        })?
+        .ok_or_else(|| anyhow::anyhow!("TSA issuing CA certificate has no keyUsage extension"))?;
+    if !key_usage.1.key_cert_sign() {
+        anyhow::bail!("TSA issuing CA keyUsage does not assert keyCertSign");
+    }
+    Ok(())
+}
+
+fn rsa_verification_params_for_oid(
+    sig_alg_oid: &str,
+) -> anyhow::Result<&'static signature::RsaParameters> {
+    if sig_alg_oid == SHA256_WITH_RSA_ENCRYPTION_OID {
+        Ok(&signature::RSA_PKCS1_2048_8192_SHA256)
+    } else if sig_alg_oid == SHA384_WITH_RSA_ENCRYPTION_OID {
+        Ok(&signature::RSA_PKCS1_2048_8192_SHA384)
+    } else if sig_alg_oid == SHA512_WITH_RSA_ENCRYPTION_OID {
+        Ok(&signature::RSA_PKCS1_2048_8192_SHA512)
+    } else {
+        anyhow::bail!(
+            "TSA certificate signature algorithm {sig_alg_oid} is not RSA-PKCS1 SHA-256/384/512"
+        )
+    }
+}
+
+fn verify_certificate_signed_by(
+    cert: &Certificate,
+    issuer_modulus: &[u8],
+    issuer_exponent: &[u8],
+) -> anyhow::Result<()> {
+    let verification_params =
+        rsa_verification_params_for_oid(&cert.signature_algorithm().oid.to_string())?;
+    let tbs_der = cert.tbs_certificate().to_der().map_err(|error| {
+        anyhow::anyhow!("TSA signer tbsCertificate DER encoding failed: {error}")
+    })?;
+    let signature_bytes = cert.signature().as_bytes().ok_or_else(|| {
+        anyhow::anyhow!("TSA signer certificate signature has unused BIT STRING bits")
+    })?;
+    signature::RsaPublicKeyComponents {
+        n: issuer_modulus,
+        e: issuer_exponent,
+    }
+    .verify(verification_params, &tbs_der, signature_bytes)
+    .map_err(|_| {
+        anyhow::anyhow!("TSA signer certificate signature did not verify against the pinned CA")
+    })?;
+    Ok(())
+}
+
+fn direct_signer_trust_anchor(
+    signer_spki_der_hex: &str,
+    signer_subject: &str,
+    trust_anchors: &Rfc3161TrustAnchors,
+) -> Option<Rfc3161VerifiedTrustAnchor> {
+    trust_anchors
+        .signer_spki_der_hexes()
+        .iter()
+        .any(|expected| expected == signer_spki_der_hex)
+        .then(|| Rfc3161VerifiedTrustAnchor {
+            kind: Rfc3161TrustAnchorKind::SignerSpki,
+            spki_der_hex: signer_spki_der_hex.to_owned(),
+            subject: signer_subject.to_owned(),
+        })
+}
+
+fn signer_chains_to_pinned_ca(
+    signer_cert: &Certificate,
+    certificates: &[&Certificate],
+    trust_anchors: &Rfc3161TrustAnchors,
+    issued_at: Timestamp,
+) -> anyhow::Result<Rfc3161VerifiedTrustAnchor> {
+    let signer_issuer = signer_cert.tbs_certificate().issuer();
+    for candidate in certificates {
+        if candidate.tbs_certificate().subject() != signer_issuer {
+            continue;
+        }
+        let (ca_spki_hex, ca_modulus, ca_exponent) =
+            match rsa_public_key_components_from_certificate(candidate) {
+                Ok(components) => components,
+                Err(_) => continue,
+            };
+        if !trust_anchors
+            .issuing_ca_spki_der_hexes()
+            .iter()
+            .any(|expected| expected == &ca_spki_hex)
+        {
+            continue;
+        }
+        validate_tsa_issuing_ca_certificate(candidate, issued_at)?;
+        verify_certificate_signed_by(signer_cert, &ca_modulus, &ca_exponent)?;
+        return Ok(Rfc3161VerifiedTrustAnchor {
+            kind: Rfc3161TrustAnchorKind::IssuingCaSpki,
+            spki_der_hex: ca_spki_hex,
+            subject: candidate.tbs_certificate().subject().to_string(),
+        });
+    }
+    anyhow::bail!("RFC 3161 TSA signer certificate did not chain to any pinned CA trust anchor")
+}
+
+fn verify_timestamp_response_with_optional_trust_anchors(
     response_der: &[u8],
     expected_subject_hash: Hash256,
     expected_message_imprint_sha256: [u8; 32],
     expected_nonce_hex: &str,
     expected_policy_oid: &str,
-    expected_tsa_spki_der_hexes: Option<&[String]>,
+    trust_anchors: Option<&Rfc3161TrustAnchors>,
 ) -> anyhow::Result<Rfc3161VerifiedTimestamp> {
     let (status, token_der) = parse_timestamp_response_status(response_der)
         .map_err(|error| anyhow::anyhow!("malformed RFC 3161 timestamp response: {error}"))?;
@@ -814,22 +1073,34 @@ fn verify_timestamp_response_with_optional_spki_pin(
     let signer_cert = signer_certificate(signer_info, &certificate_refs)?;
     let signer_spki_der_hex = verify_cms_signature(signer_info, signer_cert, &signed_attrs_der)?;
     let verified_signer_subject = signer_cert.tbs_certificate().subject().to_string();
-    if let Some(expected_tsa_spki_der_hexes) = expected_tsa_spki_der_hexes {
-        if expected_tsa_spki_der_hexes.is_empty() {
-            anyhow::bail!("expected TSA SPKI DER pin set must not be empty");
+    let trust_anchor = if let Some(trust_anchors) = trust_anchors {
+        validate_tsa_signer_certificate(signer_cert, tst_info.issued_at)?;
+        direct_signer_trust_anchor(
+            &signer_spki_der_hex,
+            &verified_signer_subject,
+            trust_anchors,
+        )
+        .map(Ok)
+        .unwrap_or_else(|| {
+            signer_chains_to_pinned_ca(
+                signer_cert,
+                &certificate_refs,
+                trust_anchors,
+                tst_info.issued_at,
+            )
+            .map_err(|error| {
+                anyhow::anyhow!(
+                    "RFC 3161 TSA signer did not match any configured trust anchor: {error}"
+                )
+            })
+        })?
+    } else {
+        Rfc3161VerifiedTrustAnchor {
+            kind: Rfc3161TrustAnchorKind::SignerSpki,
+            spki_der_hex: signer_spki_der_hex.clone(),
+            subject: verified_signer_subject.clone(),
         }
-        let mut signer_matched_pin = false;
-        for expected_tsa_spki_der_hex in expected_tsa_spki_der_hexes {
-            let expected_spki = canonical_hex(expected_tsa_spki_der_hex, "expected TSA SPKI DER")?;
-            if signer_spki_der_hex == expected_spki {
-                signer_matched_pin = true;
-                break;
-            }
-        }
-        if !signer_matched_pin {
-            anyhow::bail!("RFC 3161 TSA signer public key did not match any pinned SPKI DER");
-        }
-    }
+    };
     Ok(Rfc3161VerifiedTimestamp {
         issued_at: tst_info.issued_at,
         subject_hash: expected_subject_hash,
@@ -840,6 +1111,7 @@ fn verify_timestamp_response_with_optional_spki_pin(
         nonce_hex: tst_info.nonce_hex,
         tsa_subject: verified_signer_subject,
         tsa_public_key_spki_der_hex: signer_spki_der_hex,
+        trust_anchor,
     })
 }
 
@@ -852,31 +1124,33 @@ fn verify_timestamp_response(
     expected_policy_oid: &str,
     expected_tsa_spki_der_hex: &str,
 ) -> anyhow::Result<Rfc3161VerifiedTimestamp> {
-    verify_timestamp_response_with_spki_pins(
+    let trust_anchors =
+        Rfc3161TrustAnchors::new(vec![expected_tsa_spki_der_hex.to_owned()], Vec::new())?;
+    verify_timestamp_response_with_trust_anchors(
         response_der,
         expected_subject_hash,
         expected_message_imprint_sha256,
         expected_nonce_hex,
         expected_policy_oid,
-        &[expected_tsa_spki_der_hex.to_owned()],
+        &trust_anchors,
     )
 }
 
-pub(crate) fn verify_timestamp_response_with_spki_pins(
+pub(crate) fn verify_timestamp_response_with_trust_anchors(
     response_der: &[u8],
     expected_subject_hash: Hash256,
     expected_message_imprint_sha256: [u8; 32],
     expected_nonce_hex: &str,
     expected_policy_oid: &str,
-    expected_tsa_spki_der_hexes: &[String],
+    trust_anchors: &Rfc3161TrustAnchors,
 ) -> anyhow::Result<Rfc3161VerifiedTimestamp> {
-    verify_timestamp_response_with_optional_spki_pin(
+    verify_timestamp_response_with_optional_trust_anchors(
         response_der,
         expected_subject_hash,
         expected_message_imprint_sha256,
         expected_nonce_hex,
         expected_policy_oid,
-        Some(expected_tsa_spki_der_hexes),
+        Some(trust_anchors),
     )
 }
 
@@ -888,7 +1162,7 @@ fn inspect_timestamp_response_without_spki_pin(
     expected_nonce_hex: &str,
     expected_policy_oid: &str,
 ) -> anyhow::Result<Rfc3161VerifiedTimestamp> {
-    verify_timestamp_response_with_optional_spki_pin(
+    verify_timestamp_response_with_optional_trust_anchors(
         response_der,
         expected_subject_hash,
         expected_message_imprint_sha256,
@@ -1011,6 +1285,7 @@ mod tests {
         "891d95ab4a3aedc63c9c32b800ad15679ecd94917eb35967004f9882ac6ae69a";
     const MICROSOFT_FIXTURE_NONCE_HEX: &str = "a173ce171bc853e8";
     const MICROSOFT_FIXTURE_SIGNER_SPKI_HEX: &str = "30820222300d06092a864886f70d01010105000382020f003082020a0282020100b4a59f9bfba5d36eff77c4656fc327fe0d1052fbcba98d95b32ded23c536b454aca53668999383dc11d3f0b911f91ae130981bd558c0285372b1a2bd70b49789f3c648806b3c282cf4fe32db896b2449ab57a439cf8066a8c8483eb66112f6675a9092e073bb8d849e8bf9f1982effd44afe9792e0dcf992c5bf1dd8855c011c52c350789b107a5c8d2791e97dc1ad5d61bdb07c6a687eb6859b164ec53f5e361b782c7d1105256e79b6ba64da634bfd20b5f9bbaa2222c8fea9e8f4734d36cc9d5aac1e757f77fad6d331f1f90f90359e7052a2a64d9241f6153ce77fb6a57e6b0df2b7dae358f7f5813809b36ea82911d4246e231abd43325034a19b2708be01dd4274b6d3bb138fc33e9092f7b4e75a84fb8fa8cc2c6820a075fc30431d0ef5329eec54af6c0118b3502795d0a5fca1c6642395bd436a8f22f5d092ded3ff860fdff29ea5c6585a573a36ae9ef67f70a44e8633783397bac71d1bda68aa70f8a2e3f8a2d9985e29a9652444fb08a96915286cdf0ca0e85fdfa2343142f3e76d60f8372c7a9618d68f09a82dcc7ac351520ad6af2c2972df704b452953538a8a53169af1ded837b12aa67f573b4498d2e98ebca157ad61fbaf197ef626a2722b5d9d34e4b009d18ef7a474a4f7960ee544c7e67d953cbd73623745182734fd123aa3466d2e37f874a17c4f84d7cf62a7856f23d7186c73698533eb3c77a9370203010001";
+    const MICROSOFT_FIXTURE_CA_SPKI_HEX: &str = "30820222300d06092a864886f70d01010105000382020f003082020a02820201009e7ce75263fde0c59f057d63b50622a31c1ed7e79733d11305bd6546477791c15d706f7fb2ab43970c4aa1521c6aa0dbfa89858a8e431c2e1105c6f24078d70b0324fe5dd3398b60a018f19c6fde5624b8b0ec7ccb8812abc660e3d44401fe61b9784891044a7b7431b3c4a0a74d8a1c0ce711afd2b1a87c9d6a39849335c739e446c14fbbaadf0c7799786d566b5c084af964a4e428a1350b166f34f59d1962543c2e9ee2e45f58722165c802b09faca337f911e1f92ab9459f1a6328a4dabf07c53fa5da199196506f1365a893a20468025a9c7af6e2aa2a14cf562de0544ae773faa2f9d47c036322033d243749e1ed2a883466e6c39388442d04b19df5585dd4c69dc6819c1eb442b12e6b3bdca1bf67e3247ae6950d042179a9e0384306278a50647e799e02344ddcb56e2ebd20d055e4a9f61d5268f57c51611fc93c601a33ac46979ec48bde47530f4d57fb82df2163ae1734f3ba8b2506b0482df1cd8fc45f3b13e08eec0dbc4e98cdab978b8a2ba784a6ead176e390da14e4986d614ae59806e9c518dbf6d4ab78376d002a66deb929c69ec04277672344a1bbf7e4d7fac4de85ac0ea317de38efe347bc28de58b09067733c9607827279e14c5b72417dd7802a1ce88457bc539c3d5aebdc3f513c708c4ba0a483cc20813aed2159d8f328dbbc6394b007596de5d421001632cd1dddc443bf4f52bf055177ad5ebd0203010001";
 
     fn evidence_subject() -> AvcReceiptEvidenceSubject {
         AvcReceiptEvidenceSubject {
@@ -1052,6 +1327,26 @@ mod tests {
             MICROSOFT_ARTIFACT_SIGNING_POLICY_OID,
             MICROSOFT_FIXTURE_SIGNER_SPKI_HEX,
         )
+    }
+
+    fn verify_microsoft_fixture_with_trust_anchors(
+        anchors: Rfc3161TrustAnchors,
+    ) -> anyhow::Result<Rfc3161VerifiedTimestamp> {
+        verify_timestamp_response_with_trust_anchors(
+            &microsoft_fixture_response_der(),
+            microsoft_fixture_subject_hash(),
+            microsoft_fixture_message_imprint(),
+            MICROSOFT_FIXTURE_NONCE_HEX,
+            MICROSOFT_ARTIFACT_SIGNING_POLICY_OID,
+            &anchors,
+        )
+    }
+
+    fn microsoft_fixture_signed_data() -> SignedData {
+        let response_der = microsoft_fixture_response_der();
+        let (_status, token_der) = parse_timestamp_response_status(&response_der).unwrap();
+        let content_info = ContentInfo::from_der(token_der).unwrap();
+        SignedData::from_der(&content_info.content.to_der().unwrap()).unwrap()
     }
 
     fn read_tlv_error(bytes: &[u8]) -> String {
@@ -1218,6 +1513,220 @@ mod tests {
     }
 
     #[test]
+    fn verifier_accepts_microsoft_fixture_with_only_pinned_issuing_ca_spki() {
+        let anchors =
+            Rfc3161TrustAnchors::new(Vec::new(), vec![MICROSOFT_FIXTURE_CA_SPKI_HEX.to_owned()])
+                .unwrap();
+
+        let verified = verify_microsoft_fixture_with_trust_anchors(anchors).unwrap();
+
+        assert_eq!(
+            verified.tsa_public_key_spki_der_hex,
+            MICROSOFT_FIXTURE_SIGNER_SPKI_HEX
+        );
+        assert_eq!(
+            verified.trust_anchor.kind,
+            Rfc3161TrustAnchorKind::IssuingCaSpki
+        );
+        assert_eq!(
+            verified.trust_anchor.spki_der_hex,
+            MICROSOFT_FIXTURE_CA_SPKI_HEX
+        );
+        assert!(
+            verified
+                .trust_anchor
+                .subject
+                .contains("Microsoft Public RSA Timestamping CA 2020")
+        );
+    }
+
+    #[test]
+    fn verifier_records_direct_signer_pin_as_signer_trust_anchor() {
+        let anchors = Rfc3161TrustAnchors::new(
+            vec![MICROSOFT_FIXTURE_SIGNER_SPKI_HEX.to_owned()],
+            Vec::new(),
+        )
+        .unwrap();
+
+        let verified = verify_microsoft_fixture_with_trust_anchors(anchors).unwrap();
+
+        assert_eq!(
+            verified.trust_anchor.kind,
+            Rfc3161TrustAnchorKind::SignerSpki
+        );
+        assert_eq!(
+            verified.trust_anchor.spki_der_hex,
+            MICROSOFT_FIXTURE_SIGNER_SPKI_HEX
+        );
+        assert_eq!(verified.trust_anchor.subject, verified.tsa_subject);
+    }
+
+    #[test]
+    fn verifier_prefers_direct_signer_pin_when_leaf_and_ca_anchors_both_match() {
+        let anchors = Rfc3161TrustAnchors::new(
+            vec![MICROSOFT_FIXTURE_SIGNER_SPKI_HEX.to_owned()],
+            vec![MICROSOFT_FIXTURE_CA_SPKI_HEX.to_owned()],
+        )
+        .unwrap();
+
+        let verified = verify_microsoft_fixture_with_trust_anchors(anchors).unwrap();
+
+        assert_eq!(
+            verified.trust_anchor.kind,
+            Rfc3161TrustAnchorKind::SignerSpki
+        );
+        assert_eq!(
+            verified.trust_anchor.spki_der_hex,
+            MICROSOFT_FIXTURE_SIGNER_SPKI_HEX
+        );
+        assert_eq!(verified.trust_anchor.subject, verified.tsa_subject);
+    }
+
+    #[test]
+    fn verifier_inspection_without_pins_records_signer_identity_without_falling_open_for_runtime() {
+        let verified = inspect_timestamp_response_without_spki_pin(
+            &microsoft_fixture_response_der(),
+            microsoft_fixture_subject_hash(),
+            microsoft_fixture_message_imprint(),
+            MICROSOFT_FIXTURE_NONCE_HEX,
+            MICROSOFT_ARTIFACT_SIGNING_POLICY_OID,
+        )
+        .unwrap();
+
+        assert_eq!(
+            verified.trust_anchor.kind,
+            Rfc3161TrustAnchorKind::SignerSpki
+        );
+        assert_eq!(
+            verified.trust_anchor.spki_der_hex,
+            MICROSOFT_FIXTURE_SIGNER_SPKI_HEX
+        );
+        assert_eq!(verified.trust_anchor.subject, verified.tsa_subject);
+    }
+
+    #[test]
+    fn trust_anchor_config_canonicalizes_case_and_rejects_cross_set_duplicates() {
+        let uppercase_signer = MICROSOFT_FIXTURE_SIGNER_SPKI_HEX.to_ascii_uppercase();
+        let anchors = Rfc3161TrustAnchors::new(vec![uppercase_signer], Vec::new()).unwrap();
+
+        assert_eq!(
+            anchors.signer_spki_der_hexes(),
+            &[MICROSOFT_FIXTURE_SIGNER_SPKI_HEX.to_owned()]
+        );
+
+        let duplicate = Rfc3161TrustAnchors::new(
+            vec![MICROSOFT_FIXTURE_CA_SPKI_HEX.to_owned()],
+            vec![MICROSOFT_FIXTURE_CA_SPKI_HEX.to_owned()],
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(duplicate.contains("duplicates an existing trust anchor"));
+    }
+
+    #[test]
+    fn verifier_rejects_unrelated_trust_anchors_without_falling_open() {
+        let anchors = Rfc3161TrustAnchors::new(
+            Vec::new(),
+            vec!["30820122300d06092a864886f70d01010105000382010f".to_owned()],
+        )
+        .unwrap();
+
+        let err = verify_microsoft_fixture_with_trust_anchors(anchors)
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            err.contains("trust anchor"),
+            "unrelated CA pins must fail closed with trust-anchor context, got: {err}"
+        );
+    }
+
+    #[test]
+    fn trust_anchor_config_requires_at_least_one_non_empty_pin_set() {
+        let err = Rfc3161TrustAnchors::new(Vec::new(), Vec::new())
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("at least one RFC 3161 trust anchor"));
+    }
+
+    #[test]
+    fn chain_policy_requires_timestamping_leaf_and_real_ca_issuer() {
+        let signed_data = microsoft_fixture_signed_data();
+        let certificate_refs = certificate_set(&signed_data).unwrap();
+        let issued_at = Timestamp::new(1_782_571_620_539, 0);
+        let signer = certificate_refs
+            .iter()
+            .copied()
+            .find(|cert| {
+                cert.tbs_certificate()
+                    .subject()
+                    .to_string()
+                    .contains("Microsoft Public RSA Time Stamping Authority")
+            })
+            .unwrap();
+        let issuing_ca = certificate_refs
+            .iter()
+            .copied()
+            .find(|cert| {
+                cert.tbs_certificate()
+                    .subject()
+                    .to_string()
+                    .contains("Microsoft Public RSA Timestamping CA 2020")
+            })
+            .unwrap();
+
+        validate_tsa_signer_certificate(signer, issued_at).unwrap();
+        validate_tsa_issuing_ca_certificate(issuing_ca, issued_at).unwrap();
+
+        let signer_as_ca = validate_tsa_issuing_ca_certificate(signer, issued_at)
+            .unwrap_err()
+            .to_string();
+        assert!(signer_as_ca.contains("CA:TRUE"));
+
+        let ca_as_signer = validate_tsa_signer_certificate(issuing_ca, issued_at)
+            .unwrap_err()
+            .to_string();
+        assert!(ca_as_signer.contains("must not assert CA:TRUE"));
+    }
+
+    #[test]
+    fn certificate_policy_rejects_out_of_validity_window_and_unsupported_signature_algorithms() {
+        let signed_data = microsoft_fixture_signed_data();
+        let certificate_refs = certificate_set(&signed_data).unwrap();
+        let signer = certificate_refs
+            .iter()
+            .copied()
+            .find(|cert| {
+                cert.tbs_certificate()
+                    .subject()
+                    .to_string()
+                    .contains("Microsoft Public RSA Time Stamping Authority")
+            })
+            .unwrap();
+
+        let not_yet_valid = validate_tsa_signer_certificate(signer, Timestamp::new(0, 0))
+            .unwrap_err()
+            .to_string();
+        assert!(not_yet_valid.contains("not valid"));
+
+        let expired = validate_tsa_signer_certificate(signer, Timestamp::new(4_102_444_800_000, 0))
+            .unwrap_err()
+            .to_string();
+        assert!(expired.contains("expired"));
+
+        assert!(rsa_verification_params_for_oid(SHA256_WITH_RSA_ENCRYPTION_OID).is_ok());
+        assert!(rsa_verification_params_for_oid(SHA384_WITH_RSA_ENCRYPTION_OID).is_ok());
+        assert!(rsa_verification_params_for_oid(SHA512_WITH_RSA_ENCRYPTION_OID).is_ok());
+
+        let unsupported = rsa_verification_params_for_oid(RSA_ENCRYPTION_OID)
+            .unwrap_err()
+            .to_string();
+        assert!(unsupported.contains("not RSA-PKCS1 SHA-256/384/512"));
+    }
+
+    #[test]
     fn verifier_rejects_fixture_with_wrong_nonce_imprint_policy_missing_cert_pin_or_signature() {
         let response_der = microsoft_fixture_response_der();
 
@@ -1275,18 +1784,23 @@ mod tests {
         )
         .unwrap_err()
         .to_string();
-        assert!(wrong_pin.contains("public key"));
+        assert!(wrong_pin.contains("trust anchor"));
 
-        let accepted_by_second_pin = verify_timestamp_response_with_spki_pins(
+        let signer_trust_anchors = Rfc3161TrustAnchors::new(
+            vec![
+                "30820122300d06092a864886f70d01010105000382010f".to_owned(),
+                MICROSOFT_FIXTURE_SIGNER_SPKI_HEX.to_owned(),
+            ],
+            Vec::new(),
+        )
+        .unwrap();
+        let accepted_by_second_pin = verify_timestamp_response_with_trust_anchors(
             &response_der,
             microsoft_fixture_subject_hash(),
             microsoft_fixture_message_imprint(),
             MICROSOFT_FIXTURE_NONCE_HEX,
             MICROSOFT_ARTIFACT_SIGNING_POLICY_OID,
-            &[
-                "30820122300d06092a864886f70d01010105000382010f".to_owned(),
-                MICROSOFT_FIXTURE_SIGNER_SPKI_HEX.to_owned(),
-            ],
+            &signer_trust_anchors,
         )
         .unwrap();
         assert_eq!(
@@ -1294,17 +1808,10 @@ mod tests {
             MICROSOFT_FIXTURE_SIGNER_SPKI_HEX
         );
 
-        let empty_pin_set = verify_timestamp_response_with_spki_pins(
-            &response_der,
-            microsoft_fixture_subject_hash(),
-            microsoft_fixture_message_imprint(),
-            MICROSOFT_FIXTURE_NONCE_HEX,
-            MICROSOFT_ARTIFACT_SIGNING_POLICY_OID,
-            &[],
-        )
-        .unwrap_err()
-        .to_string();
-        assert!(empty_pin_set.contains("must not be empty"));
+        let empty_pin_set = Rfc3161TrustAnchors::new(Vec::new(), Vec::new())
+            .unwrap_err()
+            .to_string();
+        assert!(empty_pin_set.contains("at least one RFC 3161 trust anchor"));
 
         let mut bad_signature = response_der;
         *bad_signature.last_mut().unwrap() ^= 0x01;


### PR DESCRIPTION
## Summary
- Closes #716 by replacing brittle RFC3161 TSA leaf-only SPKI pinning with explicit signer-or-issuing-CA trust anchors.
- Adds deterministic RFC3161 certificate policy checks for timestamping leaf EKU, CA basicConstraints/keyUsage, certificate validity at RFC3161 genTime, and RSA SHA-256/384/512 certificate-signature verification.
- Preserves existing signer leaf SPKI env behavior while adding EXO_AVC_RFC3161_TIMESTAMP_CA_SPKI_HEX for issuer CA pins.
- Records the verified RFC3161 trust anchor kind/SPKI/issuer subject in AVC receipts with backward-compatible optional fields.
- Refreshes README repo-truth LOC/test-count metrics required by Gate 9.

## Classification
- EXOCHAIN core/runtime adapter: crates/exo-node/src/avc_rfc3161.rs, crates/exo-node/src/avc.rs
- EXOCHAIN core schema: crates/exo-avc/src/receipt.rs, crates/exo-avc/src/lib.rs
- Repo-truth documentation: README.md derived metrics only
- Adjacent surfaces/imported evidence/third-party: none

## Replacement note
This is intended as the clean replacement for draft/conflicting PR #717. It starts from current main after #714 and #715 and does not copy the conflicted branch.

## TDD and Verification
Red first:
- Added failing tests for issuer-CA-only Microsoft fixture verification, direct signer trust-anchor recording, unrelated-anchor fail-closed behavior, empty trust-anchor config rejection, CA/leaf certificate-policy enforcement, env config with CA pins, and receipt trust-anchor serialization.
- After CI showed Gate 3 coverage at 89.96%, added regression-only tests for debug redaction, malformed/cross-protocol env rejection, trust-anchor precedence/canonicalization, inspection-mode identity recording, and certificate-policy edge cases.

Green proof:
- cargo test -p exo-node avc_rfc3161 -- --nocapture
- cargo test -p exo-node rfc3161 -- --nocapture
- cargo test -p exo-node external_timestamp -- --nocapture
- cargo test -p exo-avc rfc3161 -- --nocapture
- cargo test -p exo-avc
- cargo test -p exo-node
- cargo clippy -p exo-node --all-targets -- -D warnings
- cargo clippy -p exo-avc --all-targets -- -D warnings
- cargo fmt --all -- --check
- bash tools/test_repo_truth.sh
- git diff --check

Coverage proof:
- Changed-surface tarpaulin before coverage remediation: 83.90% coverage, 1563/1863 lines covered.
- Changed-surface tarpaulin after coverage remediation: 85.83% coverage, 1599/1863 lines covered.
- Net changed-surface gain: +36 covered lines, +1.93 percentage points.

Note: the live Microsoft TSA preflight remains intentionally ignored unless EXO_AVC_RFC3161_LIVE_PREFLIGHT=1 is set; no production secrets or public-route smoke proof are claimed by this PR.
