### PR TITLE
Fix release SBOM collection and npm scope preflight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,19 +263,26 @@ jobs:
         env:
           RELEASE_VERSION: ${{ needs.validate-release-inputs.outputs.version }}
         run: |
+          set -euo pipefail
           cargo cyclonedx -f json --all
-          # Rename outputs to include version for unambiguous identification
-          for f in *.cdx.json; do
-            mv "$f" "exochain-${RELEASE_VERSION}-${f}"
-          done
+          mkdir -p sbom
+          sbom_count=0
+          while IFS= read -r -d '' f; do
+            cp "$f" "sbom/exochain-${RELEASE_VERSION}-$(basename "$f")"
+            sbom_count=$((sbom_count + 1))
+          done < <(find crates -type f -name '*.cdx.json' -print0 | sort -z)
+          if [ "$sbom_count" -eq 0 ]; then
+            echo "cargo cyclonedx produced no crate SBOM files under crates/." >&2
+            exit 1
+          fi
           echo "SBOM artifacts:"
-          ls -lh "exochain-${RELEASE_VERSION}"-*.cdx.json
+          ls -lh "sbom/exochain-${RELEASE_VERSION}"-*.cdx.json
 
       - name: Upload SBOM artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: sbom-${{ needs.validate-release-inputs.outputs.version }}
-          path: exochain-${{ needs.validate-release-inputs.outputs.version }}-*.cdx.json
+          path: sbom/exochain-${{ needs.validate-release-inputs.outputs.version }}-*.cdx.json
           retention-days: 2555  # 7 years — governance software retention policy
 
       # ── SLSA provenance attestation ──────────────────────────────────────
@@ -400,6 +407,30 @@ jobs:
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
+
+      - name: Verify npm org publish access
+        if: ${{ !inputs.dry_run }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "NPM_TOKEN is required to publish @exochain/exochain-wasm." >&2
+            exit 1
+          fi
+          npm_user="$(npm whoami --registry=https://registry.npmjs.org)"
+          export NPM_USER="$npm_user"
+          npm org ls exochain "$npm_user" --json --registry=https://registry.npmjs.org > npm-org-membership.json
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const user = process.env.NPM_USER;
+          const membership = JSON.parse(fs.readFileSync('npm-org-membership.json', 'utf8'));
+          const role = membership[user];
+          if (!['owner', 'admin', 'developer'].includes(role)) {
+            throw new Error(`NPM_TOKEN authenticates as ${user}, which is not an exochain npm org owner/admin/developer. Create an npm automation token for an account with @exochain publish rights and store it as NPM_TOKEN.`);
+          }
+          console.log(`NPM_TOKEN authenticates as ${user} with exochain npm org role ${role}.`);
+          NODE
 
       - name: Install wasm-pack
         run: bash tools/ci_cargo_retry.sh cargo install wasm-pack --version 0.14.0 --locked

--- a/tools/test_release_publish_boundaries.sh
+++ b/tools/test_release_publish_boundaries.sh
@@ -55,6 +55,10 @@ grep -F 'cargo publish -p "$crate" --allow-dirty' <<<"$publish_block" >/dev/null
   || fail "publish job must publish every crate in the dependency-ordered loop"
 grep -F 'NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}' <<<"$wasm_publish_block" >/dev/null \
   || fail "publish-wasm-npm job must use the npm automation token"
+grep -F 'name: Verify npm org publish access' <<<"$wasm_publish_block" >/dev/null \
+  || fail "publish-wasm-npm must verify npm org publish access before building the package"
+grep -F 'npm org ls exochain "$npm_user" --json --registry=https://registry.npmjs.org' <<<"$wasm_publish_block" >/dev/null \
+  || fail "publish-wasm-npm must fail closed when NPM_TOKEN lacks exochain org publish rights"
 grep -F 'npm publish --access public --provenance' <<<"$wasm_publish_block" >/dev/null \
   || fail "publish-wasm-npm must publish the public package with npm provenance"
 grep -F 'npm pack --dry-run' <<<"$wasm_publish_block" >/dev/null \

--- a/tools/test_release_sbom_boundary.sh
+++ b/tools/test_release_sbom_boundary.sh
@@ -51,7 +51,9 @@ if grep -F 'cargo cyclonedx -f json --workspace' <<<"$sbom_block" >/dev/null; th
   fail "cargo-cyclonedx 0.5.9 does not support --workspace in the release SBOM job"
 fi
 
-grep -F 'path: exochain-${{ needs.validate-release-inputs.outputs.version }}-*.cdx.json' <<<"$sbom_block" >/dev/null \
+grep -F "find crates -type f -name '*.cdx.json'" <<<"$sbom_block" >/dev/null \
+  || fail "release SBOM job must collect cargo-cyclonedx crate-local SBOM output"
+grep -F 'path: sbom/exochain-${{ needs.validate-release-inputs.outputs.version }}-*.cdx.json' <<<"$sbom_block" >/dev/null \
   || fail "release SBOM artifacts must be uploaded with versioned names"
 grep -F 'uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45' <<<"$sbom_block" >/dev/null \
   || fail "release build provenance must remain attested by the pinned SLSA action"

--- a/tools/test_wasm_npm_package_boundary.sh
+++ b/tools/test_wasm_npm_package_boundary.sh
@@ -44,7 +44,13 @@ grep -F 'wasm-pack build crates/exochain-wasm --target nodejs --scope exochain' 
 grep -F 'npm publish --access public --provenance' "$release_workflow" >/dev/null \
   || fail "release workflow must publish npm package with provenance"
 grep -F 'NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}' "$release_workflow" >/dev/null \
-  || fail "release workflow must use the npm token only at publish step"
+  || fail "release workflow must use the npm token for authenticated npm release steps"
+grep -F 'name: Verify npm org publish access' "$release_workflow" >/dev/null \
+  || fail "release workflow must verify npm org publish access before building the package"
+grep -F 'npm whoami --registry=https://registry.npmjs.org' "$release_workflow" >/dev/null \
+  || fail "release workflow must verify the npm token identity before publishing"
+grep -F 'npm org ls exochain "$npm_user" --json --registry=https://registry.npmjs.org' "$release_workflow" >/dev/null \
+  || fail "release workflow must verify npm token membership in the exochain org"
 grep -F 'id-token: write' "$release_workflow" >/dev/null \
   || fail "release workflow must grant OIDC for npm provenance"
 


### PR DESCRIPTION
## Summary
- Fixes release SBOM collection for `cargo-cyclonedx 0.5.9`: the tool writes crate-local `*.cdx.json` files under `crates/`, not root-level `*.cdx.json` files.
- Adds an authenticated npm org publish-access preflight before building/publishing `@exochain/exochain-wasm`, so a bad `NPM_TOKEN` fails closed with a clear error before package build/provenance/publish.
- Updates release guard tests to lock the corrected SBOM and npm boundaries.

## Failure Evidence
- Release run: https://github.com/exochain/exochain/actions/runs/28521736513
- CI inside release passed, including Gate 3 and All Constitutional Gates.
- `Package and publish WASM npm package` failed at `npm publish --access public --provenance` with `E404 Not Found - PUT https://registry.npmjs.org/@exochain%2fexochain-wasm`.
- `SBOM + SLSA Attestation` failed because `mv '*.cdx.json'` found no root-level SBOM files after `cargo cyclonedx -f json --all`.

## Path Classification
- EXOCHAIN core: `.github/workflows/release.yml`
- EXOCHAIN core: `tools/test_release_publish_boundaries.sh`
- EXOCHAIN core: `tools/test_release_sbom_boundary.sh`
- EXOCHAIN core: `tools/test_wasm_npm_package_boundary.sh`

## Core/Adapter/Adjacent Impact
- No Rust crate logic changed.
- No adjacent surface changed.
- Release CI/publishing contract changed only to collect SBOM artifacts correctly and fail closed earlier on npm scope authorization.

## Verification
- `bash tools/test_release_workflow_ref_binding.sh`
- `bash tools/test_release_version_input_boundary.sh`
- `bash tools/test_release_signed_tag_trust_boundary.sh`
- `bash tools/test_release_reusable_ci_boundary.sh`
- `bash tools/test_release_sbom_boundary.sh`
- `bash tools/test_release_dry_run_boundaries.sh`
- `bash tools/test_release_publish_boundaries.sh`
- `bash tools/test_cratesio_release_packaging.sh`
- `bash tools/test_wasm_npm_package_boundary.sh`
- `bash tools/test_ci_supply_chain_hardening.sh`
- Local SBOM smoke: `cargo cyclonedx -f json --all` collected 31 versioned crate SBOM files into `sbom/`.

## Operator Note
Before rerunning the release, `NPM_TOKEN` must authenticate as an npm user with `owner`, `admin`, or `developer` membership in the `exochain` npm org. Public checks show the `exochain` npm org exists, but the failed release token was not authorized to publish `@exochain/exochain-wasm`.
