### PR TITLE
fix(tools): make public route verifier bash portable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,8 @@ jobs:
         run: bash tools/test_railway_entrypoint_args.sh
       - name: Deployment readiness probes
         run: bash tools/test_deployment_readiness_probes.sh
+      - name: Public route verifier portability
+        run: bash tools/test_public_route_verifier_portability.sh
       - name: Docker production database feature contract
         run: bash tools/test_docker_production_db_feature.sh
       - name: Agent prompt boundary contract

--- a/tools/test_public_route_verifier_portability.sh
+++ b/tools/test_public_route_verifier_portability.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Copyright 2026 Exochain Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+fail() {
+  echo "public route verifier portability test failed: $*" >&2
+  exit 1
+}
+
+if grep -F '"${CURL_DNS_ARGS[@]}"' tools/verify_public_exochain_route.sh >/dev/null; then
+  fail "verify_public_exochain_route.sh must not expand an empty array under set -u"
+fi
+
+fake_bin_dir="$(mktemp -d)"
+trap 'rm -rf "${fake_bin_dir}"' EXIT
+
+cat >"${fake_bin_dir}/curl" <<'FAKE_CURL'
+#!/usr/bin/env bash
+set -euo pipefail
+
+headers=""
+body=""
+method="GET"
+url=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --doh-url)
+      echo "unexpected DoH argument in default verifier path" >&2
+      exit 2
+      ;;
+    --max-time|-w|-D|-o|-X)
+      case "$1" in
+        -D) headers="$2" ;;
+        -o) body="$2" ;;
+        -X) method="$2" ;;
+      esac
+      shift 2
+      ;;
+    -sS)
+      shift
+      ;;
+    -*)
+      echo "unexpected curl argument: $1" >&2
+      exit 2
+      ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+
+[ -n "${headers}" ] || { echo "missing -D header destination" >&2; exit 2; }
+[ -n "${body}" ] || { echo "missing -o body destination" >&2; exit 2; }
+[ -n "${url}" ] || { echo "missing URL" >&2; exit 2; }
+
+path="${url#https://exochain.test}"
+case "${method} ${path}" in
+  "GET /health")
+    code="200"
+    payload='{"status":"ok","version":"0.1.0-beta"}'
+    ;;
+  "GET /ready")
+    code="200"
+    payload='{"status":"ok","dagdb_runtime_status":"dagdb_active"}'
+    ;;
+  "GET /.well-known/exochain.json")
+    code="200"
+    payload='{"base_url":"https://exochain.io","routes":{"health":"/health","ready":"/ready","avc":{"receipts_emit":"/api/v1/avc/receipts/emit"}},"mcp":{"public_transport":false,"capabilities":["tools","resources","prompts"]}}'
+    ;;
+  "POST /api/v1/avc/issue")
+    code="401"
+    payload=''
+    ;;
+  *)
+    echo "unexpected verifier request: ${method} ${path}" >&2
+    exit 2
+    ;;
+esac
+
+printf 'HTTP/2 %s\r\nserver: railway-hikari\r\n\r\n' "${code}" >"${headers}"
+printf '%s' "${payload}" >"${body}"
+printf '%s' "${code}"
+FAKE_CURL
+
+chmod +x "${fake_bin_dir}/curl"
+
+unset EXOCHAIN_PUBLIC_ROUTE_DOH_URL
+PATH="${fake_bin_dir}:/usr/bin:/bin" \
+  EXOCHAIN_PUBLIC_ROUTE_BASE_URL="https://exochain.test" \
+  bash tools/verify_public_exochain_route.sh >/tmp/public-route-verifier-portability.out
+
+grep -F "public route verification passed for https://exochain.test" \
+  /tmp/public-route-verifier-portability.out >/dev/null \
+  || fail "verifier did not complete with the expected success message"
+
+echo "public route verifier portability test passed"

--- a/tools/verify_public_exochain_route.sh
+++ b/tools/verify_public_exochain_route.sh
@@ -19,20 +19,31 @@ fetch() {
   local body="${TMP_DIR}/${name}.body"
   local status
 
-  if ! status="$(
-    curl -sS \
-      --max-time 20 \
-      "${CURL_DNS_ARGS[@]}" \
-      -X "${method}" \
-      -D "${headers}" \
-      -o "${body}" \
-      -w '%{http_code}' \
-      "${BASE_URL}${path}"
-  )"; then
-    fail "${path} request failed before an HTTP response was accepted"
+  if [ -n "${DOH_URL}" ]; then
+    status="$(
+      curl -sS \
+        --max-time 20 \
+        --doh-url "${DOH_URL}" \
+        -X "${method}" \
+        -D "${headers}" \
+        -o "${body}" \
+        -w '%{http_code}' \
+        "${BASE_URL}${path}"
+    )" || fail "${path} request failed before an HTTP response was accepted"
+  else
+    status="$(
+      curl -sS \
+        --max-time 20 \
+        -X "${method}" \
+        -D "${headers}" \
+        -o "${body}" \
+        -w '%{http_code}' \
+        "${BASE_URL}${path}"
+    )" || fail "${path} request failed before an HTTP response was accepted"
   fi
+
   printf '%s\t%s\t%s\n' "${name}" "${status}" "${path}"
-  if rg -i '(^server:.*fly|^via:.*fly\.io|fly-request-id:)' "${headers}" >/dev/null; then
+  if grep -E -i '(^server:.*fly|^via:.*fly\.io|fly-request-id:)' "${headers}" >/dev/null; then
     sed -n '1,40p' "${headers}" >&2
     fail "${path} still traverses deprecated Fly infrastructure"
   fi
@@ -54,12 +65,6 @@ require_status() {
 
 command -v curl >/dev/null || fail "curl is required"
 command -v jq >/dev/null || fail "jq is required"
-command -v rg >/dev/null || fail "rg is required"
-
-CURL_DNS_ARGS=()
-if [ -n "${DOH_URL}" ]; then
-  CURL_DNS_ARGS=(--doh-url "${DOH_URL}")
-fi
 
 fetch health /health
 require_status "${FETCH_STATUS}" 200 /health


### PR DESCRIPTION
## Summary
- Fixes `tools/verify_public_exochain_route.sh` on macOS/bash 3.2 by removing the empty-array expansion that failed under `set -u` when no DoH URL was configured.
- Adds a stubbed portability regression test for the default no-DoH verifier path.
- Wires the new guard into CI beside the deployment readiness probes.

## Path Classification
- `tools/verify_public_exochain_route.sh` — core runtime adapter / deployment proof tooling.
- `tools/test_public_route_verifier_portability.sh` — core runtime adapter / deployment proof regression guard.
- `.github/workflows/ci.yml` — CI gate for deployment proof tooling.

## Core Regression Firewall
- No Rust crates, SDK runtime code, governance logic, secrets, or adjacent surfaces changed.
- The change is limited to public-route proof tooling and its CI guard.

## Verification
- `git diff --check`
- `bash tools/test_public_route_verifier_portability.sh`
- `bash tools/verify_public_exochain_route.sh`
- `bash tools/test_deployment_readiness_probes.sh`
- `EXO_AVC_RFC3161_LIVE_PREFLIGHT=1 bash tools/avc_rfc3161_microsoft_preflight.sh`

## Production Route Evidence
- Post-fix `https://exochain.io/health` returned 200.
- Post-fix `https://exochain.io/ready` returned 200 with `dagdb_active`.
- Post-fix `https://exochain.io/.well-known/exochain.json` returned 200.
- Post-fix `https://exochain.io/api/v1/avc/protocol` reached the node auth boundary with 401.
- Header scan found no Fly/Fly.io and no Railway fallback header.