### PR TITLE
feat(licensure): bind commercial products to bailment accounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 31 | `ls -d crates/*/` |
 | Rust source files | 471 | `git ls-files 'crates/**/*.rs'` |
-| Workspace tests | 6,248 listed | `cargo test --workspace -- --list` |
+| Workspace tests | 6,255 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 23 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
 | Latest published release | `v0.2.1-beta` (GitHub Release published 2026-07-08; `exochain-core` on crates.io and `@exochain/llm-proxy` on npm resolve the same version) | `gh release list`; `cargo search exochain-core`; `npm view @exochain/llm-proxy version` |
-| License | Apache-2.0 for EXOCHAIN core; proprietary terms for `livesafe/` and `cybermedica/` | `Cargo.toml`; `livesafe/LICENSE`; `cybermedica/LICENSE` |
+| License | Apache-2.0 for EXOCHAIN core primitives; commercial terms for Decision Forum, LegalDyne, CyberMedica, LiveSafe, and CrossChecked products | `governance/commercial-product-licensing.json`; product license files where present |
 | Live node health | Not inferred from repository state; verify each target at deploy or release time | `tools/verify_live_node_claim.sh` |
 
 ### What is verified today
 
-- **6,248 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **6,255 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -126,7 +126,7 @@ Catalyst is named explicitly.
 Layer 1: CGR Kernel         (Rust, 31 crates)
          Constitutional governance runtime — deterministic, no floats,
          production Ed25519/BLAKE3 cryptography plus unaudited pedagogical
-         SNARK/STARK/ZKML skeletons, 6,248 listed workspace tests
+         SNARK/STARK/ZKML skeletons, 6,255 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          165 verified WASM exports covered by 172 bridge checks — Rust -> WebAssembly -> JavaScript
@@ -353,11 +353,16 @@ Float arithmetic is denied workspace-wide via `#[deny(clippy::float_arithmetic)]
 
 ## License
 
-Apache-2.0 applies to EXOCHAIN core. The [`livesafe/`](livesafe/) and
-[`cybermedica/`](cybermedica/) subtrees are proprietary and commercial (all
-rights reserved); see [livesafe/LICENSE](livesafe/LICENSE) and
-[cybermedica/LICENSE](cybermedica/LICENSE).
-See also [LICENSE](LICENSE) and [docs/legal/LICENSING-POSITION.md](docs/legal/LICENSING-POSITION.md).
+Apache-2.0 applies to EXOCHAIN core primitives. The Decision Forum product,
+LegalDyne, CrossChecked, and the [`livesafe/`](livesafe/) and
+[`cybermedica/`](cybermedica/) subtrees require commercial licensing terms
+tracked through EXOCHAIN `Licensure` bailments and
+`exo-economy-use-event-v1` usage accounting. `crates/decision-forum` remains an Apache-2.0 core primitive; it does not license the Decision Forum product.
+See the
+[commercial product registry](governance/commercial-product-licensing.json),
+[livesafe/LICENSE](livesafe/LICENSE), [cybermedica/LICENSE](cybermedica/LICENSE),
+[LICENSE](LICENSE), and
+[docs/legal/LICENSING-POSITION.md](docs/legal/LICENSING-POSITION.md).
 
 ---
 *EXOCHAIN Foundation — Judicial Build Governance*

--- a/crates/exo-consent/src/bailment.rs
+++ b/crates/exo-consent/src/bailment.rs
@@ -36,6 +36,8 @@ pub enum BailmentType {
     Processing,
     /// Bailee may delegate authority to sub-bailees.
     Delegation,
+    /// Bailee receives a commercially bounded right to use a licensed product.
+    Licensure,
     /// Emergency access — time-limited, requires justification.
     Emergency,
 }

--- a/crates/exo-consent/src/contract.rs
+++ b/crates/exo-consent/src/contract.rs
@@ -34,6 +34,17 @@ use serde::{Deserialize, Serialize};
 
 use crate::{bailment::BailmentType, error::ConsentError};
 
+/// The canonical accounting policy bound into commercial licensure contracts.
+pub const LICENSURE_USAGE_ACCOUNTING_POLICY: &str = "exo-economy-use-event-v1";
+
+const LICENSURE_REQUIRED_PARAMS: [&str; 5] = [
+    "licensed_product",
+    "licensed_scope",
+    "commercial_terms_hash",
+    "usage_accounting_policy",
+    "settlement_ruleset_id",
+];
+
 // ---------------------------------------------------------------------------
 // Core Types
 // ---------------------------------------------------------------------------
@@ -370,6 +381,11 @@ pub fn default_template(bailment_type: BailmentType) -> ContractTemplate {
             "Standard Delegation Agreement",
             delegation_clauses(),
         ),
+        BailmentType::Licensure => (
+            "licensure-standard-v1",
+            "Standard Commercial Licensure Agreement",
+            licensure_clauses(),
+        ),
         BailmentType::Emergency => (
             "emergency-standard-v1",
             "Emergency Access Agreement",
@@ -404,6 +420,7 @@ pub fn compose(
 ) -> Result<ComposedContract, ConsentError> {
     let id = id.into();
     validate_constructor_metadata("contract id", &id, "composed_at", &composed_at)?;
+    validate_template_params(template.bailment_type, params)?;
 
     // Filter clauses by jurisdiction
     let mut filtered_clauses = Vec::new();
@@ -427,6 +444,7 @@ pub fn compose(
     let mut rendered_clauses = Vec::with_capacity(filtered_clauses.len());
     for (i, clause) in filtered_clauses.iter().enumerate() {
         let rendered_body = substitute_params(&clause.body, params);
+        reject_unresolved_placeholder(&clause.id, &rendered_body)?;
         rendered_clauses.push(RenderedClause {
             clause_id: clause.id.clone(),
             category: clause.category,
@@ -590,6 +608,9 @@ pub fn amend(
 ) -> Result<ComposedContract, ConsentError> {
     let id = id.into();
     validate_constructor_metadata("contract id", &id, "composed_at", &composed_at)?;
+    if original.template_id == "licensure-standard-v1" {
+        validate_licensure_params(new_params)?;
+    }
 
     // Start with original rendered clauses
     let mut clauses: Vec<RenderedClause> = original.rendered_clauses.clone();
@@ -601,14 +622,17 @@ pub fn amend(
             rc.category = new_clause.category;
             rc.title = new_clause.title.clone();
             rc.rendered_body = substitute_params(&new_clause.body, new_params);
+            reject_unresolved_placeholder(&new_clause.id, &rc.rendered_body)?;
         } else {
             // New clause — append
             let section = format!("{}", clauses.len() + 1);
+            let rendered_body = substitute_params(&new_clause.body, new_params);
+            reject_unresolved_placeholder(&new_clause.id, &rendered_body)?;
             clauses.push(RenderedClause {
                 clause_id: new_clause.id.clone(),
                 category: new_clause.category,
                 title: new_clause.title.clone(),
-                rendered_body: substitute_params(&new_clause.body, new_params),
+                rendered_body,
                 section_number: section,
             });
         }
@@ -742,6 +766,79 @@ fn substitute_params(body: &str, params: &ContractParams) -> String {
     }
 
     result
+}
+
+fn validate_template_params(
+    bailment_type: BailmentType,
+    params: &ContractParams,
+) -> Result<(), ConsentError> {
+    if bailment_type == BailmentType::Licensure {
+        validate_licensure_params(params)?;
+    }
+    Ok(())
+}
+
+fn validate_licensure_params(params: &ContractParams) -> Result<(), ConsentError> {
+    for key in LICENSURE_REQUIRED_PARAMS {
+        let value = params.custom_params.get(&key.to_string()).ok_or_else(|| {
+            ConsentError::Denied(format!(
+                "commercial licensure requires custom parameter '{key}'"
+            ))
+        })?;
+        if value.trim().is_empty() {
+            return Err(ConsentError::Denied(format!(
+                "commercial licensure parameter '{key}' must not be empty"
+            )));
+        }
+    }
+
+    for key in ["commercial_terms_hash", "settlement_ruleset_id"] {
+        let value = params.custom_params.get(&key.to_string()).ok_or_else(|| {
+            ConsentError::Denied(format!(
+                "commercial licensure requires custom parameter '{key}'"
+            ))
+        })?;
+        if value.len() != 64
+            || !value
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            return Err(ConsentError::Denied(format!(
+                "commercial licensure parameter '{key}' must be a 64-character lowercase hexadecimal hash"
+            )));
+        }
+    }
+
+    let accounting_policy = params
+        .custom_params
+        .get(&"usage_accounting_policy".to_string())
+        .ok_or_else(|| {
+            ConsentError::Denied(
+                "commercial licensure requires custom parameter 'usage_accounting_policy'"
+                    .to_string(),
+            )
+        })?;
+    if accounting_policy != LICENSURE_USAGE_ACCOUNTING_POLICY {
+        return Err(ConsentError::Denied(format!(
+            "commercial licensure usage_accounting_policy must be '{LICENSURE_USAGE_ACCOUNTING_POLICY}'"
+        )));
+    }
+
+    Ok(())
+}
+
+fn reject_unresolved_placeholder(clause_id: &str, rendered_body: &str) -> Result<(), ConsentError> {
+    let Some(start) = rendered_body.find("{{") else {
+        return Ok(());
+    };
+    let unresolved = rendered_body[start + 2..]
+        .find("}}")
+        .map_or(&rendered_body[start + 2..], |end| {
+            &rendered_body[start + 2..start + 2 + end]
+        });
+    Err(ConsentError::Denied(format!(
+        "contract clause '{clause_id}' retained unresolved placeholder '{unresolved}'"
+    )))
 }
 
 /// Generate standard clauses for Custody bailment type.
@@ -1018,6 +1115,76 @@ fn emergency_clauses() -> Vec<Clause> {
             category: ClauseCategory::Indemnification,
             title: "Indemnification".to_string(),
             body: "{{bailee_name}} shall indemnify {{bailor_name}} against all claims arising from emergency access misuse.".to_string(),
+            required: true,
+            jurisdiction: None,
+        },
+    ]
+}
+
+/// Generate standard clauses for commercial Licensure bailments.
+fn licensure_clauses() -> Vec<Clause> {
+    vec![
+        Clause {
+            id: "licensure-data-custody".to_string(),
+            category: ClauseCategory::DataCustody,
+            title: "Licensed Data Custody".to_string(),
+            body: "{{bailee_name}} may hold {{bailor_name}} data only for {{licensed_product}} within {{licensed_scope}}. Data classification: {{data_classification}}. {{classification_custody_obligations}}".to_string(),
+            required: true,
+            jurisdiction: None,
+        },
+        Clause {
+            id: "licensure-processing-rights".to_string(),
+            category: ClauseCategory::ProcessingRights,
+            title: "Commercial Use Rights".to_string(),
+            body: "The commercial right to use {{licensed_product}} is limited to {{licensed_scope}} under terms hash {{commercial_terms_hash}}. Each governed use must be recorded under {{usage_accounting_policy}}. {{classification_processing_obligations}}".to_string(),
+            required: true,
+            jurisdiction: None,
+        },
+        Clause {
+            id: "licensure-breach-remedies".to_string(),
+            category: ClauseCategory::BreachRemedies,
+            title: "Commercial Breach Remedies".to_string(),
+            body: "Unlicensed, unaccounted, or out-of-scope use of {{licensed_product}} is a material breach. {{classification_breach_notice}} Access must fail closed until the breach is cured.".to_string(),
+            required: true,
+            jurisdiction: None,
+        },
+        Clause {
+            id: "licensure-liability-caps".to_string(),
+            category: ClauseCategory::LiabilityCaps,
+            title: "Liability Caps".to_string(),
+            body: "Total liability is capped at {{liability_cap_bps}} basis points of assessed value, subject to the signed commercial terms hash {{commercial_terms_hash}}. {{classification_liability_obligations}}".to_string(),
+            required: true,
+            jurisdiction: None,
+        },
+        Clause {
+            id: "licensure-dispute-resolution".to_string(),
+            category: ClauseCategory::DisputeResolution,
+            title: "Commercial Dispute Resolution".to_string(),
+            body: "Disputes concerning {{licensed_product}}, recorded use, or settlement ruleset {{settlement_ruleset_id}} are resolved under jurisdiction {{jurisdiction}}.".to_string(),
+            required: true,
+            jurisdiction: None,
+        },
+        Clause {
+            id: "licensure-termination".to_string(),
+            category: ClauseCategory::Termination,
+            title: "Termination and Revocation".to_string(),
+            body: "Licensure of {{licensed_product}} terminates at {{expiry_date}} or earlier revocation. Use and usage accounting must cease only after the final governed use is recorded. {{classification_termination_obligations}}".to_string(),
+            required: true,
+            jurisdiction: None,
+        },
+        Clause {
+            id: "licensure-jurisdiction".to_string(),
+            category: ClauseCategory::Jurisdiction,
+            title: "Governing Jurisdiction".to_string(),
+            body: "The commercial licensure identified by {{commercial_terms_hash}} is governed by {{jurisdiction}}.".to_string(),
+            required: true,
+            jurisdiction: None,
+        },
+        Clause {
+            id: "licensure-indemnification".to_string(),
+            category: ClauseCategory::Indemnification,
+            title: "Commercial Indemnification".to_string(),
+            body: "{{bailee_name}} shall indemnify {{bailor_name}} for unauthorized use of {{licensed_product}}, missing records under {{usage_accounting_policy}}, or settlement outside ruleset {{settlement_ruleset_id}}.".to_string(),
             required: true,
             jurisdiction: None,
         },
@@ -1458,6 +1625,7 @@ mod tests {
             BailmentType::Custody,
             BailmentType::Processing,
             BailmentType::Delegation,
+            BailmentType::Licensure,
             BailmentType::Emergency,
         ] {
             let template = default_template(bailment_type);
@@ -1823,14 +1991,18 @@ mod tests {
             .custom_params
             .remove(&"usage_accounting_policy".to_string());
         let missing = compose(&template, &params, "license-1", ts(1_700_000_000_100));
-        assert!(matches!(missing, Err(ConsentError::Denied(reason)) if reason.contains("usage_accounting_policy")));
+        assert!(
+            matches!(missing, Err(ConsentError::Denied(reason)) if reason.contains("usage_accounting_policy"))
+        );
 
         let mut params = licensure_params();
         params
             .custom_params
             .insert("licensed_scope".to_string(), "   ".to_string());
         let empty = compose(&template, &params, "license-2", ts(1_700_000_000_100));
-        assert!(matches!(empty, Err(ConsentError::Denied(reason)) if reason.contains("licensed_scope")));
+        assert!(
+            matches!(empty, Err(ConsentError::Denied(reason)) if reason.contains("licensed_scope"))
+        );
     }
 
     #[test]
@@ -1841,15 +2013,52 @@ mod tests {
 
         assert!(body.contains("CyberMedica"));
         assert!(body.contains("exo-economy-use-event-v1"));
-        assert!(!body.contains("{{"), "contract retained an unresolved placeholder");
+        assert!(
+            !body.contains("{{"),
+            "contract retained an unresolved placeholder"
+        );
+    }
+
+    #[test]
+    fn licensure_composition_rejects_unrecognized_accounting_and_malformed_hashes() {
+        let template = default_template(BailmentType::Licensure);
+
+        let mut params = licensure_params();
+        params.custom_params.insert(
+            "usage_accounting_policy".to_string(),
+            "external-meter".to_string(),
+        );
+        let wrong_meter = compose(&template, &params, "license-3", ts(1_700_000_000_100));
+        assert!(
+            matches!(wrong_meter, Err(ConsentError::Denied(reason)) if reason.contains(LICENSURE_USAGE_ACCOUNTING_POLICY))
+        );
+
+        for (key, invalid_value) in [
+            ("commercial_terms_hash", "11".repeat(31)),
+            ("settlement_ruleset_id", "GG".repeat(32)),
+        ] {
+            let mut params = licensure_params();
+            params.custom_params.insert(key.to_string(), invalid_value);
+            let result = compose(&template, &params, "license-4", ts(1_700_000_000_100));
+            assert!(matches!(result, Err(ConsentError::Denied(reason)) if reason.contains(key)));
+        }
     }
 
     #[test]
     fn composition_rejects_unresolved_placeholders() {
         let mut template = default_template(BailmentType::Custody);
-        template.clauses[0].body.push_str(" {{unknown_required_value}}");
-        let result = compose(&template, &test_params(), "contract-1", ts(1_700_000_000_100));
-        assert!(matches!(result, Err(ConsentError::Denied(reason)) if reason.contains("unknown_required_value")));
+        template.clauses[0]
+            .body
+            .push_str(" {{unknown_required_value}}");
+        let result = compose(
+            &template,
+            &test_params(),
+            "contract-1",
+            ts(1_700_000_000_100),
+        );
+        assert!(
+            matches!(result, Err(ConsentError::Denied(reason)) if reason.contains("unknown_required_value"))
+        );
     }
 
     // -- Test 19: compose with a Delegation template composes + hashes --

--- a/crates/exo-consent/src/contract.rs
+++ b/crates/exo-consent/src/contract.rs
@@ -1063,6 +1063,28 @@ mod tests {
         params
     }
 
+    fn licensure_params() -> ContractParams {
+        let mut params = test_params();
+        params
+            .custom_params
+            .insert("licensed_product".to_string(), "CyberMedica".to_string());
+        params.custom_params.insert(
+            "licensed_scope".to_string(),
+            "production clinical workflow use".to_string(),
+        );
+        params
+            .custom_params
+            .insert("commercial_terms_hash".to_string(), "11".repeat(32));
+        params.custom_params.insert(
+            "usage_accounting_policy".to_string(),
+            "exo-economy-use-event-v1".to_string(),
+        );
+        params
+            .custom_params
+            .insert("settlement_ruleset_id".to_string(), "22".repeat(32));
+        params
+    }
+
     fn ts(ms: u64) -> Timestamp {
         Timestamp::new(ms, 0)
     }
@@ -1750,6 +1772,84 @@ mod tests {
         // Must cover Termination clauses — emergencies expire fast.
         let cats: Vec<ClauseCategory> = template.clauses.iter().map(|c| c.category).collect();
         assert!(cats.contains(&ClauseCategory::Termination));
+    }
+
+    #[test]
+    fn licensure_template_requires_commercial_terms_and_all_clause_categories() {
+        let template = default_template(BailmentType::Licensure);
+        assert_eq!(template.bailment_type, BailmentType::Licensure);
+        assert_eq!(template.id, "licensure-standard-v1");
+        assert_eq!(template.name, "Standard Commercial Licensure Agreement");
+        assert_eq!(template.clauses.len(), 8);
+        assert!(template.clauses.iter().all(|clause| clause.required));
+
+        let categories = template
+            .clauses
+            .iter()
+            .map(|clause| clause.category)
+            .collect::<Vec<_>>();
+        for category in all_categories() {
+            assert!(
+                categories.contains(&category),
+                "Licensure template missing category: {category:?}"
+            );
+        }
+
+        let body = template
+            .clauses
+            .iter()
+            .map(|clause| clause.body.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        for required_placeholder in [
+            "{{licensed_product}}",
+            "{{licensed_scope}}",
+            "{{commercial_terms_hash}}",
+            "{{usage_accounting_policy}}",
+            "{{settlement_ruleset_id}}",
+        ] {
+            assert!(
+                body.contains(required_placeholder),
+                "Licensure template missing {required_placeholder}"
+            );
+        }
+    }
+
+    #[test]
+    fn licensure_composition_fails_closed_without_complete_commercial_terms() {
+        let template = default_template(BailmentType::Licensure);
+        let mut params = licensure_params();
+        params
+            .custom_params
+            .remove(&"usage_accounting_policy".to_string());
+        let missing = compose(&template, &params, "license-1", ts(1_700_000_000_100));
+        assert!(matches!(missing, Err(ConsentError::Denied(reason)) if reason.contains("usage_accounting_policy")));
+
+        let mut params = licensure_params();
+        params
+            .custom_params
+            .insert("licensed_scope".to_string(), "   ".to_string());
+        let empty = compose(&template, &params, "license-2", ts(1_700_000_000_100));
+        assert!(matches!(empty, Err(ConsentError::Denied(reason)) if reason.contains("licensed_scope")));
+    }
+
+    #[test]
+    fn licensure_composition_resolves_every_commercial_placeholder() {
+        let template = default_template(BailmentType::Licensure);
+        let contract = compose_test(&template, &licensure_params());
+        let body = rendered_contract_body(&contract);
+
+        assert!(body.contains("CyberMedica"));
+        assert!(body.contains("exo-economy-use-event-v1"));
+        assert!(!body.contains("{{"), "contract retained an unresolved placeholder");
+    }
+
+    #[test]
+    fn composition_rejects_unresolved_placeholders() {
+        let mut template = default_template(BailmentType::Custody);
+        template.clauses[0].body.push_str(" {{unknown_required_value}}");
+        let result = compose(&template, &test_params(), "contract-1", ts(1_700_000_000_100));
+        assert!(matches!(result, Err(ConsentError::Denied(reason)) if reason.contains("unknown_required_value")));
     }
 
     // -- Test 19: compose with a Delegation template composes + hashes --

--- a/crates/exo-economy/src/adoption.rs
+++ b/crates/exo-economy/src/adoption.rs
@@ -20,7 +20,7 @@ use exo_core::{Hash256, Timestamp, hash::hash_structured};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    bailment::BailmentWrapper,
+    bailment::{BailmentTerms, BailmentWrapper, BailmentWrapperStatus},
     contribution_acceptance::ContributionAcceptance,
     contribution_offer::ContributionOffer,
     error::EconomyError,
@@ -232,6 +232,103 @@ impl UseEvent {
                 field: "use_event.bailment_wrapper_id",
             });
         }
+        Ok(())
+    }
+
+    /// Validate a commercially licensed product use against the complete
+    /// bailment and usage-accounting chain.
+    ///
+    /// This check fails closed unless the terms require settlement, the
+    /// wrapper is active, every hash-bound record retains canonical integrity,
+    /// and the adopter, product/system, mission, and HLC sequence agree.
+    pub fn validate_commercial_licensure(
+        &self,
+        adoption: &AdoptionEvent,
+        wrapper: &BailmentWrapper,
+        terms: &BailmentTerms,
+    ) -> Result<(), EconomyError> {
+        self.validate_against_adoption(adoption)?;
+        adoption.validate()?;
+        wrapper.validate()?;
+        terms.validate()?;
+
+        if wrapper.status != BailmentWrapperStatus::Active {
+            return Err(EconomyError::AutomatedSettlementRejected {
+                reason: "commercial licensure bailment wrapper must be active".into(),
+            });
+        }
+        if !terms.settlement_required {
+            return Err(EconomyError::AutomatedSettlementRejected {
+                reason: "commercial licensure terms must require settlement".into(),
+            });
+        }
+
+        if terms.recompute_content_hash()? != terms.terms_id || terms.content_hash != terms.terms_id
+        {
+            return Err(EconomyError::HashMismatch {
+                field: "commercial_licensure.terms_id",
+            });
+        }
+        if wrapper.recompute_content_hash()? != wrapper.wrapper_id
+            || wrapper.content_hash != wrapper.wrapper_id
+        {
+            return Err(EconomyError::HashMismatch {
+                field: "commercial_licensure.wrapper_id",
+            });
+        }
+        if adoption.recompute_content_hash()? != adoption.adoption_id
+            || adoption.content_hash != adoption.adoption_id
+        {
+            return Err(EconomyError::HashMismatch {
+                field: "commercial_licensure.adoption_id",
+            });
+        }
+        if self.recompute_content_hash()? != self.use_event_id
+            || self.content_hash != self.use_event_id
+        {
+            return Err(EconomyError::HashMismatch {
+                field: "commercial_licensure.use_event_id",
+            });
+        }
+
+        if wrapper.accepted_bailment_terms_hash != terms.terms_id {
+            return Err(EconomyError::HashMismatch {
+                field: "commercial_licensure.accepted_bailment_terms_hash",
+            });
+        }
+        if wrapper.contribution_node_id != adoption.contribution_node_id
+            || wrapper.accepted_terms_hash != adoption.accepted_terms_hash
+        {
+            return Err(EconomyError::HashMismatch {
+                field: "commercial_licensure.adoption_wrapper_binding",
+            });
+        }
+        if wrapper.bailor_ref != terms.bailor_ref || wrapper.bailee_ref != adoption.adopter_ref {
+            return Err(EconomyError::InvalidInput {
+                reason: "commercial licensure parties do not match the adoption bailment".into(),
+            });
+        }
+        if self.using_system != adoption.adopting_system {
+            return Err(EconomyError::InvalidInput {
+                reason: "commercial use must be recorded by the licensed adopting system".into(),
+            });
+        }
+        if self.mission_id != adoption.mission_id {
+            return Err(EconomyError::HashMismatch {
+                field: "commercial_licensure.mission_id",
+            });
+        }
+        if wrapper.created_at_hlc < terms.created_at_hlc
+            || adoption.created_at_hlc < wrapper.created_at_hlc
+            || self.created_at_hlc < adoption.created_at_hlc
+        {
+            return Err(EconomyError::InvalidInput {
+                reason:
+                    "commercial licensure terms, wrapper, adoption, and use HLC order is invalid"
+                        .into(),
+            });
+        }
+
         Ok(())
     }
 
@@ -511,6 +608,69 @@ mod tests {
                 .validate_commercial_licensure(&adoption, &wrapper, &terms)
                 .is_err()
         );
+    }
+
+    #[test]
+    fn commercial_use_rejects_tampered_records_mission_and_event_order() {
+        let adoption = sample_adoption().anchor().unwrap();
+        let use_event = sample_use_event().anchor().unwrap();
+        let wrapper = sample_wrapper().anchor().unwrap();
+        let terms = sample_terms().anchor().unwrap();
+
+        let mut tampered_terms = terms.clone();
+        tampered_terms.content_hash = h(0xC0);
+        assert!(matches!(
+            use_event.validate_commercial_licensure(&adoption, &wrapper, &tampered_terms),
+            Err(crate::error::EconomyError::HashMismatch {
+                field: "commercial_licensure.terms_id"
+            })
+        ));
+
+        let mut tampered_wrapper = wrapper.clone();
+        tampered_wrapper.content_hash = h(0xC1);
+        assert!(matches!(
+            use_event.validate_commercial_licensure(&adoption, &tampered_wrapper, &terms),
+            Err(crate::error::EconomyError::HashMismatch {
+                field: "commercial_licensure.wrapper_id"
+            })
+        ));
+
+        let mut tampered_adoption = adoption.clone();
+        tampered_adoption.content_hash = h(0xC2);
+        assert!(matches!(
+            use_event.validate_commercial_licensure(&tampered_adoption, &wrapper, &terms),
+            Err(crate::error::EconomyError::HashMismatch {
+                field: "commercial_licensure.adoption_id"
+            })
+        ));
+
+        let mut tampered_use = use_event.clone();
+        tampered_use.content_hash = h(0xC3);
+        assert!(matches!(
+            tampered_use.validate_commercial_licensure(&adoption, &wrapper, &terms),
+            Err(crate::error::EconomyError::HashMismatch {
+                field: "commercial_licensure.use_event_id"
+            })
+        ));
+
+        let mut wrong_mission = use_event.clone();
+        wrong_mission.mission_id = Some(h(0xC4));
+        let wrong_mission = wrong_mission.anchor().unwrap();
+        assert!(matches!(
+            wrong_mission.validate_commercial_licensure(&adoption, &wrapper, &terms),
+            Err(crate::error::EconomyError::HashMismatch {
+                field: "commercial_licensure.mission_id"
+            })
+        ));
+
+        let mut early_use = use_event;
+        early_use.created_at_hlc = crate::value_contribution::test_support::ts(1_999);
+        let early_use = early_use.anchor().unwrap();
+        assert!(matches!(
+            early_use.validate_commercial_licensure(&adoption, &wrapper, &terms),
+            Err(crate::error::EconomyError::InvalidInput { reason })
+                if reason.contains("HLC order")
+        ));
     }
 
     #[test]

--- a/crates/exo-economy/src/adoption.rs
+++ b/crates/exo-economy/src/adoption.rs
@@ -444,7 +444,10 @@ pub(crate) mod test_support {
 mod tests {
     use super::{ValueBasis, test_support::*};
     use crate::{
-        bailment::test_support::{coherent_offer_acceptance_terms, sample_wrapper},
+        bailment::{
+            BailmentWrapperStatus,
+            test_support::{coherent_offer_acceptance_terms, sample_terms, sample_wrapper},
+        },
         value_contribution::test_support::h,
     };
 
@@ -470,6 +473,44 @@ mod tests {
         let adoption = sample_adoption().anchor().unwrap();
         let use_event = sample_use_event().anchor().unwrap();
         assert!(use_event.validate_against_adoption(&adoption).is_ok());
+    }
+
+    #[test]
+    fn commercial_use_requires_active_settlement_bailment_and_bound_accounting() {
+        let adoption = sample_adoption().anchor().unwrap();
+        let use_event = sample_use_event().anchor().unwrap();
+        let wrapper = sample_wrapper().anchor().unwrap();
+        let terms = sample_terms().anchor().unwrap();
+
+        assert!(
+            use_event
+                .validate_commercial_licensure(&adoption, &wrapper, &terms)
+                .is_ok()
+        );
+
+        let mut inactive_wrapper = wrapper.clone();
+        inactive_wrapper.status = BailmentWrapperStatus::Suspended;
+        assert!(
+            use_event
+                .validate_commercial_licensure(&adoption, &inactive_wrapper, &terms)
+                .is_err()
+        );
+
+        let mut noncommercial_terms = terms.clone();
+        noncommercial_terms.settlement_required = false;
+        assert!(
+            use_event
+                .validate_commercial_licensure(&adoption, &wrapper, &noncommercial_terms)
+                .is_err()
+        );
+
+        let mut unbound_use = use_event;
+        unbound_use.using_system = "different-product".into();
+        assert!(
+            unbound_use
+                .validate_commercial_licensure(&adoption, &wrapper, &terms)
+                .is_err()
+        );
     }
 
     #[test]

--- a/docs/legal/LICENSING-POSITION.md
+++ b/docs/legal/LICENSING-POSITION.md
@@ -18,43 +18,77 @@ SPDX-License-Identifier: Apache-2.0
 
 # EXOCHAIN Licensing Position
 
-**Effective**: 2026-03-20
-**License**: Apache License 2.0 (`Apache-2.0`)
+**Effective**: 2026-07-14
+**Core license**: Apache License 2.0 (`Apache-2.0`)
 
 ---
 
 ## 1. Authoritative License
 
-EXOCHAIN is licensed under the **Apache License, Version 2.0**. The full license text is in [`LICENSE`](../../LICENSE) at the repository root.
+EXOCHAIN core primitives are licensed under the **Apache License, Version
+2.0**. The full license text is in [`LICENSE`](../../LICENSE) at the repository
+root. That grant does not license adjacent products merely because they use,
+embed, demonstrate, or are stored near an EXOCHAIN primitive.
 
-All Rust crates in the workspace inherit this license via `license.workspace = true` in their `Cargo.toml` manifests.
+All Rust crates in the workspace inherit this license via
+`license.workspace = true` in their `Cargo.toml` manifests. In particular,
+[`crates/decision-forum`](../../crates/decision-forum/) is the Apache-2.0
+deliberation primitive. It is distinct from the proprietary Decision Forum
+product.
 
 ## 2. Scope
 
-The Apache-2.0 license applies to:
-- All Rust source code in `crates/`
-- All tooling in `tools/`
-- All documentation in `docs/` and `governance/`
-- The demo platform in `demo/`
-- CI/CD configurations in `.github/`
-- The WASM compilation target (`exochain-wasm`)
+The root Apache-2.0 grant applies to the canonical Rust trust primitives in
+`crates/`, including `exochain-wasm` and `crates/decision-forum`, and to the
+core-supporting tooling, CI rules, governance records, and documentation that
+carry an explicit Apache-2.0 notice.
 
-### 2a. Proprietary Carve-Out — `livesafe/`
+It does not apply to product-branded applications, product shells, customer-zero
+surfaces, or product demos. Those are adjacent surfaces even when they call a
+core API or reuse an Apache primitive.
 
-The [`livesafe/`](../../livesafe/) subtree is the **exception**. LiveSafe is a
-proprietary, commercial application owned by the Exochain Foundation and is
-**not** licensed under Apache-2.0. Its terms are stated in
-[`livesafe/LICENSE`](../../livesafe/LICENSE) (all rights reserved). Its presence
-in this public repository is for transparency and reference only and grants no
-right to use, copy, modify, or distribute it.
+### 2a. Products requiring commercial terms
 
-Because of this carve-out:
-- `livesafe/` carries its own `LICENSE` and its nested Rust manifest declares
-  `license = "UNLICENSED"` with `publish = false`.
-- `livesafe/` is deliberately excluded from the Cargo workspace
-  (`exclude = ["livesafe"]` in the root `Cargo.toml`) so the Apache-only
-  `cargo-deny` dependency-license screen never treats the proprietary code as a
-  workspace member.
+The authoritative machine-readable product registry is
+[`governance/commercial-product-licensing.json`](../../governance/commercial-product-licensing.json).
+These products require commercial licensing terms:
+
+| Product | Boundary | License posture |
+|---------|----------|-----------------|
+| Decision Forum | External product; not `crates/decision-forum` | Commercial licensure required |
+| LegalDyne | External proprietary product | Commercial licensure required |
+| CyberMedica | [`cybermedica/`](../../cybermedica/) adjacent subtree | Commercial licensure required; see [`cybermedica/LICENSE`](../../cybermedica/LICENSE) |
+| LiveSafe | [`livesafe/`](../../livesafe/) adjacent subtree | Commercial licensure required; see [`livesafe/LICENSE`](../../livesafe/LICENSE) |
+| CrossChecked | External proprietary product | Commercial licensure required |
+
+Product-branded demo or prototype code has the same product license posture. A
+demo does not convert a product into an Apache-licensed core primitive.
+
+LiveSafe and CyberMedica carry local proprietary license files and their npm
+package manifests declare `UNLICENSED`. LiveSafe's nested Rust manifest also
+declares `license = "UNLICENSED"` and `publish = false`. Both subtrees are
+excluded from the Cargo workspace, preventing the Apache-only dependency screen
+from treating them as core workspace members.
+
+### 2b. Bailment licensure and usage accounting
+
+A repository classification is not itself an executed commercial license. A
+permitted product deployment requires a composed `Licensure` bailment using the
+`licensure-standard-v1` template. The contract must bind the licensed product,
+licensed scope, commercial-terms hash, `exo-economy-use-event-v1` accounting
+policy, and settlement ruleset hash.
+
+Each product use must then validate through the existing EXOCHAIN economy chain:
+
+1. signed `BailmentTerms` with `settlement_required = true`;
+2. an active `BailmentWrapper` bound to those terms;
+3. an `AdoptionEvent` bound to the wrapper, adopter, product system, and mission;
+4. a hash-valid `UseEvent` recorded by the same product system and mission;
+5. settlement under the wrapper's ruleset.
+
+Missing, inactive, tampered, out-of-order, or mismatched records fail closed.
+The product may not substitute a private counter, analytics event, or locally
+minted permission for this chain.
 
 ## 3. Rationale
 
@@ -81,16 +115,20 @@ All dependencies are screened via `cargo-deny` (see `deny.toml`):
 
 ## 5. Downstream Users
 
-If you use EXOCHAIN in your project:
+If you use an Apache-licensed EXOCHAIN core primitive in your project:
 - You may use, modify, and distribute under the terms of Apache-2.0
 - You must include the license notice and any NOTICE file
 - You must state changes if you modify the source
 - The patent grant in Apache-2.0 covers contributions made by ExoChain contributors
 - No copyleft obligation is imposed on your downstream code
 
+Those permissions do not grant rights to Decision Forum, LegalDyne,
+CyberMedica, LiveSafe, or CrossChecked product code, brands, hosted services, or
+commercial terms.
+
 ## 6. Consistency Enforcement
 
-The following sources must all declare `Apache-2.0`:
+The following core sources must all declare `Apache-2.0`:
 - `LICENSE` file (full text)
 - `Cargo.toml` workspace `license` field
 - All crate `Cargo.toml` files (via `license.workspace = true`)
@@ -98,7 +136,11 @@ The following sources must all declare `Apache-2.0`:
 - `README.md` license section
 - `CONTRIBUTING.md` license references
 
-Any divergence is a bug. The `tools/repo_truth.sh` utility checks for consistency.
+The proprietary product registry, the product-owned license files present in
+this repository, README boundary language, and the core licensure/accounting
+symbols are enforced by `tools/test_proprietary_license_boundaries.sh` in Gate
+9. Any divergence is a bug. The `tools/repo_truth.sh` utility separately checks
+core repository-license consistency.
 
 ## 7. Historical Note
 

--- a/governance/commercial-product-licensing.json
+++ b/governance/commercial-product-licensing.json
@@ -1,0 +1,59 @@
+{
+  "core_license": "Apache-2.0",
+  "effective_date": "2026-07-14",
+  "licensure_template": "licensure-standard-v1",
+  "products": [
+    {
+      "apache_by_proximity": false,
+      "apache_core_primitive": "crates/decision-forum",
+      "bailment_type": "Licensure",
+      "license_model": "commercial",
+      "name": "Decision Forum",
+      "product_boundary": "external proprietary product",
+      "settlement_required": true,
+      "usage_accounting_policy": "exo-economy-use-event-v1"
+    },
+    {
+      "apache_by_proximity": false,
+      "apache_core_primitive": null,
+      "bailment_type": "Licensure",
+      "license_model": "commercial",
+      "name": "LegalDyne",
+      "product_boundary": "external proprietary product",
+      "settlement_required": true,
+      "usage_accounting_policy": "exo-economy-use-event-v1"
+    },
+    {
+      "apache_by_proximity": false,
+      "apache_core_primitive": null,
+      "bailment_type": "Licensure",
+      "license_model": "commercial",
+      "name": "CyberMedica",
+      "product_boundary": "cybermedica/ proprietary adjacent subtree",
+      "settlement_required": true,
+      "usage_accounting_policy": "exo-economy-use-event-v1"
+    },
+    {
+      "apache_by_proximity": false,
+      "apache_core_primitive": null,
+      "bailment_type": "Licensure",
+      "license_model": "commercial",
+      "name": "LiveSafe",
+      "product_boundary": "livesafe/ proprietary adjacent subtree",
+      "settlement_required": true,
+      "usage_accounting_policy": "exo-economy-use-event-v1"
+    },
+    {
+      "apache_by_proximity": false,
+      "apache_core_primitive": null,
+      "bailment_type": "Licensure",
+      "license_model": "commercial",
+      "name": "CrossChecked",
+      "product_boundary": "external proprietary product",
+      "settlement_required": true,
+      "usage_accounting_policy": "exo-economy-use-event-v1"
+    }
+  ],
+  "schema_version": 1,
+  "usage_accounting_policy": "exo-economy-use-event-v1"
+}

--- a/tools/test_proprietary_license_boundaries.sh
+++ b/tools/test_proprietary_license_boundaries.sh
@@ -67,6 +67,56 @@ grep -F '`livesafe/LICENSE`' README.md >/dev/null \
 grep -F '`cybermedica/LICENSE`' README.md >/dev/null \
   || fail 'README must cite the CyberMedica license'
 
+registry='governance/commercial-product-licensing.json'
+[ -f "$registry" ] || fail "$registry is missing"
+
+expected_products="$(printf '%s\n' 'CrossChecked' 'CyberMedica' 'Decision Forum' 'LegalDyne' 'LiveSafe')"
+actual_products="$(jq -r '.products[].name' "$registry" | LC_ALL=C sort)"
+[ "$actual_products" = "$expected_products" ] \
+  || fail 'commercial product registry must contain exactly CrossChecked, CyberMedica, Decision Forum, LegalDyne, and LiveSafe'
+
+jq -e '
+  .schema_version == 1 and
+  .core_license == "Apache-2.0" and
+  .licensure_template == "licensure-standard-v1" and
+  .usage_accounting_policy == "exo-economy-use-event-v1" and
+  (.products | length == 5) and
+  all(.products[];
+    .license_model == "commercial" and
+    .bailment_type == "Licensure" and
+    .usage_accounting_policy == "exo-economy-use-event-v1" and
+    .settlement_required == true and
+    .apache_by_proximity == false
+  )
+' "$registry" >/dev/null \
+  || fail 'commercial product registry must require licensure bailment, canonical usage accounting, and settlement'
+
+jq -e '
+  .products[] |
+  select(.name == "Decision Forum") |
+  .product_boundary == "external proprietary product" and
+  .apache_core_primitive == "crates/decision-forum"
+' "$registry" >/dev/null \
+  || fail 'Decision Forum product must remain distinct from the Apache core primitive'
+
+grep -F 'Licensure,' crates/exo-consent/src/bailment.rs >/dev/null \
+  || fail 'exo-consent must expose the Licensure bailment type'
+grep -F 'licensure-standard-v1' crates/exo-consent/src/contract.rs >/dev/null \
+  || fail 'exo-consent must expose the canonical licensure template'
+grep -F 'exo-economy-use-event-v1' crates/exo-consent/src/contract.rs >/dev/null \
+  || fail 'licensure contracts must bind the canonical usage-accounting policy'
+grep -F 'validate_commercial_licensure' crates/exo-economy/src/adoption.rs >/dev/null \
+  || fail 'exo-economy must validate commercial use against licensure accounting'
+
+for product in 'Decision Forum' LegalDyne CyberMedica LiveSafe CrossChecked; do
+  grep -F "$product" docs/legal/LICENSING-POSITION.md >/dev/null \
+    || fail "licensing position must classify $product"
+done
+grep -F 'commercial-product-licensing.json' README.md >/dev/null \
+  || fail 'README must cite the commercial product licensing registry'
+grep -F '`crates/decision-forum` remains an Apache-2.0 core primitive' README.md >/dev/null \
+  || fail 'README must distinguish the Decision Forum product from its core primitive'
+
 license_section="$(
   awk '
     /^## License$/ { in_license = 1 }
@@ -82,5 +132,9 @@ printf '%s\n' "$license_section" | grep -F '[livesafe/LICENSE](livesafe/LICENSE)
   || fail 'README License section must cite the LiveSafe license'
 printf '%s\n' "$license_section" | grep -F '[cybermedica/LICENSE](cybermedica/LICENSE)' >/dev/null \
   || fail 'README License section must cite the CyberMedica license'
+for product in 'Decision Forum' LegalDyne CrossChecked; do
+  printf '%s\n' "$license_section" | grep -F "$product" >/dev/null \
+    || fail "README License section must identify $product as commercially licensed"
+done
 
 printf 'proprietary license boundary test passed\n'

--- a/tools/test_proprietary_license_boundaries.sh
+++ b/tools/test_proprietary_license_boundaries.sh
@@ -60,11 +60,9 @@ grep -F '"cybermedica/",' tools/license_headers.py >/dev/null \
 
 grep -F 'Apache-2.0 for EXOCHAIN core' README.md >/dev/null \
   || fail 'README must scope Apache-2.0 to EXOCHAIN core'
-grep -F '`livesafe/` and `cybermedica/`' README.md >/dev/null \
-  || fail 'README must identify both proprietary subtrees'
-grep -F '`livesafe/LICENSE`' README.md >/dev/null \
+grep -F '[livesafe/LICENSE](livesafe/LICENSE)' README.md >/dev/null \
   || fail 'README must cite the LiveSafe license'
-grep -F '`cybermedica/LICENSE`' README.md >/dev/null \
+grep -F '[cybermedica/LICENSE](cybermedica/LICENSE)' README.md >/dev/null \
   || fail 'README must cite the CyberMedica license'
 
 registry='governance/commercial-product-licensing.json'


### PR DESCRIPTION
## Release reconciliation

Forward-ports the surviving commercial-licensure gap onto current main. Only the EXOCHAIN core primitives remain Apache-2.0. Decision Forum product, LegalDyne, CyberMedica, LiveSafe, and CrossChecked require commercial terms tracked through EXOCHAIN bailment licensure and usage accounting. The Apache-licensed crates/decision-forum primitive is explicitly distinct from the proprietary Decision Forum product.

## Path classification

- EXOCHAIN core: crates/exo-consent and crates/exo-economy licensure state, required clauses, and deterministic usage accounting.
- Constitutional governance/documentation: governance/commercial-product-licensing.json, docs/legal/LICENSING-POSITION.md, README.md, and the source guard.
- Adjacent surfaces: none modified.
- Imported/vendor artifacts: none.

Core and documentation are separate commits but remain in one PR because the enforceable licensure contract and the authoritative five-product registry must land atomically; either half alone would leave main with a contradictory licensing boundary.

## Constitutional boundary

- Consent remains bailment-bound and fail-closed.
- Accounting uses deterministic integer units and BTreeMap-backed records.
- No product receives a core trust claim, Apache license, secret scope, or CI assumption by proximity.
- No publication, tag, or public 0.2.3 release claim is made.

## Verification

- cargo test -p exochain-consent -p exochain-economy
- cargo clippy -p exochain-consent -p exochain-economy --all-targets -- -D warnings
- bash tools/test_proprietary_license_boundaries.sh
- bash tools/test_repo_truth.sh
- bash tools/repo_truth.sh --json --skip-tests with numeric rust_loc readback
- cargo +nightly fmt --all -- --check
- git diff --check

Full constitutional CI is required before merge.