### PR TITLE
Make crates release publishing resumable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,8 +328,85 @@ jobs:
       - name: Publish crates in dependency order
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          RELEASE_VERSION: ${{ needs.validate-release-inputs.outputs.version }}
         run: |
           set -euo pipefail
+          crate_version_published() {
+            local crate="$1"
+            local response_file
+            local http_code
+            response_file="$(mktemp)"
+            http_code="$(curl -sS -H 'User-Agent: exochain-release-workflow (https://github.com/exochain/exochain)' -o "$response_file" -w '%{http_code}' "https://crates.io/api/v1/crates/${crate}/${RELEASE_VERSION}")"
+            case "$http_code" in
+              200)
+                rm -f "$response_file"
+                return 0
+                ;;
+              404)
+                rm -f "$response_file"
+                return 1
+                ;;
+              *)
+                echo "Unexpected crates.io response while checking ${crate} ${RELEASE_VERSION}: HTTP ${http_code}" >&2
+                cat "$response_file" >&2
+                rm -f "$response_file"
+                exit 1
+                ;;
+            esac
+          }
+
+          publish_crate_with_retry() {
+            local crate="$1"
+            local attempt=1
+            local max_attempts=6
+            local output
+            local status
+            local retry_after
+            local retry_epoch
+            local now_epoch
+            local retry_seconds
+
+            while [ "$attempt" -le "$max_attempts" ]; do
+              set +e
+              output="$(cargo publish -p "$crate" --allow-dirty 2>&1)"
+              status=$?
+              set -e
+              printf '%s\n' "$output"
+
+              if [ "$status" -eq 0 ]; then
+                return 0
+              fi
+
+              if crate_version_published "$crate"; then
+                echo "${crate} ${RELEASE_VERSION} is now published; continuing after publish response status ${status}."
+                return 0
+              fi
+
+              if grep -F 'status 429 Too Many Requests' <<<"$output" >/dev/null; then
+                retry_after="$(sed -nE 's/.*try again after (.* GMT) and see.*/\1/p' <<<"$output" | tail -n 1)"
+                if [ -n "$retry_after" ]; then
+                  retry_epoch="$(date -u -d "$retry_after" +%s)"
+                  now_epoch="$(date -u +%s)"
+                  retry_seconds=$((retry_epoch - now_epoch + 15))
+                  if [ "$retry_seconds" -lt 60 ]; then
+                    retry_seconds=60
+                  fi
+                else
+                  retry_seconds=$((attempt * 120))
+                fi
+                echo "crates.io rate limit while publishing ${crate}; sleeping ${retry_seconds}s before retry ${attempt}/${max_attempts}."
+                sleep "$retry_seconds"
+                attempt=$((attempt + 1))
+                continue
+              fi
+
+              return "$status"
+            done
+
+            echo "Failed to publish ${crate} ${RELEASE_VERSION} after ${max_attempts} attempts." >&2
+            return 1
+          }
+
           CRATES=(
             exochain-core
             exochain-dag-db-api
@@ -364,10 +441,18 @@ jobs:
             exochain-wasm
           )
           for crate in "${CRATES[@]}"; do
+            if crate_version_published "$crate"; then
+              echo "${crate} ${RELEASE_VERSION} is already published; skipping."
+              continue
+            fi
             echo "Dry-running $crate..."
             cargo publish -p "$crate" --dry-run --allow-dirty
+            if crate_version_published "$crate"; then
+              echo "${crate} ${RELEASE_VERSION} became available after dry-run; skipping publish."
+              continue
+            fi
             echo "Publishing $crate..."
-            cargo publish -p "$crate" --allow-dirty
+            publish_crate_with_retry "$crate"
             # crates.io index propagation delay
             sleep 30
           done

--- a/tools/test_release_publish_boundaries.sh
+++ b/tools/test_release_publish_boundaries.sh
@@ -51,6 +51,22 @@ grep -F 'if: ${{ !inputs.dry_run }}' <<<"$wasm_publish_block" >/dev/null \
 
 grep -F 'CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}' <<<"$publish_block" >/dev/null \
   || fail "publish job must use the crates.io registry token"
+grep -F 'RELEASE_VERSION: ${{ needs.validate-release-inputs.outputs.version }}' <<<"$publish_block" >/dev/null \
+  || fail "publish job must bind crates.io checks to the validated release version"
+grep -F 'crate_version_published()' <<<"$publish_block" >/dev/null \
+  || fail "publish job must support resumable partial publication checks"
+grep -F 'https://crates.io/api/v1/crates/${crate}/${RELEASE_VERSION}' <<<"$publish_block" >/dev/null \
+  || fail "publish job must check whether each crate version already exists on crates.io"
+grep -F "User-Agent: exochain-release-workflow (https://github.com/exochain/exochain)" <<<"$publish_block" >/dev/null \
+  || fail "publish job must identify itself to crates.io version checks"
+grep -F 'if crate_version_published "$crate"; then' <<<"$publish_block" >/dev/null \
+  || fail "publish job must skip crate versions already published by a prior partial release"
+grep -F 'status 429 Too Many Requests' <<<"$publish_block" >/dev/null \
+  || fail "publish job must classify crates.io rate-limit responses"
+grep -F 'try again after' <<<"$publish_block" >/dev/null \
+  || fail "publish job must parse crates.io retry-after evidence"
+grep -F 'sleep "$retry_seconds"' <<<"$publish_block" >/dev/null \
+  || fail "publish job must wait before retrying crates.io rate-limited publishes"
 grep -F 'cargo publish -p "$crate" --allow-dirty' <<<"$publish_block" >/dev/null \
   || fail "publish job must publish every crate in the dependency-ordered loop"
 grep -F 'NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}' <<<"$wasm_publish_block" >/dev/null \


### PR DESCRIPTION
## Summary
- makes the crates.io release publish loop resumable after a partial publication
- skips crate versions that already exist on crates.io before dry-run/publish
- retries crates.io 429 rate limits using the registry-provided `try again after ... GMT` evidence
- extends the release publish boundary guard so future release workflow edits preserve resumability

## Failure Evidence
Release run `28543127925` for signed tag `v0.2.0-beta` at `64aef715bacfcf2059f7e790a7e766922a9143c6` passed all constitutional gates, signed-tag verification, artifacts, and SBOM/SLSA, then failed publication:

- npm: `npm whoami` returned `E401 Unauthorized` in `Package and publish WASM npm package` before build/publish; this remains an external `NPM_TOKEN` correction.
- crates.io: successfully published `exochain-core`, `exochain-dag-db-api`, `exochain-identity`, `exochain-api`, and `exochain-authority`, then failed on `exochain-avc` with HTTP 429: `You have published too many new crates in a short period of time. Please try again after Wed, 01 Jul 2026 21:15:26 GMT`.

Without this PR, rerunning the release publish job after the rate-limit window would fail on already-published crate versions before reaching the remaining crates.

## Path Classification
- `.github/workflows/release.yml` — CI/release contract
- `tools/test_release_publish_boundaries.sh` — CI/release guard

No Rust workspace, production runtime, cryptography, DAG, consent, authority, gateway, SDK, or deployment runtime code changed.

## Verification
- `bash tools/test_release_publish_boundaries.sh`
- `bash tools/test_cratesio_release_packaging.sh`
- `bash tools/test_wasm_npm_package_boundary.sh`
- `bash tools/test_release_workflow_ref_binding.sh`
- `bash tools/test_release_version_input_boundary.sh`
- `bash tools/test_release_signed_tag_trust_boundary.sh`
- `bash tools/test_release_reusable_ci_boundary.sh`
- `bash tools/test_release_sbom_boundary.sh`
- `bash tools/test_release_dry_run_boundaries.sh`
- `bash tools/test_ci_supply_chain_hardening.sh`
- `git diff --check`

## Operator Note
Before rerunning release after this merges and the tag is retargeted, replace `NPM_TOKEN` with a valid npm automation token. The current release failure shows Actions received a token-shaped secret, but npm rejected it at `npm whoami` with `E401 Unauthorized`.
