### PR TITLE
VCG batch-3: VCG-003 -> Green-local; VCG-001b scaffold; VCG-004 finding

### DIFF
--- a/GAP-REGISTRY.md
+++ b/GAP-REGISTRY.md
@@ -143,7 +143,7 @@ Amendment baseline (2026-07-02, local run on clean `origin/main` at `2d4baec1`):
 |----|----------|--------|----------------|------------|---------------|------------------------|--------------|
 | VCG-001 | P0 | Red | EXOCHAIN core | Proof architecture | Production SNARK/STARK/ZKML soundness | `crates/exo-proofs` production backend absence tests | `cargo test -p exochain-proofs` plus backend feature gates |
 | VCG-002 | P0 | Green-local | Governance/docs | Claim integrity | Accurate proof and constitutional claims | `tools/check_systemic_integrity_claims.sh` | claim guard plus docs source scan |
-| VCG-003 | P0 | Red | Core runtime adapter | Gateway | Production GraphQL governance/API execution | GraphQL no-fabrication resolver tests | `cargo test -p exochain-gateway graphql --features production-db` |
+| VCG-003 | P0 | Green-local | Core runtime adapter | Gateway | Production GraphQL governance/API execution | GraphQL no-fabrication resolver tests | `cargo test -p exochain-gateway graphql --features production-db` |
 | VCG-004 | P0 | Red | Core runtime adapter | MCP runtime | MCP tools as constitutional runtime actions | MCP mutation-effect and CGR verifier tests | `cargo test -p exochain-node mcp` |
 | VCG-005 | P1 | Green-local | Core runtime adapter | Governance runtime | Complete validator-set lifecycle | proposal-vote-commit application tests | `cargo test -p exochain-node governance` |
 | VCG-006 | P1 | Green-local | Core runtime adapter | AVC runtime | Civilizational-class AVC closure | issues `#734`-`#737` regression tests | node/gateway AVC tests plus runtime probes |
@@ -187,6 +187,35 @@ Lane record (2026-07-02, branch `vcg/001a-proof-envelope`):
 - Row stays Red, not Green: this lane delivers the envelope/registry
   remediation item only; production backend soundness (D1: RISC Zero,
   server-side) and external cryptographic review remain open.
+
+Lane record (2026-07-04, branch `vcg/001b-riscz-verifier-scaffold`, sub-lane
+VCG-001b — RISC Zero verifier-integration SCAFFOLD; row STAYS Red):
+
+- Delivers the honest integration SEAM only. Per D1 the production verifier
+  "carries the external audit budget", so marking any backend
+  `AuditStatus::ProductionReviewed` IS the cryptographic-review claim — which has
+  NOT happened, so the row cannot go Green without overclaiming.
+- Delivered (`crates/exo-proofs/src/envelope.rs`): a third audit status
+  `AuditStatus::PendingExternalReview`; a genuine `BackendId::RiscZero` variant;
+  registration of RiscZero as PendingExternalReview in `default_registry()`; a
+  `RiscZeroReceiptVerifier` trait + `FailClosedRiscZeroVerifier` default impl
+  that ALWAYS returns `Err` (documenting exactly where the audited risc0 verify
+  call plugs in); and a `ProofEnvelope::verify()` RiscZero arm that fails closed
+  independent of the `unaudited-pedagogical-proofs` feature.
+- Anti-overclaim locks: `default_registry()` has ZERO ProductionReviewed
+  backends; RiscZero is never ProductionReviewed; `verify()` never returns
+  `Ok(true)` for RiscZero. The standing red
+  `production_backend_variant_executes_without_unaudited_flag` is UNTOUCHED
+  (0-line diff), still `#[ignore]d`, still fails for the honest reason. NO
+  external zk dependency vendored (0-line Cargo diff) — D1 makes that the
+  audit-gated supply-chain event.
+- Re-refutation NOT-REFUTED (coordinator independent verification). Gates:
+  exochain-proofs tests pass both feature configs; clippy `-D warnings` clean;
+  nightly fmt clean.
+- **Row VCG-001 STAYS RED (Blocked-external).** Action required: commission the
+  external cryptographic review of the risc0 verify path; once it lands,
+  promoting RiscZero to ProductionReviewed + swapping in the audited verifier is
+  a small localized change that flips the standing red green.
 
 Evidence:
 
@@ -367,9 +396,55 @@ cargo fmt --all -- --check
 ## VCG-003 - GraphQL Surface Is Default-Off and Unaudited
 
 **Priority:** P0
-**Status:** Red
+**Status:** Green-local
 **Classification:** Core runtime adapter
 **Owner role:** Gateway
+
+Lane record (2026-07-04, branch `vcg/003b-graphql-adjudication`, follow-on —
+Red -> Green-local):
+
+- Delivered: the unconditional GraphQL mutation kill-switch
+  (`refuse_graphql_mutation_execution`) is REMOVED from all nine mutation
+  resolvers and the function deleted. Each resolver now routes through
+  `require_permitted_actor` -> `AppState::adjudicate_mutation` -> the real
+  `exo_gatekeeper::Kernel::adjudicate` against `InvariantSet::all()` (all 8
+  constitutional invariants), gating the write on `Verdict::Permitted`. A
+  structural meta-test (`graphql_mutation_resolvers_fail_closed_before_state_mutation`)
+  asserts at source level that every resolver calls the gate and that the
+  retired kill-switch string never reappears.
+- Integrity guarantee (why this can't be gamed): the kernel's
+  `AuthorityChainValid`, `ConsentRequired`, and `ProvenanceVerifiable`
+  invariants each require REAL Ed25519 signatures over canonical messages, so a
+  forged authority grant CANNOT pass adjudication. An authenticated-but-ungranted
+  actor falls to `graphql_deny_all_adjudication_context()` and is DENIED by the
+  real kernel (deny-by-default, proven by `graphql_mutation_denied_for_unauthorized_actor`
+  and `mutations_bind_injected_authenticated_actor`). The standing red
+  `mutations_execute_with_actor_after_adjudication_wiring` (un-ignored) passes
+  ONLY because its setup seeds a genuinely-signed authority grant via the
+  test-only `seed_actor_grant`; the resolver code never auto-authorizes. The
+  audit actor is always `actor.did`; a caller-supplied `reason` can never become
+  the actor (`graphql_mutation_actor_is_bound_not_caller_reason`).
+- HONEST PRODUCTION CAVEAT (recorded loudly): the surface stays default-off
+  (`unaudited-gateway-graphql-api`). In production `actor_grants` is empty —
+  there is NO production authority-grant source wired (`seed_actor_grant` is
+  currently test-only) — so EVERY GraphQL mutation DENIES by default in
+  production. This is the CORRECT posture for a default-off, unaudited surface:
+  auto-authorizing actors on an unaudited surface would be the wrong thing.
+  Follow-on (deliberately NOT done here to avoid premature production
+  authorization): wire a real per-actor grant source — either convert the
+  existing `delegations` map to signed `AuthorityLink`s, or route through
+  `server::AppState`'s production-db `build_adjudication_context` — as part of
+  the eventual audit-and-enable of the GraphQL surface.
+- Adversarial re-refutation NOT-REFUTED (workflow refuter + independent
+  coordinator verification): kill-switch genuinely removed; deny-by-default real
+  (kernel-enforced, crypto-backed); no fabrication; actor-bound; feature-off
+  refuses; un-wired-nothing (all nine gated).
+- Gates: exochain-gateway graphql feature-off 18 pass / feature-on 34 pass
+  (incl. the previously-ignored standing red); full crate no regression; clippy
+  `-D warnings` clean; nightly fmt + doc (`-D warnings`) clean.
+- Status Green-local: real constitutional adjudication replaces the kill-switch,
+  deny-by-default enforced by the crypto-backed kernel. The surface remains
+  default-off pending audit + a production grant source. Closed after merge + CI.
 
 Lane record (2026-07-02, branch `vcg/003-graphql-actor-context`):
 
@@ -467,6 +542,36 @@ cargo clippy -p exochain-gateway --features production-db --all-targets -- -D wa
 **Status:** Red
 **Classification:** Core runtime adapter
 **Owner role:** MCP runtime
+
+Coordinator finding (2026-07-04, VCG-004b attempt — mutation-effect half NOT
+delivered; row STAYS Red):
+
+- A RED->GREEN->REFUTE lane attempted the mutation-effect half. The green was
+  REFUTED for two real defects: (1) misattribution — a caller-supplied
+  `proposer_did` was echoed as if attributed while `reactor::submit_proposal`
+  cryptographically binds the node's OWN `node_did`; there is no MCP-caller
+  authentication; (2) mutation theater — it submitted a
+  `ValidatorChange::RemoveValidator{ did: hash(proposer_did, title) }` for a
+  synthetic, non-existent validator (a DAG node with no real governance effect;
+  removing a non-validator is a no-op even at quorum). It was NOT landed.
+- Architectural blocker (the real reason this half is hard): `submit_proposal` /
+  `validate_governance_proposal_payload` accept ONLY `ValidatorChange` payloads.
+  There is NO governance-decision consensus payload type, so NO MCP governance
+  tool (create_decision, cast_vote, propose_amendment, ...) can honestly route a
+  mutation through consensus today. A genuine MCP mutation-effect requires EITHER
+  (a) building a governance-decision consensus payload type (missing
+  infrastructure), OR (b) granting MCP the authority to propose validator-set
+  changes — a RATIFICATION-LEVEL governance decision, not a coordinator fix.
+- The node-attached infrastructure the attempt prototyped is sound and reusable
+  (`NodeContext.net_handle`, `McpCapabilityProfile::NodeAttachedInterim`,
+  `is_node_attached()` gating; standalone `exochain mcp` stays fail-closed). The
+  CGR-verification half remains fail-closed and inherits VCG-001's external-audit
+  ceiling.
+- DECISION REQUIRED (principal): (1) whether to build a governance-decision
+  consensus payload type, and/or (2) whether MCP may be granted
+  validator-set-proposal authority under the named capability profile. Until
+  then the mutation-effect half stays blocked and VCG-004 stays Red — distinct
+  from the CGR half's VCG-001 ceiling. Not faked.
 
 Lane record (2026-07-02, branch `vcg/004a-cgr-lock-and-reclass`, sub-lane
 VCG-004a):

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 31 | `ls -d crates/*/` |
 | Rust source files | 461 | `find crates -name '*.rs'` |
-| Rust LOC | 377562 | `wc -l` |
+| Rust LOC | 377565 | `wc -l` |
 | Workspace tests | 6,102 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 23 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
@@ -113,7 +113,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 31 crates, 377562 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 31 crates, 377565 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          production Ed25519/BLAKE3 cryptography plus unaudited pedagogical
          SNARK/STARK/ZKML skeletons, 6,102 listed workspace tests

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 | Metric | Value | Source |
 |--------|-------|--------|
 | Rust crates | 31 | `ls -d crates/*/` |
-| Rust source files | 460 | `find crates -name '*.rs'` |
-| Rust LOC | 376840 | `wc -l` |
-| Workspace tests | 6,098 listed | `cargo test --workspace -- --list` |
+| Rust source files | 461 | `find crates -name '*.rs'` |
+| Rust LOC | 377562 | `wc -l` |
+| Workspace tests | 6,102 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 23 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
 | Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
 | License | Apache-2.0 | `Cargo.toml` |
@@ -44,7 +44,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **6,098 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **6,102 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -113,10 +113,10 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 31 crates, 376840 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 31 crates, 377562 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          production Ed25519/BLAKE3 cryptography plus unaudited pedagogical
-         SNARK/STARK/ZKML skeletons, 6,098 listed workspace tests
+         SNARK/STARK/ZKML skeletons, 6,102 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          165 verified WASM exports covered by 172 bridge checks — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-gateway/src/graphql.rs
+++ b/crates/exo-gateway/src/graphql.rs
@@ -62,14 +62,14 @@ use exo_gatekeeper::{
     invariants::InvariantSet,
     kernel::{ActionRequest as GkActionRequest, AdjudicationContext, Kernel, Verdict},
     types::{
-        AuthorityChain, BailmentState, Permission, PermissionSet, TrustedAuthorityKeys,
-        TrustedProvenanceKeys,
+        AuthorityChain, BailmentState, ConsentRecord, Permission, PermissionSet, Provenance, Role,
+        TrustedAuthorityKeys, TrustedProvenanceKeys,
     },
 };
 #[cfg(test)]
 use exo_gatekeeper::{
     invariants::{authority_link_signature_message, provenance_signature_message},
-    types::{AuthorityLink, GovernmentBranch, Provenance, Role},
+    types::{AuthorityLink, GovernmentBranch},
 };
 use exo_identity::registry::{DidRegistry, LocalDidRegistry};
 use serde::Serialize;
@@ -346,6 +346,35 @@ pub struct AppState {
     registry: Arc<RwLock<LocalDidRegistry>>,
     /// Consent policy engine — evaluates `PolicyEngine` rules for consent checks.
     consent_engine: PolicyEngine,
+    /// Real, cryptographically-verifiable per-actor constitutional grants
+    /// (authority chain, bailment/consent, provenance, roles) consulted by
+    /// [`AppState::actor_adjudication_context`] when adjudicating GraphQL
+    /// mutations. Populated only via [`AppState::seed_actor_grant`] — never
+    /// self-issued by a resolver or derived from an unauthenticated claim.
+    /// An actor with no entry here is denied by default (see
+    /// `graphql_deny_all_adjudication_context`).
+    actor_grants: BTreeMap<Did, ActorGrant>,
+}
+
+/// Real constitutional grant state held for a single actor DID.
+///
+/// This is the GraphQL gateway's own record of authority genuinely delegated
+/// to an actor — every field carries the same cryptographic material the
+/// constitutional kernel independently verifies (`AuthorityChainValid`,
+/// `ConsentRequired`, `ProvenanceVerifiable`). Nothing here is fabricated
+/// from the request; it must be established ahead of time via
+/// [`AppState::seed_actor_grant`] by a party that genuinely holds the
+/// grantor's signing key.
+#[derive(Clone)]
+pub struct ActorGrant {
+    pub roles: Vec<Role>,
+    pub authority_chain: AuthorityChain,
+    pub trusted_authority_keys: TrustedAuthorityKeys,
+    pub bailment_state: BailmentState,
+    pub consent_records: Vec<ConsentRecord>,
+    pub provenance: Provenance,
+    pub trusted_provenance_keys: TrustedProvenanceKeys,
+    pub permissions: PermissionSet,
 }
 
 impl Default for AppState {
@@ -385,6 +414,7 @@ impl AppState {
             event_tx,
             registry,
             consent_engine: PolicyEngine::new(),
+            actor_grants: BTreeMap::new(),
         }
     }
 
@@ -396,6 +426,68 @@ impl AppState {
     /// Create a new `AppState` with a shared registry, wrapped in `Arc<Mutex<>>`.
     pub fn new_arc_with_registry(registry: Arc<RwLock<LocalDidRegistry>>) -> Arc<Mutex<Self>> {
         Arc::new(Mutex::new(Self::with_registry(registry)))
+    }
+
+    /// Record a genuine constitutional grant for `actor`: a real Ed25519
+    /// authority-chain link, an active bailment + matching consent record,
+    /// and verifiable provenance — the same shape the constitutional kernel
+    /// independently verifies via [`InvariantSet::all`].
+    ///
+    /// This is **not** a GraphQL mutation and is never reachable from an
+    /// unauthenticated or self-serving request path: it exists for callers
+    /// that already hold (or, in tests, construct) a real grantor signing
+    /// key, exactly mirroring
+    /// `exo_gatekeeper::kernel::tests::valid_context`. Registering a grant
+    /// here is how an actor comes to be genuinely authorized — resolvers
+    /// never fabricate this state, they only ever read it back through this
+    /// `AppState`'s internal adjudication-context resolution.
+    pub fn seed_actor_grant(&mut self, actor: Did, grant: ActorGrant) {
+        self.actor_grants.insert(actor, grant);
+    }
+
+    /// Resolve the real per-actor [`AdjudicationContext`] for `actor` from
+    /// genuinely recorded grant state.
+    ///
+    /// An actor with no recorded grant falls back to
+    /// [`graphql_deny_all_adjudication_context`] — deny-by-default is the
+    /// property of the actor's real (absent) state, not an artifact of a
+    /// kernel that refuses everyone unconditionally (see
+    /// `graphql_mutation_denied_for_unauthorized_actor`).
+    fn actor_adjudication_context(&self, actor: &Did) -> AdjudicationContext {
+        match self.actor_grants.get(actor) {
+            Some(grant) => AdjudicationContext {
+                actor_roles: grant.roles.clone(),
+                authority_chain: grant.authority_chain.clone(),
+                consent_records: grant.consent_records.clone(),
+                bailment_state: grant.bailment_state.clone(),
+                human_override_preserved: true,
+                actor_permissions: grant.permissions.clone(),
+                trusted_authority_keys: grant.trusted_authority_keys.clone(),
+                trusted_provenance_keys: grant.trusted_provenance_keys.clone(),
+                provenance: Some(grant.provenance.clone()),
+                quorum_evidence: None,
+                active_challenge_reason: None,
+            },
+            None => graphql_deny_all_adjudication_context(),
+        }
+    }
+
+    /// Adjudicate `action` for `actor` through the shared constitutional
+    /// kernel, using this `AppState`'s real per-actor grant state. Returns
+    /// the kernel [`Verdict`] — callers must gate mutation on
+    /// `Verdict::Permitted` and must never treat `require_authenticated_actor`
+    /// succeeding as authorization by itself.
+    fn adjudicate_mutation(&self, actor: &Did, action_name: &str, scope: &str) -> Verdict {
+        let kernel = Kernel::new(b"exochain-constitution-v1", InvariantSet::all());
+        let action = GkActionRequest {
+            actor: actor.clone(),
+            action: format!("graphql.{action_name}"),
+            required_permissions: PermissionSet::new(vec![Permission::new(scope)]),
+            is_self_grant: false,
+            modifies_kernel: false,
+        };
+        let context = self.actor_adjudication_context(actor);
+        kernel.adjudicate(&action, &context)
     }
 
     fn next_timestamp(&mut self) -> GqlResult<Timestamp> {
@@ -493,12 +585,9 @@ fn graphql_mutation_execution_disabled_error() -> async_graphql::Error {
 /// Feature-gate check shared by every GraphQL mutation resolver. Mutations
 /// remain refused by default via [`guard_graphql_execution`]; when the
 /// `unaudited-gateway-graphql-api` feature is enabled, resolvers additionally
-/// require a per-request [`AuthenticatedActor`] via [`require_authenticated_actor`],
-/// and — even once an actor is present — remain unconditionally refused by
-/// [`refuse_graphql_mutation_execution`] until core-backed mutation
-/// adjudication wiring lands (VCG-003). See that function's doc comment for
-/// why the refusal lives behind a `?`-propagated call rather than an inline
-/// `return`.
+/// require a per-request [`AuthenticatedActor`] genuinely authorized by the
+/// constitutional kernel via [`require_permitted_actor`] — authentication
+/// alone is never sufficient (VCG-003).
 fn guard_graphql_mutation_execution() -> GqlResult<()> {
     guard_graphql_execution()
 }
@@ -532,23 +621,50 @@ fn require_authenticated_actor<'ctx>(
         .map_err(|_| graphql_missing_authenticated_actor_error())
 }
 
-/// Final, unconditional kill switch for every GraphQL mutation resolver.
-/// Called last — after [`guard_graphql_mutation_execution`] and
-/// [`require_authenticated_actor`] both succeed — this always returns the
-/// `unaudited_graphql_mutations_disabled` refusal: no mutation may execute or
-/// persist state in this lane, actor or no actor. Standing red test
-/// `mutations_execute_with_actor_after_adjudication_wiring` documents the
-/// intended future behavior once core-backed mutation adjudication wiring
-/// lands and this call is removed.
+/// Typed refusal for a mutation whose actor was authenticated but denied (or
+/// escalated) by the constitutional kernel. Distinct from
+/// [`graphql_missing_authenticated_actor_error`]: this fires only once an
+/// [`AuthenticatedActor`] is present but does not hold the authority,
+/// consent, or provenance state required for the requested action —
+/// authentication is never conflated with authorization.
+fn graphql_verdict_denied_error(action_name: &str, verdict: &Verdict) -> async_graphql::Error {
+    match verdict {
+        Verdict::Permitted => unreachable!("graphql_verdict_denied_error called with Permitted"),
+        Verdict::Denied { violations } => async_graphql::Error::new(format!(
+            "adjudication_denied: constitutional kernel denied '{action_name}': {violations:?}"
+        )),
+        Verdict::Escalated { reason } => async_graphql::Error::new(format!(
+            "adjudication_escalated: constitutional kernel escalated '{action_name}' for review: {reason}"
+        )),
+    }
+}
+
+/// Require that `ctx` carries an [`AuthenticatedActor`] genuinely authorized
+/// by the constitutional kernel to perform `action_name` under `scope`.
 ///
-/// Deliberately called via `?` (like `guard_graphql_mutation_execution`)
-/// rather than as a bare `return Err(...)`: `rustc` cannot see through a
-/// `?`-propagated function call to prove the callee always errors, so the
-/// remainder of each resolver body — including the actor-derived bindings
-/// used the moment core-backed adjudication wiring replaces this call — stays
-/// reachable and compiles clean under `-D warnings`.
-fn refuse_graphql_mutation_execution() -> GqlResult<()> {
-    Err(graphql_mutation_execution_disabled_error())
+/// This is the single mutation gate: [`guard_graphql_mutation_execution`]
+/// (feature-off refusal) must already have been checked by the caller.
+/// Returns the actor's DID (as an owned `String`, since callers hold the
+/// `AppState` lock across `.await` points that outlive `ctx`'s borrow) only
+/// when the kernel's `Verdict` is `Permitted` — an authenticated-but-
+/// unauthorized actor is refused with [`graphql_verdict_denied_error`] and no
+/// mutation proceeds.
+async fn require_permitted_actor(
+    ctx: &Context<'_>,
+    action_name: &str,
+    scope: &str,
+) -> GqlResult<String> {
+    let actor = require_authenticated_actor(ctx)?;
+    let did = actor.did.clone();
+    let state = app_state_from_context(ctx)?;
+    let verdict = {
+        let guard = state.lock().await;
+        guard.adjudicate_mutation(&did, action_name, scope)
+    };
+    match verdict {
+        Verdict::Permitted => Ok(did.as_str().to_owned()),
+        denied => Err(graphql_verdict_denied_error(action_name, &denied)),
+    }
 }
 
 fn app_state_from_context<'ctx>(ctx: &'ctx Context<'_>) -> GqlResult<&'ctx Arc<Mutex<AppState>>> {
@@ -928,9 +1044,7 @@ impl MutationRoot {
         input: CreateDecisionInput,
     ) -> GqlResult<GqlDecision> {
         guard_graphql_mutation_execution()?;
-        let actor = require_authenticated_actor(ctx)?;
-        refuse_graphql_mutation_execution()?;
-        let author = actor.did.as_str().to_owned();
+        let author = require_permitted_actor(ctx, "create_decision", "governance:mutate").await?;
         let state = app_state_from_context(ctx)?;
         let mut guard = state.lock().await;
         let created = guard.next_timestamp()?;
@@ -986,9 +1100,8 @@ impl MutationRoot {
         reason: Option<String>,
     ) -> GqlResult<GqlDecision> {
         guard_graphql_mutation_execution()?;
-        let actor = require_authenticated_actor(ctx)?;
-        let actor_did = actor.did.as_str().to_owned();
-        refuse_graphql_mutation_execution()?;
+        let actor_did =
+            require_permitted_actor(ctx, "advance_decision", "governance:mutate").await?;
         let state = app_state_from_context(ctx)?;
         let mut guard = state.lock().await;
         let id_str = id.to_string();
@@ -1030,9 +1143,7 @@ impl MutationRoot {
         rationale: Option<String>,
     ) -> GqlResult<GqlVote> {
         guard_graphql_mutation_execution()?;
-        let actor = require_authenticated_actor(ctx)?;
-        let voter = actor.did.as_str().to_owned();
-        refuse_graphql_mutation_execution()?;
+        let voter = require_permitted_actor(ctx, "cast_vote", "governance:mutate").await?;
         let valid_choices = ["APPROVE", "REJECT", "ABSTAIN"];
         if !valid_choices.contains(&choice.as_str()) {
             return Err(async_graphql::Error::new(format!(
@@ -1087,9 +1198,8 @@ impl MutationRoot {
         input: GrantDelegationInput,
     ) -> GqlResult<GqlDelegation> {
         guard_graphql_mutation_execution()?;
-        let actor = require_authenticated_actor(ctx)?;
-        let delegator = actor.did.as_str().to_owned();
-        refuse_graphql_mutation_execution()?;
+        let delegator =
+            require_permitted_actor(ctx, "grant_delegation", "governance:delegate").await?;
         if input.expires_in_hours <= 0 {
             return Err(async_graphql::Error::new("expires_in_hours must be > 0"));
         }
@@ -1128,8 +1238,7 @@ impl MutationRoot {
     /// Revoke an existing delegation by ID.
     async fn revoke_delegation(&self, ctx: &Context<'_>, id: ID) -> GqlResult<GqlDelegation> {
         guard_graphql_mutation_execution()?;
-        require_authenticated_actor(ctx)?;
-        refuse_graphql_mutation_execution()?;
+        require_permitted_actor(ctx, "revoke_delegation", "governance:delegate").await?;
         let state = app_state_from_context(ctx)?;
         let mut guard = state.lock().await;
         let id_str = id.to_string();
@@ -1149,9 +1258,8 @@ impl MutationRoot {
         grounds: String,
     ) -> GqlResult<GqlChallenge> {
         guard_graphql_mutation_execution()?;
-        let actor = require_authenticated_actor(ctx)?;
-        let actor_did = actor.did.as_str().to_owned();
-        refuse_graphql_mutation_execution()?;
+        let actor_did =
+            require_permitted_actor(ctx, "raise_challenge", "governance:challenge").await?;
         let state = app_state_from_context(ctx)?;
         let mut guard = state.lock().await;
         let id_str = decision_id.to_string();
@@ -1199,9 +1307,8 @@ impl MutationRoot {
         justification: String,
     ) -> GqlResult<GqlEmergencyAction> {
         guard_graphql_mutation_execution()?;
-        let actor = require_authenticated_actor(ctx)?;
-        let actor_did = actor.did.as_str().to_owned();
-        refuse_graphql_mutation_execution()?;
+        let actor_did =
+            require_permitted_actor(ctx, "take_emergency_action", "governance:emergency").await?;
         let state = app_state_from_context(ctx)?;
         let mut guard = state.lock().await;
         let id_str = decision_id.to_string();
@@ -1265,9 +1372,8 @@ impl MutationRoot {
         nature: String,
     ) -> GqlResult<GqlConflictDisclosure> {
         guard_graphql_mutation_execution()?;
-        let actor = require_authenticated_actor(ctx)?;
-        let actor_did = actor.did.as_str().to_owned();
-        refuse_graphql_mutation_execution()?;
+        let actor_did =
+            require_permitted_actor(ctx, "disclose_conflict", "governance:disclose").await?;
         let state = app_state_from_context(ctx)?;
         let mut guard = state.lock().await;
         let id_str = decision_id.to_string();
@@ -1294,8 +1400,7 @@ impl MutationRoot {
         amendment: String,
     ) -> GqlResult<GqlConstitution> {
         guard_graphql_mutation_execution()?;
-        require_authenticated_actor(ctx)?;
-        refuse_graphql_mutation_execution()?;
+        require_permitted_actor(ctx, "amend_constitution", "governance:amend").await?;
         let state = app_state_from_context(ctx)?;
         let mut guard = state.lock().await;
         let new_hash = graphql_hash_hex(&GraphqlConstitutionHashPayload {
@@ -1824,11 +1929,16 @@ mod tests {
         assert_eq!(
             mutation_section.matches("    async fn ").count(),
             mutation_section
-                .matches("refuse_graphql_mutation_execution()?;")
+                .matches("require_permitted_actor(ctx,")
                 .count(),
-            "every GraphQL mutation resolver must reach the final unconditional kill switch — \
-             no mutation may execute or persist state in this lane, actor or no actor, until \
-             core-backed mutation adjudication wiring lands (VCG-003)"
+            "every GraphQL mutation resolver must route through real constitutional kernel \
+             adjudication (require_permitted_actor) — no mutation may execute or persist state \
+             for an actor the kernel has not adjudicated Permitted (VCG-003 GREEN)"
+        );
+        assert!(
+            !mutation_section.contains("refuse_graphql_mutation_execution()?;"),
+            "the unconditional VCG-003 kill switch must be fully removed from every wired \
+             mutation resolver now that real kernel adjudication gates execution"
         );
     }
 
@@ -2163,10 +2273,10 @@ mod tests {
     /// VCG-003 corrective test 1: identity-bearing mutations must refuse with
     /// a dedicated `missing_authenticated_actor` typed error when no
     /// authenticated actor is present in the per-request GraphQL context —
-    /// distinct from the blanket `unaudited_graphql_mutations_disabled`
-    /// refusal that fires unconditionally once an actor *is* present (see
-    /// `refuse_graphql_mutation_execution`). No result/audit field may fall
-    /// back to the hardcoded `did:exo:caller` or `system` literals as actor
+    /// distinct from the `adjudication_denied` refusal that fires once an
+    /// actor *is* present but is not genuinely authorized (see
+    /// `require_permitted_actor`). No result/audit field may fall back to
+    /// the hardcoded `did:exo:caller` or `system` literals as actor
     /// identity.
     #[cfg(feature = "unaudited-gateway-graphql-api")]
     #[tokio::test]
@@ -2225,25 +2335,24 @@ mod tests {
         }
     }
 
-    /// VCG-003 corrective test 2: when a real `AuthenticatedActor` is
-    /// injected into the per-request GraphQL context (constructed via
-    /// `crate::auth` against a `LocalDidRegistry` fixture, mirroring
-    /// `auth.rs`'s own tests), `castVote` and `createDecision` must reach —
-    /// and be refused by — the unconditional mutation-execution-disabled
-    /// kill switch, *not* the `missing_authenticated_actor` refusal: the
-    /// actor-context gate engaged (proving the per-request actor plumbing
-    /// works), but execution stays fail-closed regardless, because no
-    /// core-backed mutation adjudication wiring exists yet. No output may
-    /// ever carry the hardcoded `did:exo:caller` or `system` literals as
-    /// identity, injected actor or not.
+    /// VCG-003 GREEN: when a real `AuthenticatedActor` is injected into the
+    /// per-request GraphQL context (constructed via `crate::auth` against a
+    /// `LocalDidRegistry` fixture, mirroring `auth.rs`'s own tests) but that
+    /// actor holds no recorded constitutional grant (no authority chain, no
+    /// consent/bailment, no provenance — i.e. exactly today's real, unseeded
+    /// state), `castVote` and `createDecision` must reach — and be refused
+    /// by — the real constitutional kernel's `adjudication_denied` verdict,
+    /// *not* the `missing_authenticated_actor` refusal: the actor-context
+    /// gate engaged (proving the per-request actor plumbing works) and
+    /// authentication succeeded, but the kernel denies the action because
+    /// authentication alone is never authorization. No output may ever carry
+    /// the hardcoded `did:exo:caller` or `system` literals as identity,
+    /// injected actor or not.
     ///
-    /// This is the corrected replacement for the refuted green's version of
-    /// this test, which asserted that an injected actor made these mutations
-    /// *succeed* — that required fabricating persistence (a vivified
-    /// CREATED-status decision record for `castVote`; see
-    /// `graphql_mutation_resolvers_fail_closed_before_state_mutation` and the
-    /// `refuse_graphql_mutation_execution` kill switch) that adversarial
-    /// review found and this corrective reverts.
+    /// This directly complements `graphql_mutation_denied_for_unauthorized_actor`
+    /// (kernel-level) by proving the same property holds end-to-end through
+    /// the GraphQL resolver layer: an authenticated-but-unauthorized actor
+    /// never mutates state.
     #[cfg(feature = "unaudited-gateway-graphql-api")]
     #[tokio::test]
     async fn mutations_bind_injected_authenticated_actor() {
@@ -2264,16 +2373,17 @@ mod tests {
         let vote_response = schema.execute(cast_vote_request).await;
         assert!(
             !vote_response.errors.is_empty(),
-            "castVote must still refuse even with an injected authenticated actor — mutations \
-             never execute in this lane"
+            "castVote must still refuse for an unauthorized actor — the kernel denies actors \
+             with no recorded constitutional grant"
         );
         assert!(
-            vote_response.errors.iter().any(|error| error
-                .message
-                .contains("unaudited_graphql_mutations_disabled")),
-            "castVote with an injected actor must fail via the unconditional mutation-execution- \
-             disabled refusal, not missing_authenticated_actor (the actor gate must have engaged \
-             first): {:?}",
+            vote_response
+                .errors
+                .iter()
+                .any(|error| error.message.contains("adjudication_denied")),
+            "castVote with an authenticated-but-unauthorized injected actor must fail via the \
+             real kernel's adjudication_denied verdict, not missing_authenticated_actor (the \
+             actor gate must have engaged first): {:?}",
             vote_response.errors
         );
         assert!(
@@ -2312,16 +2422,17 @@ mod tests {
         let create_response = schema.execute(create_decision_request).await;
         assert!(
             !create_response.errors.is_empty(),
-            "createDecision must still refuse even with an injected authenticated actor — \
-             mutations never execute in this lane"
+            "createDecision must still refuse for an unauthorized actor — the kernel denies \
+             actors with no recorded constitutional grant"
         );
         assert!(
-            create_response.errors.iter().any(|error| error
-                .message
-                .contains("unaudited_graphql_mutations_disabled")),
-            "createDecision with an injected actor must fail via the unconditional mutation- \
-             execution-disabled refusal, not missing_authenticated_actor (the actor gate must \
-             have engaged first): {:?}",
+            create_response
+                .errors
+                .iter()
+                .any(|error| error.message.contains("adjudication_denied")),
+            "createDecision with an authenticated-but-unauthorized injected actor must fail via \
+             the real kernel's adjudication_denied verdict, not missing_authenticated_actor (the \
+             actor gate must have engaged first): {:?}",
             create_response.errors
         );
         assert!(
@@ -2347,23 +2458,22 @@ mod tests {
         );
     }
 
-    /// VCG-003 standing red: documents the intended future behavior once
-    /// core-backed mutation adjudication wiring lands. With a real,
-    /// AUTHORIZED actor injected (`vcg003_authorized_actor_request` — a
-    /// signed authority chain link terminating at the actor, an active
-    /// bailment + matching consent record, and verifiable provenance, i.e.
-    /// the same recipe as `exo_gatekeeper::kernel::tests::valid_context`),
-    /// `createDecision` followed by `castVote` should succeed and the
-    /// recorded voter should be the injected actor's DID. Today this fails at
-    /// the restored `refuse_graphql_mutation_execution` kill switch (see
-    /// `guard_graphql_mutation_execution`, `require_authenticated_actor`,
-    /// `refuse_graphql_mutation_execution` in production code) — mutations
-    /// unconditionally refuse in this lane regardless of actor context. No
-    /// longer `#[ignore]`d: un-ignoring this is part of the VCG-003 RED
-    /// contract, and it must fail (not pass) until GREEN lands real
-    /// adjudication wiring that consumes an actor-bound `AdjudicationContext`
-    /// built from the injected actor's authorized state, not the deny-all
-    /// scaffold.
+    /// VCG-003 GREEN: with a real, AUTHORIZED actor injected — a signed
+    /// authority chain link terminating at the actor, an active bailment +
+    /// matching consent record, and verifiable provenance, i.e. the same
+    /// recipe as `exo_gatekeeper::kernel::tests::valid_context`, genuinely
+    /// recorded via [`AppState::seed_actor_grant`] (mirroring
+    /// `vcg003_authorized_adjudication_context`) — `createDecision` followed
+    /// by `castVote` succeeds and the recorded voter is the injected actor's
+    /// DID.
+    ///
+    /// Critically, the actor is granted real state through
+    /// `seed_actor_grant` here, exactly the way a legitimate out-of-band
+    /// grantor would establish it; the resolver itself never fabricates
+    /// authority for an authenticated actor (see
+    /// `graphql_mutation_denied_for_unauthorized_actor` and
+    /// `mutations_bind_injected_authenticated_actor` for the same actor
+    /// DID *without* a recorded grant, which must still be denied).
     #[cfg(feature = "unaudited-gateway-graphql-api")]
     #[tokio::test]
     async fn mutations_execute_with_actor_after_adjudication_wiring() {
@@ -2373,6 +2483,11 @@ mod tests {
             vcg003_authenticated_actor("did:exo:alice", &reg, &sk)
         };
         let state = AppState::new_arc_with_registry(registry);
+        {
+            let mut guard = state.lock().await;
+            let grant = vcg003_actor_grant_for(&actor.did);
+            guard.seed_actor_grant(actor.did.clone(), grant);
+        }
         let schema = build_schema(state);
 
         let create_decision_request = async_graphql::Request::new(
@@ -2519,6 +2634,28 @@ mod tests {
             provenance: Some(provenance),
             quorum_evidence: None,
             active_challenge_reason: None,
+        }
+    }
+
+    /// Build a real [`ActorGrant`] for `actor` with the exact same
+    /// cryptographic recipe as [`vcg003_authorized_adjudication_context`] —
+    /// a signed authority chain link, an active bailment + matching consent
+    /// record, and verifiable provenance — so callers can register it via
+    /// [`AppState::seed_actor_grant`] and have the `AppState`'s internal
+    /// adjudication-context resolution resolve to an equivalent,
+    /// genuinely-authorized `AdjudicationContext`.
+    #[cfg(feature = "unaudited-gateway-graphql-api")]
+    fn vcg003_actor_grant_for(actor: &Did) -> ActorGrant {
+        let ctx = vcg003_authorized_adjudication_context(actor);
+        ActorGrant {
+            roles: ctx.actor_roles,
+            authority_chain: ctx.authority_chain,
+            trusted_authority_keys: ctx.trusted_authority_keys,
+            bailment_state: ctx.bailment_state,
+            consent_records: ctx.consent_records,
+            provenance: ctx.provenance.expect("fixture always sets provenance"),
+            trusted_provenance_keys: ctx.trusted_provenance_keys,
+            permissions: ctx.actor_permissions,
         }
     }
 

--- a/crates/exo-gateway/src/graphql.rs
+++ b/crates/exo-gateway/src/graphql.rs
@@ -66,6 +66,11 @@ use exo_gatekeeper::{
         TrustedProvenanceKeys,
     },
 };
+#[cfg(test)]
+use exo_gatekeeper::{
+    invariants::{authority_link_signature_message, provenance_signature_message},
+    types::{AuthorityLink, GovernmentBranch, Provenance, Role},
+};
 use exo_identity::registry::{DidRegistry, LocalDidRegistry};
 use serde::Serialize;
 use tokio::sync::{Mutex, broadcast};
@@ -2343,19 +2348,24 @@ mod tests {
     }
 
     /// VCG-003 standing red: documents the intended future behavior once
-    /// core-backed mutation adjudication wiring lands. With a real actor
-    /// injected, `createDecision` followed by `castVote` should succeed and
-    /// the recorded voter should be the injected actor's DID. Today this
-    /// fails at the restored `refuse_graphql_mutation_execution` kill switch
-    /// (see `guard_graphql_mutation_execution`, `require_authenticated_actor`,
+    /// core-backed mutation adjudication wiring lands. With a real,
+    /// AUTHORIZED actor injected (`vcg003_authorized_actor_request` — a
+    /// signed authority chain link terminating at the actor, an active
+    /// bailment + matching consent record, and verifiable provenance, i.e.
+    /// the same recipe as `exo_gatekeeper::kernel::tests::valid_context`),
+    /// `createDecision` followed by `castVote` should succeed and the
+    /// recorded voter should be the injected actor's DID. Today this fails at
+    /// the restored `refuse_graphql_mutation_execution` kill switch (see
+    /// `guard_graphql_mutation_execution`, `require_authenticated_actor`,
     /// `refuse_graphql_mutation_execution` in production code) — mutations
-    /// unconditionally refuse in this lane regardless of actor context. Run
-    /// explicitly via `-- --ignored` to capture the current failure as
-    /// standing-red evidence; this test intentionally does not run in the
-    /// default `cargo test` gate.
+    /// unconditionally refuse in this lane regardless of actor context. No
+    /// longer `#[ignore]`d: un-ignoring this is part of the VCG-003 RED
+    /// contract, and it must fail (not pass) until GREEN lands real
+    /// adjudication wiring that consumes an actor-bound `AdjudicationContext`
+    /// built from the injected actor's authorized state, not the deny-all
+    /// scaffold.
     #[cfg(feature = "unaudited-gateway-graphql-api")]
     #[tokio::test]
-    #[ignore = "red until VCG-003 core-backed mutation adjudication wiring lands"]
     async fn mutations_execute_with_actor_after_adjudication_wiring() {
         let (registry, sk) = vcg003_registry_with_actor("did:exo:alice");
         let actor = {
@@ -2408,6 +2418,224 @@ mod tests {
             serde_json::json!(actor.did.as_str()),
             "castVote must bind voter to the injected authenticated actor's DID"
         );
+    }
+
+    /// Construct a signed `AuthorityLink` terminating at `grantee`, exactly
+    /// mirroring `exo_gatekeeper::kernel::tests::signed_link` — a real
+    /// Ed25519-signed grant from `grantor_str` to `grantee`, carrying the
+    /// grantor's public key so `AuthorityChainValid`'s trusted-key resolution
+    /// can verify the signature.
+    #[cfg(feature = "unaudited-gateway-graphql-api")]
+    fn vcg003_signed_authority_link(grantor_str: &str, grantee: &Did) -> AuthorityLink {
+        let (pk, sk) = exo_core::crypto::generate_keypair();
+        let grantor = Did::new(grantor_str).unwrap();
+        let permissions = PermissionSet::new(vec![Permission::new("governance:mutate")]);
+        let mut link = AuthorityLink {
+            grantor,
+            grantee: grantee.clone(),
+            permissions,
+            signature: Vec::new(),
+            grantor_public_key: Some(pk.as_bytes().to_vec()),
+        };
+        let message = authority_link_signature_message(&link).expect("canonical link payload");
+        let signature = exo_core::crypto::sign(message.as_bytes(), &sk);
+        link.signature = signature.to_bytes().to_vec();
+        link
+    }
+
+    /// Construct verifiable `Provenance` for `actor`, mirroring
+    /// `exo_gatekeeper::kernel::tests::signed_provenance` — a real
+    /// Ed25519-signed provenance record binding the action to the actor.
+    #[cfg(feature = "unaudited-gateway-graphql-api")]
+    fn vcg003_signed_provenance(actor: &Did) -> Provenance {
+        let (pk, sk) = exo_core::crypto::generate_keypair();
+        let mut provenance = Provenance {
+            actor: actor.clone(),
+            timestamp: "2026-01-01T00:00:00Z".to_owned(),
+            action_hash: vec![1, 2, 3],
+            signature: Vec::new(),
+            public_key: Some(pk.as_bytes().to_vec()),
+            voice_kind: None,
+            independence: None,
+            review_order: None,
+        };
+        let message =
+            provenance_signature_message(&provenance).expect("canonical provenance payload");
+        let signature = exo_core::crypto::sign(message.as_bytes(), &sk);
+        provenance.signature = signature.to_bytes().to_vec();
+        provenance
+    }
+
+    /// Build a fully-authorized `AdjudicationContext` for `actor`: a signed
+    /// authority chain link terminating at the actor with its grantor key
+    /// marked trusted, an active bailment with a matching active consent
+    /// record, and verifiable provenance — the same recipe as
+    /// `exo_gatekeeper::kernel::tests::valid_context`, which the kernel
+    /// adjudicates as `Verdict::Permitted` for a `governance:mutate` action.
+    /// GREEN's real per-actor `AdjudicationContext` builder must resolve to
+    /// an equivalent context for an actor who genuinely holds this state
+    /// (authority chain + bailment + consent + provenance), not fabricate it
+    /// from the request — this fixture exists only to prove the kernel path
+    /// itself is reachable and permits a genuinely-authorized actor once
+    /// GREEN wires a real (non-scaffold) context builder.
+    #[cfg(feature = "unaudited-gateway-graphql-api")]
+    fn vcg003_authorized_adjudication_context(actor: &Did) -> AdjudicationContext {
+        let bailor = Did::new("did:exo:bailor").unwrap();
+        let authority_chain = AuthorityChain {
+            links: vec![vcg003_signed_authority_link("did:exo:root", actor)],
+        };
+        let mut trusted_authority_keys = TrustedAuthorityKeys::default();
+        for link in &authority_chain.links {
+            if let Some(public_key) = &link.grantor_public_key {
+                trusted_authority_keys.insert(link.grantor.clone(), vec![public_key.clone()]);
+            }
+        }
+        let provenance = vcg003_signed_provenance(actor);
+        let mut trusted_provenance_keys = TrustedProvenanceKeys::default();
+        if let Some(public_key) = &provenance.public_key {
+            trusted_provenance_keys.insert(actor.clone(), vec![public_key.clone()]);
+        }
+        AdjudicationContext {
+            actor_roles: vec![Role {
+                name: "judge".into(),
+                branch: GovernmentBranch::Judicial,
+            }],
+            authority_chain,
+            consent_records: vec![exo_gatekeeper::types::ConsentRecord {
+                subject: bailor.clone(),
+                granted_to: actor.clone(),
+                scope: "governance:mutate".into(),
+                active: true,
+            }],
+            bailment_state: BailmentState::Active {
+                bailor,
+                bailee: actor.clone(),
+                scope: "governance:mutate".into(),
+            },
+            human_override_preserved: true,
+            actor_permissions: PermissionSet::new(vec![Permission::new("governance:mutate")]),
+            trusted_authority_keys,
+            trusted_provenance_keys,
+            provenance: Some(provenance),
+            quorum_evidence: None,
+            active_challenge_reason: None,
+        }
+    }
+
+    /// VCG-003 deny-by-default guard: an actor who is authenticated (real
+    /// Ed25519-verified `AuthenticatedActor`) but who holds NONE of the
+    /// authority/consent/provenance state `vcg003_authorized_adjudication_context`
+    /// grants — i.e. exactly today's `graphql_deny_all_adjudication_context`
+    /// scaffold — must be denied by the kernel and the mutation must refuse.
+    /// This proves the kernel's own deny-by-default verdict is authoritative:
+    /// authentication alone (`require_authenticated_actor` succeeding) must
+    /// never be conflated with authorization. Nothing may be recorded for a
+    /// denied actor.
+    ///
+    /// This is a RED-stage assertion on the *kernel adjudication itself* — it
+    /// does not require GREEN's resolver wiring to exist yet, and passes
+    /// today (deny-all is exactly this actor's real state). Once GREEN wires
+    /// resolvers through real per-actor context resolution, this same
+    /// property — an unauthorized actor denied, no mutation performed — must
+    /// continue to hold at the GraphQL layer, not just at the kernel layer.
+    #[cfg(feature = "unaudited-gateway-graphql-api")]
+    #[test]
+    fn graphql_mutation_denied_for_unauthorized_actor() {
+        let kernel = Kernel::new(b"exochain-constitution-v1", InvariantSet::all());
+        let actor = Did::new("did:exo:unauthorized-actor").unwrap();
+        let action = GkActionRequest {
+            actor: actor.clone(),
+            action: "graphql.create_decision".into(),
+            required_permissions: PermissionSet::new(vec![Permission::new("governance:mutate")]),
+            is_self_grant: false,
+            modifies_kernel: false,
+        };
+
+        // The actor has no authority chain, no consent, no provenance — this
+        // is exactly `graphql_deny_all_adjudication_context()`, the scaffold
+        // every GraphQL mutation resolver currently routes through in spirit
+        // (via the unconditional kill switch). An authenticated-but-
+        // unauthorized actor must be denied here.
+        let denied_context = graphql_deny_all_adjudication_context();
+        let verdict = kernel.adjudicate(&action, &denied_context);
+        assert!(
+            verdict.is_denied(),
+            "an actor with no authority chain, consent, or provenance must be Denied, not {verdict:?}"
+        );
+
+        // Sanity: the SAME actor, with genuinely-held authorized state
+        // (`vcg003_authorized_adjudication_context`), reaches `Permitted`.
+        // This proves the denial above is about the actor's actual state —
+        // not an artifact of a kernel that denies everyone unconditionally.
+        let authorized_context = vcg003_authorized_adjudication_context(&actor);
+        let authorized_verdict = kernel.adjudicate(&action, &authorized_context);
+        assert!(
+            authorized_verdict.is_permitted(),
+            "the same actor with genuine authority/consent/provenance must be Permitted, got {authorized_verdict:?}; \
+             deny-by-default must be a property of the actor's real state, not an unconditional kernel refusal"
+        );
+    }
+
+    /// VCG-003 actor-binding guard: the audit/identity actor recorded for a
+    /// mutation must always be the checked `AuthenticatedActor`'s DID — never
+    /// a caller-supplied field such as `advanceDecision`'s `reason`. This
+    /// documents the corrective already applied to `advance_decision`
+    /// (`let _ = reason;`) as a permanent contract: even if `reason` is
+    /// crafted to look like a DID (e.g. `"did:exo:mallory"`), it must never
+    /// appear as the audit actor once adjudicated mutations persist audit
+    /// entries. GREEN's adjudicated `advance_decision` must keep binding
+    /// `actor.did`, not `reason`, as the audit actor.
+    #[cfg(feature = "unaudited-gateway-graphql-api")]
+    #[tokio::test]
+    async fn graphql_mutation_actor_is_bound_not_caller_reason() {
+        let (registry, sk) = vcg003_registry_with_actor("did:exo:alice");
+        let actor = {
+            let reg = registry.read().unwrap();
+            vcg003_authenticated_actor("did:exo:alice", &reg, &sk)
+        };
+        let state = AppState::new_arc_with_registry(registry);
+        let schema = build_schema(state);
+
+        // A `reason` crafted to look like a different actor's DID must never
+        // become the recorded/audit actor — the bound actor must always be
+        // `actor.did` ("did:exo:alice"), regardless of this field's content.
+        let spoofed_reason = "did:exo:mallory";
+        let advance_request = async_graphql::Request::new(format!(
+            r#"mutation {{
+                advanceDecision(id: "decision-1", newStatus: "APPROVED", reason: "{spoofed_reason}") {{
+                    id status author
+                }}
+            }}"#
+        ))
+        .data(actor.clone());
+        let response = schema.execute(advance_request).await;
+        let errors_empty = response.errors.is_empty();
+
+        // Mutations remain refused in this lane today (RED baseline), but
+        // regardless of refusal, the spoofed reason must never leak into the
+        // response as if it were bound actor identity.
+        let data_json = response.data.into_json().unwrap_or(serde_json::Value::Null);
+        let rendered = data_json.to_string();
+        assert!(
+            !rendered.contains(spoofed_reason),
+            "caller-supplied 'reason' must never be surfaced as bound actor identity: {rendered}"
+        );
+
+        // Once GREEN wires adjudicated execution, the same request must
+        // succeed only with the caller genuinely authorized, and the
+        // recorded actor must equal `actor.did`, never the `reason` text.
+        // Assert that property directly against the audit-actor contract
+        // documented on `advance_decision`: the reason value it accepts must
+        // never be usable as an actor identity, which today's refusal-before-
+        // persistence path already guarantees by construction (no audit
+        // entry is written at all).
+        if errors_empty {
+            assert_ne!(
+                data_json["advanceDecision"]["author"],
+                serde_json::json!(spoofed_reason),
+                "advanceDecision must never bind the caller-supplied reason as the actor/author"
+            );
+        }
     }
 
     #[cfg(feature = "unaudited-gateway-graphql-api")]

--- a/crates/exo-gateway/src/graphql.rs
+++ b/crates/exo-gateway/src/graphql.rs
@@ -66,7 +66,10 @@ use exo_gatekeeper::{
         TrustedAuthorityKeys, TrustedProvenanceKeys,
     },
 };
-#[cfg(test)]
+// Only the `unaudited-gateway-graphql-api` mutation-adjudication tests use these
+// (they build genuinely-signed authority/provenance fixtures); gating to that
+// feature keeps the default-feature test build free of unused imports.
+#[cfg(all(test, feature = "unaudited-gateway-graphql-api"))]
 use exo_gatekeeper::{
     invariants::{authority_link_signature_message, provenance_signature_message},
     types::{AuthorityLink, GovernmentBranch},

--- a/crates/exo-proofs/src/envelope.rs
+++ b/crates/exo-proofs/src/envelope.rs
@@ -114,16 +114,33 @@ pub const UNAUDITED_BLAKE3_STANDIN_BACKEND_ID: BackendId = BackendId::UnauditedB
 /// `Unknown` accepts.
 ///
 /// Ratified decision D1 (2026-07-02, see `GAP-REGISTRY.md` VCG-001) selects
-/// RISC Zero as the production backend family. No production backend
-/// variant is added in this lane (VCG-001a) — that is lane VCG-001b, scoped
-/// out here. The only concrete backend registered today is the crate's
-/// existing unaudited blake3 stand-in.
+/// RISC Zero as the production backend family. Lane VCG-001b registers the
+/// [`BackendId::RiscZero`] variant and a fail-closed verifier *seam* for it
+/// (see [`RiscZeroReceiptVerifier`] and [`ProofEnvelope::verify`]) — but does
+/// **not** vendor the `risc0-zkvm` crate or wire an actual cryptographic
+/// verify call. Per D1, the audited risc0 proving/verification toolchain is
+/// itself a reviewed-dependency supply-chain event that "carries the
+/// external audit budget"; adding it is out of scope until that review
+/// happens. Until then, [`BackendId::RiscZero`] is registered as
+/// [`AuditStatus::PendingExternalReview`] and always fails closed at
+/// verify-time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BackendId {
     /// The crate's existing unaudited blake3 "stand-in" cryptography
     /// (`circuit.rs` / `snark.rs` / `stark.rs` / `zkml.rs`). Gated behind
     /// the `unaudited-pedagogical-proofs` feature at verification time.
     UnauditedBlake3Standin,
+    /// RISC Zero zkVM execution-receipt backend (ratified decision D1,
+    /// 2026-07-02, `GAP-REGISTRY.md` VCG-001). This variant exists so
+    /// envelopes can *name* the selected production backend family — it is
+    /// the integration seam, not a working verifier. No external
+    /// cryptographic review of the risc0 verify path has happened yet, so
+    /// this backend is registered under [`AuditStatus::PendingExternalReview`]
+    /// (never [`AuditStatus::ProductionReviewed`]) and
+    /// [`ProofEnvelope::verify`] always fails closed for it. See
+    /// [`RiscZeroReceiptVerifier`] for exactly where the audited risc0
+    /// verify call plugs in once review lands.
+    RiscZero,
     /// An unrecognized or future backend id. Always fails closed in
     /// [`ProofEnvelope::validate_backend`] — this crate refuses to treat an
     /// id it does not recognize as valid, regardless of the numeric value.
@@ -148,20 +165,32 @@ impl BackendId {
 /// This is a minimal accessor, not a verification mechanism: it exists so
 /// tests (and future callers) can ask "does a production-reviewed backend
 /// exist yet?" without hardcoding backend ids. Today every registered
-/// backend is [`AuditStatus::Pedagogical`] — no [`AuditStatus::ProductionReviewed`]
-/// entry exists until VCG-001b lands a real production backend with a wired
-/// verifier (see `tests/refusal.rs`'s standing red).
+/// backend is either [`AuditStatus::Pedagogical`] or
+/// [`AuditStatus::PendingExternalReview`] — no [`AuditStatus::ProductionReviewed`]
+/// entry exists yet. Registering one is itself the claim that external
+/// cryptographic review has happened; see `tests/refusal.rs`'s standing red
+/// and `tests/riscz_verifier_scaffold.rs`'s anti-overclaim regression locks,
+/// both of which must keep failing/holding until that review actually lands.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuditStatus {
     /// Structural/pedagogical stand-in only — not a production trust claim.
     /// Gated behind the `unaudited-pedagogical-proofs` feature at
     /// verification time (see [`crate::guard_unaudited`]).
     Pedagogical,
+    /// Integration wired but **not yet cryptographically reviewed**; not a
+    /// production trust claim. Used for backends (e.g.
+    /// [`BackendId::RiscZero`]) whose envelope shape and verifier *seam*
+    /// exist in-tree, but whose actual verify path has not undergone
+    /// external cryptographic review. [`ProofEnvelope::verify`] always fails
+    /// closed for backends in this status — the seam exists so that
+    /// wiring in the audited verifier later is a small, localized change,
+    /// not a claim that it is safe to trust today.
+    PendingExternalReview,
     /// A production backend that has undergone cryptographic review and
     /// carries its own audit evidence. Exempt from the pedagogical
     /// unaudited-refusal gate. No backend holds this status yet — it is
     /// introduced here only so the registry has somewhere to record one
-    /// once VCG-001b lands.
+    /// once external review of a production backend actually lands.
     ProductionReviewed,
 }
 
@@ -181,16 +210,98 @@ pub struct BackendDescriptor {
 /// hardening pass: it lets callers (and tests) inspect what backends are
 /// registered and whether any of them are [`AuditStatus::ProductionReviewed`]
 /// without reaching into [`ProofEnvelope::verify`] internals. Today this
-/// returns exactly one entry — the unaudited blake3 stand-in, marked
-/// [`AuditStatus::Pedagogical`] — because no production backend has been
-/// registered yet (VCG-001b, ratified decision D1, out of scope for
-/// VCG-001a).
+/// returns two entries:
+///
+/// - the unaudited blake3 stand-in, marked [`AuditStatus::Pedagogical`];
+/// - the RISC Zero integration seam (VCG-001b, ratified decision D1),
+///   marked [`AuditStatus::PendingExternalReview`] — wired but not yet
+///   cryptographically reviewed.
+///
+/// Neither entry is [`AuditStatus::ProductionReviewed`]: no backend has
+/// undergone external cryptographic review yet. See
+/// `tests/riscz_verifier_scaffold.rs`'s anti-overclaim regression locks.
 #[must_use]
 pub fn default_registry() -> Vec<BackendDescriptor> {
-    vec![BackendDescriptor {
-        backend_id: BackendId::UnauditedBlake3Standin,
-        audit_status: AuditStatus::Pedagogical,
-    }]
+    vec![
+        BackendDescriptor {
+            backend_id: BackendId::UnauditedBlake3Standin,
+            audit_status: AuditStatus::Pedagogical,
+        },
+        BackendDescriptor {
+            backend_id: BackendId::RiscZero,
+            audit_status: AuditStatus::PendingExternalReview,
+        },
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// RiscZero verifier-integration seam (VCG-001b)
+// ---------------------------------------------------------------------------
+
+/// Integration seam for the audited RISC Zero receipt verifier.
+///
+/// Ratified decision D1 (2026-07-02, `GAP-REGISTRY.md` VCG-001) selects RISC
+/// Zero as the production backend family, with Groth16 wrapping for receipt
+/// compression, server-side-only proving, and a verifier that "stays small,
+/// in-workspace, and pinned, and carries the external audit budget." That
+/// audit has not happened yet, and the `risc0-zkvm` crate itself is not a
+/// workspace dependency — vendoring it is precisely the reviewed-dependency
+/// supply-chain event D1 defers until review lands.
+///
+/// This trait exists so that event has exactly one, small, localized
+/// plug-in point: **this is where the audited risc0 `Receipt::verify` (or
+/// equivalent image-id-bound verification) call goes.** Implementing this
+/// trait against the real `risc0-zkvm` verifier — and swapping
+/// [`ProofEnvelope::verify`]'s `BackendId::RiscZero` arm to call it instead
+/// of failing closed — is the entire VCG-001c (or later) green-stage change.
+/// Until then, [`FailClosedRiscZeroVerifier`] is the only implementation,
+/// and it never returns `Ok(true)`.
+pub trait RiscZeroReceiptVerifier {
+    /// Verifies a RISC Zero execution receipt against the given image id
+    /// (or verifier key bytes) and public inputs.
+    ///
+    /// # Errors
+    ///
+    /// Real implementations return `Err` for any receipt that does not
+    /// verify. The [`FailClosedRiscZeroVerifier`] default always returns
+    /// `Err` — see its docs.
+    fn verify_receipt(
+        &self,
+        image_id_or_verifier_key: &[u8],
+        public_inputs: &[Vec<u8>],
+    ) -> Result<bool>;
+}
+
+/// Fail-closed default [`RiscZeroReceiptVerifier`]: refuses every receipt.
+///
+/// This is the only [`RiscZeroReceiptVerifier`] implementation in this
+/// crate today. It exists so [`ProofEnvelope::verify`] has a concrete seam
+/// to call for `BackendId::RiscZero` rather than inlining the refusal —
+/// swapping this type out for one backed by the audited `risc0-zkvm`
+/// verifier (once external cryptographic review lands) is the intended,
+/// localized future change. It must never be changed to return `Ok(true)`
+/// without that review having actually happened; doing so would be exactly
+/// the false soundness claim ratified decision D1 and the VCG-001b
+/// anti-overclaim regression locks (`tests/riscz_verifier_scaffold.rs`)
+/// exist to prevent.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FailClosedRiscZeroVerifier;
+
+impl RiscZeroReceiptVerifier for FailClosedRiscZeroVerifier {
+    fn verify_receipt(
+        &self,
+        _image_id_or_verifier_key: &[u8],
+        _public_inputs: &[Vec<u8>],
+    ) -> Result<bool> {
+        Err(ProofError::VerificationFailed(
+            "BackendId::RiscZero verifier is a pending-review scaffold: no external \
+             cryptographic review of the risc0 verify path has landed yet, so this refuses \
+             closed rather than trust an unaudited verifier. See \
+             RiscZeroReceiptVerifier for exactly where the audited risc0 verify call plugs \
+             in once review lands."
+                .to_string(),
+        ))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -250,16 +361,15 @@ impl ProofEnvelope {
     /// Verifies the envelope's named backend is both registered and, if
     /// unaudited, explicitly opted into.
     ///
-    /// This lane (VCG-001a) does not implement per-backend proof
-    /// verification logic: no production backend exists yet (VCG-001b,
-    /// ratified decision D1, out of scope here), and this method does not
-    /// wire up or bypass the crate's existing unaudited blake3 stand-in
-    /// verification in `snark.rs` / `stark.rs` / `zkml.rs` /
-    /// `verifier::verify_any`. Fail-closed: **every** backend currently
-    /// registered returns a typed error here — there is no verifier wired
-    /// for any backend at this stage. This is a deliberate success-shaped
-    /// surface trap avoidance: `verify()` must never report `Ok(true)`
-    /// unless it actually verified something.
+    /// No backend has a working, externally-reviewed verifier wired yet:
+    /// the unaudited blake3 stand-in is feature-gated and still a fail-closed
+    /// stub even when opted into (VCG-001a), and the RISC Zero seam
+    /// (VCG-001b, ratified decision D1) is wired but pending external
+    /// cryptographic review (see [`RiscZeroReceiptVerifier`]). Fail-closed:
+    /// **every** backend currently registered returns a typed error here —
+    /// there is no verifier wired for any backend at this stage. This is a
+    /// deliberate success-shaped surface trap avoidance: `verify()` must
+    /// never report `Ok(true)` unless it actually verified something.
     ///
     /// Behavior:
     /// - Unknown/unregistered backend id → `Err(ProofError::InvalidProofFormat)`
@@ -271,8 +381,14 @@ impl ProofEnvelope {
     ///   with `Err(ProofError::VerificationFailed)` because no verifier is
     ///   wired for this backend yet — construction/wrapping of an envelope
     ///   for this backend is feature-gated as above, but *verification* is
-    ///   not implemented at all in VCG-001a. Real verification arrives with
-    ///   VCG-001b.
+    ///   not implemented at all.
+    /// - [`BackendId::RiscZero`] → always refuses with
+    ///   `Err(ProofError::VerificationFailed)` via
+    ///   [`FailClosedRiscZeroVerifier`], independent of the
+    ///   `unaudited-pedagogical-proofs` feature flag (that flag only gates
+    ///   this crate's own blake3 stand-in, not the RiscZero seam). The
+    ///   refusal reason names pending external review, not a missing
+    ///   feature opt-in.
     pub fn verify(&self) -> Result<bool> {
         self.validate_backend()?;
 
@@ -290,6 +406,18 @@ impl ProofEnvelope {
                      VCG-001b lands real per-backend verification",
                     self.backend_id
                 )))
+            }
+            BackendId::RiscZero => {
+                // The RiscZero seam's refusal is NOT gated by
+                // `unaudited-pedagogical-proofs` — that feature concerns
+                // only this crate's own pedagogical blake3 stand-in.
+                // FailClosedRiscZeroVerifier always refuses, regardless of
+                // feature state, because no external cryptographic review
+                // of the risc0 verify path has landed yet (ratified
+                // decision D1). See RiscZeroReceiptVerifier for exactly
+                // where the audited verify call plugs in once review lands.
+                FailClosedRiscZeroVerifier
+                    .verify_receipt(&self.verifier_key_or_image_id, &self.public_inputs)
             }
             BackendId::Unknown(_) => unreachable!(
                 "validate_backend() above must have already refused an unregistered backend id"

--- a/crates/exo-proofs/tests/riscz_verifier_scaffold.rs
+++ b/crates/exo-proofs/tests/riscz_verifier_scaffold.rs
@@ -1,0 +1,229 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(clippy::expect_used)]
+
+//! RED-stage tests for lane VCG-001b: an honest, fail-closed RISC Zero
+//! verifier-integration *scaffold*.
+//!
+//! See `GAP-REGISTRY.md` "VCG-001 - Production ZK Proof Backend Absent",
+//! ratified decision D1 (2026-07-02): RISC Zero is the selected production
+//! backend family, Groth16 wrapping for receipt compression, proving is
+//! server-side only, and the verifier "stays small, in-workspace, and
+//! pinned, and carries the external audit budget."
+//!
+//! ## What this lane is honest about
+//!
+//! Ratified D1 says the production verifier *carries the external audit
+//! budget* — i.e. marking a backend [`exo_proofs::envelope::AuditStatus::ProductionReviewed`]
+//! is the claim that it has passed external cryptographic review. That
+//! review has **not** happened yet. This lane therefore:
+//!
+//! 1. Registers a genuine `BackendId::RiscZero` variant (not `Unknown`).
+//! 2. Registers it in `default_registry()` under a **third**, new
+//!    `AuditStatus` variant — `PendingExternalReview` — documented as
+//!    "integration wired but NOT yet cryptographically reviewed; not a
+//!    production trust claim." It is explicitly **not**
+//!    `AuditStatus::ProductionReviewed`.
+//! 3. Wires a verifier *seam* for `BackendId::RiscZero` in
+//!    `ProofEnvelope::verify()` that still **fails closed** — mirroring the
+//!    `UnauditedBlake3Standin` arm's fail-closed posture, but for a
+//!    distinct, documented reason (pending external review, not missing
+//!    feature opt-in).
+//!
+//! The standing red in `tests/refusal.rs`
+//! (`production_backend_variant_executes_without_unaudited_flag`) MUST stay
+//! red/`#[ignore]`d — nothing in this lane registers a
+//! `AuditStatus::ProductionReviewed` backend, and nothing here un-ignores
+//! or otherwise touches that test.
+//!
+//! ## Expected red mode
+//!
+//! Today (commit `3dc7672a`) `exo_proofs::envelope` has exactly two
+//! `BackendId` variants (`UnauditedBlake3Standin`, `Unknown(u32)`) and two
+//! `AuditStatus` variants (`Pedagogical`, `ProductionReviewed`). This file
+//! names `BackendId::RiscZero` and `AuditStatus::PendingExternalReview`,
+//! neither of which exist yet — **expected red mode is a COMPILE ERROR**
+//! (`error[E0599]: no variant named \`RiscZero\` found for enum \`BackendId\``
+//! or equivalent "no variant/associated item" errors), mirroring how
+//! `tests/envelope.rs` documented an expected compile-error red for
+//! VCG-001a. This is the documented red for RED stage VCG-001b: no
+//! production code has been written yet, so the variants cannot be named.
+
+use exo_proofs::envelope::{AuditStatus, BackendId, ProofEnvelope, ProofStatementKind};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn riscz_envelope() -> ProofEnvelope {
+    ProofEnvelope {
+        statement_kind: ProofStatementKind::ExecutionReceipt,
+        backend_id: BackendId::RiscZero,
+        version: 1,
+        public_inputs: vec![],
+        commitment_roots: vec![],
+        verifier_key_or_image_id: b"riscz-image-id-placeholder".to_vec(),
+        domain_separator: b"exo-proofs:envelope:v1:execution-receipt".to_vec(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (a) default_registry() carries a RiscZero / PendingExternalReview entry
+// ---------------------------------------------------------------------------
+
+/// RED (a): `default_registry()` must contain a `BackendId::RiscZero`
+/// descriptor whose `audit_status` is `AuditStatus::PendingExternalReview`.
+///
+/// Fails today: neither `BackendId::RiscZero` nor
+/// `AuditStatus::PendingExternalReview` exist, so this does not compile.
+/// Once both variants exist, it fails at runtime until `default_registry()`
+/// actually registers the entry.
+#[test]
+fn default_registry_contains_riscz_pending_external_review_backend() {
+    let registry = exo_proofs::envelope::default_registry();
+
+    let riscz_entry = registry
+        .iter()
+        .find(|descriptor| matches!(descriptor.backend_id, BackendId::RiscZero))
+        .unwrap_or_else(|| {
+            panic!(
+                "expected default_registry() to contain a BackendId::RiscZero descriptor \
+                 (VCG-001b honest scaffold), got {registry:?}"
+            )
+        });
+
+    assert_eq!(
+        riscz_entry.audit_status,
+        AuditStatus::PendingExternalReview,
+        "the RiscZero descriptor must be AuditStatus::PendingExternalReview — integration \
+         wired but NOT yet cryptographically reviewed; it must NOT be marked \
+         AuditStatus::ProductionReviewed until external review actually happens, got {riscz_entry:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (b) RiscZero verify() fails closed with a pending-review-specific error
+// ---------------------------------------------------------------------------
+
+/// RED (b): a `ProofEnvelope` naming `BackendId::RiscZero` must fail closed
+/// at `verify()` with an error whose message mentions the backend is
+/// pending external review / not yet audited. This must be true
+/// regardless of the `unaudited-pedagogical-proofs` feature flag — the
+/// RiscZero seam's refusal reason is "no external cryptographic review has
+/// landed yet," which is orthogonal to the pedagogical-backend opt-in gate.
+///
+/// Fails today: `BackendId::RiscZero` does not exist, so this does not
+/// compile. Once it exists, it fails at runtime until `ProofEnvelope::verify`
+/// has a match arm for it.
+#[test]
+fn riscz_backend_verify_fails_closed_pending_external_review() {
+    let envelope = riscz_envelope();
+
+    let result = envelope.verify();
+    assert!(
+        result.is_err(),
+        "BackendId::RiscZero must fail closed at verify() until external review lands, \
+         got {result:?}"
+    );
+
+    let message = result.unwrap_err().to_string();
+    let mentions_pending_review = message.to_lowercase().contains("pending")
+        || message.to_lowercase().contains("external review")
+        || message.to_lowercase().contains("not yet")
+        || message.to_lowercase().contains("not audited")
+        || message.to_lowercase().contains("unaudited");
+    assert!(
+        mentions_pending_review,
+        "RiscZero verify() error must mention pending external review / not yet audited, \
+         got message: {message:?}"
+    );
+}
+
+/// RED (b), feature-flag independence: the RiscZero pending-review refusal
+/// must NOT be gated by (or removable via) the
+/// `unaudited-pedagogical-proofs` feature — that feature only concerns the
+/// crate's own pedagogical blake3 stand-in, not the RiscZero integration
+/// seam. Enabling it must not turn RiscZero's refusal into `Ok(true)`.
+#[cfg(feature = "unaudited-pedagogical-proofs")]
+#[test]
+fn riscz_backend_verify_still_fails_closed_with_pedagogical_feature_enabled() {
+    let envelope = riscz_envelope();
+
+    let result = envelope.verify();
+    assert!(
+        result.is_err(),
+        "enabling 'unaudited-pedagogical-proofs' must not make BackendId::RiscZero verify() \
+         succeed — the RiscZero seam's refusal is about pending external review, not the \
+         pedagogical opt-in gate, got {result:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (c) anti-overclaim regression lock (must remain true before AND after green)
+// ---------------------------------------------------------------------------
+
+/// This is a REGRESSION LOCK, not a red test: it already passes today
+/// (`default_registry()` has zero `ProductionReviewed` entries because it
+/// has exactly one `Pedagogical` entry) and it MUST keep passing after this
+/// lane goes green. It protects the honest posture required by ratified
+/// decision D1: nothing in VCG-001b is permitted to claim a backend has
+/// passed external cryptographic review it has not actually passed. If a
+/// future change makes this test fail, that change is a false soundness
+/// claim and must be reverted, not the test.
+#[test]
+fn anti_overclaim_default_registry_has_zero_production_reviewed_backends() {
+    let registry = exo_proofs::envelope::default_registry();
+
+    let production_reviewed_count = registry
+        .iter()
+        .filter(|descriptor| descriptor.audit_status == AuditStatus::ProductionReviewed)
+        .count();
+
+    assert_eq!(
+        production_reviewed_count, 0,
+        "default_registry() must contain ZERO AuditStatus::ProductionReviewed backends — \
+         no backend has passed external cryptographic review yet (ratified decision D1). \
+         Registering one here would be a false soundness claim. Got: {registry:?}"
+    );
+}
+
+/// Companion regression lock: the standing red in `tests/refusal.rs`,
+/// `production_backend_variant_executes_without_unaudited_flag`, asserts
+/// that a `ProductionReviewed` backend's `verify()` succeeds without the
+/// unaudited feature. Since (per the lock above) no such backend is ever
+/// registered by this lane, that assertion's precondition
+/// (`registry.iter().find(...ProductionReviewed...)`) can never be
+/// satisfied by anything this lane adds — i.e. this lane cannot
+/// accidentally turn that standing red green. This test documents that
+/// invariant directly against the RiscZero entry specifically: it must be
+/// `PendingExternalReview`, never `ProductionReviewed`.
+#[test]
+fn riscz_backend_is_never_marked_production_reviewed() {
+    let registry = exo_proofs::envelope::default_registry();
+
+    for descriptor in registry
+        .iter()
+        .filter(|descriptor| matches!(descriptor.backend_id, BackendId::RiscZero))
+    {
+        assert_ne!(
+            descriptor.audit_status,
+            AuditStatus::ProductionReviewed,
+            "BackendId::RiscZero must never be registered as AuditStatus::ProductionReviewed \
+             until external cryptographic review actually lands, got {descriptor:?}"
+        );
+    }
+}

--- a/crates/exo-proofs/tests/riscz_verifier_scaffold.rs
+++ b/crates/exo-proofs/tests/riscz_verifier_scaffold.rs
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::expect_used)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 //! RED-stage tests for lane VCG-001b: an honest, fail-closed RISC Zero
 //! verifier-integration *scaffold*.

--- a/tools/test_gap_registry_truth.sh
+++ b/tools/test_gap_registry_truth.sh
@@ -86,7 +86,7 @@ done
 
 assert_contains GAP-REGISTRY.md "VCG-001 \\| P0 \\| Red"
 assert_contains GAP-REGISTRY.md "VCG-002 \\| P0 \\| Green-local"
-assert_contains GAP-REGISTRY.md "VCG-003 \\| P0 \\| Red"
+assert_contains GAP-REGISTRY.md "VCG-003 \\| P0 \\| Green-local"
 assert_contains GAP-REGISTRY.md "VCG-004 \\| P0 \\| Red"
 assert_contains GAP-REGISTRY.md "VCG-005 \\| P1 \\| Green-local"
 assert_contains GAP-REGISTRY.md "VCG-006 \\| P1 \\| Green-local"


### PR DESCRIPTION
## VCG remediation — batch-3 (P0 tier)

Principal ratified 'everything, incl. the VCG-001 scaffold.' This batch lands the honestly-closeable P0 work and records the genuine blockers on the rest — no false closure.

### VCG-003 — GraphQL adjudication (Red -> **Green-local**)
The unconditional mutation kill-switch is **removed** from all 9 resolvers and the function deleted. Each resolver routes through the real `exo_gatekeeper::Kernel::adjudicate` across **all 8 constitutional invariants**, gating writes on `Verdict::Permitted`. **Integrity guarantee:** the kernel's `AuthorityChainValid`/`ConsentRequired`/`ProvenanceVerifiable` invariants require real Ed25519 signatures, so a **forged grant cannot pass** — deny-by-default is crypto-enforced, not a hardcoded refusal. The standing red passes only via a genuinely-signed test grant; the resolver never auto-authorizes. **Honest caveat (recorded loudly):** production has no authority-grant source (`seed_actor_grant` is test-only), so the default-off surface denies every mutation in prod — the *correct* posture for an unaudited surface; wiring a real grant source is an audit-time follow-on, deliberately not done to avoid premature production authorization.

### VCG-001b — RISC Zero verifier scaffold (VCG-001 **stays Red**)
Honest integration seam only: new `AuditStatus::PendingExternalReview`, a genuine `BackendId::RiscZero`, a fail-closed `RiscZeroReceiptVerifier` seam documenting where the audited call plugs in. **Never `ProductionReviewed`, never `Ok(true)`, no dependency vendored, standing red untouched.** VCG-001 stays Red pending the external crypto audit — the scaffold makes that future wiring a small localized change.

### VCG-004 — coordinator finding (stays Red, NOT faked)
The mutation-effect attempt was **refuted** (misattribution + a synthetic-marker `RemoveValidator` = theater). Real blocker: `submit_proposal` accepts only `ValidatorChange` — no governance-decision consensus payload type exists, so no MCP governance tool can honestly route a mutation without new infrastructure **or** granting MCP validator-proposal authority (a ratification-level decision). Recorded; principal decision required.

### Gates
- exochain-proofs: both feature configs pass (standing red still ignored/red)
- exochain-gateway graphql: 34 pass (incl. un-ignored standing red + deny-by-default + actor-binding + structural fail-closed meta-test)
- clippy `-D warnings` clean (proofs ×2, gateway graphql); nightly fmt + repo-truth + gap/claim/cr001 guards green
- Repo-truth: 461 files, 377562 LOC, 6102 tests

### Ledger after this batch
**12 Green-local** (002/003/005/006/007/008/009/010/012/013/014/015). **3 Red-blocked with named ceilings**: VCG-001 (external crypto audit), VCG-004 (missing decision-payload infra + governance-authority decision), VCG-011 (external TEE platform review).