### PR TITLE
Fix release SBOM cyclonedx command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,8 @@ jobs:
         run: bash tools/test_release_signed_tag_trust_boundary.sh
       - name: Release reusable CI boundary
         run: bash tools/test_release_reusable_ci_boundary.sh
+      - name: Release SBOM boundary
+        run: bash tools/test_release_sbom_boundary.sh
       - name: Release version alignment
         run: bash tools/test_release_version_alignment.sh
       - name: Release dry-run publication boundary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,7 +263,7 @@ jobs:
         env:
           RELEASE_VERSION: ${{ needs.validate-release-inputs.outputs.version }}
         run: |
-          cargo cyclonedx -f json --workspace
+          cargo cyclonedx -f json --all
           # Rename outputs to include version for unambiguous identification
           for f in *.cdx.json; do
             mv "$f" "exochain-${RELEASE_VERSION}-${f}"

--- a/tools/test_release_sbom_boundary.sh
+++ b/tools/test_release_sbom_boundary.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Copyright 2026 Exochain Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+fail() {
+  printf 'release SBOM boundary test failed: %s\n' "$1" >&2
+  exit 1
+}
+
+workflow=".github/workflows/release.yml"
+ci_workflow=".github/workflows/ci.yml"
+
+[[ -f "$workflow" ]] || fail "$workflow is missing"
+[[ -f "$ci_workflow" ]] || fail "$ci_workflow is missing"
+
+job_block() {
+  local job="$1"
+  awk -v job="  ${job}:" '
+    $0 == job { capture = 1; print; next }
+    capture && $0 ~ /^  [A-Za-z0-9_-]+:$/ { exit }
+    capture { print }
+  ' "$workflow"
+}
+
+sbom_block=$(job_block "sbom-and-attest")
+[[ -n "$sbom_block" ]] || fail "sbom-and-attest job is missing"
+
+grep -F 'name: "SBOM + SLSA Attestation"' <<<"$sbom_block" >/dev/null \
+  || fail "sbom-and-attest must remain the release SBOM and SLSA attestation job"
+grep -F 'bash tools/ci_cargo_retry.sh cargo install cargo-cyclonedx --version 0.5.9 --locked' <<<"$sbom_block" >/dev/null \
+  || fail "release SBOM job must pin cargo-cyclonedx 0.5.9"
+grep -F 'cargo cyclonedx -f json --all' <<<"$sbom_block" >/dev/null \
+  || fail "release SBOM job must use cargo-cyclonedx 0.5.9 compatible --all workspace generation"
+
+if grep -F 'cargo cyclonedx -f json --workspace' <<<"$sbom_block" >/dev/null; then
+  fail "cargo-cyclonedx 0.5.9 does not support --workspace in the release SBOM job"
+fi
+
+grep -F 'path: exochain-${{ needs.validate-release-inputs.outputs.version }}-*.cdx.json' <<<"$sbom_block" >/dev/null \
+  || fail "release SBOM artifacts must be uploaded with versioned names"
+grep -F 'uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45' <<<"$sbom_block" >/dev/null \
+  || fail "release build provenance must remain attested by the pinned SLSA action"
+grep -F 'bash tools/test_release_sbom_boundary.sh' "$ci_workflow" >/dev/null \
+  || fail "CI repo hygiene must run the release SBOM boundary guard"
+
+printf 'release SBOM boundary test passed\n'


### PR DESCRIPTION
## Summary
- Fix the release SBOM job to use the cargo-cyclonedx 0.5.9 compatible workspace flag: `cargo cyclonedx -f json --all`.
- Add `tools/test_release_sbom_boundary.sh` and wire it into CI repo hygiene so the release-only SBOM command cannot drift back to unsupported `--workspace`.
- Leave the existing signed `v0.2.0-beta` tag untouched.

## Failure evidence
- Release run `28493232372` failed in `SBOM + SLSA Attestation` because `cargo cyclonedx -f json --workspace` is not accepted by the pinned `cargo-cyclonedx 0.5.9`; the tool usage lists `--all` instead.

## TDD
- RED: `bash tools/test_release_sbom_boundary.sh` failed on current main with `release SBOM job must use cargo-cyclonedx 0.5.9 compatible --all workspace generation`.
- GREEN: changed the release command and wired the guard into `.github/workflows/ci.yml`.

## Verification
- `bash tools/test_release_sbom_boundary.sh`
- `bash tools/test_release_publish_boundaries.sh`
- `bash tools/test_release_workflow_ref_binding.sh`
- `bash tools/test_release_reusable_ci_boundary.sh`
- `bash tools/test_release_signed_tag_trust_boundary.sh`
- `bash tools/test_github_actions_pinned.sh`
- `bash tools/test_release_version_input_boundary.sh`
- `bash tools/test_release_dry_run_boundaries.sh`
- `bash tools/test_release_version_alignment.sh`
- `git diff --check`