### PR TITLE
Add LiveSafe public-output ceremony

### DIFF
--- a/crates/exo-avc/src/lib.rs
+++ b/crates/exo-avc/src/lib.rs
@@ -340,14 +340,16 @@ mod public_output_authorization_tests {
             .expect("LiveSafe public-output test credential expiry");
         draft.delegated_intent.intent_id =
             crate::livesafe_public_output_ceremony::livesafe_public_output_credential_ceremony_intent_id(
-                &draft.issuer_did,
-                &draft.subject_did,
-                LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
-                LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
-                &draft.delegated_intent.allowed_objectives,
-                &evidence_hash,
-                &draft.created_at,
-                &expires_at,
+                &crate::livesafe_public_output_ceremony::LivesafePublicOutputCredentialCeremonyIntentInput {
+                    issuer_did: &draft.issuer_did,
+                    credential_subject_did: &draft.subject_did,
+                    public_subject: LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+                    public_audience: LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+                    allowed_claim_names: &draft.delegated_intent.allowed_objectives,
+                    evidence_hash: &evidence_hash,
+                    not_before: &draft.created_at,
+                    expires_at: &expires_at,
+                },
             )
             .expect("LiveSafe public-output test ceremony intent id");
     }

--- a/crates/exo-avc/src/lib.rs
+++ b/crates/exo-avc/src/lib.rs
@@ -106,6 +106,7 @@
 pub mod credential;
 pub mod delegation;
 pub mod error;
+pub mod livesafe_public_output_ceremony;
 pub mod public_output_authorization;
 pub mod receipt;
 pub mod registry;
@@ -122,6 +123,14 @@ pub use credential::{
 };
 pub use delegation::{delegate_avc, parent_id_of};
 pub use error::AvcError;
+pub use livesafe_public_output_ceremony::{
+    LIVESAFE_PUBLIC_ADAPTER_OUTPUT_CREDENTIAL_SUBJECT_DID,
+    LIVESAFE_PUBLIC_OUTPUT_CREDENTIAL_CEREMONY_DOMAIN,
+    LivesafePublicOutputAuthorizationRequestMaterial,
+    LivesafePublicOutputCredentialCeremonyEvidence, LivesafePublicOutputCredentialCeremonyInput,
+    LivesafePublicOutputCredentialCeremonyOutput, LivesafePublicOutputCredentialIssueRequest,
+    issue_livesafe_public_output_credential_ceremony, parse_livesafe_public_output_evidence_sha256,
+};
 pub use public_output_authorization::{
     LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
     LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN,
@@ -167,6 +176,7 @@ pub const AVC_SIGNING_DOMAINS: &[&str] = &[
     AVC_ACTION_SIGNING_DOMAIN,
     AVC_CREDENTIAL_SIGNING_DOMAIN,
     AVC_HUMAN_APPROVAL_SIGNING_DOMAIN,
+    LIVESAFE_PUBLIC_OUTPUT_CREDENTIAL_CEREMONY_DOMAIN,
     LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN,
     AVC_RECEIPT_EVIDENCE_SUBJECT_DOMAIN,
     AVC_RECEIPT_EXTERNAL_TIMESTAMP_DOMAIN,
@@ -200,6 +210,7 @@ mod hygiene_tests {
             include_str!("credential.rs"),
             include_str!("delegation.rs"),
             include_str!("error.rs"),
+            include_str!("livesafe_public_output_ceremony.rs"),
             include_str!("lib.rs"),
             include_str!("public_output_authorization.rs"),
             include_str!("receipt.rs"),
@@ -230,6 +241,7 @@ mod hygiene_tests {
             include_str!("credential.rs"),
             include_str!("delegation.rs"),
             include_str!("error.rs"),
+            include_str!("livesafe_public_output_ceremony.rs"),
             include_str!("lib.rs"),
             include_str!("public_output_authorization.rs"),
             include_str!("receipt.rs"),

--- a/crates/exo-avc/src/lib.rs
+++ b/crates/exo-avc/src/lib.rs
@@ -306,7 +306,9 @@ mod public_output_authorization_tests {
             delegated_intent: DelegatedIntent {
                 intent_id: h256(0xA1),
                 purpose: "Authorize narrow LiveSafe public adapter output".into(),
-                allowed_objectives: vec!["publish-redacted-trust-status".into()],
+                allowed_objectives: vec![
+                    LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN.into(),
+                ],
                 prohibited_objectives: vec![],
                 autonomy_level: AutonomyLevel::ExecuteWithinBounds,
                 delegation_allowed: false,
@@ -332,12 +334,31 @@ mod public_output_authorization_tests {
         }
     }
 
+    fn bind_ceremony_intent(draft: &mut AvcDraft, evidence_hash: Hash256) {
+        let expires_at = draft
+            .expires_at
+            .expect("LiveSafe public-output test credential expiry");
+        draft.delegated_intent.intent_id =
+            crate::livesafe_public_output_ceremony::livesafe_public_output_credential_ceremony_intent_id(
+                &draft.issuer_did,
+                &draft.subject_did,
+                LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+                LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+                &draft.delegated_intent.allowed_objectives,
+                &evidence_hash,
+                &draft.created_at,
+                &expires_at,
+            )
+            .expect("LiveSafe public-output test ceremony intent id");
+    }
+
     fn issue_credential(mut draft: AvcDraft) -> AutonomousVolitionCredential {
         let issuer = issuer_keypair();
         if draft.issuer_did != did("did:exo:livesafe-issuer") {
             draft.issuer_did = did("did:exo:livesafe-issuer");
             draft.principal_did = did("did:exo:livesafe-issuer");
         }
+        bind_ceremony_intent(&mut draft, h256(0xE1));
         issue_avc(draft, |bytes| issuer.sign(bytes)).expect("valid LiveSafe AVC")
     }
 
@@ -585,7 +606,11 @@ mod public_output_authorization_tests {
             },
             {
                 let mut altered = livesafe_draft();
-                altered.delegated_intent.intent_id = h256(0xA2);
+                altered.created_at = ts(1_000_001);
+                altered.constraints.allowed_time_window = Some(TimeWindow {
+                    not_before: ts(1_000_001),
+                    not_after: ts(2_000_000),
+                });
                 draft_for(issue_credential(altered))
             },
             {

--- a/crates/exo-avc/src/livesafe_public_output_ceremony.rs
+++ b/crates/exo-avc/src/livesafe_public_output_ceremony.rs
@@ -1,0 +1,390 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Deterministic LiveSafe public-output AVC credential ceremony.
+//!
+//! The ceremony emits a signed, narrow AVC credential plus the JSON-shaped
+//! registration and authorization material an operator can submit to the node.
+//! It never generates signing keys, reads clocks, accepts bearer tokens, or
+//! serializes raw evidence bytes into the output package.
+
+use exo_authority::permission::Permission;
+use exo_core::{Did, Hash256, Signature, Timestamp, hash::hash_structured};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    AVC_SCHEMA_VERSION, AuthorityScope, AutonomousVolitionCredential, AutonomyLevel,
+    AvcConstraints, AvcDraft, AvcSubjectKind, DataClass, DelegatedIntent, TimeWindow,
+    error::AvcError,
+    issue_avc,
+    public_output_authorization::{
+        LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+        LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN,
+        LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+        livesafe_public_adapter_output_authorization_idempotency_hash,
+    },
+};
+
+/// The only AVC subject DID admitted by the LiveSafe public-output ceremony.
+pub const LIVESAFE_PUBLIC_ADAPTER_OUTPUT_CREDENTIAL_SUBJECT_DID: &str =
+    "did:exo:livesafe-public-adapter";
+/// Domain for the deterministic ceremony intent hash.
+pub const LIVESAFE_PUBLIC_OUTPUT_CREDENTIAL_CEREMONY_DOMAIN: &str =
+    "livesafe.public_output_credential_ceremony.v1";
+
+const CEREMONY_PURPOSE: &str =
+    "Authorize narrow LiveSafe public adapter output for redacted public trust status";
+const FORBIDDEN_CLAIM_FRAGMENTS: &[&str] = &[
+    "custody",
+    "consent",
+    "emergency",
+    "legal",
+    "medical",
+    "exochain.constitutional",
+    "exochain.core",
+];
+
+/// Canonical LiveSafe evidence-summary hash supplied to the ceremony.
+///
+/// The hash is produced outside this Rust ceremony by the LiveSafe evidence
+/// contract and is consumed here only as already-canonical bytes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LivesafePublicOutputCredentialCeremonyEvidence {
+    pub sha256_hash: Hash256,
+}
+
+/// Deterministic inputs for the LiveSafe public-output credential ceremony.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LivesafePublicOutputCredentialCeremonyInput {
+    pub issuer_did: Did,
+    pub issuer_authority_scope: AuthorityScope,
+    pub credential_subject_did: Did,
+    pub public_subject: String,
+    pub public_audience: String,
+    pub allowed_claim_names: Vec<String>,
+    pub evidence: LivesafePublicOutputCredentialCeremonyEvidence,
+    pub not_before: Timestamp,
+    pub expires_at: Timestamp,
+    pub idempotency_key: String,
+}
+
+/// Node `/api/v1/avc/issue` request body emitted by the ceremony.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LivesafePublicOutputCredentialIssueRequest {
+    pub credential: AutonomousVolitionCredential,
+}
+
+/// Node public-output authorization request material emitted by the ceremony.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LivesafePublicOutputAuthorizationRequestMaterial {
+    pub credential_id: Hash256,
+    pub subject: String,
+    pub audience: String,
+    pub evidence_hash: Hash256,
+    pub idempotency_key: String,
+    pub idempotency_key_hash: Hash256,
+    pub expires_at: Timestamp,
+}
+
+/// Redacted ceremony output suitable for operator review and registration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LivesafePublicOutputCredentialCeremonyOutput {
+    pub schema_version: u16,
+    pub ceremony_domain: String,
+    pub credential_id: Hash256,
+    pub credential: AutonomousVolitionCredential,
+    pub issue_request: LivesafePublicOutputCredentialIssueRequest,
+    pub authorization_request: LivesafePublicOutputAuthorizationRequestMaterial,
+    pub evidence_hash: Hash256,
+    pub not_before: Timestamp,
+    pub expires_at: Timestamp,
+}
+
+#[derive(Serialize)]
+struct CeremonyIntentPayload<'a> {
+    domain: &'static str,
+    issuer_did: &'a Did,
+    credential_subject_did: &'a Did,
+    public_subject: &'a str,
+    public_audience: &'a str,
+    allowed_claim_names: &'a [String],
+    evidence_hash: &'a Hash256,
+    not_before: &'a Timestamp,
+    expires_at: &'a Timestamp,
+}
+
+/// Parse a LiveSafe public-output evidence hash from exact `sha256:` lowercase
+/// hex.
+///
+/// # Errors
+/// Returns [`AvcError::InvalidInput`] unless the value is exactly
+/// `sha256:<64 lowercase hex characters>`.
+pub fn parse_livesafe_public_output_evidence_sha256(value: &str) -> Result<Hash256, AvcError> {
+    const PREFIX: &str = "sha256:";
+    let Some(hex) = value.strip_prefix(PREFIX) else {
+        return Err(AvcError::InvalidInput {
+            reason: "LiveSafe public-output evidence hash must be sha256:<64 lowercase hex>".into(),
+        });
+    };
+    if hex.len() != 64
+        || !hex.as_bytes().iter().all(u8::is_ascii_hexdigit)
+        || hex.as_bytes().iter().any(u8::is_ascii_uppercase)
+    {
+        return Err(AvcError::InvalidInput {
+            reason: "LiveSafe public-output evidence hash must be sha256:<64 lowercase hex>".into(),
+        });
+    }
+
+    let mut bytes = [0u8; 32];
+    for (index, chunk) in hex.as_bytes().chunks_exact(2).enumerate() {
+        let high = hex_nibble(chunk[0])?;
+        let low = hex_nibble(chunk[1])?;
+        bytes[index] = (high << 4) | low;
+    }
+    Ok(Hash256::from_bytes(bytes))
+}
+
+/// Issue the narrow LiveSafe public-output AVC credential and redacted
+/// registration package.
+///
+/// # Errors
+/// Returns [`AvcError`] if any input widens beyond the public-output ceremony
+/// contract or if AVC issuance fails.
+pub fn issue_livesafe_public_output_credential_ceremony<F>(
+    input: LivesafePublicOutputCredentialCeremonyInput,
+    sign: F,
+) -> Result<LivesafePublicOutputCredentialCeremonyOutput, AvcError>
+where
+    F: FnOnce(&[u8]) -> Signature,
+{
+    validate_input(&input)?;
+    let evidence_hash = input.evidence.sha256_hash;
+    let mut allowed_claim_names = input.allowed_claim_names.clone();
+    allowed_claim_names.sort();
+    allowed_claim_names.dedup();
+    let intent_id = hash_structured(&CeremonyIntentPayload {
+        domain: LIVESAFE_PUBLIC_OUTPUT_CREDENTIAL_CEREMONY_DOMAIN,
+        issuer_did: &input.issuer_did,
+        credential_subject_did: &input.credential_subject_did,
+        public_subject: &input.public_subject,
+        public_audience: &input.public_audience,
+        allowed_claim_names: &allowed_claim_names,
+        evidence_hash: &evidence_hash,
+        not_before: &input.not_before,
+        expires_at: &input.expires_at,
+    })
+    .map_err(AvcError::from)?;
+    let jurisdiction = input
+        .issuer_authority_scope
+        .jurisdictions
+        .first()
+        .cloned()
+        .ok_or(AvcError::InvalidInput {
+            reason: "LiveSafe public-output issuer authority must declare a jurisdiction".into(),
+        })?;
+    let authority_scope = AuthorityScope {
+        permissions: vec![Permission::Read],
+        tools: vec![LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN.into()],
+        data_classes: vec![DataClass::Public],
+        counterparties: vec![],
+        jurisdictions: vec![jurisdiction],
+    };
+    let draft = AvcDraft {
+        schema_version: AVC_SCHEMA_VERSION,
+        issuer_did: input.issuer_did.clone(),
+        principal_did: input.issuer_did.clone(),
+        subject_did: input.credential_subject_did,
+        holder_did: None,
+        subject_kind: AvcSubjectKind::Service {
+            service_id: LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT.into(),
+        },
+        created_at: input.not_before,
+        expires_at: Some(input.expires_at),
+        delegated_intent: DelegatedIntent {
+            intent_id,
+            purpose: CEREMONY_PURPOSE.into(),
+            allowed_objectives: allowed_claim_names,
+            prohibited_objectives: forbidden_claims(),
+            autonomy_level: AutonomyLevel::ExecuteWithinBounds,
+            delegation_allowed: false,
+        },
+        authority_scope,
+        constraints: AvcConstraints {
+            allowed_time_window: Some(TimeWindow {
+                not_before: input.not_before,
+                not_after: input.expires_at,
+            }),
+            ..AvcConstraints::permissive()
+        },
+        authority_chain: None,
+        consent_refs: vec![],
+        policy_refs: vec![],
+        parent_avc_id: None,
+    };
+    let credential = issue_avc(draft, sign)?;
+    let credential_id = credential.id()?;
+    let idempotency_key_hash =
+        livesafe_public_adapter_output_authorization_idempotency_hash(&input.idempotency_key)?;
+    let authorization_request = LivesafePublicOutputAuthorizationRequestMaterial {
+        credential_id,
+        subject: LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT.into(),
+        audience: LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE.into(),
+        evidence_hash,
+        idempotency_key: input.idempotency_key,
+        idempotency_key_hash,
+        expires_at: input.expires_at,
+    };
+    Ok(LivesafePublicOutputCredentialCeremonyOutput {
+        schema_version: AVC_SCHEMA_VERSION,
+        ceremony_domain: LIVESAFE_PUBLIC_OUTPUT_CREDENTIAL_CEREMONY_DOMAIN.into(),
+        credential_id,
+        credential: credential.clone(),
+        issue_request: LivesafePublicOutputCredentialIssueRequest { credential },
+        authorization_request,
+        evidence_hash,
+        not_before: input.not_before,
+        expires_at: input.expires_at,
+    })
+}
+
+fn validate_input(input: &LivesafePublicOutputCredentialCeremonyInput) -> Result<(), AvcError> {
+    validate_issuer_authority(&input.issuer_authority_scope)?;
+    validate_public_claims(input)?;
+    if input.expires_at <= input.not_before {
+        return Err(AvcError::InvalidTimestamp {
+            reason: "LiveSafe public-output ceremony expires_at must be after not_before".into(),
+        });
+    }
+    livesafe_public_adapter_output_authorization_idempotency_hash(&input.idempotency_key)?;
+    Ok(())
+}
+
+fn validate_issuer_authority(scope: &AuthorityScope) -> Result<(), AvcError> {
+    let mut permissions = scope.permissions.clone();
+    permissions.sort();
+    permissions.dedup();
+    let mut tools = scope.tools.clone();
+    tools.sort();
+    tools.dedup();
+    let mut data_classes = scope.data_classes.clone();
+    data_classes.sort();
+    data_classes.dedup();
+
+    if permissions != vec![Permission::Read]
+        || tools != vec![LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN.to_owned()]
+        || data_classes != vec![DataClass::Public]
+        || !scope.counterparties.is_empty()
+    {
+        return Err(AvcError::InvalidInput {
+            reason: format!(
+                "LiveSafe public-output issuer authority must be exactly Permission::Read, tool {}, DataClass::Public, and no counterparties",
+                LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN
+            ),
+        });
+    }
+    if scope
+        .jurisdictions
+        .iter()
+        .any(|jurisdiction| jurisdiction.trim().is_empty())
+        || scope.jurisdictions.is_empty()
+    {
+        return Err(AvcError::InvalidInput {
+            reason: "LiveSafe public-output issuer authority must declare a jurisdiction".into(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_public_claims(
+    input: &LivesafePublicOutputCredentialCeremonyInput,
+) -> Result<(), AvcError> {
+    let expected_subject_did = Did::new(LIVESAFE_PUBLIC_ADAPTER_OUTPUT_CREDENTIAL_SUBJECT_DID)
+        .map_err(|error| AvcError::InvalidInput {
+            reason: format!("LiveSafe public-output credential subject DID is invalid: {error}"),
+        })?;
+    if input.credential_subject_did != expected_subject_did {
+        return Err(AvcError::InvalidInput {
+            reason: format!(
+                "LiveSafe public-output credential subject DID must be exactly {}",
+                LIVESAFE_PUBLIC_ADAPTER_OUTPUT_CREDENTIAL_SUBJECT_DID
+            ),
+        });
+    }
+    if input.public_subject != LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT {
+        return Err(AvcError::InvalidInput {
+            reason: format!(
+                "LiveSafe public-output subject must be exactly {}",
+                LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT
+            ),
+        });
+    }
+    if input.public_audience != LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE {
+        return Err(AvcError::InvalidInput {
+            reason: format!(
+                "LiveSafe public-output audience must be exactly {}",
+                LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE
+            ),
+        });
+    }
+    let mut claims = input.allowed_claim_names.clone();
+    claims.sort();
+    claims.dedup();
+    if claims.is_empty() {
+        return Err(AvcError::InvalidInput {
+            reason: "LiveSafe public-output allowed claim names must not be empty".into(),
+        });
+    }
+    for claim in &claims {
+        if contains_forbidden_claim_fragment(claim) {
+            return Err(AvcError::InvalidInput {
+                reason: format!("LiveSafe public-output forbidden claim cap rejected: {claim}"),
+            });
+        }
+    }
+    if claims != vec![LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN.to_owned()] {
+        return Err(AvcError::InvalidInput {
+            reason: format!(
+                "LiveSafe public-output allowed claim names must be exactly {}",
+                LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn contains_forbidden_claim_fragment(claim: &str) -> bool {
+    let lower = claim.to_ascii_lowercase();
+    FORBIDDEN_CLAIM_FRAGMENTS
+        .iter()
+        .any(|fragment| lower.contains(fragment))
+}
+
+fn forbidden_claims() -> Vec<String> {
+    FORBIDDEN_CLAIM_FRAGMENTS
+        .iter()
+        .map(|fragment| format!("forbid:{fragment}"))
+        .collect()
+}
+
+fn hex_nibble(byte: u8) -> Result<u8, AvcError> {
+    match byte {
+        b'0'..=b'9' => Ok(byte - b'0'),
+        b'a'..=b'f' => Ok(byte - b'a' + 10),
+        _ => Err(AvcError::InvalidInput {
+            reason: "LiveSafe public-output evidence hash must be sha256:<64 lowercase hex>".into(),
+        }),
+    }
+}

--- a/crates/exo-avc/src/livesafe_public_output_ceremony.rs
+++ b/crates/exo-avc/src/livesafe_public_output_ceremony.rs
@@ -90,9 +90,11 @@ pub struct LivesafePublicOutputCredentialIssueRequest {
 /// Node public-output authorization request material emitted by the ceremony.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LivesafePublicOutputAuthorizationRequestMaterial {
+    #[serde(with = "sha256_hash_serde")]
     pub credential_id: Hash256,
     pub subject: String,
     pub audience: String,
+    #[serde(with = "sha256_hash_serde")]
     pub evidence_hash: Hash256,
     pub idempotency_key: String,
     pub idempotency_key_hash: Hash256,
@@ -126,6 +128,26 @@ struct CeremonyIntentPayload<'a> {
     expires_at: &'a Timestamp,
 }
 
+mod sha256_hash_serde {
+    use exo_core::Hash256;
+    use serde::{Deserialize, Deserializer, Serializer, de};
+
+    pub fn serialize<S>(hash: &Hash256, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&format!("sha256:{hash}"))
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Hash256, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        super::parse_livesafe_public_output_evidence_sha256(&value).map_err(de::Error::custom)
+    }
+}
+
 /// Parse a LiveSafe public-output evidence hash from exact `sha256:` lowercase
 /// hex.
 ///
@@ -157,6 +179,38 @@ pub fn parse_livesafe_public_output_evidence_sha256(value: &str) -> Result<Hash2
     Ok(Hash256::from_bytes(bytes))
 }
 
+/// Compute the signed ceremony intent id that binds a credential to LiveSafe's
+/// canonical evidence hash and fixed public-output claim identity.
+///
+/// # Errors
+/// Returns [`AvcError::Serialization`] if canonical intent hashing fails.
+pub(crate) fn livesafe_public_output_credential_ceremony_intent_id(
+    issuer_did: &Did,
+    credential_subject_did: &Did,
+    public_subject: &str,
+    public_audience: &str,
+    allowed_claim_names: &[String],
+    evidence_hash: &Hash256,
+    not_before: &Timestamp,
+    expires_at: &Timestamp,
+) -> Result<Hash256, AvcError> {
+    let mut normalized_allowed_claim_names = allowed_claim_names.to_vec();
+    normalized_allowed_claim_names.sort();
+    normalized_allowed_claim_names.dedup();
+    hash_structured(&CeremonyIntentPayload {
+        domain: LIVESAFE_PUBLIC_OUTPUT_CREDENTIAL_CEREMONY_DOMAIN,
+        issuer_did,
+        credential_subject_did,
+        public_subject,
+        public_audience,
+        allowed_claim_names: &normalized_allowed_claim_names,
+        evidence_hash,
+        not_before,
+        expires_at,
+    })
+    .map_err(AvcError::from)
+}
+
 /// Issue the narrow LiveSafe public-output AVC credential and redacted
 /// registration package.
 ///
@@ -175,18 +229,16 @@ where
     let mut allowed_claim_names = input.allowed_claim_names.clone();
     allowed_claim_names.sort();
     allowed_claim_names.dedup();
-    let intent_id = hash_structured(&CeremonyIntentPayload {
-        domain: LIVESAFE_PUBLIC_OUTPUT_CREDENTIAL_CEREMONY_DOMAIN,
-        issuer_did: &input.issuer_did,
-        credential_subject_did: &input.credential_subject_did,
-        public_subject: &input.public_subject,
-        public_audience: &input.public_audience,
-        allowed_claim_names: &allowed_claim_names,
-        evidence_hash: &evidence_hash,
-        not_before: &input.not_before,
-        expires_at: &input.expires_at,
-    })
-    .map_err(AvcError::from)?;
+    let intent_id = livesafe_public_output_credential_ceremony_intent_id(
+        &input.issuer_did,
+        &input.credential_subject_did,
+        &input.public_subject,
+        &input.public_audience,
+        &allowed_claim_names,
+        &evidence_hash,
+        &input.not_before,
+        &input.expires_at,
+    )?;
     let jurisdiction = input
         .issuer_authority_scope
         .jurisdictions

--- a/crates/exo-avc/src/livesafe_public_output_ceremony.rs
+++ b/crates/exo-avc/src/livesafe_public_output_ceremony.rs
@@ -128,6 +128,18 @@ struct CeremonyIntentPayload<'a> {
     expires_at: &'a Timestamp,
 }
 
+/// Borrowed inputs for the signed LiveSafe public-output ceremony intent hash.
+pub(crate) struct LivesafePublicOutputCredentialCeremonyIntentInput<'a> {
+    pub(crate) issuer_did: &'a Did,
+    pub(crate) credential_subject_did: &'a Did,
+    pub(crate) public_subject: &'a str,
+    pub(crate) public_audience: &'a str,
+    pub(crate) allowed_claim_names: &'a [String],
+    pub(crate) evidence_hash: &'a Hash256,
+    pub(crate) not_before: &'a Timestamp,
+    pub(crate) expires_at: &'a Timestamp,
+}
+
 mod sha256_hash_serde {
     use exo_core::Hash256;
     use serde::{Deserialize, Deserializer, Serializer, de};
@@ -185,28 +197,21 @@ pub fn parse_livesafe_public_output_evidence_sha256(value: &str) -> Result<Hash2
 /// # Errors
 /// Returns [`AvcError::Serialization`] if canonical intent hashing fails.
 pub(crate) fn livesafe_public_output_credential_ceremony_intent_id(
-    issuer_did: &Did,
-    credential_subject_did: &Did,
-    public_subject: &str,
-    public_audience: &str,
-    allowed_claim_names: &[String],
-    evidence_hash: &Hash256,
-    not_before: &Timestamp,
-    expires_at: &Timestamp,
+    input: &LivesafePublicOutputCredentialCeremonyIntentInput<'_>,
 ) -> Result<Hash256, AvcError> {
-    let mut normalized_allowed_claim_names = allowed_claim_names.to_vec();
+    let mut normalized_allowed_claim_names = input.allowed_claim_names.to_vec();
     normalized_allowed_claim_names.sort();
     normalized_allowed_claim_names.dedup();
     hash_structured(&CeremonyIntentPayload {
         domain: LIVESAFE_PUBLIC_OUTPUT_CREDENTIAL_CEREMONY_DOMAIN,
-        issuer_did,
-        credential_subject_did,
-        public_subject,
-        public_audience,
+        issuer_did: input.issuer_did,
+        credential_subject_did: input.credential_subject_did,
+        public_subject: input.public_subject,
+        public_audience: input.public_audience,
         allowed_claim_names: &normalized_allowed_claim_names,
-        evidence_hash,
-        not_before,
-        expires_at,
+        evidence_hash: input.evidence_hash,
+        not_before: input.not_before,
+        expires_at: input.expires_at,
     })
     .map_err(AvcError::from)
 }
@@ -230,14 +235,16 @@ where
     allowed_claim_names.sort();
     allowed_claim_names.dedup();
     let intent_id = livesafe_public_output_credential_ceremony_intent_id(
-        &input.issuer_did,
-        &input.credential_subject_did,
-        &input.public_subject,
-        &input.public_audience,
-        &allowed_claim_names,
-        &evidence_hash,
-        &input.not_before,
-        &input.expires_at,
+        &LivesafePublicOutputCredentialCeremonyIntentInput {
+            issuer_did: &input.issuer_did,
+            credential_subject_did: &input.credential_subject_did,
+            public_subject: &input.public_subject,
+            public_audience: &input.public_audience,
+            allowed_claim_names: &allowed_claim_names,
+            evidence_hash: &evidence_hash,
+            not_before: &input.not_before,
+            expires_at: &input.expires_at,
+        },
     )?;
     let jurisdiction = input
         .issuer_authority_scope

--- a/crates/exo-avc/src/public_output_authorization.rs
+++ b/crates/exo-avc/src/public_output_authorization.rs
@@ -28,6 +28,10 @@ use crate::{
     AvcRegistryRead,
     credential::{AVC_SCHEMA_VERSION, AutonomousVolitionCredential, AvcSubjectKind, DataClass},
     error::AvcError,
+    livesafe_public_output_ceremony::{
+        LIVESAFE_PUBLIC_ADAPTER_OUTPUT_CREDENTIAL_SUBJECT_DID,
+        livesafe_public_output_credential_ceremony_intent_id,
+    },
     validation::{
         AvcActionRequest, AvcDecision, AvcValidationRequest, AvcValidationResult,
         avc_action_commitment_hash, validate_avc,
@@ -236,6 +240,9 @@ pub fn validate_livesafe_public_adapter_output_authorization<R: AvcRegistryRead>
     }
     validate_registered_issuer_grant(&draft.credential, registry)?;
     validate_subject_kind(&draft.credential)?;
+    validate_credential_subject_did(&draft.credential)?;
+    validate_allowed_public_output_objectives(&draft.credential)?;
+    validate_ceremony_evidence_hash_binding(draft)?;
     validate_expiry_bounds(draft)?;
 
     let action = livesafe_public_adapter_output_authorization_action_request(
@@ -456,6 +463,71 @@ fn validate_subject_kind(credential: &AutonomousVolitionCredential) -> Result<()
             ),
         }),
     }
+}
+
+fn validate_credential_subject_did(
+    credential: &AutonomousVolitionCredential,
+) -> Result<(), AvcError> {
+    let expected =
+        Did::new(LIVESAFE_PUBLIC_ADAPTER_OUTPUT_CREDENTIAL_SUBJECT_DID).map_err(|error| {
+            AvcError::InvalidInput {
+                reason: format!(
+                    "LiveSafe public adapter output credential subject DID is invalid: {error}"
+                ),
+            }
+        })?;
+    if credential.subject_did != expected {
+        return Err(AvcError::InvalidInput {
+            reason: format!(
+                "LiveSafe public adapter output credential subject DID must be exactly {}",
+                LIVESAFE_PUBLIC_ADAPTER_OUTPUT_CREDENTIAL_SUBJECT_DID
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn validate_allowed_public_output_objectives(
+    credential: &AutonomousVolitionCredential,
+) -> Result<(), AvcError> {
+    let mut allowed_objectives = credential.delegated_intent.allowed_objectives.clone();
+    allowed_objectives.sort();
+    allowed_objectives.dedup();
+    if allowed_objectives != vec![LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN.to_owned()] {
+        return Err(AvcError::InvalidInput {
+            reason: format!(
+                "LiveSafe public adapter output allowed objectives must be exactly {}",
+                LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn validate_ceremony_evidence_hash_binding(
+    draft: &LivesafePublicAdapterOutputAuthorizationDraft,
+) -> Result<(), AvcError> {
+    let Some(credential_expires_at) = draft.credential.expires_at else {
+        return Err(AvcError::InvalidInput {
+            reason: "LiveSafe public adapter output credential must carry a ceremony expiry".into(),
+        });
+    };
+    let expected_intent_id = livesafe_public_output_credential_ceremony_intent_id(
+        &draft.credential.issuer_did,
+        &draft.credential.subject_did,
+        &draft.subject,
+        &draft.audience,
+        &draft.credential.delegated_intent.allowed_objectives,
+        &draft.evidence_hash,
+        &draft.credential.created_at,
+        &credential_expires_at,
+    )?;
+    if draft.credential.delegated_intent.intent_id != expected_intent_id {
+        return Err(AvcError::InvalidInput {
+            reason: "LiveSafe public adapter output evidence hash does not match the signed ceremony credential binding".into(),
+        });
+    }
+    Ok(())
 }
 
 fn validate_expiry_bounds(

--- a/crates/exo-avc/src/public_output_authorization.rs
+++ b/crates/exo-avc/src/public_output_authorization.rs
@@ -30,6 +30,7 @@ use crate::{
     error::AvcError,
     livesafe_public_output_ceremony::{
         LIVESAFE_PUBLIC_ADAPTER_OUTPUT_CREDENTIAL_SUBJECT_DID,
+        LivesafePublicOutputCredentialCeremonyIntentInput,
         livesafe_public_output_credential_ceremony_intent_id,
     },
     validation::{
@@ -513,14 +514,16 @@ fn validate_ceremony_evidence_hash_binding(
         });
     };
     let expected_intent_id = livesafe_public_output_credential_ceremony_intent_id(
-        &draft.credential.issuer_did,
-        &draft.credential.subject_did,
-        &draft.subject,
-        &draft.audience,
-        &draft.credential.delegated_intent.allowed_objectives,
-        &draft.evidence_hash,
-        &draft.credential.created_at,
-        &credential_expires_at,
+        &LivesafePublicOutputCredentialCeremonyIntentInput {
+            issuer_did: &draft.credential.issuer_did,
+            credential_subject_did: &draft.credential.subject_did,
+            public_subject: &draft.subject,
+            public_audience: &draft.audience,
+            allowed_claim_names: &draft.credential.delegated_intent.allowed_objectives,
+            evidence_hash: &draft.evidence_hash,
+            not_before: &draft.credential.created_at,
+            expires_at: &credential_expires_at,
+        },
     )?;
     if draft.credential.delegated_intent.intent_id != expected_intent_id {
         return Err(AvcError::InvalidInput {

--- a/crates/exo-avc/tests/livesafe_public_output_ceremony_tests.rs
+++ b/crates/exo-avc/tests/livesafe_public_output_ceremony_tests.rs
@@ -1,0 +1,322 @@
+use std::fmt::{Debug, Display};
+
+use exo_authority::permission::Permission;
+use exo_avc::{
+    AVC_SCHEMA_VERSION, AuthorityScope, AvcDecision, AvcRegistryRead, AvcRegistryWrite, DataClass,
+    InMemoryAvcRegistry, LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+    LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN,
+    LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+    LIVESAFE_PUBLIC_ADAPTER_OUTPUT_CREDENTIAL_SUBJECT_DID,
+    LivesafePublicOutputCredentialCeremonyEvidence, LivesafePublicOutputCredentialCeremonyInput,
+    issue_livesafe_public_output_credential_ceremony,
+    livesafe_public_adapter_output_authorization_action_request,
+    parse_livesafe_public_output_evidence_sha256, validate_avc,
+};
+use exo_core::{Did, Hash256, Timestamp, crypto::KeyPair};
+
+const ISSUER_SEED: [u8; 32] = [0x42; 32];
+
+fn must_ok<T, E: Display>(result: Result<T, E>, context: &str) -> T {
+    match result {
+        Ok(value) => value,
+        Err(error) => panic!("{context}: {error}"),
+    }
+}
+
+fn must_err<T: Debug, E>(result: Result<T, E>, context: &str) -> E {
+    match result {
+        Ok(value) => panic!("{context}: unexpectedly succeeded with {value:?}"),
+        Err(error) => error,
+    }
+}
+
+fn issuer_keypair() -> KeyPair {
+    must_ok(
+        KeyPair::from_secret_bytes(ISSUER_SEED),
+        "valid issuer keypair",
+    )
+}
+
+fn did(value: &str) -> Did {
+    must_ok(Did::new(value), "valid did")
+}
+
+fn ts(ms: u64) -> Timestamp {
+    Timestamp::new(ms, 0)
+}
+
+fn evidence_bytes() -> Vec<u8> {
+    br#"{"surface":"livesafe.ai","contract":"public-adapter-output","version":1}"#.to_vec()
+}
+
+fn livesafe_sha256_hash() -> Hash256 {
+    Hash256::from_bytes([
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee,
+        0xff, 0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22,
+        0x11, 0x00,
+    ])
+}
+
+fn livesafe_sha256_value() -> &'static str {
+    "sha256:00112233445566778899aabbccddeeffffeeddccbbaa99887766554433221100"
+}
+
+fn evidence() -> LivesafePublicOutputCredentialCeremonyEvidence {
+    LivesafePublicOutputCredentialCeremonyEvidence {
+        sha256_hash: livesafe_sha256_hash(),
+    }
+}
+
+fn issuer_scope() -> AuthorityScope {
+    AuthorityScope {
+        permissions: vec![Permission::Read],
+        tools: vec![LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN.into()],
+        data_classes: vec![DataClass::Public],
+        counterparties: vec![],
+        jurisdictions: vec!["US".into()],
+    }
+}
+
+fn valid_input() -> LivesafePublicOutputCredentialCeremonyInput {
+    LivesafePublicOutputCredentialCeremonyInput {
+        issuer_did: did("did:exo:livesafe-public-output-issuer"),
+        issuer_authority_scope: issuer_scope(),
+        credential_subject_did: did(LIVESAFE_PUBLIC_ADAPTER_OUTPUT_CREDENTIAL_SUBJECT_DID),
+        public_subject: LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT.into(),
+        public_audience: LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE.into(),
+        allowed_claim_names: vec![LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN.into()],
+        evidence: evidence(),
+        not_before: ts(1_000_000),
+        expires_at: ts(2_000_000),
+        idempotency_key: "livesafe-public-output-ceremony-20260705".into(),
+    }
+}
+
+fn issue(
+    input: LivesafePublicOutputCredentialCeremonyInput,
+) -> Result<exo_avc::LivesafePublicOutputCredentialCeremonyOutput, exo_avc::AvcError> {
+    let issuer = issuer_keypair();
+    issue_livesafe_public_output_credential_ceremony(input, |payload| issuer.sign(payload))
+}
+
+#[test]
+fn ceremony_refuses_issuer_without_public_output_authority() {
+    let mut input = valid_input();
+    input.issuer_authority_scope.tools.clear();
+
+    let error = must_err(
+        issue(input),
+        "issuer missing public-output capability must fail",
+    );
+
+    assert!(error.to_string().contains("issuer authority"));
+    assert!(
+        error
+            .to_string()
+            .contains(LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN)
+    );
+}
+
+#[test]
+fn ceremony_refuses_empty_or_forbidden_claim_caps() {
+    let mut empty = valid_input();
+    empty.allowed_claim_names.clear();
+    let empty_error = must_err(issue(empty), "empty claim cap must fail");
+    assert!(empty_error.to_string().contains("allowed claim"));
+
+    let mut forbidden = valid_input();
+    forbidden.allowed_claim_names = vec!["livesafe.medical.custody.consent.emergency.v1".into()];
+    let forbidden_error = must_err(issue(forbidden), "forbidden claim cap must fail");
+    assert!(forbidden_error.to_string().contains("forbidden claim"));
+}
+
+#[test]
+fn ceremony_binds_subject_and_audience_to_livesafe_public_adapter_output_only() {
+    let mut broad_subject = valid_input();
+    broad_subject.public_subject = "exochain".into();
+    let subject_error = must_err(issue(broad_subject), "broad subject must fail");
+    assert!(subject_error.to_string().contains("subject"));
+
+    let mut broad_audience = valid_input();
+    broad_audience.public_audience = "https://livesafe.ai/api/medical/custody".into();
+    let audience_error = must_err(issue(broad_audience), "broad audience must fail");
+    assert!(audience_error.to_string().contains("audience"));
+
+    let mut wrong_subject_did = valid_input();
+    wrong_subject_did.credential_subject_did = did("did:exo:livesafe-medical-custody");
+    let subject_did_error = must_err(
+        issue(wrong_subject_did),
+        "wrong credential subject DID must fail",
+    );
+    assert!(
+        subject_did_error
+            .to_string()
+            .contains("credential subject DID")
+    );
+}
+
+#[test]
+fn ceremony_accepts_sha256_prefixed_evidence_hash_and_propagates_bytes() {
+    let parsed = must_ok(
+        parse_livesafe_public_output_evidence_sha256(livesafe_sha256_value()),
+        "parse LiveSafe sha256 evidence hash",
+    );
+    assert_eq!(parsed, livesafe_sha256_hash());
+
+    let mut input = valid_input();
+    input.evidence.sha256_hash = parsed;
+    let output = must_ok(issue(input), "issue ceremony output");
+
+    assert_eq!(output.evidence_hash, livesafe_sha256_hash());
+    assert_eq!(
+        output.authorization_request.evidence_hash,
+        livesafe_sha256_hash()
+    );
+}
+
+#[test]
+fn ceremony_rejects_bare_non_sha256_or_malformed_evidence_hash_inputs() {
+    for rejected in [
+        "00112233445566778899aabbccddeeffffeeddccbbaa99887766554433221100",
+        "blake3:00112233445566778899aabbccddeeffffeeddccbbaa99887766554433221100",
+        "sha256:00112233445566778899AABBCCDDEEFFffeeddccbbaa99887766554433221100",
+        "SHA256:00112233445566778899aabbccddeeffffeeddccbbaa99887766554433221100",
+        "sha512:00112233445566778899aabbccddeeffffeeddccbbaa99887766554433221100",
+        "sha256:abc",
+    ] {
+        let error = must_err(
+            parse_livesafe_public_output_evidence_sha256(rejected),
+            "invalid evidence hash must fail",
+        );
+        assert!(
+            error.to_string().contains("sha256:<64 lowercase hex>"),
+            "unexpected error for {rejected}: {error}"
+        );
+    }
+}
+
+#[test]
+fn ceremony_source_does_not_recompute_or_name_blake3_evidence_hashing() {
+    let source = include_str!("../src/livesafe_public_output_ceremony.rs");
+
+    assert!(!source.contains("Hash256::digest(&evidence.material)"));
+    assert!(!source.contains("BLAKE3"));
+    assert!(!source.contains("blake3"));
+}
+
+#[test]
+fn ceremony_uses_explicit_not_before_and_expiry_without_system_time() {
+    let input = valid_input();
+    let first = must_ok(issue(input.clone()), "first issue");
+    let second = must_ok(issue(input.clone()), "second issue");
+
+    assert_eq!(first.credential_id, second.credential_id);
+    assert_eq!(first.credential.created_at, input.not_before);
+    assert_eq!(first.credential.expires_at, Some(input.expires_at));
+    assert_eq!(
+        first.credential.constraints.allowed_time_window,
+        Some(exo_avc::TimeWindow {
+            not_before: input.not_before,
+            not_after: input.expires_at,
+        })
+    );
+
+    let source = include_str!("../src/livesafe_public_output_ceremony.rs");
+    assert!(!source.contains("SystemTime"));
+    assert!(!source.contains("Instant::now"));
+}
+
+#[test]
+fn ceremony_output_redacts_signing_material_and_bearer_tokens() {
+    let output = must_ok(issue(valid_input()), "issue ceremony output");
+    let rendered = format!("{output:?}");
+    let raw_private_seed_hex = "42".repeat(32);
+    let raw_evidence = evidence_bytes();
+    let raw_evidence_text = must_ok(
+        std::str::from_utf8(raw_evidence.as_slice()),
+        "evidence fixture is utf8",
+    );
+
+    assert!(!rendered.contains(&raw_private_seed_hex));
+    assert!(!rendered.contains(raw_evidence_text));
+    assert!(!rendered.contains("EXOCHAIN_ADMIN_BEARER_TOKEN"));
+    assert!(!rendered.contains("Bearer "));
+    assert!(!rendered.to_ascii_lowercase().contains("private_key"));
+    assert!(!rendered.to_ascii_lowercase().contains("secret_key"));
+}
+
+#[test]
+fn ceremony_output_is_signed_and_accepted_by_existing_avc_validation_path() {
+    let input = valid_input();
+    let output = must_ok(issue(input.clone()), "issue ceremony output");
+    let credential = output.issue_request.credential.clone();
+    assert_eq!(credential.schema_version, AVC_SCHEMA_VERSION);
+    assert_eq!(
+        must_ok(credential.id(), "credential id"),
+        output.credential_id
+    );
+    assert_eq!(
+        output.authorization_request.credential_id,
+        output.credential_id
+    );
+    assert_eq!(
+        output.authorization_request.evidence_hash,
+        input.evidence.sha256_hash
+    );
+
+    let mut registry = InMemoryAvcRegistry::new();
+    registry.put_public_key(input.issuer_did.clone(), issuer_keypair().public);
+    registry.put_issuer_permission_grant(input.issuer_did, vec![Permission::Read]);
+    let registered_id = must_ok(
+        registry.put_credential(credential.clone()),
+        "node issue path accepts credential",
+    );
+    assert_eq!(registered_id, output.credential_id);
+    assert!(registry.get_credential(&output.credential_id).is_some());
+
+    let action = livesafe_public_adapter_output_authorization_action_request(
+        &credential,
+        &output.authorization_request.subject,
+        &output.authorization_request.audience,
+        output.authorization_request.evidence_hash,
+        output.authorization_request.idempotency_key_hash,
+        &output.authorization_request.expires_at,
+    );
+    let action = must_ok(action, "build public-output action");
+    let validation = must_ok(
+        validate_avc(
+            &exo_avc::AvcValidationRequest {
+                credential,
+                action: Some(action),
+                now: input.not_before,
+            },
+            &registry,
+        ),
+        "validate credential",
+    );
+    assert_eq!(validation.decision, AvcDecision::Allow);
+}
+
+#[test]
+fn ceremony_rejects_public_output_claim_widening_even_with_valid_signature_material() {
+    for forbidden in [
+        "exochain.constitutional_trust.v1",
+        "livesafe.medical_record_read.v1",
+        "livesafe.legal_custody.v1",
+        "livesafe.consent_override.v1",
+        "livesafe.emergency_access.v1",
+    ] {
+        let mut input = valid_input();
+        input.allowed_claim_names = vec![
+            LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN.into(),
+            forbidden.into(),
+        ];
+
+        let error = must_err(issue(input), "widened claim must fail");
+
+        assert!(
+            error.to_string().contains("forbidden claim")
+                || error.to_string().contains("allowed claim")
+        );
+    }
+}

--- a/crates/exo-avc/tests/livesafe_public_output_ceremony_tests.rs
+++ b/crates/exo-avc/tests/livesafe_public_output_ceremony_tests.rs
@@ -7,14 +7,18 @@ use exo_avc::{
     LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN,
     LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
     LIVESAFE_PUBLIC_ADAPTER_OUTPUT_CREDENTIAL_SUBJECT_DID,
-    LivesafePublicOutputCredentialCeremonyEvidence, LivesafePublicOutputCredentialCeremonyInput,
-    issue_livesafe_public_output_credential_ceremony,
+    LivesafePublicAdapterOutputAuthorizationDraft, LivesafePublicOutputCredentialCeremonyEvidence,
+    LivesafePublicOutputCredentialCeremonyInput, issue_livesafe_public_output_credential_ceremony,
+    livesafe_public_adapter_output_authorization_action_commitment_hash,
     livesafe_public_adapter_output_authorization_action_request,
+    livesafe_public_adapter_output_authorization_idempotency_hash,
+    mint_livesafe_public_adapter_output_authorization_proof,
     parse_livesafe_public_output_evidence_sha256, validate_avc,
 };
 use exo_core::{Did, Hash256, Timestamp, crypto::KeyPair};
 
 const ISSUER_SEED: [u8; 32] = [0x42; 32];
+const PROOF_SIGNER_SEED: [u8; 32] = [0x24; 32];
 
 fn must_ok<T, E: Display>(result: Result<T, E>, context: &str) -> T {
     match result {
@@ -34,6 +38,13 @@ fn issuer_keypair() -> KeyPair {
     must_ok(
         KeyPair::from_secret_bytes(ISSUER_SEED),
         "valid issuer keypair",
+    )
+}
+
+fn proof_signer_keypair() -> KeyPair {
+    must_ok(
+        KeyPair::from_secret_bytes(PROOF_SIGNER_SEED),
+        "valid proof signer keypair",
     )
 }
 
@@ -97,6 +108,74 @@ fn issue(
 ) -> Result<exo_avc::LivesafePublicOutputCredentialCeremonyOutput, exo_avc::AvcError> {
     let issuer = issuer_keypair();
     issue_livesafe_public_output_credential_ceremony(input, |payload| issuer.sign(payload))
+}
+
+fn registry_for_issued_ceremony(
+    output: &exo_avc::LivesafePublicOutputCredentialCeremonyOutput,
+    issuer_did: Did,
+) -> InMemoryAvcRegistry {
+    let mut registry = InMemoryAvcRegistry::new();
+    registry.put_public_key(issuer_did.clone(), issuer_keypair().public);
+    registry.put_issuer_permission_grant(issuer_did, vec![Permission::Read]);
+    let registered_id = must_ok(
+        registry.put_credential(output.credential.clone()),
+        "node issue path accepts ceremony credential",
+    );
+    assert_eq!(registered_id, output.credential_id);
+    registry
+}
+
+fn authorization_draft_for(
+    output: &exo_avc::LivesafePublicOutputCredentialCeremonyOutput,
+    evidence_hash: Hash256,
+) -> LivesafePublicAdapterOutputAuthorizationDraft {
+    let idempotency_key_hash = must_ok(
+        livesafe_public_adapter_output_authorization_idempotency_hash(
+            &output.authorization_request.idempotency_key,
+        ),
+        "idempotency hash",
+    );
+    let issued_at = output.not_before;
+    let expires_at = output.authorization_request.expires_at;
+    let action_commitment_hash = must_ok(
+        livesafe_public_adapter_output_authorization_action_commitment_hash(
+            &output.credential,
+            &output.authorization_request.subject,
+            &output.authorization_request.audience,
+            evidence_hash,
+            idempotency_key_hash,
+            &issued_at,
+            &expires_at,
+        ),
+        "action commitment hash",
+    );
+
+    LivesafePublicAdapterOutputAuthorizationDraft {
+        credential: output.credential.clone(),
+        subject: output.authorization_request.subject.clone(),
+        audience: output.authorization_request.audience.clone(),
+        evidence_hash,
+        credential_id: Some(output.credential_id),
+        receipt_id: Hash256::from_bytes([0x5a; 32]),
+        action_commitment_hash,
+        idempotency_key_hash,
+        issued_at,
+        expires_at,
+        signer_did: did("did:exo:livesafe-public-output-proof-signer"),
+    }
+}
+
+fn cbor_map_field<'a>(
+    value: &'a ciborium::value::Value,
+    field: &str,
+) -> Option<&'a ciborium::value::Value> {
+    value.as_map()?.iter().find_map(|(key, value)| {
+        if key.as_text() == Some(field) {
+            Some(value)
+        } else {
+            None
+        }
+    })
 }
 
 #[test]
@@ -295,6 +374,124 @@ fn ceremony_output_is_signed_and_accepted_by_existing_avc_validation_path() {
         "validate credential",
     );
     assert_eq!(validation.decision, AvcDecision::Allow);
+}
+
+#[test]
+fn public_output_authorization_rejects_evidence_hash_not_bound_to_ceremony_credential() {
+    let input = valid_input();
+    let output = must_ok(issue(input.clone()), "issue ceremony output");
+    let registry = registry_for_issued_ceremony(&output, input.issuer_did);
+    let forged_evidence_hash = Hash256::from_bytes([0x77; 32]);
+    assert_ne!(
+        forged_evidence_hash,
+        output.authorization_request.evidence_hash
+    );
+
+    let error = must_err(
+        mint_livesafe_public_adapter_output_authorization_proof(
+            authorization_draft_for(&output, forged_evidence_hash),
+            &registry,
+            |payload| proof_signer_keypair().sign(payload),
+        ),
+        "draft evidence hash not bound into ceremony credential must fail",
+    );
+
+    assert!(
+        error.to_string().contains("evidence hash"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn public_output_authorization_rejects_livesafe_service_credential_with_wrong_subject_did() {
+    let input = valid_input();
+    let mut output = must_ok(issue(input.clone()), "issue ceremony output");
+    let original = output.credential.clone();
+    let wrong_subject_did = did("did:exo:livesafe-public-adapter-shadow");
+    assert_ne!(wrong_subject_did, original.subject_did);
+    let credential = must_ok(
+        exo_avc::issue_avc(
+            exo_avc::AvcDraft {
+                schema_version: original.schema_version,
+                issuer_did: original.issuer_did,
+                principal_did: original.principal_did,
+                subject_did: wrong_subject_did,
+                holder_did: original.holder_did,
+                subject_kind: original.subject_kind,
+                created_at: original.created_at,
+                expires_at: original.expires_at,
+                delegated_intent: original.delegated_intent,
+                authority_scope: original.authority_scope,
+                constraints: original.constraints,
+                authority_chain: original.authority_chain,
+                consent_refs: original.consent_refs,
+                policy_refs: original.policy_refs,
+                parent_avc_id: original.parent_avc_id,
+            },
+            |payload| issuer_keypair().sign(payload),
+        ),
+        "issue signed credential with wrong subject DID",
+    );
+    output.credential = credential;
+    output.credential_id = must_ok(output.credential.id(), "wrong subject credential id");
+    output.authorization_request.credential_id = output.credential_id;
+    let registry = registry_for_issued_ceremony(&output, input.issuer_did);
+
+    let error = must_err(
+        mint_livesafe_public_adapter_output_authorization_proof(
+            authorization_draft_for(&output, output.authorization_request.evidence_hash),
+            &registry,
+            |payload| proof_signer_keypair().sign(payload),
+        ),
+        "credential with wrong subject DID must fail",
+    );
+
+    assert!(
+        error.to_string().contains("credential subject DID"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn ceremony_authorization_request_serializes_env_ready_sha256_values() {
+    let output = must_ok(issue(valid_input()), "issue ceremony output");
+    let mut bytes = Vec::new();
+    must_ok(
+        ciborium::ser::into_writer(&output, &mut bytes),
+        "serialize ceremony output",
+    );
+    let value: ciborium::value::Value = must_ok(
+        ciborium::de::from_reader(bytes.as_slice()),
+        "decode ceremony output",
+    );
+    let authorization_request =
+        cbor_map_field(&value, "authorization_request").expect("authorization_request object");
+    let credential_id = cbor_map_field(authorization_request, "credential_id")
+        .and_then(ciborium::value::Value::as_text)
+        .expect("credential_id string");
+    let evidence_hash = cbor_map_field(authorization_request, "evidence_hash")
+        .and_then(ciborium::value::Value::as_text)
+        .expect("evidence_hash string");
+
+    assert_eq!(
+        credential_id,
+        format!("sha256:{}", output.authorization_request.credential_id)
+    );
+    assert_eq!(evidence_hash, livesafe_sha256_value());
+}
+
+#[test]
+fn ceremony_docs_instruct_livesafe_env_vars_from_prefixed_authorization_request_values() {
+    let docs = include_str!("../../../docs/avc/livesafe-public-output-ceremony.md");
+
+    assert!(docs.contains(
+        "export EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_CREDENTIAL_ID=\"$(jq -r '.authorization_request.credential_id'"
+    ));
+    assert!(docs.contains(
+        "export EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_EVIDENCE_HASH=\"$(jq -r '.authorization_request.evidence_hash'"
+    ));
+    assert!(docs.contains("sha256:<64 lowercase hex>"));
+    assert!(docs.contains("not raw `Hash256` JSON arrays or plain bytes"));
 }
 
 #[test]

--- a/crates/exo-avc/tests/livesafe_public_output_ceremony_tests.rs
+++ b/crates/exo-avc/tests/livesafe_public_output_ceremony_tests.rs
@@ -34,6 +34,13 @@ fn must_err<T: Debug, E>(result: Result<T, E>, context: &str) -> E {
     }
 }
 
+fn must_some<T>(option: Option<T>, context: &str) -> T {
+    match option {
+        Some(value) => value,
+        None => panic!("{context}"),
+    }
+}
+
 fn issuer_keypair() -> KeyPair {
     must_ok(
         KeyPair::from_secret_bytes(ISSUER_SEED),
@@ -464,14 +471,20 @@ fn ceremony_authorization_request_serializes_env_ready_sha256_values() {
         ciborium::de::from_reader(bytes.as_slice()),
         "decode ceremony output",
     );
-    let authorization_request =
-        cbor_map_field(&value, "authorization_request").expect("authorization_request object");
-    let credential_id = cbor_map_field(authorization_request, "credential_id")
-        .and_then(ciborium::value::Value::as_text)
-        .expect("credential_id string");
-    let evidence_hash = cbor_map_field(authorization_request, "evidence_hash")
-        .and_then(ciborium::value::Value::as_text)
-        .expect("evidence_hash string");
+    let authorization_request = must_some(
+        cbor_map_field(&value, "authorization_request"),
+        "authorization_request object",
+    );
+    let credential_id = must_some(
+        cbor_map_field(authorization_request, "credential_id")
+            .and_then(ciborium::value::Value::as_text),
+        "credential_id string",
+    );
+    let evidence_hash = must_some(
+        cbor_map_field(authorization_request, "evidence_hash")
+            .and_then(ciborium::value::Value::as_text),
+        "evidence_hash string",
+    );
 
     assert_eq!(
         credential_id,

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -5686,34 +5686,68 @@ mod tests {
     }
 
     fn livesafe_public_output_credential() -> AutonomousVolitionCredential {
-        livesafe_public_output_credential_with_window(
+        livesafe_public_output_credential_for_evidence(Hash256::from_bytes([0xE1; 32]))
+    }
+
+    fn livesafe_public_output_credential_for_evidence(
+        evidence_hash: Hash256,
+    ) -> AutonomousVolitionCredential {
+        livesafe_public_output_credential_with_window_for_evidence(
             Timestamp::new(1_000_000, 0),
             Timestamp::new(2_000_000, 0),
+            evidence_hash,
         )
     }
 
-    fn livesafe_public_output_credential_with_window(
+    fn livesafe_public_output_credential_with_window_for_evidence(
         created_at: Timestamp,
         expires_at: Timestamp,
+        evidence_hash: Hash256,
     ) -> AutonomousVolitionCredential {
-        let mut draft = baseline_draft();
-        draft.subject_did = Did::new("did:exo:livesafe-public-adapter").unwrap();
-        draft.subject_kind = AvcSubjectKind::Service {
-            service_id: exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT.into(),
-        };
-        draft.created_at = created_at;
-        draft.expires_at = Some(expires_at);
-        draft.delegated_intent.purpose = "Authorize narrow LiveSafe public adapter output".into();
-        draft.delegated_intent.allowed_objectives = vec!["publish-redacted-trust-status".into()];
-        draft.delegated_intent.autonomy_level = AutonomyLevel::ExecuteWithinBounds;
-        draft.authority_scope = AuthorityScope {
-            permissions: vec![Permission::Read],
-            tools: vec![exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN.into()],
-            data_classes: vec![exo_avc::DataClass::Public],
-            counterparties: vec![],
-            jurisdictions: vec!["US".into()],
-        };
-        issue_avc(draft, |bytes| issuer_keypair().sign(bytes)).unwrap()
+        exo_avc::issue_livesafe_public_output_credential_ceremony(
+            exo_avc::LivesafePublicOutputCredentialCeremonyInput {
+                issuer_did: Did::new("did:exo:issuer").unwrap(),
+                issuer_authority_scope: AuthorityScope {
+                    permissions: vec![Permission::Read],
+                    tools: vec![
+                        exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN.into(),
+                    ],
+                    data_classes: vec![exo_avc::DataClass::Public],
+                    counterparties: vec![],
+                    jurisdictions: vec!["US".into()],
+                },
+                credential_subject_did: Did::new(
+                    exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_CREDENTIAL_SUBJECT_DID,
+                )
+                .unwrap(),
+                public_subject: exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT
+                    .into(),
+                public_audience: exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE
+                    .into(),
+                allowed_claim_names: vec![
+                    exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN.into(),
+                ],
+                evidence: exo_avc::LivesafePublicOutputCredentialCeremonyEvidence {
+                    sha256_hash: evidence_hash,
+                },
+                not_before: created_at,
+                expires_at,
+                idempotency_key: "node-test-livesafe-public-output".into(),
+            },
+            |bytes| issuer_keypair().sign(bytes),
+        )
+        .unwrap()
+        .credential
+    }
+
+    fn store_livesafe_public_output_credential_for_evidence(
+        state: &AvcApiState,
+        evidence_hash: Hash256,
+    ) -> Hash256 {
+        store_livesafe_public_output_credential(
+            state,
+            livesafe_public_output_credential_for_evidence(evidence_hash),
+        )
     }
 
     fn store_livesafe_public_output_credential(
@@ -5799,13 +5833,14 @@ mod tests {
     async fn livesafe_public_output_scoped_bearer_accepts_public_output_authorization_when_configured()
      {
         let state = fresh_state();
+        let evidence_hash = Hash256::from_bytes([0xF1; 32]);
         let credential_id =
-            store_livesafe_public_output_credential(&state, livesafe_public_output_credential());
+            store_livesafe_public_output_credential_for_evidence(&state, evidence_hash);
         let app = avc_router_with_bearer_gate(Arc::clone(&state));
         let request = public_output_authorization_request(
             credential_id,
             "public-output-scoped-bearer-idem",
-            Hash256::from_bytes([0xF1; 32]),
+            evidence_hash,
             exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
         );
 
@@ -5826,13 +5861,14 @@ mod tests {
     #[tokio::test]
     async fn public_output_authorization_exports_redacted_proof_happy_path() {
         let state = fresh_state();
+        let evidence_hash = Hash256::from_bytes([0xE2; 32]);
         let credential_id =
-            store_livesafe_public_output_credential(&state, livesafe_public_output_credential());
+            store_livesafe_public_output_credential_for_evidence(&state, evidence_hash);
         let app = avc_router_with_bearer_gate(Arc::clone(&state));
         let request = public_output_authorization_request(
             credential_id,
             "public-output-idem-2",
-            Hash256::from_bytes([0xE2; 32]),
+            evidence_hash,
             exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
         );
 
@@ -5863,15 +5899,16 @@ mod tests {
     async fn public_output_authorization_uses_trusted_local_hlc_for_proof_and_receipt_time() {
         let state = fresh_state();
         let trusted_floor = trusted_local_hlc_timestamp(&state).unwrap();
+        let evidence_hash = Hash256::from_bytes([0xD1; 32]);
         let credential_id =
-            store_livesafe_public_output_credential(&state, livesafe_public_output_credential());
+            store_livesafe_public_output_credential_for_evidence(&state, evidence_hash);
         let app = avc_router_with_bearer_gate(Arc::clone(&state));
         let caller_supplied_time = Timestamp::new(1_500_000, 0);
         let request = serde_json::json!({
             "credential_id": credential_id,
             "subject": exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
             "audience": exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
-            "evidence_hash": Hash256::from_bytes([0xD1; 32]),
+            "evidence_hash": evidence_hash,
             "idempotency_key": "public-output-idem-trusted-hlc",
             "issued_at": caller_supplied_time,
             "expires_at": Timestamp::new(1_700_000, 0)
@@ -5900,9 +5937,11 @@ mod tests {
     #[tokio::test]
     async fn public_output_authorization_rejects_backdated_resurrection_of_expired_credential() {
         let state = fresh_state();
-        let credential = livesafe_public_output_credential_with_window(
+        let evidence_hash = Hash256::from_bytes([0xD2; 32]);
+        let credential = livesafe_public_output_credential_with_window_for_evidence(
             Timestamp::new(900_000, 0),
             Timestamp::new(1_000_000, 0),
+            evidence_hash,
         );
         let credential_id = store_livesafe_public_output_credential(&state, credential);
         let app = avc_router_with_bearer_gate(Arc::clone(&state));
@@ -5910,7 +5949,7 @@ mod tests {
             "credential_id": credential_id,
             "subject": exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
             "audience": exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
-            "evidence_hash": Hash256::from_bytes([0xD2; 32]),
+            "evidence_hash": evidence_hash,
             "idempotency_key": "public-output-idem-backdate-expired",
             "issued_at": Timestamp::new(950_000, 0),
             "expires_at": Timestamp::new(999_000, 0)
@@ -5926,9 +5965,11 @@ mod tests {
     #[tokio::test]
     async fn public_output_authorization_rejects_future_dated_premature_not_yet_valid_credential() {
         let state = fresh_state();
-        let credential = livesafe_public_output_credential_with_window(
+        let evidence_hash = Hash256::from_bytes([0xD3; 32]);
+        let credential = livesafe_public_output_credential_with_window_for_evidence(
             Timestamp::new(1_100_000, 0),
             Timestamp::new(1_700_000, 0),
+            evidence_hash,
         );
         let credential_id = store_livesafe_public_output_credential(&state, credential);
         let app = avc_router_with_bearer_gate(Arc::clone(&state));
@@ -5936,7 +5977,7 @@ mod tests {
             "credential_id": credential_id,
             "subject": exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
             "audience": exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
-            "evidence_hash": Hash256::from_bytes([0xD3; 32]),
+            "evidence_hash": evidence_hash,
             "idempotency_key": "public-output-idem-future-date-not-yet-valid",
             "issued_at": Timestamp::new(1_200_000, 0),
             "expires_at": Timestamp::new(1_500_000, 0)
@@ -5952,14 +5993,15 @@ mod tests {
     #[tokio::test]
     async fn public_output_authorization_replay_omits_caller_time_and_reuses_trusted_receipt() {
         let state = fresh_state();
+        let evidence_hash = Hash256::from_bytes([0xD4; 32]);
         let credential_id =
-            store_livesafe_public_output_credential(&state, livesafe_public_output_credential());
+            store_livesafe_public_output_credential_for_evidence(&state, evidence_hash);
         let app = avc_router_with_bearer_gate(Arc::clone(&state));
         let request = serde_json::json!({
             "credential_id": credential_id,
             "subject": exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
             "audience": exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
-            "evidence_hash": Hash256::from_bytes([0xD4; 32]),
+            "evidence_hash": evidence_hash,
             "idempotency_key": "public-output-idem-no-caller-time",
             "expires_at": Timestamp::new(1_700_000, 0)
         });
@@ -5982,13 +6024,14 @@ mod tests {
     #[tokio::test]
     async fn public_output_authorization_replay_same_body_returns_same_proof() {
         let state = fresh_state();
+        let evidence_hash = Hash256::from_bytes([0xE3; 32]);
         let credential_id =
-            store_livesafe_public_output_credential(&state, livesafe_public_output_credential());
+            store_livesafe_public_output_credential_for_evidence(&state, evidence_hash);
         let app = avc_router_with_bearer_gate(Arc::clone(&state));
         let request = public_output_authorization_request(
             credential_id,
             "public-output-idem-3",
-            Hash256::from_bytes([0xE3; 32]),
+            evidence_hash,
             exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
         );
 
@@ -6014,13 +6057,14 @@ mod tests {
     #[tokio::test]
     async fn public_output_authorization_conflicts_on_idempotency_key_reuse_with_changed_expiry() {
         let state = fresh_state();
+        let evidence_hash = Hash256::from_bytes([0xE7; 32]);
         let credential_id =
-            store_livesafe_public_output_credential(&state, livesafe_public_output_credential());
+            store_livesafe_public_output_credential_for_evidence(&state, evidence_hash);
         let app = avc_router_with_bearer_gate(Arc::clone(&state));
         let first_request = public_output_authorization_request(
             credential_id,
             "public-output-idem-expiry-conflict",
-            Hash256::from_bytes([0xE7; 32]),
+            evidence_hash,
             exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
         );
         let mut changed_expiry = first_request.clone();
@@ -6059,13 +6103,14 @@ mod tests {
     #[tokio::test]
     async fn public_output_authorization_conflicts_on_idempotency_key_reuse() {
         let state = fresh_state();
+        let evidence_hash = Hash256::from_bytes([0xE4; 32]);
         let credential_id =
-            store_livesafe_public_output_credential(&state, livesafe_public_output_credential());
+            store_livesafe_public_output_credential_for_evidence(&state, evidence_hash);
         let app = avc_router_with_bearer_gate(Arc::clone(&state));
         let first_request = public_output_authorization_request(
             credential_id,
             "public-output-idem-4",
-            Hash256::from_bytes([0xE4; 32]),
+            evidence_hash,
             exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
         );
         let changed_evidence = public_output_authorization_request(

--- a/crates/exo-node/src/cli.rs
+++ b/crates/exo-node/src/cli.rs
@@ -18,7 +18,7 @@
 
 use std::path::PathBuf;
 
-use clap::{Args, Parser, Subcommand};
+use clap::{ArgGroup, Args, Parser, Subcommand};
 
 pub const ROOT_GENESIS_LONG_HELP: &str = "\
 Root genesis creates a 7-of-13 institutional root authority. Genesis DKG \
@@ -192,6 +192,101 @@ pub enum Command {
         #[command(subcommand)]
         command: GenesisCommand,
     },
+
+    /// Run bounded AVC operator utilities.
+    Avc {
+        #[command(subcommand)]
+        command: AvcCommand,
+    },
+}
+
+#[derive(Subcommand)]
+/// AVC operator commands.
+pub enum AvcCommand {
+    /// Prepare or register the LiveSafe public-output credential ceremony.
+    #[command(name = "livesafe-public-output-ceremony")]
+    LivesafePublicOutputCeremony {
+        #[command(subcommand)]
+        command: LivesafePublicOutputCeremonyCommand,
+    },
+}
+
+#[derive(Subcommand)]
+/// LiveSafe public-output ceremony commands.
+pub enum LivesafePublicOutputCeremonyCommand {
+    /// Build a redacted registration package from explicit operator inputs.
+    Prepare(LivesafePublicOutputCeremonyPrepareArgs),
+
+    /// Register a prepared package with a running EXOCHAIN node.
+    Register(LivesafePublicOutputCeremonyRegisterArgs),
+}
+
+#[derive(Args)]
+/// Build a LiveSafe public-output registration package.
+pub struct LivesafePublicOutputCeremonyPrepareArgs {
+    /// Issuer DID that signs the narrow public-output AVC.
+    #[arg(long)]
+    pub issuer_did: String,
+
+    /// Path to local issuer signing material JSON. The file must contain
+    /// `issuer_did` and `signing_secret_hex`; the secret is never accepted on
+    /// argv and is never written to the ceremony output.
+    #[arg(long)]
+    pub issuer_secret_input: PathBuf,
+
+    /// Optional evidence file existence proof. The file is not hashed by this
+    /// command; the canonical hash comes from the LiveSafe evidence contract.
+    #[arg(long)]
+    pub evidence_input: Option<PathBuf>,
+
+    /// Canonical LiveSafe evidence summary hash as `sha256:<64 lowercase hex>`.
+    #[arg(long)]
+    pub evidence_hash: String,
+
+    /// Explicit credential not-before HLC physical milliseconds.
+    #[arg(long)]
+    pub not_before_physical_ms: u64,
+
+    /// Explicit credential expiry HLC physical milliseconds.
+    #[arg(long)]
+    pub expires_at_physical_ms: u64,
+
+    /// Idempotency key for the later public-output authorization proof request.
+    #[arg(long)]
+    pub idempotency_key: String,
+
+    /// Output JSON path. Omit to print the redacted public package to stdout.
+    #[arg(long)]
+    pub output: Option<PathBuf>,
+}
+
+#[derive(Args)]
+#[command(group(
+    ArgGroup::new("admin_bearer_source")
+        .required(true)
+        .args(["admin_bearer_env", "admin_bearer_file"])
+))]
+/// Register a prepared LiveSafe public-output credential package.
+pub struct LivesafePublicOutputCeremonyRegisterArgs {
+    /// Prepared ceremony package JSON path.
+    #[arg(long)]
+    pub input: PathBuf,
+
+    /// EXOCHAIN node base URL or full `/api/v1/avc/issue` URL.
+    #[arg(long)]
+    pub node_url: String,
+
+    /// Environment variable containing the operator admin bearer at runtime.
+    #[arg(long)]
+    pub admin_bearer_env: Option<String>,
+
+    /// File containing the operator admin bearer at runtime.
+    #[arg(long)]
+    pub admin_bearer_file: Option<PathBuf>,
+
+    /// Output JSON path. Omit to print the sanitized registration response.
+    #[arg(long)]
+    pub output: Option<PathBuf>,
 }
 
 #[derive(Subcommand)]
@@ -606,6 +701,141 @@ mod tests {
         assert!(
             with_argv_secret.is_err(),
             "no CLI argument may carry 32-byte signing-secret material"
+        );
+    }
+
+    #[test]
+    fn livesafe_public_output_ceremony_cli_uses_secret_and_bearer_sources_not_inline_values() {
+        use clap::Parser;
+
+        let prepare_help = long_help_for(&["avc", "livesafe-public-output-ceremony", "prepare"]);
+        assert!(prepare_help.contains("sha256:<64 lowercase hex>"));
+
+        let evidence_hash = format!("sha256:{}", "ab".repeat(32));
+        let prepare_with_secret_file = Cli::try_parse_from([
+            "exochain",
+            "avc",
+            "livesafe-public-output-ceremony",
+            "prepare",
+            "--issuer-did",
+            "did:exo:livesafe-public-output-issuer",
+            "--issuer-secret-input",
+            "issuer.private.json",
+            "--evidence-input",
+            "livesafe-public-output-evidence.json",
+            "--evidence-hash",
+            &evidence_hash,
+            "--not-before-physical-ms",
+            "1000000",
+            "--expires-at-physical-ms",
+            "2000000",
+            "--idempotency-key",
+            "livesafe-public-output-ceremony-20260705",
+            "--output",
+            "livesafe-public-output-ceremony.json",
+        ]);
+        assert!(
+            prepare_with_secret_file.is_ok(),
+            "operator signing material must be supplied by file path"
+        );
+
+        let prepare_with_inline_secret = Cli::try_parse_from([
+            "exochain",
+            "avc",
+            "livesafe-public-output-ceremony",
+            "prepare",
+            "--issuer-did",
+            "did:exo:livesafe-public-output-issuer",
+            "--issuer-secret-hex",
+            &"42".repeat(32),
+            "--evidence-input",
+            "livesafe-public-output-evidence.json",
+            "--evidence-hash",
+            &evidence_hash,
+            "--not-before-physical-ms",
+            "1000000",
+            "--expires-at-physical-ms",
+            "2000000",
+            "--idempotency-key",
+            "livesafe-public-output-ceremony-20260705",
+            "--output",
+            "livesafe-public-output-ceremony.json",
+        ]);
+        assert!(
+            prepare_with_inline_secret.is_err(),
+            "issuer secret material must not be accepted on argv"
+        );
+
+        let register_with_env_bearer = Cli::try_parse_from([
+            "exochain",
+            "avc",
+            "livesafe-public-output-ceremony",
+            "register",
+            "--input",
+            "livesafe-public-output-ceremony.json",
+            "--node-url",
+            "https://node.example.invalid",
+            "--admin-bearer-env",
+            "EXOCHAIN_OPERATOR_AVC_ADMIN_BEARER",
+            "--output",
+            "livesafe-public-output-registration.json",
+        ]);
+        assert!(
+            register_with_env_bearer.is_ok(),
+            "registration must accept an explicit runtime env bearer source"
+        );
+
+        let register_with_file_bearer = Cli::try_parse_from([
+            "exochain",
+            "avc",
+            "livesafe-public-output-ceremony",
+            "register",
+            "--input",
+            "livesafe-public-output-ceremony.json",
+            "--node-url",
+            "https://node.example.invalid",
+            "--admin-bearer-file",
+            "operator-admin-bearer.txt",
+            "--output",
+            "livesafe-public-output-registration.json",
+        ]);
+        assert!(
+            register_with_file_bearer.is_ok(),
+            "registration must accept an explicit runtime file bearer source"
+        );
+
+        let register_without_bearer_source = Cli::try_parse_from([
+            "exochain",
+            "avc",
+            "livesafe-public-output-ceremony",
+            "register",
+            "--input",
+            "livesafe-public-output-ceremony.json",
+            "--node-url",
+            "https://node.example.invalid",
+            "--output",
+            "livesafe-public-output-registration.json",
+        ]);
+        assert!(
+            register_without_bearer_source.is_err(),
+            "registration must fail closed without a runtime bearer source"
+        );
+
+        let register_with_inline_bearer = Cli::try_parse_from([
+            "exochain",
+            "avc",
+            "livesafe-public-output-ceremony",
+            "register",
+            "--input",
+            "livesafe-public-output-ceremony.json",
+            "--node-url",
+            "https://node.example.invalid",
+            "--admin-bearer",
+            "super-secret-admin-token",
+        ]);
+        assert!(
+            register_with_inline_bearer.is_err(),
+            "admin bearer values must not be accepted on argv"
         );
     }
 

--- a/crates/exo-node/src/livesafe_public_output_ceremony_cli.rs
+++ b/crates/exo-node/src/livesafe_public_output_ceremony_cli.rs
@@ -1,0 +1,244 @@
+//! LiveSafe public-output AVC ceremony CLI implementation.
+
+use std::{fs, io::Write, path::Path};
+
+use exo_authority::permission::Permission;
+use exo_core::{Did, Timestamp, crypto::KeyPair};
+use serde::{Deserialize, Serialize};
+use zeroize::{Zeroize, Zeroizing};
+
+use crate::cli::{
+    AvcCommand, LivesafePublicOutputCeremonyCommand, LivesafePublicOutputCeremonyPrepareArgs,
+    LivesafePublicOutputCeremonyRegisterArgs,
+};
+
+#[derive(Deserialize, Zeroize)]
+#[zeroize(drop)]
+struct IssuerSigningMaterial {
+    #[zeroize(skip)]
+    issuer_did: Did,
+    signing_secret_hex: String,
+}
+
+#[derive(Serialize)]
+struct RegistrationCommandOutput {
+    credential_id: exo_core::Hash256,
+    authorization_request: exo_avc::LivesafePublicOutputAuthorizationRequestMaterial,
+    http_status: u16,
+    response_body: String,
+}
+
+pub async fn run_avc_command(command: AvcCommand) -> anyhow::Result<()> {
+    match command {
+        AvcCommand::LivesafePublicOutputCeremony { command } => match command {
+            LivesafePublicOutputCeremonyCommand::Prepare(args) => run_prepare(args),
+            LivesafePublicOutputCeremonyCommand::Register(args) => run_register(args).await,
+        },
+    }
+}
+
+fn run_prepare(args: LivesafePublicOutputCeremonyPrepareArgs) -> anyhow::Result<()> {
+    let issuer_did = Did::new(&args.issuer_did)
+        .map_err(|error| anyhow::anyhow!("invalid issuer DID: {error}"))?;
+    let signing_material = read_signing_material(&args.issuer_secret_input)?;
+    if signing_material.issuer_did != issuer_did {
+        anyhow::bail!(
+            "issuer signing material DID {} does not match --issuer-did {}",
+            signing_material.issuer_did,
+            issuer_did
+        );
+    }
+    let signing_secret = decode_fixed_32(signing_material.signing_secret_hex.as_str())?;
+    let issuer_keypair = KeyPair::from_secret_bytes(*signing_secret)
+        .map_err(|error| anyhow::anyhow!("issuer signing key is invalid: {error}"))?;
+    if let Some(path) = &args.evidence_input {
+        require_non_empty_evidence_file(path)?;
+    }
+    let evidence_hash = exo_avc::parse_livesafe_public_output_evidence_sha256(&args.evidence_hash)
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+    let input = exo_avc::LivesafePublicOutputCredentialCeremonyInput {
+        issuer_did,
+        issuer_authority_scope: livesafe_public_output_scope(),
+        credential_subject_did: Did::new(
+            exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_CREDENTIAL_SUBJECT_DID,
+        )
+        .map_err(|error| anyhow::anyhow!("invalid LiveSafe credential subject DID: {error}"))?,
+        public_subject: exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT.into(),
+        public_audience: exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE.into(),
+        allowed_claim_names: vec![
+            exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN.into(),
+        ],
+        evidence: exo_avc::LivesafePublicOutputCredentialCeremonyEvidence {
+            sha256_hash: evidence_hash,
+        },
+        not_before: Timestamp::new(args.not_before_physical_ms, 0),
+        expires_at: Timestamp::new(args.expires_at_physical_ms, 0),
+        idempotency_key: args.idempotency_key,
+    };
+    let output = exo_avc::issue_livesafe_public_output_credential_ceremony(input, |payload| {
+        issuer_keypair.sign(payload)
+    })
+    .map_err(|error| anyhow::anyhow!("{error}"))?;
+    write_output(args.output.as_deref(), &output)
+}
+
+async fn run_register(args: LivesafePublicOutputCeremonyRegisterArgs) -> anyhow::Result<()> {
+    let package: exo_avc::LivesafePublicOutputCredentialCeremonyOutput = read_json(&args.input)?;
+    let bearer = read_admin_bearer(&args)?;
+    let url = avc_issue_url(&args.node_url);
+    let response = reqwest::Client::new()
+        .post(url)
+        .bearer_auth(bearer.as_str())
+        .json(&package.issue_request)
+        .send()
+        .await?;
+    let status = response.status();
+    let body = response.text().await?;
+    let sanitized_body = redact_token(&body, bearer.as_str());
+    let output = RegistrationCommandOutput {
+        credential_id: package.credential_id,
+        authorization_request: package.authorization_request,
+        http_status: status.as_u16(),
+        response_body: sanitized_body,
+    };
+    if !status.is_success() {
+        anyhow::bail!(
+            "LiveSafe public-output credential registration failed: HTTP {}: {}",
+            output.http_status,
+            output.response_body
+        );
+    }
+    write_output(args.output.as_deref(), &output)
+}
+
+fn livesafe_public_output_scope() -> exo_avc::AuthorityScope {
+    exo_avc::AuthorityScope {
+        permissions: vec![Permission::Read],
+        tools: vec![exo_avc::LIVESAFE_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_DOMAIN.into()],
+        data_classes: vec![exo_avc::DataClass::Public],
+        counterparties: vec![],
+        jurisdictions: vec!["US".into()],
+    }
+}
+
+fn avc_issue_url(base: &str) -> String {
+    let trimmed = base.trim_end_matches('/');
+    if trimmed.ends_with("/api/v1/avc/issue") {
+        trimmed.to_owned()
+    } else {
+        format!("{trimmed}/api/v1/avc/issue")
+    }
+}
+
+fn read_admin_bearer(
+    args: &LivesafePublicOutputCeremonyRegisterArgs,
+) -> anyhow::Result<Zeroizing<String>> {
+    let token = match (&args.admin_bearer_env, &args.admin_bearer_file) {
+        (Some(env_name), None) => Zeroizing::new(std::env::var(env_name).map_err(|error| {
+            anyhow::anyhow!("admin bearer env var {env_name} is unavailable: {error}")
+        })?),
+        (None, Some(path)) => {
+            let raw = fs::read_to_string(path).map_err(|error| {
+                anyhow::anyhow!(
+                    "admin bearer file {} is unavailable: {error}",
+                    path.display()
+                )
+            })?;
+            Zeroizing::new(raw)
+        }
+        _ => anyhow::bail!("exactly one admin bearer source is required"),
+    };
+    let trimmed = token.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("admin bearer source is empty");
+    }
+    Ok(Zeroizing::new(trimmed.to_owned()))
+}
+
+fn require_non_empty_evidence_file(path: &Path) -> anyhow::Result<()> {
+    let metadata = fs::metadata(path).map_err(|error| {
+        anyhow::anyhow!(
+            "failed to inspect evidence input {}: {error}",
+            path.display()
+        )
+    })?;
+    if !metadata.is_file() {
+        anyhow::bail!("evidence input {} is not a file", path.display());
+    }
+    if metadata.len() == 0 {
+        anyhow::bail!("evidence input {} is empty", path.display());
+    }
+    Ok(())
+}
+
+fn redact_token(text: &str, token: &str) -> String {
+    text.replace(token, "[redacted-admin-bearer]")
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: &Path) -> anyhow::Result<T> {
+    let bytes = fs::read(path)
+        .map_err(|error| anyhow::anyhow!("failed to read {}: {error}", path.display()))?;
+    serde_json::from_slice(&bytes)
+        .map_err(|error| anyhow::anyhow!("failed to parse JSON {}: {error}", path.display()))
+}
+
+fn read_signing_material(path: &Path) -> anyhow::Result<IssuerSigningMaterial> {
+    let bytes = Zeroizing::new(
+        fs::read(path)
+            .map_err(|error| anyhow::anyhow!("failed to read {}: {error}", path.display()))?,
+    );
+    serde_json::from_slice(bytes.as_slice())
+        .map_err(|error| anyhow::anyhow!("failed to parse JSON {}: {error}", path.display()))
+}
+
+fn write_output<T: Serialize>(path: Option<&Path>, value: &T) -> anyhow::Result<()> {
+    match path {
+        Some(path) => write_json(path, value),
+        None => {
+            println!("{}", serde_json::to_string_pretty(value)?);
+            Ok(())
+        }
+    }
+}
+
+fn write_json<T: Serialize>(path: &Path, value: &T) -> anyhow::Result<()> {
+    let bytes = serde_json::to_vec_pretty(value)?;
+    write_json_bytes(path, bytes.as_slice())
+}
+
+#[cfg(unix)]
+fn write_json_bytes(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+    let mut file = fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .mode(0o600)
+        .open(path)?;
+    file.set_permissions(fs::Permissions::from_mode(0o600))?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    file.set_permissions(fs::Permissions::from_mode(0o600))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn write_json_bytes(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
+    let mut file = fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(path)?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn decode_fixed_32(value: &str) -> anyhow::Result<Zeroizing<[u8; 32]>> {
+    let bytes = Zeroizing::new(hex::decode(value.trim())?);
+    if bytes.len() != 32 {
+        anyhow::bail!("expected 32-byte signing secret");
+    }
+    let mut result = Zeroizing::new([0u8; 32]);
+    result.copy_from_slice(bytes.as_slice());
+    Ok(result)
+}

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -48,6 +48,7 @@ mod economy;
 mod exoforge;
 mod holons;
 mod identity;
+mod livesafe_public_output_ceremony_cli;
 mod mcp;
 mod metrics;
 mod network;
@@ -1407,6 +1408,9 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             }
         }
         Command::Genesis { command } => root_genesis_cli::run_genesis_command(command).await,
+        Command::Avc { command } => {
+            livesafe_public_output_ceremony_cli::run_avc_command(command).await
+        }
     }
 }
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -73,6 +73,7 @@ SPDX-License-Identifier: Apache-2.0
 - [AVC Root Trust Authority](avc/root-trust-authority.md) — Root trust bundle semantics and ceremony-binding policy.
 - [AVC Root Trust Install Runbook](avc/root-trust-installation.md) — Emitted-bundle verification and publish manifest process.
 - [AVC Root Trust Install Intake](avc/root-trust-install-intake.md) — Adjacent-surface trust-boundary and governance record.
+- [LiveSafe Public-Output AVC Ceremony](avc/livesafe-public-output-ceremony.md) — Exact operator command sequence for the narrow LiveSafe public trust-status credential package.
 
 ## Proofs
 

--- a/docs/avc/README.md
+++ b/docs/avc/README.md
@@ -64,6 +64,7 @@ flowchart TD
 | Operation | Function | Domain tag |
 |-----------|----------|------------|
 | Issue | `issue_avc(draft, sign)` | `exo.avc.credential.v1` |
+| LiveSafe public-output ceremony | `issue_livesafe_public_output_credential_ceremony(input, sign)` | `livesafe.public_output_credential_ceremony.v1` |
 | Validate | `validate_avc(request, registry)` | (read-only) |
 | Delegate | `delegate_avc(parent, child_draft, sign)` | `exo.avc.credential.v1` |
 | Revoke | `revoke_avc(id, revoker, reason, now, sign)` | `exo.avc.revocation.v1` |

--- a/docs/avc/livesafe-public-output-ceremony.md
+++ b/docs/avc/livesafe-public-output-ceremony.md
@@ -1,0 +1,112 @@
+# LiveSafe Public-Output AVC Ceremony
+
+This runbook creates the narrow AVC credential material that lets an operator
+register a LiveSafe public adapter-output authorization credential with an
+EXOCHAIN node. It does not configure Railway, mutate LiveSafe environments, or
+give LiveSafe the node admin bearer.
+
+## Classification
+
+- Touched runtime boundary: core runtime adapter.
+- Adjacent surface: LiveSafe public trust-status output.
+- Trust claim allowed: only after LiveSafe calls the EXOCHAIN node public-output
+  authorization route and receives a matching envelope for the configured
+  credential id and evidence hash.
+- Core state written by this ceremony: the operator registration command can
+  submit the signed AVC credential to `POST /api/v1/avc/issue`.
+- LiveSafe secret boundary: LiveSafe must receive only the scoped public-output
+  authorization bearer for its route after that bearer is available; it must not
+  receive the node admin bearer used by the operator registration command.
+- Test gate: `cargo test -p exochain-avc --test livesafe_public_output_ceremony_tests`
+  and `cargo test -p exochain-node livesafe_public_output_ceremony_cli_uses_secret_and_bearer_sources_not_inline_values`.
+
+## Inputs
+
+Issuer signing material is a local operator file, never an argv value:
+
+```json
+{
+  "issuer_did": "did:exo:livesafe-public-output-issuer",
+  "signing_secret_hex": "<64 lowercase hex from the operator key manager>"
+}
+```
+
+The evidence summary hash is produced by the separate LiveSafe canonical
+evidence-summary contract. This Rust ceremony consumes that already-canonical
+value as `sha256:<64 lowercase hex>` and does not hash evidence bytes itself.
+Keep issuer signing material and any evidence files outside the repository.
+
+## Prepare
+
+```bash
+cargo run -p exochain-node -- avc livesafe-public-output-ceremony prepare \
+  --issuer-did did:exo:livesafe-public-output-issuer \
+  --issuer-secret-input /secure/operator/livesafe-public-output-issuer.private.json \
+  --evidence-input /secure/operator/livesafe-public-output-evidence.json \
+  --evidence-hash sha256:<64-lowercase-hex> \
+  --not-before-physical-ms 1783296000000 \
+  --expires-at-physical-ms 1814832000000 \
+  --idempotency-key livesafe-public-output-ceremony-20260705 \
+  --output /secure/operator/livesafe-public-output-ceremony.json
+```
+
+The `--evidence-input` file is optional presence proof and is checked only for
+file existence and non-empty contents; it is not hashed by this command. The
+command refuses malformed evidence hashes, broad claim caps, non-LiveSafe
+subjects/audiences, and non-public-output issuer scope. The output includes the
+signed AVC credential, its credential id, the
+`/api/v1/avc/issue` request body, and the later public-output authorization
+request material. It does not include raw private keys, bearer tokens, or admin
+tokens, and it does not include raw evidence bytes.
+
+## Register
+
+Use an operator-only admin bearer source at execution time:
+
+```bash
+export EXOCHAIN_OPERATOR_AVC_ADMIN_BEARER="<operator-admin-bearer-from-secret-manager>"
+
+cargo run -p exochain-node -- avc livesafe-public-output-ceremony register \
+  --input /secure/operator/livesafe-public-output-ceremony.json \
+  --node-url "$EXOCHAIN_NODE_AVC_URL" \
+  --admin-bearer-env EXOCHAIN_OPERATOR_AVC_ADMIN_BEARER \
+  --output /secure/operator/livesafe-public-output-registration.json
+```
+
+File-based bearer source is also supported:
+
+```bash
+cargo run -p exochain-node -- avc livesafe-public-output-ceremony register \
+  --input /secure/operator/livesafe-public-output-ceremony.json \
+  --node-url "$EXOCHAIN_NODE_AVC_URL" \
+  --admin-bearer-file /secure/operator/exochain-node-admin-bearer.txt \
+  --output /secure/operator/livesafe-public-output-registration.json
+```
+
+The register command posts only to `/api/v1/avc/issue`. It redacts the bearer
+from response text before writing output and refuses inline bearer argv flags.
+
+## Operator Handoff Values
+
+After registration succeeds, use the prepared package values for the later
+LiveSafe runtime configuration step:
+
+- `authorization_request.credential_id`
+- `authorization_request.evidence_hash`
+- `authorization_request.subject`
+- `authorization_request.audience`
+- `authorization_request.expires_at`
+
+The LiveSafe app still remains fail-closed until its own runtime has
+`EXOCHAIN_NODE_AVC_URL`,
+`EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_BEARER`,
+`EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_CREDENTIAL_ID`, and
+`EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_EVIDENCE_HASH` configured and the node returns a
+matching authorization envelope.
+
+## Disablement
+
+To disable this public-output trust path, remove the LiveSafe public-output
+runtime environment values or revoke the registered credential through the
+existing AVC revocation flow. Do not rotate or expose the node admin bearer to
+LiveSafe; it is operator-only registration authority.

--- a/docs/avc/livesafe-public-output-ceremony.md
+++ b/docs/avc/livesafe-public-output-ceremony.md
@@ -97,6 +97,18 @@ LiveSafe runtime configuration step:
 - `authorization_request.audience`
 - `authorization_request.expires_at`
 
+`authorization_request.credential_id` and
+`authorization_request.evidence_hash` are operator handoff strings already
+serialized as `sha256:<64 lowercase hex>`. Give LiveSafe those exact prefixed
+values, not raw `Hash256` JSON arrays or plain bytes:
+
+```bash
+export LIVESAFE_PUBLIC_OUTPUT_CEREMONY=/secure/operator/livesafe-public-output-ceremony.json
+
+export EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_CREDENTIAL_ID="$(jq -r '.authorization_request.credential_id' "$LIVESAFE_PUBLIC_OUTPUT_CEREMONY")"
+export EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_EVIDENCE_HASH="$(jq -r '.authorization_request.evidence_hash' "$LIVESAFE_PUBLIC_OUTPUT_CEREMONY")"
+```
+
 The LiveSafe app still remains fail-closed until its own runtime has
 `EXOCHAIN_NODE_AVC_URL`,
 `EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_BEARER`,


### PR DESCRIPTION
## Summary

Adds the real LiveSafe public-output AVC ceremony material:

- a deterministic `exo-avc` ceremony API for issuing the narrow LiveSafe public adapter-output credential package;
- an `exochain avc livesafe-public-output-ceremony` operator CLI with `prepare` and `register` subcommands;
- execution documentation for preparing/registering the material without configuring Railway or mutating production by default.

This branch is rebased on current `origin/main` including PR #776 (`5f719793`). It does not include or overwrite the PR #777 scoped-bearer lane, and it does not edit `livesafe/`; the canonical LiveSafe evidence-summary contract is owned separately.

## Path Classification

- `crates/exo-avc/src/livesafe_public_output_ceremony.rs` — core runtime adapter ceremony logic.
- `crates/exo-avc/src/lib.rs` — core runtime adapter exports/signing-domain registration.
- `crates/exo-avc/tests/livesafe_public_output_ceremony_tests.rs` — core runtime adapter regression tests.
- `crates/exo-node/src/cli.rs` — core runtime adapter/operator CLI surface.
- `crates/exo-node/src/livesafe_public_output_ceremony_cli.rs` — core runtime adapter/operator CLI implementation.
- `crates/exo-node/src/main.rs` — core runtime adapter CLI dispatch wiring.
- `docs/avc/livesafe-public-output-ceremony.md` — execution documentation for the exact ceremony.
- `docs/avc/README.md` and `docs/INDEX.md` — documentation indexes.

No adjacent LiveSafe app code, imported evidence, third-party/vendor code, Railway config, or production environment values changed.

## RED Evidence

Initial RED before implementation:

```bash
cargo test -p exochain-node livesafe_public_output_ceremony_cli_uses_secret_and_bearer_sources_not_inline_values
```

Expected failure: CLI had no `avc livesafe-public-output-ceremony` command; parser test failed because operator signing material could not be supplied by file path.

```bash
cargo test -p exochain-avc --test livesafe_public_output_ceremony_tests
```

Expected failure: ceremony module/types/functions/constants were missing.

Review-fix RED before the SHA-256 correction:

```bash
cargo test -p exochain-avc --test livesafe_public_output_ceremony_tests
```

Expected failure: `parse_livesafe_public_output_evidence_sha256` and `sha256_hash` evidence fields did not exist; the old evidence type still carried `expected_hash/material`.

## GREEN Evidence

Post-fix local proof:

```bash
cargo test -p exochain-avc --test livesafe_public_output_ceremony_tests
cargo test -p exochain-node livesafe_public_output_ceremony_cli_uses_secret_and_bearer_sources_not_inline_values
cargo test -p exochain-avc
cargo +nightly fmt --all -- --check
git diff --check
cargo clippy -p exochain-avc --all-targets -- -D warnings
cargo clippy -p exochain-node --all-targets -- -D warnings
```

Additional non-network CLI smoke passed with temp-only throwaway issuer/evidence files and a fixed canonical evidence summary value:

```bash
cargo run -p exochain-node --quiet -- avc livesafe-public-output-ceremony prepare \
  --issuer-did did:exo:livesafe-public-output-issuer \
  --issuer-secret-input "$issuer" \
  --evidence-input "$evidence" \
  --evidence-hash sha256:00112233445566778899aabbccddeeffffeeddccbbaa99887766554433221100 \
  --not-before-physical-ms 1783296000000 \
  --expires-at-physical-ms 1814832000000 \
  --idempotency-key livesafe-public-output-ceremony-20260705 \
  --output "$output"
```

The smoke verified the package contained `credential_id`, `authorization_request`, and evidence-hash bytes, and did not contain the throwaway signing seed, admin bearer names, bearer text, private/secret key labels, or raw evidence JSON fields.

## Evidence Hash Contract

The Rust ceremony consumes an already-canonical LiveSafe evidence summary hash as exactly `sha256:<64 lowercase hex>`. It propagates the 32 parsed bytes into `authorization_request.evidence_hash` and the signed AVC action path. It rejects bare hex, malformed prefixes, uppercase input, and non-SHA-256 algorithm prefixes. It does not compute the canonical LiveSafe evidence summary itself.

## No-Secret Assertion

- No production signing material, bearer token, or Railway configuration is committed or printed.
- Prepare consumes issuer signing material from an operator file only; no inline signing-secret argv is accepted.
- Register requires exactly one admin bearer source at execution time via `--admin-bearer-env` or `--admin-bearer-file`; no inline admin bearer argv is accepted.
- The admin bearer is operator-only registration authority. LiveSafe must not receive the node admin bearer.
- CLI output omits raw evidence bytes and never serializes raw private keys or bearer/admin tokens.
- The register command posts only to `/api/v1/avc/issue` and redacts the bearer from response text before writing output/errors.

## Operator Ceremony Steps

1. Keep issuer signing material outside the repo:

```json
{
  "issuer_did": "did:exo:livesafe-public-output-issuer",
  "signing_secret_hex": "<64 lowercase hex from the operator key manager>"
}
```

2. Obtain the canonical LiveSafe evidence summary from the separate LiveSafe evidence contract as `sha256:<64 lowercase hex>`.

3. Prepare the deterministic package:

```bash
cargo run -p exochain-node -- avc livesafe-public-output-ceremony prepare \
  --issuer-did did:exo:livesafe-public-output-issuer \
  --issuer-secret-input /secure/operator/livesafe-public-output-issuer.private.json \
  --evidence-input /secure/operator/livesafe-public-output-evidence.json \
  --evidence-hash sha256:<64-lowercase-hex> \
  --not-before-physical-ms 1783296000000 \
  --expires-at-physical-ms 1814832000000 \
  --idempotency-key livesafe-public-output-ceremony-20260705 \
  --output /secure/operator/livesafe-public-output-ceremony.json
```

`--evidence-input` is optional presence proof. When supplied, it is checked only for file existence and non-empty contents.

4. Register only when the operator intentionally supplies an admin bearer source at execution time:

```bash
cargo run -p exochain-node -- avc livesafe-public-output-ceremony register \
  --input /secure/operator/livesafe-public-output-ceremony.json \
  --node-url "$EXOCHAIN_NODE_AVC_URL" \
  --admin-bearer-env EXOCHAIN_OPERATOR_AVC_ADMIN_BEARER \
  --output /secure/operator/livesafe-public-output-registration.json
```

File bearer source is also supported with `--admin-bearer-file /secure/operator/exochain-node-admin-bearer.txt`.

5. Handoff only the public-output runtime values after registration: `authorization_request.credential_id`, `authorization_request.evidence_hash`, subject, audience, and expiry. Do not hand off the node admin bearer to LiveSafe.

## Runtime Boundary

This PR does not configure Railway, mutate production, or claim LiveSafe runtime launch. LiveSafe remains fail-closed until its runtime has `EXOCHAIN_NODE_AVC_URL`, `EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_BEARER`, `EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_CREDENTIAL_ID`, and `EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_EVIDENCE_HASH` configured and the node returns the matching authorization envelope.
