### PR TITLE
Allow LiveSafe public output HLC proofs

### DIFF
--- a/livesafe/server/utils/exochain-client.js
+++ b/livesafe/server/utils/exochain-client.js
@@ -369,6 +369,23 @@ function coreTimestampToIso(value) {
   return null;
 }
 
+function isCoreHlcTimestamp(value) {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+
+  const physicalMs = Number.isInteger(value.physical_ms)
+    ? value.physical_ms
+    : value.physicalMs;
+
+  return (
+    Number.isInteger(physicalMs) &&
+    physicalMs >= 0 &&
+    Number.isInteger(value.logical) &&
+    value.logical >= 0
+  );
+}
+
 const RAW_SENSITIVE_FIELD_KEYS = new Set([
   'authorization_header',
   'bearer_token',
@@ -609,6 +626,9 @@ function adaptCorePublicAdapterOutputAuthorizationEnvelope(
       schema: PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SCHEMA,
       subject: proof.subject,
       audience: proof.audience,
+      ...(isCoreHlcTimestamp(proof.issued_at)
+        ? { timestamp_basis: 'exochain_hlc' }
+        : {}),
       claims: [...ALLOWED_PUBLIC_ADAPTER_OUTPUT_CLAIMS],
       evidence_hash: evidenceHash,
       receipt_id: receiptId,

--- a/livesafe/server/utils/public-adapter-output-authorization.d.ts
+++ b/livesafe/server/utils/public-adapter-output-authorization.d.ts
@@ -13,6 +13,7 @@ export interface PublicAdapterOutputAuthorizationDto {
   schema: "livesafe.public_adapter_output_authorization.v1";
   subject: "livesafe.ai";
   audience: "https://livesafe.ai/api/trust/status";
+  timestamp_basis?: "exochain_hlc";
   claims: string[];
   evidence_hash: string;
   receipt_id: string;

--- a/livesafe/server/utils/public-adapter-output-authorization.js
+++ b/livesafe/server/utils/public-adapter-output-authorization.js
@@ -6,6 +6,7 @@ const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT = "livesafe.ai";
 const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE =
   "https://livesafe.ai/api/trust/status";
 const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_MAX_AGE_MS = 5 * 60 * 1000;
+const PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_EXOCHAIN_HLC_BASIS = "exochain_hlc";
 const ALLOWED_PUBLIC_ADAPTER_OUTPUT_CLAIMS = [
   "livesafe_public_trust_status",
   "exochain_production_evidence_verified",
@@ -222,6 +223,9 @@ function validateTimestamps({ authorization, currentAt, reasons }) {
   const generatedMilliseconds = parseIsoTimestamp(authorization.generated_at);
   const validFromMilliseconds = parseIsoTimestamp(authorization.valid_from);
   const expiresMilliseconds = parseIsoTimestamp(authorization.expires_at);
+  const hasExochainHlcBasis =
+    authorization.timestamp_basis ===
+    PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_EXOCHAIN_HLC_BASIS;
 
   if (currentMilliseconds === null) {
     reasons.push(
@@ -253,8 +257,9 @@ function validateTimestamps({ authorization, currentAt, reasons }) {
   }
 
   if (
+    !hasExochainHlcBasis &&
     currentMilliseconds - generatedMilliseconds >
-    PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_MAX_AGE_MS
+      PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_MAX_AGE_MS
   ) {
     reasons.push("Public adapter-output authorization is stale.");
   }

--- a/livesafe/tests/exochain-client.test.ts
+++ b/livesafe/tests/exochain-client.test.ts
@@ -103,6 +103,7 @@ const PUBLIC_ADAPTER_AUTHORIZATION_DTO_FROM_RUST = {
   schema: "livesafe.public_adapter_output_authorization.v1",
   subject: "livesafe.ai",
   audience: "https://livesafe.ai/api/trust/status",
+  timestamp_basis: "exochain_hlc",
   claims: [
     "livesafe_public_trust_status",
     "exochain_production_evidence_verified",
@@ -1014,6 +1015,48 @@ describe("EXOCHAIN client timestamp preservation", () => {
       value: {
         ...PUBLIC_ADAPTER_AUTHORIZATION_DTO_FROM_RUST,
         receipt_id: `sha256:${RECEIPT_ID_HEX}`,
+      },
+    });
+  });
+
+  it("accepts EXOCHAIN HLC-issued public adapter-output envelopes without treating them as stale wall-clock DTOs", async () => {
+    configurePublicAdapterAuthorizationEnv();
+    const client = new ExochainClient("http://example.invalid/graphql");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () =>
+          rustCoreEnvelope({
+            proof: {
+              credential_id: CREDENTIAL_ID_BYTES,
+              receipt_id: RECEIPT_ID_BYTES,
+              issued_at: {
+                physical_ms: 1000000,
+                logical: 6,
+              },
+              expires_at: {
+                physical_ms: Date.parse("2026-07-05T12:05:00.000Z"),
+                logical: 0,
+              },
+            },
+          }),
+      })),
+    );
+
+    const result = await client.getPublicAdapterOutputAuthorization({
+      subject: "livesafe.ai",
+      audience: "https://livesafe.ai/api/trust/status",
+      currentAt: "2026-07-05T12:00:00.000Z",
+    });
+
+    expect(result).toEqual({
+      state: "permit",
+      value: {
+        ...PUBLIC_ADAPTER_AUTHORIZATION_DTO_FROM_RUST,
+        receipt_id: `sha256:${RECEIPT_ID_HEX}`,
+        generated_at: "1970-01-01T00:16:40.000Z",
+        valid_from: "1970-01-01T00:16:40.000Z",
       },
     });
   });

--- a/livesafe/tests/public-adapter-output-authorization.test.ts
+++ b/livesafe/tests/public-adapter-output-authorization.test.ts
@@ -284,6 +284,23 @@ describe("public adapter-output authorization evaluator", () => {
     );
   });
 
+  it("allows EXOCHAIN HLC-backed proof timestamps without weakening wall-clock stale denial", () => {
+    const decision = evaluate(
+      validDecision({
+        value: validAuthorization({
+          timestamp_basis: "exochain_hlc",
+          generated_at: "1970-01-01T00:16:40.000Z",
+          valid_from: "1970-01-01T00:16:40.000Z",
+          expires_at: "2026-07-05T12:05:00.000Z",
+        }),
+      }),
+    );
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.reasons).toEqual([]);
+    expect(decision.metadata).not.toHaveProperty("timestamp_basis");
+  });
+
   it("denies revoked authorizations", () => {
     const decision = evaluate(
       validDecision({


### PR DESCRIPTION
## Summary
- Marks EXOCHAIN core public adapter-output envelopes with an internal `timestamp_basis: "exochain_hlc"` when the core proof uses HLC-shaped timestamps.
- Keeps stale wall-clock DTOs fail-closed, but stops treating a proof-bearing EXOCHAIN HLC `issued_at` as a stale wall-clock timestamp.
- Keeps public authorization metadata redacted; the internal timestamp basis is not emitted through evaluator metadata.

## 100% TDD Evidence
RED:
- `npm test -- tests/public-adapter-output-authorization.test.ts tests/exochain-client.test.ts` failed because HLC proof DTOs were denied as stale and the core DTO lacked the HLC timestamp marker.

GREEN:
- `npm test -- tests/public-adapter-output-authorization.test.ts tests/exochain-client.test.ts` -> 96/96 passed.
- `npm run quality` -> context lint, typecheck, 551 Vitest tests, Rust fmt, Rust clippy, and Rust tests all passed.

## Path Classification
- `livesafe/server/utils/exochain-client.js` — Adjacent surface runtime adapter.
- `livesafe/server/utils/public-adapter-output-authorization.js` — Adjacent surface trust evaluator.
- `livesafe/server/utils/public-adapter-output-authorization.d.ts` — Adjacent surface type contract.
- `livesafe/tests/exochain-client.test.ts` — Adjacent surface adapter tests.
- `livesafe/tests/public-adapter-output-authorization.test.ts` — Adjacent surface evaluator tests.

## Core Regression Firewall
- No `crates/`, `governance/`, `tools/`, WASM, SDK, or core Rust runtime behavior changed.
- Public claims still require verified adapter transport, exact subject/audience, allowed claims, evidence hash, receipt/proof IDs, expiry, non-revocation, and proof signature.
- Wall-clock stale authorization denial remains tested.
