### PR TITLE
fix(avc): verify issuer authority with validator keys

### DIFF
--- a/crates/exo-avc/src/registry.rs
+++ b/crates/exo-avc/src/registry.rs
@@ -163,6 +163,15 @@ impl InMemoryAvcRegistry {
         Self::default()
     }
 
+    /// Resolve a receipt-validator public key without making validator keys
+    /// general AVC issuer keys. This is intentionally separate from
+    /// [`AvcRegistryRead::resolve_public_key`], which must continue to omit
+    /// validator-only keys from ordinary credential issuer resolution.
+    #[must_use]
+    pub fn resolve_receipt_validator_public_key(&self, did: &Did) -> Option<PublicKey> {
+        self.receipt_validator_public_keys.get(did).copied()
+    }
+
     /// Export the durable portion of the registry.
     #[must_use]
     pub fn durable_state(&self) -> AvcRegistryDurableState {

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -2844,17 +2844,21 @@ fn verify_issuer_registration_authority(
             "AVC registry unavailable while verifying issuer registration authority".into(),
         )
     })?;
-    exo_authority::chain::verify_chain(chain, &now, |did| registry.resolve_public_key(did))
-        .map_err(|error| {
-            tracing::warn!(
-                %error,
-                "rejected AVC issuer registration: authority chain failed verification"
-            );
-            (
-                StatusCode::FORBIDDEN,
-                "issuer registration authority chain failed verification".into(),
-            )
-        })?;
+    exo_authority::chain::verify_chain(chain, &now, |did| {
+        registry
+            .resolve_public_key(did)
+            .or_else(|| registry.resolve_receipt_validator_public_key(did))
+    })
+    .map_err(|error| {
+        tracing::warn!(
+            %error,
+            "rejected AVC issuer registration: authority chain failed verification"
+        );
+        (
+            StatusCode::FORBIDDEN,
+            "issuer registration authority chain failed verification".into(),
+        )
+    })?;
 
     if !exo_authority::chain::has_permission(chain, &Permission::Govern) {
         return Err((
@@ -8318,6 +8322,62 @@ mod avc_issuer_registration_authority_tests {
         let result: AvcValidationResult =
             serde_json::from_slice(&body).expect("validation result body");
         assert_eq!(result.decision, AvcDecision::Allow);
+    }
+
+    #[tokio::test]
+    async fn issuer_registration_authority_verifies_against_startup_validator_key_set() {
+        let state = fresh_state();
+        let validator_kp = validator_keypair();
+        let issuer_did = new_issuer_did();
+        let issuer_kp = new_issuer_keypair();
+
+        state
+            .register_validator_public_keys([(validator_did(), validator_kp.public)])
+            .expect("startup validator public keys register");
+
+        let now = Timestamp::new(1_000, 0);
+        let expires = Timestamp::new(9_000_000, 0);
+        state
+            .grant_issuer_registration_authority(
+                operator_did(),
+                DelegateeKind::Human,
+                &validator_kp.public,
+                expires,
+                &now,
+                |payload| validator_kp.sign(payload),
+            )
+            .expect("grant issuer-registration authority");
+        let chain = state
+            .find_delegated_issuer_registration_chain(&operator_did())
+            .expect("delegated issuer-registration chain must be exportable");
+
+        let register_body = serde_json::json!({
+            "issuer_did": issuer_did.to_string(),
+            "public_key_hex": hex::encode(issuer_kp.public.as_bytes()),
+            "authority_chain": chain,
+            "granted_permissions": ["Read", "Write"],
+        });
+        let app = router_with_bearer_gate(Arc::clone(&state));
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/avc/issuers")
+                    .header("content-type", "application/json")
+                    .header("Authorization", "Bearer vcg-006b-authority-test-token")
+                    .body(Body::from(serde_json::to_vec(&register_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        if status != StatusCode::OK {
+            let body = read_body(response).await;
+            panic!(
+                "expected startup validator key set to verify issuer-registration authority, got {status}: {}",
+                String::from_utf8_lossy(&body)
+            );
+        }
     }
 
     /// A chain that verifies cryptographically but was never actually


### PR DESCRIPTION
## Classification
- `crates/exo-avc/src/registry.rs` — EXOCHAIN core / core runtime adapter support: exposes a narrow receipt-validator-key resolver without making validator keys general AVC issuer keys.
- `crates/exo-node/src/avc.rs` — EXOCHAIN core runtime adapter: verifies runtime issuer-registration authority chains against startup validator keys and adds the missing regression.

No adjacent LiveSafe files are changed. No public trust claims are enabled.

## RED
- `cargo test -p exochain-node issuer_registration_authority_verifies_against_startup_validator_key_set -- --nocapture`
- Failed before the fix with `403 Forbidden: issuer registration authority chain failed verification`, matching the live ARMORCLOUD ceremony failure after PR #759.

## GREEN
- `cargo test -p exochain-node issuer_registration_authority_verifies_against_startup_validator_key_set -- --nocapture`
- `cargo test -p exochain-node avc_issuer_registration_authority_tests -- --nocapture`
- `cargo test -p exochain-node avc_issuer_conformance_tests -- --nocapture`
- `cargo test -p exochain-avc`
- `cargo test -p exochain-node`
- `cargo clippy -p exochain-avc -p exochain-node --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`

## Why
Production startup grants issuer-registration authority from the node validator DID, but the verifier previously resolved chain signing keys only through general AVC issuer keys. Startup validator keys are intentionally stored as receipt-validator keys, not general AVC issuer trust anchors. This PR lets the authority-chain verifier resolve those validator keys from the receipt-validator trust set while preserving the existing credential-validation invariant that validator keys do not become issuer keys.
