### PR TITLE
Harden LiveSafe public authorization ceremony

### DIFF
--- a/.github/workflows/livesafe-railway-deploy.yml
+++ b/.github/workflows/livesafe-railway-deploy.yml
@@ -41,6 +41,14 @@ on:
         description: "Commit SHA to deploy; defaults to the workflow SHA"
         required: false
         type: string
+      expected_public_claims_allowed:
+        description: "Expected public claims state for staging/production smoke"
+        required: false
+        type: choice
+        default: "false"
+        options:
+          - "false"
+          - "true"
 
 permissions:
   contents: read
@@ -94,6 +102,7 @@ jobs:
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_STAGING_TOKEN }}
       TARGET_ENVIRONMENT: staging
       TARGET_ENVIRONMENT_ID: a223bc12-fbe4-430f-abce-8e3ee7c9abd3
+      LIVESAFE_EXPECT_PUBLIC_CLAIMS_ALLOWED: ${{ inputs.expected_public_claims_allowed || 'false' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -122,6 +131,7 @@ jobs:
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_TOKEN }}
       TARGET_ENVIRONMENT: production
       TARGET_ENVIRONMENT_ID: 1e5153e1-15f4-4447-bf7c-029af33927fb
+      LIVESAFE_EXPECT_PUBLIC_CLAIMS_ALLOWED: ${{ inputs.expected_public_claims_allowed || 'false' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:

--- a/livesafe/server/utils/exochain-client.js
+++ b/livesafe/server/utils/exochain-client.js
@@ -7,6 +7,8 @@
  * Gateway: http://localhost:8080/graphql (configurable via EXOCHAIN_GATEWAY_URL)
  */
 
+const crypto = require('node:crypto');
+
 const {
   ALLOWED_PUBLIC_ADAPTER_OUTPUT_CLAIMS,
   PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
@@ -30,11 +32,17 @@ const EXOCHAIN_GATEWAY_REJECTED_ERROR = 'EXOCHAIN_GATEWAY_REJECTED';
 const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_ROUTE =
   '/api/v1/avc/livesafe/public-adapter-output-authorization';
 const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DEFAULT_TIMEOUT_MS = 5000;
+const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DEFAULT_TTL_MS = 5 * 60 * 1000;
+const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_MAX_TTL_MS = 5 * 60 * 1000;
+const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DEFAULT_IDEMPOTENCY_NAMESPACE =
+  'livesafe-public-adapter-output';
 const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_PROOF_TYPE =
   'ed25519-public-adapter-output-authorization';
 const SHA256_EVIDENCE_HASH_PATTERN = /^sha256:[a-f0-9]{64}$/;
 const STRICT_UTC_TIMESTAMP_PATTERN =
   /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+const PUBLIC_AUTHORIZATION_IDEMPOTENCY_NAMESPACE_PATTERN =
+  /^[a-z0-9][a-z0-9_.:-]{0,79}$/;
 
 function isRequiredTransportIdentifier(value) {
   return (
@@ -154,42 +162,182 @@ function parseStrictUtcTimestampEnv(value) {
   };
 }
 
+function parsePublicAuthorizationBaseUrl(value) {
+  if (!isNonEmptyString(value)) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(value);
+    if (
+      (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') ||
+      parsed.username ||
+      parsed.password
+    ) {
+      return null;
+    }
+
+    return value;
+  } catch {
+    return null;
+  }
+}
+
+function parsePublicAuthorizationNamespace(value) {
+  const namespace = isNonEmptyString(value)
+    ? value.trim()
+    : PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DEFAULT_IDEMPOTENCY_NAMESPACE;
+
+  return PUBLIC_AUTHORIZATION_IDEMPOTENCY_NAMESPACE_PATTERN.test(namespace)
+    ? namespace
+    : null;
+}
+
+function parsePublicAuthorizationTtlMs(value) {
+  if (!isNonEmptyString(value)) {
+    return PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DEFAULT_TTL_MS;
+  }
+
+  if (!/^[1-9][0-9]*$/.test(value)) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (
+    !Number.isSafeInteger(parsed) ||
+    parsed <= 0 ||
+    parsed > PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_MAX_TTL_MS
+  ) {
+    return null;
+  }
+
+  return parsed;
+}
+
+function publicAuthorizationWindowStartMs(physicalMs, ttlMs) {
+  return physicalMs - (physicalMs % ttlMs);
+}
+
+function publicAuthorizationIdempotencyDigest(material) {
+  const canonicalMaterial = JSON.stringify({
+    audience: material.audience,
+    credential_id: material.credentialId,
+    evidence_hash: material.evidenceHash,
+    schema: PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SCHEMA,
+    subject: material.subject,
+    ttl_ms: material.ttlMs,
+    window_start_ms: material.windowStartMs,
+  });
+
+  return crypto
+    .createHash('sha256')
+    .update(canonicalMaterial, 'utf8')
+    .digest('hex');
+}
+
+function buildPublicAdapterOutputAuthorizationRequest({
+  subject,
+  audience,
+  credentialId,
+  credentialIdBytes,
+  evidenceHash,
+  evidenceHashBytes,
+  currentAt,
+  namespace,
+  ttlMs,
+}) {
+  if (
+    !isNonEmptyString(subject) ||
+    !isNonEmptyString(audience) ||
+    !SHA256_EVIDENCE_HASH_PATTERN.test(credentialId || '') ||
+    !SHA256_EVIDENCE_HASH_PATTERN.test(evidenceHash || '') ||
+    !isByteArrayOfLength(credentialIdBytes, 32) ||
+    !isByteArrayOfLength(evidenceHashBytes, 32) ||
+    !isNonEmptyString(namespace) ||
+    !PUBLIC_AUTHORIZATION_IDEMPOTENCY_NAMESPACE_PATTERN.test(namespace) ||
+    !Number.isSafeInteger(ttlMs) ||
+    ttlMs <= 0 ||
+    ttlMs > PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_MAX_TTL_MS
+  ) {
+    return null;
+  }
+
+  const currentTimestamp = parseStrictUtcTimestampEnv(currentAt);
+  if (!currentTimestamp) {
+    return null;
+  }
+
+  const expiresPhysicalMs = currentTimestamp.physical_ms + ttlMs;
+  if (!Number.isSafeInteger(expiresPhysicalMs)) {
+    return null;
+  }
+
+  const windowStartMs = publicAuthorizationWindowStartMs(
+    currentTimestamp.physical_ms,
+    ttlMs,
+  );
+  const digest = publicAuthorizationIdempotencyDigest({
+    subject,
+    audience,
+    credentialId,
+    evidenceHash,
+    ttlMs,
+    windowStartMs,
+  });
+
+  return {
+    subject,
+    audience,
+    credential_id: [...credentialIdBytes],
+    evidence_hash: [...evidenceHashBytes],
+    idempotency_key: `${namespace}:sha256:${digest}`,
+    expires_at: {
+      physical_ms: expiresPhysicalMs,
+      logical: 0,
+    },
+  };
+}
+
 function getPublicAdapterOutputAuthorizationConfig() {
   const baseUrl =
     envString('EXOCHAIN_NODE_AVC_URL') || envString('EXOCHAIN_NODE_URL');
   const bearer = envString('EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_BEARER');
   const credentialId = envString('EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_CREDENTIAL_ID');
   const evidenceHash = envString('EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_EVIDENCE_HASH');
-  const idempotencyKey = envString('EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_IDEMPOTENCY_KEY');
-  const expiresAt = envString('EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_EXPIRES_AT');
+  const namespace = parsePublicAuthorizationNamespace(
+    envString('EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_IDEMPOTENCY_NAMESPACE'),
+  );
+  const ttlMs = parsePublicAuthorizationTtlMs(
+    envString('EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_TTL_MS'),
+  );
   const timeoutMs = parsePositiveInteger(
     envString('EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_TIMEOUT_MS'),
     PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DEFAULT_TIMEOUT_MS,
   );
+  const validatedBaseUrl = parsePublicAuthorizationBaseUrl(baseUrl);
   const credentialHash = parseHash256Env(credentialId);
   const evidenceHashValue = parseHash256Env(evidenceHash);
-  const expiresAtTimestamp = parseStrictUtcTimestampEnv(expiresAt);
 
   if (
-    !baseUrl ||
+    !validatedBaseUrl ||
     !bearer ||
     !credentialHash ||
     !evidenceHashValue ||
-    !idempotencyKey ||
-    !expiresAtTimestamp
+    !namespace ||
+    !ttlMs
   ) {
     return null;
   }
 
   return {
-    baseUrl,
+    baseUrl: validatedBaseUrl,
     bearer,
     credentialId: credentialHash.canonical,
     credentialIdBytes: credentialHash.bytes,
     evidenceHash: evidenceHashValue.canonical,
     evidenceHashBytes: evidenceHashValue.bytes,
-    idempotencyKey,
-    expiresAt: expiresAtTimestamp,
+    namespace,
+    ttlMs,
     timeoutMs,
   };
 }
@@ -770,14 +918,22 @@ class ExochainClient {
         : null;
 
     try {
-      const body = {
+      const body = buildPublicAdapterOutputAuthorizationRequest({
         subject,
         audience,
-        credential_id: [...config.credentialIdBytes],
-        evidence_hash: [...config.evidenceHashBytes],
-        idempotency_key: config.idempotencyKey,
-        expires_at: { ...config.expiresAt },
-      };
+        credentialId: config.credentialId,
+        credentialIdBytes: config.credentialIdBytes,
+        evidenceHash: config.evidenceHash,
+        evidenceHashBytes: config.evidenceHashBytes,
+        currentAt,
+        namespace: config.namespace,
+        ttlMs: config.ttlMs,
+      });
+
+      if (!body) {
+        console.warn('[EXOCHAIN] public adapter-output authorization request rejected malformed freshness inputs before transport');
+        return createPublicAuthorizationDenied();
+      }
 
       const response = await fetch(
         buildPublicAdapterOutputAuthorizationUrl(config.baseUrl),
@@ -877,4 +1033,8 @@ class ExochainClient {
 // Singleton instance
 const exochain = new ExochainClient();
 
-module.exports = { ExochainClient, exochain };
+module.exports = {
+  ExochainClient,
+  buildPublicAdapterOutputAuthorizationRequest,
+  exochain,
+};

--- a/livesafe/server/utils/exochain-client.js
+++ b/livesafe/server/utils/exochain-client.js
@@ -267,15 +267,15 @@ function buildPublicAdapterOutputAuthorizationRequest({
     return null;
   }
 
-  const expiresPhysicalMs = currentTimestamp.physical_ms + ttlMs;
-  if (!Number.isSafeInteger(expiresPhysicalMs)) {
-    return null;
-  }
-
   const windowStartMs = publicAuthorizationWindowStartMs(
     currentTimestamp.physical_ms,
     ttlMs,
   );
+  const expiresPhysicalMs = windowStartMs + ttlMs;
+  if (!Number.isSafeInteger(expiresPhysicalMs)) {
+    return null;
+  }
+
   const digest = publicAuthorizationIdempotencyDigest({
     subject,
     audience,

--- a/livesafe/tests/exochain-client.test.ts
+++ b/livesafe/tests/exochain-client.test.ts
@@ -805,12 +805,12 @@ describe("EXOCHAIN client timestamp preservation", () => {
       "idem:livesafe-public-adapter-output:2026-07-05T12:00:00Z",
     );
     expect(secondRequest.expires_at).toEqual({
-      physical_ms: Date.parse("2026-07-05T12:11:00.000Z"),
+      physical_ms: Date.parse("2026-07-05T12:10:00.000Z"),
       logical: 0,
     });
   });
 
-  it("binds public adapter-output request idempotency to target, credential, evidence, and current time window", () => {
+  it("binds public adapter-output request idempotency to target, credential, evidence, and stable current time window material", () => {
     const baseRequest = {
       subject: "livesafe.ai",
       audience: "https://livesafe.ai/api/trust/status",
@@ -855,9 +855,15 @@ describe("EXOCHAIN client timestamp preservation", () => {
     expect(sameWindowRequest.idempotency_key).toBe(
       firstRequest.idempotency_key,
     );
+    expect(sameWindowRequest.expires_at).toEqual(firstRequest.expires_at);
     expect(nextWindowRequest.idempotency_key).not.toBe(
       firstRequest.idempotency_key,
     );
+    expect(nextWindowRequest.expires_at).not.toEqual(firstRequest.expires_at);
+    expect(nextWindowRequest.expires_at).toEqual({
+      physical_ms: Date.parse("2026-07-05T12:10:00.000Z"),
+      logical: 0,
+    });
     expect(evidenceChangedRequest.idempotency_key).not.toBe(
       firstRequest.idempotency_key,
     );

--- a/livesafe/tests/exochain-client.test.ts
+++ b/livesafe/tests/exochain-client.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { ExochainClient } = require("../server/utils/exochain-client.js");
+const {
+  ExochainClient,
+  buildPublicAdapterOutputAuthorizationRequest,
+} = require("../server/utils/exochain-client.js");
 
 function repeatedByte(byte: number, length: number) {
   return Array.from({ length }, () => byte);
@@ -18,6 +21,8 @@ const IDEMPOTENCY_KEY_HASH_BYTES = repeatedByte(0xee, 32);
 const ED25519_SIGNATURE_BYTES = repeatedByte(0xaa, 64);
 const EVIDENCE_HASH_HEX = repeatedHex(0xbb, 32);
 const CREDENTIAL_ID_HEX = repeatedHex(0xbc, 32);
+const ALT_EVIDENCE_HASH_HEX = repeatedHex(0xab, 32);
+const ALT_CREDENTIAL_ID_HEX = repeatedHex(0xcd, 32);
 const PROOF_HASH_HEX = repeatedHex(0xcc, 32);
 const ED25519_SIGNATURE_HEX = repeatedHex(0xaa, 64);
 
@@ -55,7 +60,10 @@ const PUBLIC_ADAPTER_AUTHORIZATION_REST_CONFIG = {
   EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_EVIDENCE_HASH: `sha256:${EVIDENCE_HASH_HEX}`,
   EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_IDEMPOTENCY_KEY:
     "idem:livesafe-public-adapter-output:2026-07-05T12:00:00Z",
+  EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_IDEMPOTENCY_NAMESPACE:
+    "livesafe-public-adapter-output",
   EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_EXPIRES_AT: "2026-07-05T12:05:00.000Z",
+  EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_TTL_MS: "300000",
   EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_TIMEOUT_MS: "2500",
 };
 
@@ -211,6 +219,43 @@ function configurePublicAdapterAuthorizationEnv(
       process.env[key] = value;
     }
   }
+}
+
+function publicAuthorizationRequestBodies(fetch: ReturnType<typeof vi.fn>) {
+  return fetch.mock.calls.map(([, requestInit]) =>
+    JSON.parse((requestInit as { body: string }).body),
+  );
+}
+
+function mockPublicAuthorizationFetchForCurrentAts(currentAts: string[]) {
+  if (currentAts.length === 0) {
+    throw new Error("at least one public authorization timestamp is required");
+  }
+
+  let callIndex = 0;
+
+  return vi.fn(async () => {
+    const currentAt = currentAts[Math.min(callIndex, currentAts.length - 1)] as string;
+    callIndex += 1;
+    const physicalMs = Date.parse(currentAt);
+
+    return {
+      ok: true,
+      json: async () =>
+        rustCoreEnvelope({
+          proof: {
+            issued_at: {
+              physical_ms: physicalMs,
+              logical: 0,
+            },
+            expires_at: {
+              physical_ms: physicalMs + 300000,
+              logical: 0,
+            },
+          },
+        }),
+    };
+  });
 }
 
 describe("EXOCHAIN client timestamp preservation", () => {
@@ -657,12 +702,26 @@ describe("EXOCHAIN client timestamp preservation", () => {
       leaked: "secret",
     },
     {
-      label: "expires_at is not a strict timestamp",
+      label: "bearer token is missing",
       override: {
-        EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_EXPIRES_AT:
-          "not-a-timestamp-secret-expiry",
+        EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_BEARER: "",
       },
-      leaked: "secret-expiry",
+      leaked: "secret-public-adapter-bearer",
+    },
+    {
+      label: "base URL is malformed",
+      override: {
+        EXOCHAIN_NODE_URL: "not-a-url-secret-host",
+        EXOCHAIN_NODE_AVC_URL: "",
+      },
+      leaked: "secret-host",
+    },
+    {
+      label: "ttl exceeds the evaluator freshness window",
+      override: {
+        EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_TTL_MS: "300001",
+      },
+      leaked: "secret-public-adapter-bearer",
     },
   ])("fails closed before REST transport when $label", async ({
     override,
@@ -684,6 +743,133 @@ describe("EXOCHAIN client timestamp preservation", () => {
     expect(fetch).not.toHaveBeenCalled();
     expect(JSON.stringify(warn.mock.calls)).not.toContain(leaked);
     expect(JSON.stringify(warn.mock.calls)).not.toContain(
+      "secret-public-adapter-bearer",
+    );
+  });
+
+  it("does not require static public adapter-output idempotency or expiry env to call EXOCHAIN", async () => {
+    configurePublicAdapterAuthorizationEnv({
+      EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_IDEMPOTENCY_KEY: "",
+      EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_EXPIRES_AT: "",
+    });
+    const client = new ExochainClient("http://example.invalid/graphql");
+    const fetch = mockPublicAuthorizationFetchForCurrentAts([
+      "2026-07-05T12:00:00.000Z",
+    ]);
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await client.getPublicAdapterOutputAuthorization({
+      subject: "livesafe.ai",
+      audience: "https://livesafe.ai/api/trust/status",
+      currentAt: "2026-07-05T12:00:00.000Z",
+    });
+
+    expect(result.state).toBe("permit");
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [requestBody] = publicAuthorizationRequestBodies(fetch);
+    expect(requestBody.idempotency_key).toMatch(
+      /^livesafe-public-adapter-output:sha256:[a-f0-9]{64}$/,
+    );
+    expect(requestBody.idempotency_key).not.toBe(
+      "idem:livesafe-public-adapter-output:2026-07-05T12:00:00Z",
+    );
+    expect(requestBody.expires_at).toEqual({
+      physical_ms: Date.parse("2026-07-05T12:05:00.000Z"),
+      logical: 0,
+    });
+  });
+
+  it("rotates public adapter-output authorization request material when currentAt leaves the freshness window", async () => {
+    configurePublicAdapterAuthorizationEnv();
+    const client = new ExochainClient("http://example.invalid/graphql");
+    const fetch = mockPublicAuthorizationFetchForCurrentAts([
+      "2026-07-05T12:00:00.000Z",
+      "2026-07-05T12:06:00.000Z",
+    ]);
+    vi.stubGlobal("fetch", fetch);
+
+    await client.getPublicAdapterOutputAuthorization({
+      subject: "livesafe.ai",
+      audience: "https://livesafe.ai/api/trust/status",
+      currentAt: "2026-07-05T12:00:00.000Z",
+    });
+    await client.getPublicAdapterOutputAuthorization({
+      subject: "livesafe.ai",
+      audience: "https://livesafe.ai/api/trust/status",
+      currentAt: "2026-07-05T12:06:00.000Z",
+    });
+
+    const [firstRequest, secondRequest] = publicAuthorizationRequestBodies(fetch);
+    expect(firstRequest.idempotency_key).not.toBe(secondRequest.idempotency_key);
+    expect(firstRequest.idempotency_key).not.toBe(
+      "idem:livesafe-public-adapter-output:2026-07-05T12:00:00Z",
+    );
+    expect(secondRequest.expires_at).toEqual({
+      physical_ms: Date.parse("2026-07-05T12:11:00.000Z"),
+      logical: 0,
+    });
+  });
+
+  it("binds public adapter-output request idempotency to target, credential, evidence, and current time window", () => {
+    const baseRequest = {
+      subject: "livesafe.ai",
+      audience: "https://livesafe.ai/api/trust/status",
+      credentialId: `sha256:${CREDENTIAL_ID_HEX}`,
+      credentialIdBytes: CREDENTIAL_ID_BYTES,
+      evidenceHash: `sha256:${EVIDENCE_HASH_HEX}`,
+      evidenceHashBytes: EVIDENCE_HASH_BYTES,
+      currentAt: "2026-07-05T12:00:00.000Z",
+      namespace: "livesafe-public-adapter-output",
+      ttlMs: 300000,
+    };
+
+    const firstRequest =
+      buildPublicAdapterOutputAuthorizationRequest(baseRequest);
+    const sameWindowRequest = buildPublicAdapterOutputAuthorizationRequest({
+      ...baseRequest,
+      currentAt: "2026-07-05T12:04:59.999Z",
+    });
+    const nextWindowRequest = buildPublicAdapterOutputAuthorizationRequest({
+      ...baseRequest,
+      currentAt: "2026-07-05T12:05:00.000Z",
+    });
+    const evidenceChangedRequest = buildPublicAdapterOutputAuthorizationRequest({
+      ...baseRequest,
+      evidenceHash: `sha256:${ALT_EVIDENCE_HASH_HEX}`,
+      evidenceHashBytes: repeatedByte(0xab, 32),
+    });
+    const credentialChangedRequest =
+      buildPublicAdapterOutputAuthorizationRequest({
+        ...baseRequest,
+        credentialId: `sha256:${ALT_CREDENTIAL_ID_HEX}`,
+        credentialIdBytes: repeatedByte(0xcd, 32),
+      });
+    const targetChangedRequest = buildPublicAdapterOutputAuthorizationRequest({
+      ...baseRequest,
+      audience: "https://livesafe.ai/api/health",
+    });
+
+    expect(firstRequest.idempotency_key).toMatch(
+      /^livesafe-public-adapter-output:sha256:[a-f0-9]{64}$/,
+    );
+    expect(sameWindowRequest.idempotency_key).toBe(
+      firstRequest.idempotency_key,
+    );
+    expect(nextWindowRequest.idempotency_key).not.toBe(
+      firstRequest.idempotency_key,
+    );
+    expect(evidenceChangedRequest.idempotency_key).not.toBe(
+      firstRequest.idempotency_key,
+    );
+    expect(credentialChangedRequest.idempotency_key).not.toBe(
+      firstRequest.idempotency_key,
+    );
+    expect(targetChangedRequest.idempotency_key).not.toBe(
+      firstRequest.idempotency_key,
+    );
+    expect(firstRequest.idempotency_key).not.toContain(CREDENTIAL_ID_HEX);
+    expect(firstRequest.idempotency_key).not.toContain(EVIDENCE_HASH_HEX);
+    expect(firstRequest.idempotency_key).not.toContain(
       "secret-public-adapter-bearer",
     );
   });
@@ -731,7 +917,9 @@ describe("EXOCHAIN client timestamp preservation", () => {
       audience: "https://livesafe.ai/api/trust/status",
       credential_id: CREDENTIAL_ID_BYTES,
       evidence_hash: EVIDENCE_HASH_BYTES,
-      idempotency_key: "idem:livesafe-public-adapter-output:2026-07-05T12:00:00Z",
+      idempotency_key: expect.stringMatching(
+        /^livesafe-public-adapter-output:sha256:[a-f0-9]{64}$/,
+      ),
       expires_at: {
         physical_ms: Date.parse("2026-07-05T12:05:00.000Z"),
         logical: 0,

--- a/livesafe/tests/railway-cicd-baseline.test.ts
+++ b/livesafe/tests/railway-cicd-baseline.test.ts
@@ -46,6 +46,17 @@ function expectRailwayAuthSecret(
   );
 }
 
+function expectPromotionSmokePublicClaimsEnv(workflow: string, jobId: string): void {
+  const job = readWorkflowJob(workflow, jobId);
+
+  expect(job, `${jobId} should pass expected public claims mode to smoke`).toContain(
+    "LIVESAFE_EXPECT_PUBLIC_CLAIMS_ALLOWED: ${{ inputs.expected_public_claims_allowed || 'false' }}",
+  );
+  expect(job, `${jobId} should run the smoke script for the selected target`).toContain(
+    'scripts/livesafe-railway-smoke.sh "$TARGET_ENVIRONMENT"',
+  );
+}
+
 describe("LiveSafe Railway CI/CD baseline", () => {
   it("declares the ARMORCLOUD LiveSafe project environments and service names without secrets", () => {
     const manifest = JSON.parse(
@@ -142,6 +153,24 @@ describe("LiveSafe Railway CI/CD baseline", () => {
     expect(workflow).toContain(
       'scripts/livesafe-railway-smoke.sh "$TARGET_ENVIRONMENT"',
     );
+  });
+
+  it("threads the expected public-claims dispatch choice into staging and production smoke only", () => {
+    const workflow = readRepoFile(".github/workflows/livesafe-railway-deploy.yml");
+    const developmentJob = readWorkflowJob(workflow, "deploy-development");
+
+    expect(workflow).toContain("expected_public_claims_allowed:");
+    expect(workflow).toContain(
+      'description: "Expected public claims state for staging/production smoke"',
+    );
+    expect(workflow).toContain("type: choice");
+    expect(workflow).toContain('default: "false"');
+    expect(workflow).toContain('          - "false"');
+    expect(workflow).toContain('          - "true"');
+    expectPromotionSmokePublicClaimsEnv(workflow, "deploy-staging");
+    expectPromotionSmokePublicClaimsEnv(workflow, "deploy-production");
+    expect(developmentJob).toContain('scripts/livesafe-railway-smoke.sh "development"');
+    expect(developmentJob).not.toContain("LIVESAFE_EXPECT_PUBLIC_CLAIMS_ALLOWED");
   });
 
   it("provides a bounded smoke probe script that never prints Railway variables", () => {

--- a/livesafe/tests/railway-cicd-baseline.test.ts
+++ b/livesafe/tests/railway-cicd-baseline.test.ts
@@ -162,4 +162,24 @@ describe("LiveSafe Railway CI/CD baseline", () => {
     expect(script).not.toContain("railway variable list");
     expect(script).not.toContain("--kv");
   });
+
+  it("supports explicit fail-closed and authorized-green public-claims smoke contracts", () => {
+    const script = readRepoFile("scripts/livesafe-railway-smoke.sh");
+
+    expect(script).toContain(
+      'expected_public_claims_allowed="${LIVESAFE_EXPECT_PUBLIC_CLAIMS_ALLOWED:-false}"',
+    );
+    expect(script).toContain('case "$expected_public_claims_allowed" in');
+    expect(script).toContain("public_claims_allowed == false");
+    expect(script).toContain("public_claims_allowed == true");
+    expect(script).toContain('.machine_state == "public_trust_claims_allowed"');
+    expect(script).toContain(
+      ".public_adapter_output_authorization.response_state == \"permit\"",
+    );
+    expect(script).toContain(
+      ".public_adapter_output_authorization.transport_called == true",
+    );
+    expect(script).not.toContain("railway variable list");
+    expect(script).not.toContain("--kv");
+  });
 });

--- a/scripts/livesafe-railway-smoke.sh
+++ b/scripts/livesafe-railway-smoke.sh
@@ -21,10 +21,50 @@ case "$target_environment" in
 esac
 
 deadline_seconds="${LIVESAFE_RAILWAY_SMOKE_TIMEOUT_SECONDS:-600}"
+expected_public_claims_allowed="${LIVESAFE_EXPECT_PUBLIC_CLAIMS_ALLOWED:-false}"
 services_json=""
 livesafe_url=""
 health_json=""
 trust_json=""
+trust_status_filter=""
+
+case "$expected_public_claims_allowed" in
+  false)
+    trust_status_filter='
+      .exochain_connected == true and
+      .verified_runtime_adapter == true and
+      .runtime_adapter_state == "verified" and
+      .public_claims_allowed == false
+    '
+    ;;
+  true)
+    trust_status_filter='
+      .exochain_connected == true and
+      .verified_runtime_adapter == true and
+      .runtime_adapter_state == "verified" and
+      .public_claims_allowed == true and
+      .machine_state == "public_trust_claims_allowed" and
+      (.public_adapter_output_authorization | type == "object") and
+      .public_adapter_output_authorization.schema == "livesafe.public_adapter_output_authorization.v1" and
+      .public_adapter_output_authorization.subject == "livesafe.ai" and
+      .public_adapter_output_authorization.audience == "https://livesafe.ai/api/trust/status" and
+      (.public_adapter_output_authorization.claims | type == "array" and length == 3) and
+      (.public_adapter_output_authorization.evidence_hash | test("^sha256:[a-f0-9]{64}$")) and
+      (.public_adapter_output_authorization.receipt_id | type == "string" and length > 0) and
+      (.public_adapter_output_authorization.proof_id | type == "string" and length > 0) and
+      (.public_adapter_output_authorization.proof_ref | type == "string" and length > 0) and
+      (.public_adapter_output_authorization.generated_at | type == "string" and length > 0) and
+      (.public_adapter_output_authorization.valid_from | type == "string" and length > 0) and
+      (.public_adapter_output_authorization.expires_at | type == "string" and length > 0) and
+      .public_adapter_output_authorization.response_state == "permit" and
+      .public_adapter_output_authorization.transport_called == true
+    '
+    ;;
+  *)
+    printf 'LIVESAFE_EXPECT_PUBLIC_CLAIMS_ALLOWED must be false or true\n' >&2
+    exit 64
+    ;;
+esac
 
 while [ "$SECONDS" -lt "$deadline_seconds" ]; do
   services_json="$(railway service list --project "$RAILWAY_PROJECT_ID" --environment "$railway_environment_id" --json)"
@@ -43,12 +83,7 @@ while [ "$SECONDS" -lt "$deadline_seconds" ]; do
         .status == "ok" and
         .database == "connected" and
         .exochain_connected == true
-      ' >/dev/null && printf '%s' "$trust_json" | jq -e '
-        .exochain_connected == true and
-        .verified_runtime_adapter == true and
-        .runtime_adapter_state == "verified" and
-        .public_claims_allowed == false
-      ' >/dev/null; then
+      ' >/dev/null && printf '%s' "$trust_json" | jq -e "$trust_status_filter" >/dev/null; then
         printf 'LiveSafe %s Railway smoke passed for %s\n' "$target_environment" "$livesafe_url"
         exit 0
       fi


### PR DESCRIPTION
## Summary
- Replace the launch-unsafe static LiveSafe public adapter-output idempotency/expiry requirement with a deterministic request builder driven by `currentAt` plus a bounded TTL.
- Bind the idempotency digest to schema, subject, audience, credential id, evidence hash, TTL, and the bounded current-time window without putting bearer tokens, raw credential bytes, evidence hash literals, PII/PHI, or authority internals in the key.
- Extend `scripts/livesafe-railway-smoke.sh` so default fail-closed mode remains `false`, while `LIVESAFE_EXPECT_PUBLIC_CLAIMS_ALLOWED=true` verifies the authorized-green public metadata contract.

## Path Classification
- `livesafe/server/utils/exochain-client.js` - Core runtime adapter boundary for the adjacent LiveSafe surface, because it transports the public adapter-output authorization request to the EXOCHAIN AVC route and evaluates the returned proof envelope.
- `livesafe/tests/exochain-client.test.ts` - Core runtime adapter boundary tests for the LiveSafe adjacent surface.
- `scripts/livesafe-railway-smoke.sh` - Adjacent surface deployment smoke contract; reads public health/trust endpoints only and does not mutate Railway or EXOCHAIN.
- `livesafe/tests/railway-cicd-baseline.test.ts` - Adjacent surface smoke/CI contract tests.

No EXOCHAIN core Rust crates, governance files, core CI contracts, UI/copy files, imported evidence, or third-party/vendor source were changed.

## Adjacent Surface Intake And Trust Boundary
- Owner/accountable maintainer: Bob Stewart / LiveSafe.
- Deployment status: production authorization-readiness code path and smoke contract; this PR does not mutate production or Railway.
- Constitutional trust claims: LiveSafe may expose public trust claims only when EXOCHAIN connectivity, production trust evidence, LiveSafe runtime adapter gates, and proof-bearing public adapter-output authorization all verify and the evaluator returns permit.
- Core read/write boundary: LiveSafe sends a metadata-only authorization request to the configured EXOCHAIN AVC route. The request contains subject, audience, credential id bytes, evidence hash bytes, dynamic idempotency key, and HLC-shaped expiry. It does not carry raw PII/PHI, raw credentials, authority-chain internals, or bearer material in public metadata.
- Trust boundary: EXOCHAIN remains the authorization/proof source. LiveSafe derives non-secret request freshness material, verifies the returned core envelope and evidence hash, and fails closed on missing config, malformed config, transport failure, rejected proof, stale proof, or evaluator denial.
- Surface test/CI gate: focused Vitest client/smoke tests plus `npm run quality` in `livesafe/`.
- Secrets inventory/config source: `EXOCHAIN_NODE_AVC_URL` or `EXOCHAIN_NODE_URL`, `EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_BEARER`, `EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_CREDENTIAL_ID`, `EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_EVIDENCE_HASH`, optional non-secret `EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_IDEMPOTENCY_NAMESPACE`, optional bounded `EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_TTL_MS`, and `EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_TIMEOUT_MS`. Static replay env values are no longer required for runtime readiness.
- Rollback/disablement path: unset the authorization bearer/base URL/credential/evidence envs or keep `LIVESAFE_EXPECT_PUBLIC_CLAIMS_ALLOWED=false`; the client and smoke contract fail closed without printing secrets.

## RED Evidence
- `cd livesafe && npm test -- tests/exochain-client.test.ts tests/railway-cicd-baseline.test.ts` failed as expected before implementation: static idempotency was reused across the freshness window, static idempotency env was still required, malformed base URL/TTL could reach transport, the builder export did not exist, and the smoke script lacked authorized-green mode.

## GREEN Evidence
- `cd livesafe && npm test -- tests/exochain-client.test.ts tests/railway-cicd-baseline.test.ts` - 2 files, 78 tests passed.
- `cd livesafe && npm run quality` - context lint, typecheck, 156 Vitest files / 530 tests, rust fmt, clippy, and cargo test passed. rustfmt emitted stable-toolchain warnings for existing unstable formatting options but exited 0.
- `git diff --check` - passed.

## Production Note
This PR does not claim LiveSafe production launch is complete and does not perform Railway or production mutation.