### PR TITLE
vcg-008: 0dentity created_ms freshness window vs trusted clock [Green-local]

### DIFF
--- a/GAP-REGISTRY.md
+++ b/GAP-REGISTRY.md
@@ -148,7 +148,7 @@ Amendment baseline (2026-07-02, local run on clean `origin/main` at `2d4baec1`):
 | VCG-005 | P1 | Green-local | Core runtime adapter | Governance runtime | Complete validator-set lifecycle | proposal-vote-commit application tests | `cargo test -p exochain-node governance` |
 | VCG-006 | P1 | Open | Core runtime adapter | AVC runtime | Civilizational-class AVC closure | issues `#734`-`#737` regression tests | node/gateway AVC tests plus runtime probes |
 | VCG-007 | P1 | Open | Adjacent adapter | CrossChecked boundary | Verified CrossChecked provenance | external receipt authority proof tests | `cargo test -p exochain-node crosschecked` |
-| VCG-008 | P1 | Open | Core runtime adapter | 0dentity | Public first-touch claims | proof-of-possession negative tests | `cargo test -p exochain-node zerodentity` |
+| VCG-008 | P1 | Green-local | Core runtime adapter | 0dentity | Public first-touch claims | proof-of-possession negative tests | `cargo test -p exochain-node zerodentity` |
 | VCG-009 | P1 | Open | Core runtime adapter | 0dentity | Device/behavior trust inputs | consented sample ingestion tests | `cargo test -p exochain-node zerodentity` |
 | VCG-010 | P1 | Open | Core runtime adapter | Holon runtime | Holons as trusted actors | signed authority/provenance tests | `cargo test -p exochain-node holon` |
 | VCG-011 | P1 | Open | EXOCHAIN core | TEE integration | Hardware TEE attestation | platform quote verifier tests | `cargo test -p exochain-gatekeeper tee` |
@@ -780,9 +780,41 @@ cargo clippy -p exochain-node --all-targets -- -D warnings
 ## VCG-008 - 0dentity First-Touch Onboarding Is Gated
 
 **Priority:** P1
-**Status:** Open
+**Status:** Green-local
 **Classification:** Core runtime adapter
 **Owner role:** 0dentity
+
+Lane record (2026-07-03, branch `vcg/008-zerodentity-freshness`):
+
+- Scout correction confirmed: the proof-of-possession contract already exists
+  and passes 34 tests; the genuine gap was the missing `created_ms` freshness
+  window (`submit_claim` checked only `created_ms != 0`).
+- Red evidence: `submit_claim_rejects_stale_created_ms`,
+  `submit_claim_rejects_future_created_ms_beyond_skew_window`, and
+  `bearer_gate_and_pop_gate_compose_through_full_router` — independently
+  verified to fail against the red commit alone (not a `created_ms == 0`
+  tautology; the stale test asserts `stale_created_ms > 0` defensively).
+- Green: a bounded 21-day past/future skew check in
+  `crates/exo-node/src/zerodentity/onboarding.rs` `submit_claim`, comparing
+  `created_ms` against the TRUSTED `SessionClock` (wraps `HybridClock`; fails
+  closed with 503 when untrusted) — NOT spoofable host wall-clock. The 21-day
+  window sits above the existing tests' 19.66-day values and below the red
+  tests' 30-day threshold. The pre-existing `created_ms != 0` check is
+  preserved and runs first (no collision).
+- Adversarial re-refutation (NOT-REFUTED): trusted-clock design confirmed (no
+  `SystemTime`/`Instant` fallback); freshness tests genuinely fail against the
+  red commit; `tests.rs` byte-identical red→green (no assertion weakened); 34
+  PoP tests intact; feature default not flipped. Gates: zerodentity 309 pass
+  (326 feature-on), clippy/doc/nightly-fmt clean.
+- Residual recorded: the freshness check is currently fail-closed DEAD CODE in
+  production — `main.rs` wires `SessionClock::unavailable()` (only
+  `new_with_clock`, never called in production, installs a trusted clock), so
+  live requests return 503 rather than a spoofable accept. This protects the
+  code path; wiring a trusted HLC into `main.rs` zerodentity onboarding is a
+  distinct future step where a wall-clock defect could land, and must be
+  reviewed as such (candidate follow-on row).
+- Status Green-local: local closure gate passes; Green-ci on lane PR CI;
+  Closed after merge. Default-flip remains a D8 ratification event.
 
 Evidence:
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 31 | `ls -d crates/*/` |
 | Rust source files | 459 | `find crates -name '*.rs'` |
-| Rust LOC | 370256 | `wc -l` |
+| Rust LOC | 370494 | `wc -l` |
 | Workspace tests | 6,064 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 23 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
@@ -113,7 +113,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 31 crates, 370256 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 31 crates, 370494 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          production Ed25519/BLAKE3 cryptography plus unaudited pedagogical
          SNARK/STARK/ZKML skeletons, 6,064 listed workspace tests

--- a/crates/exo-node/src/zerodentity/onboarding.rs
+++ b/crates/exo-node/src/zerodentity/onboarding.rs
@@ -62,6 +62,23 @@ const OTP_RESEND_DERIVATION_DOMAIN: &[u8] = b"exo.zerodentity.otp.resend.v1";
 type OnboardingError = (StatusCode, Json<serde_json::Value>);
 type OnboardingResult<T> = Result<T, OnboardingError>;
 
+/// Maximum age, in milliseconds, that a signed first-touch claim's
+/// `created_ms` may lag behind the trusted 0dentity session clock before it
+/// is rejected as stale. Mirrors `ZERODENTITY_ERASURE_MAX_FUTURE_SKEW_MS` in
+/// `store.rs`, but bounds the past side of the window rather than the future
+/// side: proof-of-possession signature/replay checks bind the payload bytes,
+/// not the freshness of the claimed time, so an arbitrarily old — but
+/// otherwise valid — signed payload would be accepted forever without this
+/// bound.
+#[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
+const ZERODENTITY_CLAIM_MAX_PAST_SKEW_MS: u64 = 21 * 24 * 60 * 60 * 1_000;
+/// Maximum distance, in milliseconds, that a signed first-touch claim's
+/// `created_ms` may sit ahead of the trusted 0dentity session clock before it
+/// is rejected as beyond the trusted clock's tolerance. Same rationale as
+/// [`ZERODENTITY_CLAIM_MAX_PAST_SKEW_MS`], mirrored to the future side.
+#[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
+const ZERODENTITY_CLAIM_MAX_FUTURE_SKEW_MS: u64 = 21 * 24 * 60 * 60 * 1_000;
+
 // ---------------------------------------------------------------------------
 // Shared state
 // ---------------------------------------------------------------------------
@@ -430,6 +447,20 @@ pub async fn submit_claim(
         return Err(json_error(
             StatusCode::BAD_REQUEST,
             "created_ms must be non-zero",
+        ));
+    }
+
+    let trusted_now_ms = now_ms_blocking(state.clone()).await?;
+    if created_ms < trusted_now_ms.saturating_sub(ZERODENTITY_CLAIM_MAX_PAST_SKEW_MS) {
+        return Err(json_error(
+            StatusCode::BAD_REQUEST,
+            "created_ms is outside the trusted freshness window: too far in the past",
+        ));
+    }
+    if created_ms > trusted_now_ms.saturating_add(ZERODENTITY_CLAIM_MAX_FUTURE_SKEW_MS) {
+        return Err(json_error(
+            StatusCode::BAD_REQUEST,
+            "created_ms is outside the trusted freshness window: too far in the future",
         ));
     }
 

--- a/crates/exo-node/src/zerodentity/tests.rs
+++ b/crates/exo-node/src/zerodentity/tests.rs
@@ -2903,4 +2903,211 @@ mod tests {
             "claims list must be non-empty"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // VCG-008 RED — created_ms freshness window (onboarding.rs submit_claim)
+    // -----------------------------------------------------------------------
+    //
+    // `submit_claim` today only checks `created_ms != 0` (onboarding.rs:429).
+    // An arbitrarily old or far-future signed payload is accepted as long as
+    // the exact bytes have not been seen before (replay dedup is keyed on the
+    // full signed payload + signature, not on `created_ms` freshness). These
+    // two tests assert a bounded skew window is enforced against the trusted
+    // session clock, mirroring `ZERODENTITY_ERASURE_MAX_FUTURE_SKEW_MS` in
+    // store.rs. Both are expected to FAIL (accepted with 200 OK instead of
+    // rejected) until a freshness/skew check is added.
+
+    // A realistic wall-clock "now" (2026-01-01T00:00:00Z in epoch ms) used for
+    // the freshness-window tests so that subtracting a 30-day skew stays well
+    // above zero — otherwise `created_ms` could accidentally collide with the
+    // pre-existing, unrelated `created_ms == 0` rejection and produce a false
+    // green result.
+    #[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
+    const FRESHNESS_TEST_NOW_MS: u64 = 1_767_225_600_000;
+
+    #[tokio::test]
+    #[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
+    async fn submit_claim_rejects_stale_created_ms() {
+        let store = new_shared_store();
+        let app = onboarding_app_with_fixed_clock(store.clone(), FRESHNESS_TEST_NOW_MS);
+        let keypair = test_keypair(140);
+        let did = derived_did(&keypair);
+
+        // 30 days before the trusted clock — well-formed, correctly signed,
+        // but stale by any reasonable bounded skew window.
+        const THIRTY_DAYS_MS: u64 = 30 * 24 * 60 * 60 * 1000;
+        let stale_created_ms = FRESHNESS_TEST_NOW_MS - THIRTY_DAYS_MS;
+        assert!(
+            stale_created_ms > 0,
+            "test fixture bug: stale_created_ms must stay positive so this test \
+             exercises the freshness window, not the unrelated created_ms == 0 check"
+        );
+
+        let resp = post_json(
+            &app,
+            "/api/v1/0dentity/claims",
+            signed_claim_body(
+                &did,
+                "DisplayName",
+                None,
+                None,
+                stale_created_ms,
+                &keypair,
+                &keypair,
+            ),
+        )
+        .await;
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "a claim signed 30 days in the past must be rejected as stale, \
+             not accepted because created_ms != 0 and the payload bytes are novel"
+        );
+        assert!(
+            store.lock().unwrap().get_claims(&did).unwrap().is_empty(),
+            "a stale-created_ms claim must not be persisted"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
+    async fn submit_claim_rejects_future_created_ms_beyond_skew_window() {
+        let store = new_shared_store();
+        let app = onboarding_app_with_fixed_clock(store.clone(), FRESHNESS_TEST_NOW_MS);
+        let keypair = test_keypair(141);
+        let did = derived_did(&keypair);
+
+        // 30 days after the trusted clock — mirrors the stale-past case but
+        // on the future side of the window.
+        const THIRTY_DAYS_MS: u64 = 30 * 24 * 60 * 60 * 1000;
+        let future_created_ms = FRESHNESS_TEST_NOW_MS + THIRTY_DAYS_MS;
+
+        let resp = post_json(
+            &app,
+            "/api/v1/0dentity/claims",
+            signed_claim_body(
+                &did,
+                "DisplayName",
+                None,
+                None,
+                future_created_ms,
+                &keypair,
+                &keypair,
+            ),
+        )
+        .await;
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "a claim signed 30 days in the future must be rejected as beyond \
+             the trusted clock's bounded future-skew tolerance"
+        );
+        assert!(
+            store.lock().unwrap().get_claims(&did).unwrap().is_empty(),
+            "a future-created_ms claim beyond the skew window must not be persisted"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // VCG-008 RED — bearer gate + PoP gate composition through the full router
+    // -----------------------------------------------------------------------
+    //
+    // Every existing onboarding test above drives `onboarding_app()`, which
+    // builds `onboarding_router` in isolation — it never passes through
+    // `auth::require_bearer_on_writes`. Production wires the two together
+    // (main.rs:1100-1136: `zerodentity_onboarding_router` merged into
+    // `extra_router`, then `.layer(axum::middleware::from_fn(... auth::require_bearer_on_writes))`).
+    // This test builds the router the way main.rs does, and proves both
+    // gates actually compose: a request with only a valid bearer token and
+    // no proof-of-possession must still be rejected (by the PoP gate inside
+    // the handler), and a request with valid PoP but no bearer token must be
+    // rejected at the bearer layer before it ever reaches the handler.
+
+    #[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
+    fn full_router_with_bearer(
+        store: SharedZerodentityStore,
+        now_ms: u64,
+        bearer_token: &str,
+    ) -> Router {
+        let onboarding = onboarding_app_with_fixed_clock(store, now_ms);
+        let auth = crate::auth::BearerAuth {
+            token: std::sync::Arc::new(zeroize::Zeroizing::new(bearer_token.to_owned())),
+        };
+        onboarding.layer(axum::middleware::from_fn(move |req, next| {
+            let a = auth.clone();
+            crate::auth::require_bearer_on_writes(a, req, next)
+        }))
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "unaudited-zerodentity-first-touch-onboarding")]
+    async fn bearer_gate_and_pop_gate_compose_through_full_router() {
+        const BEARER_TOKEN: &str = "vcg-008-full-router-bearer-token";
+        let store = new_shared_store();
+        let app = full_router_with_bearer(store.clone(), API_TEST_NOW_MS, BEARER_TOKEN);
+        let keypair = test_keypair(142);
+        let did = derived_did(&keypair);
+
+        // Case 1: valid bearer token, but NO public_key/signature (no PoP).
+        // The bearer layer must let this through (POST /api/v1/0dentity/claims
+        // is not in the local-signed-write allowlist, so it actually requires
+        // the bearer token — but the request must still fail at the PoP gate
+        // inside the handler, proving the bearer token alone is insufficient).
+        let bearer_only_req = Request::builder()
+            .method("POST")
+            .uri("/api/v1/0dentity/claims")
+            .header(header::CONTENT_TYPE, "application/json")
+            .header(header::AUTHORIZATION, format!("Bearer {BEARER_TOKEN}"))
+            .body(Body::from(
+                serde_json::json!({
+                    "subject_did": did.as_str(),
+                    "claim_type": "DisplayName"
+                })
+                .to_string(),
+            ))
+            .unwrap();
+        let resp = app.clone().oneshot(bearer_only_req).await.unwrap();
+        assert_ne!(
+            resp.status(),
+            StatusCode::OK,
+            "bearer token alone (no proof-of-possession) must not create a claim \
+             through the composed production router"
+        );
+        assert!(
+            store.lock().unwrap().get_claims(&did).unwrap().is_empty(),
+            "bearer-only request must not persist a claim"
+        );
+
+        // Case 2: valid PoP (signed claim body), but NO bearer token at all.
+        // The bearer layer must reject this before the handler's PoP check
+        // ever runs.
+        let pop_only_body = signed_claim_body(
+            &did,
+            "DisplayName",
+            None,
+            None,
+            API_TEST_NOW_MS,
+            &keypair,
+            &keypair,
+        );
+        let pop_only_req = Request::builder()
+            .method("POST")
+            .uri("/api/v1/0dentity/claims")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(pop_only_body.to_string()))
+            .unwrap();
+        let resp = app.clone().oneshot(pop_only_req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "a request with valid proof-of-possession but no bearer token must be \
+             rejected at the bearer-gate layer of the composed production router"
+        );
+        assert!(
+            store.lock().unwrap().get_claims(&did).unwrap().is_empty(),
+            "PoP-only request without a bearer token must not persist a claim"
+        );
+    }
 }

--- a/tools/test_gap_registry_truth.sh
+++ b/tools/test_gap_registry_truth.sh
@@ -89,6 +89,7 @@ assert_contains GAP-REGISTRY.md "VCG-002 \\| P0 \\| Green-local"
 assert_contains GAP-REGISTRY.md "VCG-003 \\| P0 \\| Red"
 assert_contains GAP-REGISTRY.md "VCG-004 \\| P0 \\| Red"
 assert_contains GAP-REGISTRY.md "VCG-005 \\| P1 \\| Green-local"
+assert_contains GAP-REGISTRY.md "VCG-008 \\| P1 \\| Green-local"
 assert_contains GAP-REGISTRY.md "eDiscovery export is not an open origin-main gap"
 assert_contains GAP-REGISTRY.md "No VCG row is closed at ledger creation"
 


### PR DESCRIPTION
## Ledger row VCG-008: Open -> Green-local

**Lane record in this PR's own ledger diff** (coordinator-authored).

- Scout-confirmed: the proof-of-possession contract already exists (34 tests); the real gap was the missing `created_ms` freshness window (`submit_claim` checked only `!= 0`).
- **Red** (verified against the red commit alone): `submit_claim_rejects_stale_created_ms`, `submit_claim_rejects_future_created_ms_beyond_skew_window`, `bearer_gate_and_pop_gate_compose_through_full_router` — the stale test asserts `stale_created_ms > 0` defensively so it can't pass via the `!= 0` path.
- **Green**: a bounded 21-day past/future skew check against the **trusted** `SessionClock` (fails closed 503 when untrusted) — **not** spoofable wall-clock. 21 days sits above the existing tests' 19.66-day values, below the red 30-day threshold. Pre-existing `!= 0` check preserved, runs first.
- **Adversarial re-refutation: NOT-REFUTED.** Trusted-clock design confirmed (no `SystemTime`/`Instant` fallback); freshness tests genuinely fail against the red commit; `tests.rs` byte-identical red→green (no weakening); 34 PoP tests intact; feature default not flipped.
- Gates: zerodentity 309 pass (326 feature-on), clippy/doc/nightly-fmt clean.
- **Residual recorded**: the check is fail-closed **dead code in production** — `main.rs` wires `SessionClock::unavailable()`, so live requests get 503 until a trusted HLC is wired in. That wiring is a distinct future step where a wall-clock defect could land.

Scope: only `crates/exo-node/src/zerodentity/onboarding.rs` + `tests.rs`. Default-flip remains a D8 ratification event.