### PR TITLE
Normalize LiveSafe public output proof IDs

### DIFF
--- a/livesafe/server/utils/exochain-client.js
+++ b/livesafe/server/utils/exochain-client.js
@@ -486,6 +486,14 @@ function normalizeHash256(value) {
   return `sha256:${bytesToLowerHex(value)}`;
 }
 
+function normalizePublicAuthorizationIdentifier(value) {
+  if (isNonEmptyString(value)) {
+    return value;
+  }
+
+  return normalizeHash256(value);
+}
+
 function normalizePublicAuthorizationSignature(signature) {
   if (!isObjectRecord(signature)) {
     return null;
@@ -579,15 +587,17 @@ function adaptCorePublicAdapterOutputAuthorizationEnvelope(
   const actionCommitmentHash = normalizeHash256(proof.action_commitment_hash);
   const idempotencyKeyHash = normalizeHash256(proof.idempotency_key_hash);
   const proofHash = normalizeHash256(proof.proof_hash);
+  const credentialId = normalizePublicAuthorizationIdentifier(proof.credential_id);
+  const receiptId = normalizePublicAuthorizationIdentifier(proof.receipt_id);
   const signature = normalizePublicAuthorizationSignature(proof.signature);
   if (
     !evidenceHash ||
     !actionCommitmentHash ||
     !idempotencyKeyHash ||
     !proofHash ||
+    !credentialId ||
+    !receiptId ||
     !signature ||
-    !isNonEmptyString(proof.credential_id) ||
-    !isNonEmptyString(proof.receipt_id) ||
     !isNonEmptyString(proof.signer_did)
   ) {
     return { state: 'rejected', value: null };
@@ -601,7 +611,7 @@ function adaptCorePublicAdapterOutputAuthorizationEnvelope(
       audience: proof.audience,
       claims: [...ALLOWED_PUBLIC_ADAPTER_OUTPUT_CLAIMS],
       evidence_hash: evidenceHash,
-      receipt_id: proof.receipt_id,
+      receipt_id: receiptId,
       proof_id: proofHash,
       proof_ref: `exochain-avc:${proofHash}`,
       generated_at: generatedAt,

--- a/livesafe/tests/exochain-client.test.ts
+++ b/livesafe/tests/exochain-client.test.ts
@@ -19,8 +19,10 @@ const PROOF_HASH_BYTES = repeatedByte(0xcc, 32);
 const ACTION_COMMITMENT_HASH_BYTES = repeatedByte(0xdd, 32);
 const IDEMPOTENCY_KEY_HASH_BYTES = repeatedByte(0xee, 32);
 const ED25519_SIGNATURE_BYTES = repeatedByte(0xaa, 64);
+const RECEIPT_ID_BYTES = repeatedByte(0x6f, 32);
 const EVIDENCE_HASH_HEX = repeatedHex(0xbb, 32);
 const CREDENTIAL_ID_HEX = repeatedHex(0xbc, 32);
+const RECEIPT_ID_HEX = repeatedHex(0x6f, 32);
 const ALT_EVIDENCE_HASH_HEX = repeatedHex(0xab, 32);
 const ALT_CREDENTIAL_ID_HEX = repeatedHex(0xcd, 32);
 const PROOF_HASH_HEX = repeatedHex(0xcc, 32);
@@ -981,6 +983,38 @@ describe("EXOCHAIN client timestamp preservation", () => {
     expect(result).toEqual({
       state: "permit",
       value: PUBLIC_ADAPTER_AUTHORIZATION_DTO_FROM_RUST,
+    });
+  });
+
+  it("adapts Rust core byte-array credential and receipt ids in public adapter-output envelopes", async () => {
+    configurePublicAdapterAuthorizationEnv();
+    const client = new ExochainClient("http://example.invalid/graphql");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () =>
+          rustCoreEnvelope({
+            proof: {
+              credential_id: CREDENTIAL_ID_BYTES,
+              receipt_id: RECEIPT_ID_BYTES,
+            },
+          }),
+      })),
+    );
+
+    const result = await client.getPublicAdapterOutputAuthorization({
+      subject: "livesafe.ai",
+      audience: "https://livesafe.ai/api/trust/status",
+      currentAt: "2026-07-05T12:00:00.000Z",
+    });
+
+    expect(result).toEqual({
+      state: "permit",
+      value: {
+        ...PUBLIC_ADAPTER_AUTHORIZATION_DTO_FROM_RUST,
+        receipt_id: `sha256:${RECEIPT_ID_HEX}`,
+      },
     });
   });
 


### PR DESCRIPTION
## Summary
- Normalize public adapter-output `credential_id` and `receipt_id` from real Rust core byte-array IDs as `sha256:<hex>` identifiers while preserving existing string IDs.
- Add a regression test using byte-array credential and receipt IDs from the core envelope shape observed during LiveSafe launch verification.

## TDD Evidence
- RED: `npm test -- tests/exochain-client.test.ts` failed because byte-array IDs made the REST envelope adapt as `{ state: "rejected", value: null }`.
- GREEN: `npm test -- tests/exochain-client.test.ts` passed with 75 tests.

## Verification
- `cd livesafe && npm run quality` passed: context lint, typecheck, 157 Vitest files / 549 tests, Rust fmt, clippy, and cargo tests.

## Path Classification
- `livesafe/server/utils/exochain-client.js`: Adjacent surface / core runtime adapter boundary; adapts EXOCHAIN AVC public-output envelopes for LiveSafe.
- `livesafe/tests/exochain-client.test.ts`: Adjacent surface / adapter boundary test.

## Core Regression Firewall
- No `crates/`, `packages/exochain-wasm/`, `governance/`, `tools/`, CI, or deployment contracts changed.
- Change is limited to LiveSafe adapter normalization and test coverage for the public-output authorization envelope.