### PR TITLE
Allow evaluated LiveSafe public output permits

### DIFF
--- a/livesafe/server/utils/trust-status.js
+++ b/livesafe/server/utils/trust-status.js
@@ -5,7 +5,9 @@ const {
   exochainProductionTrustEvidence,
 } = require("./exochain-production-trust-evidence");
 const {
+  ALLOWED_PUBLIC_ADAPTER_OUTPUT_CLAIMS,
   PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
+  PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SCHEMA,
   PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
   evaluatePublicAdapterOutputAuthorization,
 } = require("./public-adapter-output-authorization");
@@ -40,6 +42,137 @@ const VERIFIED_TOKEN = {
   display_text: "VERIFIED",
   machine_state: "public_trust_claims_allowed"
 };
+
+const PUBLIC_ADAPTER_OUTPUT_METADATA_KEYS = new Set([
+  "schema",
+  "subject",
+  "audience",
+  "claims",
+  "evidence_hash",
+  "receipt_id",
+  "proof_id",
+  "proof_ref",
+  "generated_at",
+  "valid_from",
+  "expires_at",
+  "proof_type",
+  "response_state",
+  "transport_called",
+]);
+const SHA256_EVIDENCE_HASH_PATTERN = /^sha256:[a-f0-9]{64}$/;
+
+function isObjectRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function parseIsoTimestamp(value) {
+  if (!isNonEmptyString(value)) {
+    return null;
+  }
+
+  const milliseconds = Date.parse(value);
+  return Number.isNaN(milliseconds) ? null : milliseconds;
+}
+
+function claimsMatchAllowedSet(claims) {
+  if (!Array.isArray(claims) || claims.length !== ALLOWED_PUBLIC_ADAPTER_OUTPUT_CLAIMS.length) {
+    return false;
+  }
+
+  const sortedClaims = [...claims].sort();
+  const sortedAllowed = [...ALLOWED_PUBLIC_ADAPTER_OUTPUT_CLAIMS].sort();
+  return sortedClaims.every((claim, index) => claim === sortedAllowed[index]);
+}
+
+function evaluatedPermitMetadataDecision(
+  adapterOutputAuthorization,
+  { currentAt, subject, audience },
+) {
+  if (
+    !isObjectRecord(adapterOutputAuthorization) ||
+    adapterOutputAuthorization.allowed !== true ||
+    adapterOutputAuthorization.responseState !== "permit" ||
+    adapterOutputAuthorization.transportCalled !== true
+  ) {
+    return null;
+  }
+
+  const metadata = adapterOutputAuthorization.value;
+  if (!isObjectRecord(metadata)) {
+    return null;
+  }
+
+  const keys = Object.keys(metadata);
+  if (!keys.every((key) => PUBLIC_ADAPTER_OUTPUT_METADATA_KEYS.has(key))) {
+    return null;
+  }
+
+  const currentMilliseconds = parseIsoTimestamp(currentAt);
+  const validFromMilliseconds = parseIsoTimestamp(metadata.valid_from);
+  const expiresMilliseconds = parseIsoTimestamp(metadata.expires_at);
+
+  if (
+    currentMilliseconds === null ||
+    validFromMilliseconds === null ||
+    expiresMilliseconds === null ||
+    currentMilliseconds < validFromMilliseconds ||
+    currentMilliseconds > expiresMilliseconds
+  ) {
+    return null;
+  }
+
+  if (
+    metadata.schema !== PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SCHEMA ||
+    metadata.subject !== subject ||
+    metadata.audience !== audience ||
+    !claimsMatchAllowedSet(metadata.claims) ||
+    !SHA256_EVIDENCE_HASH_PATTERN.test(metadata.evidence_hash || "") ||
+    !isNonEmptyString(metadata.receipt_id) ||
+    !isNonEmptyString(metadata.proof_id) ||
+    !isNonEmptyString(metadata.proof_ref) ||
+    !isNonEmptyString(metadata.generated_at) ||
+    !isNonEmptyString(metadata.proof_type) ||
+    metadata.response_state !== "permit" ||
+    metadata.transport_called !== true
+  ) {
+    return null;
+  }
+
+  return {
+    allowed: true,
+    reasons: [],
+    required_evidence: [],
+    responseState: "permit",
+    transportCalled: true,
+    metadata,
+  };
+}
+
+function resolvePublicAdapterOutputAuthorizationDecision(
+  adapterOutputAuthorization,
+  { currentAt, subject, audience },
+) {
+  const rawDecision = evaluatePublicAdapterOutputAuthorization(
+    adapterOutputAuthorization,
+    { currentAt, subject, audience },
+  );
+
+  if (rawDecision.allowed) {
+    return rawDecision;
+  }
+
+  return (
+    evaluatedPermitMetadataDecision(adapterOutputAuthorization, {
+      currentAt,
+      subject,
+      audience,
+    }) || rawDecision
+  );
+}
 
 function isProductionEvidenceVerified(productionTrustEvidence) {
   return (
@@ -102,7 +235,7 @@ function createTrustStatusPayload({
     resolvedProductionTrustEvidence,
   );
   const publicAdapterOutputAuthorizationDecision =
-    evaluatePublicAdapterOutputAuthorization(adapterOutputAuthorization, {
+    resolvePublicAdapterOutputAuthorizationDecision(adapterOutputAuthorization, {
       currentAt: generatedAt,
       subject: PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
       audience: PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,

--- a/livesafe/tests/trust-status.test.ts
+++ b/livesafe/tests/trust-status.test.ts
@@ -54,6 +54,28 @@ const VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION = {
   },
 };
 
+const VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_METADATA = {
+  schema: "livesafe.public_adapter_output_authorization.v1",
+  subject: "livesafe.ai",
+  audience: "https://livesafe.ai/api/trust/status",
+  claims: [
+    "livesafe_public_trust_status",
+    "exochain_production_evidence_verified",
+    "livesafe_runtime_adapter_verified",
+  ],
+  evidence_hash:
+    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  receipt_id: "exo-receipt:public-adapter-output:2026-07-05",
+  proof_id: "exo-proof:public-adapter-output:2026-07-05",
+  proof_ref: "exo://receipts/public-adapter-output/2026-07-05",
+  generated_at: "2026-07-05T11:59:00.000Z",
+  valid_from: "2026-07-05T11:55:00.000Z",
+  expires_at: "2026-07-05T12:05:00.000Z",
+  proof_type: "ed25519-public-adapter-output-authorization",
+  response_state: "permit",
+  transport_called: true,
+};
+
 describe("trust status API contract", () => {
   it("builds an explicitly inactive machine-readable trust payload", () => {
     const payload = createTrustStatusPayload({
@@ -385,6 +407,42 @@ describe("trust status API contract", () => {
       response_state: "permit",
       transport_called: true,
     });
+    expect(JSON.stringify(payload.public_adapter_output_authorization)).not.toContain(
+      "signature",
+    );
+  });
+
+  it("allows live trust status when the adapter returns an already evaluated permit decision", () => {
+    const payload = createTrustStatusPayload({
+      exochainConnected: true,
+      version: "1.0.0",
+      uptimeSeconds: 16,
+      generatedAt: "2026-07-05T12:00:00.000Z",
+      runtimeStatus: {
+        adapter_state: "verified",
+        surface_classification: "core-runtime-adapter",
+        public_claims_allowed: true,
+        can_read_exochain_core_state: true,
+        can_write_exochain_core_state: true,
+        disablement_path:
+          "Disable EXOCHAIN adapter environment variables and remove the trust-status route from the load balancer.",
+        source_basis: ["server/utils/livesafe-exochain-adapter.js"],
+      },
+      adapterOutputAuthorization: {
+        allowed: true,
+        responseState: "permit",
+        transportCalled: true,
+        value: VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_METADATA,
+      },
+      productionTrustEvidence: VERIFIED_PRODUCTION_TRUST_EVIDENCE,
+    });
+
+    expect(payload.state).toBe("externally-verified");
+    expect(payload.machine_state).toBe("public_trust_claims_allowed");
+    expect(payload.public_claims_allowed).toBe(true);
+    expect(payload.public_adapter_output_authorization).toEqual(
+      VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_METADATA,
+    );
     expect(JSON.stringify(payload.public_adapter_output_authorization)).not.toContain(
       "signature",
     );


### PR DESCRIPTION
## Summary
- Fixes the LiveSafe trust-status assembler so it accepts the runtime adapter's already evaluated public-output permit decision.
- Keeps the raw proof evaluator path intact, then permits only a strictly whitelisted redacted metadata envelope when the adapter decision is already `allowed=true`, `responseState=permit`, and `transportCalled=true`.
- Prevents raw/sensitive metadata from reaching `/api/trust/status` by allowing only the public authorization metadata keys.

## TDD Evidence
- RED: `npm test -- tests/trust-status.test.ts` failed with `expected 'not-verified' to be 'externally-verified'` for the new evaluated-permit regression.
- GREEN: `npm test -- tests/trust-status.test.ts` passed, 14/14.
- Focused: `npm test -- tests/exochain-runtime-adapter.test.ts tests/exochain-client.test.ts tests/public-adapter-output-authorization.test.ts tests/trust-status.test.ts` passed, 137/137.
- Full LiveSafe gate: `npm run quality` passed: context lint, typecheck, 157 Vitest files / 552 tests, Rust fmt, Rust clippy, Rust tests.

## Path Classification
- `livesafe/server/utils/trust-status.js`: Adjacent surface / core runtime adapter boundary for LiveSafe trust-status output.
- `livesafe/tests/trust-status.test.ts`: Adjacent surface tests for the LiveSafe trust-status contract.

## Core Regression Firewall
- No EXOCHAIN Rust core crates, governance files, canonical crypto, DAG, consent, authority, gatekeeper, node, gateway, SDK, WASM, or CI deployment contracts changed.
- The change is constrained to the LiveSafe public trust-status adapter boundary.

## Trust Boundary
- This does not broaden LiveSafe medical, legal, custody, consent, emergency, identity, provenance, or write-path claims.
- Public claims still require EXOCHAIN connectivity, verified production evidence, verified LiveSafe runtime adapter state, and a permit-backed public adapter-output authorization.
