### PR TITLE
fix(gateway): harden deterministic GraphQL concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 31 | `ls -d crates/*/` |
 | Rust source files | 471 | `git ls-files 'crates/**/*.rs'` |
-| Workspace tests | 6,265 listed | `cargo test --workspace -- --list` |
+| Workspace tests | 6,267 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 23 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
 | Latest published release | `v0.2.1-beta` (GitHub Release published 2026-07-08; `exochain-core` on crates.io and `@exochain/llm-proxy` on npm resolve the same version) | `gh release list`; `cargo search exochain-core`; `npm view @exochain/llm-proxy version` |
 | License | Apache-2.0 for EXOCHAIN core primitives; commercial terms for Decision Forum, LegalDyne, CyberMedica, LiveSafe, and CrossChecked products | `governance/commercial-product-licensing.json`; product license files where present |
@@ -43,7 +43,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **6,265 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **6,267 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -126,7 +126,7 @@ Catalyst is named explicitly.
 Layer 1: CGR Kernel         (Rust, 31 crates)
          Constitutional governance runtime — deterministic, no floats,
          production Ed25519/BLAKE3 cryptography plus unaudited pedagogical
-         SNARK/STARK/ZKML skeletons, 6,265 listed workspace tests
+         SNARK/STARK/ZKML skeletons, 6,267 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          165 verified WASM exports covered by 172 bridge checks — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-gateway/src/graphql.rs
+++ b/crates/exo-gateway/src/graphql.rs
@@ -16,9 +16,9 @@
 
 //! GraphQL schema, resolvers, and axum HTTP handler for the ExoChain governance API.
 //!
-//! The schema is backed by an `AppState` held behind `Arc<tokio::sync::Mutex<>>` which is
-//! shared across all requests.  Production deployments replace the in-memory collections
-//! with a database pool injected via `GatewayConfig::database_pool_url`.
+//! The schema is backed by an `AppState` held behind a Tokio reader/writer lock.
+//! Production deployments replace the in-memory collections with a database pool
+//! injected via `GatewayConfig::database_pool_url`.
 //!
 //! ## Schema surface
 //!
@@ -35,8 +35,8 @@
 //! Subscriptions use `tokio::sync::broadcast` for real-time event delivery.
 
 use std::{
-    collections::BTreeMap,
-    sync::{Arc, RwLock},
+    collections::{BTreeMap, BTreeSet},
+    sync::{Arc, Mutex as StdMutex, RwLock},
 };
 
 use async_graphql::{
@@ -76,7 +76,7 @@ use exo_gatekeeper::{
 };
 use exo_identity::registry::{DidRegistry, LocalDidRegistry};
 use serde::Serialize;
-use tokio::sync::{Mutex, broadcast};
+use tokio::sync::{RwLock as AsyncRwLock, broadcast};
 
 use crate::auth::AuthenticatedActor;
 
@@ -339,11 +339,13 @@ fn graphql_hash_hex<T: Serialize>(payload: &T) -> GqlResult<String> {
 /// `PgPool` when `GatewayConfig::database_pool_url` is set.
 pub struct AppState {
     decisions: BTreeMap<String, DecisionRecord>,
+    decision_ids_by_tenant: BTreeMap<String, BTreeSet<String>>,
+    decision_ids_by_tenant_status: BTreeMap<(String, String), BTreeSet<String>>,
     delegations: BTreeMap<String, GqlDelegation>,
     emergency_actions: BTreeMap<String, GqlEmergencyAction>,
     constitution: GqlConstitution,
     next_audit_seq: i32,
-    clock: HybridClock,
+    clock: StdMutex<HybridClock>,
     event_tx: broadcast::Sender<GovEvent>,
     /// Shared DID registry — wired from `server::AppState` for identity resolution.
     registry: Arc<RwLock<LocalDidRegistry>>,
@@ -405,6 +407,8 @@ impl AppState {
         let (event_tx, _) = broadcast::channel(256);
         Self {
             decisions: BTreeMap::new(),
+            decision_ids_by_tenant: BTreeMap::new(),
+            decision_ids_by_tenant_status: BTreeMap::new(),
             delegations: BTreeMap::new(),
             emergency_actions: BTreeMap::new(),
             constitution: GqlConstitution {
@@ -413,7 +417,7 @@ impl AppState {
                 hash: Hash256::digest(b"constitution-v1").to_string(),
             },
             next_audit_seq: 1,
-            clock,
+            clock: StdMutex::new(clock),
             event_tx,
             registry,
             consent_engine: PolicyEngine::new(),
@@ -421,14 +425,101 @@ impl AppState {
         }
     }
 
-    /// Create a new `AppState` wrapped in `Arc<Mutex<>>` for concurrent access.
-    pub fn new_arc() -> Arc<Mutex<Self>> {
-        Arc::new(Mutex::new(Self::new()))
+    /// Create a new `AppState` wrapped in a reader/writer lock for concurrent access.
+    pub fn new_arc() -> SharedGraphqlState {
+        Arc::new(AsyncRwLock::new(Self::new()))
     }
 
-    /// Create a new `AppState` with a shared registry, wrapped in `Arc<Mutex<>>`.
-    pub fn new_arc_with_registry(registry: Arc<RwLock<LocalDidRegistry>>) -> Arc<Mutex<Self>> {
-        Arc::new(Mutex::new(Self::with_registry(registry)))
+    /// Create a new `AppState` with a shared registry, wrapped in a reader/writer lock.
+    pub fn new_arc_with_registry(registry: Arc<RwLock<LocalDidRegistry>>) -> SharedGraphqlState {
+        Arc::new(AsyncRwLock::new(Self::with_registry(registry)))
+    }
+
+    fn remove_decision_index(
+        index: &mut BTreeMap<String, BTreeSet<String>>,
+        key: &str,
+        decision_id: &str,
+    ) {
+        let remove_key = index.get_mut(key).is_some_and(|ids| {
+            ids.remove(decision_id);
+            ids.is_empty()
+        });
+        if remove_key {
+            index.remove(key);
+        }
+    }
+
+    fn remove_decision_status_index(
+        index: &mut BTreeMap<(String, String), BTreeSet<String>>,
+        key: &(String, String),
+        decision_id: &str,
+    ) {
+        let remove_key = index.get_mut(key).is_some_and(|ids| {
+            ids.remove(decision_id);
+            ids.is_empty()
+        });
+        if remove_key {
+            index.remove(key);
+        }
+    }
+
+    fn index_decision_id(&mut self, decision_id: &str) {
+        if let Some(record) = self.decisions.get(decision_id) {
+            self.decision_ids_by_tenant
+                .entry(record.decision.tenant_id.clone())
+                .or_default()
+                .insert(decision_id.to_owned());
+            self.decision_ids_by_tenant_status
+                .entry((
+                    record.decision.tenant_id.clone(),
+                    record.decision.status.clone(),
+                ))
+                .or_default()
+                .insert(decision_id.to_owned());
+        }
+    }
+
+    fn remove_decision_from_indexes(&mut self, decision_id: &str, tenant_id: &str, status: &str) {
+        Self::remove_decision_index(&mut self.decision_ids_by_tenant, tenant_id, decision_id);
+        Self::remove_decision_status_index(
+            &mut self.decision_ids_by_tenant_status,
+            &(tenant_id.to_owned(), status.to_owned()),
+            decision_id,
+        );
+    }
+
+    fn insert_decision_record(&mut self, decision_id: String, record: DecisionRecord) {
+        if let Some(existing) = self.decisions.get(&decision_id) {
+            let previous_tenant_id = existing.decision.tenant_id.clone();
+            let previous_status = existing.decision.status.clone();
+            self.remove_decision_from_indexes(&decision_id, &previous_tenant_id, &previous_status);
+        }
+        self.decisions.insert(decision_id.clone(), record);
+        self.index_decision_id(&decision_id);
+    }
+
+    fn reindex_decision_after_state_change(
+        &mut self,
+        decision_id: &str,
+        previous_tenant_id: String,
+        previous_status: String,
+    ) {
+        self.remove_decision_from_indexes(decision_id, &previous_tenant_id, &previous_status);
+        self.index_decision_id(decision_id);
+    }
+
+    fn decision_ids_for_query(
+        &self,
+        tenant_id: &str,
+        status: Option<&str>,
+    ) -> Option<&BTreeSet<String>> {
+        status.map_or_else(
+            || self.decision_ids_by_tenant.get(tenant_id),
+            |status| {
+                self.decision_ids_by_tenant_status
+                    .get(&(tenant_id.to_owned(), status.to_owned()))
+            },
+        )
     }
 
     /// Record a genuine constitutional grant for `actor`: a real Ed25519
@@ -493,13 +584,17 @@ impl AppState {
         kernel.adjudicate(&action, &context)
     }
 
-    fn next_timestamp(&mut self) -> GqlResult<Timestamp> {
-        self.clock
+    fn next_timestamp(&self) -> GqlResult<Timestamp> {
+        let mut clock = self
+            .clock
+            .lock()
+            .map_err(|_| async_graphql::Error::new("GraphQL HLC mutex poisoned"))?;
+        clock
             .now()
             .map_err(|err| async_graphql::Error::new(format!("HLC clock exhausted: {err}")))
     }
 
-    fn now_str(&mut self) -> GqlResult<String> {
+    fn now_str(&self) -> GqlResult<String> {
         Ok(self.next_timestamp()?.to_string())
     }
 
@@ -661,7 +756,7 @@ async fn require_permitted_actor(
     let did = actor.did.clone();
     let state = app_state_from_context(ctx)?;
     let verdict = {
-        let guard = state.lock().await;
+        let guard = state.read().await;
         guard.adjudicate_mutation(&did, action_name, scope)
     };
     match verdict {
@@ -670,8 +765,8 @@ async fn require_permitted_actor(
     }
 }
 
-fn app_state_from_context<'ctx>(ctx: &'ctx Context<'_>) -> GqlResult<&'ctx Arc<Mutex<AppState>>> {
-    ctx.data::<Arc<Mutex<AppState>>>()
+fn app_state_from_context<'ctx>(ctx: &'ctx Context<'_>) -> GqlResult<&'ctx SharedGraphqlState> {
+    ctx.data::<SharedGraphqlState>()
 }
 
 fn graphql_nonnegative_i32_to_usize(value: i32, field: &'static str) -> GqlResult<usize> {
@@ -744,6 +839,7 @@ pub const GRAPHQL_MAX_QUERY_DEPTH: usize = 12;
 pub const GRAPHQL_MAX_QUERY_COMPLEXITY: usize = 256;
 pub const GRAPHQL_MAX_DECISIONS_LIMIT: i32 = 200;
 pub const GRAPHQL_MAX_DECISIONS_OFFSET: i32 = 10_000;
+pub type SharedGraphqlState = Arc<AsyncRwLock<AppState>>;
 pub const GRAPHQL_CONSENT_FABRICATION_INITIATIVE: &str =
     "Initiatives/fix-spline-r2-graphql-consent-fabrication.md";
 pub const GRAPHQL_PROOF_STUB_INITIATIVE: &str = "Initiatives/fix-spline-r3-graphql-proof-stub.md";
@@ -761,7 +857,7 @@ impl QueryRoot {
     async fn decision(&self, ctx: &Context<'_>, id: ID) -> GqlResult<Option<GqlDecision>> {
         guard_graphql_execution()?;
         let state = app_state_from_context(ctx)?;
-        let guard = state.lock().await;
+        let guard = state.read().await;
         Ok(guard.decisions.get(id.as_str()).map(|r| r.decision.clone()))
     }
 
@@ -776,7 +872,7 @@ impl QueryRoot {
     ) -> GqlResult<Vec<GqlDecision>> {
         guard_graphql_execution()?;
         let state = app_state_from_context(ctx)?;
-        let guard = state.lock().await;
+        let guard = state.read().await;
         let offset = graphql_nonnegative_i32_to_usize(
             offset.unwrap_or(0).clamp(0, GRAPHQL_MAX_DECISIONS_OFFSET),
             "decisions.offset",
@@ -786,13 +882,13 @@ impl QueryRoot {
             "decisions.limit",
         )?;
         let results: Vec<GqlDecision> = guard
-            .decisions
-            .values()
-            .filter(|r| r.decision.tenant_id == tenant_id.as_str())
-            .filter(|r| status.as_ref().is_none_or(|s| *s == r.decision.status))
-            .map(|r| r.decision.clone())
+            .decision_ids_for_query(tenant_id.as_str(), status.as_deref())
+            .into_iter()
+            .flat_map(|ids| ids.iter())
             .skip(offset)
             .take(limit)
+            .filter_map(|id| guard.decisions.get(id))
+            .map(|record| record.decision.clone())
             .collect();
         Ok(results)
     }
@@ -805,7 +901,7 @@ impl QueryRoot {
     ) -> GqlResult<GqlAuthorityChain> {
         guard_graphql_execution()?;
         let state = app_state_from_context(ctx)?;
-        let guard = state.lock().await;
+        let guard = state.read().await;
         let chain_length = graphql_count_to_i32(
             guard
                 .delegations
@@ -830,7 +926,7 @@ impl QueryRoot {
     ) -> GqlResult<GqlConstitution> {
         guard_graphql_execution()?;
         let state = app_state_from_context(ctx)?;
-        let guard = state.lock().await;
+        let guard = state.read().await;
         let _ = version; // version pinning reserved for DB layer
         if guard.constitution.tenant_id == tenant_id.as_str() {
             Ok(guard.constitution.clone())
@@ -850,7 +946,7 @@ impl QueryRoot {
     ) -> GqlResult<Vec<GqlDelegation>> {
         guard_graphql_execution()?;
         let state = app_state_from_context(ctx)?;
-        let guard = state.lock().await;
+        let guard = state.read().await;
         let results = guard
             .delegations
             .values()
@@ -868,7 +964,7 @@ impl QueryRoot {
     ) -> GqlResult<Vec<GqlAuditEntry>> {
         guard_graphql_execution()?;
         let state = app_state_from_context(ctx)?;
-        let guard = state.lock().await;
+        let guard = state.read().await;
         let decision_id = decision_id.to_string();
         let record = guard.decisions.get(&decision_id).ok_or_else(|| {
             async_graphql::Error::new(format!("decision {decision_id} not found"))
@@ -902,7 +998,7 @@ impl QueryRoot {
         guard_graphql_execution()?;
         let state = app_state_from_context(ctx)?;
         let registry = {
-            let guard = state.lock().await;
+            let guard = state.read().await;
             Arc::clone(&guard.registry)
         };
         let did_str = did.to_string();
@@ -959,7 +1055,7 @@ impl QueryRoot {
     ) -> GqlResult<GqlConsentResult> {
         guard_graphql_execution()?;
         let state = app_state_from_context(ctx)?;
-        let guard = state.lock().await;
+        let guard = state.read().await;
         let subject_str = subject.to_string();
         let actor_str = actor.to_string();
         Did::new(&subject_str)
@@ -1049,7 +1145,7 @@ impl MutationRoot {
         guard_graphql_mutation_execution()?;
         let author = require_permitted_actor(ctx, "create_decision", "governance:mutate").await?;
         let state = app_state_from_context(ctx)?;
-        let mut guard = state.lock().await;
+        let mut guard = state.write().await;
         let created = guard.next_timestamp()?;
         let created_at = created.to_string();
         let id = graphql_hash_hex(&GraphqlDecisionIdPayload {
@@ -1083,7 +1179,7 @@ impl MutationRoot {
         {
             tracing::warn!("Governance event channel closed — DecisionUpdated dropped");
         }
-        guard.decisions.insert(
+        guard.insert_decision_record(
             id.clone(),
             DecisionRecord {
                 decision: decision.clone(),
@@ -1106,17 +1202,20 @@ impl MutationRoot {
         let actor_did =
             require_permitted_actor(ctx, "advance_decision", "governance:mutate").await?;
         let state = app_state_from_context(ctx)?;
-        let mut guard = state.lock().await;
+        let mut guard = state.write().await;
         let id_str = id.to_string();
-        let decision = {
+        let (previous_tenant_id, previous_status, decision) = {
             let rec = guard
                 .decisions
                 .get_mut(&id_str)
                 .ok_or_else(|| async_graphql::Error::new(format!("decision {id_str} not found")))?;
+            let previous_tenant_id = rec.decision.tenant_id.clone();
+            let previous_status = rec.decision.status.clone();
             rec.decision.status = new_status.clone();
             rec.decision.content_hash = AppState::compute_decision_hash(&rec.decision)?;
-            rec.decision.clone()
+            (previous_tenant_id, previous_status, rec.decision.clone())
         };
+        guard.reindex_decision_after_state_change(&id_str, previous_tenant_id, previous_status);
         // `reason` is a human-supplied, caller-controlled annotation only; it
         // must never be bound as the acting identity. The audit actor is
         // always the checked `AuthenticatedActor`'s DID (VCG-003 corrective —
@@ -1154,7 +1253,7 @@ impl MutationRoot {
             )));
         }
         let state = app_state_from_context(ctx)?;
-        let mut guard = state.lock().await;
+        let mut guard = state.write().await;
         let id_str = decision_id.to_string();
         let duplicate_vote = guard
             .decisions
@@ -1207,7 +1306,7 @@ impl MutationRoot {
             return Err(async_graphql::Error::new("expires_in_hours must be > 0"));
         }
         let state = app_state_from_context(ctx)?;
-        let mut guard = state.lock().await;
+        let mut guard = state.write().await;
         let now = guard.next_timestamp()?;
         let id = graphql_hash_hex(&GraphqlDelegationIdPayload {
             domain: "exo.gateway.graphql.delegation_id.v1",
@@ -1243,7 +1342,7 @@ impl MutationRoot {
         guard_graphql_mutation_execution()?;
         require_permitted_actor(ctx, "revoke_delegation", "governance:delegate").await?;
         let state = app_state_from_context(ctx)?;
-        let mut guard = state.lock().await;
+        let mut guard = state.write().await;
         let id_str = id.to_string();
         let delegation = guard
             .delegations
@@ -1264,7 +1363,7 @@ impl MutationRoot {
         let actor_did =
             require_permitted_actor(ctx, "raise_challenge", "governance:challenge").await?;
         let state = app_state_from_context(ctx)?;
-        let mut guard = state.lock().await;
+        let mut guard = state.write().await;
         let id_str = decision_id.to_string();
         let challenge_created = guard.next_timestamp()?;
         let challenge_id = graphql_hash_hex(&GraphqlChallengeIdPayload {
@@ -1273,11 +1372,13 @@ impl MutationRoot {
             grounds: &grounds,
             created_at: &challenge_created,
         })?;
-        let (challenge, decision) = {
+        let (challenge, previous_tenant_id, previous_status, decision) = {
             let rec = guard
                 .decisions
                 .get_mut(&id_str)
                 .ok_or_else(|| async_graphql::Error::new(format!("decision {id_str} not found")))?;
+            let previous_tenant_id = rec.decision.tenant_id.clone();
+            let previous_status = rec.decision.status.clone();
             let challenge = GqlChallenge {
                 id: ID::from(challenge_id),
                 grounds: grounds.clone(),
@@ -1286,8 +1387,14 @@ impl MutationRoot {
             rec.decision.challenges.push(challenge.clone());
             rec.decision.status = "CONTESTED".into();
             rec.decision.content_hash = AppState::compute_decision_hash(&rec.decision)?;
-            (challenge, rec.decision.clone())
+            (
+                challenge,
+                previous_tenant_id,
+                previous_status,
+                rec.decision.clone(),
+            )
         };
+        guard.reindex_decision_after_state_change(&id_str, previous_tenant_id, previous_status);
         guard.append_audit(&id_str, &format!("ChallengeRaised:{grounds}"), &actor_did)?;
         if guard
             .event_tx
@@ -1313,7 +1420,7 @@ impl MutationRoot {
         let actor_did =
             require_permitted_actor(ctx, "take_emergency_action", "governance:emergency").await?;
         let state = app_state_from_context(ctx)?;
-        let mut guard = state.lock().await;
+        let mut guard = state.write().await;
         let id_str = decision_id.to_string();
         // Verify decision exists before creating emergency action.
         if !guard.decisions.contains_key(&id_str) {
@@ -1378,7 +1485,7 @@ impl MutationRoot {
         let actor_did =
             require_permitted_actor(ctx, "disclose_conflict", "governance:disclose").await?;
         let state = app_state_from_context(ctx)?;
-        let mut guard = state.lock().await;
+        let mut guard = state.write().await;
         let id_str = decision_id.to_string();
         // Conflict records are append-only — no update path exists.
         let disclosure = GqlConflictDisclosure {
@@ -1405,7 +1512,7 @@ impl MutationRoot {
         guard_graphql_mutation_execution()?;
         require_permitted_actor(ctx, "amend_constitution", "governance:amend").await?;
         let state = app_state_from_context(ctx)?;
-        let mut guard = state.lock().await;
+        let mut guard = state.write().await;
         let new_hash = graphql_hash_hex(&GraphqlConstitutionHashPayload {
             domain: "exo.gateway.graphql.constitution_amendment_hash.v1",
             previous_hash: &guard.constitution.hash,
@@ -1463,7 +1570,7 @@ impl SubscriptionRoot {
             stream! {
                 match state {
                     Ok(state) => {
-                        let mut rx = state.lock().await.event_tx.subscribe();
+                        let mut rx = state.read().await.event_tx.subscribe();
                         loop {
                             match rx.recv().await {
                                 Ok(GovEvent::DecisionUpdated(d)) if d.id.to_string() == id_str => yield Ok(d),
@@ -1500,7 +1607,7 @@ impl SubscriptionRoot {
             stream! {
                 match state {
                     Ok(state) => {
-                        let mut rx = state.lock().await.event_tx.subscribe();
+                        let mut rx = state.read().await.event_tx.subscribe();
                         loop {
                             match rx.recv().await {
                                 Ok(GovEvent::DelegationExpiring(d)) if d.delegatee == did || d.delegator == did => {
@@ -1539,7 +1646,7 @@ impl SubscriptionRoot {
             stream! {
                 match state {
                     Ok(state) => {
-                        let mut rx = state.lock().await.event_tx.subscribe();
+                        let mut rx = state.read().await.event_tx.subscribe();
                         loop {
                             match rx.recv().await {
                                 Ok(GovEvent::EmergencyActionCreated(a)) if a.tenant_id == tid => yield Ok(a),
@@ -1560,7 +1667,7 @@ impl SubscriptionRoot {
 // ---------------------------------------------------------------------------
 
 /// Build the executable `GovSchema` with shared `AppState` data.
-pub fn build_schema(state: Arc<Mutex<AppState>>) -> GovSchema {
+pub fn build_schema(state: SharedGraphqlState) -> GovSchema {
     Schema::build(QueryRoot, MutationRoot, SubscriptionRoot)
         .disable_introspection()
         .limit_depth(GRAPHQL_MAX_QUERY_DEPTH)
@@ -1689,7 +1796,7 @@ mod tests {
     #[test]
     fn app_state_timestamps_advance_through_hybrid_clock() {
         let registry = Arc::new(RwLock::new(LocalDidRegistry::new()));
-        let mut state =
+        let state =
             AppState::with_registry_and_clock(registry, HybridClock::with_wall_clock(|| 42_000));
 
         assert_eq!(
@@ -1827,11 +1934,11 @@ mod tests {
             "GraphQL state lookup must be centralized"
         );
         assert!(
-            production.contains("ctx.data::<Arc<Mutex<AppState>>>()"),
+            production.contains("ctx.data::<SharedGraphqlState>()"),
             "GraphQL state lookup must return an error on missing AppState"
         );
         assert!(
-            !production.contains("data_unchecked::<Arc<Mutex<AppState>>>"),
+            !production.contains("data_unchecked::<SharedGraphqlState>"),
             "GraphQL resolvers must not panic if schema data is misconfigured"
         );
     }
@@ -2055,7 +2162,7 @@ mod tests {
     fn append_audit_rejects_sequence_overflow_without_wrapping() {
         let mut state = AppState::new();
         let decision_id = "decision-overflow".to_owned();
-        state.decisions.insert(
+        state.insert_decision_record(
             decision_id.clone(),
             DecisionRecord {
                 decision: GqlDecision {
@@ -2114,7 +2221,7 @@ mod tests {
         let mut state = AppState::new();
         for index in 0..10_002 {
             let id = format!("decision-{index:05}");
-            state.decisions.insert(
+            state.insert_decision_record(
                 id.clone(),
                 DecisionRecord {
                     decision: GqlDecision {
@@ -2134,7 +2241,7 @@ mod tests {
                 },
             );
         }
-        let schema = build_schema(Arc::new(Mutex::new(state)));
+        let schema = build_schema(Arc::new(AsyncRwLock::new(state)));
 
         let res = schema
             .execute(r#"{ decisions(tenantId: "tenant-a", limit: 1, offset: 10001) { id title } }"#)
@@ -2549,7 +2656,7 @@ mod tests {
         };
         let state = AppState::new_arc_with_registry(registry);
         {
-            let mut guard = state.lock().await;
+            let mut guard = state.write().await;
             let grant = vcg003_actor_grant_for(&actor.did);
             guard.seed_actor_grant(actor.did.clone(), grant);
         }

--- a/crates/exo-gateway/src/graphql.rs
+++ b/crates/exo-gateway/src/graphql.rs
@@ -1837,6 +1837,68 @@ mod tests {
     }
 
     #[test]
+    fn graphql_app_state_uses_reader_writer_lock_not_single_mutex() {
+        let production = include_str!("graphql.rs")
+            .split("// ---------------------------------------------------------------------------\n// Tests")
+            .next()
+            .expect("production section");
+
+        assert!(
+            production.contains("type SharedGraphqlState = Arc<AsyncRwLock<AppState>>"),
+            "GraphQL AppState must use a reader/writer lock so independent queries do not serialize behind one mutex"
+        );
+        assert!(
+            !production.contains("Arc<Mutex<AppState>>"),
+            "GraphQL AppState must not expose a single shared Tokio mutex"
+        );
+        assert!(
+            !production.contains(".lock().await"),
+            "GraphQL resolvers must acquire read/write guards explicitly instead of serializing every operation through lock().await"
+        );
+    }
+
+    #[test]
+    fn graphql_decisions_query_uses_tenant_indexes_before_pagination() {
+        let production = include_str!("graphql.rs")
+            .split("// ---------------------------------------------------------------------------\n// Tests")
+            .next()
+            .expect("production section");
+        let app_state = production
+            .split("pub struct AppState")
+            .nth(1)
+            .expect("AppState section")
+            .split("impl Default for AppState")
+            .next()
+            .expect("AppState section end");
+        let decisions_resolver = production
+            .split("async fn decisions")
+            .nth(1)
+            .expect("decisions resolver")
+            .split("    /// Get the delegated authority chain")
+            .next()
+            .expect("decisions resolver end");
+
+        assert!(
+            app_state.contains("decision_ids_by_tenant: BTreeMap<String, BTreeSet<String>>"),
+            "GraphQL AppState must keep a tenant decision index"
+        );
+        assert!(
+            app_state.contains(
+                "decision_ids_by_tenant_status: BTreeMap<(String, String), BTreeSet<String>>"
+            ),
+            "GraphQL AppState must keep a tenant+status decision index"
+        );
+        assert!(
+            decisions_resolver.contains("decision_ids_for_query"),
+            "decisions resolver must fetch candidate IDs from indexes before pagination"
+        );
+        assert!(
+            !decisions_resolver.contains(".decisions\n            .values()"),
+            "decisions resolver must not scan all in-memory decision records per request"
+        );
+    }
+
+    #[test]
     fn graphql_feature_on_resolvers_use_deterministic_ids_and_structured_hashes() {
         let production = include_str!("graphql.rs")
             .split("// ---------------------------------------------------------------------------\n// Tests")


### PR DESCRIPTION
## Summary
- replace the single GraphQL state mutex with an async reader/writer lock while keeping HLC mutation in a short non-await mutex section
- add deterministic tenant and tenant/status BTree indexes so bounded pagination does not scan unrelated decisions
- preserve authenticated-actor adjudication and fail-closed mutation behavior

## Path classification
- Core runtime adapter: `crates/exo-gateway/src/graphql.rs`
- Documentation/repository truth: `README.md`
- No adjacent surface, imported evidence, governance artifact, deployment contract, or secret changed

## Red-first evidence
- `de60aeb1` added failing source/behavior regressions for concurrent reader state and indexed tenant pagination
- `41582535` implemented the minimal deterministic lock and index changes
- `a30e8df2` merged exact `origin/main` (`68cc1500`) without rewriting public history

## Local verification
- `cargo test -p exochain-gateway --features unaudited-gateway-graphql-api graphql -- --nocapture` — 36 passed
- `cargo test -p exochain-gateway --features unaudited-gateway-graphql-api --doc` — passed
- `cargo clippy -p exochain-gateway --all-targets --features unaudited-gateway-graphql-api -- -D warnings` — passed
- `bash tools/test_repo_truth.sh` — passed, 6,267 listed tests
- `cargo +nightly fmt --all -- --check` — passed
- `git diff --check` — passed

## Trust boundary
This changes only the in-process GraphQL runtime adapter. Query and mutation authorization still flows through the existing authenticated actor and canonical gatekeeper adjudication path. Missing authorization remains fail closed. No public release or deployment is performed by this PR.
