### PR TITLE
release: prepare unpublished EXOCHAIN 0.2.3 candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-07-14
+
+### Security / Correctness
+
+- Standardized private 0dentity reads on owner-session verification while
+  preserving signed writes, cryptographic attestations, and documented DID
+  binding across the node, SDK, and fabric boundary.
+- Bound SDK, Holon, and MCP action provenance to the submitting actor signer,
+  failing closed when an independent actor key cannot be resolved safely.
+- Enforced the canonical five-link authority-chain depth in gatekeeper core and
+  reused that core limit at the MCP adapter boundary.
+- Replaced the GraphQL runtime's single state mutex with deterministic indexed
+  reader/writer state while preserving authenticated adjudication and
+  fail-closed mutations.
+- Denied unknown CyberMedica governed actions and rejected caller-forged
+  LiveSafe public-output permits that lack runtime-adapter transport provenance.
+- Hardened CommandBase determinism, secrets, uploads, webhooks, and receipt
+  boundaries without promoting its adjacent heuristic records into EXOCHAIN
+  constitutional authority.
+- Constrained LiveSafe demo preview hosts and API-key provenance, verified the
+  demo WASM adapter, and removed unsupported EXOCHAIN trust language from
+  proprietary demo surfaces.
+
+### Commercial Licensing
+
+- Restricted Apache-2.0 licensing to EXOCHAIN core primitives. Decision Forum
+  product, LegalDyne, CyberMedica, LiveSafe, and CrossChecked require commercial
+  terms tracked through EXOCHAIN `Licensure` bailments,
+  `exo-economy-use-event-v1` usage accounting, and settlement. The
+  Apache-licensed `crates/decision-forum` primitive remains distinct from the
+  proprietary Decision Forum product.
+
+### Release / CI / Documentation
+
+- Removed the README Rust LOC metric and its constitutional assertions while
+  retaining the backward-compatible `repo_truth.sh --json` `rust_loc`
+  diagnostic.
+- Replaced drifting Cursor Cloud crate/test counts with manifest-derived
+  commands and validated the documented PostgreSQL cluster commands.
+- Aligned publishable crate documentation metadata with crate-specific docs.rs
+  URLs and strengthened packaging verification.
+- Reconciled every frozen local and remote branch ref through the dated 0.2.3
+  execution ledger without deleting branches or the explicit
+  `refuted-do-not-merge/*` tags.
+
 ## [0.2.2] - 2026-07-10
 
 ### Security / Correctness

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1762,7 +1762,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-api"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "blake3",
  "ciborium",
@@ -1778,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-authority"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "blake3",
  "ciborium",
@@ -1791,7 +1791,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-avc"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "ciborium",
  "exochain-authority",
@@ -1803,7 +1803,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-catapult"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "ciborium",
  "exochain-authority",
@@ -1819,7 +1819,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-consensus"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "exochain-core",
  "exochain-decision-forum",
@@ -1831,7 +1831,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-consent"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "blake3",
  "ciborium",
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "blake3",
  "chrono",
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-dag"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "blake3",
@@ -1881,7 +1881,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-dag-db-api"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -1889,7 +1889,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-dag-db-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "ciborium",
  "exochain-core",
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-dag-db-domain"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "ciborium",
  "exochain-authority",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-dag-db-exchange"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "exochain-authority",
  "exochain-avc",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-dag-db-graph"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "ciborium",
  "exochain-core",
@@ -1952,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-dag-db-lab"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "criterion",
  "exochain-core",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-dag-db-postgres"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "exochain-core",
  "exochain-dag",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-dag-db-retrieval"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "exochain-core",
  "exochain-dag-db-api",
@@ -2008,7 +2008,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-decision-forum"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "blake3",
  "exochain-authority",
@@ -2026,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-economy"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "ciborium",
  "exochain-core",
@@ -2036,7 +2036,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-escalation"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "ciborium",
  "exochain-core",
@@ -2050,7 +2050,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-gatekeeper"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "blake3",
  "ciborium",
@@ -2075,7 +2075,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-gateway"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -2118,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-governance"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "blake3",
  "ciborium",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-identity"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "blake3",
  "bs58",
@@ -2154,7 +2154,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-legal"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "blake3",
  "ciborium",
@@ -2171,7 +2171,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-messaging"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "ciborium",
  "exochain-core",
@@ -2189,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-node"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2259,7 +2259,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-proofs"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "blake3",
  "ciborium",
@@ -2273,7 +2273,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-root"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "argon2",
  "chacha20poly1305",
@@ -2293,7 +2293,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-sdk"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "blake3",
  "exochain-avc",
@@ -2312,7 +2312,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-tenant"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "blake3",
  "exochain-core",
@@ -2325,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-wasm"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "ed25519-dalek",
  "exochain-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ members = [
 exclude = ["livesafe"]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -35,8 +35,13 @@ MAJOR.MINOR.PATCH
 The workspace version is set in `Cargo.toml`:
 ```toml
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 ```
+
+This repository state is an unpublished `0.2.3` release candidate. The latest
+published release claim remains `v0.2.1-beta`; repository version alignment is
+not evidence of a tag, GitHub Release, registry publication, deployment, or live
+runtime activation.
 
 ## Release Process
 
@@ -85,9 +90,9 @@ Create and verify the signed release tag only after the key is configured:
 
 ```bash
 git fetch origin main --tags
-git tag -s v0.2.2 "$(git rev-parse origin/main)" -m "EXOCHAIN v0.2.2"
-git tag -v v0.2.2
-git push origin v0.2.2
+git tag -s v0.2.3 "$(git rev-parse origin/main)" -m "EXOCHAIN v0.2.3"
+git tag -v v0.2.3
+git push origin v0.2.3
 ```
 
 ### Dry Run
@@ -137,10 +142,10 @@ resolution requiring retraction.
 
 ```bash
 # Yank a specific crate version (repeats for each affected crate)
-cargo yank --version 0.2.2 exochain-core
+cargo yank --version 0.2.3 exochain-core
 
 # Restore a yank if issued in error
-cargo yank --version 0.2.2 exochain-core --undo
+cargo yank --version 0.2.3 exochain-core --undo
 ```
 
 Yanks must be logged as a governance action: open an issue with label

--- a/crates/decision-forum/Cargo.toml
+++ b/crates/decision-forum/Cargo.toml
@@ -33,13 +33,13 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
-exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.2" }
-exo-governance = { package = "exochain-governance", path = "../exo-governance", version = "=0.2.2" }
-exo-gatekeeper = { package = "exochain-gatekeeper", path = "../exo-gatekeeper", version = "=0.2.2" }
-exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.2" }
-exo-consent = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.2" }
-exo-legal = { package = "exochain-legal", path = "../exo-legal", version = "=0.2.2" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.3" }
+exo-governance = { package = "exochain-governance", path = "../exo-governance", version = "=0.2.3" }
+exo-gatekeeper = { package = "exochain-gatekeeper", path = "../exo-gatekeeper", version = "=0.2.3" }
+exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.3" }
+exo-consent = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.3" }
+exo-legal = { package = "exochain-legal", path = "../exo-legal", version = "=0.2.3" }
 serde = { workspace = true }
 blake3 = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/exo-api/Cargo.toml
+++ b/crates/exo-api/Cargo.toml
@@ -33,9 +33,9 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
-exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.2" }
-exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.2" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
+exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.3" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.3" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 blake3 = { workspace = true }

--- a/crates/exo-authority/Cargo.toml
+++ b/crates/exo-authority/Cargo.toml
@@ -34,8 +34,8 @@ workspace = true
 
 [dependencies]
 ciborium = { workspace = true }
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
-exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.2" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.3" }
 serde = { workspace = true }
 blake3 = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/exo-avc/Cargo.toml
+++ b/crates/exo-avc/Cargo.toml
@@ -33,8 +33,8 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
-exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.2" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
+exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.3" }
 serde = { workspace = true }
 ciborium = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/exo-catapult/Cargo.toml
+++ b/crates/exo-catapult/Cargo.toml
@@ -33,11 +33,11 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
-exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.2" }
-exo-consent = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.2" }
-exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.2" }
-exo-escalation = { package = "exochain-escalation", path = "../exo-escalation", version = "=0.2.2" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.3" }
+exo-consent = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.3" }
+exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.3" }
+exo-escalation = { package = "exochain-escalation", path = "../exo-escalation", version = "=0.2.3" }
 ciborium = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/exo-consensus/Cargo.toml
+++ b/crates/exo-consensus/Cargo.toml
@@ -38,8 +38,8 @@ serde.workspace = true
 thiserror.workspace = true
 
 # Local
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
-decision-forum = { package = "exochain-decision-forum", path = "../decision-forum", version = "=0.2.2" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
+decision-forum = { package = "exochain-decision-forum", path = "../decision-forum", version = "=0.2.3" }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/exo-consent/Cargo.toml
+++ b/crates/exo-consent/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
 serde = { workspace = true }
 blake3 = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/exo-dag-db-core/Cargo.toml
+++ b/crates/exo-dag-db-core/Cargo.toml
@@ -17,8 +17,8 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
-exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.2" }
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
+exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.3" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
 ciborium = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/exo-dag-db-domain/Cargo.toml
+++ b/crates/exo-dag-db-domain/Cargo.toml
@@ -17,14 +17,14 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
-exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.2" }
-exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.2" }
-exo-avc = { package = "exochain-avc", path = "../exo-avc", version = "=0.2.2" }
-exo-consent = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.2" }
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
-exo-dag-db-core = { package = "exochain-dag-db-core", path = "../exo-dag-db-core", version = "=0.2.2" }
-exo-dag-db-graph = { package = "exochain-dag-db-graph", path = "../exo-dag-db-graph", version = "=0.2.2" }
-exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.2" }
+exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.3" }
+exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.3" }
+exo-avc = { package = "exochain-avc", path = "../exo-avc", version = "=0.2.3" }
+exo-consent = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.3" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
+exo-dag-db-core = { package = "exochain-dag-db-core", path = "../exo-dag-db-core", version = "=0.2.3" }
+exo-dag-db-graph = { package = "exochain-dag-db-graph", path = "../exo-dag-db-graph", version = "=0.2.3" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.3" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 ciborium = { workspace = true }

--- a/crates/exo-dag-db-exchange/Cargo.toml
+++ b/crates/exo-dag-db-exchange/Cargo.toml
@@ -17,15 +17,15 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
-exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.2" }
-exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.2" }
-exo-avc = { package = "exochain-avc", path = "../exo-avc", version = "=0.2.2" }
-exo-consent = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.2" }
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
-exo-dag-db-core = { package = "exochain-dag-db-core", path = "../exo-dag-db-core", version = "=0.2.2" }
-exo-dag-db-domain = { package = "exochain-dag-db-domain", path = "../exo-dag-db-domain", version = "=0.2.2" }
-exo-dag-db-graph = { package = "exochain-dag-db-graph", path = "../exo-dag-db-graph", version = "=0.2.2" }
-exo-dag-db-retrieval = { package = "exochain-dag-db-retrieval", path = "../exo-dag-db-retrieval", version = "=0.2.2" }
+exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.3" }
+exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.3" }
+exo-avc = { package = "exochain-avc", path = "../exo-avc", version = "=0.2.3" }
+exo-consent = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.3" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
+exo-dag-db-core = { package = "exochain-dag-db-core", path = "../exo-dag-db-core", version = "=0.2.3" }
+exo-dag-db-domain = { package = "exochain-dag-db-domain", path = "../exo-dag-db-domain", version = "=0.2.3" }
+exo-dag-db-graph = { package = "exochain-dag-db-graph", path = "../exo-dag-db-graph", version = "=0.2.3" }
+exo-dag-db-retrieval = { package = "exochain-dag-db-retrieval", path = "../exo-dag-db-retrieval", version = "=0.2.3" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/exo-dag-db-graph/Cargo.toml
+++ b/crates/exo-dag-db-graph/Cargo.toml
@@ -17,8 +17,8 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
-exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.2" }
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
+exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.3" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
 ciborium = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/exo-dag-db-lab/Cargo.toml
+++ b/crates/exo-dag-db-lab/Cargo.toml
@@ -54,14 +54,14 @@ harness = false
 required-features = ["postgres"]
 
 [dependencies]
-exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.2" }
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
-exo-dag-db-core = { package = "exochain-dag-db-core", path = "../exo-dag-db-core", version = "=0.2.2" }
-exo-dag-db-domain = { package = "exochain-dag-db-domain", path = "../exo-dag-db-domain", version = "=0.2.2" }
-exo-dag-db-exchange = { package = "exochain-dag-db-exchange", path = "../exo-dag-db-exchange", version = "=0.2.2" }
-exo-dag-db-graph = { package = "exochain-dag-db-graph", path = "../exo-dag-db-graph", version = "=0.2.2" }
-exo-dag-db-postgres = { package = "exochain-dag-db-postgres", path = "../exo-dag-db-postgres", version = "=0.2.2" }
-exo-dag-db-retrieval = { package = "exochain-dag-db-retrieval", path = "../exo-dag-db-retrieval", version = "=0.2.2" }
+exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.3" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
+exo-dag-db-core = { package = "exochain-dag-db-core", path = "../exo-dag-db-core", version = "=0.2.3" }
+exo-dag-db-domain = { package = "exochain-dag-db-domain", path = "../exo-dag-db-domain", version = "=0.2.3" }
+exo-dag-db-exchange = { package = "exochain-dag-db-exchange", path = "../exo-dag-db-exchange", version = "=0.2.3" }
+exo-dag-db-graph = { package = "exochain-dag-db-graph", path = "../exo-dag-db-graph", version = "=0.2.3" }
+exo-dag-db-postgres = { package = "exochain-dag-db-postgres", path = "../exo-dag-db-postgres", version = "=0.2.3" }
+exo-dag-db-retrieval = { package = "exochain-dag-db-retrieval", path = "../exo-dag-db-retrieval", version = "=0.2.3" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/exo-dag-db-postgres/Cargo.toml
+++ b/crates/exo-dag-db-postgres/Cargo.toml
@@ -21,14 +21,14 @@ default = []
 postgres = ["dep:sqlx", "dep:tokio", "dep:tracing"]
 
 [dependencies]
-exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.2" }
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
-exo-dag = { package = "exochain-dag", path = "../exo-dag", version = "=0.2.2" }
-exo-dag-db-core = { package = "exochain-dag-db-core", path = "../exo-dag-db-core", version = "=0.2.2" }
-exo-dag-db-domain = { package = "exochain-dag-db-domain", path = "../exo-dag-db-domain", version = "=0.2.2" }
-exo-dag-db-exchange = { package = "exochain-dag-db-exchange", path = "../exo-dag-db-exchange", version = "=0.2.2" }
-exo-dag-db-graph = { package = "exochain-dag-db-graph", path = "../exo-dag-db-graph", version = "=0.2.2" }
-exo-dag-db-retrieval = { package = "exochain-dag-db-retrieval", path = "../exo-dag-db-retrieval", version = "=0.2.2" }
+exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.3" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
+exo-dag = { package = "exochain-dag", path = "../exo-dag", version = "=0.2.3" }
+exo-dag-db-core = { package = "exochain-dag-db-core", path = "../exo-dag-db-core", version = "=0.2.3" }
+exo-dag-db-domain = { package = "exochain-dag-db-domain", path = "../exo-dag-db-domain", version = "=0.2.3" }
+exo-dag-db-exchange = { package = "exochain-dag-db-exchange", path = "../exo-dag-db-exchange", version = "=0.2.3" }
+exo-dag-db-graph = { package = "exochain-dag-db-graph", path = "../exo-dag-db-graph", version = "=0.2.3" }
+exo-dag-db-retrieval = { package = "exochain-dag-db-retrieval", path = "../exo-dag-db-retrieval", version = "=0.2.3" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true, optional = true }

--- a/crates/exo-dag-db-retrieval/Cargo.toml
+++ b/crates/exo-dag-db-retrieval/Cargo.toml
@@ -17,11 +17,11 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
-exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.2" }
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
-exo-dag-db-core = { package = "exochain-dag-db-core", path = "../exo-dag-db-core", version = "=0.2.2" }
-exo-dag-db-domain = { package = "exochain-dag-db-domain", path = "../exo-dag-db-domain", version = "=0.2.2" }
-exo-dag-db-graph = { package = "exochain-dag-db-graph", path = "../exo-dag-db-graph", version = "=0.2.2" }
+exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.3" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
+exo-dag-db-core = { package = "exochain-dag-db-core", path = "../exo-dag-db-core", version = "=0.2.3" }
+exo-dag-db-domain = { package = "exochain-dag-db-domain", path = "../exo-dag-db-domain", version = "=0.2.3" }
+exo-dag-db-graph = { package = "exochain-dag-db-graph", path = "../exo-dag-db-graph", version = "=0.2.3" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/exo-dag/Cargo.toml
+++ b/crates/exo-dag/Cargo.toml
@@ -37,7 +37,7 @@ default = []
 postgres = ["dep:sqlx", "dep:serde_json"]
 
 [dependencies]
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
 serde = { workspace = true }
 blake3 = { workspace = true }
 ciborium = { workspace = true }

--- a/crates/exo-economy/Cargo.toml
+++ b/crates/exo-economy/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
 serde = { workspace = true }
 ciborium = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/exo-escalation/Cargo.toml
+++ b/crates/exo-escalation/Cargo.toml
@@ -33,16 +33,16 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
-exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.2" }
-exo-governance = { package = "exochain-governance", path = "../exo-governance", version = "=0.2.2" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.3" }
+exo-governance = { package = "exochain-governance", path = "../exo-governance", version = "=0.2.3" }
 ciborium = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
-exo-gatekeeper = { package = "exochain-gatekeeper", path = "../exo-gatekeeper", version = "=0.2.2" }
+exo-gatekeeper = { package = "exochain-gatekeeper", path = "../exo-gatekeeper", version = "=0.2.3" }
 
 [package.metadata.cargo-machete]
 # Pre-existing workspace dep used via re-exports.

--- a/crates/exo-gatekeeper/Cargo.toml
+++ b/crates/exo-gatekeeper/Cargo.toml
@@ -33,10 +33,10 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
-exo-api = { package = "exochain-api", path = "../exo-api", version = "=0.2.2" }
-exo-consent = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.2" }
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
-exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.2" }
+exo-api = { package = "exochain-api", path = "../exo-api", version = "=0.2.3" }
+exo-consent = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.3" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.3" }
 serde = { workspace = true }
 blake3 = { workspace = true }
 ciborium = { workspace = true }
@@ -47,15 +47,15 @@ ed25519-dalek = { workspace = true }
 hex = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-exo-dag-db-core = { package = "exochain-dag-db-core", path = "../exo-dag-db-core", version = "=0.2.2" }
-exo-dag-db-domain = { package = "exochain-dag-db-domain", path = "../exo-dag-db-domain", version = "=0.2.2" }
-exo-dag-db-exchange = { package = "exochain-dag-db-exchange", path = "../exo-dag-db-exchange", version = "=0.2.2" }
-exo-dag-db-postgres = { package = "exochain-dag-db-postgres", path = "../exo-dag-db-postgres", version = "=0.2.2", features = ["postgres"] }
+exo-dag-db-core = { package = "exochain-dag-db-core", path = "../exo-dag-db-core", version = "=0.2.3" }
+exo-dag-db-domain = { package = "exochain-dag-db-domain", path = "../exo-dag-db-domain", version = "=0.2.3" }
+exo-dag-db-exchange = { package = "exochain-dag-db-exchange", path = "../exo-dag-db-exchange", version = "=0.2.3" }
+exo-dag-db-postgres = { package = "exochain-dag-db-postgres", path = "../exo-dag-db-postgres", version = "=0.2.3", features = ["postgres"] }
 sqlx = { workspace = true }
 
 [dev-dependencies]
-exo-api = { package = "exochain-api", path = "../exo-api", version = "=0.2.2" }
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
+exo-api = { package = "exochain-api", path = "../exo-api", version = "=0.2.3" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 

--- a/crates/exo-gateway/Cargo.toml
+++ b/crates/exo-gateway/Cargo.toml
@@ -33,18 +33,18 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
-decision-forum = { package = "exochain-decision-forum", path = "../decision-forum", version = "=0.2.2" }
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
-exo-api = { package = "exochain-api", path = "../exo-api", version = "=0.2.2" }
-exo-dag-db-core = { package = "exochain-dag-db-core", path = "../exo-dag-db-core", version = "=0.2.2" }
-exo-dag-db-domain = { package = "exochain-dag-db-domain", path = "../exo-dag-db-domain", version = "=0.2.2" }
-exo-dag-db-exchange = { package = "exochain-dag-db-exchange", path = "../exo-dag-db-exchange", version = "=0.2.2" }
-exo-dag-db-postgres = { package = "exochain-dag-db-postgres", path = "../exo-dag-db-postgres", version = "=0.2.2", default-features = false, optional = true }
-exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.2" }
-exo-consent = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.2" }
-exo-gatekeeper = { package = "exochain-gatekeeper", path = "../exo-gatekeeper", version = "=0.2.2" }
-exo-governance = { package = "exochain-governance", path = "../exo-governance", version = "=0.2.2" }
-exo-legal = { package = "exochain-legal", path = "../exo-legal", version = "=0.2.2" }
+decision-forum = { package = "exochain-decision-forum", path = "../decision-forum", version = "=0.2.3" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
+exo-api = { package = "exochain-api", path = "../exo-api", version = "=0.2.3" }
+exo-dag-db-core = { package = "exochain-dag-db-core", path = "../exo-dag-db-core", version = "=0.2.3" }
+exo-dag-db-domain = { package = "exochain-dag-db-domain", path = "../exo-dag-db-domain", version = "=0.2.3" }
+exo-dag-db-exchange = { package = "exochain-dag-db-exchange", path = "../exo-dag-db-exchange", version = "=0.2.3" }
+exo-dag-db-postgres = { package = "exochain-dag-db-postgres", path = "../exo-dag-db-postgres", version = "=0.2.3", default-features = false, optional = true }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.3" }
+exo-consent = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.3" }
+exo-gatekeeper = { package = "exochain-gatekeeper", path = "../exo-gatekeeper", version = "=0.2.3" }
+exo-governance = { package = "exochain-governance", path = "../exo-governance", version = "=0.2.3" }
+exo-legal = { package = "exochain-legal", path = "../exo-legal", version = "=0.2.3" }
 bs58 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/exo-governance/Cargo.toml
+++ b/crates/exo-governance/Cargo.toml
@@ -33,11 +33,11 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
 ciborium = { workspace = true }
-exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.2" }
-exo-consent = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.2" }
-exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.2" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.3" }
+exo-consent = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.3" }
+exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.3" }
 serde = { workspace = true }
 blake3 = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/exo-identity/Cargo.toml
+++ b/crates/exo-identity/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
 serde = { workspace = true }
 ciborium = { workspace = true }
 blake3 = { workspace = true }

--- a/crates/exo-legal/Cargo.toml
+++ b/crates/exo-legal/Cargo.toml
@@ -33,11 +33,11 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
-exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.2" }
-exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.2" }
-exo-governance = { package = "exochain-governance", path = "../exo-governance", version = "=0.2.2" }
-exo-gatekeeper = { package = "exochain-gatekeeper", path = "../exo-gatekeeper", version = "=0.2.2" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.3" }
+exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.3" }
+exo-governance = { package = "exochain-governance", path = "../exo-governance", version = "=0.2.3" }
+exo-gatekeeper = { package = "exochain-gatekeeper", path = "../exo-gatekeeper", version = "=0.2.3" }
 serde = { workspace = true }
 ciborium = { workspace = true }
 blake3 = { workspace = true }

--- a/crates/exo-messaging/Cargo.toml
+++ b/crates/exo-messaging/Cargo.toml
@@ -33,8 +33,8 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
-exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.2" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.3" }
 ciborium = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/exo-node/Cargo.toml
+++ b/crates/exo-node/Cargo.toml
@@ -34,27 +34,27 @@ workspace = true
 
 [dependencies]
 # Workspace crates
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
-exo-dag = { package = "exochain-dag", path = "../exo-dag", version = "=0.2.2" }
-exo-gatekeeper = { package = "exochain-gatekeeper", path = "../exo-gatekeeper", version = "=0.2.2" }
-exo-gateway = { package = "exochain-gateway", path = "../exo-gateway", version = "=0.2.2", default-features = false }
-exo-api = { package = "exochain-api", path = "../exo-api", version = "=0.2.2" }
-exo-governance = { package = "exochain-governance", path = "../exo-governance", version = "=0.2.2" }
-exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.2" }
-exo-consent = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.2" }
-exo-escalation = { package = "exochain-escalation", path = "../exo-escalation", version = "=0.2.2" }
-exo-legal = { package = "exochain-legal", path = "../exo-legal", version = "=0.2.2" }
-exo-avc = { package = "exochain-avc", path = "../exo-avc", version = "=0.2.2" }
-exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.2" }
-exo-economy = { package = "exochain-economy", path = "../exo-economy", version = "=0.2.2" }
-exo-root = { package = "exochain-root", path = "../exo-root", version = "=0.2.2" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
+exo-dag = { package = "exochain-dag", path = "../exo-dag", version = "=0.2.3" }
+exo-gatekeeper = { package = "exochain-gatekeeper", path = "../exo-gatekeeper", version = "=0.2.3" }
+exo-gateway = { package = "exochain-gateway", path = "../exo-gateway", version = "=0.2.3", default-features = false }
+exo-api = { package = "exochain-api", path = "../exo-api", version = "=0.2.3" }
+exo-governance = { package = "exochain-governance", path = "../exo-governance", version = "=0.2.3" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.3" }
+exo-consent = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.3" }
+exo-escalation = { package = "exochain-escalation", path = "../exo-escalation", version = "=0.2.3" }
+exo-legal = { package = "exochain-legal", path = "../exo-legal", version = "=0.2.3" }
+exo-avc = { package = "exochain-avc", path = "../exo-avc", version = "=0.2.3" }
+exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.3" }
+exo-economy = { package = "exochain-economy", path = "../exo-economy", version = "=0.2.3" }
+exo-root = { package = "exochain-root", path = "../exo-root", version = "=0.2.3" }
 
 # DAG DB MCP gateway proxy client (P1-B SDK). The default node compiles the
 # governed gateway proxy transport so MCP DAG DB tools can call the production
 # gateway path when runtime config is present. Missing runtime config still
 # fails closed; it never falls back to fabricated packet/writeback/import/export
 # results.
-exochain-sdk = { package = "exochain-sdk", path = "../exochain-sdk", version = "=0.2.2", optional = true }
+exochain-sdk = { package = "exochain-sdk", path = "../exochain-sdk", version = "=0.2.3", optional = true }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/exo-proofs/Cargo.toml
+++ b/crates/exo-proofs/Cargo.toml
@@ -43,7 +43,7 @@ workspace = true
 unaudited-pedagogical-proofs = []
 
 [dependencies]
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
 serde = { workspace = true }
 blake3 = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/exo-root/Cargo.toml
+++ b/crates/exo-root/Cargo.toml
@@ -33,8 +33,8 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
-exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.2" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
+exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.3" }
 frost-ristretto255 = { workspace = true }
 serde = { workspace = true }
 ciborium = { workspace = true }

--- a/crates/exo-tenant/Cargo.toml
+++ b/crates/exo-tenant/Cargo.toml
@@ -33,8 +33,8 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
-exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.2" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.3" }
 serde = { workspace = true }
 blake3 = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/exochain-sdk/Cargo.toml
+++ b/crates/exochain-sdk/Cargo.toml
@@ -36,12 +36,12 @@ workspace = true
 # Core crates (only those actually `use`d today; see removed-deps
 # note in commit message when adding back — avoid drift between
 # `pub use` surface and dependency graph)
-exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
-exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.2" }
-exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.2" }
-exo-gatekeeper = { package = "exochain-gatekeeper", path = "../exo-gatekeeper", version = "=0.2.2" }
-exo-avc = { package = "exochain-avc", path = "../exo-avc", version = "=0.2.2" }
-exo-economy = { package = "exochain-economy", path = "../exo-economy", version = "=0.2.2" }
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
+exo-dag-db-api = { package = "exochain-dag-db-api", path = "../exo-dag-db-api", version = "=0.2.3" }
+exo-identity = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.3" }
+exo-gatekeeper = { package = "exochain-gatekeeper", path = "../exo-gatekeeper", version = "=0.2.3" }
+exo-avc = { package = "exochain-avc", path = "../exo-avc", version = "=0.2.3" }
+exo-economy = { package = "exochain-economy", path = "../exo-economy", version = "=0.2.3" }
 
 # Serialization
 serde = { workspace = true }

--- a/crates/exochain-sdk/src/lib.rs
+++ b/crates/exochain-sdk/src/lib.rs
@@ -168,7 +168,7 @@
 /// server reports a different major/minor so users can distinguish
 /// protocol skew from transport errors. All three SDKs (Rust, TypeScript,
 /// Python) expose a matching `PROTOCOL_VERSION` constant.
-pub const PROTOCOL_VERSION: &str = "0.2.2";
+pub const PROTOCOL_VERSION: &str = "0.2.3";
 
 pub mod authority;
 pub mod avc;
@@ -208,6 +208,6 @@ mod tests {
 
     #[test]
     fn protocol_version_is_stable() {
-        assert_eq!(PROTOCOL_VERSION, "0.2.2");
+        assert_eq!(PROTOCOL_VERSION, "0.2.3");
     }
 }

--- a/crates/exochain-wasm/Cargo.toml
+++ b/crates/exochain-wasm/Cargo.toml
@@ -29,22 +29,22 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 # ExoChain crates (excludes exo-gateway which is server-only)
-exo-core       = { package = "exochain-core", path = "../exo-core", version = "=0.2.2" }
-exo-avc        = { package = "exochain-avc", path = "../exo-avc", version = "=0.2.2" }
-exo-identity   = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.2" }
-exo-consent    = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.2" }
-exo-authority  = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.2" }
-exo-gatekeeper = { package = "exochain-gatekeeper", path = "../exo-gatekeeper", version = "=0.2.2" }
-exo-governance = { package = "exochain-governance", path = "../exo-governance", version = "=0.2.2" }
-exo-escalation = { package = "exochain-escalation", path = "../exo-escalation", version = "=0.2.2" }
-exo-legal      = { package = "exochain-legal", path = "../exo-legal", version = "=0.2.2" }
-exo-dag        = { package = "exochain-dag", path = "../exo-dag", version = "=0.2.2" }
-exo-proofs     = { package = "exochain-proofs", path = "../exo-proofs", version = "=0.2.2" }
-exo-api        = { package = "exochain-api", path = "../exo-api", version = "=0.2.2" }
-decision-forum = { package = "exochain-decision-forum", path = "../decision-forum", version = "=0.2.2" }
-exo-catapult   = { package = "exochain-catapult", path = "../exo-catapult", version = "=0.2.2" }
-exo-messaging  = { package = "exochain-messaging", path = "../exo-messaging", version = "=0.2.2" }
-exo-economy    = { package = "exochain-economy", path = "../exo-economy", version = "=0.2.2" }
+exo-core       = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
+exo-avc        = { package = "exochain-avc", path = "../exo-avc", version = "=0.2.3" }
+exo-identity   = { package = "exochain-identity", path = "../exo-identity", version = "=0.2.3" }
+exo-consent    = { package = "exochain-consent", path = "../exo-consent", version = "=0.2.3" }
+exo-authority  = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.3" }
+exo-gatekeeper = { package = "exochain-gatekeeper", path = "../exo-gatekeeper", version = "=0.2.3" }
+exo-governance = { package = "exochain-governance", path = "../exo-governance", version = "=0.2.3" }
+exo-escalation = { package = "exochain-escalation", path = "../exo-escalation", version = "=0.2.3" }
+exo-legal      = { package = "exochain-legal", path = "../exo-legal", version = "=0.2.3" }
+exo-dag        = { package = "exochain-dag", path = "../exo-dag", version = "=0.2.3" }
+exo-proofs     = { package = "exochain-proofs", path = "../exo-proofs", version = "=0.2.3" }
+exo-api        = { package = "exochain-api", path = "../exo-api", version = "=0.2.3" }
+decision-forum = { package = "exochain-decision-forum", path = "../decision-forum", version = "=0.2.3" }
+exo-catapult   = { package = "exochain-catapult", path = "../exo-catapult", version = "=0.2.3" }
+exo-messaging  = { package = "exochain-messaging", path = "../exo-messaging", version = "=0.2.3" }
+exo-economy    = { package = "exochain-economy", path = "../exo-economy", version = "=0.2.3" }
 
 # WASM bindings
 wasm-bindgen = "=0.2.100"

--- a/docs/c2/nodes/platform-release.md
+++ b/docs/c2/nodes/platform-release.md
@@ -35,7 +35,7 @@ flowchart LR
 
 ## SSOTs (progress by reference)
 
-- Gap / decision refs: `v0.2.2+`
+- Gap / decision refs: `v0.2.3+`
 - Progress sources: `CHANGELOG / repo_truth`
 - HOW owners: `CI / Railway`
 

--- a/docs/guides/production-deployment.md
+++ b/docs/guides/production-deployment.md
@@ -214,7 +214,7 @@ as the liveness probe in Kubernetes / Docker Compose.
 
 ```bash
 curl -s http://localhost:8080/health | jq .
-# {"status":"ok","version":"0.2.2","uptime_seconds":42}
+# {"status":"ok","version":"0.2.3","uptime_seconds":42}
 ```
 
 ### `GET /ready`

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-authority"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "blake3",
  "ciborium",
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-consent"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "blake3",
  "ciborium",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "blake3",
  "chrono",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-governance"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "blake3",
  "ciborium",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "exochain-identity"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "blake3",
  "bs58",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -31,8 +31,8 @@ ignored = ["ml-dsa", "pkcs8", "sha3", "signature", "spki"]
 
 [dependencies]
 ciborium = "0.2"
-exo-core = { package = "exochain-core", path = "../crates/exo-core", version = "=0.2.2" }
-exo-governance = { package = "exochain-governance", path = "../crates/exo-governance", version = "=0.2.2" }
+exo-core = { package = "exochain-core", path = "../crates/exo-core", version = "=0.2.3" }
+exo-governance = { package = "exochain-governance", path = "../crates/exo-governance", version = "=0.2.3" }
 libfuzzer-sys = "0.4"
 ml-dsa = { version = "=0.1.0-rc.7", features = ["zeroize"] }
 pkcs8 = "=0.11.0-rc.11"

--- a/packages/exochain-llm-proxy/package-lock.json
+++ b/packages/exochain-llm-proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@exochain/llm-proxy",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@exochain/llm-proxy",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "bin": {
         "exochain-llm-proxy": "dist/cli.js"

--- a/packages/exochain-llm-proxy/package.json
+++ b/packages/exochain-llm-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exochain/llm-proxy",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "EXOCHAIN LYNK Protocol proxy for receipted LLM and MCP usage",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/exochain-py/exochain/__init__.py
+++ b/packages/exochain-py/exochain/__init__.py
@@ -67,12 +67,12 @@ from .types import (
     TrustReceipt,
 )
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 #: Fabric protocol version this SDK speaks (A-066). Clients may ``/version``-probe
 #: a target gateway on init and warn when the server reports a different
 #: major/minor so users can distinguish protocol skew from transport errors.
-PROTOCOL_VERSION = "0.2.2"
+PROTOCOL_VERSION = "0.2.3"
 
 __all__ = [
     "PROTOCOL_VERSION",

--- a/packages/exochain-py/exochain/transport/http.py
+++ b/packages/exochain-py/exochain/transport/http.py
@@ -25,7 +25,7 @@ import httpx
 
 from ..errors import TransportError
 
-_DEFAULT_USER_AGENT = "exochain-py/0.2.2"
+_DEFAULT_USER_AGENT = "exochain-py/0.2.3"
 
 
 class HttpTransport:

--- a/packages/exochain-py/pyproject.toml
+++ b/packages/exochain-py/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "exochain"
-version = "0.2.2"
+version = "0.2.3"
 description = "EXOCHAIN SDK — constitutional governance fabric for AI and data sovereignty"
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/exochain-py/tests/test_crypto.py
+++ b/packages/exochain-py/tests/test_crypto.py
@@ -23,7 +23,7 @@ from exochain import PROTOCOL_VERSION, sha256, sha256_hex
 
 def test_protocol_version_is_exported() -> None:
     """The Python SDK exposes the fabric protocol version for skew checks."""
-    assert PROTOCOL_VERSION == "0.2.2"
+    assert PROTOCOL_VERSION == "0.2.3"
 
 
 def test_sha256_is_deterministic() -> None:

--- a/packages/exochain-sdk/dist-test/src/index.js
+++ b/packages/exochain-sdk/dist-test/src/index.js
@@ -30,7 +30,7 @@
  * a target gateway on init and warn when the server reports a different
  * major/minor so users can distinguish protocol skew from transport errors.
  */
-export const PROTOCOL_VERSION = '0.2.2';
+export const PROTOCOL_VERSION = '0.2.3';
 export * from './types.js';
 export * from './errors.js';
 export * from './client.js';

--- a/packages/exochain-sdk/dist-test/test/index.test.js
+++ b/packages/exochain-sdk/dist-test/test/index.test.js
@@ -17,6 +17,6 @@ import { test } from 'node:test';
 import { strictEqual } from 'node:assert/strict';
 import { PROTOCOL_VERSION } from '../src/index.js';
 test('PROTOCOL_VERSION is exported from package entry point', () => {
-    strictEqual(PROTOCOL_VERSION, '0.2.2');
+    strictEqual(PROTOCOL_VERSION, '0.2.3');
 });
 //# sourceMappingURL=index.test.js.map

--- a/packages/exochain-sdk/dist/index.d.ts
+++ b/packages/exochain-sdk/dist/index.d.ts
@@ -15,7 +15,7 @@
  * a target gateway on init and warn when the server reports a different
  * major/minor so users can distinguish protocol skew from transport errors.
  */
-export declare const PROTOCOL_VERSION = "0.2.2";
+export declare const PROTOCOL_VERSION = "0.2.3";
 export * from './types.js';
 export * from './errors.js';
 export * from './client.js';

--- a/packages/exochain-sdk/dist/index.js
+++ b/packages/exochain-sdk/dist/index.js
@@ -30,7 +30,7 @@
  * a target gateway on init and warn when the server reports a different
  * major/minor so users can distinguish protocol skew from transport errors.
  */
-export const PROTOCOL_VERSION = '0.2.2';
+export const PROTOCOL_VERSION = '0.2.3';
 export * from './types.js';
 export * from './errors.js';
 export * from './client.js';

--- a/packages/exochain-sdk/package-lock.json
+++ b/packages/exochain-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@exochain/sdk",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@exochain/sdk",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "1.8.0"

--- a/packages/exochain-sdk/package.json
+++ b/packages/exochain-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exochain/sdk",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "EXOCHAIN SDK — constitutional governance fabric for AI and data sovereignty",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/exochain-sdk/src/index.ts
+++ b/packages/exochain-sdk/src/index.ts
@@ -32,7 +32,7 @@
  * a target gateway on init and warn when the server reports a different
  * major/minor so users can distinguish protocol skew from transport errors.
  */
-export const PROTOCOL_VERSION = '0.2.2';
+export const PROTOCOL_VERSION = '0.2.3';
 
 export * from './types.js';
 export * from './errors.js';

--- a/packages/exochain-sdk/test/index.test.ts
+++ b/packages/exochain-sdk/test/index.test.ts
@@ -19,5 +19,5 @@ import { strictEqual } from 'node:assert/strict';
 import { PROTOCOL_VERSION } from '../src/index.js';
 
 test('PROTOCOL_VERSION is exported from package entry point', () => {
-  strictEqual(PROTOCOL_VERSION, '0.2.2');
+  strictEqual(PROTOCOL_VERSION, '0.2.3');
 });

--- a/packages/exochain-wasm/wasm/package.json
+++ b/packages/exochain-wasm/wasm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@exochain/exochain-wasm",
   "description": "ExoChain governance engine — WebAssembly bindings for Node.js",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/tools/verify_cratesio_release_packaging.mjs
+++ b/tools/verify_cratesio_release_packaging.mjs
@@ -28,8 +28,8 @@ const workspaceVersion = workspaceToml.match(/^\[workspace\.package\][\s\S]*?^ve
 if (!workspaceVersion) {
   throw new Error("workspace package version is missing");
 }
-if (workspaceVersion !== "0.2.2") {
-  throw new Error(`workspace package version must be 0.2.2 for this release, got ${workspaceVersion}`);
+if (workspaceVersion !== "0.2.3") {
+  throw new Error(`workspace package version must be 0.2.3 for this release, got ${workspaceVersion}`);
 }
 if (!/^\[workspace\.package\][\s\S]*^publish = true$/m.test(workspaceToml)) {
   throw new Error("workspace package publish must be true for release packaging");


### PR DESCRIPTION
## Summary

Prepares the unpublished EXOCHAIN 0.2.3 release candidate after the complete branch reconciliation in #806.

- aligns all 31 publishable Rust crates and exact first-party dependency pins at 0.2.3
- aligns Cargo/fuzz locks, Rust/TypeScript/Python protocol constants, npm/WASM/LYNK/Python metadata, and checked-in SDK artifacts
- adds the dated 0.2.3 changelog using only work proved merged in the reconciliation ledger
- updates VERSIONING.md while preserving README's latest-published-release claim at `v0.2.1-beta`
- strengthens the crates.io packaging guard so this candidate must package at 0.2.3

This PR does **not** create a tag, GitHub Release, package publication, deployment, or public-release claim.

## Path classification

- **EXOCHAIN core:** Rust workspace manifests, internal dependency pins, root and fuzz locks, SDK/protocol constants, and release packaging guard.
- **Core runtime adapter:** TypeScript/Python/WASM/LYNK package metadata and checked-in SDK artifacts aligned to the core protocol version.
- **Documentation:** `CHANGELOG.md`, `VERSIONING.md`, C2 platform-release guidance, and production-deployment version example.
- **Adjacent surface:** none.
- **Imported evidence / third-party/vendor:** none; external dependency versions are unchanged.

The Rust `crates/decision-forum` primitive remains Apache-2.0 core. Proprietary Decision Forum product, LegalDyne, CyberMedica, LiveSafe, and CrossChecked remain commercial-license adjacent surfaces governed by the merged licensure boundaries; this PR does not weaken or reclassify them.

## Local acceptance evidence

- `cargo build --workspace --release`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `cargo doc --workspace --no-deps`
- `cargo audit` (no vulnerabilities; existing allowed yanked `spin 0.9.8` warning)
- `cargo deny check` (advisories, bans, licenses, sources all pass)
- `./tools/cross-impl-test/compare.sh` (Rust/Node vector agreement and two identical Rust test runs)
- every `tools/test_release_*.sh`
- `bash tools/test_cratesio_release_packaging.sh`
- `bash tools/test_wasm_npm_package_boundary.sh`
- `bash tools/test_npm_core_package_hygiene.sh`
- `node tools/verify_cratesio_release_packaging.mjs` (31 packages at 0.2.3)
- TypeScript SDK and LYNK npm dry packs at 0.2.3
- `bash tools/test_repo_truth.sh`
- `bash tools/test_proprietary_license_boundaries.sh`
- JSON `rust_loc` compatibility readback and README/source LOC guards
- `git diff --check`

## Release boundary

Merge only after the complete PR check suite and branch-scoped `release.yml` run with `version=0.2.3` and `dry_run=true` pass. After merge, rerun CI and the same dry run against the exact merged `main` SHA. Do not tag or publish.
