### PR TITLE
Harden LiveSafe Railway deploy status smoke

### DIFF
--- a/.github/workflows/livesafe-railway-deploy.yml
+++ b/.github/workflows/livesafe-railway-deploy.yml
@@ -88,7 +88,7 @@ jobs:
           railway up . --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_DEVELOPMENT_ENVIRONMENT_ID" --service "$EXOCHAIN_NODE_SERVICE_ID" --detach --json -m "development exochain-node ${GITHUB_SHA}"
       - name: Deploy livesafe to development
         run: |
-          railway up livesafe --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_DEVELOPMENT_ENVIRONMENT_ID" --service "$LIVESAFE_SERVICE_ID" --detach --json -m "development livesafe ${GITHUB_SHA}"
+          railway up . --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_DEVELOPMENT_ENVIRONMENT_ID" --service "$LIVESAFE_SERVICE_ID" --detach --json -m "development livesafe ${GITHUB_SHA}"
       - name: Smoke development
         run: scripts/livesafe-railway-smoke.sh "development"
 
@@ -117,7 +117,7 @@ jobs:
           railway up . --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$TARGET_ENVIRONMENT_ID" --service "$EXOCHAIN_NODE_SERVICE_ID" --detach --json -m "${TARGET_ENVIRONMENT} exochain-node ${GITHUB_SHA}"
       - name: Promote livesafe
         run: |
-          railway up livesafe --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$TARGET_ENVIRONMENT_ID" --service "$LIVESAFE_SERVICE_ID" --detach --json -m "${TARGET_ENVIRONMENT} livesafe ${GITHUB_SHA}"
+          railway up . --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$TARGET_ENVIRONMENT_ID" --service "$LIVESAFE_SERVICE_ID" --detach --json -m "${TARGET_ENVIRONMENT} livesafe ${GITHUB_SHA}"
       - name: Smoke staging
         run: scripts/livesafe-railway-smoke.sh "$TARGET_ENVIRONMENT"
 
@@ -146,6 +146,6 @@ jobs:
           railway up . --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$TARGET_ENVIRONMENT_ID" --service "$EXOCHAIN_NODE_SERVICE_ID" --detach --json -m "${TARGET_ENVIRONMENT} exochain-node ${GITHUB_SHA}"
       - name: Promote livesafe
         run: |
-          railway up livesafe --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$TARGET_ENVIRONMENT_ID" --service "$LIVESAFE_SERVICE_ID" --detach --json -m "${TARGET_ENVIRONMENT} livesafe ${GITHUB_SHA}"
+          railway up . --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$TARGET_ENVIRONMENT_ID" --service "$LIVESAFE_SERVICE_ID" --detach --json -m "${TARGET_ENVIRONMENT} livesafe ${GITHUB_SHA}"
       - name: Smoke production
         run: scripts/livesafe-railway-smoke.sh "$TARGET_ENVIRONMENT"

--- a/livesafe/tests/railway-cicd-baseline.test.ts
+++ b/livesafe/tests/railway-cicd-baseline.test.ts
@@ -1,5 +1,15 @@
-import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const repoRoot = resolve(process.cwd(), "..");
@@ -55,6 +65,11 @@ function expectPromotionSmokePublicClaimsEnv(workflow: string, jobId: string): v
   expect(job, `${jobId} should run the smoke script for the selected target`).toContain(
     'scripts/livesafe-railway-smoke.sh "$TARGET_ENVIRONMENT"',
   );
+}
+
+function writeExecutable(filePath: string, content: string): void {
+  writeFileSync(filePath, content, "utf8");
+  chmodSync(filePath, 0o755);
 }
 
 describe("LiveSafe Railway CI/CD baseline", () => {
@@ -142,14 +157,15 @@ describe("LiveSafe Railway CI/CD baseline", () => {
       'railway up . --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_DEVELOPMENT_ENVIRONMENT_ID" --service "$EXOCHAIN_NODE_SERVICE_ID"',
     );
     expect(workflow).toContain(
-      'railway up livesafe --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_DEVELOPMENT_ENVIRONMENT_ID" --service "$LIVESAFE_SERVICE_ID"',
+      'railway up . --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_DEVELOPMENT_ENVIRONMENT_ID" --service "$LIVESAFE_SERVICE_ID"',
     );
     expect(workflow).toContain(
       'railway up . --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$TARGET_ENVIRONMENT_ID" --service "$EXOCHAIN_NODE_SERVICE_ID"',
     );
     expect(workflow).toContain(
-      'railway up livesafe --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$TARGET_ENVIRONMENT_ID" --service "$LIVESAFE_SERVICE_ID"',
+      'railway up . --path-as-root --project "$RAILWAY_PROJECT_ID" --environment "$TARGET_ENVIRONMENT_ID" --service "$LIVESAFE_SERVICE_ID"',
     );
+    expect(workflow).not.toContain("railway up livesafe --path-as-root");
     expect(workflow).toContain(
       'scripts/livesafe-railway-smoke.sh "$TARGET_ENVIRONMENT"',
     );
@@ -179,17 +195,170 @@ describe("LiveSafe Railway CI/CD baseline", () => {
     expect(script).toContain(
       'railway service list --project "$RAILWAY_PROJECT_ID" --environment "$railway_environment_id" --json',
     );
+    expect(script).toContain(
+      'railway service status --project "$RAILWAY_PROJECT_ID" --environment "$railway_environment_id" --service "$LIVESAFE_SERVICE_ID" --json',
+    );
+    expect(script).toContain(
+      'railway service status --project "$RAILWAY_PROJECT_ID" --environment "$railway_environment_id" --service "$EXOCHAIN_NODE_SERVICE_ID" --json',
+    );
     expect(script).toContain('railway_environment_id="3dc06fb6-c3df-4fe4-8807-0da0e62e4028"');
     expect(script).toContain('railway_environment_id="a223bc12-fbe4-430f-abce-8e3ee7c9abd3"');
     expect(script).toContain('railway_environment_id="1e5153e1-15f4-4447-bf7c-029af33927fb"');
+    expect(script).toContain('LIVESAFE_SERVICE_ID="${LIVESAFE_SERVICE_ID:-8ed3bd1a-f872-4e22-9a39-ac38953fae26}"');
+    expect(script).toContain('EXOCHAIN_NODE_SERVICE_ID="${EXOCHAIN_NODE_SERVICE_ID:-4d8384d3-be5d-48d6-a914-97eb6133e53d}"');
     expect(script).toContain("deadline_seconds=");
     expect(script).toContain("while [ \"$SECONDS\" -lt \"$deadline_seconds\" ]; do");
     expect(script).toContain("sleep 10");
+    expect(script).toContain('.status == "SUCCESS"');
+    expect(script).toContain(".stopped == false");
     expect(script).toContain('curl -fsS "$livesafe_url/api/health"');
     expect(script).toContain('curl -fsS "$livesafe_url/api/trust/status"');
     expect(script).toContain("public_claims_allowed == false");
     expect(script).not.toContain("railway variable list");
     expect(script).not.toContain("--kv");
+  });
+
+  it("rejects a stopped latest deployment before URL health can pass", () => {
+    const testRoot = mkdtempSync(join(tmpdir(), "livesafe-railway-smoke-"));
+    const binDir = join(testRoot, "bin");
+    const railwayCallLog = join(testRoot, "railway.log");
+    const curlCallLog = join(testRoot, "curl.log");
+
+    mkdirSync(binDir);
+
+    writeExecutable(
+      join(binDir, "railway"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$RAILWAY_FAKE_CALL_LOG"
+
+case "\${1:-} \${2:-}" in
+  "service list")
+    cat <<'JSON'
+[
+  {
+    "id": "8ed3bd1a-f872-4e22-9a39-ac38953fae26",
+    "name": "livesafe",
+    "status": "SUCCESS",
+    "deploymentStopped": false,
+    "deploymentId": "9a1cf48c-fbe3-4149-b6e3-a6dab107607c",
+    "latestDeployment": {
+      "id": "a595f677-fc70-43e5-b68c-f75fc8f84ce0",
+      "status": "FAILED",
+      "deploymentStopped": true
+    },
+    "url": "https://livesafe-development.up.railway.app"
+  },
+  {
+    "id": "4d8384d3-be5d-48d6-a914-97eb6133e53d",
+    "name": "exochain-node",
+    "status": "SUCCESS",
+    "deploymentStopped": false,
+    "deploymentId": "ec12cdf4-75e0-41a1-986c-c326aeec978f",
+    "latestDeployment": {
+      "id": "ec12cdf4-75e0-41a1-986c-c326aeec978f",
+      "status": "SUCCESS",
+      "deploymentStopped": false
+    }
+  },
+  { "id": "2ab3f445-d6f7-4245-940c-985a14e974f9", "name": "exochain-node-db", "status": "SUCCESS" },
+  { "id": "691122bb-025b-463d-8033-7f94f7678748", "name": "Postgres", "status": "SUCCESS" }
+]
+JSON
+    ;;
+  "service status")
+    service=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --service|-s)
+          shift
+          service="\${1:-}"
+          ;;
+      esac
+      shift || break
+    done
+
+    if [ "$service" = "8ed3bd1a-f872-4e22-9a39-ac38953fae26" ]; then
+      cat <<'JSON'
+{
+  "id": "8ed3bd1a-f872-4e22-9a39-ac38953fae26",
+  "name": "livesafe",
+  "deploymentId": "a595f677-fc70-43e5-b68c-f75fc8f84ce0",
+  "status": "FAILED",
+  "stopped": true
+}
+JSON
+    elif [ "$service" = "4d8384d3-be5d-48d6-a914-97eb6133e53d" ]; then
+      cat <<'JSON'
+{
+  "id": "4d8384d3-be5d-48d6-a914-97eb6133e53d",
+  "name": "exochain-node",
+  "deploymentId": "ec12cdf4-75e0-41a1-986c-c326aeec978f",
+  "status": "SUCCESS",
+  "stopped": false
+}
+JSON
+    else
+      printf 'unexpected service %s\\n' "$service" >&2
+      exit 2
+    fi
+    ;;
+  *)
+    printf 'unexpected railway command: %s\\n' "$*" >&2
+    exit 2
+    ;;
+esac
+`,
+    );
+
+    writeExecutable(
+      join(binDir, "curl"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$CURL_FAKE_CALL_LOG"
+url="\${@: -1}"
+
+case "$url" in
+  */api/health)
+    printf '%s\\n' '{"status":"ok","database":"connected","exochain_connected":true}'
+    ;;
+  */api/trust/status)
+    printf '%s\\n' '{"exochain_connected":true,"verified_runtime_adapter":true,"runtime_adapter_state":"verified","public_claims_allowed":false}'
+    ;;
+  *)
+    printf 'unexpected curl url: %s\\n' "$url" >&2
+    exit 2
+    ;;
+esac
+`,
+    );
+
+    try {
+      const result = spawnSync(
+        "/usr/bin/env",
+        ["bash", resolve(repoRoot, "scripts/livesafe-railway-smoke.sh"), "development"],
+        {
+          cwd: repoRoot,
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            CURL_FAKE_CALL_LOG: curlCallLog,
+            LIVESAFE_RAILWAY_SMOKE_TIMEOUT_SECONDS: "60",
+            PATH: `${binDir}:${process.env.PATH ?? ""}`,
+            RAILWAY_FAKE_CALL_LOG: railwayCallLog,
+          },
+        },
+      );
+
+      expect(result.status, result.stdout + result.stderr).not.toBe(0);
+      expect(result.stderr).toContain("livesafe");
+      expect(readFileSync(railwayCallLog, "utf8")).toContain("service status");
+      expect(existsSync(curlCallLog) ? readFileSync(curlCallLog, "utf8") : "").toBe(
+        "",
+      );
+    } finally {
+      rmSync(testRoot, { force: true, recursive: true });
+    }
   });
 
   it("supports explicit fail-closed and authorized-green public-claims smoke contracts", () => {

--- a/scripts/livesafe-railway-smoke.sh
+++ b/scripts/livesafe-railway-smoke.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 target_environment="${1:-}"
 RAILWAY_PROJECT_ID="${RAILWAY_PROJECT_ID:-372de75b-5f44-46c2-ab70-3c3185b5d81e}"
+LIVESAFE_SERVICE_ID="${LIVESAFE_SERVICE_ID:-8ed3bd1a-f872-4e22-9a39-ac38953fae26}"
+EXOCHAIN_NODE_SERVICE_ID="${EXOCHAIN_NODE_SERVICE_ID:-4d8384d3-be5d-48d6-a914-97eb6133e53d}"
 
 case "$target_environment" in
   development)
@@ -23,6 +25,8 @@ esac
 deadline_seconds="${LIVESAFE_RAILWAY_SMOKE_TIMEOUT_SECONDS:-600}"
 expected_public_claims_allowed="${LIVESAFE_EXPECT_PUBLIC_CLAIMS_ALLOWED:-false}"
 services_json=""
+livesafe_status_json=""
+exochain_node_status_json=""
 livesafe_url=""
 health_json=""
 trust_json=""
@@ -66,7 +70,53 @@ case "$expected_public_claims_allowed" in
     ;;
 esac
 
+deployment_ready() {
+  printf '%s' "$1" | jq -e '.status == "SUCCESS" and .stopped == false' >/dev/null
+}
+
+deployment_failed_or_stopped() {
+  printf '%s' "$1" | jq -e '
+    .stopped == true or
+    .status == "FAILED" or
+    .status == "CRASHED" or
+    .status == "REMOVED"
+  ' >/dev/null
+}
+
+print_deployment_failure() {
+  service_name="$1"
+  status_json="$2"
+  deployment_id="$(printf '%s' "$status_json" | jq -r '.deploymentId // "unknown"')"
+  deployment_status="$(printf '%s' "$status_json" | jq -r '.status // "unknown"')"
+  deployment_stopped="$(printf '%s' "$status_json" | jq -r '.stopped // "unknown"')"
+
+  printf 'LiveSafe %s Railway smoke failed: %s latest deployment %s status=%s stopped=%s.\n' \
+    "$target_environment" \
+    "$service_name" \
+    "$deployment_id" \
+    "$deployment_status" \
+    "$deployment_stopped" >&2
+}
+
 while [ "$SECONDS" -lt "$deadline_seconds" ]; do
+  livesafe_status_json="$(railway service status --project "$RAILWAY_PROJECT_ID" --environment "$railway_environment_id" --service "$LIVESAFE_SERVICE_ID" --json)"
+  exochain_node_status_json="$(railway service status --project "$RAILWAY_PROJECT_ID" --environment "$railway_environment_id" --service "$EXOCHAIN_NODE_SERVICE_ID" --json)"
+
+  if deployment_failed_or_stopped "$livesafe_status_json"; then
+    print_deployment_failure "livesafe" "$livesafe_status_json"
+    exit 65
+  fi
+
+  if deployment_failed_or_stopped "$exochain_node_status_json"; then
+    print_deployment_failure "exochain-node" "$exochain_node_status_json"
+    exit 65
+  fi
+
+  if ! deployment_ready "$livesafe_status_json" || ! deployment_ready "$exochain_node_status_json"; then
+    sleep 10
+    continue
+  fi
+
   services_json="$(railway service list --project "$RAILWAY_PROJECT_ID" --environment "$railway_environment_id" --json)"
 
   if printf '%s' "$services_json" | jq -e '


### PR DESCRIPTION

## Summary
- Preserve repo-root snapshot shape for LiveSafe Railway deploy/promote commands by using `railway up . --path-as-root` for the `livesafe` service.
- Add Railway latest-deployment status checks for `livesafe` and `exochain-node` before public URL health/trust probes can pass.
- Extend the LiveSafe CI/CD baseline with RED coverage for the stopped latest deployment masked by an older healthy runtime URL.

## Live Failure Signature
- `main` was `5f6853aa` after PR #773.
- GitHub LiveSafe Railway Deploy run `28751790733` reported success.
- Railway development environment `3dc06fb6-c3df-4fe4-8807-0da0e62e4028`, service `livesafe` `8ed3bd1a-f872-4e22-9a39-ac38953fae26`, latest deployment `a595f677-fc70-43e5-b68c-f75fc8f84ce0` was `FAILED` and stopped.
- Build log signature: `Build Failed: fsutil.NewFS(.../snapshot-target-unpack/livesafe): resolve : lstat .../snapshot-target-unpack/livesafe: no such file or directory`.
- Runtime URL still returned healthy because Railway was serving older successful deployment `9a1cf48c-fbe3-4149-b6e3-a6dab107607c`; prior smoke only checked service list plus public URL health/trust.

## Path Classification
- `.github/workflows/livesafe-railway-deploy.yml` - adjacent CI/CD plus runtime-adapter deployment boundary. It deploys the LiveSafe adjacent surface and the `exochain-node` adapter service, but does not change core Rust runtime logic.
- `scripts/livesafe-railway-smoke.sh` - adjacent CI/CD plus runtime-adapter deployment boundary. It gates public URL smoke on Railway control-plane status for `livesafe` and `exochain-node`.
- `livesafe/tests/railway-cicd-baseline.test.ts` - adjacent CI/CD regression coverage for workflow and smoke behavior.

## RED Evidence
- `cd livesafe && npm test -- tests/railway-cicd-baseline.test.ts` failed before implementation with 3 expected failures:
  - workflow still used `railway up livesafe --path-as-root` instead of preserving repo-root snapshot shape for the LiveSafe service;
  - smoke script lacked `railway service status --project ... --environment ... --service ... --json` checks for `livesafe` and `exochain-node`;
  - mocked stopped latest deployment `a595f677-fc70-43e5-b68c-f75fc8f84ce0` still passed because the old script accepted healthy URL responses.

## GREEN Evidence
- `cd livesafe && npm test -- tests/railway-cicd-baseline.test.ts` passed: 1 file, 6 tests.
- `cd livesafe && npm run quality` passed: context lint, typecheck, 156 Vitest files / 540 tests, Rust fmt/clippy/test. Rustfmt emitted existing stable-channel warnings for unstable config keys but exited 0.
- `git diff --check` passed.
- Live smoke proof after the change: `scripts/livesafe-railway-smoke.sh development` exits 65 with `LiveSafe development Railway smoke failed: livesafe latest deployment a595f677-fc70-43e5-b68c-f75fc8f84ce0 status=FAILED stopped=true.` before URL health can pass.

## Secrets / Variables
- The smoke script still does not call `railway variable list` or `--kv`.
- The failure output prints only service name, deployment id, deployment status, and stopped state; no Railway variables or secret-bearing values are printed.

## Residual Risk
- This PR does not redeploy or repair the already failed Railway deployment until it is merged and the LiveSafe deploy workflow runs again.
