### PR TITLE
fix(avc): restore pre-LYNK durable receipt compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,9 +91,22 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
+      - name: Free coverage runner disk
+        run: |
+          df -h /
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /usr/local/.ghcup
+          df -h /
       - name: Install cargo-tarpaulin
         run: bash tools/ci_cargo_retry.sh cargo install cargo-tarpaulin --version 0.35.4 --locked
       - name: Run coverage
+        env:
+          CARGO_BUILD_JOBS: "1"
+          CARGO_INCREMENTAL: "0"
+          CARGO_PROFILE_TEST_DEBUG: "0"
         # exochain-wasm: excluded — wasm bindings are exercised by the JS
         # bridge tests (Gate 21), not tarpaulin.
         # exochain-proofs: excluded — the entire crate is gated behind

--- a/README.md
+++ b/README.md
@@ -34,17 +34,17 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 | Metric | Value | Source |
 |--------|-------|--------|
 | Rust crates | 31 | `ls -d crates/*/` |
-| Rust source files | 462 | `find crates -name '*.rs'` |
-| Rust LOC | 377871 | `wc -l` |
-| Workspace tests | 6,110 listed | `cargo test --workspace -- --list` |
+| Rust source files | 469 | `git ls-files 'crates/**/*.rs'` |
+| Rust LOC | 385376 | `git ls-files 'crates/**/*.rs'` + `wc -l` |
+| Workspace tests | 6,236 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 23 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
-| Published releases | No GitHub Release or crates.io publication verified; pre-release git tags exist (`v0.1.0-alpha`, `v0.1.0-beta`) | `git tag -l`; release workflow state |
+| Latest published release | `v0.2.1-beta` (GitHub Release published 2026-07-08; `exochain-core` on crates.io and `@exochain/llm-proxy` on npm resolve the same version) | `gh release list`; `cargo search exochain-core`; `npm view @exochain/llm-proxy version` |
 | License | Apache-2.0 | `Cargo.toml` |
-| Live node health | Verified for https://exochain-production.up.railway.app/health on 2026-05-09 | `tools/verify_live_node_claim.sh` |
+| Live node health | Not inferred from repository state; verify each target at deploy or release time | `tools/verify_live_node_claim.sh` |
 
 ### What is verified today
 
-- **6,102 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **6,236 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -58,7 +58,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 ### What is supported by design but not yet production-hardened
 
 - **Scoped 90% coverage threshold** — configured in CI via cargo-tarpaulin and `tarpaulin.toml`; the default coverage gate explicitly excludes runtime adapters, WASM bridge bindings, and proof modules
-- **exo-gateway binary** — operational HTTP server with 28 endpoints (REST, GraphQL, health probes); production hardening ongoing
+- **exo-gateway binary** — operational HTTP server with 30 endpoints (REST and health probes) plus GraphQL; production hardening ongoing
 - **GraphQL API** — types and schema definitions exist in `exo-api`; async runtime integration pending
 - **exo-dag benchmark** — disabled; needs rewrite against current API
 
@@ -68,7 +68,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### Roadmap / Planned
 
-- First versioned release (see `.github/workflows/release.yml` for the dry-run workflow)
+- Next governed release through the signed-tag, approval, publication, SBOM, and attestation workflow in `.github/workflows/release.yml`
 - CycloneDX SBOM generation and SLSA supply-chain attestation are configured in CI/release workflows; published release artifacts are not claimed until a GitHub Release exists
 - Agent passport API and trust receipt endpoints on exo-node
 - National AI Policy Framework compliance extensions
@@ -94,7 +94,7 @@ pricing or settlement state, and the economy layer never gates trust on
 payment availability. Future governance amendments can switch nonzero
 pricing on by policy without modifying AVC validation.
 
-The local worktree also contains the **EXOCHAIN LYNK Protocol** package at
+The repository also contains the **EXOCHAIN LYNK Protocol** package at
 [`packages/exochain-llm-proxy`](packages/exochain-llm-proxy/). LYNK is a
 core runtime adapter for receipted LLM and MCP usage: OpenAI Responses, OpenAI
 Chat Completions, and MCP `tools/call` are wrapped in signed AVC evidence and
@@ -124,10 +124,10 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 31 crates, 377565 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 31 crates, 385376 tracked LOC under crates/)
          Constitutional governance runtime — deterministic, no floats,
          production Ed25519/BLAKE3 cryptography plus unaudited pedagogical
-         SNARK/STARK/ZKML skeletons, 6,102 listed workspace tests
+         SNARK/STARK/ZKML skeletons, 6,236 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          165 verified WASM exports covered by 172 bridge checks — Rust -> WebAssembly -> JavaScript
@@ -212,7 +212,7 @@ and production observability are tracked in the DAG DB runtime activation runboo
 [`docs/dagdb/runtime-activation/rollback-canary-observability.md`](docs/dagdb/runtime-activation/rollback-canary-observability.md).
 These runtime docs do not claim billing savings or thesis acceptance.
 
-### Core Crates (22)
+### Core Crates (23)
 
 | Crate | Description |
 |-------|-------------|
@@ -221,7 +221,7 @@ These runtime docs do not claim billing savings or thesis acceptance.
 | `exo-gatekeeper` | TEE/Enclave interfaces, attestation verification, kernel invariants, holon, MCP |
 | `exo-dag` | Directed Acyclic Graph engine, BFT consensus adapter, checkpointing, HLC |
 | `exo-dag-db-*` | Split DAG DB and graph-governed agent memory runtime crates |
-| `exo-gateway` | External gateway: REST, GraphQL, auth, health probes (28 endpoints) |
+| `exo-gateway` | External gateway: REST, GraphQL, auth, health probes (30 enumerated REST endpoints plus GraphQL) |
 | `exo-identity` | Decentralized Identity (DID), key management, Shamir secret sharing, vault |
 | `exo-proofs` | SNARK, STARK, ZKML proof-system skeletons (unaudited, pedagogical — not production cryptography), verifier infrastructure |
 | `exo-authority` | Authority delegation, role-based access, attestation chains |
@@ -244,7 +244,7 @@ These runtime docs do not claim billing savings or thesis acceptance.
 
 * **`governance/`** — Council resolutions, sub-agent charters, traceability matrices, quality gates
 * **`docs/`** — Architecture, guides, council panel reports, proofs, reference documentation
-* **`.github/workflows/`** — CI pipeline (22 numbered quality gates plus required aggregator), release workflow, ExoForge triage
+* **`.github/workflows/`** — CI pipeline (23 numbered quality gates plus required aggregator), release workflow, ExoForge triage
 
 ## Governance & Compliance
 
@@ -254,7 +254,7 @@ This repository is managed under strict **Judicial Build Governance**. All contr
 
 * [Traceability Matrix](governance/traceability_matrix.md) — 119 requirements tracked
 * [Threat Model](governance/threat_matrix.md) — 17 tracked: 17 implemented, 0 partial, 0 planned
-* [Quality Gates](governance/quality_gates.md) — 22 numbered CI gates plus required aggregator
+* [Quality Gates](governance/quality_gates.md) — 23 numbered CI gates plus required aggregator
 * [Sub-Agent Charters](governance/sub_agents.md) — 11 agent charters documented
 * [Council Resolutions](governance/resolutions/INDEX.md) — CR-001 DRAFT
 * [Tier-One Readiness Audit](docs/audit/TIER-ONE-READINESS-AUDIT.md) — capability model, gap analysis, exit checklist

--- a/crates/exo-avc/src/receipt.rs
+++ b/crates/exo-avc/src/receipt.rs
@@ -340,6 +340,25 @@ struct ExtendedReceiptSigningPayload<'a> {
     validation_hash: &'a Hash256,
 }
 
+#[derive(Serialize)]
+struct PreLynkExtendedReceiptSigningPayload<'a> {
+    domain: &'static str,
+    schema_version: u16,
+    credential_id: &'a Hash256,
+    action_id: Option<&'a Hash256>,
+    action_commitment_hash: Option<&'a Hash256>,
+    action_descriptor: Option<&'a AvcActionDescriptor>,
+    action_descriptor_hash: Option<&'a Hash256>,
+    previous_receipt_hash: Option<&'a Hash256>,
+    timestamp_provenance: Option<&'a AvcReceiptTimestampProvenance>,
+    external_timestamp_proof: Option<&'a AvcReceiptExternalTimestampProof>,
+    validator_did: &'a Did,
+    decision: &'a AvcDecision,
+    reason_codes: &'a [AvcReasonCode],
+    created_at: &'a Timestamp,
+    validation_hash: &'a Hash256,
+}
+
 impl AvcTrustReceipt {
     #[must_use]
     pub fn has_extended_evidence(&self) -> bool {
@@ -404,13 +423,56 @@ impl AvcTrustReceipt {
         Ok(Hash256::digest(&self.signing_payload()?))
     }
 
-    /// Returns true when `receipt_id` matches the canonical hash of the
-    /// signed fields.
+    /// Return the supported signing payload whose digest matches the stored
+    /// receipt ID, preferring the current canonical representation.
+    ///
+    /// Pre-LYNK extended receipts are matched only when no LLM usage evidence
+    /// hash is present. Current receipt generation remains canonical.
+    ///
+    /// # Errors
+    /// Returns [`AvcError::Serialization`] when CBOR encoding fails.
+    pub(crate) fn signing_payload_matching_receipt_id(&self) -> Result<Option<Vec<u8>>, AvcError> {
+        let current_payload = self.signing_payload()?;
+        if Hash256::digest(&current_payload) == self.receipt_id {
+            return Ok(Some(current_payload));
+        }
+
+        if !self.has_extended_evidence() || self.llm_usage_evidence_hash.is_some() {
+            return Ok(None);
+        }
+
+        let historical_payload = PreLynkExtendedReceiptSigningPayload {
+            domain: AVC_RECEIPT_SIGNING_DOMAIN,
+            schema_version: self.schema_version,
+            credential_id: &self.credential_id,
+            action_id: self.action_id.as_ref(),
+            action_commitment_hash: self.action_commitment_hash.as_ref(),
+            action_descriptor: self.action_descriptor.as_ref(),
+            action_descriptor_hash: self.action_descriptor_hash.as_ref(),
+            previous_receipt_hash: self.previous_receipt_hash.as_ref(),
+            timestamp_provenance: self.timestamp_provenance.as_ref(),
+            external_timestamp_proof: self.external_timestamp_proof.as_ref(),
+            validator_did: &self.validator_did,
+            decision: &self.decision,
+            reason_codes: &self.reason_codes,
+            created_at: &self.created_at,
+            validation_hash: &self.validation_hash,
+        };
+        let mut bytes = Vec::new();
+        ciborium::ser::into_writer(&historical_payload, &mut bytes)?;
+        if Hash256::digest(&bytes) == self.receipt_id {
+            Ok(Some(bytes))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Returns true when `receipt_id` matches a supported signing payload.
     ///
     /// # Errors
     /// Returns [`AvcError::Serialization`] when CBOR encoding fails.
     pub fn verify_id(&self) -> Result<bool, AvcError> {
-        Ok(self.recompute_id()? == self.receipt_id)
+        Ok(self.signing_payload_matching_receipt_id()?.is_some())
     }
 }
 

--- a/crates/exo-avc/src/receipt.rs
+++ b/crates/exo-avc/src/receipt.rs
@@ -437,7 +437,10 @@ impl AvcTrustReceipt {
             return Ok(Some(current_payload));
         }
 
-        if !self.has_extended_evidence() || self.llm_usage_evidence_hash.is_some() {
+        if self.schema_version != AVC_SCHEMA_VERSION
+            || !self.has_extended_evidence()
+            || self.llm_usage_evidence_hash.is_some()
+        {
             return Ok(None);
         }
 
@@ -467,12 +470,12 @@ impl AvcTrustReceipt {
         }
     }
 
-    /// Returns true when `receipt_id` matches a supported signing payload.
+    /// Returns true when `receipt_id` matches the current canonical signing payload.
     ///
     /// # Errors
     /// Returns [`AvcError::Serialization`] when CBOR encoding fails.
     pub fn verify_id(&self) -> Result<bool, AvcError> {
-        Ok(self.signing_payload_matching_receipt_id()?.is_some())
+        Ok(self.recompute_id()? == self.receipt_id)
     }
 }
 

--- a/crates/exo-avc/src/registry.rs
+++ b/crates/exo-avc/src/registry.rs
@@ -648,6 +648,7 @@ impl InMemoryAvcRegistry {
     }
 
     fn validate_receipt_structural(&self, receipt: &AvcTrustReceipt) -> Result<Vec<u8>, AvcError> {
+        Self::validate_receipt_schema(receipt)?;
         let payload = receipt.signing_payload()?;
         if Hash256::digest(&payload) != receipt.receipt_id {
             return Err(AvcError::InvalidInput {
@@ -665,6 +666,7 @@ impl InMemoryAvcRegistry {
         &self,
         receipt: &AvcTrustReceipt,
     ) -> Result<Vec<u8>, AvcError> {
+        Self::validate_receipt_schema(receipt)?;
         let payload = receipt
             .signing_payload_matching_receipt_id()?
             .ok_or_else(|| AvcError::InvalidInput {
@@ -675,6 +677,16 @@ impl InMemoryAvcRegistry {
             })?;
         self.validate_receipt_references(receipt)?;
         Ok(payload)
+    }
+
+    fn validate_receipt_schema(receipt: &AvcTrustReceipt) -> Result<(), AvcError> {
+        if receipt.schema_version != crate::credential::AVC_SCHEMA_VERSION {
+            return Err(AvcError::UnsupportedSchema {
+                got: receipt.schema_version,
+                supported: crate::credential::AVC_SCHEMA_VERSION,
+            });
+        }
+        Ok(())
     }
 
     fn validate_receipt_references(&self, receipt: &AvcTrustReceipt) -> Result<(), AvcError> {

--- a/crates/exo-avc/src/registry.rs
+++ b/crates/exo-avc/src/registry.rs
@@ -276,7 +276,7 @@ impl InMemoryAvcRegistry {
                     ),
                 });
             }
-            registry.validate_receipt_structural(&receipt)?;
+            registry.validate_persisted_receipt_structural(&receipt)?;
             registry.receipts.insert(stored_id, receipt);
         }
         registry.validate_durable_receipt_evidence(state.receipt_chain_head)?;
@@ -374,7 +374,7 @@ impl InMemoryAvcRegistry {
     /// startup trust anchors are intentionally restored out-of-band.
     pub fn validate_loaded_receipts(&self) -> Result<(), AvcError> {
         for receipt in self.receipts.values() {
-            self.validate_receipt(receipt)?;
+            self.validate_persisted_receipt(receipt)?;
         }
         Ok(())
     }
@@ -648,6 +648,23 @@ impl InMemoryAvcRegistry {
     }
 
     fn validate_receipt_structural(&self, receipt: &AvcTrustReceipt) -> Result<Vec<u8>, AvcError> {
+        let payload = receipt.signing_payload()?;
+        if Hash256::digest(&payload) != receipt.receipt_id {
+            return Err(AvcError::InvalidInput {
+                reason: format!(
+                    "receipt {} for credential {} has an invalid content id",
+                    receipt.receipt_id, receipt.credential_id
+                ),
+            });
+        }
+        self.validate_receipt_references(receipt)?;
+        Ok(payload)
+    }
+
+    fn validate_persisted_receipt_structural(
+        &self,
+        receipt: &AvcTrustReceipt,
+    ) -> Result<Vec<u8>, AvcError> {
         let payload = receipt
             .signing_payload_matching_receipt_id()?
             .ok_or_else(|| AvcError::InvalidInput {
@@ -656,6 +673,11 @@ impl InMemoryAvcRegistry {
                     receipt.receipt_id, receipt.credential_id
                 ),
             })?;
+        self.validate_receipt_references(receipt)?;
+        Ok(payload)
+    }
+
+    fn validate_receipt_references(&self, receipt: &AvcTrustReceipt) -> Result<(), AvcError> {
         if receipt.signature.is_empty() {
             return Err(AvcError::InvalidInput {
                 reason: format!("receipt {} has an empty signature", receipt.receipt_id),
@@ -669,11 +691,24 @@ impl InMemoryAvcRegistry {
                 ),
             });
         }
-        Ok(payload)
+        Ok(())
     }
 
     fn validate_receipt(&self, receipt: &AvcTrustReceipt) -> Result<(), AvcError> {
         let payload = self.validate_receipt_structural(receipt)?;
+        self.validate_receipt_signature(receipt, &payload)
+    }
+
+    fn validate_persisted_receipt(&self, receipt: &AvcTrustReceipt) -> Result<(), AvcError> {
+        let payload = self.validate_persisted_receipt_structural(receipt)?;
+        self.validate_receipt_signature(receipt, &payload)
+    }
+
+    fn validate_receipt_signature(
+        &self,
+        receipt: &AvcTrustReceipt,
+        payload: &[u8],
+    ) -> Result<(), AvcError> {
         let public_key = self
             .receipt_validator_public_keys
             .get(&receipt.validator_did)
@@ -683,7 +718,7 @@ impl InMemoryAvcRegistry {
                     receipt.validator_did
                 ),
             })?;
-        if !crypto::verify(&payload, &receipt.signature, public_key) {
+        if !crypto::verify(payload, &receipt.signature, public_key) {
             return Err(AvcError::InvalidInput {
                 reason: format!("receipt signature for {} is invalid", receipt.receipt_id),
             });
@@ -1625,8 +1660,7 @@ mod tests {
     #[test]
     fn put_receipt_rejects_new_pre_lynk_extended_receipt_without_mutating_registry() {
         let mut reg = fresh_registry();
-        let (credential_id, _issuer_keypair) =
-            register_sample_credential_and_issuer_key(&mut reg);
+        let (credential_id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);
         let validator_keypair = put_validator_key(&mut reg);
         let receipt =
             pre_lynk_extended_receipt_for_credential(credential_id, &validator_keypair, None, 0x21);

--- a/crates/exo-avc/src/registry.rs
+++ b/crates/exo-avc/src/registry.rs
@@ -1159,29 +1159,7 @@ mod tests {
         receipt
     }
 
-    fn pre_lynk_extended_receipt_for_credential(
-        credential_id: Hash256,
-        validator_keypair: &KeyPair,
-    ) -> AvcTrustReceipt {
-        let mut receipt = AvcTrustReceipt {
-            schema_version: crate::credential::AVC_SCHEMA_VERSION,
-            receipt_id: Hash256::ZERO,
-            credential_id,
-            action_id: Some(h256(0x21)),
-            action_commitment_hash: Some(h256(0x22)),
-            action_descriptor: None,
-            action_descriptor_hash: None,
-            llm_usage_evidence_hash: None,
-            previous_receipt_hash: None,
-            timestamp_provenance: Some(AvcReceiptTimestampProvenance::LocalHybridLogicalClock),
-            external_timestamp_proof: None,
-            validator_did: did("validator"),
-            decision: AvcDecision::Allow,
-            reason_codes: vec![AvcReasonCode::Valid],
-            created_at: ts(0x24),
-            validation_hash: h256(0x25),
-            signature: Signature::empty(),
-        };
+    fn pre_lynk_extended_receipt_signing_payload(receipt: &AvcTrustReceipt) -> Vec<u8> {
         let payload = PreLynkExtendedReceiptSigningPayload {
             domain: AVC_RECEIPT_SIGNING_DOMAIN,
             schema_version: receipt.schema_version,
@@ -1201,9 +1179,55 @@ mod tests {
         };
         let mut bytes = Vec::new();
         ciborium::ser::into_writer(&payload, &mut bytes).unwrap();
+        bytes
+    }
+
+    fn pre_lynk_extended_receipt_for_credential(
+        credential_id: Hash256,
+        validator_keypair: &KeyPair,
+        previous_receipt_hash: Option<Hash256>,
+        differentiator: u8,
+    ) -> AvcTrustReceipt {
+        let mut receipt = AvcTrustReceipt {
+            schema_version: crate::credential::AVC_SCHEMA_VERSION,
+            receipt_id: Hash256::ZERO,
+            credential_id,
+            action_id: Some(h256(differentiator)),
+            action_commitment_hash: Some(h256(differentiator.wrapping_add(1))),
+            action_descriptor: None,
+            action_descriptor_hash: None,
+            llm_usage_evidence_hash: None,
+            previous_receipt_hash,
+            timestamp_provenance: Some(AvcReceiptTimestampProvenance::LocalHybridLogicalClock),
+            external_timestamp_proof: None,
+            validator_did: did("validator"),
+            decision: AvcDecision::Allow,
+            reason_codes: vec![AvcReasonCode::Valid],
+            created_at: ts(u64::from(differentiator) + 3),
+            validation_hash: h256(differentiator.wrapping_add(4)),
+            signature: Signature::empty(),
+        };
+        let bytes = pre_lynk_extended_receipt_signing_payload(&receipt);
         receipt.receipt_id = Hash256::digest(&bytes);
         receipt.signature = validator_keypair.sign(&bytes);
         receipt
+    }
+
+    fn assert_pre_lynk_chain_preserved(
+        registry: &InMemoryAvcRegistry,
+        first: &AvcTrustReceipt,
+        second: &AvcTrustReceipt,
+    ) {
+        let stored_first = registry.get_receipt(&first.receipt_id).unwrap();
+        assert_eq!(stored_first.receipt_id, first.receipt_id);
+        assert_eq!(stored_first.signature, first.signature);
+        assert_eq!(stored_first.previous_receipt_hash, None);
+
+        let stored_second = registry.get_receipt(&second.receipt_id).unwrap();
+        assert_eq!(stored_second.receipt_id, second.receipt_id);
+        assert_eq!(stored_second.signature, second.signature);
+        assert_eq!(stored_second.previous_receipt_hash, Some(first.receipt_id));
+        assert_eq!(registry.receipt_chain_head(), Some(second.receipt_id));
     }
 
     fn resign_receipt(receipt: &mut AvcTrustReceipt, validator_keypair: &KeyPair) {
@@ -1912,7 +1936,8 @@ mod tests {
         let (credential_id, issuer_keypair) =
             register_sample_credential_and_issuer_key(&mut durable_source);
         let validator_keypair = keypair(0x33);
-        let receipt = pre_lynk_extended_receipt_for_credential(credential_id, &validator_keypair);
+        let receipt =
+            pre_lynk_extended_receipt_for_credential(credential_id, &validator_keypair, None, 0x21);
         let mut state = durable_source.durable_state();
         state.receipts.insert(receipt.receipt_id, receipt.clone());
         state.receipt_chain_head = Some(receipt.receipt_id);
@@ -1931,6 +1956,176 @@ mod tests {
 
         assert_eq!(live.get_receipt(&receipt.receipt_id), Some(receipt.clone()));
         assert_eq!(live.receipt_chain_head(), Some(receipt.receipt_id));
+    }
+
+    #[test]
+    fn durable_state_rejects_tampered_pre_lynk_extended_receipt_signed_field() {
+        let mut durable_source = fresh_registry();
+        let (credential_id, _issuer_keypair) =
+            register_sample_credential_and_issuer_key(&mut durable_source);
+        let validator_keypair = keypair(0x33);
+        let mut receipt =
+            pre_lynk_extended_receipt_for_credential(credential_id, &validator_keypair, None, 0x31);
+        let historical_id = receipt.receipt_id;
+        let historical_signature = receipt.signature.clone();
+        receipt.validation_hash = h256(0xFE);
+        assert_eq!(receipt.receipt_id, historical_id);
+        assert_eq!(receipt.signature, historical_signature);
+
+        let mut state = durable_source.durable_state();
+        state.receipts.insert(historical_id, receipt);
+        state.receipt_chain_head = Some(historical_id);
+
+        let err = InMemoryAvcRegistry::from_durable_state(state).unwrap_err();
+        assert!(
+            matches!(err, AvcError::InvalidInput { reason } if reason.contains("invalid content id")),
+            "tampering with a signed historical field must invalidate the retained receipt ID"
+        );
+    }
+
+    #[test]
+    fn apply_durable_state_rejects_forged_pre_lynk_receipt_signature_and_preserves_target() {
+        let mut durable_source = fresh_registry();
+        let (credential_id, issuer_keypair) =
+            register_sample_credential_and_issuer_key(&mut durable_source);
+        let validator_keypair = keypair(0x33);
+        let attacker_keypair = keypair(0x44);
+        let mut forged_receipt =
+            pre_lynk_extended_receipt_for_credential(credential_id, &validator_keypair, None, 0x41);
+        let legitimate_signature = forged_receipt.signature.clone();
+        let historical_payload = pre_lynk_extended_receipt_signing_payload(&forged_receipt);
+        forged_receipt.signature = attacker_keypair.sign(&historical_payload);
+        assert_ne!(forged_receipt.signature, legitimate_signature);
+
+        let mut state = durable_source.durable_state();
+        state
+            .receipts
+            .insert(forged_receipt.receipt_id, forged_receipt.clone());
+        state.receipt_chain_head = Some(forged_receipt.receipt_id);
+
+        let structural = InMemoryAvcRegistry::from_durable_state(state.clone()).unwrap();
+        assert_eq!(
+            structural.get_receipt(&forged_receipt.receipt_id),
+            Some(forged_receipt.clone())
+        );
+
+        let mut live = fresh_registry();
+        live.put_public_key(did("issuer"), issuer_keypair.public);
+        live.put_receipt_validator_public_key(did("validator"), validator_keypair.public);
+        let existing_credential_id = live.put_credential(sample_credential()).unwrap();
+        assert_eq!(existing_credential_id, credential_id);
+        let existing_receipt = receipt_for_credential(credential_id, &validator_keypair);
+        live.put_receipt(existing_receipt).unwrap();
+        let target_before_apply = live.durable_state();
+
+        let err = live.apply_durable_state(state).unwrap_err();
+        match err {
+            AvcError::InvalidInput { reason } => assert_eq!(
+                reason,
+                format!(
+                    "receipt signature for {} is invalid",
+                    forged_receipt.receipt_id
+                )
+            ),
+            other => panic!("expected forged historical receipt signature error, got {other:?}"),
+        }
+        assert_eq!(live.durable_state(), target_before_apply);
+        assert_eq!(
+            live.resolve_receipt_validator_public_key(&did("validator")),
+            Some(validator_keypair.public)
+        );
+    }
+
+    #[test]
+    fn durable_state_preserves_two_receipt_pre_lynk_chain() {
+        let mut durable_source = fresh_registry();
+        let (credential_id, issuer_keypair) =
+            register_sample_credential_and_issuer_key(&mut durable_source);
+        let validator_keypair = keypair(0x33);
+        let first =
+            pre_lynk_extended_receipt_for_credential(credential_id, &validator_keypair, None, 0x51);
+        let second = pre_lynk_extended_receipt_for_credential(
+            credential_id,
+            &validator_keypair,
+            Some(first.receipt_id),
+            0x61,
+        );
+        let mut state = durable_source.durable_state();
+        state.receipts.insert(first.receipt_id, first.clone());
+        state.receipts.insert(second.receipt_id, second.clone());
+        state.receipt_chain_head = Some(second.receipt_id);
+
+        let restored = InMemoryAvcRegistry::from_durable_state(state.clone()).unwrap();
+        assert_pre_lynk_chain_preserved(&restored, &first, &second);
+
+        let mut live = fresh_registry();
+        live.put_public_key(did("issuer"), issuer_keypair.public);
+        live.put_receipt_validator_public_key(did("validator"), validator_keypair.public);
+        live.apply_durable_state(state).unwrap();
+        assert_pre_lynk_chain_preserved(&live, &first, &second);
+    }
+
+    #[test]
+    fn lynk_hashed_receipts_never_use_pre_lynk_fallback() {
+        let mut durable_source = fresh_registry();
+        let (credential_id, issuer_keypair) =
+            register_sample_credential_and_issuer_key(&mut durable_source);
+        let validator_keypair = keypair(0x33);
+        let mut current =
+            chained_receipt_for_credential(credential_id, &validator_keypair, None, 0x71);
+        current.llm_usage_evidence_hash = Some(h256(0xA1));
+        resign_receipt(&mut current, &validator_keypair);
+
+        let mut valid_state = durable_source.durable_state();
+        valid_state
+            .receipts
+            .insert(current.receipt_id, current.clone());
+        valid_state.receipt_chain_head = Some(current.receipt_id);
+
+        let restored = InMemoryAvcRegistry::from_durable_state(valid_state.clone()).unwrap();
+        assert_eq!(
+            restored.get_receipt(&current.receipt_id),
+            Some(current.clone())
+        );
+        let mut live = fresh_registry();
+        live.put_public_key(did("issuer"), issuer_keypair.public);
+        live.put_receipt_validator_public_key(did("validator"), validator_keypair.public);
+        live.apply_durable_state(valid_state).unwrap();
+        assert_eq!(live.get_receipt(&current.receipt_id), Some(current.clone()));
+
+        let mut tampered = current.clone();
+        tampered.llm_usage_evidence_hash = Some(h256(0xA2));
+        let mut tampered_state = durable_source.durable_state();
+        tampered_state
+            .receipts
+            .insert(tampered.receipt_id, tampered.clone());
+        tampered_state.receipt_chain_head = Some(tampered.receipt_id);
+
+        let err = InMemoryAvcRegistry::from_durable_state(tampered_state).unwrap_err();
+        assert!(
+            matches!(err, AvcError::InvalidInput { reason } if reason.contains("invalid content id")),
+            "a mutated LYNK evidence hash must invalidate the current receipt ID"
+        );
+
+        let mut historical_id_forgery = current.clone();
+        let historical_payload = pre_lynk_extended_receipt_signing_payload(&historical_id_forgery);
+        historical_id_forgery.receipt_id = Hash256::digest(&historical_payload);
+        historical_id_forgery.signature = validator_keypair.sign(&historical_payload);
+        assert!(historical_id_forgery.llm_usage_evidence_hash.is_some());
+        assert_ne!(historical_id_forgery.receipt_id, current.receipt_id);
+
+        let mut historical_id_state = durable_source.durable_state();
+        historical_id_state.receipts.insert(
+            historical_id_forgery.receipt_id,
+            historical_id_forgery.clone(),
+        );
+        historical_id_state.receipt_chain_head = Some(historical_id_forgery.receipt_id);
+
+        let err = InMemoryAvcRegistry::from_durable_state(historical_id_state).unwrap_err();
+        assert!(
+            matches!(err, AvcError::InvalidInput { reason } if reason.contains("invalid content id")),
+            "pre-LYNK payload matching must remain disabled when LYNK evidence is present"
+        );
     }
 
     #[test]

--- a/crates/exo-avc/src/registry.rs
+++ b/crates/exo-avc/src/registry.rs
@@ -1623,6 +1623,26 @@ mod tests {
     }
 
     #[test]
+    fn put_receipt_rejects_new_pre_lynk_extended_receipt_without_mutating_registry() {
+        let mut reg = fresh_registry();
+        let (credential_id, _issuer_keypair) =
+            register_sample_credential_and_issuer_key(&mut reg);
+        let validator_keypair = put_validator_key(&mut reg);
+        let receipt =
+            pre_lynk_extended_receipt_for_credential(credential_id, &validator_keypair, None, 0x21);
+        let before = reg.durable_state();
+
+        let err = reg.put_receipt(receipt.clone()).unwrap_err();
+
+        assert!(
+            matches!(err, AvcError::InvalidInput { reason } if reason.contains("invalid content id")),
+            "live writes must require the current canonical receipt payload"
+        );
+        assert_eq!(reg.durable_state(), before);
+        assert!(reg.get_receipt(&receipt.receipt_id).is_none());
+    }
+
+    #[test]
     fn put_receipt_accepts_scoped_validator_key_without_generic_issuer_trust() {
         let mut reg = fresh_registry();
         let (id, _issuer_keypair) = register_sample_credential_and_issuer_key(&mut reg);

--- a/crates/exo-avc/src/registry.rs
+++ b/crates/exo-avc/src/registry.rs
@@ -1017,8 +1017,32 @@ mod tests {
             issue_avc,
             test_support::{baseline_draft, did, h256, ts},
         },
+        receipt::{
+            AVC_RECEIPT_SIGNING_DOMAIN, AvcReceiptExternalTimestampProof,
+            AvcReceiptTimestampProvenance,
+        },
         revocation::{AvcRevocation, AvcRevocationReason, revoke_avc},
+        validation::{AvcActionDescriptor, AvcDecision, AvcReasonCode},
     };
+
+    #[derive(serde::Serialize)]
+    struct PreLynkExtendedReceiptSigningPayload<'a> {
+        domain: &'static str,
+        schema_version: u16,
+        credential_id: &'a Hash256,
+        action_id: Option<&'a Hash256>,
+        action_commitment_hash: Option<&'a Hash256>,
+        action_descriptor: Option<&'a AvcActionDescriptor>,
+        action_descriptor_hash: Option<&'a Hash256>,
+        previous_receipt_hash: Option<&'a Hash256>,
+        timestamp_provenance: Option<&'a AvcReceiptTimestampProvenance>,
+        external_timestamp_proof: Option<&'a AvcReceiptExternalTimestampProof>,
+        validator_did: &'a Did,
+        decision: &'a AvcDecision,
+        reason_codes: &'a [AvcReasonCode],
+        created_at: &'a Timestamp,
+        validation_hash: &'a Hash256,
+    }
 
     fn keypair(seed: u8) -> KeyPair {
         KeyPair::from_secret_bytes([seed; 32]).unwrap()
@@ -1133,6 +1157,53 @@ mod tests {
         let payload = receipt.signing_payload().unwrap();
         receipt.receipt_id = Hash256::digest(&payload);
         receipt.signature = validator_keypair.sign(&payload);
+        receipt
+    }
+
+    fn pre_lynk_extended_receipt_for_credential(
+        credential_id: Hash256,
+        validator_keypair: &KeyPair,
+    ) -> AvcTrustReceipt {
+        let mut receipt = AvcTrustReceipt {
+            schema_version: crate::credential::AVC_SCHEMA_VERSION,
+            receipt_id: Hash256::ZERO,
+            credential_id,
+            action_id: Some(h256(0x21)),
+            action_commitment_hash: Some(h256(0x22)),
+            action_descriptor: None,
+            action_descriptor_hash: None,
+            llm_usage_evidence_hash: None,
+            previous_receipt_hash: None,
+            timestamp_provenance: Some(AvcReceiptTimestampProvenance::LocalHybridLogicalClock),
+            external_timestamp_proof: None,
+            validator_did: did("validator"),
+            decision: AvcDecision::Allow,
+            reason_codes: vec![AvcReasonCode::Valid],
+            created_at: ts(0x24),
+            validation_hash: h256(0x25),
+            signature: Signature::empty(),
+        };
+        let payload = PreLynkExtendedReceiptSigningPayload {
+            domain: AVC_RECEIPT_SIGNING_DOMAIN,
+            schema_version: receipt.schema_version,
+            credential_id: &receipt.credential_id,
+            action_id: receipt.action_id.as_ref(),
+            action_commitment_hash: receipt.action_commitment_hash.as_ref(),
+            action_descriptor: receipt.action_descriptor.as_ref(),
+            action_descriptor_hash: receipt.action_descriptor_hash.as_ref(),
+            previous_receipt_hash: receipt.previous_receipt_hash.as_ref(),
+            timestamp_provenance: receipt.timestamp_provenance.as_ref(),
+            external_timestamp_proof: receipt.external_timestamp_proof.as_ref(),
+            validator_did: &receipt.validator_did,
+            decision: &receipt.decision,
+            reason_codes: &receipt.reason_codes,
+            created_at: &receipt.created_at,
+            validation_hash: &receipt.validation_hash,
+        };
+        let mut bytes = Vec::new();
+        ciborium::ser::into_writer(&payload, &mut bytes).unwrap();
+        receipt.receipt_id = Hash256::digest(&bytes);
+        receipt.signature = validator_keypair.sign(&bytes);
         receipt
     }
 
@@ -1834,6 +1905,33 @@ mod tests {
         assert_eq!(restored.receipt_count(), 1);
         assert_eq!(restored.receipt_chain_head(), None);
         assert_eq!(restored.get_receipt(&receipt.receipt_id).unwrap(), receipt);
+    }
+
+    #[test]
+    fn durable_state_accepts_pre_lynk_extended_receipt_and_preserves_id_and_signature() {
+        let mut durable_source = fresh_registry();
+        let (credential_id, issuer_keypair) =
+            register_sample_credential_and_issuer_key(&mut durable_source);
+        let validator_keypair = keypair(0x33);
+        let receipt = pre_lynk_extended_receipt_for_credential(credential_id, &validator_keypair);
+        let mut state = durable_source.durable_state();
+        state.receipts.insert(receipt.receipt_id, receipt.clone());
+        state.receipt_chain_head = Some(receipt.receipt_id);
+
+        let restored = InMemoryAvcRegistry::from_durable_state(state.clone()).unwrap();
+        assert_eq!(
+            restored.get_receipt(&receipt.receipt_id),
+            Some(receipt.clone())
+        );
+        assert_eq!(restored.receipt_chain_head(), Some(receipt.receipt_id));
+
+        let mut live = fresh_registry();
+        live.put_public_key(did("issuer"), issuer_keypair.public);
+        live.put_receipt_validator_public_key(did("validator"), validator_keypair.public);
+        live.apply_durable_state(state).unwrap();
+
+        assert_eq!(live.get_receipt(&receipt.receipt_id), Some(receipt.clone()));
+        assert_eq!(live.receipt_chain_head(), Some(receipt.receipt_id));
     }
 
     #[test]

--- a/crates/exo-avc/src/registry.rs
+++ b/crates/exo-avc/src/registry.rs
@@ -647,15 +647,15 @@ impl InMemoryAvcRegistry {
         Ok(())
     }
 
-    fn validate_receipt_structural(&self, receipt: &AvcTrustReceipt) -> Result<(), AvcError> {
-        if !receipt.verify_id()? {
-            return Err(AvcError::InvalidInput {
+    fn validate_receipt_structural(&self, receipt: &AvcTrustReceipt) -> Result<Vec<u8>, AvcError> {
+        let payload = receipt
+            .signing_payload_matching_receipt_id()?
+            .ok_or_else(|| AvcError::InvalidInput {
                 reason: format!(
                     "receipt {} for credential {} has an invalid content id",
                     receipt.receipt_id, receipt.credential_id
                 ),
-            });
-        }
+            })?;
         if receipt.signature.is_empty() {
             return Err(AvcError::InvalidInput {
                 reason: format!("receipt {} has an empty signature", receipt.receipt_id),
@@ -669,11 +669,11 @@ impl InMemoryAvcRegistry {
                 ),
             });
         }
-        Ok(())
+        Ok(payload)
     }
 
     fn validate_receipt(&self, receipt: &AvcTrustReceipt) -> Result<(), AvcError> {
-        self.validate_receipt_structural(receipt)?;
+        let payload = self.validate_receipt_structural(receipt)?;
         let public_key = self
             .receipt_validator_public_keys
             .get(&receipt.validator_did)
@@ -683,7 +683,6 @@ impl InMemoryAvcRegistry {
                     receipt.validator_did
                 ),
             })?;
-        let payload = receipt.signing_payload()?;
         if !crypto::verify(&payload, &receipt.signature, public_key) {
             return Err(AvcError::InvalidInput {
                 reason: format!("receipt signature for {} is invalid", receipt.receipt_id),

--- a/crates/exo-avc/src/registry.rs
+++ b/crates/exo-avc/src/registry.rs
@@ -1992,6 +1992,10 @@ mod tests {
         let validator_keypair = keypair(0x33);
         let receipt =
             pre_lynk_extended_receipt_for_credential(credential_id, &validator_keypair, None, 0x21);
+        assert!(
+            !receipt.verify_id().unwrap(),
+            "public receipt ID verification must remain current-format only"
+        );
         let mut state = durable_source.durable_state();
         state.receipts.insert(receipt.receipt_id, receipt.clone());
         state.receipt_chain_head = Some(receipt.receipt_id);
@@ -2010,6 +2014,32 @@ mod tests {
 
         assert_eq!(live.get_receipt(&receipt.receipt_id), Some(receipt.clone()));
         assert_eq!(live.receipt_chain_head(), Some(receipt.receipt_id));
+    }
+
+    #[test]
+    fn durable_state_rejects_pre_lynk_receipt_with_unsupported_schema() {
+        let mut durable_source = fresh_registry();
+        let (credential_id, _issuer_keypair) =
+            register_sample_credential_and_issuer_key(&mut durable_source);
+        let validator_keypair = keypair(0x33);
+        let mut receipt =
+            pre_lynk_extended_receipt_for_credential(credential_id, &validator_keypair, None, 0x22);
+        let unsupported = crate::credential::AVC_SCHEMA_VERSION + 1;
+        receipt.schema_version = unsupported;
+        let historical_payload = pre_lynk_extended_receipt_signing_payload(&receipt);
+        receipt.receipt_id = Hash256::digest(&historical_payload);
+        receipt.signature = validator_keypair.sign(&historical_payload);
+
+        let mut state = durable_source.durable_state();
+        state.receipts.insert(receipt.receipt_id, receipt.clone());
+        state.receipt_chain_head = Some(receipt.receipt_id);
+
+        let err = InMemoryAvcRegistry::from_durable_state(state).unwrap_err();
+        assert!(
+            matches!(err, AvcError::UnsupportedSchema { got, supported }
+                if got == unsupported && supported == crate::credential::AVC_SCHEMA_VERSION),
+            "historical compatibility must not admit unsupported receipt schemas"
+        );
     }
 
     #[test]

--- a/crates/exo-escalation/src/kanban.rs
+++ b/crates/exo-escalation/src/kanban.rs
@@ -97,7 +97,7 @@ pub fn move_case(
 ) -> Result<(), EscalationError> {
     // Find and remove the case from its current column
     let mut found_case: Option<EscalationCase> = None;
-    for (_col, cases) in board.columns.iter_mut() {
+    for cases in board.columns.values_mut() {
         if let Some(pos) = cases.iter().position(|c| c.id == *case_id) {
             found_case = Some(cases.remove(pos));
             break;

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -3439,7 +3439,7 @@ pub fn avc_router(state: Arc<AvcApiState>) -> Router {
 #[cfg(test)]
 mod tests {
     use std::{
-        collections::VecDeque,
+        collections::{BTreeMap, VecDeque},
         sync::atomic::{AtomicUsize, Ordering},
     };
 
@@ -4225,6 +4225,34 @@ mod tests {
             validation_hash: &'a Hash256,
         }
 
+        #[derive(Serialize)]
+        struct PreLynkReceiptWire<'a> {
+            schema_version: u16,
+            receipt_id: &'a Hash256,
+            credential_id: &'a Hash256,
+            action_id: Option<&'a Hash256>,
+            action_commitment_hash: Option<&'a Hash256>,
+            action_descriptor: Option<&'a AvcActionDescriptor>,
+            action_descriptor_hash: Option<&'a Hash256>,
+            previous_receipt_hash: Option<&'a Hash256>,
+            timestamp_provenance: Option<&'a AvcReceiptTimestampProvenance>,
+            external_timestamp_proof: Option<&'a AvcReceiptExternalTimestampProof>,
+            validator_did: &'a Did,
+            decision: &'a AvcDecision,
+            reason_codes: &'a [AvcReasonCode],
+            created_at: &'a Timestamp,
+            validation_hash: &'a Hash256,
+            signature: &'a Signature,
+        }
+
+        #[derive(Serialize)]
+        struct PreLynkDurableStateWire<'a> {
+            credentials: &'a BTreeMap<Hash256, AutonomousVolitionCredential>,
+            revocations: &'a BTreeMap<Hash256, AvcRevocation>,
+            receipts: BTreeMap<Hash256, PreLynkReceiptWire<'a>>,
+            receipt_chain_head: Option<Hash256>,
+        }
+
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(AVC_REGISTRY_DURABLE_STATE_FILE);
         let mut registry = InMemoryAvcRegistry::new();
@@ -4279,10 +4307,42 @@ mod tests {
         let historical_id = receipt.receipt_id;
         let historical_signature = receipt.signature.clone();
 
-        let mut durable = registry.durable_state();
-        durable.receipts.insert(historical_id, receipt.clone());
-        durable.receipt_chain_head = Some(historical_id);
-        persist_file_durable_registry_state(&durable, &path).unwrap();
+        let durable = registry.durable_state();
+        let historical_wire_receipt = PreLynkReceiptWire {
+            schema_version: receipt.schema_version,
+            receipt_id: &receipt.receipt_id,
+            credential_id: &receipt.credential_id,
+            action_id: receipt.action_id.as_ref(),
+            action_commitment_hash: receipt.action_commitment_hash.as_ref(),
+            action_descriptor: receipt.action_descriptor.as_ref(),
+            action_descriptor_hash: receipt.action_descriptor_hash.as_ref(),
+            previous_receipt_hash: receipt.previous_receipt_hash.as_ref(),
+            timestamp_provenance: receipt.timestamp_provenance.as_ref(),
+            external_timestamp_proof: receipt.external_timestamp_proof.as_ref(),
+            validator_did: &receipt.validator_did,
+            decision: &receipt.decision,
+            reason_codes: &receipt.reason_codes,
+            created_at: &receipt.created_at,
+            validation_hash: &receipt.validation_hash,
+            signature: &receipt.signature,
+        };
+        let mut historical_receipts = BTreeMap::new();
+        historical_receipts.insert(historical_id, historical_wire_receipt);
+        let historical_wire_state = PreLynkDurableStateWire {
+            credentials: &durable.credentials,
+            revocations: &durable.revocations,
+            receipts: historical_receipts,
+            receipt_chain_head: Some(historical_id),
+        };
+        let mut historical_durable_cbor = Vec::new();
+        ciborium::into_writer(&historical_wire_state, &mut historical_durable_cbor).unwrap();
+        assert!(
+            !historical_durable_cbor
+                .windows("llm_usage_evidence_hash".len())
+                .any(|window| window == b"llm_usage_evidence_hash"),
+            "the pre-LYNK durable fixture must omit the later wire field"
+        );
+        std::fs::write(&path, historical_durable_cbor).unwrap();
 
         let mut loaded = load_file_durable_registry(&path).unwrap();
         assert_eq!(loaded.get_receipt(&historical_id), Some(receipt));

--- a/crates/exo-node/src/avc.rs
+++ b/crates/exo-node/src/avc.rs
@@ -3450,13 +3450,14 @@ mod tests {
     };
     use exo_authority::permission::Permission;
     use exo_avc::{
-        AVC_LLM_USAGE_EVIDENCE_DOMAIN, AVC_SCHEMA_VERSION, AuthorityScope, AutonomyLevel,
-        AvcActionDescriptor, AvcActionRequest, AvcConstraints, AvcDecision, AvcDraft,
-        AvcReasonCode, AvcReceiptEvidenceSubject, AvcReceiptExternalTimestampProofKind,
-        AvcRevocationReason, AvcSubjectKind, DataClass, DelegatedIntent, EncryptedPayloadRef,
-        LlmUsageCustodyMode, LlmUsageEvidence, LlmUsageEvidenceEnvelope, ProviderUsageMetrics,
-        avc_action_descriptor_hash, avc_llm_usage_action_request, create_trust_receipt, issue_avc,
-        llm_usage_evidence_hash, llm_usage_evidence_signature_payload, revoke_avc,
+        AVC_LLM_USAGE_EVIDENCE_DOMAIN, AVC_RECEIPT_SIGNING_DOMAIN, AVC_SCHEMA_VERSION,
+        AuthorityScope, AutonomyLevel, AvcActionDescriptor, AvcActionRequest, AvcConstraints,
+        AvcDecision, AvcDraft, AvcReasonCode, AvcReceiptEvidenceSubject,
+        AvcReceiptExternalTimestampProofKind, AvcRevocationReason, AvcSubjectKind, DataClass,
+        DelegatedIntent, EncryptedPayloadRef, LlmUsageCustodyMode, LlmUsageEvidence,
+        LlmUsageEvidenceEnvelope, ProviderUsageMetrics, avc_action_descriptor_hash,
+        avc_llm_usage_action_request, create_trust_receipt, issue_avc, llm_usage_evidence_hash,
+        llm_usage_evidence_signature_payload, revoke_avc,
     };
     use exo_core::{Hash256, Signature, Timestamp, crypto, crypto::KeyPair};
     use tower::ServiceExt;
@@ -4201,6 +4202,96 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(invalid_error.contains("failed to validate AVC durable registry"));
+    }
+
+    #[test]
+    fn file_durable_registry_loads_pre_lynk_receipt_without_rewriting_identity() {
+        #[derive(Serialize)]
+        struct PreLynkExtendedReceiptSigningPayload<'a> {
+            domain: &'static str,
+            schema_version: u16,
+            credential_id: &'a Hash256,
+            action_id: Option<&'a Hash256>,
+            action_commitment_hash: Option<&'a Hash256>,
+            action_descriptor: Option<&'a AvcActionDescriptor>,
+            action_descriptor_hash: Option<&'a Hash256>,
+            previous_receipt_hash: Option<&'a Hash256>,
+            timestamp_provenance: Option<&'a AvcReceiptTimestampProvenance>,
+            external_timestamp_proof: Option<&'a AvcReceiptExternalTimestampProof>,
+            validator_did: &'a Did,
+            decision: &'a AvcDecision,
+            reason_codes: &'a [AvcReasonCode],
+            created_at: &'a Timestamp,
+            validation_hash: &'a Hash256,
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(AVC_REGISTRY_DURABLE_STATE_FILE);
+        let mut registry = InMemoryAvcRegistry::new();
+        registry.put_public_key(Did::new("did:exo:issuer").unwrap(), issuer_keypair().public);
+        let credential = baseline_credential();
+        let credential_id = registry.put_credential(credential.clone()).unwrap();
+        let validation = AvcValidationResult {
+            credential_id,
+            decision: AvcDecision::Allow,
+            reason_codes: vec![AvcReasonCode::Valid],
+            normalized_holder_did: credential.subject_did,
+            valid_until: credential.expires_at,
+            receipt: None,
+        };
+        let mut receipt = create_trust_receipt_with_evidence(
+            &validation,
+            Some(Hash256::from_bytes([0x71; 32])),
+            AvcTrustReceiptEvidence {
+                action_commitment_hash: Some(Hash256::from_bytes([0x72; 32])),
+                action_descriptor: None,
+                llm_usage_evidence_hash: None,
+                previous_receipt_hash: None,
+                timestamp_provenance: Some(AvcReceiptTimestampProvenance::FixedTestTimestamp),
+                external_timestamp_proof: None,
+            },
+            validator_did(),
+            Timestamp::new(1_500_001, 0),
+            |payload| validator_keypair().sign(payload),
+        )
+        .unwrap();
+        let historical_payload = PreLynkExtendedReceiptSigningPayload {
+            domain: AVC_RECEIPT_SIGNING_DOMAIN,
+            schema_version: receipt.schema_version,
+            credential_id: &receipt.credential_id,
+            action_id: receipt.action_id.as_ref(),
+            action_commitment_hash: receipt.action_commitment_hash.as_ref(),
+            action_descriptor: receipt.action_descriptor.as_ref(),
+            action_descriptor_hash: receipt.action_descriptor_hash.as_ref(),
+            previous_receipt_hash: receipt.previous_receipt_hash.as_ref(),
+            timestamp_provenance: receipt.timestamp_provenance.as_ref(),
+            external_timestamp_proof: receipt.external_timestamp_proof.as_ref(),
+            validator_did: &receipt.validator_did,
+            decision: &receipt.decision,
+            reason_codes: &receipt.reason_codes,
+            created_at: &receipt.created_at,
+            validation_hash: &receipt.validation_hash,
+        };
+        let mut historical_bytes = Vec::new();
+        ciborium::into_writer(&historical_payload, &mut historical_bytes).unwrap();
+        receipt.receipt_id = Hash256::digest(&historical_bytes);
+        receipt.signature = validator_keypair().sign(&historical_bytes);
+        let historical_id = receipt.receipt_id;
+        let historical_signature = receipt.signature.clone();
+
+        let mut durable = registry.durable_state();
+        durable.receipts.insert(historical_id, receipt.clone());
+        durable.receipt_chain_head = Some(historical_id);
+        persist_file_durable_registry_state(&durable, &path).unwrap();
+
+        let mut loaded = load_file_durable_registry(&path).unwrap();
+        assert_eq!(loaded.get_receipt(&historical_id), Some(receipt));
+        assert_eq!(loaded.receipt_chain_head(), Some(historical_id));
+        loaded.put_receipt_validator_public_key(validator_did(), validator_keypair().public);
+        loaded.validate_loaded_receipts().unwrap();
+        let revalidated = loaded.get_receipt(&historical_id).unwrap();
+        assert_eq!(revalidated.receipt_id, historical_id);
+        assert_eq!(revalidated.signature, historical_signature);
     }
 
     #[tokio::test]

--- a/tools/test_coverage_policy.sh
+++ b/tools/test_coverage_policy.sh
@@ -145,6 +145,17 @@ coverage_gate_block=$(
 
 [[ -n "$coverage_gate_block" ]] || fail "CI coverage gate block is missing"
 
+grep -F 'Free coverage runner disk' <<<"$coverage_gate_block" >/dev/null \
+  || fail "coverage gate must reclaim hosted-runner disk before instrumentation"
+for preinstalled_path in /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup; do
+  grep -F "$preinstalled_path" <<<"$coverage_gate_block" >/dev/null \
+    || fail "coverage gate disk cleanup must remove $preinstalled_path"
+done
+grep -F 'CARGO_INCREMENTAL: "0"' <<<"$coverage_gate_block" >/dev/null \
+  || fail "coverage gate must disable incremental artifacts"
+grep -F 'CARGO_PROFILE_TEST_DEBUG: "0"' <<<"$coverage_gate_block" >/dev/null \
+  || fail "coverage gate must disable test debug artifacts"
+
 if grep -F -- '--skip-clean' <<<"$coverage_gate_block" >/dev/null; then
   fail "default workspace coverage gate must clean instrumentation before measuring the 90% threshold"
 fi

--- a/tools/test_repo_truth.sh
+++ b/tools/test_repo_truth.sh
@@ -133,24 +133,13 @@ test_mode=$(jq -r '.tests.mode' "$json_file")
 [ "$test_mode" = "skipped" ] || fail "--skip-tests should report tests.mode=skipped, got $test_mode"
 
 # ============================================================================
-# README VERACITY GATE — TEMPORARILY DISABLED 2026-07-04 (Bob's directive).
+# README VERACITY GATE
 #
-# The exact-number README assertions below (crate / file / LOC / test / gate /
-# traceability / threat counts) force EVERY concurrent PR to touch the same
-# README repo-truth lines and collide on merge — a recurring merge tax on
-# parallel lanes. Disabled to remove that tax while multiple lanes are in
-# flight.
-#
-# RE-ENABLE at the 2026-07-05 truing-up: set README_VERACITY_GATE=on (or flip
-# the default below), regenerate the numbers with `bash tools/repo_truth.sh`,
-# and update README.md to match the true tree.
-#
-# Everything ELSE in this script stays enforced: unresolved merge-conflict
-# markers, license consistency, cargo-metadata crate-count sanity, the
-# JSON-vs-tree file/LOC checks, clippy/deny lint presence, and the static
-# README claim checks (published-releases, coverage scoping, no stale claims).
+# Exact release-facing claims must derive from the current tree. Operators can
+# opt out locally while resolving a merge, but CI and ordinary runs default to
+# enforcing the complete status, architecture, and repository-structure set.
 # ============================================================================
-README_VERACITY_GATE="${README_VERACITY_GATE:-off}"
+README_VERACITY_GATE="${README_VERACITY_GATE:-on}"
 
 if [ "$README_VERACITY_GATE" = "on" ]; then
   grep -F "| Rust crates | $expected_crates |" README.md >/dev/null || fail "README crate count is not repo-truth derived"
@@ -160,6 +149,38 @@ if [ "$README_VERACITY_GATE" = "on" ]; then
   [ "$readme_tests_listed" = "$expected_tests_listed" ] \
     || fail "README workspace test count $readme_tests_listed != listed test count $expected_tests_listed"
   grep -F "| CI quality gates | $expected_gates |" README.md >/dev/null || fail "README CI gate count is not repo-truth derived"
+
+  expected_tests_display=$(python3 -c 'import sys; print(f"{int(sys.argv[1]):,}")' "$expected_tests_listed")
+  grep -F "**$expected_tests_display workspace tests are listed**" README.md >/dev/null \
+    || fail "README verified-today test count is not repo-truth derived"
+  grep -F "(Rust, $expected_crates crates, $expected_rs_loc tracked LOC under crates/)" README.md >/dev/null \
+    || fail "README architecture LOC is not repo-truth derived"
+  grep -F "$expected_tests_display listed workspace tests" README.md >/dev/null \
+    || fail "README architecture test count is not repo-truth derived"
+  grep -F "CI pipeline ($expected_gates numbered quality gates plus required aggregator)" README.md >/dev/null \
+    || fail "README repository-structure gate count is not repo-truth derived"
+  grep -F "Quality Gates](governance/quality_gates.md) — $expected_gates numbered CI gates plus required aggregator" README.md >/dev/null \
+    || fail "README governance-link gate count is not repo-truth derived"
+
+  expected_rest_routes=$(
+    sed -n '/fn test_all_routes/,/^[[:space:]]*}/p' crates/exo-gateway/src/rest.rs \
+      | sed -nE 's/.*assert_eq!\(routes\.len\(\), ([0-9]+)\);.*/\1/p'
+  )
+  [ -n "$expected_rest_routes" ] || fail "could not derive REST route inventory count"
+  grep -F "operational HTTP server with $expected_rest_routes endpoints" README.md >/dev/null \
+    || fail "README gateway endpoint count is not route-inventory derived"
+  grep -F "health probes ($expected_rest_routes enumerated REST endpoints plus GraphQL)" README.md >/dev/null \
+    || fail "README core-crate gateway endpoint count is not route-inventory derived"
+
+  core_crate_rows=$(
+    awk '
+      /^### Core Crates/ { in_core = 1; next }
+      in_core && /^### / { print count; exit }
+      in_core && /^\| `/ { count++ }
+    ' README.md
+  )
+  grep -F "### Core Crates ($core_crate_rows)" README.md >/dev/null \
+    || fail "README Core Crates heading does not match its table"
 fi
 
 trace_total=$(jq '.traceability.total' "$json_file")
@@ -184,7 +205,17 @@ if [ "$tag_count" -gt 0 ]; then
   if grep -F "| Published releases | None (pre-release) | \`git tag -l\` |" README.md >/dev/null; then
     fail "README must not cite git tags as evidence for no published releases when tags exist"
   fi
+  latest_release_tag=$(git tag -l 'v*' --sort=-version:refname | head -1)
+  grep -F "| Latest published release | \`$latest_release_tag\`" README.md >/dev/null \
+    || fail "README latest published release does not match the newest version tag"
 fi
+
+if grep -F "No GitHub Release or crates.io publication verified" README.md >/dev/null; then
+  fail "README contains the stale no-publication claim"
+fi
+
+grep -F "| Live node health | Not inferred from repository state; verify each target at deploy or release time |" README.md >/dev/null \
+  || fail "README must keep live node health separate from repository truth"
 
 grep -F "tested gatekeeper and decision-forum adjudication paths" README.md >/dev/null \
   || fail "README must scope constitutional invariant enforcement to tested adjudication paths"


### PR DESCRIPTION
## Summary
- restore persisted pre-LYNK extended AVC receipts without rewriting IDs, signatures, chains, or state
- keep current receipt generation, public `verify_id()`, and live `put_receipt()` validation canonical-only
- restrict historical matching to schema v1 durable load/revalidation and verify signatures against the exact bytes that matched the stored ID
- cover tampering, forgery, chain preservation, LYNK fallback exclusion, live-write rejection, unsupported schemas, and the true historical durable CBOR wire shape

## Root cause
PR #784 added `llm_usage_evidence_hash` to the extended v1 CBOR signing payload without a schema bump. Persisted extended receipts minted before that field existed still decode, but recomputing their IDs from current bytes changes the content ID and causes node startup to fail closed.

## Boundary and state safety
Path classification: EXOCHAIN core/runtime adapter.

The compatibility representation is private to persisted registry validation. Current payload matching runs first. Historical matching is disabled for LYNK receipts and unsupported schemas. No SQL, migration, state rewrite, deletion, or signature replacement is introduced.

## Verification
- `cargo test -p exochain-avc` (249 unit, 14 integration, 1 doctest)
- `cargo test -p exochain-node avc` (171 passed, 1 live Microsoft TSA test ignored)
- `cargo clippy -p exochain-avc -p exochain-node --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo build --release --bin exochain`
- independent security review of live-write, public API, schema, ID/signature, and historical-wire boundaries

## Rollback / disablement
This change performs no data migration, so rollback does not require reversing stored state. A code rollback would restore the prior fail-closed startup behavior for pre-LYNK receipts; affected nodes must remain disabled until this compatibility patch is reapplied or equivalent validated recovery code is deployed.