### PR TITLE
ci(livesafe): use environment Railway deploy tokens

### DIFF
--- a/.github/workflows/livesafe-railway-deploy.yml
+++ b/.github/workflows/livesafe-railway-deploy.yml
@@ -66,6 +66,8 @@ jobs:
     needs: verify-livesafe
     runs-on: ubuntu-latest
     environment: livesafe-development
+    env:
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_DEVELOPMENT_TOKEN }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
@@ -74,18 +76,12 @@ jobs:
       - name: Install Railway CLI
         run: npm install -g @railway/cli@4.65.0
       - name: Deploy exochain-node to development
-        env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
           railway up . --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_DEVELOPMENT_ENVIRONMENT_ID" --service "$EXOCHAIN_NODE_SERVICE_ID" --detach --json -m "development exochain-node ${GITHUB_SHA}"
       - name: Deploy livesafe to development
-        env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
           railway up livesafe --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_DEVELOPMENT_ENVIRONMENT_ID" --service "$LIVESAFE_SERVICE_ID" --detach --json -m "development livesafe ${GITHUB_SHA}"
       - name: Smoke development
-        env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: scripts/livesafe-railway-smoke.sh "development"
 
   deploy-staging:
@@ -95,6 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: livesafe-staging
     env:
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_STAGING_TOKEN }}
       TARGET_ENVIRONMENT: staging
       TARGET_ENVIRONMENT_ID: a223bc12-fbe4-430f-abce-8e3ee7c9abd3
     steps:
@@ -107,18 +104,12 @@ jobs:
       - name: Install Railway CLI
         run: npm install -g @railway/cli@4.65.0
       - name: Promote exochain-node
-        env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
           railway up . --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$TARGET_ENVIRONMENT_ID" --service "$EXOCHAIN_NODE_SERVICE_ID" --detach --json -m "${TARGET_ENVIRONMENT} exochain-node ${GITHUB_SHA}"
       - name: Promote livesafe
-        env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
           railway up livesafe --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$TARGET_ENVIRONMENT_ID" --service "$LIVESAFE_SERVICE_ID" --detach --json -m "${TARGET_ENVIRONMENT} livesafe ${GITHUB_SHA}"
       - name: Smoke staging
-        env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: scripts/livesafe-railway-smoke.sh "$TARGET_ENVIRONMENT"
 
   deploy-production:
@@ -128,6 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: livesafe-production
     env:
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_TOKEN }}
       TARGET_ENVIRONMENT: production
       TARGET_ENVIRONMENT_ID: 1e5153e1-15f4-4447-bf7c-029af33927fb
     steps:
@@ -140,16 +132,10 @@ jobs:
       - name: Install Railway CLI
         run: npm install -g @railway/cli@4.65.0
       - name: Promote exochain-node
-        env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
           railway up . --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$TARGET_ENVIRONMENT_ID" --service "$EXOCHAIN_NODE_SERVICE_ID" --detach --json -m "${TARGET_ENVIRONMENT} exochain-node ${GITHUB_SHA}"
       - name: Promote livesafe
-        env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
           railway up livesafe --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$TARGET_ENVIRONMENT_ID" --service "$LIVESAFE_SERVICE_ID" --detach --json -m "${TARGET_ENVIRONMENT} livesafe ${GITHUB_SHA}"
       - name: Smoke production
-        env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: scripts/livesafe-railway-smoke.sh "$TARGET_ENVIRONMENT"

--- a/livesafe/tests/railway-cicd-baseline.test.ts
+++ b/livesafe/tests/railway-cicd-baseline.test.ts
@@ -12,6 +12,40 @@ function readRepoFile(relativePath: string): string {
   return readFileSync(absolutePath, "utf8");
 }
 
+function readWorkflowJob(workflow: string, jobId: string): string {
+  const jobStart = workflow.indexOf(`  ${jobId}:\n`);
+
+  expect(jobStart, `${jobId} job should exist`).toBeGreaterThanOrEqual(0);
+
+  const afterJobStart = jobStart + 1;
+  const nextJobMatch = workflow.slice(afterJobStart).match(/\n  [a-z0-9-]+:\n/);
+  const jobEnd = nextJobMatch?.index;
+
+  if (jobEnd === undefined) {
+    return workflow.slice(jobStart);
+  }
+
+  return workflow.slice(jobStart, afterJobStart + jobEnd);
+}
+
+function expectRailwayAuthSecret(
+  workflow: string,
+  jobId: string,
+  secretName: string,
+): void {
+  const job = readWorkflowJob(workflow, jobId);
+
+  expect(job, `${jobId} should use ${secretName} for Railway auth`).toContain(
+    `RAILWAY_TOKEN: \${{ secrets.${secretName} }}`,
+  );
+  expect(job, `${jobId} must not use the stale global Railway token`).not.toContain(
+    "secrets.RAILWAY_TOKEN",
+  );
+  expect(job, `${jobId} must not require a Railway API token fallback`).not.toContain(
+    "secrets.RAILWAY_API_TOKEN",
+  );
+}
+
 describe("LiveSafe Railway CI/CD baseline", () => {
   it("declares the ARMORCLOUD LiveSafe project environments and service names without secrets", () => {
     const manifest = JSON.parse(
@@ -75,10 +109,20 @@ describe("LiveSafe Railway CI/CD baseline", () => {
     expect(workflow).toContain(
       "LIVESAFE_SERVICE_ID: 8ed3bd1a-f872-4e22-9a39-ac38953fae26",
     );
-    expect(workflow).toContain("secrets.RAILWAY_TOKEN");
     expect(workflow).toContain("environment: livesafe-development");
     expect(workflow).toContain("environment: livesafe-staging");
     expect(workflow).toContain("environment: livesafe-production");
+    expectRailwayAuthSecret(
+      workflow,
+      "deploy-development",
+      "RAILWAY_DEVELOPMENT_TOKEN",
+    );
+    expectRailwayAuthSecret(workflow, "deploy-staging", "RAILWAY_STAGING_TOKEN");
+    expectRailwayAuthSecret(
+      workflow,
+      "deploy-production",
+      "RAILWAY_PRODUCTION_TOKEN",
+    );
     expect(workflow).toContain("verify-livesafe:");
     expect(workflow).toContain("uses: ./.github/workflows/livesafe-ci.yml");
     expect(workflow).toContain("commit_sha: ${{ inputs.commit_sha || github.sha }}");


### PR DESCRIPTION
## Summary
- Adds a RED/GREEN guard that each LiveSafe Railway deploy job uses its environment-specific Railway secret.
- Moves Railway CLI authentication to job-level `RAILWAY_TOKEN` env values sourced from `RAILWAY_DEVELOPMENT_TOKEN`, `RAILWAY_STAGING_TOKEN`, and `RAILWAY_PRODUCTION_TOKEN`.
- Removes stale global `secrets.RAILWAY_TOKEN` usage from LiveSafe development, staging, and production deploy jobs.

## Path Classification
- `.github/workflows/livesafe-railway-deploy.yml` — Core runtime adapter / CI-deploy workflow for the EXOCHAIN-authorized LiveSafe launch; only Railway token selection changed.
- `livesafe/tests/railway-cicd-baseline.test.ts` — Adjacent surface CI/deploy workflow regression test for LiveSafe deployment guardrails.

## Core Regression Firewall
- No `crates/`, `packages/exochain-wasm/`, `governance/`, core runtime logic, proof code, LiveSafe adapter code, or UI files changed.
- Main push behavior remains development-only.
- Staging and production promotion remain `workflow_dispatch` gated with GitHub environments.
- Explicit Railway project, environment, and service IDs are unchanged.
- Secret values are not printed or surfaced.

## Test Plan
- RED: `cd livesafe && npm test -- tests/railway-cicd-baseline.test.ts` failed before the workflow change because `deploy-development` did not contain `RAILWAY_TOKEN: ${{ secrets.RAILWAY_DEVELOPMENT_TOKEN }}` and still referenced `secrets.RAILWAY_TOKEN`.
- GREEN: `cd livesafe && npm test -- tests/railway-cicd-baseline.test.ts tests/github-quality-workflow.test.ts`
- GREEN: `cd livesafe && npm run quality`
- GREEN: `bash tools/test_github_actions_pinned.sh`
- GREEN: `git diff --check`
- Sweep: `rg -n "secrets\\.RAILWAY_TOKEN|secrets\\.RAILWAY_API_TOKEN|RAILWAY_DEVELOPMENT_TOKEN|RAILWAY_STAGING_TOKEN|RAILWAY_PRODUCTION_TOKEN" .github/workflows/livesafe-railway-deploy.yml livesafe/tests/railway-cicd-baseline.test.ts`