### PR TITLE
ci: harden coverage gate timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,8 @@ jobs:
         # code belongs in a separate dedicated tarpaulin pass under
         # `--features unaudited-pedagogical-proofs`; it is not in scope
         # for the default workspace coverage gate.
+        # The largest LLVM-instrumented test binaries can run close to
+        # five minutes; keep runner variance out of the coverage claim.
         run: |
           cargo tarpaulin \
             --workspace \
@@ -108,7 +110,7 @@ jobs:
             --out xml \
             --output-dir coverage \
             --engine llvm \
-            --timeout 300 \
+            --timeout 900 \
             --fail-under 90
       - name: Upload coverage report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/tools/test_coverage_policy.sh
+++ b/tools/test_coverage_policy.sh
@@ -149,6 +149,34 @@ if grep -F -- '--skip-clean' <<<"$coverage_gate_block" >/dev/null; then
   fail "default workspace coverage gate must clean instrumentation before measuring the 90% threshold"
 fi
 
+coverage_timeout="$(
+  awk '
+    $1 == "--timeout" {
+      print $2
+      found = 1
+      exit
+    }
+    $1 ~ /^--timeout=/ {
+      sub(/^--timeout=/, "", $1)
+      print $1
+      found = 1
+      exit
+    }
+    END {
+      if (!found) {
+        exit 1
+      }
+    }
+  ' <<<"$coverage_gate_block"
+)" || fail "default workspace coverage gate must set an explicit tarpaulin timeout"
+
+[[ "$coverage_timeout" =~ ^[0-9]+$ ]] \
+  || fail "coverage gate tarpaulin timeout must be a positive integer"
+
+if (( coverage_timeout < 600 )); then
+  fail "coverage gate tarpaulin timeout must be at least 600 seconds for instrumented workspace variance"
+fi
+
 if grep -nE '90%[+[:space:]-]*line coverage|Coverage.*>=90|Coverage.*>= 90' README.md .github/workflows/ci.yml docs/guides/GETTING-STARTED.md \
   | grep -viE 'scoped|tarpaulin.toml|not independently verified outside CI' >/tmp/coverage-policy-claims.txt; then
   if grep -nE 'exclude-files|--exclude' tarpaulin.toml .github/workflows/ci.yml >/dev/null; then


### PR DESCRIPTION
## Summary
- Hardens Gate 3 coverage by increasing tarpaulin's per-binary timeout from 300s to 900s.
- Adds a coverage-policy guard requiring the default workspace coverage gate to declare an explicit tarpaulin timeout of at least 600s.
- Keeps the scoped `--fail-under 90` coverage threshold unchanged.

## Why
The post-merge `main` run for PR #723 failed in Gate 3 after the coverage step, while a clean local reproduction of the same source passed at `91.03%` scoped coverage. The largest LLVM-instrumented local binary, `exo-dag`, took `293.39s`, leaving only ~6.6s of margin under the previous `--timeout 300` setting. Shared GitHub runners need enough headroom for variance so Gate 3 measures coverage instead of timing out a valid run.

## Path Classification
- `.github/workflows/ci.yml` — CI / constitutional gate configuration.
- `tools/test_coverage_policy.sh` — CI source guard for the coverage gate.

No Rust runtime, core cryptography, DAG, consent, authority, gateway runtime adapter, deployment contract, or adjacent surface behavior changed.

## Verification
- `bash tools/test_coverage_policy.sh` — passed.
- `git diff --check` — passed.
- `cargo tarpaulin --workspace --exclude exochain-wasm --exclude exo-proofs --out xml --output-dir coverage --engine llvm --timeout 900 --fail-under 90` — passed: `91.03% coverage, 41685/45794 lines covered`.
