### PR TITLE
Authorize LiveSafe public adapter output proof

### DIFF
--- a/crates/exo-avc/src/lib.rs
+++ b/crates/exo-avc/src/lib.rs
@@ -347,6 +347,7 @@ mod public_output_authorization_tests {
                 .expect("idempotency hash");
         let evidence_hash = h256(0xE1);
         let issued_at = ts(1_500_000);
+        let expires_at = ts(1_700_000);
         let action_commitment_hash =
             livesafe_public_adapter_output_authorization_action_commitment_hash(
                 &credential,
@@ -355,6 +356,7 @@ mod public_output_authorization_tests {
                 evidence_hash,
                 idempotency_key_hash,
                 &issued_at,
+                &expires_at,
             )
             .expect("action commitment");
         LivesafePublicAdapterOutputAuthorizationDraft {
@@ -367,7 +369,7 @@ mod public_output_authorization_tests {
             action_commitment_hash,
             idempotency_key_hash,
             issued_at,
-            expires_at: ts(1_700_000),
+            expires_at,
             signer_did: did("did:exo:public-output-proof-signer"),
         }
     }
@@ -490,6 +492,30 @@ mod public_output_authorization_tests {
     }
 
     #[test]
+    fn public_output_authorization_action_commitment_binds_expiry() {
+        let credential = issue_credential(livesafe_draft());
+        let base = draft_for(credential.clone());
+        let mut changed_expiry = draft_for(credential);
+        changed_expiry.expires_at = ts(1_800_000);
+        changed_expiry.action_commitment_hash =
+            livesafe_public_adapter_output_authorization_action_commitment_hash(
+                &changed_expiry.credential,
+                &changed_expiry.subject,
+                &changed_expiry.audience,
+                changed_expiry.evidence_hash,
+                changed_expiry.idempotency_key_hash,
+                &changed_expiry.issued_at,
+                &changed_expiry.expires_at,
+            )
+            .expect("changed-expiry commitment");
+
+        assert_ne!(
+            base.action_commitment_hash, changed_expiry.action_commitment_hash,
+            "public-output action commitment must bind expires_at"
+        );
+    }
+
+    #[test]
     fn public_output_authorization_payload_binds_public_claim_identity() {
         let credential = issue_credential(livesafe_draft());
         let base = sign_unchecked(draft_for(credential.clone()))
@@ -524,6 +550,7 @@ mod public_output_authorization_tests {
                         d.evidence_hash,
                         d.idempotency_key_hash,
                         &d.issued_at,
+                        &d.expires_at,
                     )
                     .expect("variant commitment");
                 d
@@ -531,6 +558,17 @@ mod public_output_authorization_tests {
             {
                 let mut d = draft_for(credential.clone());
                 d.expires_at = ts(1_800_000);
+                d.action_commitment_hash =
+                    livesafe_public_adapter_output_authorization_action_commitment_hash(
+                        &d.credential,
+                        &d.subject,
+                        &d.audience,
+                        d.evidence_hash,
+                        d.idempotency_key_hash,
+                        &d.issued_at,
+                        &d.expires_at,
+                    )
+                    .expect("variant commitment");
                 d
             },
             {
@@ -551,6 +589,7 @@ mod public_output_authorization_tests {
                         d.evidence_hash,
                         d.idempotency_key_hash,
                         &d.issued_at,
+                        &d.expires_at,
                     )
                     .expect("variant commitment");
                 d

--- a/crates/exo-avc/src/lib.rs
+++ b/crates/exo-avc/src/lib.rs
@@ -106,6 +106,7 @@
 pub mod credential;
 pub mod delegation;
 pub mod error;
+pub mod public_output_authorization;
 pub mod receipt;
 pub mod registry;
 pub mod revocation;
@@ -121,6 +122,21 @@ pub use credential::{
 };
 pub use delegation::{delegate_avc, parent_id_of};
 pub use error::AvcError;
+pub use public_output_authorization::{
+    LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+    LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN,
+    LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+    LivesafePublicAdapterOutputAuthorizationDraft,
+    LivesafePublicAdapterOutputAuthorizationEnvelope,
+    LivesafePublicAdapterOutputAuthorizationProof,
+    LivesafePublicAdapterOutputAuthorizationRevocationStatus,
+    livesafe_public_adapter_output_authorization_action_commitment_hash,
+    livesafe_public_adapter_output_authorization_action_request,
+    livesafe_public_adapter_output_authorization_idempotency_hash,
+    mint_livesafe_public_adapter_output_authorization_proof,
+    validate_livesafe_public_adapter_output_authorization,
+    verify_livesafe_public_adapter_output_authorization_proof,
+};
 pub use receipt::{
     AVC_RECEIPT_EVIDENCE_SUBJECT_DOMAIN, AVC_RECEIPT_EXTERNAL_TIMESTAMP_DOMAIN,
     AVC_RECEIPT_SIGNING_DOMAIN, AvcReceiptEvidenceSubject, AvcReceiptExternalTimestampProof,
@@ -151,6 +167,7 @@ pub const AVC_SIGNING_DOMAINS: &[&str] = &[
     AVC_ACTION_SIGNING_DOMAIN,
     AVC_CREDENTIAL_SIGNING_DOMAIN,
     AVC_HUMAN_APPROVAL_SIGNING_DOMAIN,
+    LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN,
     AVC_RECEIPT_EVIDENCE_SUBJECT_DOMAIN,
     AVC_RECEIPT_EXTERNAL_TIMESTAMP_DOMAIN,
     AVC_RECEIPT_SIGNING_DOMAIN,
@@ -184,6 +201,7 @@ mod hygiene_tests {
             include_str!("delegation.rs"),
             include_str!("error.rs"),
             include_str!("lib.rs"),
+            include_str!("public_output_authorization.rs"),
             include_str!("receipt.rs"),
             include_str!("registry.rs"),
             include_str!("revocation.rs"),
@@ -213,6 +231,7 @@ mod hygiene_tests {
             include_str!("delegation.rs"),
             include_str!("error.rs"),
             include_str!("lib.rs"),
+            include_str!("public_output_authorization.rs"),
             include_str!("receipt.rs"),
             include_str!("registry.rs"),
             include_str!("revocation.rs"),
@@ -226,6 +245,320 @@ mod hygiene_tests {
                     "AVC production sources must not contain `{token}`"
                 );
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod public_output_authorization_tests {
+    use exo_authority::permission::Permission;
+    use exo_core::{Did, Hash256, Timestamp, crypto::KeyPair};
+
+    use super::*;
+
+    const ISSUER_SEED: [u8; 32] = [0x11; 32];
+    const PROOF_SIGNER_SEED: [u8; 32] = [0x33; 32];
+
+    fn issuer_keypair() -> KeyPair {
+        KeyPair::from_secret_bytes(ISSUER_SEED).expect("valid issuer seed")
+    }
+
+    fn proof_signer_keypair() -> KeyPair {
+        KeyPair::from_secret_bytes(PROOF_SIGNER_SEED).expect("valid proof signer seed")
+    }
+
+    fn did(value: &str) -> Did {
+        Did::new(value).expect("valid DID")
+    }
+
+    fn ts(ms: u64) -> Timestamp {
+        Timestamp::new(ms, 0)
+    }
+
+    fn h256(byte: u8) -> Hash256 {
+        Hash256::from_bytes([byte; 32])
+    }
+
+    fn livesafe_draft() -> AvcDraft {
+        AvcDraft {
+            schema_version: AVC_SCHEMA_VERSION,
+            issuer_did: did("did:exo:livesafe-issuer"),
+            principal_did: did("did:exo:livesafe-issuer"),
+            subject_did: did("did:exo:livesafe-public-adapter"),
+            holder_did: None,
+            subject_kind: AvcSubjectKind::Service {
+                service_id: LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT.into(),
+            },
+            created_at: ts(1_000_000),
+            expires_at: Some(ts(2_000_000)),
+            delegated_intent: DelegatedIntent {
+                intent_id: h256(0xA1),
+                purpose: "Authorize narrow LiveSafe public adapter output".into(),
+                allowed_objectives: vec!["publish-redacted-trust-status".into()],
+                prohibited_objectives: vec![],
+                autonomy_level: AutonomyLevel::ExecuteWithinBounds,
+                delegation_allowed: false,
+            },
+            authority_scope: AuthorityScope {
+                permissions: vec![Permission::Read],
+                tools: vec![LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN.into()],
+                data_classes: vec![DataClass::Public],
+                counterparties: vec![],
+                jurisdictions: vec!["US".into()],
+            },
+            constraints: AvcConstraints {
+                allowed_time_window: Some(TimeWindow {
+                    not_before: ts(1_000_000),
+                    not_after: ts(2_000_000),
+                }),
+                ..AvcConstraints::permissive()
+            },
+            authority_chain: None,
+            consent_refs: vec![],
+            policy_refs: vec![],
+            parent_avc_id: None,
+        }
+    }
+
+    fn issue_credential(mut draft: AvcDraft) -> AutonomousVolitionCredential {
+        let issuer = issuer_keypair();
+        if draft.issuer_did != did("did:exo:livesafe-issuer") {
+            draft.issuer_did = did("did:exo:livesafe-issuer");
+            draft.principal_did = did("did:exo:livesafe-issuer");
+        }
+        issue_avc(draft, |bytes| issuer.sign(bytes)).expect("valid LiveSafe AVC")
+    }
+
+    fn registry_with_issuer(grant: Option<Vec<Permission>>) -> InMemoryAvcRegistry {
+        let mut registry = InMemoryAvcRegistry::new();
+        registry.put_public_key(did("did:exo:livesafe-issuer"), issuer_keypair().public);
+        if let Some(granted_permissions) = grant {
+            registry
+                .put_issuer_permission_grant(did("did:exo:livesafe-issuer"), granted_permissions);
+        }
+        registry
+    }
+
+    fn draft_for(
+        credential: AutonomousVolitionCredential,
+    ) -> LivesafePublicAdapterOutputAuthorizationDraft {
+        let idempotency_key_hash =
+            livesafe_public_adapter_output_authorization_idempotency_hash("idem-live-1")
+                .expect("idempotency hash");
+        let evidence_hash = h256(0xE1);
+        let issued_at = ts(1_500_000);
+        let action_commitment_hash =
+            livesafe_public_adapter_output_authorization_action_commitment_hash(
+                &credential,
+                LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+                LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+                evidence_hash,
+                idempotency_key_hash,
+                &issued_at,
+            )
+            .expect("action commitment");
+        LivesafePublicAdapterOutputAuthorizationDraft {
+            credential,
+            subject: LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT.into(),
+            audience: LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE.into(),
+            evidence_hash,
+            credential_id: None,
+            receipt_id: h256(0xC1),
+            action_commitment_hash,
+            idempotency_key_hash,
+            issued_at,
+            expires_at: ts(1_700_000),
+            signer_did: did("did:exo:public-output-proof-signer"),
+        }
+    }
+
+    fn mint(
+        draft: LivesafePublicAdapterOutputAuthorizationDraft,
+        registry: &InMemoryAvcRegistry,
+    ) -> Result<LivesafePublicAdapterOutputAuthorizationEnvelope, AvcError> {
+        mint_livesafe_public_adapter_output_authorization_proof(draft, registry, |bytes| {
+            proof_signer_keypair().sign(bytes)
+        })
+    }
+
+    fn sign_unchecked(
+        draft: LivesafePublicAdapterOutputAuthorizationDraft,
+    ) -> Result<LivesafePublicAdapterOutputAuthorizationEnvelope, AvcError> {
+        crate::public_output_authorization::sign_livesafe_public_adapter_output_authorization_proof_unchecked(
+            draft,
+            |bytes| proof_signer_keypair().sign(bytes),
+        )
+    }
+
+    #[test]
+    fn public_output_authorization_denies_missing_issuer_grant() {
+        let credential = issue_credential(livesafe_draft());
+        let registry = registry_with_issuer(None);
+
+        let error = mint(draft_for(credential), &registry).expect_err("missing issuer grant");
+
+        assert!(error.to_string().contains("issuer grant"));
+    }
+
+    #[test]
+    fn public_output_authorization_denies_grant_without_narrow_permission() {
+        let credential = issue_credential(livesafe_draft());
+        let registry = registry_with_issuer(Some(vec![Permission::Write]));
+
+        let error = mint(draft_for(credential), &registry).expect_err("missing Read grant");
+
+        assert!(error.to_string().contains("Permission::Read"));
+    }
+
+    #[test]
+    fn public_output_authorization_denies_expired_credential() {
+        let mut draft = livesafe_draft();
+        draft.expires_at = Some(ts(1_400_000));
+        let credential = issue_credential(draft);
+        let registry = registry_with_issuer(Some(vec![Permission::Read]));
+
+        let error = mint(draft_for(credential), &registry).expect_err("expired credential");
+
+        assert!(error.to_string().contains("Expired"));
+    }
+
+    #[test]
+    fn public_output_authorization_denies_revoked_credential() {
+        let credential = issue_credential(livesafe_draft());
+        let credential_id = credential.id().expect("credential id");
+        let mut registry = registry_with_issuer(Some(vec![Permission::Read]));
+        registry
+            .put_credential(credential.clone())
+            .expect("stored credential");
+        let revocation = revoke_avc(
+            credential_id,
+            did("did:exo:livesafe-issuer"),
+            AvcRevocationReason::IssuerRevoked,
+            ts(1_450_000),
+            |bytes| issuer_keypair().sign(bytes),
+        )
+        .expect("signed revocation");
+        registry
+            .put_revocation(revocation)
+            .expect("stored revocation");
+
+        let error = mint(draft_for(credential), &registry).expect_err("revoked credential");
+
+        assert!(error.to_string().contains("Revoked"));
+    }
+
+    #[test]
+    fn public_output_authorization_denies_non_livesafe_service_subject() {
+        let mut draft = livesafe_draft();
+        draft.subject_kind = AvcSubjectKind::Service {
+            service_id: "example.invalid".into(),
+        };
+        let credential = issue_credential(draft);
+        let registry = registry_with_issuer(Some(vec![Permission::Read]));
+
+        let error = mint(draft_for(credential), &registry).expect_err("wrong service subject");
+
+        assert!(error.to_string().contains("livesafe.ai"));
+    }
+
+    #[test]
+    fn public_output_authorization_denies_wrong_audience() {
+        let credential = issue_credential(livesafe_draft());
+        let registry = registry_with_issuer(Some(vec![Permission::Read]));
+        let mut draft = draft_for(credential);
+        draft.audience = "https://example.invalid/trust/status".into();
+
+        let error = mint(draft, &registry).expect_err("wrong audience");
+
+        assert!(error.to_string().contains("audience"));
+    }
+
+    #[test]
+    fn public_output_authorization_denies_tampered_evidence_hash_after_signing() {
+        let credential = issue_credential(livesafe_draft());
+        let registry = registry_with_issuer(Some(vec![Permission::Read]));
+        let mut envelope = mint(draft_for(credential), &registry).expect("mint proof");
+        envelope.proof.evidence_hash = h256(0xE2);
+
+        let error = verify_livesafe_public_adapter_output_authorization_proof(
+            &envelope.proof,
+            &proof_signer_keypair().public,
+        )
+        .expect_err("tampered proof rejected");
+
+        assert!(error.to_string().contains("signature"));
+    }
+
+    #[test]
+    fn public_output_authorization_payload_binds_public_claim_identity() {
+        let credential = issue_credential(livesafe_draft());
+        let base = sign_unchecked(draft_for(credential.clone()))
+            .expect("base proof")
+            .proof;
+
+        let mut changed_subject = draft_for(credential.clone());
+        changed_subject.subject = "example.invalid".into();
+        let changed_subject = sign_unchecked(changed_subject)
+            .expect("changed subject signed payload")
+            .proof;
+        assert_ne!(base.proof_hash, changed_subject.proof_hash);
+        assert_ne!(base.signature, changed_subject.signature);
+
+        let mut changed_audience = draft_for(credential.clone());
+        changed_audience.audience = "https://livesafe.ai/api/trust/status?variant=preview".into();
+        let changed_audience = sign_unchecked(changed_audience)
+            .expect("changed audience signed payload")
+            .proof;
+        assert_ne!(base.proof_hash, changed_audience.proof_hash);
+        assert_ne!(base.signature, changed_audience.signature);
+
+        for variant in [
+            {
+                let mut d = draft_for(credential.clone());
+                d.evidence_hash = h256(0xE3);
+                d.action_commitment_hash =
+                    livesafe_public_adapter_output_authorization_action_commitment_hash(
+                        &d.credential,
+                        &d.subject,
+                        &d.audience,
+                        d.evidence_hash,
+                        d.idempotency_key_hash,
+                        &d.issued_at,
+                    )
+                    .expect("variant commitment");
+                d
+            },
+            {
+                let mut d = draft_for(credential.clone());
+                d.expires_at = ts(1_800_000);
+                d
+            },
+            {
+                let mut altered = livesafe_draft();
+                altered.delegated_intent.intent_id = h256(0xA2);
+                draft_for(issue_credential(altered))
+            },
+            {
+                let mut d = draft_for(credential.clone());
+                d.idempotency_key_hash =
+                    livesafe_public_adapter_output_authorization_idempotency_hash("idem-live-2")
+                        .expect("idempotency hash");
+                d.action_commitment_hash =
+                    livesafe_public_adapter_output_authorization_action_commitment_hash(
+                        &d.credential,
+                        &d.subject,
+                        &d.audience,
+                        d.evidence_hash,
+                        d.idempotency_key_hash,
+                        &d.issued_at,
+                    )
+                    .expect("variant commitment");
+                d
+            },
+        ] {
+            let proof = sign_unchecked(variant).expect("variant proof").proof;
+            assert_ne!(base.proof_hash, proof.proof_hash);
+            assert_ne!(base.signature, proof.signature);
         }
     }
 }

--- a/crates/exo-avc/src/public_output_authorization.rs
+++ b/crates/exo-avc/src/public_output_authorization.rs
@@ -111,6 +111,7 @@ struct ActionNamePayload<'a> {
     audience: &'a str,
     evidence_hash: &'a Hash256,
     idempotency_key_hash: &'a Hash256,
+    expires_at: &'a Timestamp,
 }
 
 #[derive(Serialize)]
@@ -161,6 +162,7 @@ pub fn livesafe_public_adapter_output_authorization_action_request(
     audience: &str,
     evidence_hash: Hash256,
     idempotency_key_hash: Hash256,
+    expires_at: &Timestamp,
 ) -> Result<AvcActionRequest, AvcError> {
     let action_name_hash = hash_structured(&ActionNamePayload {
         domain: LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN,
@@ -168,6 +170,7 @@ pub fn livesafe_public_adapter_output_authorization_action_request(
         audience,
         evidence_hash: &evidence_hash,
         idempotency_key_hash: &idempotency_key_hash,
+        expires_at,
     })
     .map_err(AvcError::from)?;
     Ok(AvcActionRequest {
@@ -198,6 +201,7 @@ pub fn livesafe_public_adapter_output_authorization_action_commitment_hash(
     evidence_hash: Hash256,
     idempotency_key_hash: Hash256,
     issued_at: &Timestamp,
+    expires_at: &Timestamp,
 ) -> Result<Hash256, AvcError> {
     let action = livesafe_public_adapter_output_authorization_action_request(
         credential,
@@ -205,6 +209,7 @@ pub fn livesafe_public_adapter_output_authorization_action_commitment_hash(
         audience,
         evidence_hash,
         idempotency_key_hash,
+        expires_at,
     )?;
     avc_action_commitment_hash(credential, &action, issued_at)
 }
@@ -239,6 +244,7 @@ pub fn validate_livesafe_public_adapter_output_authorization<R: AvcRegistryRead>
         &draft.audience,
         draft.evidence_hash,
         draft.idempotency_key_hash,
+        &draft.expires_at,
     )?;
     let expected_action_commitment =
         avc_action_commitment_hash(&draft.credential, &action, &draft.issued_at)?;

--- a/crates/exo-avc/src/public_output_authorization.rs
+++ b/crates/exo-avc/src/public_output_authorization.rs
@@ -1,0 +1,503 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Narrow EXOCHAIN-core proof for LiveSafe public adapter output.
+//!
+//! This module is intentionally scoped to the LiveSafe public trust-status
+//! adapter. It never returns raw credential bytes, authority-chain internals,
+//! private keys, bearer tokens, or actor-signed request material.
+
+use exo_authority::permission::Permission;
+use exo_core::{Did, Hash256, PublicKey, Signature, Timestamp, crypto, hash::hash_structured};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    AvcRegistryRead,
+    credential::{AVC_SCHEMA_VERSION, AutonomousVolitionCredential, AvcSubjectKind, DataClass},
+    error::AvcError,
+    validation::{
+        AvcActionRequest, AvcDecision, AvcValidationRequest, AvcValidationResult,
+        avc_action_commitment_hash, validate_avc,
+    },
+};
+
+/// Canonical signing domain for LiveSafe public adapter-output authorization.
+pub const LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN: &str =
+    "livesafe.public_adapter_output_authorization.v1";
+/// The only public subject admitted by this proof surface.
+pub const LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT: &str = "livesafe.ai";
+/// The only public audience admitted by this proof surface.
+pub const LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE: &str =
+    "https://livesafe.ai/api/trust/status";
+const LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_ACTION_NAME: &str =
+    "livesafe.public_adapter_output_authorization";
+
+/// Redacted revocation state carried in the public proof.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LivesafePublicAdapterOutputAuthorizationRevocationStatus {
+    /// The backing AVC was not revoked at proof mint time.
+    NotRevoked,
+}
+
+/// Core minting draft. The raw AVC is consumed only for validation and
+/// content-addressed IDs; it is not returned in the public envelope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LivesafePublicAdapterOutputAuthorizationDraft {
+    pub credential: AutonomousVolitionCredential,
+    pub subject: String,
+    pub audience: String,
+    pub evidence_hash: Hash256,
+    pub credential_id: Option<Hash256>,
+    pub receipt_id: Hash256,
+    pub action_commitment_hash: Hash256,
+    pub idempotency_key_hash: Hash256,
+    pub issued_at: Timestamp,
+    pub expires_at: Timestamp,
+    pub signer_did: Did,
+}
+
+/// Redacted public proof. All authority and credential internals are replaced
+/// by canonical hashes and identifiers.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LivesafePublicAdapterOutputAuthorizationProof {
+    pub schema_version: u16,
+    pub domain: String,
+    pub subject: String,
+    pub audience: String,
+    pub evidence_hash: Hash256,
+    pub credential_id: Hash256,
+    pub receipt_id: Hash256,
+    pub action_commitment_hash: Hash256,
+    pub idempotency_key_hash: Hash256,
+    pub issued_at: Timestamp,
+    pub expires_at: Timestamp,
+    pub revocation_status: LivesafePublicAdapterOutputAuthorizationRevocationStatus,
+    pub signer_did: Did,
+    pub proof_hash: Hash256,
+    pub signature: Signature,
+}
+
+/// Public envelope returned by runtime adapters.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LivesafePublicAdapterOutputAuthorizationEnvelope {
+    pub schema_version: u16,
+    pub domain: String,
+    pub proof: LivesafePublicAdapterOutputAuthorizationProof,
+}
+
+#[derive(Serialize)]
+struct IdempotencyHashPayload<'a> {
+    domain: &'static str,
+    idempotency_key: &'a str,
+}
+
+#[derive(Serialize)]
+struct ActionNamePayload<'a> {
+    domain: &'static str,
+    subject: &'a str,
+    audience: &'a str,
+    evidence_hash: &'a Hash256,
+    idempotency_key_hash: &'a Hash256,
+}
+
+#[derive(Serialize)]
+struct ProofSigningPayload<'a> {
+    domain: &'static str,
+    schema_version: u16,
+    subject: &'a str,
+    audience: &'a str,
+    evidence_hash: &'a Hash256,
+    credential_id: &'a Hash256,
+    receipt_id: &'a Hash256,
+    action_commitment_hash: &'a Hash256,
+    idempotency_key_hash: &'a Hash256,
+    issued_at: &'a Timestamp,
+    expires_at: &'a Timestamp,
+    revocation_status: &'a LivesafePublicAdapterOutputAuthorizationRevocationStatus,
+    signer_did: &'a Did,
+}
+
+/// Deterministically hash a caller idempotency key without exposing the raw key
+/// in the public proof.
+///
+/// # Errors
+/// Returns [`AvcError::EmptyField`] when the key is blank.
+pub fn livesafe_public_adapter_output_authorization_idempotency_hash(
+    idempotency_key: &str,
+) -> Result<Hash256, AvcError> {
+    let trimmed = idempotency_key.trim();
+    if trimmed.is_empty() {
+        return Err(AvcError::EmptyField {
+            field: "public_output_authorization.idempotency_key",
+        });
+    }
+    hash_structured(&IdempotencyHashPayload {
+        domain: LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN,
+        idempotency_key: trimmed,
+    })
+    .map_err(AvcError::from)
+}
+
+/// Build the deterministic AVC action represented by a public-output proof.
+///
+/// # Errors
+/// Returns [`AvcError::Serialization`] if canonical action-name hashing fails.
+pub fn livesafe_public_adapter_output_authorization_action_request(
+    credential: &AutonomousVolitionCredential,
+    subject: &str,
+    audience: &str,
+    evidence_hash: Hash256,
+    idempotency_key_hash: Hash256,
+) -> Result<AvcActionRequest, AvcError> {
+    let action_name_hash = hash_structured(&ActionNamePayload {
+        domain: LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN,
+        subject,
+        audience,
+        evidence_hash: &evidence_hash,
+        idempotency_key_hash: &idempotency_key_hash,
+    })
+    .map_err(AvcError::from)?;
+    Ok(AvcActionRequest {
+        action_id: idempotency_key_hash,
+        actor_did: credential.effective_holder().clone(),
+        requested_permission: Permission::Read,
+        tool: Some(LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN.into()),
+        target_did: None,
+        data_class: Some(DataClass::Public),
+        estimated_budget_minor_units: None,
+        estimated_risk_bp: None,
+        human_approval: None,
+        requires_human_approval: false,
+        action_name: Some(format!(
+            "{LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_ACTION_NAME}:{action_name_hash}"
+        )),
+    })
+}
+
+/// Compute the AVC action commitment for a public-output authorization draft.
+///
+/// # Errors
+/// Returns [`AvcError::Serialization`] if canonical hashing fails.
+pub fn livesafe_public_adapter_output_authorization_action_commitment_hash(
+    credential: &AutonomousVolitionCredential,
+    subject: &str,
+    audience: &str,
+    evidence_hash: Hash256,
+    idempotency_key_hash: Hash256,
+    issued_at: &Timestamp,
+) -> Result<Hash256, AvcError> {
+    let action = livesafe_public_adapter_output_authorization_action_request(
+        credential,
+        subject,
+        audience,
+        evidence_hash,
+        idempotency_key_hash,
+    )?;
+    avc_action_commitment_hash(credential, &action, issued_at)
+}
+
+/// Validate the narrow LiveSafe public-output authorization and return the
+/// underlying AVC validation result for receipt anchoring.
+///
+/// # Errors
+/// Returns [`AvcError`] for any denied or malformed proof input.
+pub fn validate_livesafe_public_adapter_output_authorization<R: AvcRegistryRead>(
+    draft: &LivesafePublicAdapterOutputAuthorizationDraft,
+    registry: &R,
+) -> Result<AvcValidationResult, AvcError> {
+    validate_fixed_public_claim(draft)?;
+    let credential_id = draft.credential.id()?;
+    if let Some(expected) = draft.credential_id {
+        if expected != credential_id {
+            return Err(AvcError::InvalidInput {
+                reason: format!(
+                    "LiveSafe public adapter output credential_id {expected} does not match computed AVC id {credential_id}"
+                ),
+            });
+        }
+    }
+    validate_registered_issuer_grant(&draft.credential, registry)?;
+    validate_subject_kind(&draft.credential)?;
+    validate_expiry_bounds(draft)?;
+
+    let action = livesafe_public_adapter_output_authorization_action_request(
+        &draft.credential,
+        &draft.subject,
+        &draft.audience,
+        draft.evidence_hash,
+        draft.idempotency_key_hash,
+    )?;
+    let expected_action_commitment =
+        avc_action_commitment_hash(&draft.credential, &action, &draft.issued_at)?;
+    if expected_action_commitment != draft.action_commitment_hash {
+        return Err(AvcError::InvalidInput {
+            reason: format!(
+                "LiveSafe public adapter output action commitment mismatch: expected {expected_action_commitment}, got {}",
+                draft.action_commitment_hash
+            ),
+        });
+    }
+
+    let validation = validate_avc(
+        &AvcValidationRequest {
+            credential: draft.credential.clone(),
+            action: Some(action),
+            now: draft.issued_at,
+        },
+        registry,
+    )?;
+    if validation.decision != AvcDecision::Allow {
+        return Err(AvcError::InvalidInput {
+            reason: format!(
+                "LiveSafe public adapter output authorization denied: {:?}",
+                validation.reason_codes
+            ),
+        });
+    }
+    Ok(validation)
+}
+
+/// Mint a validated, redacted public proof envelope.
+///
+/// # Errors
+/// Returns [`AvcError`] when the draft is outside the narrow LiveSafe public
+/// adapter-output authorization contract or the backing AVC validation denies.
+pub fn mint_livesafe_public_adapter_output_authorization_proof<R, F>(
+    draft: LivesafePublicAdapterOutputAuthorizationDraft,
+    registry: &R,
+    sign: F,
+) -> Result<LivesafePublicAdapterOutputAuthorizationEnvelope, AvcError>
+where
+    R: AvcRegistryRead,
+    F: FnOnce(&[u8]) -> Signature,
+{
+    validate_livesafe_public_adapter_output_authorization(&draft, registry)?;
+    sign_livesafe_public_adapter_output_authorization_proof_unchecked(draft, sign)
+}
+
+pub(crate) fn sign_livesafe_public_adapter_output_authorization_proof_unchecked<F>(
+    draft: LivesafePublicAdapterOutputAuthorizationDraft,
+    sign: F,
+) -> Result<LivesafePublicAdapterOutputAuthorizationEnvelope, AvcError>
+where
+    F: FnOnce(&[u8]) -> Signature,
+{
+    let credential_id = draft.credential_id.unwrap_or(draft.credential.id()?);
+    let mut proof = LivesafePublicAdapterOutputAuthorizationProof {
+        schema_version: AVC_SCHEMA_VERSION,
+        domain: LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN.into(),
+        subject: draft.subject,
+        audience: draft.audience,
+        evidence_hash: draft.evidence_hash,
+        credential_id,
+        receipt_id: draft.receipt_id,
+        action_commitment_hash: draft.action_commitment_hash,
+        idempotency_key_hash: draft.idempotency_key_hash,
+        issued_at: draft.issued_at,
+        expires_at: draft.expires_at,
+        revocation_status: LivesafePublicAdapterOutputAuthorizationRevocationStatus::NotRevoked,
+        signer_did: draft.signer_did,
+        proof_hash: Hash256::ZERO,
+        signature: Signature::empty(),
+    };
+    let payload = proof.signing_payload()?;
+    proof.proof_hash = Hash256::digest(&payload);
+    proof.signature = sign(&payload);
+    Ok(LivesafePublicAdapterOutputAuthorizationEnvelope {
+        schema_version: AVC_SCHEMA_VERSION,
+        domain: LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN.into(),
+        proof,
+    })
+}
+
+/// Verify the redacted public proof against a signer public key.
+///
+/// # Errors
+/// Returns [`AvcError`] if fixed LiveSafe fields, proof hash, or signature
+/// verification fail.
+pub fn verify_livesafe_public_adapter_output_authorization_proof(
+    proof: &LivesafePublicAdapterOutputAuthorizationProof,
+    signer_public_key: &PublicKey,
+) -> Result<(), AvcError> {
+    validate_fixed_proof(proof)?;
+    let payload = proof.signing_payload()?;
+    let computed_hash = Hash256::digest(&payload);
+    if computed_hash != proof.proof_hash {
+        return Err(AvcError::InvalidInput {
+            reason: format!(
+                "LiveSafe public adapter output proof hash/signature mismatch: expected {computed_hash}, got {}",
+                proof.proof_hash
+            ),
+        });
+    }
+    if proof.signature.is_empty() || !crypto::verify(&payload, &proof.signature, signer_public_key)
+    {
+        return Err(AvcError::InvalidInput {
+            reason: "LiveSafe public adapter output proof signature is invalid".into(),
+        });
+    }
+    Ok(())
+}
+
+impl LivesafePublicAdapterOutputAuthorizationProof {
+    fn signing_payload(&self) -> Result<Vec<u8>, AvcError> {
+        let payload = ProofSigningPayload {
+            domain: LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN,
+            schema_version: self.schema_version,
+            subject: &self.subject,
+            audience: &self.audience,
+            evidence_hash: &self.evidence_hash,
+            credential_id: &self.credential_id,
+            receipt_id: &self.receipt_id,
+            action_commitment_hash: &self.action_commitment_hash,
+            idempotency_key_hash: &self.idempotency_key_hash,
+            issued_at: &self.issued_at,
+            expires_at: &self.expires_at,
+            revocation_status: &self.revocation_status,
+            signer_did: &self.signer_did,
+        };
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&payload, &mut buf)?;
+        Ok(buf)
+    }
+}
+
+fn validate_fixed_public_claim(
+    draft: &LivesafePublicAdapterOutputAuthorizationDraft,
+) -> Result<(), AvcError> {
+    if draft.subject != LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT {
+        return Err(AvcError::InvalidInput {
+            reason: format!(
+                "LiveSafe public adapter output subject must be exactly {}",
+                LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT
+            ),
+        });
+    }
+    if draft.audience != LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE {
+        return Err(AvcError::InvalidInput {
+            reason: format!(
+                "LiveSafe public adapter output audience must be exactly {}",
+                LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn validate_fixed_proof(
+    proof: &LivesafePublicAdapterOutputAuthorizationProof,
+) -> Result<(), AvcError> {
+    if proof.schema_version != AVC_SCHEMA_VERSION {
+        return Err(AvcError::UnsupportedSchema {
+            got: proof.schema_version,
+            supported: AVC_SCHEMA_VERSION,
+        });
+    }
+    if proof.domain != LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN {
+        return Err(AvcError::InvalidInput {
+            reason: "LiveSafe public adapter output proof domain is invalid".into(),
+        });
+    }
+    if proof.subject != LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT {
+        return Err(AvcError::InvalidInput {
+            reason: format!(
+                "LiveSafe public adapter output subject must be exactly {}",
+                LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT
+            ),
+        });
+    }
+    if proof.audience != LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE {
+        return Err(AvcError::InvalidInput {
+            reason: format!(
+                "LiveSafe public adapter output audience must be exactly {}",
+                LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE
+            ),
+        });
+    }
+    if proof.expires_at <= proof.issued_at {
+        return Err(AvcError::InvalidTimestamp {
+            reason: "LiveSafe public adapter output proof expires_at must be after issued_at"
+                .into(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_subject_kind(credential: &AutonomousVolitionCredential) -> Result<(), AvcError> {
+    match &credential.subject_kind {
+        AvcSubjectKind::Service { service_id }
+            if service_id == LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT =>
+        {
+            Ok(())
+        }
+        _ => Err(AvcError::InvalidInput {
+            reason: format!(
+                "LiveSafe public adapter output credential subject service must be exactly {}",
+                LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT
+            ),
+        }),
+    }
+}
+
+fn validate_expiry_bounds(
+    draft: &LivesafePublicAdapterOutputAuthorizationDraft,
+) -> Result<(), AvcError> {
+    if draft.expires_at <= draft.issued_at {
+        return Err(AvcError::InvalidTimestamp {
+            reason: "LiveSafe public adapter output proof expires_at must be after issued_at"
+                .into(),
+        });
+    }
+    if let Some(credential_expiry) = draft.credential.expires_at {
+        if credential_expiry <= draft.issued_at {
+            return Err(AvcError::InvalidInput {
+                reason: "LiveSafe public adapter output authorization denied: [Expired]".into(),
+            });
+        }
+        if draft.expires_at > credential_expiry {
+            return Err(AvcError::InvalidTimestamp {
+                reason: "LiveSafe public adapter output proof expires after its AVC credential"
+                    .into(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_registered_issuer_grant<R: AvcRegistryRead>(
+    credential: &AutonomousVolitionCredential,
+    registry: &R,
+) -> Result<(), AvcError> {
+    let Some(granted_permissions) =
+        registry.resolve_issuer_permission_grant(&credential.issuer_did)
+    else {
+        return Err(AvcError::InvalidInput {
+            reason: format!(
+                "LiveSafe public adapter output issuer grant is missing for {}",
+                credential.issuer_did
+            ),
+        });
+    };
+    if !granted_permissions.contains(&Permission::Read) {
+        return Err(AvcError::InvalidInput {
+            reason: format!(
+                "LiveSafe public adapter output issuer grant for {} lacks narrow Permission::Read",
+                credential.issuer_did
+            ),
+        });
+    }
+    Ok(())
+}

--- a/crates/exo-avc/src/registry.rs
+++ b/crates/exo-avc/src/registry.rs
@@ -821,6 +821,14 @@ impl InMemoryAvcRegistry {
         self.get_receipt_by_action_commitment_excluding(action_commitment_hash, Hash256::ZERO)
     }
 
+    #[must_use]
+    pub fn get_receipt_by_action_id(&self, action_id: &Hash256) -> Option<AvcTrustReceipt> {
+        self.receipts
+            .values()
+            .find(|receipt| receipt.action_id.as_ref() == Some(action_id))
+            .cloned()
+    }
+
     fn get_receipt_by_action_commitment_excluding(
         &self,
         action_commitment_hash: &Hash256,

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -2028,7 +2028,6 @@ pub struct PublicOutputAuthorizationRequest {
     pub audience: String,
     pub evidence_hash: Hash256,
     pub idempotency_key: String,
-    pub issued_at: Timestamp,
     pub expires_at: Timestamp,
 }
 
@@ -2713,8 +2712,8 @@ async fn handle_public_output_authorization(
     let subject = payload.subject;
     let audience = payload.audience;
     let evidence_hash = payload.evidence_hash;
-    let issued_at = payload.issued_at;
     let expires_at = payload.expires_at;
+    let state_for_clock = Arc::clone(&state);
 
     let envelope = with_registry_blocking(state, true, move |registry| {
         let credential = registry.get_credential(&credential_id).ok_or((
@@ -2729,18 +2728,18 @@ async fn handle_public_output_authorization(
             idempotency_key_hash,
         )
         .map_err(map_avc_error)?;
-        let action_commitment_hash =
-            livesafe_public_adapter_output_authorization_action_commitment_hash(
-                &credential,
-                &subject,
-                &audience,
-                evidence_hash,
-                idempotency_key_hash,
-                &issued_at,
-            )
-            .map_err(map_avc_error)?;
 
         if let Some(existing) = registry.get_receipt_by_action_id(&idempotency_key_hash) {
+            let action_commitment_hash =
+                livesafe_public_adapter_output_authorization_action_commitment_hash(
+                    &credential,
+                    &subject,
+                    &audience,
+                    evidence_hash,
+                    idempotency_key_hash,
+                    &existing.created_at,
+                )
+                .map_err(map_avc_error)?;
             if existing.credential_id != credential_id
                 || existing.action_commitment_hash != Some(action_commitment_hash)
             {
@@ -2758,7 +2757,7 @@ async fn handle_public_output_authorization(
                 receipt_id: existing.receipt_id,
                 action_commitment_hash,
                 idempotency_key_hash,
-                issued_at,
+                issued_at: existing.created_at,
                 expires_at,
                 signer_did: validator_did,
             };
@@ -2770,6 +2769,18 @@ async fn handle_public_output_authorization(
             .map_err(map_avc_error);
         }
 
+        let issued_at =
+            trusted_local_hlc_timestamp(&state_for_clock).map_err(local_hlc_timestamp_error)?;
+        let action_commitment_hash =
+            livesafe_public_adapter_output_authorization_action_commitment_hash(
+                &credential,
+                &subject,
+                &audience,
+                evidence_hash,
+                idempotency_key_hash,
+                &issued_at,
+            )
+            .map_err(map_avc_error)?;
         let action_descriptor = AvcActionDescriptor::from_action(&action);
         let previous_receipt_hash = registry.receipt_chain_head();
         let pre_receipt_draft = LivesafePublicAdapterOutputAuthorizationDraft {
@@ -2795,7 +2806,7 @@ async fn handle_public_output_authorization(
                 action_commitment_hash: Some(action_commitment_hash),
                 action_descriptor: Some(action_descriptor),
                 previous_receipt_hash,
-                timestamp_provenance: None,
+                timestamp_provenance: Some(AvcReceiptTimestampProvenance::LocalHybridLogicalClock),
                 external_timestamp_proof: None,
             },
             validator_did.clone(),
@@ -5672,11 +5683,23 @@ mod tests {
     }
 
     fn livesafe_public_output_credential() -> AutonomousVolitionCredential {
+        livesafe_public_output_credential_with_window(
+            Timestamp::new(1_000_000, 0),
+            Timestamp::new(2_000_000, 0),
+        )
+    }
+
+    fn livesafe_public_output_credential_with_window(
+        created_at: Timestamp,
+        expires_at: Timestamp,
+    ) -> AutonomousVolitionCredential {
         let mut draft = baseline_draft();
         draft.subject_did = Did::new("did:exo:livesafe-public-adapter").unwrap();
         draft.subject_kind = AvcSubjectKind::Service {
             service_id: exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT.into(),
         };
+        draft.created_at = created_at;
+        draft.expires_at = Some(expires_at);
         draft.delegated_intent.purpose = "Authorize narrow LiveSafe public adapter output".into();
         draft.delegated_intent.allowed_objectives = vec!["publish-redacted-trust-status".into()];
         draft.delegated_intent.autonomy_level = AutonomyLevel::ExecuteWithinBounds;
@@ -5716,7 +5739,6 @@ mod tests {
             audience: audience.into(),
             evidence_hash,
             idempotency_key: idempotency_key.into(),
-            issued_at: Timestamp::new(1_500_000, 0),
             expires_at: Timestamp::new(1_700_000, 0),
         }
     }
@@ -5724,6 +5746,15 @@ mod tests {
     async fn post_public_output_authorization(
         app: Router,
         request: PublicOutputAuthorizationRequest,
+        bearer: Option<&str>,
+    ) -> axum::response::Response {
+        post_public_output_authorization_json(app, serde_json::to_value(request).unwrap(), bearer)
+            .await
+    }
+
+    async fn post_public_output_authorization_json(
+        app: Router,
+        request: serde_json::Value,
         bearer: Option<&str>,
     ) -> axum::response::Response {
         let mut builder = Request::builder()
@@ -5794,6 +5825,126 @@ mod tests {
             !String::from_utf8(body).unwrap().contains("livesafe-issuer"),
             "redacted proof envelope must not return raw credential internals"
         );
+        assert_eq!(state.registry.lock().unwrap().receipt_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn public_output_authorization_uses_trusted_local_hlc_for_proof_and_receipt_time() {
+        let state = fresh_state();
+        let trusted_floor = trusted_local_hlc_timestamp(&state).unwrap();
+        let credential_id =
+            store_livesafe_public_output_credential(&state, livesafe_public_output_credential());
+        let app = avc_router_with_bearer_gate(Arc::clone(&state));
+        let caller_supplied_time = Timestamp::new(1_500_000, 0);
+        let request = serde_json::json!({
+            "credential_id": credential_id,
+            "subject": exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+            "audience": exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+            "evidence_hash": Hash256::from_bytes([0xD1; 32]),
+            "idempotency_key": "public-output-idem-trusted-hlc",
+            "issued_at": caller_supplied_time,
+            "expires_at": Timestamp::new(1_700_000, 0)
+        });
+
+        let response =
+            post_public_output_authorization_json(app, request, Some("vcg-006a-admin-token")).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let envelope: exo_avc::LivesafePublicAdapterOutputAuthorizationEnvelope =
+            serde_json::from_slice(&read_body(response).await).unwrap();
+        let receipt = state
+            .registry
+            .lock()
+            .unwrap()
+            .get_receipt(&envelope.proof.receipt_id)
+            .unwrap();
+        assert_ne!(envelope.proof.issued_at, caller_supplied_time);
+        assert!(
+            envelope.proof.issued_at > trusted_floor,
+            "public-output proof time must come from this node's trusted local HLC"
+        );
+        assert_eq!(receipt.created_at, envelope.proof.issued_at);
+    }
+
+    #[tokio::test]
+    async fn public_output_authorization_rejects_backdated_resurrection_of_expired_credential() {
+        let state = fresh_state();
+        let credential = livesafe_public_output_credential_with_window(
+            Timestamp::new(900_000, 0),
+            Timestamp::new(1_000_000, 0),
+        );
+        let credential_id = store_livesafe_public_output_credential(&state, credential);
+        let app = avc_router_with_bearer_gate(Arc::clone(&state));
+        let request = serde_json::json!({
+            "credential_id": credential_id,
+            "subject": exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+            "audience": exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+            "evidence_hash": Hash256::from_bytes([0xD2; 32]),
+            "idempotency_key": "public-output-idem-backdate-expired",
+            "issued_at": Timestamp::new(950_000, 0),
+            "expires_at": Timestamp::new(999_000, 0)
+        });
+
+        let response =
+            post_public_output_authorization_json(app, request, Some("vcg-006a-admin-token")).await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(state.registry.lock().unwrap().receipt_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn public_output_authorization_rejects_future_dated_premature_not_yet_valid_credential() {
+        let state = fresh_state();
+        let credential = livesafe_public_output_credential_with_window(
+            Timestamp::new(1_100_000, 0),
+            Timestamp::new(1_700_000, 0),
+        );
+        let credential_id = store_livesafe_public_output_credential(&state, credential);
+        let app = avc_router_with_bearer_gate(Arc::clone(&state));
+        let request = serde_json::json!({
+            "credential_id": credential_id,
+            "subject": exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+            "audience": exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+            "evidence_hash": Hash256::from_bytes([0xD3; 32]),
+            "idempotency_key": "public-output-idem-future-date-not-yet-valid",
+            "issued_at": Timestamp::new(1_200_000, 0),
+            "expires_at": Timestamp::new(1_500_000, 0)
+        });
+
+        let response =
+            post_public_output_authorization_json(app, request, Some("vcg-006a-admin-token")).await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(state.registry.lock().unwrap().receipt_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn public_output_authorization_replay_omits_caller_time_and_reuses_trusted_receipt() {
+        let state = fresh_state();
+        let credential_id =
+            store_livesafe_public_output_credential(&state, livesafe_public_output_credential());
+        let app = avc_router_with_bearer_gate(Arc::clone(&state));
+        let request = serde_json::json!({
+            "credential_id": credential_id,
+            "subject": exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+            "audience": exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+            "evidence_hash": Hash256::from_bytes([0xD4; 32]),
+            "idempotency_key": "public-output-idem-no-caller-time",
+            "expires_at": Timestamp::new(1_700_000, 0)
+        });
+
+        let first = post_public_output_authorization_json(
+            app.clone(),
+            request.clone(),
+            Some("vcg-006a-admin-token"),
+        )
+        .await;
+        let second =
+            post_public_output_authorization_json(app, request, Some("vcg-006a-admin-token")).await;
+
+        assert_eq!(first.status(), StatusCode::OK);
+        assert_eq!(second.status(), StatusCode::OK);
+        assert_eq!(read_body(first).await, read_body(second).await);
         assert_eq!(state.registry.lock().unwrap().receipt_count(), 1);
     }
 

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -2726,6 +2726,7 @@ async fn handle_public_output_authorization(
             &audience,
             evidence_hash,
             idempotency_key_hash,
+            &expires_at,
         )
         .map_err(map_avc_error)?;
 
@@ -2738,6 +2739,7 @@ async fn handle_public_output_authorization(
                     evidence_hash,
                     idempotency_key_hash,
                     &existing.created_at,
+                    &expires_at,
                 )
                 .map_err(map_avc_error)?;
             if existing.credential_id != credential_id
@@ -2779,6 +2781,7 @@ async fn handle_public_output_authorization(
                 evidence_hash,
                 idempotency_key_hash,
                 &issued_at,
+                &expires_at,
             )
             .map_err(map_avc_error)?;
         let action_descriptor = AvcActionDescriptor::from_action(&action);
@@ -5977,6 +5980,51 @@ mod tests {
             state.registry.lock().unwrap().receipt_count(),
             1,
             "same public-output authorization body must reuse the same receipt/proof"
+        );
+    }
+
+    #[tokio::test]
+    async fn public_output_authorization_conflicts_on_idempotency_key_reuse_with_changed_expiry() {
+        let state = fresh_state();
+        let credential_id =
+            store_livesafe_public_output_credential(&state, livesafe_public_output_credential());
+        let app = avc_router_with_bearer_gate(Arc::clone(&state));
+        let first_request = public_output_authorization_request(
+            credential_id,
+            "public-output-idem-expiry-conflict",
+            Hash256::from_bytes([0xE7; 32]),
+            exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+        );
+        let mut changed_expiry = first_request.clone();
+        changed_expiry.expires_at = Timestamp::new(1_800_000, 0);
+
+        let first = post_public_output_authorization(
+            app.clone(),
+            first_request,
+            Some("vcg-006a-admin-token"),
+        )
+        .await;
+        let first_body = read_body(first).await;
+        let first_proof: exo_avc::LivesafePublicAdapterOutputAuthorizationEnvelope =
+            serde_json::from_slice(&first_body).unwrap();
+        let changed =
+            post_public_output_authorization(app, changed_expiry, Some("vcg-006a-admin-token"))
+                .await;
+
+        assert_eq!(changed.status(), StatusCode::CONFLICT);
+        assert_eq!(
+            state.registry.lock().unwrap().receipt_count(),
+            1,
+            "changed expires_at under the same idempotency key must not mint a second proof/receipt"
+        );
+        assert!(
+            state
+                .registry
+                .lock()
+                .unwrap()
+                .get_receipt(&first_proof.proof.receipt_id)
+                .is_some(),
+            "original receipt must remain the only replay target"
         );
     }
 

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -30,6 +30,7 @@
 //! | `POST` | `/api/v1/avc/issue` | Register a signed credential. |
 //! | `POST` | `/api/v1/avc/validate` | Validate a credential and optional action. |
 //! | `POST` | `/api/v1/avc/receipts/emit` | Validate a subject-signed action and mint a node-signed receipt. |
+//! | `POST` | `/api/v1/avc/livesafe/public-adapter-output-authorization` | Mint/export the redacted LiveSafe public adapter-output authorization proof. |
 //! | `GET`  | `/api/v1/avc/receipts/:hash` | Fetch a stored AVC trust receipt by hash. |
 //! | `GET`  | `/api/v1/avc/receipts?actor=<did>&limit=N` | List stored AVC trust receipts for a subject DID. |
 //! | `GET`  | `/api/v1/avc/protocol` | Discover node AVC protocol compatibility metadata. |
@@ -69,9 +70,16 @@ use exo_avc::{
     AvcReceiptEvidenceSubject, AvcReceiptExternalTimestampProof, AvcReceiptRfc3161TimestampProof,
     AvcReceiptRfc3161TrustAnchorKind, AvcReceiptTimestampProvenance, AvcRegistryDurableState,
     AvcRegistryRead, AvcRegistryWrite, AvcRevocation, AvcTrustReceipt, AvcTrustReceiptEvidence,
-    AvcValidationRequest, AvcValidationResult, InMemoryAvcRegistry, avc_action_commitment_hash,
+    AvcValidationRequest, AvcValidationResult, InMemoryAvcRegistry,
+    LivesafePublicAdapterOutputAuthorizationDraft,
+    LivesafePublicAdapterOutputAuthorizationEnvelope, avc_action_commitment_hash,
     avc_action_descriptor_hash, avc_action_signature_payload, create_trust_receipt_with_evidence,
+    livesafe_public_adapter_output_authorization_action_commitment_hash,
+    livesafe_public_adapter_output_authorization_action_request,
+    livesafe_public_adapter_output_authorization_idempotency_hash,
+    mint_livesafe_public_adapter_output_authorization_proof,
     require_supported_avc_protocol_version, validate_avc,
+    validate_livesafe_public_adapter_output_authorization,
 };
 use exo_core::{
     Did, Hash256, PublicKey, Signature, Timestamp, crypto,
@@ -2013,6 +2021,17 @@ pub struct EmitReceiptResponse {
     pub validation: AvcValidationResult,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PublicOutputAuthorizationRequest {
+    pub credential_id: Hash256,
+    pub subject: String,
+    pub audience: String,
+    pub evidence_hash: Hash256,
+    pub idempotency_key: String,
+    pub issued_at: Timestamp,
+    pub expires_at: Timestamp,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ListAvcReceiptsResponse {
     pub did: String,
@@ -2681,6 +2700,133 @@ async fn handle_emit_receipt(
     Ok(Json(response))
 }
 
+async fn handle_public_output_authorization(
+    State(state): State<Arc<AvcApiState>>,
+    Json(payload): Json<PublicOutputAuthorizationRequest>,
+) -> ApiResult<Json<LivesafePublicAdapterOutputAuthorizationEnvelope>> {
+    let validator_did = state.validator_did.clone();
+    let receipt_signer = Arc::clone(&state.receipt_signer);
+    let idempotency_key_hash =
+        livesafe_public_adapter_output_authorization_idempotency_hash(&payload.idempotency_key)
+            .map_err(map_avc_error)?;
+    let credential_id = payload.credential_id;
+    let subject = payload.subject;
+    let audience = payload.audience;
+    let evidence_hash = payload.evidence_hash;
+    let issued_at = payload.issued_at;
+    let expires_at = payload.expires_at;
+
+    let envelope = with_registry_blocking(state, true, move |registry| {
+        let credential = registry.get_credential(&credential_id).ok_or((
+            StatusCode::NOT_FOUND,
+            "public output authorization credential is not registered".into(),
+        ))?;
+        let action = livesafe_public_adapter_output_authorization_action_request(
+            &credential,
+            &subject,
+            &audience,
+            evidence_hash,
+            idempotency_key_hash,
+        )
+        .map_err(map_avc_error)?;
+        let action_commitment_hash =
+            livesafe_public_adapter_output_authorization_action_commitment_hash(
+                &credential,
+                &subject,
+                &audience,
+                evidence_hash,
+                idempotency_key_hash,
+                &issued_at,
+            )
+            .map_err(map_avc_error)?;
+
+        if let Some(existing) = registry.get_receipt_by_action_id(&idempotency_key_hash) {
+            if existing.credential_id != credential_id
+                || existing.action_commitment_hash != Some(action_commitment_hash)
+            {
+                return Err((
+                    StatusCode::CONFLICT,
+                    "public output authorization idempotency key conflict".into(),
+                ));
+            }
+            let draft = LivesafePublicAdapterOutputAuthorizationDraft {
+                credential,
+                subject,
+                audience,
+                evidence_hash,
+                credential_id: Some(credential_id),
+                receipt_id: existing.receipt_id,
+                action_commitment_hash,
+                idempotency_key_hash,
+                issued_at,
+                expires_at,
+                signer_did: validator_did,
+            };
+            return mint_livesafe_public_adapter_output_authorization_proof(
+                draft,
+                registry,
+                |bytes| (receipt_signer)(bytes),
+            )
+            .map_err(map_avc_error);
+        }
+
+        let action_descriptor = AvcActionDescriptor::from_action(&action);
+        let previous_receipt_hash = registry.receipt_chain_head();
+        let pre_receipt_draft = LivesafePublicAdapterOutputAuthorizationDraft {
+            credential: credential.clone(),
+            subject: subject.clone(),
+            audience: audience.clone(),
+            evidence_hash,
+            credential_id: Some(credential_id),
+            receipt_id: Hash256::ZERO,
+            action_commitment_hash,
+            idempotency_key_hash,
+            issued_at,
+            expires_at,
+            signer_did: validator_did.clone(),
+        };
+        let validation =
+            validate_livesafe_public_adapter_output_authorization(&pre_receipt_draft, registry)
+                .map_err(map_avc_error)?;
+        let receipt = create_trust_receipt_with_evidence(
+            &validation,
+            Some(action.action_id),
+            AvcTrustReceiptEvidence {
+                action_commitment_hash: Some(action_commitment_hash),
+                action_descriptor: Some(action_descriptor),
+                previous_receipt_hash,
+                timestamp_provenance: None,
+                external_timestamp_proof: None,
+            },
+            validator_did.clone(),
+            issued_at,
+            |bytes| (receipt_signer)(bytes),
+        )
+        .map_err(map_avc_error)?;
+        store_receipt_idempotent(registry, receipt.clone())?;
+
+        let draft = LivesafePublicAdapterOutputAuthorizationDraft {
+            credential,
+            subject,
+            audience,
+            evidence_hash,
+            credential_id: Some(credential_id),
+            receipt_id: receipt.receipt_id,
+            action_commitment_hash,
+            idempotency_key_hash,
+            issued_at,
+            expires_at,
+            signer_did: validator_did,
+        };
+        mint_livesafe_public_adapter_output_authorization_proof(draft, registry, |bytes| {
+            (receipt_signer)(bytes)
+        })
+        .map_err(map_avc_error)
+    })
+    .await?;
+    Ok(Json(envelope))
+}
+
 async fn handle_get_receipt(
     State(state): State<Arc<AvcApiState>>,
     Path(id): Path<String>,
@@ -3008,6 +3154,10 @@ pub fn avc_router(state: Arc<AvcApiState>) -> Router {
         .route("/api/v1/avc/issue", post(handle_issue))
         .route("/api/v1/avc/validate", post(handle_validate))
         .route("/api/v1/avc/receipts/emit", post(handle_emit_receipt))
+        .route(
+            "/api/v1/avc/livesafe/public-adapter-output-authorization",
+            post(handle_public_output_authorization),
+        )
         .route("/api/v1/avc/receipts", get(handle_list_receipts))
         .route("/api/v1/avc/receipts/:hash", get(handle_get_receipt))
         .route("/api/v1/avc/protocol", get(handle_protocol_info))
@@ -5519,6 +5669,248 @@ mod tests {
             1,
             "identical receipt emission requests must remain idempotent"
         );
+    }
+
+    fn livesafe_public_output_credential() -> AutonomousVolitionCredential {
+        let mut draft = baseline_draft();
+        draft.subject_did = Did::new("did:exo:livesafe-public-adapter").unwrap();
+        draft.subject_kind = AvcSubjectKind::Service {
+            service_id: exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT.into(),
+        };
+        draft.delegated_intent.purpose = "Authorize narrow LiveSafe public adapter output".into();
+        draft.delegated_intent.allowed_objectives = vec!["publish-redacted-trust-status".into()];
+        draft.delegated_intent.autonomy_level = AutonomyLevel::ExecuteWithinBounds;
+        draft.authority_scope = AuthorityScope {
+            permissions: vec![Permission::Read],
+            tools: vec![exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN.into()],
+            data_classes: vec![exo_avc::DataClass::Public],
+            counterparties: vec![],
+            jurisdictions: vec!["US".into()],
+        };
+        issue_avc(draft, |bytes| issuer_keypair().sign(bytes)).unwrap()
+    }
+
+    fn store_livesafe_public_output_credential(
+        state: &AvcApiState,
+        credential: AutonomousVolitionCredential,
+    ) -> Hash256 {
+        let credential_id = credential.id().unwrap();
+        let mut registry = state.registry.lock().unwrap();
+        registry.put_issuer_permission_grant(
+            Did::new("did:exo:issuer").unwrap(),
+            vec![Permission::Read],
+        );
+        registry.put_credential(credential).unwrap();
+        credential_id
+    }
+
+    fn public_output_authorization_request(
+        credential_id: Hash256,
+        idempotency_key: &str,
+        evidence_hash: Hash256,
+        audience: &str,
+    ) -> PublicOutputAuthorizationRequest {
+        PublicOutputAuthorizationRequest {
+            credential_id,
+            subject: exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT.into(),
+            audience: audience.into(),
+            evidence_hash,
+            idempotency_key: idempotency_key.into(),
+            issued_at: Timestamp::new(1_500_000, 0),
+            expires_at: Timestamp::new(1_700_000, 0),
+        }
+    }
+
+    async fn post_public_output_authorization(
+        app: Router,
+        request: PublicOutputAuthorizationRequest,
+        bearer: Option<&str>,
+    ) -> axum::response::Response {
+        let mut builder = Request::builder()
+            .method(Method::POST)
+            .uri("/api/v1/avc/livesafe/public-adapter-output-authorization")
+            .header("content-type", "application/json");
+        if let Some(token) = bearer {
+            builder = builder.header("authorization", format!("Bearer {token}"));
+        }
+        app.oneshot(
+            builder
+                .body(Body::from(serde_json::to_vec(&request).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn public_output_authorization_bearer_required() {
+        let state = fresh_state();
+        let credential_id =
+            store_livesafe_public_output_credential(&state, livesafe_public_output_credential());
+        let app = avc_router_with_bearer_gate(Arc::clone(&state));
+        let request = public_output_authorization_request(
+            credential_id,
+            "public-output-idem-1",
+            Hash256::from_bytes([0xE1; 32]),
+            exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+        );
+
+        let response = post_public_output_authorization(app, request, None).await;
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(state.registry.lock().unwrap().receipt_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn public_output_authorization_exports_redacted_proof_happy_path() {
+        let state = fresh_state();
+        let credential_id =
+            store_livesafe_public_output_credential(&state, livesafe_public_output_credential());
+        let app = avc_router_with_bearer_gate(Arc::clone(&state));
+        let request = public_output_authorization_request(
+            credential_id,
+            "public-output-idem-2",
+            Hash256::from_bytes([0xE2; 32]),
+            exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+        );
+
+        let response =
+            post_public_output_authorization(app, request, Some("vcg-006a-admin-token")).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = read_body(response).await;
+        let envelope: exo_avc::LivesafePublicAdapterOutputAuthorizationEnvelope =
+            serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            envelope.proof.subject,
+            exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT
+        );
+        assert_eq!(
+            envelope.proof.audience,
+            exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE
+        );
+        assert_eq!(envelope.proof.credential_id, credential_id);
+        assert!(
+            !String::from_utf8(body).unwrap().contains("livesafe-issuer"),
+            "redacted proof envelope must not return raw credential internals"
+        );
+        assert_eq!(state.registry.lock().unwrap().receipt_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn public_output_authorization_replay_same_body_returns_same_proof() {
+        let state = fresh_state();
+        let credential_id =
+            store_livesafe_public_output_credential(&state, livesafe_public_output_credential());
+        let app = avc_router_with_bearer_gate(Arc::clone(&state));
+        let request = public_output_authorization_request(
+            credential_id,
+            "public-output-idem-3",
+            Hash256::from_bytes([0xE3; 32]),
+            exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+        );
+
+        let first = post_public_output_authorization(
+            app.clone(),
+            request.clone(),
+            Some("vcg-006a-admin-token"),
+        )
+        .await;
+        let second =
+            post_public_output_authorization(app, request, Some("vcg-006a-admin-token")).await;
+
+        assert_eq!(first.status(), StatusCode::OK);
+        assert_eq!(second.status(), StatusCode::OK);
+        assert_eq!(read_body(first).await, read_body(second).await);
+        assert_eq!(
+            state.registry.lock().unwrap().receipt_count(),
+            1,
+            "same public-output authorization body must reuse the same receipt/proof"
+        );
+    }
+
+    #[tokio::test]
+    async fn public_output_authorization_conflicts_on_idempotency_key_reuse() {
+        let state = fresh_state();
+        let credential_id =
+            store_livesafe_public_output_credential(&state, livesafe_public_output_credential());
+        let app = avc_router_with_bearer_gate(Arc::clone(&state));
+        let first_request = public_output_authorization_request(
+            credential_id,
+            "public-output-idem-4",
+            Hash256::from_bytes([0xE4; 32]),
+            exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+        );
+        let changed_evidence = public_output_authorization_request(
+            credential_id,
+            "public-output-idem-4",
+            Hash256::from_bytes([0xE5; 32]),
+            exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+        );
+        let changed_audience = public_output_authorization_request(
+            credential_id,
+            "public-output-idem-4",
+            Hash256::from_bytes([0xE4; 32]),
+            "https://example.invalid/api/trust/status",
+        );
+
+        let first = post_public_output_authorization(
+            app.clone(),
+            first_request,
+            Some("vcg-006a-admin-token"),
+        )
+        .await;
+        let evidence_conflict = post_public_output_authorization(
+            app.clone(),
+            changed_evidence,
+            Some("vcg-006a-admin-token"),
+        )
+        .await;
+        let audience_conflict =
+            post_public_output_authorization(app, changed_audience, Some("vcg-006a-admin-token"))
+                .await;
+
+        assert_eq!(first.status(), StatusCode::OK);
+        assert_eq!(evidence_conflict.status(), StatusCode::CONFLICT);
+        assert_eq!(audience_conflict.status(), StatusCode::CONFLICT);
+        assert_eq!(state.registry.lock().unwrap().receipt_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn public_output_authorization_is_not_receipts_emit_subject_signature_carve_out() {
+        let state = fresh_state();
+        let credential_id =
+            store_livesafe_public_output_credential(&state, livesafe_public_output_credential());
+        let app = avc_router_with_bearer_gate(Arc::clone(&state));
+        let request = serde_json::json!({
+            "credential_id": credential_id,
+            "subject": exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+            "audience": exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+            "evidence_hash": Hash256::from_bytes([0xE6; 32]),
+            "idempotency_key": "public-output-idem-5",
+            "issued_at": Timestamp::new(1_500_000, 0),
+            "expires_at": Timestamp::new(1_700_000, 0),
+            "subject_signature": Signature::from_bytes([0x7A; 64])
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/avc/livesafe/public-adapter-output-authorization")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&request).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "only /api/v1/avc/receipts/emit may use the subject-signature carve-out"
+        );
+        assert_eq!(state.registry.lock().unwrap().receipt_count(), 0);
     }
 
     #[tokio::test]

--- a/crates/exochain-sdk/src/avc.rs
+++ b/crates/exochain-sdk/src/avc.rs
@@ -38,6 +38,43 @@ pub use exo_avc::{
     AvcDraft, AvcError, AvcReasonCode, AvcRegistryRead, AvcRegistryWrite, AvcRevocation,
     AvcRevocationReason, AvcSubjectKind, AvcTrustReceipt, AvcValidationRequest,
     AvcValidationResult, ConsentRef, DataClass, DelegatedIntent, InMemoryAvcRegistry,
-    MAX_BASIS_POINTS, PolicyRef, TimeWindow, create_trust_receipt, delegate_avc, issue_avc,
-    parent_id_of, revoke_avc, validate_avc,
+    LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+    LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN,
+    LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+    LivesafePublicAdapterOutputAuthorizationDraft,
+    LivesafePublicAdapterOutputAuthorizationEnvelope,
+    LivesafePublicAdapterOutputAuthorizationProof,
+    LivesafePublicAdapterOutputAuthorizationRevocationStatus, MAX_BASIS_POINTS, PolicyRef,
+    TimeWindow, create_trust_receipt, delegate_avc, issue_avc,
+    livesafe_public_adapter_output_authorization_action_commitment_hash,
+    livesafe_public_adapter_output_authorization_action_request,
+    livesafe_public_adapter_output_authorization_idempotency_hash,
+    mint_livesafe_public_adapter_output_authorization_proof, parent_id_of, revoke_avc,
+    validate_avc, validate_livesafe_public_adapter_output_authorization,
+    verify_livesafe_public_adapter_output_authorization_proof,
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn public_output_authorization_reexports_core_proof_surface() {
+        assert_eq!(
+            LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN,
+            "livesafe.public_adapter_output_authorization.v1"
+        );
+        assert_eq!(
+            LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+            "livesafe.ai"
+        );
+        assert_eq!(
+            LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+            "https://livesafe.ai/api/trust/status"
+        );
+        let _: Option<LivesafePublicAdapterOutputAuthorizationDraft> = None;
+        let _: Option<LivesafePublicAdapterOutputAuthorizationEnvelope> = None;
+        let _: Option<LivesafePublicAdapterOutputAuthorizationProof> = None;
+        let _: Option<LivesafePublicAdapterOutputAuthorizationRevocationStatus> = None;
+    }
+}


### PR DESCRIPTION
## Summary

Adds the narrow EXOCHAIN core proof source for `livesafe.public_adapter_output_authorization.v1`.

This PR authorizes only LiveSafe public adapter-output status metadata. It does not authorize medical, legal, custody, consent, emergency, identity, revocation, or broad constitutional trust claims.

## Path Classification

- `crates/exo-avc/src/public_output_authorization.rs` — EXOCHAIN core proof surface.
- `crates/exo-avc/src/lib.rs` — EXOCHAIN core export/signing-domain registration and focused tests.
- `crates/exo-avc/src/registry.rs` — EXOCHAIN core registry read helper for receipt idempotency.
- `crates/exo-node/src/avc.rs` — Core runtime adapter REST route under existing AVC bearer write guard.
- `crates/exochain-sdk/src/avc.rs` — SDK re-export of the narrow proof DTO/helpers.

## Contract

- Adds bearer-gated `POST /api/v1/avc/livesafe/public-adapter-output-authorization`.
- Requires registered credential, issuer Read cap, exact LiveSafe service subject, exact trust-status audience, evidence hash, idempotency key, bounded expiry, non-revoked credential, and AVC validation allow.
- Uses trusted node HLC for proof/receipt issue time; caller-supplied `issued_at` is not part of the typed request and cannot backdate/future-date validation.
- Binds `expires_at` into the deterministic action commitment so idempotent replay cannot re-sign a different expiry over the same receipt.
- Returns a redacted proof envelope only: ids, hashes, signer DID, timestamps, revocation status, proof hash/signature. No raw credential bytes, bearer tokens, private keys, or authority-chain internals.

## RED Evidence

- `cargo test -p exochain-avc public_output_authorization -- --nocapture` initially failed on missing proof DTO/helper and later proved changed expiry did not alter commitment.
- `cargo test -p exochain-node public_output_authorization -- --nocapture` initially failed on missing route/auth, then caught caller-controlled `issued_at`, backdated/future-dated validation, and changed-expiry replay returning `200` instead of `409`.
- `cargo test -p exochain-sdk public_output_authorization -- --nocapture` initially failed on missing SDK re-export.

## GREEN Evidence

Post-rebase on `origin/main` (`73d22951`):

- `cargo test -p exochain-node public_output_authorization -- --nocapture` — 10 passed.
- `cargo test -p exochain-avc public_output_authorization -- --nocapture` — 9 passed.
- `cargo test -p exochain-sdk public_output_authorization -- --nocapture` — 1 passed.
- `cargo test -p exochain-node avc_receipts_emit -- --nocapture` — 2 passed.
- `cargo test -p exochain-node bearer -- --nocapture` — 12 passed.
- `cargo +nightly fmt --all -- --check` — passed.
- `cargo clippy -p exochain-avc -p exochain-node -p exochain-sdk --all-targets -- -D warnings` — passed.
- `git diff --check` — passed.

## Merge Gate

Full EXOCHAIN Constitutional CI must be green before merge.
