### PR TITLE
vcg-010: Holon legitimacy under D5 — reject self-issued root, Scaling Holon recommendation-only [Green-local]

### DIFF
--- a/GAP-REGISTRY.md
+++ b/GAP-REGISTRY.md
@@ -150,7 +150,7 @@ Amendment baseline (2026-07-02, local run on clean `origin/main` at `2d4baec1`):
 | VCG-007 | P1 | Open | Adjacent adapter | CrossChecked boundary | Verified CrossChecked provenance | external receipt authority proof tests | `cargo test -p exochain-node crosschecked` |
 | VCG-008 | P1 | Green-local | Core runtime adapter | 0dentity | Public first-touch claims | proof-of-possession negative tests | `cargo test -p exochain-node zerodentity` |
 | VCG-009 | P1 | Open | Core runtime adapter | 0dentity | Device/behavior trust inputs | consented sample ingestion tests | `cargo test -p exochain-node zerodentity` |
-| VCG-010 | P1 | Open | Core runtime adapter | Holon runtime | Holons as trusted actors | signed authority/provenance tests | `cargo test -p exochain-node holon` |
+| VCG-010 | P1 | Green-local | Core runtime adapter | Holon runtime | Holons as trusted actors | signed authority/provenance tests | `cargo test -p exochain-node holon` |
 | VCG-011 | P1 | Open | EXOCHAIN core | TEE integration | Hardware TEE attestation | platform quote verifier tests | `cargo test -p exochain-gatekeeper tee` |
 | VCG-012 | P2 | Open | EXOCHAIN core | Distributed time | Multi-node causal finality | multi-node HLC partition tests | `cargo test -p exochain-core hlc` |
 | VCG-013 | P2 | Open | EXOCHAIN core | Tenant platform | SaaS tenant ops and billing | tenant metering and billing export tests | `cargo test -p exochain-tenant` |
@@ -961,9 +961,43 @@ cargo clippy -p exochain-node --all-targets -- -D warnings
 ## VCG-010 - Infrastructure Holons Are Gated
 
 **Priority:** P1
-**Status:** Open
+**Status:** Green-local
 **Classification:** Core runtime adapter
 **Owner role:** Holon runtime
+
+Lane record (2026-07-04, branch `vcg/010-holon-legitimacy`):
+
+- Red evidence: `holon_rejects_self_issued_root_authority` and
+  `scaling_holon_emits_zero_validator_set_change_proposals`, independently
+  verified to fail for the documented D5 reasons (tautological self-issued
+  trust at build_holon_adjudication_context; the Scaling Holon broadcasting a
+  real `ValidatorSetChange::AddValidator` proposal for a fabricated
+  `did:exo:auto-promoted-{n}` candidate).
+- Green per D5: (1) self-issued root authority is rejected — the trust anchor
+  for `root_did` is populated only from an external `RootAttestation` distinct
+  from the signer; (2) the Scaling Holon auto-promotion path emits a
+  recommendation event and submits ZERO DAG proposals (promotion is a
+  ratification event with named evidence); (3) the stale sentinel-bytes
+  Cargo.toml comment corrected and `Initiatives/fix-onyx-4-r5-holons-stub-context.md`
+  created.
+- Adversarial review found a MAJOR gap and it was fixed: the self-issued-root
+  guard originally checked only `attester_did != root_did` (DID-label
+  inequality), so a `RootAttestation` with a distinct DID label but the same
+  cryptographic key as the root signer could launder self-issuance one hop.
+  The guard now also requires `attester_public_key != root_public_key`; a new
+  red test (`holon_rejects_attestation_that_reuses_the_root_signer_key`) proves
+  the key-reusing attestation is rejected (genuine regression guard — fails
+  against pre-fix code). Re-refutation of the hardening: NOT-REFUTED (byte-for-
+  byte PublicKey comparison; both original D5 tests intact; scope clean).
+- Gates: holon 28 pass (both feature configs); full crate green; clippy, doc,
+  nightly fmt clean. Real Ed25519 signing (pre-existing) untouched; feature
+  default off.
+- Residual (documented in the initiative doc, not hidden): full D5 depth — a
+  witnessed multi-party ceremony and wiring a real external attestation into
+  the production default (currently `root_attestation: None`, fail-closed) —
+  remains follow-on work. Status Green-local: the row's stated deliverables
+  (reject self-issued root, Scaling Holon recommendation-only) are met and
+  tested; the deeper ceremony is out of this row's scope.
 
 Evidence:
 

--- a/Initiatives/fix-onyx-4-r5-holons-stub-context.md
+++ b/Initiatives/fix-onyx-4-r5-holons-stub-context.md
@@ -1,0 +1,67 @@
+<!--
+Copyright 2026 Exochain Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at:
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# fix-onyx-4-r5-holons-stub-context
+
+This is a minimal pointer document, not an implementation plan. This
+initiative is tracked as **GAP-REGISTRY.md row VCG-010** and is governed
+by **ratified decision D5** (root legitimacy: witnessed ceremony plus
+external attestation plus lineage; self-issued roots are rejected;
+Scaling-Holon promotion is recommendation-only).
+
+## Current state (as of the VCG-010 remediation)
+
+`crates/exo-node/src/holons.rs` — infrastructure Holon adjudication
+contexts carry real Ed25519 authority and provenance signatures
+(`build_holon_adjudication_context`, `signed_authority_link`,
+`signed_provenance`). The stale "sentinel `vec![1, 2, 3]`" signatures this
+initiative originally tracked no longer exist.
+
+Two residual gaps were closed under this initiative:
+
+1. **Self-issued root rejection.** `build_holon_adjudication_context` no
+   longer trusts `config.root_did`'s key merely because it is the key that
+   signed the root→Holon authority link. Trust for the root authority is
+   populated only from an independent `RootAttestation` (a distinct
+   attester DID/key vouching for the root), when one is configured. With
+   no `root_attestation` configured, the kernel's `AuthorityChainValid`
+   invariant fails closed and `holon::step` rejects the self-issued root.
+2. **Scaling Holon recommendation-only, full stop.** The Scaling Holon's
+   auto-promotion path no longer calls `reactor::submit_proposal`. It
+   emits a `GovernanceEventType::RecommendationOnly` event carrying the
+   same named candidate/evidence a real `ValidatorSetChange::AddValidator`
+   proposal would have carried, and submits zero DAG proposals. Promotion
+   remains a ratification event with named evidence, never an automatic
+   state change.
+
+## Why the runtime still refuses by default
+
+No external-attestation source (a witnessed ceremony distinct from the
+node's own signer) is wired into production yet — see
+`crates/exo-node/src/main.rs`, the `unaudited-infrastructure-holons` block,
+where `root_attestation` is set to `None`. Until a real external attester
+(for example an `exo-authority` DelegationRegistry entry per ratified
+decision D3, or an equivalent out-of-band witnessed-ceremony record) is
+wired in, every root authority built from that config is self-issued, and
+the kernel correctly rejects every infrastructure Holon step.
+
+This tool/runtime stays refusing (compiled out of the default build) unless
+the crate is built with the `unaudited-infrastructure-holons` feature (see
+`crates/exo-node/Cargo.toml`), which is never safe to enable in production
+until a real external-attestation source exists. See GAP-REGISTRY.md row
+VCG-010 for scope and status.

--- a/Initiatives/fix-onyx-4-r5-holons-stub-context.md
+++ b/Initiatives/fix-onyx-4-r5-holons-stub-context.md
@@ -37,10 +37,19 @@ Two residual gaps were closed under this initiative:
 1. **Self-issued root rejection.** `build_holon_adjudication_context` no
    longer trusts `config.root_did`'s key merely because it is the key that
    signed the root→Holon authority link. Trust for the root authority is
-   populated only from an independent `RootAttestation` (a distinct
-   attester DID/key vouching for the root), when one is configured. With
-   no `root_attestation` configured, the kernel's `AuthorityChainValid`
-   invariant fails closed and `holon::step` rejects the self-issued root.
+   populated only from an independent `RootAttestation` that is distinct
+   from the signer on **both** axes D5 requires: a different `attester_did`
+   label **and** a different `attester_public_key` from
+   `config.root_public_key`. An attestation carrying a distinct DID label
+   but reusing the root's own key (self-issuance laundered through a second
+   label) fails the key-inequality guard and falls through to the
+   self-issued arm. With no `root_attestation` configured, or a
+   key-reusing one, the kernel's `AuthorityChainValid` invariant fails
+   closed and `holon::step` rejects the root.
+   Remaining D5 depth (a fully witnessed multi-party ceremony and wiring an
+   external attestation into the production default, which currently sets
+   `root_attestation: None` and is therefore fail-closed) is tracked as
+   follow-on work, not claimed complete by this change.
 2. **Scaling Holon recommendation-only, full stop.** The Scaling Holon's
    auto-promotion path no longer calls `reactor::submit_proposal`. It
    emits a `GovernanceEventType::RecommendationOnly` event carrying the

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 31 | `ls -d crates/*/` |
 | Rust source files | 459 | `find crates -name '*.rs'` |
-| Rust LOC | 370750 | `wc -l` |
-| Workspace tests | 6,067 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 371181 | `wc -l` |
+| Workspace tests | 6,070 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 23 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **6,067 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **6,070 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,10 +113,10 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 31 crates, 370750 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 31 crates, 371181 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          production Ed25519/BLAKE3 cryptography plus unaudited pedagogical
-         SNARK/STARK/ZKML skeletons, 6,067 listed workspace tests
+         SNARK/STARK/ZKML skeletons, 6,070 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          165 verified WASM exports covered by 172 bridge checks — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-node/Cargo.toml
+++ b/crates/exo-node/Cargo.toml
@@ -239,15 +239,21 @@ unaudited-mcp-simulation-tools = []
 # unaudited onboarding contract tracked by Onyx-4 R1."
 unaudited-zerodentity-first-touch-onboarding = []
 
-# ONYX-4 RED R5: infrastructure Holons currently build kernel adjudication
-# contexts with sentinel authority/provenance signatures (`vec![1, 2, 3]`) and
-# no public key. The Holons are recommendation-only today, but the runtime must
-# not start by default until the context carries real signed authority and
-# provenance.
+# ONYX-4 RED R5 / VCG-010 (ratified decision D5): infrastructure Holons build
+# kernel adjudication contexts with real Ed25519 authority/provenance
+# signatures (holons.rs) and reject a self-issued root authority (grantor key
+# == signer key with no external attestation distinct from the signer). The
+# Scaling Holon's auto-promotion path is recommendation-only, full stop — it
+# emits a `RecommendationOnly` governance event and never submits a
+# `ValidatorSetChange` proposal on its own; promotion remains a ratification
+# event with named evidence. The runtime still does not start by default: no
+# external-attestation source (a witnessed ceremony distinct from the node's
+# own signer) is wired into production yet, so the default config's root
+# authority is self-issued and the kernel would reject every Holon step.
 #
 # Do NOT enable this in production. Enabling it means: "I accept that
-# infrastructure Holons run with the unaudited R5 adjudication context tracked
-# by fix-onyx-4-r5-holons-stub-context.md."
+# infrastructure Holons run without a real external-attestation source for
+# the root authority, tracked by fix-onyx-4-r5-holons-stub-context.md."
 unaudited-infrastructure-holons = []
 
 # ONYX-4 RED R3: the 0dentity device fingerprint and behavioral biometric

--- a/crates/exo-node/src/holons.rs
+++ b/crates/exo-node/src/holons.rs
@@ -1719,9 +1719,8 @@ mod tests {
             validator_public_keys,
             round_timeout_ms: 5000,
         };
-        let sign_fn: Arc<dyn Fn(&[u8]) -> Signature + Send + Sync> = Arc::new(move |message| {
-            exo_core::crypto::sign(message, &node_secret_key)
-        });
+        let sign_fn: Arc<dyn Fn(&[u8]) -> Signature + Send + Sync> =
+            Arc::new(move |message| exo_core::crypto::sign(message, &node_secret_key));
         let reactor_state = crate::reactor::create_reactor_state(&reactor_config, sign_fn, None);
 
         let (cmd_tx, mut cmd_rx) = mpsc::channel(256);

--- a/crates/exo-node/src/holons.rs
+++ b/crates/exo-node/src/holons.rs
@@ -1410,11 +1410,10 @@ mod tests {
         // control" laundering case.
         let mut config = test_config_with_attestation();
         let root_public_key = config.root_public_key;
-        let same_key_secret =
-            exo_core::crypto::KeyPair::from_secret_bytes([0x48; 32])
-                .unwrap()
-                .secret_key()
-                .clone();
+        let same_key_secret = exo_core::crypto::KeyPair::from_secret_bytes([0x48; 32])
+            .unwrap()
+            .secret_key()
+            .clone();
         config.root_attestation = Some(RootAttestation {
             attester_did: Did::new("did:exo:laundered-witness").unwrap(),
             attester_public_key: root_public_key,

--- a/crates/exo-node/src/holons.rs
+++ b/crates/exo-node/src/holons.rs
@@ -1204,6 +1204,72 @@ mod tests {
         );
     }
 
+    /// VCG-010 / D5 red test: a root authority is legitimate only with a
+    /// witnessed ceremony, external attestation, and lineage distinct from
+    /// the signer. `test_config()` wires `root_public_key` as the exact key
+    /// that `root_signer` uses to sign the authority link — i.e. the
+    /// grantor key equals the signer key with no external delegation chain
+    /// (this mirrors the production wiring in `main.rs:783-798`, where
+    /// `holon_authority_did`/`holon_authority_public_key`/`holon_authority_signer`
+    /// are all derived from the same freshly-loaded node identity).
+    ///
+    /// `build_holon_adjudication_context` (holons.rs:435-440) currently
+    /// inserts `config.root_public_key` into `trusted_authority_keys` keyed
+    /// by `config.root_did` directly from the link it just signed — a
+    /// tautological trust check with no independent/external resolution.
+    /// The kernel's `AuthorityChainValid` invariant then "verifies" the
+    /// signature against that self-supplied key and the holon step is
+    /// permitted.
+    ///
+    /// Expected red: today this self-issued root authority is trusted and
+    /// `holon::step` returns `Ok(..)`. Per D5, a self-issued root authority
+    /// with no external attestation/delegation chain distinct from the
+    /// signer must be REJECTED.
+    #[test]
+    fn holon_rejects_self_issued_root_authority() {
+        let kernel = create_infrastructure_kernel();
+        let config = test_config();
+
+        // Sanity-check the self-issuance premise this test exercises: the
+        // configured signer produces signatures verifiable under
+        // config.root_public_key, i.e. grantor key == signer key.
+        let probe_message = b"vcg-010-self-issuance-probe";
+        let probe_signature = (config.root_signer)(probe_message);
+        assert!(
+            exo_core::crypto::verify(probe_message, &probe_signature, &config.root_public_key),
+            "test premise: root_signer must produce signatures under root_public_key"
+        );
+
+        let mut h = create_health_holon(&test_did());
+        let ctx = build_holon_adjudication_context(&h, &config).expect("holon context");
+
+        // The authority chain's sole link is self-issued: its grantor is
+        // config.root_did and its grantor_public_key is config.root_public_key
+        // — the same key that produced the signature. There is no external
+        // attestation or delegation link distinct from the signer anywhere
+        // in the chain.
+        assert_eq!(ctx.authority_chain.links.len(), 1);
+        let root_link = &ctx.authority_chain.links[0];
+        assert_eq!(root_link.grantor, config.root_did);
+        assert_eq!(
+            root_link.grantor_public_key.as_deref(),
+            Some(config.root_public_key.as_bytes().as_slice())
+        );
+
+        let input = CombinatorInput::new()
+            .with("consensus_round", "1")
+            .with("committed_height", "1");
+
+        let result = holon::step(&mut h, &input, &kernel, &ctx);
+
+        assert!(
+            result.is_err(),
+            "a self-issued root authority (grantor key == signer key, no external \
+             delegation/attestation chain) must be REJECTED per D5, but holon::step \
+             returned {result:?}"
+        );
+    }
+
     #[cfg(not(feature = "unaudited-infrastructure-holons"))]
     #[test]
     fn infrastructure_holons_disabled_without_feature_flag() {
@@ -1478,5 +1544,166 @@ mod tests {
         }
 
         manager.abort();
+    }
+
+    /// VCG-010 / D5 red test: the Scaling Holon is recommendation-only, full
+    /// stop. Per the module doc (holons.rs:29-39) and D5, promotion is a
+    /// ratification event with named evidence — never an automatic
+    /// state-changing action.
+    ///
+    /// Today (holons.rs:787-860), whenever `validator_count < 3` and the
+    /// node `is_validator`, the Scaling Holon fabricates a candidate DID
+    /// (`did:exo:auto-promoted-{node_count}`) and calls
+    /// `execute_governance_action` -> `reactor::submit_proposal`, which is a
+    /// real `ValidatorSetChange::AddValidator` DAG proposal, plus a matching
+    /// `GovernanceEvent` broadcast over the network `Publish` command. This
+    /// test drains the network-command channel and does NOT suppress the
+    /// scaling path (unlike `holon_manager_emits_health_event`, which sets
+    /// `scaling_interval_secs` to 3600 to dodge it) — it fires the scaling
+    /// tick quickly with `validator_count == 1 < 3` and `is_validator == true`
+    /// and asserts zero `ValidatorSetChange::AddValidator` proposals are ever
+    /// submitted or broadcast.
+    ///
+    /// Expected red: today at least one `GovernanceEvent` with
+    /// `event_type: ValidatorSetChange` decoding to
+    /// `ValidatorChange::AddValidator { did: "did:exo:auto-promoted-*" }` is
+    /// published, and the DAG store gains a matching committed/pending node.
+    #[tokio::test]
+    async fn scaling_holon_emits_zero_validator_set_change_proposals() {
+        use std::{
+            collections::BTreeSet,
+            sync::atomic::{AtomicUsize, Ordering as AtomicOrdering},
+        };
+
+        use exo_core::types::Signature;
+
+        // Single-validator set with this node as the sole validator: any
+        // node_count > validator_count (guaranteed once at least one peer is
+        // reported) keeps validator_count(1) < 3 true throughout the test.
+        let validators: BTreeSet<Did> = std::iter::once(test_did()).collect();
+
+        // A real keypair is required: `submit_proposal` verifies the
+        // self-proposal/self-vote signature against `validator_public_keys`,
+        // so an empty resolver (as in `holon_manager_emits_health_event`,
+        // which never reaches consensus signing) would make the proposal
+        // path reject before ever reaching the network layer — masking the
+        // very state-changing behavior D5 says must not happen.
+        let node_keypair = exo_core::crypto::KeyPair::from_secret_bytes([0x51; 32]).unwrap();
+        let node_public_key = *node_keypair.public_key();
+        let node_secret_key = node_keypair.secret_key().clone();
+        let mut validator_public_keys = std::collections::BTreeMap::new();
+        validator_public_keys.insert(test_did(), node_public_key);
+
+        let reactor_config = crate::reactor::ReactorConfig {
+            node_did: test_did(),
+            is_validator: true,
+            validators,
+            validator_public_keys,
+            round_timeout_ms: 5000,
+        };
+        let sign_fn: Arc<dyn Fn(&[u8]) -> Signature + Send + Sync> = Arc::new(move |message| {
+            exo_core::crypto::sign(message, &node_secret_key)
+        });
+        let reactor_state = crate::reactor::create_reactor_state(&reactor_config, sign_fn, None);
+
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(256);
+        let net_handle = NetworkHandle::new(cmd_tx);
+
+        let (event_tx, mut event_rx) = mpsc::channel(32);
+        // Scaling fires quickly and is NOT suppressed. Topology/health are
+        // slow so this test isolates the scaling-tick auto-promotion path.
+        let config = test_config_with_intervals(3600, 1, 3600);
+
+        let validator_set_change_proposals = Arc::new(AtomicUsize::new(0));
+        let observed_governance_events = Arc::new(AtomicUsize::new(0));
+
+        // Drain network commands, recording every ValidatorSetChange
+        // governance-event broadcast that decodes to AddValidator instead of
+        // suppressing/ignoring it as the existing health test does.
+        let counter = Arc::clone(&validator_set_change_proposals);
+        let governance_seen = Arc::clone(&observed_governance_events);
+        tokio::spawn(async move {
+            while let Some(cmd) = cmd_rx.recv().await {
+                match cmd {
+                    crate::network::NetworkCommand::Publish { message, reply, .. } => {
+                        if let crate::wire::WireMessage::GovernanceEvent(event) = &message {
+                            governance_seen.fetch_add(1, AtomicOrdering::SeqCst);
+                            if matches!(
+                                event.event_type,
+                                crate::wire::GovernanceEventType::ValidatorSetChange
+                            ) {
+                                let decoded: Result<ValidatorChange, _> =
+                                    ciborium::from_reader(event.payload.as_slice());
+                                if let Ok(ValidatorChange::AddValidator { did }) = decoded {
+                                    assert!(
+                                        did.to_string().starts_with("did:exo:auto-promoted-"),
+                                        "unexpected AddValidator candidate: {did}"
+                                    );
+                                    counter.fetch_add(1, AtomicOrdering::SeqCst);
+                                }
+                            }
+                        }
+                        let _ = reply.send(Ok(()));
+                    }
+                    crate::network::NetworkCommand::PeerCount { reply } => {
+                        // node_count = peer_count + 1 = 2, keeping
+                        // validator_count(1) < 3 and node_count > validator_count.
+                        let _ = reply.send(1);
+                    }
+                    _ => {}
+                }
+            }
+        });
+
+        // Create a temporary store for the test and keep a handle to inspect
+        // the DAG tips after the run (a real proposal appends a node).
+        let dir = tempfile::tempdir().unwrap();
+        let shared_store = std::sync::Arc::new(std::sync::Mutex::new(
+            crate::store::SqliteDagStore::open(dir.path()).unwrap(),
+        ));
+        let tips_before = shared_store.lock().unwrap().tips_sync().unwrap();
+
+        let manager = tokio::spawn(run_holon_manager(
+            config,
+            reactor_state,
+            Arc::clone(&shared_store),
+            net_handle,
+            event_tx,
+        ));
+
+        // Wait for at least one ScalingRecommendation event (first scaling
+        // tick fires immediately), then give the auto-promotion branch a
+        // moment to run before inspecting side effects.
+        loop {
+            let event = tokio::time::timeout(Duration::from_secs(5), event_rx.recv())
+                .await
+                .expect("Should receive an event within 5s")
+                .expect("Channel should not be closed");
+            if matches!(event, HolonEvent::ScalingRecommendation { .. }) {
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        manager.abort();
+
+        assert!(
+            observed_governance_events.load(AtomicOrdering::SeqCst) > 0,
+            "test premise: scaling tick must have run at least once and reached the network layer"
+        );
+
+        assert_eq!(
+            validator_set_change_proposals.load(AtomicOrdering::SeqCst),
+            0,
+            "Scaling Holon must emit recommendation objects only and submit ZERO \
+             ValidatorSetChange::AddValidator proposals per D5 (recommendation-only, \
+             full stop), but at least one was broadcast"
+        );
+
+        let tips_after = shared_store.lock().unwrap().tips_sync().unwrap();
+        assert_eq!(
+            tips_after, tips_before,
+            "Scaling Holon must not append a real DAG proposal for auto-promotion \
+             (recommendation-only, full stop)"
+        );
     }
 }

--- a/crates/exo-node/src/holons.rs
+++ b/crates/exo-node/src/holons.rs
@@ -508,12 +508,18 @@ pub fn build_holon_adjudication_context(
     // grantor DID" and the self-issued root is rejected.
     let mut trusted_authority_keys = TrustedAuthorityKeys::default();
     let authority_chain = match &config.root_attestation {
-        Some(attestation) if attestation.attester_did != config.root_did => {
+        Some(attestation)
+            if attestation.attester_did != config.root_did
+                && attestation.attester_public_key != config.root_public_key =>
+        {
             let attestation_link = signed_attestation_link(holon, config, attestation)?;
             // The attester is the external trust anchor (the witnessed
-            // ceremony). Its key is independent of `root_signer` by
-            // construction (`attester_did != root_did`), so trusting it here
-            // is not self-referential in the way the rejected case is.
+            // ceremony). D5 requires lineage genuinely distinct from the
+            // signer, so both the attester DID *and* its cryptographic key
+            // must differ from the root's: a differently-labelled DID under
+            // the same key control is still self-issuance and is rejected by
+            // the guard above (it falls through to the self-issued arm, where
+            // `root_did` gets no trusted key and the kernel fails closed).
             trusted_authority_keys.insert(
                 attestation.attester_did.clone(),
                 vec![attestation.attester_public_key.as_bytes().to_vec()],
@@ -1385,6 +1391,62 @@ mod tests {
             "a self-issued root authority (grantor key == signer key, no external \
              delegation/attestation chain) must be REJECTED per D5, but holon::step \
              returned {result:?}"
+        );
+    }
+
+    /// D5 requires lineage genuinely distinct from the signer. A
+    /// `RootAttestation` that carries a *different* attester DID label but the
+    /// *same* cryptographic key as the root signer is still self-issuance,
+    /// laundered one hop through a second label. The key-inequality guard in
+    /// `build_holon_adjudication_context` must treat this as self-issued (no
+    /// trusted key for `root_did`), so `holon::step` fails closed.
+    #[test]
+    fn holon_rejects_attestation_that_reuses_the_root_signer_key() {
+        let kernel = create_infrastructure_kernel();
+
+        // Start from a legitimately-attested config, then rewrite the
+        // attestation so it keeps a distinct DID label but reuses the root's
+        // own key + signer — the "differently-labelled DID under the same key
+        // control" laundering case.
+        let mut config = test_config_with_attestation();
+        let root_public_key = config.root_public_key;
+        let same_key_secret =
+            exo_core::crypto::KeyPair::from_secret_bytes([0x48; 32])
+                .unwrap()
+                .secret_key()
+                .clone();
+        config.root_attestation = Some(RootAttestation {
+            attester_did: Did::new("did:exo:laundered-witness").unwrap(),
+            attester_public_key: root_public_key,
+            attester_signer: Arc::new(move |message: &[u8]| {
+                exo_core::crypto::sign(message, &same_key_secret)
+            }),
+        });
+
+        let mut h = create_health_holon(&test_did());
+        let ctx = build_holon_adjudication_context(&h, &config).expect("holon context");
+
+        // The key-inequality guard must reject the laundered attestation and
+        // fall through to the self-issued arm: a single self-issued link with
+        // no independently-trusted key for root_did.
+        assert_eq!(
+            ctx.authority_chain.links.len(),
+            1,
+            "attestation reusing the root key must fall through to the \
+             self-issued (single-link) arm, not be trusted as external lineage"
+        );
+
+        let input = CombinatorInput::new()
+            .with("consensus_round", "1")
+            .with("committed_height", "1");
+
+        let result = holon::step(&mut h, &input, &kernel, &ctx);
+
+        assert!(
+            result.is_err(),
+            "an attestation whose key equals the root signer key (distinct DID \
+             label only) is self-issuance laundered through a second label and \
+             must be REJECTED per D5, but holon::step returned {result:?}"
         );
     }
 

--- a/crates/exo-node/src/holons.rs
+++ b/crates/exo-node/src/holons.rs
@@ -26,16 +26,28 @@
 //! - **INV-005 KernelImmutability**: AI cannot modify the governance kernel
 //! - **MCP-001/002**: AI operates within defined scope, cannot self-escalate
 //!
-//! # Audit status — Onyx-4 R5 (default-off runtime)
+//! # Audit status — Onyx-4 R5 / VCG-010 (default-off runtime)
 //!
-//! The infrastructure Holon adjudication context now requires a configured
+//! The infrastructure Holon adjudication context requires a configured
 //! Ed25519 authority key and signer. The authority chain and provenance are
 //! signed over the same canonical payloads enforced by `exo-gatekeeper`.
 //!
+//! Per ratified decision D5, a root authority is legitimate only with a
+//! witnessed ceremony, external attestation, and lineage distinct from the
+//! signer: a self-issued root (grantor key == signer key, no independent
+//! attestation) is rejected by the kernel's `AuthorityChainValid` invariant.
+//! The Scaling Holon's auto-promotion path is recommendation-only, full
+//! stop — it emits a `RecommendationOnly` governance event and never
+//! submits a `ValidatorSetChange` proposal; promotion is a ratification
+//! event with named evidence, not an automatic action.
+//!
 //! The runtime background manager is therefore disabled by default behind the
-//! `unaudited-infrastructure-holons` feature flag. Enabling the feature means
-//! the operator accepts the recommendation-only Holon runtime while the
-//! product decision for shipping infrastructure Holons is tracked in
+//! `unaudited-infrastructure-holons` feature flag: no external-attestation
+//! source is wired into production yet, so the default config's root
+//! authority is self-issued and every Holon step is rejected. Enabling the
+//! feature means the operator accepts the recommendation-only Holon runtime
+//! while the product decision for shipping infrastructure Holons (including a
+//! real external-attestation source) is tracked in
 //! `Initiatives/fix-onyx-4-r5-holons-stub-context.md`.
 //!
 //! ## Holons
@@ -138,6 +150,26 @@ pub enum HealthStatus {
 // Infrastructure Holon configuration
 // ---------------------------------------------------------------------------
 
+/// External attestation of the root authority's legitimacy — a witnessed
+/// ceremony record signed by a key distinct from `root_signer`.
+///
+/// Per ratified decision D5, a root authority is legitimate only with a
+/// witnessed ceremony, external attestation, and lineage distinct from the
+/// signer. A self-issued root (grantor key == signer key, no external
+/// delegation chain) must be rejected. This struct is the minimal carrier of
+/// that external lineage: `attester_did`/`attester_public_key` name a party
+/// distinct from `root_did`/`root_public_key`, and `attester_signer` signs
+/// the delegation link vouching for the root key.
+#[derive(Clone)]
+pub struct RootAttestation {
+    /// DID of the external attester (distinct from `root_did`).
+    pub attester_did: Did,
+    /// Ed25519 public key of the external attester.
+    pub attester_public_key: PublicKey,
+    /// Signs the attestation link that delegates authority to `root_did`.
+    pub attester_signer: Arc<dyn Fn(&[u8]) -> Signature + Send + Sync>,
+}
+
 /// Configuration for infrastructure Holons.
 #[derive(Clone)]
 pub struct HolonManagerConfig {
@@ -149,6 +181,11 @@ pub struct HolonManagerConfig {
     pub root_public_key: PublicKey,
     /// Signs canonical authority/provenance payload hashes for infrastructure Holon context.
     pub root_signer: Arc<dyn Fn(&[u8]) -> Signature + Send + Sync>,
+    /// External attestation of the root authority's legitimacy (witnessed
+    /// ceremony + lineage distinct from `root_signer`, per D5). `None` means
+    /// the root authority is self-issued with no external delegation chain,
+    /// which the kernel's `AuthorityChainValid` invariant must reject.
+    pub root_attestation: Option<RootAttestation>,
     /// Supplies deterministic HLC metadata for each signed Holon provenance record.
     pub provenance_timestamp_source: Arc<dyn Fn() -> Result<Timestamp, String> + Send + Sync>,
     /// How often to run the topology optimizer (seconds).
@@ -165,6 +202,10 @@ impl std::fmt::Debug for HolonManagerConfig {
             .field("node_did", &self.node_did)
             .field("root_did", &self.root_did)
             .field("root_public_key", &self.root_public_key)
+            .field(
+                "root_attestation",
+                &self.root_attestation.as_ref().map(|a| &a.attester_did),
+            )
             .field("provenance_timestamp_source", &"<deterministic-hlc-source>")
             .field("topology_interval_secs", &self.topology_interval_secs)
             .field("scaling_interval_secs", &self.scaling_interval_secs)
@@ -373,6 +414,29 @@ fn signed_authority_link(
     Ok(link)
 }
 
+/// Build the external-attestation link (attester → root_did) when `config`
+/// carries a `RootAttestation`. Per D5, this link is the witnessed-ceremony
+/// evidence that the root authority is not self-issued: its grantor is the
+/// attester's own DID/key, structurally distinct from `root_signer`.
+fn signed_attestation_link(
+    holon: &Holon,
+    config: &HolonManagerConfig,
+    attestation: &RootAttestation,
+) -> Result<AuthorityLink, String> {
+    let mut link = AuthorityLink {
+        grantor: attestation.attester_did.clone(),
+        grantee: config.root_did.clone(),
+        permissions: holon.capabilities.clone(),
+        signature: Vec::new(),
+        grantor_public_key: Some(attestation.attester_public_key.as_bytes().to_vec()),
+    };
+    let message = authority_link_signature_message(&link)
+        .map_err(|err| format!("failed to encode attestation-link signature payload: {err}"))?;
+    let signature = (attestation.attester_signer)(message.as_bytes());
+    link.signature = signature.to_bytes().to_vec();
+    Ok(link)
+}
+
 fn signed_provenance(
     holon: &Holon,
     config: &HolonManagerConfig,
@@ -429,15 +493,46 @@ pub fn build_holon_adjudication_context(
     config: &HolonManagerConfig,
 ) -> Result<AdjudicationContext, String> {
     let provenance_timestamp = next_provenance_timestamp(config)?;
-    let authority_chain = AuthorityChain {
-        links: vec![signed_authority_link(holon, config)?],
-    };
+    let root_link = signed_authority_link(holon, config)?;
+
+    // Per D5: a root authority is legitimate only with a witnessed ceremony,
+    // external attestation, and lineage distinct from the signer. The trust
+    // anchor for `root_did` therefore comes exclusively from an external
+    // attester's key when one is configured — never from the self-signed
+    // root→holon link itself, which would be a tautological trust check
+    // (trusting a key because it is the key that produced the signature).
+    //
+    // Without a configured `root_attestation`, `root_did` gets no entry in
+    // `trusted_authority_keys`, so the kernel's `AuthorityChainValid`
+    // invariant fails closed with "grantor_public_key is unresolved for
+    // grantor DID" and the self-issued root is rejected.
     let mut trusted_authority_keys = TrustedAuthorityKeys::default();
-    for link in &authority_chain.links {
-        if let Some(public_key) = &link.grantor_public_key {
-            trusted_authority_keys.insert(link.grantor.clone(), vec![public_key.clone()]);
+    let authority_chain = match &config.root_attestation {
+        Some(attestation) if attestation.attester_did != config.root_did => {
+            let attestation_link = signed_attestation_link(holon, config, attestation)?;
+            // The attester is the external trust anchor (the witnessed
+            // ceremony). Its key is independent of `root_signer` by
+            // construction (`attester_did != root_did`), so trusting it here
+            // is not self-referential in the way the rejected case is.
+            trusted_authority_keys.insert(
+                attestation.attester_did.clone(),
+                vec![attestation.attester_public_key.as_bytes().to_vec()],
+            );
+            // The root's key is trusted only because the external attester
+            // vouches for it via `attestation_link`, not because the root
+            // signed its own delegation to the Holon.
+            trusted_authority_keys.insert(
+                config.root_did.clone(),
+                vec![config.root_public_key.as_bytes().to_vec()],
+            );
+            AuthorityChain {
+                links: vec![attestation_link, root_link],
+            }
         }
-    }
+        _ => AuthorityChain {
+            links: vec![root_link],
+        },
+    };
     let mut trusted_provenance_keys = TrustedProvenanceKeys::default();
     trusted_provenance_keys.insert(
         holon.id.clone(),
@@ -571,25 +666,6 @@ fn analyze_health(consensus_round: u64, committed_height: u64) -> HealthStatus {
 // Holon action execution
 // ---------------------------------------------------------------------------
 
-/// Execute a governance action on behalf of a Holon.
-///
-/// This submits a DAG proposal for BFT consensus and broadcasts the
-/// governance event. The action must have been validated by kernel
-/// adjudication before calling this function.
-async fn execute_governance_action(
-    state: &SharedReactorState,
-    store: &std::sync::Arc<std::sync::Mutex<SqliteDagStore>>,
-    net_handle: &NetworkHandle,
-    action_type: GovernanceEventType,
-    payload: &[u8],
-) -> anyhow::Result<()> {
-    // Submit as a DAG proposal for BFT consensus.
-    reactor::submit_proposal(state, store, net_handle, payload).await?;
-
-    // Broadcast the governance event.
-    reactor::broadcast_governance_event(state, net_handle, action_type, payload.to_vec()).await
-}
-
 fn encode_validator_change(change: &ValidatorChange) -> Result<Vec<u8>, String> {
     let mut buf = Vec::new();
     ciborium::into_writer(change, &mut buf)
@@ -662,7 +738,12 @@ async fn read_holon_health_snapshot(
 pub async fn run_holon_manager(
     config: HolonManagerConfig,
     reactor_state: SharedReactorState,
-    shared_store: std::sync::Arc<std::sync::Mutex<SqliteDagStore>>,
+    // Retained for API stability (callers already pass the shared DAG
+    // store). No longer read here: per VCG-010/D5, the Scaling Holon's
+    // auto-promotion path is recommendation-only, full stop, and no longer
+    // submits a DAG proposal, so this manager has no state-changing use for
+    // direct store access.
+    _shared_store: std::sync::Arc<std::sync::Mutex<SqliteDagStore>>,
     net_handle: NetworkHandle,
     event_tx: mpsc::Sender<HolonEvent>,
 ) {
@@ -811,9 +892,13 @@ pub async fn run_holon_manager(
                             tracing::warn!("Holon event channel closed — ScalingRecommendation dropped");
                         }
 
-                        // Auto-action: if validator count is critical (< 3) and
-                        // we're a validator, attempt to propose validator promotion
-                        // for an eligible peer via a governance action.
+                        // Recommendation-only, full stop (D5): if validator count
+                        // is critical (< 3) and we're a validator, emit a named
+                        // promotion RECOMMENDATION for an eligible peer. This is
+                        // evidence for a human/governance ratification decision —
+                        // it never submits a state-changing ValidatorSetChange
+                        // proposal on its own. Promotion is a ratification event
+                        // with named evidence, not an automatic action.
                         if validator_count < 3
                             && node_count > validator_count
                             && scaling_snapshot.is_validator
@@ -825,29 +910,33 @@ pub async fn run_holon_manager(
                             ))
                             .unwrap_or_else(|_| static_did("did:exo:candidate"));
 
+                            // Same fail-closed CBOR encoding as a real
+                            // ValidatorSetChange payload would use — this value
+                            // is never submitted as a DAG proposal, only carried
+                            // as named evidence in a RecommendationOnly event.
                             let change = ValidatorChange::AddValidator {
                                 did: candidate.clone(),
                             };
                             match encode_validator_change(&change) {
                                 Ok(buf) => {
-                                    if let Err(e) = execute_governance_action(
+                                    if let Err(e) = reactor::broadcast_governance_event(
                                         &reactor_state,
-                                        &shared_store,
                                         &net_handle,
-                                        GovernanceEventType::ValidatorSetChange,
-                                        &buf,
+                                        GovernanceEventType::RecommendationOnly,
+                                        buf,
                                     )
                                     .await
                                     {
                                         tracing::warn!(
                                             err = %e,
                                             candidate = %candidate,
-                                            "Scaling Holon: auto-promotion failed"
+                                            "Scaling Holon: promotion recommendation broadcast failed"
                                         );
                                     } else {
                                         tracing::info!(
                                             candidate = %candidate,
-                                            "Scaling Holon: auto-promoted candidate"
+                                            "Scaling Holon: promotion recommendation emitted \
+                                             (recommendation-only, full stop — no proposal submitted)"
                                         );
                                     }
                                 }
@@ -986,6 +1075,12 @@ mod tests {
         })
     }
 
+    /// A `HolonManagerConfig` with a legitimate external attestation by
+    /// default: the root authority's key is vouched for by a distinct
+    /// attester DID/key (a witnessed ceremony), satisfying D5's
+    /// lineage-distinct-from-the-signer requirement. This is the config
+    /// used by tests that exercise the normal (non-adversarial) Holon step
+    /// path, including the Scaling Holon manager-loop tests.
     fn test_config_with_intervals(
         topology_interval_secs: u64,
         scaling_interval_secs: u64,
@@ -994,12 +1089,22 @@ mod tests {
         let keypair = exo_core::crypto::KeyPair::from_secret_bytes([0x48; 32]).unwrap();
         let root_public_key = *keypair.public_key();
         let root_secret_key = keypair.secret_key().clone();
+        let attester_keypair = exo_core::crypto::KeyPair::from_secret_bytes([0x99; 32]).unwrap();
+        let attester_public_key = *attester_keypair.public_key();
+        let attester_secret_key = attester_keypair.secret_key().clone();
         HolonManagerConfig {
             node_did: test_did(),
             root_did: Did::new("did:exo:test-root").unwrap(),
             root_public_key,
             root_signer: Arc::new(move |message: &[u8]| {
                 exo_core::crypto::sign(message, &root_secret_key)
+            }),
+            root_attestation: Some(RootAttestation {
+                attester_did: Did::new("did:exo:test-ceremony-witness").unwrap(),
+                attester_public_key,
+                attester_signer: Arc::new(move |message: &[u8]| {
+                    exo_core::crypto::sign(message, &attester_secret_key)
+                }),
             }),
             provenance_timestamp_source: deterministic_provenance_timestamp_source(1),
             topology_interval_secs,
@@ -1008,7 +1113,20 @@ mod tests {
         }
     }
 
+    /// A `HolonManagerConfig` with no external attestation: the D5
+    /// self-issued-root scenario (grantor key == signer key, no lineage
+    /// distinct from the signer), which the kernel must reject during
+    /// `holon::step`.
     fn test_config() -> HolonManagerConfig {
+        let mut config = test_config_with_intervals(60, 300, 30);
+        config.root_attestation = None;
+        config
+    }
+
+    /// Convenience alias for `test_config_with_intervals` at the default
+    /// intervals — reads at call sites as "a legitimately attested config",
+    /// contrasting with the self-issued `test_config()`.
+    fn test_config_with_attestation() -> HolonManagerConfig {
         test_config_with_intervals(60, 300, 30)
     }
 
@@ -1312,7 +1430,7 @@ mod tests {
     #[test]
     fn topology_holon_step_succeeds_with_peers() {
         let kernel = create_infrastructure_kernel();
-        let config = test_config();
+        let config = test_config_with_attestation();
         let mut h = create_topology_holon(&test_did());
         let ctx = build_holon_adjudication_context(&h, &config).expect("holon context");
 
@@ -1330,7 +1448,7 @@ mod tests {
     #[test]
     fn topology_holon_guard_rejects_no_peer_count() {
         let kernel = create_infrastructure_kernel();
-        let config = test_config();
+        let config = test_config_with_attestation();
         let mut h = create_topology_holon(&test_did());
         let ctx = build_holon_adjudication_context(&h, &config).expect("holon context");
 
@@ -1352,7 +1470,7 @@ mod tests {
     #[test]
     fn scaling_holon_step_succeeds() {
         let kernel = create_infrastructure_kernel();
-        let config = test_config();
+        let config = test_config_with_attestation();
         let mut h = create_scaling_holon(&test_did());
         let ctx = build_holon_adjudication_context(&h, &config).expect("holon context");
 
@@ -1368,7 +1486,7 @@ mod tests {
     #[test]
     fn health_holon_step_succeeds() {
         let kernel = create_infrastructure_kernel();
-        let config = test_config();
+        let config = test_config_with_attestation();
         let mut h = create_health_holon(&test_did());
         let ctx = build_holon_adjudication_context(&h, &config).expect("holon context");
 
@@ -1442,7 +1560,7 @@ mod tests {
         // Verify that a Holon with is_self_grant=true would be denied.
         // The kernel's NoSelfGrant invariant prevents AI from self-escalating.
         let kernel = create_infrastructure_kernel();
-        let config = test_config();
+        let config = test_config_with_attestation();
         let h = create_health_holon(&test_did());
 
         // Build context normally.

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -791,6 +791,14 @@ async fn start_node(
             root_did: holon_authority_did,
             root_public_key: holon_authority_public_key,
             root_signer: holon_authority_signer,
+            // No external attestation is wired yet: `root_did`/`root_public_key`/
+            // `root_signer` above are all derived from the same freshly-loaded
+            // node identity, i.e. a self-issued root authority with no
+            // witnessed ceremony or lineage distinct from the signer. Per
+            // ratified decision D5, the kernel must reject this until a real
+            // external attestation source (a distinct witnessing party) is
+            // wired in — tracked in `Initiatives/fix-onyx-4-r5-holons-stub-context.md`.
+            root_attestation: None,
             provenance_timestamp_source: holons::hlc_provenance_timestamp_source(),
             topology_interval_secs: 60,
             scaling_interval_secs: 300,

--- a/crates/exo-node/src/reactor.rs
+++ b/crates/exo-node/src/reactor.rs
@@ -388,6 +388,12 @@ async fn apply_committed_validator_change_after_commit(
     );
 }
 
+// Reachable in production only via `submit_proposal` under the
+// `unaudited-admin-governance-shortcut` feature (see `api.rs`); the
+// infrastructure-Holon Scaling path no longer calls `submit_proposal` as of
+// VCG-010/D5 (recommendation-only, full stop — it never submits a DAG
+// proposal). Exercised directly by `reactor::tests` regardless of feature.
+#[cfg_attr(not(feature = "unaudited-admin-governance-shortcut"), allow(dead_code))]
 fn sign_proposal(
     proposal: &Proposal,
     sign_fn: &(dyn Fn(&[u8]) -> Signature + Send + Sync),
@@ -1455,7 +1461,14 @@ async fn check_and_commit(
 
 /// Submit a governance mutation as a DAG node and propose it for consensus.
 ///
-/// Called by the API layer when a new governance action is requested.
+/// Called by the API layer when a new governance action is requested, behind
+/// the `unaudited-admin-governance-shortcut` feature (see `api.rs`). The
+/// infrastructure-Holon Scaling path no longer calls this as of VCG-010/D5
+/// (recommendation-only, full stop — it emits a `RecommendationOnly`
+/// governance event via `broadcast_governance_event` instead of submitting a
+/// DAG proposal). Exercised directly by `reactor::tests` regardless of
+/// feature.
+#[cfg_attr(not(feature = "unaudited-admin-governance-shortcut"), allow(dead_code))]
 pub async fn submit_proposal(
     state: &SharedReactorState,
     store: &Arc<Mutex<SqliteDagStore>>,

--- a/crates/exo-node/src/wire.rs
+++ b/crates/exo-node/src/wire.rs
@@ -585,6 +585,11 @@ pub enum GovernanceEventType {
     AuditEntry,
     /// Validator set change — add or remove a validator.
     ValidatorSetChange,
+    /// A recommendation-only signal (e.g. Scaling Holon auto-promotion
+    /// advice). Per ratified decision D5, this event type is informational
+    /// evidence only — it never authorizes a state change on its own.
+    /// Promotion remains a ratification event with named evidence.
+    RecommendationOnly,
 }
 
 /// A request to change the validator set.

--- a/tools/test_gap_registry_truth.sh
+++ b/tools/test_gap_registry_truth.sh
@@ -90,6 +90,7 @@ assert_contains GAP-REGISTRY.md "VCG-003 \\| P0 \\| Red"
 assert_contains GAP-REGISTRY.md "VCG-004 \\| P0 \\| Red"
 assert_contains GAP-REGISTRY.md "VCG-005 \\| P1 \\| Green-local"
 assert_contains GAP-REGISTRY.md "VCG-008 \\| P1 \\| Green-local"
+assert_contains GAP-REGISTRY.md "VCG-010 \\| P1 \\| Green-local"
 assert_contains GAP-REGISTRY.md "eDiscovery export is not an open origin-main gap"
 assert_contains GAP-REGISTRY.md "No VCG row is closed at ledger creation"
 


### PR DESCRIPTION
## Ledger row VCG-010: Open -> Green-local

**Lane record in this PR's own ledger diff** (coordinator-authored).

- **Red** (D5): `holon_rejects_self_issued_root_authority` + `scaling_holon_emits_zero_validator_set_change_proposals` — the tautological self-issued trust, and the Scaling Holon broadcasting a real `ValidatorSetChange` for a fabricated `did:exo:auto-promoted-{n}`.
- **Green**: self-issued root rejected (trust anchored only from external attestation distinct from the signer); Scaling Holon emits a recommendation event and **zero** DAG proposals; stale sentinel-bytes comment fixed; initiative doc created.
- **Major refutation caught + fixed**: the guard originally checked only `attester_did != root_did`, so a distinct-DID-but-same-key attestation could launder self-issuance. Now requires `attester_public_key != root_public_key` too; new red test `holon_rejects_attestation_that_reuses_the_root_signer_key` proves rejection (genuine — fails against pre-fix code). **Re-refutation: NOT-REFUTED** (byte-for-byte key comparison; both original D5 tests intact).
- Gates: holon 28 pass (both feature configs); clippy/doc/nightly-fmt clean; Ed25519 signing untouched; feature default off.
- **Residual (documented)**: full D5 depth — witnessed multi-party ceremony + wiring external attestation into the production default (currently `root_attestation: None`, fail-closed) — is follow-on work.

Scope: `crates/exo-node/**` + `Initiatives/`.