### PR TITLE
fix(deploy): build node images on rustc 1.90

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,10 @@
 # Run locally:    docker run -p 4001:4001 -p 8080:8080 -v exochain:/data exochain/node
 
 # Stage 1: Build Rust binaries
-# Use 1.88 — workspace minimum is 1.85, but some transitive deps
-# (time 0.3.47, async-graphql 7.0.17) require newer rustc. 1.88 is
-# the lowest version that satisfies the current full dep graph.
-FROM rust:1.88-slim-bookworm AS rust-builder
+# Use 1.90 — workspace rust-version is 1.85, but the 0.2.4 CGR / RISC Zero
+# graph pulls ruint 1.20 (rustc 1.90) and enum-ordinalize 4.4.1 (rustc 1.89).
+# Railway's previous 1.88 builder failed closed on that graph.
+FROM rust:1.90-slim-bookworm AS rust-builder
 WORKDIR /app
 RUN apt-get update && apt-get install -y pkg-config libssl-dev clang && rm -rf /var/lib/apt/lists/*
 COPY Cargo.toml Cargo.lock ./

--- a/deploy/Dockerfile.node
+++ b/deploy/Dockerfile.node
@@ -26,7 +26,8 @@
 #   docker run -d -p 4001:4001 -p 8080:8080 -v exochain:/data \
 #     -e SEED_ADDR=seed1.exochain.io:4001 exochain/node
 
-FROM rust:1.88-slim-bookworm AS builder
+# 1.90: ruint 1.20 and enum-ordinalize 4.4.1 reject rustc 1.88.
+FROM rust:1.90-slim-bookworm AS builder
 WORKDIR /app
 RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
 COPY Cargo.toml Cargo.lock ./


### PR DESCRIPTION
## Why

Railway deploy of signed `v0.2.4` (`9ad6068a`) failed in `exochain-node`:

```
error: rustc 1.88.0 is not supported by the following packages:
  enum-ordinalize@4.4.1 requires rustc 1.89
  ruint@1.20.0 requires rustc 1.90
```

Those crates arrived with the 0.2.4 CGR / RISC Zero graph. Constitutional CI was green because GitHub runners use current stable.

## What

- `Dockerfile` and `deploy/Dockerfile.node` now use `rust:1.90-slim-bookworm`.

Does not retag `v0.2.4`. Image-only follow-up so Railway can run the 0.2.4 binary.