### PR TITLE
fix(cybermedica): deny unknown governed actions

### DIFF
--- a/cybermedica/src/qms-contracts.mjs
+++ b/cybermedica/src/qms-contracts.mjs
@@ -315,6 +315,7 @@ function hasPermission(authority, permission) {
 
 function evaluateAuthority(action, authority, reasons) {
   const requiredPermission = GOVERNED_ACTION_PERMISSION[action];
+  addReason(reasons, !hasText(requiredPermission), 'governed_action_unknown');
   addReason(reasons, !authority || authority.valid !== true, 'authority_chain_invalid');
   addReason(reasons, authority?.revoked === true, 'authority_chain_revoked');
   addReason(reasons, authority?.expired === true, 'authority_chain_expired');

--- a/cybermedica/tests/license-boundary.test.mjs
+++ b/cybermedica/tests/license-boundary.test.mjs
@@ -39,8 +39,15 @@ test('CyberMedica carries the LiveSafe proprietary subtree boundary', async () =
     `CyberMedica files still declare Apache-2.0:\n${apacheMarkers.stdout}${apacheMarkers.stderr}`,
   );
 
-  assert.match(repositoryReadme, /Apache-2\.0 for EXOCHAIN core/);
-  assert.match(repositoryReadme, /`livesafe\/` and `cybermedica\/`/);
-  assert.match(repositoryReadme, /`livesafe\/LICENSE`/);
-  assert.match(repositoryReadme, /`cybermedica\/LICENSE`/);
+  assert.match(repositoryReadme, /Apache-2\.0 applies to EXOCHAIN core primitives/);
+  assert.match(
+    repositoryReadme,
+    /\[`livesafe\/`\]\(livesafe\/\) and\s+\[`cybermedica\/`\]\(cybermedica\/\) subtrees require commercial licensing terms/,
+  );
+  assert.match(
+    repositoryReadme,
+    /EXOCHAIN `Licensure` bailments and\s+`exo-economy-use-event-v1` usage accounting/,
+  );
+  assert.match(repositoryReadme, /\[livesafe\/LICENSE\]\(livesafe\/LICENSE\)/);
+  assert.match(repositoryReadme, /\[cybermedica\/LICENSE\]\(cybermedica\/LICENSE\)/);
 });

--- a/cybermedica/tests/qms-contracts.test.mjs
+++ b/cybermedica/tests/qms-contracts.test.mjs
@@ -218,3 +218,29 @@ test('participant consent revocation and tenant mismatch deny regulated access',
   assert.equal(tenantMismatchDecision.decision, 'denied');
   assert.ok(tenantMismatchDecision.reasons.includes('tenant_boundary_violation'));
 });
+
+test('unknown governed actions fail closed even with otherwise valid authority', async () => {
+  const { evaluateGovernedAction } = await loadQmsContracts();
+
+  const decision = evaluateGovernedAction({
+    action: 'unregistered_public_claim_lift',
+    tenantId: 'tenant-site-alpha',
+    targetTenantId: 'tenant-site-alpha',
+    actor: { did: 'did:exo:principal-investigator-alpha', kind: 'human' },
+    authority: { valid: true, revoked: false, expired: false, permissions: ['govern', 'read', 'write'] },
+    consent: { required: false },
+    decisionForum: {
+      verified: true,
+      state: 'approved',
+      humanGate: { verified: true },
+      quorum: { status: 'met' },
+      openChallenge: false,
+    },
+    evidenceBundle: { complete: true, phiBoundaryAttested: true },
+  });
+
+  assert.equal(decision.decision, 'denied');
+  assert.equal(decision.failClosed, true);
+  assert.ok(decision.reasons.includes('governed_action_unknown'));
+  assert.equal(decision.exochainProductionClaim, false);
+});


### PR DESCRIPTION
## Summary

- Fail closed when a CyberMedica governed action has no registered permission mapping, even if the supplied authority object is otherwise valid.
- Add the red-first regression for an unknown public-claim action.
- Align the proprietary-license source guard with the merged commercial licensure policy: EXOCHAIN `Licensure` bailments plus `exo-economy-use-event-v1` accounting.

## Adjacent-surface intake

- Owner/accountable maintainer: Bob Stewart until delegated in writing.
- Deployment status: `prototype`; not production.
- Constitutional trust claims: prohibited. CyberMedica may describe inactive contracts and activation gates only.
- Core reads/writes: production access to signatures, credentials, governance, consent, or provenance requires a selected verified adapter and fail-closed tests.
- Trust boundary: CyberMedica owns regulated QMS workflow/operational state; EXOCHAIN owns constitutional primitives and receipts. Requests may cross only through verified adapters.
- Test/CI gate: `npm run quality`.
- Secrets/config: baseline contracts require no secrets; any production credentials require a CyberMedica-only scope and selected deployment secret manager. Missing or malformed configuration fails closed.
- Rollback/disablement: feature-gate trust-claim surfaces and disable EXOCHAIN-backed language whenever root/gateway/node/receipt dependencies are unavailable.
- License: CyberMedica is proprietary adjacent code requiring commercial terms; it does not inherit Apache-2.0 or core trust claims by proximity.

## Path classification / core firewall

- Adjacent surface: `cybermedica/src/qms-contracts.mjs` and two CyberMedica tests.
- EXOCHAIN core, runtime adapters, `packages/exochain-wasm/`, governance, tools, CI, deployment contracts, imported evidence, and vendor artifacts: unchanged relative to `main`.
- Sibling ingress search confirmed QMS approvals, support access, and diligence exports call the shared `evaluateGovernedAction` boundary.

## Red-first and validation evidence

- `0dd7ea95`: regression proving an unknown governed action was previously permitted.
- `d3ee7add`: minimal central fail-closed enforcement.
- Exact `main` merged at `650d05cc` without rewriting history.
- Focused license plus QMS tests: 7 passed.
- `npm run quality`: 1,007 passed; line coverage 98.55%; dependency audit 0 vulnerabilities; all hazard, secret, activation, council, lineage, adapter, adjacent-decision, context, glossary, integration, build, and coverage guards passed.
- `bash tools/test_proprietary_license_boundaries.sh`.
- `git diff --check`.

No EXOCHAIN core behavior, deployment, publication, or production trust state is changed by this PR.
