### PR TITLE
ci: trust release signing public key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,8 @@ jobs:
         run: bash tools/test_release_workflow_ref_binding.sh
       - name: Release version input boundary
         run: bash tools/test_release_version_input_boundary.sh
+      - name: Release signed-tag trust boundary
+        run: bash tools/test_release_signed_tag_trust_boundary.sh
       - name: Release version alignment
         run: bash tools/test_release_version_alignment.sh
       - name: Release dry-run publication boundary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,11 +103,35 @@ jobs:
         env:
           DRY_RUN: ${{ inputs.dry_run }}
           RELEASE_TAG: ${{ needs.validate-release-inputs.outputs.tag }}
+          EXOCHAIN_RELEASE_SIGNING_PUBLIC_KEY_ASC: ${{ vars.EXOCHAIN_RELEASE_SIGNING_PUBLIC_KEY_ASC }}
+          EXOCHAIN_RELEASE_SIGNING_FINGERPRINT: ${{ vars.EXOCHAIN_RELEASE_SIGNING_FINGERPRINT }}
         run: |
           set -euo pipefail
           if [ "$DRY_RUN" = "true" ]; then
             echo "Dry run: signed tag requirement is skipped."
             exit 0
+          fi
+
+          signing_key_fingerprint="$(printf '%s' "$EXOCHAIN_RELEASE_SIGNING_FINGERPRINT" | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')"
+          if ! [[ "$signing_key_fingerprint" =~ ^[0-9A-F]{40}$ ]]; then
+            echo "EXOCHAIN_RELEASE_SIGNING_FINGERPRINT must be a 40-character OpenPGP fingerprint." >&2
+            exit 1
+          fi
+          if [ -z "$EXOCHAIN_RELEASE_SIGNING_PUBLIC_KEY_ASC" ]; then
+            echo "EXOCHAIN_RELEASE_SIGNING_PUBLIC_KEY_ASC repository variable is required." >&2
+            exit 1
+          fi
+
+          GNUPGHOME="$(mktemp -d)"
+          export GNUPGHOME
+          chmod 700 "$GNUPGHOME"
+          trap 'rm -rf "$GNUPGHOME"' EXIT
+          printf '%s\n' "$EXOCHAIN_RELEASE_SIGNING_PUBLIC_KEY_ASC" | gpg --batch --import
+
+          imported_fingerprint="$(gpg --batch --with-colons --fingerprint "$signing_key_fingerprint" | awk -F: '/^fpr:/ { print toupper($10); exit }')"
+          if [ "$imported_fingerprint" != "$signing_key_fingerprint" ]; then
+            echo "Imported release signing public key does not match EXOCHAIN_RELEASE_SIGNING_FINGERPRINT." >&2
+            exit 1
           fi
 
           git fetch --tags --force

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -51,6 +51,46 @@ See `.github/workflows/release.yml` for the automated release workflow:
 7. GitHub Release artifacts are attached to `v<version>`.
 8. Crates are published to crates.io in dependency order unless the run is a dry run.
 
+### Release Signing Key Setup
+
+Live releases require an approved OpenPGP signing key controlled by the release
+maintainer. The public key and full fingerprint must be configured as repository
+variables so the release workflow can import the key on the GitHub runner before
+executing `git tag -v`.
+
+Create the signing key locally:
+
+```bash
+gpg --quick-generate-key "Bob Stewart EXOCHAIN Release Signing <bob@bobstewart.com>" ed25519 sign 2y
+```
+
+Record the full fingerprint and export the public key:
+
+```bash
+RELEASE_SIGNING_UID="Bob Stewart EXOCHAIN Release Signing <bob@bobstewart.com>"
+RELEASE_SIGNING_FINGERPRINT="$(gpg --with-colons --fingerprint "$RELEASE_SIGNING_UID" | awk -F: '/^fpr:/ { print $10; exit }')"
+gpg --armor --export "$RELEASE_SIGNING_FINGERPRINT" > exochain-release-signing-public.asc
+git config --global user.signingkey "$RELEASE_SIGNING_FINGERPRINT"
+git config --global tag.gpgSign true
+```
+
+Configure the repository variables used by `.github/workflows/release.yml`:
+
+```bash
+gh variable set EXOCHAIN_RELEASE_SIGNING_FINGERPRINT --repo exochain/exochain --body "$RELEASE_SIGNING_FINGERPRINT"
+gh variable set EXOCHAIN_RELEASE_SIGNING_PUBLIC_KEY_ASC --repo exochain/exochain < exochain-release-signing-public.asc
+gh gpg-key add exochain-release-signing-public.asc --title "EXOCHAIN Release Signing"
+```
+
+Create and verify the signed release tag only after the key is configured:
+
+```bash
+git fetch origin main --tags
+git tag -s v0.2.0-beta "$(git rev-parse origin/main)" -m "EXOCHAIN v0.2.0-beta"
+git tag -v v0.2.0-beta
+git push origin v0.2.0-beta
+```
+
 ### Dry Run
 
 Trigger via the GitHub Actions UI with `dry_run=true`. This runs CI and builds

--- a/tools/test_release_signed_tag_trust_boundary.sh
+++ b/tools/test_release_signed_tag_trust_boundary.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Copyright 2026 Exochain Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+fail() {
+  printf 'release signed-tag trust boundary test failed: %s\n' "$1" >&2
+  exit 1
+}
+
+workflow=".github/workflows/release.yml"
+ci_workflow=".github/workflows/ci.yml"
+
+[[ -f "$workflow" ]] || fail "$workflow is missing"
+[[ -f "$ci_workflow" ]] || fail "$ci_workflow is missing"
+
+verify_block=$(
+  awk '
+    $0 == "  verify-signed-tag:" { capture = 1; print; next }
+    capture && $0 ~ /^  [A-Za-z0-9_-]+:$/ { exit }
+    capture { print }
+  ' "$workflow"
+)
+[[ -n "$verify_block" ]] || fail "verify-signed-tag job is missing"
+
+grep -F 'EXOCHAIN_RELEASE_SIGNING_PUBLIC_KEY_ASC: ${{ vars.EXOCHAIN_RELEASE_SIGNING_PUBLIC_KEY_ASC }}' <<<"$verify_block" >/dev/null \
+  || fail "verify-signed-tag must receive the approved release public key from repository variables"
+grep -F 'EXOCHAIN_RELEASE_SIGNING_FINGERPRINT: ${{ vars.EXOCHAIN_RELEASE_SIGNING_FINGERPRINT }}' <<<"$verify_block" >/dev/null \
+  || fail "verify-signed-tag must receive the approved release signing fingerprint from repository variables"
+grep -F 'GNUPGHOME="$(mktemp -d)"' <<<"$verify_block" >/dev/null \
+  || fail "verify-signed-tag must isolate the release verification keyring"
+grep -F 'gpg --batch --import' <<<"$verify_block" >/dev/null \
+  || fail "verify-signed-tag must import the approved release public key before verification"
+grep -F '^[0-9A-F]{40}$' <<<"$verify_block" >/dev/null \
+  || fail "verify-signed-tag must enforce a full 40-hex-character OpenPGP fingerprint"
+grep -F 'imported_fingerprint="$(gpg --batch --with-colons --fingerprint "$signing_key_fingerprint"' <<<"$verify_block" >/dev/null \
+  || fail "verify-signed-tag must prove the imported key matches the configured fingerprint"
+grep -F 'git tag -v "${RELEASE_TAG}"' <<<"$verify_block" >/dev/null \
+  || fail "verify-signed-tag must still use git tag -v for the release tag"
+
+grep -F 'bash tools/test_release_signed_tag_trust_boundary.sh' "$ci_workflow" >/dev/null \
+  || fail "CI repo hygiene must run the release signed-tag trust boundary guard"
+
+printf 'release signed-tag trust boundary test passed\n'


### PR DESCRIPTION
## Summary
- Imports the approved EXOCHAIN release signing public key from repository variables before non-dry-run release tag verification.
- Requires `EXOCHAIN_RELEASE_SIGNING_FINGERPRINT` to be a full 40-character OpenPGP fingerprint and proves the imported public key matches it.
- Adds a Gate 9 guard so release signed-tag trust cannot silently regress.
- Documents the maintainer key setup, repository variables, GitHub GPG key upload, and signed-tag creation flow in `VERSIONING.md`.

## Path Classification
- `.github/workflows/release.yml` — EXOCHAIN core CI/release contract.
- `.github/workflows/ci.yml` — EXOCHAIN core CI gate wiring.
- `tools/test_release_signed_tag_trust_boundary.sh` — EXOCHAIN core release guard.
- `VERSIONING.md` — EXOCHAIN release governance documentation.

## TDD / Verification
- RED: `bash tools/test_release_signed_tag_trust_boundary.sh` failed before workflow changes with `verify-signed-tag must receive the approved release public key from repository variables`.
- GREEN: `bash tools/test_release_signed_tag_trust_boundary.sh`
- GREEN: temporary local signed-tag cryptographic smoke using an isolated GPG secret key, exported public key, isolated verification keyring, and `git tag -v`.
- GREEN: `bash tools/test_release_version_input_boundary.sh`
- GREEN: `bash tools/test_release_workflow_ref_binding.sh`
- GREEN: `bash tools/test_release_dry_run_boundaries.sh`
- GREEN: `bash tools/test_release_publish_boundaries.sh`
- GREEN: `bash tools/test_release_version_alignment.sh`
- GREEN: `bash tools/test_github_actions_pinned.sh`
- GREEN: `bash tools/test_repo_truth.sh`
- GREEN: `git diff --check`

## Release Operator Note
Before creating `v0.2.0-beta`, an authorized maintainer must generate or import the approved OpenPGP signing key, then configure:

- `EXOCHAIN_RELEASE_SIGNING_FINGERPRINT`
- `EXOCHAIN_RELEASE_SIGNING_PUBLIC_KEY_ASC`

After this PR merges, create the signed tag against the new `origin/main` SHA, push the tag, and dispatch `release.yml` with `version=0.2.0-beta`, `dry_run=false`, and `--ref v0.2.0-beta`.
