### PR TITLE
fix(livesafe): bind public trust permits to adapter transport

### DIFF
--- a/livesafe/server/utils/livesafe-exochain-adapter.js
+++ b/livesafe/server/utils/livesafe-exochain-adapter.js
@@ -10,6 +10,7 @@ const {
 } = require("./public-adapter-output-authorization");
 
 const VERIFIED_ADAPTER_STATE = "verified";
+const PUBLIC_AUTHORIZATION_BY_ADAPTER_DECISION = new WeakMap();
 const EXOCHAIN_DID_PATTERN = /^did:exo:[a-z0-9_-]+:[A-Za-z0-9._:-]+$/;
 const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/;
 const CONSENT_SCOPE_PATTERN = /^[a-z0-9][a-z0-9_:-]*$/;
@@ -284,19 +285,29 @@ function createRuntimeExochainAdapter({
           currentAt,
         }),
     );
+    const evaluationInput = {
+      allowed: operationDecision.allowed,
+      responseState: operationDecision.responseState,
+      transportCalled: operationDecision.transportCalled,
+      value: operationDecision.value,
+    };
     const evaluation = evaluatePublicAdapterOutputAuthorization(
-      {
-        allowed: operationDecision.allowed,
-        responseState: operationDecision.responseState,
-        transportCalled: operationDecision.transportCalled,
-        value: operationDecision.value,
-      },
+      evaluationInput,
       {
         currentAt,
         subject: PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
         audience: PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
       },
     );
+    const publicAdapterDecision = {
+      allowed: operationDecision.allowed && evaluation.allowed,
+      reasons: [],
+      required_evidence: [],
+      responseState: operationDecision.responseState,
+      transportCalled: operationDecision.transportCalled,
+      value: evaluation.allowed ? evaluation.metadata : null,
+      metadata: evaluation.metadata,
+    };
     const reasons = [
       ...operationDecision.reasons,
       ...evaluation.reasons.filter(
@@ -310,15 +321,14 @@ function createRuntimeExochainAdapter({
       ),
     ];
 
-    return {
-      allowed: operationDecision.allowed && evaluation.allowed,
-      reasons,
-      required_evidence: requiredEvidence,
-      responseState: operationDecision.responseState,
-      transportCalled: operationDecision.transportCalled,
-      value: evaluation.allowed ? evaluation.metadata : null,
-      metadata: evaluation.metadata,
-    };
+    publicAdapterDecision.allowed = operationDecision.allowed && evaluation.allowed;
+    publicAdapterDecision.reasons = reasons;
+    publicAdapterDecision.required_evidence = requiredEvidence;
+    PUBLIC_AUTHORIZATION_BY_ADAPTER_DECISION.set(
+      publicAdapterDecision,
+      operationDecision.value,
+    );
+    return publicAdapterDecision;
   }
 
   return {
@@ -427,8 +437,26 @@ function createRuntimeExochainAdapter({
 
 const runtimeExochainAdapter = createRuntimeExochainAdapter();
 
+function evaluateVerifiedPublicAdapterOutputDecision(decision, options) {
+  const authorization = PUBLIC_AUTHORIZATION_BY_ADAPTER_DECISION.get(decision);
+  if (typeof authorization === "undefined") {
+    return null;
+  }
+
+  return evaluatePublicAdapterOutputAuthorization(
+    {
+      allowed: decision.allowed,
+      responseState: decision.responseState,
+      transportCalled: decision.transportCalled,
+      value: authorization,
+    },
+    options,
+  );
+}
+
 module.exports = {
   createRuntimeExochainAdapter,
+  evaluateVerifiedPublicAdapterOutputDecision,
   executeRuntimeExochainOperation,
   runtimeExochainAdapter,
 };

--- a/livesafe/server/utils/trust-status.js
+++ b/livesafe/server/utils/trust-status.js
@@ -1,13 +1,14 @@
 "use strict";
 
-const { runtimeExochainAdapter } = require("./livesafe-exochain-adapter");
+const {
+  evaluateVerifiedPublicAdapterOutputDecision,
+  runtimeExochainAdapter,
+} = require("./livesafe-exochain-adapter");
 const {
   exochainProductionTrustEvidence,
 } = require("./exochain-production-trust-evidence");
 const {
-  ALLOWED_PUBLIC_ADAPTER_OUTPUT_CLAIMS,
   PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_AUDIENCE,
-  PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SCHEMA,
   PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SUBJECT,
   evaluatePublicAdapterOutputAuthorization,
 } = require("./public-adapter-output-authorization");
@@ -43,135 +44,36 @@ const VERIFIED_TOKEN = {
   machine_state: "public_trust_claims_allowed"
 };
 
-const PUBLIC_ADAPTER_OUTPUT_METADATA_KEYS = new Set([
-  "schema",
-  "subject",
-  "audience",
-  "claims",
-  "evidence_hash",
-  "receipt_id",
-  "proof_id",
-  "proof_ref",
-  "generated_at",
-  "valid_from",
-  "expires_at",
-  "proof_type",
-  "response_state",
-  "transport_called",
-]);
-const SHA256_EVIDENCE_HASH_PATTERN = /^sha256:[a-f0-9]{64}$/;
-
-function isObjectRecord(value) {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
-
-function isNonEmptyString(value) {
-  return typeof value === "string" && value.trim().length > 0;
-}
-
-function parseIsoTimestamp(value) {
-  if (!isNonEmptyString(value)) {
-    return null;
-  }
-
-  const milliseconds = Date.parse(value);
-  return Number.isNaN(milliseconds) ? null : milliseconds;
-}
-
-function claimsMatchAllowedSet(claims) {
-  if (!Array.isArray(claims) || claims.length !== ALLOWED_PUBLIC_ADAPTER_OUTPUT_CLAIMS.length) {
-    return false;
-  }
-
-  const sortedClaims = [...claims].sort();
-  const sortedAllowed = [...ALLOWED_PUBLIC_ADAPTER_OUTPUT_CLAIMS].sort();
-  return sortedClaims.every((claim, index) => claim === sortedAllowed[index]);
-}
-
-function evaluatedPermitMetadataDecision(
-  adapterOutputAuthorization,
-  { currentAt, subject, audience },
-) {
-  if (
-    !isObjectRecord(adapterOutputAuthorization) ||
-    adapterOutputAuthorization.allowed !== true ||
-    adapterOutputAuthorization.responseState !== "permit" ||
-    adapterOutputAuthorization.transportCalled !== true
-  ) {
-    return null;
-  }
-
-  const metadata = adapterOutputAuthorization.value;
-  if (!isObjectRecord(metadata)) {
-    return null;
-  }
-
-  const keys = Object.keys(metadata);
-  if (!keys.every((key) => PUBLIC_ADAPTER_OUTPUT_METADATA_KEYS.has(key))) {
-    return null;
-  }
-
-  const currentMilliseconds = parseIsoTimestamp(currentAt);
-  const validFromMilliseconds = parseIsoTimestamp(metadata.valid_from);
-  const expiresMilliseconds = parseIsoTimestamp(metadata.expires_at);
-
-  if (
-    currentMilliseconds === null ||
-    validFromMilliseconds === null ||
-    expiresMilliseconds === null ||
-    currentMilliseconds < validFromMilliseconds ||
-    currentMilliseconds > expiresMilliseconds
-  ) {
-    return null;
-  }
-
-  if (
-    metadata.schema !== PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_SCHEMA ||
-    metadata.subject !== subject ||
-    metadata.audience !== audience ||
-    !claimsMatchAllowedSet(metadata.claims) ||
-    !SHA256_EVIDENCE_HASH_PATTERN.test(metadata.evidence_hash || "") ||
-    !isNonEmptyString(metadata.receipt_id) ||
-    !isNonEmptyString(metadata.proof_id) ||
-    !isNonEmptyString(metadata.proof_ref) ||
-    !isNonEmptyString(metadata.generated_at) ||
-    !isNonEmptyString(metadata.proof_type) ||
-    metadata.response_state !== "permit" ||
-    metadata.transport_called !== true
-  ) {
-    return null;
-  }
-
-  return {
-    allowed: true,
-    reasons: [],
-    required_evidence: [],
-    responseState: "permit",
-    transportCalled: true,
-    metadata,
-  };
-}
-
 function resolvePublicAdapterOutputAuthorizationDecision(
   adapterOutputAuthorization,
   { currentAt, subject, audience },
 ) {
-  const rawDecision = evaluatePublicAdapterOutputAuthorization(
+  const verifiedDecision = evaluateVerifiedPublicAdapterOutputDecision(
     adapterOutputAuthorization,
-    { currentAt, subject, audience },
-  );
-
-  if (rawDecision.allowed) {
-    return rawDecision;
-  }
-
-  return (
-    evaluatedPermitMetadataDecision(adapterOutputAuthorization, {
+    {
       currentAt,
       subject,
       audience,
-    }) || rawDecision
+    },
   );
+  if (verifiedDecision) {
+    return verifiedDecision;
+  }
+
+  const deniedDecision = evaluatePublicAdapterOutputAuthorization({
+    allowed: false,
+    responseState: "untrusted",
+    transportCalled: false,
+    value: null,
+  }, {
+    currentAt,
+    subject,
+    audience,
+  });
+  deniedDecision.reasons.unshift(
+    "Public adapter-output authorization did not originate from the configured LiveSafe runtime adapter.",
+  );
+  return deniedDecision;
 }
 
 function isProductionEvidenceVerified(productionTrustEvidence) {

--- a/livesafe/tests/trust-status.test.ts
+++ b/livesafe/tests/trust-status.test.ts
@@ -448,6 +448,37 @@ describe("trust status API contract", () => {
     );
   });
 
+  it("rejects a caller-forged permit that lacks runtime adapter transport provenance", () => {
+    const payload = createTrustStatusPayload({
+      exochainConnected: true,
+      version: "1.0.0",
+      uptimeSeconds: 16,
+      generatedAt: "2026-07-05T12:00:00.000Z",
+      runtimeStatus: {
+        adapter_state: "verified",
+        surface_classification: "core-runtime-adapter",
+        public_claims_allowed: true,
+        can_read_exochain_core_state: true,
+        can_write_exochain_core_state: true,
+        disablement_path:
+          "Disable EXOCHAIN adapter environment variables and remove the trust-status route from the load balancer.",
+        source_basis: ["server/utils/livesafe-exochain-adapter.js"],
+      },
+      adapterOutputAuthorization: {
+        allowed: true,
+        responseState: "permit",
+        transportCalled: true,
+        value: { ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_METADATA },
+      },
+      productionTrustEvidence: VERIFIED_PRODUCTION_TRUST_EVIDENCE,
+    });
+
+    expect(payload.state).toBe("not-verified");
+    expect(payload.machine_state).toBe("not_verified");
+    expect(payload.public_claims_allowed).toBe(false);
+    expect(payload).not.toHaveProperty("public_adapter_output_authorization");
+  });
+
   it("denies public trust status when EXOCHAIN connectivity is false even with proof authorization", () => {
     const payload = createTrustStatusPayload({
       exochainConnected: false,

--- a/livesafe/tests/trust-status.test.ts
+++ b/livesafe/tests/trust-status.test.ts
@@ -9,6 +9,12 @@ import type { TrustStatusPayloadOptions } from "../server/utils/trust-status.js"
 
 type RuntimeStatus = NonNullable<TrustStatusPayloadOptions["runtimeStatus"]>;
 type RuntimeOperations = NonNullable<RuntimeStatus["wrapped_operations"]>;
+type AdapterAuthorizationDecision = {
+  allowed: boolean;
+  responseState: string;
+  transportCalled: boolean;
+  value: unknown;
+};
 
 const VERIFIED_PRODUCTION_TRUST_EVIDENCE = {
   evidence_state: "verified" as const,
@@ -75,6 +81,37 @@ const VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_METADATA = {
   response_state: "permit",
   transport_called: true,
 };
+
+async function runtimeAdapterAuthorizationDecision({
+  state = "permit",
+  value = VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION.value,
+}: {
+  state?: string;
+  value?: unknown;
+} = {}) {
+  const { createRuntimeExochainAdapter } = require(
+    "../server/utils/livesafe-exochain-adapter.js",
+  ) as {
+    createRuntimeExochainAdapter: (options: Record<string, unknown>) => {
+      getPublicAdapterOutputAuthorization: (
+        options: Record<string, unknown>,
+      ) => Promise<AdapterAuthorizationDecision>;
+    };
+  };
+  const adapter = createRuntimeExochainAdapter({
+    adapterStatus: "verified",
+    client: {
+      async getPublicAdapterOutputAuthorization() {
+        return { state, value };
+      },
+    },
+  });
+
+  return adapter.getPublicAdapterOutputAuthorization({
+    currentAt: "2026-07-05T12:00:00.000Z",
+    returnDecision: true,
+  });
+}
 
 describe("trust status API contract", () => {
   it("builds an explicitly inactive machine-readable trust payload", () => {
@@ -263,75 +300,62 @@ describe("trust status API contract", () => {
     expect(payload).not.toHaveProperty("public_adapter_output_authorization");
   });
 
-  it("denies verified public trust status unless the public adapter-output authorization decision and DTO are complete", () => {
+  it("denies verified public trust status unless the public adapter-output authorization decision and DTO are complete", async () => {
     const invalidAuthorizations = [
       {
         name: "denied evaluator decision",
-        adapterOutputAuthorization: {
-          ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION,
-          allowed: false,
-        },
+        state: "deny",
+        value: VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION.value,
       },
       {
         name: "non-permit EXOCHAIN response",
-        adapterOutputAuthorization: {
-          ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION,
-          responseState: "stale",
-        },
+        state: "stale",
+        value: VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION.value,
       },
       {
         name: "uncalled transport",
-        adapterOutputAuthorization: {
-          ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION,
-          transportCalled: false,
-        },
+        state: "not-called",
+        value: VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION.value,
       },
       {
         name: "wrong subject",
-        adapterOutputAuthorization: {
-          ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION,
-          value: {
-            ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION.value,
-            subject: "www.livesafe.ai",
-          },
+        value: {
+          ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION.value,
+          subject: "www.livesafe.ai",
         },
       },
       {
         name: "wrong audience",
-        adapterOutputAuthorization: {
-          ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION,
-          value: {
-            ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION.value,
-            audience: "https://livesafe.ai/api/health",
-          },
+        value: {
+          ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION.value,
+          audience: "https://livesafe.ai/api/health",
         },
       },
       {
         name: "forbidden claim",
-        adapterOutputAuthorization: {
-          ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION,
-          value: {
-            ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION.value,
-            claims: [
-              ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION.value.claims,
-              "medical_status_verified",
-            ],
-          },
+        value: {
+          ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION.value,
+          claims: [
+            ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION.value.claims,
+            "medical_status_verified",
+          ],
         },
       },
       {
         name: "missing evidence hash",
-        adapterOutputAuthorization: {
-          ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION,
-          value: {
-            ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION.value,
-            evidence_hash: "",
-          },
+        value: {
+          ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION.value,
+          evidence_hash: "",
         },
       },
     ];
 
-    for (const { adapterOutputAuthorization, name } of invalidAuthorizations) {
+    for (const { name, state, value } of invalidAuthorizations) {
+      const adapterOutputAuthorization =
+        await runtimeAdapterAuthorizationDecision({
+          state: state ?? "permit",
+          value,
+        });
       const payload = createTrustStatusPayload({
         exochainConnected: true,
         version: "1.0.0",
@@ -359,7 +383,9 @@ describe("trust status API contract", () => {
     }
   });
 
-  it("allows verified public trust status only with permit-backed proof-bearing public adapter-output authorization", () => {
+  it("allows verified public trust status only with a runtime-adapter-bound proof-bearing authorization", async () => {
+    const adapterOutputAuthorization =
+      await runtimeAdapterAuthorizationDecision();
     const payload = createTrustStatusPayload({
       exochainConnected: true,
       version: "1.0.0",
@@ -375,7 +401,7 @@ describe("trust status API contract", () => {
           "Disable EXOCHAIN adapter environment variables and remove the trust-status route from the load balancer.",
         source_basis: ["server/utils/livesafe-exochain-adapter.js"],
       },
-      adapterOutputAuthorization: VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION,
+      adapterOutputAuthorization,
       productionTrustEvidence: VERIFIED_PRODUCTION_TRUST_EVIDENCE,
     });
 
@@ -412,7 +438,7 @@ describe("trust status API contract", () => {
     );
   });
 
-  it("allows live trust status when the adapter returns an already evaluated permit decision", () => {
+  it("denies caller-supplied sanitized metadata masquerading as an evaluated permit", () => {
     const payload = createTrustStatusPayload({
       exochainConnected: true,
       version: "1.0.0",
@@ -437,15 +463,13 @@ describe("trust status API contract", () => {
       productionTrustEvidence: VERIFIED_PRODUCTION_TRUST_EVIDENCE,
     });
 
-    expect(payload.state).toBe("externally-verified");
-    expect(payload.machine_state).toBe("public_trust_claims_allowed");
-    expect(payload.public_claims_allowed).toBe(true);
-    expect(payload.public_adapter_output_authorization).toEqual(
-      VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION_METADATA,
+    expect(payload.state).toBe("not-verified");
+    expect(payload.machine_state).toBe("not_verified");
+    expect(payload.public_claims_allowed).toBe(false);
+    expect(payload.public_claims_reason).toContain(
+      "proof-bearing public adapter-output authorization",
     );
-    expect(JSON.stringify(payload.public_adapter_output_authorization)).not.toContain(
-      "signature",
-    );
+    expect(payload).not.toHaveProperty("public_adapter_output_authorization");
   });
 
   it("rejects a caller-forged permit that lacks runtime adapter transport provenance", () => {
@@ -479,7 +503,40 @@ describe("trust status API contract", () => {
     expect(payload).not.toHaveProperty("public_adapter_output_authorization");
   });
 
-  it("denies public trust status when EXOCHAIN connectivity is false even with proof authorization", () => {
+  it("denies caller-supplied or cloned decisions that did not retain runtime adapter provenance", async () => {
+    const trustedDecision = await runtimeAdapterAuthorizationDecision();
+
+    for (const adapterOutputAuthorization of [
+      VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION,
+      { ...trustedDecision },
+    ]) {
+      const payload = createTrustStatusPayload({
+        exochainConnected: true,
+        version: "1.0.0",
+        uptimeSeconds: 16,
+        generatedAt: "2026-07-05T12:00:00.000Z",
+        runtimeStatus: {
+          adapter_state: "verified",
+          surface_classification: "core-runtime-adapter",
+          can_read_exochain_core_state: true,
+          can_write_exochain_core_state: true,
+          disablement_path:
+            "Disable EXOCHAIN adapter environment variables and remove the trust-status route from the load balancer.",
+          source_basis: ["server/utils/livesafe-exochain-adapter.js"],
+        },
+        adapterOutputAuthorization,
+        productionTrustEvidence: VERIFIED_PRODUCTION_TRUST_EVIDENCE,
+      });
+
+      expect(payload.public_claims_allowed).toBe(false);
+      expect(payload.machine_state).toBe("not_verified");
+      expect(payload).not.toHaveProperty("public_adapter_output_authorization");
+    }
+  });
+
+  it("denies public trust status when EXOCHAIN connectivity is false even with proof authorization", async () => {
+    const adapterOutputAuthorization =
+      await runtimeAdapterAuthorizationDecision();
     const payload = createTrustStatusPayload({
       exochainConnected: false,
       version: "1.0.0",
@@ -495,7 +552,7 @@ describe("trust status API contract", () => {
           "Disable EXOCHAIN adapter environment variables and remove the trust-status route from the load balancer.",
         source_basis: ["server/utils/livesafe-exochain-adapter.js"],
       },
-      adapterOutputAuthorization: VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION,
+      adapterOutputAuthorization,
       productionTrustEvidence: VERIFIED_PRODUCTION_TRUST_EVIDENCE,
     });
 
@@ -530,16 +587,18 @@ describe("trust status API contract", () => {
         source_basis: ["server/utils/livesafe-exochain-adapter.js"],
       } as RuntimeStatus,
     },
-  ])("allows verified public trust status with $label when proof authorization permits", ({
+  ])("allows verified public trust status with $label when proof authorization permits", async ({
     runtimeStatus,
   }) => {
+    const adapterOutputAuthorization =
+      await runtimeAdapterAuthorizationDecision();
     const payload = createTrustStatusPayload({
       exochainConnected: true,
       version: "1.0.0",
       uptimeSeconds: 16,
       generatedAt: "2026-07-05T12:00:00.000Z",
       runtimeStatus,
-      adapterOutputAuthorization: VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION,
+      adapterOutputAuthorization,
       productionTrustEvidence: VERIFIED_PRODUCTION_TRUST_EVIDENCE,
     });
 
@@ -577,32 +636,23 @@ describe("trust status API contract", () => {
   it("live trust status responder requests proof-bearing adapter output with the generated timestamp before sending", async () => {
     const currentAt = "2026-07-05T12:00:00.000Z";
     const getPublicAdapterOutputAuthorization = vi.fn(async () => ({
-      ...VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION,
+      state: "permit",
+      value: VALID_PUBLIC_ADAPTER_OUTPUT_AUTHORIZATION.value,
     }));
-    const adapter = {
-      getRuntimeStatus(): RuntimeStatus {
-        return {
-          adapter_state: "verified" as const,
-          surface_classification: "core-runtime-adapter" as const,
-          public_claims_allowed: true,
-          can_read_exochain_core_state: true,
-          can_write_exochain_core_state: true,
-          wrapped_operations: [
-            "getIdentity",
-            "registerIdentity",
-            "anchorAuditReceipt",
-            "anchorScan",
-            "anchorConsent",
-            "getPaceStatus",
-            "getPublicAdapterOutputAuthorization",
-          ] as RuntimeOperations,
-          disablement_path:
-            "Disable EXOCHAIN adapter environment variables and remove the trust-status route from the load balancer.",
-          source_basis: ["server/utils/livesafe-exochain-adapter.js"],
-        };
-      },
-      getPublicAdapterOutputAuthorization,
+    const { createRuntimeExochainAdapter } = require(
+      "../server/utils/livesafe-exochain-adapter.js",
+    ) as {
+      createRuntimeExochainAdapter: (options: Record<string, unknown>) => {
+        getRuntimeStatus: () => RuntimeStatus;
+        getPublicAdapterOutputAuthorization: (
+          options: Record<string, unknown>,
+        ) => Promise<AdapterAuthorizationDecision>;
+      };
     };
+    const adapter = createRuntimeExochainAdapter({
+      adapterStatus: "verified",
+      client: { getPublicAdapterOutputAuthorization },
+    });
     const json = vi.fn();
     const response = {
       status: vi.fn(() => ({ json })),
@@ -618,8 +668,9 @@ describe("trust status API contract", () => {
     });
 
     expect(getPublicAdapterOutputAuthorization).toHaveBeenCalledWith({
+      audience: "https://livesafe.ai/api/trust/status",
       currentAt,
-      returnDecision: true,
+      subject: "livesafe.ai",
     });
     expect(response.status).toHaveBeenCalledWith(200);
     expect(json).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

- reject caller-forged or cloned permit metadata that lacks runtime-adapter transport provenance
- bind proof-bearing public-output authorization decisions to the adapter-produced object through a private WeakMap
- keep LiveSafe public trust status fail closed unless connectivity, production evidence, the runtime adapter, and the transport-backed permit all verify

## Adjacent-surface intake

- Owner/accountable maintainer: Bob Stewart
- Deployment status: production adjacent product; this PR changes repository behavior only and makes no deployment claim
- Constitutional trust claims: not allowed by proximity; only the tested adapter path may surface a verified public-output state
- Core access: the adapter can read/write core state only when configured as verified; this change does not add a core API or credential path
- Trust boundary: proprietary LiveSafe calls the EXOCHAIN adapter; EXOCHAIN remains the sole authority for permit decisions, and unbound/caller-supplied decisions fail closed
- Surface test/CI gate: `npm --prefix livesafe run quality`; repository constitutional CI
- Secrets/configuration: separate LiveSafe runtime configuration; no EXOCHAIN bootstrap, signing, tenant, or emergency-override secret is added or shared
- Rollback/disablement: disable EXOCHAIN adapter environment variables and remove the trust-status route from the load balancer
- Licensing: LiveSafe is proprietary and requires commercial licensing terms tracked by EXOCHAIN `Licensure` bailments and `exo-economy-use-event-v1` usage accounting

## Path classification

- Adjacent surface: `livesafe/server/utils/livesafe-exochain-adapter.js`
- Adjacent surface: `livesafe/server/utils/trust-status.js`
- Adjacent surface tests: `livesafe/tests/trust-status.test.ts`
- EXOCHAIN core/runtime adapter/governance/CI/deployment changes: none in the surviving diff against current `main`

## Verification

- red-first regression: `a23c8bdc`
- focused: `npm --prefix livesafe test -- tests/trust-status.test.ts` (16 passed)
- full surface gate: `npm --prefix livesafe run quality` (157 files, 555 JS/TS tests; Rust fmt, Clippy, and tests; dependency audits: 0 vulnerabilities)
- licensing: `bash tools/test_proprietary_license_boundaries.sh`
- whitespace: `git diff --check origin/main...HEAD`
- sibling-ingress search: reviewed `public_claims_allowed`, public-permit, and verified-adapter paths across `livesafe/server`, `src`, `client`, and `responder`; the public route resolves authorization through the adapter/trust-status boundary, while other matches are deny-only propagation or separate typed policy contracts

No tag, release, package publication, deployment, or public 0.2.3 release claim is included.