### PR TITLE
W3(A)/R1.5: enforce BFT min-4 validator floor at apply-on-commit (closes concurrent-remove race)

### DIFF
--- a/GAP-REGISTRY.md
+++ b/GAP-REGISTRY.md
@@ -678,8 +678,11 @@ delivered; row STAYS Red):
   row green needs both halves.
 - Status is Red-with-reason (R1.2) until the objectives are met — the ledger
   functioning, not failing. Hardening (R1.5) executes under W3: push the BFT min-4
-  floor into the validate layer, coordinated with the VCG-014 concurrent-remove race
-  so it lands once. Decision resolved — no longer awaiting the principal.
+  floor into the validate layer. The concurrent-remove race this note used to
+  cross-reference as "VCG-014" is a VCG-005 residual, not a VCG-014 one (see the
+  correction in the VCG-005 lane record) — closed by W3(A)/R1.5's apply-time
+  floor check in `reactor.rs`, coordinate with that fix rather than VCG-014 so
+  it lands once. Decision resolved — no longer awaiting the principal.
 
 Lane record (2026-07-02, branch `vcg/004a-cgr-lock-and-reclass`, sub-lane
 VCG-004a):
@@ -813,12 +816,28 @@ Lane record (2026-07-03, branch `vcg/005-validator-set-lifecycle`):
   reach quorum and jointly drop the live set below `BFT_MIN_VALIDATORS`
   because the floor is checked at proposal-submission time only (api.rs,
   untouched), not at commit-application time. Recorded for a follow-on design
-  decision (proposal vs vote vs commit-application gating); tracked under
-  VCG-014 governance-completeness scope.
+  decision (proposal vs vote vs commit-application gating).
+- Correction (2026-07-04): the concurrent-remove residual above was
+  previously cross-referenced to "VCG-014 governance-completeness scope."
+  That was a mislabel — VCG-014's delivered lane is the CR-001
+  legal-completeness drift-guard (`tools/test_cr001_completeness.sh`), which
+  has no runtime mechanism touching validator-set application and never
+  claimed to. The concurrent-remove race is closed instead under W3(A)/R1.5
+  (branch `vcg/w3a-bft-floor-apply-time`): the BFT min-4 floor is now
+  re-checked inside `apply_committed_validator_change_in_memory`'s
+  `RemoveValidator` arm, at apply-on-commit time, inside the same
+  `with_reactor_state_blocking` critical section as the mutation itself —
+  the existing single `Mutex<ReactorState>` lock discipline this module
+  already documents is what serializes the two concurrent apply tasks, so
+  no new lock, queue, or VCG-014-style guard mechanism was needed. Covered
+  by `remove_validator_at_floor_refused_at_apply_time_even_bypassing_http_handler`
+  and `concurrent_removals_cannot_drop_validator_set_below_floor` in
+  `reactor.rs`.
 - Status Green-local: the core lifecycle (committed ValidatorChange mutates and
   persists live state with an audit receipt) is delivered and tested; the
   admin-bearer authority surface (issue #737) is a separate lane (VCG-006);
-  the placeholder-key liveness gap is VCG-015. Closed after merge + CI.
+  the placeholder-key liveness gap is VCG-015; the concurrent-remove race is
+  closed per the correction above. Closed after merge + CI.
 
 Evidence:
 

--- a/crates/exo-node/src/api.rs
+++ b/crates/exo-node/src/api.rs
@@ -640,6 +640,21 @@ async fn handle_validator_change(
                 }
             }
             "remove" => {
+                // Fast-fail UX pre-check ONLY — not the safety boundary.
+                // This rejects an obviously-doomed proposal early (before
+                // spending a round on it) by checking the *current* live
+                // validator count at submission time. It cannot prevent two
+                // concurrent `RemoveValidator` proposals from each passing
+                // this check (each sees the count still above the floor
+                // when it submits) and both reaching quorum, which would
+                // jointly drop the set below the BFT floor if nothing else
+                // caught it. The authoritative, race-proof invariant lives
+                // at apply-on-commit time in
+                // `reactor::apply_committed_validator_change_in_memory`'s
+                // `RemoveValidator` arm (W3(A)/R1.5), which re-checks the
+                // floor inside the same lock as the mutation and refuses
+                // any commit that would breach it — regardless of caller,
+                // and regardless of what this pre-check saw.
                 let validator_count = read_validator_count(Arc::clone(&api.reactor_state)).await?;
                 if validator_count <= 4 {
                     return Err((

--- a/crates/exo-node/src/reactor.rs
+++ b/crates/exo-node/src/reactor.rs
@@ -188,6 +188,41 @@ fn apply_committed_validator_change_in_memory(
             s.validator_public_keys = ValidatorPublicKeys::new(keys);
         }
         ValidatorChange::RemoveValidator { did } => {
+            // W3(A)/R1.5: BFT min-4 validator floor, enforced HERE at
+            // apply-on-commit time — not just at api.rs's propose-time
+            // pre-check (`validator_count <= 4` in
+            // `handle_validator_change`), which only fast-fails the UX for
+            // a single proposer and is not the safety boundary. Two
+            // `RemoveValidator` proposals can each individually pass that
+            // pre-check (each sees the count still at or above the floor
+            // when submitted) and both reach quorum; applied sequentially
+            // through the same lock with no re-check here, the set would
+            // drop 5 -> 4 -> 3, one below the 3f+1=4 safety floor. This
+            // whole match arm already runs inside the single
+            // `with_reactor_state_blocking` critical section entered via
+            // the `Mutex<ReactorState>`, so the two concurrent apply tasks
+            // are serialized: whichever runs second observes the
+            // already-decremented count below and refuses here, closing
+            // the race without needing any new lock or coordination
+            // mechanism.
+            //
+            // `BFT_MIN_VALIDATORS` also exists in `sentinels.rs` (detective
+            // health-check, not importable — it's a private module-level
+            // const there). This local copy must stay in sync with that
+            // value (4).
+            const BFT_MIN_VALIDATORS: usize = 4;
+            if s.consensus.config.validators.len() <= BFT_MIN_VALIDATORS {
+                tracing::warn!(
+                    %did,
+                    current_count = s.consensus.config.validators.len(),
+                    floor = BFT_MIN_VALIDATORS,
+                    "Refusing to apply quorum-certified RemoveValidator commit: \
+                     validator set is at or below the BFT minimum floor. \
+                     Discarding this already-committed change as a no-op to \
+                     preserve the 3f+1 safety invariant."
+                );
+                return None;
+            }
             s.consensus.config.validators.remove(did);
             let mut keys = s.validator_public_keys.as_map().clone();
             keys.remove(did);
@@ -305,20 +340,28 @@ async fn commit_receipt_from_certificate(
 /// the audit trail reflects *what* changed, not just *that* something
 /// committed.
 ///
-/// KNOWN GAP (concurrent-remove BFT floor race): the minimum-validator BFT
-/// floor (`BFT_MIN_VALIDATORS` in `sentinels.rs`) is enforced only at
-/// proposal-submission time, in `api.rs::handle_validator_change` (which
-/// checks the *current* live validator count before accepting a removal
-/// proposal). Two `RemoveValidator` proposals that each individually pass
-/// that check — because each sees a validator count still at or above the
-/// floor at the moment it is submitted — can both independently reach
-/// quorum and commit here in sequence, jointly dropping the live set below
-/// the BFT-safe minimum even though neither commit violated the floor on
-/// its own. This function does not re-check the floor at application time:
-/// doing so would mean rejecting an already quorum-certified commit, which
-/// raises a bigger design question (does the floor gate proposal
-/// submission, vote casting, or commit application?) than this lane's
-/// scope covers. Surfaced, not fixed, per VCG-005 remediation notes.
+/// CLOSED (W3(A)/R1.5, was: concurrent-remove BFT floor race): the
+/// minimum-validator BFT floor is now re-enforced *here*, at apply-on-commit
+/// time, inside `apply_committed_validator_change_in_memory`'s
+/// `RemoveValidator` arm — not only at proposal-submission time in
+/// `api.rs::handle_validator_change` (which checks the *current* live
+/// validator count before accepting a removal proposal, and remains a
+/// fast-fail UX pre-check, not the safety boundary). Previously, two
+/// `RemoveValidator` proposals that each individually passed that
+/// propose-time check — because each saw a validator count still at or
+/// above the floor at the moment it was submitted — could both
+/// independently reach quorum and commit here in sequence, jointly dropping
+/// the live set below the BFT-safe minimum even though neither commit
+/// violated the floor on its own. The apply-time re-check closes this: it
+/// runs inside the same `with_reactor_state_blocking` critical section as
+/// the mutation, so the single `Mutex<ReactorState>` serializes concurrent
+/// apply tasks and whichever runs second observes the already-decremented
+/// count and discards its already-quorum-certified commit as a no-op. See
+/// `apply_committed_validator_change_in_memory`'s `RemoveValidator` arm for
+/// the guard itself, and the `remove_validator_at_floor_refused_at_apply_time_even_bypassing_http_handler`
+/// / `concurrent_removals_cannot_drop_validator_set_below_floor` tests below
+/// for RED-before/GREEN-after evidence. VCG-005 remediation notes updated
+/// accordingly in GAP-REGISTRY.md.
 async fn apply_committed_validator_change_after_commit(
     state: &SharedReactorState,
     store: &Arc<Mutex<SqliteDagStore>>,
@@ -3200,6 +3243,239 @@ mod tests {
                 "persisted validator set must not change without quorum-gated commit"
             );
         }
+    }
+
+    // ------------------------------------------------------------------
+    // W3(A)/R1.5: BFT min-4 validator floor enforced at apply-on-commit,
+    // not just at api.rs's propose-time pre-check. See the module-level
+    // `apply_committed_validator_change_in_memory` doc comment for the
+    // concurrent-remove race this closes.
+
+    /// Minimal `TrustReceipt` fixture for driving
+    /// `apply_committed_validator_change_after_commit` directly in tests,
+    /// bypassing the full propose/vote/commit machinery already covered by
+    /// the sibling tests above. Content doesn't matter for these tests —
+    /// the function only reads `receipt.receipt_hash` for a log field.
+    fn dummy_receipt_for_test(
+        node_hash: Hash256,
+        sign_fn: &Arc<dyn Fn(&[u8]) -> Signature + Send + Sync>,
+    ) -> TrustReceipt {
+        TrustReceipt::new(
+            Did::new("did:exo:v0").unwrap(),
+            Hash256::digest(b"test-authority-chain"),
+            None,
+            "dag.commit".to_string(),
+            node_hash,
+            ReceiptOutcome::Executed,
+            Timestamp::new(1_700_000_000, 0),
+            &**sign_fn,
+        )
+        .expect("dummy trust receipt builds")
+    }
+
+    /// Persist a `RemoveValidator` governance payload for `target` as a
+    /// committed DAG node, returning its hash. Mirrors the persistence the
+    /// real propose → quorum → commit path performs (`store.put_sync` +
+    /// `store.save_governance_payload`) without needing to actually drive
+    /// consensus voting — these tests target
+    /// `apply_committed_validator_change_after_commit` directly, which only
+    /// needs the committed node + governance payload to already exist.
+    fn persist_remove_validator_node(
+        store: &Arc<Mutex<SqliteDagStore>>,
+        dag: &mut Dag,
+        clock: &mut DeterministicDagClock,
+        parents: &[Hash256],
+        creator: &Did,
+        sign_fn: &dyn Fn(&[u8]) -> Signature,
+        target: &Did,
+    ) -> Hash256 {
+        let change = crate::wire::ValidatorChange::RemoveValidator {
+            did: target.clone(),
+        };
+        let mut payload = Vec::new();
+        ciborium::into_writer(&change, &mut payload).unwrap();
+
+        let node = append(dag, parents, &payload, creator, sign_fn, clock).unwrap();
+        store.lock().unwrap().put_sync(node.clone()).unwrap();
+        store
+            .lock()
+            .unwrap()
+            .save_governance_payload(&node.hash, &payload)
+            .unwrap();
+        node.hash
+    }
+
+    #[tokio::test]
+    async fn remove_validator_at_floor_refused_at_apply_time_even_bypassing_http_handler() {
+        // Exactly at the BFT floor (4 validators). A RemoveValidator commit
+        // reaching the apply step here must be refused as a no-op — this
+        // is the invariant api.rs's propose-time `validator_count <= 4`
+        // check cannot enforce for any caller that reaches
+        // `apply_committed_validator_change_after_commit` directly (e.g. a
+        // future internal caller, or the second half of the concurrent
+        // race exercised by the sibling test below).
+        let validators = make_validators(4);
+        let validator_vec: Vec<Did> = validators.iter().cloned().collect();
+        let target = validator_vec[3].clone();
+        let config = config_for(validator_vec[0].clone(), true, validators.clone());
+        let sign_fn = make_sign_fn();
+        let state = create_reactor_state(&config, Arc::clone(&sign_fn), None);
+        let (_dir, store) = temp_store();
+        let mut dag = Dag::new();
+        let mut clock = DeterministicDagClock::new();
+
+        let hash = persist_remove_validator_node(
+            &store,
+            &mut dag,
+            &mut clock,
+            &[],
+            &validator_vec[0],
+            &*sign_fn,
+            &target,
+        );
+        let receipt = dummy_receipt_for_test(hash, &sign_fn);
+
+        apply_committed_validator_change_after_commit(&state, &store, &hash, &receipt).await;
+
+        let s = state.lock().unwrap();
+        assert_eq!(
+            s.consensus.config.validators.len(),
+            4,
+            "validator set must stay at the BFT floor — apply-time refusal is a no-op"
+        );
+        assert!(
+            s.consensus.config.validators.contains(&target),
+            "target validator must still be present — the removal must have been refused"
+        );
+        assert!(
+            s.validator_public_keys.as_map().contains_key(&target),
+            "target validator's public key must not be dropped when the removal is refused"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_removals_cannot_drop_validator_set_below_floor() {
+        // THE RACE (VCG-005 concurrent-remove gap): 5 validators, two
+        // independent RemoveValidator commits for two different DIDs, each
+        // individually legitimate (5 > 4 at the moment either is proposed).
+        // Applied sequentially through the same lock with no re-check, the
+        // set would drop 5 -> 4 -> 3, one below the 3f+1=4 safety floor.
+        // Before the fix this test observes exactly that: both removals
+        // apply and the set drops to 3. After the fix, the single
+        // `Mutex<ReactorState>` (entered via `with_reactor_state_blocking`)
+        // serializes the two apply tasks, and whichever runs second sees
+        // the already-decremented count and refuses.
+        let validators = make_validators(5);
+        let validator_vec: Vec<Did> = validators.iter().cloned().collect();
+        let target_a = validator_vec[3].clone();
+        let target_b = validator_vec[4].clone();
+        let config = config_for(validator_vec[0].clone(), true, validators.clone());
+        let sign_fn = make_sign_fn();
+        let state = create_reactor_state(&config, Arc::clone(&sign_fn), None);
+        let (_dir, store) = temp_store();
+        let mut dag = Dag::new();
+        let mut clock = DeterministicDagClock::new();
+
+        // Two independently committed RemoveValidator nodes, each targeting
+        // a different DID. Both are persisted up front (mirroring two
+        // proposals that each already reached quorum before either applied)
+        // — the race under test is in the apply step, not the propose/vote
+        // machinery already covered by the sibling quorum tests above.
+        let hash_a = persist_remove_validator_node(
+            &store,
+            &mut dag,
+            &mut clock,
+            &[],
+            &validator_vec[0],
+            &*sign_fn,
+            &target_a,
+        );
+        let hash_b = persist_remove_validator_node(
+            &store,
+            &mut dag,
+            &mut clock,
+            &[hash_a],
+            &validator_vec[0],
+            &*sign_fn,
+            &target_b,
+        );
+        let receipt_a = dummy_receipt_for_test(hash_a, &sign_fn);
+        let receipt_b = dummy_receipt_for_test(hash_b, &sign_fn);
+
+        let state_a = Arc::clone(&state);
+        let store_a = Arc::clone(&store);
+        let task_a = tokio::spawn(async move {
+            apply_committed_validator_change_after_commit(&state_a, &store_a, &hash_a, &receipt_a)
+                .await;
+        });
+
+        let state_b = Arc::clone(&state);
+        let store_b = Arc::clone(&store);
+        let task_b = tokio::spawn(async move {
+            apply_committed_validator_change_after_commit(&state_b, &store_b, &hash_b, &receipt_b)
+                .await;
+        });
+
+        let (joined_a, joined_b) = tokio::join!(task_a, task_b);
+        joined_a.expect("apply task A joins");
+        joined_b.expect("apply task B joins");
+
+        let s = state.lock().unwrap();
+        assert_eq!(
+            s.consensus.config.validators.len(),
+            4,
+            "concurrent removals must never drop the live validator set below the BFT floor of 4"
+        );
+        let a_present = s.consensus.config.validators.contains(&target_a);
+        let b_present = s.consensus.config.validators.contains(&target_b);
+        assert_ne!(
+            a_present, b_present,
+            "exactly one of the two concurrent removals must have applied — the other refused"
+        );
+    }
+
+    #[tokio::test]
+    async fn remove_validator_above_floor_still_applies() {
+        // The new `<=` floor guard must not block a legitimate removal that
+        // keeps the set at or above the BFT minimum: 5 validators, single
+        // removal, set must drop to 4 with the target's key gone.
+        let validators = make_validators(5);
+        let validator_vec: Vec<Did> = validators.iter().cloned().collect();
+        let target = validator_vec[4].clone();
+        let config = config_for(validator_vec[0].clone(), true, validators.clone());
+        let sign_fn = make_sign_fn();
+        let state = create_reactor_state(&config, Arc::clone(&sign_fn), None);
+        let (_dir, store) = temp_store();
+        let mut dag = Dag::new();
+        let mut clock = DeterministicDagClock::new();
+
+        let hash = persist_remove_validator_node(
+            &store,
+            &mut dag,
+            &mut clock,
+            &[],
+            &validator_vec[0],
+            &*sign_fn,
+            &target,
+        );
+        let receipt = dummy_receipt_for_test(hash, &sign_fn);
+
+        apply_committed_validator_change_after_commit(&state, &store, &hash, &receipt).await;
+
+        let s = state.lock().unwrap();
+        assert_eq!(
+            s.consensus.config.validators.len(),
+            4,
+            "a legitimate above-floor removal must still apply"
+        );
+        assert!(
+            !s.consensus.config.validators.contains(&target),
+            "removed validator must be gone from the live set"
+        );
+        assert!(
+            !s.validator_public_keys.as_map().contains_key(&target),
+            "removed validator's public key must be gone from the resolver"
+        );
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## Ratified directive

R1.5 (W3 Part A): enforce the BFT minimum-validator floor at the apply-on-commit path.

## The bug

The BFT min-4 validator floor was enforced only at **propose-time**, in the HTTP handler (`crates/exo-node/src/api.rs` `handle_validator_change`'s `"remove"` arm: `validator_count <= 4` → 409 CONFLICT). Direct `reactor::submit_proposal` callers bypassed it entirely, and — critically — even the propose-time check is insufficient against a race: two `RemoveValidator` proposals can each individually see a validator count still above the floor at submit time, each reach quorum, and both apply sequentially through the same lock with **no re-check**, dropping the set 5→4→3 — one below the `3f+1=4` safety floor. The apply path (`apply_committed_validator_change_in_memory`) had no floor check at all.

## The fix

Added the floor check to the **`RemoveValidator` arm only** (`AddValidator` is untouched) in `apply_committed_validator_change_in_memory` (`crates/exo-node/src/reactor.rs`), before the `s.consensus.config.validators.remove(did)` mutation:

```rust
const BFT_MIN_VALIDATORS: usize = 4; // must match sentinels.rs
if s.consensus.config.validators.len() <= BFT_MIN_VALIDATORS {
    tracing::warn!(...);
    return None; // reuses the function's existing "not an actionable change" contract
}
```

`sentinels.rs`'s `BFT_MIN_VALIDATORS` is a private module-level `const` (not `pub`/`pub(crate)`), so it isn't importable — a local copy is defined with a comment that it must stay in sync.

This closes the race **in-lock**: the whole match arm already runs inside the single `with_reactor_state_blocking` critical section entered via the `Mutex<ReactorState>`, so two concurrent apply tasks are serialized — whichever runs second observes the already-decremented count and refuses. No new lock or coordination mechanism was needed.

`api.rs`'s propose-time check is kept as-is; its comment now states it is a fast-fail UX pre-check, not the safety boundary — the apply-time invariant is authoritative for all callers.

## GAP-REGISTRY correction

No VCG-014 runtime mechanism ever existed for this race. A prior VCG-005 lane-record note mislabeled the concurrent-remove residual as "tracked under VCG-014 governance-completeness scope." VCG-014's actual delivered lane is the CR-001 legal-completeness drift-guard (`tools/test_cr001_completeness.sh`) — unrelated to validator-set runtime application. Corrected in place under the VCG-005 lane record (and a stale VCG-004 cross-reference to the same mislabel); **no new VCG row added** — the guard pins exactly 15 rows + 15 of each label.

## TDD — RED then GREEN

Two RED tests captured failing before the fix:

- `remove_validator_at_floor_refused_at_apply_time_even_bypassing_http_handler` — 4 validators, single removal at the floor, driven directly through `apply_committed_validator_change_after_commit` (bypassing api.rs entirely). **RED: set dropped to 3** (assertion `left: 3, right: 4`).
- `concurrent_removals_cannot_drop_validator_set_below_floor` (**the race**) — 5 validators, two independent `RemoveValidator` commits for two different DIDs, applied concurrently via `tokio::spawn` + `tokio::join!` against the same shared `Arc<Mutex<ReactorState>>`/store. **RED: both removals applied, set dropped to 3** — exactly reproducing the bug.

A third test guards the non-regression case:

- `remove_validator_above_floor_still_applies` — 5 validators, single removal, confirms the new `<=` guard does not block a legitimate above-floor removal (5→4).

All three pass after the fix. Verified deterministic across 15 repeated runs of the concurrency test.

## Gates

| Gate | Result |
|---|---|
| `cargo test -p exochain-node --bin exochain reactor::` | PASS — 55 passed, 0 failed |
| `cargo test -p exochain-node --bin exochain governance` | PASS — 48 passed, 0 failed |
| `cargo build --workspace` | PASS |
| `cargo clippy -p exochain-node --all-targets -- -D warnings` | PASS — 0 warnings |
| `cargo +nightly fmt --check` | PASS (after `cargo +nightly fmt`) |
| `bash tools/test_gap_registry_truth.sh` | PASS |
| `bash tools/test_repo_truth.sh` | PASS |
| Full crate suite (`cargo test -p exochain-node --bin exochain`) | PASS — 1335 passed, 0 failed, 2 ignored |

## Scope confirmation

- `AddValidator` arm is byte-for-byte untouched — only the `RemoveValidator` arm gained the guard.
- `holons.rs` and `sentinels.rs` untouched (advisory/detective, already correct per the directive).
- No checks added to `handle_propose`/`submit_proposal` — the apply-time fix covers all callers regardless of entry point.
