### PR TITLE
fix(avc): retry transient RFC3161 timestamp fetches

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 31 | `ls -d crates/*/` |
 | Rust source files | 456 | `find crates -name '*.rs'` |
-| Rust LOC | 367848 | `wc -l` |
-| Workspace tests | 6,042 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 368010 | `wc -l` |
+| Workspace tests | 6,044 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **6,029 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **6,044 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 31 crates, 367021 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 31 crates, 368010 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 6,029 listed workspace tests
+         cryptographic proofs, 6,044 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          165 verified WASM exports covered by 172 bridge checks — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -87,6 +87,12 @@ use tower::limit::ConcurrencyLimitLayer;
 const MAX_AVC_API_BODY_BYTES: usize = 64 * 1024;
 const MAX_AVC_API_CONCURRENT_REQUESTS: usize = 64;
 const AVC_EXTERNAL_TIMESTAMP_AUTHORITY_TIMEOUT: Duration = Duration::from_secs(10);
+#[cfg(not(test))]
+const AVC_RFC3161_TIMESTAMP_FETCH_RETRY_DELAYS: [Duration; 2] =
+    [Duration::from_millis(250), Duration::from_millis(1_000)];
+#[cfg(test)]
+const AVC_RFC3161_TIMESTAMP_FETCH_RETRY_DELAYS: [Duration; 2] =
+    [Duration::from_millis(0), Duration::from_millis(0)];
 pub const AVC_ROOT_TRUST_BUNDLE_ENV: &str = "EXO_AVC_ROOT_TRUST_BUNDLE";
 pub const AVC_REQUIRE_POSTGRES_DURABILITY_ENV: &str = "EXO_AVC_REQUIRE_POSTGRES_DURABILITY";
 pub const AVC_REQUIRE_EXTERNAL_TIMESTAMP_AUTHORITY_ENV: &str =
@@ -260,6 +266,87 @@ fn external_timestamp_error_class(err: &anyhow::Error) -> &'static str {
         .map_or("unknown", AvcExternalTimestampFailure::operator_class)
 }
 
+fn rfc3161_fetch_status_is_retryable(status: StatusCode) -> bool {
+    status.is_server_error() || status == StatusCode::TOO_MANY_REQUESTS
+}
+
+fn rfc3161_fetch_retry_delay(attempt_index: usize) -> Option<Duration> {
+    AVC_RFC3161_TIMESTAMP_FETCH_RETRY_DELAYS
+        .get(attempt_index)
+        .copied()
+}
+
+async fn wait_before_rfc3161_fetch_retry(delay: Duration) {
+    if !delay.is_zero() {
+        tokio::time::sleep(delay).await;
+    }
+}
+
+async fn fetch_rfc3161_timestamp_response(
+    client: &reqwest::Client,
+    endpoint: &str,
+    request_der: &[u8],
+) -> Result<Vec<u8>, AvcExternalTimestampFailure> {
+    let max_attempts = AVC_RFC3161_TIMESTAMP_FETCH_RETRY_DELAYS.len() + 1;
+    for attempt_index in 0..max_attempts {
+        let attempt = attempt_index + 1;
+        let response = client
+            .post(endpoint)
+            .header("Content-Type", "application/timestamp-query")
+            .header("Accept", "application/timestamp-reply")
+            .body(request_der.to_vec())
+            .send()
+            .await;
+        let response = match response {
+            Ok(response) => response,
+            Err(error) => {
+                if let Some(delay) = rfc3161_fetch_retry_delay(attempt_index) {
+                    tracing::warn!(
+                        attempt = attempt,
+                        max_attempts = max_attempts,
+                        err = %error,
+                        "retrying RFC 3161 timestamp authority fetch after transport failure"
+                    );
+                    wait_before_rfc3161_fetch_retry(delay).await;
+                    continue;
+                }
+                return Err(AvcExternalTimestampFailure::Unreachable {
+                    reason: format!("after {attempt} attempts: {error}"),
+                });
+            }
+        };
+
+        let status = response.status();
+        if status.is_success() {
+            return response
+                .bytes()
+                .await
+                .map(|bytes| bytes.to_vec())
+                .map_err(|error| AvcExternalTimestampFailure::InvalidResponse {
+                    reason: error.to_string(),
+                });
+        }
+        if rfc3161_fetch_status_is_retryable(status) {
+            if let Some(delay) = rfc3161_fetch_retry_delay(attempt_index) {
+                tracing::warn!(
+                    attempt = attempt,
+                    max_attempts = max_attempts,
+                    status = %status,
+                    "retrying RFC 3161 timestamp authority fetch after transient status"
+                );
+                wait_before_rfc3161_fetch_retry(delay).await;
+                continue;
+            }
+        }
+        return Err(AvcExternalTimestampFailure::Rejected {
+            status: status.to_string(),
+        });
+    }
+    Err(AvcExternalTimestampFailure::Unreachable {
+        reason: format!("exhausted {max_attempts} RFC 3161 timestamp fetch attempts"),
+    })
+}
+
 impl AvcReceiptExternalTimestampSource {
     async fn issue_proof(
         &self,
@@ -333,28 +420,9 @@ impl AvcReceiptExternalTimestampSource {
                 .map_err(|error| AvcExternalTimestampFailure::InvalidProof {
                     reason: error.to_string(),
                 })?;
-                let response = client
-                    .post(endpoint.as_str())
-                    .header("Content-Type", "application/timestamp-query")
-                    .header("Accept", "application/timestamp-reply")
-                    .body(request.der)
-                    .send()
-                    .await
-                    .map_err(|error| AvcExternalTimestampFailure::Unreachable {
-                        reason: error.to_string(),
-                    })?;
-                let status = response.status();
-                if !status.is_success() {
-                    return Err(AvcExternalTimestampFailure::Rejected {
-                        status: status.to_string(),
-                    }
-                    .into());
-                }
-                let response_der = response.bytes().await.map_err(|error| {
-                    AvcExternalTimestampFailure::InvalidResponse {
-                        reason: error.to_string(),
-                    }
-                })?;
+                let response_der =
+                    fetch_rfc3161_timestamp_response(client, endpoint.as_str(), &request.der)
+                        .await?;
                 let trust_anchors = crate::avc_rfc3161::Rfc3161TrustAnchors::new(
                     authority_public_key_spki_der_hexes.as_ref().clone(),
                     issuing_ca_spki_der_hexes.as_ref().clone(),
@@ -2445,6 +2513,11 @@ pub fn avc_router(state: Arc<AvcApiState>) -> Router {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        collections::VecDeque,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+
     use axum::{
         body::{self, Body},
         http::{Method, Request},
@@ -2820,6 +2893,51 @@ mod tests {
             axum::serve(listener, app).await.unwrap();
         });
         (format!("http://{address}"), handle)
+    }
+
+    async fn serve_test_rfc3161_timestamp_authority_sequence(
+        responses: Vec<(StatusCode, Vec<u8>)>,
+    ) -> (String, Arc<AtomicUsize>, tokio::task::JoinHandle<()>) {
+        async fn issue_timestamp(
+            State((responses, attempts)): State<(
+                Arc<Mutex<VecDeque<(StatusCode, Vec<u8>)>>>,
+                Arc<AtomicUsize>,
+            )>,
+            headers: axum::http::HeaderMap,
+            body: axum::body::Bytes,
+        ) -> axum::response::Response {
+            assert_eq!(
+                headers
+                    .get("content-type")
+                    .and_then(|value| value.to_str().ok()),
+                Some("application/timestamp-query")
+            );
+            assert!(!body.is_empty(), "RFC 3161 request body must be DER");
+            attempts.fetch_add(1, Ordering::SeqCst);
+            let (status, response_der) = responses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or((StatusCode::INTERNAL_SERVER_ERROR, Vec::new()));
+            (
+                status,
+                [("content-type", "application/timestamp-reply")],
+                response_der,
+            )
+                .into_response()
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let responses = Arc::new(Mutex::new(VecDeque::from(responses)));
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let app = Router::new()
+            .route("/", post(issue_timestamp))
+            .with_state((responses, Arc::clone(&attempts)));
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{address}"), attempts, handle)
     }
 
     async fn emit_baseline_receipt_with_source(
@@ -4644,6 +4762,50 @@ mod tests {
 
         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(state.registry.lock().unwrap().receipt_count(), 0);
+        timestamp_authority.abort();
+    }
+
+    #[tokio::test]
+    async fn rfc3161_timestamp_fetch_retries_transient_status_before_success() {
+        let (endpoint, attempts, timestamp_authority) =
+            serve_test_rfc3161_timestamp_authority_sequence(vec![
+                (StatusCode::SERVICE_UNAVAILABLE, Vec::new()),
+                (StatusCode::TOO_MANY_REQUESTS, Vec::new()),
+                (StatusCode::OK, vec![0x30, 0x00]),
+            ])
+            .await;
+
+        let response_der = fetch_rfc3161_timestamp_response(
+            &reqwest::Client::new(),
+            endpoint.as_str(),
+            &[0x30, 0x01, 0x00],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response_der, vec![0x30, 0x00]);
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+        timestamp_authority.abort();
+    }
+
+    #[tokio::test]
+    async fn receipt_emit_does_not_retry_rfc3161_verification_failures() {
+        let (endpoint, attempts, timestamp_authority) =
+            serve_test_rfc3161_timestamp_authority_sequence(vec![(
+                StatusCode::OK,
+                vec![0x30, 0x03, 0x02],
+            )])
+            .await;
+
+        let (status, state, _) = emit_baseline_receipt_with_source_and_strict(
+            rfc3161_external_timestamp_source(endpoint),
+            true,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(state.registry.lock().unwrap().receipt_count(), 0);
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
         timestamp_authority.abort();
     }
 

--- a/docs/proof/avc-issue-713-production-closure-proof.md
+++ b/docs/proof/avc-issue-713-production-closure-proof.md
@@ -1,0 +1,116 @@
+# AVC Issue 713 Production Closure Proof
+
+Status: PR-bound closure candidate.
+
+This packet records the production evidence and code-level hardening for GitHub
+issue `#713`: intermittent AVC receipt emission fail-closing with RFC 3161 TSA
+unavailability.
+
+## Classification
+
+- `crates/exo-node/src/avc.rs`: EXOCHAIN core runtime adapter.
+- Railway HTTP logs, Postgres read-only queries, and GitHub issue comments:
+  imported evidence.
+- This file: constitutional governance/proof documentation.
+
+## Production Runtime Evidence
+
+Observed on 2026-06-29 against `https://exochain.io`:
+
+- Railway production service `exochain` was deployed from
+  `38d30e1a6c8a68581f6ae166f82642b9f4f88473`.
+- `GET /ready` returned `status: ok`, `dagdb_runtime_status: dagdb_active`,
+  and `dagdb_runtime_reason: db_probe_ok`.
+- Authenticated `GET /api/v1/avc/protocol` returned protocol version `1`,
+  schema version `1`, and WASM package `@exochain/exochain-wasm`.
+- Railway HTTP logs recorded 27 successful authenticated production calls to
+  `POST /api/v1/avc/receipts/emit` between
+  `2026-06-29T16:31:52.491712167Z` and
+  `2026-06-29T16:46:44.032478126Z`, all HTTP `200`.
+- Production Postgres `dagdb.avc_registry_state` contained 64 AVC receipts for
+  actor `did:exo:44sVCyeMCcef7PzAeM8jY7qpRUpmaQxabaC4etXeE9zr`.
+- All 64 read back through `GET /api/v1/avc/receipts?actor=...` with
+  `timestamp_provenance: ExternalTimestampAuthority` and RFC 3161 proof.
+- The 27 post-fix trust-anchor receipts included 18 `signer_spki` anchors and
+  9 `issuing_ca_spki` anchors.
+- `dagdb.dagdb_node_committed` and `dagdb.dagdb_node_trust_receipts` each
+  contained 64 EXOCHAIN finality rows for `avc.receipt.exochain_finality`.
+
+## Readback Samples
+
+Signer-SPKI anchored sample:
+
+- AVC receipt hash:
+  `0c01f1dd4d2d78f81753caf86cd44ec0779e3c50b2cd79514a9188f49a234a7e`
+- `GET /api/v1/avc/receipts/<hash>` returned `decision: Allow`,
+  `timestamp_provenance: ExternalTimestampAuthority`, proof kind `Rfc3161`,
+  authority DID `did:exo:microsoft-public-rsa-tsa`, action
+  `archon.workflow.success`, actor DID
+  `did:exo:44sVCyeMCcef7PzAeM8jY7qpRUpmaQxabaC4etXeE9zr`,
+  and `tsa_trust_anchor_kind: signer_spki`.
+- The receipt contained RFC 3161 token bytes and trust-anchor SPKI evidence.
+
+Issuing-CA-SPKI anchored sample:
+
+- AVC receipt hash:
+  `29058510dbbe27d194cdb7f3784dcb3f5b90886bbe5632db0aae01b1a7878cbc`
+- `GET /api/v1/avc/receipts/<hash>` returned `decision: Allow`,
+  `timestamp_provenance: ExternalTimestampAuthority`, proof kind `Rfc3161`,
+  authority DID `did:exo:microsoft-public-rsa-tsa`, action
+  `archon.workflow.success`, actor DID
+  `did:exo:44sVCyeMCcef7PzAeM8jY7qpRUpmaQxabaC4etXeE9zr`,
+  and `tsa_trust_anchor_kind: issuing_ca_spki`.
+- The receipt contained RFC 3161 token bytes and trust-anchor SPKI evidence.
+
+Latest observed EXOCHAIN finality row:
+
+- finality hash:
+  `b20e1818d9963c52a37843cab2a888a97a147eead8a909521a6005efddc94439`
+- finality height: `64`
+- finality receipt hash:
+  `14a00075ef03f7826f1c62b177938455e36fa4a9ef3d5f0cfb4181e78fedb008`
+
+## Code Closure
+
+The residual valid scope of `#713` after PRs `#714` and `#718` was genuine
+transient RFC 3161 TSA fetch failure. This branch adds bounded retry/backoff
+only around the RFC 3161 HTTP fetch path:
+
+- retryable: request transport failures, HTTP `5xx`, and HTTP `429`;
+- not retryable: malformed DER, nonce/imprint/policy mismatch, trust-anchor
+  mismatch, invalid proof, and all other verification failures;
+- attempts: one initial attempt plus two bounded retries;
+- production delays: 250 ms then 1000 ms;
+- test delays: zero-duration, preserving fast deterministic tests.
+
+## Verification
+
+Commands run from `/Users/bobstewart/dev/exochain-avc-rfc3161-retry`:
+
+```bash
+CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/bobstewart/dev/exochain/target cargo test -p exo-node rfc3161_timestamp_fetch_retries_transient_status_before_success -- --nocapture
+CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/bobstewart/dev/exochain/target cargo test -p exo-node receipt_emit_does_not_retry_rfc3161_verification_failures -- --nocapture
+CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/bobstewart/dev/exochain/target cargo test -p exo-node rfc3161 -- --nocapture
+CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/bobstewart/dev/exochain/target cargo test -p exo-node external_timestamp_error_surfaces_operator_class_in_public_message -- --nocapture
+cargo fmt --all -- --check
+git diff --check
+CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/bobstewart/dev/exochain/target cargo clippy -p exo-node --all-targets -- -D warnings
+```
+
+Results:
+
+- new retry test: passed;
+- new verification-failure no-retry test: passed;
+- RFC 3161 test slice: 24 passed, 1 live Microsoft preflight ignored by design;
+- operator-class diagnostic test: passed;
+- format check: passed;
+- diff whitespace check: passed;
+- focused `exo-node` clippy: passed.
+
+## Disposition
+
+`#713` may be closed after this branch is merged, deployed, and the issue comment
+links this packet plus the production receipt evidence above. The production
+blocker is no longer open: post-`#718` production emitted and read back 27/27
+RFC 3161 AVC receipts with trust-anchor evidence, and this branch completes the
+remaining bounded retry/backoff hardening requested by the issue title.


### PR DESCRIPTION
## Summary
- Adds bounded retry/backoff around the RFC 3161 timestamp authority HTTP fetch path only.
- Retries transport failures plus transient HTTP 5xx / 429 responses; malformed DER, nonce/imprint/policy mismatch, trust-anchor mismatch, and invalid proof still fail closed immediately.
- Adds durable production closure proof for issue #713 under docs/proof/.

## Path Classification
- crates/exo-node/src/avc.rs: EXOCHAIN core runtime adapter.
- docs/proof/avc-issue-713-production-closure-proof.md: constitutional governance/proof documentation.
- Railway logs, Postgres read-only queries, and GitHub comments cited in the proof packet: imported evidence.

## Production Evidence
- Production at 38d30e1a6c8a68581f6ae166f82642b9f4f88473 reported /ready ok with dagdb_active/db_probe_ok.
- Authenticated production AVC protocol discovery returned protocol_version=1, schema_version=1, wasm_package_name=@exochain/exochain-wasm.
- Railway HTTP logs showed 27/27 successful authenticated POST /api/v1/avc/receipts/emit calls after #718.
- Production readback found 64 AVC receipts for the Archon actor, all ExternalTimestampAuthority + RFC3161; the 27 post-fix trust-anchor receipts split as 18 signer_spki and 9 issuing_ca_spki.
- Sample receipt hashes and finality row evidence are recorded in docs/proof/avc-issue-713-production-closure-proof.md.

## Verification
- CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/bobstewart/dev/exochain/target cargo test -p exo-node rfc3161_timestamp_fetch_retries_transient_status_before_success -- --nocapture
- CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/bobstewart/dev/exochain/target cargo test -p exo-node receipt_emit_does_not_retry_rfc3161_verification_failures -- --nocapture
- CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/bobstewart/dev/exochain/target cargo test -p exo-node rfc3161 -- --nocapture
- CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/bobstewart/dev/exochain/target cargo test -p exo-node external_timestamp_error_surfaces_operator_class_in_public_message -- --nocapture
- cargo fmt --all -- --check
- git diff --check
- CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/bobstewart/dev/exochain/target cargo clippy -p exo-node --all-targets -- -D warnings

Closes #713