### PR TITLE
W1/O-1.2(A): thread receipt bytes through verify() to the RiscZero seam

### DIFF
--- a/crates/exo-proofs/src/envelope.rs
+++ b/crates/exo-proofs/src/envelope.rs
@@ -264,6 +264,14 @@ pub trait RiscZeroReceiptVerifier {
     /// Verifies a RISC Zero execution receipt against the given image id (or
     /// verifier key bytes) and the envelope's journal-binding digest.
     ///
+    /// `receipt_bytes` are the serialized risc0 `Receipt`/proof bytes the
+    /// audited verifier will decode and check (objective O-1.2): an audited
+    /// implementation deserializes them into a risc0 `Receipt` and runs its
+    /// verify path. The [`FailClosedRiscZeroVerifier`] default ignores them and
+    /// refuses unconditionally — threading the bytes here now means wiring the
+    /// audited verifier later is a small, localized change rather than a new
+    /// signature break.
+    ///
     /// `journal_digest` is [`ProofEnvelope::binding_digest`] — the canonical
     /// digest over the full envelope context (`statement_kind`,
     /// `commitment_roots`, `domain_separator`, `public_inputs`, ...). An audited
@@ -279,6 +287,7 @@ pub trait RiscZeroReceiptVerifier {
     /// `Err` — see its docs.
     fn verify_receipt(
         &self,
+        receipt_bytes: &[u8],
         image_id_or_verifier_key: &[u8],
         journal_digest: &Hash256,
     ) -> Result<bool>;
@@ -302,6 +311,7 @@ pub struct FailClosedRiscZeroVerifier;
 impl RiscZeroReceiptVerifier for FailClosedRiscZeroVerifier {
     fn verify_receipt(
         &self,
+        _receipt_bytes: &[u8],
         _image_id_or_verifier_key: &[u8],
         _journal_digest: &Hash256,
     ) -> Result<bool> {
@@ -431,17 +441,36 @@ impl ProofEnvelope {
         Ok(Hash256(*blake3::hash(&encoded).as_bytes()))
     }
 
-    /// Runs the RISC Zero seam against `verifier`, binding the full envelope
-    /// context via [`Self::binding_digest`] (objective O-1.1). Production
+    /// Runs the RISC Zero seam against `verifier`, threading the serialized
+    /// `receipt_bytes` (objective O-1.2) and binding the full envelope context
+    /// via [`Self::binding_digest`] (objective O-1.1). Production
     /// [`Self::verify`] passes [`FailClosedRiscZeroVerifier`]; tests inject a
-    /// spy to assert the binding digest actually reaches the verifier.
-    fn verify_riscz(&self, verifier: &dyn RiscZeroReceiptVerifier) -> Result<bool> {
+    /// spy to assert the receipt bytes and the binding digest actually reach
+    /// the verifier.
+    fn verify_riscz(
+        &self,
+        receipt_bytes: &[u8],
+        verifier: &dyn RiscZeroReceiptVerifier,
+    ) -> Result<bool> {
         let journal_digest = self.binding_digest()?;
-        verifier.verify_receipt(&self.verifier_key_or_image_id, &journal_digest)
+        verifier.verify_receipt(
+            receipt_bytes,
+            &self.verifier_key_or_image_id,
+            &journal_digest,
+        )
     }
 
     /// Verifies the envelope's named backend is both registered and, if
     /// unaudited, explicitly opted into.
+    ///
+    /// `receipt_bytes` are the serialized risc0 `Receipt`/proof bytes to check
+    /// (objective O-1.2). They are threaded down to the
+    /// [`RiscZeroReceiptVerifier`] seam for the [`BackendId::RiscZero`] arm so
+    /// the future audited verifier can decode and check them; the
+    /// [`FailClosedRiscZeroVerifier`] default ignores them and still refuses.
+    /// The `UnauditedBlake3Standin` and `Unknown` arms never inspect
+    /// `receipt_bytes` — for them it is simply an unused parameter — so passing
+    /// any value (including `&[]`) cannot change their fail-closed outcomes.
     ///
     /// No backend has a working, externally-reviewed verifier wired yet:
     /// the unaudited blake3 stand-in is feature-gated and still a fail-closed
@@ -471,7 +500,7 @@ impl ProofEnvelope {
     ///   this crate's own blake3 stand-in, not the RiscZero seam). The
     ///   refusal reason names pending external review, not a missing
     ///   feature opt-in.
-    pub fn verify(&self) -> Result<bool> {
+    pub fn verify(&self, receipt_bytes: &[u8]) -> Result<bool> {
         self.validate_backend()?;
 
         match self.backend_id {
@@ -500,8 +529,10 @@ impl ProofEnvelope {
                 // context (statement_kind, commitment_roots, domain_separator,
                 // ...) into the journal digest the audited verifier will check
                 // the receipt against, so it can never certify an unbound
-                // statement once wired.
-                self.verify_riscz(&FailClosedRiscZeroVerifier)
+                // statement once wired. O-1.2: receipt_bytes are threaded to
+                // the seam so the audited verifier has the serialized receipt
+                // to decode and check; the fail-closed default ignores them.
+                self.verify_riscz(receipt_bytes, &FailClosedRiscZeroVerifier)
             }
             BackendId::Unknown(_) => unreachable!(
                 "validate_backend() above must have already refused an unregistered backend id"
@@ -563,6 +594,7 @@ mod riscz_seam_binding_unit {
     impl RiscZeroReceiptVerifier for SpyVerifier {
         fn verify_receipt(
             &self,
+            _receipt_bytes: &[u8],
             _image_id_or_verifier_key: &[u8],
             journal_digest: &Hash256,
         ) -> Result<bool> {
@@ -592,7 +624,7 @@ mod riscz_seam_binding_unit {
             seen_digest: RefCell::new(None),
         };
         // Refuses (fail-closed spy), but must have received the digest.
-        let _ = env.verify_riscz(&spy);
+        let _ = env.verify_riscz(b"some-bytes", &spy);
         assert_eq!(
             *spy.seen_digest.borrow(),
             Some(env.binding_digest().expect("binding digest")),
@@ -606,13 +638,13 @@ mod riscz_seam_binding_unit {
         let spy1 = SpyVerifier {
             seen_digest: RefCell::new(None),
         };
-        let _ = env.verify_riscz(&spy1);
+        let _ = env.verify_riscz(b"receipt-bytes-a", &spy1);
 
         env.domain_separator = b"dom-CHANGED".to_vec();
         let spy2 = SpyVerifier {
             seen_digest: RefCell::new(None),
         };
-        let _ = env.verify_riscz(&spy2);
+        let _ = env.verify_riscz(b"receipt-bytes-a", &spy2);
 
         assert!(
             spy1.seen_digest.borrow().is_some(),
@@ -622,6 +654,70 @@ mod riscz_seam_binding_unit {
             *spy1.seen_digest.borrow(),
             *spy2.seen_digest.borrow(),
             "the digest reaching the verifier must change with domain_separator"
+        );
+    }
+
+    /// O-1.2(A): test-only verifier that records the `receipt_bytes` it is
+    /// handed, then STILL refuses — mirrors [`SpyVerifier`]'s discipline: a spy
+    /// must never manufacture a success-shaped result.
+    struct ReceiptBytesSpyVerifier {
+        seen_receipt_bytes: RefCell<Option<Vec<u8>>>,
+    }
+
+    impl RiscZeroReceiptVerifier for ReceiptBytesSpyVerifier {
+        fn verify_receipt(
+            &self,
+            receipt_bytes: &[u8],
+            _image_id_or_verifier_key: &[u8],
+            _journal_digest: &Hash256,
+        ) -> Result<bool> {
+            *self.seen_receipt_bytes.borrow_mut() = Some(receipt_bytes.to_vec());
+            Err(ProofError::VerificationFailed(
+                "spy verifier records the receipt bytes only; it never manufactures success"
+                    .to_string(),
+            ))
+        }
+    }
+
+    #[test]
+    fn verify_riscz_passes_receipt_bytes_to_seam() {
+        let env = riscz_env();
+        let spy = ReceiptBytesSpyVerifier {
+            seen_receipt_bytes: RefCell::new(None),
+        };
+        // Refuses (fail-closed spy), but must have received the exact bytes.
+        let _ = env.verify_riscz(b"distinct-receipt-bytes", &spy);
+        assert_eq!(
+            spy.seen_receipt_bytes.borrow().as_deref(),
+            Some(b"distinct-receipt-bytes".as_slice()),
+            "the seam must hand the verifier exactly the receipt bytes it was called with"
+        );
+    }
+
+    #[test]
+    fn verify_riscz_receipt_bytes_reflect_the_argument_change() {
+        // Proves live plumbing, not a hardcoded constant: changing the bytes
+        // passed in changes what the spy records.
+        let env = riscz_env();
+
+        let spy1 = ReceiptBytesSpyVerifier {
+            seen_receipt_bytes: RefCell::new(None),
+        };
+        let _ = env.verify_riscz(b"receipt-bytes-one", &spy1);
+
+        let spy2 = ReceiptBytesSpyVerifier {
+            seen_receipt_bytes: RefCell::new(None),
+        };
+        let _ = env.verify_riscz(b"receipt-bytes-TWO", &spy2);
+
+        assert!(
+            spy1.seen_receipt_bytes.borrow().is_some(),
+            "spy1 verifier must have been called"
+        );
+        assert_ne!(
+            *spy1.seen_receipt_bytes.borrow(),
+            *spy2.seen_receipt_bytes.borrow(),
+            "the receipt bytes reaching the verifier must change with the argument passed"
         );
     }
 }

--- a/crates/exo-proofs/tests/envelope.rs
+++ b/crates/exo-proofs/tests/envelope.rs
@@ -198,7 +198,7 @@ fn envelope_backend_registry_rejects_unregistered_numeric_id() {
 fn envelope_wrapping_unaudited_backend_refuses_without_feature() {
     let envelope = sample_envelope(); // backend_id == UNAUDITED_BLAKE3_STANDIN_BACKEND_ID
 
-    let result = envelope.verify();
+    let result = envelope.verify(&[]);
     assert!(
         matches!(
             result,
@@ -225,7 +225,7 @@ fn envelope_wrapping_unaudited_backend_construction_allowed_but_verify_fails_clo
     // itself is not implemented in this lane (VCG-001a). `verify()` must
     // still fail closed with a typed "no verifier wired" error, never
     // `Ok(true)`.
-    let result = envelope.verify();
+    let result = envelope.verify(&[]);
     assert!(
         !matches!(
             result,

--- a/crates/exo-proofs/tests/refusal.rs
+++ b/crates/exo-proofs/tests/refusal.rs
@@ -151,7 +151,7 @@ fn production_backend_variant_executes_without_unaudited_flag() {
     // unaudited-pedagogical-proofs feature enabled — this test binary is
     // compiled with that feature off (see the `#![cfg(not(feature =
     // "unaudited-pedagogical-proofs"))]` crate-level gate above).
-    let result = envelope.verify();
+    let result = envelope.verify(&[]);
     assert!(
         result.is_ok(),
         "a production-reviewed backend (e.g. RISC Zero, ratified decision D1) must \

--- a/crates/exo-proofs/tests/riscz_receipt_bytes_wiring.rs
+++ b/crates/exo-proofs/tests/riscz_receipt_bytes_wiring.rs
@@ -1,0 +1,79 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+//! Objective O-1.2 increment (A), lane VCG-001c2: thread `receipt_bytes`
+//! through the public [`exo_proofs::envelope::ProofEnvelope::verify`] entry
+//! point down to the RISC Zero verifier seam, so the future audited verifier
+//! has the actual serialized receipt bytes to decode and check. Before this
+//! increment, nothing passed receipt bytes at all — only the image id and the
+//! journal-binding digest reached the seam.
+//!
+//! This file only asserts the PUBLIC path. Because `verify()` hardcodes
+//! [`exo_proofs::envelope::FailClosedRiscZeroVerifier`] and exposes no
+//! injection point, the seam-threading proof (that the exact bytes reach the
+//! verifier) lives as in-module unit tests next to the private `verify_riscz`
+//! method in `src/envelope.rs`. Here we only need to confirm the public path
+//! still refuses, regardless of the receipt bytes it is handed — no
+//! receipt-bytes value may turn the fail-closed RiscZero arm into `Ok`.
+
+use exo_proofs::envelope::{BackendId, ProofEnvelope, ProofStatementKind};
+
+fn riscz_envelope() -> ProofEnvelope {
+    ProofEnvelope {
+        statement_kind: ProofStatementKind::ExecutionReceipt,
+        backend_id: BackendId::RiscZero,
+        version: 1,
+        public_inputs: vec![],
+        commitment_roots: vec![],
+        verifier_key_or_image_id: b"riscz-image-id-placeholder".to_vec(),
+        domain_separator: b"exo-proofs:envelope:v1:execution-receipt".to_vec(),
+    }
+}
+
+/// The public `verify()` path must refuse a RiscZero-backend envelope when
+/// handed EMPTY receipt bytes. Threading `receipt_bytes` through the seam must
+/// not open any new success path: an empty receipt is still refused
+/// fail-closed, because no external cryptographic review of the risc0 verify
+/// path has landed yet (ratified decision D1).
+#[test]
+fn riscz_verify_refuses_with_empty_receipt_bytes() {
+    let envelope = riscz_envelope();
+
+    let result = envelope.verify(&[]);
+    assert!(
+        result.is_err(),
+        "BackendId::RiscZero verify(&[]) must fail closed regardless of receipt bytes, \
+         got {result:?}"
+    );
+}
+
+/// The public `verify()` path must ALSO refuse a RiscZero-backend envelope
+/// when handed plausible-looking, non-empty receipt bytes. The point of this
+/// increment is only to *thread the bytes to the seam*, not to add a verifier:
+/// the fail-closed default ignores them and still refuses.
+#[test]
+fn riscz_verify_refuses_with_plausible_receipt_bytes() {
+    let envelope = riscz_envelope();
+
+    let result = envelope.verify(b"plausible-receipt");
+    assert!(
+        result.is_err(),
+        "BackendId::RiscZero verify(b\"plausible-receipt\") must fail closed regardless of \
+         receipt bytes, got {result:?}"
+    );
+}

--- a/crates/exo-proofs/tests/riscz_verifier_scaffold.rs
+++ b/crates/exo-proofs/tests/riscz_verifier_scaffold.rs
@@ -133,7 +133,7 @@ fn default_registry_contains_riscz_pending_external_review_backend() {
 fn riscz_backend_verify_fails_closed_pending_external_review() {
     let envelope = riscz_envelope();
 
-    let result = envelope.verify();
+    let result = envelope.verify(&[]);
     assert!(
         result.is_err(),
         "BackendId::RiscZero must fail closed at verify() until external review lands, \
@@ -163,7 +163,7 @@ fn riscz_backend_verify_fails_closed_pending_external_review() {
 fn riscz_backend_verify_still_fails_closed_with_pedagogical_feature_enabled() {
     let envelope = riscz_envelope();
 
-    let result = envelope.verify();
+    let result = envelope.verify(&[]);
     assert!(
         result.is_err(),
         "enabling 'unaudited-pedagogical-proofs' must not make BackendId::RiscZero verify() \


### PR DESCRIPTION
## What

Threads `receipt_bytes: &[u8]` through `ProofEnvelope::verify()` -> `verify_riscz()` -> the `RiscZeroReceiptVerifier` seam, so a real risc0 verifier (a later lane) can receive the actual serialized receipt bytes it must decode and check.

- `RiscZeroReceiptVerifier::verify_receipt` — new leading `receipt_bytes: &[u8]` parameter; doc comment updated to describe it.
- `FailClosedRiscZeroVerifier::verify_receipt` — ignores the new `_receipt_bytes` parameter; body unchanged (still unconditional `Err(ProofError::VerificationFailed(...))`).
- `ProofEnvelope::verify_riscz` (private) — gains `receipt_bytes: &[u8]`, passes it through to the seam alongside the existing binding digest.
- `ProofEnvelope::verify` (public) — new signature `pub fn verify(&self, receipt_bytes: &[u8]) -> Result<bool>`. The `UnauditedBlake3Standin` and `Unknown` arms ignore the new parameter and keep their exact existing fail-closed behavior; the `RiscZero` arm passes it through to `verify_riscz`.

## Why

This is a precursor increment (O-1.2(A)) to wiring the real, externally-reviewed risc0 verifier (ratified decision D1, VCG-001). Threading the receipt bytes now means the eventual audited-verifier swap is a small, localized change to `FailClosedRiscZeroVerifier`'s replacement, not a new signature break across the seam. No verification logic changes: every arm stays fail-closed, and no new dependencies are introduced (no `risc0-zkvm`, no Cargo.toml/Cargo.lock/deny.toml changes).

## Tests

- RED first: the branch's existing test scaffolding (a spy verifier + `verify_riscz` calls already written against the target 4-arg signature) produced a genuine `cargo test -p exochain-proofs --lib` compile failure (E0050/E0061/E0277 — trait/impl/call-site arity mismatches) before the production code was updated. Captured as the RED evidence for this change.
- Extends the existing `riscz_seam_binding_unit` unit test module in `src/envelope.rs` (required because `verify_riscz` is private) with a `ReceiptBytesSpyVerifier` that records the `receipt_bytes` it is handed and still returns `Err` (a spy never manufactures success):
  - `verify_riscz_passes_receipt_bytes_to_seam` — asserts the seam hands the verifier exactly the bytes it was called with.
  - `verify_riscz_receipt_bytes_reflect_the_argument_change` — asserts different input bytes produce different recorded values (live plumbing, not a hardcoded constant).
- New integration file `tests/riscz_receipt_bytes_wiring.rs`: asserts the public `envelope.verify(&[])` and `envelope.verify(b"plausible-receipt")` both still return `Err` for a RiscZero-backend envelope — verify refuses regardless of the receipt bytes handed to it.
- Updated existing call sites (`tests/refusal.rs`, `tests/riscz_verifier_scaffold.rs`, `tests/envelope.rs`) to the new `verify(&[])` call signature without changing any asserted outcome.

## Gates (all from the worktree)

1. `cargo test -p exochain-proofs` — PASS (28 lib + 9 envelope + 3 passed/1 ignored refusal + 2 riscz_receipt_bytes_wiring + 6 riscz_seam_binding + 4 riscz_verifier_scaffold; 0 failed)
2. `cargo test -p exochain-proofs --features unaudited-pedagogical-proofs` — PASS (124 lib + 9 envelope + 0 refusal (feature-gated out) + 2 riscz_receipt_bytes_wiring + 6 riscz_seam_binding + 5 riscz_verifier_scaffold; 0 failed)
3. `cargo clippy -p exochain-proofs --all-targets -- -D warnings` — PASS, clean
4. `RUSTDOCFLAGS="-D warnings" cargo doc -p exochain-proofs --no-deps` — PASS
5. `cargo +nightly fmt --check` — PASS (after one `cargo +nightly fmt` pass to wrap the new multi-arg `verify_receipt` call)
6. `cargo build --workspace` — PASS
7. `bash tools/test_repo_truth.sh` — PASS ("repo-truth test passed")
8. `bash tools/test_gap_registry_truth.sh` — PASS ("GAP registry truth test passed")

## Invariants confirmed intact

- `anti_overclaim_default_registry_has_zero_production_reviewed_backends` — PASS, unchanged
- `riscz_backend_is_never_marked_production_reviewed` — PASS, unchanged
- `production_backend_variant_executes_without_unaudited_flag` (`tests/refusal.rs`) — still `#[ignore = "red until VCG-001b lands a production backend"]`; forcing it with `--ignored` still fails with the same standing-red panic message. Only its call arg changed (`.verify()` -> `.verify(&[])`).
- `default_registry()` / `AuditStatus` definitions — untouched (no diff).
- No `Ok(true)` added anywhere in production code.
- No Cargo.toml / Cargo.lock / deny.toml changes.

VCG-001 stays Red; no status flip; zero dependencies.