### PR TITLE
ci(livesafe): add Railway promotion baseline

### DIFF
--- a/.github/workflows/livesafe-ci.yml
+++ b/.github/workflows/livesafe-ci.yml
@@ -29,6 +29,12 @@
 name: LiveSafe CI
 
 on:
+  workflow_call:
+    inputs:
+      commit_sha:
+        description: "Commit SHA to verify; defaults to the workflow SHA"
+        required: false
+        type: string
   push:
     paths:
       - 'livesafe/**'
@@ -37,6 +43,9 @@ on:
     paths:
       - 'livesafe/**'
       - '.github/workflows/livesafe-ci.yml'
+
+permissions:
+  contents: read
 
 defaults:
   run:
@@ -48,6 +57,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ inputs.commit_sha || github.sha }}
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
@@ -67,3 +78,6 @@ jobs:
         run: |
           npm --prefix responder ci
           npm --prefix responder run build
+      - name: Build LiveSafe Docker image
+        working-directory: .
+        run: docker build -f livesafe/Dockerfile livesafe

--- a/.github/workflows/livesafe-railway-deploy.yml
+++ b/.github/workflows/livesafe-railway-deploy.yml
@@ -1,0 +1,155 @@
+# Copyright 2026 Exochain Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: LiveSafe Railway Deploy
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "livesafe/**"
+      - "crates/exo-avc/**"
+      - "crates/exo-node/**"
+      - "railway.json"
+      - "livesafe/railway.json"
+      - "scripts/livesafe-railway-smoke.sh"
+      - ".github/workflows/livesafe-railway-deploy.yml"
+  workflow_dispatch:
+    inputs:
+      target_environment:
+        description: "Railway environment to promote to"
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+      commit_sha:
+        description: "Commit SHA to deploy; defaults to the workflow SHA"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  RAILWAY_PROJECT_ID: 372de75b-5f44-46c2-ab70-3c3185b5d81e
+  RAILWAY_DEVELOPMENT_ENVIRONMENT_ID: 3dc06fb6-c3df-4fe4-8807-0da0e62e4028
+  RAILWAY_STAGING_ENVIRONMENT_ID: a223bc12-fbe4-430f-abce-8e3ee7c9abd3
+  RAILWAY_PRODUCTION_ENVIRONMENT_ID: 1e5153e1-15f4-4447-bf7c-029af33927fb
+  EXOCHAIN_NODE_SERVICE_ID: 4d8384d3-be5d-48d6-a914-97eb6133e53d
+  LIVESAFE_SERVICE_ID: 8ed3bd1a-f872-4e22-9a39-ac38953fae26
+
+jobs:
+  verify-livesafe:
+    name: Verify LiveSafe deployable artifact
+    uses: ./.github/workflows/livesafe-ci.yml
+    with:
+      commit_sha: ${{ inputs.commit_sha || github.sha }}
+
+  deploy-development:
+    name: Deploy LiveSafe development
+    if: github.event_name == 'push'
+    needs: verify-livesafe
+    runs-on: ubuntu-latest
+    environment: livesafe-development
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 22
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli@4.65.0
+      - name: Deploy exochain-node to development
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          railway up . --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_DEVELOPMENT_ENVIRONMENT_ID" --service "$EXOCHAIN_NODE_SERVICE_ID" --detach --json -m "development exochain-node ${GITHUB_SHA}"
+      - name: Deploy livesafe to development
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          railway up livesafe --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_DEVELOPMENT_ENVIRONMENT_ID" --service "$LIVESAFE_SERVICE_ID" --detach --json -m "development livesafe ${GITHUB_SHA}"
+      - name: Smoke development
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: scripts/livesafe-railway-smoke.sh "development"
+
+  deploy-staging:
+    name: Promote LiveSafe staging
+    if: github.event_name == 'workflow_dispatch' && inputs.target_environment == 'staging'
+    needs: verify-livesafe
+    runs-on: ubuntu-latest
+    environment: livesafe-staging
+    env:
+      TARGET_ENVIRONMENT: staging
+      TARGET_ENVIRONMENT_ID: a223bc12-fbe4-430f-abce-8e3ee7c9abd3
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ inputs.commit_sha || github.sha }}
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 22
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli@4.65.0
+      - name: Promote exochain-node
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          railway up . --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$TARGET_ENVIRONMENT_ID" --service "$EXOCHAIN_NODE_SERVICE_ID" --detach --json -m "${TARGET_ENVIRONMENT} exochain-node ${GITHUB_SHA}"
+      - name: Promote livesafe
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          railway up livesafe --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$TARGET_ENVIRONMENT_ID" --service "$LIVESAFE_SERVICE_ID" --detach --json -m "${TARGET_ENVIRONMENT} livesafe ${GITHUB_SHA}"
+      - name: Smoke staging
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: scripts/livesafe-railway-smoke.sh "$TARGET_ENVIRONMENT"
+
+  deploy-production:
+    name: Promote LiveSafe production
+    if: github.event_name == 'workflow_dispatch' && inputs.target_environment == 'production'
+    needs: verify-livesafe
+    runs-on: ubuntu-latest
+    environment: livesafe-production
+    env:
+      TARGET_ENVIRONMENT: production
+      TARGET_ENVIRONMENT_ID: 1e5153e1-15f4-4447-bf7c-029af33927fb
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ inputs.commit_sha || github.sha }}
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 22
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli@4.65.0
+      - name: Promote exochain-node
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          railway up . --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$TARGET_ENVIRONMENT_ID" --service "$EXOCHAIN_NODE_SERVICE_ID" --detach --json -m "${TARGET_ENVIRONMENT} exochain-node ${GITHUB_SHA}"
+      - name: Promote livesafe
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          railway up livesafe --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$TARGET_ENVIRONMENT_ID" --service "$LIVESAFE_SERVICE_ID" --detach --json -m "${TARGET_ENVIRONMENT} livesafe ${GITHUB_SHA}"
+      - name: Smoke production
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: scripts/livesafe-railway-smoke.sh "$TARGET_ENVIRONMENT"

--- a/livesafe/config/railway-environments.json
+++ b/livesafe/config/railway-environments.json
@@ -1,0 +1,39 @@
+{
+  "projectId": "372de75b-5f44-46c2-ab70-3c3185b5d81e",
+  "workspace": "ARMORCLOUD",
+  "environments": [
+    {
+      "id": "3dc06fb6-c3df-4fe4-8807-0da0e62e4028",
+      "livesafeDomain": "https://livesafe-development.up.railway.app",
+      "name": "development"
+    },
+    {
+      "id": "a223bc12-fbe4-430f-abce-8e3ee7c9abd3",
+      "livesafeDomain": "https://livesafe-staging.up.railway.app",
+      "name": "staging"
+    },
+    {
+      "id": "1e5153e1-15f4-4447-bf7c-029af33927fb",
+      "name": "production"
+    }
+  ],
+  "services": [
+    {
+      "id": "8ed3bd1a-f872-4e22-9a39-ac38953fae26",
+      "name": "livesafe"
+    },
+    {
+      "id": "4d8384d3-be5d-48d6-a914-97eb6133e53d",
+      "name": "exochain-node"
+    },
+    {
+      "id": "2ab3f445-d6f7-4245-940c-985a14e974f9",
+      "name": "exochain-node-db"
+    },
+    {
+      "id": "691122bb-025b-463d-8033-7f94f7678748",
+      "name": "Postgres"
+    }
+  ],
+  "productionDomain": "https://livesafe.ai"
+}

--- a/livesafe/tests/github-quality-workflow.test.ts
+++ b/livesafe/tests/github-quality-workflow.test.ts
@@ -14,8 +14,18 @@ describe("GitHub quality workflow", () => {
     const qualityIndex = workflow.indexOf("run: npm run quality");
 
     expect(workflow).toContain("livesafe/**");
+    expect(workflow).toContain("workflow_call:");
+    expect(workflow).toContain("commit_sha:");
+    expect(workflow).toContain("permissions:");
+    expect(workflow).toContain("contents: read");
+    expect(workflow).toContain("ref: ${{ inputs.commit_sha || github.sha }}");
     expect(rootInstallIndex).toBeGreaterThanOrEqual(0);
     expect(serverInstallIndex).toBeGreaterThan(rootInstallIndex);
     expect(qualityIndex).toBeGreaterThan(serverInstallIndex);
+    expect(workflow).toContain(
+      "docker build -f livesafe/Dockerfile livesafe",
+    );
+    expect(workflow).not.toContain("RAILWAY_TOKEN");
+    expect(workflow).not.toContain("railway up");
   });
 });

--- a/livesafe/tests/railway-cicd-baseline.test.ts
+++ b/livesafe/tests/railway-cicd-baseline.test.ts
@@ -1,0 +1,121 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(process.cwd(), "..");
+
+function readRepoFile(relativePath: string): string {
+  const absolutePath = resolve(repoRoot, relativePath);
+
+  expect(existsSync(absolutePath), `${relativePath} should exist`).toBe(true);
+
+  return readFileSync(absolutePath, "utf8");
+}
+
+describe("LiveSafe Railway CI/CD baseline", () => {
+  it("declares the ARMORCLOUD LiveSafe project environments and service names without secrets", () => {
+    const manifest = JSON.parse(
+      readRepoFile("livesafe/config/railway-environments.json"),
+    ) as {
+      projectId: string;
+      workspace: string;
+      environments: Array<{ id: string; name: string; livesafeDomain?: string }>;
+      services: Array<{ id: string; name: string }>;
+      productionDomain: string;
+    };
+
+    expect(manifest).toEqual({
+      projectId: "372de75b-5f44-46c2-ab70-3c3185b5d81e",
+      workspace: "ARMORCLOUD",
+      environments: [
+        {
+          id: "3dc06fb6-c3df-4fe4-8807-0da0e62e4028",
+          livesafeDomain: "https://livesafe-development.up.railway.app",
+          name: "development",
+        },
+        {
+          id: "a223bc12-fbe4-430f-abce-8e3ee7c9abd3",
+          livesafeDomain: "https://livesafe-staging.up.railway.app",
+          name: "staging",
+        },
+        {
+          id: "1e5153e1-15f4-4447-bf7c-029af33927fb",
+          name: "production",
+        },
+      ],
+      services: [
+        { id: "8ed3bd1a-f872-4e22-9a39-ac38953fae26", name: "livesafe" },
+        { id: "4d8384d3-be5d-48d6-a914-97eb6133e53d", name: "exochain-node" },
+        { id: "2ab3f445-d6f7-4245-940c-985a14e974f9", name: "exochain-node-db" },
+        { id: "691122bb-025b-463d-8033-7f94f7678748", name: "Postgres" },
+      ],
+      productionDomain: "https://livesafe.ai",
+    });
+  });
+
+  it("adds a protected Railway promotion workflow for development, staging, and production", () => {
+    const workflow = readRepoFile(".github/workflows/livesafe-railway-deploy.yml");
+
+    expect(workflow).toContain("name: LiveSafe Railway Deploy");
+    expect(workflow).toContain(
+      "RAILWAY_PROJECT_ID: 372de75b-5f44-46c2-ab70-3c3185b5d81e",
+    );
+    expect(workflow).toContain(
+      "RAILWAY_DEVELOPMENT_ENVIRONMENT_ID: 3dc06fb6-c3df-4fe4-8807-0da0e62e4028",
+    );
+    expect(workflow).toContain(
+      "RAILWAY_STAGING_ENVIRONMENT_ID: a223bc12-fbe4-430f-abce-8e3ee7c9abd3",
+    );
+    expect(workflow).toContain(
+      "RAILWAY_PRODUCTION_ENVIRONMENT_ID: 1e5153e1-15f4-4447-bf7c-029af33927fb",
+    );
+    expect(workflow).toContain(
+      "EXOCHAIN_NODE_SERVICE_ID: 4d8384d3-be5d-48d6-a914-97eb6133e53d",
+    );
+    expect(workflow).toContain(
+      "LIVESAFE_SERVICE_ID: 8ed3bd1a-f872-4e22-9a39-ac38953fae26",
+    );
+    expect(workflow).toContain("secrets.RAILWAY_TOKEN");
+    expect(workflow).toContain("environment: livesafe-development");
+    expect(workflow).toContain("environment: livesafe-staging");
+    expect(workflow).toContain("environment: livesafe-production");
+    expect(workflow).toContain("verify-livesafe:");
+    expect(workflow).toContain("uses: ./.github/workflows/livesafe-ci.yml");
+    expect(workflow).toContain("commit_sha: ${{ inputs.commit_sha || github.sha }}");
+    expect(workflow).toContain("needs: verify-livesafe");
+    expect(workflow).toContain(
+      'railway up . --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_DEVELOPMENT_ENVIRONMENT_ID" --service "$EXOCHAIN_NODE_SERVICE_ID"',
+    );
+    expect(workflow).toContain(
+      'railway up livesafe --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_DEVELOPMENT_ENVIRONMENT_ID" --service "$LIVESAFE_SERVICE_ID"',
+    );
+    expect(workflow).toContain(
+      'railway up . --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$TARGET_ENVIRONMENT_ID" --service "$EXOCHAIN_NODE_SERVICE_ID"',
+    );
+    expect(workflow).toContain(
+      'railway up livesafe --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$TARGET_ENVIRONMENT_ID" --service "$LIVESAFE_SERVICE_ID"',
+    );
+    expect(workflow).toContain(
+      'scripts/livesafe-railway-smoke.sh "$TARGET_ENVIRONMENT"',
+    );
+  });
+
+  it("provides a bounded smoke probe script that never prints Railway variables", () => {
+    const script = readRepoFile("scripts/livesafe-railway-smoke.sh");
+
+    expect(script).toContain(
+      'railway service list --project "$RAILWAY_PROJECT_ID" --environment "$railway_environment_id" --json',
+    );
+    expect(script).toContain('railway_environment_id="3dc06fb6-c3df-4fe4-8807-0da0e62e4028"');
+    expect(script).toContain('railway_environment_id="a223bc12-fbe4-430f-abce-8e3ee7c9abd3"');
+    expect(script).toContain('railway_environment_id="1e5153e1-15f4-4447-bf7c-029af33927fb"');
+    expect(script).toContain("deadline_seconds=");
+    expect(script).toContain("while [ \"$SECONDS\" -lt \"$deadline_seconds\" ]; do");
+    expect(script).toContain("sleep 10");
+    expect(script).toContain('curl -fsS "$livesafe_url/api/health"');
+    expect(script).toContain('curl -fsS "$livesafe_url/api/trust/status"');
+    expect(script).toContain("public_claims_allowed == false");
+    expect(script).not.toContain("railway variable list");
+    expect(script).not.toContain("--kv");
+  });
+});

--- a/scripts/livesafe-railway-smoke.sh
+++ b/scripts/livesafe-railway-smoke.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+target_environment="${1:-}"
+RAILWAY_PROJECT_ID="${RAILWAY_PROJECT_ID:-372de75b-5f44-46c2-ab70-3c3185b5d81e}"
+
+case "$target_environment" in
+  development)
+    railway_environment_id="3dc06fb6-c3df-4fe4-8807-0da0e62e4028"
+    ;;
+  staging)
+    railway_environment_id="a223bc12-fbe4-430f-abce-8e3ee7c9abd3"
+    ;;
+  production)
+    railway_environment_id="1e5153e1-15f4-4447-bf7c-029af33927fb"
+    ;;
+  *)
+    printf 'usage: %s development|staging|production\n' "$0" >&2
+    exit 64
+    ;;
+esac
+
+deadline_seconds="${LIVESAFE_RAILWAY_SMOKE_TIMEOUT_SECONDS:-600}"
+services_json=""
+livesafe_url=""
+health_json=""
+trust_json=""
+
+while [ "$SECONDS" -lt "$deadline_seconds" ]; do
+  services_json="$(railway service list --project "$RAILWAY_PROJECT_ID" --environment "$railway_environment_id" --json)"
+
+  if printf '%s' "$services_json" | jq -e '
+    def named($name): any(.[]; .name == $name and .status == "SUCCESS");
+    named("livesafe") and named("exochain-node") and named("exochain-node-db") and named("Postgres")
+  ' >/dev/null; then
+    livesafe_url="$(printf '%s' "$services_json" | jq -r '.[] | select(.name == "livesafe") | .url // ""')"
+
+    if [ -n "$livesafe_url" ]; then
+      health_json="$(curl -fsS "$livesafe_url/api/health" || true)"
+      trust_json="$(curl -fsS "$livesafe_url/api/trust/status" || true)"
+
+      if printf '%s' "$health_json" | jq -e '
+        .status == "ok" and
+        .database == "connected" and
+        .exochain_connected == true
+      ' >/dev/null && printf '%s' "$trust_json" | jq -e '
+        .exochain_connected == true and
+        .verified_runtime_adapter == true and
+        .runtime_adapter_state == "verified" and
+        .public_claims_allowed == false
+      ' >/dev/null; then
+        printf 'LiveSafe %s Railway smoke passed for %s\n' "$target_environment" "$livesafe_url"
+        exit 0
+      fi
+    fi
+  fi
+
+  sleep 10
+done
+
+printf 'LiveSafe %s Railway smoke did not become ready before timeout.\n' "$target_environment" >&2
+exit 66


### PR DESCRIPTION
## Summary
- add an ID-pinned Railway promotion workflow for LiveSafe development, staging, and production
- make LiveSafe CI reusable, read-only, and deploy-secret-free, with Docker image build coverage
- record the ARMORCLOUD LiveSafe Railway project, environment IDs, service IDs, and public domains in a manifest
- add a bounded smoke probe that waits for Railway service success, /api/health, and /api/trust/status while keeping public trust claims fail-closed

## Path Classification
- Core runtime adapter / CI: .github/workflows/livesafe-ci.yml, .github/workflows/livesafe-railway-deploy.yml, scripts/livesafe-railway-smoke.sh
- Adjacent surface: livesafe/config/railway-environments.json, livesafe/tests/github-quality-workflow.test.ts, livesafe/tests/railway-cicd-baseline.test.ts
- EXOCHAIN core crates: unchanged

## Test Plan
- RED: npm test -- tests/railway-cicd-baseline.test.ts failed on missing explicit Railway IDs and name-based deploy/smoke wiring
- RED: npm test -- tests/github-quality-workflow.test.ts failed on missing workflow_call / Docker build coverage
- RED: npm test -- tests/github-quality-workflow.test.ts tests/railway-cicd-baseline.test.ts failed on missing reusable deploy prerequisite and bounded smoke polling
- GREEN: npm test -- tests/github-quality-workflow.test.ts tests/railway-cicd-baseline.test.ts
- npm run quality
- bash tools/test_github_actions_pinned.sh
- bash -n scripts/livesafe-railway-smoke.sh
- scripts/livesafe-railway-smoke.sh development
- scripts/livesafe-railway-smoke.sh production

## Runtime Notes
- development and production smoke probes pass
- staging LiveSafe and databases are successful; staging exochain-node duplicate deployment is still stopped/BUILDING in Railway and remains a launch blocker before staging promotion use
- Railway GitHub auto-deploy triggers must be disabled before this can be treated as a protected promotion model
- this PR does not authorize public EXOCHAIN trust claims; /api/trust/status must remain public_claims_allowed:false until the separate authorization PR lands
