### PR TITLE
fix(gatekeeper): enforce authority chain depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 31 | `ls -d crates/*/` |
 | Rust source files | 471 | `git ls-files 'crates/**/*.rs'` |
-| Workspace tests | 6,264 listed | `cargo test --workspace -- --list` |
+| Workspace tests | 6,265 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 23 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
 | Latest published release | `v0.2.1-beta` (GitHub Release published 2026-07-08; `exochain-core` on crates.io and `@exochain/llm-proxy` on npm resolve the same version) | `gh release list`; `cargo search exochain-core`; `npm view @exochain/llm-proxy version` |
 | License | Apache-2.0 for EXOCHAIN core primitives; commercial terms for Decision Forum, LegalDyne, CyberMedica, LiveSafe, and CrossChecked products | `governance/commercial-product-licensing.json`; product license files where present |
@@ -43,7 +43,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **6,264 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **6,265 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -126,7 +126,7 @@ Catalyst is named explicitly.
 Layer 1: CGR Kernel         (Rust, 31 crates)
          Constitutional governance runtime — deterministic, no floats,
          production Ed25519/BLAKE3 cryptography plus unaudited pedagogical
-         SNARK/STARK/ZKML skeletons, 6,264 listed workspace tests
+         SNARK/STARK/ZKML skeletons, 6,265 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          165 verified WASM exports covered by 172 bridge checks — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-gatekeeper/src/invariants.rs
+++ b/crates/exo-gatekeeper/src/invariants.rs
@@ -24,8 +24,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::{
     AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch,
-    IndependenceClaim, PermissionSet, Provenance, QuorumEvidence, QuorumVote, ReviewOrder, Role,
-    TrustedAuthorityKeys, TrustedProvenanceKeys, VoiceKind,
+    IndependenceClaim, MAX_AUTHORITY_CHAIN_LINKS, PermissionSet, Provenance, QuorumEvidence,
+    QuorumVote, ReviewOrder, Role, TrustedAuthorityKeys, TrustedProvenanceKeys, VoiceKind,
 };
 
 // ---------------------------------------------------------------------------
@@ -563,6 +563,15 @@ fn check_authority_chain_valid(ctx: &InvariantContext) -> Result<(), InvariantVi
             invariant: ConstitutionalInvariant::AuthorityChainValid,
             description: "Authority chain is empty — no delegation path".into(),
             evidence: vec!["authority_chain: empty".into()],
+        });
+    }
+    if ctx.authority_chain.depth() > MAX_AUTHORITY_CHAIN_LINKS {
+        return Err(InvariantViolation {
+            invariant: ConstitutionalInvariant::AuthorityChainValid,
+            description: format!(
+                "Authority chain may contain at most five signed links ({MAX_AUTHORITY_CHAIN_LINKS})"
+            ),
+            evidence: vec![format!("depth: {}", ctx.authority_chain.depth())],
         });
     }
     let links = &ctx.authority_chain.links;
@@ -2562,7 +2571,7 @@ mod tests {
             ConstitutionalInvariant::AuthorityChainValid,
         ]));
         let mut ctx = passing_context();
-        let canonical_max_links = 5usize;
+        let canonical_max_links = MAX_AUTHORITY_CHAIN_LINKS;
         let mut links = Vec::new();
         ctx.trusted_authority_keys = TrustedAuthorityKeys::default();
 
@@ -2578,10 +2587,8 @@ mod tests {
                 format!("did:exo:delegate-{}", idx + 1)
             };
             let (link, public_key) = signed_link(&grantor, &grantee);
-            ctx.trusted_authority_keys.insert(
-                link.grantor.clone(),
-                vec![public_key.as_bytes().to_vec()],
-            );
+            ctx.trusted_authority_keys
+                .insert(link.grantor.clone(), vec![public_key.as_bytes().to_vec()]);
             links.push(link);
         }
         ctx.authority_chain = AuthorityChain { links };

--- a/crates/exo-gatekeeper/src/invariants.rs
+++ b/crates/exo-gatekeeper/src/invariants.rs
@@ -2557,6 +2557,45 @@ mod tests {
     }
 
     #[test]
+    fn authority_chain_rejects_more_than_five_signed_links_in_core() {
+        let engine = InvariantEngine::new(InvariantSet::with(vec![
+            ConstitutionalInvariant::AuthorityChainValid,
+        ]));
+        let mut ctx = passing_context();
+        let canonical_max_links = 5usize;
+        let mut links = Vec::new();
+        ctx.trusted_authority_keys = TrustedAuthorityKeys::default();
+
+        for idx in 0..=canonical_max_links {
+            let grantor = if idx == 0 {
+                "did:exo:root".to_owned()
+            } else {
+                format!("did:exo:delegate-{idx}")
+            };
+            let grantee = if idx == canonical_max_links {
+                ctx.actor.to_string()
+            } else {
+                format!("did:exo:delegate-{}", idx + 1)
+            };
+            let (link, public_key) = signed_link(&grantor, &grantee);
+            ctx.trusted_authority_keys.insert(
+                link.grantor.clone(),
+                vec![public_key.as_bytes().to_vec()],
+            );
+            links.push(link);
+        }
+        ctx.authority_chain = AuthorityChain { links };
+
+        let violations = enforce_all(&engine, &ctx)
+            .expect_err("gatekeeper core must reject an over-depth signed authority chain");
+        assert_eq!(
+            violations[0].invariant,
+            ConstitutionalInvariant::AuthorityChainValid
+        );
+        assert!(violations[0].description.contains("at most five"));
+    }
+
+    #[test]
     fn authority_chain_fails_when_requested_permission_absent_from_actor_permissions() {
         let engine = InvariantEngine::new(InvariantSet::with(vec![
             ConstitutionalInvariant::AuthorityChainValid,

--- a/crates/exo-gatekeeper/src/types.rs
+++ b/crates/exo-gatekeeper/src/types.rs
@@ -313,6 +313,12 @@ pub struct AuthorityLink {
 /// resolved key material for the claimed grantor DID.
 pub type TrustedAuthorityKeys = BTreeMap<Did, Vec<Vec<u8>>>;
 
+/// Maximum number of signed delegation links accepted by gatekeeper core.
+///
+/// Adapters may reject an over-depth chain earlier, but direct kernel callers
+/// must receive the same fail-closed bound.
+pub const MAX_AUTHORITY_CHAIN_LINKS: usize = 5;
+
 /// DID-resolved Ed25519 public keys trusted for actor provenance.
 ///
 /// Provenance objects still carry the key used for signature verification, but

--- a/crates/exo-node/src/mcp/tools/authority.rs
+++ b/crates/exo-node/src/mcp/tools/authority.rs
@@ -31,8 +31,9 @@ use exo_gatekeeper::{
     },
     kernel::{ActionRequest, AdjudicationContext, Kernel, Verdict},
     types::{
-        AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch, Permission,
-        PermissionSet, Provenance, Role, TrustedAuthorityKeys, TrustedProvenanceKeys,
+        AuthorityChain, AuthorityLink, BailmentState, ConsentRecord, GovernmentBranch,
+        MAX_AUTHORITY_CHAIN_LINKS, Permission, PermissionSet, Provenance, Role,
+        TrustedAuthorityKeys, TrustedProvenanceKeys,
     },
 };
 use serde::Serialize;
@@ -45,7 +46,6 @@ use crate::mcp::{
 
 /// Constitution bytes used to initialise the CGR Kernel for adjudication.
 const CONSTITUTION: &[u8] = b"We the people of the EXOCHAIN constitutional trust fabric...";
-const MAX_AUTHORITY_CHAIN_LINKS: usize = 5;
 const MAX_AUTHORITY_DID_BYTES: usize = 512;
 const MAX_AUTHORITY_ACTION_BYTES: usize = 16 * 1024;
 const MAX_PERMISSION_SET_ENTRIES: usize = 64;


### PR DESCRIPTION
## Release reconciliation

Forward-ports the surviving authority-chain depth gap from closed PR #396 onto current main. Gatekeeper core now rejects authority chains longer than five signed links, and the MCP authority parser and schemas reuse the same canonical core limit.

## Path classification

- EXOCHAIN core: crates/exo-gatekeeper authority-chain type and invariant enforcement.
- Core runtime adapter: crates/exo-node MCP authority validation and schemas.
- Adjacent surfaces: none modified.
- Imported/vendor artifacts: none.

## Reproduction and boundary

The red-first commit proved that a cryptographically valid chain longer than the constitutional delegation limit was accepted by core enforcement. The fix enforces the limit in the gatekeeper invariant itself, so adapters cannot bypass it, while the MCP boundary provides earlier fail-closed validation using the same constant.

## Verification

- cargo test -p exochain-gatekeeper authority_chain_rejects_more_than_five_signed_links_in_core
- cargo test -p exochain-node mcp::tools::authority
- cargo test -p exochain-gatekeeper --doc
- cargo clippy -p exochain-gatekeeper -p exochain-node --all-targets -- -D warnings
- bash tools/test_repo_truth.sh
- cargo +nightly fmt --all -- --check
- git diff --check

Full constitutional CI is required before merge.