### PR TITLE
Gate LiveSafe trust copy on adapter proof metadata

### DIFF
--- a/livesafe/client/src/components/landing/TrustStrip.tsx
+++ b/livesafe/client/src/components/landing/TrustStrip.tsx
@@ -14,6 +14,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import {
+  getLandingPublicTrustDisplayCopy,
+  type PublicTrustRouteContract,
+} from './publicTrustDisplayCopy';
+
 /** Small hex-node glyph for the EXOCHAIN item. */
 function HexNode() {
   return (
@@ -35,14 +40,13 @@ function HexNode() {
   );
 }
 
-const ITEMS: string[] = [
-  'Consent-gated access by design',
-  'did:exo identity, derived on your device by design',
-  'X25519 encryption envelope (spec)',
-  'Apache-2.0 open architecture',
-];
+interface TrustStripProps {
+  trustStatus?: PublicTrustRouteContract | null;
+}
 
-export default function TrustStrip() {
+export default function TrustStrip({ trustStatus = null }: TrustStripProps) {
+  const copy = getLandingPublicTrustDisplayCopy(trustStatus);
+
   return (
     <section className="bg-white/[0.02] border-y border-white/[0.06] py-6">
       <div className="max-w-6xl mx-auto px-6 md:px-8">
@@ -50,11 +54,12 @@ export default function TrustStrip() {
           <span className="flex items-center gap-2 text-gray-300">
             <HexNode />
             <span>
-              <span className="font-medium">Built on the EXOCHAIN model</span>
-              {' — constitutional trust fabric'}
+              <span className="font-medium">{copy.trustStripLead}</span>
+              {' - '}
+              {copy.trustStripDetail}
             </span>
           </span>
-          {ITEMS.map((item) => (
+          {copy.trustStripItems.map((item) => (
             <span key={item}>{item}</span>
           ))}
         </div>

--- a/livesafe/client/src/components/landing/UnderTheHood.tsx
+++ b/livesafe/client/src/components/landing/UnderTheHood.tsx
@@ -14,68 +14,80 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import type { ReactNode } from 'react';
 import {
   Fingerprint, KeyRound, TimerReset, Landmark, type LucideIcon,
 } from 'lucide-react';
+import {
+  getLandingPublicTrustDisplayCopy,
+  type LandingPublicTrustDisplayCopy,
+  type PublicTrustRouteContract,
+} from './publicTrustDisplayCopy';
 
 interface HoodCard {
   icon: LucideIcon;
   title: string;
-  body: React.ReactNode;
+  body: ReactNode;
+}
+
+interface UnderTheHoodProps {
+  trustStatus?: PublicTrustRouteContract | null;
 }
 
 /*
  * Copy hedge contract: "designed to / architecture calls for / in the
  * protocol" hedges are load-bearing legal-truth anchors. Do not strip.
  */
-const CARDS: HoodCard[] = [
-  {
-    icon: Fingerprint,
-    title: 'Identity without accounts',
-    body: (
-      <>
-        Your identifier is designed to be derived on your device from your passphrase —
-        SHA-256 to a <code className="font-mono text-xs text-gray-400">did:exo</code>{' '}
-        DID. There is no password table to breach because there are no passwords.
-      </>
-    ),
-  },
-  {
-    icon: KeyRound,
-    title: 'Your passphrase stays home',
-    body: (
-      <>
-        The passphrase itself is designed never to be transmitted — identity
-        derivation belongs client-side, and the architecture calls for X25519
-        encryption envelopes around your profile.
-      </>
-    ),
-  },
-  {
-    icon: TimerReset,
-    title: 'Consent with a clock',
-    body: (
-      <>
-        Every scan grant in the protocol carries{' '}
-        <code className="font-mono text-xs text-gray-400">consent_expires_at_ms</code>.
-        Access that can&rsquo;t expire isn&rsquo;t consent — it&rsquo;s exposure.
-      </>
-    ),
-  },
-  {
-    icon: Landmark,
-    title: 'Governed, not just hosted',
-    body: (
-      <>
-        EXOCHAIN&rsquo;s constitutional model separates powers: no component is
-        designed to both hold your data and decide who sees it. Governance is
-        the runtime, not the PDF.
-      </>
-    ),
-  },
-];
+function buildCards(copy: LandingPublicTrustDisplayCopy): HoodCard[] {
+  return [
+    {
+      icon: Fingerprint,
+      title: 'Identity without accounts',
+      body: (
+        <>
+          Your identifier is designed to be derived on your device from your
+          passphrase into a{' '}
+          <code className="font-mono text-xs text-gray-400">
+            {copy.identityIdentifierLabel}
+          </code>
+          . There is no password table to breach because there are no passwords.
+        </>
+      ),
+    },
+    {
+      icon: KeyRound,
+      title: 'Your passphrase stays home',
+      body: (
+        <>
+          The passphrase itself is designed never to be transmitted. Identity
+          derivation belongs client-side, and the architecture calls for
+          encryption envelopes around your profile.
+        </>
+      ),
+    },
+    {
+      icon: TimerReset,
+      title: 'Consent with a clock',
+      body: (
+        <>
+          Every scan grant in the protocol carries{' '}
+          <code className="font-mono text-xs text-gray-400">consent_expires_at_ms</code>.
+          Access that can&rsquo;t expire is exposure, not consent.
+        </>
+      ),
+    },
+    {
+      icon: Landmark,
+      title: copy.governanceCardTitle,
+      body: copy.governanceCardBody,
+    },
+  ];
+}
 
-export default function UnderTheHood() {
+export default function UnderTheHood({ trustStatus = null }: UnderTheHoodProps) {
+  const copy = getLandingPublicTrustDisplayCopy(trustStatus);
+  const cards = buildCards(copy);
+
   return (
     <section id="under-the-hood" className="scroll-mt-16 bg-white/[0.02] border-y border-white/[0.06] py-20 md:py-28">
       <div className="max-w-6xl mx-auto px-6 md:px-8">
@@ -83,18 +95,14 @@ export default function UnderTheHood() {
           ARCHITECTURE
         </p>
         <h2 className="text-3xl md:text-4xl font-heading font-bold text-white mb-5">
-          Built on a trust fabric, not a terms-of-service.
+          {copy.underTheHoodHeading}
         </h2>
         <p className="text-gray-400 max-w-2xl leading-relaxed mb-12">
-          LiveSafe is a demonstration app built for EXOCHAIN, a constitutional
-          governance runtime. The
-          rules that protect you — consent gating, identified access, threshold
-          custody — are expressed as architecture, designed to be enforced by
-          the system rather than promised by a policy page.
+          {copy.underTheHoodBody}
         </p>
 
         <div className="grid md:grid-cols-2 gap-6">
-          {CARDS.map(({ icon: Icon, title, body }) => (
+          {cards.map(({ icon: Icon, title, body }) => (
             <div
               key={title}
               className="p-8 bg-white/[0.03] border border-white/10 rounded-2xl hover:border-blue-400/30 transition-colors"
@@ -109,7 +117,7 @@ export default function UnderTheHood() {
         </div>
 
         <p className="text-xs text-gray-500 mt-10">
-          EXOCHAIN v0.1.0-beta · Apache-2.0 · open specification
+          {copy.footerStatus} · Apache-2.0 · open specification
         </p>
       </div>
     </section>

--- a/livesafe/client/src/components/landing/publicTrustDisplayCopy.ts
+++ b/livesafe/client/src/components/landing/publicTrustDisplayCopy.ts
@@ -21,6 +21,24 @@ export interface PublicTrustRouteContract {
   public_claims_allowed: boolean;
   runtime_adapter_state: string | null;
   verified_runtime_adapter: boolean;
+  public_adapter_output_authorization: PublicAdapterOutputAuthorizationMetadata | null;
+}
+
+export interface PublicAdapterOutputAuthorizationMetadata {
+  schema: string | null;
+  subject: string | null;
+  audience: string | null;
+  claims: readonly string[];
+  evidence_hash: string | null;
+  receipt_id: string | null;
+  proof_id: string | null;
+  proof_ref: string | null;
+  generated_at: string | null;
+  valid_from: string | null;
+  expires_at: string | null;
+  proof_type: string | null;
+  response_state: string | null;
+  transport_called: boolean;
 }
 
 export interface LandingPublicTrustDisplayCopy {
@@ -63,15 +81,15 @@ const ACTIVE_COPY: LandingPublicTrustDisplayCopy = {
   machineState: 'public_trust_claims_allowed',
   trustStripLead: 'EXOCHAIN public trust output authorized',
   trustStripDetail:
-    'Route status: public_claims_allowed=true and machine_state=public_trust_claims_allowed.',
+    'Route status: public_claims_allowed=true and machine_state=public_trust_claims_allowed; public_adapter_output_authorization.response_state=permit.',
   trustStripItems: [
-    'Adapter-returned public trust state',
+    'Proof-bearing adapter output',
     'Source route: /api/trust/status',
     'Safety operations remain separate',
   ],
   underTheHoodHeading: 'Public trust display is route-authorized.',
   underTheHoodBody:
-    'The landing page may show this EXOCHAIN public trust output because the trust-status route returned the authorized public-claims machine state. Medical, legal, custody, consent, and emergency decisions remain separate operational duties.',
+    'The landing page may show this EXOCHAIN public trust output because the trust-status route returned the authorized public-claims machine state with proof-bearing public adapter-output metadata. Medical, legal, custody, consent, and emergency decisions remain separate operational duties.',
   identityIdentifierLabel: 'did:exo DID',
   governanceCardTitle: 'Governed by authorized route state',
   governanceCardBody:
@@ -81,6 +99,39 @@ const ACTIVE_COPY: LandingPublicTrustDisplayCopy = {
 
 function readString(value: unknown): string | null {
   return typeof value === 'string' ? value : null;
+}
+
+function readStringArray(value: unknown): readonly string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string')
+    ? value
+    : [];
+}
+
+function normalizePublicAdapterOutputAuthorization(
+  authorization: unknown,
+): PublicAdapterOutputAuthorizationMetadata | null {
+  if (!authorization || typeof authorization !== 'object' || Array.isArray(authorization)) {
+    return null;
+  }
+
+  const record = authorization as Record<string, unknown>;
+
+  return {
+    schema: readString(record.schema),
+    subject: readString(record.subject),
+    audience: readString(record.audience),
+    claims: readStringArray(record.claims),
+    evidence_hash: readString(record.evidence_hash),
+    receipt_id: readString(record.receipt_id),
+    proof_id: readString(record.proof_id),
+    proof_ref: readString(record.proof_ref),
+    generated_at: readString(record.generated_at),
+    valid_from: readString(record.valid_from),
+    expires_at: readString(record.expires_at),
+    proof_type: readString(record.proof_type),
+    response_state: readString(record.response_state),
+    transport_called: record.transport_called === true,
+  };
 }
 
 export function normalizePublicTrustRouteContract(
@@ -99,7 +150,48 @@ export function normalizePublicTrustRouteContract(
     public_claims_allowed: record.public_claims_allowed === true,
     runtime_adapter_state: readString(record.runtime_adapter_state),
     verified_runtime_adapter: record.verified_runtime_adapter === true,
+    public_adapter_output_authorization: normalizePublicAdapterOutputAuthorization(
+      record.public_adapter_output_authorization,
+    ),
   };
+}
+
+const REQUIRED_PUBLIC_ADAPTER_OUTPUT_CLAIMS = [
+  'livesafe_public_trust_status',
+  'exochain_production_evidence_verified',
+  'livesafe_runtime_adapter_verified',
+] as const;
+
+function isNonEmptyString(value: string | null): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function hasRequiredAdapterOutputClaims(claims: readonly string[]): boolean {
+  return REQUIRED_PUBLIC_ADAPTER_OUTPUT_CLAIMS.every((claim) =>
+    claims.includes(claim),
+  );
+}
+
+function hasAuthorizedPublicAdapterOutputMetadata(
+  authorization: PublicAdapterOutputAuthorizationMetadata | null,
+): boolean {
+  return (
+    authorization?.schema === 'livesafe.public_adapter_output_authorization.v1' &&
+    authorization.subject === 'livesafe.ai' &&
+    authorization.audience === 'https://livesafe.ai/api/trust/status' &&
+    hasRequiredAdapterOutputClaims(authorization.claims) &&
+    isNonEmptyString(authorization.evidence_hash) &&
+    authorization.evidence_hash.startsWith('sha256:') &&
+    isNonEmptyString(authorization.receipt_id) &&
+    isNonEmptyString(authorization.proof_id) &&
+    isNonEmptyString(authorization.proof_ref) &&
+    isNonEmptyString(authorization.generated_at) &&
+    isNonEmptyString(authorization.valid_from) &&
+    isNonEmptyString(authorization.expires_at) &&
+    authorization.proof_type === 'ed25519-public-adapter-output-authorization' &&
+    authorization.response_state === 'permit' &&
+    authorization.transport_called === true
+  );
 }
 
 export function isAuthorizedPublicTrustRoute(status?: unknown): boolean {
@@ -111,7 +203,10 @@ export function isAuthorizedPublicTrustRoute(status?: unknown): boolean {
     routeStatus.state === 'externally-verified' &&
     routeStatus.display_text === 'VERIFIED' &&
     routeStatus.runtime_adapter_state === 'verified' &&
-    routeStatus.verified_runtime_adapter === true
+    routeStatus.verified_runtime_adapter === true &&
+    hasAuthorizedPublicAdapterOutputMetadata(
+      routeStatus.public_adapter_output_authorization,
+    )
   );
 }
 

--- a/livesafe/client/src/components/landing/publicTrustDisplayCopy.ts
+++ b/livesafe/client/src/components/landing/publicTrustDisplayCopy.ts
@@ -1,0 +1,122 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export interface PublicTrustRouteContract {
+  state: string | null;
+  display_text: string | null;
+  machine_state: string | null;
+  public_claims_allowed: boolean;
+  runtime_adapter_state: string | null;
+  verified_runtime_adapter: boolean;
+}
+
+export interface LandingPublicTrustDisplayCopy {
+  trustBearingClaimsVisible: boolean;
+  machineState: 'not_verified' | 'public_trust_claims_allowed';
+  trustStripLead: string;
+  trustStripDetail: string;
+  trustStripItems: readonly string[];
+  underTheHoodHeading: string;
+  underTheHoodBody: string;
+  identityIdentifierLabel: string;
+  governanceCardTitle: string;
+  governanceCardBody: string;
+  footerStatus: string;
+}
+
+const INACTIVE_COPY: LandingPublicTrustDisplayCopy = {
+  trustBearingClaimsVisible: false,
+  machineState: 'not_verified',
+  trustStripLead: 'EXOCHAIN public trust copy inactive',
+  trustStripDetail:
+    'The public route has not authorized public EXOCHAIN trust claims.',
+  trustStripItems: [
+    'Safety app copy only',
+    'Adapter proof required',
+    'No public trust claim',
+  ],
+  underTheHoodHeading: 'Trust claims stay off until the route allows them.',
+  underTheHoodBody:
+    'LiveSafe can explain its safety workflow here, but public EXOCHAIN trust-bearing claims remain inactive until /api/trust/status returns the authorized public-claims machine state.',
+  identityIdentifierLabel: 'local identifier',
+  governanceCardTitle: 'Governance claims stay gated',
+  governanceCardBody:
+    'This page does not claim EXOCHAIN enforcement while the public trust route is inactive. The safety workflow remains an app-level design until adapter output allows public trust copy.',
+  footerStatus: 'Public trust display inactive',
+};
+
+const ACTIVE_COPY: LandingPublicTrustDisplayCopy = {
+  trustBearingClaimsVisible: true,
+  machineState: 'public_trust_claims_allowed',
+  trustStripLead: 'EXOCHAIN public trust output authorized',
+  trustStripDetail:
+    'Route status: public_claims_allowed=true and machine_state=public_trust_claims_allowed.',
+  trustStripItems: [
+    'Adapter-returned public trust state',
+    'Source route: /api/trust/status',
+    'Safety operations remain separate',
+  ],
+  underTheHoodHeading: 'Public trust display is route-authorized.',
+  underTheHoodBody:
+    'The landing page may show this EXOCHAIN public trust output because the trust-status route returned the authorized public-claims machine state. Medical, legal, custody, consent, and emergency decisions remain separate operational duties.',
+  identityIdentifierLabel: 'did:exo DID',
+  governanceCardTitle: 'Governed by authorized route state',
+  governanceCardBody:
+    'The public trust display is tied to the adapter-returned route state, not to proximity or marketing copy. If the route drops out of the authorized machine state, this section returns to inactive language.',
+  footerStatus: 'Public trust display authorized by route state',
+};
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+export function normalizePublicTrustRouteContract(
+  status?: unknown,
+): PublicTrustRouteContract | null {
+  if (!status || typeof status !== 'object' || Array.isArray(status)) {
+    return null;
+  }
+
+  const record = status as Record<string, unknown>;
+
+  return {
+    state: readString(record.state),
+    display_text: readString(record.display_text),
+    machine_state: readString(record.machine_state),
+    public_claims_allowed: record.public_claims_allowed === true,
+    runtime_adapter_state: readString(record.runtime_adapter_state),
+    verified_runtime_adapter: record.verified_runtime_adapter === true,
+  };
+}
+
+export function isAuthorizedPublicTrustRoute(status?: unknown): boolean {
+  const routeStatus = normalizePublicTrustRouteContract(status);
+
+  return (
+    routeStatus?.public_claims_allowed === true &&
+    routeStatus.machine_state === 'public_trust_claims_allowed' &&
+    routeStatus.state === 'externally-verified' &&
+    routeStatus.display_text === 'VERIFIED' &&
+    routeStatus.runtime_adapter_state === 'verified' &&
+    routeStatus.verified_runtime_adapter === true
+  );
+}
+
+export function getLandingPublicTrustDisplayCopy(
+  status?: unknown,
+): LandingPublicTrustDisplayCopy {
+  return isAuthorizedPublicTrustRoute(status) ? ACTIVE_COPY : INACTIVE_COPY;
+}

--- a/livesafe/client/src/components/landing/publicTrustDisplayCopy.ts
+++ b/livesafe/client/src/components/landing/publicTrustDisplayCopy.ts
@@ -166,9 +166,17 @@ function isNonEmptyString(value: string | null): value is string {
   return typeof value === 'string' && value.length > 0;
 }
 
+function isRequiredPublicAdapterOutputClaim(claim: string): boolean {
+  return (REQUIRED_PUBLIC_ADAPTER_OUTPUT_CLAIMS as readonly string[]).includes(
+    claim,
+  );
+}
+
 function hasRequiredAdapterOutputClaims(claims: readonly string[]): boolean {
-  return REQUIRED_PUBLIC_ADAPTER_OUTPUT_CLAIMS.every((claim) =>
-    claims.includes(claim),
+  return (
+    claims.length === REQUIRED_PUBLIC_ADAPTER_OUTPUT_CLAIMS.length &&
+    claims.every(isRequiredPublicAdapterOutputClaim) &&
+    REQUIRED_PUBLIC_ADAPTER_OUTPUT_CLAIMS.every((claim) => claims.includes(claim))
   );
 }
 

--- a/livesafe/client/src/pages/Landing.tsx
+++ b/livesafe/client/src/pages/Landing.tsx
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import { useEffect, useState } from 'react';
 import {
   Header,
   Hero,
@@ -25,6 +26,12 @@ import {
   FinalCta,
   Footer,
 } from '../components/landing';
+import {
+  normalizePublicTrustRouteContract,
+  type PublicTrustRouteContract,
+} from '../components/landing/publicTrustDisplayCopy';
+
+const TRUST_STATUS_ROUTE = '/api/trust/status';
 
 /**
  * Landing page — thin assembler only. Section order per build spec v2.0:
@@ -32,15 +39,58 @@ import {
  * → Features → Under the hood → What we don't do → Final CTA → Footer.
  */
 export default function Landing() {
+  const [publicTrustStatus, setPublicTrustStatus] =
+    useState<PublicTrustRouteContract | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    const controller = new AbortController();
+
+    async function loadPublicTrustStatus() {
+      try {
+        const response = await fetch(TRUST_STATUS_ROUTE, {
+          headers: { Accept: 'application/json' },
+          signal: controller.signal,
+        });
+
+        if (!isMounted) {
+          return;
+        }
+
+        if (!response.ok) {
+          setPublicTrustStatus(null);
+          return;
+        }
+
+        const payload: unknown = await response.json();
+
+        if (isMounted) {
+          setPublicTrustStatus(normalizePublicTrustRouteContract(payload));
+        }
+      } catch {
+        if (isMounted) {
+          setPublicTrustStatus(null);
+        }
+      }
+    }
+
+    void loadPublicTrustStatus();
+
+    return () => {
+      isMounted = false;
+      controller.abort();
+    };
+  }, []);
+
   return (
     <div className="min-h-screen bg-gradient-to-b from-[#0a0a10] via-[#0a1628] to-[#0a0a10]">
       <Header />
       <main>
         <Hero />
-        <TrustStrip />
+        <TrustStrip trustStatus={publicTrustStatus} />
         <Explainers />
         <FeaturesGrid />
-        <UnderTheHood />
+        <UnderTheHood trustStatus={publicTrustStatus} />
         <HonestyBlock />
         <FinalCta />
       </main>

--- a/livesafe/tests/public-exochain-copy-boundary.test.ts
+++ b/livesafe/tests/public-exochain-copy-boundary.test.ts
@@ -125,13 +125,40 @@ function flattenCopy(copy: ReturnType<PublicTrustDisplayCopyModule["getLandingPu
   ].join(" ");
 }
 
-const authorizedPublicTrustStatus = {
+const genericPublicTrustStatus = {
   state: "externally-verified",
   display_text: "VERIFIED",
   machine_state: "public_trust_claims_allowed",
   public_claims_allowed: true,
   runtime_adapter_state: "verified",
   verified_runtime_adapter: true,
+} as const;
+
+const publicAdapterOutputAuthorization = {
+  schema: "livesafe.public_adapter_output_authorization.v1",
+  subject: "livesafe.ai",
+  audience: "https://livesafe.ai/api/trust/status",
+  claims: [
+    "livesafe_public_trust_status",
+    "exochain_production_evidence_verified",
+    "livesafe_runtime_adapter_verified",
+  ],
+  evidence_hash:
+    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  receipt_id: "exo-receipt:public-adapter-output:2026-07-05",
+  proof_id: "exo-proof:public-adapter-output:2026-07-05",
+  proof_ref: "exo://receipts/public-adapter-output/2026-07-05",
+  generated_at: "2026-07-05T11:59:00.000Z",
+  valid_from: "2026-07-05T11:55:00.000Z",
+  expires_at: "2026-07-05T12:05:00.000Z",
+  proof_type: "ed25519-public-adapter-output-authorization",
+  response_state: "permit",
+  transport_called: true,
+} as const;
+
+const authorizedPublicTrustStatus = {
+  ...genericPublicTrustStatus,
+  public_adapter_output_authorization: publicAdapterOutputAuthorization,
 } as const;
 
 describe("public EXOCHAIN copy boundary", () => {
@@ -197,25 +224,54 @@ describe("public EXOCHAIN copy boundary", () => {
         runtime_adapter_state: "verified",
         verified_runtime_adapter: true,
       },
+      genericPublicTrustStatus,
       {
-        ...authorizedPublicTrustStatus,
+        ...genericPublicTrustStatus,
         public_claims_allowed: false,
       },
       {
-        ...authorizedPublicTrustStatus,
+        ...genericPublicTrustStatus,
         machine_state: "not_verified",
       },
       {
-        ...authorizedPublicTrustStatus,
+        ...genericPublicTrustStatus,
         state: "not-verified",
       },
       {
-        ...authorizedPublicTrustStatus,
+        ...genericPublicTrustStatus,
         runtime_adapter_state: "unverified",
       },
       {
-        ...authorizedPublicTrustStatus,
+        ...genericPublicTrustStatus,
         verified_runtime_adapter: false,
+      },
+      {
+        ...genericPublicTrustStatus,
+        public_adapter_output_authorization: {
+          ...publicAdapterOutputAuthorization,
+          response_state: "deny",
+        },
+      },
+      {
+        ...genericPublicTrustStatus,
+        public_adapter_output_authorization: {
+          ...publicAdapterOutputAuthorization,
+          transport_called: false,
+        },
+      },
+      {
+        ...genericPublicTrustStatus,
+        public_adapter_output_authorization: {
+          ...publicAdapterOutputAuthorization,
+          evidence_hash: "",
+        },
+      },
+      {
+        ...genericPublicTrustStatus,
+        public_adapter_output_authorization: {
+          ...publicAdapterOutputAuthorization,
+          proof_id: "",
+        },
       },
     ];
 
@@ -229,6 +285,22 @@ describe("public EXOCHAIN copy boundary", () => {
       expect(renderedText).toContain("EXOCHAIN public trust copy inactive");
       expect(renderedText).not.toContain("EXOCHAIN public trust output authorized");
     }
+  });
+
+  it("keeps the old six-field generic public route status inactive", async () => {
+    const {
+      getLandingPublicTrustDisplayCopy,
+      isAuthorizedPublicTrustRoute,
+    } = await loadPublicTrustDisplayCopy();
+
+    const copy = getLandingPublicTrustDisplayCopy(genericPublicTrustStatus);
+    const renderedText = flattenCopy(copy);
+
+    expect(isAuthorizedPublicTrustRoute(genericPublicTrustStatus)).toBe(false);
+    expect(copy.trustBearingClaimsVisible).toBe(false);
+    expect(copy.machineState).toBe("not_verified");
+    expect(renderedText).toContain("EXOCHAIN public trust copy inactive");
+    expect(renderedText).not.toContain("EXOCHAIN public trust output authorized");
   });
 
   it("allows landing trust copy only for the authorized public adapter-output state", async () => {
@@ -246,6 +318,9 @@ describe("public EXOCHAIN copy boundary", () => {
     expect(renderedText).toContain("EXOCHAIN public trust output authorized");
     expect(renderedText).toContain(
       "public_claims_allowed=true and machine_state=public_trust_claims_allowed",
+    );
+    expect(renderedText).toContain(
+      "public_adapter_output_authorization.response_state=permit",
     );
     for (const pattern of ACTIVE_COPY_DENIED_PATTERNS) {
       expect(renderedText).not.toMatch(pattern);

--- a/livesafe/tests/public-exochain-copy-boundary.test.ts
+++ b/livesafe/tests/public-exochain-copy-boundary.test.ts
@@ -303,6 +303,94 @@ describe("public EXOCHAIN copy boundary", () => {
     expect(renderedText).not.toContain("EXOCHAIN public trust output authorized");
   });
 
+  it("denies active landing trust copy when adapter output includes an unsupported claim", async () => {
+    const {
+      getLandingPublicTrustDisplayCopy,
+      isAuthorizedPublicTrustRoute,
+    } = await loadPublicTrustDisplayCopy();
+
+    const status = {
+      ...genericPublicTrustStatus,
+      public_adapter_output_authorization: {
+        ...publicAdapterOutputAuthorization,
+        claims: [
+          ...publicAdapterOutputAuthorization.claims,
+          "livesafe_marketing_trust_claim",
+        ],
+      },
+    };
+    const copy = getLandingPublicTrustDisplayCopy(status);
+    const renderedText = flattenCopy(copy);
+
+    expect(isAuthorizedPublicTrustRoute(status)).toBe(false);
+    expect(copy.trustBearingClaimsVisible).toBe(false);
+    expect(copy.machineState).toBe("not_verified");
+    expect(renderedText).toContain("EXOCHAIN public trust copy inactive");
+    expect(renderedText).not.toContain("EXOCHAIN public trust output authorized");
+  });
+
+  it("denies active landing trust copy when adapter output duplicates a required claim", async () => {
+    const {
+      getLandingPublicTrustDisplayCopy,
+      isAuthorizedPublicTrustRoute,
+    } = await loadPublicTrustDisplayCopy();
+
+    const status = {
+      ...genericPublicTrustStatus,
+      public_adapter_output_authorization: {
+        ...publicAdapterOutputAuthorization,
+        claims: [
+          ...publicAdapterOutputAuthorization.claims,
+          "livesafe_public_trust_status",
+        ],
+      },
+    };
+    const copy = getLandingPublicTrustDisplayCopy(status);
+    const renderedText = flattenCopy(copy);
+
+    expect(isAuthorizedPublicTrustRoute(status)).toBe(false);
+    expect(copy.trustBearingClaimsVisible).toBe(false);
+    expect(copy.machineState).toBe("not_verified");
+    expect(renderedText).toContain("EXOCHAIN public trust copy inactive");
+    expect(renderedText).not.toContain("EXOCHAIN public trust output authorized");
+  });
+
+  it("denies active landing trust copy when adapter output adds forbidden public claim terms", async () => {
+    const {
+      getLandingPublicTrustDisplayCopy,
+      isAuthorizedPublicTrustRoute,
+    } = await loadPublicTrustDisplayCopy();
+
+    const forbiddenClaims = [
+      "medical_trust_claim",
+      "legal_trust_claim",
+      "custody_trust_claim",
+      "consent_trust_claim",
+      "emergency_trust_claim",
+    ];
+
+    for (const forbiddenClaim of forbiddenClaims) {
+      const status = {
+        ...genericPublicTrustStatus,
+        public_adapter_output_authorization: {
+          ...publicAdapterOutputAuthorization,
+          claims: [
+            ...publicAdapterOutputAuthorization.claims,
+            forbiddenClaim,
+          ],
+        },
+      };
+      const copy = getLandingPublicTrustDisplayCopy(status);
+      const renderedText = flattenCopy(copy);
+
+      expect(isAuthorizedPublicTrustRoute(status)).toBe(false);
+      expect(copy.trustBearingClaimsVisible).toBe(false);
+      expect(copy.machineState).toBe("not_verified");
+      expect(renderedText).toContain("EXOCHAIN public trust copy inactive");
+      expect(renderedText).not.toContain("EXOCHAIN public trust output authorized");
+    }
+  });
+
   it("allows landing trust copy only for the authorized public adapter-output state", async () => {
     const {
       getLandingPublicTrustDisplayCopy,

--- a/livesafe/tests/public-exochain-copy-boundary.test.ts
+++ b/livesafe/tests/public-exochain-copy-boundary.test.ts
@@ -54,6 +54,86 @@ const FORBIDDEN_ACTIVE_TRUST_COPY = [
   /per EXOCHAIN policy/i,
 ];
 
+const LANDING_TRUST_COPY_FILES = [
+  "client/src/pages/Landing.tsx",
+  "client/src/components/landing/TrustStrip.tsx",
+  "client/src/components/landing/UnderTheHood.tsx",
+];
+
+const UNCONDITIONAL_LANDING_TRUST_COPY = [
+  /Built on the EXOCHAIN model/i,
+  /constitutional trust fabric/i,
+  /Built on a trust fabric/i,
+  /trust fabric, not a terms-of-service/i,
+  /EXOCHAIN(?:&rsquo;|'|’)?s constitutional model separates powers/i,
+  /Governance is\s+the runtime/i,
+  /rules that protect you/i,
+  /threshold\s+custody/i,
+  /designed to be enforced by\s+the system/i,
+  /did:exo identity/i,
+  /did:exo(?:<\/code>|)\s+DID/i,
+];
+
+const ACTIVE_COPY_DENIED_PATTERNS = [
+  /medical guarantee/i,
+  /legal guarantee/i,
+  /custody guarantee/i,
+  /consent guarantee/i,
+  /emergency guarantee/i,
+  /emergency access is guaranteed/i,
+];
+
+type PublicTrustDisplayCopyModule = {
+  getLandingPublicTrustDisplayCopy: (status?: unknown) => {
+    trustBearingClaimsVisible: boolean;
+    trustStripLead: string;
+    trustStripDetail: string;
+    trustStripItems: readonly string[];
+    underTheHoodHeading: string;
+    underTheHoodBody: string;
+    governanceCardTitle: string;
+    governanceCardBody: string;
+    machineState: string;
+  };
+  isAuthorizedPublicTrustRoute: (status?: unknown) => boolean;
+};
+
+async function loadPublicTrustDisplayCopy(): Promise<PublicTrustDisplayCopyModule> {
+  try {
+    return (await import(
+      "../client/src/components/landing/publicTrustDisplayCopy.js"
+    )) as PublicTrustDisplayCopyModule;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Landing public trust display copy contract is missing: ${detail}`);
+  }
+}
+
+function read(relativePath: string): string {
+  return readFileSync(path.join(root, relativePath), "utf8");
+}
+
+function flattenCopy(copy: ReturnType<PublicTrustDisplayCopyModule["getLandingPublicTrustDisplayCopy"]>): string {
+  return [
+    copy.trustStripLead,
+    copy.trustStripDetail,
+    ...copy.trustStripItems,
+    copy.underTheHoodHeading,
+    copy.underTheHoodBody,
+    copy.governanceCardTitle,
+    copy.governanceCardBody,
+  ].join(" ");
+}
+
+const authorizedPublicTrustStatus = {
+  state: "externally-verified",
+  display_text: "VERIFIED",
+  machine_state: "public_trust_claims_allowed",
+  public_claims_allowed: true,
+  runtime_adapter_state: "verified",
+  verified_runtime_adapter: true,
+} as const;
+
 describe("public EXOCHAIN copy boundary", () => {
   it("does not claim active EXOCHAIN trust, bailment, audit, or sovereignty before LiveSafe adapter proof", () => {
     const violations = [];
@@ -68,5 +148,107 @@ describe("public EXOCHAIN copy boundary", () => {
     }
 
     expect(violations).toEqual([]);
+  });
+
+  it("does not keep active EXOCHAIN trust copy unconditionally in first-viewport landing components", () => {
+    const violations = [];
+
+    for (const relativePath of LANDING_TRUST_COPY_FILES) {
+      const content = read(relativePath);
+      for (const pattern of UNCONDITIONAL_LANDING_TRUST_COPY) {
+        if (pattern.test(content)) {
+          violations.push(`${relativePath}: ${pattern}`);
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it("shows fail-closed landing copy when the public route status is missing", async () => {
+    const {
+      getLandingPublicTrustDisplayCopy,
+      isAuthorizedPublicTrustRoute,
+    } = await loadPublicTrustDisplayCopy();
+
+    const copy = getLandingPublicTrustDisplayCopy();
+    const renderedText = flattenCopy(copy);
+
+    expect(isAuthorizedPublicTrustRoute()).toBe(false);
+    expect(copy.trustBearingClaimsVisible).toBe(false);
+    expect(copy.machineState).toBe("not_verified");
+    expect(renderedText).toContain("EXOCHAIN public trust copy inactive");
+    expect(renderedText).toContain("has not authorized public EXOCHAIN trust claims");
+    expect(renderedText).not.toContain("EXOCHAIN public trust output authorized");
+  });
+
+  it("denies active landing trust copy for inactive or partial route status", async () => {
+    const {
+      getLandingPublicTrustDisplayCopy,
+      isAuthorizedPublicTrustRoute,
+    } = await loadPublicTrustDisplayCopy();
+
+    const deniedStatuses = [
+      {
+        state: "not-verified",
+        display_text: "THIS IS NOT YET VERIFIED",
+        machine_state: "not_verified",
+        public_claims_allowed: false,
+        runtime_adapter_state: "verified",
+        verified_runtime_adapter: true,
+      },
+      {
+        ...authorizedPublicTrustStatus,
+        public_claims_allowed: false,
+      },
+      {
+        ...authorizedPublicTrustStatus,
+        machine_state: "not_verified",
+      },
+      {
+        ...authorizedPublicTrustStatus,
+        state: "not-verified",
+      },
+      {
+        ...authorizedPublicTrustStatus,
+        runtime_adapter_state: "unverified",
+      },
+      {
+        ...authorizedPublicTrustStatus,
+        verified_runtime_adapter: false,
+      },
+    ];
+
+    for (const status of deniedStatuses) {
+      const copy = getLandingPublicTrustDisplayCopy(status);
+      const renderedText = flattenCopy(copy);
+
+      expect(isAuthorizedPublicTrustRoute(status)).toBe(false);
+      expect(copy.trustBearingClaimsVisible).toBe(false);
+      expect(copy.machineState).toBe("not_verified");
+      expect(renderedText).toContain("EXOCHAIN public trust copy inactive");
+      expect(renderedText).not.toContain("EXOCHAIN public trust output authorized");
+    }
+  });
+
+  it("allows landing trust copy only for the authorized public adapter-output state", async () => {
+    const {
+      getLandingPublicTrustDisplayCopy,
+      isAuthorizedPublicTrustRoute,
+    } = await loadPublicTrustDisplayCopy();
+
+    const copy = getLandingPublicTrustDisplayCopy(authorizedPublicTrustStatus);
+    const renderedText = flattenCopy(copy);
+
+    expect(isAuthorizedPublicTrustRoute(authorizedPublicTrustStatus)).toBe(true);
+    expect(copy.trustBearingClaimsVisible).toBe(true);
+    expect(copy.machineState).toBe("public_trust_claims_allowed");
+    expect(renderedText).toContain("EXOCHAIN public trust output authorized");
+    expect(renderedText).toContain(
+      "public_claims_allowed=true and machine_state=public_trust_claims_allowed",
+    );
+    for (const pattern of ACTIVE_COPY_DENIED_PATTERNS) {
+      expect(renderedText).not.toMatch(pattern);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- stack LiveSafe landing public-trust copy on the proof-bearing adapter authorization contract from #771
- require redacted `public_adapter_output_authorization` metadata before active EXOCHAIN public trust copy can render
- keep the old generic six-field status payload fail-closed in public landing copy

## Path Classification
- Adjacent surface UI/copy: `livesafe/client/src/components/landing/publicTrustDisplayCopy.ts`
- Adjacent surface tests: `livesafe/tests/public-exochain-copy-boundary.test.ts`

## Tests
- RED: focused copy-boundary test failed when helper allowed the old generic six-field payload and omitted `public_adapter_output_authorization.response_state=permit`
- GREEN: `npm test -- tests/public-exochain-copy-boundary.test.ts`
- `npm run typecheck`
- `npm run quality`
- `git diff --check`
- extra sanity: `npm run build` in `livesafe/client`

## Notes
- Does not touch EXOCHAIN core crates, server adapter implementation, deployment scripts, Railway/CI workflows, or production state.
- Does not merge this stack.
