### PR TITLE
Release crates under the exochain crates.io namespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Run coverage
         # exochain-wasm: excluded — wasm bindings are exercised by the JS
         # bridge tests (Gate 21), not tarpaulin.
-        # exo-proofs: excluded — the entire crate is gated behind
+        # exochain-proofs: excluded — the entire crate is gated behind
         # `unaudited-pedagogical-proofs` (default OFF) after PR #106.
         # With the feature OFF, the crate compiles to refusal stubs that
         # tarpaulin correctly reports as 0% covered. Testing the gated
@@ -109,7 +109,7 @@ jobs:
           cargo tarpaulin \
             --workspace \
             --exclude exochain-wasm \
-            --exclude exo-proofs \
+            --exclude exochain-proofs \
             --out xml \
             --output-dir coverage \
             --engine llvm \
@@ -283,6 +283,8 @@ jobs:
         run: bash tools/test_release_dry_run_boundaries.sh
       - name: Release publish completion boundary
         run: bash tools/test_release_publish_boundaries.sh
+      - name: Crates.io release packaging boundary
+        run: bash tools/test_cratesio_release_packaging.sh
       - name: WASM npm package boundary
         run: bash tools/test_wasm_npm_package_boundary.sh
       - name: Repo truth and public claims
@@ -436,11 +438,11 @@ jobs:
       - name: Run DAG DB migration upgrade regression
         env:
           EXO_DAGDB_TEST_DATABASE_URL: ${{ env.DATABASE_URL }}
-        run: cargo test -p exo-dag-db-postgres --features postgres --test migration_contract pr708_migrator_upgrades_from_last_successful_deployed_ledger -- --nocapture
+        run: cargo test -p exochain-dag-db-postgres --features postgres --test migration_contract pr708_migrator_upgrades_from_last_successful_deployed_ledger -- --nocapture
       - name: Run DB-backed gateway library tests
-        run: cargo test -p exo-gateway --lib --features production-db -- --test-threads=1
+        run: cargo test -p exochain-gateway --lib --features production-db -- --test-threads=1
       - name: Run DB-backed integration tests
-        run: cargo test --workspace --test '*' --features exo-gateway/production-db
+        run: cargo test --workspace --test '*' --features exochain-gateway/production-db
       - name: Stop Postgres
         if: always()
         run: docker compose -f docker-compose.ci.yml down
@@ -472,10 +474,10 @@ jobs:
         if: steps.filter.outputs.node == 'true'
       - name: Run exo-node unit and integration tests
         if: steps.filter.outputs.node == 'true'
-        run: cargo test -p exo-node
+        run: cargo test -p exochain-node
       - name: Run exo-dag consensus tests
         if: steps.filter.outputs.node == 'true'
-        run: cargo test -p exo-dag -- consensus
+        run: cargo test -p exochain-dag -- consensus
 
   # -----------------------------------------------------------------------
   # Gate 15: State sync and join test
@@ -503,16 +505,16 @@ jobs:
         if: steps.filter.outputs.sync == 'true'
       - name: Run sync engine tests
         if: steps.filter.outputs.sync == 'true'
-        run: cargo test -p exo-node -- sync
+        run: cargo test -p exochain-node -- sync
       - name: Run store tests
         if: steps.filter.outputs.sync == 'true'
-        run: cargo test -p exo-node -- store
+        run: cargo test -p exochain-node -- store
       - name: Run wire protocol tests
         if: steps.filter.outputs.sync == 'true'
-        run: cargo test -p exo-node -- wire
+        run: cargo test -p exochain-node -- wire
       - name: Run metrics tests
         if: steps.filter.outputs.sync == 'true'
-        run: cargo test -p exo-node -- metrics
+        run: cargo test -p exochain-node -- metrics
 
   # -----------------------------------------------------------------------
   # Gate 16: Cross-platform binary build
@@ -577,7 +579,7 @@ jobs:
       - name: Run 0dentity module coverage
         run: |
           cargo tarpaulin \
-            --packages exo-node \
+            --packages exochain-node \
             --include-files "crates/exo-node/src/zerodentity/**" \
             --out xml \
             --output-dir coverage-zerodentity \
@@ -610,7 +612,7 @@ jobs:
       - name: Run exo-root coverage
         run: |
           cargo tarpaulin \
-            --packages exo-root \
+            --packages exochain-root \
             --include-files "crates/exo-root/src/**" \
             --out xml \
             --out stdout \
@@ -644,7 +646,7 @@ jobs:
       - name: Run root genesis portal coverage
         run: |
           cargo tarpaulin \
-            --packages exo-node \
+            --packages exochain-node \
             --include-files "crates/exo-node/src/root_genesis.rs" \
             --out xml \
             --output-dir coverage-root-genesis-portal \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,29 +313,52 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Verify crates.io namespace ownership
+        env:
+          EXOCHAIN_CRATES_IO_ALLOWED_OWNERS: ${{ vars.EXOCHAIN_CRATES_IO_ALLOWED_OWNERS }}
+        run: node tools/check_cratesio_namespace_ownership.mjs
+
       - name: Publish crates in dependency order
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           set -euo pipefail
           CRATES=(
-            exo-core
-            exo-identity
-            exo-consent
-            exo-authority
-            exo-dag
-            exo-proofs
-            exo-gatekeeper
-            exo-governance
-            exo-escalation
-            exo-legal
-            exo-tenant
-            exo-api
-            exo-gateway
-            decision-forum
+            exochain-core
+            exochain-dag-db-api
+            exochain-identity
+            exochain-api
+            exochain-authority
+            exochain-avc
+            exochain-consent
+            exochain-dag-db-core
+            exochain-dag-db-graph
+            exochain-dag-db-domain
+            exochain-dag-db-retrieval
+            exochain-dag-db-exchange
+            exochain-dag
+            exochain-dag-db-postgres
+            exochain-gatekeeper
+            exochain-governance
+            exochain-escalation
+            exochain-tenant
+            exochain-catapult
+            exochain-legal
+            exochain-decision-forum
+            exochain-consensus
+            exochain-dag-db-lab
+            exochain-economy
+            exochain-gateway
+            exochain-messaging
+            exochain-root
+            exochain-sdk
+            exochain-node
+            exochain-proofs
             exochain-wasm
           )
           for crate in "${CRATES[@]}"; do
+            echo "Dry-running $crate..."
+            cargo publish -p "$crate" --dry-run --allow-dirty
             echo "Publishing $crate..."
             cargo publish -p "$crate" --allow-dirty
             # crates.io index propagation delay

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1154,24 +1154,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "decision-forum"
-version = "0.2.0-beta"
-dependencies = [
- "blake3",
- "exo-authority",
- "exo-consent",
- "exo-core",
- "exo-gatekeeper",
- "exo-governance",
- "exo-identity",
- "exo-legal",
- "serde",
- "serde_json",
- "thiserror 2.0.17",
- "uuid",
-]
-
-[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1401,14 +1383,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "exo-api"
+name = "exochain-api"
 version = "0.2.0-beta"
 dependencies = [
  "blake3",
  "ciborium",
- "exo-core",
- "exo-dag-db-api",
- "exo-identity",
+ "exochain-core",
+ "exochain-dag-db-api",
+ "exochain-identity",
  "jsonschema",
  "serde",
  "serde_json",
@@ -1417,41 +1399,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "exo-authority"
+name = "exochain-authority"
 version = "0.2.0-beta"
 dependencies = [
  "blake3",
  "ciborium",
  "ed25519-dalek",
- "exo-core",
- "exo-identity",
+ "exochain-core",
+ "exochain-identity",
  "serde",
  "thiserror 2.0.17",
 ]
 
 [[package]]
-name = "exo-avc"
+name = "exochain-avc"
 version = "0.2.0-beta"
 dependencies = [
  "ciborium",
- "exo-authority",
- "exo-core",
+ "exochain-authority",
+ "exochain-core",
  "serde",
  "sha2",
  "thiserror 2.0.17",
 ]
 
 [[package]]
-name = "exo-catapult"
+name = "exochain-catapult"
 version = "0.2.0-beta"
 dependencies = [
  "ciborium",
- "exo-authority",
- "exo-consent",
- "exo-core",
- "exo-escalation",
- "exo-identity",
- "exo-tenant",
+ "exochain-authority",
+ "exochain-consent",
+ "exochain-core",
+ "exochain-escalation",
+ "exochain-identity",
+ "exochain-tenant",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -1459,29 +1441,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "exo-consensus"
+name = "exochain-consensus"
 version = "0.2.0-beta"
 dependencies = [
- "decision-forum",
- "exo-core",
+ "exochain-core",
+ "exochain-decision-forum",
  "proptest",
  "serde",
  "thiserror 2.0.17",
 ]
 
 [[package]]
-name = "exo-consent"
+name = "exochain-consent"
 version = "0.2.0-beta"
 dependencies = [
  "blake3",
  "ciborium",
- "exo-core",
+ "exochain-core",
  "serde",
  "thiserror 2.0.17",
 ]
 
 [[package]]
-name = "exo-core"
+name = "exochain-core"
 version = "0.2.0-beta"
 dependencies = [
  "blake3",
@@ -1502,14 +1484,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "exo-dag"
+name = "exochain-dag"
 version = "0.2.0-beta"
 dependencies = [
  "async-trait",
  "blake3",
  "ciborium",
  "criterion",
- "exo-core",
+ "exochain-core",
  "proptest",
  "serde",
  "serde_json",
@@ -1520,7 +1502,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "exo-dag-db-api"
+name = "exochain-dag-db-api"
 version = "0.2.0-beta"
 dependencies = [
  "serde",
@@ -1528,30 +1510,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "exo-dag-db-core"
+name = "exochain-dag-db-core"
 version = "0.2.0-beta"
 dependencies = [
  "ciborium",
- "exo-core",
- "exo-dag-db-api",
+ "exochain-core",
+ "exochain-dag-db-api",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
 ]
 
 [[package]]
-name = "exo-dag-db-domain"
+name = "exochain-dag-db-domain"
 version = "0.2.0-beta"
 dependencies = [
  "ciborium",
- "exo-authority",
- "exo-avc",
- "exo-consent",
- "exo-core",
- "exo-dag-db-api",
- "exo-dag-db-core",
- "exo-dag-db-graph",
- "exo-identity",
+ "exochain-authority",
+ "exochain-avc",
+ "exochain-consent",
+ "exochain-core",
+ "exochain-dag-db-api",
+ "exochain-dag-db-core",
+ "exochain-dag-db-graph",
+ "exochain-identity",
  "serde",
  "serde_json",
  "sha2",
@@ -1559,18 +1541,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "exo-dag-db-exchange"
+name = "exochain-dag-db-exchange"
 version = "0.2.0-beta"
 dependencies = [
- "exo-authority",
- "exo-avc",
- "exo-consent",
- "exo-core",
- "exo-dag-db-api",
- "exo-dag-db-core",
- "exo-dag-db-domain",
- "exo-dag-db-graph",
- "exo-dag-db-retrieval",
+ "exochain-authority",
+ "exochain-avc",
+ "exochain-consent",
+ "exochain-core",
+ "exochain-dag-db-api",
+ "exochain-dag-db-core",
+ "exochain-dag-db-domain",
+ "exochain-dag-db-graph",
+ "exochain-dag-db-retrieval",
  "serde",
  "serde_json",
  "sha2",
@@ -1578,12 +1560,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "exo-dag-db-graph"
+name = "exochain-dag-db-graph"
 version = "0.2.0-beta"
 dependencies = [
  "ciborium",
- "exo-core",
- "exo-dag-db-api",
+ "exochain-core",
+ "exochain-dag-db-api",
  "serde",
  "serde_json",
  "sha2",
@@ -1591,18 +1573,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "exo-dag-db-lab"
+name = "exochain-dag-db-lab"
 version = "0.2.0-beta"
 dependencies = [
  "criterion",
- "exo-core",
- "exo-dag-db-api",
- "exo-dag-db-core",
- "exo-dag-db-domain",
- "exo-dag-db-exchange",
- "exo-dag-db-graph",
- "exo-dag-db-postgres",
- "exo-dag-db-retrieval",
+ "exochain-core",
+ "exochain-dag-db-api",
+ "exochain-dag-db-core",
+ "exochain-dag-db-domain",
+ "exochain-dag-db-exchange",
+ "exochain-dag-db-graph",
+ "exochain-dag-db-postgres",
+ "exochain-dag-db-retrieval",
  "serde",
  "serde_json",
  "sha2",
@@ -1612,17 +1594,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "exo-dag-db-postgres"
+name = "exochain-dag-db-postgres"
 version = "0.2.0-beta"
 dependencies = [
- "exo-core",
- "exo-dag",
- "exo-dag-db-api",
- "exo-dag-db-core",
- "exo-dag-db-domain",
- "exo-dag-db-exchange",
- "exo-dag-db-graph",
- "exo-dag-db-retrieval",
+ "exochain-core",
+ "exochain-dag",
+ "exochain-dag-db-api",
+ "exochain-dag-db-core",
+ "exochain-dag-db-domain",
+ "exochain-dag-db-exchange",
+ "exochain-dag-db-graph",
+ "exochain-dag-db-retrieval",
  "serde",
  "serde_json",
  "sqlx",
@@ -1632,14 +1614,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "exo-dag-db-retrieval"
+name = "exochain-dag-db-retrieval"
 version = "0.2.0-beta"
 dependencies = [
- "exo-core",
- "exo-dag-db-api",
- "exo-dag-db-core",
- "exo-dag-db-domain",
- "exo-dag-db-graph",
+ "exochain-core",
+ "exochain-dag-db-api",
+ "exochain-dag-db-core",
+ "exochain-dag-db-domain",
+ "exochain-dag-db-graph",
  "serde",
  "serde_json",
  "sha2",
@@ -1647,44 +1629,62 @@ dependencies = [
 ]
 
 [[package]]
-name = "exo-economy"
+name = "exochain-decision-forum"
+version = "0.2.0-beta"
+dependencies = [
+ "blake3",
+ "exochain-authority",
+ "exochain-consent",
+ "exochain-core",
+ "exochain-gatekeeper",
+ "exochain-governance",
+ "exochain-identity",
+ "exochain-legal",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "uuid",
+]
+
+[[package]]
+name = "exochain-economy"
 version = "0.2.0-beta"
 dependencies = [
  "ciborium",
- "exo-core",
+ "exochain-core",
  "serde",
  "thiserror 2.0.17",
 ]
 
 [[package]]
-name = "exo-escalation"
+name = "exochain-escalation"
 version = "0.2.0-beta"
 dependencies = [
  "ciborium",
- "exo-core",
- "exo-gatekeeper",
- "exo-governance",
- "exo-identity",
+ "exochain-core",
+ "exochain-gatekeeper",
+ "exochain-governance",
+ "exochain-identity",
  "serde",
  "thiserror 2.0.17",
  "uuid",
 ]
 
 [[package]]
-name = "exo-gatekeeper"
+name = "exochain-gatekeeper"
 version = "0.2.0-beta"
 dependencies = [
  "blake3",
  "ciborium",
  "ed25519-dalek",
- "exo-api",
- "exo-consent",
- "exo-core",
- "exo-dag-db-core",
- "exo-dag-db-domain",
- "exo-dag-db-exchange",
- "exo-dag-db-postgres",
- "exo-identity",
+ "exochain-api",
+ "exochain-consent",
+ "exochain-core",
+ "exochain-dag-db-core",
+ "exochain-dag-db-domain",
+ "exochain-dag-db-exchange",
+ "exochain-dag-db-postgres",
+ "exochain-identity",
  "hex",
  "serde",
  "serde_json",
@@ -1696,7 +1696,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "exo-gateway"
+name = "exochain-gateway"
 version = "0.2.0-beta"
 dependencies = [
  "async-graphql",
@@ -1708,18 +1708,18 @@ dependencies = [
  "bs58",
  "chrono",
  "ciborium",
- "decision-forum",
- "exo-api",
- "exo-consent",
- "exo-core",
- "exo-dag-db-core",
- "exo-dag-db-domain",
- "exo-dag-db-exchange",
- "exo-dag-db-postgres",
- "exo-gatekeeper",
- "exo-governance",
- "exo-identity",
- "exo-legal",
+ "exochain-api",
+ "exochain-consent",
+ "exochain-core",
+ "exochain-dag-db-core",
+ "exochain-dag-db-domain",
+ "exochain-dag-db-exchange",
+ "exochain-dag-db-postgres",
+ "exochain-decision-forum",
+ "exochain-gatekeeper",
+ "exochain-governance",
+ "exochain-identity",
+ "exochain-legal",
  "getrandom 0.2.16",
  "hex",
  "percent-encoding",
@@ -1739,15 +1739,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "exo-governance"
+name = "exochain-governance"
 version = "0.2.0-beta"
 dependencies = [
  "blake3",
  "ciborium",
- "exo-authority",
- "exo-consent",
- "exo-core",
- "exo-identity",
+ "exochain-authority",
+ "exochain-consent",
+ "exochain-core",
+ "exochain-identity",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -1755,14 +1755,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "exo-identity"
+name = "exochain-identity"
 version = "0.2.0-beta"
 dependencies = [
  "blake3",
  "bs58",
  "chacha20poly1305",
  "ciborium",
- "exo-core",
+ "exochain-core",
  "getrandom 0.2.16",
  "hkdf",
  "proptest",
@@ -1775,16 +1775,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "exo-legal"
+name = "exochain-legal"
 version = "0.2.0-beta"
 dependencies = [
  "blake3",
  "ciborium",
- "exo-authority",
- "exo-core",
- "exo-gatekeeper",
- "exo-governance",
- "exo-identity",
+ "exochain-authority",
+ "exochain-core",
+ "exochain-gatekeeper",
+ "exochain-governance",
+ "exochain-identity",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -1792,12 +1792,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "exo-messaging"
+name = "exochain-messaging"
 version = "0.2.0-beta"
 dependencies = [
  "ciborium",
- "exo-core",
- "exo-identity",
+ "exochain-core",
+ "exochain-identity",
  "hex",
  "hkdf",
  "serde",
@@ -1810,7 +1810,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "exo-node"
+name = "exochain-node"
 version = "0.2.0-beta"
 dependencies = [
  "anyhow",
@@ -1827,20 +1827,20 @@ dependencies = [
  "der 0.8.0",
  "directories",
  "ed25519-dalek",
- "exo-api",
- "exo-authority",
- "exo-avc",
- "exo-consent",
- "exo-core",
- "exo-dag",
- "exo-economy",
- "exo-escalation",
- "exo-gatekeeper",
- "exo-gateway",
- "exo-governance",
- "exo-identity",
- "exo-legal",
- "exo-root",
+ "exochain-api",
+ "exochain-authority",
+ "exochain-avc",
+ "exochain-consent",
+ "exochain-core",
+ "exochain-dag",
+ "exochain-economy",
+ "exochain-escalation",
+ "exochain-gatekeeper",
+ "exochain-gateway",
+ "exochain-governance",
+ "exochain-identity",
+ "exochain-legal",
+ "exochain-root",
  "exochain-sdk",
  "futures",
  "getrandom 0.2.16",
@@ -1880,12 +1880,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "exo-proofs"
+name = "exochain-proofs"
 version = "0.2.0-beta"
 dependencies = [
  "blake3",
  "ciborium",
- "exo-core",
+ "exochain-core",
  "serde",
  "serde_json",
  "sha2",
@@ -1893,14 +1893,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "exo-root"
+name = "exochain-root"
 version = "0.2.0-beta"
 dependencies = [
  "argon2",
  "chacha20poly1305",
  "ciborium",
- "exo-authority",
- "exo-core",
+ "exochain-authority",
+ "exochain-core",
  "frost-ristretto255",
  "hkdf",
  "rand 0.8.6",
@@ -1913,29 +1913,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "exo-tenant"
-version = "0.2.0-beta"
-dependencies = [
- "blake3",
- "exo-core",
- "exo-identity",
- "serde",
- "serde_json",
- "thiserror 2.0.17",
- "uuid",
-]
-
-[[package]]
 name = "exochain-sdk"
 version = "0.2.0-beta"
 dependencies = [
  "blake3",
- "exo-avc",
- "exo-core",
- "exo-dag-db-api",
- "exo-economy",
- "exo-gatekeeper",
- "exo-identity",
+ "exochain-avc",
+ "exochain-core",
+ "exochain-dag-db-api",
+ "exochain-economy",
+ "exochain-gatekeeper",
+ "exochain-identity",
  "reqwest",
  "serde",
  "serde_json",
@@ -1945,27 +1932,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "exochain-tenant"
+version = "0.2.0-beta"
+dependencies = [
+ "blake3",
+ "exochain-core",
+ "exochain-identity",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "uuid",
+]
+
+[[package]]
 name = "exochain-wasm"
 version = "0.2.0-beta"
 dependencies = [
- "decision-forum",
  "ed25519-dalek",
- "exo-api",
- "exo-authority",
- "exo-avc",
- "exo-catapult",
- "exo-consent",
- "exo-core",
- "exo-dag",
- "exo-economy",
- "exo-escalation",
- "exo-gatekeeper",
- "exo-governance",
- "exo-identity",
- "exo-legal",
- "exo-messaging",
- "exo-proofs",
- "exo-tenant",
+ "exochain-api",
+ "exochain-authority",
+ "exochain-avc",
+ "exochain-catapult",
+ "exochain-consent",
+ "exochain-core",
+ "exochain-dag",
+ "exochain-decision-forum",
+ "exochain-economy",
+ "exochain-escalation",
+ "exochain-gatekeeper",
+ "exochain-governance",
+ "exochain-identity",
+ "exochain-legal",
+ "exochain-messaging",
+ "exochain-proofs",
+ "exochain-tenant",
  "getrandom 0.2.16",
  "hex",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
 repository = "https://github.com/exochain/exochain"
-publish = false
+publish = true
 
 [workspace.dependencies]
 # Deterministic serialization

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/
 # Build the distributed node binary and standalone gateway with DB-backed
 # adjudication enabled for production container deployments.
-RUN cargo build --release --bin exochain --bin exo-gateway --features exo-gateway/production-db
+RUN cargo build --release --bin exochain --bin exo-gateway --features exochain-gateway/production-db
 
 # Stage 2: Runtime
 FROM debian:bookworm-slim

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 31 | `ls -d crates/*/` |
 | Rust source files | 456 | `find crates -name '*.rs'` |
-| Rust LOC | 368010 | `wc -l` |
-| Workspace tests | 6,044 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 368035 | `wc -l` |
+| Workspace tests | 6,046 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 22 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **6,044 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **6,046 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,9 +113,9 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 31 crates, 368010 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 31 crates, 368035 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
-         cryptographic proofs, 6,044 listed workspace tests
+         cryptographic proofs, 6,046 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          165 verified WASM exports covered by 172 bridge checks — Rust -> WebAssembly -> JavaScript

--- a/crates/decision-forum/Cargo.toml
+++ b/crates/decision-forum/Cargo.toml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "decision-forum"
+name = "exochain-decision-forum"
 description = "EXOCHAIN decision.forum — constitutional governance application layer"
 documentation = "https://docs.exochain.io"
 version.workspace = true
@@ -25,17 +25,21 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[lib]
+name = "decision_forum"
+path = "src/lib.rs"
+
 [lints]
 workspace = true
 
 [dependencies]
-exo-core = { path = "../exo-core" }
-exo-identity = { path = "../exo-identity" }
-exo-governance = { path = "../exo-governance" }
-exo-gatekeeper = { path = "../exo-gatekeeper" }
-exo-authority = { path = "../exo-authority" }
-exo-consent = { path = "../exo-consent" }
-exo-legal = { path = "../exo-legal" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.0-beta" }
+exo-governance = { package = "exochain-governance", path = "../exo-governance", version = "=0.2.0-beta" }
+exo-gatekeeper = { package = "exochain-gatekeeper", path = "../exo-gatekeeper", version = "=0.2.0-beta" }
+exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.0-beta" }
+exo-consent = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.0-beta" }
+exo-legal = { package = "exochain-legal", path = "../exo-legal", version = "=0.2.0-beta" }
 serde = { workspace = true }
 blake3 = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/exo-api/Cargo.toml
+++ b/crates/exo-api/Cargo.toml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "exo-api"
+name = "exochain-api"
 description = "EXOCHAIN constitutional trust fabric — P2P networking and external API types"
 documentation = "https://docs.exochain.io"
 version.workspace = true
@@ -25,13 +25,17 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[lib]
+name = "exo_api"
+path = "src/lib.rs"
+
 [lints]
 workspace = true
 
 [dependencies]
-exo-core = { path = "../exo-core" }
-exo-dag-db-api = { path = "../exo-dag-db-api" }
-exo-identity = { path = "../exo-identity" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
+exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.0-beta" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.0-beta" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 blake3 = { workspace = true }

--- a/crates/exo-authority/Cargo.toml
+++ b/crates/exo-authority/Cargo.toml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "exo-authority"
+name = "exochain-authority"
 description = "EXOCHAIN authority chain verification and delegation management"
 documentation = "https://docs.exochain.io"
 version.workspace = true
@@ -25,13 +25,17 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[lib]
+name = "exo_authority"
+path = "src/lib.rs"
+
 [lints]
 workspace = true
 
 [dependencies]
 ciborium = { workspace = true }
-exo-core = { path = "../exo-core" }
-exo-identity = { path = "../exo-identity" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.0-beta" }
 serde = { workspace = true }
 blake3 = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/exo-avc/Cargo.toml
+++ b/crates/exo-avc/Cargo.toml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "exo-avc"
+name = "exochain-avc"
 description = "EXOCHAIN Autonomous Volition Credential — portable signed credential for autonomous agent intent, authority, constraints, delegation, revocation, and trust receipts"
 documentation = "https://docs.exochain.io"
 version.workspace = true
@@ -25,12 +25,16 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[lib]
+name = "exo_avc"
+path = "src/lib.rs"
+
 [lints]
 workspace = true
 
 [dependencies]
-exo-core = { path = "../exo-core" }
-exo-authority = { path = "../exo-authority" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
+exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.0-beta" }
 serde = { workspace = true }
 ciborium = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/exo-catapult/Cargo.toml
+++ b/crates/exo-catapult/Cargo.toml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "exo-catapult"
+name = "exochain-catapult"
 description = "EXOCHAIN Catapult — franchise business incubator with FM 3-05 operational doctrine"
 documentation = "https://docs.exochain.io"
 version.workspace = true
@@ -25,16 +25,20 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[lib]
+name = "exo_catapult"
+path = "src/lib.rs"
+
 [lints]
 workspace = true
 
 [dependencies]
-exo-core = { path = "../exo-core" }
-exo-identity = { path = "../exo-identity" }
-exo-consent = { path = "../exo-consent" }
-exo-authority = { path = "../exo-authority" }
-exo-tenant = { path = "../exo-tenant" }
-exo-escalation = { path = "../exo-escalation" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.0-beta" }
+exo-consent = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.0-beta" }
+exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.0-beta" }
+exo-tenant = { package = "exochain-tenant", path = "../exo-tenant", version = "=0.2.0-beta" }
+exo-escalation = { package = "exochain-escalation", path = "../exo-escalation", version = "=0.2.0-beta" }
 ciborium = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/exo-consensus/Cargo.toml
+++ b/crates/exo-consensus/Cargo.toml
@@ -15,7 +15,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "exo-consensus"
+name = "exochain-consensus"
+description = "EXOCHAIN constitutional trust fabric — consensus proofs and model quorum coordination"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -34,11 +35,15 @@ serde.workspace = true
 thiserror.workspace = true
 
 # Local
-exo-core = { path = "../exo-core" }
-decision-forum = { path = "../decision-forum" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
+decision-forum = { package = "exochain-decision-forum", path = "../decision-forum", version = "=0.2.0-beta" }
 
 [dev-dependencies]
 proptest.workspace = true
+
+[lib]
+name = "exo_consensus"
+path = "src/lib.rs"
 
 [lints]
 workspace = true

--- a/crates/exo-consent/Cargo.toml
+++ b/crates/exo-consent/Cargo.toml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "exo-consent"
+name = "exochain-consent"
 description = "EXOCHAIN bailment-conditioned consent enforcement — no action without consent"
 documentation = "https://docs.exochain.io"
 version.workspace = true
@@ -25,11 +25,15 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[lib]
+name = "exo_consent"
+path = "src/lib.rs"
+
 [lints]
 workspace = true
 
 [dependencies]
-exo-core = { path = "../exo-core" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
 serde = { workspace = true }
 blake3 = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/exo-core/Cargo.toml
+++ b/crates/exo-core/Cargo.toml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "exo-core"
+name = "exochain-core"
 description = "EXOCHAIN constitutional trust fabric — foundational deterministic types, HLC, crypto, BCTS state machine"
 documentation = "https://docs.exochain.io"
 version.workspace = true
@@ -24,6 +24,10 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 publish.workspace = true
+
+[lib]
+name = "exo_core"
+path = "src/lib.rs"
 
 [lints]
 workspace = true

--- a/crates/exo-dag-db-api/Cargo.toml
+++ b/crates/exo-dag-db-api/Cargo.toml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "exo-dag-db-api"
+name = "exochain-dag-db-api"
 description = "EXOCHAIN DAG DB API DTO wire contracts"
 documentation = "https://docs.exochain.io"
 version.workspace = true
@@ -24,6 +24,10 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 publish.workspace = true
+
+[lib]
+name = "exo_dag_db_api"
+path = "src/lib.rs"
 
 [lints]
 workspace = true

--- a/crates/exo-dag-db-core/Cargo.toml
+++ b/crates/exo-dag-db-core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "exo-dag-db-core"
+name = "exochain-dag-db-core"
 description = "EXOCHAIN DAG DB deterministic primitives and shared validation"
 version.workspace = true
 edition.workspace = true
@@ -8,12 +8,16 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[lib]
+name = "exo_dag_db_core"
+path = "src/lib.rs"
+
 [lints]
 workspace = true
 
 [dependencies]
-exo-dag-db-api = { path = "../exo-dag-db-api" }
-exo-core = { path = "../exo-core" }
+exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.0-beta" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
 ciborium = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/exo-dag-db-domain/Cargo.toml
+++ b/crates/exo-dag-db-domain/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "exo-dag-db-domain"
+name = "exochain-dag-db-domain"
 description = "EXOCHAIN DAG DB governed domain services"
 version.workspace = true
 edition.workspace = true
@@ -8,18 +8,22 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[lib]
+name = "exo_dag_db_domain"
+path = "src/lib.rs"
+
 [lints]
 workspace = true
 
 [dependencies]
-exo-dag-db-api = { path = "../exo-dag-db-api" }
-exo-authority = { path = "../exo-authority" }
-exo-avc = { path = "../exo-avc" }
-exo-consent = { path = "../exo-consent" }
-exo-core = { path = "../exo-core" }
-exo-dag-db-core = { path = "../exo-dag-db-core" }
-exo-dag-db-graph = { path = "../exo-dag-db-graph" }
-exo-identity = { path = "../exo-identity" }
+exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.0-beta" }
+exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.0-beta" }
+exo-avc = { package = "exochain-avc", path = "../exo-avc", version = "=0.2.0-beta" }
+exo-consent = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.0-beta" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
+exo-dag-db-core = { package = "exochain-dag-db-core", path = "../exo-dag-db-core", version = "=0.2.0-beta" }
+exo-dag-db-graph = { package = "exochain-dag-db-graph", path = "../exo-dag-db-graph", version = "=0.2.0-beta" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.0-beta" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 ciborium = { workspace = true }

--- a/crates/exo-dag-db-exchange/Cargo.toml
+++ b/crates/exo-dag-db-exchange/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "exo-dag-db-exchange"
+name = "exochain-dag-db-exchange"
 description = "EXOCHAIN DAG DB import, export, and writeback contracts"
 version.workspace = true
 edition.workspace = true
@@ -8,19 +8,23 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[lib]
+name = "exo_dag_db_exchange"
+path = "src/lib.rs"
+
 [lints]
 workspace = true
 
 [dependencies]
-exo-dag-db-api = { path = "../exo-dag-db-api" }
-exo-authority = { path = "../exo-authority" }
-exo-avc = { path = "../exo-avc" }
-exo-consent = { path = "../exo-consent" }
-exo-core = { path = "../exo-core" }
-exo-dag-db-core = { path = "../exo-dag-db-core" }
-exo-dag-db-domain = { path = "../exo-dag-db-domain" }
-exo-dag-db-graph = { path = "../exo-dag-db-graph" }
-exo-dag-db-retrieval = { path = "../exo-dag-db-retrieval" }
+exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.0-beta" }
+exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.0-beta" }
+exo-avc = { package = "exochain-avc", path = "../exo-avc", version = "=0.2.0-beta" }
+exo-consent = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.0-beta" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
+exo-dag-db-core = { package = "exochain-dag-db-core", path = "../exo-dag-db-core", version = "=0.2.0-beta" }
+exo-dag-db-domain = { package = "exochain-dag-db-domain", path = "../exo-dag-db-domain", version = "=0.2.0-beta" }
+exo-dag-db-graph = { package = "exochain-dag-db-graph", path = "../exo-dag-db-graph", version = "=0.2.0-beta" }
+exo-dag-db-retrieval = { package = "exochain-dag-db-retrieval", path = "../exo-dag-db-retrieval", version = "=0.2.0-beta" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/exo-dag-db-graph/Cargo.toml
+++ b/crates/exo-dag-db-graph/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "exo-dag-db-graph"
+name = "exochain-dag-db-graph"
 description = "EXOCHAIN DAG DB graph and layered organization"
 version.workspace = true
 edition.workspace = true
@@ -8,12 +8,16 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[lib]
+name = "exo_dag_db_graph"
+path = "src/lib.rs"
+
 [lints]
 workspace = true
 
 [dependencies]
-exo-dag-db-api = { path = "../exo-dag-db-api" }
-exo-core = { path = "../exo-core" }
+exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.0-beta" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
 ciborium = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/exo-dag-db-lab/Cargo.toml
+++ b/crates/exo-dag-db-lab/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "exo-dag-db-lab"
+name = "exochain-dag-db-lab"
 description = "EXOCHAIN DAG DB diagnostics, graph explorer, benchmarks, and lab tools"
 version.workspace = true
 edition.workspace = true
@@ -7,6 +7,10 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 publish.workspace = true
+
+[lib]
+name = "exo_dag_db_lab"
+path = "src/lib.rs"
 
 [lints]
 workspace = true
@@ -49,14 +53,14 @@ harness = false
 required-features = ["postgres"]
 
 [dependencies]
-exo-dag-db-api = { path = "../exo-dag-db-api" }
-exo-core = { path = "../exo-core" }
-exo-dag-db-core = { path = "../exo-dag-db-core" }
-exo-dag-db-domain = { path = "../exo-dag-db-domain" }
-exo-dag-db-exchange = { path = "../exo-dag-db-exchange" }
-exo-dag-db-graph = { path = "../exo-dag-db-graph" }
-exo-dag-db-postgres = { path = "../exo-dag-db-postgres" }
-exo-dag-db-retrieval = { path = "../exo-dag-db-retrieval" }
+exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.0-beta" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
+exo-dag-db-core = { package = "exochain-dag-db-core", path = "../exo-dag-db-core", version = "=0.2.0-beta" }
+exo-dag-db-domain = { package = "exochain-dag-db-domain", path = "../exo-dag-db-domain", version = "=0.2.0-beta" }
+exo-dag-db-exchange = { package = "exochain-dag-db-exchange", path = "../exo-dag-db-exchange", version = "=0.2.0-beta" }
+exo-dag-db-graph = { package = "exochain-dag-db-graph", path = "../exo-dag-db-graph", version = "=0.2.0-beta" }
+exo-dag-db-postgres = { package = "exochain-dag-db-postgres", path = "../exo-dag-db-postgres", version = "=0.2.0-beta" }
+exo-dag-db-retrieval = { package = "exochain-dag-db-retrieval", path = "../exo-dag-db-retrieval", version = "=0.2.0-beta" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/exo-dag-db-lab/src/layered_backfill.rs
+++ b/crates/exo-dag-db-lab/src/layered_backfill.rs
@@ -1394,12 +1394,12 @@ mod tests {
             vec![
                 surface(
                     "flat_retrieval",
-                    "cargo test -p exo-dag-db-retrieval kg_retrieval",
+                    "cargo test -p exochain-dag-db-retrieval kg_retrieval",
                     "passed",
                 ),
                 surface(
                     "context_packets",
-                    "cargo test -p exo-dag-db-retrieval context_packet_output",
+                    "cargo test -p exochain-dag-db-retrieval context_packet_output",
                     "passed",
                 ),
             ],

--- a/crates/exo-dag-db-postgres/Cargo.toml
+++ b/crates/exo-dag-db-postgres/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "exo-dag-db-postgres"
+name = "exochain-dag-db-postgres"
 description = "EXOCHAIN DAG DB PostgreSQL persistence adapters"
 version.workspace = true
 edition.workspace = true
@@ -7,6 +7,10 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 publish.workspace = true
+
+[lib]
+name = "exo_dag_db_postgres"
+path = "src/lib.rs"
 
 [lints]
 workspace = true
@@ -16,14 +20,14 @@ default = []
 postgres = ["dep:sqlx", "dep:tokio", "dep:tracing"]
 
 [dependencies]
-exo-dag-db-api = { path = "../exo-dag-db-api" }
-exo-core = { path = "../exo-core" }
-exo-dag = { path = "../exo-dag" }
-exo-dag-db-core = { path = "../exo-dag-db-core" }
-exo-dag-db-domain = { path = "../exo-dag-db-domain" }
-exo-dag-db-exchange = { path = "../exo-dag-db-exchange" }
-exo-dag-db-graph = { path = "../exo-dag-db-graph" }
-exo-dag-db-retrieval = { path = "../exo-dag-db-retrieval" }
+exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.0-beta" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
+exo-dag = { package = "exochain-dag", path = "../exo-dag", version = "=0.2.0-beta" }
+exo-dag-db-core = { package = "exochain-dag-db-core", path = "../exo-dag-db-core", version = "=0.2.0-beta" }
+exo-dag-db-domain = { package = "exochain-dag-db-domain", path = "../exo-dag-db-domain", version = "=0.2.0-beta" }
+exo-dag-db-exchange = { package = "exochain-dag-db-exchange", path = "../exo-dag-db-exchange", version = "=0.2.0-beta" }
+exo-dag-db-graph = { package = "exochain-dag-db-graph", path = "../exo-dag-db-graph", version = "=0.2.0-beta" }
+exo-dag-db-retrieval = { package = "exochain-dag-db-retrieval", path = "../exo-dag-db-retrieval", version = "=0.2.0-beta" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true, optional = true }

--- a/crates/exo-dag-db-retrieval/Cargo.toml
+++ b/crates/exo-dag-db-retrieval/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "exo-dag-db-retrieval"
+name = "exochain-dag-db-retrieval"
 description = "EXOCHAIN DAG DB retrieval, routing, and context packet selection"
 version.workspace = true
 edition.workspace = true
@@ -8,15 +8,19 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[lib]
+name = "exo_dag_db_retrieval"
+path = "src/lib.rs"
+
 [lints]
 workspace = true
 
 [dependencies]
-exo-dag-db-api = { path = "../exo-dag-db-api" }
-exo-core = { path = "../exo-core" }
-exo-dag-db-core = { path = "../exo-dag-db-core" }
-exo-dag-db-domain = { path = "../exo-dag-db-domain" }
-exo-dag-db-graph = { path = "../exo-dag-db-graph" }
+exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.0-beta" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
+exo-dag-db-core = { package = "exochain-dag-db-core", path = "../exo-dag-db-core", version = "=0.2.0-beta" }
+exo-dag-db-domain = { package = "exochain-dag-db-domain", path = "../exo-dag-db-domain", version = "=0.2.0-beta" }
+exo-dag-db-graph = { package = "exochain-dag-db-graph", path = "../exo-dag-db-graph", version = "=0.2.0-beta" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/exo-dag/Cargo.toml
+++ b/crates/exo-dag/Cargo.toml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "exo-dag"
+name = "exochain-dag"
 description = "EXOCHAIN append-only DAG with BFT consensus and Merkle structures"
 documentation = "https://docs.exochain.io"
 version.workspace = true
@@ -25,6 +25,10 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[lib]
+name = "exo_dag"
+path = "src/lib.rs"
+
 [lints]
 workspace = true
 
@@ -33,7 +37,7 @@ default = []
 postgres = ["dep:sqlx", "dep:serde_json"]
 
 [dependencies]
-exo-core = { path = "../exo-core" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
 serde = { workspace = true }
 blake3 = { workspace = true }
 ciborium = { workspace = true }

--- a/crates/exo-economy/Cargo.toml
+++ b/crates/exo-economy/Cargo.toml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "exo-economy"
+name = "exochain-economy"
 description = "EXOCHAIN custody-native transaction economy — quote, settle, and revenue-share scaffolding with zero-priced launch policy"
 documentation = "https://docs.exochain.io"
 version.workspace = true
@@ -25,11 +25,15 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[lib]
+name = "exo_economy"
+path = "src/lib.rs"
+
 [lints]
 workspace = true
 
 [dependencies]
-exo-core = { path = "../exo-core" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
 serde = { workspace = true }
 ciborium = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/exo-escalation/Cargo.toml
+++ b/crates/exo-escalation/Cargo.toml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "exo-escalation"
+name = "exochain-escalation"
 description = "EXOCHAIN constitutional trust fabric — operational nervous system: detection, triage, kanban, HITL, Sybil adjudication"
 documentation = "https://docs.exochain.io"
 version.workspace = true
@@ -25,20 +25,24 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[lib]
+name = "exo_escalation"
+path = "src/lib.rs"
+
 [lints]
 workspace = true
 
 [dependencies]
-exo-core = { path = "../exo-core" }
-exo-identity = { path = "../exo-identity" }
-exo-governance = { path = "../exo-governance" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.0-beta" }
+exo-governance = { package = "exochain-governance", path = "../exo-governance", version = "=0.2.0-beta" }
 ciborium = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
-exo-gatekeeper = { path = "../exo-gatekeeper" }
+exo-gatekeeper = { package = "exochain-gatekeeper", path = "../exo-gatekeeper", version = "=0.2.0-beta" }
 
 [package.metadata.cargo-machete]
 # Pre-existing workspace dep used via re-exports.

--- a/crates/exo-gatekeeper/Cargo.toml
+++ b/crates/exo-gatekeeper/Cargo.toml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "exo-gatekeeper"
+name = "exochain-gatekeeper"
 description = "EXOCHAIN judicial branch — CGR kernel, combinator algebra, invariant enforcement, Holon runtime, MCP middleware"
 documentation = "https://docs.exochain.io"
 version.workspace = true
@@ -25,14 +25,18 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[lib]
+name = "exo_gatekeeper"
+path = "src/lib.rs"
+
 [lints]
 workspace = true
 
 [dependencies]
-exo-api = { path = "../exo-api" }
-exo-consent = { path = "../exo-consent" }
-exo-core = { path = "../exo-core" }
-exo-identity = { path = "../exo-identity" }
+exo-api = { package = "exochain-api", path = "../exo-api", version = "=0.2.0-beta" }
+exo-consent = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.0-beta" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.0-beta" }
 serde = { workspace = true }
 blake3 = { workspace = true }
 ciborium = { workspace = true }
@@ -46,15 +50,15 @@ hex = { workspace = true }
 allow-simulated-tee = []
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-exo-dag-db-core = { path = "../exo-dag-db-core" }
-exo-dag-db-domain = { path = "../exo-dag-db-domain" }
-exo-dag-db-exchange = { path = "../exo-dag-db-exchange" }
-exo-dag-db-postgres = { path = "../exo-dag-db-postgres", features = ["postgres"] }
+exo-dag-db-core = { package = "exochain-dag-db-core", path = "../exo-dag-db-core", version = "=0.2.0-beta" }
+exo-dag-db-domain = { package = "exochain-dag-db-domain", path = "../exo-dag-db-domain", version = "=0.2.0-beta" }
+exo-dag-db-exchange = { package = "exochain-dag-db-exchange", path = "../exo-dag-db-exchange", version = "=0.2.0-beta" }
+exo-dag-db-postgres = { package = "exochain-dag-db-postgres", path = "../exo-dag-db-postgres", version = "=0.2.0-beta", features = ["postgres"] }
 sqlx = { workspace = true }
 
 [dev-dependencies]
-exo-api = { path = "../exo-api" }
-exo-core = { path = "../exo-core" }
+exo-api = { package = "exochain-api", path = "../exo-api", version = "=0.2.0-beta" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 

--- a/crates/exo-gateway/Cargo.toml
+++ b/crates/exo-gateway/Cargo.toml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "exo-gateway"
+name = "exochain-gateway"
 description = "EXOCHAIN constitutional trust fabric — HTTP gateway server with default-deny pattern"
 documentation = "https://docs.exochain.io"
 version.workspace = true
@@ -25,22 +25,26 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[lib]
+name = "exo_gateway"
+path = "src/lib.rs"
+
 [lints]
 workspace = true
 
 [dependencies]
-decision-forum = { path = "../decision-forum" }
-exo-core = { path = "../exo-core" }
-exo-api = { path = "../exo-api" }
-exo-dag-db-core = { path = "../exo-dag-db-core" }
-exo-dag-db-domain = { path = "../exo-dag-db-domain" }
-exo-dag-db-exchange = { path = "../exo-dag-db-exchange" }
-exo-dag-db-postgres = { path = "../exo-dag-db-postgres", default-features = false, optional = true }
-exo-identity = { path = "../exo-identity" }
-exo-consent = { path = "../exo-consent" }
-exo-gatekeeper = { path = "../exo-gatekeeper" }
-exo-governance = { path = "../exo-governance" }
-exo-legal = { path = "../exo-legal" }
+decision-forum = { package = "exochain-decision-forum", path = "../decision-forum", version = "=0.2.0-beta" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
+exo-api = { package = "exochain-api", path = "../exo-api", version = "=0.2.0-beta" }
+exo-dag-db-core = { package = "exochain-dag-db-core", path = "../exo-dag-db-core", version = "=0.2.0-beta" }
+exo-dag-db-domain = { package = "exochain-dag-db-domain", path = "../exo-dag-db-domain", version = "=0.2.0-beta" }
+exo-dag-db-exchange = { package = "exochain-dag-db-exchange", path = "../exo-dag-db-exchange", version = "=0.2.0-beta" }
+exo-dag-db-postgres = { package = "exochain-dag-db-postgres", path = "../exo-dag-db-postgres", version = "=0.2.0-beta", default-features = false, optional = true }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.0-beta" }
+exo-consent = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.0-beta" }
+exo-gatekeeper = { package = "exochain-gatekeeper", path = "../exo-gatekeeper", version = "=0.2.0-beta" }
+exo-governance = { package = "exochain-governance", path = "../exo-governance", version = "=0.2.0-beta" }
+exo-legal = { package = "exochain-legal", path = "../exo-legal", version = "=0.2.0-beta" }
 bs58 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -65,6 +69,10 @@ tracing-subscriber = { workspace = true }
 async-graphql = { workspace = true }
 async-graphql-axum = { workspace = true }
 async-stream = { workspace = true }
+
+[[bin]]
+name = "exo-gateway"
+path = "src/main.rs"
 
 [[bin]]
 name = "dagdb_writeback_sign"

--- a/crates/exo-gateway/src/dagdb.rs
+++ b/crates/exo-gateway/src/dagdb.rs
@@ -9576,8 +9576,8 @@ mod tests {
         let proof = repo_file("docs/dagdb/full-migration/live-proof.md");
         for required in [
             "EXO_DAGDB_TEST_DATABASE_URL",
-            "cargo test -p exo-gateway --features production-db --test dagdb_route_integration_contract dagdb_routes_integration_contract",
-            "cargo test -p exo-gateway --features production-db --test dagdb_cross_tenant",
+            "cargo test -p exochain-gateway --features production-db --test dagdb_route_integration_contract dagdb_routes_integration_contract",
+            "cargo test -p exochain-gateway --features production-db --test dagdb_cross_tenant",
             "write/read/lookup",
             "tenant mismatch",
             "database_unavailable",

--- a/crates/exo-governance/Cargo.toml
+++ b/crates/exo-governance/Cargo.toml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "exo-governance"
+name = "exochain-governance"
 description = "EXOCHAIN constitutional trust fabric — legislative legitimacy: quorum, clearance, crosscheck, challenge, delegation, deliberation"
 documentation = "https://docs.exochain.io"
 version.workspace = true
@@ -25,15 +25,19 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[lib]
+name = "exo_governance"
+path = "src/lib.rs"
+
 [lints]
 workspace = true
 
 [dependencies]
-exo-core = { path = "../exo-core" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
 ciborium = { workspace = true }
-exo-identity = { path = "../exo-identity" }
-exo-consent = { path = "../exo-consent" }
-exo-authority = { path = "../exo-authority" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.0-beta" }
+exo-consent = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.0-beta" }
+exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.0-beta" }
 serde = { workspace = true }
 blake3 = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/exo-identity/Cargo.toml
+++ b/crates/exo-identity/Cargo.toml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "exo-identity"
+name = "exochain-identity"
 description = "EXOCHAIN constitutional trust fabric — privacy-preserving identity adjudication"
 documentation = "https://docs.exochain.io"
 version.workspace = true
@@ -25,11 +25,15 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[lib]
+name = "exo_identity"
+path = "src/lib.rs"
+
 [lints]
 workspace = true
 
 [dependencies]
-exo-core = { path = "../exo-core" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
 serde = { workspace = true }
 ciborium = { workspace = true }
 blake3 = { workspace = true }

--- a/crates/exo-legal/Cargo.toml
+++ b/crates/exo-legal/Cargo.toml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "exo-legal"
+name = "exochain-legal"
 description = "EXOCHAIN constitutional trust fabric — litigation-grade evidence, eDiscovery, privilege, fiduciary duty"
 documentation = "https://docs.exochain.io"
 version.workspace = true
@@ -25,15 +25,19 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[lib]
+name = "exo_legal"
+path = "src/lib.rs"
+
 [lints]
 workspace = true
 
 [dependencies]
-exo-core = { path = "../exo-core" }
-exo-identity = { path = "../exo-identity" }
-exo-authority = { path = "../exo-authority" }
-exo-governance = { path = "../exo-governance" }
-exo-gatekeeper = { path = "../exo-gatekeeper" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.0-beta" }
+exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.0-beta" }
+exo-governance = { package = "exochain-governance", path = "../exo-governance", version = "=0.2.0-beta" }
+exo-gatekeeper = { package = "exochain-gatekeeper", path = "../exo-gatekeeper", version = "=0.2.0-beta" }
 serde = { workspace = true }
 ciborium = { workspace = true }
 blake3 = { workspace = true }

--- a/crates/exo-messaging/Cargo.toml
+++ b/crates/exo-messaging/Cargo.toml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "exo-messaging"
+name = "exochain-messaging"
 description = "EXOCHAIN constitutional trust fabric — end-to-end encrypted messaging with X25519 key exchange"
 documentation = "https://docs.exochain.io"
 version.workspace = true
@@ -25,12 +25,16 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[lib]
+name = "exo_messaging"
+path = "src/lib.rs"
+
 [lints]
 workspace = true
 
 [dependencies]
-exo-core = { path = "../exo-core" }
-exo-identity = { path = "../exo-identity" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.0-beta" }
 ciborium = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/exo-node/Cargo.toml
+++ b/crates/exo-node/Cargo.toml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "exo-node"
+name = "exochain-node"
 description = "EXOCHAIN distributed node — single binary for joining and participating in the constitutional governance network"
 documentation = "https://docs.exochain.io"
 version.workspace = true
@@ -34,27 +34,27 @@ workspace = true
 
 [dependencies]
 # Workspace crates
-exo-core = { path = "../exo-core" }
-exo-dag = { path = "../exo-dag" }
-exo-gatekeeper = { path = "../exo-gatekeeper" }
-exo-gateway = { path = "../exo-gateway", default-features = false }
-exo-api = { path = "../exo-api" }
-exo-governance = { path = "../exo-governance" }
-exo-identity = { path = "../exo-identity" }
-exo-consent = { path = "../exo-consent" }
-exo-escalation = { path = "../exo-escalation" }
-exo-legal = { path = "../exo-legal" }
-exo-avc = { path = "../exo-avc" }
-exo-authority = { path = "../exo-authority" }
-exo-economy = { path = "../exo-economy" }
-exo-root = { path = "../exo-root" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
+exo-dag = { package = "exochain-dag", path = "../exo-dag", version = "=0.2.0-beta" }
+exo-gatekeeper = { package = "exochain-gatekeeper", path = "../exo-gatekeeper", version = "=0.2.0-beta" }
+exo-gateway = { package = "exochain-gateway", path = "../exo-gateway", version = "=0.2.0-beta", default-features = false }
+exo-api = { package = "exochain-api", path = "../exo-api", version = "=0.2.0-beta" }
+exo-governance = { package = "exochain-governance", path = "../exo-governance", version = "=0.2.0-beta" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.0-beta" }
+exo-consent = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.0-beta" }
+exo-escalation = { package = "exochain-escalation", path = "../exo-escalation", version = "=0.2.0-beta" }
+exo-legal = { package = "exochain-legal", path = "../exo-legal", version = "=0.2.0-beta" }
+exo-avc = { package = "exochain-avc", path = "../exo-avc", version = "=0.2.0-beta" }
+exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.0-beta" }
+exo-economy = { package = "exochain-economy", path = "../exo-economy", version = "=0.2.0-beta" }
+exo-root = { package = "exochain-root", path = "../exo-root", version = "=0.2.0-beta" }
 
 # DAG DB MCP gateway proxy client (P1-B SDK). The default node compiles the
 # governed gateway proxy transport so MCP DAG DB tools can call the production
 # gateway path when runtime config is present. Missing runtime config still
 # fails closed; it never falls back to fabricated packet/writeback/import/export
 # results.
-exochain-sdk = { path = "../exochain-sdk", optional = true }
+exochain-sdk = { package = "exochain-sdk", path = "../exochain-sdk", version = "=0.2.0-beta", optional = true }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/exo-node/src/api.rs
+++ b/crates/exo-node/src/api.rs
@@ -336,7 +336,7 @@ async fn handle_propose(
         tracing::warn!(
             "refusing POST /api/v1/governance/propose: raw admin governance \
              proposal shortcut is gated. Build with \
-             --features exo-node/unaudited-admin-governance-shortcut only for \
+             --features exochain-node/unaudited-admin-governance-shortcut only for \
              isolated development clusters."
         );
         return Err((
@@ -382,7 +382,7 @@ async fn handle_broadcast(
         tracing::warn!(
             "refusing POST /api/v1/governance/broadcast: raw admin governance \
              event broadcast shortcut is gated. Build with \
-             --features exo-node/unaudited-admin-governance-shortcut only for \
+             --features exochain-node/unaudited-admin-governance-shortcut only for \
              isolated development clusters."
         );
         return Err((
@@ -483,7 +483,7 @@ async fn handle_validator_change(
             "refusing POST /api/v1/governance/validators: admin bearer \
              shortcut is gated. See fix-admin-governance-bypass \
              initiative. To opt in for a dev cluster, build with \
-             --features exo-node/unaudited-admin-governance-shortcut."
+             --features exochain-node/unaudited-admin-governance-shortcut."
         );
         return Err((
             StatusCode::FORBIDDEN,

--- a/crates/exo-node/src/zerodentity/onboarding.rs
+++ b/crates/exo-node/src/zerodentity/onboarding.rs
@@ -377,7 +377,7 @@ fn first_touch_onboarding_refusal() -> (StatusCode, Json<serde_json::Value>) {
         "refusing POST /api/v1/0dentity/claims: first-touch onboarding \
          is gated. See fix-onyx-4-r1-onboarding-auth initiative. To opt \
          in for a dev cluster, build with \
-         --features exo-node/unaudited-zerodentity-first-touch-onboarding."
+         --features exochain-node/unaudited-zerodentity-first-touch-onboarding."
     );
     (
         StatusCode::FORBIDDEN,

--- a/crates/exo-proofs/Cargo.toml
+++ b/crates/exo-proofs/Cargo.toml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "exo-proofs"
+name = "exochain-proofs"
 description = "EXOCHAIN zero-knowledge proof skeleton -- UNAUDITED, pedagogical only. See crate README."
 documentation = "https://docs.exochain.io"
 version.workspace = true
@@ -24,6 +24,10 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 publish.workspace = true
+
+[lib]
+name = "exo_proofs"
+path = "src/lib.rs"
 
 [lints]
 workspace = true
@@ -39,7 +43,7 @@ workspace = true
 unaudited-pedagogical-proofs = []
 
 [dependencies]
-exo-core = { path = "../exo-core" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
 serde = { workspace = true }
 blake3 = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/exo-proofs/README.md
+++ b/crates/exo-proofs/README.md
@@ -75,11 +75,11 @@ the feature flag anywhere downstream.
 
 ## Tests
 
-- **Default build (feature OFF):** `cargo test -p exo-proofs` runs the
+- **Default build (feature OFF):** `cargo test -p exochain-proofs` runs the
   refusal integration tests in `tests/refusal.rs`, verifying that every
   gated entry point errors out. Unit tests inside each module are
   `#[cfg(feature = "unaudited-pedagogical-proofs")]` and do not run.
-- **Pedagogical build (feature ON):** `cargo test -p exo-proofs --features
+- **Pedagogical build (feature ON):** `cargo test -p exochain-proofs --features
   unaudited-pedagogical-proofs` runs the full 79-test suite exercising the
   skeleton's internal consistency.
 

--- a/crates/exo-root/Cargo.toml
+++ b/crates/exo-root/Cargo.toml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "exo-root"
+name = "exochain-root"
 description = "EXOCHAIN root genesis authority ceremony, FROST DKG, threshold signatures, and trust bundle verification"
 documentation = "https://docs.exochain.io"
 version.workspace = true
@@ -25,12 +25,16 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[lib]
+name = "exo_root"
+path = "src/lib.rs"
+
 [lints]
 workspace = true
 
 [dependencies]
-exo-core = { path = "../exo-core" }
-exo-authority = { path = "../exo-authority" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
+exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.0-beta" }
 frost-ristretto255 = { workspace = true }
 serde = { workspace = true }
 ciborium = { workspace = true }

--- a/crates/exo-tenant/Cargo.toml
+++ b/crates/exo-tenant/Cargo.toml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "exo-tenant"
+name = "exochain-tenant"
 description = "EXOCHAIN constitutional trust fabric — multi-tenant isolation, cold storage, sharding"
 documentation = "https://docs.exochain.io"
 version.workspace = true
@@ -25,12 +25,16 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[lib]
+name = "exo_tenant"
+path = "src/lib.rs"
+
 [lints]
 workspace = true
 
 [dependencies]
-exo-core = { path = "../exo-core" }
-exo-identity = { path = "../exo-identity" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.0-beta" }
 serde = { workspace = true }
 blake3 = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/exo-tenant/src/sharding.rs
+++ b/crates/exo-tenant/src/sharding.rs
@@ -114,6 +114,31 @@ mod tests {
     }
 
     #[test]
+    fn rejects_nil_tenant_id_for_all_strategies() {
+        let strategies = [
+            ShardStrategy::HashBased { total_shards: 16 },
+            ShardStrategy::RangeBased { shard_size: 16 },
+            ShardStrategy::Geographic {
+                region: "us-east-1".into(),
+            },
+            ShardStrategy::Single,
+        ];
+
+        for strategy in strategies {
+            assert!(strategy.assign(Uuid::nil()).is_err());
+        }
+    }
+
+    #[test]
+    fn geographic_strategy_uses_single_region_shard() {
+        let strategy = ShardStrategy::Geographic {
+            region: "eu-central-1".into(),
+        };
+        let shard = strategy.assign(Uuid::from_bytes([7u8; 16])).unwrap();
+        assert_eq!(shard, 0);
+    }
+
+    #[test]
     fn range_based_rejects_zero_shard_size() {
         let strategy = ShardStrategy::RangeBased { shard_size: 0 };
         assert!(strategy.assign(Uuid::from_bytes([1u8; 16])).is_err());

--- a/crates/exochain-sdk/Cargo.toml
+++ b/crates/exochain-sdk/Cargo.toml
@@ -25,6 +25,10 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[lib]
+name = "exochain_sdk"
+path = "src/lib.rs"
+
 [lints]
 workspace = true
 
@@ -32,12 +36,12 @@ workspace = true
 # Core crates (only those actually `use`d today; see removed-deps
 # note in commit message when adding back — avoid drift between
 # `pub use` surface and dependency graph)
-exo-core = { path = "../exo-core" }
-exo-dag-db-api = { path = "../exo-dag-db-api" }
-exo-identity = { path = "../exo-identity" }
-exo-gatekeeper = { path = "../exo-gatekeeper" }
-exo-avc = { path = "../exo-avc" }
-exo-economy = { path = "../exo-economy" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
+exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.0-beta" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.0-beta" }
+exo-gatekeeper = { package = "exochain-gatekeeper", path = "../exo-gatekeeper", version = "=0.2.0-beta" }
+exo-avc = { package = "exochain-avc", path = "../exo-avc", version = "=0.2.0-beta" }
+exo-economy = { package = "exochain-economy", path = "../exo-economy", version = "=0.2.0-beta" }
 
 # Serialization
 serde = { workspace = true }

--- a/crates/exochain-wasm/Cargo.toml
+++ b/crates/exochain-wasm/Cargo.toml
@@ -29,23 +29,23 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 # ExoChain crates (excludes exo-gateway which is server-only)
-exo-core       = { path = "../exo-core" }
-exo-avc        = { path = "../exo-avc" }
-exo-identity   = { path = "../exo-identity" }
-exo-consent    = { path = "../exo-consent" }
-exo-authority  = { path = "../exo-authority" }
-exo-gatekeeper = { path = "../exo-gatekeeper" }
-exo-governance = { path = "../exo-governance" }
-exo-escalation = { path = "../exo-escalation" }
-exo-legal      = { path = "../exo-legal" }
-exo-dag        = { path = "../exo-dag" }
-exo-proofs     = { path = "../exo-proofs" }
-exo-api        = { path = "../exo-api" }
-exo-tenant     = { path = "../exo-tenant" }
-decision-forum = { path = "../decision-forum" }
-exo-catapult   = { path = "../exo-catapult" }
-exo-messaging  = { path = "../exo-messaging" }
-exo-economy    = { path = "../exo-economy" }
+exo-core       = { package = "exochain-core", path = "../exo-core", version = "=0.2.0-beta" }
+exo-avc        = { package = "exochain-avc", path = "../exo-avc", version = "=0.2.0-beta" }
+exo-identity   = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.0-beta" }
+exo-consent    = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.0-beta" }
+exo-authority  = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.0-beta" }
+exo-gatekeeper = { package = "exochain-gatekeeper", path = "../exo-gatekeeper", version = "=0.2.0-beta" }
+exo-governance = { package = "exochain-governance", path = "../exo-governance", version = "=0.2.0-beta" }
+exo-escalation = { package = "exochain-escalation", path = "../exo-escalation", version = "=0.2.0-beta" }
+exo-legal      = { package = "exochain-legal", path = "../exo-legal", version = "=0.2.0-beta" }
+exo-dag        = { package = "exochain-dag", path = "../exo-dag", version = "=0.2.0-beta" }
+exo-proofs     = { package = "exochain-proofs", path = "../exo-proofs", version = "=0.2.0-beta" }
+exo-api        = { package = "exochain-api", path = "../exo-api", version = "=0.2.0-beta" }
+exo-tenant     = { package = "exochain-tenant", path = "../exo-tenant", version = "=0.2.0-beta" }
+decision-forum = { package = "exochain-decision-forum", path = "../decision-forum", version = "=0.2.0-beta" }
+exo-catapult   = { package = "exochain-catapult", path = "../exo-catapult", version = "=0.2.0-beta" }
+exo-messaging  = { package = "exochain-messaging", path = "../exo-messaging", version = "=0.2.0-beta" }
+exo-economy    = { package = "exochain-economy", path = "../exo-economy", version = "=0.2.0-beta" }
 
 # WASM bindings
 wasm-bindgen = "=0.2.100"

--- a/deny.toml
+++ b/deny.toml
@@ -93,10 +93,10 @@ license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 # ---------------------------------------------------------------------------
 [bans]
 multiple-versions = "warn"
-# External wildcard dependency requirements weaken the supply-chain gate.
-# Private workspace path dependencies are the only allowed wildcard form.
+# External and path wildcard dependency requirements weaken the supply-chain gate.
+# Publishable workspace path dependencies must carry exact package versions.
 wildcards = "deny"
-allow-wildcard-paths = true
+allow-wildcard-paths = false
 highlight = "all"
 
 deny = [

--- a/deploy/Dockerfile.node
+++ b/deploy/Dockerfile.node
@@ -31,7 +31,7 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/
-RUN cargo build --release --bin exochain --features exo-gateway/production-db
+RUN cargo build --release --bin exochain --features exochain-gateway/production-db
 
 FROM debian:bookworm-slim
 RUN apt-get update && \

--- a/docs/dagdb/full-migration/live-proof.md
+++ b/docs/dagdb/full-migration/live-proof.md
@@ -22,7 +22,7 @@ The live proof covers:
 `EXO_DAGDB_TEST_DATABASE_URL` was not set in the starting environment, so a live
 runtime smoke could not be claimed without provisioning Postgres evidence.
 
-`cargo test -p exo-gateway dagdb_full_migration_live_proof_artifact_contract`
+`cargo test -p exochain-gateway dagdb_full_migration_live_proof_artifact_contract`
 failed before this file existed:
 
 ```text
@@ -32,7 +32,7 @@ failed to read .../docs/dagdb/full-migration/live-proof.md: No such file or dire
 The first live gateway run exposed stale contracts and migration defects:
 
 ```text
-cargo test -p exo-gateway --features production-db --test dagdb_route_integration_contract dagdb_routes_integration_contract -- --nocapture
+cargo test -p exochain-gateway --features production-db --test dagdb_route_integration_contract dagdb_routes_integration_contract -- --nocapture
 ```
 
 RED failures included:
@@ -78,13 +78,13 @@ Commands:
 
 ```bash
 EXO_DAGDB_TEST_DATABASE_URL=postgres://postgres@127.0.0.1:55432/exochain_qm19 \
-  cargo test -p exo-gateway --features production-db --test dagdb_route_integration_contract dagdb_routes_integration_contract -- --nocapture
+  cargo test -p exochain-gateway --features production-db --test dagdb_route_integration_contract dagdb_routes_integration_contract -- --nocapture
 
 EXO_DAGDB_TEST_DATABASE_URL=postgres://postgres@127.0.0.1:55432/exochain_qm19 \
-  cargo test -p exo-gateway --features production-db --test dagdb_cross_tenant -- --nocapture
+  cargo test -p exochain-gateway --features production-db --test dagdb_cross_tenant -- --nocapture
 
 EXO_DAGDB_TEST_DATABASE_URL=postgres://postgres@127.0.0.1:55432/exochain_qm19 \
-  cargo test -p exo-gateway --features production-db live_idempotency -- --nocapture
+  cargo test -p exochain-gateway --features production-db live_idempotency -- --nocapture
 ```
 
 Results:

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -374,31 +374,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "exo-authority"
+name = "exo-fuzz"
+version = "0.0.0"
+dependencies = [
+ "ciborium",
+ "exochain-core",
+ "exochain-governance",
+ "libfuzzer-sys",
+ "ml-dsa",
+ "pkcs8 0.11.0-rc.11",
+ "serde_json",
+ "sha3",
+ "signature 3.0.0-rc.10",
+ "spki 0.8.0-rc.4",
+]
+
+[[package]]
+name = "exochain-authority"
 version = "0.2.0-beta"
 dependencies = [
  "blake3",
  "ciborium",
  "ed25519-dalek",
- "exo-core",
- "exo-identity",
+ "exochain-core",
+ "exochain-identity",
  "serde",
  "thiserror",
 ]
 
 [[package]]
-name = "exo-consent"
+name = "exochain-consent"
 version = "0.2.0-beta"
 dependencies = [
  "blake3",
  "ciborium",
- "exo-core",
+ "exochain-core",
  "serde",
  "thiserror",
 ]
 
 [[package]]
-name = "exo-core"
+name = "exochain-core"
 version = "0.2.0-beta"
 dependencies = [
  "blake3",
@@ -417,31 +433,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "exo-fuzz"
-version = "0.0.0"
-dependencies = [
- "ciborium",
- "exo-core",
- "exo-governance",
- "libfuzzer-sys",
- "ml-dsa",
- "pkcs8 0.11.0-rc.11",
- "serde_json",
- "sha3",
- "signature 3.0.0-rc.10",
- "spki 0.8.0-rc.4",
-]
-
-[[package]]
-name = "exo-governance"
+name = "exochain-governance"
 version = "0.2.0-beta"
 dependencies = [
  "blake3",
  "ciborium",
- "exo-authority",
- "exo-consent",
- "exo-core",
- "exo-identity",
+ "exochain-authority",
+ "exochain-consent",
+ "exochain-core",
+ "exochain-identity",
  "serde",
  "serde_json",
  "thiserror",
@@ -449,14 +449,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "exo-identity"
+name = "exochain-identity"
 version = "0.2.0-beta"
 dependencies = [
  "blake3",
  "bs58",
  "chacha20poly1305",
  "ciborium",
- "exo-core",
+ "exochain-core",
  "getrandom 0.2.16",
  "hkdf",
  "serde",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -31,8 +31,8 @@ ignored = ["ml-dsa", "pkcs8", "sha3", "signature", "spki"]
 
 [dependencies]
 ciborium = "0.2"
-exo-core = { path = "../crates/exo-core" }
-exo-governance = { path = "../crates/exo-governance" }
+exo-core = { package = "exochain-core", path = "../crates/exo-core", version = "=0.2.0-beta" }
+exo-governance = { package = "exochain-governance", path = "../crates/exo-governance", version = "=0.2.0-beta" }
 libfuzzer-sys = "0.4"
 ml-dsa = { version = "=0.1.0-rc.7", features = ["zeroize"] }
 pkcs8 = "=0.11.0-rc.11"

--- a/tools/avc_rfc3161_microsoft_preflight.sh
+++ b/tools/avc_rfc3161_microsoft_preflight.sh
@@ -3,4 +3,4 @@ set -euo pipefail
 
 export EXO_AVC_RFC3161_LIVE_PREFLIGHT="${EXO_AVC_RFC3161_LIVE_PREFLIGHT:-1}"
 
-cargo test -p exo-node live_microsoft_rfc3161_preflight -- --ignored --nocapture
+cargo test -p exochain-node live_microsoft_rfc3161_preflight -- --ignored --nocapture

--- a/tools/check_cratesio_namespace_ownership.mjs
+++ b/tools/check_cratesio_namespace_ownership.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/*
+ * Copyright 2026 Exochain Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const allowedOwners = new Set(
+  (process.env.EXOCHAIN_CRATES_IO_ALLOWED_OWNERS || "exochain,exochain-foundation,bob-stewart")
+    .split(",")
+    .map((owner) => owner.trim().toLowerCase())
+    .filter(Boolean),
+);
+
+if (allowedOwners.size === 0) {
+  throw new Error("EXOCHAIN_CRATES_IO_ALLOWED_OWNERS must contain at least one crates.io owner login");
+}
+
+const metadata = JSON.parse(
+  execFileSync("cargo", ["metadata", "--no-deps", "--format-version", "1"], {
+    encoding: "utf8",
+    maxBuffer: 20 * 1024 * 1024,
+  }),
+);
+
+const workspacePackageIds = new Set(metadata.workspace_members);
+const packageNames = metadata.packages
+  .filter((pkg) => workspacePackageIds.has(pkg.id))
+  .filter((pkg) => pkg.manifest_path.includes("/crates/"))
+  .map((pkg) => pkg.name)
+  .sort();
+
+const fixtureDir = process.env.EXOCHAIN_CRATES_IO_FIXTURE_DIR;
+
+async function loadPublishedCrateOwners(crateName) {
+  if (fixtureDir) {
+    const fixturePath = path.join(fixtureDir, `${crateName}.json`);
+    if (!fs.existsSync(fixturePath)) {
+      return null;
+    }
+    return JSON.parse(fs.readFileSync(fixturePath, "utf8"));
+  }
+
+  const response = await fetch(`https://crates.io/api/v1/crates/${encodeURIComponent(crateName)}`, {
+    headers: {
+      "User-Agent": "exochain-release-namespace-guard (https://github.com/exochain/exochain)",
+    },
+  });
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(`crates.io lookup for ${crateName} failed: HTTP ${response.status}`);
+  }
+  await response.json();
+
+  const ownersResponse = await fetch(`https://crates.io/api/v1/crates/${encodeURIComponent(crateName)}/owners`, {
+    headers: {
+      "User-Agent": "exochain-release-namespace-guard (https://github.com/exochain/exochain)",
+    },
+  });
+  if (!ownersResponse.ok) {
+    throw new Error(`crates.io owner lookup for ${crateName} failed: HTTP ${ownersResponse.status}`);
+  }
+  return ownersResponse.json();
+}
+
+const failures = [];
+
+for (const crateName of packageNames) {
+  if (!crateName.startsWith("exochain-")) {
+    failures.push(`${crateName} does not use the exochain-* namespace`);
+    continue;
+  }
+
+  const payload = await loadPublishedCrateOwners(crateName);
+  if (!payload) {
+    continue;
+  }
+
+  const ownerLogins = (payload.users || [])
+    .map((user) => String(user.login || "").toLowerCase())
+    .filter(Boolean);
+  const hasAllowedOwner = ownerLogins.some((login) => allowedOwners.has(login));
+
+  if (!hasAllowedOwner) {
+    failures.push(`${crateName} already exists on crates.io and is owned by [${ownerLogins.join(", ")}], not an approved EXOCHAIN owner`);
+  }
+}
+
+if (failures.length > 0) {
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(`crates.io namespace ownership guard passed for ${packageNames.length} package(s)`);

--- a/tools/check_dagdb_crate_boundaries.sh
+++ b/tools/check_dagdb_crate_boundaries.sh
@@ -10,14 +10,14 @@ mkdir -p "$REPORT_DIR"
 
 metadata="$(cargo metadata --format-version=1 --no-deps)"
 required=(
-  exo-dag-db-api
-  exo-dag-db-core
-  exo-dag-db-graph
-  exo-dag-db-domain
-  exo-dag-db-retrieval
-  exo-dag-db-exchange
-  exo-dag-db-postgres
-  exo-dag-db-lab
+  exochain-dag-db-api
+  exochain-dag-db-core
+  exochain-dag-db-graph
+  exochain-dag-db-domain
+  exochain-dag-db-retrieval
+  exochain-dag-db-exchange
+  exochain-dag-db-postgres
+  exochain-dag-db-lab
 )
 
 missing=()
@@ -38,13 +38,13 @@ forbidden_edges="$(
     | @tsv
   ' <<<"$metadata" | awk '
     function rank(name) {
-      if (name == "exo-dag-db-core") return 1
-      if (name == "exo-dag-db-graph") return 2
-      if (name == "exo-dag-db-domain") return 3
-      if (name == "exo-dag-db-retrieval") return 4
-      if (name == "exo-dag-db-exchange") return 5
-      if (name == "exo-dag-db-postgres") return 6
-      if (name == "exo-dag-db-lab") return 7
+      if (name == "exochain-dag-db-core") return 1
+      if (name == "exochain-dag-db-graph") return 2
+      if (name == "exochain-dag-db-domain") return 3
+      if (name == "exochain-dag-db-retrieval") return 4
+      if (name == "exochain-dag-db-exchange") return 5
+      if (name == "exochain-dag-db-postgres") return 6
+      if (name == "exochain-dag-db-lab") return 7
       return 0
     }
     {
@@ -63,16 +63,16 @@ forbidden_exo_api_edges="$(
     | select(.source == null)
     | .name as $from
     | select([
-        "exo-dag-db-core",
-        "exo-dag-db-graph",
-        "exo-dag-db-domain",
-        "exo-dag-db-retrieval",
-        "exo-dag-db-exchange",
-        "exo-dag-db-postgres",
-        "exo-dag-db-lab"
+        "exochain-dag-db-core",
+        "exochain-dag-db-graph",
+        "exochain-dag-db-domain",
+        "exochain-dag-db-retrieval",
+        "exochain-dag-db-exchange",
+        "exochain-dag-db-postgres",
+        "exochain-dag-db-lab"
       ] | index($from))
     | (.dependencies // [])[]
-    | select(.source == null and .name == "exo-api")
+    | select(.source == null and .name == "exochain-api")
     | "\($from) -> \(.name)"
   ' <<<"$metadata"
 )"

--- a/tools/cross-impl-test/compare.sh
+++ b/tools/cross-impl-test/compare.sh
@@ -201,7 +201,7 @@ run_hash_vectors() {
     log_info "Verifying $hash_vector_count canonical hash vector(s)..."
 
     if EXOCHAIN_CROSS_IMPL_HASH_VECTORS="$vectors_dir" \
-        cargo test -p exo-core cross_impl_hash_vectors_match_golden -- --exact --nocapture \
+        cargo test -p exochain-core cross_impl_hash_vectors_match_golden -- --exact --nocapture \
         > "$output_dir/rust_hash_vectors.txt" 2>&1; then
         log_pass "Rust canonical hash vectors passed"
     else

--- a/tools/root-trust-install.sh
+++ b/tools/root-trust-install.sh
@@ -275,11 +275,11 @@ git -C "$REPO_ROOT" cat-file -e "$verifier_commit^{commit}" 2>/dev/null \
 mkdir -p "$verifier_source"
 git -C "$REPO_ROOT" archive "$verifier_commit" | tar -x -C "$verifier_source"
 
-verification_command="CARGO_TARGET_DIR=$REPO_ROOT/target-root-trust-$verifier_short cargo run -p exo-node -- genesis verify-bundle --input $verify_input"
+verification_command="CARGO_TARGET_DIR=$REPO_ROOT/target-root-trust-$verifier_short cargo run -p exochain-node -- genesis verify-bundle --input $verify_input"
 if ! (
   cd "$verifier_source" &&
   CARGO_TARGET_DIR="$REPO_ROOT/target-root-trust-$verifier_short" \
-    cargo run -p exo-node -- genesis verify-bundle --input "$verify_input" \
+    cargo run -p exochain-node -- genesis verify-bundle --input "$verify_input" \
       >"$verification_output" 2>"$verification_error"
 ); then
   cat "$verification_error" || true

--- a/tools/syntaxis/generate_workflow.py
+++ b/tools/syntaxis/generate_workflow.py
@@ -627,7 +627,7 @@ def main() -> None:
     print("To integrate:")
     print(f"  1. Copy {snake_name}.rs into the appropriate crate's src/ directory")
     print(f"  2. Add 'pub mod {snake_name};' to the crate's lib.rs")
-    print(f"  3. Run: cargo test -p exo-gatekeeper")
+    print(f"  3. Run: cargo test -p exochain-gatekeeper")
 
 
 if __name__ == "__main__":

--- a/tools/test_cratesio_release_packaging.sh
+++ b/tools/test_cratesio_release_packaging.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Copyright 2026 Exochain Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+fail() {
+  printf 'crates.io release packaging test failed: %s\n' "$1" >&2
+  exit 1
+}
+
+workflow=".github/workflows/release.yml"
+ci_workflow=".github/workflows/ci.yml"
+
+[[ -f "$workflow" ]] || fail "$workflow is missing"
+[[ -f "$ci_workflow" ]] || fail "$ci_workflow is missing"
+[[ -f tools/check_cratesio_namespace_ownership.mjs ]] \
+  || fail "tools/check_cratesio_namespace_ownership.mjs is missing"
+[[ -f tools/verify_cratesio_release_packaging.mjs ]] \
+  || fail "tools/verify_cratesio_release_packaging.mjs is missing"
+
+node tools/verify_cratesio_release_packaging.mjs
+
+fixture_dir="$(mktemp -d)"
+trap 'rm -rf "$fixture_dir"' EXIT
+owner_guard_output="$fixture_dir/owner-guard.out"
+printf '{"users":[{"login":"unapproved-owner"}]}\n' > "$fixture_dir/exochain-core.json"
+if EXOCHAIN_CRATES_IO_ALLOWED_OWNERS=exochain \
+  EXOCHAIN_CRATES_IO_FIXTURE_DIR="$fixture_dir" \
+  node tools/check_cratesio_namespace_ownership.mjs >"$owner_guard_output" 2>&1; then
+  fail "crates.io namespace guard must reject packages owned by non-EXOCHAIN accounts"
+fi
+grep -F 'not an approved EXOCHAIN owner' "$owner_guard_output" >/dev/null \
+  || fail "crates.io namespace guard rejection must explain the non-EXOCHAIN owner"
+
+printf '{"users":[{"login":"exochain"}]}\n' > "$fixture_dir/exochain-core.json"
+EXOCHAIN_CRATES_IO_ALLOWED_OWNERS=exochain \
+  EXOCHAIN_CRATES_IO_FIXTURE_DIR="$fixture_dir" \
+  node tools/check_cratesio_namespace_ownership.mjs >/dev/null
+
+grep -F 'node tools/check_cratesio_namespace_ownership.mjs' "$workflow" >/dev/null \
+  || fail "release workflow must run the crates.io namespace ownership guard before publishing"
+grep -F '/owners' tools/check_cratesio_namespace_ownership.mjs >/dev/null \
+  || fail "crates.io namespace guard must inspect crates.io owner records, not only crate metadata"
+grep -F 'cargo publish -p "$crate" --dry-run --allow-dirty' "$workflow" >/dev/null \
+  || fail "release workflow must dry-run cargo publish for every crate before real publish"
+grep -F 'bash tools/test_cratesio_release_packaging.sh' "$ci_workflow" >/dev/null \
+  || fail "CI repo hygiene must run the crates.io release packaging guard"
+
+if grep -E '^[[:space:]]+exo-(core|node|identity|consent|authority|dag|proofs|gatekeeper|governance|escalation|legal|tenant|api|gateway)[[:space:]]*$' "$workflow" >/dev/null; then
+  fail "release publish loop must use final exochain-* package names, not legacy exo-* names"
+fi
+
+stale_cargo_selectors="$fixture_dir/stale-cargo-selectors.out"
+if rg -n -- 'cargo [^\n]*(^|[[:space:]])(-p|--packages)[[:space:]]+(exo-[A-Za-z0-9_-]+|decision-forum)([[:space:]]|$)' .github tools crates Dockerfile deploy >"$stale_cargo_selectors"; then
+  cat "$stale_cargo_selectors" >&2
+  fail "Cargo package selectors in CI/tools must use final exochain-* package names"
+fi
+
+stale_feature_selectors="$fixture_dir/stale-feature-selectors.out"
+if rg -n -- '--features[[:space:]]+exo-[A-Za-z0-9_-]+/' .github tools crates Dockerfile deploy >"$stale_feature_selectors"; then
+  cat "$stale_feature_selectors" >&2
+  fail "Cargo feature selectors in CI/tools must use final exochain-* package names"
+fi
+
+printf 'crates.io release packaging test passed\n'

--- a/tools/test_docker_production_db_feature.sh
+++ b/tools/test_docker_production_db_feature.sh
@@ -46,7 +46,7 @@ assert_exochain_build_enables_production_db() {
       }
       if (command ~ /--bin[[:space:]]+exochain/) {
         found = 1
-        if (command !~ /--features[[:space:]][^\\n]*exo-gateway\/production-db/) {
+        if (command !~ /--features[[:space:]][^\\n]*exochain-gateway\/production-db/) {
           bad = 1
         }
       }
@@ -57,7 +57,7 @@ assert_exochain_build_enables_production_db() {
       }
     }
   ' "$file"; then
-    fail "$file must build exochain with --features exo-gateway/production-db"
+    fail "$file must build exochain with --features exochain-gateway/production-db"
   fi
 }
 

--- a/tools/test_gateway_db_ci.sh
+++ b/tools/test_gateway_db_ci.sh
@@ -30,19 +30,19 @@ workflow=".github/workflows/ci.yml"
 grep -F 'DATABASE_URL: postgres://exochain:test@localhost:5432/exochain_test' "$workflow" >/dev/null \
   || fail "Gate 13 must run with an explicit live PostgreSQL DATABASE_URL"
 
-grep -F 'cargo test -p exo-gateway --lib --features production-db' "$workflow" >/dev/null \
+grep -F 'cargo test -p exochain-gateway --lib --features production-db' "$workflow" >/dev/null \
   || fail "Gate 13 must run exo-gateway DB-backed library tests"
 
 grep -F 'EXO_DAGDB_TEST_DATABASE_URL: ${{ env.DATABASE_URL }}' "$workflow" >/dev/null \
   || fail "Gate 13 must pass its live PostgreSQL URL to DAG DB migration regressions"
 
-grep -F 'cargo test -p exo-dag-db-postgres --features postgres --test migration_contract pr708_migrator_upgrades_from_last_successful_deployed_ledger' "$workflow" >/dev/null \
+grep -F 'cargo test -p exochain-dag-db-postgres --features postgres --test migration_contract pr708_migrator_upgrades_from_last_successful_deployed_ledger' "$workflow" >/dev/null \
   || fail "Gate 13 must run the DAG DB PR #708 upgrade regression"
 
 grep -F -- '--test-threads=1' "$workflow" >/dev/null \
   || fail "DB-backed gateway library tests must run serially against the shared CI database"
 
-grep -F "cargo test --workspace --test '*' --features exo-gateway/production-db" "$workflow" >/dev/null \
+grep -F "cargo test --workspace --test '*' --features exochain-gateway/production-db" "$workflow" >/dev/null \
   || fail "Gate 13 must retain workspace DB-backed integration tests"
 
 printf 'gateway DB CI test passed\n'

--- a/tools/test_security_critical_dependencies_pinned.sh
+++ b/tools/test_security_critical_dependencies_pinned.sh
@@ -69,8 +69,12 @@ def dependency_tables(manifest):
 
 expected_path_version = f"={workspace_version}"
 path_pin_violations = []
-for member in sorted(cargo["workspace"]["members"]):
-    manifest_path = Path(member) / "Cargo.toml"
+manifest_paths = [Path(member) / "Cargo.toml" for member in sorted(cargo["workspace"]["members"])]
+manifest_paths.extend(Path(path) for path in ("fuzz/Cargo.toml",))
+
+for manifest_path in manifest_paths:
+    if not manifest_path.exists():
+        continue
     with manifest_path.open("rb") as member_manifest:
         member_cargo = tomllib.load(member_manifest)
     for table_name, table in dependency_tables(member_cargo):

--- a/tools/test_security_critical_dependencies_pinned.sh
+++ b/tools/test_security_critical_dependencies_pinned.sh
@@ -24,6 +24,7 @@ manifest="Cargo.toml"
 python3 - <<'PY'
 import sys
 import tomllib
+from pathlib import Path
 
 with open("Cargo.toml", "rb") as manifest:
     cargo = tomllib.load(manifest)
@@ -35,13 +36,14 @@ bans = deny["bans"]
 if bans.get("wildcards") != "deny":
     print('cargo-deny must reject wildcard dependency requirements: set [bans].wildcards = "deny"', file=sys.stderr)
     sys.exit(1)
-if bans.get("allow-wildcard-paths") is not True:
-    print("cargo-deny must allow only private path dependency wildcards: set [bans].allow-wildcard-paths = true", file=sys.stderr)
+if bans.get("allow-wildcard-paths") is not False:
+    print("cargo-deny must reject path dependency wildcards for publishable workspace packages: set [bans].allow-wildcard-paths = false", file=sys.stderr)
     sys.exit(1)
 
 workspace_package = cargo["workspace"].get("package", {})
-if workspace_package.get("publish") is not False:
-    print("workspace packages must inherit publish = false so cargo-deny can allow private path dependency wildcards only", file=sys.stderr)
+workspace_version = workspace_package.get("version")
+if not isinstance(workspace_version, str) or not workspace_version:
+    print("workspace package version must be set before checking path dependency release pins", file=sys.stderr)
     sys.exit(1)
 
 dependencies = cargo["workspace"]["dependencies"]
@@ -56,6 +58,36 @@ if unpinned:
     print("workspace dependencies must be exactly pinned:", file=sys.stderr)
     for dependency in unpinned:
         print(f"  - {dependency}", file=sys.stderr)
+    sys.exit(1)
+
+def dependency_tables(manifest):
+    for table_name in ("dependencies", "dev-dependencies", "build-dependencies"):
+        yield table_name, manifest.get(table_name, {})
+    for target_name, target in manifest.get("target", {}).items():
+        for table_name in ("dependencies", "dev-dependencies", "build-dependencies"):
+            yield f"target.{target_name}.{table_name}", target.get(table_name, {})
+
+expected_path_version = f"={workspace_version}"
+path_pin_violations = []
+for member in sorted(cargo["workspace"]["members"]):
+    manifest_path = Path(member) / "Cargo.toml"
+    with manifest_path.open("rb") as member_manifest:
+        member_cargo = tomllib.load(member_manifest)
+    for table_name, table in dependency_tables(member_cargo):
+        for dependency_name, spec in sorted(table.items()):
+            if not isinstance(spec, dict) or "path" not in spec:
+                continue
+            version = spec.get("version")
+            if version != expected_path_version:
+                path_pin_violations.append(
+                    f"{manifest_path}:{table_name}.{dependency_name} "
+                    f"path={spec['path']!r} version={version!r}"
+                )
+
+if path_pin_violations:
+    print("publishable workspace path dependencies must be exactly release-pinned:", file=sys.stderr)
+    for violation in path_pin_violations:
+        print(f"  - {violation}", file=sys.stderr)
     sys.exit(1)
 PY
 

--- a/tools/verify_cratesio_release_packaging.mjs
+++ b/tools/verify_cratesio_release_packaging.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/*
+ * Copyright 2026 Exochain Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const workspaceToml = fs.readFileSync(path.join(repoRoot, "Cargo.toml"), "utf8");
+const workspaceVersion = workspaceToml.match(/^\[workspace\.package\][\s\S]*?^version = "([^"]+)"/m)?.[1];
+
+if (!workspaceVersion) {
+  throw new Error("workspace package version is missing");
+}
+if (!/^0\.2\.0-beta$/.test(workspaceVersion)) {
+  throw new Error(`workspace package version must be 0.2.0-beta for this release, got ${workspaceVersion}`);
+}
+if (!/^\[workspace\.package\][\s\S]*^publish = true$/m.test(workspaceToml)) {
+  throw new Error("workspace package publish must be true for release packaging");
+}
+
+const metadata = JSON.parse(
+  execFileSync("cargo", ["metadata", "--no-deps", "--format-version", "1"], {
+    encoding: "utf8",
+    maxBuffer: 20 * 1024 * 1024,
+  }),
+);
+
+const workspacePackageIds = new Set(metadata.workspace_members);
+const packages = metadata.packages.filter((pkg) => workspacePackageIds.has(pkg.id));
+const packageNames = new Set(packages.map((pkg) => pkg.name));
+const cratePackageMap = new Map(
+  packages
+    .filter((pkg) => pkg.manifest_path.includes("/crates/"))
+    .map((pkg) => [path.basename(path.dirname(pkg.manifest_path)), pkg.name]),
+);
+
+const failures = [];
+const requiredBinaryNamesByLegacyDir = new Map([
+  ["exo-gateway", "exo-gateway"],
+  ["exo-node", "exochain"],
+]);
+
+for (const pkg of packages) {
+  const relativeManifest = path.relative(repoRoot, pkg.manifest_path);
+  if (relativeManifest === "fuzz/Cargo.toml") {
+    if (pkg.name !== "exo-fuzz" || pkg.version !== "0.0.0") {
+      failures.push("fuzz package must remain unpublished exo-fuzz 0.0.0");
+    }
+    continue;
+  }
+
+  if (!pkg.manifest_path.includes("/crates/")) {
+    failures.push(`unexpected workspace package outside crates/: ${relativeManifest}`);
+    continue;
+  }
+
+  const legacyDirName = path.basename(path.dirname(pkg.manifest_path));
+  const expectedName = legacyDirName.startsWith("exo-")
+    ? `exochain-${legacyDirName.slice("exo-".length)}`
+    : legacyDirName === "decision-forum"
+      ? "exochain-decision-forum"
+      : legacyDirName;
+
+  if (pkg.name !== expectedName) {
+    failures.push(`${relativeManifest} package name must be ${expectedName}, got ${pkg.name}`);
+  }
+  if (!pkg.name.startsWith("exochain-")) {
+    failures.push(`${relativeManifest} package name must use the exochain-* crates.io namespace`);
+  }
+  if (pkg.name.startsWith("exo-") || pkg.name === "decision-forum") {
+    failures.push(`${relativeManifest} still uses legacy or first-come-sensitive package name ${pkg.name}`);
+  }
+  if (pkg.version !== workspaceVersion) {
+    failures.push(`${relativeManifest} version ${pkg.version} does not match workspace ${workspaceVersion}`);
+  }
+  if (!pkg.description || !pkg.description.trim()) {
+    failures.push(`${relativeManifest} must include a crates.io package description`);
+  }
+  if (Array.isArray(pkg.publish) && pkg.publish.length === 0) {
+    failures.push(`${relativeManifest} is still publish=false through workspace inheritance`);
+  }
+
+  const libTarget = pkg.targets.find((target) => target.kind.includes("lib"));
+  if (libTarget) {
+    const expectedLibName = legacyDirName.replaceAll("-", "_");
+    if (libTarget.name !== expectedLibName) {
+      failures.push(`${relativeManifest} lib target must remain ${expectedLibName}, got ${libTarget.name}`);
+    }
+  }
+
+  const requiredBinaryName = requiredBinaryNamesByLegacyDir.get(legacyDirName);
+  if (requiredBinaryName) {
+    const hasRequiredBinary = pkg.targets.some(
+      (target) => target.kind.includes("bin") && target.name === requiredBinaryName,
+    );
+    if (!hasRequiredBinary) {
+      failures.push(`${relativeManifest} must preserve binary target ${requiredBinaryName}`);
+    }
+  }
+
+  const manifestText = fs.readFileSync(pkg.manifest_path, "utf8");
+  const pathDependencyLines = manifestText
+    .split(/\r?\n/)
+    .filter((line) => /= \{/.test(line) && /path = "\.\./.test(line));
+
+  for (const line of pathDependencyLines) {
+    const dependencyKey = line.match(/^([A-Za-z0-9_-]+)\s*=/)?.[1];
+    const dependencyPath = line.match(/path = "\.\.\/([^"]+)"/)?.[1];
+    if (!dependencyKey || !dependencyPath) {
+      failures.push(`${relativeManifest} has unparsable path dependency line: ${line}`);
+      continue;
+    }
+
+    const targetPackage = cratePackageMap.get(dependencyPath);
+    if (!targetPackage) {
+      failures.push(`${relativeManifest} path dependency ${dependencyKey} points at non-workspace crate ${dependencyPath}`);
+      continue;
+    }
+    if (!line.includes(`package = "${targetPackage}"`)) {
+      failures.push(`${relativeManifest} dependency ${dependencyKey} must set package = "${targetPackage}"`);
+    }
+    if (!line.includes(`version = "=${workspaceVersion}"`)) {
+      failures.push(`${relativeManifest} dependency ${dependencyKey} must set version = "=${workspaceVersion}"`);
+    }
+  }
+}
+
+const releaseWorkflow = fs.readFileSync(path.join(repoRoot, ".github/workflows/release.yml"), "utf8");
+const releaseCrateBlock = releaseWorkflow.match(/CRATES=\(\n([\s\S]*?)\n[ \t]*\)/)?.[1];
+if (!releaseCrateBlock) {
+  failures.push("release publish loop must declare a CRATES bash array");
+}
+const releasePackageNames = releaseCrateBlock
+  ? releaseCrateBlock
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+  : [];
+const releasePackageIndexes = new Map(releasePackageNames.map((name, index) => [name, index]));
+
+for (const pkg of packages.filter((pkg) => pkg.manifest_path.includes("/crates/"))) {
+  if (!releaseWorkflow.includes(`            ${pkg.name}`)) {
+    failures.push(`release publish loop must include ${pkg.name}`);
+  }
+}
+
+for (const crateName of releasePackageNames) {
+  if (!packageNames.has(crateName)) {
+    failures.push(`release publish loop includes unknown package ${crateName}`);
+  }
+}
+if (releasePackageIndexes.size !== releasePackageNames.length) {
+  failures.push("release publish loop must not contain duplicate packages");
+}
+
+for (const pkg of packages.filter((pkg) => pkg.manifest_path.includes("/crates/"))) {
+  const packageIndex = releasePackageIndexes.get(pkg.name);
+  if (packageIndex === undefined) {
+    continue;
+  }
+
+  const manifestText = fs.readFileSync(pkg.manifest_path, "utf8");
+  const pathDependencyLines = manifestText
+    .split(/\r?\n/)
+    .filter((line) => /= \{/.test(line) && /path = "\.\./.test(line));
+
+  for (const line of pathDependencyLines) {
+    const dependencyPath = line.match(/path = "\.\.\/([^"]+)"/)?.[1];
+    const targetPackage = dependencyPath ? cratePackageMap.get(dependencyPath) : undefined;
+    if (!targetPackage) {
+      continue;
+    }
+    const dependencyIndex = releasePackageIndexes.get(targetPackage);
+    if (dependencyIndex !== undefined && dependencyIndex > packageIndex) {
+      failures.push(`release publish loop must publish ${targetPackage} before ${pkg.name}`);
+    }
+  }
+}
+
+if (failures.length > 0) {
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(`crates.io release packaging verifier passed for ${releasePackageNames.length} package(s) at ${workspaceVersion}`);


### PR DESCRIPTION
## Summary

This PR moves the Rust publish surface out of first-come-sensitive `exo-*` / `decision-forum` package names and into the EXOCHAIN-owned `exochain-*` crates.io namespace for the v0.2.0-beta release.

It preserves Rust import ergonomics by keeping legacy library target names such as `exo_core`, `exo_node`-adjacent imports, and existing dependency keys, while setting publish package names such as `exochain-core`, `exochain-node`, and `exochain-decision-forum`.

## Path Classification

- EXOCHAIN core: `Cargo.toml`, `Cargo.lock`, all touched `crates/*/Cargo.toml`, crate README/operator strings, and core command guidance updated for final package selectors.
- Core runtime adapter / CI-release guard: `.github/workflows/*`, Docker production feature selectors, release/package guard scripts, DAG DB boundary metadata guard, root trust and AVC helper commands.
- Adjacent surface: none.
- Imported evidence: live crates.io API/owner lookup used for verification only; no imported evidence committed.
- Third-party/vendor: none.

## Release Behavior

- Renames every `/crates/` workspace package to `exochain-*`.
- Keeps library target names stable, e.g. `exochain-core` still exposes `exo_core`.
- Keeps binary target names stable for `exochain` and `exo-gateway`.
- Adds exact internal dependency package aliases and `=0.2.0-beta` requirements.
- Enables workspace publishing for release packages.
- Updates release publish order to all 31 crates in dependency order.
- Runs a crates.io ownership guard before publish.
- Performs `cargo publish --dry-run --allow-dirty` immediately before each real publish.
- Adds CI coverage for namespace, version, metadata, publish-order, stale selector, and ownership failure behavior.

## Release Sequencing Note

This PR is the crates.io packaging pass. PR #729 is the separate SBOM command fix. For the first public release, merge #729 first or rebase this PR after #729 so `v0.2.0-beta` has both the SBOM fix and the crates.io namespace packaging.

## Verification

TDD RED was observed before implementation: the new packaging guard failed on legacy/non-publishable package metadata and old release loop names.

Focused verification completed:

- `bash tools/test_cratesio_release_packaging.sh`
- `node tools/verify_cratesio_release_packaging.mjs`
- `node tools/check_cratesio_namespace_ownership.mjs`
- `bash tools/test_docker_production_db_feature.sh`
- `bash tools/test_gateway_db_ci.sh`
- `bash tools/check_dagdb_crate_boundaries.sh`
- `bash tools/test_release_publish_boundaries.sh`
- `bash tools/test_release_dry_run_boundaries.sh`
- `bash tools/test_release_version_alignment.sh`
- `bash tools/test_release_workflow_ref_binding.sh`
- `bash tools/test_release_reusable_ci_boundary.sh`
- `bash tools/test_release_signed_tag_trust_boundary.sh`
- `bash tools/test_release_version_input_boundary.sh`
- `CARGO_BUILD_JOBS=2 cargo check --workspace`
- `cargo package --workspace --allow-dirty --no-verify`
- `cargo publish -p exochain-core --dry-run --allow-dirty`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`

Live crates.io ownership guard result: 31 `exochain-*` package names passed current namespace/owner checks.
