### PR TITLE
Refresh repository truth and harden anchor persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 | Metric | Value | Source |
 |--------|-------|--------|
 | Rust crates | 32 | `cargo metadata --no-deps --format-version 1` |
-| Rust source files | 502 | `git ls-files 'crates/**/*.rs'` |
-| Workspace tests | 6,387 listed | `cargo test --workspace -- --list` |
+| Rust source files | 505 | `git ls-files 'crates/**/*.rs'` |
+| Workspace tests | 6,403 listed | `cargo test --workspace -- --list` |
 | CI quality gates | 23 | `.github/workflows/ci.yml` numbered gates; required aggregator is separate |
 | Latest published release | `v0.2.4` (GitHub Release published 2026-08-18; release crates plus `@exochain/exochain-wasm` and `@exochain/llm-proxy` resolve the same version) | `gh release list`; crates.io version API; `npm view @exochain/exochain-wasm version`; `npm view @exochain/llm-proxy version` |
 | License | Apache-2.0 for EXOCHAIN core primitives; commercial terms for Decision Forum, LegalDyne, CyberMedica, LiveSafe, and CrossChecked products | `governance/commercial-product-licensing.json`; product license files where present |
@@ -43,7 +43,7 @@ EXOCHAIN is a verifiable, privacy-preserving substrate enabling secure identity 
 
 ### What is verified today
 
-- **6,387 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
+- **6,403 workspace tests are listed** by `cargo test --workspace -- --list`; CI Gate 2 runs them in debug and release modes
 - **Build succeeds** for all library crates, binaries, tests, and benchmarks
 - **Clippy clean** under `-D warnings` for all workspace targets
 - **Format clean** under `cargo +nightly fmt --all -- --check`
@@ -127,7 +127,7 @@ Layer 1: CGR Kernel         (Rust, 32 crates)
          Constitutional governance runtime — deterministic, no floats,
          production Ed25519/BLAKE3 cryptography, RISC Zero execution-receipt
          verify (not production-reviewed), plus unaudited pedagogical
-         SNARK/STARK/ZKML skeletons, 6,387 listed workspace tests
+         SNARK/STARK/ZKML skeletons, 6,403 listed workspace tests
 
 Layer 2: WASM Bridge        (packages/exochain-wasm/)
          166 verified WASM exports covered by 175 bridge checks — Rust -> WebAssembly -> JavaScript

--- a/crates/exo-node/src/crosschecked_anchor_authority_admin_cli.rs
+++ b/crates/exo-node/src/crosschecked_anchor_authority_admin_cli.rs
@@ -773,3 +773,210 @@ fn write_redacted_summary(operation: &str, package_bytes: &[u8]) -> anyhow::Resu
         .write_all(b"\n")
         .map_err(|_| anyhow::anyhow!("redacted owner output write failed"))
 }
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn key(byte: u8) -> KeyPair {
+        KeyPair::from_secret_bytes([byte; 32]).unwrap()
+    }
+
+    fn signing_material() -> IntermediateSigningMaterialV1 {
+        IntermediateSigningMaterialV1 {
+            protocol_version: 1,
+            intermediate_did: "did:exo:crosschecked-intermediate".to_owned(),
+            intermediate_key_id: "did:exo:crosschecked-intermediate#key-1".to_owned(),
+            signing_secret_hex: hex::encode([0x41; 32]),
+        }
+    }
+
+    fn provision_command(intermediate: &KeyPair) -> ProvisionAuthorityCommandV1 {
+        let node = key(0x29);
+        let authority = key(0x17);
+        let governance = key(0x77);
+        ProvisionAuthorityCommandV1 {
+            protocol_version: 1,
+            expected_audience: "exochain-node-production".to_owned(),
+            intermediate_did: "did:exo:crosschecked-intermediate".to_owned(),
+            intermediate_key_id: "did:exo:crosschecked-intermediate#key-1".to_owned(),
+            intermediate_public_key_hex: hex::encode(intermediate.public_key().as_bytes()),
+            node_did: "did:exo:node".to_owned(),
+            node_key_id: "did:exo:node#key-1".to_owned(),
+            node_public_key_hex: hex::encode(node.public_key().as_bytes()),
+            governance_group_public_key_hex: hex::encode(governance.public_key().as_bytes()),
+            governance_key_epoch: 3,
+            authority_did: "did:exo:workspace-authority".to_owned(),
+            authority_key_id: "did:exo:workspace-authority#key-1".to_owned(),
+            authority_public_key_hex: hex::encode(authority.public_key().as_bytes()),
+            grant_id_hex: hex::encode([0x31; 32]),
+            scope_alias_hex: hex::encode([0x42; 32]),
+            key_epoch: 1,
+            valid_from_ms: 1_000,
+            valid_until_ms: 10_000,
+        }
+    }
+
+    fn retirement_command(intermediate: &KeyPair) -> RetireAuthorityCommandV1 {
+        let provision = provision_command(intermediate);
+        RetireAuthorityCommandV1 {
+            protocol_version: provision.protocol_version,
+            expected_audience: provision.expected_audience.clone(),
+            intermediate_did: provision.intermediate_did.clone(),
+            intermediate_key_id: provision.intermediate_key_id.clone(),
+            intermediate_public_key_hex: provision.intermediate_public_key_hex.clone(),
+            node_did: provision.node_did.clone(),
+            node_key_id: provision.node_key_id.clone(),
+            node_public_key_hex: provision.node_public_key_hex.clone(),
+            governance_group_public_key_hex: provision.governance_group_public_key_hex.clone(),
+            governance_key_epoch: provision.governance_key_epoch,
+            authority_did: provision.authority_did.clone(),
+            authority_key_id: provision.authority_key_id.clone(),
+            key_epoch: provision.key_epoch,
+            retired_at_ms: 5_000,
+        }
+    }
+
+    fn authorization(event: &str) -> GovernanceAuthorizationInputV1 {
+        GovernanceAuthorizationInputV1 {
+            protocol_version: 1,
+            authorization_id_hex: hex::encode([1; 32]),
+            ceremony_id_hex: hex::encode([2; 32]),
+            governance_key_epoch: 3,
+            threshold: 7,
+            participant_count: 13,
+            signer_ids: vec![1, 2, 3, 4, 5, 6, 7],
+            lifecycle_event: event.to_owned(),
+            authority_did: "did:exo:workspace-authority".to_owned(),
+            authority_key_id: "did:exo:workspace-authority#key-1".to_owned(),
+            authority_key_epoch: 1,
+            scope_alias_hex: hex::encode([3; 32]),
+            package_hash_hex: hex::encode([4; 32]),
+            node_policy_hash_hex: hex::encode([5; 32]),
+            authorization_sequence: 9,
+            prior_authorization_hash_hex: hex::encode([0; 32]),
+            valid_from_ms: 1_000,
+            valid_until_ms: 10_000,
+            signature_algorithm: "frost-ed25519-sha512".to_owned(),
+            signature_hex: hex::encode([6; 64]),
+        }
+    }
+
+    #[test]
+    fn owner_command_builders_cover_valid_packages_and_closed_rejections() {
+        let intermediate = key(0x41);
+        let material = signing_material();
+        let command = provision_command(&intermediate);
+        assert_eq!(command.store_policy().governance_key_epoch, 3);
+        let parsed_key = intermediate_key(&material).unwrap();
+        assert_eq!(parsed_key.public_key(), intermediate.public_key());
+        let config = store_config(command.store_policy(), &material, &parsed_key).unwrap();
+        assert_eq!(config.expected_audience, "exochain-node-production");
+        let package = signed_provisioning(&command, &material, &parsed_key).unwrap();
+        assert_eq!(package.did_documents.len(), 2);
+        assert_eq!(package.authority_chain.links.len(), 1);
+        assert_eq!(
+            package.scope_binding.permission,
+            Permission::AnchorReceiptCommitment
+        );
+
+        let retirement_command = retirement_command(&intermediate);
+        assert_eq!(retirement_command.store_policy().governance_key_epoch, 3);
+        let retirement = signed_retirement(&retirement_command, &material, &parsed_key).unwrap();
+        assert_eq!(retirement.retired_at_ms, 5_000);
+
+        for event in ["provision", "retire", "revoke"] {
+            assert_eq!(
+                governance_authorization(authorization(event))
+                    .unwrap()
+                    .lifecycle_event
+                    .code(),
+                event
+            );
+        }
+        assert!(governance_authorization(authorization("unknown")).is_err());
+        assert!(require_protocol(2).is_err());
+        assert!(parse_did("not-a-did").is_err());
+        assert!(decode_public_hex(&"AA".repeat(32)).is_err());
+        assert!(decode_secret_hex(&"AA".repeat(32)).is_err());
+        assert_eq!(decode_public_hex(&hex::encode([7; 32])).unwrap(), [7; 32]);
+        assert_eq!(*decode_secret_hex(&hex::encode([8; 32])).unwrap(), [8; 32]);
+
+        let mut wrong_material = signing_material();
+        wrong_material.intermediate_key_id = "did:exo:other#key".to_owned();
+        assert!(store_config(command.store_policy(), &wrong_material, &parsed_key).is_err());
+    }
+
+    #[test]
+    fn owner_only_files_and_registry_paths_fail_closed() {
+        let directory = tempdir().unwrap();
+        let input = directory.path().join("input.json");
+        fs::write(&input, br#"{"protocol_version":1}"#).unwrap();
+        fs::set_permissions(&input, fs::Permissions::from_mode(0o600)).unwrap();
+        let value: serde_json::Value = read_private_json(&input, 1024, "rejected").unwrap();
+        assert_eq!(value["protocol_version"], 1);
+        assert!(read_owner_only_file(&input, 2, "rejected").is_err());
+
+        fs::set_permissions(&input, fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(read_owner_only_file(&input, 1024, "rejected").is_err());
+        fs::set_permissions(&input, fs::Permissions::from_mode(0o600)).unwrap();
+        let link = directory.path().join("link.json");
+        symlink(&input, &link).unwrap();
+        assert!(read_owner_only_file(&link, 1024, "rejected").is_err());
+
+        let data = directory.path().join("data");
+        fs::create_dir(&data).unwrap();
+        let records = records_path(&data, false).unwrap();
+        assert!(records.ends_with("crosschecked_anchor/records.sqlite3"));
+        assert!(records_path(&data, true).is_err());
+        fs::write(&records, b"sqlite-fixture").unwrap();
+        restrict_registry_file(&records).unwrap();
+        assert_eq!(
+            fs::metadata(&records).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert_eq!(records_path(&data, true).unwrap(), records);
+
+        let output = directory.path().join("signed.cbor");
+        write_optional_package(Some(&output), b"package").unwrap();
+        assert_eq!(fs::read(&output).unwrap(), b"package");
+        assert!(write_optional_package(Some(&output), b"replace").is_err());
+        write_optional_package(None, b"ignored").unwrap();
+
+        let bad_data = directory.path().join("bad-data");
+        symlink(&data, &bad_data).unwrap();
+        assert!(records_path(&bad_data, false).is_err());
+    }
+
+    #[test]
+    fn path_separation_and_clock_contracts_are_enforced() {
+        let directory = tempdir().unwrap();
+        let base = CrossCheckedAnchorAuthorityAdminArgs {
+            data_dir: directory.path().join("data"),
+            command: directory.path().join("command.json"),
+            intermediate_secret_file: directory.path().join("secret.json"),
+            governance_authorization: directory.path().join("authorization.json"),
+            signed_package_out: Some(directory.path().join("package.cbor")),
+        };
+        assert!(ensure_distinct_inputs(&base).is_ok());
+        let mut duplicate = base;
+        duplicate.signed_package_out = Some(duplicate.command.clone());
+        assert!(ensure_distinct_inputs(&duplicate).is_err());
+        assert!(current_time_ms().unwrap() > 0);
+
+        let public_key = *key(9).public_key();
+        let document = did_document(
+            Did::new("did:exo:test").unwrap(),
+            "did:exo:test#key-1",
+            public_key,
+            4,
+            123,
+        );
+        assert_eq!(document.verification_methods[0].version, 4);
+        assert_eq!(document.created.physical_ms, 123);
+    }
+}

--- a/crates/exo-node/src/crosschecked_anchor_store.rs
+++ b/crates/exo-node/src/crosschecked_anchor_store.rs
@@ -24,6 +24,7 @@
 use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
+    sync::{Arc, Mutex, MutexGuard},
     time::Duration,
 };
 
@@ -378,12 +379,14 @@ pub enum AnchorStoreError {
     ReadbackValidation(String),
 }
 
-/// SQLite-backed store. Each operation opens its own connection so callers
-/// may safely share the store across worker threads.
+/// SQLite-backed store. Each operation opens its own connection. Mutations
+/// share one process-local gate so expensive durable signing never holds a
+/// SQLite write transaction while sibling workers exhaust their busy timeout.
 #[derive(Clone, Debug)]
 pub struct AnchorStore {
     path: PathBuf,
     config: AnchorStoreConfig,
+    write_gate: Arc<Mutex<()>>,
 }
 
 #[derive(Clone, Debug)]
@@ -463,6 +466,7 @@ impl AnchorStore {
         let store = Self {
             path: path.as_ref().to_path_buf(),
             config,
+            write_gate: Arc::new(Mutex::new(())),
         };
         let connection = store.connection()?;
         initialize_schema(&connection, &store.config)?;
@@ -482,6 +486,7 @@ impl AnchorStore {
         authorization: &AuthorityGovernanceAuthorizationV1,
         applied_at_ms: u64,
     ) -> Result<(), AnchorStoreError> {
+        let _write_guard = self.write_guard()?;
         let validated = validate_provisioning(&self.config, provisioning)?;
         let provisioning_cbor = provisioning.to_cbor_bytes()?;
         let package_hash = Hash256::digest(&provisioning_cbor);
@@ -646,6 +651,7 @@ impl AnchorStore {
         authorization: &AuthorityGovernanceAuthorizationV1,
         applied_at_ms: u64,
     ) -> Result<(), AnchorStoreError> {
+        let _write_guard = self.write_guard()?;
         let retirement_cbor = retirement.to_cbor_bytes()?;
         let package_hash = Hash256::digest(&retirement_cbor);
         let mut connection = self.connection()?;
@@ -736,6 +742,7 @@ impl AnchorStore {
         submission: SubmissionContext<'_>,
         signer: &dyn DurableAnchorSigner,
     ) -> Result<AnchorRecord, AnchorStoreError> {
+        let _write_guard = self.write_guard()?;
         let locator = decode_unverified_replay_locator(
             submission.body,
             submission.method,
@@ -950,6 +957,12 @@ impl AnchorStore {
             .execute_batch("PRAGMA foreign_keys = ON; PRAGMA synchronous = FULL;")
             .map_err(storage)?;
         Ok(connection)
+    }
+
+    fn write_guard(&self) -> Result<MutexGuard<'_, ()>, AnchorStoreError> {
+        self.write_gate.lock().map_err(|_| {
+            AnchorStoreError::Storage("anchor store write serialization is unavailable".into())
+        })
     }
 }
 


### PR DESCRIPTION
Repairs the Gate 9 repository-truth failure observed after PR #828 merged and closes the SQLite writer-exhaustion regression exposed by Gate 17 coverage instrumentation.\n\nExact derived values:\n- Rust source files: 505\n- Workspace tests: 6,403\n- Head: 726948014262e06e7f6d0f30a07a33f1a3b0aa11\n\nThe anchor store now serializes same-process authority provisioning, lifecycle mutation, and receipt recording before opening SQLite write transactions. This preserves exact replay and sign-once semantics while preventing concurrent workers from exhausting the database busy timeout.\n\nVerification:\n- repository truth check passes\n- 100 concurrent identical requests pass normally\n- the same 100-request test passes under LLVM coverage instrumentation\n- complete anchor persistence suite: 21 passed\n- strict clippy and formatting pass\n- Codex Security diff scan 486dabdf-ff9e-47dd-b7fd-5d0fead1eca6: complete, zero findings\n\nNo production authority was provisioned and no consensus or finality claim is made.