### PR TITLE
feat(avc): durable issuer permission cap + issuer-registration chain export

### DIFF
--- a/.github/workflows/livesafe-ci.yml
+++ b/.github/workflows/livesafe-ci.yml
@@ -53,19 +53,17 @@ jobs:
           node-version: 22
       - name: Install root dev dependencies
         run: npm ci
+      - name: Install server dependencies for quality tests
+        run: npm --prefix server ci
+      - name: Run LiveSafe quality gate
+        run: npm run quality
       - name: Typecheck (tsc --noEmit)
         run: npm run typecheck
       - name: Build client (production artifact)
         run: |
-          cd client
-          npm ci
-          npm run build
+          npm --prefix client ci
+          npm --prefix client run build
       - name: Build responder
         run: |
-          cd responder
-          npm ci
-          npm run build
-      - name: Install server dependencies (resolve check)
-        run: |
-          cd server
-          npm ci
+          npm --prefix responder ci
+          npm --prefix responder run build

--- a/crates/exo-avc/src/registry.rs
+++ b/crates/exo-avc/src/registry.rs
@@ -101,6 +101,8 @@ pub struct RegisteredIssuerKey {
     pub public_key: PublicKey,
     pub authority_chain: AuthorityChain,
     pub registered_at: Timestamp,
+    #[serde(default)]
+    pub granted_permissions: BTreeSet<Permission>,
 }
 
 /// Durable AVC runtime records.
@@ -410,7 +412,10 @@ impl InMemoryAvcRegistry {
         for (issuer_did, record) in records {
             match self.verify_registered_issuer_key_chain(&issuer_did, &record, now) {
                 Ok(()) => {
-                    self.public_keys.insert(issuer_did, record.public_key);
+                    self.public_keys
+                        .insert(issuer_did.clone(), record.public_key);
+                    self.issuer_permission_grants
+                        .insert(issuer_did, record.granted_permissions.clone());
                 }
                 Err(error) => {
                     // Fail closed on trust (the key is never admitted), but
@@ -944,6 +949,9 @@ impl AvcRegistryWrite for InMemoryAvcRegistry {
     fn put_registered_issuer_key(&mut self, did: Did, record: RegisteredIssuerKey) {
         // Immediately resolvable on this running node (no restart needed) ...
         self.public_keys.insert(did.clone(), record.public_key);
+        // ... and immediately capped to the durable permission ceiling.
+        self.issuer_permission_grants
+            .insert(did.clone(), record.granted_permissions.clone());
         // ... AND durably recorded with its authorizing provenance so it
         // survives a restart (VCG-006b / #736 hard requirement (a)). Distinct
         // from `put_public_key`'s startup-config anchors, which are never
@@ -2331,6 +2339,7 @@ mod tests {
                 public_key: issuer_keypair.public,
                 authority_chain: chain,
                 registered_at: now,
+                granted_permissions: BTreeSet::from([Permission::Read, Permission::Write]),
             },
         );
 
@@ -2341,6 +2350,11 @@ mod tests {
             Some(issuer_keypair.public)
         );
         assert_eq!(live.registered_issuer_key_count(), 1);
+        assert_eq!(
+            live.resolve_issuer_permission_grant(&issuer_did),
+            Some(vec![Permission::Read, Permission::Write]),
+            "runtime issuer permission cap must be applied immediately"
+        );
 
         // Simulate a restart: export durable state, reconstruct fresh, then
         // restore verified startup configuration (the validator's own key)
@@ -2366,6 +2380,11 @@ mod tests {
             restarted.resolve_public_key(&issuer_did),
             Some(issuer_keypair.public),
             "runtime-registered issuer key must survive a restart (#736 hard requirement (a))"
+        );
+        assert_eq!(
+            restarted.resolve_issuer_permission_grant(&issuer_did),
+            Some(vec![Permission::Read, Permission::Write]),
+            "runtime issuer permission cap must survive a restart alongside its key"
         );
 
         // A credential from that issuer still validates end-to-end on the
@@ -2406,6 +2425,7 @@ mod tests {
                 public_key: issuer_keypair.public,
                 authority_chain: chain,
                 registered_at: now,
+                granted_permissions: BTreeSet::new(),
             },
         );
 
@@ -2460,6 +2480,7 @@ mod tests {
                 public_key: issuer_keypair.public,
                 authority_chain: chain,
                 registered_at: now,
+                granted_permissions: BTreeSet::new(),
             },
         );
 
@@ -2531,6 +2552,7 @@ mod tests {
                 public_key: good_issuer_keypair.public,
                 authority_chain: good_chain,
                 registered_at: now,
+                granted_permissions: BTreeSet::new(),
             },
         );
         live.put_registered_issuer_key(
@@ -2539,6 +2561,7 @@ mod tests {
                 public_key: bad_issuer_keypair.public,
                 authority_chain: bad_chain,
                 registered_at: now,
+                granted_permissions: BTreeSet::new(),
             },
         );
         assert_eq!(live.registered_issuer_key_count(), 2);

--- a/crates/exo-avc/src/validation.rs
+++ b/crates/exo-avc/src/validation.rs
@@ -371,11 +371,12 @@ fn enforce_registered_issuer_grant<R: AvcRegistryRead>(
     else {
         return;
     };
-    if credential
-        .authority_scope
-        .permissions
-        .iter()
-        .any(|permission| !granted_permissions.contains(permission))
+    if granted_permissions.is_empty()
+        || credential
+            .authority_scope
+            .permissions
+            .iter()
+            .any(|permission| !granted_permissions.contains(permission))
     {
         reasons.insert(AvcReasonCode::ScopeWidening);
     }
@@ -1080,6 +1081,25 @@ mod tests {
         assert!(
             result.reason_codes.contains(&AvcReasonCode::ScopeWidening),
             "root issuer grants must cap credential-declared permissions"
+        );
+    }
+
+    #[test]
+    fn denies_all_credentials_from_issuer_capped_to_empty_permission_set() {
+        let mut h = Harness::new();
+        h.registry
+            .put_issuer_permission_grant(did("issuer"), vec![]);
+        let mut draft = baseline_draft();
+        draft.authority_scope.permissions = vec![];
+        let cred = h.issue(draft);
+        let request = baseline_request(cred, ts(1_500_000));
+
+        let result = validate_avc(&request, &h.registry).unwrap();
+
+        assert_eq!(result.decision, AvcDecision::Deny);
+        assert!(
+            result.reason_codes.contains(&AvcReasonCode::ScopeWidening),
+            "an issuer capped to no permissions must be able to sign nothing"
         );
     }
 

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -2037,6 +2037,8 @@ pub struct RegisterIssuerRequest {
     pub public_key_hex: String,
     #[serde(default)]
     pub authority_chain: Option<exo_authority::AuthorityChain>,
+    #[serde(default)]
+    pub granted_permissions: Vec<Permission>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -2054,6 +2056,11 @@ struct ListAvcReceiptsQuery {
 #[derive(Debug, Deserialize)]
 struct AvcProtocolQuery {
     protocol_version: Option<u16>,
+}
+
+#[derive(Debug, Deserialize)]
+struct IssuerRegistrationAuthorityQuery {
+    operator_did: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -2893,11 +2900,21 @@ async fn handle_register_issuer(
     };
     verify_issuer_registration_authority(&state, chain)?;
 
+    if payload.granted_permissions.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "issuer registration requires a non-empty granted_permissions cap".into(),
+        ));
+    }
+    let granted_permissions: BTreeSet<Permission> =
+        payload.granted_permissions.iter().copied().collect();
+
     let registered_at = trusted_local_hlc_timestamp(&state).map_err(local_hlc_timestamp_error)?;
     let record = exo_avc::RegisteredIssuerKey {
         public_key,
         authority_chain: chain.clone(),
         registered_at,
+        granted_permissions,
     };
     let issuer_did_for_registry = issuer_did.clone();
     with_registry_blocking(state, true, move |registry| {
@@ -2950,6 +2967,24 @@ async fn handle_list_for_subject(
     }))
 }
 
+async fn handle_get_issuer_registration_authority_chain(
+    State(state): State<Arc<AvcApiState>>,
+    Query(query): Query<IssuerRegistrationAuthorityQuery>,
+) -> ApiResult<Json<exo_authority::AuthorityChain>> {
+    let operator_did_raw = query.operator_did.ok_or((
+        StatusCode::BAD_REQUEST,
+        "operator_did query parameter is required".into(),
+    ))?;
+    let operator_did = parse_did(&operator_did_raw)?;
+    let chain = state
+        .find_delegated_issuer_registration_chain(&operator_did)
+        .ok_or((
+            StatusCode::NOT_FOUND,
+            "no active issuer-registration authority grant for that operator_did".into(),
+        ))?;
+    Ok(Json(chain))
+}
+
 // ---------------------------------------------------------------------------
 // Router
 // ---------------------------------------------------------------------------
@@ -2969,6 +3004,10 @@ pub fn avc_router(state: Arc<AvcApiState>) -> Router {
         .route("/api/v1/avc/delegate", post(handle_delegate))
         .route("/api/v1/avc/revoke", post(handle_revoke))
         .route("/api/v1/avc/issuers", post(handle_register_issuer))
+        .route(
+            "/api/v1/avc/issuer-registration-authority",
+            get(handle_get_issuer_registration_authority_chain),
+        )
         .route("/api/v1/avc/:id", get(handle_get))
         .route("/api/v1/agents/:did/avcs", get(handle_list_for_subject))
         .with_state(state)
@@ -7799,6 +7838,7 @@ mod avc_issuer_conformance_tests {
             "issuer_did": issuer_did.to_string(),
             "public_key_hex": hex::encode(issuer_kp.public.as_bytes()),
             "authority_chain": chain,
+            "granted_permissions": ["Read", "Write"],
         });
         let app = issuer_router_with_bearer_gate(Arc::clone(&state));
         let register_response = app
@@ -8204,6 +8244,7 @@ mod avc_issuer_registration_authority_tests {
             "issuer_did": issuer_did.to_string(),
             "public_key_hex": hex::encode(issuer_kp.public.as_bytes()),
             "authority_chain": chain,
+            "granted_permissions": ["Read", "Write"],
         });
         let app = router_with_bearer_gate(Arc::clone(&state));
         let register_response = app
@@ -8348,5 +8389,190 @@ mod avc_issuer_registration_authority_tests {
                 .resolve_public_key(&issuer_did),
             None
         );
+    }
+
+    fn state_with_granted_operator() -> (Arc<AvcApiState>, exo_authority::AuthorityChain) {
+        let state = fresh_state();
+        let validator_kp = validator_keypair();
+        state
+            .registry
+            .lock()
+            .unwrap()
+            .put_public_key(validator_did(), validator_kp.public);
+        let now = Timestamp::new(1_000, 0);
+        let expires = Timestamp::new(9_000_000, 0);
+        state
+            .grant_issuer_registration_authority(
+                operator_did(),
+                DelegateeKind::Human,
+                &validator_kp.public,
+                expires,
+                &now,
+                |payload| validator_kp.sign(payload),
+            )
+            .expect("grant issuer-registration authority");
+        let chain = state
+            .find_delegated_issuer_registration_chain(&operator_did())
+            .expect("chain resolvable after grant");
+        (state, chain)
+    }
+
+    #[tokio::test]
+    async fn issuer_registration_rejects_empty_permission_cap() {
+        let (state, chain) = state_with_granted_operator();
+        let issuer_did = new_issuer_did();
+        let issuer_kp = new_issuer_keypair();
+        let register_body = serde_json::json!({
+            "issuer_did": issuer_did.to_string(),
+            "public_key_hex": hex::encode(issuer_kp.public.as_bytes()),
+            "authority_chain": chain,
+            "granted_permissions": [],
+        });
+        let app = router_with_bearer_gate(Arc::clone(&state));
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/avc/issuers")
+                    .header("content-type", "application/json")
+                    .header("Authorization", "Bearer vcg-006b-authority-test-token")
+                    .body(Body::from(serde_json::to_vec(&register_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            state
+                .registry
+                .lock()
+                .unwrap()
+                .resolve_public_key(&issuer_did),
+            None,
+            "a rejected registration must not register the key"
+        );
+    }
+
+    #[tokio::test]
+    async fn issuer_registration_applies_permission_cap() {
+        let (state, chain) = state_with_granted_operator();
+        let issuer_did = new_issuer_did();
+        let issuer_kp = new_issuer_keypair();
+        let register_body = serde_json::json!({
+            "issuer_did": issuer_did.to_string(),
+            "public_key_hex": hex::encode(issuer_kp.public.as_bytes()),
+            "authority_chain": chain,
+            "granted_permissions": ["Read", "Write"],
+        });
+        let app = router_with_bearer_gate(Arc::clone(&state));
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/avc/issuers")
+                    .header("content-type", "application/json")
+                    .header("Authorization", "Bearer vcg-006b-authority-test-token")
+                    .body(Body::from(serde_json::to_vec(&register_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            state
+                .registry
+                .lock()
+                .unwrap()
+                .resolve_issuer_permission_grant(&issuer_did),
+            Some(vec![Permission::Read, Permission::Write]),
+            "the registered issuer must be capped to exactly the granted permissions"
+        );
+    }
+
+    #[tokio::test]
+    async fn issuer_registration_authority_chain_export_returns_granted_chain() {
+        let (state, chain) = state_with_granted_operator();
+        let app = router_with_bearer_gate(Arc::clone(&state));
+        let uri = format!(
+            "/api/v1/avc/issuer-registration-authority?operator_did={}",
+            operator_did()
+        );
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri(uri)
+                    .header("Authorization", "Bearer vcg-006b-authority-test-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = read_body(response).await;
+        let exported: exo_authority::AuthorityChain =
+            serde_json::from_slice(&body).expect("export body is an AuthorityChain");
+        assert_eq!(exported, chain);
+    }
+
+    #[tokio::test]
+    async fn issuer_registration_authority_chain_export_requires_operator_did() {
+        let (state, _chain) = state_with_granted_operator();
+        let app = router_with_bearer_gate(Arc::clone(&state));
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/api/v1/avc/issuer-registration-authority")
+                    .header("Authorization", "Bearer vcg-006b-authority-test-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn issuer_registration_authority_chain_export_absent_grant_is_not_found() {
+        let state = fresh_state();
+        let app = router_with_bearer_gate(Arc::clone(&state));
+        let uri = format!(
+            "/api/v1/avc/issuer-registration-authority?operator_did={}",
+            operator_did()
+        );
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri(uri)
+                    .header("Authorization", "Bearer vcg-006b-authority-test-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn issuer_registration_authority_chain_export_requires_bearer() {
+        let (state, _chain) = state_with_granted_operator();
+        let app = router_with_bearer_gate(Arc::clone(&state));
+        let uri = format!(
+            "/api/v1/avc/issuer-registration-authority?operator_did={}",
+            operator_did()
+        );
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri(uri)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 }

--- a/livesafe/tests/github-quality-workflow.test.ts
+++ b/livesafe/tests/github-quality-workflow.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 describe("GitHub quality workflow", () => {
   it("installs server dependencies before root quality tests import server routes", () => {
     const workflow = readFileSync(
-      resolve(process.cwd(), ".github/workflows/quality.yml"),
+      resolve(process.cwd(), "../.github/workflows/livesafe-ci.yml"),
       "utf8",
     );
 
@@ -13,7 +13,7 @@ describe("GitHub quality workflow", () => {
     const serverInstallIndex = workflow.indexOf("run: npm --prefix server ci");
     const qualityIndex = workflow.indexOf("run: npm run quality");
 
-    expect(workflow).toContain("server/package-lock.json");
+    expect(workflow).toContain("livesafe/**");
     expect(rootInstallIndex).toBeGreaterThanOrEqual(0);
     expect(serverInstallIndex).toBeGreaterThan(rootInstallIndex);
     expect(qualityIndex).toBeGreaterThan(serverInstallIndex);


### PR DESCRIPTION
## Why

Stage 1 of LiveSafe Tier 2 governed issuer provisioning. LiveSafe needs to become a registered, scoped AVC issuer whose credentials validate without giving the issuer broader authority than the deployment grants.

## What

1. **Durable per-issuer permission cap.** `RegisteredIssuerKey` now stores `granted_permissions: BTreeSet<Permission>`. `POST /api/v1/avc/issuers` requires a non-empty `granted_permissions` cap and rejects an empty cap with `400`. The cap is applied by both `put_registered_issuer_key` and `restore_registered_issuer_keys`, so restart restores the key and cap together.

2. **Fail-closed empty cap.** AVC validation treats a recorded empty issuer cap as “may sign nothing” and returns `ScopeWidening`, including for credentials with an empty permission list.

3. **Issuer authority export.** `GET /api/v1/avc/issuer-registration-authority?operator_did=<did>` returns the active `exo-authority` chain granted to the issuer-registration operator, with bearer auth, `400` for missing `operator_did`, and `404` for no active grant.

4. **LiveSafe monorepo quality gate.** The path-scoped LiveSafe workflow now installs server dependencies and runs `npm run quality` from the monorepo location before artifact builds. This preserves the adjacent-surface gate after the move into `exochain/exochain/livesafe`.

## Path classification

- `crates/exo-avc/src/registry.rs`, `crates/exo-avc/src/validation.rs`: EXOCHAIN core.
- `crates/exo-node/src/avc.rs`: core runtime adapter.
- `.github/workflows/livesafe-ci.yml`: CI/deployment contract for adjacent LiveSafe surface.
- `livesafe/tests/github-quality-workflow.test.ts`: adjacent LiveSafe surface test.

## LiveSafe cap

The intended LiveSafe issuer registration cap is `[Read, Write]` for deployment-time ceremony input. This PR does not hardcode that value in production code and does not enable public EXOCHAIN trust claims.

## TDD proof

RED observed:

- `cargo test -p exochain-avc registered_issuer_key_survives_restart_and_credential_still_validates -- --nocapture` failed because `RegisteredIssuerKey` had no `granted_permissions` field.
- `cargo test -p exochain-node issuer_registration_rejects_empty_permission_cap -- --nocapture` failed `200` vs expected `400`.
- `cargo test -p exochain-node issuer_registration_authority_chain_export_returns_granted_chain -- --nocapture` failed `400` vs expected `200`.
- `npm test -- tests/github-quality-workflow.test.ts` failed against the moved monorepo workflow contract before the workflow fix.

GREEN verified locally:

- `cargo test -p exochain-avc` — 209 tests plus doctest passed.
- `cargo test -p exochain-node avc_issuer_registration_authority_tests -- --nocapture` — 8 passed.
- `cargo test -p exochain-node avc_issuer_conformance_tests -- --nocapture` — 3 passed.
- `cargo test -p exochain-node` — 1341 passed, 2 ignored.
- `cargo clippy -p exochain-avc -p exochain-node --all-targets -- -D warnings` — passed.
- `cargo +nightly fmt --all -- --check` — passed.
- `npm run quality` from `livesafe/` — context lint, typecheck, 154 Vitest files / 444 tests, Rust fmt/clippy/tests passed.
- `bash tools/repo_truth.sh --skip-tests` — passed with format clean.

## Notes

- Existing startup/root-trust issuers with no recorded cap keep existing behavior; runtime registered issuers get the durable cap.
- Empty cap is rejected at registration and fail-closed during validation for legacy durable records.
- LiveSafe remains an adjacent surface. Runtime health or adapter connectivity is not public trust activation.
