### PR TITLE
docs(c2): record Railway presidential secret activation status

### DIFF
--- a/docs/c2/DOGFOOD-REHEARSAL-2026-07-12.md
+++ b/docs/c2/DOGFOOD-REHEARSAL-2026-07-12.md
@@ -47,18 +47,22 @@ SPDX-License-Identifier: Apache-2.0
 Binding worksheet: [DOGFOOD-LIVE-ITEM-PUSH-ENABLEMENT.md](DOGFOOD-LIVE-ITEM-PUSH-ENABLEMENT.md)
 (push-enablement ratification; AI-IRB seats + Bob/Max rows still blank).
 
+## Secrets status (2026-07-14)
+
+- **Railway:** `PRESIDENTIAL_SLACK_WEBHOOK_URL`, `PRESIDENTIAL_TWILIO_AUTH_TOKEN`, `PRESIDENTIAL_TWILIO_ACCOUNT_SID`, `PRESIDENTIAL_TWILIO_FROM`, `PRESIDENTIAL_TWILIO_TO` set (names only) on `commandbase-web` production and on `exochain-node` + `livesafe` for development/staging/production. `EXOCHAIN_API_BASE_URL` already present.
+- **GitHub Actions:** still blocked for cloud agents (`HTTP 403`); repo admin must set the same `PRESIDENTIAL_*` names.
+
 ## Blockers to full dogfood close
 
 - Human Bob+Max attestation on the live item above (not only the automated bridge fixture).
-- GitHub Actions secrets not writable by this cloud-agent token (`HTTP 403` on `gh secret set/list`).
-- Railway variables require Bob’s Railway OAuth/session (device login) — see [SECRETS-ACTIVATION.md](SECRETS-ACTIVATION.md).
+- GitHub Actions secrets still need admin `gh secret set` (see commands below / [SECRETS-ACTIVATION.md](SECRETS-ACTIVATION.md)).
 
 ## Push enablement decision
 
 **Do not enable live Slack/SMS push yet.** Remain fail-closed until:
 
-1. PR #791 merged to `main`
-2. Secrets configured per [SECRETS-ACTIVATION.md](SECRETS-ACTIVATION.md)
+1. PR #791 merged to `main` ✅
+2. Secrets configured — Railway ✅ / GitHub ⏳ admin
 3. Bob+Max complete one live dual-gate ratify/veto on a real item and update this record to **Complete**
 
 ## Required secrets (names only — values must be set by operators)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Records that Mission C2 presidential push secrets are now present on Railway (`commandbase-web` + `exochain-node`/`livesafe` across envs). GitHub Actions secrets remain admin-only (`403` for cloud agents). Live Slack/SMS push stays fail-closed until Bob+Max close the dogfood dual-gate item.

## Classification

- Documentation / C2 steering status only (no core runtime change)
- No secret values in the diff

## Validation

- Presence-only Railway variable checks (names, not values)
- Push automation remains advisory/fail-closed in `presidential-daily-attention.yml`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36ded9ea-b4aa-4fe0-8134-109a4cf227bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36ded9ea-b4aa-4fe0-8134-109a4cf227bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

