### PR TITLE
fix(livesafe): bind provider consent grants to authenticated subscribers

### DIFF
--- a/livesafe/server/routes/consent.js
+++ b/livesafe/server/routes/consent.js
@@ -63,6 +63,10 @@ function authMiddleware(req, res, next) {
   try {
     const token = authHeader.split(' ')[1];
     const decoded = jwt.verify(token, JWT_SECRET);
+    const isSubscriber = decoded.user_type === 'subscriber' || decoded.role === 'subscriber';
+    if (!isSubscriber) {
+      return res.status(403).json({ error: 'Subscriber account required' });
+    }
     req.user = decoded;
     next();
   } catch (err) {
@@ -619,16 +623,25 @@ router.post('/provider', authMiddleware, async (req, res) => {
       return res.status(400).json({ error: 'Scope is required' });
     }
 
-    // Resolve subscriber ID from DID if needed
-    let resolvedSubscriberId = subscriber_id;
-    let resolvedSubscriberDid = subscriber_did;
-    if (!resolvedSubscriberId && subscriber_did) {
-      const subResult = await db.query('SELECT id, did FROM subscribers WHERE did = $1', [subscriber_did]);
-      if (subResult.rows.length === 0) {
-        return res.status(404).json({ error: 'Subscriber not found' });
-      }
-      resolvedSubscriberId = subResult.rows[0].id;
-      resolvedSubscriberDid = subResult.rows[0].did;
+    const authenticatedSubscriberId = String(req.user.id);
+    const authenticatedSubscriberDid = req.user.did || null;
+
+    if (subscriber_id && String(subscriber_id) !== authenticatedSubscriberId) {
+      return res.status(403).json({ error: 'Cannot grant consent for another subscriber' });
+    }
+    if (subscriber_did && authenticatedSubscriberDid && subscriber_did !== authenticatedSubscriberDid) {
+      return res.status(403).json({ error: 'Cannot grant consent for another subscriber' });
+    }
+
+    const subResult = await db.query('SELECT id, did FROM subscribers WHERE id = $1', [req.user.id]);
+    if (subResult.rows.length === 0) {
+      return res.status(404).json({ error: 'Subscriber not found' });
+    }
+    const resolvedSubscriberId = subResult.rows[0].id;
+    const resolvedSubscriberDid = subResult.rows[0].did;
+
+    if (subscriber_did && subscriber_did !== resolvedSubscriberDid) {
+      return res.status(403).json({ error: 'Cannot grant consent for another subscriber' });
     }
 
     // Resolve provider ID from DID if needed

--- a/livesafe/tests/consent-provider-authorization.test.ts
+++ b/livesafe/tests/consent-provider-authorization.test.ts
@@ -1,0 +1,32 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+describe("provider consent grant authorization boundary", () => {
+  it("requires a subscriber token before consent can be granted", () => {
+    const consentRoute = fs.readFileSync(
+      path.join(process.cwd(), "server/routes/consent.js"),
+      "utf8",
+    );
+
+    expect(consentRoute).toContain("const isSubscriber = decoded.user_type === 'subscriber' || decoded.role === 'subscriber';");
+    expect(consentRoute).toContain("return res.status(403).json({ error: 'Subscriber account required' });");
+  });
+
+  it("binds provider consent creation to the authenticated subscriber", () => {
+    const consentRoute = fs.readFileSync(
+      path.join(process.cwd(), "server/routes/consent.js"),
+      "utf8",
+    );
+    const providerGrantRoute = consentRoute.slice(
+      consentRoute.indexOf("router.post('/provider'"),
+      consentRoute.indexOf("// POST /api/consent/request-access"),
+    );
+
+    expect(providerGrantRoute).toContain("const authenticatedSubscriberId = String(req.user.id);");
+    expect(providerGrantRoute).toContain("String(subscriber_id) !== authenticatedSubscriberId");
+    expect(providerGrantRoute).toContain("Cannot grant consent for another subscriber");
+    expect(providerGrantRoute).toContain("SELECT id, did FROM subscribers WHERE id = $1");
+    expect(providerGrantRoute).toContain("const resolvedSubscriberId = subResult.rows[0].id;");
+    expect(providerGrantRoute).not.toContain("let resolvedSubscriberId = subscriber_id;");
+  });
+});


### PR DESCRIPTION
### Motivation
- Close an authorization boundary in the LiveSafe adjacent application where self-registered provider tokens could be used to mint consent for arbitrary subscribers and then read sensitive medical data.
- Ensure consent creation is performed only by the authenticated subscriber it concerns, preventing forged consent events from being inserted by unauthorised callers.

### Description
- Hardened subscriber auth middleware in `livesafe/server/routes/consent.js` to require the JWT subject be a subscriber by checking `decoded.user_type === 'subscriber' || decoded.role === 'subscriber'` and return `403` for non-subscriber tokens.
- Updated `POST /api/consent/provider` in `livesafe/server/routes/consent.js` to bind consent creation to the authenticated subscriber by validating `subscriber_id`/`subscriber_did` against `req.user.id`/`req.user.did` and resolving the subscriber from `req.user.id` instead of trusting caller-supplied values.
- Added a regression test `livesafe/tests/consent-provider-authorization.test.ts` that asserts the subscriber-token requirement and that the provider-consent route is bound to the authenticated subscriber.
- Classification: touched files are part of the LiveSafe adjacent surface and do not modify EXOCHAIN core or core runtime adapters.

### Testing
- Ran the focused regression test: `npm test -- --run tests/consent-provider-authorization.test.ts` — PASS (2 tests passed).
- Performed static check: `node --check livesafe/server/routes/consent.js` — PASS.
- Attempted full quality gate: `npm run quality` and `npm test` (full suite); the full-suite run surfaced pre-existing environment issues unrelated to this fix: after installing nested server deps many tests ran but one CI-workflow-related test failed due to missing repository artifact (`livesafe/.github/workflows/quality.yml`); this failure is an existing repo/setup issue and not caused by the authorization change.
- Files changed: `livesafe/server/routes/consent.js` (auth and consent-binding logic), `livesafe/tests/consent-provider-authorization.test.ts` (new regression test).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4942c97348832f93da0639c96edc82)