### PR TITLE
fix(livesafe): require authorization to read subscriber consent history

### DIFF
--- a/livesafe/server/routes/consent.js
+++ b/livesafe/server/routes/consent.js
@@ -584,8 +584,33 @@ router.get('/expiry-check', authMiddleware, async (req, res) => {
   }
 });
 
+// Auth middleware (subscriber OR provider) - accepts either token type so the
+// route below can apply per-role scoping instead of a single fixed role gate.
+function subscriberOrProviderAuthMiddleware(req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+  try {
+    const token = authHeader.split(' ')[1];
+    const decoded = jwt.verify(token, JWT_SECRET);
+    const isSubscriber = decoded.user_type === 'subscriber' || decoded.role === 'subscriber';
+    const isProvider = decoded.user_type === 'provider';
+    if (!isSubscriber && !isProvider) {
+      return res.status(403).json({ error: 'Subscriber or provider account required' });
+    }
+    req.user = decoded;
+    req.authRole = isProvider ? 'provider' : 'subscriber';
+    next();
+  } catch (err) {
+    return res.status(401).json({ error: 'Invalid or expired token' });
+  }
+}
+
 // GET /api/consent/:subscriberDid - Get consent events for subscriber (legacy)
-router.get('/:subscriberDid', async (req, res) => {
+// Feature: authorization boundary - a subscriber may only read their OWN consent
+// history; a provider may only read consent_events that name them as the provider.
+router.get('/:subscriberDid', subscriberOrProviderAuthMiddleware, async (req, res) => {
   try {
     const db = req.app.locals.db;
     const { subscriberDid } = req.params;
@@ -594,10 +619,26 @@ router.get('/:subscriberDid', async (req, res) => {
     if (subResult.rows.length === 0) {
       return res.status(404).json({ error: 'Subscriber not found' });
     }
+    const resolvedSubscriberId = subResult.rows[0].id;
 
+    if (req.authRole === 'subscriber') {
+      if (String(req.user.id) !== String(resolvedSubscriberId)) {
+        return res.status(403).json({ error: 'Cannot read consent history for another subscriber' });
+      }
+
+      const result = await db.query(
+        'SELECT * FROM consent_events WHERE subscriber_id = $1 ORDER BY granted_at DESC',
+        [resolvedSubscriberId]
+      );
+
+      return res.json(buildConsentCollectionResponse(result.rows));
+    }
+
+    // Provider: only consent_events that name this provider for this subscriber
+    const providerId = req.user.id;
     const result = await db.query(
-      'SELECT * FROM consent_events WHERE subscriber_id = $1 ORDER BY granted_at DESC',
-      [subResult.rows[0].id]
+      'SELECT * FROM consent_events WHERE subscriber_id = $1 AND provider_id = $2 ORDER BY granted_at DESC',
+      [resolvedSubscriberId, providerId]
     );
 
     res.json(buildConsentCollectionResponse(result.rows));

--- a/livesafe/tests/consent-subscriber-did-read-authorization.test.ts
+++ b/livesafe/tests/consent-subscriber-did-read-authorization.test.ts
@@ -1,0 +1,74 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+describe("legacy subscriber DID consent read authorization boundary", () => {
+  it("requires a subscriber-or-provider token before returning consent history", () => {
+    const consentRoute = fs.readFileSync(
+      path.join(process.cwd(), "server/routes/consent.js"),
+      "utf8",
+    );
+
+    expect(consentRoute).toContain(
+      "router.get('/:subscriberDid', subscriberOrProviderAuthMiddleware, async (req, res) => {",
+    );
+    expect(consentRoute).not.toContain(
+      "router.get('/:subscriberDid', async (req, res) => {",
+    );
+  });
+
+  it("scopes the subscriber branch to the authenticated subscriber's own DID", () => {
+    const consentRoute = fs.readFileSync(
+      path.join(process.cwd(), "server/routes/consent.js"),
+      "utf8",
+    );
+    const legacyRoute = consentRoute.slice(
+      consentRoute.indexOf("router.get('/:subscriberDid'"),
+      consentRoute.indexOf("// POST /api/consent/provider"),
+    );
+
+    expect(legacyRoute).toContain("if (req.authRole === 'subscriber') {");
+    expect(legacyRoute).toContain(
+      "if (String(req.user.id) !== String(resolvedSubscriberId)) {",
+    );
+    expect(legacyRoute).toContain(
+      "return res.status(403).json({ error: 'Cannot read consent history for another subscriber' });",
+    );
+  });
+
+  it("scopes the provider branch to consent_events naming that provider", () => {
+    const consentRoute = fs.readFileSync(
+      path.join(process.cwd(), "server/routes/consent.js"),
+      "utf8",
+    );
+    const legacyRoute = consentRoute.slice(
+      consentRoute.indexOf("router.get('/:subscriberDid'"),
+      consentRoute.indexOf("// POST /api/consent/provider"),
+    );
+
+    expect(legacyRoute).toContain(
+      "SELECT * FROM consent_events WHERE subscriber_id = $1 AND provider_id = $2 ORDER BY granted_at DESC",
+    );
+    expect(legacyRoute).toContain("const providerId = req.user.id;");
+  });
+
+  it("defines subscriberOrProviderAuthMiddleware to fail closed without a valid bearer token", () => {
+    const consentRoute = fs.readFileSync(
+      path.join(process.cwd(), "server/routes/consent.js"),
+      "utf8",
+    );
+    const middleware = consentRoute.slice(
+      consentRoute.indexOf("function subscriberOrProviderAuthMiddleware"),
+      consentRoute.indexOf("// GET /api/consent/:subscriberDid"),
+    );
+
+    expect(middleware).toContain(
+      "return res.status(401).json({ error: 'Authentication required' });",
+    );
+    expect(middleware).toContain(
+      "return res.status(403).json({ error: 'Subscriber or provider account required' });",
+    );
+    expect(middleware).toContain(
+      "return res.status(401).json({ error: 'Invalid or expired token' });",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`GET /api/consent/:subscriberDid` in `livesafe/server/routes/consent.js` had **no auth middleware** — the sole exception in this file, where every other route uses `authMiddleware` (subscriber) or `providerAuthMiddleware` (provider). It looked up a subscriber by DID and returned every `consent_events` row for them: scope, purpose, provider linkage, and grant/expiry/revocation timestamps — sensitive relationship/medical-adjacent metadata — to any caller who knew or obtained the subscriber's DID.

This is a broken access control vulnerability (CWE-862, missing authorization).

## Why this is exploitable, not just theoretical

Subscriber DIDs (`did:exo:subscriber:<uuid>`) are not a secret in this system by design — they're embedded in emergency QR codes on physical LiveSafe cards and are scanned by first responders (`GET /api/scan/data/:subscriberDid`) or bystanders. Critically, **even that emergency-scan route requires `responderAuth`** (a valid first-responder credential) — the system's own design intentionally treats "knows/scanned the DID" as insufficient authorization for sensitive reads. This legacy consent route was the one place that invariant didn't hold.

## Investigation (no legitimate unauthenticated caller found)

- Searched `livesafe/client/`, `livesafe/responder/`, `livesafe/server/`, `livesafe/tests/`, and all `livesafe/docs/*.md` for any caller of this route (`api/consent/${...}`, template-literal URL builds, `subscriberDid` usages). No caller anywhere hits this route; the client's only `/consent/*` calls go to `/consent/patient/:id/data`, `/consent/providers`, `/consent/access-requests/:id/{approve,deny}`, and `DELETE /consent/:id` — all already authenticated.
- The client's shared `api.js` axios instance attaches a bearer token to every request by default when logged in, so adding an auth requirement does not break any existing call path.
- PR #763 (merged) hardened the sibling `POST /provider` route (fixed a consent-forgery bug where `subscriber_id`/`subscriber_did` could be spoofed in the body) but did not touch this `GET` route — it was untouched dead legacy code, not a reviewed/intentional public endpoint.
- No doc, comment, or spec marks this route as intentionally public. The `(legacy)` comment plus its position below other `/consent/*` GET routes (which had to be explicitly reordered — "MOVED before /:subscriberDid" — to avoid being shadowed by this wildcard) indicates it predates the auth model used elsewhere in the file.

**Verdict: CLEAR VULNERABILITY — remediated.**

## Fix

Added `subscriberOrProviderAuthMiddleware`, which requires a valid bearer token (either a subscriber or provider JWT) and sets `req.authRole`. The route now scopes reads per role, failing closed:

- **Subscriber token**: only their own consent history (`req.user.id` must match the DID's resolved subscriber id, else 403).
- **Provider token**: only `consent_events` rows naming that provider for that subscriber (`subscriber_id AND provider_id` match).

This mirrors the existing `/my-consents` (subscriber-self) and `/patient/:subscriberId/data` (provider-scoped-by-own-id) patterns already in this file.

## Tests

Added `livesafe/tests/consent-subscriber-did-read-authorization.test.ts` following this repo's static-analysis test convention (see `consent-provider-authorization.test.ts`, `admin-*-route-redaction.test.ts`): asserts the route now carries `subscriberOrProviderAuthMiddleware`, that the old unauthenticated route signature is gone, and that both the subscriber-ownership check and provider-scoping query are present.

```
Test Files  2 passed (2)
     Tests  6 passed (6)
```

(existing `consent-provider-authorization.test.ts` unaffected; full suite run separately — 443 passing, 1 pre-existing unrelated failure caused by a missing `.github/workflows/quality.yml` in this checkout, reproduced identically on unmodified `main`)

`node --check server/routes/consent.js` passes.

## Scope

LiveSafe adjacent-surface only. No EXOCHAIN core / Rust / `crates/` code touched.