### PR TITLE
docs: record v0.2.3 as latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 | Rust source files | 471 | `git ls-files 'crates/**/*.rs'` |
 | Workspace tests | 6,267 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 23 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
-| Latest published release | `v0.2.1-beta` (GitHub Release published 2026-07-08; `exochain-core` on crates.io and `@exochain/llm-proxy` on npm resolve the same version) | `gh release list`; `cargo search exochain-core`; `npm view @exochain/llm-proxy version` |
+| Latest published release | `v0.2.3` (GitHub Release published 2026-07-15; all release crates plus `@exochain/exochain-wasm` and `@exochain/llm-proxy` resolve the same version) | `gh release list`; crates.io version API; `npm view @exochain/exochain-wasm version`; `npm view @exochain/llm-proxy version` |
 | License | Apache-2.0 for EXOCHAIN core primitives; commercial terms for Decision Forum, LegalDyne, CyberMedica, LiveSafe, and CrossChecked products | `governance/commercial-product-licensing.json`; product license files where present |
 | Live node health | Not inferred from repository state; verify each target at deploy or release time | `tools/verify_live_node_claim.sh` |
 


### PR DESCRIPTION
## Summary

- update the README latest-published-release claim after the public v0.2.3 publication
- preserve the Apache core primitive vs commercial product licensing boundary
- close the tag-push Gate 9 repo-truth failure caused by the intentionally frozen pre-release claim

## Path classification

- `README.md`: documentation
- no `crates/`, packages, governance, tools, CI, deployment, runtime, adjacent-surface, or imported-evidence files changed

## Red/green evidence

- RED on fresh `origin/main`: `bash tools/test_repo_truth.sh` failed because README did not match newest tag `v0.2.3`
- GREEN after the one-row update: `bash tools/test_repo_truth.sh`

## Verification

- `cargo build --workspace --release`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `cargo doc --workspace --no-deps`
- `cargo audit` (configured allowed yanked warning only)
- `cargo deny check`
- `./tools/cross-impl-test/compare.sh`
- `bash tools/test_release_version_alignment.sh`
- `bash tools/test_proprietary_license_boundaries.sh`
- `git diff --check`

## Release truth

The signed v0.2.3 tag remains immutable at `a50a15fd17a171deec012b9b07f6ed8f9f1e8bf6`; this post-publication documentation commit updates `main` without changing published artifacts.