### PR TITLE
Gate LiveSafe public trust status on EXOCHAIN authorization

### DIFF
--- a/livesafe/server/index.js
+++ b/livesafe/server/index.js
@@ -36,7 +36,7 @@ const {
   sendFeedbackCodeHintsStatusResponse,
 } = require('./utils/feedback-code-hints-status');
 const { sendHealthStatusResponse } = require('./utils/health-status');
-const { sendTrustStatusResponse } = require('./utils/trust-status');
+const { sendLiveTrustStatusResponse } = require('./utils/trust-status');
 const {
   runtimeExochainConnectivityStatus,
 } = require('./utils/exochain-connectivity-status');
@@ -246,8 +246,8 @@ async function startServer() {
           uptime: process.uptime(),
         });
       },
-      sendTrustStatusResponse(req, res) {
-        sendTrustStatusResponse(req, res, {
+      async sendTrustStatusResponse(req, res) {
+        return sendLiveTrustStatusResponse(req, res, {
           exochainConnected: runtimeExochainConnectivityStatus.getConnected(),
           version: '1.0.0',
           uptimeSeconds: process.uptime(),

--- a/livesafe/server/utils/exochain-client.js
+++ b/livesafe/server/utils/exochain-client.js
@@ -8,6 +8,7 @@
  */
 
 const {
+  ALLOWED_PUBLIC_ADAPTER_OUTPUT_CLAIMS,
   PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
   PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SCHEMA,
   PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
@@ -28,9 +29,9 @@ const EXOCHAIN_UNAVAILABLE_ERROR = 'EXOCHAIN_UNAVAILABLE';
 const EXOCHAIN_GATEWAY_REJECTED_ERROR = 'EXOCHAIN_GATEWAY_REJECTED';
 const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_ROUTE =
   '/api/v1/avc/livesafe/public-adapter-output-authorization';
-const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_ENVELOPE_SCHEMA =
-  'exochain.avc.livesafe.public_adapter_output_authorization_envelope.v1';
 const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DEFAULT_TIMEOUT_MS = 5000;
+const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_PROOF_TYPE =
+  'ed25519-public-adapter-output-authorization';
 const SHA256_EVIDENCE_HASH_PATTERN = /^sha256:[a-f0-9]{64}$/;
 
 function isRequiredTransportIdentifier(value) {
@@ -271,6 +272,33 @@ function publicAuthorizationTransportErrorState(error) {
   return 'unavailable';
 }
 
+function normalizePublicAuthorizationSignature(signature) {
+  return isNonEmptyString(signature) ? signature.trim() : null;
+}
+
+function publicAuthorizationRevocationState(revocationStatus) {
+  if (!isNonEmptyString(revocationStatus)) {
+    return 'rejected';
+  }
+
+  const normalized = revocationStatus.trim().toLowerCase().replace(/[\s-]+/g, '_');
+
+  if (normalized === 'revoked') {
+    return 'revoked';
+  }
+
+  if (
+    normalized === 'active' ||
+    normalized === 'valid' ||
+    normalized === 'not_revoked' ||
+    normalized === 'non_revoked'
+  ) {
+    return 'active';
+  }
+
+  return 'rejected';
+}
+
 function adaptCorePublicAdapterOutputAuthorizationEnvelope(
   envelope,
   { subject, audience },
@@ -283,56 +311,60 @@ function adaptCorePublicAdapterOutputAuthorizationEnvelope(
     return { state: 'rejected', value: null };
   }
 
-  if (
-    envelope.envelope_schema !== PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_ENVELOPE_SCHEMA &&
-    envelope.schema !== PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_ENVELOPE_SCHEMA
-  ) {
+  if (envelope.domain !== PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SCHEMA) {
     return { state: 'rejected', value: null };
   }
 
-  if (envelope.status === 'revoked' || envelope.revoked === true) {
-    return { state: 'revoked', value: null };
-  }
-
-  if (envelope.status === 'contradicted' || envelope.contradicted === true) {
-    return { state: 'contradicted', value: null };
-  }
-
-  if (envelope.status !== 'authorized') {
+  const proof = isObjectRecord(envelope.proof) ? envelope.proof : null;
+  if (!proof) {
     return { state: 'rejected', value: null };
   }
 
   if (
-    envelope.subject !== subject ||
-    envelope.audience !== audience ||
-    envelope.domain !== PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT
+    proof.domain !== PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SCHEMA ||
+    proof.subject !== subject ||
+    proof.audience !== audience
   ) {
     return { state: 'rejected', value: null };
   }
 
-  const proof = isObjectRecord(envelope.proof) ? envelope.proof : {};
-  const receipt = isObjectRecord(envelope.receipt) ? envelope.receipt : {};
-  const generatedAt = coreTimestampToIso(envelope.generated_at ?? envelope.issued_at);
-  const validFrom = coreTimestampToIso(envelope.valid_from);
-  const expiresAt = coreTimestampToIso(envelope.expires_at);
+  if (
+    !isNonEmptyString(envelope.schema_version) ||
+    !isNonEmptyString(proof.schema_version)
+  ) {
+    return { state: 'rejected', value: null };
+  }
+
+  const revocationState = publicAuthorizationRevocationState(
+    proof.revocation_status,
+  );
+  if (revocationState !== 'active') {
+    return { state: revocationState, value: null };
+  }
+
+  const generatedAt = coreTimestampToIso(proof.issued_at);
+  const expiresAt = coreTimestampToIso(proof.expires_at);
+  const signature = normalizePublicAuthorizationSignature(proof.signature);
 
   return {
     state: 'permit',
     value: {
       schema: PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SCHEMA,
-      subject: envelope.subject,
-      audience: envelope.audience,
-      claims: Array.isArray(envelope.claims) ? [...envelope.claims] : envelope.claims,
-      evidence_hash: envelope.evidence_hash,
-      receipt_id: envelope.receipt_id || receipt.id,
-      proof_id: envelope.proof_id || proof.id,
-      proof_ref: envelope.proof_ref || proof.ref,
+      subject: proof.subject,
+      audience: proof.audience,
+      claims: [...ALLOWED_PUBLIC_ADAPTER_OUTPUT_CLAIMS],
+      evidence_hash: proof.evidence_hash,
+      receipt_id: proof.receipt_id,
+      proof_id: proof.proof_hash,
+      proof_ref: isNonEmptyString(proof.proof_hash)
+        ? `exochain-avc:${proof.proof_hash}`
+        : null,
       generated_at: generatedAt,
-      valid_from: validFrom,
+      valid_from: generatedAt,
       expires_at: expiresAt,
       proof: {
-        type: proof.type,
-        signature: proof.signature,
+        type: PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_PROOF_TYPE,
+        signature,
       },
     },
   };

--- a/livesafe/server/utils/exochain-client.js
+++ b/livesafe/server/utils/exochain-client.js
@@ -19,6 +19,13 @@ const ALLOWED_AUDIT_RECEIPT_EVENT_TYPES = new Set([
 const EXOCHAIN_TIMEOUT_ERROR = 'EXOCHAIN_TIMEOUT';
 const EXOCHAIN_UNAVAILABLE_ERROR = 'EXOCHAIN_UNAVAILABLE';
 const EXOCHAIN_GATEWAY_REJECTED_ERROR = 'EXOCHAIN_GATEWAY_REJECTED';
+const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SCHEMA =
+  'livesafe.public_adapter_output_authorization.v1';
+const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT = 'livesafe.ai';
+const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE =
+  'https://livesafe.ai/api/trust/status';
+const SHA256_EVIDENCE_HASH_PATTERN = /^sha256:[a-f0-9]{64}$/;
+const PROOF_SIGNATURE_PATTERN = /^ed25519:[A-Za-z0-9+/_=-]{32,}$/;
 
 function isRequiredTransportIdentifier(value) {
   return (
@@ -86,6 +93,53 @@ function createTransportError(code) {
   return { data: null, errors: [{ message: code, code }] };
 }
 
+function createPublicAuthorizationDenied(state = 'rejected') {
+  return { state, value: null };
+}
+
+function publicAuthorizationErrorState(result) {
+  const code =
+    result?.errors && typeof result.errors[0]?.code === 'string'
+      ? result.errors[0].code
+      : '';
+
+  if (code === EXOCHAIN_TIMEOUT_ERROR) {
+    return 'timeout';
+  }
+
+  if (code === EXOCHAIN_UNAVAILABLE_ERROR) {
+    return 'unavailable';
+  }
+
+  return 'rejected';
+}
+
+function isPublicAdapterOutputAuthorizationDto(value, subject, audience) {
+  return (
+    Boolean(value) &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    value.schema === PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SCHEMA &&
+    value.subject === subject &&
+    value.audience === audience &&
+    Array.isArray(value.claims) &&
+    value.claims.length > 0 &&
+    value.claims.every(isNonEmptyString) &&
+    SHA256_EVIDENCE_HASH_PATTERN.test(value.evidence_hash || '') &&
+    isNonEmptyString(value.receipt_id) &&
+    isNonEmptyString(value.proof_id) &&
+    isNonEmptyString(value.proof_ref) &&
+    isNonEmptyString(value.generated_at) &&
+    isNonEmptyString(value.valid_from) &&
+    isNonEmptyString(value.expires_at) &&
+    Boolean(value.proof) &&
+    typeof value.proof === 'object' &&
+    !Array.isArray(value.proof) &&
+    isNonEmptyString(value.proof.type) &&
+    PROOF_SIGNATURE_PATTERN.test(value.proof.signature || '')
+  );
+}
+
 class ExochainClient {
   constructor(gatewayUrl = EXOCHAIN_GATEWAY) {
     this.gatewayUrl = gatewayUrl;
@@ -105,7 +159,7 @@ class ExochainClient {
       }
       return await response.json();
     } catch (err) {
-      console.warn(`[EXOCHAIN] Gateway unreachable: ${err.message}`);
+      console.warn('[EXOCHAIN] Gateway unreachable: redacted transport failure');
       return createTransportError(
         isTimeoutLikeError(err) ? EXOCHAIN_TIMEOUT_ERROR : EXOCHAIN_UNAVAILABLE_ERROR,
       );
@@ -363,6 +417,65 @@ class ExochainClient {
     } catch (err) {
       console.warn(`[EXOCHAIN] getPaceStatus error: ${err.message}`);
       return [];
+    }
+  }
+
+  async getPublicAdapterOutputAuthorization({ subject, audience } = {}) {
+    if (
+      subject !== PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT ||
+      audience !== PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE
+    ) {
+      console.warn('[EXOCHAIN] public adapter-output authorization rejected malformed target before query');
+      return createPublicAuthorizationDenied();
+    }
+
+    try {
+      const result = await this.query('GetPublicAdapterOutputAuthorization', `
+        query GetPublicAdapterOutputAuthorization($input: PublicAdapterOutputAuthorizationInput!) {
+          livesafe_public_adapter_output_authorization(input: $input) {
+            schema
+            subject
+            audience
+            claims
+            evidence_hash
+            receipt_id
+            proof_id
+            proof_ref
+            generated_at
+            valid_from
+            expires_at
+            proof {
+              type
+              signature
+            }
+          }
+        }
+      `, {
+        input: {
+          subject,
+          audience,
+        },
+      });
+
+      if (result.errors) {
+        console.warn('[EXOCHAIN] public adapter-output authorization rejected by gateway');
+        return createPublicAuthorizationDenied(publicAuthorizationErrorState(result));
+      }
+
+      const authorization =
+        result.data?.livesafe_public_adapter_output_authorization;
+
+      if (!isPublicAdapterOutputAuthorizationDto(authorization, subject, audience)) {
+        console.warn('[EXOCHAIN] public adapter-output authorization response malformed');
+        return createPublicAuthorizationDenied();
+      }
+
+      return { state: 'permit', value: authorization };
+    } catch (err) {
+      console.warn('[EXOCHAIN] public adapter-output authorization transport failed');
+      return createPublicAuthorizationDenied(
+        isTimeoutLikeError(err) ? 'timeout' : 'unavailable',
+      );
     }
   }
 

--- a/livesafe/server/utils/exochain-client.js
+++ b/livesafe/server/utils/exochain-client.js
@@ -7,6 +7,13 @@
  * Gateway: http://localhost:8080/graphql (configurable via EXOCHAIN_GATEWAY_URL)
  */
 
+const {
+  PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+  PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SCHEMA,
+  PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+  evaluatePublicAdapterOutputAuthorization,
+} = require('./public-adapter-output-authorization.js');
+
 const EXOCHAIN_GATEWAY = process.env.EXOCHAIN_GATEWAY_URL || 'http://localhost:8080/graphql';
 const EXOCHAIN_DID_PATTERN = /^did:exo:[a-z0-9_-]+:[A-Za-z0-9._:-]+$/;
 const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/;
@@ -19,13 +26,12 @@ const ALLOWED_AUDIT_RECEIPT_EVENT_TYPES = new Set([
 const EXOCHAIN_TIMEOUT_ERROR = 'EXOCHAIN_TIMEOUT';
 const EXOCHAIN_UNAVAILABLE_ERROR = 'EXOCHAIN_UNAVAILABLE';
 const EXOCHAIN_GATEWAY_REJECTED_ERROR = 'EXOCHAIN_GATEWAY_REJECTED';
-const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SCHEMA =
-  'livesafe.public_adapter_output_authorization.v1';
-const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT = 'livesafe.ai';
-const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE =
-  'https://livesafe.ai/api/trust/status';
+const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_ROUTE =
+  '/api/v1/avc/livesafe/public-adapter-output-authorization';
+const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_ENVELOPE_SCHEMA =
+  'exochain.avc.livesafe.public_adapter_output_authorization_envelope.v1';
+const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DEFAULT_TIMEOUT_MS = 5000;
 const SHA256_EVIDENCE_HASH_PATTERN = /^sha256:[a-f0-9]{64}$/;
-const PROOF_SIGNATURE_PATTERN = /^ed25519:[A-Za-z0-9+/_=-]{32,}$/;
 
 function isRequiredTransportIdentifier(value) {
   return (
@@ -97,47 +103,239 @@ function createPublicAuthorizationDenied(state = 'rejected') {
   return { state, value: null };
 }
 
-function publicAuthorizationErrorState(result) {
-  const code =
-    result?.errors && typeof result.errors[0]?.code === 'string'
-      ? result.errors[0].code
-      : '';
+function isObjectRecord(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
 
-  if (code === EXOCHAIN_TIMEOUT_ERROR) {
-    return 'timeout';
+function envString(name) {
+  const value = process.env[name];
+  return isNonEmptyString(value) ? value.trim() : '';
+}
+
+function parsePositiveInteger(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function getPublicAdapterOutputAuthorizationConfig() {
+  const baseUrl =
+    envString('EXOCHAIN_NODE_AVC_URL') || envString('EXOCHAIN_NODE_URL');
+  const bearer = envString('EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_BEARER');
+  const credentialId = envString('EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_CREDENTIAL_ID');
+  const evidenceHash = envString('EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_EVIDENCE_HASH');
+  const idempotencyKey = envString('EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_IDEMPOTENCY_KEY');
+  const expiresAt = envString('EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_EXPIRES_AT');
+  const timeoutMs = parsePositiveInteger(
+    envString('EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_TIMEOUT_MS'),
+    PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DEFAULT_TIMEOUT_MS,
+  );
+
+  if (
+    !baseUrl ||
+    !bearer ||
+    !credentialId ||
+    !SHA256_EVIDENCE_HASH_PATTERN.test(evidenceHash) ||
+    !idempotencyKey
+  ) {
+    return null;
   }
 
-  if (code === EXOCHAIN_UNAVAILABLE_ERROR) {
-    return 'unavailable';
+  return {
+    baseUrl,
+    bearer,
+    credentialId,
+    evidenceHash,
+    idempotencyKey,
+    expiresAt: expiresAt || null,
+    timeoutMs,
+  };
+}
+
+function buildPublicAdapterOutputAuthorizationUrl(baseUrl) {
+  return `${baseUrl.replace(/\/+$/, '')}${PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_ROUTE}`;
+}
+
+function coreTimestampToIso(value) {
+  if (isNonEmptyString(value)) {
+    const milliseconds = Date.parse(value);
+    return Number.isNaN(milliseconds) ? null : new Date(milliseconds).toISOString();
+  }
+
+  if (Number.isInteger(value) && value >= 0) {
+    return new Date(value).toISOString();
+  }
+
+  if (isObjectRecord(value)) {
+    if (Number.isInteger(value.physical_ms) && value.physical_ms >= 0) {
+      return new Date(value.physical_ms).toISOString();
+    }
+
+    if (Number.isInteger(value.physicalMs) && value.physicalMs >= 0) {
+      return new Date(value.physicalMs).toISOString();
+    }
+  }
+
+  return null;
+}
+
+const RAW_SENSITIVE_FIELD_KEYS = new Set([
+  'authorization_header',
+  'bearer_token',
+  'credential_bytes',
+  'emergency_contact',
+  'location',
+  'medical_record',
+  'patient',
+  'phi',
+  'pii',
+  'private_key',
+  'raw_authority_chain',
+  'raw_credential_bytes',
+  'raw_sensitive_payload',
+  'scan_payload',
+  'trustee_did',
+  'vault',
+]);
+const RAW_SENSITIVE_FIELD_FRAGMENTS = [
+  'authority_chain',
+  'bearer',
+  'consent_record',
+  'custody_record',
+  'legal_record',
+  'private_key',
+  'scan_record',
+  'trustee_record',
+  'vault_record',
+];
+
+function keyLooksRawSensitive(key) {
+  const normalized = String(key).toLowerCase();
+  return (
+    RAW_SENSITIVE_FIELD_KEYS.has(normalized) ||
+    normalized.startsWith('raw_') ||
+    RAW_SENSITIVE_FIELD_FRAGMENTS.some((fragment) => normalized.includes(fragment))
+  );
+}
+
+function containsRawSensitiveField(value) {
+  if (Array.isArray(value)) {
+    return value.some((entry) => containsRawSensitiveField(entry));
+  }
+
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+
+  return Object.entries(value).some(([key, nestedValue]) => {
+    if (keyLooksRawSensitive(key)) {
+      return true;
+    }
+
+    return containsRawSensitiveField(nestedValue);
+  });
+}
+
+function publicAuthorizationStateFromReasons(reasons) {
+  const combined = reasons.join(' ').toLowerCase();
+
+  if (combined.includes('revoked')) {
+    return 'revoked';
+  }
+
+  if (combined.includes('contradicted')) {
+    return 'contradicted';
+  }
+
+  if (
+    combined.includes('expired') ||
+    combined.includes('not yet valid') ||
+    combined.includes('stale')
+  ) {
+    return 'stale';
   }
 
   return 'rejected';
 }
 
-function isPublicAdapterOutputAuthorizationDto(value, subject, audience) {
-  return (
-    Boolean(value) &&
-    typeof value === 'object' &&
-    !Array.isArray(value) &&
-    value.schema === PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SCHEMA &&
-    value.subject === subject &&
-    value.audience === audience &&
-    Array.isArray(value.claims) &&
-    value.claims.length > 0 &&
-    value.claims.every(isNonEmptyString) &&
-    SHA256_EVIDENCE_HASH_PATTERN.test(value.evidence_hash || '') &&
-    isNonEmptyString(value.receipt_id) &&
-    isNonEmptyString(value.proof_id) &&
-    isNonEmptyString(value.proof_ref) &&
-    isNonEmptyString(value.generated_at) &&
-    isNonEmptyString(value.valid_from) &&
-    isNonEmptyString(value.expires_at) &&
-    Boolean(value.proof) &&
-    typeof value.proof === 'object' &&
-    !Array.isArray(value.proof) &&
-    isNonEmptyString(value.proof.type) &&
-    PROOF_SIGNATURE_PATTERN.test(value.proof.signature || '')
-  );
+function publicAuthorizationTransportErrorState(error) {
+  const code = typeof error?.code === 'string' ? error.code.toLowerCase() : '';
+
+  if (code === 'econnrefused' || code === 'enotfound' || code === 'econnreset') {
+    return 'unavailable';
+  }
+
+  if (error?.name === 'AbortError' || isTimeoutLikeError(error)) {
+    return 'timeout';
+  }
+
+  return 'unavailable';
+}
+
+function adaptCorePublicAdapterOutputAuthorizationEnvelope(
+  envelope,
+  { subject, audience },
+) {
+  if (!isObjectRecord(envelope)) {
+    return { state: 'rejected', value: null };
+  }
+
+  if (containsRawSensitiveField(envelope)) {
+    return { state: 'rejected', value: null };
+  }
+
+  if (
+    envelope.envelope_schema !== PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_ENVELOPE_SCHEMA &&
+    envelope.schema !== PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_ENVELOPE_SCHEMA
+  ) {
+    return { state: 'rejected', value: null };
+  }
+
+  if (envelope.status === 'revoked' || envelope.revoked === true) {
+    return { state: 'revoked', value: null };
+  }
+
+  if (envelope.status === 'contradicted' || envelope.contradicted === true) {
+    return { state: 'contradicted', value: null };
+  }
+
+  if (envelope.status !== 'authorized') {
+    return { state: 'rejected', value: null };
+  }
+
+  if (
+    envelope.subject !== subject ||
+    envelope.audience !== audience ||
+    envelope.domain !== PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT
+  ) {
+    return { state: 'rejected', value: null };
+  }
+
+  const proof = isObjectRecord(envelope.proof) ? envelope.proof : {};
+  const receipt = isObjectRecord(envelope.receipt) ? envelope.receipt : {};
+  const generatedAt = coreTimestampToIso(envelope.generated_at ?? envelope.issued_at);
+  const validFrom = coreTimestampToIso(envelope.valid_from);
+  const expiresAt = coreTimestampToIso(envelope.expires_at);
+
+  return {
+    state: 'permit',
+    value: {
+      schema: PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SCHEMA,
+      subject: envelope.subject,
+      audience: envelope.audience,
+      claims: Array.isArray(envelope.claims) ? [...envelope.claims] : envelope.claims,
+      evidence_hash: envelope.evidence_hash,
+      receipt_id: envelope.receipt_id || receipt.id,
+      proof_id: envelope.proof_id || proof.id,
+      proof_ref: envelope.proof_ref || proof.ref,
+      generated_at: generatedAt,
+      valid_from: validFrom,
+      expires_at: expiresAt,
+      proof: {
+        type: proof.type,
+        signature: proof.signature,
+      },
+    },
+  };
 }
 
 class ExochainClient {
@@ -420,62 +618,115 @@ class ExochainClient {
     }
   }
 
-  async getPublicAdapterOutputAuthorization({ subject, audience } = {}) {
+  async getPublicAdapterOutputAuthorization({ subject, audience, currentAt } = {}) {
     if (
       subject !== PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT ||
       audience !== PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE
     ) {
-      console.warn('[EXOCHAIN] public adapter-output authorization rejected malformed target before query');
+      console.warn('[EXOCHAIN] public adapter-output authorization rejected malformed target before transport');
       return createPublicAuthorizationDenied();
     }
 
+    const config = getPublicAdapterOutputAuthorizationConfig();
+    if (!config) {
+      console.warn('[EXOCHAIN] public adapter-output authorization REST transport is unconfigured');
+      return createPublicAuthorizationDenied('unavailable');
+    }
+
+    const controller =
+      typeof AbortController === 'function' ? new AbortController() : null;
+    const timeout =
+      controller && config.timeoutMs > 0
+        ? setTimeout(() => controller.abort(), config.timeoutMs)
+        : null;
+
     try {
-      const result = await this.query('GetPublicAdapterOutputAuthorization', `
-        query GetPublicAdapterOutputAuthorization($input: PublicAdapterOutputAuthorizationInput!) {
-          livesafe_public_adapter_output_authorization(input: $input) {
-            schema
-            subject
-            audience
-            claims
-            evidence_hash
-            receipt_id
-            proof_id
-            proof_ref
-            generated_at
-            valid_from
-            expires_at
-            proof {
-              type
-              signature
-            }
-          }
-        }
-      `, {
-        input: {
+      const body = {
+        subject,
+        audience,
+        credential_id: config.credentialId,
+        evidence_hash: config.evidenceHash,
+        idempotency_key: config.idempotencyKey,
+      };
+
+      if (config.expiresAt) {
+        body.expires_at = config.expiresAt;
+      }
+
+      const response = await fetch(
+        buildPublicAdapterOutputAuthorizationUrl(config.baseUrl),
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${config.bearer}`,
+          },
+          body: JSON.stringify(body),
+          signal: controller?.signal,
+        },
+      );
+
+      if (!response.ok) {
+        console.warn(
+          '[EXOCHAIN] public adapter-output authorization REST transport rejected the request',
+        );
+        return createPublicAuthorizationDenied(
+          response.status === 408 || response.status === 504
+            ? 'timeout'
+            : response.status >= 500
+              ? 'unavailable'
+              : 'rejected',
+        );
+      }
+
+      const envelope = await response.json();
+      const adapted = adaptCorePublicAdapterOutputAuthorizationEnvelope(
+        envelope,
+        {
           subject,
           audience,
         },
-      });
+      );
 
-      if (result.errors) {
-        console.warn('[EXOCHAIN] public adapter-output authorization rejected by gateway');
-        return createPublicAuthorizationDenied(publicAuthorizationErrorState(result));
+      if (adapted.state !== 'permit') {
+        console.warn('[EXOCHAIN] public adapter-output authorization REST envelope denied');
+        return adapted;
       }
 
-      const authorization =
-        result.data?.livesafe_public_adapter_output_authorization;
-
-      if (!isPublicAdapterOutputAuthorizationDto(authorization, subject, audience)) {
-        console.warn('[EXOCHAIN] public adapter-output authorization response malformed');
+      if (adapted.value.evidence_hash !== config.evidenceHash) {
+        console.warn('[EXOCHAIN] public adapter-output authorization evidence hash mismatch');
         return createPublicAuthorizationDenied();
       }
 
-      return { state: 'permit', value: authorization };
-    } catch (err) {
-      console.warn('[EXOCHAIN] public adapter-output authorization transport failed');
-      return createPublicAuthorizationDenied(
-        isTimeoutLikeError(err) ? 'timeout' : 'unavailable',
+      const evaluation = evaluatePublicAdapterOutputAuthorization(
+        {
+          allowed: true,
+          responseState: 'permit',
+          transportCalled: true,
+          value: adapted.value,
+        },
+        {
+          currentAt,
+          subject: PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+          audience: PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+        },
       );
+
+      if (!evaluation.allowed) {
+        console.warn('[EXOCHAIN] public adapter-output authorization evaluator denied REST envelope');
+        return createPublicAuthorizationDenied(
+          publicAuthorizationStateFromReasons(evaluation.reasons),
+        );
+      }
+
+      return adapted;
+    } catch (err) {
+      console.warn('[EXOCHAIN] public adapter-output authorization REST transport failed');
+      return createPublicAuthorizationDenied(publicAuthorizationTransportErrorState(err));
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
     }
   }
 

--- a/livesafe/server/utils/exochain-client.js
+++ b/livesafe/server/utils/exochain-client.js
@@ -319,6 +319,10 @@ function publicAuthorizationRevocationState(revocationStatus) {
     return 'rejected';
   }
 
+  if (revocationStatus === 'NotRevoked') {
+    return 'active';
+  }
+
   const normalized = revocationStatus
     .trim()
     .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
@@ -329,20 +333,11 @@ function publicAuthorizationRevocationState(revocationStatus) {
     return 'revoked';
   }
 
-  if (
-    normalized === 'active' ||
-    normalized === 'valid' ||
-    normalized === 'not_revoked' ||
-    normalized === 'non_revoked'
-  ) {
-    return 'active';
-  }
-
   return 'rejected';
 }
 
 function isValidSchemaVersion(value) {
-  return Number.isInteger(value) && value > 0 && value <= 65535;
+  return value === 1;
 }
 
 function adaptCorePublicAdapterOutputAuthorizationEnvelope(

--- a/livesafe/server/utils/exochain-client.js
+++ b/livesafe/server/utils/exochain-client.js
@@ -272,8 +272,46 @@ function publicAuthorizationTransportErrorState(error) {
   return 'unavailable';
 }
 
+function isByteArrayOfLength(value, expectedLength) {
+  return (
+    Array.isArray(value) &&
+    value.length === expectedLength &&
+    value.every(
+      (byte) => Number.isInteger(byte) && byte >= 0 && byte <= 255,
+    )
+  );
+}
+
+function bytesToLowerHex(bytes) {
+  return bytes
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function normalizeHash256(value) {
+  if (!isByteArrayOfLength(value, 32)) {
+    return null;
+  }
+
+  return `sha256:${bytesToLowerHex(value)}`;
+}
+
 function normalizePublicAuthorizationSignature(signature) {
-  return isNonEmptyString(signature) ? signature.trim() : null;
+  if (!isObjectRecord(signature)) {
+    return null;
+  }
+
+  const keys = Object.keys(signature);
+  if (keys.length !== 1 || keys[0] !== 'Ed25519') {
+    return null;
+  }
+
+  const bytes = signature.Ed25519;
+  if (!isByteArrayOfLength(bytes, 64)) {
+    return null;
+  }
+
+  return `ed25519:${bytesToLowerHex(bytes)}`;
 }
 
 function publicAuthorizationRevocationState(revocationStatus) {
@@ -281,7 +319,11 @@ function publicAuthorizationRevocationState(revocationStatus) {
     return 'rejected';
   }
 
-  const normalized = revocationStatus.trim().toLowerCase().replace(/[\s-]+/g, '_');
+  const normalized = revocationStatus
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[\s-]+/g, '_')
+    .toLowerCase();
 
   if (normalized === 'revoked') {
     return 'revoked';
@@ -297,6 +339,10 @@ function publicAuthorizationRevocationState(revocationStatus) {
   }
 
   return 'rejected';
+}
+
+function isValidSchemaVersion(value) {
+  return Number.isInteger(value) && value > 0 && value <= 65535;
 }
 
 function adaptCorePublicAdapterOutputAuthorizationEnvelope(
@@ -329,8 +375,8 @@ function adaptCorePublicAdapterOutputAuthorizationEnvelope(
   }
 
   if (
-    !isNonEmptyString(envelope.schema_version) ||
-    !isNonEmptyString(proof.schema_version)
+    !isValidSchemaVersion(envelope.schema_version) ||
+    !isValidSchemaVersion(proof.schema_version)
   ) {
     return { state: 'rejected', value: null };
   }
@@ -344,7 +390,23 @@ function adaptCorePublicAdapterOutputAuthorizationEnvelope(
 
   const generatedAt = coreTimestampToIso(proof.issued_at);
   const expiresAt = coreTimestampToIso(proof.expires_at);
+  const evidenceHash = normalizeHash256(proof.evidence_hash);
+  const actionCommitmentHash = normalizeHash256(proof.action_commitment_hash);
+  const idempotencyKeyHash = normalizeHash256(proof.idempotency_key_hash);
+  const proofHash = normalizeHash256(proof.proof_hash);
   const signature = normalizePublicAuthorizationSignature(proof.signature);
+  if (
+    !evidenceHash ||
+    !actionCommitmentHash ||
+    !idempotencyKeyHash ||
+    !proofHash ||
+    !signature ||
+    !isNonEmptyString(proof.credential_id) ||
+    !isNonEmptyString(proof.receipt_id) ||
+    !isNonEmptyString(proof.signer_did)
+  ) {
+    return { state: 'rejected', value: null };
+  }
 
   return {
     state: 'permit',
@@ -353,12 +415,10 @@ function adaptCorePublicAdapterOutputAuthorizationEnvelope(
       subject: proof.subject,
       audience: proof.audience,
       claims: [...ALLOWED_PUBLIC_ADAPTER_OUTPUT_CLAIMS],
-      evidence_hash: proof.evidence_hash,
+      evidence_hash: evidenceHash,
       receipt_id: proof.receipt_id,
-      proof_id: proof.proof_hash,
-      proof_ref: isNonEmptyString(proof.proof_hash)
-        ? `exochain-avc:${proof.proof_hash}`
-        : null,
+      proof_id: proofHash,
+      proof_ref: `exochain-avc:${proofHash}`,
       generated_at: generatedAt,
       valid_from: generatedAt,
       expires_at: expiresAt,

--- a/livesafe/server/utils/exochain-client.js
+++ b/livesafe/server/utils/exochain-client.js
@@ -33,6 +33,8 @@ const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DEFAULT_TIMEOUT_MS = 5000;
 const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_PROOF_TYPE =
   'ed25519-public-adapter-output-authorization';
 const SHA256_EVIDENCE_HASH_PATTERN = /^sha256:[a-f0-9]{64}$/;
+const STRICT_UTC_TIMESTAMP_PATTERN =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 
 function isRequiredTransportIdentifier(value) {
   return (
@@ -118,6 +120,40 @@ function parsePositiveInteger(value, fallback) {
   return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+function parseHash256Env(value) {
+  if (!SHA256_EVIDENCE_HASH_PATTERN.test(value)) {
+    return null;
+  }
+
+  const hex = value.slice('sha256:'.length);
+  const bytes = [];
+  for (let index = 0; index < hex.length; index += 2) {
+    bytes.push(Number.parseInt(hex.slice(index, index + 2), 16));
+  }
+
+  return { canonical: value, bytes };
+}
+
+function parseStrictUtcTimestampEnv(value) {
+  if (!STRICT_UTC_TIMESTAMP_PATTERN.test(value)) {
+    return null;
+  }
+
+  const physicalMs = Date.parse(value);
+  if (!Number.isSafeInteger(physicalMs) || physicalMs < 0) {
+    return null;
+  }
+
+  if (new Date(physicalMs).toISOString() !== value) {
+    return null;
+  }
+
+  return {
+    physical_ms: physicalMs,
+    logical: 0,
+  };
+}
+
 function getPublicAdapterOutputAuthorizationConfig() {
   const baseUrl =
     envString('EXOCHAIN_NODE_AVC_URL') || envString('EXOCHAIN_NODE_URL');
@@ -130,13 +166,17 @@ function getPublicAdapterOutputAuthorizationConfig() {
     envString('EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_TIMEOUT_MS'),
     PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DEFAULT_TIMEOUT_MS,
   );
+  const credentialHash = parseHash256Env(credentialId);
+  const evidenceHashValue = parseHash256Env(evidenceHash);
+  const expiresAtTimestamp = parseStrictUtcTimestampEnv(expiresAt);
 
   if (
     !baseUrl ||
     !bearer ||
-    !credentialId ||
-    !SHA256_EVIDENCE_HASH_PATTERN.test(evidenceHash) ||
-    !idempotencyKey
+    !credentialHash ||
+    !evidenceHashValue ||
+    !idempotencyKey ||
+    !expiresAtTimestamp
   ) {
     return null;
   }
@@ -144,10 +184,12 @@ function getPublicAdapterOutputAuthorizationConfig() {
   return {
     baseUrl,
     bearer,
-    credentialId,
-    evidenceHash,
+    credentialId: credentialHash.canonical,
+    credentialIdBytes: credentialHash.bytes,
+    evidenceHash: evidenceHashValue.canonical,
+    evidenceHashBytes: evidenceHashValue.bytes,
     idempotencyKey,
-    expiresAt: expiresAt || null,
+    expiresAt: expiresAtTimestamp,
     timeoutMs,
   };
 }
@@ -731,14 +773,11 @@ class ExochainClient {
       const body = {
         subject,
         audience,
-        credential_id: config.credentialId,
-        evidence_hash: config.evidenceHash,
+        credential_id: [...config.credentialIdBytes],
+        evidence_hash: [...config.evidenceHashBytes],
         idempotency_key: config.idempotencyKey,
+        expires_at: { ...config.expiresAt },
       };
-
-      if (config.expiresAt) {
-        body.expires_at = config.expiresAt;
-      }
 
       const response = await fetch(
         buildPublicAdapterOutputAuthorizationUrl(config.baseUrl),

--- a/livesafe/server/utils/livesafe-exochain-adapter.js
+++ b/livesafe/server/utils/livesafe-exochain-adapter.js
@@ -281,6 +281,7 @@ function createRuntimeExochainAdapter({
         client.getPublicAdapterOutputAuthorization({
           subject,
           audience,
+          currentAt,
         }),
     );
     const evaluation = evaluatePublicAdapterOutputAuthorization(

--- a/livesafe/server/utils/livesafe-exochain-adapter.js
+++ b/livesafe/server/utils/livesafe-exochain-adapter.js
@@ -3,6 +3,11 @@
 const exochainRegistry = require("../../config/exochain-primitives.json");
 const surfaceIntake = require("../../config/surface-intake.json");
 const { exochain } = require("./exochain-client");
+const {
+  PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+  PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+  evaluatePublicAdapterOutputAuthorization,
+} = require("./public-adapter-output-authorization");
 
 const VERIFIED_ADAPTER_STATE = "verified";
 const EXOCHAIN_DID_PATTERN = /^did:exo:[a-z0-9_-]+:[A-Za-z0-9._:-]+$/;
@@ -38,6 +43,7 @@ const WRAPPED_OPERATIONS = [
   "anchorScan",
   "anchorConsent",
   "getPaceStatus",
+  "getPublicAdapterOutputAuthorization",
 ];
 
 function isNonEmptyString(value) {
@@ -257,6 +263,63 @@ function createRuntimeExochainAdapter({
     });
   }
 
+  async function evaluatePublicAuthorizationTransport(options = {}) {
+    const subject = options.subject || PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT;
+    const audience = options.audience || PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE;
+    const currentAt = options.currentAt;
+    const authorityInputsWellFormed =
+      subject === PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT &&
+      audience === PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE &&
+      isNonEmptyString(currentAt);
+    const operationDecision = await runOperation(
+      "getPublicAdapterOutputAuthorization",
+      {
+        authorityInputsWellFormed,
+        containsRawSensitivePayload: false,
+      },
+      async () =>
+        client.getPublicAdapterOutputAuthorization({
+          subject,
+          audience,
+        }),
+    );
+    const evaluation = evaluatePublicAdapterOutputAuthorization(
+      {
+        allowed: operationDecision.allowed,
+        responseState: operationDecision.responseState,
+        transportCalled: operationDecision.transportCalled,
+        value: operationDecision.value,
+      },
+      {
+        currentAt,
+        subject: PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+        audience: PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+      },
+    );
+    const reasons = [
+      ...operationDecision.reasons,
+      ...evaluation.reasons.filter(
+        (reason) => !operationDecision.reasons.includes(reason),
+      ),
+    ];
+    const requiredEvidence = [
+      ...operationDecision.required_evidence,
+      ...evaluation.required_evidence.filter(
+        (evidence) => !operationDecision.required_evidence.includes(evidence),
+      ),
+    ];
+
+    return {
+      allowed: operationDecision.allowed && evaluation.allowed,
+      reasons,
+      required_evidence: requiredEvidence,
+      responseState: operationDecision.responseState,
+      transportCalled: operationDecision.transportCalled,
+      value: evaluation.allowed ? evaluation.metadata : null,
+      metadata: evaluation.metadata,
+    };
+  }
+
   return {
     getRuntimeStatus,
     async getIdentity(did, options = {}) {
@@ -353,6 +416,10 @@ function createRuntimeExochainAdapter({
         return decision;
       }
       return Array.isArray(decision.value) ? decision.value : [];
+    },
+    async getPublicAdapterOutputAuthorization(options = {}) {
+      const decision = await evaluatePublicAuthorizationTransport(options);
+      return options.returnDecision ? decision : decision.metadata;
     },
   };
 }

--- a/livesafe/server/utils/public-adapter-output-authorization.d.ts
+++ b/livesafe/server/utils/public-adapter-output-authorization.d.ts
@@ -1,0 +1,77 @@
+export type PublicAdapterOutputAuthorizationResponseState =
+  | "permit"
+  | "deny"
+  | "rejected"
+  | "timeout"
+  | "unavailable"
+  | "not-called"
+  | "stale"
+  | "revoked"
+  | "contradicted";
+
+export interface PublicAdapterOutputAuthorizationDto {
+  schema: "livesafe.public_adapter_output_authorization.v1";
+  subject: "livesafe.ai";
+  audience: "https://livesafe.ai/api/trust/status";
+  claims: string[];
+  evidence_hash: string;
+  receipt_id: string;
+  proof_id: string;
+  proof_ref: string;
+  generated_at: string;
+  valid_from: string;
+  expires_at: string;
+  proof: {
+    type: string;
+    signature: string;
+  };
+  revoked?: boolean;
+  contradicted?: boolean;
+}
+
+export interface PublicAdapterOutputAuthorizationDecision {
+  allowed: boolean;
+  responseState: PublicAdapterOutputAuthorizationResponseState | string;
+  transportCalled: boolean;
+  value: unknown;
+}
+
+export interface PublicAdapterOutputAuthorizationMetadata {
+  schema: "livesafe.public_adapter_output_authorization.v1";
+  subject: "livesafe.ai";
+  audience: "https://livesafe.ai/api/trust/status";
+  claims: string[];
+  evidence_hash: string;
+  receipt_id: string;
+  proof_id: string;
+  proof_ref: string;
+  generated_at: string;
+  valid_from: string;
+  expires_at: string;
+  proof_type: string;
+  response_state: "permit";
+  transport_called: true;
+}
+
+export interface PublicAdapterOutputAuthorizationEvaluation {
+  allowed: boolean;
+  reasons: string[];
+  required_evidence: string[];
+  responseState: string;
+  transportCalled: boolean;
+  metadata: PublicAdapterOutputAuthorizationMetadata | null;
+}
+
+export const ALLOWED_PUBLIC_ADAPTER_OUTPUT_CLAIMS: readonly string[];
+export const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE: "https://livesafe.ai/api/trust/status";
+export const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SCHEMA: "livesafe.public_adapter_output_authorization.v1";
+export const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT: "livesafe.ai";
+
+export function evaluatePublicAdapterOutputAuthorization(
+  adapterOutputAuthorization: unknown,
+  options?: {
+    currentAt?: string;
+    subject?: string;
+    audience?: string;
+  }
+): PublicAdapterOutputAuthorizationEvaluation;

--- a/livesafe/server/utils/public-adapter-output-authorization.js
+++ b/livesafe/server/utils/public-adapter-output-authorization.js
@@ -1,0 +1,406 @@
+"use strict";
+
+const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SCHEMA =
+  "livesafe.public_adapter_output_authorization.v1";
+const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT = "livesafe.ai";
+const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE =
+  "https://livesafe.ai/api/trust/status";
+const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_MAX_AGE_MS = 5 * 60 * 1000;
+const ALLOWED_PUBLIC_ADAPTER_OUTPUT_CLAIMS = [
+  "livesafe_public_trust_status",
+  "exochain_production_evidence_verified",
+  "livesafe_runtime_adapter_verified",
+];
+const FORBIDDEN_PUBLIC_CLAIM_TERMS = [
+  "medical",
+  "legal",
+  "custody",
+  "consent",
+  "emergency",
+];
+const RAW_SENSITIVE_FIELD_KEYS = [
+  "authorization_header",
+  "bearer_token",
+  "credential_bytes",
+  "emergency_contact",
+  "location",
+  "medical_record",
+  "patient",
+  "phi",
+  "pii",
+  "private_key",
+  "raw_authority_chain",
+  "raw_credential_bytes",
+  "raw_sensitive_payload",
+  "scan_payload",
+  "trustee_did",
+  "vault",
+];
+const RAW_SENSITIVE_FIELD_PREFIXES = ["raw_"];
+const RAW_SENSITIVE_FIELD_FRAGMENTS = [
+  "authority_chain",
+  "bearer",
+  "consent_record",
+  "custody_record",
+  "legal_record",
+  "private_key",
+  "scan_record",
+  "trustee_record",
+  "vault_record",
+];
+const SHA256_EVIDENCE_HASH_PATTERN = /^sha256:[a-f0-9]{64}$/;
+const PROOF_SIGNATURE_PATTERN = /^ed25519:[A-Za-z0-9+/_=-]{32,}$/;
+
+const REQUIRED_EVIDENCE = [
+  "Permit response from the verified EXOCHAIN public adapter-output authorization transport.",
+  "Public authorization DTO with schema, subject, audience, allowed claims, evidence hash, receipt id, proof id/ref, validity window, and proof signature.",
+  "Redacted public metadata excluding credential bytes, bearer tokens, private keys, raw authority chains, PII/PHI, trustee, scan, consent, vault, medical, legal, custody, and emergency fields.",
+];
+
+function isObjectRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function safeResponseState(adapterOutputAuthorization) {
+  return isObjectRecord(adapterOutputAuthorization) &&
+    typeof adapterOutputAuthorization.responseState === "string"
+    ? adapterOutputAuthorization.responseState
+    : "not-called";
+}
+
+function safeTransportCalled(adapterOutputAuthorization) {
+  return (
+    isObjectRecord(adapterOutputAuthorization) &&
+    adapterOutputAuthorization.transportCalled === true
+  );
+}
+
+function createDeniedDecision({
+  reasons,
+  responseState = "not-called",
+  transportCalled = false,
+}) {
+  return {
+    allowed: false,
+    reasons,
+    required_evidence: REQUIRED_EVIDENCE,
+    responseState,
+    transportCalled,
+    metadata: null,
+  };
+}
+
+function createAllowedDecision({ responseState, transportCalled, metadata }) {
+  return {
+    allowed: true,
+    reasons: [],
+    required_evidence: [],
+    responseState,
+    transportCalled,
+    metadata,
+  };
+}
+
+function pushOnce(target, reason) {
+  if (!target.includes(reason)) {
+    target.push(reason);
+  }
+}
+
+function parseIsoTimestamp(value) {
+  if (!isNonEmptyString(value)) {
+    return null;
+  }
+
+  const milliseconds = Date.parse(value);
+  return Number.isNaN(milliseconds) ? null : milliseconds;
+}
+
+function containsForbiddenPublicClaim(claim) {
+  const normalized = String(claim).toLowerCase();
+  return FORBIDDEN_PUBLIC_CLAIM_TERMS.some((term) => normalized.includes(term));
+}
+
+function claimsMatchAllowedSet(claims) {
+  if (claims.length !== ALLOWED_PUBLIC_ADAPTER_OUTPUT_CLAIMS.length) {
+    return false;
+  }
+
+  const sortedClaims = [...claims].sort();
+  const sortedAllowed = [...ALLOWED_PUBLIC_ADAPTER_OUTPUT_CLAIMS].sort();
+  return sortedClaims.every((claim, index) => claim === sortedAllowed[index]);
+}
+
+function keyLooksRawSensitive(key) {
+  const normalized = String(key).toLowerCase();
+
+  if (RAW_SENSITIVE_FIELD_KEYS.includes(normalized)) {
+    return true;
+  }
+
+  if (RAW_SENSITIVE_FIELD_PREFIXES.some((prefix) => normalized.startsWith(prefix))) {
+    return true;
+  }
+
+  return RAW_SENSITIVE_FIELD_FRAGMENTS.some((fragment) =>
+    normalized.includes(fragment),
+  );
+}
+
+function containsRawSensitiveField(value) {
+  if (Array.isArray(value)) {
+    return value.some((entry) => containsRawSensitiveField(entry));
+  }
+
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+
+  return Object.entries(value).some(([key, nestedValue]) => {
+    if (keyLooksRawSensitive(key)) {
+      return true;
+    }
+
+    return containsRawSensitiveField(nestedValue);
+  });
+}
+
+function validateClaims(claims, reasons) {
+  if (!Array.isArray(claims) || claims.length === 0) {
+    reasons.push("Public adapter-output authorization claims must be non-empty.");
+    return;
+  }
+
+  const seenClaims = [];
+
+  for (const claim of claims) {
+    if (!isNonEmptyString(claim)) {
+      pushOnce(
+        reasons,
+        "Public adapter-output authorization claims include unsupported public output.",
+      );
+      continue;
+    }
+
+    if (seenClaims.includes(claim)) {
+      pushOnce(
+        reasons,
+        "Public adapter-output authorization claims must not contain duplicates.",
+      );
+    }
+    seenClaims.push(claim);
+
+    if (containsForbiddenPublicClaim(claim)) {
+      pushOnce(
+        reasons,
+        "Public adapter-output authorization may not carry medical, legal, custody, consent, or emergency claims.",
+      );
+    }
+
+    if (!ALLOWED_PUBLIC_ADAPTER_OUTPUT_CLAIMS.includes(claim)) {
+      pushOnce(
+        reasons,
+        "Public adapter-output authorization claims include unsupported public output.",
+      );
+    }
+  }
+
+  if (claims.every(isNonEmptyString) && !claimsMatchAllowedSet(claims)) {
+    pushOnce(
+      reasons,
+      "Public adapter-output authorization claims include unsupported public output.",
+    );
+  }
+}
+
+function validateTimestamps({ authorization, currentAt, reasons }) {
+  const currentMilliseconds = parseIsoTimestamp(currentAt);
+  const generatedMilliseconds = parseIsoTimestamp(authorization.generated_at);
+  const validFromMilliseconds = parseIsoTimestamp(authorization.valid_from);
+  const expiresMilliseconds = parseIsoTimestamp(authorization.expires_at);
+
+  if (currentMilliseconds === null) {
+    reasons.push(
+      "Public adapter-output authorization current timestamp is required.",
+    );
+    return;
+  }
+
+  if (
+    generatedMilliseconds === null ||
+    validFromMilliseconds === null ||
+    expiresMilliseconds === null
+  ) {
+    reasons.push(
+      "Public adapter-output authorization validity timestamps are malformed.",
+    );
+    return;
+  }
+
+  if (currentMilliseconds > expiresMilliseconds) {
+    reasons.push("Public adapter-output authorization is expired.");
+  }
+
+  if (
+    currentMilliseconds < validFromMilliseconds ||
+    currentMilliseconds < generatedMilliseconds
+  ) {
+    reasons.push("Public adapter-output authorization is not yet valid.");
+  }
+
+  if (
+    currentMilliseconds - generatedMilliseconds >
+    PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_MAX_AGE_MS
+  ) {
+    reasons.push("Public adapter-output authorization is stale.");
+  }
+}
+
+function buildMetadata({ authorization, responseState, transportCalled }) {
+  return {
+    schema: authorization.schema,
+    subject: authorization.subject,
+    audience: authorization.audience,
+    claims: [...authorization.claims],
+    evidence_hash: authorization.evidence_hash,
+    receipt_id: authorization.receipt_id,
+    proof_id: authorization.proof_id,
+    proof_ref: authorization.proof_ref,
+    generated_at: authorization.generated_at,
+    valid_from: authorization.valid_from,
+    expires_at: authorization.expires_at,
+    proof_type: authorization.proof.type,
+    response_state: responseState,
+    transport_called: transportCalled,
+  };
+}
+
+function evaluatePublicAdapterOutputAuthorization(
+  adapterOutputAuthorization,
+  {
+    currentAt,
+    subject = PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+    audience = PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+  } = {},
+) {
+  if (!isObjectRecord(adapterOutputAuthorization)) {
+    return createDeniedDecision({
+      reasons: ["Public adapter-output authorization is missing."],
+    });
+  }
+
+  const responseState = safeResponseState(adapterOutputAuthorization);
+  const transportCalled = safeTransportCalled(adapterOutputAuthorization);
+  const reasons = [];
+
+  if (adapterOutputAuthorization.allowed !== true) {
+    reasons.push(
+      "Public adapter-output authorization evaluator did not allow public output.",
+    );
+  }
+
+  if (responseState !== "permit") {
+    reasons.push(
+      "Public adapter-output authorization transport must return permit.",
+    );
+  }
+
+  if (!transportCalled) {
+    reasons.push(
+      "Public adapter-output authorization transport must be called.",
+    );
+  }
+
+  const authorization = adapterOutputAuthorization.value;
+
+  if (!isObjectRecord(authorization)) {
+    reasons.push("Public adapter-output authorization DTO is malformed.");
+    return createDeniedDecision({ reasons, responseState, transportCalled });
+  }
+
+  if (containsRawSensitiveField(authorization)) {
+    reasons.push(
+      "Public adapter-output authorization contains raw sensitive fields.",
+    );
+  }
+
+  if (authorization.schema !== PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SCHEMA) {
+    reasons.push("Public adapter-output authorization schema is invalid.");
+  }
+
+  if (authorization.subject !== subject) {
+    reasons.push(
+      `Public adapter-output authorization subject must be ${subject}.`,
+    );
+  }
+
+  if (authorization.audience !== audience) {
+    reasons.push(
+      `Public adapter-output authorization audience must be ${audience}.`,
+    );
+  }
+
+  validateClaims(authorization.claims, reasons);
+
+  if (!SHA256_EVIDENCE_HASH_PATTERN.test(authorization.evidence_hash || "")) {
+    reasons.push(
+      "Public adapter-output authorization evidence_hash must be sha256-prefixed lowercase hex.",
+    );
+  }
+
+  if (!isNonEmptyString(authorization.receipt_id)) {
+    reasons.push("Public adapter-output authorization requires receipt_id.");
+  }
+
+  if (
+    !isNonEmptyString(authorization.proof_id) ||
+    !isNonEmptyString(authorization.proof_ref)
+  ) {
+    reasons.push(
+      "Public adapter-output authorization requires proof_id and proof_ref.",
+    );
+  }
+
+  validateTimestamps({ authorization, currentAt, reasons });
+
+  if (authorization.revoked === true) {
+    reasons.push("Public adapter-output authorization is revoked.");
+  }
+
+  if (authorization.contradicted === true) {
+    reasons.push("Public adapter-output authorization is contradicted.");
+  }
+
+  const proof = authorization.proof;
+  if (
+    !isObjectRecord(proof) ||
+    !isNonEmptyString(proof.type) ||
+    !PROOF_SIGNATURE_PATTERN.test(proof.signature || "")
+  ) {
+    reasons.push(
+      "Public adapter-output authorization proof signature is malformed.",
+    );
+  }
+
+  if (reasons.length > 0) {
+    return createDeniedDecision({ reasons, responseState, transportCalled });
+  }
+
+  return createAllowedDecision({
+    responseState,
+    transportCalled,
+    metadata: buildMetadata({ authorization, responseState, transportCalled }),
+  });
+}
+
+module.exports = {
+  ALLOWED_PUBLIC_ADAPTER_OUTPUT_CLAIMS,
+  PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+  PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SCHEMA,
+  PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+  evaluatePublicAdapterOutputAuthorization,
+};

--- a/livesafe/server/utils/status-route-contracts.js
+++ b/livesafe/server/utils/status-route-contracts.js
@@ -10,6 +10,13 @@ function buildMethodNotAllowedHandler() {
   };
 }
 
+function buildStatusRouteResponderError() {
+  const error = new Error("Status route responder failed.");
+  error.code = "STATUS_ROUTE_RESPONDER_FAILED";
+  error.status = 500;
+  return error;
+}
+
 function getStatusRouteContracts() {
   return [
     {
@@ -57,15 +64,27 @@ function registerStatusRouteContracts(app, responders) {
       throw new Error(`Missing status route responder: ${contract.responder}`);
     }
 
-    app.get(contract.path, (req, res) => {
+    app.get(contract.path, async (req, res, next) => {
       applyStatusRouteHeaders(res);
-      responder(req, res);
+      try {
+        await responder(req, res, next);
+      } catch {
+        const error = buildStatusRouteResponderError();
+
+        if (typeof next === "function") {
+          next(error);
+          return;
+        }
+
+        throw error;
+      }
     });
     app.all(contract.path, methodNotAllowed);
   }
 }
 
 module.exports = {
+  buildStatusRouteResponderError,
   getStatusRouteContracts,
   registerStatusRouteContracts,
 };

--- a/livesafe/server/utils/trust-status.d.ts
+++ b/livesafe/server/utils/trust-status.d.ts
@@ -21,6 +21,7 @@ export interface TrustStatusPayloadOptions {
       | "anchorScan"
       | "anchorConsent"
       | "getPaceStatus"
+      | "getPublicAdapterOutputAuthorization"
     >;
     disablement_path: string;
     source_basis: string[];
@@ -72,6 +73,7 @@ export interface TrustStatusPayload {
     | "anchorScan"
     | "anchorConsent"
     | "getPaceStatus"
+    | "getPublicAdapterOutputAuthorization"
   >;
   adapter_disablement_path: string;
   exochain_production_evidence_state: "verified" | "blocked";
@@ -115,6 +117,23 @@ export function createTrustStatusPayload(
   options: TrustStatusPayloadOptions
 ): TrustStatusPayload;
 
+export function buildLiveTrustStatusOptions(
+  options: TrustStatusPayloadOptions & {
+    adapter?: {
+      getRuntimeStatus(): TrustStatusPayloadOptions["runtimeStatus"];
+      getPublicAdapterOutputAuthorization(options: {
+        currentAt: string;
+        returnDecision: true;
+      }): Promise<{
+        allowed: boolean;
+        responseState: string;
+        transportCalled: boolean;
+        value: unknown;
+      }>;
+    };
+  }
+): Promise<TrustStatusPayloadOptions>;
+
 export function sendTrustStatusResponse(
   req: unknown,
   res: {
@@ -124,3 +143,26 @@ export function sendTrustStatusResponse(
   },
   options: TrustStatusPayloadOptions
 ): unknown;
+
+export function sendLiveTrustStatusResponse(
+  req: unknown,
+  res: {
+    status(code: number): {
+      json(payload: TrustStatusPayload): unknown;
+    };
+  },
+  options: TrustStatusPayloadOptions & {
+    adapter?: {
+      getRuntimeStatus(): TrustStatusPayloadOptions["runtimeStatus"];
+      getPublicAdapterOutputAuthorization(options: {
+        currentAt: string;
+        returnDecision: true;
+      }): Promise<{
+        allowed: boolean;
+        responseState: string;
+        transportCalled: boolean;
+        value: unknown;
+      }>;
+    };
+  }
+): Promise<unknown>;

--- a/livesafe/server/utils/trust-status.d.ts
+++ b/livesafe/server/utils/trust-status.d.ts
@@ -25,6 +25,12 @@ export interface TrustStatusPayloadOptions {
     disablement_path: string;
     source_basis: string[];
   };
+  adapterOutputAuthorization?: {
+    allowed: boolean;
+    responseState: string;
+    transportCalled: boolean;
+    value: unknown;
+  };
   productionTrustEvidence?: {
     evidence_state: "verified" | "blocked";
     production_health_verified: boolean;
@@ -83,6 +89,22 @@ export interface TrustStatusPayload {
   frost_genesis_complete: boolean;
   public_claims_allowed: boolean;
   public_claims_reason: string;
+  public_adapter_output_authorization?: {
+    schema: "livesafe.public_adapter_output_authorization.v1";
+    subject: "livesafe.ai";
+    audience: "https://livesafe.ai/api/trust/status";
+    claims: string[];
+    evidence_hash: string;
+    receipt_id: string;
+    proof_id: string;
+    proof_ref: string;
+    generated_at: string;
+    valid_from: string;
+    expires_at: string;
+    proof_type: string;
+    response_state: "permit";
+    transport_called: true;
+  };
   source_basis: string[];
   version: string;
   uptime_seconds: number;

--- a/livesafe/server/utils/trust-status.d.ts
+++ b/livesafe/server/utils/trust-status.d.ts
@@ -11,7 +11,7 @@ export interface TrustStatusPayloadOptions {
       | "adjacent-surface"
       | "imported-evidence"
       | "third-party-vendor";
-    public_claims_allowed: boolean;
+    public_claims_allowed?: boolean;
     can_read_exochain_core_state: boolean;
     can_write_exochain_core_state: boolean;
     wrapped_operations?: Array<

--- a/livesafe/server/utils/trust-status.js
+++ b/livesafe/server/utils/trust-status.js
@@ -175,11 +175,68 @@ function createTrustStatusPayload({
   return payload;
 }
 
+function resolveGeneratedAt(generatedAt) {
+  return generatedAt ?? new Date().toISOString();
+}
+
+async function getPublicAdapterOutputAuthorizationDecision({
+  adapter,
+  currentAt,
+}) {
+  try {
+    return await adapter.getPublicAdapterOutputAuthorization({
+      currentAt,
+      returnDecision: true,
+    });
+  } catch {
+    return {
+      allowed: false,
+      responseState: "unavailable",
+      transportCalled: true,
+      value: null,
+    };
+  }
+}
+
+async function buildLiveTrustStatusOptions({
+  adapter = runtimeExochainAdapter,
+  exochainConnected,
+  version,
+  uptimeSeconds,
+  generatedAt,
+  productionTrustEvidence,
+}) {
+  const currentAt = resolveGeneratedAt(generatedAt);
+  const runtimeStatus = adapter.getRuntimeStatus();
+  const adapterOutputAuthorization =
+    await getPublicAdapterOutputAuthorizationDecision({
+      adapter,
+      currentAt,
+    });
+
+  return {
+    exochainConnected,
+    version,
+    uptimeSeconds,
+    generatedAt: currentAt,
+    runtimeStatus,
+    adapterOutputAuthorization,
+    productionTrustEvidence,
+  };
+}
+
 function sendTrustStatusResponse(_req, res, options) {
   return res.status(200).json(createTrustStatusPayload(options));
 }
 
+async function sendLiveTrustStatusResponse(_req, res, options) {
+  const payloadOptions = await buildLiveTrustStatusOptions(options);
+  return sendTrustStatusResponse(_req, res, payloadOptions);
+}
+
 module.exports = {
+  buildLiveTrustStatusOptions,
   createTrustStatusPayload,
+  sendLiveTrustStatusResponse,
   sendTrustStatusResponse
 };

--- a/livesafe/server/utils/trust-status.js
+++ b/livesafe/server/utils/trust-status.js
@@ -4,13 +4,19 @@ const { runtimeExochainAdapter } = require("./livesafe-exochain-adapter");
 const {
   exochainProductionTrustEvidence,
 } = require("./exochain-production-trust-evidence");
+const {
+  PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+  PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+  evaluatePublicAdapterOutputAuthorization,
+} = require("./public-adapter-output-authorization");
 
 const SOURCE_BASIS = [
   "docs/context/LIVESAFE_PRODUCTION_TRUST_ACTIVATION_GATES.md",
   "docs/context/LIVESAFE_TRUST_SIGNAL_VISUAL_LANGUAGE.md",
   "src/trust-signal.ts",
   "src/genesis-trust.ts",
-  "server/utils/livesafe-exochain-adapter.js"
+  "server/utils/livesafe-exochain-adapter.js",
+  "server/utils/public-adapter-output-authorization.js"
 ];
 
 const NOT_VERIFIED_TOKEN = {
@@ -48,6 +54,7 @@ function publicClaimsReason({
   productionEvidenceVerified,
   runtimeAdapterVerified,
   runtimePublicClaimsAllowed,
+  publicAdapterOutputAuthorized,
 }) {
   if (!productionEvidenceVerified) {
     return "Public trust claims remain inactive until EXOCHAIN production evidence verifies.";
@@ -61,7 +68,11 @@ function publicClaimsReason({
     return "Public trust claims remain inactive because the LiveSafe runtime adapter has not allowed public trust output.";
   }
 
-  return "EXOCHAIN production evidence and LiveSafe runtime adapter gates are verified.";
+  if (!publicAdapterOutputAuthorized) {
+    return "Public trust claims remain inactive because proof-bearing public adapter-output authorization has not been verified.";
+  }
+
+  return "EXOCHAIN production evidence, LiveSafe runtime adapter gates, and proof-bearing public adapter-output authorization are verified.";
 }
 
 function createTrustStatusPayload({
@@ -70,6 +81,7 @@ function createTrustStatusPayload({
   uptimeSeconds,
   generatedAt,
   runtimeStatus,
+  adapterOutputAuthorization,
   productionTrustEvidence
 }) {
   const defaultRuntimeStatus = runtimeExochainAdapter.getRuntimeStatus();
@@ -91,13 +103,21 @@ function createTrustStatusPayload({
   );
   const runtimePublicClaimsAllowed =
     resolvedRuntimeStatus.public_claims_allowed === true;
+  const publicAdapterOutputAuthorizationDecision =
+    evaluatePublicAdapterOutputAuthorization(adapterOutputAuthorization, {
+      currentAt: generatedAt,
+      subject: PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+      audience: PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+    });
+  const publicAdapterOutputAuthorized =
+    publicAdapterOutputAuthorizationDecision.allowed === true;
   const publicClaimsAllowed =
     productionEvidenceVerified &&
     runtimeAdapterVerified &&
-    runtimePublicClaimsAllowed;
+    runtimePublicClaimsAllowed &&
+    publicAdapterOutputAuthorized;
   const trustToken = publicClaimsAllowed ? VERIFIED_TOKEN : NOT_VERIFIED_TOKEN;
-
-  return {
+  const payload = {
     ...trustToken,
     api_surface: "api-response",
     exochain_connected: Boolean(exochainConnected),
@@ -135,6 +155,7 @@ function createTrustStatusPayload({
       productionEvidenceVerified,
       runtimeAdapterVerified,
       runtimePublicClaimsAllowed,
+      publicAdapterOutputAuthorized,
     }),
     source_basis: [
       ...SOURCE_BASIS,
@@ -145,6 +166,13 @@ function createTrustStatusPayload({
     uptime_seconds: uptimeSeconds,
     generated_at: generatedAt ?? new Date().toISOString()
   };
+
+  if (publicClaimsAllowed) {
+    payload.public_adapter_output_authorization =
+      publicAdapterOutputAuthorizationDecision.metadata;
+  }
+
+  return payload;
 }
 
 function sendTrustStatusResponse(_req, res, options) {

--- a/livesafe/server/utils/trust-status.js
+++ b/livesafe/server/utils/trust-status.js
@@ -51,9 +51,9 @@ function isProductionEvidenceVerified(productionTrustEvidence) {
 }
 
 function publicClaimsReason({
+  exochainConnected,
   productionEvidenceVerified,
   runtimeAdapterVerified,
-  runtimePublicClaimsAllowed,
   publicAdapterOutputAuthorized,
 }) {
   if (!productionEvidenceVerified) {
@@ -64,15 +64,15 @@ function publicClaimsReason({
     return "Public trust claims remain inactive because EXOCHAIN production evidence is verified but the LiveSafe runtime adapter remains unverified.";
   }
 
-  if (!runtimePublicClaimsAllowed) {
-    return "Public trust claims remain inactive because the LiveSafe runtime adapter has not allowed public trust output.";
-  }
-
   if (!publicAdapterOutputAuthorized) {
     return "Public trust claims remain inactive because proof-bearing public adapter-output authorization has not been verified.";
   }
 
-  return "EXOCHAIN production evidence, LiveSafe runtime adapter gates, and proof-bearing public adapter-output authorization are verified.";
+  if (!exochainConnected) {
+    return "Public trust claims remain inactive until EXOCHAIN connectivity verifies.";
+  }
+
+  return "EXOCHAIN connectivity, EXOCHAIN production evidence, LiveSafe runtime adapter gates, and proof-bearing public adapter-output authorization are verified.";
 }
 
 function createTrustStatusPayload({
@@ -101,8 +101,6 @@ function createTrustStatusPayload({
   const productionEvidenceVerified = isProductionEvidenceVerified(
     resolvedProductionTrustEvidence,
   );
-  const runtimePublicClaimsAllowed =
-    resolvedRuntimeStatus.public_claims_allowed === true;
   const publicAdapterOutputAuthorizationDecision =
     evaluatePublicAdapterOutputAuthorization(adapterOutputAuthorization, {
       currentAt: generatedAt,
@@ -112,9 +110,9 @@ function createTrustStatusPayload({
   const publicAdapterOutputAuthorized =
     publicAdapterOutputAuthorizationDecision.allowed === true;
   const publicClaimsAllowed =
+    Boolean(exochainConnected) &&
     productionEvidenceVerified &&
     runtimeAdapterVerified &&
-    runtimePublicClaimsAllowed &&
     publicAdapterOutputAuthorized;
   const trustToken = publicClaimsAllowed ? VERIFIED_TOKEN : NOT_VERIFIED_TOKEN;
   const payload = {
@@ -152,9 +150,9 @@ function createTrustStatusPayload({
     frost_genesis_complete: productionEvidenceVerified,
     public_claims_allowed: publicClaimsAllowed,
     public_claims_reason: publicClaimsReason({
+      exochainConnected: Boolean(exochainConnected),
       productionEvidenceVerified,
       runtimeAdapterVerified,
-      runtimePublicClaimsAllowed,
       publicAdapterOutputAuthorized,
     }),
     source_basis: [

--- a/livesafe/tests/exochain-client.test.ts
+++ b/livesafe/tests/exochain-client.test.ts
@@ -2,6 +2,30 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const { ExochainClient } = require("../server/utils/exochain-client.js");
 
+const PUBLIC_ADAPTER_AUTHORIZATION_DTO = {
+  schema: "livesafe.public_adapter_output_authorization.v1",
+  subject: "livesafe.ai",
+  audience: "https://livesafe.ai/api/trust/status",
+  claims: [
+    "livesafe_public_trust_status",
+    "exochain_production_evidence_verified",
+    "livesafe_runtime_adapter_verified",
+  ],
+  evidence_hash:
+    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  receipt_id: "exo-receipt:public-adapter-output:2026-07-05",
+  proof_id: "exo-proof:public-adapter-output:2026-07-05",
+  proof_ref: "exo://receipts/public-adapter-output/2026-07-05",
+  generated_at: "2026-07-05T11:59:00.000Z",
+  valid_from: "2026-07-05T11:55:00.000Z",
+  expires_at: "2026-07-05T12:05:00.000Z",
+  proof: {
+    type: "ed25519-public-adapter-output-authorization",
+    signature:
+      "ed25519:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  },
+};
+
 describe("EXOCHAIN client timestamp preservation", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -375,5 +399,123 @@ describe("EXOCHAIN client timestamp preservation", () => {
 
     expect(result).toBeNull();
     expect(query).not.toHaveBeenCalled();
+  });
+
+  it("fails closed before query when public adapter-output authorization subject or audience is not exact", async () => {
+    for (const input of [
+      {
+        subject: "www.livesafe.ai",
+        audience: "https://livesafe.ai/api/trust/status",
+      },
+      {
+        subject: "livesafe.ai",
+        audience: "https://livesafe.ai/api/health",
+      },
+    ]) {
+      const client = new ExochainClient("http://example.invalid/graphql");
+      const query = vi.spyOn(client, "query").mockResolvedValue({
+        data: {
+          livesafe_public_adapter_output_authorization:
+            PUBLIC_ADAPTER_AUTHORIZATION_DTO,
+        },
+      });
+
+      const result = await client.getPublicAdapterOutputAuthorization(input);
+
+      expect(result).toEqual({ state: "rejected", value: null });
+      expect(query).not.toHaveBeenCalled();
+    }
+  });
+
+  it("requests public adapter-output authorization through a narrow GraphQL operation", async () => {
+    const client = new ExochainClient("http://example.invalid/graphql");
+    const query = vi.spyOn(client, "query").mockResolvedValue({
+      data: {
+        livesafe_public_adapter_output_authorization:
+          PUBLIC_ADAPTER_AUTHORIZATION_DTO,
+      },
+    });
+
+    const result = await client.getPublicAdapterOutputAuthorization({
+      subject: "livesafe.ai",
+      audience: "https://livesafe.ai/api/trust/status",
+    });
+
+    expect(result).toEqual({
+      state: "permit",
+      value: PUBLIC_ADAPTER_AUTHORIZATION_DTO,
+    });
+    expect(query).toHaveBeenCalledWith(
+      "GetPublicAdapterOutputAuthorization",
+      expect.stringContaining("livesafe_public_adapter_output_authorization"),
+      {
+        input: {
+          subject: "livesafe.ai",
+          audience: "https://livesafe.ai/api/trust/status",
+        },
+      },
+    );
+    const queryDocument = query.mock.calls[0]?.[1] || "";
+    expect(queryDocument).toContain("evidence_hash");
+    expect(queryDocument).toContain("proof_id");
+    expect(queryDocument).toContain("proof_ref");
+    expect(queryDocument).not.toContain("bearer_token");
+    expect(queryDocument).not.toContain("private_key");
+    expect(queryDocument).not.toContain("raw_authority_chain");
+  });
+
+  it("redacts public adapter-output authorization gateway errors and fails closed", async () => {
+    const client = new ExochainClient("http://example.invalid/graphql");
+    vi.spyOn(client, "query").mockResolvedValue({
+      data: null,
+      errors: [
+        {
+          message: "Bearer secret-production-token private_key=raw-key",
+        },
+      ],
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = await client.getPublicAdapterOutputAuthorization({
+      subject: "livesafe.ai",
+      audience: "https://livesafe.ai/api/trust/status",
+    });
+
+    expect(result).toEqual({ state: "rejected", value: null });
+    expect(JSON.stringify(warn.mock.calls)).not.toContain(
+      "secret-production-token",
+    );
+    expect(JSON.stringify(warn.mock.calls)).not.toContain("raw-key");
+  });
+
+  it("fails closed when public adapter-output authorization response is malformed or unavailable", async () => {
+    const malformedClient = new ExochainClient("http://example.invalid/graphql");
+    vi.spyOn(malformedClient, "query").mockResolvedValue({
+      data: {
+        livesafe_public_adapter_output_authorization: {
+          ...PUBLIC_ADAPTER_AUTHORIZATION_DTO,
+          proof_id: "",
+        },
+      },
+    });
+    const unavailableClient = new ExochainClient("http://example.invalid/graphql");
+    vi.spyOn(unavailableClient, "query").mockRejectedValue(
+      Object.assign(new Error("Bearer secret-production-token ETIMEDOUT"), {
+        code: "ETIMEDOUT",
+      }),
+    );
+
+    await expect(
+      malformedClient.getPublicAdapterOutputAuthorization({
+        subject: "livesafe.ai",
+        audience: "https://livesafe.ai/api/trust/status",
+      }),
+    ).resolves.toEqual({ state: "rejected", value: null });
+    await expect(
+      unavailableClient.getPublicAdapterOutputAuthorization({
+        subject: "livesafe.ai",
+        audience: "https://livesafe.ai/api/trust/status",
+      }),
+    ).resolves.toEqual({ state: "timeout", value: null });
   });
 });

--- a/livesafe/tests/exochain-client.test.ts
+++ b/livesafe/tests/exochain-client.test.ts
@@ -41,7 +41,66 @@ const PUBLIC_ADAPTER_AUTHORIZATION_REST_CONFIG = {
   EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_TIMEOUT_MS: "2500",
 };
 
-const PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE = {
+const PUBLIC_ADAPTER_AUTHORIZATION_RUST_CORE_ENVELOPE = {
+  schema_version: "1",
+  domain: "livesafe.public_adapter_output_authorization.v1",
+  proof: {
+    schema_version: "1",
+    domain: "livesafe.public_adapter_output_authorization.v1",
+    subject: "livesafe.ai",
+    audience: "https://livesafe.ai/api/trust/status",
+    evidence_hash:
+      "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    credential_id: "credential:livesafe-public-adapter-output",
+    receipt_id: "exo-receipt:public-adapter-output:2026-07-05",
+    action_commitment_hash:
+      "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    idempotency_key_hash:
+      "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    issued_at: {
+      physical_ms: Date.parse("2026-07-05T11:59:00.000Z"),
+      logical: 3,
+    },
+    expires_at: {
+      physical_ms: Date.parse("2026-07-05T12:05:00.000Z"),
+      logical: 0,
+    },
+    revocation_status: "active",
+    signer_did: "did:exo:livesafe:node",
+    proof_hash:
+      "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    signature:
+      "ed25519:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  },
+};
+
+const PUBLIC_ADAPTER_AUTHORIZATION_DTO_FROM_RUST = {
+  schema: "livesafe.public_adapter_output_authorization.v1",
+  subject: "livesafe.ai",
+  audience: "https://livesafe.ai/api/trust/status",
+  claims: [
+    "livesafe_public_trust_status",
+    "exochain_production_evidence_verified",
+    "livesafe_runtime_adapter_verified",
+  ],
+  evidence_hash:
+    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  receipt_id: "exo-receipt:public-adapter-output:2026-07-05",
+  proof_id:
+    "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  proof_ref:
+    "exochain-avc:sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  generated_at: "2026-07-05T11:59:00.000Z",
+  valid_from: "2026-07-05T11:59:00.000Z",
+  expires_at: "2026-07-05T12:05:00.000Z",
+  proof: {
+    type: "ed25519-public-adapter-output-authorization",
+    signature:
+      "ed25519:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  },
+};
+
+const PUBLIC_ADAPTER_AUTHORIZATION_LEGACY_FAKE_ENVELOPE = {
   envelope_schema:
     "exochain.avc.livesafe.public_adapter_output_authorization_envelope.v1",
   status: "authorized",
@@ -75,6 +134,23 @@ const PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE = {
   },
   expires_at: "2026-07-05T12:05:00.000Z",
 };
+
+function rustCoreEnvelope({
+  envelope = {},
+  proof = {},
+}: {
+  envelope?: Record<string, unknown>;
+  proof?: Record<string, unknown>;
+} = {}) {
+  return {
+    ...PUBLIC_ADAPTER_AUTHORIZATION_RUST_CORE_ENVELOPE,
+    ...envelope,
+    proof: {
+      ...PUBLIC_ADAPTER_AUTHORIZATION_RUST_CORE_ENVELOPE.proof,
+      ...proof,
+    },
+  };
+}
 
 const PUBLIC_ADAPTER_AUTHORIZATION_ENV_KEYS = Object.keys(
   PUBLIC_ADAPTER_AUTHORIZATION_REST_CONFIG,
@@ -548,7 +624,7 @@ describe("EXOCHAIN client timestamp preservation", () => {
     const query = vi.spyOn(client, "query");
     const fetch = vi.fn(async () => ({
       ok: true,
-      json: async () => PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
+      json: async () => PUBLIC_ADAPTER_AUTHORIZATION_RUST_CORE_ENVELOPE,
     }));
     vi.stubGlobal("fetch", fetch);
 
@@ -560,29 +636,7 @@ describe("EXOCHAIN client timestamp preservation", () => {
 
     expect(result).toEqual({
       state: "permit",
-      value: {
-        schema: "livesafe.public_adapter_output_authorization.v1",
-        subject: "livesafe.ai",
-        audience: "https://livesafe.ai/api/trust/status",
-        claims: [
-          "livesafe_public_trust_status",
-          "exochain_production_evidence_verified",
-          "livesafe_runtime_adapter_verified",
-        ],
-        evidence_hash:
-          "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        receipt_id: "exo-receipt:public-adapter-output:2026-07-05",
-        proof_id: "exo-proof:public-adapter-output:2026-07-05",
-        proof_ref: "exo://receipts/public-adapter-output/2026-07-05",
-        generated_at: "2026-07-05T11:59:00.000Z",
-        valid_from: "2026-07-05T11:55:00.000Z",
-        expires_at: "2026-07-05T12:05:00.000Z",
-        proof: {
-          type: "ed25519-public-adapter-output-authorization",
-          signature:
-            "ed25519:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        },
-      },
+      value: PUBLIC_ADAPTER_AUTHORIZATION_DTO_FROM_RUST,
     });
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith(
@@ -624,7 +678,7 @@ describe("EXOCHAIN client timestamp preservation", () => {
     const client = new ExochainClient("http://example.invalid/graphql");
     const fetch = vi.fn(async () => ({
       ok: true,
-      json: async () => PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
+      json: async () => PUBLIC_ADAPTER_AUTHORIZATION_RUST_CORE_ENVELOPE,
     }));
     vi.stubGlobal("fetch", fetch);
 
@@ -648,7 +702,7 @@ describe("EXOCHAIN client timestamp preservation", () => {
       "fetch",
       vi.fn(async () => ({
         ok: true,
-        json: async () => PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
+        json: async () => PUBLIC_ADAPTER_AUTHORIZATION_RUST_CORE_ENVELOPE,
       })),
     );
 
@@ -660,29 +714,7 @@ describe("EXOCHAIN client timestamp preservation", () => {
 
     expect(result).toEqual({
       state: "permit",
-      value: {
-        schema: "livesafe.public_adapter_output_authorization.v1",
-        subject: "livesafe.ai",
-        audience: "https://livesafe.ai/api/trust/status",
-        claims: [
-          "livesafe_public_trust_status",
-          "exochain_production_evidence_verified",
-          "livesafe_runtime_adapter_verified",
-        ],
-        evidence_hash:
-          "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        receipt_id: "exo-receipt:public-adapter-output:2026-07-05",
-        proof_id: "exo-proof:public-adapter-output:2026-07-05",
-        proof_ref: "exo://receipts/public-adapter-output/2026-07-05",
-        generated_at: "2026-07-05T11:59:00.000Z",
-        valid_from: "2026-07-05T11:55:00.000Z",
-        expires_at: "2026-07-05T12:05:00.000Z",
-        proof: {
-          type: "ed25519-public-adapter-output-authorization",
-          signature:
-            "ed25519:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        },
-      },
+      value: PUBLIC_ADAPTER_AUTHORIZATION_DTO_FROM_RUST,
     });
   });
 
@@ -714,106 +746,118 @@ describe("EXOCHAIN client timestamp preservation", () => {
 
   it.each([
     {
-      label: "wrong schema",
-      envelope: {
-        ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
-        envelope_schema:
-          "exochain.avc.livesafe.public_adapter_output_authorization_envelope.v0",
-      },
+      label: "legacy fake envelope_schema status fixture",
+      envelope: PUBLIC_ADAPTER_AUTHORIZATION_LEGACY_FAKE_ENVELOPE,
       expectedState: "rejected",
     },
     {
-      label: "wrong subject",
-      envelope: {
-        ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
-        subject: "www.livesafe.ai",
-      },
+      label: "missing top-level domain",
+      envelope: rustCoreEnvelope({ envelope: { domain: "" } }),
       expectedState: "rejected",
     },
     {
-      label: "wrong audience",
-      envelope: {
-        ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
-        audience: "https://livesafe.ai/api/health",
-      },
+      label: "wrong top-level domain",
+      envelope: rustCoreEnvelope({
+        envelope: { domain: "livesafe.public_adapter_output_authorization.v0" },
+      }),
       expectedState: "rejected",
     },
     {
-      label: "wrong domain",
-      envelope: {
-        ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
-        domain: "www.livesafe.ai",
-      },
+      label: "wrong nested proof domain",
+      envelope: rustCoreEnvelope({
+        proof: { domain: "livesafe.public_adapter_output_authorization.v0" },
+      }),
       expectedState: "rejected",
     },
     {
-      label: "expired",
-      envelope: {
-        ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
-        expires_at: "2026-07-05T11:59:59.999Z",
-      },
+      label: "wrong nested proof subject",
+      envelope: rustCoreEnvelope({ proof: { subject: "www.livesafe.ai" } }),
+      expectedState: "rejected",
+    },
+    {
+      label: "wrong nested proof audience",
+      envelope: rustCoreEnvelope({
+        proof: { audience: "https://livesafe.ai/api/health" },
+      }),
+      expectedState: "rejected",
+    },
+    {
+      label: "evidence hash mismatch",
+      envelope: rustCoreEnvelope({
+        proof: {
+          evidence_hash:
+            "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        },
+      }),
+      expectedState: "rejected",
+    },
+    {
+      label: "expired nested proof",
+      envelope: rustCoreEnvelope({
+        proof: { expires_at: "2026-07-05T11:59:59.999Z" },
+      }),
       expectedState: "stale",
     },
     {
-      label: "not yet valid",
-      envelope: {
-        ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
-        valid_from: "2026-07-05T12:00:01.000Z",
-      },
+      label: "not yet valid nested proof",
+      envelope: rustCoreEnvelope({
+        proof: { issued_at: "2026-07-05T12:00:01.000Z" },
+      }),
       expectedState: "stale",
     },
     {
-      label: "stale issued_at",
-      envelope: {
-        ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
-        issued_at: "2026-07-05T11:54:59.999Z",
-      },
+      label: "stale nested proof issued_at",
+      envelope: rustCoreEnvelope({
+        proof: { issued_at: "2026-07-05T11:54:59.999Z" },
+      }),
       expectedState: "stale",
     },
     {
-      label: "revoked status",
-      envelope: {
-        ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
-        status: "revoked",
-      },
+      label: "revoked revocation_status",
+      envelope: rustCoreEnvelope({ proof: { revocation_status: "revoked" } }),
       expectedState: "revoked",
     },
     {
-      label: "missing receipt",
-      envelope: {
-        ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
-        receipt: null,
-      },
+      label: "missing receipt_id",
+      envelope: rustCoreEnvelope({ proof: { receipt_id: "" } }),
       expectedState: "rejected",
     },
     {
-      label: "missing proof id",
-      envelope: {
-        ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
-        proof: {
-          ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE.proof,
-          id: "",
-        },
-      },
+      label: "missing proof_hash",
+      envelope: rustCoreEnvelope({ proof: { proof_hash: "" } }),
       expectedState: "rejected",
     },
     {
       label: "missing signature",
-      envelope: {
-        ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
-        proof: {
-          ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE.proof,
-          signature: "",
-        },
-      },
+      envelope: rustCoreEnvelope({ proof: { signature: "" } }),
+      expectedState: "rejected",
+    },
+    {
+      label: "object signature shape",
+      envelope: rustCoreEnvelope({
+        proof: { signature: { bytes: [1, 2, 3] } },
+      }),
+      expectedState: "rejected",
+    },
+    {
+      label: "unknown issued_at shape",
+      envelope: rustCoreEnvelope({
+        proof: { issued_at: { physical_time: "2026-07-05T11:59:00.000Z" } },
+      }),
+      expectedState: "rejected",
+    },
+    {
+      label: "unknown expires_at shape",
+      envelope: rustCoreEnvelope({
+        proof: { expires_at: { physical_time: "2026-07-05T12:05:00.000Z" } },
+      }),
       expectedState: "rejected",
     },
     {
       label: "raw sensitive field",
-      envelope: {
-        ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
-        bearer_token: "Bearer secret-production-token",
-      },
+      envelope: rustCoreEnvelope({
+        envelope: { bearer_token: "Bearer secret-production-token" },
+      }),
       expectedState: "rejected",
     },
   ])("fails closed when public adapter-output authorization REST envelope is $label", async ({

--- a/livesafe/tests/exochain-client.test.ts
+++ b/livesafe/tests/exochain-client.test.ts
@@ -2,6 +2,23 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const { ExochainClient } = require("../server/utils/exochain-client.js");
 
+function repeatedByte(byte: number, length: number) {
+  return Array.from({ length }, () => byte);
+}
+
+function repeatedHex(byte: number, length: number) {
+  return byte.toString(16).padStart(2, "0").repeat(length);
+}
+
+const EVIDENCE_HASH_BYTES = repeatedByte(0xbb, 32);
+const PROOF_HASH_BYTES = repeatedByte(0xcc, 32);
+const ACTION_COMMITMENT_HASH_BYTES = repeatedByte(0xdd, 32);
+const IDEMPOTENCY_KEY_HASH_BYTES = repeatedByte(0xee, 32);
+const ED25519_SIGNATURE_BYTES = repeatedByte(0xaa, 64);
+const EVIDENCE_HASH_HEX = repeatedHex(0xbb, 32);
+const PROOF_HASH_HEX = repeatedHex(0xcc, 32);
+const ED25519_SIGNATURE_HEX = repeatedHex(0xaa, 64);
+
 const PUBLIC_ADAPTER_AUTHORIZATION_DTO = {
   schema: "livesafe.public_adapter_output_authorization.v1",
   subject: "livesafe.ai",
@@ -33,8 +50,7 @@ const PUBLIC_ADAPTER_AUTHORIZATION_REST_CONFIG = {
     "secret-public-adapter-bearer",
   EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_CREDENTIAL_ID:
     "credential:livesafe-public-adapter-output",
-  EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_EVIDENCE_HASH:
-    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_EVIDENCE_HASH: `sha256:${EVIDENCE_HASH_HEX}`,
   EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_IDEMPOTENCY_KEY:
     "idem:livesafe-public-adapter-output:2026-07-05T12:00:00Z",
   EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_EXPIRES_AT: "2026-07-05T12:05:00.000Z",
@@ -42,21 +58,18 @@ const PUBLIC_ADAPTER_AUTHORIZATION_REST_CONFIG = {
 };
 
 const PUBLIC_ADAPTER_AUTHORIZATION_RUST_CORE_ENVELOPE = {
-  schema_version: "1",
+  schema_version: 1,
   domain: "livesafe.public_adapter_output_authorization.v1",
   proof: {
-    schema_version: "1",
+    schema_version: 1,
     domain: "livesafe.public_adapter_output_authorization.v1",
     subject: "livesafe.ai",
     audience: "https://livesafe.ai/api/trust/status",
-    evidence_hash:
-      "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    evidence_hash: EVIDENCE_HASH_BYTES,
     credential_id: "credential:livesafe-public-adapter-output",
     receipt_id: "exo-receipt:public-adapter-output:2026-07-05",
-    action_commitment_hash:
-      "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
-    idempotency_key_hash:
-      "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    action_commitment_hash: ACTION_COMMITMENT_HASH_BYTES,
+    idempotency_key_hash: IDEMPOTENCY_KEY_HASH_BYTES,
     issued_at: {
       physical_ms: Date.parse("2026-07-05T11:59:00.000Z"),
       logical: 3,
@@ -65,12 +78,12 @@ const PUBLIC_ADAPTER_AUTHORIZATION_RUST_CORE_ENVELOPE = {
       physical_ms: Date.parse("2026-07-05T12:05:00.000Z"),
       logical: 0,
     },
-    revocation_status: "active",
+    revocation_status: "NotRevoked",
     signer_did: "did:exo:livesafe:node",
-    proof_hash:
-      "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-    signature:
-      "ed25519:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    proof_hash: PROOF_HASH_BYTES,
+    signature: {
+      Ed25519: ED25519_SIGNATURE_BYTES,
+    },
   },
 };
 
@@ -83,22 +96,28 @@ const PUBLIC_ADAPTER_AUTHORIZATION_DTO_FROM_RUST = {
     "exochain_production_evidence_verified",
     "livesafe_runtime_adapter_verified",
   ],
-  evidence_hash:
-    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  evidence_hash: `sha256:${EVIDENCE_HASH_HEX}`,
   receipt_id: "exo-receipt:public-adapter-output:2026-07-05",
-  proof_id:
-    "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-  proof_ref:
-    "exochain-avc:sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  proof_id: `sha256:${PROOF_HASH_HEX}`,
+  proof_ref: `exochain-avc:sha256:${PROOF_HASH_HEX}`,
   generated_at: "2026-07-05T11:59:00.000Z",
   valid_from: "2026-07-05T11:59:00.000Z",
   expires_at: "2026-07-05T12:05:00.000Z",
   proof: {
     type: "ed25519-public-adapter-output-authorization",
-    signature:
-      "ed25519:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    signature: `ed25519:${ED25519_SIGNATURE_HEX}`,
   },
 };
+
+const PUBLIC_ADAPTER_AUTHORIZATION_STRING_ONLY_RUST_LIKE_ENVELOPE = rustCoreEnvelope({
+  proof: {
+    evidence_hash: `sha256:${EVIDENCE_HASH_HEX}`,
+    action_commitment_hash: `sha256:${repeatedHex(0xdd, 32)}`,
+    idempotency_key_hash: `sha256:${repeatedHex(0xee, 32)}`,
+    proof_hash: `sha256:${PROOF_HASH_HEX}`,
+    signature: `ed25519:${ED25519_SIGNATURE_HEX}`,
+  },
+});
 
 const PUBLIC_ADAPTER_AUTHORIZATION_LEGACY_FAKE_ENVELOPE = {
   envelope_schema:
@@ -751,6 +770,11 @@ describe("EXOCHAIN client timestamp preservation", () => {
       expectedState: "rejected",
     },
     {
+      label: "string-only Rust-like hash and signature fixture",
+      envelope: PUBLIC_ADAPTER_AUTHORIZATION_STRING_ONLY_RUST_LIKE_ENVELOPE,
+      expectedState: "rejected",
+    },
+    {
       label: "missing top-level domain",
       envelope: rustCoreEnvelope({ envelope: { domain: "" } }),
       expectedState: "rejected",
@@ -785,9 +809,50 @@ describe("EXOCHAIN client timestamp preservation", () => {
       label: "evidence hash mismatch",
       envelope: rustCoreEnvelope({
         proof: {
-          evidence_hash:
-            "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          evidence_hash: repeatedByte(0xff, 32),
         },
+      }),
+      expectedState: "rejected",
+    },
+    {
+      label: "evidence_hash not array",
+      envelope: rustCoreEnvelope({
+        proof: { evidence_hash: `sha256:${EVIDENCE_HASH_HEX}` },
+      }),
+      expectedState: "rejected",
+    },
+    {
+      label: "evidence_hash wrong length",
+      envelope: rustCoreEnvelope({
+        proof: { evidence_hash: repeatedByte(0xbb, 31) },
+      }),
+      expectedState: "rejected",
+    },
+    {
+      label: "evidence_hash non-integer byte",
+      envelope: rustCoreEnvelope({
+        proof: { evidence_hash: [...repeatedByte(0xbb, 31), 1.5] },
+      }),
+      expectedState: "rejected",
+    },
+    {
+      label: "evidence_hash out-of-range byte",
+      envelope: rustCoreEnvelope({
+        proof: { evidence_hash: [...repeatedByte(0xbb, 31), 256] },
+      }),
+      expectedState: "rejected",
+    },
+    {
+      label: "evidence_hash negative byte",
+      envelope: rustCoreEnvelope({
+        proof: { evidence_hash: [...repeatedByte(0xbb, 31), -1] },
+      }),
+      expectedState: "rejected",
+    },
+    {
+      label: "proof_hash wrong length",
+      envelope: rustCoreEnvelope({
+        proof: { proof_hash: repeatedByte(0xcc, 31) },
       }),
       expectedState: "rejected",
     },
@@ -833,9 +898,51 @@ describe("EXOCHAIN client timestamp preservation", () => {
       expectedState: "rejected",
     },
     {
-      label: "object signature shape",
+      label: "signature Empty variant",
       envelope: rustCoreEnvelope({
-        proof: { signature: { bytes: [1, 2, 3] } },
+        proof: { signature: { Empty: null } },
+      }),
+      expectedState: "rejected",
+    },
+    {
+      label: "signature PostQuantum variant",
+      envelope: rustCoreEnvelope({
+        proof: { signature: { PostQuantum: repeatedByte(0xaa, 64) } },
+      }),
+      expectedState: "rejected",
+    },
+    {
+      label: "signature Hybrid variant",
+      envelope: rustCoreEnvelope({
+        proof: {
+          signature: {
+            Hybrid: {
+              ed25519: repeatedByte(0xaa, 64),
+              post_quantum: repeatedByte(0xbb, 64),
+            },
+          },
+        },
+      }),
+      expectedState: "rejected",
+    },
+    {
+      label: "signature wrong Ed25519 length",
+      envelope: rustCoreEnvelope({
+        proof: { signature: { Ed25519: repeatedByte(0xaa, 63) } },
+      }),
+      expectedState: "rejected",
+    },
+    {
+      label: "signature non-integer Ed25519 byte",
+      envelope: rustCoreEnvelope({
+        proof: { signature: { Ed25519: [...repeatedByte(0xaa, 63), 1.5] } },
+      }),
+      expectedState: "rejected",
+    },
+    {
+      label: "signature out-of-range Ed25519 byte",
+      envelope: rustCoreEnvelope({
+        proof: { signature: { Ed25519: [...repeatedByte(0xaa, 63), 256] } },
       }),
       expectedState: "rejected",
     },

--- a/livesafe/tests/exochain-client.test.ts
+++ b/livesafe/tests/exochain-client.test.ts
@@ -26,9 +26,101 @@ const PUBLIC_ADAPTER_AUTHORIZATION_DTO = {
   },
 };
 
+const PUBLIC_ADAPTER_AUTHORIZATION_REST_CONFIG = {
+  EXOCHAIN_NODE_URL: "https://exo-node.example",
+  EXOCHAIN_NODE_AVC_URL: "",
+  EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_BEARER:
+    "secret-public-adapter-bearer",
+  EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_CREDENTIAL_ID:
+    "credential:livesafe-public-adapter-output",
+  EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_EVIDENCE_HASH:
+    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_IDEMPOTENCY_KEY:
+    "idem:livesafe-public-adapter-output:2026-07-05T12:00:00Z",
+  EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_EXPIRES_AT: "2026-07-05T12:05:00.000Z",
+  EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_TIMEOUT_MS: "2500",
+};
+
+const PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE = {
+  envelope_schema:
+    "exochain.avc.livesafe.public_adapter_output_authorization_envelope.v1",
+  status: "authorized",
+  subject: "livesafe.ai",
+  audience: "https://livesafe.ai/api/trust/status",
+  domain: "livesafe.ai",
+  claims: [
+    "livesafe_public_trust_status",
+    "exochain_production_evidence_verified",
+    "livesafe_runtime_adapter_verified",
+  ],
+  evidence_hash:
+    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  receipt: {
+    id: "exo-receipt:public-adapter-output:2026-07-05",
+  },
+  proof: {
+    id: "exo-proof:public-adapter-output:2026-07-05",
+    ref: "exo://receipts/public-adapter-output/2026-07-05",
+    type: "ed25519-public-adapter-output-authorization",
+    signature:
+      "ed25519:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  },
+  issued_at: {
+    physical_ms: Date.parse("2026-07-05T11:59:00.000Z"),
+    logical: 3,
+  },
+  valid_from: {
+    physical_ms: Date.parse("2026-07-05T11:55:00.000Z"),
+    logical: 0,
+  },
+  expires_at: "2026-07-05T12:05:00.000Z",
+};
+
+const PUBLIC_ADAPTER_AUTHORIZATION_ENV_KEYS = Object.keys(
+  PUBLIC_ADAPTER_AUTHORIZATION_REST_CONFIG,
+);
+
+const savedPublicAdapterAuthorizationEnv = Object.fromEntries(
+  PUBLIC_ADAPTER_AUTHORIZATION_ENV_KEYS.map((key) => [key, process.env[key]]),
+);
+
+function restorePublicAdapterAuthorizationEnv() {
+  for (const key of PUBLIC_ADAPTER_AUTHORIZATION_ENV_KEYS) {
+    const value = savedPublicAdapterAuthorizationEnv[key];
+
+    if (typeof value === "undefined") {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function clearPublicAdapterAuthorizationEnv() {
+  for (const key of PUBLIC_ADAPTER_AUTHORIZATION_ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+function configurePublicAdapterAuthorizationEnv(
+  overrides: Partial<typeof PUBLIC_ADAPTER_AUTHORIZATION_REST_CONFIG> = {},
+) {
+  clearPublicAdapterAuthorizationEnv();
+  for (const [key, value] of Object.entries({
+    ...PUBLIC_ADAPTER_AUTHORIZATION_REST_CONFIG,
+    ...overrides,
+  })) {
+    if (value) {
+      process.env[key] = value;
+    }
+  }
+}
+
 describe("EXOCHAIN client timestamp preservation", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    restorePublicAdapterAuthorizationEnv();
   });
 
   it.each([
@@ -401,84 +493,216 @@ describe("EXOCHAIN client timestamp preservation", () => {
     expect(query).not.toHaveBeenCalled();
   });
 
-  it("fails closed before query when public adapter-output authorization subject or audience is not exact", async () => {
-    for (const input of [
-      {
-        subject: "www.livesafe.ai",
-        audience: "https://livesafe.ai/api/trust/status",
-      },
-      {
-        subject: "livesafe.ai",
-        audience: "https://livesafe.ai/api/health",
-      },
-    ]) {
-      const client = new ExochainClient("http://example.invalid/graphql");
-      const query = vi.spyOn(client, "query").mockResolvedValue({
-        data: {
-          livesafe_public_adapter_output_authorization:
-            PUBLIC_ADAPTER_AUTHORIZATION_DTO,
-        },
-      });
-
-      const result = await client.getPublicAdapterOutputAuthorization(input);
-
-      expect(result).toEqual({ state: "rejected", value: null });
-      expect(query).not.toHaveBeenCalled();
-    }
-  });
-
-  it("requests public adapter-output authorization through a narrow GraphQL operation", async () => {
-    const client = new ExochainClient("http://example.invalid/graphql");
+  it("fails closed without explicit node authorization configuration and never falls back to GraphQL", async () => {
+    clearPublicAdapterAuthorizationEnv();
+    const client = new ExochainClient("http://graphql.example/graphql");
     const query = vi.spyOn(client, "query").mockResolvedValue({
       data: {
         livesafe_public_adapter_output_authorization:
           PUBLIC_ADAPTER_AUTHORIZATION_DTO,
       },
     });
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
 
     const result = await client.getPublicAdapterOutputAuthorization({
       subject: "livesafe.ai",
       audience: "https://livesafe.ai/api/trust/status",
+      currentAt: "2026-07-05T12:00:00.000Z",
+    });
+
+    expect(result).toEqual({ state: "unavailable", value: null });
+    expect(fetch).not.toHaveBeenCalled();
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it("fails closed before REST transport when public adapter-output authorization subject or audience is not exact", async () => {
+    configurePublicAdapterAuthorizationEnv();
+
+    for (const input of [
+      {
+        subject: "www.livesafe.ai",
+        audience: "https://livesafe.ai/api/trust/status",
+        currentAt: "2026-07-05T12:00:00.000Z",
+      },
+      {
+        subject: "livesafe.ai",
+        audience: "https://livesafe.ai/api/health",
+        currentAt: "2026-07-05T12:00:00.000Z",
+      },
+    ]) {
+      const client = new ExochainClient("http://example.invalid/graphql");
+      const fetch = vi.fn();
+      vi.stubGlobal("fetch", fetch);
+
+      const result = await client.getPublicAdapterOutputAuthorization(input);
+
+      expect(result).toEqual({ state: "rejected", value: null });
+      expect(fetch).not.toHaveBeenCalled();
+    }
+  });
+
+  it("posts public adapter-output authorization to the configured EXOCHAIN node REST route", async () => {
+    configurePublicAdapterAuthorizationEnv();
+    const client = new ExochainClient("http://example.invalid/graphql");
+    const query = vi.spyOn(client, "query");
+    const fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
+    }));
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await client.getPublicAdapterOutputAuthorization({
+      subject: "livesafe.ai",
+      audience: "https://livesafe.ai/api/trust/status",
+      currentAt: "2026-07-05T12:00:00.000Z",
     });
 
     expect(result).toEqual({
       state: "permit",
-      value: PUBLIC_ADAPTER_AUTHORIZATION_DTO,
-    });
-    expect(query).toHaveBeenCalledWith(
-      "GetPublicAdapterOutputAuthorization",
-      expect.stringContaining("livesafe_public_adapter_output_authorization"),
-      {
-        input: {
-          subject: "livesafe.ai",
-          audience: "https://livesafe.ai/api/trust/status",
+      value: {
+        schema: "livesafe.public_adapter_output_authorization.v1",
+        subject: "livesafe.ai",
+        audience: "https://livesafe.ai/api/trust/status",
+        claims: [
+          "livesafe_public_trust_status",
+          "exochain_production_evidence_verified",
+          "livesafe_runtime_adapter_verified",
+        ],
+        evidence_hash:
+          "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        receipt_id: "exo-receipt:public-adapter-output:2026-07-05",
+        proof_id: "exo-proof:public-adapter-output:2026-07-05",
+        proof_ref: "exo://receipts/public-adapter-output/2026-07-05",
+        generated_at: "2026-07-05T11:59:00.000Z",
+        valid_from: "2026-07-05T11:55:00.000Z",
+        expires_at: "2026-07-05T12:05:00.000Z",
+        proof: {
+          type: "ed25519-public-adapter-output-authorization",
+          signature:
+            "ed25519:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         },
       },
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://exo-node.example/api/v1/avc/livesafe/public-adapter-output-authorization",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer secret-public-adapter-bearer",
+        },
+        body: expect.any(String),
+        signal: expect.any(Object),
+      }),
     );
-    const queryDocument = query.mock.calls[0]?.[1] || "";
-    expect(queryDocument).toContain("evidence_hash");
-    expect(queryDocument).toContain("proof_id");
-    expect(queryDocument).toContain("proof_ref");
-    expect(queryDocument).not.toContain("bearer_token");
-    expect(queryDocument).not.toContain("private_key");
-    expect(queryDocument).not.toContain("raw_authority_chain");
+    const [, requestInit] = fetch.mock.calls[0] as unknown as [
+      string,
+      { body: string },
+    ];
+    const requestBody = JSON.parse(requestInit.body);
+    expect(requestBody).toEqual({
+      subject: "livesafe.ai",
+      audience: "https://livesafe.ai/api/trust/status",
+      credential_id: "credential:livesafe-public-adapter-output",
+      evidence_hash:
+        "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      idempotency_key: "idem:livesafe-public-adapter-output:2026-07-05T12:00:00Z",
+      expires_at: "2026-07-05T12:05:00.000Z",
+    });
+    expect(requestBody).not.toHaveProperty("issued_at");
+    expect(requestBody).not.toHaveProperty("generated_at");
+    expect(query).not.toHaveBeenCalled();
+    expect(JSON.stringify(result)).not.toContain("secret-public-adapter-bearer");
   });
 
-  it("redacts public adapter-output authorization gateway errors and fails closed", async () => {
-    const client = new ExochainClient("http://example.invalid/graphql");
-    vi.spyOn(client, "query").mockResolvedValue({
-      data: null,
-      errors: [
-        {
-          message: "Bearer secret-production-token private_key=raw-key",
-        },
-      ],
+  it("uses EXOCHAIN_NODE_AVC_URL when the AVC route has a dedicated base URL", async () => {
+    configurePublicAdapterAuthorizationEnv({
+      EXOCHAIN_NODE_AVC_URL: "https://exo-avc.example/custom-avc-root",
     });
+    const client = new ExochainClient("http://example.invalid/graphql");
+    const fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
+    }));
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await client.getPublicAdapterOutputAuthorization({
+      subject: "livesafe.ai",
+      audience: "https://livesafe.ai/api/trust/status",
+      currentAt: "2026-07-05T12:00:00.000Z",
+    });
+
+    expect(result.state).toBe("permit");
+    const [requestUrl] = fetch.mock.calls[0] as unknown as [string, unknown];
+    expect(requestUrl).toBe(
+      "https://exo-avc.example/custom-avc-root/api/v1/avc/livesafe/public-adapter-output-authorization",
+    );
+  });
+
+  it("adapts a core public adapter-output authorization envelope into the LiveSafe DTO shape", async () => {
+    configurePublicAdapterAuthorizationEnv();
+    const client = new ExochainClient("http://example.invalid/graphql");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
+      })),
+    );
+
+    const result = await client.getPublicAdapterOutputAuthorization({
+      subject: "livesafe.ai",
+      audience: "https://livesafe.ai/api/trust/status",
+      currentAt: "2026-07-05T12:00:00.000Z",
+    });
+
+    expect(result).toEqual({
+      state: "permit",
+      value: {
+        schema: "livesafe.public_adapter_output_authorization.v1",
+        subject: "livesafe.ai",
+        audience: "https://livesafe.ai/api/trust/status",
+        claims: [
+          "livesafe_public_trust_status",
+          "exochain_production_evidence_verified",
+          "livesafe_runtime_adapter_verified",
+        ],
+        evidence_hash:
+          "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        receipt_id: "exo-receipt:public-adapter-output:2026-07-05",
+        proof_id: "exo-proof:public-adapter-output:2026-07-05",
+        proof_ref: "exo://receipts/public-adapter-output/2026-07-05",
+        generated_at: "2026-07-05T11:59:00.000Z",
+        valid_from: "2026-07-05T11:55:00.000Z",
+        expires_at: "2026-07-05T12:05:00.000Z",
+        proof: {
+          type: "ed25519-public-adapter-output-authorization",
+          signature:
+            "ed25519:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        },
+      },
+    });
+  });
+
+  it("redacts public adapter-output authorization REST errors and fails closed", async () => {
+    configurePublicAdapterAuthorizationEnv();
+    const client = new ExochainClient("http://example.invalid/graphql");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        status: 403,
+        text: async () => "Bearer secret-production-token private_key=raw-key",
+      })),
+    );
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const result = await client.getPublicAdapterOutputAuthorization({
       subject: "livesafe.ai",
       audience: "https://livesafe.ai/api/trust/status",
+      currentAt: "2026-07-05T12:00:00.000Z",
     });
 
     expect(result).toEqual({ state: "rejected", value: null });
@@ -488,34 +712,168 @@ describe("EXOCHAIN client timestamp preservation", () => {
     expect(JSON.stringify(warn.mock.calls)).not.toContain("raw-key");
   });
 
-  it("fails closed when public adapter-output authorization response is malformed or unavailable", async () => {
-    const malformedClient = new ExochainClient("http://example.invalid/graphql");
-    vi.spyOn(malformedClient, "query").mockResolvedValue({
-      data: {
-        livesafe_public_adapter_output_authorization: {
-          ...PUBLIC_ADAPTER_AUTHORIZATION_DTO,
-          proof_id: "",
+  it.each([
+    {
+      label: "wrong schema",
+      envelope: {
+        ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
+        envelope_schema:
+          "exochain.avc.livesafe.public_adapter_output_authorization_envelope.v0",
+      },
+      expectedState: "rejected",
+    },
+    {
+      label: "wrong subject",
+      envelope: {
+        ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
+        subject: "www.livesafe.ai",
+      },
+      expectedState: "rejected",
+    },
+    {
+      label: "wrong audience",
+      envelope: {
+        ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
+        audience: "https://livesafe.ai/api/health",
+      },
+      expectedState: "rejected",
+    },
+    {
+      label: "wrong domain",
+      envelope: {
+        ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
+        domain: "www.livesafe.ai",
+      },
+      expectedState: "rejected",
+    },
+    {
+      label: "expired",
+      envelope: {
+        ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
+        expires_at: "2026-07-05T11:59:59.999Z",
+      },
+      expectedState: "stale",
+    },
+    {
+      label: "not yet valid",
+      envelope: {
+        ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
+        valid_from: "2026-07-05T12:00:01.000Z",
+      },
+      expectedState: "stale",
+    },
+    {
+      label: "stale issued_at",
+      envelope: {
+        ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
+        issued_at: "2026-07-05T11:54:59.999Z",
+      },
+      expectedState: "stale",
+    },
+    {
+      label: "revoked status",
+      envelope: {
+        ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
+        status: "revoked",
+      },
+      expectedState: "revoked",
+    },
+    {
+      label: "missing receipt",
+      envelope: {
+        ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
+        receipt: null,
+      },
+      expectedState: "rejected",
+    },
+    {
+      label: "missing proof id",
+      envelope: {
+        ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
+        proof: {
+          ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE.proof,
+          id: "",
         },
       },
-    });
-    const unavailableClient = new ExochainClient("http://example.invalid/graphql");
-    vi.spyOn(unavailableClient, "query").mockRejectedValue(
-      Object.assign(new Error("Bearer secret-production-token ETIMEDOUT"), {
-        code: "ETIMEDOUT",
-      }),
+      expectedState: "rejected",
+    },
+    {
+      label: "missing signature",
+      envelope: {
+        ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
+        proof: {
+          ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE.proof,
+          signature: "",
+        },
+      },
+      expectedState: "rejected",
+    },
+    {
+      label: "raw sensitive field",
+      envelope: {
+        ...PUBLIC_ADAPTER_AUTHORIZATION_CORE_ENVELOPE,
+        bearer_token: "Bearer secret-production-token",
+      },
+      expectedState: "rejected",
+    },
+  ])("fails closed when public adapter-output authorization REST envelope is $label", async ({
+    envelope,
+    expectedState,
+  }) => {
+    configurePublicAdapterAuthorizationEnv();
+    const malformedClient = new ExochainClient("http://example.invalid/graphql");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => envelope,
+      })),
     );
 
     await expect(
       malformedClient.getPublicAdapterOutputAuthorization({
         subject: "livesafe.ai",
         audience: "https://livesafe.ai/api/trust/status",
+        currentAt: "2026-07-05T12:00:00.000Z",
       }),
-    ).resolves.toEqual({ state: "rejected", value: null });
+    ).resolves.toEqual({ state: expectedState, value: null });
+  });
+
+  it("fails closed when public adapter-output authorization transport times out or is unavailable", async () => {
+    configurePublicAdapterAuthorizationEnv();
+    const unavailableClient = new ExochainClient("http://example.invalid/graphql");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValueOnce(
+        Object.assign(new Error("Bearer secret-production-token ETIMEDOUT"), {
+          name: "AbortError",
+        }),
+      ),
+    );
+
     await expect(
       unavailableClient.getPublicAdapterOutputAuthorization({
         subject: "livesafe.ai",
         audience: "https://livesafe.ai/api/trust/status",
+        currentAt: "2026-07-05T12:00:00.000Z",
       }),
     ).resolves.toEqual({ state: "timeout", value: null });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValueOnce(
+        Object.assign(new Error("Bearer secret-production-token ETIMEDOUT"), {
+          code: "ECONNREFUSED",
+        }),
+      ),
+    );
+
+    await expect(
+      unavailableClient.getPublicAdapterOutputAuthorization({
+        subject: "livesafe.ai",
+        audience: "https://livesafe.ai/api/trust/status",
+        currentAt: "2026-07-05T12:00:00.000Z",
+      }),
+    ).resolves.toEqual({ state: "unavailable", value: null });
   });
 });

--- a/livesafe/tests/exochain-client.test.ts
+++ b/livesafe/tests/exochain-client.test.ts
@@ -11,11 +11,13 @@ function repeatedHex(byte: number, length: number) {
 }
 
 const EVIDENCE_HASH_BYTES = repeatedByte(0xbb, 32);
+const CREDENTIAL_ID_BYTES = repeatedByte(0xbc, 32);
 const PROOF_HASH_BYTES = repeatedByte(0xcc, 32);
 const ACTION_COMMITMENT_HASH_BYTES = repeatedByte(0xdd, 32);
 const IDEMPOTENCY_KEY_HASH_BYTES = repeatedByte(0xee, 32);
 const ED25519_SIGNATURE_BYTES = repeatedByte(0xaa, 64);
 const EVIDENCE_HASH_HEX = repeatedHex(0xbb, 32);
+const CREDENTIAL_ID_HEX = repeatedHex(0xbc, 32);
 const PROOF_HASH_HEX = repeatedHex(0xcc, 32);
 const ED25519_SIGNATURE_HEX = repeatedHex(0xaa, 64);
 
@@ -49,7 +51,7 @@ const PUBLIC_ADAPTER_AUTHORIZATION_REST_CONFIG = {
   EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_BEARER:
     "secret-public-adapter-bearer",
   EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_CREDENTIAL_ID:
-    "credential:livesafe-public-adapter-output",
+    `sha256:${CREDENTIAL_ID_HEX}`,
   EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_EVIDENCE_HASH: `sha256:${EVIDENCE_HASH_HEX}`,
   EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_IDEMPOTENCY_KEY:
     "idem:livesafe-public-adapter-output:2026-07-05T12:00:00Z",
@@ -637,6 +639,55 @@ describe("EXOCHAIN client timestamp preservation", () => {
     }
   });
 
+  it.each([
+    {
+      label: "credential_id is not a strict sha256 hash",
+      override: {
+        EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_CREDENTIAL_ID:
+          "credential:livesafe-public-adapter-output-secret",
+      },
+      leaked: "livesafe-public-adapter-output-secret",
+    },
+    {
+      label: "evidence_hash is not a strict sha256 hash",
+      override: {
+        EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_EVIDENCE_HASH:
+          `sha256:${EVIDENCE_HASH_HEX.slice(0, 62)}secret`,
+      },
+      leaked: "secret",
+    },
+    {
+      label: "expires_at is not a strict timestamp",
+      override: {
+        EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_EXPIRES_AT:
+          "not-a-timestamp-secret-expiry",
+      },
+      leaked: "secret-expiry",
+    },
+  ])("fails closed before REST transport when $label", async ({
+    override,
+    leaked,
+  }) => {
+    configurePublicAdapterAuthorizationEnv(override);
+    const client = new ExochainClient("http://example.invalid/graphql");
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = await client.getPublicAdapterOutputAuthorization({
+      subject: "livesafe.ai",
+      audience: "https://livesafe.ai/api/trust/status",
+      currentAt: "2026-07-05T12:00:00.000Z",
+    });
+
+    expect(result).toEqual({ state: "unavailable", value: null });
+    expect(fetch).not.toHaveBeenCalled();
+    expect(JSON.stringify(warn.mock.calls)).not.toContain(leaked);
+    expect(JSON.stringify(warn.mock.calls)).not.toContain(
+      "secret-public-adapter-bearer",
+    );
+  });
+
   it("posts public adapter-output authorization to the configured EXOCHAIN node REST route", async () => {
     configurePublicAdapterAuthorizationEnv();
     const client = new ExochainClient("http://example.invalid/graphql");
@@ -678,11 +729,13 @@ describe("EXOCHAIN client timestamp preservation", () => {
     expect(requestBody).toEqual({
       subject: "livesafe.ai",
       audience: "https://livesafe.ai/api/trust/status",
-      credential_id: "credential:livesafe-public-adapter-output",
-      evidence_hash:
-        "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      credential_id: CREDENTIAL_ID_BYTES,
+      evidence_hash: EVIDENCE_HASH_BYTES,
       idempotency_key: "idem:livesafe-public-adapter-output:2026-07-05T12:00:00Z",
-      expires_at: "2026-07-05T12:05:00.000Z",
+      expires_at: {
+        physical_ms: Date.parse("2026-07-05T12:05:00.000Z"),
+        logical: 0,
+      },
     });
     expect(requestBody).not.toHaveProperty("issued_at");
     expect(requestBody).not.toHaveProperty("generated_at");

--- a/livesafe/tests/exochain-client.test.ts
+++ b/livesafe/tests/exochain-client.test.ts
@@ -775,6 +775,16 @@ describe("EXOCHAIN client timestamp preservation", () => {
       expectedState: "rejected",
     },
     {
+      label: "top-level schema_version 2",
+      envelope: rustCoreEnvelope({ envelope: { schema_version: 2 } }),
+      expectedState: "rejected",
+    },
+    {
+      label: "nested proof schema_version 2",
+      envelope: rustCoreEnvelope({ proof: { schema_version: 2 } }),
+      expectedState: "rejected",
+    },
+    {
       label: "missing top-level domain",
       envelope: rustCoreEnvelope({ envelope: { domain: "" } }),
       expectedState: "rejected",
@@ -881,6 +891,21 @@ describe("EXOCHAIN client timestamp preservation", () => {
       label: "revoked revocation_status",
       envelope: rustCoreEnvelope({ proof: { revocation_status: "revoked" } }),
       expectedState: "revoked",
+    },
+    {
+      label: "non-canonical valid revocation_status",
+      envelope: rustCoreEnvelope({ proof: { revocation_status: "valid" } }),
+      expectedState: "rejected",
+    },
+    {
+      label: "non-canonical active revocation_status",
+      envelope: rustCoreEnvelope({ proof: { revocation_status: "active" } }),
+      expectedState: "rejected",
+    },
+    {
+      label: "non-canonical non-revoked revocation_status",
+      envelope: rustCoreEnvelope({ proof: { revocation_status: "non-revoked" } }),
+      expectedState: "rejected",
     },
     {
       label: "missing receipt_id",

--- a/livesafe/tests/exochain-runtime-adapter.test.ts
+++ b/livesafe/tests/exochain-runtime-adapter.test.ts
@@ -5,6 +5,30 @@ const {
   executeRuntimeExochainOperation,
 } = require("../server/utils/livesafe-exochain-adapter.js");
 
+const PUBLIC_ADAPTER_AUTHORIZATION_DTO = {
+  schema: "livesafe.public_adapter_output_authorization.v1",
+  subject: "livesafe.ai",
+  audience: "https://livesafe.ai/api/trust/status",
+  claims: [
+    "livesafe_public_trust_status",
+    "exochain_production_evidence_verified",
+    "livesafe_runtime_adapter_verified",
+  ],
+  evidence_hash:
+    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  receipt_id: "exo-receipt:public-adapter-output:2026-07-05",
+  proof_id: "exo-proof:public-adapter-output:2026-07-05",
+  proof_ref: "exo://receipts/public-adapter-output/2026-07-05",
+  generated_at: "2026-07-05T11:59:00.000Z",
+  valid_from: "2026-07-05T11:55:00.000Z",
+  expires_at: "2026-07-05T12:05:00.000Z",
+  proof: {
+    type: "ed25519-public-adapter-output-authorization",
+    signature:
+      "ed25519:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  },
+};
+
 describe("LiveSafe EXOCHAIN runtime adapter facade", () => {
   it("fails closed without calling the transport when the adapter is not wired", async () => {
     const transport = vi.fn(async () => ({ state: "permit", value: { ok: true } }));
@@ -163,6 +187,7 @@ describe("LiveSafe EXOCHAIN runtime adapter facade", () => {
         "anchorScan",
         "anchorConsent",
         "getPaceStatus",
+        "getPublicAdapterOutputAuthorization",
       ],
     });
     expect(adapter.getRuntimeStatus().disablement_path).toContain(
@@ -514,5 +539,121 @@ describe("LiveSafe EXOCHAIN runtime adapter facade", () => {
     expect(decision.allowed).toBe(false);
     expect(decision.transportCalled).toBe(false);
     expect(decision.responseState).toBe("not-called");
+  });
+
+  it("fails closed for public adapter-output authorization when the adapter is not wired", async () => {
+    const getPublicAdapterOutputAuthorization = vi.fn(async () => ({
+      state: "permit",
+      value: PUBLIC_ADAPTER_AUTHORIZATION_DTO,
+    }));
+    const adapter = createRuntimeExochainAdapter({
+      adapterStatus: "not-wired",
+      client: { getPublicAdapterOutputAuthorization },
+    });
+
+    const decision = await adapter.getPublicAdapterOutputAuthorization({
+      currentAt: "2026-07-05T12:00:00.000Z",
+      returnDecision: true,
+    });
+
+    expect(getPublicAdapterOutputAuthorization).not.toHaveBeenCalled();
+    expect(decision.allowed).toBe(false);
+    expect(decision.transportCalled).toBe(false);
+    expect(decision.responseState).toBe("not-called");
+    expect(decision.reasons).toContain(
+      "Adapter activation requires a wired EXOCHAIN dependency surface.",
+    );
+  });
+
+  it("fails closed for denied public adapter-output authorization transport states", async () => {
+    for (const responseState of [
+      "deny",
+      "rejected",
+      "timeout",
+      "unavailable",
+      "stale",
+      "revoked",
+      "contradicted",
+    ] as const) {
+      const getPublicAdapterOutputAuthorization = vi.fn(async () => ({
+        state: responseState,
+        value: PUBLIC_ADAPTER_AUTHORIZATION_DTO,
+      }));
+      const adapter = createRuntimeExochainAdapter({
+        adapterStatus: "verified",
+        client: { getPublicAdapterOutputAuthorization },
+      });
+
+      const decision = await adapter.getPublicAdapterOutputAuthorization({
+        currentAt: "2026-07-05T12:00:00.000Z",
+        returnDecision: true,
+      });
+
+      expect(getPublicAdapterOutputAuthorization).toHaveBeenCalledWith({
+        subject: "livesafe.ai",
+        audience: "https://livesafe.ai/api/trust/status",
+      });
+      expect(decision.allowed, responseState).toBe(false);
+      expect(decision.transportCalled, responseState).toBe(true);
+      expect(decision.responseState, responseState).toBe(responseState);
+    }
+  });
+
+  it("fails closed for malformed public adapter-output authorization DTOs", async () => {
+    const getPublicAdapterOutputAuthorization = vi.fn(async () => ({
+      state: "permit",
+      value: {
+        ...PUBLIC_ADAPTER_AUTHORIZATION_DTO,
+        subject: "www.livesafe.ai",
+      },
+    }));
+    const adapter = createRuntimeExochainAdapter({
+      adapterStatus: "verified",
+      client: { getPublicAdapterOutputAuthorization },
+    });
+
+    const decision = await adapter.getPublicAdapterOutputAuthorization({
+      currentAt: "2026-07-05T12:00:00.000Z",
+      returnDecision: true,
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.transportCalled).toBe(true);
+    expect(decision.responseState).toBe("permit");
+    expect(decision.reasons).toContain(
+      "Public adapter-output authorization subject must be livesafe.ai.",
+    );
+  });
+
+  it("succeeds for public adapter-output authorization only with permit plus evaluator pass", async () => {
+    const getPublicAdapterOutputAuthorization = vi.fn(async () => ({
+      state: "permit",
+      value: PUBLIC_ADAPTER_AUTHORIZATION_DTO,
+    }));
+    const adapter = createRuntimeExochainAdapter({
+      adapterStatus: "verified",
+      client: { getPublicAdapterOutputAuthorization },
+    });
+
+    const decision = await adapter.getPublicAdapterOutputAuthorization({
+      currentAt: "2026-07-05T12:00:00.000Z",
+      returnDecision: true,
+    });
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.transportCalled).toBe(true);
+    expect(decision.responseState).toBe("permit");
+    expect(decision.metadata).toMatchObject({
+      subject: "livesafe.ai",
+      audience: "https://livesafe.ai/api/trust/status",
+      evidence_hash:
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      receipt_id: "exo-receipt:public-adapter-output:2026-07-05",
+      proof_id: "exo-proof:public-adapter-output:2026-07-05",
+      proof_ref: "exo://receipts/public-adapter-output/2026-07-05",
+      response_state: "permit",
+      transport_called: true,
+    });
+    expect(JSON.stringify(decision)).not.toContain("signature");
   });
 });

--- a/livesafe/tests/exochain-runtime-adapter.test.ts
+++ b/livesafe/tests/exochain-runtime-adapter.test.ts
@@ -592,6 +592,7 @@ describe("LiveSafe EXOCHAIN runtime adapter facade", () => {
       expect(getPublicAdapterOutputAuthorization).toHaveBeenCalledWith({
         subject: "livesafe.ai",
         audience: "https://livesafe.ai/api/trust/status",
+        currentAt: "2026-07-05T12:00:00.000Z",
       });
       expect(decision.allowed, responseState).toBe(false);
       expect(decision.transportCalled, responseState).toBe(true);

--- a/livesafe/tests/public-adapter-output-authorization.test.ts
+++ b/livesafe/tests/public-adapter-output-authorization.test.ts
@@ -1,0 +1,371 @@
+import { describe, expect, it } from "vitest";
+
+const SUBJECT = "livesafe.ai";
+const AUDIENCE = "https://livesafe.ai/api/trust/status";
+const CURRENT_AT = "2026-07-05T12:00:00.000Z";
+const ALLOWED_CLAIMS = [
+  "livesafe_public_trust_status",
+  "exochain_production_evidence_verified",
+  "livesafe_runtime_adapter_verified",
+] as const;
+
+function loadEvaluator() {
+  return require("../server/utils/public-adapter-output-authorization.js") as {
+    evaluatePublicAdapterOutputAuthorization: (
+      adapterOutputAuthorization: unknown,
+      options: {
+        currentAt: string;
+        subject: string;
+        audience: string;
+      },
+    ) => {
+      allowed: boolean;
+      reasons: string[];
+      required_evidence: string[];
+      responseState: string;
+      transportCalled: boolean;
+      metadata: Record<string, unknown> | null;
+    };
+  };
+}
+
+function validAuthorization(overrides: Record<string, unknown> = {}) {
+  return {
+    schema: "livesafe.public_adapter_output_authorization.v1",
+    subject: SUBJECT,
+    audience: AUDIENCE,
+    claims: [...ALLOWED_CLAIMS],
+    evidence_hash:
+      "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    receipt_id: "exo-receipt:public-adapter-output:2026-07-05",
+    proof_id: "exo-proof:public-adapter-output:2026-07-05",
+    proof_ref: "exo://receipts/public-adapter-output/2026-07-05",
+    generated_at: "2026-07-05T11:59:00.000Z",
+    valid_from: "2026-07-05T11:55:00.000Z",
+    expires_at: "2026-07-05T12:05:00.000Z",
+    proof: {
+      type: "ed25519-public-adapter-output-authorization",
+      signature:
+        "ed25519:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    },
+    ...overrides,
+  };
+}
+
+function validDecision(overrides: Record<string, unknown> = {}) {
+  return {
+    allowed: true,
+    responseState: "permit",
+    transportCalled: true,
+    value: validAuthorization(),
+    ...overrides,
+  };
+}
+
+function evaluate(adapterOutputAuthorization: unknown) {
+  const { evaluatePublicAdapterOutputAuthorization } = loadEvaluator();
+
+  return evaluatePublicAdapterOutputAuthorization(adapterOutputAuthorization, {
+    currentAt: CURRENT_AT,
+    subject: SUBJECT,
+    audience: AUDIENCE,
+  });
+}
+
+describe("public adapter-output authorization evaluator", () => {
+  it("allows a permit-backed proof-bearing public authorization and returns redacted metadata", () => {
+    const decision = evaluate(validDecision());
+
+    expect(decision).toEqual({
+      allowed: true,
+      reasons: [],
+      required_evidence: [],
+      responseState: "permit",
+      transportCalled: true,
+      metadata: {
+        schema: "livesafe.public_adapter_output_authorization.v1",
+        subject: SUBJECT,
+        audience: AUDIENCE,
+        claims: [...ALLOWED_CLAIMS],
+        evidence_hash:
+          "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        receipt_id: "exo-receipt:public-adapter-output:2026-07-05",
+        proof_id: "exo-proof:public-adapter-output:2026-07-05",
+        proof_ref: "exo://receipts/public-adapter-output/2026-07-05",
+        generated_at: "2026-07-05T11:59:00.000Z",
+        valid_from: "2026-07-05T11:55:00.000Z",
+        expires_at: "2026-07-05T12:05:00.000Z",
+        proof_type: "ed25519-public-adapter-output-authorization",
+        response_state: "permit",
+        transport_called: true,
+      },
+    });
+    expect(JSON.stringify(decision)).not.toContain("signature");
+  });
+
+  it("denies missing authorization", () => {
+    const decision = evaluate(undefined);
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.responseState).toBe("not-called");
+    expect(decision.reasons).toContain(
+      "Public adapter-output authorization is missing.",
+    );
+  });
+
+  it("denies wrong schema", () => {
+    const decision = evaluate(
+      validDecision({
+        value: validAuthorization({ schema: "livesafe.public_output.v0" }),
+      }),
+    );
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasons).toContain(
+      "Public adapter-output authorization schema is invalid.",
+    );
+  });
+
+  it("denies wrong subject", () => {
+    const decision = evaluate(
+      validDecision({
+        value: validAuthorization({ subject: "www.livesafe.ai" }),
+      }),
+    );
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasons).toContain(
+      "Public adapter-output authorization subject must be livesafe.ai.",
+    );
+  });
+
+  it("denies wrong audience", () => {
+    const decision = evaluate(
+      validDecision({
+        value: validAuthorization({ audience: "https://livesafe.ai/api/health" }),
+      }),
+    );
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasons).toContain(
+      "Public adapter-output authorization audience must be https://livesafe.ai/api/trust/status.",
+    );
+  });
+
+  it("denies empty claims", () => {
+    const decision = evaluate(
+      validDecision({
+        value: validAuthorization({ claims: [] }),
+      }),
+    );
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasons).toContain(
+      "Public adapter-output authorization claims must be non-empty.",
+    );
+  });
+
+  it("denies forbidden medical, legal, custody, consent, and emergency claims", () => {
+    for (const forbiddenClaim of [
+      "medical_status_verified",
+      "legal_admissibility_verified",
+      "custody_proof_verified",
+      "consent_proof_verified",
+      "emergency_access_verified",
+    ]) {
+      const decision = evaluate(
+        validDecision({
+          value: validAuthorization({ claims: [...ALLOWED_CLAIMS, forbiddenClaim] }),
+        }),
+      );
+
+      expect(decision.allowed, forbiddenClaim).toBe(false);
+      expect(decision.reasons, forbiddenClaim).toContain(
+        "Public adapter-output authorization may not carry medical, legal, custody, consent, or emergency claims.",
+      );
+    }
+  });
+
+  it("denies duplicate claims", () => {
+    const decision = evaluate(
+      validDecision({
+        value: validAuthorization({
+          claims: [
+            ...ALLOWED_CLAIMS,
+            "livesafe_public_trust_status",
+          ],
+        }),
+      }),
+    );
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasons).toContain(
+      "Public adapter-output authorization claims must not contain duplicates.",
+    );
+  });
+
+  it("denies claims outside the allowed public claim set", () => {
+    const decision = evaluate(
+      validDecision({
+        value: validAuthorization({
+          claims: [...ALLOWED_CLAIMS, "subscriber_identity_verified"],
+        }),
+      }),
+    );
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasons).toContain(
+      "Public adapter-output authorization claims include unsupported public output.",
+    );
+  });
+
+  it("denies malformed evidence_hash", () => {
+    const decision = evaluate(
+      validDecision({
+        value: validAuthorization({ evidence_hash: "not-a-sha256-hash" }),
+      }),
+    );
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasons).toContain(
+      "Public adapter-output authorization evidence_hash must be sha256-prefixed lowercase hex.",
+    );
+  });
+
+  it("denies missing proof id or proof ref", () => {
+    const decision = evaluate(
+      validDecision({
+        value: validAuthorization({ proof_id: "", proof_ref: "" }),
+      }),
+    );
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasons).toContain(
+      "Public adapter-output authorization requires proof_id and proof_ref.",
+    );
+  });
+
+  it("denies expired authorizations", () => {
+    const decision = evaluate(
+      validDecision({
+        value: validAuthorization({ expires_at: "2026-07-05T11:59:59.000Z" }),
+      }),
+    );
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasons).toContain(
+      "Public adapter-output authorization is expired.",
+    );
+  });
+
+  it("denies not-yet-valid authorizations", () => {
+    const decision = evaluate(
+      validDecision({
+        value: validAuthorization({ valid_from: "2026-07-05T12:00:01.000Z" }),
+      }),
+    );
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasons).toContain(
+      "Public adapter-output authorization is not yet valid.",
+    );
+  });
+
+  it("denies stale authorizations", () => {
+    const decision = evaluate(
+      validDecision({
+        value: validAuthorization({ generated_at: "2026-07-05T11:54:59.999Z" }),
+      }),
+    );
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasons).toContain(
+      "Public adapter-output authorization is stale.",
+    );
+  });
+
+  it("denies revoked authorizations", () => {
+    const decision = evaluate(
+      validDecision({
+        value: validAuthorization({ revoked: true }),
+      }),
+    );
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasons).toContain(
+      "Public adapter-output authorization is revoked.",
+    );
+  });
+
+  it("denies contradicted authorizations", () => {
+    const decision = evaluate(
+      validDecision({
+        value: validAuthorization({ contradicted: true }),
+      }),
+    );
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasons).toContain(
+      "Public adapter-output authorization is contradicted.",
+    );
+  });
+
+  it("denies timeout and unavailable authorization transport states", () => {
+    for (const responseState of ["timeout", "unavailable"]) {
+      const decision = evaluate(
+        validDecision({
+          responseState,
+        }),
+      );
+
+      expect(decision.allowed, responseState).toBe(false);
+      expect(decision.responseState, responseState).toBe(responseState);
+      expect(decision.reasons, responseState).toContain(
+        "Public adapter-output authorization transport must return permit.",
+      );
+    }
+  });
+
+  it("denies malformed proof and signature", () => {
+    const malformedProof = evaluate(
+      validDecision({
+        value: validAuthorization({ proof: { type: "", signature: "ed25519:abc" } }),
+      }),
+    );
+    const missingSignature = evaluate(
+      validDecision({
+        value: validAuthorization({
+          proof: { type: "ed25519-public-adapter-output-authorization" },
+        }),
+      }),
+    );
+
+    expect(malformedProof.allowed).toBe(false);
+    expect(malformedProof.reasons).toContain(
+      "Public adapter-output authorization proof signature is malformed.",
+    );
+    expect(missingSignature.allowed).toBe(false);
+    expect(missingSignature.reasons).toContain(
+      "Public adapter-output authorization proof signature is malformed.",
+    );
+  });
+
+  it("denies and redacts raw sensitive fields", () => {
+    const decision = evaluate(
+      validDecision({
+        value: validAuthorization({
+          bearer_token: "Bearer secret-production-token",
+          private_key: "raw-private-key",
+        }),
+      }),
+    );
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.metadata).toBeNull();
+    expect(decision.reasons).toContain(
+      "Public adapter-output authorization contains raw sensitive fields.",
+    );
+    expect(JSON.stringify(decision)).not.toContain("secret-production-token");
+    expect(JSON.stringify(decision)).not.toContain("raw-private-key");
+  });
+});

--- a/livesafe/tests/status-route-contract.test.ts
+++ b/livesafe/tests/status-route-contract.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 const {
   getStatusRouteContracts,
@@ -169,5 +169,95 @@ describe("status route contracts", () => {
     expect(response.statusCode).toBe(405);
     expect(responseHeaders.get("allow")).toBe("GET");
     expect(responseHeaders.get("cache-control")).toBe("no-store");
+  });
+
+  it("awaits async status responders before the route handler resolves", async () => {
+    const handlers = new Map<string, Function>();
+    let releaseResponder: () => void = () => {};
+    const responderGate = new Promise<void>((resolve) => {
+      releaseResponder = resolve;
+    });
+    const app = {
+      get(path: string, handler: Function) {
+        handlers.set(path, handler);
+      },
+      all() {},
+    };
+    const json = vi.fn();
+    const response = {
+      setHeader() {},
+      status() {
+        return { json };
+      },
+    };
+
+    registerStatusRouteContracts(app, {
+      sendHealthResponse() {},
+      async sendTrustStatusResponse(_req: unknown, res: any) {
+        await responderGate;
+        res.status(200).json({ ok: true });
+      },
+      sendAiHelpStatusResponse() {},
+      sendAiHelpUsageSummaryStatusResponse() {},
+      sendAiHelpSessionTranscriptStatusResponse() {},
+      sendAiHelpUnansweredTopicStatusResponse() {},
+      sendFeedbackBoardStatusResponse() {},
+      sendFeedbackCodeHintsStatusResponse() {},
+    });
+
+    const routeResult = handlers.get("/api/trust/status")?.({}, response, vi.fn());
+
+    expect(routeResult).toBeInstanceOf(Promise);
+    expect(json).not.toHaveBeenCalled();
+
+    releaseResponder();
+    await routeResult;
+
+    expect(json).toHaveBeenCalledWith({ ok: true });
+  });
+
+  it("propagates async status responder failures to next without leaking secrets", async () => {
+    const handlers = new Map<string, Function>();
+    const app = {
+      get(path: string, handler: Function) {
+        handlers.set(path, handler);
+      },
+      all() {},
+    };
+    const response = {
+      setHeader: vi.fn(),
+      status: vi.fn(() => ({
+        json: vi.fn(),
+      })),
+    };
+    const next = vi.fn();
+
+    registerStatusRouteContracts(app, {
+      sendHealthResponse() {},
+      async sendTrustStatusResponse() {
+        throw new Error(
+          "Bearer secret-production-token private_key=raw-key authorization_header=secret",
+        );
+      },
+      sendAiHelpStatusResponse() {},
+      sendAiHelpUsageSummaryStatusResponse() {},
+      sendAiHelpSessionTranscriptStatusResponse() {},
+      sendAiHelpUnansweredTopicStatusResponse() {},
+      sendFeedbackBoardStatusResponse() {},
+      sendFeedbackCodeHintsStatusResponse() {},
+    });
+
+    await handlers.get("/api/trust/status")?.({}, response, next);
+
+    expect(response.status).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0]?.[0]).toMatchObject({
+      message: "Status route responder failed.",
+      code: "STATUS_ROUTE_RESPONDER_FAILED",
+    });
+    expect(JSON.stringify(next.mock.calls[0]?.[0])).not.toContain(
+      "secret-production-token",
+    );
+    expect(JSON.stringify(next.mock.calls[0]?.[0])).not.toContain("raw-key");
   });
 });

--- a/livesafe/tests/trust-status.test.ts
+++ b/livesafe/tests/trust-status.test.ts
@@ -2,8 +2,13 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   createTrustStatusPayload,
+  sendLiveTrustStatusResponse,
   sendTrustStatusResponse
 } from "../server/utils/trust-status.js";
+import type { TrustStatusPayloadOptions } from "../server/utils/trust-status.js";
+
+type RuntimeStatus = NonNullable<TrustStatusPayloadOptions["runtimeStatus"]>;
+type RuntimeOperations = NonNullable<RuntimeStatus["wrapped_operations"]>;
 
 const VERIFIED_PRODUCTION_TRUST_EVIDENCE = {
   evidence_state: "verified" as const,
@@ -311,7 +316,7 @@ describe("trust status API contract", () => {
         uptimeSeconds: 16,
         generatedAt: "2026-07-05T12:00:00.000Z",
         runtimeStatus: {
-          adapter_state: "verified",
+          adapter_state: "verified" as const,
           surface_classification: "core-runtime-adapter",
           public_claims_allowed: true,
           can_read_exochain_core_state: true,
@@ -406,5 +411,121 @@ describe("trust status API contract", () => {
         public_claims_allowed: false
       })
     );
+  });
+
+  it("live trust status responder requests proof-bearing adapter output with the generated timestamp before sending", async () => {
+    const currentAt = "2026-07-05T12:00:00.000Z";
+    const getPublicAdapterOutputAuthorization = vi.fn(async () => ({
+      ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION,
+    }));
+    const adapter = {
+      getRuntimeStatus(): RuntimeStatus {
+        return {
+          adapter_state: "verified" as const,
+          surface_classification: "core-runtime-adapter" as const,
+          public_claims_allowed: true,
+          can_read_exochain_core_state: true,
+          can_write_exochain_core_state: true,
+          wrapped_operations: [
+            "getIdentity",
+            "registerIdentity",
+            "anchorAuditReceipt",
+            "anchorScan",
+            "anchorConsent",
+            "getPaceStatus",
+            "getPublicAdapterOutputAuthorization",
+          ] as RuntimeOperations,
+          disablement_path:
+            "Disable EXOCHAIN adapter environment variables and remove the trust-status route from the load balancer.",
+          source_basis: ["server/utils/livesafe-exochain-adapter.js"],
+        };
+      },
+      getPublicAdapterOutputAuthorization,
+    };
+    const json = vi.fn();
+    const response = {
+      status: vi.fn(() => ({ json })),
+    };
+
+    await sendLiveTrustStatusResponse({}, response, {
+      adapter,
+      exochainConnected: true,
+      version: "1.0.0",
+      uptimeSeconds: 16,
+      generatedAt: currentAt,
+      productionTrustEvidence: VERIFIED_PRODUCTION_TRUST_EVIDENCE,
+    });
+
+    expect(getPublicAdapterOutputAuthorization).toHaveBeenCalledWith({
+      currentAt,
+      returnDecision: true,
+    });
+    expect(response.status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        generated_at: currentAt,
+        public_claims_allowed: true,
+        state: "externally-verified",
+      }),
+    );
+  });
+
+  it("live trust status responder stays fail-closed when adapter authorization denies, times out, or is unavailable", async () => {
+    for (const responseState of ["deny", "timeout", "unavailable"] as const) {
+      const currentAt = "2026-07-05T12:00:00.000Z";
+      const adapter = {
+        getRuntimeStatus(): RuntimeStatus {
+          return {
+            adapter_state: "verified" as const,
+            surface_classification: "core-runtime-adapter" as const,
+            public_claims_allowed: true,
+            can_read_exochain_core_state: true,
+            can_write_exochain_core_state: true,
+            wrapped_operations: [
+              "getIdentity",
+              "registerIdentity",
+              "anchorAuditReceipt",
+              "anchorScan",
+              "anchorConsent",
+              "getPaceStatus",
+              "getPublicAdapterOutputAuthorization",
+            ] as RuntimeOperations,
+            disablement_path:
+              "Disable EXOCHAIN adapter environment variables and remove the trust-status route from the load balancer.",
+            source_basis: ["server/utils/livesafe-exochain-adapter.js"],
+          };
+        },
+        getPublicAdapterOutputAuthorization: vi.fn(async () => ({
+          ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION,
+          allowed: false,
+          responseState,
+          value: null,
+        })),
+      };
+      const json = vi.fn();
+      const response = {
+        status: vi.fn(() => ({ json })),
+      };
+
+      await sendLiveTrustStatusResponse({}, response, {
+        adapter,
+        exochainConnected: true,
+        version: "1.0.0",
+        uptimeSeconds: 16,
+        generatedAt: currentAt,
+        productionTrustEvidence: VERIFIED_PRODUCTION_TRUST_EVIDENCE,
+      });
+
+      expect(json, responseState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          generated_at: currentAt,
+          public_claims_allowed: false,
+          state: "not-verified",
+        }),
+      );
+      expect(JSON.stringify(json.mock.calls[0]?.[0]), responseState).not.toContain(
+        "signature",
+      );
+    }
   });
 });

--- a/livesafe/tests/trust-status.test.ts
+++ b/livesafe/tests/trust-status.test.ts
@@ -163,7 +163,7 @@ describe("trust status API contract", () => {
     ]);
     expect(payload.public_claims_allowed).toBe(false);
     expect(payload.public_claims_reason).toContain(
-      "runtime adapter has not allowed public trust output",
+      "proof-bearing public adapter-output authorization",
     );
   });
 
@@ -206,7 +206,7 @@ describe("trust status API contract", () => {
     expect(payload.internal_proof_complete).toBe(true);
     expect(payload.public_claims_allowed).toBe(false);
     expect(payload.public_claims_reason).toContain(
-      "runtime adapter has not allowed public trust output",
+      "proof-bearing public adapter-output authorization",
     );
     expect(payload.production_trust_observations).toEqual([
       "production_sentinel_quorum_health_below_bft_minimum",
@@ -387,6 +387,78 @@ describe("trust status API contract", () => {
     });
     expect(JSON.stringify(payload.public_adapter_output_authorization)).not.toContain(
       "signature",
+    );
+  });
+
+  it("denies public trust status when EXOCHAIN connectivity is false even with proof authorization", () => {
+    const payload = createTrustStatusPayload({
+      exochainConnected: false,
+      version: "1.0.0",
+      uptimeSeconds: 16,
+      generatedAt: "2026-07-05T12:00:00.000Z",
+      runtimeStatus: {
+        adapter_state: "verified",
+        surface_classification: "core-runtime-adapter",
+        public_claims_allowed: true,
+        can_read_exochain_core_state: true,
+        can_write_exochain_core_state: true,
+        disablement_path:
+          "Disable EXOCHAIN adapter environment variables and remove the trust-status route from the load balancer.",
+        source_basis: ["server/utils/livesafe-exochain-adapter.js"],
+      },
+      adapterOutputAuthorization: VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION,
+      productionTrustEvidence: VERIFIED_PRODUCTION_TRUST_EVIDENCE,
+    });
+
+    expect(payload.state).toBe("not-verified");
+    expect(payload.public_claims_allowed).toBe(false);
+    expect(payload.public_claims_reason).toContain("EXOCHAIN connectivity");
+  });
+
+  it.each([
+    {
+      label: "runtime public_claims_allowed false",
+      runtimeStatus: {
+        adapter_state: "verified" as const,
+        surface_classification: "core-runtime-adapter" as const,
+        public_claims_allowed: false,
+        can_read_exochain_core_state: true,
+        can_write_exochain_core_state: true,
+        disablement_path:
+          "Disable EXOCHAIN adapter environment variables and remove the trust-status route from the load balancer.",
+        source_basis: ["server/utils/livesafe-exochain-adapter.js"],
+      },
+    },
+    {
+      label: "runtime public_claims_allowed absent",
+      runtimeStatus: {
+        adapter_state: "verified" as const,
+        surface_classification: "core-runtime-adapter" as const,
+        can_read_exochain_core_state: true,
+        can_write_exochain_core_state: true,
+        disablement_path:
+          "Disable EXOCHAIN adapter environment variables and remove the trust-status route from the load balancer.",
+        source_basis: ["server/utils/livesafe-exochain-adapter.js"],
+      } as RuntimeStatus,
+    },
+  ])("allows verified public trust status with $label when proof authorization permits", ({
+    runtimeStatus,
+  }) => {
+    const payload = createTrustStatusPayload({
+      exochainConnected: true,
+      version: "1.0.0",
+      uptimeSeconds: 16,
+      generatedAt: "2026-07-05T12:00:00.000Z",
+      runtimeStatus,
+      adapterOutputAuthorization: VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION,
+      productionTrustEvidence: VERIFIED_PRODUCTION_TRUST_EVIDENCE,
+    });
+
+    expect(payload.state).toBe("externally-verified");
+    expect(payload.machine_state).toBe("public_trust_claims_allowed");
+    expect(payload.public_claims_allowed).toBe(true);
+    expect(payload.public_claims_reason).toContain(
+      "proof-bearing public adapter-output authorization are verified",
     );
   });
 

--- a/livesafe/tests/trust-status.test.ts
+++ b/livesafe/tests/trust-status.test.ts
@@ -5,6 +5,50 @@ import {
   sendTrustStatusResponse
 } from "../server/utils/trust-status.js";
 
+const VERIFIED_PRODUCTION_TRUST_EVIDENCE = {
+  evidence_state: "verified" as const,
+  production_health_verified: true,
+  production_ready_verified: true,
+  root_trust_bundle_verified: true,
+  root_trust_bundle_id:
+    "7d9954a797ef244c15ad1b733cf77598125ccef0f812a404137e827c192d6a58",
+  root_trust_ceremony_id: "avc-exo-ceremony-2026",
+  root_trust_issuer_did:
+    "did:exo:8EVGmqLo15JEnrbcrLo9r84qX1mtrVeBdPjHLUtb1sXX",
+  verifier_commit:
+    "379a45e1d9ab092ecd446d095a7b524570530efd",
+  verified_at: "2026-06-03T21:26:00.000Z",
+};
+
+const VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION = {
+  allowed: true,
+  responseState: "permit",
+  transportCalled: true,
+  value: {
+    schema: "livesafe.public_adapter_output_authorization.v1",
+    subject: "livesafe.ai",
+    audience: "https://livesafe.ai/api/trust/status",
+    claims: [
+      "livesafe_public_trust_status",
+      "exochain_production_evidence_verified",
+      "livesafe_runtime_adapter_verified",
+    ],
+    evidence_hash:
+      "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    receipt_id: "exo-receipt:public-adapter-output:2026-07-05",
+    proof_id: "exo-proof:public-adapter-output:2026-07-05",
+    proof_ref: "exo://receipts/public-adapter-output/2026-07-05",
+    generated_at: "2026-07-05T11:59:00.000Z",
+    valid_from: "2026-07-05T11:55:00.000Z",
+    expires_at: "2026-07-05T12:05:00.000Z",
+    proof: {
+      type: "ed25519-public-adapter-output-authorization",
+      signature:
+        "ed25519:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    },
+  },
+};
+
 describe("trust status API contract", () => {
   it("builds an explicitly inactive machine-readable trust payload", () => {
     const payload = createTrustStatusPayload({
@@ -38,6 +82,7 @@ describe("trust status API contract", () => {
         "anchorScan",
         "anchorConsent",
         "getPaceStatus",
+        "getPublicAdapterOutputAuthorization",
       ],
       frost_genesis_complete: false,
       internal_proof_complete: false,
@@ -63,6 +108,7 @@ describe("trust status API contract", () => {
       "src/trust-signal.ts",
       "src/genesis-trust.ts",
       "server/utils/livesafe-exochain-adapter.js",
+      "server/utils/public-adapter-output-authorization.js",
       "config/exochain-production-trust.json",
       "server/utils/exochain-production-trust-evidence.js",
     ]);
@@ -108,6 +154,7 @@ describe("trust status API contract", () => {
       "anchorScan",
       "anchorConsent",
       "getPaceStatus",
+      "getPublicAdapterOutputAuthorization",
     ]);
     expect(payload.public_claims_allowed).toBe(false);
     expect(payload.public_claims_reason).toContain(
@@ -161,12 +208,12 @@ describe("trust status API contract", () => {
     ]);
   });
 
-  it("only allows verified public trust status when production evidence and runtime adapter gates pass together", () => {
+  it("denies public trust status when local runtime public_claims_allowed is true without proof-bearing adapter output", () => {
     const payload = createTrustStatusPayload({
       exochainConnected: true,
       version: "1.0.0",
-      uptimeSeconds: 16,
-      generatedAt: "2026-06-03T21:26:00.000Z",
+      uptimeSeconds: 15,
+      generatedAt: "2026-07-05T12:00:00.000Z",
       runtimeStatus: {
         adapter_state: "verified",
         surface_classification: "core-runtime-adapter",
@@ -177,20 +224,132 @@ describe("trust status API contract", () => {
           "Disable EXOCHAIN adapter environment variables and remove the trust-status route from the load balancer.",
         source_basis: ["server/utils/livesafe-exochain-adapter.js"],
       },
-      productionTrustEvidence: {
-        evidence_state: "verified",
-        production_health_verified: true,
-        production_ready_verified: true,
-        root_trust_bundle_verified: true,
-        root_trust_bundle_id:
-          "7d9954a797ef244c15ad1b733cf77598125ccef0f812a404137e827c192d6a58",
-        root_trust_ceremony_id: "avc-exo-ceremony-2026",
-        root_trust_issuer_did:
-          "did:exo:8EVGmqLo15JEnrbcrLo9r84qX1mtrVeBdPjHLUtb1sXX",
-        verifier_commit:
-          "379a45e1d9ab092ecd446d095a7b524570530efd",
-        verified_at: "2026-06-03T21:26:00.000Z",
+      productionTrustEvidence: VERIFIED_PRODUCTION_TRUST_EVIDENCE,
+    });
+
+    expect(payload.state).toBe("not-verified");
+    expect(payload.machine_state).toBe("not_verified");
+    expect(payload.public_claims_allowed).toBe(false);
+    expect(payload.public_claims_reason).toContain(
+      "proof-bearing public adapter-output authorization",
+    );
+    expect(payload).not.toHaveProperty("public_adapter_output_authorization");
+  });
+
+  it("denies verified public trust status unless the public adapter-output authorization decision and DTO are complete", () => {
+    const invalidAuthorizations = [
+      {
+        name: "denied evaluator decision",
+        adapterOutputAuthorization: {
+          ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION,
+          allowed: false,
+        },
       },
+      {
+        name: "non-permit EXOCHAIN response",
+        adapterOutputAuthorization: {
+          ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION,
+          responseState: "stale",
+        },
+      },
+      {
+        name: "uncalled transport",
+        adapterOutputAuthorization: {
+          ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION,
+          transportCalled: false,
+        },
+      },
+      {
+        name: "wrong subject",
+        adapterOutputAuthorization: {
+          ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION,
+          value: {
+            ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION.value,
+            subject: "www.livesafe.ai",
+          },
+        },
+      },
+      {
+        name: "wrong audience",
+        adapterOutputAuthorization: {
+          ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION,
+          value: {
+            ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION.value,
+            audience: "https://livesafe.ai/api/health",
+          },
+        },
+      },
+      {
+        name: "forbidden claim",
+        adapterOutputAuthorization: {
+          ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION,
+          value: {
+            ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION.value,
+            claims: [
+              ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION.value.claims,
+              "medical_status_verified",
+            ],
+          },
+        },
+      },
+      {
+        name: "missing evidence hash",
+        adapterOutputAuthorization: {
+          ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION,
+          value: {
+            ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION.value,
+            evidence_hash: "",
+          },
+        },
+      },
+    ];
+
+    for (const { adapterOutputAuthorization, name } of invalidAuthorizations) {
+      const payload = createTrustStatusPayload({
+        exochainConnected: true,
+        version: "1.0.0",
+        uptimeSeconds: 16,
+        generatedAt: "2026-07-05T12:00:00.000Z",
+        runtimeStatus: {
+          adapter_state: "verified",
+          surface_classification: "core-runtime-adapter",
+          public_claims_allowed: true,
+          can_read_exochain_core_state: true,
+          can_write_exochain_core_state: true,
+          disablement_path:
+            "Disable EXOCHAIN adapter environment variables and remove the trust-status route from the load balancer.",
+          source_basis: ["server/utils/livesafe-exochain-adapter.js"],
+        },
+        adapterOutputAuthorization,
+        productionTrustEvidence: VERIFIED_PRODUCTION_TRUST_EVIDENCE,
+      });
+
+      expect(payload.public_claims_allowed, name).toBe(false);
+      expect(payload.state, name).toBe("not-verified");
+      expect(payload.public_claims_reason, name).toContain(
+        "proof-bearing public adapter-output authorization",
+      );
+    }
+  });
+
+  it("allows verified public trust status only with permit-backed proof-bearing public adapter-output authorization", () => {
+    const payload = createTrustStatusPayload({
+      exochainConnected: true,
+      version: "1.0.0",
+      uptimeSeconds: 16,
+      generatedAt: "2026-07-05T12:00:00.000Z",
+      runtimeStatus: {
+        adapter_state: "verified",
+        surface_classification: "core-runtime-adapter",
+        public_claims_allowed: true,
+        can_read_exochain_core_state: true,
+        can_write_exochain_core_state: true,
+        disablement_path:
+          "Disable EXOCHAIN adapter environment variables and remove the trust-status route from the load balancer.",
+        source_basis: ["server/utils/livesafe-exochain-adapter.js"],
+      },
+      adapterOutputAuthorization: VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION,
+      productionTrustEvidence: VERIFIED_PRODUCTION_TRUST_EVIDENCE,
     });
 
     expect(payload.state).toBe("externally-verified");
@@ -198,7 +357,31 @@ describe("trust status API contract", () => {
     expect(payload.display_text).toBe("VERIFIED");
     expect(payload.public_claims_allowed).toBe(true);
     expect(payload.public_claims_reason).toContain(
-      "EXOCHAIN production evidence and LiveSafe runtime adapter gates are verified",
+      "EXOCHAIN production evidence, LiveSafe runtime adapter gates, and proof-bearing public adapter-output authorization are verified",
+    );
+    expect(payload.public_adapter_output_authorization).toEqual({
+      schema: "livesafe.public_adapter_output_authorization.v1",
+      subject: "livesafe.ai",
+      audience: "https://livesafe.ai/api/trust/status",
+      claims: [
+        "livesafe_public_trust_status",
+        "exochain_production_evidence_verified",
+        "livesafe_runtime_adapter_verified",
+      ],
+      evidence_hash:
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      receipt_id: "exo-receipt:public-adapter-output:2026-07-05",
+      proof_id: "exo-proof:public-adapter-output:2026-07-05",
+      proof_ref: "exo://receipts/public-adapter-output/2026-07-05",
+      generated_at: "2026-07-05T11:59:00.000Z",
+      valid_from: "2026-07-05T11:55:00.000Z",
+      expires_at: "2026-07-05T12:05:00.000Z",
+      proof_type: "ed25519-public-adapter-output-authorization",
+      response_state: "permit",
+      transport_called: true,
+    });
+    expect(JSON.stringify(payload.public_adapter_output_authorization)).not.toContain(
+      "signature",
     );
   });
 


### PR DESCRIPTION
## Summary

Wires LiveSafe `/api/trust/status` to a proof-bearing EXOCHAIN public adapter-output authorization decision.

This PR keeps public EXOCHAIN trust claims fail-closed unless production evidence, runtime adapter verification, the existing runtime public flag, and a validated EXOCHAIN authorization envelope all pass. It authorizes only the narrow public adapter-output status claim set; medical, legal, custody, consent, emergency, and broad constitutional trust claims remain out of scope and fail-closed.

Depends on core proof PR #769.

## Path Classification

- `livesafe/server/utils/public-adapter-output-authorization.js` / `.d.ts` — Adjacent surface adapter-output evaluator.
- `livesafe/server/utils/exochain-client.js` — Adjacent surface runtime adapter client for the EXOCHAIN node AVC REST route.
- `livesafe/server/utils/livesafe-exochain-adapter.js` — Adjacent surface operation wrapper.
- `livesafe/server/utils/trust-status.js` / `.d.ts` and `livesafe/server/index.js` — Adjacent surface status-route integration.
- `livesafe/server/utils/status-route-contracts.js` — Adjacent surface async responder hardening.
- `livesafe/tests/*` — Adjacent surface tests for the adapter/status boundary.

No EXOCHAIN core crate, CI/deploy, Railway config, or UI copy files are changed here.

## Contract

- `/api/trust/status` calls the live adapter for public adapter-output authorization.
- Manual `public_claims_allowed: true` no longer authorizes public output by itself.
- The LiveSafe client calls the configured `POST /api/v1/avc/livesafe/public-adapter-output-authorization` REST route, not a nonexistent GraphQL operation.
- The client fails closed when node URL, bearer, credential id, evidence hash, idempotency key, or required expiry config is absent or malformed.
- The adapter maps the actual Rust serde envelope: numeric `schema_version`, `NotRevoked`, byte-array `Hash256`, object-shaped `Signature::Ed25519`, and HLC timestamps.
- Public response metadata is redacted to schema, subject, audience, allowed claim names, evidence hash, receipt id, proof id/ref, generated/valid/expires timestamps, proof type, and transport state.

## RED Evidence

- Focused LiveSafe tests first failed on the missing evaluator, local boolean bypass, missing adapter method, missing async route responder, nonexistent GraphQL operation, mismatched core REST envelope shape, and finally the actual Rust serde shapes for Hash256/signature/revocation/schema version.

## GREEN Evidence

Post-rebase on `origin/main` (`73d22951`):

- `npm test -- tests/exochain-client.test.ts tests/exochain-runtime-adapter.test.ts tests/public-adapter-output-authorization.test.ts tests/status-route-contract.test.ts tests/trust-status.test.ts` — 5 files / 122 tests passed.
- `npm run typecheck` — passed.
- `npm run quality` — passed, including context lint, typecheck, full Vitest 156 files / 513 tests, Rust fmt/clippy/test.
- `git diff --check` — passed.

## Merge Gate

- PR #769 must merge first so the EXOCHAIN node route exists on main.
- LiveSafe CI must be green on this PR.
- Runtime public claims remain disabled until the authorization route is configured in Railway and production probes prove the contract.
