### PR TITLE
fix(deps): bump anyhow to 1.0.103 (RUSTSEC-2026-0190)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ async-trait = "=0.1.89"
 
 # Error handling
 thiserror = "=2.0.17"
-anyhow = "=1.0.100"
+anyhow = "=1.0.103"
 
 # Logging / tracing
 tracing = "=0.1.43"


### PR DESCRIPTION
## Summary

Bumps `anyhow` `1.0.100` → `1.0.103` to clear **RUSTSEC-2026-0190** ("Unsoundness in `anyhow::Error::downcast_mut()`", published 2026-06-25).

## Why now

This advisory was published **after** `main`'s last green run (`38d30e1a`, 13:45 UTC 2026-06-29). `cargo-audit` and `cargo-deny` fetch a fresh advisory DB at runtime, so it now fails **Gate 6 (Cargo Audit)** and **Gate 7 (Cargo Deny)** on `main` and on every open PR — independent of PR content. It surfaced on the CR-004 docs PR (#720), which is docs-only and could not have caused it.

## Fix

- Advisory affected range: `anyhow < 1.0.103`; patched: `>= 1.0.103`.
- `1.0.103` is a drop-in patch release (no API change).
- Updated the workspace exact pin in `Cargo.toml` and the lockfile version + checksum (checksum `2a4385e2…` verified against the crates.io sparse index; not yanked).

## Validation

CI is the validation: Gate 1 (release build) confirms the lockfile checksum resolves, and Gates 6/7 confirm the advisory clears. No source changes, so coverage/clippy/format gates are unaffected; repo-truth (Gate 9) counts only `crates/**/*.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)