### PR TITLE
ci: harden npm release preflight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -493,7 +493,7 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org
 
-      - name: Verify npm org publish access
+      - name: Verify npm registry authentication
         if: ${{ !inputs.dry_run }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -503,19 +503,9 @@ jobs:
             echo "NPM_TOKEN is required to publish @exochain/exochain-wasm." >&2
             exit 1
           fi
+          npm ping --registry=https://registry.npmjs.org
           npm_user="$(npm whoami --registry=https://registry.npmjs.org)"
-          export NPM_USER="$npm_user"
-          npm org ls exochain "$npm_user" --json --registry=https://registry.npmjs.org > npm-org-membership.json
-          node - <<'NODE'
-          const fs = require('node:fs');
-          const user = process.env.NPM_USER;
-          const membership = JSON.parse(fs.readFileSync('npm-org-membership.json', 'utf8'));
-          const role = membership[user];
-          if (!['owner', 'admin', 'developer'].includes(role)) {
-            throw new Error(`NPM_TOKEN authenticates as ${user}, which is not an exochain npm org owner/admin/developer. Create an npm automation token for an account with @exochain publish rights and store it as NPM_TOKEN.`);
-          }
-          console.log(`NPM_TOKEN authenticates as ${user} with exochain npm org role ${role}.`);
-          NODE
+          echo "NPM_TOKEN authenticates to npm registry as ${npm_user}; npm publish will perform the authoritative package permission check."
 
       - name: Install wasm-pack
         run: bash tools/ci_cargo_retry.sh cargo install wasm-pack --version 0.14.0 --locked
@@ -555,7 +545,35 @@ jobs:
         if: ${{ !inputs.dry_run }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public --provenance
+          RELEASE_VERSION: ${{ needs.validate-release-inputs.outputs.version }}
+        run: |
+          set -euo pipefail
+          npm_package_version_published() {
+            local output
+            local status
+
+            set +e
+            output="$(npm view "@exochain/exochain-wasm@${RELEASE_VERSION}" version --registry=https://registry.npmjs.org 2>&1)"
+            status=$?
+            set -e
+
+            if [ "$status" -eq 0 ] && [ "$output" = "$RELEASE_VERSION" ]; then
+              return 0
+            fi
+            if grep -E 'E404|404 Not Found' <<<"$output" >/dev/null; then
+              return 1
+            fi
+
+            printf '%s\n' "$output" >&2
+            return "$status"
+          }
+
+          if npm_package_version_published; then
+            echo "@exochain/exochain-wasm ${RELEASE_VERSION} is already published; skipping npm publish."
+            exit 0
+          fi
+
+          npm publish --access public --provenance
         working-directory: packages/exochain-wasm/wasm
 
   # -----------------------------------------------------------------------

--- a/tools/test_release_publish_boundaries.sh
+++ b/tools/test_release_publish_boundaries.sh
@@ -71,10 +71,21 @@ grep -F 'cargo publish -p "$crate" --allow-dirty' <<<"$publish_block" >/dev/null
   || fail "publish job must publish every crate in the dependency-ordered loop"
 grep -F 'NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}' <<<"$wasm_publish_block" >/dev/null \
   || fail "publish-wasm-npm job must use the npm automation token"
-grep -F 'name: Verify npm org publish access' <<<"$wasm_publish_block" >/dev/null \
-  || fail "publish-wasm-npm must verify npm org publish access before building the package"
-grep -F 'npm org ls exochain "$npm_user" --json --registry=https://registry.npmjs.org' <<<"$wasm_publish_block" >/dev/null \
-  || fail "publish-wasm-npm must fail closed when NPM_TOKEN lacks exochain org publish rights"
+grep -F 'name: Verify npm registry authentication' <<<"$wasm_publish_block" >/dev/null \
+  || fail "publish-wasm-npm must verify npm registry authentication before building the package"
+grep -F 'npm ping --registry=https://registry.npmjs.org' <<<"$wasm_publish_block" >/dev/null \
+  || fail "publish-wasm-npm must verify npm registry reachability before publishing"
+grep -F 'npm whoami --registry=https://registry.npmjs.org' <<<"$wasm_publish_block" >/dev/null \
+  || fail "publish-wasm-npm must verify npm token identity before publishing"
+if grep -F 'npm org ls exochain' <<<"$wasm_publish_block" >/dev/null; then
+  fail "publish-wasm-npm must not use npm org membership endpoints as publish preflight"
+fi
+grep -F 'npm_package_version_published()' <<<"$wasm_publish_block" >/dev/null \
+  || fail "publish-wasm-npm must support resumable npm package publication checks"
+grep -F 'npm view "@exochain/exochain-wasm@${RELEASE_VERSION}" version --registry=https://registry.npmjs.org' <<<"$wasm_publish_block" >/dev/null \
+  || fail "publish-wasm-npm must check whether the WASM npm package version already exists"
+grep -F '@exochain/exochain-wasm ${RELEASE_VERSION} is already published; skipping npm publish.' <<<"$wasm_publish_block" >/dev/null \
+  || fail "publish-wasm-npm must skip already-published WASM npm package versions"
 grep -F 'npm publish --access public --provenance' <<<"$wasm_publish_block" >/dev/null \
   || fail "publish-wasm-npm must publish the public package with npm provenance"
 grep -F 'npm pack --dry-run' <<<"$wasm_publish_block" >/dev/null \

--- a/tools/test_wasm_npm_package_boundary.sh
+++ b/tools/test_wasm_npm_package_boundary.sh
@@ -45,12 +45,21 @@ grep -F 'npm publish --access public --provenance' "$release_workflow" >/dev/nul
   || fail "release workflow must publish npm package with provenance"
 grep -F 'NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}' "$release_workflow" >/dev/null \
   || fail "release workflow must use the npm token for authenticated npm release steps"
-grep -F 'name: Verify npm org publish access' "$release_workflow" >/dev/null \
-  || fail "release workflow must verify npm org publish access before building the package"
+grep -F 'name: Verify npm registry authentication' "$release_workflow" >/dev/null \
+  || fail "release workflow must verify npm registry authentication before building the package"
+grep -F 'npm ping --registry=https://registry.npmjs.org' "$release_workflow" >/dev/null \
+  || fail "release workflow must verify npm registry reachability before publishing"
 grep -F 'npm whoami --registry=https://registry.npmjs.org' "$release_workflow" >/dev/null \
   || fail "release workflow must verify the npm token identity before publishing"
-grep -F 'npm org ls exochain "$npm_user" --json --registry=https://registry.npmjs.org' "$release_workflow" >/dev/null \
-  || fail "release workflow must verify npm token membership in the exochain org"
+if grep -F 'npm org ls exochain' "$release_workflow" >/dev/null; then
+  fail "release workflow must not use npm org membership endpoints as publish preflight"
+fi
+grep -F 'npm_package_version_published()' "$release_workflow" >/dev/null \
+  || fail "release workflow must support resumable npm package publication checks"
+grep -F 'npm view "@exochain/exochain-wasm@${RELEASE_VERSION}" version --registry=https://registry.npmjs.org' "$release_workflow" >/dev/null \
+  || fail "release workflow must check whether the WASM npm package version is already published"
+grep -F '@exochain/exochain-wasm ${RELEASE_VERSION} is already published; skipping npm publish.' "$release_workflow" >/dev/null \
+  || fail "release workflow must skip already-published WASM npm package versions"
 grep -F 'id-token: write' "$release_workflow" >/dev/null \
   || fail "release workflow must grant OIDC for npm provenance"
 


### PR DESCRIPTION
## Summary
- replace the brittle `npm org ls exochain <user>` preflight with registry reachability plus `npm whoami`
- leave package authorization to `npm publish --access public --provenance`, which is the authoritative publish-permission check
- make the WASM npm publish step resumable by skipping `@exochain/exochain-wasm@${RELEASE_VERSION}` when that exact version already exists

## Evidence
- release run `28559169730` passed embedded CI and signed-tag verification, then failed in `Package and publish WASM npm package` at `Verify npm org publish access`
- job `84680239381` showed `npm whoami` reached auth, then `npm org ls exochain "$npm_user"` failed with `E403 Forbidden - GET https://registry.npmjs.org/-/org/exochain/user`
- local red/green: changed release boundary guards failed against the old workflow, then passed after the workflow patch

## Tests
- `bash tools/test_wasm_npm_package_boundary.sh`
- `bash tools/test_release_publish_boundaries.sh`
- `bash tools/test_release_workflow_ref_binding.sh`
- `bash tools/test_release_version_input_boundary.sh`
- `bash tools/test_release_signed_tag_trust_boundary.sh`
- `bash tools/test_release_reusable_ci_boundary.sh`
- `bash tools/test_release_sbom_boundary.sh`
- `bash tools/test_release_dry_run_boundaries.sh`

## Path Classification
- `.github/workflows/release.yml` — EXOCHAIN release CI/runtime adapter
- `tools/test_wasm_npm_package_boundary.sh` — EXOCHAIN CI guard
- `tools/test_release_publish_boundaries.sh` — EXOCHAIN CI guard
