### PR TITLE
ci: make release CI workflow reusable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,10 @@
 #   - License compliance (Apache-2.0; no copyleft contamination)
 
 name: EXOCHAIN Constitutional CI
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_call:
 
 env:
   CARGO_TERM_COLOR: always
@@ -272,6 +275,8 @@ jobs:
         run: bash tools/test_release_version_input_boundary.sh
       - name: Release signed-tag trust boundary
         run: bash tools/test_release_signed_tag_trust_boundary.sh
+      - name: Release reusable CI boundary
+        run: bash tools/test_release_reusable_ci_boundary.sh
       - name: Release version alignment
         run: bash tools/test_release_version_alignment.sh
       - name: Release dry-run publication boundary

--- a/tools/test_release_reusable_ci_boundary.sh
+++ b/tools/test_release_reusable_ci_boundary.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Copyright 2026 Exochain Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+fail() {
+  printf 'release reusable-CI boundary test failed: %s\n' "$1" >&2
+  exit 1
+}
+
+release_workflow=".github/workflows/release.yml"
+ci_workflow=".github/workflows/ci.yml"
+
+[[ -f "$release_workflow" ]] || fail "$release_workflow is missing"
+[[ -f "$ci_workflow" ]] || fail "$ci_workflow is missing"
+
+grep -F 'uses: ./.github/workflows/ci.yml' "$release_workflow" >/dev/null \
+  || fail "release workflow must keep the full CI pipeline as an explicit local workflow dependency"
+
+grep -E '^[[:space:]]+workflow_call:[[:space:]]*$' "$ci_workflow" >/dev/null \
+  || fail "ci workflow must expose on.workflow_call before release.yml can call it"
+
+grep -F 'bash tools/test_release_reusable_ci_boundary.sh' "$ci_workflow" >/dev/null \
+  || fail "CI repo hygiene must run the release reusable-CI boundary guard"
+
+printf 'release reusable-CI boundary test passed\n'


### PR DESCRIPTION
## Summary
- adds `workflow_call` to `.github/workflows/ci.yml` so `release.yml` can call the constitutional CI pipeline as a reusable workflow
- adds `tools/test_release_reusable_ci_boundary.sh` and wires it into Gate 9
- preserves the signed `v0.2.0-beta` tag as the release source; after merge, dispatch `release.yml` from `main` with `version=0.2.0-beta`

## Path Classification
- `.github/workflows/ci.yml` — EXOCHAIN core CI/release gate
- `tools/test_release_reusable_ci_boundary.sh` — EXOCHAIN core CI/release guard

## Verification
- RED: `bash tools/test_release_reusable_ci_boundary.sh` failed before `workflow_call` was added
- GREEN: `bash tools/test_release_reusable_ci_boundary.sh`
- GREEN: `bash tools/test_release_signed_tag_trust_boundary.sh`
- GREEN: `bash tools/test_release_version_input_boundary.sh`
- GREEN: `bash tools/test_release_workflow_ref_binding.sh`
- GREEN: `bash tools/test_release_dry_run_boundaries.sh`
- GREEN: `bash tools/test_release_publish_boundaries.sh`
- GREEN: `bash tools/test_release_version_alignment.sh`
- GREEN: `bash tools/test_github_actions_pinned.sh`
- GREEN: `git diff --check`

## Release Follow-up
Once this merges, do not recreate the already-pushed signed tag. Run:

```sh
gh workflow run release.yml --repo exochain/exochain --ref main -f version=0.2.0-beta -f dry_run=false
```