### PR TITLE
Add canonical LiveSafe public-output evidence hash

### DIFF
--- a/livesafe/docs/TEST_PLAN.md
+++ b/livesafe/docs/TEST_PLAN.md
@@ -923,6 +923,12 @@ The gate runs:
   root-trust bundle id, issuer DID, verifier commit, verified timestamp, and
   non-blocking observations while keeping `public_claims_allowed: false`
   unless LiveSafe adapter proof also passes.
+- The public-output evidence summary hash contract validates sorted-key
+  canonical JSON determinism, hash changes for required public evidence field
+  changes, fail-closed rejection for missing or false production, EXOCHAIN
+  connectivity, runtime-adapter, or pre-authorization public-claim evidence,
+  explicit timestamp freshness without system time, secret/sensitive material
+  rejection, and the one-command non-secret machine-readable operator output.
 - The public EXOCHAIN copy boundary validates that customer-facing UI and
   public metadata do not claim active EXOCHAIN trust, bailment, audit,
   sovereignty, on-chain custody, active consent anchoring, or immutable

--- a/livesafe/docs/context/LIVESAFE_PRODUCTION_TRUST_ACTIVATION_GATES.md
+++ b/livesafe/docs/context/LIVESAFE_PRODUCTION_TRUST_ACTIVATION_GATES.md
@@ -9,12 +9,16 @@
 - `docs/context/LIVESAFE_TRUST_SIGNAL_VISUAL_LANGUAGE.md`
 - `config/exochain-production-trust.json`
 - `server/utils/exochain-production-trust-evidence.js`
+- `server/utils/public-adapter-output-authorization.js`
 - `server/utils/trust-status.js`
+- `scripts/exochain-public-output-evidence-hash.mjs`
 - `src/exochain-root-trust-state.ts`
 - `src/exochain_adapter_activation.rs`
 - `src/genesis-trust.ts`
 - `src/trust-signal.ts`
 - `tests/exochain-production-trust-evidence.test.ts`
+- `tests/public-output-evidence-summary.test.ts`
+- `tests/public-adapter-output-authorization.test.ts`
 - `tests/exochain-root-trust-state.test.ts`
 - `tests/public-exochain-copy-boundary.test.ts`
 - `tests/exochain_adapter_activation.rs`
@@ -43,6 +47,14 @@ signaling.
 That means LiveSafe may describe the requirement for future verification, but it
 must not present current customer-facing output as verified enforcement,
 verified custody proof, verified consent proof, or verified root-backed trust.
+
+The canonical public-output evidence summary hash is ceremony input only. It is
+the deterministic `sha256:<hex>` material that AVC public adapter-output
+authorization can bind to; it does not itself authorize public claims. The
+summary builder requires explicit `asOf` input, verified EXOCHAIN production
+evidence, verified EXOCHAIN connectivity, verified LiveSafe runtime-adapter
+metadata, `public_claims_allowed: false` before authorization, and a
+non-secret public metadata summary.
 
 The controlling ladder is:
 
@@ -79,6 +91,14 @@ Current repo coverage establishes only the inactive, fail-closed posture:
   source-backed EXOCHAIN production evidence bundle while carrying
   `production_sentinel_quorum_health_below_bft_minimum` as a non-blocking
   observation.
+- `server/utils/exochain-production-trust-evidence.js`,
+  `scripts/exochain-public-output-evidence-hash.mjs`, and
+  `tests/public-output-evidence-summary.test.ts` define the canonical
+  public-output evidence summary contract. The hash is SHA-256 over sorted-key
+  canonical JSON, changes when required public evidence changes, rejects stale
+  or malformed explicit timestamps, rejects missing or false production,
+  EXOCHAIN connectivity, runtime-adapter, or pre-authorization public-claim
+  evidence, and refuses secret or sensitive LiveSafe material.
 - `server/utils/trust-status.js` and `tests/trust-status.test.ts` expose
   `exochain_production_evidence_state`, production health/readiness, root
   bundle, issuer, verifier, and observation fields while keeping
@@ -111,6 +131,7 @@ Current repo coverage establishes only the inactive, fail-closed posture:
 | Contradicted path | tests prove denial when adapter/runtime evidence contradicts permit state |
 | Sensitive data boundary | tests prove raw sensitive records stay off-chain and out of anchors |
 | Receipt boundary | tests prove receipts contain commitments, references, policy ids, and hashes only |
+| Canonical public-output evidence hash | `npm run --silent evidence:public-output-hash -- --as-of <ISO-UTC>` emits one non-secret JSON record with `evidence_hash`, `algorithm`, `subject`, `audience`, `generated_from`, state, and reasons |
 | External signal | rendered AVC badge, lock or shield symbol, color, glow, text, and machine-readable state |
 
 ## Current State
@@ -120,6 +141,7 @@ Current repo coverage establishes only the inactive, fail-closed posture:
 | EXOCHAIN production/root evidence verified | `exochain_root_evidence_verified` | production `/health` and `/ready` returned `ok`; root-trust bundle id `7d9954a797ef244c15ad1b733cf77598125ccef0f812a404137e827c192d6a58` verified at EXOCHAIN commit `379a45e1d9ab092ecd446d095a7b524570530efd`; read-only source evidence shows `crates/exo-root`, 7-of-13 ceremony policy, FROST DKG, root bundle verification, and root signature verification |
 | LiveSafe adapter verified | inactive | no verified LiveSafe adapter path is wired |
 | Public trust claims allowed | inactive | EXOCHAIN production evidence is verified, but LiveSafe adapter proof is still missing |
+| Public-output evidence hash | ceremony evidence only | deterministic summary hash can be generated for AVC binding; the hash does not allow public claims without separate proof-bearing public adapter-output authorization |
 | Production sentinel observation | non-blocking observation | `QuorumHealth` reports one validator, below BFT minimum; `Liveness` and `ReceiptIntegrity` are the required healthy sentinels for this LiveSafe production-evidence gate |
 | Medical jacket custody proof | inactive | custody receipt adapter is not wired |
 | Consent and revocation proof | inactive | consent adapter is not wired |
@@ -149,7 +171,8 @@ Until that adapter proof exists, public trust claims remain inactive.
 - Disablement path: keep trust-bearing output on the inactive display state or
   remove the trust-bearing output from public surfaces. To rollback this slice,
   revert `config/exochain-production-trust.json`,
-  `server/utils/exochain-production-trust-evidence.js`, the trust-status
+  `server/utils/exochain-production-trust-evidence.js`,
+  `scripts/exochain-public-output-evidence-hash.mjs`, the trust-status
   production-evidence fields, and the public-copy wording changes; this returns
   LiveSafe to production-evidence-blocked status without enabling adapter
-  claims.
+  claims or public-output hash generation.

--- a/livesafe/docs/context/LIVESAFE_TO_EXOCHAIN_INTEGRATION_MAP.md
+++ b/livesafe/docs/context/LIVESAFE_TO_EXOCHAIN_INTEGRATION_MAP.md
@@ -15,12 +15,15 @@
 - `fly.toml`
 - `server/index.js`
 - `server/utils/exochain-production-trust-evidence.js`
+- `server/utils/public-adapter-output-authorization.js`
 - `server/utils/livesafe-exochain-adapter.js`
 - `server/utils/exochain-client.js`
+- `scripts/exochain-public-output-evidence-hash.mjs`
 - `src/exochain-root-trust-state.ts`
 - `src/exochain-boundary.ts`
 - `src/exochain_adapter_activation.rs`
 - `tests/exochain-production-trust-evidence.test.ts`
+- `tests/public-output-evidence-summary.test.ts`
 - `tests/public-exochain-copy-boundary.test.ts`
 - `tests/exochain-root-trust-state.test.ts`
 - Read-only EXOCHAIN commit `3fb81ea457e727c010052beafcfe49735ebd0546`.
@@ -90,6 +93,10 @@ The current integration state is fail-closed and incomplete:
   classification `exochain_root_evidence_verified`.
 - Current EXOCHAIN production evidence verifies the AVC root-trust bundle, but
   this does not authorize LiveSafe public trust claims without adapter proof.
+- The canonical public-output evidence summary hash is deterministic AVC
+  ceremony input for public adapter-output authorization. It is generated from
+  non-secret public metadata only and does not authorize public claims by
+  itself.
 - The runtime reports `exochain_connected: false` in current production health
   evidence.
 - The repo contains EXOCHAIN-facing client code, a fail-closed runtime adapter
@@ -106,6 +113,7 @@ The current integration state is fail-closed and incomplete:
 | Health route | `GET /api/health` in `server/index.js`; `server/utils/health-status.js`; `server/utils/exochain-connectivity-status.js` | Returns app, database, and EXOCHAIN connection status | active runtime, reports `exochain_connected: false` in live production evidence, skips raw EXOCHAIN probes while the adapter remains unverified, and redacts raw database error text from the public failure payload |
 | Trust-status route | `GET /api/trust/status` in `server/index.js`; `server/utils/trust-status.js` | Returns explicit inactive trust-state metadata for API consumers | active runtime, live production evidence reports `state: not-verified`, `machine_state: not_verified`, and `public_claims_allowed: false` |
 | EXOCHAIN production evidence evaluator | `config/exochain-production-trust.json`; `server/utils/exochain-production-trust-evidence.js` | Evaluates source-backed EXOCHAIN production health, readiness, root-trust bundle verification, and sentinel observations | active repo contract, reports verified EXOCHAIN production evidence while keeping public LiveSafe claims gated by adapter proof |
+| Public-output evidence summary hash | `server/utils/exochain-production-trust-evidence.js`; `scripts/exochain-public-output-evidence-hash.mjs` | Builds and hashes sorted-key canonical public evidence metadata for AVC public adapter-output binding | adjacent operator contract; emits non-secret `sha256:<hex>` evidence only and keeps `public_claims_allowed: false` until separate proof-bearing authorization passes |
 | Runtime adapter facade | `server/utils/livesafe-exochain-adapter.js` | Fail-closed LiveSafe boundary around EXOCHAIN-facing runtime calls | active in runtime, but still inactive because `runtimeAdapterStatus` remains `not-wired` |
 | EXOCHAIN client | `server/utils/exochain-client.js` | GraphQL client for identity, audit, scan, consent, and P.A.C.E. calls | subordinate transport only; now wrapped by the runtime adapter facade and fails closed on malformed direct-client audit inputs, identity/P.A.C.E. subscriber DIDs, scan/consent identifiers, missing consent input objects, and optional authority fields |
 | Boundary evaluator | `src/exochain-boundary.ts` | Denies trust claims and core access without a verified adapter | implemented policy gate |

--- a/livesafe/package.json
+++ b/livesafe/package.json
@@ -13,6 +13,7 @@
     "rust:test": "cargo test",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "evidence:public-output-hash": "node scripts/exochain-public-output-evidence-hash.mjs",
     "quality": "npm run context:lint && npm run typecheck && npm test && npm run rust:fmt && npm run rust:clippy && npm run rust:test"
   },
   "engines": {

--- a/livesafe/scripts/exochain-public-output-evidence-hash.mjs
+++ b/livesafe/scripts/exochain-public-output-evidence-hash.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+const {
+  DEFAULT_PUBLIC_OUTPUT_EVIDENCE_GENERATED_FROM,
+  DEFAULT_PUBLIC_OUTPUT_EVIDENCE_MAX_AGE_MS,
+  PUBLIC_OUTPUT_EVIDENCE_HASH_ALGORITHM,
+  PublicOutputEvidenceSummaryError,
+  buildPublicOutputEvidenceHashRecord,
+  evaluateExochainProductionTrustEvidence,
+  exochainProductionTrustConfig,
+} = require("../server/utils/exochain-production-trust-evidence.js");
+const {
+  PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+  PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+} = require("../server/utils/public-adapter-output-authorization.js");
+const {
+  runtimeExochainAdapter,
+} = require("../server/utils/livesafe-exochain-adapter.js");
+
+function parseArgs(argv) {
+  const options = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--as-of") {
+      options.asOf = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--max-age-ms") {
+      options.maxEvidenceAgeMs = Number(argv[index + 1]);
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--pretty") {
+      options.pretty = true;
+      continue;
+    }
+
+    if (arg === "--help") {
+      options.help = true;
+      continue;
+    }
+
+    throw new PublicOutputEvidenceSummaryError([
+      `Unsupported argument: ${arg}`,
+    ]);
+  }
+
+  return options;
+}
+
+function printUsage() {
+  process.stdout.write(
+    [
+      "Usage: npm run evidence:public-output-hash -- --as-of ISO_UTC [--max-age-ms INTEGER] [--pretty]",
+      "",
+      "Emits a non-secret JSON record with the canonical LiveSafe public-output evidence hash.",
+    ].join("\n"),
+  );
+  process.stdout.write("\n");
+}
+
+function serialize(record, pretty) {
+  return JSON.stringify(record, null, pretty ? 2 : 0);
+}
+
+function blockedRecord(reasons) {
+  return {
+    evidence_hash: null,
+    algorithm: PUBLIC_OUTPUT_EVIDENCE_HASH_ALGORITHM,
+    subject: PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+    audience: PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+    generated_from: DEFAULT_PUBLIC_OUTPUT_EVIDENCE_GENERATED_FROM,
+    state: "blocked",
+    reasons,
+    public_claims_allowed: false,
+  };
+}
+
+function reasonsFor(error) {
+  if (
+    error instanceof PublicOutputEvidenceSummaryError &&
+    Array.isArray(error.reasons)
+  ) {
+    return error.reasons;
+  }
+
+  return ["Public output evidence hash generation failed."];
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  if (options.help) {
+    printUsage();
+    return 0;
+  }
+
+  const productionTrustEvidence = evaluateExochainProductionTrustEvidence({
+    config: exochainProductionTrustConfig,
+  });
+  const runtimeStatus = runtimeExochainAdapter.getRuntimeStatus();
+  const record = buildPublicOutputEvidenceHashRecord({
+    subject: PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+    audience: PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+    asOf: options.asOf,
+    maxEvidenceAgeMs:
+      options.maxEvidenceAgeMs ||
+      DEFAULT_PUBLIC_OUTPUT_EVIDENCE_MAX_AGE_MS,
+    exochainConnected:
+      productionTrustEvidence.production_health_verified === true &&
+      productionTrustEvidence.production_ready_verified === true,
+    productionTrustEvidence,
+    runtimeStatus,
+    generatedFrom: DEFAULT_PUBLIC_OUTPUT_EVIDENCE_GENERATED_FROM,
+  });
+
+  process.stdout.write(serialize(record, options.pretty));
+  process.stdout.write("\n");
+  return 0;
+}
+
+try {
+  process.exitCode = main();
+} catch (error) {
+  process.stdout.write(serialize(blockedRecord(reasonsFor(error)), false));
+  process.stdout.write("\n");
+  process.exitCode = 1;
+}

--- a/livesafe/server/utils/exochain-production-trust-evidence.js
+++ b/livesafe/server/utils/exochain-production-trust-evidence.js
@@ -1,16 +1,106 @@
 "use strict";
 
+const crypto = require("node:crypto");
+
 const exochainProductionTrustConfig = require("../../config/exochain-production-trust.json");
+const {
+  ALLOWED_PUBLIC_ADAPTER_OUTPUT_CLAIMS,
+  PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+  PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+} = require("./public-adapter-output-authorization");
 
 const DID_PATTERN = /^did:exo:[A-Za-z0-9._:-]+$/;
 const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/;
+const GIT_COMMIT_HEX_PATTERN = /^[a-f0-9]{40}$/;
+const ISO_TIMESTAMP_PATTERN =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
+const PUBLIC_OUTPUT_EVIDENCE_SCHEMA =
+  "livesafe.public_output_evidence_summary.v1";
+const PUBLIC_OUTPUT_EVIDENCE_HASH_ALGORITHM =
+  "sha256.canonical_json.sorted_keys.v1";
+const PUBLIC_OUTPUT_EVIDENCE_READY_STATE =
+  "ready_for_avc_ceremony_binding";
+const DEFAULT_PUBLIC_OUTPUT_EVIDENCE_MAX_AGE_MS = 10 * 60 * 1000;
+const DEFAULT_PUBLIC_OUTPUT_EVIDENCE_GENERATED_FROM = [
+  "config/exochain-production-trust.json",
+  "server/utils/exochain-production-trust-evidence.js",
+  "server/utils/livesafe-exochain-adapter.js",
+  "server/utils/public-adapter-output-authorization.js",
+];
+const REQUIRED_PUBLIC_ADAPTER_OUTPUT_OPERATION =
+  "getPublicAdapterOutputAuthorization";
+const SENSITIVE_SUMMARY_KEY_FRAGMENTS = [
+  "admin_token",
+  "authorization_header",
+  "bearer",
+  "consent_record",
+  "custody_record",
+  "database_url",
+  "db_url",
+  "emergency_contact",
+  "legal_record",
+  "location",
+  "medical_record",
+  "patient",
+  "phi",
+  "pii",
+  "private_key",
+  "raw_authority_chain",
+  "raw_credential",
+  "raw_sensitive_payload",
+  "scan_payload",
+  "scan_record",
+  "secret",
+  "sensitive_livesafe_payload",
+  "trustee",
+  "vault",
+];
+const SENSITIVE_SUMMARY_VALUE_PATTERNS = [
+  /bearer\s+[A-Za-z0-9._~+/-]+=*/i,
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+  /\b(?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis):\/\//i,
+  /\bsk-[A-Za-z0-9_-]{8,}/,
+  /admin-token/i,
+];
+
+class PublicOutputEvidenceSummaryError extends Error {
+  constructor(reasons) {
+    super(reasons.join(" "));
+    this.name = "PublicOutputEvidenceSummaryError";
+    this.reasons = reasons;
+  }
+}
 
 function hasOkStatus(payload) {
   return Boolean(payload) && payload.status === "ok";
 }
 
+function isObjectRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
 function isHttpsUrl(value) {
   return typeof value === "string" && value.startsWith("https://");
+}
+
+function parseExplicitIsoTimestamp(value) {
+  if (!isNonEmptyString(value) || !ISO_TIMESTAMP_PATTERN.test(value)) {
+    return null;
+  }
+
+  const milliseconds = Date.parse(value);
+  if (Number.isNaN(milliseconds)) {
+    return null;
+  }
+
+  return {
+    milliseconds,
+    iso: new Date(milliseconds).toISOString(),
+  };
 }
 
 function hasSevenOfThirteenSignerPolicy(bundle) {
@@ -156,8 +246,379 @@ function evaluateExochainProductionTrustEvidence({
 const exochainProductionTrustEvidence =
   evaluateExochainProductionTrustEvidence();
 
+function pushPublicOutputReason(reasons, reason) {
+  if (!reasons.includes(reason)) {
+    reasons.push(reason);
+  }
+}
+
+function validateGeneratedFrom(generatedFrom, reasons) {
+  if (!Array.isArray(generatedFrom) || generatedFrom.length === 0) {
+    reasons.push("Public output evidence generated_from must be non-empty.");
+    return;
+  }
+
+  for (const entry of generatedFrom) {
+    if (!isNonEmptyString(entry)) {
+      pushPublicOutputReason(
+        reasons,
+        "Public output evidence generated_from must contain only non-empty strings.",
+      );
+    }
+  }
+}
+
+function validateProductionTrustEvidence(productionTrustEvidence, reasons) {
+  if (!isObjectRecord(productionTrustEvidence)) {
+    reasons.push("EXOCHAIN production evidence is required.");
+    return;
+  }
+
+  if (productionTrustEvidence.evidence_state !== "verified") {
+    reasons.push("EXOCHAIN production evidence must be verified.");
+  }
+
+  if (productionTrustEvidence.production_health_verified !== true) {
+    reasons.push("EXOCHAIN production health evidence must be verified.");
+  }
+
+  if (productionTrustEvidence.production_ready_verified !== true) {
+    reasons.push("EXOCHAIN production readiness evidence must be verified.");
+  }
+
+  if (productionTrustEvidence.root_trust_bundle_verified !== true) {
+    reasons.push("EXOCHAIN root trust bundle evidence must be verified.");
+  }
+
+  if (!isHttpsUrl(productionTrustEvidence.production_base_url)) {
+    reasons.push("EXOCHAIN production evidence base URL must be HTTPS.");
+  }
+
+  if (!SHA256_HEX_PATTERN.test(productionTrustEvidence.root_trust_bundle_id || "")) {
+    reasons.push("EXOCHAIN root trust bundle id is missing or malformed.");
+  }
+
+  if (productionTrustEvidence.root_trust_ceremony_id !== "avc-exo-ceremony-2026") {
+    reasons.push("EXOCHAIN root trust ceremony id is invalid.");
+  }
+
+  if (!DID_PATTERN.test(productionTrustEvidence.root_trust_issuer_did || "")) {
+    reasons.push("EXOCHAIN root trust issuer DID is missing or malformed.");
+  }
+
+  if (!GIT_COMMIT_HEX_PATTERN.test(productionTrustEvidence.verifier_commit || "")) {
+    reasons.push("EXOCHAIN root trust verifier commit is missing or malformed.");
+  }
+}
+
+function validateRuntimeStatus(runtimeStatus, reasons) {
+  if (!isObjectRecord(runtimeStatus)) {
+    reasons.push("LiveSafe runtime adapter evidence is required.");
+    return;
+  }
+
+  if (runtimeStatus.adapter_state !== "verified") {
+    reasons.push("LiveSafe runtime adapter evidence must be verified.");
+  }
+
+  if (runtimeStatus.public_claims_allowed !== false) {
+    reasons.push(
+      "LiveSafe public claims must not already be allowed before AVC authorization.",
+    );
+  }
+
+  if (runtimeStatus.can_read_exochain_core_state !== true) {
+    reasons.push("LiveSafe runtime adapter read evidence must be verified.");
+  }
+
+  if (runtimeStatus.can_write_exochain_core_state !== true) {
+    reasons.push("LiveSafe runtime adapter write evidence must be verified.");
+  }
+
+  if (
+    !Array.isArray(runtimeStatus.wrapped_operations) ||
+    !runtimeStatus.wrapped_operations.includes(
+      REQUIRED_PUBLIC_ADAPTER_OUTPUT_OPERATION,
+    )
+  ) {
+    reasons.push(
+      "LiveSafe runtime adapter must include public adapter-output authorization evidence.",
+    );
+  }
+
+  if (!isNonEmptyString(runtimeStatus.disablement_path)) {
+    reasons.push("LiveSafe runtime adapter disablement path is required.");
+  }
+}
+
+function resolvePublicOutputTimestamps({
+  asOf,
+  productionTrustEvidence,
+  maxEvidenceAgeMs,
+  reasons,
+}) {
+  const parsedAsOf = parseExplicitIsoTimestamp(asOf);
+  const parsedEvidence = parseExplicitIsoTimestamp(
+    productionTrustEvidence?.verified_at,
+  );
+
+  if (!parsedAsOf || !parsedEvidence) {
+    reasons.push("Public output evidence timestamp is malformed.");
+    return {
+      asOfIso: null,
+      evidenceIso: null,
+    };
+  }
+
+  if (parsedEvidence.milliseconds > parsedAsOf.milliseconds) {
+    reasons.push("Public output evidence timestamp is after as_of.");
+  }
+
+  if (parsedAsOf.milliseconds - parsedEvidence.milliseconds > maxEvidenceAgeMs) {
+    reasons.push("Public output evidence timestamp is stale.");
+  }
+
+  return {
+    asOfIso: parsedAsOf.iso,
+    evidenceIso: parsedEvidence.iso,
+  };
+}
+
+function normalizeStringArray(value) {
+  return Array.isArray(value)
+    ? value.filter(isNonEmptyString).map((entry) => entry.trim())
+    : [];
+}
+
+function sensitiveSummaryKey(key) {
+  const normalized = String(key).toLowerCase();
+  return SENSITIVE_SUMMARY_KEY_FRAGMENTS.some((fragment) =>
+    normalized.includes(fragment),
+  );
+}
+
+function sensitiveSummaryString(value) {
+  return SENSITIVE_SUMMARY_VALUE_PATTERNS.some((pattern) => pattern.test(value));
+}
+
+function assertNoSensitiveSummaryMaterial(value) {
+  function visit(candidate) {
+    if (typeof candidate === "string") {
+      if (sensitiveSummaryString(candidate)) {
+        throw new PublicOutputEvidenceSummaryError([
+          "Public output evidence summary must not contain secret or sensitive material.",
+        ]);
+      }
+      return;
+    }
+
+    if (Array.isArray(candidate)) {
+      for (const entry of candidate) {
+        visit(entry);
+      }
+      return;
+    }
+
+    if (!isObjectRecord(candidate)) {
+      return;
+    }
+
+    for (const [key, nestedValue] of Object.entries(candidate)) {
+      if (sensitiveSummaryKey(key)) {
+        throw new PublicOutputEvidenceSummaryError([
+          "Public output evidence summary must not contain secret or sensitive material.",
+        ]);
+      }
+      visit(nestedValue);
+    }
+  }
+
+  visit(value);
+}
+
+function canonicalizePublicOutputEvidenceSummary(value) {
+  if (value === null) {
+    return "null";
+  }
+
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value)) {
+      throw new PublicOutputEvidenceSummaryError([
+        "Public output evidence summary numbers must be safe integers.",
+      ]);
+    }
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalizePublicOutputEvidenceSummary).join(",")}]`;
+  }
+
+  if (isObjectRecord(value)) {
+    const serializedEntries = Object.keys(value)
+      .sort()
+      .map(
+        (key) =>
+          `${JSON.stringify(key)}:${canonicalizePublicOutputEvidenceSummary(
+            value[key],
+          )}`,
+      );
+    return `{${serializedEntries.join(",")}}`;
+  }
+
+  throw new PublicOutputEvidenceSummaryError([
+    "Public output evidence summary contains unsupported JSON material.",
+  ]);
+}
+
+function buildPublicOutputEvidenceSummary({
+  subject = PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
+  audience = PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+  asOf,
+  maxEvidenceAgeMs = DEFAULT_PUBLIC_OUTPUT_EVIDENCE_MAX_AGE_MS,
+  exochainConnected,
+  productionTrustEvidence,
+  runtimeStatus,
+  generatedFrom = DEFAULT_PUBLIC_OUTPUT_EVIDENCE_GENERATED_FROM,
+} = {}) {
+  const reasons = [];
+
+  if (subject !== PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT) {
+    reasons.push(
+      `Public output evidence subject must be ${PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT}.`,
+    );
+  }
+
+  if (audience !== PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE) {
+    reasons.push(
+      `Public output evidence audience must be ${PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE}.`,
+    );
+  }
+
+  if (exochainConnected !== true) {
+    reasons.push("EXOCHAIN connectivity must be verified.");
+  }
+
+  if (!Number.isSafeInteger(maxEvidenceAgeMs) || maxEvidenceAgeMs <= 0) {
+    reasons.push("Public output evidence max age must be a positive integer.");
+  }
+
+  validateGeneratedFrom(generatedFrom, reasons);
+  validateProductionTrustEvidence(productionTrustEvidence, reasons);
+  validateRuntimeStatus(runtimeStatus, reasons);
+
+  const { asOfIso, evidenceIso } = resolvePublicOutputTimestamps({
+    asOf,
+    productionTrustEvidence,
+    maxEvidenceAgeMs: Number.isSafeInteger(maxEvidenceAgeMs)
+      ? maxEvidenceAgeMs
+      : DEFAULT_PUBLIC_OUTPUT_EVIDENCE_MAX_AGE_MS,
+    reasons,
+  });
+
+  if (reasons.length > 0) {
+    throw new PublicOutputEvidenceSummaryError(reasons);
+  }
+
+  const summary = {
+    schema: PUBLIC_OUTPUT_EVIDENCE_SCHEMA,
+    subject,
+    audience,
+    as_of: asOfIso,
+    evidence_timestamp: evidenceIso,
+    max_evidence_age_ms: maxEvidenceAgeMs,
+    hash_algorithm: PUBLIC_OUTPUT_EVIDENCE_HASH_ALGORITHM,
+    generated_from: normalizeStringArray(generatedFrom),
+    exochain_connected: true,
+    public_claims_allowed: false,
+    production_evidence: {
+      state: productionTrustEvidence.evidence_state,
+      base_url: productionTrustEvidence.production_base_url,
+      health_verified: true,
+      readiness_verified: true,
+      root_trust_bundle_verified: true,
+      root_trust_bundle_id: productionTrustEvidence.root_trust_bundle_id,
+      root_trust_ceremony_id: productionTrustEvidence.root_trust_ceremony_id,
+      root_trust_issuer_did: productionTrustEvidence.root_trust_issuer_did,
+      verifier_commit: productionTrustEvidence.verifier_commit,
+      verified_at: evidenceIso,
+      non_blocking_observations: normalizeStringArray(
+        productionTrustEvidence.non_blocking_observations,
+      ),
+    },
+    runtime_adapter_evidence: {
+      state: runtimeStatus.adapter_state,
+      surface_classification: runtimeStatus.surface_classification,
+      can_read_exochain_core_state: true,
+      can_write_exochain_core_state: true,
+      public_claims_allowed: false,
+      wrapped_operations: normalizeStringArray(runtimeStatus.wrapped_operations),
+      disablement_path: runtimeStatus.disablement_path,
+      source_basis: normalizeStringArray(runtimeStatus.source_basis),
+    },
+    public_output_evidence: {
+      authorization_required: true,
+      authorized_by_this_hash: false,
+      required_claims: [...ALLOWED_PUBLIC_ADAPTER_OUTPUT_CLAIMS],
+    },
+  };
+
+  assertNoSensitiveSummaryMaterial(summary);
+  return summary;
+}
+
+function hashPublicOutputEvidenceSummary(summary) {
+  if (!isObjectRecord(summary)) {
+    throw new PublicOutputEvidenceSummaryError([
+      "Public output evidence summary is required.",
+    ]);
+  }
+
+  assertNoSensitiveSummaryMaterial(summary);
+  const canonicalJson = canonicalizePublicOutputEvidenceSummary(summary);
+  const hex = crypto
+    .createHash("sha256")
+    .update(canonicalJson, "utf8")
+    .digest("hex");
+  return `sha256:${hex}`;
+}
+
+function buildPublicOutputEvidenceHashRecord(input) {
+  const summary = buildPublicOutputEvidenceSummary(input);
+  const evidenceHash = hashPublicOutputEvidenceSummary(summary);
+
+  return {
+    evidence_hash: evidenceHash,
+    algorithm: PUBLIC_OUTPUT_EVIDENCE_HASH_ALGORITHM,
+    subject: summary.subject,
+    audience: summary.audience,
+    generated_from: summary.generated_from,
+    state: PUBLIC_OUTPUT_EVIDENCE_READY_STATE,
+    reasons: [],
+    public_claims_allowed: false,
+    summary,
+  };
+}
+
 module.exports = {
+  DEFAULT_PUBLIC_OUTPUT_EVIDENCE_GENERATED_FROM,
+  DEFAULT_PUBLIC_OUTPUT_EVIDENCE_MAX_AGE_MS,
+  PUBLIC_OUTPUT_EVIDENCE_HASH_ALGORITHM,
+  PUBLIC_OUTPUT_EVIDENCE_READY_STATE,
+  PublicOutputEvidenceSummaryError,
+  buildPublicOutputEvidenceHashRecord,
+  buildPublicOutputEvidenceSummary,
+  canonicalizePublicOutputEvidenceSummary,
   evaluateExochainProductionTrustEvidence,
   exochainProductionTrustConfig,
   exochainProductionTrustEvidence,
+  hashPublicOutputEvidenceSummary,
 };

--- a/livesafe/tests/public-output-evidence-summary.test.ts
+++ b/livesafe/tests/public-output-evidence-summary.test.ts
@@ -1,0 +1,337 @@
+import { spawnSync } from "node:child_process";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const SUBJECT = "livesafe.ai";
+const AUDIENCE = "https://livesafe.ai/api/trust/status";
+const AS_OF = "2026-07-05T12:00:00.000Z";
+const OBSERVED_AT = "2026-07-05T11:59:00.000Z";
+const MAX_EVIDENCE_AGE_MS = 10 * 60 * 1000;
+
+const GENERATED_FROM = [
+  "config/exochain-production-trust.json",
+  "server/utils/exochain-production-trust-evidence.js",
+  "server/utils/livesafe-exochain-adapter.js",
+  "server/utils/public-adapter-output-authorization.js",
+];
+
+const WRAPPED_OPERATIONS = [
+  "getIdentity",
+  "registerIdentity",
+  "anchorAuditReceipt",
+  "anchorScan",
+  "anchorConsent",
+  "getPaceStatus",
+  "getPublicAdapterOutputAuthorization",
+];
+
+const PRODUCTION_TRUST_EVIDENCE = {
+  evidence_state: "verified",
+  production_base_url: "https://exochain-production.up.railway.app",
+  production_health_verified: true,
+  production_ready_verified: true,
+  root_trust_bundle_verified: true,
+  root_trust_bundle_id:
+    "7d9954a797ef244c15ad1b733cf77598125ccef0f812a404137e827c192d6a58",
+  root_trust_ceremony_id: "avc-exo-ceremony-2026",
+  root_trust_issuer_did:
+    "did:exo:8EVGmqLo15JEnrbcrLo9r84qX1mtrVeBdPjHLUtb1sXX",
+  verifier_commit: "379a45e1d9ab092ecd446d095a7b524570530efd",
+  verified_at: OBSERVED_AT,
+  reasons: [],
+  non_blocking_observations: [
+    "production_sentinel_quorum_health_below_bft_minimum",
+  ],
+};
+
+const RUNTIME_STATUS = {
+  adapter_state: "verified",
+  surface_classification: "core-runtime-adapter",
+  public_claims_allowed: false,
+  can_read_exochain_core_state: true,
+  can_write_exochain_core_state: true,
+  wrapped_operations: WRAPPED_OPERATIONS,
+  disablement_path:
+    "Disable EXOCHAIN adapter environment variables and remove the trust-status route from the load balancer.",
+  source_basis: ["server/utils/livesafe-exochain-adapter.js"],
+};
+
+function loadContract() {
+  return require("../server/utils/exochain-production-trust-evidence.js") as {
+    buildPublicOutputEvidenceHashRecord: (
+      input: Record<string, unknown>,
+    ) => Record<string, unknown>;
+    buildPublicOutputEvidenceSummary: (
+      input: Record<string, unknown>,
+    ) => Record<string, unknown>;
+    hashPublicOutputEvidenceSummary: (
+      summary: Record<string, unknown>,
+    ) => string;
+  };
+}
+
+function validInput(overrides: Record<string, unknown> = {}) {
+  return {
+    subject: SUBJECT,
+    audience: AUDIENCE,
+    asOf: AS_OF,
+    maxEvidenceAgeMs: MAX_EVIDENCE_AGE_MS,
+    exochainConnected: true,
+    productionTrustEvidence: {
+      ...PRODUCTION_TRUST_EVIDENCE,
+      reasons: [...PRODUCTION_TRUST_EVIDENCE.reasons],
+      non_blocking_observations: [
+        ...PRODUCTION_TRUST_EVIDENCE.non_blocking_observations,
+      ],
+    },
+    runtimeStatus: {
+      ...RUNTIME_STATUS,
+      wrapped_operations: [...RUNTIME_STATUS.wrapped_operations],
+      source_basis: [...RUNTIME_STATUS.source_basis],
+    },
+    generatedFrom: [...GENERATED_FROM],
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("LiveSafe public-output evidence summary hash contract", () => {
+  it("canonicalizes semantically identical evidence with reordered object keys to the same hash", () => {
+    const { buildPublicOutputEvidenceHashRecord } = loadContract();
+    const reorderedInput = {
+      generatedFrom: [...GENERATED_FROM],
+      runtimeStatus: {
+        source_basis: ["server/utils/livesafe-exochain-adapter.js"],
+        disablement_path: RUNTIME_STATUS.disablement_path,
+        wrapped_operations: [...WRAPPED_OPERATIONS],
+        can_write_exochain_core_state: true,
+        can_read_exochain_core_state: true,
+        public_claims_allowed: false,
+        surface_classification: "core-runtime-adapter",
+        adapter_state: "verified",
+      },
+      productionTrustEvidence: {
+        non_blocking_observations: [
+          "production_sentinel_quorum_health_below_bft_minimum",
+        ],
+        reasons: [],
+        verified_at: OBSERVED_AT,
+        verifier_commit: "379a45e1d9ab092ecd446d095a7b524570530efd",
+        root_trust_issuer_did:
+          "did:exo:8EVGmqLo15JEnrbcrLo9r84qX1mtrVeBdPjHLUtb1sXX",
+        root_trust_ceremony_id: "avc-exo-ceremony-2026",
+        root_trust_bundle_id:
+          "7d9954a797ef244c15ad1b733cf77598125ccef0f812a404137e827c192d6a58",
+        root_trust_bundle_verified: true,
+        production_ready_verified: true,
+        production_health_verified: true,
+        production_base_url: "https://exochain-production.up.railway.app",
+        evidence_state: "verified",
+      },
+      maxEvidenceAgeMs: MAX_EVIDENCE_AGE_MS,
+      asOf: AS_OF,
+      audience: AUDIENCE,
+      subject: SUBJECT,
+      exochainConnected: true,
+    };
+
+    const first = buildPublicOutputEvidenceHashRecord(validInput());
+    const second = buildPublicOutputEvidenceHashRecord(reorderedInput);
+
+    expect(first.evidence_hash).toBe(second.evidence_hash);
+    expect(first.summary).toEqual(second.summary);
+  });
+
+  it("changes the hash when any required public evidence field changes", () => {
+    const { buildPublicOutputEvidenceHashRecord } = loadContract();
+    const first = buildPublicOutputEvidenceHashRecord(validInput());
+    const changed = buildPublicOutputEvidenceHashRecord(
+      validInput({
+        productionTrustEvidence: {
+          ...PRODUCTION_TRUST_EVIDENCE,
+          root_trust_bundle_id:
+            "8d9954a797ef244c15ad1b733cf77598125ccef0f812a404137e827c192d6a58",
+        },
+      }),
+    );
+
+    expect(first.evidence_hash).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(changed.evidence_hash).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(changed.evidence_hash).not.toBe(first.evidence_hash);
+  });
+
+  it("rejects missing or false production, EXOCHAIN, runtime-adapter, and pre-authorization public-claim evidence", () => {
+    const { buildPublicOutputEvidenceSummary } = loadContract();
+    const cases = [
+      {
+        name: "production evidence blocked",
+        input: validInput({
+          productionTrustEvidence: {
+            ...PRODUCTION_TRUST_EVIDENCE,
+            evidence_state: "blocked",
+          },
+        }),
+        reason: "EXOCHAIN production evidence must be verified.",
+      },
+      {
+        name: "production health false",
+        input: validInput({
+          productionTrustEvidence: {
+            ...PRODUCTION_TRUST_EVIDENCE,
+            production_health_verified: false,
+          },
+        }),
+        reason: "EXOCHAIN production health evidence must be verified.",
+      },
+      {
+        name: "EXOCHAIN connectivity false",
+        input: validInput({ exochainConnected: false }),
+        reason: "EXOCHAIN connectivity must be verified.",
+      },
+      {
+        name: "runtime adapter not verified",
+        input: validInput({
+          runtimeStatus: {
+            ...RUNTIME_STATUS,
+            adapter_state: "unverified",
+          },
+        }),
+        reason: "LiveSafe runtime adapter evidence must be verified.",
+      },
+      {
+        name: "public claims already allowed",
+        input: validInput({
+          runtimeStatus: {
+            ...RUNTIME_STATUS,
+            public_claims_allowed: true,
+          },
+        }),
+        reason:
+          "LiveSafe public claims must not already be allowed before AVC authorization.",
+      },
+    ];
+
+    for (const testCase of cases) {
+      expect(
+        () => buildPublicOutputEvidenceSummary(testCase.input),
+        testCase.name,
+      ).toThrow(testCase.reason);
+    }
+  });
+
+  it("rejects stale or malformed evidence timestamps using only explicit input time", () => {
+    const { buildPublicOutputEvidenceSummary } = loadContract();
+
+    expect(() =>
+      buildPublicOutputEvidenceSummary(
+        validInput({ asOf: "2026-07-05T12:10:01.000Z" }),
+      ),
+    ).toThrow("Public output evidence timestamp is stale.");
+
+    expect(() =>
+      buildPublicOutputEvidenceSummary(
+        validInput({
+          productionTrustEvidence: {
+            ...PRODUCTION_TRUST_EVIDENCE,
+            verified_at: "not-a-timestamp",
+          },
+        }),
+      ),
+    ).toThrow("Public output evidence timestamp is malformed.");
+
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => {
+      throw new Error("system time must not be used for evidence freshness");
+    });
+    const summary = buildPublicOutputEvidenceSummary(validInput());
+
+    expect(summary.as_of).toBe(AS_OF);
+    expect(nowSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects hashes for summaries containing secrets, raw authority, database URLs, or sensitive LiveSafe payloads", () => {
+    const {
+      buildPublicOutputEvidenceSummary,
+      hashPublicOutputEvidenceSummary,
+    } = loadContract();
+    const summary = buildPublicOutputEvidenceSummary(validInput());
+    const sensitiveMutations = [
+      { bearer_token: "bearer-secret-value" },
+      { admin_token: "admin-secret-value" },
+      { private_key: "-----BEGIN PRIVATE KEY-----abc-----END PRIVATE KEY-----" },
+      { raw_authority_chain: ["did:exo:livesafe:raw-authority"] },
+      { database_url: "postgres://user:password@db.example/livesafe" },
+      { sensitive_livesafe_payload: { medical_record: "raw PHI payload" } },
+      { generated_from: ["Authorization: Bearer hidden-token"] },
+    ];
+
+    for (const mutation of sensitiveMutations) {
+      expect(
+        () => hashPublicOutputEvidenceSummary({ ...summary, ...mutation }),
+        JSON.stringify(mutation),
+      ).toThrow(
+        "Public output evidence summary must not contain secret or sensitive material.",
+      );
+    }
+  });
+
+  it("operator command emits only non-secret machine-readable evidence hash metadata", () => {
+    const command = spawnSync(
+      process.execPath,
+      [
+        "scripts/exochain-public-output-evidence-hash.mjs",
+        "--as-of",
+        "2026-06-03T21:26:00.000Z",
+      ],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          EXOCHAIN_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_BEARER:
+            "super-secret-public-adapter-bearer",
+          DATABASE_URL: "postgres://secret-user:secret-pass@db.example/livesafe",
+          LIVESAFE_ADMIN_TOKEN: "admin-token-that-must-not-print",
+        },
+      },
+    );
+
+    expect(command.status, command.stderr).toBe(0);
+    expect(command.stderr).toBe("");
+
+    const output = command.stdout.trim();
+    expect(output).not.toContain("super-secret-public-adapter-bearer");
+    expect(output).not.toContain("postgres://secret-user");
+    expect(output).not.toContain("admin-token-that-must-not-print");
+
+    const record = JSON.parse(output) as {
+      evidence_hash: string;
+      algorithm: string;
+      subject: string;
+      audience: string;
+      generated_from: string[];
+      state: string;
+      reasons: string[];
+      public_claims_allowed: boolean;
+      summary: Record<string, unknown>;
+    };
+
+    expect(record).toMatchObject({
+      algorithm: "sha256.canonical_json.sorted_keys.v1",
+      subject: SUBJECT,
+      audience: AUDIENCE,
+      generated_from: GENERATED_FROM,
+      state: "ready_for_avc_ceremony_binding",
+      reasons: [],
+      public_claims_allowed: false,
+    });
+    expect(record.evidence_hash).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(record.summary).toMatchObject({
+      subject: SUBJECT,
+      audience: AUDIENCE,
+      public_claims_allowed: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the canonical LiveSafe public-output evidence summary/hash contract in `server/utils/exochain-production-trust-evidence.js` using sorted-key canonical JSON and `sha256:<hex>` output.
- Adds `scripts/exochain-public-output-evidence-hash.mjs` plus `npm run --silent evidence:public-output-hash -- --as-of <ISO-UTC>` for a non-secret machine-readable operator record.
- Documents the contract in the production trust gates, integration map, and test plan.

## Path classification
- Adjacent surface, production public-trust entrypoint: `livesafe/server/utils/exochain-production-trust-evidence.js`, `livesafe/scripts/exochain-public-output-evidence-hash.mjs`, `livesafe/tests/public-output-evidence-summary.test.ts`, `livesafe/package.json`, and the updated LiveSafe docs.
- EXOCHAIN core: none changed.
- Core runtime adapter: none changed.
- Imported evidence: none changed.
- Third-party/vendor: none changed.
- Explicitly untouched: `crates/exo-node`, `crates/exo-avc`.

## RED evidence
- `cd livesafe && npm test -- tests/public-output-evidence-summary.test.ts` failed before implementation with 6/6 expected failures because the canonical summary/hash functions and operator script did not exist.

## GREEN evidence
- `cd livesafe && npm test -- tests/public-output-evidence-summary.test.ts` passed: 1 file, 6 tests.
- `cd livesafe && npm test -- tests/public-output-evidence-summary.test.ts tests/exochain-production-trust-evidence.test.ts tests/public-adapter-output-authorization.test.ts tests/trust-status.test.ts tests/exochain-runtime-adapter.test.ts tests/exochain-client.test.ts` passed: 6 files, 143 tests.
- `cd livesafe && npm run quality` passed: context lint, typecheck, 157 Vitest files / 548 tests, Rust fmt/clippy/test. Rust fmt still prints existing stable-channel warnings for unstable rustfmt options, but exits 0.
- `cd livesafe && npm run --silent evidence:public-output-hash -- --as-of 2026-06-03T21:26:00.000Z` emitted `sha256:2da87f76c72b2d447a7f3cb40f7c414fe6567041709c8b48d7363c9d4a36dd1c`.

## No-secret assertion
- The operator command emits only a JSON public metadata record with `evidence_hash`, `algorithm`, `subject`, `audience`, `generated_from`, state, reasons, and a redacted summary.
- Tests run the operator command with secret env values and assert those values are not printed.
- The hash function rejects summaries containing bearer/admin tokens, private keys, raw authority chains, database URLs, and sensitive LiveSafe payload fields before hashing.

## Operator command
```bash
cd livesafe
npm run --silent evidence:public-output-hash -- --as-of 2026-06-03T21:26:00.000Z
```

## Notes
- This hash is evidence material for AVC ceremony binding only; it does not authorize public claims.
- No Railway or production configuration was changed.