### PR TITLE
VCG-012: Distributed HLC sync wire protocol (Open -> Green-local, D6)

### DIFF
--- a/GAP-REGISTRY.md
+++ b/GAP-REGISTRY.md
@@ -152,7 +152,7 @@ Amendment baseline (2026-07-02, local run on clean `origin/main` at `2d4baec1`):
 | VCG-009 | P1 | Open | Core runtime adapter | 0dentity | Device/behavior trust inputs | consented sample ingestion tests | `cargo test -p exochain-node zerodentity` |
 | VCG-010 | P1 | Open | Core runtime adapter | Holon runtime | Holons as trusted actors | signed authority/provenance tests | `cargo test -p exochain-node holon` |
 | VCG-011 | P1 | Open | EXOCHAIN core | TEE integration | Hardware TEE attestation | platform quote verifier tests | `cargo test -p exochain-gatekeeper tee` |
-| VCG-012 | P2 | Open | EXOCHAIN core | Distributed time | Multi-node causal finality | multi-node HLC partition tests | `cargo test -p exochain-core hlc` |
+| VCG-012 | P2 | Green-local | EXOCHAIN core | Distributed time | Multi-node causal finality | multi-node HLC partition tests | `cargo test -p exochain-core hlc` |
 | VCG-013 | P2 | Open | EXOCHAIN core | Tenant platform | SaaS tenant ops and billing | tenant metering and billing export tests | `cargo test -p exochain-tenant` |
 | VCG-014 | P2 | Open | Governance/legal | Council/legal | Constitutional completeness | unresolved Sybil/no-admin traceability guard | governance guard plus legal sign-off record |
 | VCG-015 | P1 | Open | Core runtime adapter | Governance runtime | New validators can cast verifiable votes | validator public-key registration tests | `cargo test -p exochain-node governance` |
@@ -1065,9 +1065,43 @@ claims are upgraded.
 ## VCG-012 - Distributed HLC Sync Protocol Is Not Built
 
 **Priority:** P2
-**Status:** Open
+**Status:** Green-local
 **Classification:** EXOCHAIN core
 **Owner role:** Distributed time
+
+Lane record (2026-07-04, branch `vcg/012-hlc-sync`):
+
+- Scout correction confirmed: `hlc.rs` local merge math (drift/overflow/
+  monotonicity guards, 25 tests) was already complete and untouched. The open
+  surface was the WIRE PROTOCOL — multi-node HLC exchange and partition
+  recovery — only.
+- Green per D6 (`exo-core/src/hlc.rs`, `exo-node/src/{wire,sync,network}.rs`):
+  a `WireMessage::HlcSync(HlcSyncMsg { sender, timestamp })` variant rides the
+  EXISTING DAG-sync (consensus) gossipsub topic — no dedicated clock topic.
+  The real receive path (`run_sync_engine` → `handle_message` →
+  `handle_hlc_sync`, spawned in `main.rs`) merges each remote timestamp via
+  `observe_remote_hlc_timestamp`, which calls `HybridClock::update` unmodified
+  and, on any drift/overflow anomaly, records a RETRIEVABLE `HlcAnomalyEvidence`
+  object (append-only `HlcAnomalyRecorder`) AND re-propagates the error —
+  satisfying D6's "time anomalies are constitutional events, not log lines"
+  and "fail-closed guard never weakened".
+- Partition recovery (`reconcile_partition_recovery`) converges to the quorum
+  MEDIAN (`sorted[(len-1)/2]`, deterministic lower-of-two-middle), never the
+  max — directly enforcing D6's "silent accept-max is forbidden". An empty
+  peer set fails closed. A wide-outlier peer is reported, not silently folded.
+- Adversarial correction (coordinator): the red-stage round-trip test was
+  internally contradictory (constant `|0|` clock asserting acceptance of a
+  2.7h-ahead timestamp the 5s drift guard must reject). The GREEN worker
+  correctly refused to weaken the guard and escalated (D3); the corrective
+  made the fixture coherent (fresh remote 100 ms ahead of a realistic base)
+  so it proves the real happy-path round-trip WITHOUT touching any guard.
+  Re-refutation: NOT-REFUTED (wiring real end-to-end; `MAX_DRIFT_MS` and
+  `HybridClock::update` unchanged; median-not-max verified).
+- Gates: `exochain-core` 321 pass; `exochain-node` full suite 1320 pass
+  (hlc 9/9); clippy `-D warnings` clean on both crates; nightly fmt clean.
+- Status Green-local: distributed HLC wire sync, partition-recovery median
+  reconciliation, and constitutional anomaly evidence delivered. Closed after
+  merge + CI.
 
 Evidence:
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 31 | `ls -d crates/*/` |
 | Rust source files | 459 | `find crates -name '*.rs'` |
-| Rust LOC | 370750 | `wc -l` |
-| Workspace tests | 6,067 listed | `cargo test --workspace -- --list` |
+| Rust LOC | 371200 | `wc -l` |
+| Workspace tests | 6,071 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 23 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **6,067 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **6,071 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,10 +113,10 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 31 crates, 370750 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 31 crates, 371200 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          production Ed25519/BLAKE3 cryptography plus unaudited pedagogical
-         SNARK/STARK/ZKML skeletons, 6,067 listed workspace tests
+         SNARK/STARK/ZKML skeletons, 6,071 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          165 verified WASM exports covered by 172 bridge checks — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-core/src/hlc.rs
+++ b/crates/exo-core/src/hlc.rs
@@ -599,4 +599,63 @@ mod tests {
             "HLC wall-clock failures must propagate instead of silently using epoch zero"
         );
     }
+
+    // -----------------------------------------------------------------
+    // VCG-012 RED — partition-recovery peer-set reconciliation (D6).
+    //
+    // D6 (ratified 2026-07-02): partition recovery converges to the
+    // quorum-MEDIAN of peers' latest known timestamps, never accept-max.
+    // One bad/drifted clock must not steer history ordering. No such
+    // reconciliation policy exists yet on `HybridClock` — this is expected
+    // compile-red until the D6 peer-set reconciliation API lands.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn partition_recovery_converges_to_quorum_median_not_accept_max() {
+        // Five peers' last-known timestamps before reconnect. Constructed so
+        // the median (100_500) is neither the max (999_999) nor the min
+        // (100_000) — this proves the reconciliation is genuinely
+        // median-based and not a disguised accept-max.
+        let peer_timestamps = vec![
+            Timestamp::new(100_000, 0),
+            Timestamp::new(100_200, 0),
+            Timestamp::new(100_500, 0),
+            Timestamp::new(100_800, 0),
+            Timestamp::new(999_999, 0), // one wildly drifted / malicious peer
+        ];
+
+        let reconciled = HybridClock::reconcile_partition_recovery(&peer_timestamps)
+            .expect("quorum-median reconciliation must succeed with an odd-sized peer set");
+
+        assert_eq!(
+            reconciled,
+            Timestamp::new(100_500, 0),
+            "partition recovery must converge to the quorum MEDIAN, not the max"
+        );
+        assert_ne!(
+            reconciled,
+            Timestamp::new(999_999, 0),
+            "silent accept-max is forbidden by D6: one bad clock must not steer history ordering"
+        );
+    }
+
+    #[test]
+    fn partition_recovery_flags_anomaly_when_a_peer_is_a_wide_outlier() {
+        let peer_timestamps = vec![
+            Timestamp::new(100_000, 0),
+            Timestamp::new(100_100, 0),
+            Timestamp::new(100_200, 0),
+            Timestamp::new(100_300, 0),
+            Timestamp::new(999_999, 0), // wide outlier vs. the quorum
+        ];
+
+        let outcome = HybridClock::reconcile_partition_recovery_with_anomaly_report(&peer_timestamps)
+            .expect("reconciliation with anomaly reporting must succeed");
+
+        assert_eq!(outcome.median, Timestamp::new(100_200, 0));
+        assert!(
+            !outcome.anomalous_peers.is_empty(),
+            "a wide-outlier peer must be flagged, not silently folded into the median"
+        );
+    }
 }

--- a/crates/exo-core/src/hlc.rs
+++ b/crates/exo-core/src/hlc.rs
@@ -737,8 +737,9 @@ mod tests {
             Timestamp::new(999_999, 0), // wide outlier vs. the quorum
         ];
 
-        let outcome = HybridClock::reconcile_partition_recovery_with_anomaly_report(&peer_timestamps)
-            .expect("reconciliation with anomaly reporting must succeed");
+        let outcome =
+            HybridClock::reconcile_partition_recovery_with_anomaly_report(&peer_timestamps)
+                .expect("reconciliation with anomaly reporting must succeed");
 
         assert_eq!(outcome.median, Timestamp::new(100_200, 0));
         assert!(

--- a/crates/exo-core/src/hlc.rs
+++ b/crates/exo-core/src/hlc.rs
@@ -110,6 +110,54 @@ impl HybridClock {
         self.max_drift_ms
     }
 
+    /// Reconcile a partition-recovery peer set to the quorum **median** of
+    /// their last-known timestamps.
+    ///
+    /// Per ratified decision D6 (2026-07-02): on reconnect after a network
+    /// partition, the recovering node converges its causal-ordering view to
+    /// the median of its peers' latest known HLC timestamps — never the
+    /// maximum. Silent accept-max would let a single drifted or malicious
+    /// peer steer history ordering for the whole network; the median is
+    /// resilient to any single outlier as long as a majority of the peer set
+    /// is honest.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ExoError::ClockUnavailable` if `peer_timestamps` is empty —
+    /// there is nothing to reconcile against.
+    pub fn reconcile_partition_recovery(peer_timestamps: &[Timestamp]) -> Result<Timestamp> {
+        Ok(quorum_median(peer_timestamps)?.0)
+    }
+
+    /// Reconcile a partition-recovery peer set to the quorum median, and
+    /// additionally report any peer whose timestamp is a wide outlier
+    /// relative to that median.
+    ///
+    /// Per D6, time anomalies detected during partition recovery are
+    /// constitutional events, not silent log lines — the caller is expected
+    /// to record `anomalous_peers` as DAG evidence rather than folding the
+    /// outlier silently into the reconciled median.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ExoError::ClockUnavailable` if `peer_timestamps` is empty.
+    pub fn reconcile_partition_recovery_with_anomaly_report(
+        peer_timestamps: &[Timestamp],
+    ) -> Result<PartitionRecoveryOutcome> {
+        let (median, max_drift_ms) = quorum_median(peer_timestamps)?;
+
+        let anomalous_peers: Vec<Timestamp> = peer_timestamps
+            .iter()
+            .copied()
+            .filter(|peer| is_wide_outlier(peer, &median, max_drift_ms))
+            .collect();
+
+        Ok(PartitionRecoveryOutcome {
+            median,
+            anomalous_peers,
+        })
+    }
+
     /// Generate the next timestamp.
     ///
     /// Guarantees: the returned timestamp is strictly greater than any
@@ -177,6 +225,46 @@ impl HybridClock {
     pub fn current(&self) -> Timestamp {
         Timestamp::new(self.physical, self.logical)
     }
+}
+
+/// Outcome of [`HybridClock::reconcile_partition_recovery_with_anomaly_report`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PartitionRecoveryOutcome {
+    /// The quorum-median timestamp the recovering node should adopt.
+    pub median: Timestamp,
+    /// Peers whose last-known timestamp was a wide outlier relative to the
+    /// median (a candidate constitutional-event / DAG-evidence anomaly).
+    pub anomalous_peers: Vec<Timestamp>,
+}
+
+/// A wide outlier is a peer timestamp whose physical component differs from
+/// the reconciled median by more than the quorum's own drift tolerance. This
+/// reuses the same `MAX_DRIFT_MS` semantics as `HybridClock::update` so
+/// "anomalous" has one consistent meaning across the sync protocol.
+fn is_wide_outlier(peer: &Timestamp, median: &Timestamp, max_drift_ms: u64) -> bool {
+    peer.physical_ms.abs_diff(median.physical_ms) > max_drift_ms
+}
+
+/// Compute the quorum median of a peer timestamp set, ordering by the total
+/// `Timestamp` order (physical, then logical) so ties are broken
+/// deterministically. Returns the median timestamp plus the drift tolerance
+/// to apply against it.
+///
+/// For an even-sized peer set the lower of the two middle elements is used —
+/// deterministic and reproducible across nodes without floating-point
+/// averaging (which `Timestamp`'s integer fields do not support losslessly).
+fn quorum_median(peer_timestamps: &[Timestamp]) -> Result<(Timestamp, u64)> {
+    if peer_timestamps.is_empty() {
+        return Err(ExoError::ClockUnavailable {
+            reason: "cannot reconcile partition recovery: empty peer timestamp set".to_string(),
+        });
+    }
+
+    let mut sorted: Vec<Timestamp> = peer_timestamps.to_vec();
+    sorted.sort_unstable();
+
+    let mid = (sorted.len() - 1) / 2;
+    Ok((sorted[mid], MAX_DRIFT_MS))
 }
 
 fn advance_logical_or_carry_physical(physical: &mut u64, logical: &mut u32) -> Result<()> {

--- a/crates/exo-node/src/network.rs
+++ b/crates/exo-node/src/network.rs
@@ -964,7 +964,11 @@ mod tests {
 
         let (cmd_tx1, cmd_rx1) = mpsc::channel(32);
         let (event_tx1, _event_rx1) = mpsc::channel(32);
-        let (cmd_tx2, cmd_rx2) = mpsc::channel(32);
+        // Node B is a pure receiver in this round-trip; its command sender is
+        // never used to publish, but must stay bound (underscore, not dropped)
+        // so node B's network loop keeps a live command channel for its
+        // lifetime.
+        let (_cmd_tx2, cmd_rx2) = mpsc::channel(32);
         let (event_tx2, mut event_rx2) = mpsc::channel(32);
 
         tokio::spawn(run_network_loop(swarm1, cmd_rx1, event_tx1));
@@ -978,11 +982,18 @@ mod tests {
         // (consensus) topic before publishing — no dedicated clock topic.
         tokio::time::sleep(Duration::from_millis(500)).await;
 
-        let remote_timestamp = Timestamp::new(9_999_999, 3);
+        // A *legitimately fresh* remote HLC timestamp: node B's physical clock
+        // sits at a realistic base and node A's timestamp is only 100 ms ahead
+        // — well inside HybridClock's 5 s drift tolerance. This is the
+        // happy-path round trip: a fresh remote reading is received over the
+        // wire and merged. The pathological "far-future" timestamp that must
+        // be rejected-and-recorded is the domain of
+        // clock_anomaly_emits_dag_evidence_object, not this test.
+        let node_b_physical_ms: u64 = 1_000_000;
+        let remote_timestamp = Timestamp::new(node_b_physical_ms + 100, 3);
 
-        // This variant does not exist yet — compile-red until the D6 wire
-        // protocol change lands. HLC rides the existing DAG-sync channel,
-        // it does not get a dedicated clock topic.
+        // HLC rides the existing DAG-sync (consensus) gossipsub channel per
+        // D6 — it does not get a dedicated clock topic.
         let hlc_message = WireMessage::HlcSync(wire::HlcSyncMsg {
             sender: Did::new("did:exo:hlc-node-a").unwrap(),
             timestamp: remote_timestamp,
@@ -993,7 +1004,8 @@ mod tests {
             .await
             .expect("HLC wire message should publish over the existing DAG-sync channel");
 
-        let mut node_b_clock = exo_core::hlc::HybridClock::with_wall_clock(|| 0);
+        let mut node_b_clock =
+            exo_core::hlc::HybridClock::with_wall_clock(move || node_b_physical_ms);
 
         let advanced = tokio::time::timeout(Duration::from_secs(15), async {
             while let Some(event) = event_rx2.recv().await {
@@ -1034,7 +1046,8 @@ mod tests {
         let mut clock = exo_core::hlc::HybridClock::with_wall_clock(|| 1_000);
         let excessive_drift = Timestamp::new(1_000 + clock.max_drift_ms() + 1, 0);
 
-        let outcome = crate::sync::observe_remote_hlc_timestamp(&mut clock, &excessive_drift, &recorder);
+        let outcome =
+            crate::sync::observe_remote_hlc_timestamp(&mut clock, &excessive_drift, &recorder);
 
         assert!(
             outcome.is_err(),

--- a/crates/exo-node/src/network.rs
+++ b/crates/exo-node/src/network.rs
@@ -931,4 +931,122 @@ mod tests {
         .unwrap_or(0);
         assert_eq!(count, 1, "Should have exactly 1 peer");
     }
+
+    // -----------------------------------------------------------------
+    // VCG-012 RED — distributed HLC sync (D6: HLC rides the existing
+    // gossipsub DAG-sync channel; no dedicated clock topic).
+    // -----------------------------------------------------------------
+
+    /// RED (expected compile failure until D6 lands): there is no
+    /// `WireMessage` variant carrying an HLC `Timestamp` today. D6 requires
+    /// HLC timestamps to piggyback on the existing gossipsub DAG-sync
+    /// channel (`topics::CONSENSUS`) rather than adding a dedicated clock
+    /// topic. This test performs a REAL two-node wire round trip: node A
+    /// publishes an HLC-carrying wire message over gossipsub, node B
+    /// receives it via its real `NetworkEvent::MessageReceived` stream and
+    /// must call `HybridClock::update` on receipt, advancing its local
+    /// clock past the received remote timestamp.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn hlc_timestamp_round_trips_over_gossipsub() {
+        let mut swarm1 = build_swarm().unwrap();
+        let mut swarm2 = build_swarm().unwrap();
+        let peer2 = *swarm2.local_peer_id();
+
+        swarm1
+            .listen_on("/ip4/127.0.0.1/tcp/0".parse().unwrap())
+            .unwrap();
+        swarm2
+            .listen_on("/ip4/127.0.0.1/tcp/0".parse().unwrap())
+            .unwrap();
+
+        let mut addr2 = wait_for_tcp_listen_addr(&mut swarm2).await;
+        addr2.push(Protocol::P2p(peer2));
+
+        let (cmd_tx1, cmd_rx1) = mpsc::channel(32);
+        let (event_tx1, _event_rx1) = mpsc::channel(32);
+        let (cmd_tx2, cmd_rx2) = mpsc::channel(32);
+        let (event_tx2, mut event_rx2) = mpsc::channel(32);
+
+        tokio::spawn(run_network_loop(swarm1, cmd_rx1, event_tx1));
+        tokio::spawn(run_network_loop(swarm2, cmd_rx2, event_tx2));
+
+        let handle1 = NetworkHandle::new(cmd_tx1);
+
+        handle1.dial(addr2).await.unwrap();
+
+        // Wait for the gossipsub mesh to form on the existing DAG-sync
+        // (consensus) topic before publishing — no dedicated clock topic.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let remote_timestamp = Timestamp::new(9_999_999, 3);
+
+        // This variant does not exist yet — compile-red until the D6 wire
+        // protocol change lands. HLC rides the existing DAG-sync channel,
+        // it does not get a dedicated clock topic.
+        let hlc_message = WireMessage::HlcSync(wire::HlcSyncMsg {
+            sender: Did::new("did:exo:hlc-node-a").unwrap(),
+            timestamp: remote_timestamp,
+        });
+
+        handle1
+            .publish(topics::CONSENSUS, hlc_message)
+            .await
+            .expect("HLC wire message should publish over the existing DAG-sync channel");
+
+        let mut node_b_clock = exo_core::hlc::HybridClock::with_wall_clock(|| 0);
+
+        let advanced = tokio::time::timeout(Duration::from_secs(15), async {
+            while let Some(event) = event_rx2.recv().await {
+                if let NetworkEvent::MessageReceived { message, .. } = event {
+                    if let WireMessage::HlcSync(hlc) = message {
+                        node_b_clock
+                            .update(&hlc.timestamp)
+                            .expect("HLC update should accept a fresh remote timestamp");
+                        return true;
+                    }
+                }
+            }
+            false
+        })
+        .await
+        .unwrap_or(false);
+
+        assert!(
+            advanced,
+            "node B should receive the HLC wire message over gossipsub and call HybridClock::update"
+        );
+        assert!(
+            node_b_clock.current() > remote_timestamp,
+            "node B's HybridClock must advance strictly past the received remote HLC timestamp"
+        );
+    }
+
+    /// RED (expected behavioral failure until D6 lands): D6 requires that
+    /// any drift/replay anomaly detected during HLC sync is recorded as a
+    /// DAG evidence object (a constitutional event), not merely logged.
+    /// This test simulates a replay/drift anomaly arriving over the wire
+    /// and asserts a retrievable evidence object was recorded.
+    #[tokio::test]
+    async fn clock_anomaly_emits_dag_evidence_object() {
+        // No such recorder exists yet on the exo-node side — compile-red.
+        let recorder = crate::sync::HlcAnomalyRecorder::new();
+
+        let mut clock = exo_core::hlc::HybridClock::with_wall_clock(|| 1_000);
+        let excessive_drift = Timestamp::new(1_000 + clock.max_drift_ms() + 1, 0);
+
+        let outcome = crate::sync::observe_remote_hlc_timestamp(&mut clock, &excessive_drift, &recorder);
+
+        assert!(
+            outcome.is_err(),
+            "excessive drift must still fail closed at the clock layer"
+        );
+
+        let recorded = recorder.recorded_evidence();
+        assert_eq!(
+            recorded.len(),
+            1,
+            "a clock drift anomaly must record exactly one DAG evidence object, not just a log line"
+        );
+        assert_eq!(recorded[0].anomaly_physical_ms, excessive_drift.physical_ms);
+    }
 }

--- a/crates/exo-node/src/sync.rs
+++ b/crates/exo-node/src/sync.rs
@@ -38,7 +38,10 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use exo_core::types::{Did, Hash256, PublicKey};
+use exo_core::{
+    hlc::HybridClock,
+    types::{Did, Hash256, PublicKey, Timestamp},
+};
 use exo_dag::{
     append::verify_node_creator_signature,
     consensus::{CommitCertificate, ConsensusConfig},
@@ -51,12 +54,100 @@ use crate::{
     network::{NetworkEvent, NetworkHandle},
     store::SqliteDagStore,
     wire::{
-        DagSyncRequestMsg, DagSyncResponseMsg, StateSnapshotChunkMsg, StateSnapshotRequestMsg,
-        WireMessage, topics,
+        DagSyncRequestMsg, DagSyncResponseMsg, HlcSyncMsg, StateSnapshotChunkMsg,
+        StateSnapshotRequestMsg, WireMessage, topics,
     },
 };
 
 const MAX_SNAPSHOT_CHUNK_SIZE: u32 = 500;
+
+// ---------------------------------------------------------------------------
+// Distributed HLC sync anomaly evidence (VCG-012 / D6)
+// ---------------------------------------------------------------------------
+//
+// Per ratified decision D6 (2026-07-02), any drift, replay, or partition
+// anomaly detected while syncing HLC timestamps over the wire is a
+// constitutional event — it must be recorded as a retrievable DAG evidence
+// object, never only emitted as a log line, because deliberation order is
+// legitimacy-relevant.
+
+/// A recorded HLC anomaly — a constitutional event describing a rejected or
+/// suspect remote timestamp observed during distributed HLC sync.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HlcAnomalyEvidence {
+    /// The physical millisecond component of the anomalous remote timestamp.
+    pub anomaly_physical_ms: u64,
+    /// The logical counter of the anomalous remote timestamp.
+    pub anomaly_logical: u32,
+    /// Human-readable reason the timestamp was flagged (drift, overflow, etc.).
+    pub reason: String,
+}
+
+/// Append-only recorder for HLC anomaly evidence objects.
+///
+/// This is intentionally the minimal, in-process DAG-evidence surface for
+/// VCG-012: every anomaly recorded here is retrievable, ordered, and never
+/// silently dropped. Production wiring may persist these into the durable
+/// DAG evidence store; the recorder is the constitutional seam that
+/// guarantees an anomaly is never *just* a log line.
+#[derive(Debug, Default)]
+pub struct HlcAnomalyRecorder {
+    evidence: Mutex<Vec<HlcAnomalyEvidence>>,
+}
+
+impl HlcAnomalyRecorder {
+    /// Create an empty recorder.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a new anomaly evidence object.
+    fn record(&self, evidence: HlcAnomalyEvidence) {
+        let mut guard = self
+            .evidence
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.push(evidence);
+    }
+
+    /// Return all recorded anomaly evidence objects, in recording order.
+    #[must_use]
+    pub fn recorded_evidence(&self) -> Vec<HlcAnomalyEvidence> {
+        self.evidence
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+}
+
+/// Observe a remote HLC timestamp received over the wire: merge it into
+/// `clock` via [`HybridClock::update`], recording a DAG evidence object via
+/// `recorder` if the merge fails (excessive drift, overflow, etc.) instead of
+/// only logging the failure.
+///
+/// # Errors
+///
+/// Propagates the same error `HybridClock::update` returns — the clock
+/// layer's fail-closed guards are never weakened or bypassed here; this
+/// function only adds constitutional-evidence recording around them.
+pub fn observe_remote_hlc_timestamp(
+    clock: &mut HybridClock,
+    remote: &Timestamp,
+    recorder: &HlcAnomalyRecorder,
+) -> exo_core::Result<Timestamp> {
+    match clock.update(remote) {
+        Ok(advanced) => Ok(advanced),
+        Err(err) => {
+            recorder.record(HlcAnomalyEvidence {
+                anomaly_physical_ms: remote.physical_ms,
+                anomaly_logical: remote.logical,
+                reason: err.to_string(),
+            });
+            Err(err)
+        }
+    }
+}
 
 fn static_did(value: &'static str) -> Did {
     match Did::new(value) {
@@ -295,6 +386,15 @@ pub struct SyncEngine {
     syncing: bool,
     /// The height we're syncing to (from the peer).
     sync_target_height: u64,
+    /// This node's Hybrid Logical Clock, advanced by `HlcSync` wire messages
+    /// received over the existing DAG-sync gossipsub channel (VCG-012 / D6).
+    /// `Mutex`-wrapped (rather than held by value) so `SyncEngine` stays
+    /// `Send + Sync`, matching `HlcAnomalyRecorder` below — `HybridClock`'s
+    /// physical source is a boxed `Fn` that is `Send` but not `Sync`.
+    hlc: Arc<Mutex<HybridClock>>,
+    /// Records HLC drift/replay anomalies as DAG evidence objects rather
+    /// than silent log lines (D6: time anomalies are constitutional events).
+    hlc_anomalies: Arc<HlcAnomalyRecorder>,
 }
 
 impl SyncEngine {
@@ -312,6 +412,51 @@ impl SyncEngine {
             event_tx,
             syncing: false,
             sync_target_height: 0,
+            hlc: Arc::new(Mutex::new(HybridClock::new())),
+            hlc_anomalies: Arc::new(HlcAnomalyRecorder::new()),
+        }
+    }
+
+    /// This node's recorded HLC anomaly evidence (drift/replay events
+    /// detected while processing `HlcSync` messages).
+    #[must_use]
+    #[allow(dead_code)] // Constitutional-evidence introspection API; wired to observability once the DAG evidence store lands.
+    pub fn hlc_anomalies(&self) -> Vec<HlcAnomalyEvidence> {
+        self.hlc_anomalies.recorded_evidence()
+    }
+
+    /// This node's current HLC state, after any `HlcSync` updates.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal HLC mutex is poisoned by a prior panic while
+    /// held — the same fail-loud posture the store helpers use elsewhere in
+    /// this module.
+    #[must_use]
+    #[allow(dead_code)] // Introspection API for callers that need this node's post-sync HLC state.
+    pub fn hlc_current(&self) -> Timestamp {
+        self.hlc
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .current()
+    }
+
+    /// Handle an inbound `HlcSync` wire message: merge the remote timestamp
+    /// into this node's `HybridClock`. A drift/replay anomaly is recorded as
+    /// a DAG evidence object (D6) rather than only logged.
+    async fn handle_hlc_sync(&mut self, msg: HlcSyncMsg) {
+        let mut clock = self
+            .hlc
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Err(err) =
+            observe_remote_hlc_timestamp(&mut clock, &msg.timestamp, &self.hlc_anomalies)
+        {
+            tracing::warn!(
+                sender = %msg.sender,
+                err = %err,
+                "HLC sync anomaly recorded as DAG evidence"
+            );
         }
     }
 
@@ -381,6 +526,9 @@ impl SyncEngine {
             }
             WireMessage::DagSyncResponse(msg) => {
                 self.handle_dag_sync_response(msg).await;
+            }
+            WireMessage::HlcSync(msg) => {
+                self.handle_hlc_sync(msg).await;
             }
             _ => {} // Not a sync message
         }
@@ -794,7 +942,8 @@ pub async fn run_sync_engine(mut engine: SyncEngine, mut net_events: mpsc::Recei
                     WireMessage::StateSnapshotRequest(_)
                     | WireMessage::StateSnapshotChunk(_)
                     | WireMessage::DagSyncRequest(_)
-                    | WireMessage::DagSyncResponse(_) => {
+                    | WireMessage::DagSyncResponse(_)
+                    | WireMessage::HlcSync(_) => {
                         engine.handle_message(message).await;
                     }
                     _ => {} // Other messages handled by reactor

--- a/crates/exo-node/src/wire.rs
+++ b/crates/exo-node/src/wire.rs
@@ -467,6 +467,15 @@ pub enum WireMessage {
     StateSnapshotRequest(StateSnapshotRequestMsg),
     /// A chunk of the state snapshot.
     StateSnapshotChunk(StateSnapshotChunkMsg),
+
+    // -- Distributed time (gossipsub broadcast) --
+    /// An HLC timestamp broadcast for causal-clock sync (VCG-012 / D6).
+    ///
+    /// Per ratified decision D6, HLC timestamps piggyback on the existing
+    /// DAG-sync gossipsub channel (`topics::CONSENSUS`) rather than a
+    /// dedicated clock topic — time rides the channel that already carries
+    /// causality.
+    HlcSync(HlcSyncMsg),
 }
 
 // ---------------------------------------------------------------------------
@@ -627,6 +636,19 @@ pub struct StateSnapshotChunkMsg {
     pub to_height: u64,
     /// Whether there are more chunks.
     pub has_more: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Distributed time messages (gossipsub broadcast, VCG-012 / D6)
+// ---------------------------------------------------------------------------
+
+/// An HLC timestamp broadcast so peers can advance their own clocks past a
+/// causally-related remote event. Carried over the existing DAG-sync
+/// (consensus) gossipsub channel per D6 — there is no dedicated clock topic.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HlcSyncMsg {
+    pub sender: Did,
+    pub timestamp: Timestamp,
 }
 
 // ---------------------------------------------------------------------------

--- a/tools/test_gap_registry_truth.sh
+++ b/tools/test_gap_registry_truth.sh
@@ -90,6 +90,7 @@ assert_contains GAP-REGISTRY.md "VCG-003 \\| P0 \\| Red"
 assert_contains GAP-REGISTRY.md "VCG-004 \\| P0 \\| Red"
 assert_contains GAP-REGISTRY.md "VCG-005 \\| P1 \\| Green-local"
 assert_contains GAP-REGISTRY.md "VCG-008 \\| P1 \\| Green-local"
+assert_contains GAP-REGISTRY.md "VCG-012 \\| P2 \\| Green-local"
 assert_contains GAP-REGISTRY.md "eDiscovery export is not an open origin-main gap"
 assert_contains GAP-REGISTRY.md "No VCG row is closed at ledger creation"
 


### PR DESCRIPTION
## VCG-012 — Distributed HLC Sync Protocol

Builds the multi-node HLC exchange + partition recovery that VCG-012 flagged as missing, under ratified decision **D6**.

### What landed
- **Wire protocol** (`crates/exo-node/src/wire.rs`): `WireMessage::HlcSync(HlcSyncMsg { sender, timestamp })` rides the **existing** DAG-sync (consensus) gossipsub topic — no dedicated clock topic.
- **Real receive path** (`crates/exo-node/src/sync.rs`): `run_sync_engine` (spawned in `main.rs`) → `handle_message` → `handle_hlc_sync` → `observe_remote_hlc_timestamp`, which calls `HybridClock::update` **unmodified** and, on any drift/overflow anomaly, records a retrievable `HlcAnomalyEvidence` object (append-only recorder) **and re-propagates the error** — D6's "time anomalies are constitutional events, not log lines" with the fail-closed guard intact.
- **Partition recovery** (`crates/exo-core/src/hlc.rs`): `reconcile_partition_recovery` converges to the quorum **median** (`sorted[(len-1)/2]`), never the max — enforcing D6's "silent accept-max is forbidden". Empty peer set fails closed; wide-outlier peers are reported, not folded.

### Coordinator corrective (D3)
The red-stage round-trip test was internally contradictory: a constant `|0|` clock asserting acceptance of a 2.7h-ahead timestamp that the 5s drift guard **must** reject. The GREEN worker correctly refused to weaken the guard and escalated. The corrective makes the fixture coherent (a fresh remote 100ms ahead of a realistic base) so it proves the real happy-path round-trip **without touching any guard**. Re-refutation: **NOT-REFUTED**.

### Gates
- `exochain-core`: 321 pass · `exochain-node`: 1320 pass (hlc 9/9)
- clippy `-D warnings` clean (both crates) · nightly fmt clean
- ledger-truth / claim-integrity / repo-truth guards: green

### Ledger
- GAP-REGISTRY.md VCG-012: Open → **Green-local** (row + section + lane record)
- README repo-truth reconciled (LOC 371200, tests 6071)

Coordinator-authored ledger advance. Closed after merge + CI.