### PR TITLE
fix(packaging): align crate documentation with docs.rs

### DIFF
--- a/crates/decision-forum/Cargo.toml
+++ b/crates/decision-forum/Cargo.toml
@@ -17,7 +17,7 @@
 [package]
 name = "exochain-decision-forum"
 description = "EXOCHAIN decision.forum — constitutional governance application layer"
-documentation = "https://docs.exochain.io"
+documentation = "https://docs.rs/exochain-decision-forum"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-api/Cargo.toml
+++ b/crates/exo-api/Cargo.toml
@@ -17,7 +17,7 @@
 [package]
 name = "exochain-api"
 description = "EXOCHAIN constitutional trust fabric — P2P networking and external API types"
-documentation = "https://docs.exochain.io"
+documentation = "https://docs.rs/exochain-api"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-authority/Cargo.toml
+++ b/crates/exo-authority/Cargo.toml
@@ -17,7 +17,7 @@
 [package]
 name = "exochain-authority"
 description = "EXOCHAIN authority chain verification and delegation management"
-documentation = "https://docs.exochain.io"
+documentation = "https://docs.rs/exochain-authority"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-avc/Cargo.toml
+++ b/crates/exo-avc/Cargo.toml
@@ -17,7 +17,7 @@
 [package]
 name = "exochain-avc"
 description = "EXOCHAIN Autonomous Volition Credential — portable signed credential for autonomous agent intent, authority, constraints, delegation, revocation, and trust receipts"
-documentation = "https://docs.exochain.io"
+documentation = "https://docs.rs/exochain-avc"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-catapult/Cargo.toml
+++ b/crates/exo-catapult/Cargo.toml
@@ -17,7 +17,7 @@
 [package]
 name = "exochain-catapult"
 description = "EXOCHAIN Catapult — franchise business incubator with FM 3-05 operational doctrine"
-documentation = "https://docs.exochain.io"
+documentation = "https://docs.rs/exochain-catapult"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-consensus/Cargo.toml
+++ b/crates/exo-consensus/Cargo.toml
@@ -17,6 +17,7 @@
 [package]
 name = "exochain-consensus"
 description = "EXOCHAIN constitutional trust fabric — consensus proofs and model quorum coordination"
+documentation = "https://docs.rs/exochain-consensus"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-consent/Cargo.toml
+++ b/crates/exo-consent/Cargo.toml
@@ -17,7 +17,7 @@
 [package]
 name = "exochain-consent"
 description = "EXOCHAIN bailment-conditioned consent enforcement — no action without consent"
-documentation = "https://docs.exochain.io"
+documentation = "https://docs.rs/exochain-consent"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-core/Cargo.toml
+++ b/crates/exo-core/Cargo.toml
@@ -17,7 +17,7 @@
 [package]
 name = "exochain-core"
 description = "EXOCHAIN constitutional trust fabric — foundational deterministic types, HLC, crypto, BCTS state machine"
-documentation = "https://docs.exochain.io"
+documentation = "https://docs.rs/exochain-core"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-dag-db-api/Cargo.toml
+++ b/crates/exo-dag-db-api/Cargo.toml
@@ -17,7 +17,7 @@
 [package]
 name = "exochain-dag-db-api"
 description = "EXOCHAIN DAG DB API DTO wire contracts"
-documentation = "https://docs.exochain.io"
+documentation = "https://docs.rs/exochain-dag-db-api"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-dag-db-core/Cargo.toml
+++ b/crates/exo-dag-db-core/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "exochain-dag-db-core"
 description = "EXOCHAIN DAG DB deterministic primitives and shared validation"
+documentation = "https://docs.rs/exochain-dag-db-core"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-dag-db-domain/Cargo.toml
+++ b/crates/exo-dag-db-domain/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "exochain-dag-db-domain"
 description = "EXOCHAIN DAG DB governed domain services"
+documentation = "https://docs.rs/exochain-dag-db-domain"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-dag-db-exchange/Cargo.toml
+++ b/crates/exo-dag-db-exchange/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "exochain-dag-db-exchange"
 description = "EXOCHAIN DAG DB import, export, and writeback contracts"
+documentation = "https://docs.rs/exochain-dag-db-exchange"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-dag-db-graph/Cargo.toml
+++ b/crates/exo-dag-db-graph/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "exochain-dag-db-graph"
 description = "EXOCHAIN DAG DB graph and layered organization"
+documentation = "https://docs.rs/exochain-dag-db-graph"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-dag-db-lab/Cargo.toml
+++ b/crates/exo-dag-db-lab/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "exochain-dag-db-lab"
 description = "EXOCHAIN DAG DB diagnostics, graph explorer, benchmarks, and lab tools"
+documentation = "https://docs.rs/exochain-dag-db-lab"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-dag-db-postgres/Cargo.toml
+++ b/crates/exo-dag-db-postgres/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "exochain-dag-db-postgres"
 description = "EXOCHAIN DAG DB PostgreSQL persistence adapters"
+documentation = "https://docs.rs/exochain-dag-db-postgres"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-dag-db-retrieval/Cargo.toml
+++ b/crates/exo-dag-db-retrieval/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "exochain-dag-db-retrieval"
 description = "EXOCHAIN DAG DB retrieval, routing, and context packet selection"
+documentation = "https://docs.rs/exochain-dag-db-retrieval"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-dag/Cargo.toml
+++ b/crates/exo-dag/Cargo.toml
@@ -17,7 +17,7 @@
 [package]
 name = "exochain-dag"
 description = "EXOCHAIN append-only DAG with BFT consensus and Merkle structures"
-documentation = "https://docs.exochain.io"
+documentation = "https://docs.rs/exochain-dag"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-economy/Cargo.toml
+++ b/crates/exo-economy/Cargo.toml
@@ -17,7 +17,7 @@
 [package]
 name = "exochain-economy"
 description = "EXOCHAIN custody-native transaction economy — quote, settle, and revenue-share scaffolding with zero-priced launch policy"
-documentation = "https://docs.exochain.io"
+documentation = "https://docs.rs/exochain-economy"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-escalation/Cargo.toml
+++ b/crates/exo-escalation/Cargo.toml
@@ -17,7 +17,7 @@
 [package]
 name = "exochain-escalation"
 description = "EXOCHAIN constitutional trust fabric — operational nervous system: detection, triage, kanban, HITL, Sybil adjudication"
-documentation = "https://docs.exochain.io"
+documentation = "https://docs.rs/exochain-escalation"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-gatekeeper/Cargo.toml
+++ b/crates/exo-gatekeeper/Cargo.toml
@@ -17,7 +17,7 @@
 [package]
 name = "exochain-gatekeeper"
 description = "EXOCHAIN judicial branch — CGR kernel, combinator algebra, invariant enforcement, Holon runtime, MCP middleware"
-documentation = "https://docs.exochain.io"
+documentation = "https://docs.rs/exochain-gatekeeper"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-gateway/Cargo.toml
+++ b/crates/exo-gateway/Cargo.toml
@@ -17,7 +17,7 @@
 [package]
 name = "exochain-gateway"
 description = "EXOCHAIN constitutional trust fabric — HTTP gateway server with default-deny pattern"
-documentation = "https://docs.exochain.io"
+documentation = "https://docs.rs/exochain-gateway"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-governance/Cargo.toml
+++ b/crates/exo-governance/Cargo.toml
@@ -17,7 +17,7 @@
 [package]
 name = "exochain-governance"
 description = "EXOCHAIN constitutional trust fabric — legislative legitimacy: quorum, clearance, crosscheck, challenge, delegation, deliberation"
-documentation = "https://docs.exochain.io"
+documentation = "https://docs.rs/exochain-governance"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-identity/Cargo.toml
+++ b/crates/exo-identity/Cargo.toml
@@ -17,7 +17,7 @@
 [package]
 name = "exochain-identity"
 description = "EXOCHAIN constitutional trust fabric — privacy-preserving identity adjudication"
-documentation = "https://docs.exochain.io"
+documentation = "https://docs.rs/exochain-identity"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-legal/Cargo.toml
+++ b/crates/exo-legal/Cargo.toml
@@ -17,7 +17,7 @@
 [package]
 name = "exochain-legal"
 description = "EXOCHAIN constitutional trust fabric — litigation-grade evidence, eDiscovery, privilege, fiduciary duty"
-documentation = "https://docs.exochain.io"
+documentation = "https://docs.rs/exochain-legal"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-messaging/Cargo.toml
+++ b/crates/exo-messaging/Cargo.toml
@@ -17,7 +17,7 @@
 [package]
 name = "exochain-messaging"
 description = "EXOCHAIN constitutional trust fabric — end-to-end encrypted messaging with X25519 key exchange"
-documentation = "https://docs.exochain.io"
+documentation = "https://docs.rs/exochain-messaging"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-node/Cargo.toml
+++ b/crates/exo-node/Cargo.toml
@@ -17,7 +17,7 @@
 [package]
 name = "exochain-node"
 description = "EXOCHAIN distributed node — single binary for joining and participating in the constitutional governance network"
-documentation = "https://docs.exochain.io"
+documentation = "https://docs.rs/exochain-node"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-proofs/Cargo.toml
+++ b/crates/exo-proofs/Cargo.toml
@@ -17,7 +17,7 @@
 [package]
 name = "exochain-proofs"
 description = "EXOCHAIN zero-knowledge proof skeleton -- UNAUDITED, pedagogical only. See crate README."
-documentation = "https://docs.exochain.io"
+documentation = "https://docs.rs/exochain-proofs"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-root/Cargo.toml
+++ b/crates/exo-root/Cargo.toml
@@ -17,7 +17,7 @@
 [package]
 name = "exochain-root"
 description = "EXOCHAIN root genesis authority ceremony, FROST DKG, threshold signatures, and trust bundle verification"
-documentation = "https://docs.exochain.io"
+documentation = "https://docs.rs/exochain-root"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exo-tenant/Cargo.toml
+++ b/crates/exo-tenant/Cargo.toml
@@ -17,7 +17,7 @@
 [package]
 name = "exochain-tenant"
 description = "EXOCHAIN constitutional trust fabric — multi-tenant isolation, cold storage, sharding"
-documentation = "https://docs.exochain.io"
+documentation = "https://docs.rs/exochain-tenant"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exochain-sdk/Cargo.toml
+++ b/crates/exochain-sdk/Cargo.toml
@@ -17,7 +17,7 @@
 [package]
 name = "exochain-sdk"
 description = "EXOCHAIN SDK — ergonomic Rust API for the constitutional governance fabric"
-documentation = "https://docs.exochain.io/sdk"
+documentation = "https://docs.rs/exochain-sdk"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/exochain-wasm/Cargo.toml
+++ b/crates/exochain-wasm/Cargo.toml
@@ -17,7 +17,7 @@
 [package]
 name = "exochain-wasm"
 description = "ExoChain governance engine — WebAssembly bindings for Node.js"
-documentation = "https://docs.exochain.io"
+documentation = "https://docs.rs/exochain-wasm"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/tools/verify_cratesio_release_packaging.mjs
+++ b/tools/verify_cratesio_release_packaging.mjs
@@ -120,6 +120,12 @@ for (const pkg of packages) {
   if (!pkg.description || !pkg.description.trim()) {
     failures.push(`${relativeManifest} must include a crates.io package description`);
   }
+  const expectedDocumentation = `https://docs.rs/${pkg.name}`;
+  if (pkg.documentation !== expectedDocumentation) {
+    failures.push(
+      `${relativeManifest} documentation must be ${expectedDocumentation}, got ${pkg.documentation ?? "missing"}`,
+    );
+  }
   if (Array.isArray(pkg.publish) && pkg.publish.length === 0) {
     failures.push(`${relativeManifest} is still publish=false through workspace inheritance`);
   }


### PR DESCRIPTION
## Summary

- Require every publishable Rust crate to declare its crate-specific docs.rs URL.
- Align all 31 publishable crate manifests with that deterministic packaging contract.
- Preserve `crates/decision-forum` as the Apache-2.0 core primitive; this PR does not touch the proprietary Decision Forum product or any adjacent surface.

## Path classification

- EXOCHAIN core/package metadata: `crates/*/Cargo.toml`.
- Release tooling: `tools/verify_cratesio_release_packaging.mjs`.
- Adjacent surfaces, imported evidence, vendor artifacts: none.

## Red-first evidence

- `e445dc0c` extends the packaging verifier so missing or non-crate-specific documentation metadata fails.
- `fff8f851` aligns the 31 publishable manifests with the new invariant.
- `e0c3aa5c` merges exact `origin/main` (`a6984840`) without rewriting public history.

## Validation

- `node tools/verify_cratesio_release_packaging.mjs` — 31 packages passed at 0.2.2.
- `cargo metadata --format-version 1 --no-deps` plus a jq assertion over publishable package documentation URLs.
- `bash tools/test_repo_truth.sh`.
- `cargo +nightly fmt --all -- --check`.
- `git diff --check`.

No package is published and no release tag is created by this PR.
