### PR TITLE
ci: isolate Gate 16 target cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,8 @@ jobs:
         run: bash tools/test_github_issue_workflow_boundaries.sh
       - name: CI tool installer supply-chain hardening
         run: bash tools/test_ci_supply_chain_hardening.sh
+      - name: Cross-platform target cache boundary
+        run: bash tools/test_cross_platform_target_cache_boundary.sh
       - name: Core npm package supply-chain hardening
         run: bash tools/test_npm_core_package_hygiene.sh
       - name: Release workflow ref binding
@@ -535,14 +537,17 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
         with:
-          key: ${{ matrix.target }}
+          key: gate16-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}
+          workspaces: ". -> target/gate16-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}"
+      - name: Isolate Cargo target dir
+        run: echo "CARGO_TARGET_DIR=target/gate16-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}" >> "$GITHUB_ENV"
       - name: Build exochain binary
         run: bash tools/ci_cargo_retry.sh cargo build --release --bin exochain --target ${{ matrix.target }}
       - name: Upload binary artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: exochain-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/exochain
+          path: target/gate16-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}/${{ matrix.target }}/release/exochain
           retention-days: 30
 
   # -----------------------------------------------------------------------

--- a/tools/test_cross_platform_target_cache_boundary.sh
+++ b/tools/test_cross_platform_target_cache_boundary.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright 2026 Exochain Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+fail() {
+  printf 'cross-platform target cache boundary test failed: %s\n' "$1" >&2
+  exit 1
+}
+
+workflow=".github/workflows/ci.yml"
+[[ -f "$workflow" ]] || fail "$workflow is missing"
+
+cross_platform_block=$(
+  awk '
+    $0 == "  cross-platform:" { capture = 1; print; next }
+    capture && $0 ~ /^  [A-Za-z0-9_-]+:$/ { exit }
+    capture { print }
+  ' "$workflow"
+)
+[[ -n "$cross_platform_block" ]] || fail "Gate 16 cross-platform job is missing"
+
+grep -F 'CARGO_TARGET_DIR=target/gate16-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}' <<<"$cross_platform_block" >/dev/null \
+  || fail "Gate 16 must isolate CARGO_TARGET_DIR by runner OS, runner architecture, and target triple"
+grep -F 'key: gate16-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}' <<<"$cross_platform_block" >/dev/null \
+  || fail "Gate 16 rust-cache key must include runner OS, runner architecture, and target triple"
+grep -F 'workspaces: ". -> target/gate16-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}"' <<<"$cross_platform_block" >/dev/null \
+  || fail "Gate 16 rust-cache workspace must match the isolated CARGO_TARGET_DIR"
+grep -F 'path: target/gate16-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}/${{ matrix.target }}/release/exochain' <<<"$cross_platform_block" >/dev/null \
+  || fail "Gate 16 artifact upload must read from the isolated target directory"
+
+grep -F 'bash tools/test_cross_platform_target_cache_boundary.sh' "$workflow" >/dev/null \
+  || fail "Gate 9 repo hygiene must run the Gate 16 cache boundary guard"
+
+printf 'cross-platform target cache boundary test passed\n'


### PR DESCRIPTION
## Summary
- Fixes the post-merge `main` Gate 16 `aarch64-apple-darwin` failure by isolating Cargo target output and rust-cache state by runner OS, runner architecture, and matrix target triple.
- Adds a Gate 9 guard proving the Gate 16 cache key, `CARGO_TARGET_DIR`, rust-cache workspace, and upload artifact path all share the isolated target boundary.

## Failure Classification
Post-merge `main` run `28459747675` failed only Gate 16 `aarch64-apple-darwin` while executing cached build-script binaries:

- `system-configuration-sys v0.6.0`: `cannot execute binary file`
- `crunchy v0.2.4`: `cannot execute binary file`

The same target passed on both #726 pre-merge runs, so this is CI cache/host-architecture contamination, not a release-signing source regression.

## Path Classification
- `.github/workflows/ci.yml` — EXOCHAIN core CI gate contract.
- `tools/test_cross_platform_target_cache_boundary.sh` — EXOCHAIN core CI guard.

## TDD / Verification
- RED: `bash tools/test_cross_platform_target_cache_boundary.sh` failed before the workflow change with `Gate 16 must isolate CARGO_TARGET_DIR by runner OS, runner architecture, and target triple`.
- GREEN: `bash tools/test_cross_platform_target_cache_boundary.sh`
- GREEN: `bash tools/test_github_actions_pinned.sh`
- GREEN: `bash tools/test_release_signed_tag_trust_boundary.sh`
- GREEN: `git diff --check`

## Release Note
Do not create or push `v0.2.0-beta` until this PR is merged and post-merge `main` CI returns green.
