### PR TITLE
release: remove README LOC metric and harden audit guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 31 | `ls -d crates/*/` |
 | Rust source files | 471 | `git ls-files 'crates/**/*.rs'` |
-| Rust LOC | 386120 | `git ls-files 'crates/**/*.rs'` + `wc -l` |
 | Workspace tests | 6,248 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 23 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
 | Latest published release | `v0.2.1-beta` (GitHub Release published 2026-07-08; `exochain-core` on crates.io and `@exochain/llm-proxy` on npm resolve the same version) | `gh release list`; `cargo search exochain-core`; `npm view @exochain/llm-proxy version` |
@@ -124,7 +123,7 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 31 crates, 386120 tracked LOC under crates/)
+Layer 1: CGR Kernel         (Rust, 31 crates)
          Constitutional governance runtime — deterministic, no floats,
          production Ed25519/BLAKE3 cryptography plus unaudited pedagogical
          SNARK/STARK/ZKML skeletons, 6,248 listed workspace tests

--- a/tools/test_audit_ignore_policy.sh
+++ b/tools/test_audit_ignore_policy.sh
@@ -55,7 +55,12 @@ active_ids = {
 }
 
 for warning_items in report.get("warnings", {}).values():
-    active_ids.update(item["advisory"]["id"] for item in warning_items)
+    active_ids.update(
+        advisory["id"]
+        for item in warning_items
+        if (advisory := item.get("advisory")) is not None
+        and advisory.get("id")
+    )
 
 with open(".cargo/audit.toml", "rb") as config_file:
     configured_ids = set(

--- a/tools/test_repo_truth.sh
+++ b/tools/test_repo_truth.sh
@@ -89,10 +89,6 @@ expected_rs_files=$(git ls-files 'crates/**/*.rs' | wc -l | tr -d ' ')
 actual_rs_files=$(jq '.rust_source_files' "$json_file")
 [ "$actual_rs_files" = "$expected_rs_files" ] || fail "Rust source file count $actual_rs_files != $expected_rs_files"
 
-expected_rs_loc=$(git ls-files 'crates/**/*.rs' | xargs wc -l | tail -1 | awk '{print $1}')
-actual_rs_loc=$(jq '.rust_loc' "$json_file")
-[ "$actual_rs_loc" = "$expected_rs_loc" ] || fail "Rust LOC $actual_rs_loc != $expected_rs_loc"
-
 if ! test_list_output=$(cargo test --workspace -- --list 2>&1); then
   printf '%s\n' "$test_list_output" >&2
   fail "cargo test --workspace -- --list failed while deriving README test count"
@@ -159,7 +155,6 @@ README_VERACITY_GATE="${README_VERACITY_GATE:-on}"
 if [ "$README_VERACITY_GATE" = "on" ]; then
   grep -F "| Rust crates | $expected_crates |" README.md >/dev/null || fail "README crate count is not repo-truth derived"
   grep -F "| Rust source files | $expected_rs_files |" README.md >/dev/null || fail "README Rust source file count is not repo-truth derived"
-  grep -F "| Rust LOC | $expected_rs_loc |" README.md >/dev/null || fail "README Rust LOC is not repo-truth derived"
   readme_tests_listed=$(awk -F'|' '/Workspace tests/ { gsub(/[^0-9]/, "", $3); print $3; exit }' README.md)
   [ "$readme_tests_listed" = "$expected_tests_listed" ] \
     || fail "README workspace test count $readme_tests_listed != listed test count $expected_tests_listed"
@@ -168,8 +163,8 @@ if [ "$README_VERACITY_GATE" = "on" ]; then
   expected_tests_display=$(python3 -c 'import sys; print(f"{int(sys.argv[1]):,}")' "$expected_tests_listed")
   grep -F "**$expected_tests_display workspace tests are listed**" README.md >/dev/null \
     || fail "README verified-today test count is not repo-truth derived"
-  grep -F "(Rust, $expected_crates crates, $expected_rs_loc tracked LOC under crates/)" README.md >/dev/null \
-    || fail "README architecture LOC is not repo-truth derived"
+  grep -F "(Rust, $expected_crates crates)" README.md >/dev/null \
+    || fail "README architecture crate count is not repo-truth derived"
   grep -F "$expected_tests_display listed workspace tests" README.md >/dev/null \
     || fail "README architecture test count is not repo-truth derived"
   grep -F "CI pipeline ($expected_gates numbered quality gates plus required aggregator)" README.md >/dev/null \


### PR DESCRIPTION
## Summary
- remove the volatile Rust LOC row and architecture claim from README
- remove Gate 9 assertions for README LOC while retaining `tools/repo_truth.sh` diagnostic `rust_loc` output
- make the audit-ignore policy parser ignore advisory-less warning records such as current yanked-package warnings, while continuing to reconcile every real RustSec advisory ID

## Classification
- `README.md`: documentation
- `tools/test_repo_truth.sh`: EXOCHAIN CI/repository-truth gate
- `tools/test_audit_ignore_policy.sh`: EXOCHAIN CI/audit-policy gate
- no Rust crates, governance runtime, adapters, deployments, or adjacent products changed

## Test plan
- [x] `bash tools/test_repo_truth.sh`
- [x] verify README and Gate 9 contain no Rust LOC claim
- [x] verify `bash tools/repo_truth.sh --json --skip-tests` retains numeric `.rust_loc`
- [x] reproduce audit parser failure against advisory database commit `9f3e138` with `{ advisory: null }` yanked warning
- [x] `cargo audit --deny unsound --deny unmaintained`
- [x] `bash tools/test_audit_ignore_policy.sh`
- [x] `git diff --check`