### PR TITLE
docs: record v0.2.4 as the published release

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 | Rust source files | 491 | `git ls-files 'crates/**/*.rs'` |
 | Workspace tests | 6,331 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 23 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
-| Latest published release | `v0.2.3` (GitHub Release published 2026-07-15; all release crates plus `@exochain/exochain-wasm` and `@exochain/llm-proxy` resolve the same version) | `gh release list`; crates.io version API; `npm view @exochain/exochain-wasm version`; `npm view @exochain/llm-proxy version` |
+| Latest published release | `v0.2.4` (GitHub Release published 2026-08-18; all release crates plus `@exochain/exochain-wasm` and `@exochain/llm-proxy` resolve the same version) | `gh release list`; crates.io version API; `npm view @exochain/exochain-wasm version`; `npm view @exochain/llm-proxy version` |
 | License | Apache-2.0 for EXOCHAIN core primitives; commercial terms for Decision Forum, LegalDyne, CyberMedica, LiveSafe, and CrossChecked products | `governance/commercial-product-licensing.json`; product license files where present |
 | Live node health | Not inferred from repository state; verify each target at deploy or release time | `tools/verify_live_node_claim.sh` |
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -38,11 +38,10 @@ The workspace version is set in `Cargo.toml`:
 version = "0.2.4"
 ```
 
-This repository state is the unpublished `0.2.4` release candidate: PDP
-decides, AVC records, x402 adapts; crates.io `ml-dsa` consumers can build.
-The latest published release remains `v0.2.3`. Workspace version alignment
-is not evidence of a tag, GitHub Release, registry publication, deployment,
-or live runtime activation.
+The published release is `v0.2.4`: PDP decides, AVC records, x402 adapts;
+crates.io `ml-dsa` consumers can build. Workspace version alignment is not
+by itself evidence of a later tag, GitHub Release, registry publication,
+deployment, or live runtime activation.
 
 ## Release Process
 

--- a/governance/releases/v0.2.4/RC.md
+++ b/governance/releases/v0.2.4/RC.md
@@ -42,7 +42,7 @@ This is **not** v0.3.0 evidence-grade closure. Issue #813 stays open.
 | VCG-001 `ProductionReviewed` | External cryptographic review of the integration has not landed. Receipt verify is live; the registry label is not. |
 | Groth16 receipt compression wrap | Default prover emits a zkVM execution receipt, not the on-chain Groth16 wrap. |
 | #813 evidence-grade train | G00 / Art. 26 certification not claimed. |
-| Signed tag + crates.io publish | Requires two environment approvals and a signed `v0.2.4` tag. |
+| Signed tag + crates.io publish | Done: `v0.2.4` on `9ad6068a`; GitHub Release and 32 crates plus npm live. Yank of `0.2.3` is #822. |
 
 ## Publication sequence
 


### PR DESCRIPTION
## Why

`tools/test_repo_truth.sh` requires README \`Latest published release\` to match the newest \`v*\` tag. \`v0.2.4\` is now a published GitHub Release with all 32 crates and both npm packages at 0.2.4.

## What

- README latest published → \`v0.2.4\` (2026-08-18)
- VERSIONING current status no longer calls 0.2.4 unpublished
- RC.md publication row updated; yank remains #822

Does not yank 0.2.3. Does not claim ProductionReviewed or Article 26.