### PR TITLE
fix(adapters): bind provenance to actor signers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 31 | `ls -d crates/*/` |
 | Rust source files | 471 | `git ls-files 'crates/**/*.rs'` |
-| Workspace tests | 6,258 listed | `cargo test --workspace -- --list` |
+| Workspace tests | 6,264 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 23 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
 | Latest published release | `v0.2.1-beta` (GitHub Release published 2026-07-08; `exochain-core` on crates.io and `@exochain/llm-proxy` on npm resolve the same version) | `gh release list`; `cargo search exochain-core`; `npm view @exochain/llm-proxy version` |
 | License | Apache-2.0 for EXOCHAIN core primitives; commercial terms for Decision Forum, LegalDyne, CyberMedica, LiveSafe, and CrossChecked products | `governance/commercial-product-licensing.json`; product license files where present |
@@ -43,7 +43,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **6,258 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **6,264 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -126,7 +126,7 @@ Catalyst is named explicitly.
 Layer 1: CGR Kernel         (Rust, 31 crates)
          Constitutional governance runtime — deterministic, no floats,
          production Ed25519/BLAKE3 cryptography plus unaudited pedagogical
-         SNARK/STARK/ZKML skeletons, 6,258 listed workspace tests
+         SNARK/STARK/ZKML skeletons, 6,264 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          165 verified WASM exports covered by 172 bridge checks — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-node/src/holons.rs
+++ b/crates/exo-node/src/holons.rs
@@ -1177,6 +1177,25 @@ mod tests {
     }
 
     #[test]
+    fn holon_provenance_uses_a_did_bound_actor_key_not_the_root_authority_key() {
+        let config = test_config_with_attestation();
+        let holon = create_health_holon(&config.node_did);
+        let context = build_holon_adjudication_context(&holon, &config)
+            .expect("attested Holon context should be constructed");
+        let provenance_key = context
+            .provenance
+            .as_ref()
+            .and_then(|provenance| provenance.public_key.as_ref())
+            .expect("Holon provenance public key");
+
+        assert_ne!(
+            provenance_key.as_slice(),
+            config.root_public_key.as_bytes(),
+            "root authority key must not masquerade as a distinct Holon actor"
+        );
+    }
+
+    #[test]
     fn production_holon_config_does_not_compile_default_authority_secret() {
         let source = include_str!("holons.rs");
         let production = source

--- a/crates/exo-node/src/holons.rs
+++ b/crates/exo-node/src/holons.rs
@@ -28,9 +28,10 @@
 //!
 //! # Audit status — Onyx-4 R5 / VCG-010 (default-off runtime)
 //!
-//! The infrastructure Holon adjudication context requires a configured
-//! Ed25519 authority key and signer. The authority chain and provenance are
-//! signed over the same canonical payloads enforced by `exo-gatekeeper`.
+//! The infrastructure Holon adjudication context now requires a configured
+//! Ed25519 authority key and signer plus a distinct DID-bound actor signer for
+//! each Holon. Authority chains and provenance are signed over the same
+//! canonical payloads enforced by `exo-gatekeeper`.
 //!
 //! Per ratified decision D5, a root authority is legitimate only with a
 //! witnessed ceremony, external attestation, and lineage distinct from the
@@ -63,7 +64,7 @@
 
 #![cfg_attr(not(feature = "unaudited-infrastructure-holons"), allow(dead_code))]
 
-use std::{sync::Arc, time::Duration};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use exo_core::{
     PublicKey, Signature,
@@ -179,8 +180,16 @@ pub struct HolonManagerConfig {
     pub root_did: Did,
     /// Ed25519 public key for `root_did`.
     pub root_public_key: PublicKey,
-    /// Signs canonical authority/provenance payload hashes for infrastructure Holon context.
+    /// Signs canonical authority payload hashes for infrastructure Holon context.
     pub root_signer: Arc<dyn Fn(&[u8]) -> Signature + Send + Sync>,
+    /// DID used for the topology Holon actor.
+    pub topology_holon_did: Did,
+    /// DID used for the scaling Holon actor.
+    pub scaling_holon_did: Did,
+    /// DID used for the health Holon actor.
+    pub health_holon_did: Did,
+    /// DID-bound Holon actor public keys and signers used for provenance.
+    pub holon_actor_keys: BTreeMap<Did, HolonActorKey>,
     /// External attestation of the root authority's legitimacy (witnessed
     /// ceremony + lineage distinct from `root_signer`, per D5). `None` means
     /// the root authority is self-issued with no external delegation chain,
@@ -196,12 +205,34 @@ pub struct HolonManagerConfig {
     pub health_interval_secs: u64,
 }
 
+/// DID-bound actor key and signer for one infrastructure Holon.
+#[derive(Clone)]
+pub struct HolonActorKey {
+    /// Public key resolved for the Holon actor DID.
+    pub public_key: PublicKey,
+    /// Signs canonical provenance payloads for the Holon actor DID.
+    pub signer: Arc<dyn Fn(&[u8]) -> Signature + Send + Sync>,
+}
+
+impl std::fmt::Debug for HolonActorKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HolonActorKey")
+            .field("public_key", &self.public_key)
+            .field("signer", &"<holon-actor-signer>")
+            .finish()
+    }
+}
+
 impl std::fmt::Debug for HolonManagerConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HolonManagerConfig")
             .field("node_did", &self.node_did)
             .field("root_did", &self.root_did)
             .field("root_public_key", &self.root_public_key)
+            .field("topology_holon_did", &self.topology_holon_did)
+            .field("scaling_holon_did", &self.scaling_holon_did)
+            .field("health_holon_did", &self.health_holon_did)
+            .field("holon_actor_key_count", &self.holon_actor_keys.len())
             .field(
                 "root_attestation",
                 &self.root_attestation.as_ref().map(|a| &a.attester_did),
@@ -236,21 +267,6 @@ fn static_did(value: &'static str) -> Did {
     }
 }
 
-fn did_with_static_fallback(candidate: String, fallback: &'static str) -> Did {
-    match Did::new(&candidate) {
-        Ok(did) => did,
-        Err(error) => {
-            tracing::warn!(
-                candidate,
-                fallback,
-                err = %error,
-                "Generated Holon DID was invalid; using static fallback"
-            );
-            static_did(fallback)
-        }
-    }
-}
-
 fn ratio_basis_points(numerator: usize, denominator: usize) -> u32 {
     if denominator == 0 {
         return 0;
@@ -270,15 +286,8 @@ fn usize_to_u64_saturating(value: usize) -> u64 {
 // Holon construction
 // ---------------------------------------------------------------------------
 
-/// Create the topology optimizer Holon.
-///
-/// Program: Guard(peer_count ≥ 1) → Transform(compute diversity) → Checkpoint
-pub fn create_topology_holon(node_did: &Did) -> Holon {
-    let holon_did = did_with_static_fallback(
-        format!("did:exo:archon-topology-{node_did}"),
-        "did:exo:archon-topology",
-    );
-
+/// Create the topology optimizer Holon for an already-resolved Holon DID.
+pub fn create_topology_holon_with_did(holon_did: Did) -> Holon {
     holon::spawn(
         holon_did,
         PermissionSet::new(vec![
@@ -308,15 +317,8 @@ pub fn create_topology_holon(node_did: &Did) -> Holon {
     )
 }
 
-/// Create the scaling advisor Holon.
-///
-/// Program: Guard(validator_count exists) → Transform(scaling recommendation)
-pub fn create_scaling_holon(node_did: &Did) -> Holon {
-    let holon_did = did_with_static_fallback(
-        format!("did:exo:archon-scaling-{node_did}"),
-        "did:exo:archon-scaling",
-    );
-
+/// Create the scaling advisor Holon for an already-resolved Holon DID.
+pub fn create_scaling_holon_with_did(holon_did: Did) -> Holon {
     holon::spawn(
         holon_did,
         PermissionSet::new(vec![
@@ -346,15 +348,8 @@ pub fn create_scaling_holon(node_did: &Did) -> Holon {
     )
 }
 
-/// Create the health monitor Holon.
-///
-/// Program: Transform(health status) — always runs.
-pub fn create_health_holon(node_did: &Did) -> Holon {
-    let holon_did = did_with_static_fallback(
-        format!("did:exo:archon-health-{node_did}"),
-        "did:exo:archon-health",
-    );
-
+/// Create the health monitor Holon for an already-resolved Holon DID.
+pub fn create_health_holon_with_did(holon_did: Did) -> Holon {
     holon::spawn(
         holon_did,
         PermissionSet::new(vec![
@@ -439,7 +434,7 @@ fn signed_attestation_link(
 
 fn signed_provenance(
     holon: &Holon,
-    config: &HolonManagerConfig,
+    actor_key: &HolonActorKey,
     provenance_timestamp: Timestamp,
 ) -> Result<Provenance, String> {
     let timestamp = provenance_timestamp.to_string();
@@ -457,14 +452,14 @@ fn signed_provenance(
         timestamp,
         action_hash,
         signature: Vec::new(),
-        public_key: Some(config.root_public_key.as_bytes().to_vec()),
+        public_key: Some(actor_key.public_key.as_bytes().to_vec()),
         voice_kind: None,
         independence: None,
         review_order: None,
     };
     let message = provenance_signature_message(&provenance)
         .map_err(|err| format!("failed to encode provenance signature payload: {err}"))?;
-    let signature = (config.root_signer)(message.as_bytes());
+    let signature = (actor_key.signer)(message.as_bytes());
     provenance.signature = signature.to_bytes().to_vec();
     Ok(provenance)
 }
@@ -493,6 +488,12 @@ pub fn build_holon_adjudication_context(
     config: &HolonManagerConfig,
 ) -> Result<AdjudicationContext, String> {
     let provenance_timestamp = next_provenance_timestamp(config)?;
+    let actor_key = config.holon_actor_keys.get(&holon.id).ok_or_else(|| {
+        format!(
+            "Holon actor signer is required for DID-bound provenance: {}",
+            holon.id
+        )
+    })?;
     let root_link = signed_authority_link(holon, config)?;
 
     // Per D5: a root authority is legitimate only with a witnessed ceremony,
@@ -542,7 +543,7 @@ pub fn build_holon_adjudication_context(
     let mut trusted_provenance_keys = TrustedProvenanceKeys::default();
     trusted_provenance_keys.insert(
         holon.id.clone(),
-        vec![config.root_public_key.as_bytes().to_vec()],
+        vec![actor_key.public_key.as_bytes().to_vec()],
     );
     let consent_scope = capability_scope(&holon.capabilities);
     Ok(AdjudicationContext {
@@ -566,7 +567,7 @@ pub fn build_holon_adjudication_context(
         actor_permissions: holon.capabilities.clone(),
         trusted_authority_keys,
         trusted_provenance_keys,
-        provenance: Some(signed_provenance(holon, config, provenance_timestamp)?),
+        provenance: Some(signed_provenance(holon, actor_key, provenance_timestamp)?),
         quorum_evidence: None,
         active_challenge_reason: None,
     })
@@ -755,9 +756,9 @@ pub async fn run_holon_manager(
 ) {
     let kernel = create_infrastructure_kernel();
 
-    let mut topology_holon = create_topology_holon(&config.node_did);
-    let mut scaling_holon = create_scaling_holon(&config.node_did);
-    let mut health_holon = create_health_holon(&config.node_did);
+    let mut topology_holon = create_topology_holon_with_did(config.topology_holon_did.clone());
+    let mut scaling_holon = create_scaling_holon_with_did(config.scaling_holon_did.clone());
+    let mut health_holon = create_health_holon_with_did(config.health_holon_did.clone());
 
     let mut topology_timer =
         tokio::time::interval(Duration::from_secs(config.topology_interval_secs));
@@ -1090,6 +1091,23 @@ mod tests {
         Did::new("did:exo:test-node").unwrap()
     }
 
+    fn test_holon_did(node_did: &Did, role: &str) -> Did {
+        Did::new(&format!("did:exo:archon-{role}-{node_did}"))
+            .unwrap_or_else(|_| Did::new(&format!("did:exo:archon-{role}")).unwrap())
+    }
+
+    fn create_topology_holon(node_did: &Did) -> Holon {
+        create_topology_holon_with_did(test_holon_did(node_did, "topology"))
+    }
+
+    fn create_scaling_holon(node_did: &Did) -> Holon {
+        create_scaling_holon_with_did(test_holon_did(node_did, "scaling"))
+    }
+
+    fn create_health_holon(node_did: &Did) -> Holon {
+        create_health_holon_with_did(test_holon_did(node_did, "health"))
+    }
+
     fn deterministic_provenance_timestamp_source(
         start_physical_ms: u64,
     ) -> Arc<dyn Fn() -> Result<Timestamp, String> + Send + Sync> {
@@ -1111,19 +1129,46 @@ mod tests {
         scaling_interval_secs: u64,
         health_interval_secs: u64,
     ) -> HolonManagerConfig {
+        let node_did = test_did();
+        let topology_holon_did = create_topology_holon(&node_did).id;
+        let scaling_holon_did = create_scaling_holon(&node_did).id;
+        let health_holon_did = create_health_holon(&node_did).id;
         let keypair = exo_core::crypto::KeyPair::from_secret_bytes([0x48; 32]).unwrap();
         let root_public_key = *keypair.public_key();
         let root_secret_key = keypair.secret_key().clone();
         let attester_keypair = exo_core::crypto::KeyPair::from_secret_bytes([0x99; 32]).unwrap();
         let attester_public_key = *attester_keypair.public_key();
         let attester_secret_key = attester_keypair.secret_key().clone();
+        let mut holon_actor_keys = BTreeMap::new();
+        for (holon_did, secret_seed) in [
+            (topology_holon_did.clone(), [0x51; 32]),
+            (scaling_holon_did.clone(), [0x52; 32]),
+            (health_holon_did.clone(), [0x53; 32]),
+        ] {
+            let keypair = exo_core::crypto::KeyPair::from_secret_bytes(secret_seed).unwrap();
+            let public_key = *keypair.public_key();
+            let secret_key = keypair.secret_key().clone();
+            holon_actor_keys.insert(
+                holon_did,
+                HolonActorKey {
+                    public_key,
+                    signer: Arc::new(move |message: &[u8]| {
+                        exo_core::crypto::sign(message, &secret_key)
+                    }),
+                },
+            );
+        }
         HolonManagerConfig {
-            node_did: test_did(),
+            node_did,
             root_did: Did::new("did:exo:test-root").unwrap(),
             root_public_key,
             root_signer: Arc::new(move |message: &[u8]| {
                 exo_core::crypto::sign(message, &root_secret_key)
             }),
+            topology_holon_did,
+            scaling_holon_did,
+            health_holon_did,
+            holon_actor_keys,
             root_attestation: Some(RootAttestation {
                 attester_did: Did::new("did:exo:test-ceremony-witness").unwrap(),
                 attester_public_key,
@@ -1173,6 +1218,10 @@ mod tests {
         assert!(
             src.contains("Ed25519 authority key"),
             "module doc must call out the signed adjudication authority"
+        );
+        assert!(
+            src.contains("distinct DID-bound actor signer"),
+            "module doc must call out per-Holon provenance actor signers"
         );
     }
 
@@ -1242,6 +1291,24 @@ mod tests {
         assert!(
             production.contains("hash_structured"),
             "Holon provenance action hashes must use canonical structured hashing"
+        );
+    }
+
+    #[test]
+    fn production_holon_source_does_not_synthesize_root_key_as_actor_provenance() {
+        let source = include_str!("holons.rs");
+        let production = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("test module marker present");
+        assert!(
+            !production.contains("trusted_provenance_keys.insert(\n        holon.id.clone(),\n        vec![config.root_public_key.as_bytes().to_vec()],"),
+            "Holon trusted provenance keys must come from DID-bound Holon actor keys, not the root authority key"
+        );
+        assert!(
+            !production
+                .contains("\n        public_key: Some(config.root_public_key.as_bytes().to_vec())"),
+            "Holon provenance must not be signed as the Holon actor with the root authority key"
         );
     }
 
@@ -1484,6 +1551,19 @@ mod tests {
             "an attestation whose key equals the root signer key (distinct DID \
              label only) is self-issuance laundered through a second label and \
              must be REJECTED per D5, but holon::step returned {result:?}"
+        );
+    }
+
+    #[test]
+    fn holon_context_rejects_root_key_synthesized_as_holon_provenance_key() {
+        let mut config = test_config();
+        let h = create_health_holon(&test_did());
+        config.holon_actor_keys.remove(&h.id);
+        let err = build_holon_adjudication_context(&h, &config)
+            .expect_err("Holon provenance must require a DID-bound Holon signer");
+        assert!(
+            err.contains("Holon actor signer"),
+            "unexpected error: {err}"
         );
     }
 

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -76,7 +76,7 @@ use clap::Parser;
 use cli::{Cli, Command};
 use exo_core::types::{Did, PublicKey};
 #[cfg(feature = "unaudited-infrastructure-holons")]
-use holons::{HolonEvent, HolonManagerConfig};
+use holons::{HolonActorKey, HolonEvent, HolonManagerConfig};
 use libp2p_core::Multiaddr;
 use network::{NetworkConfig, NetworkEvent, NetworkHandle};
 use reactor::{ReactorConfig, ReactorEvent};
@@ -817,11 +817,52 @@ async fn start_node(
         let holon_authority_did = holon_identity.did.clone();
         let holon_authority_public_key = *holon_identity.public_key();
         let holon_authority_signer = Arc::new(move |message: &[u8]| holon_identity.sign(message));
+
+        let holon_identity_dir = data_dir.join("holons");
+        std::fs::create_dir_all(&holon_identity_dir)?;
+        let topology_holon_identity =
+            identity::load_or_create(&holon_identity_dir.join("topology"))?;
+        let scaling_holon_identity = identity::load_or_create(&holon_identity_dir.join("scaling"))?;
+        let health_holon_identity = identity::load_or_create(&holon_identity_dir.join("health"))?;
+
+        let topology_holon_did = topology_holon_identity.did.clone();
+        let topology_holon_public_key = *topology_holon_identity.public_key();
+        let scaling_holon_did = scaling_holon_identity.did.clone();
+        let scaling_holon_public_key = *scaling_holon_identity.public_key();
+        let health_holon_did = health_holon_identity.did.clone();
+        let health_holon_public_key = *health_holon_identity.public_key();
+
+        let mut holon_actor_keys = BTreeMap::new();
+        holon_actor_keys.insert(
+            topology_holon_did.clone(),
+            HolonActorKey {
+                public_key: topology_holon_public_key,
+                signer: Arc::new(move |message: &[u8]| topology_holon_identity.sign(message)),
+            },
+        );
+        holon_actor_keys.insert(
+            scaling_holon_did.clone(),
+            HolonActorKey {
+                public_key: scaling_holon_public_key,
+                signer: Arc::new(move |message: &[u8]| scaling_holon_identity.sign(message)),
+            },
+        );
+        holon_actor_keys.insert(
+            health_holon_did.clone(),
+            HolonActorKey {
+                public_key: health_holon_public_key,
+                signer: Arc::new(move |message: &[u8]| health_holon_identity.sign(message)),
+            },
+        );
         let holon_config = HolonManagerConfig {
             node_did: node_identity.did.clone(),
             root_did: holon_authority_did,
             root_public_key: holon_authority_public_key,
             root_signer: holon_authority_signer,
+            topology_holon_did,
+            scaling_holon_did,
+            health_holon_did,
+            holon_actor_keys,
             // No external attestation is wired yet: `root_did`/`root_public_key`/
             // `root_signer` above are all derived from the same freshly-loaded
             // node identity, i.e. a self-issued root authority with no

--- a/crates/exo-node/src/mcp/middleware.rs
+++ b/crates/exo-node/src/mcp/middleware.rs
@@ -573,6 +573,18 @@ mod tests {
     }
 
     #[test]
+    fn production_mcp_source_does_not_map_authority_key_to_another_actor() {
+        let source = include_str!("middleware.rs")
+            .split("// ===========================================================================\n// Tests")
+            .next()
+            .expect("production section");
+        assert!(
+            source.contains("actor_did != &authority.did"),
+            "MCP middleware must reject authority-key provenance for a different actor DID"
+        );
+    }
+
+    #[test]
     fn middleware_mcp_rules_pass_valid() {
         let mw = signed_middleware();
         let did = test_did();

--- a/crates/exo-node/src/mcp/middleware.rs
+++ b/crates/exo-node/src/mcp/middleware.rs
@@ -227,6 +227,12 @@ impl ConstitutionalMiddleware {
                 "MCP authority signer is required for verified MCP invocation context".into(),
             )
         })?;
+        if actor_did != &authority.did {
+            return Err(McpError::ConstitutionalViolation(
+                "MCP actor provenance key must be resolved independently of the configured authority signer"
+                    .into(),
+            ));
+        }
         let Some(root_link) = context.authority_chain.links.first() else {
             return Err(McpError::ConstitutionalViolation(
                 "verified MCP invocation context authority_chain is empty".into(),
@@ -262,6 +268,12 @@ impl ConstitutionalMiddleware {
                 "MCP authority signer is required for verified MCP invocation context".into(),
             )
         })?;
+        if actor_did != &authority.did {
+            return Err(McpError::ConstitutionalViolation(
+                "MCP actor provenance key must be resolved independently of the configured authority signer"
+                    .into(),
+            ));
+        }
         let public_key = authority.public_key.as_bytes().to_vec();
         let mut trusted_authority_keys = TrustedAuthorityKeys::default();
         trusted_authority_keys.insert(authority.did.clone(), vec![public_key.clone()]);

--- a/crates/exochain-sdk/src/kernel.rs
+++ b/crates/exochain-sdk/src/kernel.rs
@@ -642,6 +642,17 @@ mod tests {
     }
 
     #[test]
+    fn authority_signer_cannot_masquerade_as_a_different_actor() {
+        let k = signed_kernel();
+        let actor = did("did:exo:independent-actor");
+        let verdict = k.adjudicate(&actor, "read-medical-record");
+        assert!(
+            verdict.is_denied(),
+            "authority signing material must not be promoted as another actor's provenance key: {verdict:?}"
+        );
+    }
+
+    #[test]
     fn adjudicate_without_authority_signer_fails_closed() {
         let k = ConstitutionalKernel::new();
         let actor = did("did:exo:valid-actor");

--- a/crates/exochain-sdk/src/kernel.rs
+++ b/crates/exochain-sdk/src/kernel.rs
@@ -46,9 +46,9 @@
 //! use exo_core::Did;
 //!
 //! let authority = exochain_sdk::identity::Identity::generate("authority");
+//! let actor = exochain_sdk::identity::Identity::generate("alice");
 //! let kernel = ConstitutionalKernel::with_authority_identity(authority);
-//! let actor = Did::new("did:exo:alice").expect("valid");
-//! let verdict = kernel.adjudicate(&actor, "data:medical:read");
+//! let verdict = kernel.adjudicate_as(&actor, "data:medical:read");
 //! assert!(verdict.is_permitted());
 //! ```
 
@@ -157,7 +157,7 @@ impl KernelVerdict {
 ///
 /// Provides a minimal adjudication interface suitable for common SDK use
 /// cases: a single actor performing an action, with caller-supplied authority
-/// signing material, signed provenance, and an active bailment from that
+/// signing material, actor-signed provenance, and an active bailment from that
 /// authority. Callers needing fine-grained control over the adjudication
 /// context should use [`exo_gatekeeper::Kernel`] directly.
 ///
@@ -168,12 +168,12 @@ impl KernelVerdict {
 /// use exo_core::Did;
 ///
 /// let authority = exochain_sdk::identity::Identity::generate("authority");
+/// let actor = exochain_sdk::identity::Identity::generate("alice");
 /// let kernel = ConstitutionalKernel::with_authority_identity(authority);
 /// assert!(kernel.verify_integrity());
 /// assert_eq!(kernel.invariant_count(), 8);
 ///
-/// let actor = Did::new("did:exo:alice").expect("valid");
-/// let verdict = kernel.adjudicate(&actor, "read:profile");
+/// let verdict = kernel.adjudicate_as(&actor, "read:profile");
 /// assert!(verdict.is_permitted());
 /// ```
 pub struct ConstitutionalKernel {
@@ -188,6 +188,44 @@ struct KernelAuthority {
     did: Did,
     public_key: PublicKey,
     signer: AuthoritySigner,
+}
+
+#[derive(Clone, Copy)]
+struct AdjudicationFlags {
+    is_self_grant: bool,
+    modifies_kernel: bool,
+    include_bailment: bool,
+    human_override_preserved: bool,
+}
+
+impl AdjudicationFlags {
+    const DEFAULT: Self = Self {
+        is_self_grant: false,
+        modifies_kernel: false,
+        include_bailment: true,
+        human_override_preserved: true,
+    };
+
+    const SELF_GRANT: Self = Self {
+        is_self_grant: true,
+        ..Self::DEFAULT
+    };
+
+    const KERNEL_MODIFICATION: Self = Self {
+        modifies_kernel: true,
+        ..Self::DEFAULT
+    };
+
+    const WITHOUT_BAILMENT: Self = Self {
+        include_bailment: false,
+        ..Self::DEFAULT
+    };
+}
+
+struct ActorProvenanceSigner<'a> {
+    actor: &'a Did,
+    public_key: &'a PublicKey,
+    signer: &'a dyn Fn(&[u8]) -> Signature,
 }
 
 impl ConstitutionalKernel {
@@ -215,8 +253,9 @@ impl ConstitutionalKernel {
     ///
     /// This is the common SDK path: the identity's DID becomes the authority
     /// grantor and bailor for the default adjudication context, and its secret
-    /// key signs the canonical authority/provenance payloads that the kernel
-    /// verifies.
+    /// key signs the canonical authority payloads that the kernel verifies.
+    /// Actor provenance must still be signed by the actor identity through
+    /// [`Self::adjudicate_as`].
     ///
     /// # Examples
     ///
@@ -283,14 +322,17 @@ impl ConstitutionalKernel {
     /// - An active bailment from the configured authority to `actor` scoped to
     ///   the requested permission set.
     /// - Full human-override preservation.
-    /// - Signed provenance with timestamp `"sdk"`.
+    /// - Signed provenance with timestamp `"sdk"` when `actor` is the
+    ///   authority DID itself.
     ///
     /// If the kernel was created with [`Self::new`] rather than
     /// [`Self::with_authority`] or [`Self::with_authority_identity`], this
     /// method fails closed with a denied verdict.
     ///
-    /// Callers needing richer context should reach for
-    /// [`exo_gatekeeper::Kernel`] directly.
+    /// Passing an arbitrary DID without its signer fails closed. Use
+    /// [`Self::adjudicate_as`] when acting for a distinct SDK identity, or
+    /// reach for [`exo_gatekeeper::Kernel`] directly when building a fully
+    /// resolved adjudication context.
     ///
     /// The action is flagged as `is_self_grant = false` and
     /// `modifies_kernel = false` by default. Helpers are available for the
@@ -303,17 +345,28 @@ impl ConstitutionalKernel {
     ///
     /// ```
     /// use exochain_sdk::kernel::ConstitutionalKernel;
-    /// use exo_core::Did;
     ///
     /// let authority = exochain_sdk::identity::Identity::generate("authority");
+    /// let actor = authority.did().clone();
     /// let kernel = ConstitutionalKernel::with_authority_identity(authority);
-    /// let actor = Did::new("did:exo:alice").expect("valid");
     /// let verdict = kernel.adjudicate(&actor, "data:read");
     /// assert!(verdict.is_permitted());
     /// ```
     #[must_use]
     pub fn adjudicate(&self, actor: &Did, action: &str) -> KernelVerdict {
-        self.adjudicate_internal(actor, action, false, false, true, true)
+        self.adjudicate_internal(actor, action, AdjudicationFlags::DEFAULT)
+    }
+
+    /// Adjudicate `action` performed by `actor` using actor-signed
+    /// provenance and authority-signed delegation.
+    ///
+    /// This is the normal SDK path for actions performed by a principal other
+    /// than the configured authority. The actor identity signs the provenance
+    /// payload, and the trusted provenance key map is populated from that
+    /// same actor identity rather than from the authority signer.
+    #[must_use]
+    pub fn adjudicate_as(&self, actor: &crate::identity::Identity, action: &str) -> KernelVerdict {
+        self.adjudicate_identity_internal(actor, action, AdjudicationFlags::DEFAULT)
     }
 
     /// Same as [`Self::adjudicate`] but sets `is_self_grant = true` so the
@@ -326,17 +379,26 @@ impl ConstitutionalKernel {
     ///
     /// ```
     /// use exochain_sdk::kernel::ConstitutionalKernel;
-    /// use exo_core::Did;
     ///
     /// let authority = exochain_sdk::identity::Identity::generate("authority");
+    /// let actor = exochain_sdk::identity::Identity::generate("self-granter");
     /// let kernel = ConstitutionalKernel::with_authority_identity(authority);
-    /// let actor = Did::new("did:exo:self-granter").expect("valid");
-    /// let verdict = kernel.adjudicate_self_grant(&actor, "escalate-self");
+    /// let verdict = kernel.adjudicate_self_grant_as(&actor, "escalate-self");
     /// assert!(verdict.is_denied());
     /// ```
     #[must_use]
     pub fn adjudicate_self_grant(&self, actor: &Did, action: &str) -> KernelVerdict {
-        self.adjudicate_internal(actor, action, true, false, true, true)
+        self.adjudicate_internal(actor, action, AdjudicationFlags::SELF_GRANT)
+    }
+
+    /// Same as [`Self::adjudicate_as`] but sets `is_self_grant = true`.
+    #[must_use]
+    pub fn adjudicate_self_grant_as(
+        &self,
+        actor: &crate::identity::Identity,
+        action: &str,
+    ) -> KernelVerdict {
+        self.adjudicate_identity_internal(actor, action, AdjudicationFlags::SELF_GRANT)
     }
 
     /// Same as [`Self::adjudicate`] but sets `modifies_kernel = true` so the
@@ -346,17 +408,26 @@ impl ConstitutionalKernel {
     ///
     /// ```
     /// use exochain_sdk::kernel::ConstitutionalKernel;
-    /// use exo_core::Did;
     ///
     /// let authority = exochain_sdk::identity::Identity::generate("authority");
+    /// let actor = exochain_sdk::identity::Identity::generate("patcher");
     /// let kernel = ConstitutionalKernel::with_authority_identity(authority);
-    /// let actor = Did::new("did:exo:patcher").expect("valid");
-    /// let verdict = kernel.adjudicate_kernel_modification(&actor, "patch-kernel");
+    /// let verdict = kernel.adjudicate_kernel_modification_as(&actor, "patch-kernel");
     /// assert!(verdict.is_denied());
     /// ```
     #[must_use]
     pub fn adjudicate_kernel_modification(&self, actor: &Did, action: &str) -> KernelVerdict {
-        self.adjudicate_internal(actor, action, false, true, true, true)
+        self.adjudicate_internal(actor, action, AdjudicationFlags::KERNEL_MODIFICATION)
+    }
+
+    /// Same as [`Self::adjudicate_as`] but sets `modifies_kernel = true`.
+    #[must_use]
+    pub fn adjudicate_kernel_modification_as(
+        &self,
+        actor: &crate::identity::Identity,
+        action: &str,
+    ) -> KernelVerdict {
+        self.adjudicate_identity_internal(actor, action, AdjudicationFlags::KERNEL_MODIFICATION)
     }
 
     /// Same as [`Self::adjudicate`] but omits the default bailment so the
@@ -366,17 +437,26 @@ impl ConstitutionalKernel {
     ///
     /// ```
     /// use exochain_sdk::kernel::ConstitutionalKernel;
-    /// use exo_core::Did;
     ///
     /// let authority = exochain_sdk::identity::Identity::generate("authority");
+    /// let actor = exochain_sdk::identity::Identity::generate("unauth");
     /// let kernel = ConstitutionalKernel::with_authority_identity(authority);
-    /// let actor = Did::new("did:exo:unauth").expect("valid");
-    /// let verdict = kernel.adjudicate_without_bailment(&actor, "read-data");
+    /// let verdict = kernel.adjudicate_without_bailment_as(&actor, "read-data");
     /// assert!(verdict.is_denied());
     /// ```
     #[must_use]
     pub fn adjudicate_without_bailment(&self, actor: &Did, action: &str) -> KernelVerdict {
-        self.adjudicate_internal(actor, action, false, false, false, true)
+        self.adjudicate_internal(actor, action, AdjudicationFlags::WITHOUT_BAILMENT)
+    }
+
+    /// Same as [`Self::adjudicate_as`] but omits the default bailment.
+    #[must_use]
+    pub fn adjudicate_without_bailment_as(
+        &self,
+        actor: &crate::identity::Identity,
+        action: &str,
+    ) -> KernelVerdict {
+        self.adjudicate_identity_internal(actor, action, AdjudicationFlags::WITHOUT_BAILMENT)
     }
 
     /// Verify that the kernel's stored constitution hash matches the
@@ -431,9 +511,10 @@ impl ConstitutionalKernel {
     }
 
     fn signed_provenance(
-        authority: &KernelAuthority,
         actor: &Did,
         action: &str,
+        actor_public_key: &PublicKey,
+        actor_signer: &dyn Fn(&[u8]) -> Signature,
     ) -> exo_core::Result<Provenance> {
         let timestamp = "sdk".to_owned();
         let action_hash = Hash256::digest(action.as_bytes()).as_bytes().to_vec();
@@ -443,13 +524,13 @@ impl ConstitutionalKernel {
             timestamp,
             action_hash,
             signature: Vec::new(),
-            public_key: Some(authority.public_key.as_bytes().to_vec()),
+            public_key: Some(actor_public_key.as_bytes().to_vec()),
             voice_kind: None,
             independence: None,
             review_order: None,
         };
         let message = provenance_signature_message(&provenance)?;
-        let signature = (authority.signer)(message.as_bytes());
+        let signature = actor_signer(message.as_bytes());
         provenance.signature = signature.to_bytes().to_vec();
         Ok(provenance)
     }
@@ -465,14 +546,29 @@ impl ConstitutionalKernel {
         labels.join(";")
     }
 
+    fn adjudicate_identity_internal(
+        &self,
+        actor: &crate::identity::Identity,
+        action: &str,
+        flags: AdjudicationFlags,
+    ) -> KernelVerdict {
+        let signer = |message: &[u8]| actor.sign(message);
+        self.adjudicate_internal_with_actor_provenance(
+            action,
+            flags,
+            ActorProvenanceSigner {
+                actor: actor.did(),
+                public_key: actor.public_key(),
+                signer: &signer,
+            },
+        )
+    }
+
     fn adjudicate_internal(
         &self,
         actor: &Did,
         action: &str,
-        is_self_grant: bool,
-        modifies_kernel: bool,
-        include_bailment: bool,
-        human_override_preserved: bool,
+        flags: AdjudicationFlags,
     ) -> KernelVerdict {
         let Some(authority) = self.authority.as_ref() else {
             return KernelVerdict::Denied {
@@ -481,28 +577,58 @@ impl ConstitutionalKernel {
                 ],
             };
         };
+        if actor != &authority.did {
+            return KernelVerdict::Denied {
+                violations: vec![
+                    "ProvenanceVerifiable: SDK actor identity signer is required for non-authority actor provenance".into(),
+                ],
+            };
+        }
+        self.adjudicate_internal_with_actor_provenance(
+            action,
+            flags,
+            ActorProvenanceSigner {
+                actor,
+                public_key: &authority.public_key,
+                signer: authority.signer.as_ref(),
+            },
+        )
+    }
 
+    fn adjudicate_internal_with_actor_provenance(
+        &self,
+        action: &str,
+        flags: AdjudicationFlags,
+        actor_provenance: ActorProvenanceSigner<'_>,
+    ) -> KernelVerdict {
+        let Some(authority) = self.authority.as_ref() else {
+            return KernelVerdict::Denied {
+                violations: vec![
+                    "AuthorityChainValid: SDK authority signer is required for adjudication".into(),
+                ],
+            };
+        };
         let permissions = PermissionSet::new(vec![Permission::new("read")]);
         let request = ActionRequest {
-            actor: actor.clone(),
+            actor: actor_provenance.actor.clone(),
             action: action.to_owned(),
             required_permissions: permissions.clone(),
-            is_self_grant,
-            modifies_kernel,
+            is_self_grant: flags.is_self_grant,
+            modifies_kernel: flags.modifies_kernel,
         };
 
         let scope = Self::permission_scope(&permissions);
 
-        let (bailment_state, consent_records) = if include_bailment {
+        let (bailment_state, consent_records) = if flags.include_bailment {
             (
                 BailmentState::Active {
                     bailor: authority.did.clone(),
-                    bailee: actor.clone(),
+                    bailee: actor_provenance.actor.clone(),
                     scope: scope.clone(),
                 },
                 vec![ConsentRecord {
                     subject: authority.did.clone(),
-                    granted_to: actor.clone(),
+                    granted_to: actor_provenance.actor.clone(),
                     scope,
                     active: true,
                 }],
@@ -511,7 +637,11 @@ impl ConstitutionalKernel {
             (BailmentState::None, Vec::new())
         };
 
-        let authority_link = match Self::signed_authority_link(authority, actor, &permissions) {
+        let authority_link = match Self::signed_authority_link(
+            authority,
+            actor_provenance.actor,
+            &permissions,
+        ) {
             Ok(link) => link,
             Err(err) => {
                 return KernelVerdict::Denied {
@@ -521,7 +651,12 @@ impl ConstitutionalKernel {
                 };
             }
         };
-        let provenance = match Self::signed_provenance(authority, actor, action) {
+        let provenance = match Self::signed_provenance(
+            actor_provenance.actor,
+            action,
+            actor_provenance.public_key,
+            actor_provenance.signer,
+        ) {
             Ok(provenance) => provenance,
             Err(err) => {
                 return KernelVerdict::Denied {
@@ -543,8 +678,8 @@ impl ConstitutionalKernel {
         }
         let mut trusted_provenance_keys = TrustedProvenanceKeys::default();
         trusted_provenance_keys.insert(
-            actor.clone(),
-            vec![authority.public_key.as_bytes().to_vec()],
+            actor_provenance.actor.clone(),
+            vec![actor_provenance.public_key.as_bytes().to_vec()],
         );
 
         let context = AdjudicationContext {
@@ -555,7 +690,7 @@ impl ConstitutionalKernel {
             authority_chain,
             consent_records,
             bailment_state,
-            human_override_preserved,
+            human_override_preserved: flags.human_override_preserved,
             actor_permissions: permissions,
             trusted_authority_keys,
             trusted_provenance_keys,
@@ -633,8 +768,8 @@ mod tests {
     #[test]
     fn valid_action_permitted() {
         let k = signed_kernel();
-        let actor = did("did:exo:valid-actor");
-        let verdict = k.adjudicate(&actor, "read-medical-record");
+        let actor = crate::identity::Identity::generate("valid-actor");
+        let verdict = k.adjudicate_as(&actor, "read-medical-record");
         assert!(
             verdict.is_permitted(),
             "expected Permitted, got {verdict:?}"
@@ -650,6 +785,15 @@ mod tests {
             verdict.is_denied(),
             "authority signing material must not be promoted as another actor's provenance key: {verdict:?}"
         );
+        match verdict {
+            KernelVerdict::Denied { violations } => {
+                assert!(
+                    violations.iter().any(|v| v.contains("Provenance")),
+                    "denial must identify provenance key binding: {violations:?}"
+                );
+            }
+            other => panic!("expected Denied, got {other:?}"),
+        }
     }
 
     #[test]
@@ -669,8 +813,8 @@ mod tests {
     #[test]
     fn self_grant_denied() {
         let k = signed_kernel();
-        let actor = did("did:exo:self-granter");
-        let verdict = k.adjudicate_self_grant(&actor, "escalate-self");
+        let actor = crate::identity::Identity::generate("self-granter");
+        let verdict = k.adjudicate_self_grant_as(&actor, "escalate-self");
         assert!(verdict.is_denied(), "expected Denied, got {verdict:?}");
         match verdict {
             KernelVerdict::Denied { violations } => {
@@ -688,16 +832,16 @@ mod tests {
     #[test]
     fn kernel_modification_denied() {
         let k = signed_kernel();
-        let actor = did("did:exo:patcher");
-        let verdict = k.adjudicate_kernel_modification(&actor, "patch-kernel");
+        let actor = crate::identity::Identity::generate("patcher");
+        let verdict = k.adjudicate_kernel_modification_as(&actor, "patch-kernel");
         assert!(verdict.is_denied(), "expected Denied, got {verdict:?}");
     }
 
     #[test]
     fn no_bailment_denied() {
         let k = signed_kernel();
-        let actor = did("did:exo:unauth");
-        let verdict = k.adjudicate_without_bailment(&actor, "read-data");
+        let actor = crate::identity::Identity::generate("unauth");
+        let verdict = k.adjudicate_without_bailment_as(&actor, "read-data");
         assert!(verdict.is_denied(), "expected Denied, got {verdict:?}");
     }
 
@@ -710,6 +854,20 @@ mod tests {
         assert!(
             !source.contains("format!(\"{:?}: {}\", v.invariant, v.description)"),
             "SDK violation labels must use stable invariant IDs"
+        );
+    }
+
+    #[test]
+    fn sdk_source_does_not_synthesize_authority_key_as_actor_provenance() {
+        let source = include_str!("kernel.rs")
+            .split("// ===========================================================================\n// Tests")
+            .next()
+            .expect("production section");
+        assert!(
+            !source.contains(
+                "trusted_provenance_keys.insert(\n            actor.clone(),\n            vec![authority.public_key.as_bytes().to_vec()],"
+            ),
+            "SDK trusted provenance keys must come from actor identity material, not authority key substitution"
         );
     }
 

--- a/crates/exochain-sdk/src/lib.rs
+++ b/crates/exochain-sdk/src/lib.rs
@@ -104,7 +104,7 @@
 //! // 5. Ask the kernel whether bob may perform the action.
 //! // The SDK kernel requires caller-supplied authority signing material.
 //! let kernel = ConstitutionalKernel::with_authority_identity(root);
-//! let verdict = kernel.adjudicate(bob.did(), "data:medical:read");
+//! let verdict = kernel.adjudicate_as(&bob, "data:medical:read");
 //! assert!(verdict.is_permitted(), "expected Permitted, got {verdict:?}");
 //! # Ok::<(), exochain_sdk::error::ExoError>(())
 //! ```


### PR DESCRIPTION
## Release reconciliation

Forward-ports the surviving actor-provenance signer gap from closed PR #393 onto current main. SDK adjudication now signs provenance with the submitting actor identity, each Holon persists and reuses its own actor key, and the MCP adapter fails closed when a caller actor differs from the configured authority until an independent actor-key resolver is available.

## Path classification

- Core runtime adapter: crates/exochain-sdk/src/kernel.rs and the exo-node Holon/MCP wiring.
- EXOCHAIN core: none modified.
- Adjacent surfaces: none modified.
- Imported/vendor artifacts: none.

## Reproduction and boundary

The red-first commit demonstrated that SDK submissions, Holon actions, and MCP calls could attribute one actor while using another signer provenance key. The implementation preserves root authority attestation while binding action provenance to the actual actor. The MCP boundary rejects unsupported independent-actor resolution instead of reusing the authority key.

## Verification

- cargo test -p exochain-sdk kernel
- cargo test -p exochain-node holons
- cargo test -p exochain-node mcp::middleware
- cargo clippy -p exochain-sdk -p exochain-node --all-targets -- -D warnings
- bash tools/test_repo_truth.sh
- cargo +nightly fmt --all -- --check
- git diff --check

Full constitutional CI is required before merge.