### PR TITLE
feat(pdp): runtime authority and independently verifiable evidence packs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -720,7 +720,7 @@ jobs:
         run: npm pack --dry-run
         working-directory: packages/exochain-wasm/wasm
       - name: Verify WASM exports
-        # Expected export count = 165. Baseline was 110 before
+        # Expected export count = 166. Baseline was 110 before
         # decision-forum, messaging, death-trigger, and franchise/NewCo
         # scaffold were added; the adjudicated decision transition bridge
         # adds the current security boundary, and the HonorGood economy bridge
@@ -734,7 +734,7 @@ jobs:
         run: |
           COUNT=$(grep -c "module.exports.wasm_" packages/exochain-wasm/wasm/exochain_wasm.js)
           echo "Found $COUNT WASM exports"
-          [ "$COUNT" -eq 165 ] || (echo "Expected 165 exports, got $COUNT" && exit 1)
+          [ "$COUNT" -eq 166 ] || (echo "Expected 166 exports, got $COUNT" && exit 1)
       - name: Upload WASM artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
@@ -776,7 +776,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Verify Rust exports match JS expectations
-        # Expected #[wasm_bindgen] count = 165. Baseline was 110 before the
+        # Expected #[wasm_bindgen] count = 166. Baseline was 110 before the
         # Sprint-4 additions (decision-forum, messaging, death-trigger,
         # franchise/NewCo scaffold); the adjudicated decision transition bridge
         # adds the current security boundary, the HonorGood economy bridge
@@ -791,7 +791,7 @@ jobs:
         run: |
           RUST_COUNT=$(grep -r '#\[wasm_bindgen\]' crates/exochain-wasm/src/ | wc -l | tr -d ' ')
           echo "Rust #[wasm_bindgen] exports: $RUST_COUNT"
-          [ "$RUST_COUNT" -eq 165 ] || (echo "WASM export count changed from 165 to $RUST_COUNT — update bridge tests" && exit 1)
+          [ "$RUST_COUNT" -eq 166 ] || (echo "WASM export count changed from 166 to $RUST_COUNT — update bridge tests" && exit 1)
 
   # -----------------------------------------------------------------------
   # Gate 23: Unaudited feature matrix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -414,6 +414,7 @@ jobs:
             exochain-identity
             exochain-api
             exochain-authority
+            exochain-pdp
             exochain-avc
             exochain-consent
             exochain-dag-db-core

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,7 +1439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.111",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1725,7 +1725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1741,11 +1741,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -2263,16 +2262,13 @@ name = "exochain-pdp"
 version = "0.2.3"
 dependencies = [
  "axum 0.7.9",
- "blake3",
- "ed25519-dalek",
+ "ciborium",
  "exochain-authority",
  "exochain-core",
  "hex",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -3240,7 +3236,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5088,9 +5084,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45caf26f647c19115bf9c453c70ffe4a4a3a6390dceebd942610584f99b8ddce"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "borsh",
  "proptest",
@@ -5156,7 +5152,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5848,7 +5844,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6698,7 +6694,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2218,6 +2218,7 @@ dependencies = [
  "exochain-governance",
  "exochain-identity",
  "exochain-legal",
+ "exochain-pdp",
  "exochain-root",
  "exochain-sdk",
  "futures",
@@ -2255,6 +2256,23 @@ dependencies = [
  "x25519-dalek",
  "x509-cert",
  "zeroize",
+]
+
+[[package]]
+name = "exochain-pdp"
+version = "0.2.3"
+dependencies = [
+ "axum 0.7.9",
+ "blake3",
+ "ed25519-dalek",
+ "exochain-authority",
+ "exochain-core",
+ "hex",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2343,6 +2361,7 @@ dependencies = [
  "exochain-identity",
  "exochain-legal",
  "exochain-messaging",
+ "exochain-pdp",
  "exochain-proofs",
  "getrandom 0.2.16",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2269,6 +2269,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.17",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ members = [
     "crates/exo-avc",
     "crates/exo-economy",
     "crates/exo-root",
+    "crates/exo-pdp",
 ]
 # The livesafe/ and cybermedica/ subtrees are proprietary commercial
 # applications (see their subtree LICENSE files), not part of the Apache-2.0

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 |--------|-------|--------|
 | Rust crates | 32 | `cargo metadata --no-deps --format-version 1` |
 | Rust source files | 484 | `git ls-files 'crates/**/*.rs'` |
-| Workspace tests | 6,309 listed | `cargo test --workspace -- --list` |
+| Workspace tests | 6,311 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 23 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
 | Latest published release | `v0.2.3` (GitHub Release published 2026-07-15; all release crates plus `@exochain/exochain-wasm` and `@exochain/llm-proxy` resolve the same version) | `gh release list`; crates.io version API; `npm view @exochain/exochain-wasm version`; `npm view @exochain/llm-proxy version` |
 | License | Apache-2.0 for EXOCHAIN core primitives; commercial terms for Decision Forum, LegalDyne, CyberMedica, LiveSafe, and CrossChecked products | `governance/commercial-product-licensing.json`; product license files where present |
@@ -43,7 +43,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **6,309 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **6,311 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -126,7 +126,7 @@ Catalyst is named explicitly.
 Layer 1: CGR Kernel         (Rust, 32 crates)
          Constitutional governance runtime — deterministic, no floats,
          production Ed25519/BLAKE3 cryptography plus unaudited pedagogical
-         SNARK/STARK/ZKML skeletons, 6,309 listed workspace tests
+         SNARK/STARK/ZKML skeletons, 6,311 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          166 verified WASM exports covered by 175 bridge checks — Rust -> WebAssembly -> JavaScript

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 > Run `bash tools/repo_truth.sh` to regenerate these numbers from source.
 >
 > The crate count includes `exo-root`, `exo-catapult`, `exo-consensus`,
-> `exo-messaging`, `exochain-sdk`, `exo-avc`, and `exo-economy`.
+> `exo-messaging`, `exochain-sdk`, `exo-avc`, `exo-economy`, and `exo-pdp`.
 
 | Metric | Value | Source |
 |--------|-------|--------|
-| Rust crates | 31 | `ls -d crates/*/` |
-| Rust source files | 471 | `git ls-files 'crates/**/*.rs'` |
-| Workspace tests | 6,267 listed | `cargo test --workspace -- --list` |
+| Rust crates | 32 | `cargo metadata --no-deps --format-version 1` |
+| Rust source files | 484 | `git ls-files 'crates/**/*.rs'` |
+| Workspace tests | 6,309 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 23 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
 | Latest published release | `v0.2.3` (GitHub Release published 2026-07-15; all release crates plus `@exochain/exochain-wasm` and `@exochain/llm-proxy` resolve the same version) | `gh release list`; crates.io version API; `npm view @exochain/exochain-wasm version`; `npm view @exochain/llm-proxy version` |
 | License | Apache-2.0 for EXOCHAIN core primitives; commercial terms for Decision Forum, LegalDyne, CyberMedica, LiveSafe, and CrossChecked products | `governance/commercial-product-licensing.json`; product license files where present |
@@ -43,7 +43,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **6,267 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **6,309 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -123,13 +123,13 @@ Catalyst is named explicitly.
 ## Architecture
 
 ```
-Layer 1: CGR Kernel         (Rust, 31 crates)
+Layer 1: CGR Kernel         (Rust, 32 crates)
          Constitutional governance runtime — deterministic, no floats,
          production Ed25519/BLAKE3 cryptography plus unaudited pedagogical
-         SNARK/STARK/ZKML skeletons, 6,267 listed workspace tests
+         SNARK/STARK/ZKML skeletons, 6,309 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
-         165 verified WASM exports covered by 172 bridge checks — Rust -> WebAssembly -> JavaScript
+         166 verified WASM exports covered by 175 bridge checks — Rust -> WebAssembly -> JavaScript
 
 Layer 3: CommandBase.ai     (command-base/)
          Adjacent cockpit adapter for cognitiveplane.ai

--- a/crates/exo-authority/src/delegation.rs
+++ b/crates/exo-authority/src/delegation.rs
@@ -511,6 +511,40 @@ impl DelegationRegistry {
         Ok(revocation)
     }
 
+    /// Number of active delegations granted by `did`.
+    #[must_use]
+    pub fn granted_by(&self, did: &Did) -> usize {
+        self.by_delegator
+            .get(did.as_str())
+            .map(Vec::len)
+            .unwrap_or(0)
+    }
+
+    /// Number of active delegations received by `did`.
+    #[must_use]
+    pub fn received_by(&self, did: &Did) -> usize {
+        self.by_delegate
+            .get(did.as_str())
+            .map(Vec::len)
+            .unwrap_or(0)
+    }
+
+    /// Union of permissions on links where `did` is the delegate.
+    #[must_use]
+    pub fn permissions_held_by(&self, did: &Did) -> crate::permission::PermissionSet {
+        let mut set = crate::permission::PermissionSet::empty();
+        if let Some(ids) = self.by_delegate.get(did.as_str()) {
+            for id in ids {
+                if let Some(link) = self.links.get(id) {
+                    for p in &link.scope {
+                        set.insert(*p);
+                    }
+                }
+            }
+        }
+        set
+    }
+
     /// Find a delegation chain from `from` to `to`.
     #[must_use]
     pub fn find_chain(&self, from: &Did, to: &Did) -> Option<AuthorityChain> {

--- a/crates/exo-authority/src/delegation.rs
+++ b/crates/exo-authority/src/delegation.rs
@@ -33,7 +33,7 @@ const DELEGATION_AUDIT_EVENT_DOMAIN: &str = "exo.authority.delegation_audit_even
 const DELEGATION_AUDIT_EVENT_SCHEMA_VERSION: u16 = 1;
 
 /// Registry of all active delegations.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DelegationRegistry {
     /// Links indexed by their hash ID.
     links: BTreeMap<Hash256, AuthorityLink>,
@@ -310,6 +310,82 @@ impl DelegationRegistry {
             }
             previous_event_hash = event.event_hash;
         }
+        Ok(())
+    }
+
+    /// Validate a deserialized registry before it becomes authoritative.
+    ///
+    /// This closes over the active-link signatures and every derived index in
+    /// addition to the append-only audit chain.
+    pub fn validate_persisted_state(&self) -> Result<(), AuthorityError> {
+        self.verify_audit_chain()?;
+
+        if self.links.len() != self.link_delegator_public_keys.len() {
+            return Err(AuthorityError::InvalidDelegation {
+                reason: "persisted delegation link/key cardinality mismatch".into(),
+            });
+        }
+
+        for (id, link) in &self.links {
+            if link.id()? != *id {
+                return Err(AuthorityError::InvalidDelegation {
+                    reason: format!("persisted delegation id mismatch for {id}"),
+                });
+            }
+            let key = self.link_delegator_public_keys.get(id).ok_or_else(|| {
+                AuthorityError::InvalidDelegation {
+                    reason: format!("persisted delegation {id} has no verifying key"),
+                }
+            })?;
+            if !crypto::verify(&link.signing_payload()?, &link.signature, key) {
+                return Err(AuthorityError::InvalidSignature { index: link.depth });
+            }
+            let forward = self
+                .by_delegator
+                .get(link.delegator_did.as_str())
+                .is_some_and(|ids| ids.iter().any(|candidate| candidate == id));
+            let reverse = self
+                .by_delegate
+                .get(link.delegate_did.as_str())
+                .is_some_and(|ids| ids.iter().any(|candidate| candidate == id));
+            if !forward || !reverse {
+                return Err(AuthorityError::InvalidDelegation {
+                    reason: format!("persisted delegation {id} is missing a derived index"),
+                });
+            }
+        }
+
+        for (did, ids) in &self.by_delegator {
+            for id in ids {
+                let link = self
+                    .links
+                    .get(id)
+                    .ok_or_else(|| AuthorityError::InvalidDelegation {
+                        reason: format!("delegator index {did} references missing link {id}"),
+                    })?;
+                if link.delegator_did.as_str() != did {
+                    return Err(AuthorityError::InvalidDelegation {
+                        reason: format!("delegator index {did} misbinds link {id}"),
+                    });
+                }
+            }
+        }
+        for (did, ids) in &self.by_delegate {
+            for id in ids {
+                let link = self
+                    .links
+                    .get(id)
+                    .ok_or_else(|| AuthorityError::InvalidDelegation {
+                        reason: format!("delegate index {did} references missing link {id}"),
+                    })?;
+                if link.delegate_did.as_str() != did {
+                    return Err(AuthorityError::InvalidDelegation {
+                        reason: format!("delegate index {did} misbinds link {id}"),
+                    });
+                }
+            }
+        }
+
         Ok(())
     }
 

--- a/crates/exo-authority/src/lib.rs
+++ b/crates/exo-authority/src/lib.rs
@@ -30,8 +30,8 @@ pub mod permission;
 pub use cache::ChainCache;
 pub use chain::{AuthorityChain, AuthorityLink, DelegateeKind};
 pub use delegation::{
-    AuthorityRevocation, DelegationAuditAction, DelegationAuditEvent, DelegationRegistry,
-    DelegationRevocationGrant,
+    AuthorityRevocation, DelegationAuditAction, DelegationAuditEvent, DelegationGrant,
+    DelegationRegistry, DelegationRevocationGrant,
 };
 pub use error::AuthorityError;
 pub use permission::{Permission, PermissionSet};

--- a/crates/exo-authority/src/permission.rs
+++ b/crates/exo-authority/src/permission.rs
@@ -30,6 +30,8 @@ pub enum Permission {
     Govern,
     Escalate,
     Challenge,
+    /// Authorize an agent to initiate a payment. Never grants custody.
+    Spend,
 }
 
 /// A deterministic set of permissions (BTreeSet for canonical ordering).
@@ -207,6 +209,7 @@ mod tests {
         assert_ne!(Permission::Execute, Permission::Delegate);
         assert_ne!(Permission::Govern, Permission::Escalate);
         assert_ne!(Permission::Challenge, Permission::Read);
+        assert_ne!(Permission::Spend, Permission::Read);
         assert_eq!(Permission::Read, Permission::Read);
     }
 

--- a/crates/exo-node/Cargo.toml
+++ b/crates/exo-node/Cargo.toml
@@ -48,6 +48,7 @@ exo-avc = { package = "exochain-avc", path = "../exo-avc", version = "=0.2.3" }
 exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.3" }
 exo-economy = { package = "exochain-economy", path = "../exo-economy", version = "=0.2.3" }
 exo-root = { package = "exochain-root", path = "../exo-root", version = "=0.2.3" }
+exo-pdp = { package = "exochain-pdp", path = "../exo-pdp", version = "=0.2.3" }
 
 # DAG DB MCP gateway proxy client (P1-B SDK). The default node compiles the
 # governed gateway proxy transport so MCP DAG DB tools can call the production

--- a/crates/exo-node/src/auth.rs
+++ b/crates/exo-node/src/auth.rs
@@ -204,6 +204,7 @@ fn is_sensitive_read_path(path: &str) -> bool {
         || path.starts_with("/api/v1/receipts/")
         || path.starts_with("/api/v1/provenance/")
         || path.starts_with("/api/v1/avc/")
+        || path.starts_with("/api/v1/authority/")
         || path == "/api/v1/challenges"
         || path.starts_with("/api/v1/challenges/")
         || path == "/exoforge"
@@ -861,6 +862,17 @@ mod tests {
         assert!(is_sensitive_read_path("/api/v1/forge/tasks"));
         assert!(is_sensitive_read_path("/api/v1/forge/stats"));
         assert!(is_sensitive_read_path("/api/v1/forge/activity"));
+    }
+
+    #[test]
+    fn authority_evidence_reads_require_bearer_authentication() {
+        assert!(is_sensitive_read_path("/api/v1/authority/pack"));
+        assert!(is_sensitive_read_path(
+            "/api/v1/authority/evidence/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ));
+        assert!(is_sensitive_read_path(
+            "/api/v1/authority/evidence/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/verify"
+        ));
     }
 
     #[tokio::test]

--- a/crates/exo-node/src/cli.rs
+++ b/crates/exo-node/src/cli.rs
@@ -198,6 +198,29 @@ pub enum Command {
         #[command(subcommand)]
         command: AvcCommand,
     },
+
+    /// Policy decision point — never moves money.
+    Pdp {
+        #[command(subcommand)]
+        command: PdpCommand,
+    },
+}
+
+/// Offline evidence-pack tools. A third party can verify a pack without a node.
+#[derive(Subcommand)]
+pub enum PdpCommand {
+    /// Independently verify an exported evidence pack (Article 26 log).
+    Verify {
+        /// Path to `pdp-evidence.json` (or any `exochain-evidence-pack-v1` file).
+        #[arg(long)]
+        pack: PathBuf,
+    },
+    /// Print Article 26 summary of a pack without mutating it.
+    Inspect {
+        /// Path to an evidence pack.
+        #[arg(long)]
+        pack: PathBuf,
+    },
 }
 
 #[derive(Subcommand)]

--- a/crates/exo-node/src/cli.rs
+++ b/crates/exo-node/src/cli.rs
@@ -206,7 +206,7 @@ pub enum Command {
     },
 }
 
-/// Offline evidence-pack tools. A third party can verify a pack without a node.
+/// Offline evidence-pack tools. Verification requires a separately obtained service key.
 #[derive(Subcommand)]
 pub enum PdpCommand {
     /// Independently verify an exported evidence pack (Article 26 log).
@@ -214,8 +214,11 @@ pub enum PdpCommand {
         /// Path to `pdp-evidence.json` (or any `exochain-evidence-pack-v1` file).
         #[arg(long)]
         pack: PathBuf,
+        /// Trusted service Ed25519 public key (32-byte hex), obtained separately.
+        #[arg(long)]
+        service_public_key: String,
     },
-    /// Print Article 26 summary of a pack without mutating it.
+    /// Print an unverified Article 26 summary without mutating the pack.
     Inspect {
         /// Path to an evidence pack.
         #[arg(long)]

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -1277,19 +1277,30 @@ async fn start_node(
     let pdp = pdp_store::load_or_create(data_dir)?;
     let shared_pdp = exo_pdp::SharedPdp::from_pdp(pdp);
     let persist_pdp = shared_pdp.clone();
+    let shutdown_pdp = shared_pdp.clone();
     let persist_dir = data_dir.to_path_buf();
-    tokio::spawn(async move {
+    background_tasks.spawn_critical("PDP state persistence", async move {
         let mut tick = tokio::time::interval(std::time::Duration::from_secs(5));
         loop {
             tick.tick().await;
-            if let Ok(guard) = persist_pdp.lock() {
-                if let Err(e) = pdp_store::save(&persist_dir, &guard) {
-                    tracing::warn!(err = %e, "failed to persist PDP evidence pack");
+            let guard = match persist_pdp.lock() {
+                Ok(guard) => guard,
+                Err(error) => {
+                    tracing::error!(err = %error, "PDP state lock failed; stopping node");
+                    return;
                 }
+            };
+            if let Err(error) = pdp_store::save(&persist_dir, &guard) {
+                tracing::error!(err = %error, "PDP state persistence failed; stopping node");
+                return;
             }
         }
     });
-    let pdp_router = exo_pdp::http::pdp_router(shared_pdp);
+    let request_persist_dir = data_dir.to_path_buf();
+    let pdp_router = exo_pdp::http::pdp_router_with_persistence(shared_pdp, move |pdp| {
+        pdp_store::save(&request_persist_dir, pdp)
+            .map_err(|error| exo_pdp::PdpError::Persistence(error.to_string()))
+    });
 
     let extra_router = metrics_router
         .merge(governance_router)
@@ -1366,6 +1377,10 @@ async fn start_node(
         task_result = background_tasks.next_failure() => task_result,
     };
     background_tasks.shutdown().await;
+    {
+        let guard = shutdown_pdp.lock()?;
+        pdp_store::save(data_dir, &guard)?;
+    }
     run_result?;
 
     tracing::info!("HTTP server drained — signaling subsystems to stop");
@@ -1539,10 +1554,14 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
 
 fn run_pdp(command: cli::PdpCommand) -> anyhow::Result<()> {
     match command {
-        cli::PdpCommand::Verify { pack } => {
+        cli::PdpCommand::Verify {
+            pack,
+            service_public_key,
+        } => {
             let bytes = std::fs::read(&pack)?;
             let pack = exo_pdp::EvidencePack::from_json(&bytes)?;
-            pack.verify()?;
+            let expected_key = exo_pdp::pack::parse_public_key_hex(&service_public_key)?;
+            pack.verify_with_key(&expected_key)?;
             println!("ok");
             println!("spec:                 {}", pack.spec);
             println!("never_moves_money:    {}", pack.never_moves_money);
@@ -1558,7 +1577,16 @@ fn run_pdp(command: cli::PdpCommand) -> anyhow::Result<()> {
         cli::PdpCommand::Inspect { pack } => {
             let bytes = std::fs::read(&pack)?;
             let pack = exo_pdp::EvidencePack::from_json(&bytes)?;
-            println!("{}", String::from_utf8_lossy(&pack.to_json()?));
+            println!("unverified:           true");
+            println!("spec:                 {}", pack.spec);
+            println!("never_moves_money:    {}", pack.never_moves_money);
+            println!("entries:              {}", pack.entries.len());
+            println!(
+                "article_26.retention: {} days",
+                pack.article_26.retention_days_min
+            );
+            println!("article_26.denies:    {}", pack.article_26.incident_denies);
+            println!("tip:                  {}", pack.tip_hex);
             Ok(())
         }
     }
@@ -1929,6 +1957,11 @@ mod tests {
         assert!(
             !production.contains("tokio::spawn("),
             "startup must not discard JoinHandles from raw tokio::spawn"
+        );
+        assert!(
+            production.contains("spawn_critical(\"PDP state persistence\"")
+                && production.contains("pdp_router_with_persistence"),
+            "PDP state must be synchronously durable and supervised"
         );
     }
 

--- a/crates/exo-node/src/main.rs
+++ b/crates/exo-node/src/main.rs
@@ -53,6 +53,7 @@ mod mcp;
 mod metrics;
 mod network;
 mod passport;
+mod pdp_store;
 mod provenance;
 mod reactor;
 mod receipt_dashboard;
@@ -1273,8 +1274,26 @@ async fn start_node(
     // and apply bearer-token auth middleware. 0dentity signed writes use their
     // local DID session and request-signature verifiers.
     // NOTE: /health and /ready are provided by the gateway's own router.
+    let pdp = pdp_store::load_or_create(data_dir)?;
+    let shared_pdp = exo_pdp::SharedPdp::from_pdp(pdp);
+    let persist_pdp = shared_pdp.clone();
+    let persist_dir = data_dir.to_path_buf();
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(std::time::Duration::from_secs(5));
+        loop {
+            tick.tick().await;
+            if let Ok(guard) = persist_pdp.lock() {
+                if let Err(e) = pdp_store::save(&persist_dir, &guard) {
+                    tracing::warn!(err = %e, "failed to persist PDP evidence pack");
+                }
+            }
+        }
+    });
+    let pdp_router = exo_pdp::http::pdp_router(shared_pdp);
+
     let extra_router = metrics_router
         .merge(governance_router)
+        .merge(pdp_router)
         .merge(passport_router)
         .merge(dashboard_router)
         .merge(challenge_router)
@@ -1450,6 +1469,8 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             Ok(())
         }
 
+        Command::Pdp { command } => run_pdp(command),
+
         Command::Mcp {
             data_dir,
             actor_did,
@@ -1512,6 +1533,33 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
         Command::Genesis { command } => root_genesis_cli::run_genesis_command(command).await,
         Command::Avc { command } => {
             livesafe_public_output_ceremony_cli::run_avc_command(command).await
+        }
+    }
+}
+
+fn run_pdp(command: cli::PdpCommand) -> anyhow::Result<()> {
+    match command {
+        cli::PdpCommand::Verify { pack } => {
+            let bytes = std::fs::read(&pack)?;
+            let pack = exo_pdp::EvidencePack::from_json(&bytes)?;
+            pack.verify()?;
+            println!("ok");
+            println!("spec:                 {}", pack.spec);
+            println!("never_moves_money:    {}", pack.never_moves_money);
+            println!("entries:              {}", pack.entries.len());
+            println!(
+                "article_26.retention: {} days",
+                pack.article_26.retention_days_min
+            );
+            println!("article_26.denies:    {}", pack.article_26.incident_denies);
+            println!("tip:                  {}", pack.tip_hex);
+            Ok(())
+        }
+        cli::PdpCommand::Inspect { pack } => {
+            let bytes = std::fs::read(&pack)?;
+            let pack = exo_pdp::EvidencePack::from_json(&bytes)?;
+            println!("{}", String::from_utf8_lossy(&pack.to_json()?));
+            Ok(())
         }
     }
 }

--- a/crates/exo-node/src/pdp_store.rs
+++ b/crates/exo-node/src/pdp_store.rs
@@ -1,0 +1,76 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+//! Durable PDP identity + Article 26 evidence pack.
+
+use std::path::Path;
+
+use exo_core::crypto::KeyPair;
+use exo_pdp::{EvidencePack, PolicyDecisionPoint};
+
+/// Load a durable PDP from `data_dir`, or create one and persist the key.
+pub fn load_or_create(data_dir: &Path) -> anyhow::Result<PolicyDecisionPoint> {
+    std::fs::create_dir_all(data_dir)?;
+    let key_path = data_dir.join("pdp.key");
+    let pack_path = data_dir.join("pdp-evidence.json");
+
+    let keypair = if key_path.exists() {
+        let secret_bytes = std::fs::read(&key_path)?;
+        if secret_bytes.len() != 32 {
+            anyhow::bail!(
+                "corrupt PDP key at {} — expected 32 bytes, got {}",
+                key_path.display(),
+                secret_bytes.len()
+            );
+        }
+        let mut buf = [0u8; 32];
+        buf.copy_from_slice(&secret_bytes);
+        KeyPair::from_secret_bytes(buf)?
+    } else {
+        let keypair = KeyPair::generate();
+        std::fs::write(&key_path, keypair.secret_key().as_bytes())?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&key_path)?.permissions();
+            perms.set_mode(0o600);
+            std::fs::set_permissions(&key_path, perms)?;
+        }
+        keypair
+    };
+
+    let mut pdp = PolicyDecisionPoint::new(keypair);
+    if pack_path.exists() {
+        let bytes = std::fs::read(&pack_path)?;
+        let pack = EvidencePack::from_json(&bytes)?;
+        pdp.import_pack(pack)?;
+        tracing::info!(path = %pack_path.display(), "loaded PDP evidence pack");
+    }
+    Ok(pdp)
+}
+
+/// Write the current pack to disk (Article 26 retention copy).
+pub fn save(data_dir: &Path, pdp: &PolicyDecisionPoint) -> anyhow::Result<()> {
+    let pack = pdp.export_pack();
+    let bytes = pack.to_json()?;
+    let tmp = data_dir.join("pdp-evidence.json.tmp");
+    let dest = data_dir.join("pdp-evidence.json");
+    std::fs::write(&tmp, bytes)?;
+    std::fs::rename(&tmp, dest)?;
+    Ok(())
+}

--- a/crates/exo-node/src/pdp_store.rs
+++ b/crates/exo-node/src/pdp_store.rs
@@ -16,61 +16,179 @@
 
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
-//! Durable PDP identity + Article 26 evidence pack.
+//! Durable PDP identity and service-signed runtime authority state.
 
-use std::path::Path;
+use std::{
+    fs::{File, OpenOptions},
+    io::{ErrorKind, Read, Write},
+    path::Path,
+};
 
 use exo_core::crypto::KeyPair;
-use exo_pdp::{EvidencePack, PolicyDecisionPoint};
+use exo_pdp::{PdpSnapshot, PolicyDecisionPoint};
+
+const KEY_FILE: &str = "pdp.key";
+const STATE_FILE: &str = "pdp-state.cbor";
+
+fn open_private_new(path: &Path) -> std::io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options.open(path)
+}
+
+fn read_key(path: &Path) -> anyhow::Result<KeyPair> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(path)?.permissions().mode() & 0o777;
+        if mode & 0o077 != 0 {
+            anyhow::bail!(
+                "PDP key at {} has unsafe mode {:o}; expected owner-only permissions",
+                path.display(),
+                mode
+            );
+        }
+    }
+    let mut file = OpenOptions::new().read(true).open(path)?;
+    let mut secret_bytes = Vec::new();
+    file.read_to_end(&mut secret_bytes)?;
+    if secret_bytes.len() != 32 {
+        anyhow::bail!(
+            "corrupt PDP key at {} — expected 32 bytes, got {}",
+            path.display(),
+            secret_bytes.len()
+        );
+    }
+    let mut buf = [0u8; 32];
+    buf.copy_from_slice(&secret_bytes);
+    Ok(KeyPair::from_secret_bytes(buf)?)
+}
+
+fn load_or_create_key(path: &Path) -> anyhow::Result<KeyPair> {
+    match read_key(path) {
+        Ok(key) => Ok(key),
+        Err(read_error)
+            if read_error
+                .downcast_ref::<std::io::Error>()
+                .is_some_and(|error| error.kind() == ErrorKind::NotFound) =>
+        {
+            let keypair = KeyPair::generate();
+            match open_private_new(path) {
+                Ok(mut file) => {
+                    file.write_all(keypair.secret_key().as_bytes())?;
+                    file.sync_all()?;
+                    Ok(keypair)
+                }
+                Err(error) if error.kind() == ErrorKind::AlreadyExists => read_key(path),
+                Err(error) => Err(error.into()),
+            }
+        }
+        Err(error) => Err(error),
+    }
+}
 
 /// Load a durable PDP from `data_dir`, or create one and persist the key.
 pub fn load_or_create(data_dir: &Path) -> anyhow::Result<PolicyDecisionPoint> {
     std::fs::create_dir_all(data_dir)?;
-    let key_path = data_dir.join("pdp.key");
-    let pack_path = data_dir.join("pdp-evidence.json");
-
-    let keypair = if key_path.exists() {
-        let secret_bytes = std::fs::read(&key_path)?;
-        if secret_bytes.len() != 32 {
-            anyhow::bail!(
-                "corrupt PDP key at {} — expected 32 bytes, got {}",
-                key_path.display(),
-                secret_bytes.len()
-            );
-        }
-        let mut buf = [0u8; 32];
-        buf.copy_from_slice(&secret_bytes);
-        KeyPair::from_secret_bytes(buf)?
-    } else {
-        let keypair = KeyPair::generate();
-        std::fs::write(&key_path, keypair.secret_key().as_bytes())?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = std::fs::metadata(&key_path)?.permissions();
-            perms.set_mode(0o600);
-            std::fs::set_permissions(&key_path, perms)?;
-        }
-        keypair
-    };
+    let key_path = data_dir.join(KEY_FILE);
+    let state_path = data_dir.join(STATE_FILE);
+    let keypair = load_or_create_key(&key_path)?;
 
     let mut pdp = PolicyDecisionPoint::new(keypair);
-    if pack_path.exists() {
-        let bytes = std::fs::read(&pack_path)?;
-        let pack = EvidencePack::from_json(&bytes)?;
-        pdp.import_pack(pack)?;
-        tracing::info!(path = %pack_path.display(), "loaded PDP evidence pack");
+    match std::fs::read(&state_path) {
+        Ok(bytes) => {
+            let snapshot = PdpSnapshot::from_cbor(&bytes)?;
+            pdp.import_snapshot(snapshot)?;
+            tracing::info!(path = %state_path.display(), "loaded signed PDP runtime state");
+        }
+        Err(error) if error.kind() == ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
     }
     Ok(pdp)
 }
 
-/// Write the current pack to disk (Article 26 retention copy).
+/// Atomically write all signed PDP runtime state to disk.
 pub fn save(data_dir: &Path, pdp: &PolicyDecisionPoint) -> anyhow::Result<()> {
-    let pack = pdp.export_pack();
-    let bytes = pack.to_json()?;
-    let tmp = data_dir.join("pdp-evidence.json.tmp");
-    let dest = data_dir.join("pdp-evidence.json");
-    std::fs::write(&tmp, bytes)?;
-    std::fs::rename(&tmp, dest)?;
+    let bytes = pdp.export_snapshot()?.to_cbor()?;
+    let tmp = data_dir.join("pdp-state.cbor.tmp");
+    let dest = data_dir.join(STATE_FILE);
+    let mut file = open_private_new(&tmp)?;
+    file.write_all(&bytes)?;
+    file.sync_all()?;
+    drop(file);
+    std::fs::rename(&tmp, &dest)?;
+    File::open(data_dir)?.sync_all()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use exo_core::{Did, Hash256, Timestamp, crypto::KeyPair};
+
+    use super::*;
+
+    #[test]
+    fn restart_preserves_key_revocation_and_consumed_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut pdp = load_or_create(dir.path()).unwrap();
+        let principal = Did::new("did:exo:principal").unwrap();
+        let principal_key = KeyPair::generate();
+        let mandate_hash = Hash256::digest(b"durable-mandate");
+        pdp.register_key(principal.clone(), *principal_key.public_key());
+        pdp.reserve(mandate_hash, Timestamp::new(1, 0)).unwrap();
+        pdp.commit(&mandate_hash).unwrap();
+        pdp.revoke_mandate(mandate_hash, Timestamp::new(2, 0), "revoked".into());
+        let service_public_key = pdp.service_public_key();
+        save(dir.path(), &pdp).unwrap();
+
+        let restored = load_or_create(dir.path()).unwrap();
+        assert_eq!(restored.service_public_key(), service_public_key);
+        assert_eq!(
+            restored.resolve_public(&principal),
+            Some(*principal_key.public_key())
+        );
+        assert!(restored.is_consumed(&mandate_hash));
+        assert!(restored.is_mandate_revoked(&mandate_hash));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn new_key_and_state_files_are_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let pdp = load_or_create(dir.path()).unwrap();
+        save(dir.path(), &pdp).unwrap();
+        let key_mode = std::fs::metadata(dir.path().join(KEY_FILE))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        let state_mode = std::fs::metadata(dir.path().join(STATE_FILE))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(key_mode, 0o600);
+        assert_eq!(state_mode, 0o600);
+    }
+
+    #[test]
+    fn existing_key_is_never_overwritten() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(KEY_FILE);
+        let original = [7u8; 32];
+        let mut file = open_private_new(&path).unwrap();
+        file.write_all(&original).unwrap();
+        file.sync_all().unwrap();
+
+        let loaded = load_or_create(dir.path()).unwrap();
+        assert_eq!(loaded.service_secret_bytes(), original);
+        assert_eq!(std::fs::read(path).unwrap(), original);
+    }
 }

--- a/crates/exo-pdp/Cargo.toml
+++ b/crates/exo-pdp/Cargo.toml
@@ -1,0 +1,50 @@
+# Copyright 2026 Exochain Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "exochain-pdp"
+description = "EXOCHAIN policy decision point — mandate verify, deny-outranks-payment, revocation, signed evidence"
+documentation = "https://docs.rs/exochain-pdp"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[lib]
+name = "exo_pdp"
+path = "src/lib.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3" }
+exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.3" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+blake3 = { workspace = true }
+ed25519-dalek = { workspace = true }
+hex = { workspace = true }
+axum = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true }
+tracing = { workspace = true }
+
+[features]
+default = ["http"]
+http = ["dep:axum", "dep:tokio"]

--- a/crates/exo-pdp/Cargo.toml
+++ b/crates/exo-pdp/Cargo.toml
@@ -45,3 +45,6 @@ axum = { workspace = true, optional = true }
 [features]
 default = ["http"]
 http = ["dep:axum"]
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/exo-pdp/Cargo.toml
+++ b/crates/exo-pdp/Cargo.toml
@@ -37,14 +37,11 @@ exo-core = { package = "exochain-core", path = "../exo-core", version = "=0.2.3"
 exo-authority = { package = "exochain-authority", path = "../exo-authority", version = "=0.2.3" }
 serde = { workspace = true }
 serde_json = { workspace = true }
+ciborium = { workspace = true }
 thiserror = { workspace = true }
-blake3 = { workspace = true }
-ed25519-dalek = { workspace = true }
 hex = { workspace = true }
 axum = { workspace = true, optional = true }
-tokio = { workspace = true, optional = true }
-tracing = { workspace = true }
 
 [features]
 default = ["http"]
-http = ["dep:axum", "dep:tokio"]
+http = ["dep:axum"]

--- a/crates/exo-pdp/src/error.rs
+++ b/crates/exo-pdp/src/error.rs
@@ -1,0 +1,124 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Policy-decision-point errors.
+
+use thiserror::Error;
+
+/// Failures produced by mandate verification, policy evaluation, or evidence.
+#[derive(Debug, Error, PartialEq, Eq, Clone)]
+pub enum PdpError {
+    #[error("invalid mandate: {0}")]
+    InvalidMandate(String),
+
+    #[error("invalid signature")]
+    InvalidSignature,
+
+    #[error("mandate expired")]
+    Expired,
+
+    #[error("mandate revoked")]
+    Revoked,
+
+    #[error("mandate already consumed")]
+    AlreadyConsumed,
+
+    #[error("mandate already reserved")]
+    AlreadyReserved,
+
+    #[error("reservation not found: {0}")]
+    ReservationNotFound(String),
+
+    #[error("reservation not in expected state")]
+    ReservationState,
+
+    #[error("policy denied: {0}")]
+    Denied(String),
+
+    #[error("caveat failed: {0}")]
+    CaveatFailed(String),
+
+    #[error("delegation required")]
+    DelegationRequired,
+
+    #[error("scope widening is forbidden")]
+    ScopeWidening,
+
+    #[error("unknown principal or agent: {0}")]
+    UnknownActor(String),
+
+    #[error("evidence not found")]
+    EvidenceNotFound,
+
+    #[error("evidence chain broken")]
+    EvidenceBroken,
+
+    #[error("lock poisoned")]
+    LockPoisoned,
+
+    #[error("bad request: {0}")]
+    BadRequest(String),
+
+    #[error("authority: {0}")]
+    Authority(String),
+}
+
+impl From<exo_authority::AuthorityError> for PdpError {
+    fn from(e: exo_authority::AuthorityError) -> Self {
+        Self::Authority(e.to_string())
+    }
+}
+
+impl From<exo_core::ExoError> for PdpError {
+    fn from(e: exo_core::ExoError) -> Self {
+        Self::BadRequest(e.to_string())
+    }
+}
+
+/// Convenience alias.
+pub type Result<T> = std::result::Result<T, PdpError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_covers_variants() {
+        let errs = [
+            PdpError::InvalidMandate("x".into()),
+            PdpError::InvalidSignature,
+            PdpError::Expired,
+            PdpError::Revoked,
+            PdpError::AlreadyConsumed,
+            PdpError::AlreadyReserved,
+            PdpError::ReservationNotFound("h".into()),
+            PdpError::ReservationState,
+            PdpError::Denied("no".into()),
+            PdpError::CaveatFailed("amt".into()),
+            PdpError::DelegationRequired,
+            PdpError::ScopeWidening,
+            PdpError::UnknownActor("a".into()),
+            PdpError::EvidenceNotFound,
+            PdpError::EvidenceBroken,
+            PdpError::LockPoisoned,
+            PdpError::BadRequest("b".into()),
+            PdpError::Authority("c".into()),
+        ];
+        for e in errs {
+            assert!(!e.to_string().is_empty());
+        }
+    }
+}

--- a/crates/exo-pdp/src/error.rs
+++ b/crates/exo-pdp/src/error.rs
@@ -72,6 +72,12 @@ pub enum PdpError {
     #[error("bad request: {0}")]
     BadRequest(String),
 
+    #[error("canonical serialization failed: {0}")]
+    Serialization(String),
+
+    #[error("durable state persistence failed: {0}")]
+    Persistence(String),
+
     #[error("authority: {0}")]
     Authority(String),
 }
@@ -115,6 +121,8 @@ mod tests {
             PdpError::EvidenceBroken,
             PdpError::LockPoisoned,
             PdpError::BadRequest("b".into()),
+            PdpError::Serialization("s".into()),
+            PdpError::Persistence("p".into()),
             PdpError::Authority("c".into()),
         ];
         for e in errs {

--- a/crates/exo-pdp/src/evidence.rs
+++ b/crates/exo-pdp/src/evidence.rs
@@ -1,0 +1,324 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Third-party-verifiable, hash-chained evidence packs.
+//!
+//! The pack is the commercial artifact: independently checkable without
+//! trusting this process. EXOCHAIN never moves money; the pack only records
+//! the policy decision and the mandate that was evaluated.
+
+use std::collections::BTreeMap;
+
+use exo_core::{
+    Did, Hash256, PublicKey, Signature, Timestamp,
+    crypto::{KeyPair, verify},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    error::{PdpError, Result},
+    mandate::{Mandate, MandateKind, ProposedAction},
+};
+
+/// Policy outcome recorded in the evidence pack.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Decision {
+    Allow,
+    Deny,
+}
+
+/// Inputs for a new evidence entry.
+pub struct EvidenceDraft<'a> {
+    pub decision: Decision,
+    pub reason: String,
+    pub mandate: &'a Mandate,
+    pub proposed: &'a ProposedAction,
+    pub payment_presented: bool,
+    pub payment_outranked: bool,
+    pub now: Timestamp,
+}
+
+/// One hash-linked evidence entry.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvidenceEntry {
+    pub seq: u64,
+    pub prev_hash: Hash256,
+    pub entry_hash: Hash256,
+    pub decision: Decision,
+    pub reason: String,
+    pub mandate_hash: Hash256,
+    pub mandate_kind: MandateKind,
+    pub principal: Did,
+    pub agent: Did,
+    pub action: String,
+    pub amount_minor: Option<u64>,
+    pub currency: Option<String>,
+    pub payment_presented: bool,
+    pub payment_outranked: bool,
+    pub timestamp: Timestamp,
+    pub signature: Signature,
+}
+
+impl EvidenceEntry {
+    fn signable(&self) -> Vec<u8> {
+        let mut d = Vec::new();
+        d.extend_from_slice(&self.seq.to_le_bytes());
+        d.extend_from_slice(self.prev_hash.as_bytes());
+        d.extend_from_slice(format!("{:?}", self.decision).as_bytes());
+        d.extend_from_slice(self.reason.as_bytes());
+        d.extend_from_slice(self.mandate_hash.as_bytes());
+        d.extend_from_slice(format!("{:?}", self.mandate_kind).as_bytes());
+        d.extend_from_slice(self.principal.as_str().as_bytes());
+        d.extend_from_slice(self.agent.as_str().as_bytes());
+        d.extend_from_slice(self.action.as_bytes());
+        if let Some(a) = self.amount_minor {
+            d.extend_from_slice(&a.to_le_bytes());
+        }
+        if let Some(c) = &self.currency {
+            d.extend_from_slice(c.as_bytes());
+        }
+        d.push(u8::from(self.payment_presented));
+        d.push(u8::from(self.payment_outranked));
+        d.extend_from_slice(&self.timestamp.physical_ms.to_le_bytes());
+        d.extend_from_slice(&self.timestamp.logical.to_le_bytes());
+        d
+    }
+}
+
+/// Hash-chained, service-signed evidence log.
+#[derive(Debug)]
+pub struct EvidenceLog {
+    entries: Vec<EvidenceEntry>,
+    by_hash: BTreeMap<Hash256, usize>,
+    tip: Hash256,
+}
+
+impl Default for EvidenceLog {
+    fn default() -> Self {
+        Self {
+            entries: Vec::new(),
+            by_hash: BTreeMap::new(),
+            tip: Hash256::ZERO,
+        }
+    }
+}
+
+impl EvidenceLog {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append a signed entry. Returns the new entry.
+    pub fn append(&mut self, signer: &KeyPair, draft: EvidenceDraft<'_>) -> EvidenceEntry {
+        let seq = u64::try_from(self.entries.len()).unwrap_or(u64::MAX);
+        let mut entry = EvidenceEntry {
+            seq,
+            prev_hash: self.tip,
+            entry_hash: Hash256::ZERO,
+            decision: draft.decision,
+            reason: draft.reason,
+            mandate_hash: draft.mandate.mandate_hash(),
+            mandate_kind: draft.mandate.kind,
+            principal: draft.mandate.principal.clone(),
+            agent: draft.mandate.agent.clone(),
+            action: draft.proposed.action.clone(),
+            amount_minor: draft.proposed.amount_minor,
+            currency: draft.proposed.currency.clone(),
+            payment_presented: draft.payment_presented,
+            payment_outranked: draft.payment_outranked,
+            timestamp: draft.now,
+            signature: Signature::empty(),
+        };
+        let payload = entry.signable();
+        entry.signature = signer.sign(&payload);
+        entry.entry_hash = Hash256::digest(&payload);
+        self.by_hash.insert(entry.entry_hash, self.entries.len());
+        self.tip = entry.entry_hash;
+        self.entries.push(entry.clone());
+        entry
+    }
+
+    #[must_use]
+    pub fn get(&self, hash: &Hash256) -> Option<&EvidenceEntry> {
+        self.by_hash.get(hash).and_then(|i| self.entries.get(*i))
+    }
+
+    #[must_use]
+    pub fn tip(&self) -> Hash256 {
+        self.tip
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Exported entries in chain order.
+    #[must_use]
+    pub fn entries(&self) -> &[EvidenceEntry] {
+        &self.entries
+    }
+
+    /// Rebuild a log from previously exported entries. Does not verify signatures.
+    pub fn from_entries(entries: Vec<EvidenceEntry>) -> Result<Self> {
+        let mut log = Self::new();
+        for (i, e) in entries.into_iter().enumerate() {
+            let expect = u64::try_from(i).unwrap_or(u64::MAX);
+            if e.seq != expect {
+                return Err(PdpError::EvidenceBroken);
+            }
+            if e.prev_hash != log.tip {
+                return Err(PdpError::EvidenceBroken);
+            }
+            log.by_hash.insert(e.entry_hash, log.entries.len());
+            log.tip = e.entry_hash;
+            log.entries.push(e);
+        }
+        Ok(log)
+    }
+
+    /// Independently verify the whole chain against the service public key.
+    pub fn verify_all(&self, service_key: &PublicKey) -> Result<()> {
+        let mut expected_prev = Hash256::ZERO;
+        for (i, e) in self.entries.iter().enumerate() {
+            if e.prev_hash != expected_prev {
+                return Err(PdpError::EvidenceBroken);
+            }
+            let payload = e.signable();
+            if Hash256::digest(&payload) != e.entry_hash {
+                return Err(PdpError::EvidenceBroken);
+            }
+            if !verify(&payload, &e.signature, service_key) {
+                return Err(PdpError::InvalidSignature);
+            }
+            let expect_seq = u64::try_from(i).unwrap_or(u64::MAX);
+            if e.seq != expect_seq {
+                return Err(PdpError::EvidenceBroken);
+            }
+            expected_prev = e.entry_hash;
+        }
+        Ok(())
+    }
+
+    /// Verify a single entry (hash + signature). Does not walk the chain.
+    pub fn verify_entry(entry: &EvidenceEntry, service_key: &PublicKey) -> Result<()> {
+        let payload = entry.signable();
+        if Hash256::digest(&payload) != entry.entry_hash {
+            return Err(PdpError::EvidenceBroken);
+        }
+        if !verify(&payload, &entry.signature, service_key) {
+            return Err(PdpError::InvalidSignature);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mandate::MandateKind;
+
+    fn did(n: &str) -> Did {
+        Did::new(&format!("did:exo:{n}")).unwrap()
+    }
+
+    fn mandate() -> Mandate {
+        Mandate {
+            kind: MandateKind::Native,
+            principal: did("alice"),
+            agent: did("agent"),
+            action: "payment.settle".into(),
+            amount_minor: Some(100),
+            currency: Some("USD".into()),
+            merchant: None,
+            caveats: vec![],
+            expires: None,
+            consume_once: false,
+            signature: Signature::empty(),
+            raw_hash: Hash256::ZERO,
+        }
+    }
+
+    #[test]
+    fn chain_verifies() {
+        let kp = KeyPair::generate();
+        let mut log = EvidenceLog::new();
+        let proposed = ProposedAction {
+            action: "payment.settle".into(),
+            amount_minor: Some(100),
+            currency: Some("USD".into()),
+            merchant: None,
+            rail: None,
+        };
+        log.append(
+            &kp,
+            EvidenceDraft {
+                decision: Decision::Allow,
+                reason: "ok".into(),
+                mandate: &mandate(),
+                proposed: &proposed,
+                payment_presented: false,
+                payment_outranked: false,
+                now: Timestamp::new(1, 0),
+            },
+        );
+        log.append(
+            &kp,
+            EvidenceDraft {
+                decision: Decision::Deny,
+                reason: "cap".into(),
+                mandate: &mandate(),
+                proposed: &proposed,
+                payment_presented: true,
+                payment_outranked: true,
+                now: Timestamp::new(2, 0),
+            },
+        );
+        assert_eq!(log.len(), 2);
+        assert!(log.verify_all(kp.public_key()).is_ok());
+    }
+
+    #[test]
+    fn tamper_detected() {
+        let kp = KeyPair::generate();
+        let mut log = EvidenceLog::new();
+        let proposed = ProposedAction {
+            action: "x".into(),
+            ..ProposedAction::default()
+        };
+        log.append(
+            &kp,
+            EvidenceDraft {
+                decision: Decision::Allow,
+                reason: "ok".into(),
+                mandate: &mandate(),
+                proposed: &proposed,
+                payment_presented: false,
+                payment_outranked: false,
+                now: Timestamp::new(1, 0),
+            },
+        );
+        log.entries[0].reason = "tampered".into();
+        assert!(log.verify_all(kp.public_key()).is_err());
+    }
+}

--- a/crates/exo-pdp/src/evidence.rs
+++ b/crates/exo-pdp/src/evidence.rs
@@ -33,6 +33,9 @@ use crate::{
     mandate::{Mandate, MandateKind, ProposedAction},
 };
 
+const EVIDENCE_ENTRY_SIGNING_DOMAIN: &str = "exo.pdp.evidence_entry.v1";
+const EVIDENCE_ENTRY_SIGNING_SCHEMA_VERSION: u16 = 1;
+
 /// Policy outcome recorded in the evidence pack.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -74,28 +77,48 @@ pub struct EvidenceEntry {
 }
 
 impl EvidenceEntry {
-    fn signable(&self) -> Vec<u8> {
-        let mut d = Vec::new();
-        d.extend_from_slice(&self.seq.to_le_bytes());
-        d.extend_from_slice(self.prev_hash.as_bytes());
-        d.extend_from_slice(format!("{:?}", self.decision).as_bytes());
-        d.extend_from_slice(self.reason.as_bytes());
-        d.extend_from_slice(self.mandate_hash.as_bytes());
-        d.extend_from_slice(format!("{:?}", self.mandate_kind).as_bytes());
-        d.extend_from_slice(self.principal.as_str().as_bytes());
-        d.extend_from_slice(self.agent.as_str().as_bytes());
-        d.extend_from_slice(self.action.as_bytes());
-        if let Some(a) = self.amount_minor {
-            d.extend_from_slice(&a.to_le_bytes());
+    fn signable(&self) -> Result<Vec<u8>> {
+        #[derive(Serialize)]
+        struct SigningPayload<'a> {
+            domain: &'static str,
+            schema_version: u16,
+            seq: u64,
+            prev_hash: &'a Hash256,
+            decision: Decision,
+            reason: &'a str,
+            mandate_hash: &'a Hash256,
+            mandate_kind: MandateKind,
+            principal: &'a Did,
+            agent: &'a Did,
+            action: &'a str,
+            amount_minor: Option<u64>,
+            currency: &'a Option<String>,
+            payment_presented: bool,
+            payment_outranked: bool,
+            timestamp: &'a Timestamp,
         }
-        if let Some(c) = &self.currency {
-            d.extend_from_slice(c.as_bytes());
-        }
-        d.push(u8::from(self.payment_presented));
-        d.push(u8::from(self.payment_outranked));
-        d.extend_from_slice(&self.timestamp.physical_ms.to_le_bytes());
-        d.extend_from_slice(&self.timestamp.logical.to_le_bytes());
-        d
+        let payload = SigningPayload {
+            domain: EVIDENCE_ENTRY_SIGNING_DOMAIN,
+            schema_version: EVIDENCE_ENTRY_SIGNING_SCHEMA_VERSION,
+            seq: self.seq,
+            prev_hash: &self.prev_hash,
+            decision: self.decision,
+            reason: &self.reason,
+            mandate_hash: &self.mandate_hash,
+            mandate_kind: self.mandate_kind,
+            principal: &self.principal,
+            agent: &self.agent,
+            action: &self.action,
+            amount_minor: self.amount_minor,
+            currency: &self.currency,
+            payment_presented: self.payment_presented,
+            payment_outranked: self.payment_outranked,
+            timestamp: &self.timestamp,
+        };
+        let mut data = Vec::new();
+        ciborium::ser::into_writer(&payload, &mut data)
+            .map_err(|e| PdpError::Serialization(e.to_string()))?;
+        Ok(data)
     }
 }
 
@@ -124,7 +147,7 @@ impl EvidenceLog {
     }
 
     /// Append a signed entry. Returns the new entry.
-    pub fn append(&mut self, signer: &KeyPair, draft: EvidenceDraft<'_>) -> EvidenceEntry {
+    pub fn append(&mut self, signer: &KeyPair, draft: EvidenceDraft<'_>) -> Result<EvidenceEntry> {
         let seq = u64::try_from(self.entries.len()).unwrap_or(u64::MAX);
         let mut entry = EvidenceEntry {
             seq,
@@ -132,7 +155,7 @@ impl EvidenceLog {
             entry_hash: Hash256::ZERO,
             decision: draft.decision,
             reason: draft.reason,
-            mandate_hash: draft.mandate.mandate_hash(),
+            mandate_hash: draft.mandate.mandate_hash()?,
             mandate_kind: draft.mandate.kind,
             principal: draft.mandate.principal.clone(),
             agent: draft.mandate.agent.clone(),
@@ -144,13 +167,13 @@ impl EvidenceLog {
             timestamp: draft.now,
             signature: Signature::empty(),
         };
-        let payload = entry.signable();
+        let payload = entry.signable()?;
         entry.signature = signer.sign(&payload);
         entry.entry_hash = Hash256::digest(&payload);
         self.by_hash.insert(entry.entry_hash, self.entries.len());
         self.tip = entry.entry_hash;
         self.entries.push(entry.clone());
-        entry
+        Ok(entry)
     }
 
     #[must_use]
@@ -204,7 +227,7 @@ impl EvidenceLog {
             if e.prev_hash != expected_prev {
                 return Err(PdpError::EvidenceBroken);
             }
-            let payload = e.signable();
+            let payload = e.signable()?;
             if Hash256::digest(&payload) != e.entry_hash {
                 return Err(PdpError::EvidenceBroken);
             }
@@ -222,7 +245,7 @@ impl EvidenceLog {
 
     /// Verify a single entry (hash + signature). Does not walk the chain.
     pub fn verify_entry(entry: &EvidenceEntry, service_key: &PublicKey) -> Result<()> {
-        let payload = entry.signable();
+        let payload = entry.signable()?;
         if Hash256::digest(&payload) != entry.entry_hash {
             return Err(PdpError::EvidenceBroken);
         }
@@ -281,7 +304,8 @@ mod tests {
                 payment_outranked: false,
                 now: Timestamp::new(1, 0),
             },
-        );
+        )
+        .unwrap();
         log.append(
             &kp,
             EvidenceDraft {
@@ -293,7 +317,8 @@ mod tests {
                 payment_outranked: true,
                 now: Timestamp::new(2, 0),
             },
-        );
+        )
+        .unwrap();
         assert_eq!(log.len(), 2);
         assert!(log.verify_all(kp.public_key()).is_ok());
     }
@@ -317,8 +342,60 @@ mod tests {
                 payment_outranked: false,
                 now: Timestamp::new(1, 0),
             },
-        );
+        )
+        .unwrap();
         log.entries[0].reason = "tampered".into();
         assert!(log.verify_all(kp.public_key()).is_err());
+    }
+
+    #[test]
+    fn entry_hash_separates_agent_and_action_fields() {
+        let kp = KeyPair::generate();
+        let mut first_mandate = mandate();
+        first_mandate.agent = did("a");
+        first_mandate.action = "bc".into();
+        let mut second_mandate = first_mandate.clone();
+        second_mandate.agent = did("ab");
+        second_mandate.action = "c".into();
+        let first_action = ProposedAction {
+            action: "bc".into(),
+            ..ProposedAction::default()
+        };
+        let second_action = ProposedAction {
+            action: "c".into(),
+            ..ProposedAction::default()
+        };
+        let mut first_log = EvidenceLog::new();
+        let mut second_log = EvidenceLog::new();
+        let first = first_log
+            .append(
+                &kp,
+                EvidenceDraft {
+                    decision: Decision::Allow,
+                    reason: "permitted".into(),
+                    mandate: &first_mandate,
+                    proposed: &first_action,
+                    payment_presented: true,
+                    payment_outranked: false,
+                    now: Timestamp::new(1, 0),
+                },
+            )
+            .unwrap();
+        let second = second_log
+            .append(
+                &kp,
+                EvidenceDraft {
+                    decision: Decision::Allow,
+                    reason: "permitted".into(),
+                    mandate: &second_mandate,
+                    proposed: &second_action,
+                    payment_presented: true,
+                    payment_outranked: false,
+                    now: Timestamp::new(1, 0),
+                },
+            )
+            .unwrap();
+
+        assert_ne!(first.entry_hash, second.entry_hash);
     }
 }

--- a/crates/exo-pdp/src/http.rs
+++ b/crates/exo-pdp/src/http.rs
@@ -1,0 +1,376 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Axum routes for the policy decision point.
+
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    http::StatusCode,
+    routing::{get, post},
+};
+use exo_authority::{DelegateeKind, DelegationGrant, Permission};
+use exo_core::{Hash256, Timestamp};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    error::PdpError,
+    mandate::{MandateAdapter, ProposedAction, WireMandate},
+    policy::DecisionRequest,
+    service::{DecideResponse, SharedPdp},
+    x402::{self, X402VerifyRequest, X402VerifyResponse},
+};
+
+/// Build the PDP router (own state — merge after gateway `with_state`).
+pub fn pdp_router(pdp: SharedPdp) -> Router {
+    Router::new()
+        .route("/api/v1/authority/decide", post(handle_decide))
+        .route("/api/v1/authority/register-key", post(handle_register_key))
+        .route("/api/v1/authority/delegate", post(handle_delegate))
+        .route("/api/v1/authority/revoke", post(handle_revoke))
+        .route("/api/v1/authority/reserve", post(handle_reserve))
+        .route("/api/v1/authority/commit", post(handle_commit))
+        .route("/api/v1/authority/release", post(handle_release))
+        .route("/api/v1/authority/evidence/:hash", get(handle_evidence))
+        .route(
+            "/api/v1/authority/evidence/:hash/verify",
+            get(handle_verify_evidence),
+        )
+        .route("/api/v1/authority/pack", get(handle_export_pack))
+        .route("/api/v1/authority/pack/verify", post(handle_verify_pack))
+        .route("/x402/verify", post(handle_x402_verify))
+        .with_state(pdp)
+}
+
+fn require_now_ms(now_ms: Option<u64>) -> crate::error::Result<Timestamp> {
+    match now_ms {
+        Some(ms) if ms > 0 => Ok(Timestamp::new(ms, 0)),
+        _ => Err(PdpError::BadRequest(
+            "now_ms is required (HLC physical milliseconds, non-zero)".into(),
+        )),
+    }
+}
+
+fn err(e: PdpError) -> (StatusCode, Json<serde_json::Value>) {
+    let status = match e {
+        PdpError::BadRequest(_) | PdpError::InvalidMandate(_) => StatusCode::BAD_REQUEST,
+        PdpError::EvidenceNotFound | PdpError::ReservationNotFound(_) => StatusCode::NOT_FOUND,
+        PdpError::Denied(_)
+        | PdpError::Revoked
+        | PdpError::Expired
+        | PdpError::AlreadyConsumed
+        | PdpError::AlreadyReserved
+        | PdpError::CaveatFailed(_)
+        | PdpError::DelegationRequired
+        | PdpError::InvalidSignature => StatusCode::FORBIDDEN,
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    };
+    (
+        status,
+        Json(serde_json::json!({ "error": e.to_string(), "never_moves_money": true })),
+    )
+}
+
+#[derive(Debug, Deserialize)]
+struct DecideBody {
+    mandate: WireMandate,
+    #[serde(default)]
+    proposed: Option<ProposedAction>,
+    #[serde(default)]
+    payment_valid: bool,
+    #[serde(default)]
+    now_ms: Option<u64>,
+}
+
+async fn handle_decide(
+    State(pdp): State<SharedPdp>,
+    Json(body): Json<DecideBody>,
+) -> Result<Json<DecideResponse>, (StatusCode, Json<serde_json::Value>)> {
+    let mandate = body.mandate.into_mandate().map_err(err)?;
+    let proposed = body.proposed.unwrap_or_else(|| ProposedAction {
+        action: mandate.action.clone(),
+        amount_minor: mandate.amount_minor,
+        currency: mandate.currency.clone(),
+        merchant: mandate.merchant.clone(),
+        rail: None,
+    });
+    let req = DecisionRequest {
+        mandate,
+        proposed,
+        payment_valid: body.payment_valid,
+        now: require_now_ms(body.now_ms).map_err(err)?,
+    };
+    let mut guard = pdp.lock().map_err(err)?;
+    let out = guard.decide(req).map_err(err)?;
+    Ok(Json(DecideResponse::from(&out)))
+}
+
+#[derive(Debug, Deserialize)]
+struct RegisterKeyBody {
+    did: String,
+    public_key_hex: String,
+}
+
+async fn handle_register_key(
+    State(pdp): State<SharedPdp>,
+    Json(body): Json<RegisterKeyBody>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let did = crate::mandate::coerce_did(&body.did).map_err(err)?;
+    let bytes =
+        hex::decode(&body.public_key_hex).map_err(|e| err(PdpError::BadRequest(e.to_string())))?;
+    if bytes.len() != 32 {
+        return Err(err(PdpError::BadRequest(
+            "public key must be 32 bytes".into(),
+        )));
+    }
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(&bytes);
+    let mut guard = pdp.lock().map_err(err)?;
+    guard.register_key(did.clone(), exo_core::PublicKey::from_bytes(arr));
+    Ok(Json(
+        serde_json::json!({ "did": did.to_string(), "registered": true }),
+    ))
+}
+
+#[derive(Debug, Deserialize)]
+struct DelegateBody {
+    from: String,
+    to: String,
+    scope: Vec<String>,
+    expires_ms: u64,
+    now_ms: u64,
+    #[serde(default)]
+    model_id: Option<String>,
+    /// Hex signature from the delegator over the link payload.
+    /// If omitted, the request is rejected — unsigned delegations are closed.
+    signature_hex: String,
+}
+
+fn parse_perm(s: &str) -> Result<Permission, PdpError> {
+    match s.to_ascii_lowercase().as_str() {
+        "read" => Ok(Permission::Read),
+        "write" => Ok(Permission::Write),
+        "execute" => Ok(Permission::Execute),
+        "delegate" => Ok(Permission::Delegate),
+        "govern" => Ok(Permission::Govern),
+        "escalate" => Ok(Permission::Escalate),
+        "challenge" => Ok(Permission::Challenge),
+        "spend" => Ok(Permission::Spend),
+        other => Err(PdpError::BadRequest(format!("unknown permission {other}"))),
+    }
+}
+
+async fn handle_delegate(
+    State(pdp): State<SharedPdp>,
+    Json(body): Json<DelegateBody>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let from = crate::mandate::coerce_did(&body.from).map_err(err)?;
+    let to = crate::mandate::coerce_did(&body.to).map_err(err)?;
+    let mut scope = Vec::new();
+    for s in &body.scope {
+        scope.push(parse_perm(s).map_err(err)?);
+    }
+    let sig = crate::mandate::parse_sig_hex(&body.signature_hex).map_err(err)?;
+    let kind = match body.model_id {
+        Some(id) => DelegateeKind::AiAgent { model_id: id },
+        None => DelegateeKind::Human,
+    };
+    let mut guard = pdp.lock().map_err(err)?;
+    let pk = guard
+        .resolve_public(&from)
+        .ok_or_else(|| err(PdpError::UnknownActor(from.to_string())))?;
+    let now = require_now_ms(Some(body.now_ms)).map_err(err)?;
+    let grant = DelegationGrant {
+        from: &from,
+        to: &to,
+        scope: &scope,
+        expires: Timestamp::new(body.expires_ms, 0),
+        now: &now,
+        parent_link_id: None,
+        delegatee_kind: kind,
+        delegator_public_key: &pk,
+    };
+    let link = guard.delegate(grant, move |_| sig).map_err(err)?;
+    let link_id = link.id().map_err(|e| err(PdpError::from(e)))?;
+    Ok(Json(serde_json::json!({
+        "link_id": link_id.to_string(),
+        "from": from.to_string(),
+        "to": to.to_string(),
+    })))
+}
+
+#[derive(Debug, Deserialize)]
+struct RevokeBody {
+    #[serde(default)]
+    mandate_hash: Option<String>,
+    #[serde(default)]
+    agent: Option<String>,
+    #[serde(default)]
+    delegation_id: Option<String>,
+    #[serde(default)]
+    reason: Option<String>,
+    #[serde(default)]
+    now_ms: Option<u64>,
+}
+
+fn parse_hash(s: &str) -> Result<Hash256, PdpError> {
+    let bytes = hex::decode(s).map_err(|e| PdpError::BadRequest(e.to_string()))?;
+    if bytes.len() != 32 {
+        return Err(PdpError::BadRequest("hash must be 32 bytes".into()));
+    }
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(&bytes);
+    Ok(Hash256::from_bytes(arr))
+}
+
+async fn handle_revoke(
+    State(pdp): State<SharedPdp>,
+    Json(body): Json<RevokeBody>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let now = Timestamp::new(body.now_ms.unwrap_or(0), 0);
+    let reason = body.reason.unwrap_or_else(|| "revoked".into());
+    let mut guard = pdp.lock().map_err(err)?;
+    if let Some(h) = body.mandate_hash {
+        let hash = parse_hash(&h).map_err(err)?;
+        guard.revoke_mandate(hash, now, reason.clone());
+    }
+    if let Some(a) = body.agent {
+        let did = crate::mandate::coerce_did(&a).map_err(err)?;
+        guard.revoke_agent(did, now, reason.clone());
+    }
+    if let Some(d) = body.delegation_id {
+        let hash = parse_hash(&d).map_err(err)?;
+        guard.revoke_delegation(hash, now, reason);
+    }
+    Ok(Json(serde_json::json!({ "revoked": true })))
+}
+
+#[derive(Debug, Deserialize)]
+struct HashBody {
+    mandate_hash: String,
+    #[serde(default)]
+    now_ms: Option<u64>,
+}
+
+async fn handle_reserve(
+    State(pdp): State<SharedPdp>,
+    Json(body): Json<HashBody>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let hash = parse_hash(&body.mandate_hash).map_err(err)?;
+    let mut guard = pdp.lock().map_err(err)?;
+    guard
+        .reserve(hash, require_now_ms(body.now_ms).map_err(err)?)
+        .map_err(err)?;
+    Ok(Json(serde_json::json!({ "state": "reserved" })))
+}
+
+async fn handle_commit(
+    State(pdp): State<SharedPdp>,
+    Json(body): Json<HashBody>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let hash = parse_hash(&body.mandate_hash).map_err(err)?;
+    let mut guard = pdp.lock().map_err(err)?;
+    guard.commit(&hash).map_err(err)?;
+    Ok(Json(serde_json::json!({ "state": "committed" })))
+}
+
+async fn handle_release(
+    State(pdp): State<SharedPdp>,
+    Json(body): Json<HashBody>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let hash = parse_hash(&body.mandate_hash).map_err(err)?;
+    let mut guard = pdp.lock().map_err(err)?;
+    guard.release(&hash).map_err(err)?;
+    Ok(Json(serde_json::json!({ "state": "released" })))
+}
+
+async fn handle_evidence(
+    State(pdp): State<SharedPdp>,
+    Path(hash): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let h = parse_hash(&hash).map_err(err)?;
+    let guard = pdp.lock().map_err(err)?;
+    let entry = guard
+        .evidence(&h)
+        .ok_or_else(|| err(PdpError::EvidenceNotFound))?;
+    serde_json::to_value(entry)
+        .map(Json)
+        .map_err(|e| err(PdpError::BadRequest(e.to_string())))
+}
+
+async fn handle_verify_evidence(
+    State(pdp): State<SharedPdp>,
+    Path(hash): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let h = parse_hash(&hash).map_err(err)?;
+    let guard = pdp.lock().map_err(err)?;
+    let entry = guard.verify_evidence(&h).map_err(err)?;
+    Ok(Json(serde_json::json!({
+        "ok": true,
+        "evidence_hash": entry.entry_hash.to_string(),
+        "decision": entry.decision,
+        "independently_verifiable": true,
+    })))
+}
+
+async fn handle_export_pack(
+    State(pdp): State<SharedPdp>,
+) -> Result<Json<crate::pack::EvidencePack>, (StatusCode, Json<serde_json::Value>)> {
+    let guard = pdp.lock().map_err(err)?;
+    Ok(Json(guard.export_pack()))
+}
+
+async fn handle_verify_pack(
+    Json(pack): Json<crate::pack::EvidencePack>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    pack.verify().map_err(err)?;
+    Ok(Json(serde_json::json!({
+        "ok": true,
+        "independently_verifiable": true,
+        "never_moves_money": true,
+        "article_26": pack.article_26,
+        "entries": pack.entries.len(),
+        "tip": pack.tip_hex,
+    })))
+}
+
+async fn handle_x402_verify(
+    State(pdp): State<SharedPdp>,
+    Json(body): Json<X402VerifyRequest>,
+) -> Result<Json<X402VerifyResponse>, (StatusCode, Json<serde_json::Value>)> {
+    let mut guard = pdp.lock().map_err(err)?;
+    let resp = x402::verify(&mut guard, body).map_err(err)?;
+    Ok(Json(resp))
+}
+
+/// Shared-pdp snapshot used by the agent passport.
+#[derive(Debug, Serialize)]
+pub struct DelegationSnapshot {
+    pub granted: u64,
+    pub received: u64,
+    pub permissions: Vec<String>,
+}
+
+impl SharedPdp {
+    pub fn snapshot_for(&self, did: &exo_core::Did) -> crate::error::Result<DelegationSnapshot> {
+        let guard = self.lock()?;
+        Ok(DelegationSnapshot {
+            granted: u64::try_from(guard.granted_by(did)).unwrap_or(0),
+            received: u64::try_from(guard.received_by(did)).unwrap_or(0),
+            permissions: guard.permissions_for(did),
+        })
+    }
+}

--- a/crates/exo-pdp/src/http.rs
+++ b/crates/exo-pdp/src/http.rs
@@ -16,6 +16,8 @@
 
 //! Axum routes for the policy decision point.
 
+use std::sync::Arc;
+
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -34,8 +36,65 @@ use crate::{
     x402::{self, X402VerifyRequest, X402VerifyResponse},
 };
 
+type PersistHook =
+    Arc<dyn Fn(&crate::service::PolicyDecisionPoint) -> crate::error::Result<()> + Send + Sync>;
+
+#[derive(Clone)]
+struct PdpHttpState {
+    pdp: SharedPdp,
+    persist: Option<PersistHook>,
+}
+
+impl PdpHttpState {
+    fn checkpoint(
+        &self,
+        pdp: &crate::service::PolicyDecisionPoint,
+    ) -> crate::error::Result<Option<crate::service::PdpSnapshot>> {
+        self.persist
+            .as_ref()
+            .map(|_| pdp.export_snapshot())
+            .transpose()
+    }
+
+    fn persist_or_rollback(
+        &self,
+        pdp: &mut crate::service::PolicyDecisionPoint,
+        checkpoint: Option<crate::service::PdpSnapshot>,
+    ) -> crate::error::Result<()> {
+        let Some(persist) = &self.persist else {
+            return Ok(());
+        };
+        if let Err(persistence_error) = persist(pdp) {
+            if let Some(checkpoint) = checkpoint {
+                pdp.import_snapshot(checkpoint).map_err(|rollback_error| {
+                    PdpError::Persistence(format!(
+                        "{persistence_error}; in-memory rollback failed: {rollback_error}"
+                    ))
+                })?;
+            }
+            return Err(persistence_error);
+        }
+        Ok(())
+    }
+}
+
 /// Build the PDP router (own state — merge after gateway `with_state`).
 pub fn pdp_router(pdp: SharedPdp) -> Router {
+    build_pdp_router(PdpHttpState { pdp, persist: None })
+}
+
+/// Build the PDP router with a fail-closed mutation persistence boundary.
+pub fn pdp_router_with_persistence<F>(pdp: SharedPdp, persist: F) -> Router
+where
+    F: Fn(&crate::service::PolicyDecisionPoint) -> crate::error::Result<()> + Send + Sync + 'static,
+{
+    build_pdp_router(PdpHttpState {
+        pdp,
+        persist: Some(Arc::new(persist)),
+    })
+}
+
+fn build_pdp_router(state: PdpHttpState) -> Router {
     Router::new()
         .route("/api/v1/authority/decide", post(handle_decide))
         .route("/api/v1/authority/register-key", post(handle_register_key))
@@ -52,7 +111,7 @@ pub fn pdp_router(pdp: SharedPdp) -> Router {
         .route("/api/v1/authority/pack", get(handle_export_pack))
         .route("/api/v1/authority/pack/verify", post(handle_verify_pack))
         .route("/x402/verify", post(handle_x402_verify))
-        .with_state(pdp)
+        .with_state(state)
 }
 
 fn require_now_ms(now_ms: Option<u64>) -> crate::error::Result<Timestamp> {
@@ -96,9 +155,10 @@ struct DecideBody {
 }
 
 async fn handle_decide(
-    State(pdp): State<SharedPdp>,
+    State(state): State<PdpHttpState>,
     Json(body): Json<DecideBody>,
 ) -> Result<Json<DecideResponse>, (StatusCode, Json<serde_json::Value>)> {
+    let pdp = &state.pdp;
     let mandate = body.mandate.into_mandate().map_err(err)?;
     let proposed = body.proposed.unwrap_or_else(|| ProposedAction {
         action: mandate.action.clone(),
@@ -114,7 +174,11 @@ async fn handle_decide(
         now: require_now_ms(body.now_ms).map_err(err)?,
     };
     let mut guard = pdp.lock().map_err(err)?;
+    let checkpoint = state.checkpoint(&guard).map_err(err)?;
     let out = guard.decide(req).map_err(err)?;
+    state
+        .persist_or_rollback(&mut guard, checkpoint)
+        .map_err(err)?;
     Ok(Json(DecideResponse::from(&out)))
 }
 
@@ -125,9 +189,10 @@ struct RegisterKeyBody {
 }
 
 async fn handle_register_key(
-    State(pdp): State<SharedPdp>,
+    State(state): State<PdpHttpState>,
     Json(body): Json<RegisterKeyBody>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let pdp = &state.pdp;
     let did = crate::mandate::coerce_did(&body.did).map_err(err)?;
     let bytes =
         hex::decode(&body.public_key_hex).map_err(|e| err(PdpError::BadRequest(e.to_string())))?;
@@ -139,7 +204,11 @@ async fn handle_register_key(
     let mut arr = [0u8; 32];
     arr.copy_from_slice(&bytes);
     let mut guard = pdp.lock().map_err(err)?;
+    let checkpoint = state.checkpoint(&guard).map_err(err)?;
     guard.register_key(did.clone(), exo_core::PublicKey::from_bytes(arr));
+    state
+        .persist_or_rollback(&mut guard, checkpoint)
+        .map_err(err)?;
     Ok(Json(
         serde_json::json!({ "did": did.to_string(), "registered": true }),
     ))
@@ -174,9 +243,10 @@ fn parse_perm(s: &str) -> Result<Permission, PdpError> {
 }
 
 async fn handle_delegate(
-    State(pdp): State<SharedPdp>,
+    State(state): State<PdpHttpState>,
     Json(body): Json<DelegateBody>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let pdp = &state.pdp;
     let from = crate::mandate::coerce_did(&body.from).map_err(err)?;
     let to = crate::mandate::coerce_did(&body.to).map_err(err)?;
     let mut scope = Vec::new();
@@ -203,7 +273,11 @@ async fn handle_delegate(
         delegatee_kind: kind,
         delegator_public_key: &pk,
     };
+    let checkpoint = state.checkpoint(&guard).map_err(err)?;
     let link = guard.delegate(grant, move |_| sig).map_err(err)?;
+    state
+        .persist_or_rollback(&mut guard, checkpoint)
+        .map_err(err)?;
     let link_id = link.id().map_err(|e| err(PdpError::from(e)))?;
     Ok(Json(serde_json::json!({
         "link_id": link_id.to_string(),
@@ -237,12 +311,14 @@ fn parse_hash(s: &str) -> Result<Hash256, PdpError> {
 }
 
 async fn handle_revoke(
-    State(pdp): State<SharedPdp>,
+    State(state): State<PdpHttpState>,
     Json(body): Json<RevokeBody>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
-    let now = Timestamp::new(body.now_ms.unwrap_or(0), 0);
+    let pdp = &state.pdp;
+    let now = require_now_ms(body.now_ms).map_err(err)?;
     let reason = body.reason.unwrap_or_else(|| "revoked".into());
     let mut guard = pdp.lock().map_err(err)?;
+    let checkpoint = state.checkpoint(&guard).map_err(err)?;
     if let Some(h) = body.mandate_hash {
         let hash = parse_hash(&h).map_err(err)?;
         guard.revoke_mandate(hash, now, reason.clone());
@@ -255,6 +331,9 @@ async fn handle_revoke(
         let hash = parse_hash(&d).map_err(err)?;
         guard.revoke_delegation(hash, now, reason);
     }
+    state
+        .persist_or_rollback(&mut guard, checkpoint)
+        .map_err(err)?;
     Ok(Json(serde_json::json!({ "revoked": true })))
 }
 
@@ -266,41 +345,57 @@ struct HashBody {
 }
 
 async fn handle_reserve(
-    State(pdp): State<SharedPdp>,
+    State(state): State<PdpHttpState>,
     Json(body): Json<HashBody>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let pdp = &state.pdp;
     let hash = parse_hash(&body.mandate_hash).map_err(err)?;
     let mut guard = pdp.lock().map_err(err)?;
+    let checkpoint = state.checkpoint(&guard).map_err(err)?;
     guard
         .reserve(hash, require_now_ms(body.now_ms).map_err(err)?)
+        .map_err(err)?;
+    state
+        .persist_or_rollback(&mut guard, checkpoint)
         .map_err(err)?;
     Ok(Json(serde_json::json!({ "state": "reserved" })))
 }
 
 async fn handle_commit(
-    State(pdp): State<SharedPdp>,
+    State(state): State<PdpHttpState>,
     Json(body): Json<HashBody>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let pdp = &state.pdp;
     let hash = parse_hash(&body.mandate_hash).map_err(err)?;
     let mut guard = pdp.lock().map_err(err)?;
+    let checkpoint = state.checkpoint(&guard).map_err(err)?;
     guard.commit(&hash).map_err(err)?;
+    state
+        .persist_or_rollback(&mut guard, checkpoint)
+        .map_err(err)?;
     Ok(Json(serde_json::json!({ "state": "committed" })))
 }
 
 async fn handle_release(
-    State(pdp): State<SharedPdp>,
+    State(state): State<PdpHttpState>,
     Json(body): Json<HashBody>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let pdp = &state.pdp;
     let hash = parse_hash(&body.mandate_hash).map_err(err)?;
     let mut guard = pdp.lock().map_err(err)?;
+    let checkpoint = state.checkpoint(&guard).map_err(err)?;
     guard.release(&hash).map_err(err)?;
+    state
+        .persist_or_rollback(&mut guard, checkpoint)
+        .map_err(err)?;
     Ok(Json(serde_json::json!({ "state": "released" })))
 }
 
 async fn handle_evidence(
-    State(pdp): State<SharedPdp>,
+    State(state): State<PdpHttpState>,
     Path(hash): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let pdp = &state.pdp;
     let h = parse_hash(&hash).map_err(err)?;
     let guard = pdp.lock().map_err(err)?;
     let entry = guard
@@ -312,9 +407,10 @@ async fn handle_evidence(
 }
 
 async fn handle_verify_evidence(
-    State(pdp): State<SharedPdp>,
+    State(state): State<PdpHttpState>,
     Path(hash): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let pdp = &state.pdp;
     let h = parse_hash(&hash).map_err(err)?;
     let guard = pdp.lock().map_err(err)?;
     let entry = guard.verify_evidence(&h).map_err(err)?;
@@ -327,32 +423,46 @@ async fn handle_verify_evidence(
 }
 
 async fn handle_export_pack(
-    State(pdp): State<SharedPdp>,
+    State(state): State<PdpHttpState>,
 ) -> Result<Json<crate::pack::EvidencePack>, (StatusCode, Json<serde_json::Value>)> {
+    let pdp = &state.pdp;
     let guard = pdp.lock().map_err(err)?;
-    Ok(Json(guard.export_pack()))
+    guard.export_pack().map(Json).map_err(err)
+}
+
+#[derive(Debug, Deserialize)]
+struct VerifyPackBody {
+    pack: crate::pack::EvidencePack,
+    expected_service_public_key_hex: String,
 }
 
 async fn handle_verify_pack(
-    Json(pack): Json<crate::pack::EvidencePack>,
+    Json(body): Json<VerifyPackBody>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
-    pack.verify().map_err(err)?;
+    let expected_key =
+        crate::pack::parse_public_key_hex(&body.expected_service_public_key_hex).map_err(err)?;
+    body.pack.verify_with_key(&expected_key).map_err(err)?;
     Ok(Json(serde_json::json!({
         "ok": true,
         "independently_verifiable": true,
         "never_moves_money": true,
-        "article_26": pack.article_26,
-        "entries": pack.entries.len(),
-        "tip": pack.tip_hex,
+        "article_26": body.pack.article_26,
+        "entries": body.pack.entries.len(),
+        "tip": body.pack.tip_hex,
     })))
 }
 
 async fn handle_x402_verify(
-    State(pdp): State<SharedPdp>,
+    State(state): State<PdpHttpState>,
     Json(body): Json<X402VerifyRequest>,
 ) -> Result<Json<X402VerifyResponse>, (StatusCode, Json<serde_json::Value>)> {
+    let pdp = &state.pdp;
     let mut guard = pdp.lock().map_err(err)?;
+    let checkpoint = state.checkpoint(&guard).map_err(err)?;
     let resp = x402::verify(&mut guard, body).map_err(err)?;
+    state
+        .persist_or_rollback(&mut guard, checkpoint)
+        .map_err(err)?;
     Ok(Json(resp))
 }
 
@@ -372,5 +482,33 @@ impl SharedPdp {
             received: u64::try_from(guard.received_by(did)).unwrap_or(0),
             permissions: guard.permissions_for(did),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use exo_core::{Did, crypto::KeyPair};
+
+    use super::*;
+
+    #[test]
+    fn failed_persistence_rolls_back_authority_mutation() {
+        let state = PdpHttpState {
+            pdp: SharedPdp::ephemeral(),
+            persist: Some(Arc::new(|_| {
+                Err(PdpError::Persistence("disk unavailable".into()))
+            })),
+        };
+        let actor = Did::new("did:exo:persistence-test").unwrap();
+        let key = KeyPair::generate();
+        let mut guard = state.pdp.lock().unwrap();
+        let checkpoint = state.checkpoint(&guard).unwrap();
+        guard.register_key(actor.clone(), *key.public_key());
+
+        assert_eq!(
+            state.persist_or_rollback(&mut guard, checkpoint),
+            Err(PdpError::Persistence("disk unavailable".into()))
+        );
+        assert!(guard.resolve_public(&actor).is_none());
     }
 }

--- a/crates/exo-pdp/src/http.rs
+++ b/crates/exo-pdp/src/http.rs
@@ -511,4 +511,193 @@ mod tests {
         );
         assert!(guard.resolve_public(&actor).is_none());
     }
+
+    #[test]
+    fn http_helpers_cover_router_inputs_and_successful_persistence() {
+        let pdp = SharedPdp::ephemeral();
+        let no_persist = PdpHttpState {
+            pdp: pdp.clone(),
+            persist: None,
+        };
+        let mut guard = no_persist.pdp.lock().unwrap();
+        assert!(no_persist.checkpoint(&guard).unwrap().is_none());
+        assert!(no_persist.persist_or_rollback(&mut guard, None).is_ok());
+        drop(guard);
+
+        let persisted = PdpHttpState {
+            pdp: pdp.clone(),
+            persist: Some(Arc::new(|_| Ok(()))),
+        };
+        let mut guard = persisted.pdp.lock().unwrap();
+        let checkpoint = persisted.checkpoint(&guard).unwrap();
+        assert!(checkpoint.is_some());
+        assert!(
+            persisted
+                .persist_or_rollback(&mut guard, checkpoint)
+                .is_ok()
+        );
+        drop(guard);
+
+        let _ephemeral_router = pdp_router(pdp.clone());
+        let _persistent_router = pdp_router_with_persistence(pdp.clone(), |_| Ok(()));
+
+        assert_eq!(require_now_ms(Some(7)).unwrap(), Timestamp::new(7, 0));
+        assert!(matches!(require_now_ms(None), Err(PdpError::BadRequest(_))));
+        assert!(matches!(
+            require_now_ms(Some(0)),
+            Err(PdpError::BadRequest(_))
+        ));
+
+        let expected = [
+            ("READ", Permission::Read),
+            ("write", Permission::Write),
+            ("execute", Permission::Execute),
+            ("delegate", Permission::Delegate),
+            ("govern", Permission::Govern),
+            ("escalate", Permission::Escalate),
+            ("challenge", Permission::Challenge),
+            ("spend", Permission::Spend),
+        ];
+        for (wire, permission) in expected {
+            assert_eq!(parse_perm(wire).unwrap(), permission);
+        }
+        assert!(matches!(parse_perm("mint"), Err(PdpError::BadRequest(_))));
+
+        let hash_hex = "ab".repeat(32);
+        assert_eq!(parse_hash(&hash_hex).unwrap().to_string(), hash_hex);
+        assert!(matches!(parse_hash("zz"), Err(PdpError::BadRequest(_))));
+        assert!(matches!(parse_hash("ab"), Err(PdpError::BadRequest(_))));
+
+        assert_eq!(
+            err(PdpError::BadRequest("bad".into())).0,
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(err(PdpError::EvidenceNotFound).0, StatusCode::NOT_FOUND);
+        assert_eq!(err(PdpError::Revoked).0, StatusCode::FORBIDDEN);
+        let internal = err(PdpError::Persistence("disk".into()));
+        assert_eq!(internal.0, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(internal.1.0["never_moves_money"], true);
+
+        let actor = Did::new("did:exo:snapshot-test").unwrap();
+        let snapshot = pdp.snapshot_for(&actor).unwrap();
+        assert_eq!(snapshot.granted, 0);
+        assert_eq!(snapshot.received, 0);
+        assert!(snapshot.permissions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn mutation_and_pack_handlers_cover_fail_closed_http_boundary() {
+        let state = PdpHttpState {
+            pdp: SharedPdp::ephemeral(),
+            persist: Some(Arc::new(|_| Ok(()))),
+        };
+        let actor = Did::new("did:exo:http-handler-test").unwrap();
+        let actor_key = KeyPair::generate();
+
+        let registered = handle_register_key(
+            State(state.clone()),
+            Json(RegisterKeyBody {
+                did: actor.to_string(),
+                public_key_hex: hex::encode(actor_key.public_key().as_bytes()),
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(registered.0["registered"], true);
+        assert_eq!(registered.0["did"], actor.to_string());
+
+        let invalid_key = handle_register_key(
+            State(state.clone()),
+            Json(RegisterKeyBody {
+                did: actor.to_string(),
+                public_key_hex: "ab".into(),
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(invalid_key.0, StatusCode::BAD_REQUEST);
+
+        let mandate_hash = "11".repeat(32);
+        let reserved = handle_reserve(
+            State(state.clone()),
+            Json(HashBody {
+                mandate_hash: mandate_hash.clone(),
+                now_ms: Some(10),
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(reserved.0["state"], "reserved");
+
+        let released = handle_release(
+            State(state.clone()),
+            Json(HashBody {
+                mandate_hash: mandate_hash.clone(),
+                now_ms: None,
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(released.0["state"], "released");
+
+        let _ = handle_reserve(
+            State(state.clone()),
+            Json(HashBody {
+                mandate_hash: mandate_hash.clone(),
+                now_ms: Some(11),
+            }),
+        )
+        .await
+        .unwrap();
+        let committed = handle_commit(
+            State(state.clone()),
+            Json(HashBody {
+                mandate_hash: mandate_hash.clone(),
+                now_ms: None,
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(committed.0["state"], "committed");
+
+        let delegation_hash = "22".repeat(32);
+        let revoked = handle_revoke(
+            State(state.clone()),
+            Json(RevokeBody {
+                mandate_hash: Some(mandate_hash.clone()),
+                agent: Some(actor.to_string()),
+                delegation_id: Some(delegation_hash),
+                reason: None,
+                now_ms: Some(12),
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(revoked.0["revoked"], true);
+
+        let missing = handle_evidence(State(state.clone()), Path("33".repeat(32)))
+            .await
+            .unwrap_err();
+        assert_eq!(missing.0, StatusCode::NOT_FOUND);
+
+        let (pack, service_key_hex) = {
+            let guard = state.pdp.lock().unwrap();
+            (
+                guard.export_pack().unwrap(),
+                hex::encode(guard.service_public_key().as_bytes()),
+            )
+        };
+        let exported = handle_export_pack(State(state.clone())).await.unwrap();
+        assert_eq!(exported.0.spec, pack.spec);
+
+        let verified = handle_verify_pack(Json(VerifyPackBody {
+            pack,
+            expected_service_public_key_hex: service_key_hex,
+        }))
+        .await
+        .unwrap();
+        assert_eq!(verified.0["ok"], true);
+        assert_eq!(verified.0["independently_verifiable"], true);
+        assert_eq!(verified.0["never_moves_money"], true);
+    }
 }

--- a/crates/exo-pdp/src/lib.rs
+++ b/crates/exo-pdp/src/lib.rs
@@ -1,0 +1,51 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+//! EXOCHAIN policy decision point.
+//!
+//! Runtime authority for agent actions and payments:
+//! verify a signed mandate, apply policy, fail-closed deny, emit a
+//! third-party-verifiable evidence pack. Never moves money.
+//!
+//! Deny always outranks a valid payment payload. Sit this crate at or
+//! before the x402 `/verify` hop; emit/consume AP2-shaped mandates via
+//! [`mandate::WireMandate`].
+
+pub mod error;
+pub mod evidence;
+#[cfg(feature = "http")]
+pub mod http;
+pub mod mandate;
+pub mod pack;
+pub mod policy;
+pub mod reservation;
+pub mod revocation;
+pub mod service;
+pub mod x402;
+
+pub use error::{PdpError, Result};
+pub use evidence::{Decision, EvidenceDraft, EvidenceEntry, EvidenceLog};
+pub use mandate::{Caveat, Mandate, MandateAdapter, MandateKind, ProposedAction, WireMandate};
+pub use pack::{
+    ART26_RETENTION_DAYS, Article26Record, EVIDENCE_PACK_SPEC, EvidencePack, MS_PER_DAY,
+};
+pub use policy::{DecisionRequest, PolicyVerdict};
+pub use reservation::{Reservation, ReservationBook, ReservationState};
+pub use revocation::{Revocation, RevocationSet, RevocationTarget};
+pub use service::{DecideOutcome, DecideResponse, PolicyDecisionPoint, SharedPdp};
+pub use x402::{X402VerifyRequest, X402VerifyResponse};

--- a/crates/exo-pdp/src/lib.rs
+++ b/crates/exo-pdp/src/lib.rs
@@ -47,5 +47,5 @@ pub use pack::{
 pub use policy::{DecisionRequest, PolicyVerdict};
 pub use reservation::{Reservation, ReservationBook, ReservationState};
 pub use revocation::{Revocation, RevocationSet, RevocationTarget};
-pub use service::{DecideOutcome, DecideResponse, PolicyDecisionPoint, SharedPdp};
+pub use service::{DecideOutcome, DecideResponse, PdpSnapshot, PolicyDecisionPoint, SharedPdp};
 pub use x402::{X402VerifyRequest, X402VerifyResponse};

--- a/crates/exo-pdp/src/mandate.rs
+++ b/crates/exo-pdp/src/mandate.rs
@@ -1,0 +1,456 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Protocol-neutral mandates and adapters for AP2 / ACP / x402 / native.
+
+use exo_authority::Permission;
+use exo_core::{Did, ExoError, Hash256, PublicKey, Signature, Timestamp};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{PdpError, Result};
+
+/// Wire format of a mandate. The enforcement core is format-neutral.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MandateKind {
+    Native,
+    Ap2Intent,
+    Ap2Cart,
+    Ap2Payment,
+    AcpDelegatePayment,
+    X402Payload,
+}
+
+/// A narrowing constraint. New caveats may only be appended (attenuation).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Caveat {
+    ActionEq(String),
+    AmountMax { minor: u64, currency: String },
+    MerchantEq(String),
+    NotAfter(Timestamp),
+    ConsumeOnce,
+    RailIn(Vec<String>),
+}
+
+/// Canonical mandate the PDP evaluates. Never moves money.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Mandate {
+    pub kind: MandateKind,
+    pub principal: Did,
+    pub agent: Did,
+    pub action: String,
+    pub amount_minor: Option<u64>,
+    pub currency: Option<String>,
+    pub merchant: Option<String>,
+    pub caveats: Vec<Caveat>,
+    pub expires: Option<Timestamp>,
+    pub consume_once: bool,
+    pub signature: Signature,
+    /// BLAKE3 of the original wire bytes (or of the canonical payload if native).
+    pub raw_hash: Hash256,
+}
+
+impl Mandate {
+    /// Canonical bytes the principal must sign.
+    #[must_use]
+    pub fn signable_payload(&self) -> Vec<u8> {
+        let mut data = Vec::new();
+        data.extend_from_slice(format!("{:?}", self.kind).as_bytes());
+        data.extend_from_slice(self.principal.as_str().as_bytes());
+        data.extend_from_slice(self.agent.as_str().as_bytes());
+        data.extend_from_slice(self.action.as_bytes());
+        if let Some(amt) = self.amount_minor {
+            data.extend_from_slice(&amt.to_le_bytes());
+        }
+        if let Some(cur) = &self.currency {
+            data.extend_from_slice(cur.as_bytes());
+        }
+        if let Some(m) = &self.merchant {
+            data.extend_from_slice(m.as_bytes());
+        }
+        for c in &self.caveats {
+            data.extend_from_slice(format!("{c:?}").as_bytes());
+        }
+        if let Some(exp) = &self.expires {
+            data.extend_from_slice(&exp.physical_ms.to_le_bytes());
+            data.extend_from_slice(&exp.logical.to_le_bytes());
+        }
+        data.push(u8::from(self.consume_once));
+        data
+    }
+
+    /// Content-addressed mandate hash (independent of signature).
+    #[must_use]
+    pub fn mandate_hash(&self) -> Hash256 {
+        Hash256::digest(&self.signable_payload())
+    }
+
+    /// Append caveats only. Existing caveats cannot be removed or relaxed.
+    pub fn attenuate(&mut self, extra: Vec<Caveat>) -> Result<()> {
+        for c in extra {
+            if self.would_widen(&c) {
+                return Err(PdpError::ScopeWidening);
+            }
+            if matches!(c, Caveat::ConsumeOnce) {
+                self.consume_once = true;
+            }
+            self.caveats.push(c);
+        }
+        Ok(())
+    }
+
+    fn would_widen(&self, next: &Caveat) -> bool {
+        match next {
+            Caveat::AmountMax { minor, currency } => self.caveats.iter().any(|c| {
+                matches!(
+                    c,
+                    Caveat::AmountMax { minor: prev, currency: prev_c }
+                        if prev_c == currency && *minor > *prev
+                )
+            }),
+            Caveat::NotAfter(ts) => self.caveats.iter().any(|c| match c {
+                Caveat::NotAfter(prev) => ts.physical_ms > prev.physical_ms,
+                _ => false,
+            }),
+            _ => false,
+        }
+    }
+
+    /// Verify the principal's Ed25519 signature over the canonical payload.
+    pub fn verify_signature(&self, principal_key: &PublicKey) -> Result<()> {
+        if self.signature.is_empty() {
+            return Err(PdpError::InvalidSignature);
+        }
+        if !exo_core::crypto::verify(&self.signable_payload(), &self.signature, principal_key) {
+            return Err(PdpError::InvalidSignature);
+        }
+        Ok(())
+    }
+
+    /// Evaluate caveats + expiry against a proposed action. Fail-closed.
+    pub fn check_caveats(&self, now: &Timestamp, proposed: &ProposedAction) -> Result<()> {
+        if let Some(exp) = &self.expires {
+            if exp.is_expired(now) {
+                return Err(PdpError::Expired);
+            }
+        }
+        for c in &self.caveats {
+            match c {
+                Caveat::ActionEq(allowed) => {
+                    if &proposed.action != allowed {
+                        return Err(PdpError::CaveatFailed(format!(
+                            "action {} != {allowed}",
+                            proposed.action
+                        )));
+                    }
+                }
+                Caveat::AmountMax { minor, currency } => {
+                    let Some(amt) = proposed.amount_minor else {
+                        return Err(PdpError::CaveatFailed("amount required".into()));
+                    };
+                    if proposed.currency.as_deref() != Some(currency.as_str()) {
+                        return Err(PdpError::CaveatFailed("currency mismatch".into()));
+                    }
+                    if amt > *minor {
+                        return Err(PdpError::CaveatFailed(format!(
+                            "amount {amt} exceeds cap {minor}"
+                        )));
+                    }
+                }
+                Caveat::MerchantEq(m) => {
+                    if proposed.merchant.as_deref() != Some(m.as_str()) {
+                        return Err(PdpError::CaveatFailed("merchant mismatch".into()));
+                    }
+                }
+                Caveat::NotAfter(ts) => {
+                    if ts.is_expired(now) {
+                        return Err(PdpError::Expired);
+                    }
+                }
+                Caveat::ConsumeOnce => {}
+                Caveat::RailIn(rails) => {
+                    if let Some(rail) = &proposed.rail {
+                        if !rails.iter().any(|r| r == rail) {
+                            return Err(PdpError::CaveatFailed(format!("rail {rail} not allowed")));
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Permission implied by this mandate's action.
+    #[must_use]
+    pub fn implied_permission(&self) -> Permission {
+        if self.action.starts_with("payment") || self.action.contains("settle") {
+            Permission::Spend
+        } else if self.action.contains("write") {
+            Permission::Write
+        } else if self.action.contains("execute") {
+            Permission::Execute
+        } else {
+            Permission::Read
+        }
+    }
+}
+
+/// Proposed action presented to the PDP (pre-settlement).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ProposedAction {
+    pub action: String,
+    pub amount_minor: Option<u64>,
+    pub currency: Option<String>,
+    pub merchant: Option<String>,
+    pub rail: Option<String>,
+}
+
+/// Maps a native / AP2 / ACP / x402 wire shape onto one [`Mandate`].
+pub trait MandateAdapter {
+    fn kind(&self) -> MandateKind;
+    fn into_mandate(self) -> Result<Mandate>;
+}
+
+/// JSON body accepted by HTTP adapters.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WireMandate {
+    pub kind: MandateKind,
+    pub principal: String,
+    pub agent: String,
+    pub action: String,
+    #[serde(default)]
+    pub amount_minor: Option<u64>,
+    #[serde(default)]
+    pub currency: Option<String>,
+    #[serde(default)]
+    pub merchant: Option<String>,
+    #[serde(default)]
+    pub caveats: Vec<Caveat>,
+    #[serde(default)]
+    pub expires_ms: Option<u64>,
+    #[serde(default)]
+    pub consume_once: bool,
+    /// Hex-encoded Ed25519 signature (128 hex chars).
+    pub signature_hex: String,
+    /// Optional original wire bytes (hex) whose hash is stored as `raw_hash`.
+    #[serde(default)]
+    pub raw_hex: Option<String>,
+}
+
+impl MandateAdapter for WireMandate {
+    fn kind(&self) -> MandateKind {
+        self.kind
+    }
+
+    fn into_mandate(self) -> Result<Mandate> {
+        let principal = coerce_did(&self.principal)?;
+        let agent = coerce_did(&self.agent)?;
+        let signature = parse_sig_hex(&self.signature_hex)?;
+        let raw_hash = if let Some(raw) = &self.raw_hex {
+            let bytes = hex::decode(raw).map_err(|e| PdpError::BadRequest(e.to_string()))?;
+            Hash256::digest(&bytes)
+        } else {
+            Hash256::ZERO
+        };
+        let mut mandate = Mandate {
+            kind: self.kind,
+            principal,
+            agent,
+            action: self.action,
+            amount_minor: self.amount_minor,
+            currency: self.currency,
+            merchant: self.merchant,
+            caveats: self.caveats,
+            expires: self.expires_ms.map(|ms| Timestamp::new(ms, 0)),
+            consume_once: self.consume_once,
+            signature,
+            raw_hash,
+        };
+        if mandate.raw_hash == Hash256::ZERO {
+            mandate.raw_hash = mandate.mandate_hash();
+        }
+        if mandate.consume_once
+            && !mandate
+                .caveats
+                .iter()
+                .any(|c| matches!(c, Caveat::ConsumeOnce))
+        {
+            mandate.caveats.push(Caveat::ConsumeOnce);
+        }
+        Ok(mandate)
+    }
+}
+
+/// Coerce any DID-like string into EXOCHAIN `did:exo:…`.
+pub fn coerce_did(raw: &str) -> Result<Did> {
+    match Did::new(raw) {
+        Ok(d) => Ok(d),
+        Err(ExoError::InvalidDid { .. }) => {
+            let sanitized: String = raw
+                .chars()
+                .map(|c| {
+                    if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == ':' {
+                        c
+                    } else {
+                        '-'
+                    }
+                })
+                .collect();
+            Did::new(&format!("did:exo:ext:{sanitized}")).map_err(PdpError::from)
+        }
+        Err(e) => Err(PdpError::from(e)),
+    }
+}
+
+pub(crate) fn parse_sig_hex(hex_str: &str) -> Result<Signature> {
+    let bytes = hex::decode(hex_str.trim()).map_err(|e| PdpError::BadRequest(e.to_string()))?;
+    if bytes.len() != 64 {
+        return Err(PdpError::BadRequest(format!(
+            "signature must be 64 bytes, got {}",
+            bytes.len()
+        )));
+    }
+    let mut arr = [0u8; 64];
+    arr.copy_from_slice(&bytes);
+    Ok(Signature::from_bytes(arr))
+}
+
+#[cfg(test)]
+mod tests {
+    use exo_core::crypto::KeyPair;
+
+    use super::*;
+
+    fn did(n: &str) -> Did {
+        Did::new(&format!("did:exo:{n}")).unwrap()
+    }
+
+    fn signed_mandate(kp: &KeyPair, consume_once: bool) -> Mandate {
+        let mut m = Mandate {
+            kind: MandateKind::Native,
+            principal: did("alice"),
+            agent: did("agent"),
+            action: "payment.settle".into(),
+            amount_minor: Some(500),
+            currency: Some("USD".into()),
+            merchant: Some("store".into()),
+            caveats: vec![Caveat::AmountMax {
+                minor: 1000,
+                currency: "USD".into(),
+            }],
+            expires: Some(Timestamp::new(10_000, 0)),
+            consume_once,
+            signature: Signature::empty(),
+            raw_hash: Hash256::ZERO,
+        };
+        m.signature = kp.sign(&m.signable_payload());
+        m.raw_hash = m.mandate_hash();
+        m
+    }
+
+    #[test]
+    fn signature_roundtrip() {
+        let kp = KeyPair::generate();
+        let m = signed_mandate(&kp, true);
+        assert!(m.verify_signature(kp.public_key()).is_ok());
+    }
+
+    #[test]
+    fn tamper_breaks_signature() {
+        let kp = KeyPair::generate();
+        let mut m = signed_mandate(&kp, false);
+        m.amount_minor = Some(9999);
+        assert_eq!(
+            m.verify_signature(kp.public_key()),
+            Err(PdpError::InvalidSignature)
+        );
+    }
+
+    #[test]
+    fn attenuate_only_narrows() {
+        let kp = KeyPair::generate();
+        let mut m = signed_mandate(&kp, false);
+        assert!(
+            m.attenuate(vec![Caveat::AmountMax {
+                minor: 200,
+                currency: "USD".into(),
+            }])
+            .is_ok()
+        );
+        assert!(
+            m.attenuate(vec![Caveat::AmountMax {
+                minor: 5000,
+                currency: "USD".into(),
+            }])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn caveats_reject_overspend() {
+        let kp = KeyPair::generate();
+        let m = signed_mandate(&kp, false);
+        let proposed = ProposedAction {
+            action: "payment.settle".into(),
+            amount_minor: Some(2000),
+            currency: Some("USD".into()),
+            merchant: Some("store".into()),
+            rail: None,
+        };
+        assert!(
+            m.check_caveats(&Timestamp::new(1000, 0), &proposed)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn coerce_foreign_did() {
+        let d = coerce_did("did:web:example.com:alice").unwrap();
+        assert!(d.as_str().starts_with("did:exo:"));
+    }
+
+    #[test]
+    fn wire_adapter_native() {
+        let kp = KeyPair::generate();
+        let mut m = signed_mandate(&kp, true);
+        let hex_sig = hex::encode(m.signature.ed25519_bytes().expect("ed25519"));
+        m.signature = Signature::empty();
+        let wire = WireMandate {
+            kind: MandateKind::Ap2Intent,
+            principal: "did:exo:alice".into(),
+            agent: "did:exo:agent".into(),
+            action: "payment.settle".into(),
+            amount_minor: Some(500),
+            currency: Some("USD".into()),
+            merchant: Some("store".into()),
+            caveats: vec![],
+            expires_ms: Some(10_000),
+            consume_once: true,
+            signature_hex: hex_sig,
+            raw_hex: None,
+        };
+        let parsed = wire.into_mandate().unwrap();
+        assert_eq!(parsed.kind, MandateKind::Ap2Intent);
+        assert!(parsed.consume_once);
+        assert!(
+            parsed
+                .caveats
+                .iter()
+                .any(|c| matches!(c, Caveat::ConsumeOnce))
+        );
+    }
+}

--- a/crates/exo-pdp/src/mandate.rs
+++ b/crates/exo-pdp/src/mandate.rs
@@ -22,6 +22,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{PdpError, Result};
 
+const MANDATE_SIGNING_DOMAIN: &str = "exo.pdp.mandate.v1";
+const MANDATE_SIGNING_SCHEMA_VERSION: u16 = 1;
+const FOREIGN_DID_HASH_DOMAIN: &str = "exo.pdp.foreign-did.v1";
+const WIRE_BYTES_HASH_DOMAIN: &str = "exo.pdp.wire-bytes.v1";
+
 /// Wire format of a mandate. The enforcement core is format-neutral.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -60,43 +65,54 @@ pub struct Mandate {
     pub expires: Option<Timestamp>,
     pub consume_once: bool,
     pub signature: Signature,
-    /// BLAKE3 of the original wire bytes (or of the canonical payload if native).
+    /// BLAKE3 of the original wire bytes, or zero when no original bytes exist.
     pub raw_hash: Hash256,
 }
 
 impl Mandate {
-    /// Canonical bytes the principal must sign.
-    #[must_use]
-    pub fn signable_payload(&self) -> Vec<u8> {
+    /// Domain-separated canonical CBOR bytes the principal must sign.
+    pub fn signable_payload(&self) -> Result<Vec<u8>> {
+        #[derive(Serialize)]
+        struct SigningPayload<'a> {
+            domain: &'static str,
+            schema_version: u16,
+            kind: MandateKind,
+            principal: &'a Did,
+            agent: &'a Did,
+            action: &'a str,
+            amount_minor: Option<u64>,
+            currency: &'a Option<String>,
+            merchant: &'a Option<String>,
+            caveats: &'a [Caveat],
+            expires: &'a Option<Timestamp>,
+            consume_once: bool,
+            raw_hash: &'a Hash256,
+        }
+
+        let payload = SigningPayload {
+            domain: MANDATE_SIGNING_DOMAIN,
+            schema_version: MANDATE_SIGNING_SCHEMA_VERSION,
+            kind: self.kind,
+            principal: &self.principal,
+            agent: &self.agent,
+            action: &self.action,
+            amount_minor: self.amount_minor,
+            currency: &self.currency,
+            merchant: &self.merchant,
+            caveats: &self.caveats,
+            expires: &self.expires,
+            consume_once: self.consume_once,
+            raw_hash: &self.raw_hash,
+        };
         let mut data = Vec::new();
-        data.extend_from_slice(format!("{:?}", self.kind).as_bytes());
-        data.extend_from_slice(self.principal.as_str().as_bytes());
-        data.extend_from_slice(self.agent.as_str().as_bytes());
-        data.extend_from_slice(self.action.as_bytes());
-        if let Some(amt) = self.amount_minor {
-            data.extend_from_slice(&amt.to_le_bytes());
-        }
-        if let Some(cur) = &self.currency {
-            data.extend_from_slice(cur.as_bytes());
-        }
-        if let Some(m) = &self.merchant {
-            data.extend_from_slice(m.as_bytes());
-        }
-        for c in &self.caveats {
-            data.extend_from_slice(format!("{c:?}").as_bytes());
-        }
-        if let Some(exp) = &self.expires {
-            data.extend_from_slice(&exp.physical_ms.to_le_bytes());
-            data.extend_from_slice(&exp.logical.to_le_bytes());
-        }
-        data.push(u8::from(self.consume_once));
-        data
+        ciborium::ser::into_writer(&payload, &mut data)
+            .map_err(|e| PdpError::Serialization(e.to_string()))?;
+        Ok(data)
     }
 
     /// Content-addressed mandate hash (independent of signature).
-    #[must_use]
-    pub fn mandate_hash(&self) -> Hash256 {
-        Hash256::digest(&self.signable_payload())
+    pub fn mandate_hash(&self) -> Result<Hash256> {
+        Ok(Hash256::digest(&self.signable_payload()?))
     }
 
     /// Append caveats only. Existing caveats cannot be removed or relaxed.
@@ -135,7 +151,7 @@ impl Mandate {
         if self.signature.is_empty() {
             return Err(PdpError::InvalidSignature);
         }
-        if !exo_core::crypto::verify(&self.signable_payload(), &self.signature, principal_key) {
+        if !exo_core::crypto::verify(&self.signable_payload()?, &self.signature, principal_key) {
             return Err(PdpError::InvalidSignature);
         }
         Ok(())
@@ -143,6 +159,40 @@ impl Mandate {
 
     /// Evaluate caveats + expiry against a proposed action. Fail-closed.
     pub fn check_caveats(&self, now: &Timestamp, proposed: &ProposedAction) -> Result<()> {
+        if self.implied_permission()? == Permission::Spend
+            && (self.amount_minor.is_none() || self.currency.is_none())
+        {
+            return Err(PdpError::InvalidMandate(
+                "spend mandates require signed amount_minor and currency bounds".into(),
+            ));
+        }
+        if proposed.action != self.action {
+            return Err(PdpError::CaveatFailed(format!(
+                "proposed action {} does not match signed mandate action {}",
+                proposed.action, self.action
+            )));
+        }
+        if let Some(amount) = self.amount_minor {
+            if proposed.amount_minor != Some(amount) {
+                return Err(PdpError::CaveatFailed(
+                    "proposed amount does not match signed mandate amount".into(),
+                ));
+            }
+        }
+        if let Some(currency) = &self.currency {
+            if proposed.currency.as_deref() != Some(currency.as_str()) {
+                return Err(PdpError::CaveatFailed(
+                    "proposed currency does not match signed mandate currency".into(),
+                ));
+            }
+        }
+        if let Some(merchant) = &self.merchant {
+            if proposed.merchant.as_deref() != Some(merchant.as_str()) {
+                return Err(PdpError::CaveatFailed(
+                    "proposed merchant does not match signed mandate merchant".into(),
+                ));
+            }
+        }
         if let Some(exp) = &self.expires {
             if exp.is_expired(now) {
                 return Err(PdpError::Expired);
@@ -183,10 +233,13 @@ impl Mandate {
                 }
                 Caveat::ConsumeOnce => {}
                 Caveat::RailIn(rails) => {
-                    if let Some(rail) = &proposed.rail {
-                        if !rails.iter().any(|r| r == rail) {
-                            return Err(PdpError::CaveatFailed(format!("rail {rail} not allowed")));
-                        }
+                    let Some(rail) = &proposed.rail else {
+                        return Err(PdpError::CaveatFailed(
+                            "rail required by signed mandate".into(),
+                        ));
+                    };
+                    if !rails.iter().any(|r| r == rail) {
+                        return Err(PdpError::CaveatFailed(format!("rail {rail} not allowed")));
                     }
                 }
             }
@@ -195,17 +248,35 @@ impl Mandate {
     }
 
     /// Permission implied by this mandate's action.
-    #[must_use]
-    pub fn implied_permission(&self) -> Permission {
-        if self.action.starts_with("payment") || self.action.contains("settle") {
-            Permission::Spend
-        } else if self.action.contains("write") {
-            Permission::Write
-        } else if self.action.contains("execute") {
-            Permission::Execute
-        } else {
-            Permission::Read
+    pub fn implied_permission(&self) -> Result<Permission> {
+        if self.kind != MandateKind::Native {
+            return Ok(Permission::Spend);
         }
+
+        let action = self.action.to_ascii_lowercase();
+        let verb = action.split(['.', ':', '/']).next().unwrap_or_default();
+        match verb {
+            "payment" | "pay" | "purchase" | "settle" | "spend" | "transfer" => {
+                Ok(Permission::Spend)
+            }
+            "write" | "create" | "update" | "delete" | "mutate" => Ok(Permission::Write),
+            "execute" | "run" | "invoke" => Ok(Permission::Execute),
+            "read" | "get" | "list" | "view" => Ok(Permission::Read),
+            _ => Err(PdpError::InvalidMandate(format!(
+                "unsupported native action {}",
+                self.action
+            ))),
+        }
+    }
+
+    /// Whether the signed mandate requires reserve/commit single use.
+    #[must_use]
+    pub fn requires_single_use(&self) -> bool {
+        self.consume_once
+            || self
+                .caveats
+                .iter()
+                .any(|c| matches!(c, Caveat::ConsumeOnce))
     }
 }
 
@@ -262,7 +333,7 @@ impl MandateAdapter for WireMandate {
         let signature = parse_sig_hex(&self.signature_hex)?;
         let raw_hash = if let Some(raw) = &self.raw_hex {
             let bytes = hex::decode(raw).map_err(|e| PdpError::BadRequest(e.to_string()))?;
-            Hash256::digest(&bytes)
+            domain_separated_hash(WIRE_BYTES_HASH_DOMAIN, &bytes)?
         } else {
             Hash256::ZERO
         };
@@ -280,9 +351,7 @@ impl MandateAdapter for WireMandate {
             signature,
             raw_hash,
         };
-        if mandate.raw_hash == Hash256::ZERO {
-            mandate.raw_hash = mandate.mandate_hash();
-        }
+        mandate.consume_once = mandate.requires_single_use();
         if mandate.consume_once
             && !mandate
                 .caveats
@@ -295,25 +364,23 @@ impl MandateAdapter for WireMandate {
     }
 }
 
-/// Coerce any DID-like string into EXOCHAIN `did:exo:…`.
+/// Coerce any DID-like string into a collision-resistant EXOCHAIN external DID.
 pub fn coerce_did(raw: &str) -> Result<Did> {
     match Did::new(raw) {
         Ok(d) => Ok(d),
         Err(ExoError::InvalidDid { .. }) => {
-            let sanitized: String = raw
-                .chars()
-                .map(|c| {
-                    if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == ':' {
-                        c
-                    } else {
-                        '-'
-                    }
-                })
-                .collect();
-            Did::new(&format!("did:exo:ext:{sanitized}")).map_err(PdpError::from)
+            let digest = domain_separated_hash(FOREIGN_DID_HASH_DOMAIN, raw)?;
+            Did::new(&format!("did:exo:ext:{digest}")).map_err(PdpError::from)
         }
         Err(e) => Err(PdpError::from(e)),
     }
+}
+
+fn domain_separated_hash<T: Serialize + ?Sized>(domain: &str, value: &T) -> Result<Hash256> {
+    let mut data = Vec::new();
+    ciborium::ser::into_writer(&(domain, 1_u16, value), &mut data)
+        .map_err(|e| PdpError::Serialization(e.to_string()))?;
+    Ok(Hash256::digest(&data))
 }
 
 pub(crate) fn parse_sig_hex(hex_str: &str) -> Result<Signature> {
@@ -357,8 +424,7 @@ mod tests {
             signature: Signature::empty(),
             raw_hash: Hash256::ZERO,
         };
-        m.signature = kp.sign(&m.signable_payload());
-        m.raw_hash = m.mandate_hash();
+        m.signature = kp.sign(&m.signable_payload().unwrap());
         m
     }
 
@@ -377,6 +443,141 @@ mod tests {
         assert_eq!(
             m.verify_signature(kp.public_key()),
             Err(PdpError::InvalidSignature)
+        );
+    }
+
+    #[test]
+    fn signable_payload_separates_agent_and_action_fields() {
+        let kp = KeyPair::generate();
+        let mut first = signed_mandate(&kp, false);
+        first.agent = did("a");
+        first.action = "bc".into();
+        let mut second = first.clone();
+        second.agent = did("ab");
+        second.action = "c".into();
+
+        assert_ne!(
+            first.signable_payload().unwrap(),
+            second.signable_payload().unwrap(),
+            "distinct typed mandates must never share signing bytes"
+        );
+    }
+
+    #[test]
+    fn all_signed_payment_fields_are_enforced_against_proposed_action() {
+        let kp = KeyPair::generate();
+        let m = signed_mandate(&kp, false);
+        let valid = ProposedAction {
+            action: m.action.clone(),
+            amount_minor: m.amount_minor,
+            currency: m.currency.clone(),
+            merchant: m.merchant.clone(),
+            rail: None,
+        };
+        let mut substitutions = Vec::new();
+        let mut action = valid.clone();
+        action.action = "account.read".into();
+        substitutions.push(action);
+        let mut amount = valid.clone();
+        amount.amount_minor = Some(501);
+        substitutions.push(amount);
+        let mut currency = valid.clone();
+        currency.currency = Some("EUR".into());
+        substitutions.push(currency);
+        let mut merchant = valid;
+        merchant.merchant = Some("other-store".into());
+        substitutions.push(merchant);
+
+        for proposed in substitutions {
+            assert!(
+                m.check_caveats(&Timestamp::new(1_000, 0), &proposed)
+                    .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn rail_caveat_requires_an_explicit_allowed_rail() {
+        let kp = KeyPair::generate();
+        let mut m = signed_mandate(&kp, false);
+        m.caveats.push(Caveat::RailIn(vec!["ach".into()]));
+        let proposed = ProposedAction {
+            action: m.action.clone(),
+            amount_minor: m.amount_minor,
+            currency: m.currency.clone(),
+            merchant: m.merchant.clone(),
+            rail: None,
+        };
+
+        assert!(
+            m.check_caveats(&Timestamp::new(1_000, 0), &proposed)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn consume_once_caveat_normalizes_wire_mandate_to_single_use() {
+        let wire = WireMandate {
+            kind: MandateKind::X402Payload,
+            principal: "did:exo:alice".into(),
+            agent: "did:exo:agent".into(),
+            action: "payment.settle".into(),
+            amount_minor: Some(1),
+            currency: Some("USD".into()),
+            merchant: None,
+            caveats: vec![Caveat::ConsumeOnce],
+            expires_ms: None,
+            consume_once: false,
+            signature_hex: "00".repeat(64),
+            raw_hex: None,
+        };
+
+        let mandate = wire.into_mandate().unwrap();
+        assert!(mandate.consume_once);
+    }
+
+    #[test]
+    fn payment_protocol_kind_requires_spend_for_short_action_name() {
+        let kp = KeyPair::generate();
+        let mut m = signed_mandate(&kp, false);
+        m.kind = MandateKind::X402Payload;
+        m.action = "pay".into();
+        assert_eq!(m.implied_permission().unwrap(), Permission::Spend);
+    }
+
+    #[test]
+    fn unknown_native_action_is_denied() {
+        let kp = KeyPair::generate();
+        let mut m = signed_mandate(&kp, false);
+        m.action = "custom-operation".into();
+        assert!(matches!(
+            m.implied_permission(),
+            Err(PdpError::InvalidMandate(_))
+        ));
+    }
+
+    #[test]
+    fn spend_mandate_requires_signed_amount_and_currency_bounds() {
+        let kp = KeyPair::generate();
+        let mut m = signed_mandate(&kp, false);
+        m.amount_minor = None;
+        let proposed = ProposedAction {
+            action: m.action.clone(),
+            amount_minor: Some(500),
+            currency: m.currency.clone(),
+            merchant: m.merchant.clone(),
+            rail: None,
+        };
+        assert!(
+            m.check_caveats(&Timestamp::new(1_000, 0), &proposed)
+                .is_err()
+        );
+
+        m.amount_minor = Some(500);
+        m.currency = None;
+        assert!(
+            m.check_caveats(&Timestamp::new(1_000, 0), &proposed)
+                .is_err()
         );
     }
 
@@ -420,7 +621,14 @@ mod tests {
     #[test]
     fn coerce_foreign_did() {
         let d = coerce_did("did:web:example.com:alice").unwrap();
-        assert!(d.as_str().starts_with("did:exo:"));
+        assert!(d.as_str().starts_with("did:exo:ext:"));
+    }
+
+    #[test]
+    fn coerce_foreign_did_does_not_collapse_distinct_inputs() {
+        let dotted = coerce_did("did:web:example.com:alice").unwrap();
+        let slashed = coerce_did("did:web:example/com:alice").unwrap();
+        assert_ne!(dotted, slashed);
     }
 
     #[test]

--- a/crates/exo-pdp/src/pack.rs
+++ b/crates/exo-pdp/src/pack.rs
@@ -1,0 +1,245 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Portable evidence pack — the commercial artifact.
+//!
+//! A pack is JSON a third party can check with only this crate and the
+//! embedded service public key. No running node. No settlement. Aligns
+//! to EU AI Act (Regulation 2024/1689) Article 26 deployer logs:
+//! automatically generated, retained at least six months, records
+//! human-oversight posture and incident-class denies.
+
+use exo_core::PublicKey;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    error::{PdpError, Result},
+    evidence::{Decision, EvidenceEntry, EvidenceLog},
+};
+
+/// Spec id written into every pack.
+pub const EVIDENCE_PACK_SPEC: &str = "exochain-evidence-pack-v1";
+
+/// Article 26 minimum retention, in whole days.
+pub const ART26_RETENTION_DAYS: u64 = 180;
+
+/// Milliseconds in one day (integer; no floats).
+pub const MS_PER_DAY: u64 = 86_400_000;
+
+/// EU AI Act Article 26 metadata bound into the pack.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Article26Record {
+    pub regulation: String,
+    pub article: String,
+    pub automatically_generated: bool,
+    pub retention_days_min: u64,
+    pub human_oversight: String,
+    pub incident_denies: u64,
+    pub never_moves_money: bool,
+}
+
+impl Article26Record {
+    #[must_use]
+    pub fn from_entries(entries: &[EvidenceEntry]) -> Self {
+        let incident_denies = entries
+            .iter()
+            .filter(|e| e.decision == Decision::Deny)
+            .count();
+        Self {
+            regulation: "EU 2024/1689".into(),
+            article: "26".into(),
+            automatically_generated: true,
+            retention_days_min: ART26_RETENTION_DAYS,
+            human_oversight: "principal-signed mandate required; deny-outranks-payment".into(),
+            incident_denies: u64::try_from(incident_denies).unwrap_or(u64::MAX),
+            never_moves_money: true,
+        }
+    }
+}
+
+/// A self-contained, independently verifiable evidence pack.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvidencePack {
+    pub spec: String,
+    pub never_moves_money: bool,
+    pub service_public_key_hex: String,
+    pub tip_hex: String,
+    pub article_26: Article26Record,
+    pub entries: Vec<EvidenceEntry>,
+}
+
+impl EvidencePack {
+    /// Build a pack from a live log and the service verifying key.
+    #[must_use]
+    pub fn from_log(log: &EvidenceLog, service_key: &PublicKey) -> Self {
+        Self {
+            spec: EVIDENCE_PACK_SPEC.into(),
+            never_moves_money: true,
+            service_public_key_hex: hex::encode(service_key.as_bytes()),
+            tip_hex: log.tip().to_string(),
+            article_26: Article26Record::from_entries(log.entries()),
+            entries: log.entries().to_vec(),
+        }
+    }
+
+    /// Parse JSON bytes.
+    pub fn from_json(bytes: &[u8]) -> Result<Self> {
+        serde_json::from_slice(bytes).map_err(|e| PdpError::BadRequest(e.to_string()))
+    }
+
+    /// Canonical JSON for export.
+    pub fn to_json(&self) -> Result<Vec<u8>> {
+        serde_json::to_vec_pretty(self).map_err(|e| PdpError::BadRequest(e.to_string()))
+    }
+
+    /// Check the pack without a running EXOCHAIN node.
+    pub fn verify(&self) -> Result<()> {
+        if self.spec != EVIDENCE_PACK_SPEC {
+            return Err(PdpError::BadRequest(format!(
+                "unknown evidence spec {}",
+                self.spec
+            )));
+        }
+        if !self.never_moves_money || !self.article_26.never_moves_money {
+            return Err(PdpError::BadRequest(
+                "pack claims to move money — rejected".into(),
+            ));
+        }
+        if self.article_26.retention_days_min < ART26_RETENTION_DAYS {
+            return Err(PdpError::BadRequest(
+                "Article 26 retention below six months".into(),
+            ));
+        }
+        if !self.article_26.automatically_generated {
+            return Err(PdpError::BadRequest(
+                "Article 26 requires automatically generated logs".into(),
+            ));
+        }
+        let key = parse_public_key_hex(&self.service_public_key_hex)?;
+        let log = EvidenceLog::from_entries(self.entries.clone())?;
+        log.verify_all(&key)?;
+        if log.tip().to_string() != self.tip_hex {
+            return Err(PdpError::EvidenceBroken);
+        }
+        let expected = Article26Record::from_entries(&self.entries);
+        if expected.incident_denies != self.article_26.incident_denies {
+            return Err(PdpError::EvidenceBroken);
+        }
+        Ok(())
+    }
+
+    /// Earliest timestamp at which an entry may be discarded (now + 180 days
+    /// from the entry's own clock). Integer milliseconds.
+    #[must_use]
+    pub fn retention_until_ms(entry: &EvidenceEntry) -> u64 {
+        entry
+            .timestamp
+            .physical_ms
+            .saturating_add(ART26_RETENTION_DAYS.saturating_mul(MS_PER_DAY))
+    }
+}
+
+pub(crate) fn parse_public_key_hex(hex_str: &str) -> Result<PublicKey> {
+    let bytes = hex::decode(hex_str.trim()).map_err(|e| PdpError::BadRequest(e.to_string()))?;
+    if bytes.len() != 32 {
+        return Err(PdpError::BadRequest("public key must be 32 bytes".into()));
+    }
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(&bytes);
+    Ok(PublicKey::from_bytes(arr))
+}
+
+#[cfg(test)]
+mod tests {
+    use exo_core::{Did, Hash256, Signature, Timestamp, crypto::KeyPair};
+
+    use super::*;
+    use crate::{
+        evidence::{EvidenceDraft, EvidenceLog},
+        mandate::{Mandate, MandateKind, ProposedAction},
+    };
+
+    fn mandate() -> Mandate {
+        Mandate {
+            kind: MandateKind::Native,
+            principal: Did::new("did:exo:alice").unwrap(),
+            agent: Did::new("did:exo:agent").unwrap(),
+            action: "payment.settle".into(),
+            amount_minor: Some(1),
+            currency: Some("USD".into()),
+            merchant: None,
+            caveats: vec![],
+            expires: None,
+            consume_once: false,
+            signature: Signature::empty(),
+            raw_hash: Hash256::ZERO,
+        }
+    }
+
+    #[test]
+    fn pack_roundtrip_verifies() {
+        let kp = KeyPair::generate();
+        let mut log = EvidenceLog::new();
+        let proposed = ProposedAction {
+            action: "payment.settle".into(),
+            amount_minor: Some(1),
+            currency: Some("USD".into()),
+            merchant: None,
+            rail: None,
+        };
+        log.append(
+            &kp,
+            EvidenceDraft {
+                decision: Decision::Deny,
+                reason: "cap".into(),
+                mandate: &mandate(),
+                proposed: &proposed,
+                payment_presented: true,
+                payment_outranked: true,
+                now: Timestamp::new(1_000, 0),
+            },
+        );
+        let pack = EvidencePack::from_log(&log, kp.public_key());
+        assert_eq!(pack.article_26.incident_denies, 1);
+        assert_eq!(pack.article_26.retention_days_min, 180);
+        assert!(pack.verify().is_ok());
+        let json = pack.to_json().unwrap();
+        let parsed = EvidencePack::from_json(&json).unwrap();
+        assert!(parsed.verify().is_ok());
+        assert_eq!(
+            EvidencePack::retention_until_ms(&parsed.entries[0]),
+            1_000 + 180 * 86_400_000
+        );
+    }
+
+    #[test]
+    fn pack_tamper_fails() {
+        let kp = KeyPair::generate();
+        let log = EvidenceLog::new();
+        let mut pack = EvidencePack::from_log(&log, kp.public_key());
+        pack.tip_hex = Hash256::digest(b"nope").to_string();
+        assert!(pack.verify().is_err());
+    }
+
+    #[test]
+    fn pack_rejects_money_claim() {
+        let kp = KeyPair::generate();
+        let log = EvidenceLog::new();
+        let mut pack = EvidencePack::from_log(&log, kp.public_key());
+        pack.never_moves_money = false;
+        assert!(pack.verify().is_err());
+    }
+}

--- a/crates/exo-pdp/src/pack.rs
+++ b/crates/exo-pdp/src/pack.rs
@@ -16,13 +16,13 @@
 
 //! Portable evidence pack — the commercial artifact.
 //!
-//! A pack is JSON a third party can check with only this crate and the
-//! embedded service public key. No running node. No settlement. Aligns
-//! to EU AI Act (Regulation 2024/1689) Article 26 deployer logs:
+//! A pack is JSON a third party can check with this crate and a service
+//! public key obtained through a separate trusted channel. No running node.
+//! No settlement. Aligns to EU AI Act (Regulation 2024/1689) Article 26 deployer logs:
 //! automatically generated, retained at least six months, records
 //! human-oversight posture and incident-class denies.
 
-use exo_core::PublicKey;
+use exo_core::{PublicKey, Signature, crypto::KeyPair};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -38,6 +38,8 @@ pub const ART26_RETENTION_DAYS: u64 = 180;
 
 /// Milliseconds in one day (integer; no floats).
 pub const MS_PER_DAY: u64 = 86_400_000;
+const EVIDENCE_PACK_SIGNING_DOMAIN: &str = "exo.pdp.evidence_pack.v1";
+const EVIDENCE_PACK_SIGNING_SCHEMA_VERSION: u16 = 1;
 
 /// EU AI Act Article 26 metadata bound into the pack.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -70,7 +72,7 @@ impl Article26Record {
     }
 }
 
-/// A self-contained, independently verifiable evidence pack.
+/// A portable evidence pack independently verifiable against a trusted service key.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EvidencePack {
     pub spec: String,
@@ -79,20 +81,23 @@ pub struct EvidencePack {
     pub tip_hex: String,
     pub article_26: Article26Record,
     pub entries: Vec<EvidenceEntry>,
+    pub pack_signature: Signature,
 }
 
 impl EvidencePack {
-    /// Build a pack from a live log and the service verifying key.
-    #[must_use]
-    pub fn from_log(log: &EvidenceLog, service_key: &PublicKey) -> Self {
-        Self {
+    /// Build and sign a pack from a live log.
+    pub fn from_log(log: &EvidenceLog, service_key: &KeyPair) -> Result<Self> {
+        let mut pack = Self {
             spec: EVIDENCE_PACK_SPEC.into(),
             never_moves_money: true,
-            service_public_key_hex: hex::encode(service_key.as_bytes()),
+            service_public_key_hex: hex::encode(service_key.public_key().as_bytes()),
             tip_hex: log.tip().to_string(),
             article_26: Article26Record::from_entries(log.entries()),
             entries: log.entries().to_vec(),
-        }
+            pack_signature: Signature::empty(),
+        };
+        pack.pack_signature = service_key.sign(&pack.signing_payload()?);
+        Ok(pack)
     }
 
     /// Parse JSON bytes.
@@ -105,8 +110,18 @@ impl EvidencePack {
         serde_json::to_vec_pretty(self).map_err(|e| PdpError::BadRequest(e.to_string()))
     }
 
-    /// Check the pack without a running EXOCHAIN node.
+    /// Verify internal integrity using the embedded key.
+    ///
+    /// This proves that one key signed the pack, not that the key belongs to a
+    /// particular service. External verifiers must call [`Self::verify_with_key`]
+    /// with a separately trusted service key before accepting provenance.
     pub fn verify(&self) -> Result<()> {
+        let embedded_key = parse_public_key_hex(&self.service_public_key_hex)?;
+        self.verify_with_key(&embedded_key)
+    }
+
+    /// Verify the pack against a service key obtained through a trusted channel.
+    pub fn verify_with_key(&self, expected_service_key: &PublicKey) -> Result<()> {
         if self.spec != EVIDENCE_PACK_SPEC {
             return Err(PdpError::BadRequest(format!(
                 "unknown evidence spec {}",
@@ -128,17 +143,57 @@ impl EvidencePack {
                 "Article 26 requires automatically generated logs".into(),
             ));
         }
-        let key = parse_public_key_hex(&self.service_public_key_hex)?;
+        let embedded_key = parse_public_key_hex(&self.service_public_key_hex)?;
+        if embedded_key != *expected_service_key {
+            return Err(PdpError::InvalidSignature);
+        }
+        if self.pack_signature.is_empty()
+            || !exo_core::crypto::verify(
+                &self.signing_payload()?,
+                &self.pack_signature,
+                expected_service_key,
+            )
+        {
+            return Err(PdpError::InvalidSignature);
+        }
         let log = EvidenceLog::from_entries(self.entries.clone())?;
-        log.verify_all(&key)?;
+        log.verify_all(expected_service_key)?;
         if log.tip().to_string() != self.tip_hex {
             return Err(PdpError::EvidenceBroken);
         }
         let expected = Article26Record::from_entries(&self.entries);
-        if expected.incident_denies != self.article_26.incident_denies {
+        if expected != self.article_26 {
             return Err(PdpError::EvidenceBroken);
         }
         Ok(())
+    }
+
+    fn signing_payload(&self) -> Result<Vec<u8>> {
+        #[derive(Serialize)]
+        struct SigningPayload<'a> {
+            domain: &'static str,
+            schema_version: u16,
+            spec: &'a str,
+            never_moves_money: bool,
+            service_public_key_hex: &'a str,
+            tip_hex: &'a str,
+            article_26: &'a Article26Record,
+            entries: &'a [EvidenceEntry],
+        }
+        let payload = SigningPayload {
+            domain: EVIDENCE_PACK_SIGNING_DOMAIN,
+            schema_version: EVIDENCE_PACK_SIGNING_SCHEMA_VERSION,
+            spec: &self.spec,
+            never_moves_money: self.never_moves_money,
+            service_public_key_hex: &self.service_public_key_hex,
+            tip_hex: &self.tip_hex,
+            article_26: &self.article_26,
+            entries: &self.entries,
+        };
+        let mut data = Vec::new();
+        ciborium::ser::into_writer(&payload, &mut data)
+            .map_err(|e| PdpError::Serialization(e.to_string()))?;
+        Ok(data)
     }
 
     /// Earliest timestamp at which an entry may be discarded (now + 180 days
@@ -152,7 +207,7 @@ impl EvidencePack {
     }
 }
 
-pub(crate) fn parse_public_key_hex(hex_str: &str) -> Result<PublicKey> {
+pub fn parse_public_key_hex(hex_str: &str) -> Result<PublicKey> {
     let bytes = hex::decode(hex_str.trim()).map_err(|e| PdpError::BadRequest(e.to_string()))?;
     if bytes.len() != 32 {
         return Err(PdpError::BadRequest("public key must be 32 bytes".into()));
@@ -211,14 +266,15 @@ mod tests {
                 payment_outranked: true,
                 now: Timestamp::new(1_000, 0),
             },
-        );
-        let pack = EvidencePack::from_log(&log, kp.public_key());
+        )
+        .unwrap();
+        let pack = EvidencePack::from_log(&log, &kp).unwrap();
         assert_eq!(pack.article_26.incident_denies, 1);
         assert_eq!(pack.article_26.retention_days_min, 180);
-        assert!(pack.verify().is_ok());
+        assert!(pack.verify_with_key(kp.public_key()).is_ok());
         let json = pack.to_json().unwrap();
         let parsed = EvidencePack::from_json(&json).unwrap();
-        assert!(parsed.verify().is_ok());
+        assert!(parsed.verify_with_key(kp.public_key()).is_ok());
         assert_eq!(
             EvidencePack::retention_until_ms(&parsed.entries[0]),
             1_000 + 180 * 86_400_000
@@ -229,7 +285,7 @@ mod tests {
     fn pack_tamper_fails() {
         let kp = KeyPair::generate();
         let log = EvidenceLog::new();
-        let mut pack = EvidencePack::from_log(&log, kp.public_key());
+        let mut pack = EvidencePack::from_log(&log, &kp).unwrap();
         pack.tip_hex = Hash256::digest(b"nope").to_string();
         assert!(pack.verify().is_err());
     }
@@ -238,8 +294,30 @@ mod tests {
     fn pack_rejects_money_claim() {
         let kp = KeyPair::generate();
         let log = EvidenceLog::new();
-        let mut pack = EvidencePack::from_log(&log, kp.public_key());
+        let mut pack = EvidencePack::from_log(&log, &kp).unwrap();
         pack.never_moves_money = false;
         assert!(pack.verify().is_err());
+    }
+
+    #[test]
+    fn pack_rejects_tampered_article_26_metadata() {
+        let kp = KeyPair::generate();
+        let log = EvidenceLog::new();
+        let mut pack = EvidencePack::from_log(&log, &kp).unwrap();
+        pack.article_26.human_oversight = "none".into();
+        assert!(pack.verify().is_err());
+    }
+
+    #[test]
+    fn pack_rejects_an_attacker_selected_embedded_key() {
+        let trusted = KeyPair::generate();
+        let attacker = KeyPair::generate();
+        let log = EvidenceLog::new();
+        let forged = EvidencePack::from_log(&log, &attacker).unwrap();
+
+        assert_eq!(
+            forged.verify_with_key(trusted.public_key()),
+            Err(PdpError::InvalidSignature)
+        );
     }
 }

--- a/crates/exo-pdp/src/policy.rs
+++ b/crates/exo-pdp/src/policy.rs
@@ -58,16 +58,17 @@ pub fn evaluate(
     revocations: &RevocationSet,
 ) -> Result<PolicyVerdict> {
     let mandate = &req.mandate;
-    let hash = mandate.mandate_hash();
+    let hash = mandate.mandate_hash()?;
 
     if revocations.is_mandate_revoked(&hash) || revocations.is_agent_revoked(&mandate.agent) {
         return Ok(deny(req, "revoked"));
     }
 
-    if mandate.consume_once && reservations.is_consumed(&hash) {
+    let requires_single_use = mandate.requires_single_use();
+    if requires_single_use && reservations.is_consumed(&hash) {
         return Ok(deny(req, "mandate already consumed"));
     }
-    if mandate.consume_once && reservations.is_reserved(&hash) {
+    if requires_single_use && reservations.is_reserved(&hash) {
         return Ok(deny(req, "mandate already reserved"));
     }
 
@@ -82,6 +83,10 @@ pub fn evaluate(
         return Ok(deny(req, &e.to_string()));
     }
 
+    if !req.payment_valid {
+        return Ok(deny(req, "payment payload is not valid"));
+    }
+
     // Delegation must exist principal → agent and include the implied permission.
     // Fail-closed: missing chain is a deny, never an allow.
     match delegations.find_chain(&mandate.principal, &mandate.agent) {
@@ -89,15 +94,17 @@ pub fn evaluate(
             if let Err(e) = verify_chain_or_deny(&chain, &req.now, keys) {
                 return Ok(deny(req, &e.to_string()));
             }
-            let needed = mandate.implied_permission();
+            let needed = match mandate.implied_permission() {
+                Ok(permission) => permission,
+                Err(e) => return Ok(deny(req, &e.to_string())),
+            };
             if !chain::has_permission(&chain, &needed) {
                 return Ok(deny(req, &format!("delegation does not grant {needed:?}")));
             }
             for link in &chain.links {
-                if let Ok(id) = link.id() {
-                    if revocations.is_delegation_revoked(&id) {
-                        return Ok(deny(req, "delegation link revoked"));
-                    }
+                let id = link.id()?;
+                if revocations.is_delegation_revoked(&id) {
+                    return Ok(deny(req, "delegation link revoked"));
                 }
             }
         }
@@ -158,7 +165,7 @@ mod tests {
             signature: exo_core::Signature::empty(),
             raw_hash: exo_core::Hash256::ZERO,
         };
-        mandate.signature = principal.sign(&mandate.signable_payload());
+        mandate.signature = principal.sign(&mandate.signable_payload().unwrap());
 
         let req = DecisionRequest {
             mandate,
@@ -192,7 +199,7 @@ mod tests {
     }
 
     #[test]
-    fn allow_with_signed_delegation() {
+    fn invalid_payment_is_denied_even_with_signed_delegation() {
         let alice = KeyPair::generate();
         let mut mandate = Mandate {
             kind: MandateKind::Native,
@@ -208,7 +215,7 @@ mod tests {
             signature: exo_core::Signature::empty(),
             raw_hash: exo_core::Hash256::ZERO,
         };
-        mandate.signature = alice.sign(&mandate.signable_payload());
+        mandate.signature = alice.sign(&mandate.signable_payload().unwrap());
 
         let mut reg = DelegationRegistry::new();
         let now = Timestamp::new(1, 0);
@@ -259,7 +266,55 @@ mod tests {
             &RevocationSet::new(),
         )
         .unwrap();
-        assert_eq!(v.decision, Decision::Allow);
+        assert_eq!(v.decision, Decision::Deny);
         assert!(!v.payment_outranked);
+    }
+
+    #[test]
+    fn consume_once_caveat_cannot_bypass_existing_reservation() {
+        let principal = KeyPair::generate();
+        let mut mandate = Mandate {
+            kind: MandateKind::X402Payload,
+            principal: did("alice"),
+            agent: did("agent"),
+            action: "payment.settle".into(),
+            amount_minor: Some(5),
+            currency: Some("USD".into()),
+            merchant: None,
+            caveats: vec![Caveat::ConsumeOnce],
+            expires: None,
+            consume_once: false,
+            signature: exo_core::Signature::empty(),
+            raw_hash: exo_core::Hash256::ZERO,
+        };
+        mandate.signature = principal.sign(&mandate.signable_payload().unwrap());
+        let mut reservations = ReservationBook::new();
+        reservations
+            .reserve(mandate.mandate_hash().unwrap(), Timestamp::new(1, 0))
+            .unwrap();
+        let req = DecisionRequest {
+            mandate,
+            proposed: ProposedAction {
+                action: "payment.settle".into(),
+                amount_minor: Some(5),
+                currency: Some("USD".into()),
+                merchant: None,
+                rail: None,
+            },
+            payment_valid: true,
+            now: Timestamp::new(2, 0),
+        };
+
+        let verdict = evaluate(
+            &req,
+            &|_| None,
+            &DelegationRegistry::new(),
+            &reservations,
+            &RevocationSet::new(),
+        )
+        .unwrap();
+
+        assert_eq!(verdict.decision, Decision::Deny);
+        assert_eq!(verdict.reason, "mandate already reserved");
     }
 }

--- a/crates/exo-pdp/src/policy.rs
+++ b/crates/exo-pdp/src/policy.rs
@@ -1,0 +1,265 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Deny-outranks-payment policy evaluation.
+
+use exo_authority::{
+    DelegationRegistry,
+    chain::{self, AuthorityChain},
+};
+use exo_core::{Did, PublicKey, Timestamp};
+
+use crate::{
+    error::Result,
+    evidence::Decision,
+    mandate::{Mandate, ProposedAction},
+    reservation::ReservationBook,
+    revocation::RevocationSet,
+};
+
+/// Input to a single policy decision. Payment validity never overrides deny.
+#[derive(Debug, Clone)]
+pub struct DecisionRequest {
+    pub mandate: Mandate,
+    pub proposed: ProposedAction,
+    /// Facilitator/PSP says the payment payload itself is valid.
+    pub payment_valid: bool,
+    pub now: Timestamp,
+}
+
+/// Result of policy evaluation before evidence is appended.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolicyVerdict {
+    pub decision: Decision,
+    pub reason: String,
+    /// True when a valid payment was presented and still denied.
+    pub payment_outranked: bool,
+}
+
+/// Evaluate policy. Never settles. Fail-closed.
+pub fn evaluate(
+    req: &DecisionRequest,
+    keys: &dyn Fn(&Did) -> Option<PublicKey>,
+    delegations: &DelegationRegistry,
+    reservations: &ReservationBook,
+    revocations: &RevocationSet,
+) -> Result<PolicyVerdict> {
+    let mandate = &req.mandate;
+    let hash = mandate.mandate_hash();
+
+    if revocations.is_mandate_revoked(&hash) || revocations.is_agent_revoked(&mandate.agent) {
+        return Ok(deny(req, "revoked"));
+    }
+
+    if mandate.consume_once && reservations.is_consumed(&hash) {
+        return Ok(deny(req, "mandate already consumed"));
+    }
+    if mandate.consume_once && reservations.is_reserved(&hash) {
+        return Ok(deny(req, "mandate already reserved"));
+    }
+
+    let Some(pk) = keys(&mandate.principal) else {
+        return Ok(deny(req, "unknown principal key"));
+    };
+    if let Err(e) = mandate.verify_signature(&pk) {
+        return Ok(deny(req, &e.to_string()));
+    }
+
+    if let Err(e) = mandate.check_caveats(&req.now, &req.proposed) {
+        return Ok(deny(req, &e.to_string()));
+    }
+
+    // Delegation must exist principal → agent and include the implied permission.
+    // Fail-closed: missing chain is a deny, never an allow.
+    match delegations.find_chain(&mandate.principal, &mandate.agent) {
+        Some(chain) => {
+            if let Err(e) = verify_chain_or_deny(&chain, &req.now, keys) {
+                return Ok(deny(req, &e.to_string()));
+            }
+            let needed = mandate.implied_permission();
+            if !chain::has_permission(&chain, &needed) {
+                return Ok(deny(req, &format!("delegation does not grant {needed:?}")));
+            }
+            for link in &chain.links {
+                if let Ok(id) = link.id() {
+                    if revocations.is_delegation_revoked(&id) {
+                        return Ok(deny(req, "delegation link revoked"));
+                    }
+                }
+            }
+        }
+        None => return Ok(deny(req, "no principal→agent delegation")),
+    }
+
+    Ok(PolicyVerdict {
+        decision: Decision::Allow,
+        reason: "permitted".into(),
+        payment_outranked: false,
+    })
+}
+
+fn verify_chain_or_deny<F>(chain: &AuthorityChain, now: &Timestamp, keys: F) -> Result<()>
+where
+    F: Fn(&Did) -> Option<PublicKey>,
+{
+    chain::verify_chain(chain, now, keys).map_err(Into::into)
+}
+
+fn deny(req: &DecisionRequest, reason: &str) -> PolicyVerdict {
+    PolicyVerdict {
+        decision: Decision::Deny,
+        reason: reason.to_owned(),
+        payment_outranked: req.payment_valid,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use exo_authority::{DelegateeKind, Permission};
+    use exo_core::crypto::KeyPair;
+
+    use super::*;
+    use crate::mandate::{Caveat, MandateKind};
+
+    fn did(n: &str) -> Did {
+        Did::new(&format!("did:exo:{n}")).unwrap()
+    }
+
+    #[test]
+    fn deny_outranks_valid_payment() {
+        let principal = KeyPair::generate();
+        let mut mandate = Mandate {
+            kind: MandateKind::X402Payload,
+            principal: did("alice"),
+            agent: did("agent"),
+            action: "payment.settle".into(),
+            amount_minor: Some(50),
+            currency: Some("USD".into()),
+            merchant: None,
+            caveats: vec![Caveat::AmountMax {
+                minor: 10,
+                currency: "USD".into(),
+            }],
+            expires: None,
+            consume_once: false,
+            signature: exo_core::Signature::empty(),
+            raw_hash: exo_core::Hash256::ZERO,
+        };
+        mandate.signature = principal.sign(&mandate.signable_payload());
+
+        let req = DecisionRequest {
+            mandate,
+            proposed: ProposedAction {
+                action: "payment.settle".into(),
+                amount_minor: Some(50),
+                currency: Some("USD".into()),
+                merchant: None,
+                rail: None,
+            },
+            payment_valid: true,
+            now: Timestamp::new(1, 0),
+        };
+        let keys = |d: &Did| {
+            if d == &did("alice") {
+                Some(*principal.public_key())
+            } else {
+                None
+            }
+        };
+        let v = evaluate(
+            &req,
+            &keys,
+            &DelegationRegistry::new(),
+            &ReservationBook::new(),
+            &RevocationSet::new(),
+        )
+        .unwrap();
+        assert_eq!(v.decision, Decision::Deny);
+        assert!(v.payment_outranked);
+    }
+
+    #[test]
+    fn allow_with_signed_delegation() {
+        let alice = KeyPair::generate();
+        let mut mandate = Mandate {
+            kind: MandateKind::Native,
+            principal: did("alice"),
+            agent: did("agent"),
+            action: "payment.settle".into(),
+            amount_minor: Some(5),
+            currency: Some("USD".into()),
+            merchant: None,
+            caveats: vec![],
+            expires: None,
+            consume_once: false,
+            signature: exo_core::Signature::empty(),
+            raw_hash: exo_core::Hash256::ZERO,
+        };
+        mandate.signature = alice.sign(&mandate.signable_payload());
+
+        let mut reg = DelegationRegistry::new();
+        let now = Timestamp::new(1, 0);
+        let alice_did = did("alice");
+        let agent_did = did("agent");
+        let alice_pk = *alice.public_key();
+        reg.delegate(
+            exo_authority::DelegationGrant {
+                from: &alice_did,
+                to: &agent_did,
+                scope: &[Permission::Spend],
+                expires: Timestamp::new(99_000, 0),
+                now: &now,
+                parent_link_id: None,
+                delegatee_kind: DelegateeKind::AiAgent {
+                    model_id: "shopper".into(),
+                },
+                delegator_public_key: &alice_pk,
+            },
+            |bytes| alice.sign(bytes),
+        )
+        .unwrap();
+
+        let req = DecisionRequest {
+            mandate,
+            proposed: ProposedAction {
+                action: "payment.settle".into(),
+                amount_minor: Some(5),
+                currency: Some("USD".into()),
+                merchant: None,
+                rail: None,
+            },
+            payment_valid: false,
+            now,
+        };
+        let keys = |d: &Did| {
+            if d == &did("alice") {
+                Some(*alice.public_key())
+            } else {
+                None
+            }
+        };
+        let v = evaluate(
+            &req,
+            &keys,
+            &reg,
+            &ReservationBook::new(),
+            &RevocationSet::new(),
+        )
+        .unwrap();
+        assert_eq!(v.decision, Decision::Allow);
+        assert!(!v.payment_outranked);
+    }
+}

--- a/crates/exo-pdp/src/reservation.rs
+++ b/crates/exo-pdp/src/reservation.rs
@@ -119,6 +119,23 @@ impl ReservationBook {
             Some(ReservationState::Reserved)
         )
     }
+
+    /// Stable records for durable state snapshots.
+    #[must_use]
+    pub fn records(&self) -> Vec<Reservation> {
+        self.entries.values().cloned().collect()
+    }
+
+    /// Rebuild a reservation book from a signed durable snapshot.
+    pub fn from_records(records: Vec<Reservation>) -> Result<Self> {
+        let mut entries = BTreeMap::new();
+        for record in records {
+            if entries.insert(record.mandate_hash, record).is_some() {
+                return Err(PdpError::ReservationState);
+            }
+        }
+        Ok(Self { entries })
+    }
 }
 
 #[cfg(test)]

--- a/crates/exo-pdp/src/reservation.rs
+++ b/crates/exo-pdp/src/reservation.rs
@@ -1,0 +1,170 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Consume-once reserve / commit / release around a mandate hash.
+
+use std::collections::BTreeMap;
+
+use exo_core::{Hash256, Timestamp};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{PdpError, Result};
+
+/// Lifecycle of a consume-once mandate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReservationState {
+    Reserved,
+    Committed,
+    Released,
+}
+
+/// A single reservation record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Reservation {
+    pub mandate_hash: Hash256,
+    pub state: ReservationState,
+    pub created: Timestamp,
+}
+
+/// Book of consume-once reservations keyed by mandate hash.
+#[derive(Debug, Default)]
+pub struct ReservationBook {
+    entries: BTreeMap<Hash256, Reservation>,
+}
+
+impl ReservationBook {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Reserve a mandate. Fails if already reserved or committed.
+    pub fn reserve(&mut self, mandate_hash: Hash256, now: Timestamp) -> Result<()> {
+        match self.entries.get(&mandate_hash) {
+            Some(r) if r.state == ReservationState::Released => {}
+            Some(r) if r.state == ReservationState::Committed => {
+                return Err(PdpError::AlreadyConsumed);
+            }
+            Some(_) => return Err(PdpError::AlreadyReserved),
+            None => {}
+        }
+        self.entries.insert(
+            mandate_hash,
+            Reservation {
+                mandate_hash,
+                state: ReservationState::Reserved,
+                created: now,
+            },
+        );
+        Ok(())
+    }
+
+    /// Commit a reserved mandate (consume-once).
+    pub fn commit(&mut self, mandate_hash: &Hash256) -> Result<()> {
+        let entry = self
+            .entries
+            .get_mut(mandate_hash)
+            .ok_or_else(|| PdpError::ReservationNotFound(mandate_hash.to_string()))?;
+        if entry.state != ReservationState::Reserved {
+            return Err(PdpError::ReservationState);
+        }
+        entry.state = ReservationState::Committed;
+        Ok(())
+    }
+
+    /// Release a reservation so the mandate may be retried.
+    pub fn release(&mut self, mandate_hash: &Hash256) -> Result<()> {
+        let entry = self
+            .entries
+            .get_mut(mandate_hash)
+            .ok_or_else(|| PdpError::ReservationNotFound(mandate_hash.to_string()))?;
+        if entry.state == ReservationState::Committed {
+            return Err(PdpError::AlreadyConsumed);
+        }
+        entry.state = ReservationState::Released;
+        Ok(())
+    }
+
+    #[must_use]
+    pub fn get(&self, mandate_hash: &Hash256) -> Option<&Reservation> {
+        self.entries.get(mandate_hash)
+    }
+
+    #[must_use]
+    pub fn is_consumed(&self, mandate_hash: &Hash256) -> bool {
+        matches!(
+            self.entries.get(mandate_hash).map(|r| r.state),
+            Some(ReservationState::Committed)
+        )
+    }
+
+    #[must_use]
+    pub fn is_reserved(&self, mandate_hash: &Hash256) -> bool {
+        matches!(
+            self.entries.get(mandate_hash).map(|r| r.state),
+            Some(ReservationState::Reserved)
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn h(s: &str) -> Hash256 {
+        Hash256::digest(s.as_bytes())
+    }
+    fn ts() -> Timestamp {
+        Timestamp::new(1, 0)
+    }
+
+    #[test]
+    fn reserve_commit() {
+        let mut b = ReservationBook::new();
+        let id = h("m");
+        b.reserve(id, ts()).unwrap();
+        assert!(b.is_reserved(&id));
+        b.commit(&id).unwrap();
+        assert!(b.is_consumed(&id));
+    }
+
+    #[test]
+    fn double_reserve_fails() {
+        let mut b = ReservationBook::new();
+        let id = h("m");
+        b.reserve(id, ts()).unwrap();
+        assert_eq!(b.reserve(id, ts()), Err(PdpError::AlreadyReserved));
+    }
+
+    #[test]
+    fn release_then_rereserve() {
+        let mut b = ReservationBook::new();
+        let id = h("m");
+        b.reserve(id, ts()).unwrap();
+        b.release(&id).unwrap();
+        assert!(b.reserve(id, ts()).is_ok());
+    }
+
+    #[test]
+    fn cannot_release_committed() {
+        let mut b = ReservationBook::new();
+        let id = h("m");
+        b.reserve(id, ts()).unwrap();
+        b.commit(&id).unwrap();
+        assert_eq!(b.release(&id), Err(PdpError::AlreadyConsumed));
+    }
+}

--- a/crates/exo-pdp/src/revocation.rs
+++ b/crates/exo-pdp/src/revocation.rs
@@ -21,6 +21,8 @@ use std::collections::BTreeSet;
 use exo_core::{Did, Hash256, Timestamp};
 use serde::{Deserialize, Serialize};
 
+use crate::error::{PdpError, Result};
+
 /// A revocation entry. Presence in the set is sufficient to deny.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Revocation {
@@ -99,6 +101,20 @@ impl RevocationSet {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.log.is_empty()
+    }
+
+    /// Rebuild the indexes from a signed append-only revocation log.
+    pub fn from_log(log: Vec<Revocation>) -> Result<Self> {
+        let mut set = Self::new();
+        for revocation in log {
+            if revocation.revoked_at == Timestamp::ZERO {
+                return Err(PdpError::InvalidMandate(
+                    "revocation timestamp must be non-zero".into(),
+                ));
+            }
+            set.revoke(revocation.target, revocation.revoked_at, revocation.reason);
+        }
+        Ok(set)
     }
 }
 

--- a/crates/exo-pdp/src/revocation.rs
+++ b/crates/exo-pdp/src/revocation.rs
@@ -1,0 +1,133 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Real-time revocation of mandates and delegated capabilities.
+
+use std::collections::BTreeSet;
+
+use exo_core::{Did, Hash256, Timestamp};
+use serde::{Deserialize, Serialize};
+
+/// A revocation entry. Presence in the set is sufficient to deny.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct Revocation {
+    pub target: RevocationTarget,
+    pub revoked_at: Timestamp,
+    pub reason: String,
+}
+
+/// What was revoked.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum RevocationTarget {
+    Mandate(Hash256),
+    Agent(Did),
+    Delegation(Hash256),
+}
+
+/// In-memory revocation set. Lookups are fail-closed on hit.
+#[derive(Debug, Default)]
+pub struct RevocationSet {
+    mandates: BTreeSet<Hash256>,
+    agents: BTreeSet<Did>,
+    delegations: BTreeSet<Hash256>,
+    log: Vec<Revocation>,
+}
+
+impl RevocationSet {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn revoke(&mut self, target: RevocationTarget, now: Timestamp, reason: String) {
+        match &target {
+            RevocationTarget::Mandate(h) => {
+                self.mandates.insert(*h);
+            }
+            RevocationTarget::Agent(d) => {
+                self.agents.insert(d.clone());
+            }
+            RevocationTarget::Delegation(h) => {
+                self.delegations.insert(*h);
+            }
+        }
+        self.log.push(Revocation {
+            target,
+            revoked_at: now,
+            reason,
+        });
+    }
+
+    #[must_use]
+    pub fn is_mandate_revoked(&self, h: &Hash256) -> bool {
+        self.mandates.contains(h)
+    }
+
+    #[must_use]
+    pub fn is_agent_revoked(&self, d: &Did) -> bool {
+        self.agents.contains(d)
+    }
+
+    #[must_use]
+    pub fn is_delegation_revoked(&self, h: &Hash256) -> bool {
+        self.delegations.contains(h)
+    }
+
+    #[must_use]
+    pub fn log(&self) -> &[Revocation] {
+        &self.log
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.log.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.log.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn revoke_mandate() {
+        let mut s = RevocationSet::new();
+        let h = Hash256::digest(b"m");
+        s.revoke(
+            RevocationTarget::Mandate(h),
+            Timestamp::new(1, 0),
+            "user cancelled".into(),
+        );
+        assert!(s.is_mandate_revoked(&h));
+        assert!(!s.is_empty());
+    }
+
+    #[test]
+    fn revoke_agent() {
+        let mut s = RevocationSet::new();
+        let d = Did::new("did:exo:bot").unwrap();
+        s.revoke(
+            RevocationTarget::Agent(d.clone()),
+            Timestamp::new(1, 0),
+            "compromised".into(),
+        );
+        assert!(s.is_agent_revoked(&d));
+    }
+}

--- a/crates/exo-pdp/src/service.rs
+++ b/crates/exo-pdp/src/service.rs
@@ -1,0 +1,338 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! In-process policy decision point. Never moves money.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use exo_authority::{DelegationGrant, DelegationRegistry, chain::AuthorityLink};
+use exo_core::{Did, Hash256, PublicKey, Timestamp, crypto::KeyPair};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    error::{PdpError, Result},
+    evidence::{Decision, EvidenceEntry, EvidenceLog},
+    policy::{self, DecisionRequest, PolicyVerdict},
+    reservation::ReservationBook,
+    revocation::{RevocationSet, RevocationTarget},
+};
+
+/// Shared handle used by gateway and node routers.
+#[derive(Clone)]
+pub struct SharedPdp(Arc<Mutex<PolicyDecisionPoint>>);
+
+impl SharedPdp {
+    #[must_use]
+    pub fn ephemeral() -> Self {
+        Self(Arc::new(Mutex::new(PolicyDecisionPoint::ephemeral())))
+    }
+
+    #[must_use]
+    pub fn from_pdp(pdp: PolicyDecisionPoint) -> Self {
+        Self(Arc::new(Mutex::new(pdp)))
+    }
+
+    pub fn lock(&self) -> Result<std::sync::MutexGuard<'_, PolicyDecisionPoint>> {
+        self.0.lock().map_err(|_| PdpError::LockPoisoned)
+    }
+}
+
+/// Runtime authority + receipt service.
+pub struct PolicyDecisionPoint {
+    service_key: KeyPair,
+    pub(crate) keys: BTreeMap<Did, PublicKey>,
+    pub delegations: DelegationRegistry,
+    reservations: ReservationBook,
+    revocations: RevocationSet,
+    evidence: EvidenceLog,
+}
+
+impl PolicyDecisionPoint {
+    #[must_use]
+    pub fn new(service_key: KeyPair) -> Self {
+        Self {
+            service_key,
+            keys: BTreeMap::new(),
+            delegations: DelegationRegistry::new(),
+            reservations: ReservationBook::new(),
+            revocations: RevocationSet::new(),
+            evidence: EvidenceLog::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn ephemeral() -> Self {
+        Self::new(KeyPair::generate())
+    }
+
+    #[must_use]
+    pub fn service_public_key(&self) -> PublicKey {
+        *self.service_key.public_key()
+    }
+
+    /// Register a principal/agent verification key.
+    pub fn register_key(&mut self, did: Did, key: PublicKey) {
+        self.keys.insert(did, key);
+    }
+
+    fn resolve(&self, did: &Did) -> Option<PublicKey> {
+        self.keys.get(did).copied()
+    }
+
+    /// Public key registered for a principal or agent.
+    #[must_use]
+    pub fn resolve_public(&self, did: &Did) -> Option<PublicKey> {
+        self.resolve(did)
+    }
+
+    /// Create a signed, attenuated delegation principal → agent.
+    pub fn delegate(
+        &mut self,
+        grant: DelegationGrant<'_>,
+        sign: impl FnOnce(&[u8]) -> exo_core::Signature,
+    ) -> Result<AuthorityLink> {
+        Ok(self.delegations.delegate(grant, sign)?)
+    }
+
+    pub fn revoke_mandate(&mut self, hash: Hash256, now: Timestamp, reason: String) {
+        self.revocations
+            .revoke(RevocationTarget::Mandate(hash), now, reason);
+    }
+
+    pub fn revoke_agent(&mut self, agent: Did, now: Timestamp, reason: String) {
+        self.revocations
+            .revoke(RevocationTarget::Agent(agent), now, reason);
+    }
+
+    pub fn revoke_delegation(&mut self, link_id: Hash256, now: Timestamp, reason: String) {
+        self.revocations
+            .revoke(RevocationTarget::Delegation(link_id), now, reason);
+    }
+
+    /// Policy check + signed evidence. Does not settle.
+    pub fn decide(&mut self, req: DecisionRequest) -> Result<DecideOutcome> {
+        let verdict = policy::evaluate(
+            &req,
+            &|d| self.resolve(d),
+            &self.delegations,
+            &self.reservations,
+            &self.revocations,
+        )?;
+        let entry = self.evidence.append(
+            &self.service_key,
+            crate::evidence::EvidenceDraft {
+                decision: verdict.decision,
+                reason: verdict.reason.clone(),
+                mandate: &req.mandate,
+                proposed: &req.proposed,
+                payment_presented: req.payment_valid,
+                payment_outranked: verdict.payment_outranked,
+                now: req.now,
+            },
+        );
+        Ok(DecideOutcome {
+            verdict,
+            evidence: entry,
+        })
+    }
+
+    /// x402 `/verify` hop: decide, then reserve consume-once mandates on allow.
+    pub fn verify_before_settle(&mut self, req: DecisionRequest) -> Result<DecideOutcome> {
+        let consume = req.mandate.consume_once;
+        let hash = req.mandate.mandate_hash();
+        let now = req.now;
+        let out = self.decide(req)?;
+        if out.verdict.decision == Decision::Allow && consume {
+            self.reservations.reserve(hash, now)?;
+        }
+        Ok(out)
+    }
+
+    pub fn reserve(&mut self, mandate_hash: Hash256, now: Timestamp) -> Result<()> {
+        self.reservations.reserve(mandate_hash, now)
+    }
+
+    pub fn commit(&mut self, mandate_hash: &Hash256) -> Result<()> {
+        self.reservations.commit(mandate_hash)
+    }
+
+    pub fn release(&mut self, mandate_hash: &Hash256) -> Result<()> {
+        self.reservations.release(mandate_hash)
+    }
+
+    #[must_use]
+    pub fn evidence(&self, hash: &Hash256) -> Option<&EvidenceEntry> {
+        self.evidence.get(hash)
+    }
+
+    pub fn verify_evidence(&self, hash: &Hash256) -> Result<&EvidenceEntry> {
+        let entry = self.evidence.get(hash).ok_or(PdpError::EvidenceNotFound)?;
+        EvidenceLog::verify_entry(entry, self.service_key.public_key())?;
+        Ok(entry)
+    }
+
+    pub fn verify_log(&self) -> Result<()> {
+        self.evidence.verify_all(self.service_key.public_key())
+    }
+
+    /// Export a portable Article 26 evidence pack.
+    #[must_use]
+    pub fn export_pack(&self) -> crate::pack::EvidencePack {
+        crate::pack::EvidencePack::from_log(&self.evidence, self.service_key.public_key())
+    }
+
+    /// Replace the in-memory log from a previously exported pack.
+    pub fn import_pack(&mut self, pack: crate::pack::EvidencePack) -> Result<()> {
+        pack.verify()?;
+        let expected = hex::encode(self.service_key.public_key().as_bytes());
+        if pack.service_public_key_hex != expected {
+            return Err(PdpError::InvalidSignature);
+        }
+        self.evidence = crate::evidence::EvidenceLog::from_entries(pack.entries)?;
+        Ok(())
+    }
+
+    /// Secret key bytes for durable service identity (never the money).
+    #[must_use]
+    pub fn service_secret_bytes(&self) -> [u8; 32] {
+        *self.service_key.secret_key().as_bytes()
+    }
+
+    #[must_use]
+    pub fn granted_by(&self, did: &Did) -> usize {
+        self.delegations.granted_by(did)
+    }
+
+    #[must_use]
+    pub fn received_by(&self, did: &Did) -> usize {
+        self.delegations.received_by(did)
+    }
+
+    #[must_use]
+    pub fn permissions_for(&self, did: &Did) -> Vec<String> {
+        self.delegations
+            .permissions_held_by(did)
+            .iter()
+            .map(|p| format!("{p:?}"))
+            .collect()
+    }
+}
+
+/// Decision plus the signed evidence entry.
+#[derive(Debug, Clone)]
+pub struct DecideOutcome {
+    pub verdict: PolicyVerdict,
+    pub evidence: EvidenceEntry,
+}
+
+/// JSON-friendly decide response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DecideResponse {
+    pub decision: Decision,
+    pub reason: String,
+    pub payment_outranked: bool,
+    pub evidence_hash: String,
+    pub mandate_hash: String,
+    pub never_moves_money: bool,
+}
+
+impl From<&DecideOutcome> for DecideResponse {
+    fn from(o: &DecideOutcome) -> Self {
+        Self {
+            decision: o.verdict.decision,
+            reason: o.verdict.reason.clone(),
+            payment_outranked: o.verdict.payment_outranked,
+            evidence_hash: o.evidence.entry_hash.to_string(),
+            mandate_hash: o.evidence.mandate_hash.to_string(),
+            never_moves_money: true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mandate::{Caveat, Mandate, MandateKind, ProposedAction};
+    use exo_authority::{DelegateeKind, Permission};
+    use exo_core::crypto::KeyPair;
+
+    fn did(n: &str) -> Did {
+        Did::new(&format!("did:exo:{n}")).unwrap()
+    }
+
+    #[test]
+    fn verify_hook_reserves_consume_once() {
+        let alice = KeyPair::generate();
+        let mut pdp = PolicyDecisionPoint::ephemeral();
+        pdp.register_key(did("alice"), *alice.public_key());
+        let alice_did = did("alice");
+        let agent_did = did("agent");
+        let alice_pk = *alice.public_key();
+        let now = Timestamp::new(1, 0);
+        pdp.delegate(
+            DelegationGrant {
+                from: &alice_did,
+                to: &agent_did,
+                scope: &[Permission::Spend],
+                expires: Timestamp::new(99_000, 0),
+                now: &now,
+                parent_link_id: None,
+                delegatee_kind: DelegateeKind::AiAgent {
+                    model_id: "a".into(),
+                },
+                delegator_public_key: &alice_pk,
+            },
+            |b| alice.sign(b),
+        )
+        .unwrap();
+
+        let mut mandate = Mandate {
+            kind: MandateKind::Ap2Payment,
+            principal: did("alice"),
+            agent: did("agent"),
+            action: "payment.settle".into(),
+            amount_minor: Some(1),
+            currency: Some("USD".into()),
+            merchant: None,
+            caveats: vec![Caveat::ConsumeOnce],
+            expires: None,
+            consume_once: true,
+            signature: exo_core::Signature::empty(),
+            raw_hash: Hash256::ZERO,
+        };
+        mandate.signature = alice.sign(&mandate.signable_payload());
+        let hash = mandate.mandate_hash();
+
+        let req = DecisionRequest {
+            mandate,
+            proposed: ProposedAction {
+                action: "payment.settle".into(),
+                amount_minor: Some(1),
+                currency: Some("USD".into()),
+                merchant: None,
+                rail: None,
+            },
+            payment_valid: true,
+            now: Timestamp::new(2, 0),
+        };
+        let out = pdp.verify_before_settle(req).unwrap();
+        assert_eq!(out.verdict.decision, Decision::Allow);
+        assert!(pdp.reservations.is_reserved(&hash));
+        pdp.commit(&hash).unwrap();
+        assert!(pdp.reservations.is_consumed(&hash));
+    }
+}

--- a/crates/exo-pdp/src/service.rs
+++ b/crates/exo-pdp/src/service.rs
@@ -16,11 +16,13 @@
 
 //! In-process policy decision point. Never moves money.
 
-use std::collections::BTreeMap;
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+};
 
 use exo_authority::{DelegationGrant, DelegationRegistry, chain::AuthorityLink};
-use exo_core::{Did, Hash256, PublicKey, Timestamp, crypto::KeyPair};
+use exo_core::{Did, Hash256, PublicKey, Signature, Timestamp, crypto::KeyPair};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -31,9 +33,71 @@ use crate::{
     revocation::{RevocationSet, RevocationTarget},
 };
 
+const PDP_STATE_SPEC: &str = "exochain-pdp-state-v1";
+const PDP_STATE_SIGNING_DOMAIN: &str = "exo.pdp.state.v1";
+const PDP_STATE_SIGNING_SCHEMA_VERSION: u16 = 1;
+
 /// Shared handle used by gateway and node routers.
 #[derive(Clone)]
 pub struct SharedPdp(Arc<Mutex<PolicyDecisionPoint>>);
+
+/// Service-signed durable runtime authority state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PdpSnapshot {
+    spec: String,
+    service_public_key_hex: String,
+    keys: BTreeMap<Did, PublicKey>,
+    delegations: DelegationRegistry,
+    reservations: Vec<crate::reservation::Reservation>,
+    revocations: Vec<crate::revocation::Revocation>,
+    evidence_entries: Vec<EvidenceEntry>,
+    signature: Signature,
+}
+
+impl PdpSnapshot {
+    fn signing_payload(&self) -> Result<Vec<u8>> {
+        #[derive(Serialize)]
+        struct SigningPayload<'a> {
+            domain: &'static str,
+            schema_version: u16,
+            spec: &'a str,
+            service_public_key_hex: &'a str,
+            keys: &'a BTreeMap<Did, PublicKey>,
+            delegations: &'a DelegationRegistry,
+            reservations: &'a [crate::reservation::Reservation],
+            revocations: &'a [crate::revocation::Revocation],
+            evidence_entries: &'a [EvidenceEntry],
+        }
+        let payload = SigningPayload {
+            domain: PDP_STATE_SIGNING_DOMAIN,
+            schema_version: PDP_STATE_SIGNING_SCHEMA_VERSION,
+            spec: &self.spec,
+            service_public_key_hex: &self.service_public_key_hex,
+            keys: &self.keys,
+            delegations: &self.delegations,
+            reservations: &self.reservations,
+            revocations: &self.revocations,
+            evidence_entries: &self.evidence_entries,
+        };
+        let mut data = Vec::new();
+        ciborium::ser::into_writer(&payload, &mut data)
+            .map_err(|e| PdpError::Serialization(e.to_string()))?;
+        Ok(data)
+    }
+
+    /// Encode the signed snapshot as deterministic CBOR.
+    pub fn to_cbor(&self) -> Result<Vec<u8>> {
+        let mut data = Vec::new();
+        ciborium::ser::into_writer(self, &mut data)
+            .map_err(|e| PdpError::Serialization(e.to_string()))?;
+        Ok(data)
+    }
+
+    /// Decode a signed snapshot. The PDP verifies it before import.
+    pub fn from_cbor(bytes: &[u8]) -> Result<Self> {
+        ciborium::de::from_reader(bytes).map_err(|e| PdpError::BadRequest(e.to_string()))
+    }
+}
 
 impl SharedPdp {
     #[must_use]
@@ -143,7 +207,7 @@ impl PolicyDecisionPoint {
                 payment_outranked: verdict.payment_outranked,
                 now: req.now,
             },
-        );
+        )?;
         Ok(DecideOutcome {
             verdict,
             evidence: entry,
@@ -152,8 +216,8 @@ impl PolicyDecisionPoint {
 
     /// x402 `/verify` hop: decide, then reserve consume-once mandates on allow.
     pub fn verify_before_settle(&mut self, req: DecisionRequest) -> Result<DecideOutcome> {
-        let consume = req.mandate.consume_once;
-        let hash = req.mandate.mandate_hash();
+        let consume = req.mandate.requires_single_use();
+        let hash = req.mandate.mandate_hash()?;
         let now = req.now;
         let out = self.decide(req)?;
         if out.verdict.decision == Decision::Allow && consume {
@@ -190,19 +254,64 @@ impl PolicyDecisionPoint {
     }
 
     /// Export a portable Article 26 evidence pack.
-    #[must_use]
-    pub fn export_pack(&self) -> crate::pack::EvidencePack {
-        crate::pack::EvidencePack::from_log(&self.evidence, self.service_key.public_key())
+    pub fn export_pack(&self) -> Result<crate::pack::EvidencePack> {
+        crate::pack::EvidencePack::from_log(&self.evidence, &self.service_key)
     }
 
     /// Replace the in-memory log from a previously exported pack.
     pub fn import_pack(&mut self, pack: crate::pack::EvidencePack) -> Result<()> {
-        pack.verify()?;
-        let expected = hex::encode(self.service_key.public_key().as_bytes());
-        if pack.service_public_key_hex != expected {
+        pack.verify_with_key(self.service_key.public_key())?;
+        self.evidence = crate::evidence::EvidenceLog::from_entries(pack.entries)?;
+        Ok(())
+    }
+
+    /// Export all replay-, revocation-, authority-, and evidence-critical state.
+    pub fn export_snapshot(&self) -> Result<PdpSnapshot> {
+        let mut snapshot = PdpSnapshot {
+            spec: PDP_STATE_SPEC.into(),
+            service_public_key_hex: hex::encode(self.service_key.public_key().as_bytes()),
+            keys: self.keys.clone(),
+            delegations: self.delegations.clone(),
+            reservations: self.reservations.records(),
+            revocations: self.revocations.log().to_vec(),
+            evidence_entries: self.evidence.entries().to_vec(),
+            signature: Signature::empty(),
+        };
+        snapshot.signature = self.service_key.sign(&snapshot.signing_payload()?);
+        Ok(snapshot)
+    }
+
+    /// Verify and atomically replace all in-memory PDP state from a snapshot.
+    pub fn import_snapshot(&mut self, snapshot: PdpSnapshot) -> Result<()> {
+        if snapshot.spec != PDP_STATE_SPEC {
+            return Err(PdpError::BadRequest(format!(
+                "unknown PDP state spec {}",
+                snapshot.spec
+            )));
+        }
+        let expected_key_hex = hex::encode(self.service_key.public_key().as_bytes());
+        if snapshot.service_public_key_hex != expected_key_hex
+            || snapshot.signature.is_empty()
+            || !exo_core::crypto::verify(
+                &snapshot.signing_payload()?,
+                &snapshot.signature,
+                self.service_key.public_key(),
+            )
+        {
             return Err(PdpError::InvalidSignature);
         }
-        self.evidence = crate::evidence::EvidenceLog::from_entries(pack.entries)?;
+
+        snapshot.delegations.validate_persisted_state()?;
+        let reservations = ReservationBook::from_records(snapshot.reservations)?;
+        let revocations = RevocationSet::from_log(snapshot.revocations)?;
+        let evidence = EvidenceLog::from_entries(snapshot.evidence_entries)?;
+        evidence.verify_all(self.service_key.public_key())?;
+
+        self.keys = snapshot.keys;
+        self.delegations = snapshot.delegations;
+        self.reservations = reservations;
+        self.revocations = revocations;
+        self.evidence = evidence;
         Ok(())
     }
 
@@ -229,6 +338,16 @@ impl PolicyDecisionPoint {
             .iter()
             .map(|p| format!("{p:?}"))
             .collect()
+    }
+
+    #[must_use]
+    pub fn is_mandate_revoked(&self, hash: &Hash256) -> bool {
+        self.revocations.is_mandate_revoked(hash)
+    }
+
+    #[must_use]
+    pub fn is_consumed(&self, hash: &Hash256) -> bool {
+        self.reservations.is_consumed(hash)
     }
 }
 
@@ -265,10 +384,11 @@ impl From<&DecideOutcome> for DecideResponse {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::mandate::{Caveat, Mandate, MandateKind, ProposedAction};
     use exo_authority::{DelegateeKind, Permission};
     use exo_core::crypto::KeyPair;
+
+    use super::*;
+    use crate::mandate::{Caveat, Mandate, MandateKind, ProposedAction};
 
     fn did(n: &str) -> Did {
         Did::new(&format!("did:exo:{n}")).unwrap()
@@ -314,8 +434,8 @@ mod tests {
             signature: exo_core::Signature::empty(),
             raw_hash: Hash256::ZERO,
         };
-        mandate.signature = alice.sign(&mandate.signable_payload());
-        let hash = mandate.mandate_hash();
+        mandate.signature = alice.sign(&mandate.signable_payload().unwrap());
+        let hash = mandate.mandate_hash().unwrap();
 
         let req = DecisionRequest {
             mandate,
@@ -334,5 +454,71 @@ mod tests {
         assert!(pdp.reservations.is_reserved(&hash));
         pdp.commit(&hash).unwrap();
         assert!(pdp.reservations.is_consumed(&hash));
+    }
+
+    #[test]
+    fn signed_snapshot_preserves_authority_revocation_and_replay_state() {
+        let service = KeyPair::generate();
+        let service_secret = *service.secret_key().as_bytes();
+        let alice = KeyPair::generate();
+        let alice_did = did("alice");
+        let agent_did = did("agent");
+        let now = Timestamp::new(1, 0);
+        let mut pdp = PolicyDecisionPoint::new(service);
+        pdp.register_key(alice_did.clone(), *alice.public_key());
+        pdp.delegate(
+            DelegationGrant {
+                from: &alice_did,
+                to: &agent_did,
+                scope: &[Permission::Spend],
+                expires: Timestamp::new(99_000, 0),
+                now: &now,
+                parent_link_id: None,
+                delegatee_kind: DelegateeKind::AiAgent {
+                    model_id: "snapshot-agent".into(),
+                },
+                delegator_public_key: alice.public_key(),
+            },
+            |payload| alice.sign(payload),
+        )
+        .unwrap();
+        let mandate_hash = Hash256::digest(b"snapshot-mandate");
+        pdp.reserve(mandate_hash, Timestamp::new(2, 0)).unwrap();
+        pdp.commit(&mandate_hash).unwrap();
+        pdp.revoke_mandate(mandate_hash, Timestamp::new(3, 0), "revoked".into());
+
+        let encoded = pdp.export_snapshot().unwrap().to_cbor().unwrap();
+        let snapshot = PdpSnapshot::from_cbor(&encoded).unwrap();
+        let mut restored =
+            PolicyDecisionPoint::new(KeyPair::from_secret_bytes(service_secret).unwrap());
+        restored.import_snapshot(snapshot).unwrap();
+
+        assert_eq!(
+            restored.resolve_public(&alice_did),
+            Some(*alice.public_key())
+        );
+        assert_eq!(restored.granted_by(&alice_did), 1);
+        assert!(restored.is_consumed(&mandate_hash));
+        assert!(restored.is_mandate_revoked(&mandate_hash));
+    }
+
+    #[test]
+    fn signed_snapshot_rejects_tampered_authority_state() {
+        let service = KeyPair::generate();
+        let service_secret = *service.secret_key().as_bytes();
+        let mut pdp = PolicyDecisionPoint::new(service);
+        let mut snapshot = pdp.export_snapshot().unwrap();
+        snapshot
+            .keys
+            .insert(did("forged"), *KeyPair::generate().public_key());
+
+        let err = pdp.import_snapshot(snapshot).unwrap_err();
+        assert_eq!(err, PdpError::InvalidSignature);
+        assert!(pdp.resolve_public(&did("forged")).is_none());
+
+        let clean = pdp.export_snapshot().unwrap();
+        let mut restored =
+            PolicyDecisionPoint::new(KeyPair::from_secret_bytes(service_secret).unwrap());
+        restored.import_snapshot(clean).unwrap();
     }
 }

--- a/crates/exo-pdp/src/x402.rs
+++ b/crates/exo-pdp/src/x402.rs
@@ -139,7 +139,7 @@ mod tests {
             signature: exo_core::Signature::empty(),
             raw_hash: exo_core::Hash256::ZERO,
         };
-        m.signature = alice.sign(&m.signable_payload());
+        m.signature = alice.sign(&m.signable_payload().unwrap());
 
         let body = X402VerifyRequest {
             mandate: WireMandate {
@@ -212,7 +212,7 @@ mod tests {
             signature: exo_core::Signature::empty(),
             raw_hash: exo_core::Hash256::ZERO,
         };
-        m.signature = alice.sign(&m.signable_payload());
+        m.signature = alice.sign(&m.signable_payload().unwrap());
 
         let body = X402VerifyRequest {
             mandate: WireMandate {

--- a/crates/exo-pdp/src/x402.rs
+++ b/crates/exo-pdp/src/x402.rs
@@ -1,0 +1,240 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! x402 `/verify` hop — policy gate before `/settle`.
+//!
+//! EXOCHAIN never implements settle. A deny here is the facilitator signal
+//! that settlement must not be attempted.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    evidence::Decision,
+    mandate::{MandateAdapter, ProposedAction, WireMandate},
+    policy::DecisionRequest,
+    service::{DecideResponse, PolicyDecisionPoint},
+};
+
+/// Body posted to `POST /x402/verify`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct X402VerifyRequest {
+    pub mandate: WireMandate,
+    #[serde(default)]
+    pub proposed: Option<ProposedAction>,
+    /// Facilitator already validated the PaymentPayload locally.
+    #[serde(default)]
+    pub payment_valid: bool,
+    #[serde(default)]
+    pub now_ms: Option<u64>,
+}
+
+/// Facilitator-shaped verify response. `is_valid == false` blocks settle.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct X402VerifyResponse {
+    pub is_valid: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub invalid_reason: Option<String>,
+    pub decision: Decision,
+    pub payment_outranked: bool,
+    pub evidence_hash: String,
+    pub mandate_hash: String,
+    pub never_moves_money: bool,
+}
+
+impl From<DecideResponse> for X402VerifyResponse {
+    fn from(d: DecideResponse) -> Self {
+        let is_valid = d.decision == Decision::Allow;
+        Self {
+            invalid_reason: if is_valid {
+                None
+            } else {
+                Some(d.reason.clone())
+            },
+            is_valid,
+            decision: d.decision,
+            payment_outranked: d.payment_outranked,
+            evidence_hash: d.evidence_hash,
+            mandate_hash: d.mandate_hash,
+            never_moves_money: true,
+        }
+    }
+}
+
+/// Run the verify hop against a live PDP.
+pub fn verify(
+    pdp: &mut PolicyDecisionPoint,
+    body: X402VerifyRequest,
+) -> crate::error::Result<X402VerifyResponse> {
+    let mandate = body.mandate.into_mandate()?;
+    let proposed = body.proposed.unwrap_or_else(|| ProposedAction {
+        action: mandate.action.clone(),
+        amount_minor: mandate.amount_minor,
+        currency: mandate.currency.clone(),
+        merchant: mandate.merchant.clone(),
+        rail: None,
+    });
+    let now = match body.now_ms {
+        Some(ms) if ms > 0 => exo_core::Timestamp::new(ms, 0),
+        _ => {
+            return Err(crate::error::PdpError::BadRequest(
+                "now_ms is required (HLC physical milliseconds, non-zero)".into(),
+            ));
+        }
+    };
+    let req = DecisionRequest {
+        mandate,
+        proposed,
+        payment_valid: body.payment_valid,
+        now,
+    };
+    let out = pdp.verify_before_settle(req)?;
+    Ok(DecideResponse::from(&out).into())
+}
+
+#[cfg(test)]
+mod tests {
+    use exo_authority::{DelegateeKind, Permission};
+    use exo_core::{Did, Timestamp, crypto::KeyPair};
+
+    use super::*;
+    use crate::mandate::{Caveat, Mandate, MandateKind};
+
+    fn did(n: &str) -> Did {
+        Did::new(&format!("did:exo:{n}")).unwrap()
+    }
+
+    #[test]
+    fn valid_payment_still_denied() {
+        let alice = KeyPair::generate();
+        let mut pdp = PolicyDecisionPoint::ephemeral();
+        pdp.register_key(did("alice"), *alice.public_key());
+
+        let mut m = Mandate {
+            kind: MandateKind::X402Payload,
+            principal: did("alice"),
+            agent: did("agent"),
+            action: "payment.settle".into(),
+            amount_minor: Some(99),
+            currency: Some("USD".into()),
+            merchant: None,
+            caveats: vec![Caveat::AmountMax {
+                minor: 1,
+                currency: "USD".into(),
+            }],
+            expires: None,
+            consume_once: false,
+            signature: exo_core::Signature::empty(),
+            raw_hash: exo_core::Hash256::ZERO,
+        };
+        m.signature = alice.sign(&m.signable_payload());
+
+        let body = X402VerifyRequest {
+            mandate: WireMandate {
+                kind: MandateKind::X402Payload,
+                principal: "did:exo:alice".into(),
+                agent: "did:exo:agent".into(),
+                action: m.action.clone(),
+                amount_minor: m.amount_minor,
+                currency: m.currency.clone(),
+                merchant: None,
+                caveats: m.caveats.clone(),
+                expires_ms: None,
+                consume_once: false,
+                signature_hex: hex::encode(m.signature.ed25519_bytes().expect("ed25519")),
+                raw_hex: None,
+            },
+            proposed: Some(ProposedAction {
+                action: "payment.settle".into(),
+                amount_minor: Some(99),
+                currency: Some("USD".into()),
+                merchant: None,
+                rail: None,
+            }),
+            payment_valid: true,
+            now_ms: Some(1),
+        };
+        let resp = verify(&mut pdp, body).unwrap();
+        assert!(!resp.is_valid);
+        assert!(resp.payment_outranked);
+        assert!(resp.never_moves_money);
+    }
+
+    #[test]
+    fn allow_when_delegated() {
+        let alice = KeyPair::generate();
+        let mut pdp = PolicyDecisionPoint::ephemeral();
+        pdp.register_key(did("alice"), *alice.public_key());
+        let alice_did = did("alice");
+        let agent_did = did("agent");
+        let alice_pk = *alice.public_key();
+        let now = Timestamp::new(1, 0);
+        pdp.delegate(
+            exo_authority::DelegationGrant {
+                from: &alice_did,
+                to: &agent_did,
+                scope: &[Permission::Spend],
+                expires: Timestamp::new(99_000, 0),
+                now: &now,
+                parent_link_id: None,
+                delegatee_kind: DelegateeKind::AiAgent {
+                    model_id: "a".into(),
+                },
+                delegator_public_key: &alice_pk,
+            },
+            |b| alice.sign(b),
+        )
+        .unwrap();
+
+        let mut m = Mandate {
+            kind: MandateKind::X402Payload,
+            principal: did("alice"),
+            agent: did("agent"),
+            action: "payment.settle".into(),
+            amount_minor: Some(1),
+            currency: Some("USD".into()),
+            merchant: None,
+            caveats: vec![],
+            expires: None,
+            consume_once: false,
+            signature: exo_core::Signature::empty(),
+            raw_hash: exo_core::Hash256::ZERO,
+        };
+        m.signature = alice.sign(&m.signable_payload());
+
+        let body = X402VerifyRequest {
+            mandate: WireMandate {
+                kind: MandateKind::X402Payload,
+                principal: "did:exo:alice".into(),
+                agent: "did:exo:agent".into(),
+                action: m.action,
+                amount_minor: m.amount_minor,
+                currency: m.currency,
+                merchant: None,
+                caveats: vec![],
+                expires_ms: None,
+                consume_once: false,
+                signature_hex: hex::encode(m.signature.ed25519_bytes().expect("ed25519")),
+                raw_hex: None,
+            },
+            proposed: None,
+            payment_valid: true,
+            now_ms: Some(2),
+        };
+        let resp = verify(&mut pdp, body).unwrap();
+        assert!(resp.is_valid);
+        assert_eq!(resp.decision, Decision::Allow);
+    }
+}

--- a/crates/exochain-wasm/Cargo.toml
+++ b/crates/exochain-wasm/Cargo.toml
@@ -45,6 +45,7 @@ decision-forum = { package = "exochain-decision-forum", path = "../decision-foru
 exo-catapult   = { package = "exochain-catapult", path = "../exo-catapult", version = "=0.2.3" }
 exo-messaging  = { package = "exochain-messaging", path = "../exo-messaging", version = "=0.2.3" }
 exo-economy    = { package = "exochain-economy", path = "../exo-economy", version = "=0.2.3" }
+exo-pdp        = { package = "exochain-pdp", path = "../exo-pdp", version = "=0.2.3", default-features = false }
 
 # WASM bindings
 wasm-bindgen = "=0.2.100"

--- a/crates/exochain-wasm/src/lib.rs
+++ b/crates/exochain-wasm/src/lib.rs
@@ -35,6 +35,7 @@ pub mod governance_bindings;
 pub mod identity_bindings;
 pub mod legal_bindings;
 pub mod messaging_bindings;
+pub mod pdp_bindings;
 mod serde_bridge;
 
 // Flat re-exports so integration tests and downstream rlib consumers can
@@ -52,6 +53,7 @@ pub use governance_bindings::*;
 pub use identity_bindings::*;
 pub use legal_bindings::*;
 pub use messaging_bindings::*;
+pub use pdp_bindings::*;
 
 #[cfg(test)]
 mod source_guard_tests {
@@ -68,6 +70,7 @@ mod source_guard_tests {
             ),
             ("economy_bindings.rs", include_str!("economy_bindings.rs")),
             ("avc_bindings.rs", include_str!("avc_bindings.rs")),
+            ("pdp_bindings.rs", include_str!("pdp_bindings.rs")),
         ];
 
         for (path, source) in binding_sources {

--- a/crates/exochain-wasm/src/pdp_bindings.rs
+++ b/crates/exochain-wasm/src/pdp_bindings.rs
@@ -1,0 +1,48 @@
+// Copyright 2026 Exochain Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+//! Offline evidence-pack verification for JS / CommandBase.
+
+use wasm_bindgen::prelude::*;
+
+use crate::serde_bridge::*;
+
+/// Independently verify an `exochain-evidence-pack-v1` JSON document.
+///
+/// Does not talk to a node and never moves money. Returns
+/// `{ok: true, ...}` or `{ok: false, error: "..."}`.
+#[wasm_bindgen]
+pub fn wasm_verify_evidence_pack(pack_json: &str) -> Result<JsValue, JsValue> {
+    let pack: exo_pdp::EvidencePack = from_json_str(pack_json)?;
+    match pack.verify() {
+        Ok(()) => to_js_value(&serde_json::json!({
+            "ok": true,
+            "independently_verifiable": true,
+            "never_moves_money": true,
+            "spec": pack.spec,
+            "entries": pack.entries.len(),
+            "article_26": pack.article_26,
+            "tip": pack.tip_hex,
+        })),
+        Err(e) => to_js_value(&serde_json::json!({
+            "ok": false,
+            "error": e.to_string(),
+            "never_moves_money": true,
+        })),
+    }
+}

--- a/crates/exochain-wasm/src/pdp_bindings.rs
+++ b/crates/exochain-wasm/src/pdp_bindings.rs
@@ -27,9 +27,38 @@ use crate::serde_bridge::*;
 /// Does not talk to a node and never moves money. Returns
 /// `{ok: true, ...}` or `{ok: false, error: "..."}`.
 #[wasm_bindgen]
-pub fn wasm_verify_evidence_pack(pack_json: &str) -> Result<JsValue, JsValue> {
-    let pack: exo_pdp::EvidencePack = from_json_str(pack_json)?;
-    match pack.verify() {
+pub fn wasm_verify_evidence_pack(
+    pack_json: &str,
+    expected_service_public_key_hex: &str,
+) -> Result<JsValue, JsValue> {
+    if pack_json.len() > MAX_JSON_INPUT_BYTES {
+        return to_js_value(&serde_json::json!({
+            "ok": false,
+            "error": "JSON input exceeds maximum size",
+            "never_moves_money": true,
+        }));
+    }
+    let pack: exo_pdp::EvidencePack = match serde_json::from_str(pack_json) {
+        Ok(pack) => pack,
+        Err(_) => {
+            return to_js_value(&serde_json::json!({
+                "ok": false,
+                "error": "JSON parse error",
+                "never_moves_money": true,
+            }));
+        }
+    };
+    let expected_key = match exo_pdp::pack::parse_public_key_hex(expected_service_public_key_hex) {
+        Ok(key) => key,
+        Err(e) => {
+            return to_js_value(&serde_json::json!({
+                "ok": false,
+                "error": e.to_string(),
+                "never_moves_money": true,
+            }));
+        }
+    };
+    match pack.verify_with_key(&expected_key) {
         Ok(()) => to_js_value(&serde_json::json!({
             "ok": true,
             "independently_verifiable": true,

--- a/packages/exochain-wasm/test/bridge_verification.mjs
+++ b/packages/exochain-wasm/test/bridge_verification.mjs
@@ -2782,6 +2782,65 @@ test('wasm_avc_build_emit_request_from_signature includes explicit subject publi
 });
 
 // =========================================================================
+// Module 26b — PDP Evidence Pack
+// =========================================================================
+
+console.log('\n--- PDP Evidence Pack ---');
+
+const PDP_SERVICE_PUBLIC_KEY = 'ea4a6c63e29c520abef5507b132ec5f9954776aebebe7b92421eea691446d22c';
+const PDP_EMPTY_PACK = {
+  spec: 'exochain-evidence-pack-v1',
+  never_moves_money: true,
+  service_public_key_hex: PDP_SERVICE_PUBLIC_KEY,
+  tip_hex: ZERO_32_HEX,
+  article_26: {
+    regulation: 'EU 2024/1689',
+    article: '26',
+    automatically_generated: true,
+    retention_days_min: 180,
+    human_oversight: 'principal-signed mandate required; deny-outranks-payment',
+    incident_denies: 0,
+    never_moves_money: true,
+  },
+  entries: [],
+  pack_signature: {
+    Ed25519: [
+      70, 175, 175, 243, 72, 39, 220, 203, 244, 160, 75, 204, 118, 209, 178, 166,
+      147, 105, 132, 25, 92, 0, 51, 27, 8, 52, 58, 86, 105, 131, 35, 52,
+      186, 223, 89, 154, 26, 167, 11, 223, 24, 216, 183, 94, 239, 214, 112, 167,
+      58, 89, 219, 23, 150, 168, 15, 144, 139, 19, 52, 148, 125, 173, 2, 15,
+    ],
+  },
+};
+
+test('wasm_verify_evidence_pack accepts a correctly signed pack with a pinned key', () => {
+  const result = wasm.wasm_verify_evidence_pack(
+    JSON.stringify(PDP_EMPTY_PACK),
+    PDP_SERVICE_PUBLIC_KEY,
+  );
+  if (!result.ok || !result.independently_verifiable || !result.never_moves_money) {
+    throw new Error('signed evidence pack must verify against its separately pinned service key');
+  }
+  return result;
+});
+
+test('wasm_verify_evidence_pack rejects an attacker-selected embedded key', () => {
+  const result = wasm.wasm_verify_evidence_pack(JSON.stringify(PDP_EMPTY_PACK), NONZERO_32_HEX);
+  if (result.ok !== false) {
+    throw new Error('pack must not verify against a different trusted service key');
+  }
+  return result;
+});
+
+test('wasm_verify_evidence_pack returns a structured malformed-input denial', () => {
+  const result = wasm.wasm_verify_evidence_pack('{not-json', PDP_SERVICE_PUBLIC_KEY);
+  if (result.ok !== false || result.error !== 'JSON parse error') {
+    throw new Error('malformed evidence JSON must return a structured fail-closed result');
+  }
+  return result;
+});
+
+// =========================================================================
 // Module 27 — Bridge Coverage Guard
 // =========================================================================
 


### PR DESCRIPTION
## Summary

EXOCHAIN is the runtime policy decision point for agent actions and payments; it does not settle or move funds.

- Verifies signed native, AP2, ACP, and x402 mandate shapes.
- Binds the proposed action, amount, currency, merchant, rail, payment validity, and consume-once behavior to signed authority.
- Enforces strict kind-aware permissions, revocations, delegation limits, and durable replay prevention.
- Produces hash-chained, service-signed Article 26 evidence packs.
- Requires an independently obtained service public key for offline, HTTP, CLI, and WASM pack verification.
- Persists the full signed PDP state atomically in `pdp-state.cbor`; creates `pdp.key` exclusively with owner-only permissions.
- Authenticates sensitive authority-pack and evidence reads and treats persistence failure as a critical runtime failure.

## Security review

The exact range `86e9a029b7a62417b658b04d0def7a979e21fc8b..49ea877005db731f0e2844ad481b436a0a975da8` received complete diff coverage: 24/24 changed paths reviewed, zero reportable findings; final sealed scan `f35316fc-58a2-4841-aa7e-e16c6aaf3064`.

## Validation on exact head

- [x] `cargo test --workspace`
- [x] `cargo test -p exochain-pdp --all-features` (40 passed)
- [x] `cargo test -p exochain-pdp --release --all-features` (40 passed)
- [x] `cargo tarpaulin -p exochain-pdp --all-features --engine llvm` (`http.rs`: 160/233 covered, up from 9/218)
- [x] `cargo build --workspace --release`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- [x] `cargo audit`, `cargo deny check`, and `cargo machete`
- [x] All 41 repository hygiene/source guards
- [x] Rust/Node cross-implementation canonical vector comparison
- [x] WASM release build and package dry-run; 166 Rust exports and 175/175 bridge checks
- [x] WASM demo tests (27 passed)
- [x] Required GitHub checks on `49ea877005db731f0e2844ad481b436a0a975da8` (both exact-head runs; coverage 90.31%)

## Offline verification

```bash
exochain pdp verify \
  --pack pdp-evidence.json \
  --service-public-key <trusted-32-byte-ed25519-key-hex>
```

The trusted key must be obtained independently of the evidence pack. `exochain pdp inspect` prints an explicitly unverified summary.

