### PR TITLE
vcg-006a: AVC durability flag (#735) + subject-signature bearer carve-out (#737)

### DIFF
--- a/GAP-REGISTRY.md
+++ b/GAP-REGISTRY.md
@@ -661,6 +661,47 @@ cargo clippy -p exochain-node --all-targets -- -D warnings
 **Classification:** Core runtime adapter
 **Owner role:** AVC runtime
 
+Lane record (2026-07-03, branch `vcg/006a-avc-durability-bearer`, sub-lane
+VCG-006a — closes 2 of the 4 sub-issues; row stays Open until #734/#736):
+
+- **#735 (Postgres durability)** — Red evidence:
+  `avc_startup_fails_closed_when_durability_required_without_pool`. Green: the
+  `require_postgres_durability` bool is now threaded from `main.rs:514` (where
+  it was previously parsed and discarded — a structurally inert flag) into
+  `AvcApiState::with_durable_registry`, which returns `Err` when the flag is
+  set and `database_pool` is `None`, instead of silently using the file
+  fallback.
+- **#737 (subject-signature bearer carve-out)** — Red evidence:
+  `avc_receipts_emit_accepts_subject_signature_without_bearer` plus
+  `avc_receipts_emit_still_rejects_unsigned_without_bearer` (guards against an
+  unauthenticated hole). Green: an `is_avc_receipts_emit_route` +
+  `avc_emit_receipt_carve_out` in `auth.rs` that buffers the request body
+  (bounded 64KiB), confirms a genuine non-empty subject signature is present,
+  and only then exempts the bearer gate; unsigned requests fall through to
+  the normal 401. `verify_subject_action_signature` remains the sole
+  cryptographic authority gate, unweakened.
+- Adversarial re-refutation (NOT-REFUTED): traced every path — no combination
+  (malformed/oversized body, present-but-invalid signature, wrong
+  content-type) admits an unsigned or wrong-signed write; wrong-signed
+  requests reach the handler's unweakened crypto gate and are rejected at
+  preflight before any mutation; the all-zero-signature spoof is closed; the
+  body is correctly buffered and reconstructed for the downstream handler.
+- Gates: `cargo test -p exochain-node avc` 124 pass / 1 ignored; auth:: 39
+  pass; full crate 1314 pass; clippy, doc, nightly fmt clean.
+- Residuals recorded: (1) no full-wrapped-stack test for the
+  present-but-cryptographically-wrong-signature-without-bearer case (behavior
+  correct by trace, not asserted at that exact seam — fold into VCG-006b or a
+  follow-up test); (2) the carve-out intentionally makes `/receipts/emit`
+  reachable without a bearer by anyone shaping a plausible JSON body with a
+  non-empty signature, costing one registry lookup + one Ed25519 verify before
+  rejection — bounded (64KiB cap, no mutation on failure), a deliberate design
+  tradeoff, not a defect.
+- Remaining for lane VCG-006b: #736 (runtime issuer allow-list
+  registration/rotation endpoint, under the D3 one-authority-model rule) and
+  #734 (conformance-test-root feature with source-guard proving production
+  root-trust constants untouched when off). Row closes when all four
+  sub-issues land with source, CI, and runtime proof.
+
 Evidence:
 
 - Live `/ready` returned HTTP 200 with `dagdb_runtime_status=dagdb_active`.

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 31 | `ls -d crates/*/` |
 | Rust source files | 459 | `find crates -name '*.rs'` |
-| Rust LOC | 370256 | `wc -l` |
-| Workspace tests | 6,064 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 370512 | `wc -l` |
+| Workspace tests | 6,067 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 23 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **6,064 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **6,067 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,10 +113,10 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 31 crates, 370256 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 31 crates, 370512 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          production Ed25519/BLAKE3 cryptography plus unaudited pedagogical
-         SNARK/STARK/ZKML skeletons, 6,064 listed workspace tests
+         SNARK/STARK/ZKML skeletons, 6,067 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          165 verified WASM exports covered by 172 bridge checks — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-node/src/auth.rs
+++ b/crates/exo-node/src/auth.rs
@@ -187,6 +187,64 @@ fn is_zerodentity_local_signed_write(method: &axum::http::Method, path: &str) ->
     method == axum::http::Method::DELETE && segments.next().is_none()
 }
 
+/// Route-shape check for the AVC subject-signed receipt-emission write
+/// (VCG-006a / #737).
+///
+/// This only recognizes the exact `POST /api/v1/avc/receipts/emit` route by
+/// method and path — mirroring `is_zerodentity_local_signed_write`'s
+/// route-shape style. It makes no claim about authority; it just identifies
+/// which route may be eligible for the carve-out in
+/// `require_bearer_on_writes`, which independently confirms a genuine
+/// (non-empty) subject signature is present before admitting the request.
+fn is_avc_receipts_emit_route(method: &axum::http::Method, path: &str) -> bool {
+    method == axum::http::Method::POST && path == "/api/v1/avc/receipts/emit"
+}
+
+/// Maximum body size read while peeking for a subject signature on the AVC
+/// receipt-emission carve-out. Matches the AVC router's own request body cap
+/// (`MAX_AVC_API_BODY_BYTES` in `avc.rs`) so this check never admits a body
+/// the downstream router would have rejected anyway.
+const AVC_EMIT_RECEIPT_CARVE_OUT_MAX_BODY_BYTES: usize = 64 * 1024;
+
+/// Determine whether a `POST /api/v1/avc/receipts/emit` request carries a
+/// genuine (non-empty) subject signature, without weakening the real
+/// authority check.
+///
+/// This buffers the request body (bounded to
+/// `AVC_EMIT_RECEIPT_CARVE_OUT_MAX_BODY_BYTES`) and parses it as
+/// `crate::avc::EmitReceiptRequest`, reusing the exact same type and
+/// `Signature::is_empty()` predicate the handler and `verify_subject_action_signature`
+/// use — no duplicated signature-shape logic. It reconstructs an equivalent
+/// request from the buffered bytes so the downstream handler still receives
+/// the original body.
+///
+/// This function never performs cryptographic signature verification —
+/// that remains exclusively `verify_subject_action_signature` inside
+/// `handle_emit_receipt`. A body that merely contains a non-empty signature
+/// field is let through to the handler, which is the actual authority gate
+/// and can still reject an invalid signature. A body with no signature
+/// (empty, missing, or unparseable) is never let through — this carve-out
+/// must never open an unauthenticated hole.
+async fn avc_emit_receipt_carve_out(request: Request<Body>) -> (Request<Body>, bool) {
+    let (parts, body) = request.into_parts();
+    let bytes = match axum::body::to_bytes(body, AVC_EMIT_RECEIPT_CARVE_OUT_MAX_BODY_BYTES).await {
+        Ok(bytes) => bytes,
+        Err(_) => {
+            // Body could not be buffered (too large or a read error).
+            // Reconstruct an empty-bodied request and fall through to the
+            // bearer-token check — never admit on a body we could not
+            // inspect.
+            return (Request::from_parts(parts, Body::empty()), false);
+        }
+    };
+
+    let has_subject_signature = serde_json::from_slice::<crate::avc::EmitReceiptRequest>(&bytes)
+        .is_ok_and(|parsed| !parsed.subject_signature.is_empty());
+
+    let rebuilt = Request::from_parts(parts, Body::from(bytes));
+    (rebuilt, has_subject_signature)
+}
+
 /// axum middleware: require bearer token on mutating requests and sensitive
 /// trust-object reads.
 ///
@@ -196,17 +254,29 @@ fn is_zerodentity_local_signed_write(method: &axum::http::Method, path: &str) ->
 /// The active economy policy remains public. All other methods (`POST`, `PUT`,
 /// `DELETE`, `PATCH`) require
 /// `Authorization: Bearer <token>` unless they are exact 0dentity signed-write
-/// routes whose handlers perform identity-session and request-signature checks.
+/// routes whose handlers perform identity-session and request-signature
+/// checks, or the exact AVC `/receipts/emit` route carrying a genuine
+/// (non-empty) subject signature, whose handler verifies that signature
+/// cryptographically.
 pub async fn require_bearer_on_writes(
     auth: BearerAuth,
     request: Request<Body>,
     next: Next,
 ) -> Result<Response, StatusCode> {
     let method = request.method().clone();
-    let path = request.uri().path();
+    let path = request.uri().path().to_owned();
     let is_public_read = (method == axum::http::Method::GET || method == axum::http::Method::HEAD)
-        && !is_sensitive_read_path(path);
-    if is_public_read || is_zerodentity_local_signed_write(&method, path) {
+        && !is_sensitive_read_path(&path);
+    if is_public_read || is_zerodentity_local_signed_write(&method, &path) {
+        return Ok(next.run(request).await);
+    }
+
+    if is_avc_receipts_emit_route(&method, &path) {
+        let (request, has_subject_signature) = avc_emit_receipt_carve_out(request).await;
+        if has_subject_signature {
+            return Ok(next.run(request).await);
+        }
+        verify_bearer_header(request.headers(), &auth)?;
         return Ok(next.run(request).await);
     }
 

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -767,12 +767,17 @@ impl AvcApiState {
     /// Postgres database when available, otherwise from the node data directory.
     /// Public-key trust anchors are intentionally reloaded separately from
     /// verified startup configuration.
+    ///
+    /// When `require_postgres_durability` is `true` and no `database_pool` is
+    /// supplied, startup fails closed with an `Err` instead of silently
+    /// falling back to the local file-backed registry (VCG-006a / #735).
     pub async fn with_durable_registry(
         data_dir: &FsPath,
         validator_did: Did,
         receipt_signer: AvcReceiptSigner,
         database_pool: Option<PgPool>,
         finality_store: Option<Arc<Mutex<crate::store::SqliteDagStore>>>,
+        require_postgres_durability: bool,
     ) -> anyhow::Result<Self> {
         let durable_state_path = data_dir.join(AVC_REGISTRY_DURABLE_STATE_FILE);
         let (registry, durability) = match database_pool {
@@ -783,6 +788,14 @@ impl AvcApiState {
                 (registry, AvcRegistryDurability::Postgres(pool.clone()))
             }
             None => {
+                if require_postgres_durability {
+                    anyhow::bail!(
+                        "{} is set but no Postgres database pool is configured; \
+                         refusing to fall back to the local AVC file registry \
+                         for production durability",
+                        AVC_REQUIRE_POSTGRES_DURABILITY_ENV
+                    );
+                }
                 tracing::warn!(
                     path = %durable_state_path.display(),
                     "AVC registry using local file fallback without Postgres-backed durability; set DATABASE_URL for production AVC registry durability"
@@ -2665,10 +2678,16 @@ mod tests {
 
     async fn fresh_durable_state(data_dir: &FsPath) -> Arc<AvcApiState> {
         let signer: AvcReceiptSigner = Arc::new(|payload: &[u8]| validator_keypair().sign(payload));
-        let mut state =
-            AvcApiState::with_durable_registry(data_dir, validator_did(), signer, None, None)
-                .await
-                .expect("durable AVC state");
+        let mut state = AvcApiState::with_durable_registry(
+            data_dir,
+            validator_did(),
+            signer,
+            None,
+            None,
+            false,
+        )
+        .await
+        .expect("durable AVC state");
         state.external_timestamp_source =
             fixed_external_timestamp_source(Timestamp::new(1_600_000, 0));
         seed_avc_trust_keys(&state);
@@ -3221,6 +3240,7 @@ mod tests {
             signer,
             None,
             None,
+            false,
         )
         .await
         {
@@ -3290,6 +3310,7 @@ mod tests {
             Arc::clone(&signer),
             Some(pool.clone()),
             None,
+            false,
         )
         .await
         {
@@ -3344,6 +3365,7 @@ mod tests {
             Arc::clone(&signer),
             Some(pool.clone()),
             None,
+            false,
         )
         .await
         .expect("Postgres AVC state");
@@ -3426,6 +3448,7 @@ mod tests {
             signer,
             Some(pool.clone()),
             None,
+            false,
         )
         .await
         .expect("reloaded Postgres AVC state");

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -6621,6 +6621,168 @@ mod tests {
             "AVC durable registry must keep a no-DATABASE_URL file fallback for local nodes"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // VCG-006a RED — #735 Postgres durability requirement is inert
+    // -----------------------------------------------------------------------
+    //
+    // `avc_require_postgres_durability_from_env()` is parsed at
+    // `main.rs:514` but its `bool` result is discarded — the flag never
+    // reaches `AvcApiState::with_durable_registry`, so a deployment that sets
+    // `EXO_AVC_REQUIRE_POSTGRES_DURABILITY=true` without `DATABASE_URL`
+    // silently falls back to the local file-backed registry instead of
+    // failing closed at startup.
+    //
+    // This test is COMPILE-RED today: `with_durable_registry` has no
+    // parameter through which to express "Postgres durability is required."
+    // The fix must thread a `require_postgres_durability: bool` (or
+    // equivalent) into `with_durable_registry`'s signature so that
+    // `database_pool: None` plus `require_postgres_durability: true` returns
+    // `Err` instead of constructing a file-backed registry. Until that
+    // parameter exists, this call site fails to compile — that compile
+    // failure IS the red evidence for #735.
+    #[tokio::test]
+    async fn avc_startup_fails_closed_when_durability_required_without_pool() {
+        let dir = tempfile::tempdir().expect("temp data dir");
+        let signer: AvcReceiptSigner = Arc::new(|payload: &[u8]| validator_keypair().sign(payload));
+
+        let result = AvcApiState::with_durable_registry(
+            dir.path(),
+            validator_did(),
+            signer,
+            None, // database_pool
+            None, // finality_store
+            true, // require_postgres_durability — parameter does not exist yet
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "startup must fail closed when Postgres durability is required but no database pool is configured"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // VCG-006a RED — #737 subject-signed /receipts/emit blocked by admin bearer gate
+    // -----------------------------------------------------------------------
+    //
+    // `handle_emit_receipt` already fully verifies the subject's Ed25519
+    // signature over the requested action (see
+    // `verify_subject_action_signature` calls at ~2282 and ~2304). The gap is
+    // purely in the router wiring: `main.rs:1127-1136` merges `avc_router`
+    // into `extra_router` and layers `auth::require_bearer_on_writes`
+    // uniformly over the whole merged router with no carve-out for
+    // subject-signed AVC writes — unlike the existing
+    // `is_zerodentity_local_signed_write` carve-out for 0dentity attest/delete.
+    //
+    // These tests build the SAME middleware stack production uses (avc_router
+    // wrapped in `require_bearer_on_writes`, not a bare handler call) so they
+    // prove something about the wired stack, not just the handler in
+    // isolation.
+    fn avc_router_with_bearer_gate(state: Arc<AvcApiState>) -> Router {
+        let auth = crate::auth::BearerAuth {
+            token: Arc::new(zeroize::Zeroizing::new("vcg-006a-admin-token".to_string())),
+        };
+        avc_router(state).layer(axum::middleware::from_fn(move |req, next| {
+            let auth = auth.clone();
+            crate::auth::require_bearer_on_writes(auth, req, next)
+        }))
+    }
+
+    #[tokio::test]
+    async fn avc_receipts_emit_accepts_subject_signature_without_bearer() {
+        let state = fresh_state();
+        let credential = baseline_credential();
+        state
+            .registry
+            .lock()
+            .unwrap()
+            .put_credential(credential.clone())
+            .unwrap();
+        let request = AvcValidationRequest {
+            credential,
+            action: Some(baseline_action(Did::new("did:exo:agent").unwrap())),
+            now: Timestamp::new(1_500_000, 0),
+        };
+        let body = serde_json::to_vec(&EmitReceiptRequest {
+            subject_signature: sign_action(&request, &subject_keypair()),
+            validation: request,
+            subject_public_key: None,
+        })
+        .unwrap();
+
+        let app = avc_router_with_bearer_gate(Arc::clone(&state));
+        let response = app
+            .oneshot(
+                // Deliberately NO Authorization header — only a valid subject
+                // Ed25519 signature over the action authorizes this write.
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/avc/receipts/emit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "a request bearing a valid subject Ed25519 signature over the action must be \
+             admitted through the production require_bearer_on_writes gate without an admin \
+             bearer token, mirroring the existing is_zerodentity_local_signed_write carve-out"
+        );
+        assert_eq!(state.registry.lock().unwrap().receipt_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn avc_receipts_emit_still_rejects_unsigned_without_bearer() {
+        let state = fresh_state();
+        let credential = baseline_credential();
+        state
+            .registry
+            .lock()
+            .unwrap()
+            .put_credential(credential.clone())
+            .unwrap();
+        let request = AvcValidationRequest {
+            credential,
+            action: Some(baseline_action(Did::new("did:exo:agent").unwrap())),
+            now: Timestamp::new(1_500_000, 0),
+        };
+        // No genuine subject signature (empty signature, no admin bearer
+        // token) — this must NOT be admitted. Proves the carve-out only
+        // exempts genuinely subject-signed emits and never opens an
+        // unauthenticated hole.
+        let body = serde_json::to_vec(&EmitReceiptRequest {
+            subject_signature: Signature::empty(),
+            validation: request,
+            subject_public_key: None,
+        })
+        .unwrap();
+
+        let app = avc_router_with_bearer_gate(Arc::clone(&state));
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/avc/receipts/emit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "an unsigned write with no admin bearer token must still be rejected by the \
+             production require_bearer_on_writes gate"
+        );
+        assert_eq!(state.registry.lock().unwrap().receipt_count(), 0);
+    }
 }
 
 #[cfg(test)]

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -511,7 +511,7 @@ async fn start_node(
         "Node identity ready"
     );
 
-    avc_require_postgres_durability_from_env()?;
+    let avc_require_postgres_durability = avc_require_postgres_durability_from_env()?;
     let gateway_pool = gateway_pool_from_env().await?;
     let (dagdb_tenant_id, dagdb_namespace) = dagdb_node_scope_from_env()?;
 
@@ -1058,6 +1058,7 @@ async fn start_node(
             Arc::clone(&sign_fn),
             Some(gateway_pool.clone()),
             Some(Arc::clone(&shared_store)),
+            avc_require_postgres_durability,
         )
         .await?,
     );


### PR DESCRIPTION
## Ledger row VCG-006: stays Open (sub-lane 006a closes 2 of 4 sub-issues)

**Lane record in this PR's own ledger diff** (coordinator-authored).

- **#735 (Postgres durability)**: `EXO_AVC_REQUIRE_POSTGRES_DURABILITY` was structurally inert — `main.rs:514` parsed the flag and discarded it. Now threaded into `with_durable_registry`, which returns `Err` when required && no pool, instead of the silent file fallback. Red test `avc_startup_fails_closed_when_durability_required_without_pool`.
- **#737 (subject-signature bearer carve-out)**: the admin bearer gate wrapped all AVC routes with no exemption for genuinely subject-signed emits. Added a carve-out that buffers the body (64KiB bound), confirms a non-empty subject signature, and only then exempts the bearer check — unsigned falls through to 401. `verify_subject_action_signature` remains the sole crypto gate, unweakened.
- **Adversarial re-refutation: NOT-REFUTED.** Every path traced: no combination (malformed/oversized body, invalid signature, wrong content-type) admits an unsigned or wrong-signed write; wrong-signed reaches the unweakened crypto gate and is rejected at preflight before any mutation; all-zero-signature spoof closed; body correctly buffered + reconstructed.
- Gates: avc 124 pass / 1 ignored; auth:: 39 pass; full crate 1314 pass; clippy, doc, nightly-fmt clean.
- **Residuals recorded**: a test-coverage seam (wrong-signature-without-bearer, correct by trace) and a bounded DoS-amplification tradeoff (deliberate).

Scope: only `crates/exo-node/src/{avc.rs,auth.rs,main.rs}`. #734/#736 = future lane VCG-006b; row closes when all four sub-issues land.