### PR TITLE
W1/O-1.2(B): vendor risc0 (verifier-only) + real Groth16 verifier behind the seam

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -38,4 +38,20 @@ ignore = [
     # EXOCHAIN runtime DB access is PostgreSQL-only; MySQL connection support is
     # not exposed by any owned runtime configuration.
     "RUSTSEC-2023-0071",
+
+    # derivative — no longer maintained proc-macro (Gate 6 "unmaintained" class).
+    # Transitive via ark-crypto-primitives -> ark-groth16 -> risc0-groth16 ->
+    # risc0-zkvm (VCG-001c risc0 verifier-only vendoring, ratified decision D1).
+    # Compile-time-only derive-macro helper; no runtime code path.
+    "RUSTSEC-2024-0388",
+
+    # tracing-subscriber 0.2.25 ANSI escape sequence injection when logging
+    # untrusted input to a terminal. Reported by cargo-audit as a vulnerability
+    # (denied by default regardless of --deny unsound/unmaintained). Transitive
+    # via risc0-zkvm's own dependency tree (ark-relations' internal tracing
+    # instrumentation, pulled in by the VCG-001c risc0 verifier-only vendoring).
+    # EXOCHAIN does not use this tracing-subscriber version to format or log
+    # untrusted external input; it is an internal dependency of the vendored
+    # verifier crate graph, not a logging sink this workspace configures.
+    "RUSTSEC-2025-0055",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,220 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-bn254"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-r1cs-std",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-crypto-primitives"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0c292754729c8a190e50414fd1a37093c786c709899f29c9f7daccecfa855e"
+dependencies = [
+ "ahash",
+ "ark-crypto-primitives-macros",
+ "ark-ec",
+ "ark-ff",
+ "ark-relations",
+ "ark-serialize",
+ "ark-snark",
+ "ark-std",
+ "blake2",
+ "derivative",
+ "digest 0.10.7",
+ "fnv",
+ "merlin",
+ "sha2",
+]
+
+[[package]]
+name = "ark-crypto-primitives-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e89fe77d1f0f4fe5b96dfc940923d88d17b6a773808124f21e764dfb063c6a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+dependencies = [
+ "ahash",
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.5",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
+ "arrayvec",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "ark-groth16"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88f1d0f3a534bb54188b8dcc104307db6c56cdae574ddc3212aec0625740fc7e"
+dependencies = [
+ "ark-crypto-primitives",
+ "ark-ec",
+ "ark-ff",
+ "ark-poly",
+ "ark-relations",
+ "ark-serialize",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+dependencies = [
+ "ahash",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "ark-r1cs-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941551ef1df4c7a401de7068758db6503598e6f01850bdb2cfdb614a1f9dbea1"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-relations",
+ "ark-std",
+ "educe",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "tracing",
+]
+
+[[package]]
+name = "ark-relations"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec46ddc93e7af44bcab5230937635b06fb5744464dd6a7e7b083e80ebd274384"
+dependencies = [
+ "ark-ff",
+ "ark-std",
+ "tracing",
+ "tracing-subscriber 0.2.25",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std",
+ "arrayvec",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "ark-snark"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d368e2848c2d4c129ce7679a7d0d2d612b6a274d3ea6a13bad4445d61b381b88"
+dependencies = [
+ "ark-ff",
+ "ark-relations",
+ "ark-serialize",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,7 +425,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
  "synstructure",
 ]
 
@@ -223,7 +437,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -302,7 +516,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strum",
- "syn",
+ "syn 2.0.111",
  "thiserror 1.0.69",
 ]
 
@@ -367,7 +581,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -378,7 +592,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -534,7 +748,7 @@ checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -625,6 +839,12 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
@@ -655,6 +875,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,6 +896,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "borsh"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -692,6 +941,26 @@ name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
 
 [[package]]
 name = "byteorder"
@@ -843,7 +1112,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -862,6 +1131,15 @@ dependencies = [
  "der 0.8.0",
  "spki 0.8.0-rc.4",
  "x509-cert",
+]
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -924,6 +1202,17 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -1089,7 +1378,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1113,7 +1402,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1124,7 +1413,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1150,7 +1439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1198,7 +1487,7 @@ checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1211,6 +1500,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive-getters"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1218,7 +1518,29 @@ checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.111",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1272,7 +1594,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1289,6 +1611,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "ed25519"
@@ -1317,6 +1645,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,12 +1666,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "elf"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4445909572dbd556c457c849c4ca58623d84b27c8fff1e74b0b4227d8b90d17b"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1732,7 +2110,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
  "uuid",
  "zeroize",
 ]
@@ -1871,7 +2249,7 @@ dependencies = [
  "toml",
  "tower",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
  "uuid",
  "x25519-dalek",
  "x509-cert",
@@ -1885,6 +2263,7 @@ dependencies = [
  "blake3",
  "ciborium",
  "exochain-core",
+ "risc0-zkvm",
  "serde",
  "serde_json",
  "sha2",
@@ -2057,6 +2436,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2220,7 +2626,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2434,6 +2840,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hex_fmt"
@@ -2758,6 +3170,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_bytes_aligned"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee796ad498c8d9a1d68e477df8f754ed784ef875de1414ebdaf169f70a6a784"
+
+[[package]]
 name = "indexmap"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2831,6 +3249,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2880,6 +3307,15 @@ dependencies = [
  "time",
  "url",
  "uuid-simd",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -3133,7 +3569,7 @@ checksum = "dd297cf53f0cb3dee4d2620bb319ae47ef27c702684309f682bdb7e55a18ae9c"
 dependencies = [
  "heck",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3192,7 +3628,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "libc",
  "plain",
  "redox_syscall 0.7.3",
@@ -3249,6 +3685,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "match-lookup"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3256,7 +3701,7 @@ checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3295,6 +3740,33 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "merlin"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
+dependencies = [
+ "byteorder",
+ "keccak 0.1.6",
+ "rand_core 0.6.4",
+ "zeroize",
+]
+
+[[package]]
+name = "metal"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
+dependencies = [
+ "bitflags 2.10.0",
+ "block",
+ "core-graphics-types",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
+]
 
 [[package]]
 name = "mime"
@@ -3443,7 +3915,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "libc",
  "log",
  "netlink-packet-core",
@@ -3482,11 +3954,17 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
 ]
+
+[[package]]
+name = "no_std_strings"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5b0c77c1b780822bc749a33e39aeb2c07584ab93332303babeabb645298a76e"
 
 [[package]]
 name = "nohash-hasher"
@@ -3622,6 +4100,36 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]
@@ -3770,7 +4278,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3800,7 +4308,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3924,6 +4432,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3954,7 +4474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3983,7 +4503,7 @@ checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
- "bitflags",
+ "bitflags 2.10.0",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -4212,7 +4732,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -4221,7 +4741,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -4317,6 +4837,198 @@ dependencies = [
 ]
 
 [[package]]
+name = "risc0-binfmt"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1883f0c5d19b865f395209a137dcb29e56dc49951424967b8d0114c129f46e77"
+dependencies = [
+ "anyhow",
+ "borsh",
+ "bytemuck",
+ "derive_more",
+ "elf",
+ "lazy_static",
+ "postcard",
+ "rand 0.9.4",
+ "risc0-zkp",
+ "risc0-zkvm-platform",
+ "ruint",
+ "semver",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-circuit-keccak"
+version = "4.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f543c60287fece797a5da4209384ab1bfebd9644fcfe591e11b1aa85f1a02f8"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "paste",
+ "risc0-binfmt",
+ "risc0-circuit-recursion",
+ "risc0-core",
+ "risc0-zkp",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-circuit-recursion"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2347e909c6b2a65584b5898f3802eec5b8c1b4b45329edfdd8587b6a04dd3357"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "hex",
+ "metal",
+ "risc0-core",
+ "risc0-zkp",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-circuit-rv32im"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61676419814a818fdb5e10066b13c5488b3f54aa9668794bd06c99bc91bff1f2"
+dependencies = [
+ "anyhow",
+ "bit-vec 0.8.0",
+ "bytemuck",
+ "derive_more",
+ "paste",
+ "risc0-binfmt",
+ "risc0-core",
+ "risc0-zkp",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-core"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b956a976b8ce4713694dcc6c370b522a42ccef4ba45da5b6e57dbf26cdb7b1"
+dependencies = [
+ "bytemuck",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "risc0-groth16"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc57e76bb87193d154ac5ee6ee352fbd7edabddab36f02a81f40a048e5ca14f9"
+dependencies = [
+ "anyhow",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff",
+ "ark-groth16",
+ "ark-serialize",
+ "bytemuck",
+ "hex",
+ "num-bigint",
+ "num-traits",
+ "risc0-binfmt",
+ "risc0-zkp",
+ "serde",
+]
+
+[[package]]
+name = "risc0-zkos-v1compat"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bd70cb45b5d37d025f25663b87c6b9dc9df7f413ee2068531a57f50b0eb95db"
+dependencies = [
+ "include_bytes_aligned",
+ "no_std_strings",
+ "risc0-zkvm-platform",
+]
+
+[[package]]
+name = "risc0-zkp"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f40d362a6c146ec6dc69208f539b92fd86e47b0dbc2083801423034a38155a2"
+dependencies = [
+ "anyhow",
+ "blake2",
+ "borsh",
+ "bytemuck",
+ "cfg-if",
+ "digest 0.10.7",
+ "hex",
+ "hex-literal",
+ "metal",
+ "paste",
+ "rand_core 0.9.3",
+ "risc0-core",
+ "risc0-zkvm-platform",
+ "serde",
+ "sha2",
+ "stability",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-zkvm"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22b7eafb5d85be59cbd9da83f662cf47d834f1b836e14f675d1530b12c666867"
+dependencies = [
+ "anyhow",
+ "borsh",
+ "bytemuck",
+ "derive_more",
+ "hex",
+ "risc0-binfmt",
+ "risc0-circuit-keccak",
+ "risc0-circuit-recursion",
+ "risc0-circuit-rv32im",
+ "risc0-core",
+ "risc0-groth16",
+ "risc0-zkos-v1compat",
+ "risc0-zkp",
+ "risc0-zkvm-platform",
+ "rrs-lib",
+ "semver",
+ "serde",
+ "sha2",
+ "stability",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-zkvm-platform"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4db893788c416287e2e1a87e6b8f5302511a04a45329e699d6a32a16874fd24f"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "getrandom 0.3.4",
+ "libm",
+ "num_enum",
+ "paste",
+ "stability",
+]
+
+[[package]]
+name = "rrs-lib"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4382d3af3a4ebdae7f64ba6edd9114fff92c89808004c4943b393377a25d001"
+dependencies = [
+ "downcast-rs",
+ "paste",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4355,12 +5067,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruint"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45caf26f647c19115bf9c453c70ffe4a4a3a6390dceebd942610584f99b8ddce"
+dependencies = [
+ "borsh",
+ "proptest",
+ "rand 0.8.6",
+ "rand 0.9.4",
+ "ruint-macro",
+ "serde_core",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink 0.9.1",
@@ -4398,7 +5132,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4495,6 +5229,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -4534,7 +5272,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4621,7 +5359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b233a7d59d7bfc027208506a33ffc9532b2acb24ddc61fe7e758dc2250db431"
 dependencies = [
  "digest 0.11.2",
- "keccak",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -4810,7 +5548,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4833,7 +5571,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn",
+ "syn 2.0.111",
  "tokio",
  "url",
 ]
@@ -4846,7 +5584,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64",
- "bitflags",
+ "bitflags 2.10.0",
  "byteorder",
  "bytes",
  "crc",
@@ -4889,7 +5627,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64",
- "bitflags",
+ "bitflags 2.10.0",
  "byteorder",
  "crc",
  "dotenvy",
@@ -4942,6 +5680,16 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "stability"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
+dependencies = [
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4998,7 +5746,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5006,6 +5754,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -5035,7 +5794,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5044,7 +5803,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -5098,7 +5857,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5109,7 +5868,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5205,7 +5964,7 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5233,7 +5992,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5366,7 +6125,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "bytes",
  "futures-util",
  "http",
@@ -5412,7 +6171,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5443,6 +6202,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
  "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
  "tracing-core",
 ]
 
@@ -5660,7 +6428,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5749,7 +6517,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
  "wasm-bindgen-shared",
 ]
 
@@ -5784,7 +6552,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5819,7 +6587,7 @@ checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5850,7 +6618,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -5966,7 +6734,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5977,7 +6745,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6222,7 +6990,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.111",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -6238,7 +7006,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -6250,7 +7018,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.10.0",
  "indexmap",
  "log",
  "serde",
@@ -6386,7 +7154,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
  "synstructure",
 ]
 
@@ -6407,7 +7175,7 @@ checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6427,7 +7195,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
  "synstructure",
 ]
 
@@ -6449,7 +7217,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6482,5 +7250,5 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]

--- a/crates/exo-proofs/Cargo.toml
+++ b/crates/exo-proofs/Cargo.toml
@@ -49,6 +49,17 @@ blake3 = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
 ciborium = { workspace = true }
+# Verifier-only vendoring of RISC Zero (VCG-001b/c, ratified decision D1).
+# default-features = false is MANDATORY: risc0-zkvm's default features pull
+# in the full prover client + Bonsai remote-proving stack, neither of which
+# this crate ever needs -- EXOCHAIN proving is server-side-only elsewhere and
+# this crate is verifier-only. "std" is the minimal feature that keeps
+# Receipt::verify's dependency graph (Groth16 verifying key material, seal
+# decoding) buildable off std. This crate deliberately does NOT depend on any
+# "prove"/"client"/"bonsai" feature -- pulling those in would reintroduce the
+# exact heavy prover surface (and its supply chain) this seam is designed to
+# avoid on the verify-only path.
+risc0-zkvm = { version = "=3.0.5", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/exo-proofs/src/lib.rs
+++ b/crates/exo-proofs/src/lib.rs
@@ -57,6 +57,7 @@
 pub mod circuit;
 pub mod envelope;
 pub mod error;
+pub mod riscz;
 pub mod snark;
 pub mod stark;
 pub mod verifier;

--- a/crates/exo-proofs/src/riscz.rs
+++ b/crates/exo-proofs/src/riscz.rs
@@ -1,0 +1,230 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Real (vendored) RISC Zero receipt verifier — VCG-001c artifact.
+//!
+//! [`Risc0Groth16Verifier`] is a concrete [`crate::envelope::RiscZeroReceiptVerifier`]
+//! implementation backed by the actual, vendored `risc0-zkvm` crate (verifier-only:
+//! `default-features = false, features = ["std"]` — no prover, no client API, no
+//! Bonsai remote-proving surface). It exists as a **reviewable artifact**, frozen
+//! for external cryptographic review (ratified decision D1, `GAP-REGISTRY.md`
+//! VCG-001).
+//!
+//! ## This type is NOT wired into production verification
+//!
+//! [`ProofEnvelope::verify`](crate::envelope::ProofEnvelope::verify) continues to
+//! call [`FailClosedRiscZeroVerifier`](crate::envelope::FailClosedRiscZeroVerifier)
+//! exclusively, and [`crate::envelope::default_registry`] continues to register
+//! [`crate::envelope::BackendId::RiscZero`] as
+//! [`crate::envelope::AuditStatus::PendingExternalReview`] (never
+//! `ProductionReviewed`). Swapping this verifier into the seam — and promoting the
+//! registry entry — is a separate, later change (O-1.6) that must not happen
+//! before external cryptographic review of this code lands. Until then this module
+//! is dead-code-linted-safe (kept `pub`) but otherwise inert.
+//!
+//! ## Verification contract
+//!
+//! [`Risc0Groth16Verifier::verify_receipt`] performs, in order:
+//!
+//! 1. **Decode**: deserialize `receipt_bytes` as canonical CBOR
+//!    ([`ciborium`], matching this crate's canonical-CBOR-not-JSON convention;
+//!    see `src/verifier.rs`) into a risc0 [`Receipt`]. Malformed bytes → `Err`.
+//! 2. **Parse image id**: convert `image_id_or_verifier_key` into a risc0
+//!    [`Digest`] (exactly 32 bytes). Wrong length → `Err`.
+//! 3. **Cryptographic verify**: call `receipt.verify(image_id)`, which checks
+//!    the wrapped seal (Groth16 or otherwise, per risc0's `InnerReceipt`
+//!    dispatch) against the image id and confirms successful guest exit.
+//!    Failure → `Err`.
+//! 4. **Journal binding** (objective O-1.1): BLAKE3-hash the receipt's
+//!    `journal.bytes` and require it equal `journal_digest` exactly — this is
+//!    the contract that binds a receipt to one, and only one, envelope
+//!    context, so a receipt proven for one (statement, roots, domain) can
+//!    never be replayed as valid under another. Mismatch → `Err`.
+//!
+//! Only if all four steps succeed does this return `Ok(true)`. Every other
+//! path returns `Err`, never `Ok(false)` — mirroring this crate's existing
+//! fail-closed convention (see [`FailClosedRiscZeroVerifier`](crate::envelope::FailClosedRiscZeroVerifier)).
+
+use exo_core::types::Hash256;
+use risc0_zkvm::{Digest, Receipt};
+
+use crate::{
+    envelope::RiscZeroReceiptVerifier,
+    error::{ProofError, Result},
+};
+
+/// Real, vendored RISC Zero Groth16 receipt verifier.
+///
+/// See the module docs for the full verification contract and the standing
+/// prohibition on wiring this into [`crate::envelope::ProofEnvelope::verify`]
+/// or promoting the registry entry before external cryptographic review.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Risc0Groth16Verifier;
+
+impl RiscZeroReceiptVerifier for Risc0Groth16Verifier {
+    fn verify_receipt(
+        &self,
+        receipt_bytes: &[u8],
+        image_id_or_verifier_key: &[u8],
+        journal_digest: &Hash256,
+    ) -> Result<bool> {
+        // Step 1: decode receipt_bytes as canonical CBOR into a risc0 Receipt.
+        // Uses ciborium (this crate's canonical wire format elsewhere) rather
+        // than bincode/postcard: those codecs live behind risc0-zkvm's
+        // `client`/`prove` features, which this verifier-only vendoring
+        // deliberately does not enable.
+        let receipt: Receipt = ciborium::from_reader(receipt_bytes).map_err(|err| {
+            ProofError::DeserializationError(format!(
+                "failed to decode receipt_bytes as a canonical-CBOR risc0 Receipt: {err}"
+            ))
+        })?;
+
+        // Step 2: parse the image id / verifier key bytes into a risc0 Digest
+        // (32 bytes, fixed width). Any other length is rejected.
+        let image_id = Digest::try_from(image_id_or_verifier_key).map_err(|err| {
+            ProofError::InvalidProofFormat(format!(
+                "image_id_or_verifier_key is not a valid 32-byte risc0 image id \
+                 digest (expected {} bytes): {err}",
+                risc0_zkvm::sha::DIGEST_BYTES
+            ))
+        })?;
+
+        // Step 3: cryptographic verification — checks the seal (Groth16 or
+        // otherwise) against the image id and confirms a successful guest
+        // exit. This is the actual zero-knowledge proof check.
+        receipt.verify(image_id).map_err(|err| {
+            ProofError::VerificationFailed(format!("risc0 receipt failed to verify: {err}"))
+        })?;
+
+        // Step 4 (objective O-1.1): the receipt's journal must commit to
+        // exactly this envelope's binding digest, so a receipt proven for one
+        // (statement, roots, domain) context can never be replayed as valid
+        // under another. blake3 matches ProofEnvelope::binding_digest's own
+        // hash function.
+        let actual_journal_digest = Hash256(*blake3::hash(&receipt.journal.bytes).as_bytes());
+        if &actual_journal_digest != journal_digest {
+            return Err(ProofError::VerificationFailed(format!(
+                "risc0 receipt journal does not commit to the expected envelope binding \
+                 digest: receipt journal hashes to {actual_journal_digest:?}, expected \
+                 {journal_digest:?}. A receipt proven for one envelope context must never \
+                 verify under another."
+            )));
+        }
+
+        Ok(true)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    //! Honesty note (VCG-001c): these tests exercise the fail-closed /
+    //! rejection paths of [`Risc0Groth16Verifier::verify_receipt`] against
+    //! malformed, garbage, and structurally-invalid input. They do NOT
+    //! exercise the accept path (a genuinely valid Groth16 receipt verifying
+    //! successfully) — that would require either a real serialized risc0
+    //! `Receipt` fixture or the `prove` feature (guest ELF + prover stack),
+    //! and this crate deliberately vendors risc0-zkvm verifier-only
+    //! (`default-features = false, features = ["std"]`), excluding `prove`.
+    //! risc0-zkvm 3.0.5 as distributed on crates.io ships no serialized
+    //! `Receipt`/`Groth16Receipt` test vector usable from the verify-only
+    //! feature surface (checked directly against the vendored crate source
+    //! under `~/.cargo/registry/src/.../risc0-zkvm-3.0.5`; `risc0-groth16`
+    //! ships raw `ark-groth16` proof/vk/public-input JSON fixtures under
+    //! `tests/data/`, but those are not a serialized `risc0_zkvm::Receipt`
+    //! and wrapping them into one is exactly the `prove`-only surface this
+    //! seam avoids). A happy-path test is therefore deferred to a follow-up
+    //! that lands a committed real-receipt fixture (see the `#[ignore]`d stub
+    //! below) rather than faked here.
+
+    use exo_core::types::Hash256;
+
+    use super::Risc0Groth16Verifier;
+    use crate::envelope::RiscZeroReceiptVerifier;
+
+    fn verifier() -> Risc0Groth16Verifier {
+        Risc0Groth16Verifier
+    }
+
+    #[test]
+    fn empty_receipt_bytes_are_rejected() {
+        let result = verifier().verify_receipt(&[], &[0u8; 32], &Hash256([0u8; 32]));
+        assert!(
+            result.is_err(),
+            "empty receipt_bytes must fail closed, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn garbage_receipt_bytes_are_rejected() {
+        let garbage = vec![0xFFu8; 256];
+        let result = verifier().verify_receipt(&garbage, &[0u8; 32], &Hash256([0u8; 32]));
+        assert!(
+            result.is_err(),
+            "garbage (non-CBOR, non-Receipt) receipt_bytes must fail closed, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn truncated_cbor_receipt_bytes_are_rejected() {
+        // A handful of bytes that are valid-ish CBOR prefix but not a
+        // complete, valid Receipt encoding.
+        let truncated: Vec<u8> = vec![0xA1, 0x64, b't', b'e', b's', b't'];
+        let result = verifier().verify_receipt(&truncated, &[0u8; 32], &Hash256([0u8; 32]));
+        assert!(
+            result.is_err(),
+            "truncated/malformed CBOR must fail closed, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn wrong_length_image_id_is_rejected_even_with_empty_receipt() {
+        // Wrong-length image id should fail regardless of decode outcome;
+        // exercised here with an empty receipt to isolate the check (the
+        // implementation decodes first, so this also documents that decode
+        // failure is reported before the image-id check runs).
+        let too_short = vec![0u8; 4];
+        let result = verifier().verify_receipt(&[], &too_short, &Hash256([0u8; 32]));
+        assert!(
+            result.is_err(),
+            "wrong-length image id must fail closed, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn wrong_length_image_id_is_rejected_independent_of_decode_error_message() {
+        let too_long = vec![0u8; 64];
+        let garbage_receipt = vec![0x00u8; 16];
+        let result = verifier().verify_receipt(&garbage_receipt, &too_long, &Hash256([0u8; 32]));
+        assert!(
+            result.is_err(),
+            "wrong-length image id combined with malformed receipt bytes must still fail \
+             closed, got {result:?}"
+        );
+    }
+
+    #[test]
+    #[ignore = "needs a committed real-receipt fixture (follow-up, see module docs): \
+                risc0-zkvm 3.0.5 ships no serialized Receipt/Groth16Receipt test vector \
+                reachable without the excluded 'prove' feature, and this test must not \
+                fake acceptance. Once a real, small, committable Groth16 receipt fixture \
+                exists (generated out-of-band with the full prove stack and committed as \
+                a binary fixture), this test should decode it, call verify_receipt with \
+                its true image id and journal digest, and assert Ok(true)."]
+    fn accepts_a_genuinely_valid_groth16_receipt() {
+        unimplemented!("deferred: requires a committed real-receipt fixture; see #[ignore] reason")
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -52,6 +52,24 @@ ignore = [
     # paste is a proc-macro utility; the unmaintained status poses no runtime risk.
     # Upgrade tracked in APE-12 hygiene sprint.
     { id = "RUSTSEC-2024-0436", reason = "pre-existing transitive via async-graphql; proc-macro only; no runtime security impact" },
+
+    # derivative — no longer maintained proc-macro.
+    # Transitive via ark-crypto-primitives -> ark-groth16 -> risc0-groth16 ->
+    # risc0-zkvm (VCG-001c risc0 verifier-only vendoring, ratified decision D1).
+    # derivative is a compile-time-only derive-macro helper (generates trait
+    # impls at build time); it has no runtime surface and ships no code that
+    # executes against untrusted input. Upgrade tracked alongside the eventual
+    # arkworks/risc0 version bump.
+    { id = "RUSTSEC-2024-0388", reason = "derivative is an unmaintained compile-time-only proc-macro pulled transitively via ark-crypto-primitives -> ark-groth16 -> risc0-groth16 -> risc0-zkvm (verifier-only vendoring, VCG-001c); no runtime code path" },
+
+    # tracing-subscriber 0.2.25 — ANSI escape sequence injection in output
+    # formatting when logging untrusted input directly to a terminal.
+    # Transitive via risc0-zkvm's own dependency tree (arkworks-internal
+    # tracing instrumentation, e.g. ark-relations). EXOCHAIN does not use this
+    # tracing-subscriber version to format or log untrusted external input —
+    # it is an internal dependency of the vendored verifier crate graph, not
+    # a logging sink this workspace configures or writes to.
+    { id = "RUSTSEC-2025-0055", reason = "tracing-subscriber 0.2.25 ANSI-injection advisory concerns logging untrusted input to a terminal; pulled transitively via risc0-zkvm's arkworks-internal tracing instrumentation, not used by EXOCHAIN for untrusted-input logging" },
 ]
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## O-1.2(B): vendor risc0 (verifier-only) + real Groth16 verifier behind the seam

Lane VCG-001c (`GAP-REGISTRY.md` VCG-001, ratified decision D1, 2026-07-02). This is a **supply-chain vendoring change explicitly ratified by the principal** ("vendor it").

### What this does

1. **Vendors `risc0-zkvm` as a verifier-only dependency.** `crates/exo-proofs/Cargo.toml` pins `risc0-zkvm = { version = "=3.0.5", default-features = false, features = ["std"] }`. `default-features = false` is mandatory — risc0-zkvm's `default = ["client", "bonsai"]` pulls in the full prover client + remote-proving stack, neither of which this crate needs (proving is server-side-only elsewhere; this crate is verifier-only). Confirmed directly against the vendored crate source (not just docs) that `std` alone is sufficient: `Receipt`, `Journal`, `Digest`, `VerifierContext`, and `VerificationError` are all re-exported outside the `client`/`prove`/`bonsai`-gated blocks in `risc0-zkvm`'s `lib.rs`. No feature deviation from the plan was needed.

2. **Documents two new advisory ignores** in `deny.toml` and `.cargo/audit.toml` (Gate 6's separate ignore list, validated by `tools/test_audit_ignore_policy.sh`):
   - `RUSTSEC-2024-0388` (`derivative`, unmaintained compile-time-only proc-macro; transitive via `ark-crypto-primitives -> ark-groth16 -> risc0-groth16 -> risc0-zkvm`).
   - `RUSTSEC-2025-0055` (`tracing-subscriber` 0.2.25 ANSI-injection; reported by `cargo-audit` as a **vulnerability**, not merely `unmaintained` — verified by running `cargo audit --deny unsound --deny unmaintained` locally before/after the ignore; transitive via risc0-zkvm's own `ark-relations` tracing instrumentation, not used by EXOCHAIN for untrusted-input logging).

3. **Implements `Risc0Groth16Verifier`** (`crates/exo-proofs/src/riscz.rs`), a concrete `RiscZeroReceiptVerifier`:
   - Decode `receipt_bytes` as canonical CBOR (`ciborium`, matching this crate's existing wire-format convention) into a risc0 `Receipt`. Malformed → `Err`.
   - Parse `image_id_or_verifier_key` into a risc0 `Digest` (32 bytes). Wrong length → `Err`.
   - `receipt.verify(image_id)` — the actual Groth16/seal + image-id + successful-exit check. Failure → `Err`.
   - BLAKE3-hash `receipt.journal.bytes` and require it equal `journal_digest` (`ProofEnvelope::binding_digest`, the O-1.1 contract) exactly. Mismatch → `Err`.
   - Only if all four pass → `Ok(true)`. Result-based throughout; no `unwrap`/`expect`/panics (workspace lints deny these).

### What this explicitly does NOT do

- `ProofEnvelope::verify()` is **unchanged** — still calls `FailClosedRiscZeroVerifier` exclusively.
- `default_registry()` is **unchanged** — `BackendId::RiscZero` stays `AuditStatus::PendingExternalReview`, never `ProductionReviewed`.
- **VCG-001 stays Red**: `tests/refusal.rs::production_backend_variant_executes_without_unaudited_flag` remains `#[ignore]`d and was confirmed to still fail when run explicitly.
- Both anti-overclaim regression locks in `tests/riscz_verifier_scaffold.rs` still pass.

`Risc0Groth16Verifier` is a frozen, reviewable artifact for external cryptographic review — kept `pub` (not dead-code-linted) but not wired into anything. Swapping it into the seam and promoting the registry entry is a separate, later change (**O-1.6**), gated on that review actually landing.

### Honesty on the happy-path test

Per the task's honesty requirement: risc0-zkvm 3.0.5 as distributed on crates.io ships **no serialized `Receipt`/`Groth16Receipt` test vector** reachable without the excluded `prove` feature (checked directly against the vendored crate source under `~/.cargo/registry/src/.../risc0-zkvm-3.0.5`). `risc0-groth16` ships raw `ark-groth16` proof/verification-key/public-input JSON fixtures under `tests/data/`, but those are not a serialized `risc0_zkvm::Receipt` — wrapping them into one is exactly the `prove`-only surface this seam avoids.

Rather than fake acceptance, this PR ships:
- Five fail-closed/rejection-path tests (empty bytes, garbage bytes, truncated CBOR, wrong-length image id — two variations) — all pass, proving the fail-closed posture.
- One explicit `#[ignore]`d happy-path stub (`accepts_a_genuinely_valid_groth16_receipt`) documenting that it needs a committed real-receipt fixture as a follow-up.

**No happy-path (accept) test exists in this diff.** This is deliberate and disclosed, not an oversight.

### Gates (all run locally)

| Gate | Result |
|---|---|
| `cargo build -p exochain-proofs` | PASS |
| `cargo build --workspace` | PASS |
| `cargo test -p exochain-proofs` (default) | PASS — 33 passed, 1 ignored (the new happy-path stub) |
| `cargo test -p exochain-proofs --features unaudited-pedagogical-proofs` | PASS — 129 passed, 1 ignored |
| `cargo clippy -p exochain-proofs --all-targets -- -D warnings` | PASS |
| `RUSTDOCFLAGS="-D warnings" cargo doc -p exochain-proofs --no-deps` | PASS |
| `cargo +nightly fmt --check` | PASS |
| `cargo audit --deny unsound --deny unmaintained` (Gate 6) | PASS (exit 0) |
| `tools/test_audit_ignore_policy.sh` | PASS |
| `cargo deny check` (Gate 7) | PASS — `advisories ok, bans ok, licenses ok, sources ok` |
| `tools/test_repo_truth.sh` | PASS |
| `tools/test_gap_registry_truth.sh` | PASS |
| Standing red (`production_backend_variant_executes_without_unaudited_flag`) | Confirmed still fails when run with `--ignored` (expected) |
| Anti-overclaim locks (`riscz_verifier_scaffold.rs`) | PASS (4/4) |

### Cargo.lock delta

64 new crates resolved, 0 removed. All arkworks/risc0-internal (`ark-*`, `risc0-*`, `borsh`, `postcard`, `ruint`, `merlin`, etc.) — no OpenSSL, no `reqwest`/`tokio`/`hyper`/Bonsai/S3/AWS client crates pulled in, consistent with the verifier-only, `default-features = false` vendoring.

### Do not merge

Per instructions, this PR should be refuted/merged by the coordinator, not by this change itself.
